### PR TITLE
Use structured data for string contexts.

### DIFF
--- a/src/libexpr/Makefile.am
+++ b/src/libexpr/Makefile.am
@@ -8,7 +8,7 @@ libexpr_la_SOURCES = \
 pkginclude_HEADERS = \
  nixexpr.hh eval.hh eval-inline.hh lexer-tab.hh parser-tab.hh \
  get-drvs.hh attr-path.hh value-to-xml.hh common-opts.hh \
- names.hh symbol-table.hh value.hh
+ names.hh symbol-table.hh context.hh value.hh
 
 libexpr_la_LIBADD = ../libutil/libutil.la ../libstore/libstore.la \
  ../boost/format/libformat.la @BDW_GC_LIBS@

--- a/src/libexpr/context.hh
+++ b/src/libexpr/context.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstring>
+
+namespace nix {
+
+
+struct ContextEntry
+{
+    const char *path;
+    const char *output;
+    bool discardOutputs;
+};
+
+
+struct CompareContextEntry
+{
+    inline bool operator() (const ContextEntry* const & c1, const ContextEntry* const & c2) {
+        return (strcmp(c1->path,c2->path) < 0) || ((strcmp(c1->path,c2->path) == 0) && (strcmp(c1->output,c2->output) < 0));
+    }
+};
+
+
+typedef std::set<const ContextEntry *, CompareContextEntry> ContextEntrySet;
+
+
+}

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -71,10 +71,9 @@ struct Attr
     }
 };
 
+void mkString(Value & v, const string & s, const ContextEntrySet & context = ContextEntrySet());
 
-void mkString(Value & v, const string & s, const PathSet & context = PathSet());
-
-void copyContext(const Value & v, PathSet & context);
+void copyContext(const Value & v, ContextEntrySet & context);
 
 
 /* Cache for calls to addToStore(); maps source paths to the store
@@ -160,7 +159,7 @@ public:
     inline void forceList(Value & v);
     void forceFunction(Value & v); // either lambda or primop
     string forceString(Value & v);
-    string forceString(Value & v, PathSet & context);
+    string forceString(Value & v, ContextEntrySet & context);
     string forceStringNoCtx(Value & v);
 
     /* Return true iff the value `v' denotes a derivation (i.e. a
@@ -171,13 +170,13 @@ public:
        string.  If `coerceMore' is set, also converts nulls, integers,
        booleans and lists to a string.  If `copyToStore' is set,
        referenced paths are copied to the Nix store as a side effect.q */
