### PR TITLE
Shortcut already-hardlinked files

### DIFF
--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -315,6 +315,7 @@ private:
 #endif
 
     InodeHash loadInodeHash();
+    Strings readDirectoryIgnoringInodes(const Path & path, const InodeHash & inodeHash, OptimiseStats & stats);
     void optimisePath_(OptimiseStats & stats, const Path & path, InodeHash & inodeHash);
 
     // Internal versions that are not wrapped in retry_sqlite.


### PR DESCRIPTION
If an inode in the Nix store has more than 1 link, it probably means that it was linked into .links/ by us. If so, skip. This results in super-fast optimization runs.

There's a possibility that something else hardlinked the file, so it would be nice to be able to override this.

Note: by looking at the number of hardlinks for each of the files in .links/, you can get accurate deduplication numbers and space savings. This requires going through all files in the .links/ directory, but that may be a good idea anyway, to remove the ones that have only one link.
