### PR TITLE
Updated instructions and scripts for non-NixOS multi-user installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ Makefile.in
 
 # /scripts/
 /scripts/nix-profile.sh
+/scripts/nix-profile-multiuser.sh
 /scripts/nix-pull
 /scripts/nix-push
 /scripts/nix-switch

--- a/doc/manual/installation.xml
+++ b/doc/manual/installation.xml
@@ -386,7 +386,7 @@ $ chmod 1775 /nix/store
 
 </para>
 
-<para>Finally, you should tell Nix to use the build users by
+<para>You should tell Nix to use the build users by
 specifying the build users group in the <link
 linkend="conf-build-users-group"><literal>build-users-group</literal>
 option</link> in the <link linkend="sec-conf-file">Nix configuration
@@ -395,6 +395,18 @@ file</link> (usually <literal>/etc/nix/nix.conf</literal>):
 <programlisting>
 build-users-group = nixbld
 </programlisting>
+
+</para>
+
+<para>
+Finally, each individual user may also need to set up a custom user profile
+and garbarge collector root. The following commands creates per-user
+directories with the appropriate permissions:
+
+<screen>
+$ mkdir -p -m1777 /nix/var/nix/profiles/per-user
+$ mkdir -p -m1777 /nix/var/nix/gcroots/per-user
+</screen>
 
 </para>
 

--- a/release.nix
+++ b/release.nix
@@ -8,7 +8,6 @@ let
 
   systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "x86_64-freebsd" "i686-freebsd" "i686-cygwin" "i686-solaris" ];
 
-
   jobs = rec {
 
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -3,15 +3,20 @@ bin_SCRIPTS = nix-collect-garbage \
   nix-install-package nix-channel nix-build \
   nix-copy-closure nix-generate-patches
 
-noinst_SCRIPTS = nix-profile.sh \
+noinst_SCRIPTS = nix-profile.sh nix-profile-multiuser.sh nix-daemon.sh \
   find-runtime-roots.pl build-remote.pl nix-reduce-build \
   copy-from-other-stores.pl nix-http-export.cgi
 
 profiledir = $(sysconfdir)/profile.d
 
+initdir = $(sysconfdir)/init.d
+
 install-exec-local: download-using-manifests.pl copy-from-other-stores.pl download-from-binary-cache.pl find-runtime-roots.pl
 	$(INSTALL) -d $(DESTDIR)$(profiledir)
 	$(INSTALL_DATA) nix-profile.sh $(DESTDIR)$(profiledir)/nix.sh
+	$(INSTALL_DATA) nix-profile-multiuser.sh $(DESTDIR)$(profiledir)/nix-multiuser.sh
+	$(INSTALL) -d $(DESTDIR)$(initdir)
+	$(INSTALL_DATA) nix-daemon.sh $(DESTDIR)$(initdir)/nix-daemon
 	$(INSTALL) -d $(DESTDIR)$(libexecdir)/nix
 	$(INSTALL_PROGRAM) find-runtime-roots.pl $(DESTDIR)$(libexecdir)/nix 
 	$(INSTALL_PROGRAM) build-remote.pl $(DESTDIR)$(libexecdir)/nix 
@@ -22,7 +27,7 @@ install-exec-local: download-using-manifests.pl copy-from-other-stores.pl downlo
 include ../substitute.mk
 
 EXTRA_DIST = nix-collect-garbage.in \
-  nix-pull.in nix-push.in nix-profile.sh.in \
+  nix-pull.in nix-push.in nix-profile.sh.in nix-profile-multiuser.sh.in nix-daemon.sh \
   nix-prefetch-url.in nix-install-package.in \
   nix-channel.in \
   nix-build.in \

--- a/scripts/nix-daemon.sh
+++ b/scripts/nix-daemon.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          nix-daemon
+# Required-Start:    $local_fs $remote_fs $network $syslog
+# Required-Stop:     $local_fs $remote_fs $network $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: starts the Nix daemon
+# Description:       starts the Nix daemon start-stop-daemon
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=$(readlink -f /root/.nix-profile/bin/nix-daemon)
+NAME=nix-daemon
+DESC=nix-daemon
+
+test -x $DAEMON || exit 0
+
+set -e
+
+if test -f /etc/default/nix-daemon; then
+    . /etc/default/nix-daemon
+fi
+
+. /lib/lsb/init-functions
+
+case "$1" in
+	start)
+		echo -n "Starting $DESC: "
+		
+		if test "$NIX_DISTRIBUTED_BUILDS" = "1"; then
+		    NIX_BUILD_HOOK=$(dirname $DAEMON)/../libexec/nix/build-remote.pl
+		
+		    if test "$NIX_REMOTE_SYSTEMS" = "" ; then
+			NIX_REMOTE_SYSTEMS=/etc/nix/remote-systems.conf
+		    fi
+		
+		    # Set the current load facilities
+		    NIX_CURRENT_LOAD=/var/run/nix/current-load
+		
+		    if test ! -d $NIX_CURRENT_LOAD; then
+		        mkdir -p $NIX_CURRENT_LOAD
+		    fi
+		fi
+		
+		start-stop-daemon -b --start --quiet \
+		    --exec /usr/bin/env \
+		    NIX_REMOTE_SYSTEMS=$NIX_REMOTE_SYSTEMS \
+		    NIX_BUILD_HOOK=$NIX_BUILD_HOOK \
+		    NIX_CURRENT_LOAD=$NIX_CURRENT_LOAD \
+		    $DAEMON -- $DAEMON_OPTS
+		echo "$NAME."
+		;;
+
+	stop)
+		echo -n "Stopping $DESC: "
+		start-stop-daemon --stop --quiet --exec $DAEMON
+		echo "$NAME."
+		;;
+
+	restart|force-reload)
+		echo -n "Restarting $DESC: "
+		start-stop-daemon --stop --quiet --exec $DAEMON
+		sleep 1
+		start-stop-daemon --start --quiet --exec $DAEMON -- $DAEMON_OPTS
+		echo "$NAME."
+		;;
+
+	reload)
+		echo -n "Reloading $DESC configuration: "
+		start-stop-daemon --stop --signal HUP --quiet --exec $DAEMON
+		echo "$NAME."
+		;;
+
+	status)
+		status_of_proc "$DAEMON" nix-daemon && exit 0 || exit $?
+		;;
+	*)
+		echo "Usage: $NAME {start|stop|restart|reload|force-reload|status}" >&2
+		exit 1
+		;;
+esac
+
+exit 0

