### PR TITLE
Fix compile errors on Illumos

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -32,7 +32,9 @@ ifeq ($(BUILD_SHARED_LIBS), 1)
   GLOBAL_CFLAGS += -fPIC
   GLOBAL_CXXFLAGS += -fPIC
   ifneq ($(OS), Darwin)
+   ifneq ($(OS), SunOS)
     GLOBAL_LDFLAGS += -Wl,--no-copy-dt-needed-entries
+   endif
   endif
 endif
 

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <algorithm>
 
+#include <limits.h>
 #include <time.h>
 #include <sys/time.h>
 #include <sys/wait.h>

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -10,6 +10,10 @@ libstore_LIBS = libutil libformat
 
 libstore_LDFLAGS = -lsqlite3 -lbz2
 
+ifeq ($(OS), SunOS)
+	libstore_LDFLAGS += -lsocket
+endif
+
 libstore_CXXFLAGS = \
  -DNIX_STORE_DIR=\"$(storedir)\" \
  -DNIX_DATA_DIR=\"$(datadir)\" \

--- a/src/nix-daemon/local.mk
+++ b/src/nix-daemon/local.mk
@@ -6,4 +6,8 @@ nix-daemon_SOURCES := $(d)/nix-daemon.cc
 
 nix-daemon_LIBS = libmain libstore libutil libformat
 
+ifeq ($(OS), SunOS)
+        nix-daemon_LDFLAGS += -lsocket
+endif
+
 $(eval $(call install-symlink, nix-daemon, $(bindir)/nix-worker))


### PR DESCRIPTION
Tested in a SmartOS zone.

Needed to include limits.h for this:

```
building src/libstore/build.o
  CXX    src/libstore/build.o
src/libstore/build.cc: In member function 'void nix::Worker::waitForInput()':
src/libstore/build.cc:3153:22: error: 'LONG_MAX' was not declared in this scope
     time_t nearest = LONG_MAX; // nearest deadline
                      ^
```

And -lsocket for missing symbols:

```
Undefined                       first referenced
 symbol                             in file
__xnet_socket                       src/nix-daemon/nix-daemon.o  (symbol belongs to implicit dependency /lib/amd64/libsocket.so.1)
accept                              src/nix-daemon/nix-daemon.o  (symbol belongs to implicit dependency /lib/amd64/libsocket.so.1)
listen                              src/nix-daemon/nix-daemon.o  (symbol belongs to implicit dependency /lib/amd64/libsocket.so.1)
__xnet_bind                         src/nix-daemon/nix-daemon.o  (symbol belongs to implicit dependency /lib/amd64/libsocket.so.1)

ld: fatal: symbol referencing errors. No output written to src/nix-daemon/nix-daemon
collect2: error: ld returned 1 exit status
```
