### PR TITLE
fix use-after-free bug in mkString(Value&, Symbol&)

### DIFF
--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -131,7 +131,7 @@ static inline void mkStringNoCopy(Value & v, const char * s)
 
 static inline void mkString(Value & v, const Symbol & s)
 {
-    mkStringNoCopy(v, ((string) s).c_str());
+    mkStringNoCopy(v, ((const string &) s).c_str());
 }
 
 


### PR DESCRIPTION
The Symbol variant of mkString makes a temporary copy of a std::string from the SymbolTable, then calls c_str() on it and keeps around the resulting pointer, but that pointer becomes invalid as soon as the temporary is destroyed.  This change gets rid of the temporary and just calls c_str() directly on the original string.

(Under clang libc++, std::string stores its data on the stack, so it quickly gets overwritten, leading to nasty errors like "invalid character `¿' in name `b¿'".)
