### PR TITLE
corepkgs/nar.nix: Prefer local builds

### DIFF
--- a/corepkgs/nar.nix
+++ b/corepkgs/nar.nix
@@ -43,4 +43,7 @@ derivation {
 
   # Don't build in a chroot because Nix's dependencies may not be there.
   __noChroot = true;
+
+  # Remote machines may not have ${nixBinDir} or ${coreutils} in the same prefixes
+  preferLocalBuild = true;
 }


### PR DESCRIPTION
nar.nix's builder depends on coreutils and nix itself being in $PATH.
Unfortunately, there's no good way to ensure that these packages exist
in the same place on the remote machine: The local machine may have nix
installed in /usr, and the remote machine in /usr/local, but the
generated nar.sh builder will refer to /usr and thus fail on the remote
machine. This ensures that nar.sh is run on the same machine that
instantiates it.
