### PR TITLE
nix-shell: Play nicely with non-interactive shells

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -202,7 +202,8 @@ foreach my $expr (@exprs) {
         my $rcfile = "$tmpDir/rc";
         writeFile(
             $rcfile,
-            '[ -e ~/.bashrc ] && source ~/.bashrc; ' .
+            'unset BASH_ENV; ' .
+            '[ -n "$PS1" ] && [ -e ~/.bashrc ] && source ~/.bashrc; ' .
             ($pure ? '' : 'p=$PATH; ' ) .
             'dontAddDisableDepTrack=1; ' .
             '[ -e $stdenv/setup ] && source $stdenv/setup; ' .
@@ -212,6 +213,7 @@ foreach my $expr (@exprs) {
             'unset NIX_ENFORCE_PURITY; ' .
             'shopt -u nullglob; ' .
             $envCommand);
+        $ENV{BASH_ENV} = $rcfile;
         exec($ENV{NIX_BUILD_SHELL} // "bash", "--rcfile", $rcfile);
         die;
     }


### PR DESCRIPTION
nix-shell with the --command flag might be used non-interactively, but
if bash starts non-interactively (i.e. with stdin or stderr not a
terminal), it won't source the script given in --rcfile. However, in
that case it _will_ source the script found in $BASH_ENV, so we can use
that instead.

Also, don't source ~/.bashrc in a non-interactive shell (detectable by
checking the PS1 env var)

Signed-off-by: Shea Levy shea@shealevy.com
