### PR TITLE
prim_functionArgs: More info about default values.

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -299,6 +299,21 @@ void mkPath(Value & v, const char * s)
 }
 
 
+void mkLambda(Value & v,
+        Env * env,
+        Pos & pos,
+        const Symbol & arg,
+        bool matchAttrs,
+        Formals * formals,
+        Expr * body
+        )
+{
+    v.type = tLambda;
+    v.lambda.env = env;
+    v.lambda.fun = NEW ExprLambda(pos, arg, matchAttrs, formals, body);
+}
+
+
 inline Value * EvalState::lookupVar(Env * env, const VarRef & var)
 {
     for (unsigned int l = var.level; l; --l, env = env->up) ;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -74,6 +74,15 @@ struct Attr
 
 void mkString(Value & v, const string & s, const PathSet & context = PathSet());
 
+void mkLambda(Value & v,
+        Env * env,
+        Pos & pos,
+        const Symbol & arg,
+        bool matchAttrs,
+        Formals * formals,
+        Expr * body
+        );
+
 void copyContext(const Value & v, PathSet & context);
 
 

--- a/tests/lang/eval-okay-functionargs.exp.xml
+++ b/tests/lang/eval-okay-functionargs.exp.xml
@@ -11,5 +11,7 @@
     <string value="mplayer-stdenv2.libXv-libX11_2" />
     <string value="nix-stdenv-aterm-stdenv" />
     <string value="nix-stdenv2-aterm2-stdenv2" />
+    <string value="default-string" />
+    <string value="not-default-string" />
   </list>
 </expr>

--- a/tests/lang/eval-okay-functionargs.nix
+++ b/tests/lang/eval-okay-functionargs.nix
@@ -51,6 +51,10 @@ let
       libXv = callPackage libXvFun { };
     };
 
+  funWithDefault = rec {
+    fn = { a ? "default", b ? "${a}-string" }: throw "Don't evaluate me";
+    bFun = (builtins.functionArgs fn).b;
+  };
 in
 
 let
@@ -64,7 +68,7 @@ let
       xorg = pkgsPrev.xorg // { libX11 = libX11_2Fun { inherit (pkgs) stdenv fetchurl; }; };
     };
   };
-  
+
 in
 
   [ pkgs.stdenv.name
@@ -77,4 +81,6 @@ in
     pkgs2.mplayer.name
     pkgs.nix.name
     pkgs2.nix.name
+    (funWithDefault.bFun { })
+    (funWithDefault.bFun { a = "not-default"; })
   ]


### PR DESCRIPTION
Rather than using a bool to indicate the presence or absence of a
default value for a given argument, provide a function that, when
called, evaluates to what the default value of that argument would be if
the arguments you called the function with were passed to the original
function. If an argument has no default, its corresponding attribute
will evaluate to null instead of a function as described above.