-    string coerceToString(Value & v, PathSet & context,
+    string coerceToString(Value & v, ContextEntrySet & context,
         bool coerceMore = false, bool copyToStore = true);
 
     /* Path coercion.  Converts strings, paths and derivations to a
        path.  The result is guaranteed to be a canonicalised, absolute
        path.  Nothing is copied to the store. */
-    Path coerceToPath(Value & v, PathSet & context);
+    Path coerceToPath(Value & v, ContextEntrySet & context);
 
 private:
 
@@ -224,6 +223,9 @@ public:
     
     /* Allocation primitives. */
     Value * allocValue();
+
+    ContextEntry * allocContextEntry(const Path & path, const string & output = string());
+
     Env & allocEnv(unsigned int size);
 
     Value * allocAttr(Value & vAttrs, const Symbol & name);
@@ -242,6 +244,8 @@ private:
     unsigned long nrEnvs;
     unsigned long nrValuesInEnvs;
     unsigned long nrValues;
+    unsigned long nrContextEntries;
+    unsigned long nrContextEntryBytes;
     unsigned long nrListElems;
     unsigned long nrAttrsets;
     unsigned long nrOpUpdates;

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -10,7 +10,7 @@ string DrvInfo::queryDrvPath(EvalState & state) const
 {
     if (drvPath == "" && attrs) {
         Bindings::iterator i = attrs->find(state.sDrvPath);
-        PathSet context;
+        ContextEntrySet context;
         (string &) drvPath = i != attrs->end() ? state.coerceToPath(*i->value, context) : "";
     }
     return drvPath;
@@ -21,7 +21,7 @@ string DrvInfo::queryOutPath(EvalState & state) const
 {
     if (outPath == "" && attrs) {
         Bindings::iterator i = attrs->find(state.sOutPath);
-        PathSet context;
+        ContextEntrySet context;
         (string &) outPath = i != attrs->end() ? state.coerceToPath(*i->value, context) : "";
     }
     return outPath;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -24,32 +24,20 @@ namespace nix {
  *************************************************************/
 
 
-/* Decode a context string ‘!<name>!<path>’ into a pair <path,
-   name>. */
-std::pair<string, string> decodeContext(const string & s)
-{
-    if (s.at(0) == '!') {
-        size_t index = s.find("!", 1);
-        return std::pair<string, string>(string(s, index + 1), string(s, 1, index - 1));
-    } else
-        return std::pair<string, string>(s, "");
-}
-
-
 /* Load and evaluate an expression from path specified by the
    argument. */ 
 static void prim_import(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     Path path = state.coerceToPath(*args[0], context);
 
-    foreach (PathSet::iterator, i, context) {
-        Path ctx = decodeContext(*i).first;
+    foreach (ContextEntrySet::iterator, i, context) {
+        Path ctx = (*i)->path;
         assert(isStorePath(ctx));
         if (!store->isValidPath(ctx))
             throw EvalError(format("cannot import `%1%', since path `%2%' is not valid")
                 % path % ctx);
-        if (isDerivation(ctx))
+        if (isDerivation(ctx) && !(*i)->discardOutputs)
             try {
                 /* For performance, prefetch all substitute info. */
                 PathSet willBuild, willSubstitute, unknown;
@@ -69,14 +57,14 @@ static void prim_import(EvalState & state, Value * * args, Value & v)
         Derivation drv = parseDerivation(readFile(path));
         Value & w = *state.allocValue();
         state.mkAttrs(w, 1 + drv.outputs.size());
-        mkString(*state.allocAttr(w, state.sDrvPath), path, singleton<PathSet>("=" + path));
+        mkString(*state.allocAttr(w, state.sDrvPath), path, singleton<ContextEntrySet>(state.allocContextEntry(path)));
         state.mkList(*state.allocAttr(w, state.symbols.create("outputs")), drv.outputs.size());
         unsigned int outputs_index = 0;
 
         Value * outputsVal = w.attrs->find(state.symbols.create("outputs"))->value;
         foreach (DerivationOutputs::iterator, i, drv.outputs) {
             mkString(*state.allocAttr(w, state.symbols.create(i->first)),
-                i->second.path, singleton<PathSet>("!" + i->first + "!" + path));
+                i->second.path, singleton<ContextEntrySet>(state.allocContextEntry(path,i->first)));
             mkString(*(outputsVal->list.elems[outputs_index++] = state.allocValue()),
                 i->first);
         }
@@ -220,7 +208,7 @@ static void prim_genericClosure(EvalState & state, Value * * args, Value & v)
 
 static void prim_abort(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     throw Abort(format("evaluation aborted with the following error message: `%1%'") %
         state.coerceToString(*args[0], context));
 }
@@ -228,7 +216,7 @@ static void prim_abort(EvalState & state, Value * * args, Value & v)
 
 static void prim_throw(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     throw ThrownError(format("user-thrown exception: %1%") %
         state.coerceToString(*args[0], context));
 }
@@ -240,7 +228,7 @@ static void prim_addErrorContext(EvalState & state, Value * * args, Value & v)
         state.forceValue(*args[1]);
         v = *args[1];
     } catch (Error & e) {
-        PathSet context;
+        ContextEntrySet context;
         e.addPrefix(format("%1%\n") % state.coerceToString(*args[0], context));
         throw;
     }
@@ -320,7 +308,7 @@ static void prim_derivationStrict(EvalState & state, Value * * args, Value & v)
     /* Build the derivation expression by processing the attributes. */
     Derivation drv;
     
-    PathSet context;
+    ContextEntrySet context;
 
     string outputHash, outputHashAlgo;
     bool outputHashRecursive = false;
@@ -394,46 +382,24 @@ static void prim_derivationStrict(EvalState & state, Value * * args, Value & v)
     /* Everything in the context of the strings in the derivation
        attributes should be added as dependencies of the resulting
        derivation. */
-    foreach (PathSet::iterator, i, context) {
-        Path path = *i;
-        
-        /* Paths marked with `=' denote that the path of a derivation
-           is explicitly passed to the builder.  Since that allows the
-           builder to gain access to every path in the dependency
-           graph of the derivation (including all outputs), all paths
-           in the graph must be added to this derivation's list of
-           inputs to ensure that they are available when the builder
-           runs. */
-        if (path.at(0) == '=') {
+    foreach (ContextEntrySet::iterator, i, context) {
+        Path path = (*i)->path;
+        string output = (*i)->output;
+        if (!isDerivation(path) || (*i)->discardOutputs)
+            drv.inputSrcs.insert(path);
+        else if (!output.empty())
+            drv.inputDrvs[path].insert(output);
+        else {
             /* !!! This doesn't work if readOnlyMode is set. */
-            PathSet refs; computeFSClosure(*store, string(path, 1), refs);
+            PathSet refs; computeFSClosure(*store, path, refs);
             foreach (PathSet::iterator, j, refs) {
                 drv.inputSrcs.insert(*j);
                 if (isDerivation(*j))
                     drv.inputDrvs[*j] = store->queryDerivationOutputNames(*j);
             }
         }
-
-        /* See prim_unsafeDiscardOutputDependency. */
-        else if (path.at(0) == '~')
-            drv.inputSrcs.insert(string(path, 1));
-
-        /* Handle derivation outputs of the form ‘!<name>!<path>’. */
-        else if (path.at(0) == '!') {
-            std::pair<string, string> ctx = decodeContext(path);
-            drv.inputDrvs[ctx.first].insert(ctx.second);
-        }
-
-        /* Handle derivation contexts returned by
-           ‘builtins.storePath’. */
-        else if (isDerivation(path))
-            drv.inputDrvs[path] = store->queryDerivationOutputNames(path);
-
-        /* Otherwise it's a source file. */
-        else
-            drv.inputSrcs.insert(path);
     }
-            
+
     /* Do we have all required attributes? */
     if (drv.builder == "")
         throw EvalError("required attribute `builder' missing");
@@ -498,11 +464,10 @@ static void prim_derivationStrict(EvalState & state, Value * * args, Value & v)
     drvHashes[drvPath] = hashDerivationModulo(*store, drv);
 
     state.mkAttrs(v, 1 + drv.outputs.size());
-    mkString(*state.allocAttr(v, state.sDrvPath), drvPath, singleton<PathSet>("=" + drvPath));
-    foreach (DerivationOutputs::iterator, i, drv.outputs) {
+    mkString(*state.allocAttr(v, state.sDrvPath), drvPath, singleton<ContextEntrySet>(state.allocContextEntry(drvPath)));
+    foreach (DerivationOutputs::iterator, i, drv.outputs)
         mkString(*state.allocAttr(v, state.symbols.create(i->first)),
-            i->second.path, singleton<PathSet>("!" + i->first + "!" + drvPath));
-    }
+            i->second.path, singleton<ContextEntrySet>(state.allocContextEntry(drvPath, i->first)));
     v.attrs->sort();
 }
 
@@ -515,7 +480,7 @@ static void prim_derivationStrict(EvalState & state, Value * * args, Value & v)
 /* Convert the argument to a path.  !!! obsolete? */
 static void prim_toPath(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     Path path = state.coerceToPath(*args[0], context);
     mkString(v, canonPath(path), context);
 }
@@ -531,7 +496,7 @@ static void prim_toPath(EvalState & state, Value * * args, Value & v)
    corner cases. */
 static void prim_storePath(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     Path path = state.coerceToPath(*args[0], context);
     /* Resolve symlinks in ‘path’, unless ‘path’ itself is a symlink
        directly in the store.  The latter condition is necessary so
@@ -542,14 +507,14 @@ static void prim_storePath(EvalState & state, Value * * args, Value & v)
     Path path2 = toStorePath(path);
     if (!store->isValidPath(path2))
         throw EvalError(format("store path `%1%' is not valid") % path2);
-    context.insert(path2);
+    context.insert(state.allocContextEntry(path2));
     mkString(v, path, context);
 }
 
 
 static void prim_pathExists(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     Path path = state.coerceToPath(*args[0], context);
     if (!context.empty())
         throw EvalError(format("string `%1%' cannot refer to other paths") % path);
@@ -561,7 +526,7 @@ static void prim_pathExists(EvalState & state, Value * * args, Value & v)
    following the last slash. */
 static void prim_baseNameOf(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     mkString(v, baseNameOf(state.coerceToString(*args[0], context)), context);
 }
 
@@ -571,7 +536,7 @@ static void prim_baseNameOf(EvalState & state, Value * * args, Value & v)
    of the argument. */
 static void prim_dirOf(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     Path dir = dirOf(state.coerceToPath(*args[0], context));
     if (args[0]->type == tPath) mkPath(v, dir.c_str()); else mkString(v, dir, context);
 }
@@ -580,7 +545,7 @@ static void prim_dirOf(EvalState & state, Value * * args, Value & v)
 /* Return the contents of a file as a string. */
 static void prim_readFile(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     Path path = state.coerceToPath(*args[0], context);
     if (!context.empty())
         throw EvalError(format("string `%1%' cannot refer to other paths") % path);
@@ -599,7 +564,7 @@ static void prim_readFile(EvalState & state, Value * * args, Value & v)
 static void prim_toXML(EvalState & state, Value * * args, Value & v)
 {
     std::ostringstream out;
-    PathSet context;
+    ContextEntrySet context;
     printValueAsXML(state, true, false, *args[0], out, context);
     mkString(v, out.str(), context);
 }
@@ -609,16 +574,15 @@ static void prim_toXML(EvalState & state, Value * * args, Value & v)
    as an input by derivations. */
 static void prim_toFile(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     string name = state.forceStringNoCtx(*args[0]);
     string contents = state.forceString(*args[1], context);
 
     PathSet refs;
 
-    foreach (PathSet::iterator, i, context) {
-        Path path = *i;
-        if (path.at(0) == '=') path = string(path, 1);
-        if (isDerivation(path))
+    foreach (ContextEntrySet::iterator, i, context) {
+        Path path = (*i)->path;
+        if (isDerivation(path) && !(*i)->discardOutputs)
             throw EvalError(format("in `toFile': the file `%1%' cannot refer to derivation outputs") % name);
         refs.insert(path);
     }
@@ -631,7 +595,7 @@ static void prim_toFile(EvalState & state, Value * * args, Value & v)
        result, since `storePath' itself has references to the paths
        used in args[1]. */
 
-    mkString(v, storePath, singleton<PathSet>(storePath));
+    mkString(v, storePath, singleton<ContextEntrySet>(state.allocContextEntry(storePath)));
 }
 
 
@@ -676,7 +640,7 @@ struct FilterFromExpr : PathFilter
 
 static void prim_filterSource(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     Path path = state.coerceToPath(*args[1], context);
     if (!context.empty())
         throw EvalError(format("string `%1%' cannot refer to other paths") % path);
@@ -691,7 +655,7 @@ static void prim_filterSource(EvalState & state, Value * * args, Value & v)
         ? computeStorePathForPath(path, true, htSHA256, filter).first
         : store->addToStore(path, true, htSHA256, filter);
 
-    mkString(v, dstPath, singleton<PathSet>(dstPath));
+    mkString(v, dstPath, singleton<ContextEntrySet>(state.allocContextEntry(dstPath)));
 }
 
 
@@ -1027,7 +991,7 @@ static void prim_lessThan(EvalState & state, Value * * args, Value & v)
    `"/nix/store/whatever..."'. */
 static void prim_toString(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     string s = state.coerceToString(*args[0], context, true, false);
     mkString(v, s, context);
 }
@@ -1041,7 +1005,7 @@ static void prim_substring(EvalState & state, Value * * args, Value & v)
 {
     int start = state.forceInt(*args[0]);
     int len = state.forceInt(*args[1]);
-    PathSet context;
+    ContextEntrySet context;
     string s = state.coerceToString(*args[2], context);
 
     if (start < 0) throw EvalError("negative start position in `substring'");
@@ -1052,7 +1016,7 @@ static void prim_substring(EvalState & state, Value * * args, Value & v)
 
 static void prim_stringLength(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     string s = state.coerceToString(*args[0], context);
     mkInt(v, s.size());
 }
@@ -1060,9 +1024,9 @@ static void prim_stringLength(EvalState & state, Value * * args, Value & v)
 
 static void prim_unsafeDiscardStringContext(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     string s = state.coerceToString(*args[0], context);
-    mkString(v, s, PathSet());
+    mkString(v, s);
 }
 
 
@@ -1074,16 +1038,21 @@ static void prim_unsafeDiscardStringContext(EvalState & state, Value * * args, V
    drv.inputDrvs. */
 static void prim_unsafeDiscardOutputDependency(EvalState & state, Value * * args, Value & v)
 {
-    PathSet context;
+    ContextEntrySet context;
     string s = state.coerceToString(*args[0], context);
 
-    PathSet context2;
-    foreach (PathSet::iterator, i, context) {
-        Path p = *i;
-        if (p.at(0) == '=') p = "~" + string(p, 1);
-        context2.insert(p);
+    ContextEntrySet context2;
+    foreach (ContextEntrySet::iterator, i, context) {
+        Path path = (*i)->path;
+        string output = (*i)->output;
+        if (isDerivation(path) && output.empty()) {
+            ContextEntry * c = state.allocContextEntry(path,output);
+            c->discardOutputs = true;
+            context2.insert(c);
+        } else
+            context2.insert(*i);
     }
-    
+
     mkString(v, s, context2);
 }
 

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -18,7 +18,7 @@ static XMLAttrs singletonAttrs(const string & name, const string & value)
 
 
 static void printValueAsXML(EvalState & state, bool strict, bool location,
-    Value & v, XMLWriter & doc, PathSet & context, PathSet & drvsSeen);
+    Value & v, XMLWriter & doc, ContextEntrySet & context, PathSet & drvsSeen);
 
 
 static void posToXML(XMLAttrs & xmlAttrs, const Pos & pos)
@@ -30,7 +30,7 @@ static void posToXML(XMLAttrs & xmlAttrs, const Pos & pos)
 
 
 static void showAttrs(EvalState & state, bool strict, bool location,
-    Bindings & attrs, XMLWriter & doc, PathSet & context, PathSet & drvsSeen)
+    Bindings & attrs, XMLWriter & doc, ContextEntrySet & context, PathSet & drvsSeen)
 {
     StringSet names;
     
@@ -52,7 +52,7 @@ static void showAttrs(EvalState & state, bool strict, bool location,
 
 
 static void printValueAsXML(EvalState & state, bool strict, bool location,
-    Value & v, XMLWriter & doc, PathSet & context, PathSet & drvsSeen)
+    Value & v, XMLWriter & doc, ContextEntrySet & context, PathSet & drvsSeen)
 {
     checkInterrupt();
 
@@ -151,7 +151,7 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
 
 
 void printValueAsXML(EvalState & state, bool strict, bool location,
-    Value & v, std::ostream & out, PathSet & context)
+    Value & v, std::ostream & out, ContextEntrySet & context)
 {
     XMLWriter doc(true, out);
     XMLOpenElement root(doc, "expr");

--- a/src/libexpr/value-to-xml.hh
+++ b/src/libexpr/value-to-xml.hh
@@ -9,6 +9,6 @@
 namespace nix {
 
 void printValueAsXML(EvalState & state, bool strict, bool location,
-    Value & v, std::ostream & out, PathSet & context);
+    Value & v, std::ostream & out, ContextEntrySet & context);
     
 }

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "symbol-table.hh"
+#include "context.hh"
 
 namespace nix {
 
@@ -61,7 +62,7 @@ struct Value
            For canonicity, the store paths should be in sorted order. */
         struct {
             const char * s;
-            const char * * context; // must be in sorted order
+            const ContextEntry * * context;
         } string;
         
         const char * path;

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -119,7 +119,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
     Value args, topLevel;
     state.mkAttrs(args, 3);
     mkString(*state.allocAttr(args, state.symbols.create("manifest")),
-        manifestFile, singleton<PathSet>(manifestFile));
+        manifestFile, singleton<ContextEntrySet>(state.allocContextEntry(manifestFile)));
     args.attrs->push_back(Attr(state.symbols.create("derivations"), &manifest));
     args.attrs->sort();
     mkApp(topLevel, envBuilder, args);

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -47,7 +47,7 @@ void processExpr(EvalState & state, const Strings & attrPaths,
             findAlongAttrPath(state, *i, autoArgs, e, v);
             state.forceValue(v);
 
-            PathSet context;
+            ContextEntrySet context;
             if (evalOnly)
                 if (xmlOutput)
                     printValueAsXML(state, strict, location, v, std::cout, context);


### PR DESCRIPTION
Rather than relying on magic characters and string scanning to extract information out of a string context, a string's context is now a structured data type.

To avoid fragmentation and extra allocations, the context struct and the memory for the strings it points to are all allocated in one call.
