### PR TITLE
Fix nix-shell for derivation with multiple outputs

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -196,6 +196,7 @@ foreach my $expr (@exprs) {
     if ($runEnv) {
         die "$0: a single derivation is required\n" if scalar @drvPaths != 1;
         my $drvPath = $drvPaths[0];
+        $drvPath = (split '!',$drvPath)[0];
         $drvPath = readlink $drvPath or die "cannot read symlink `$drvPath'" if -l $drvPath;
         my $drv = derivationFromPath($drvPath);
 


### PR DESCRIPTION
If derivation declares multiple outputs and first (default) output
if not "out", then "nix-instantiate" calls return path with output
names appended after "!". Than suffix must be stripped before
ant path checks are done.
