### PR TITLE
Simplify inherited attribute handling 

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -206,7 +206,7 @@ private:
     void addPrimOp(const string & name,
         unsigned int arity, PrimOpFun primOp);
 
-    inline Value * lookupVar(Env * env, const VarRef & var, bool noEval = false);
+    inline Value * lookupVar(Env * env, const VarRef & var, bool noEval);
     
     friend class ExprVar;
     friend class ExprAttrs;

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -230,14 +230,12 @@ void ExprAttrs::bindVars(const StaticEnv & env)
             newEnv.vars[i->first] = i->second.displ = displ++;
         
         foreach (AttrDefs::iterator, i, attrs)
-            if (i->second.inherited) i->second.var.bind(env);
-            else i->second.e->bindVars(newEnv);
+            i->second.e->bindVars(i->second.inherited ? env : newEnv);
     }
 
     else
         foreach (AttrDefs::iterator, i, attrs)
-            if (i->second.inherited) i->second.var.bind(env);
-            else i->second.e->bindVars(env);
+            i->second.e->bindVars(env);
 }
 
 void ExprList::bindVars(const StaticEnv & env)
@@ -274,8 +272,7 @@ void ExprLet::bindVars(const StaticEnv & env)
         newEnv.vars[i->first] = i->second.displ = displ++;
     
     foreach (ExprAttrs::AttrDefs::iterator, i, attrs->attrs)
-        if (i->second.inherited) i->second.var.bind(env);
-        else i->second.e->bindVars(newEnv);
+        i->second.e->bindVars(i->second.inherited ? env : newEnv);
     
     body->bindVars(newEnv);
 }

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -159,12 +159,10 @@ struct ExprAttrs : Expr
     bool recursive;
     struct AttrDef {
         bool inherited;
-        Expr * e; // if not inherited
-        VarRef var; // if inherited
+        Expr * e;
         Pos pos;
         unsigned int displ; // displacement
-        AttrDef(Expr * e, const Pos & pos) : inherited(false), e(e), pos(pos) { };
-        AttrDef(const Symbol & name, const Pos & pos) : inherited(true), var(name), pos(pos) { };
+        AttrDef(Expr * e, const Pos & pos, bool inherited=false) : inherited(inherited), e(e), pos(pos) { };
         AttrDef() { };
     };
     typedef std::map<Symbol, AttrDef> AttrDefs;

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -402,7 +402,7 @@ binds
           if ($$->attrs.find(*i) != $$->attrs.end())
               dupAttr(*i, makeCurPos(@3, data), $$->attrs[*i].pos);
           Pos pos = makeCurPos(@3, data);
-          $$->attrs[*i] = ExprAttrs::AttrDef(*i, pos);
+          $$->attrs[*i] = ExprAttrs::AttrDef(new ExprVar(*i), pos, true);
       }
     }
   | binds INHERIT '(' expr ')' attrs ';'

--- a/tests/lang/eval-okay-delayed-with-inherit.exp
+++ b/tests/lang/eval-okay-delayed-with-inherit.exp
@@ -1,0 +1,1 @@
+"b-overridden"

--- a/tests/lang/eval-okay-delayed-with-inherit.nix
+++ b/tests/lang/eval-okay-delayed-with-inherit.nix
@@ -1,0 +1,24 @@
+let
+  pkgs_ = with pkgs; {
+    a = derivation {
+      name = "a";
+      system = builtins.currentSystem;
+      builder = "/bin/sh";
+      args = [ "-c" "touch $out" ];
+      inherit b;
+    };
+
+    inherit b;
+  };
+
+  packageOverrides = p: {
+    b = derivation {
+      name = "b-overridden";
+      system = builtins.currentSystem;
+      builder = "/bin/sh";
+      args = [ "-c" "touch $out" ];
+    };
+  };
+
+  pkgs = pkgs_ // (packageOverrides pkgs_);
+in pkgs.a.b.name


### PR DESCRIPTION
This reduces the difference between inherited and non-inherited
attribute handling to the choice of which env to use (in recs and lets)
by setting the AttrDef::e to a new ExprVar in the parser rather than
carrying a separate AttrDef::v VarRef member.

As an added bonus, this allows inherited attributes that inherit from a
with to delay forcing evaluation of the with's attributes.

Depends on/includes #130 for the test case
