### PR TITLE
Add MANPATH handling to nix-profile

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -9,6 +9,7 @@ if test -n "$HOME"; then
     fi
 
     export PATH=$NIX_LINK/bin:$NIX_LINK/sbin:$PATH
+    export MANPATH=$NIX_LINK/share/man:$MANPATH
 
     # Subscribe the root user to the Nixpkgs channel by default.
     if [ ! -e $HOME/.nix-channels ]; then


### PR DESCRIPTION
It makes man pages from installed nix packages available to host's
man utility.