### PR TITLE
findFile: Realise the context of the path attributes

### DIFF
--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -16,6 +16,7 @@ MakeError(ThrownError, AssertionError)
 MakeError(Abort, EvalError)
 MakeError(TypeError, EvalError)
 MakeError(ImportError, EvalError) // error building an imported derivation
+MakeError(FindError, EvalError) // error building a nix-path component
 MakeError(UndefinedVarError, Error)
 
 


### PR DESCRIPTION
This allows us to set the `nixPath` to contain entries from e.g. `fetchgit` derivations.

I prefer we merge this, but if not we should require that the `context` of the `nixPath` be empty.

Built on top of #267 for convenience.
