### PR TITLE
Some trivial fixes to make Nix working on Cygwin again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ makefiles = \
   doc/manual/local.mk \
   tests/local.mk
 
-GLOBAL_CXXFLAGS += -std=c++0x
+GLOBAL_CXXFLAGS += -std=gnu++0x
 
 include Makefile.config
 

--- a/configure.ac
+++ b/configure.ac
@@ -315,6 +315,10 @@ fi
 AC_SUBST(tarFlags)
 
 
+# Some platforms, such as Cygwin don't support srandom(). Detect if this is the case.
+AC_CHECK_LIB([c], [srandom], [HAVE_SRANDOM=1], [HAVE_SRANDOM=0])
+AC_SUBST(HAVE_SRANDOM)
+
 # Expand all variables in config.status.
 test "$prefix" = NONE && prefix=$ac_default_prefix
 test "$exec_prefix" = NONE && exec_prefix='${prefix}'

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -9,12 +9,16 @@
 #include <iostream>
 #include <cctype>
 #include <exception>
+#include <cstdlib>
 
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <signal.h>
 
+#ifndef HAVE_SRANDOM
+#define srandom srand
+#endif
 
 namespace nix {
 

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -4,6 +4,8 @@
 #include "local-store.hh"
 #include "globals.hh"
 
+#include <cstdlib>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -11,6 +11,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <fcntl.h>
+#include <errno.h>
 
 #include <iostream>
 #include <unistd.h>

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -10,6 +10,7 @@
 #include <algorithm>
 
 #include <cstring>
+#include <cstdlib>
 #include <unistd.h>
 #include <signal.h>
 #include <sys/types.h>


### PR DESCRIPTION
These changes allows me to build and run Nix on Cygwin (both i686-cygwin and x86_64-cygwin) again, if I compile it as follows:

./configure --disable-perl-bindings
make BUILD_SHARED_LIBS=0
make BUILD_SHARED_LIBS=0 install