--- a/scripts/nix-profile-multiuser.sh.in
+++ b/scripts/nix-profile-multiuser.sh.in
@@ -1,0 +1,60 @@
+if test -n "$HOME"; then
+    # Set up the per-user profile.
+
+    export NIX_USER_PROFILE_DIR=@localstatedir@/nix/profiles/per-user/$USER
+
+    mkdir -m 0755 -p $NIX_USER_PROFILE_DIR
+    if test "$(stat --printf '%u' $NIX_USER_PROFILE_DIR)" != "$(id -u)"; then
+        echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
+    fi
+
+    # Create ~/.nix-profile if needed
+
+    if ! test -L $HOME/.nix-profile; then
+        echo "creating $HOME/.nix-profile" >&2
+        if test "$USER" != root; then
+            ln -s $NIX_USER_PROFILE_DIR/profile $HOME/.nix-profile
+        else
+            # Root installs in the system-wide profile by default.
+            ln -s @localstatedir@/nix/profiles/default $HOME/.nix-profile
+        fi
+    fi
+
+    # Put stuff in the global profile and the user profile in the PATH
+
+    export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+
+    for i in $NIX_PROFILES; do
+        export PATH=$i/bin:$PATH
+    done
+
+    # Subscribe the root user to the NixOS channel by default.
+    if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
+        echo "http://nixos.org/channels/nixpkgs-unstable nixpkgs" > $HOME/.nix-channels
+    fi
+
+    # Create the per-user garbage collector roots directory.
+    NIX_USER_GCROOTS_DIR=@localstatedir@/nix/gcroots/per-user/$USER
+    mkdir -m 0755 -p $NIX_USER_GCROOTS_DIR
+    if test "$(stat --printf '%u' $NIX_USER_GCROOTS_DIR)" != "$(id -u)"; then
+        echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
+    fi
+
+    # Set up a default Nix expression from which to install stuff.
+    if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
+        echo "creating $HOME/.nix-defexpr" >&2
+        rm -f $HOME/.nix-defexpr
+        mkdir $HOME/.nix-defexpr
+        if [ "$USER" != root ]; then
+            ln -s @localstatedir@/nix/profiles/per-user/root/channels $HOME/.nix-defexpr/channels_root
+        fi
+    fi
+
+    # Set up secure multi-user builds: non-root users build through the
+    # Nix daemon.
+    if test "$USER" != root; then
+        export NIX_REMOTE=daemon
+    else
+        export NIX_REMOTE=
+    fi
+fi

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,8 @@ XFAIL_TESTS =
 
 profiledir = $(sysconfdir)/profile.d
 
+initdir = $(sysconfdir)/init.d
+
 include ../substitute.mk
 
 $(TESTS): common.sh config.nix


### PR DESCRIPTION
To do a multi-user Nix installation on regular Linux distros, one detail is missing. The gcroots and profile directories need the right permissions. Without it per-user profiles cannot be created.

Furthermore, I've created a profile.d script containing all stuff needed for multi-user Nix installation (ported from NixOS), as the original nix.sh is missing quite a lot.

I've also created an init.d script for starting and stopping the nix-daemon.

More info about my findings: http://sandervanderburg.blogspot.com/2013/06/setting-up-multi-user-nix-installation.html

I don't know yet if nix.sh and nix-multiuser.sh should both be installed. Maybe we can implement a configure switch for this, or merge nix.sh with nix-multiuser.sh. I need some feedback on this.
