### PR TITLE
prim_toPath: Actually make the string a path

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -517,7 +517,9 @@ static void prim_toPath(EvalState & state, Value * * args, Value & v)
 {
     PathSet context;
     Path path = state.coerceToPath(*args[0], context);
-    mkString(v, canonPath(path), context);
+    if (!context.empty())
+        throw EvalError(format("string `%1%' cannot refer to other paths") % path);
+    mkPath(v, canonPath(path).c_str());
 }
 
 


### PR DESCRIPTION
builtins.toPath currently doesn't actually turn something into a path. In fact, while it does check if the argument is indeed a path and canonicalize it, it actually returns a string even the argument was a path! This fixes that.

$ cat test.nix

```
let
  a = builtins.readFile (builtins.unsafeDiscardStringContext (derivation {
    name = "a";
    builder = "/bin/false";
    system = "sys";
    path = /etc/nixos/configuration.nix;
  }).drvPath);

  b = builtins.readFile (builtins.unsafeDiscardStringContext (derivation {
    name = "b";
    builder = "/bin/false";
    system = "sys";
    path = builtins.toPath "/etc/nixos/configuration.nix";
  }).drvPath);

  c = builtins.readFile (builtins.unsafeDiscardStringContext (derivation {
    name = "c";
    builder = "/bin/false";
    system = "sys";
    path = builtins.toPath /etc/nixos/configuration.nix;
  }).drvPath);
in

import "${(import <nixpkgs> {}).runCommand "paths.nix" {} ''
  echo "'''" > $out
  echo "${a}" | sed 's/.*\(path,[^)]*\)).*/\1/' >> $out
  echo "${b}" | sed 's/.*\(path,[^)]*\)).*/\1/' >> $out
  echo "${c}" | sed 's/.*\(path,[^)]*\)).*/\1/' >> $out
  echo "'''" >> $out
''}"
```

Before:
$ echo -e $(nix-instantiate test.nix >/dev/null 2>&1 || nix-instantiate test.nix --eval-only | sed 's\"\g')

```
path,/nix/store/ms6xqxb4pvxga4m9wlmj5rp8my418dwz-configuration.nix
path,/etc/nixos/configuration.nix
path,/etc/nixos/configuration.nix
```

After:
$ echo -e $(nix-instantiate test.nix >/dev/null 2>&1 || nix-instantiate test.nix --eval-only | sed 's\"\g')

```
path,/nix/store/ms6xqxb4pvxga4m9wlmj5rp8my418dwz-configuration.nix
path,/nix/store/ms6xqxb4pvxga4m9wlmj5rp8my418dwz-configuration.nix
path,/nix/store/ms6xqxb4pvxga4m9wlmj5rp8my418dwz-configuration.nix
```
