### PR TITLE
Add use-ssh-substituter setting.

### DIFF
--- a/src/download-via-ssh/download-via-ssh.cc
+++ b/src/download-via-ssh/download-via-ssh.cc
@@ -111,6 +111,18 @@ void run(Strings args)
     if (args.empty())
         throw UsageError("download-via-ssh requires an argument");
 
+    Settings::SettingsMap overrides = settings.getOverrides();
+    Settings::SettingsMap::iterator use = overrides.find("untrusted-use-ssh-substituter");
+    if (use != overrides.end()) {
+        if (use->second == "true") settings.useSshSubstituter = true;
+        else if (use->second == "false") settings.useSshSubstituter = false;
+        else throw Error(format("configuration option `use-ssh-substituter' should be either `true' or `false', not `%1%'")
+                        % use->second);
+    }
+
+    if (!settings.useSshSubstituter)
+        return;
+
     if (settings.sshSubstituterHosts.empty())
         return;
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -41,6 +41,7 @@ Settings::Settings()
     syncBeforeRegistering = false;
     useSubstitutes = true;
     useChroot = false;
+    useSshSubstituter = false;
     dirsInChroot.insert("/dev");
     dirsInChroot.insert("/dev/pts");
     impersonateLinux26 = false;
@@ -153,6 +154,7 @@ void Settings::update()
     get(autoOptimiseStore, "auto-optimise-store");
     get(envKeepDerivations, "env-keep-derivations");
     get(sshSubstituterHosts, "ssh-substituter-hosts");
+    get(useSshSubstituter, "use-ssh-substituter");
 }
 
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -149,6 +149,9 @@ struct Settings {
     /* Set of ssh connection strings for the ssh substituter */
     Strings sshSubstituterHosts;
 
+    /* Whether to use the ssh substituter at all */
+    bool useSshSubstituter;
+
     /* Whether to impersonate a Linux 2.6 machine on newer kernels. */
     bool impersonateLinux26;
 


### PR DESCRIPTION
It defaults to false and can be overridden by RemoteStore.

Untested currently, just quickly put this together
