### PR TITLE
canonicalizePathMetaData: Fall-back to utimes if lutimes fails due to ENOSYS

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -467,6 +467,8 @@ void canonicalisePathMetaData(const Path & path, bool recurse)
         times[1].tv_usec = 0;
 #if HAVE_LUTIMES
         if (lutimes(path.c_str(), times) == -1)
+            if (errno != ENOSYS ||
+                (!S_ISLNK(st.st_mode) && utimes(path.c_str(), times) == -1))
 #else
         if (!S_ISLNK(st.st_mode) && utimes(path.c_str(), times) == -1)
 #endif


### PR DESCRIPTION
This will allow nix built with newer kernel headers to be run on older kernels, so for example the binary distribution will work in more cases.
