### PR TITLE
Add gzip support for channel unpacking 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,10 +183,10 @@ NEED_PROG(perl, perl)
 NEED_PROG(sed, sed)
 NEED_PROG(tar, tar)
 NEED_PROG(bzip2, bzip2)
+NEED_PROG(gzip, gzip)
 NEED_PROG(xz, xz)
 AC_PATH_PROG(dot, dot)
 AC_PATH_PROG(dblatex, dblatex)
-AC_PATH_PROG(gzip, gzip)
 AC_PATH_PROG(pv, pv, pv)
 
 

--- a/corepkgs/config.nix.in
+++ b/corepkgs/config.nix.in
@@ -7,6 +7,7 @@ in {
   shell = "@shell@";
   coreutils = "@coreutils@";
   bzip2 = "@bzip2@";
+  gzip = "@gzip@";
   xz = "@xz@";
   tar = "@tar@";
   tarFlags = "@tarFlags@";

--- a/corepkgs/unpack-channel.nix
+++ b/corepkgs/unpack-channel.nix
@@ -6,9 +6,12 @@ let
     ''
       mkdir $out
       cd $out
-      pat="\.xz\$"
-      if [[ "$src" =~ $pat ]]; then
+      xzpat="\.xz\$"
+      gzpat="\.gz\$"
+      if [[ "$src" =~ $xzpat ]]; then
         ${xz} -d < $src | ${tar} xf - ${tarFlags}
+      else if [[ "$src" =~ $gzpat ]]; then
+        ${gzip} -d < $src | ${tar} xf - ${tarFlags}
       else
         ${bzip2} -d < $src | ${tar} xf - ${tarFlags}
       fi

--- a/nix.spec.in
+++ b/nix.spec.in
@@ -22,6 +22,7 @@ Requires: /usr/bin/perl
 Requires: curl
 Requires: perl-DBD-SQLite
 Requires: bzip2
+Requires: gzip
 Requires: xz
 BuildRequires: bzip2-devel
 BuildRequires: sqlite-devel


### PR DESCRIPTION
I need this, because in my pet project ceh (http://github.com/errge/ceh) I download nixpkgs snapshots from github instead of http://nixos.org/releases/nixpkgs/...

At nixos.org, old snapshots are continuously garbage collected, while github has the whole history of the project and I'd like to have old versions installable too.

Unfortunately github only offers gzip and zip compression for archive downloads.  I think this is because, both bzip2 and xz is a bit expensive to compress.

Currently I have a big hack to first download the gzip, then recompress to bzip2 on the client side.  That of course is a big performance hit for my users.
