### PR TITLE
Ignore status of killUser() process on darwin.

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -854,8 +854,16 @@ void killUser(uid_t uid)
     
     /* parent */
     int status = pid.wait(true);
+
+    /*
+     * According to kill(2), kill on pid -1 should send the signal to every
+     * process except to the process sending the signal. Unfortunately, this is
+     * not the case, so let's ignore the status if we're on Darwin.
+     */
+#ifndef __APPLE__
     if (status != 0)
         throw Error(format("cannot kill processes for uid `%1%': %2%") % uid % statusToString(status));
+#endif
 
     /* !!! We should really do some check to make sure that there are
        no processes left running under `uid', but there is no portable


### PR DESCRIPTION
Quoting from the man page of _kill(2)_:

```
If pid is -1:
    If the user has super-user privileges, the signal is
    sent to all processes excluding system processes and the
    process sending the signal. If the user is not the super
    user, the signal is sent to all processes with the same
    uid as the user, excluding the process sending the
    signal. No error is returned if any process could be
    signaled.
```

Unfortunately this is not the case and the process sending the signal is killed as well, so we can't assume that wait() will return 0 if the process drops dead in-between.
