### PR TITLE
killUser: Don't fail if child kills itself

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -856,7 +856,7 @@ void killUser(uid_t uid)
 
     /* parent */
     int status = pid.wait(true);
-    if (status != 0)
+    if (status != 0 && !(WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL))
         throw Error(format("cannot kill processes for uid `%1%': %2%") % uid % statusToString(status));
 
     /* !!! We should really do some check to make sure that there are


### PR DESCRIPTION
POSIX doesn't specify that kill(-1, signo) doesn't kill the calling
process, and in fact on darwin it does.
