### PR TITLE
use USER environmental variable if getting user id by getpwuid is failed...

### DIFF
--- a/scripts/download-from-binary-cache.pl.in
+++ b/scripts/download-from-binary-cache.pl.in
@@ -40,7 +40,7 @@ my %requests;
 my %scheduled;
 my $caBundle = $ENV{"CURL_CA_BUNDLE"} // $ENV{"OPENSSL_X509_CERT_FILE"};
 
-my $userName = getpwuid($<) or die "cannot figure out user name";
+my $userName = getpwuid($<) or $ENV{"USER"} or die "cannot figure out user name";
 
 my $requireSignedBinaryCaches = ($Nix::Config::config{"signed-binary-caches"} // "0") ne "0";
 

--- a/scripts/nix-channel.in
+++ b/scripts/nix-channel.in
@@ -22,7 +22,7 @@ my $channelsList = "$home/.nix-channels";
 my $nixDefExpr = "$home/.nix-defexpr";
 
 # Figure out the name of the channels profile.
-my $userName = getpwuid($<) or die "cannot figure out user name";
+my $userName = getpwuid($<) or $ENV{"USER"} or die "cannot figure out user name");
 my $profile = "$Nix::Config::stateDir/profiles/per-user/$userName/channels";
 mkpath(dirname $profile, 0, 0755);
 


### PR DESCRIPTION
in perl scripts: download-from-binary-cache.pl and nix-channel
This problem is described in issue #209
