### PR TITLE
[nix-mode] Add autoloads, make code more concise & idiomatic

### DIFF
--- a/misc/emacs/nix-mode.el
+++ b/misc/emacs/nix-mode.el
@@ -1,10 +1,51 @@
-;;; nix-mode.el --- Major mode for editing Nix expressions.
+;;; nix-mode.el --- Major mode for editing Nix expressions
 
 ;; Author: Eelco Dolstra
 ;; URL: https://github.com/NixOS/nix/tree/master/misc/emacs
 ;; Version: 1.0
 
-(defun nix-mode ()
+;;; Commentary:
+
+;;; Code:
+
+(defconst nix-font-lock-keywords
+  '("\\<if\\>" "\\<then\\>" "\\<else\\>" "\\<assert\\>" "\\<with\\>"
+    "\\<let\\>" "\\<in\\>" "\\<rec\\>" "\\<inherit\\>" "\\<or\\>"
+    ("\\<true\\>" . font-lock-builtin-face)
+    ("\\<false\\>" . font-lock-builtin-face)
+    ("\\<null\\>" . font-lock-builtin-face)
+    ("\\<import\\>" . font-lock-builtin-face)
+    ("\\<derivation\\>" . font-lock-builtin-face)
+    ("\\<baseNameOf\\>" . font-lock-builtin-face)
+    ("\\<toString\\>" . font-lock-builtin-face)
+    ("\\<isNull\\>" . font-lock-builtin-face)
+    ("[a-zA-Z][a-zA-Z0-9\\+-\\.]*:[a-zA-Z0-9%/\\?:@&=\\+\\$,_\\.!~\\*'-]+"
+     . font-lock-constant-face)
+    ("\\<\\([a-zA-Z_][a-zA-Z0-9_'\-\.]*\\)[ \t]*="
+     (1 font-lock-variable-name-face nil nil))
+    ("<[a-zA-Z0-9._\\+-]+\\(/[a-zA-Z0-9._\\+-]+\\)*>"
+     . font-lock-constant-face)
+    ("[a-zA-Z0-9._\\+-]*\\(/[a-zA-Z0-9._\\+-]+\\)+"
+     . font-lock-constant-face))
+  "Font lock keywords for nix.")
+
+(defvar nix-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    (modify-syntax-entry ?/ ". 14" table)
+    (modify-syntax-entry ?* ". 23" table)
+    (modify-syntax-entry ?# "< b" table)
+    (modify-syntax-entry ?\n "> b" table)
+    table)
+  "Syntax table for Nix mode.")
+
+(defun nix-indent-line ()
+  "Indent current line in a Nix expression."
+  (interactive)
+  (indent-relative-maybe))
+
+
+;;;###autoload
+(define-derived-mode nix-mode fundamental-mode "Nix"
   "Major mode for editing Nix expressions.
 
 The following commands may be useful:
@@ -25,93 +66,29 @@ The hook `nix-mode-hook' is run when Nix mode is started.
 
 \\{nix-mode-map}
 "
-
-  (interactive)
-
-  (kill-all-local-variables)
-
-  (setq major-mode 'nix-mode)
-  (setq mode-name "Nix")
-
-  (use-local-map nix-mode-map)
-
   (set-syntax-table nix-mode-syntax-table)
 
   ;; Font lock support.
-  (setq font-lock-defaults '(nix-keywords nil nil nil nil))
+  (setq font-lock-defaults '(nix-font-lock-keywords nil nil nil nil))
 
   ;; Automatic indentation [C-j].
-  (make-local-variable 'indent-line-function)
-  (setq indent-line-function 'nix-indent-line)
+  (set (make-local-variable 'indent-line-function) 'nix-indent-line)
 
   ;; Indenting of comments.
-  (make-local-variable 'comment-start)
-  (setq comment-start "# ")
-  (make-local-variable 'comment-end)
-  (setq comment-end "")
-  (make-local-variable 'comment-start-skip)
-  (setq comment-start-skip "\\(^\\|\\s-\\);?#+ *")
+  (set (make-local-variable 'comment-start) "# ")
+  (set (make-local-variable 'comment-end) "")
+  (set (make-local-variable 'comment-start-skip) "\\(^\\|\\s-\\);?#+ *")
 
   ;; Filling of comments.
-  (make-local-variable 'adaptive-fill-mode)
-  (setq adaptive-fill-mode t)
-  (make-local-variable 'paragraph-start)
-  (setq paragraph-start "[ \t]*\\(#+[ \t]*\\)?$")
-  (make-local-variable 'paragraph-separate)
-  (setq paragraph-separate paragraph-start)
-
-  (run-hooks 'nix-mode-hook))
+  (set (make-local-variable 'adaptive-fill-mode) t)
+  (set (make-local-variable 'paragraph-start) "[ \t]*\\(#+[ \t]*\\)?$")
+  (set (make-local-variable 'paragraph-separate) paragraph-start))
 
 
-(defvar nix-mode-map nil
-  "Keymap for Nix mode.")
-
-(setq nix-mode-map (make-sparse-keymap))
-;(define-key nix-mode-map [tab] 'tab-to-tab-stop)
-
-
-(defvar nix-keywords
-  '("\\<if\\>" "\\<then\\>" "\\<else\\>" "\\<assert\\>" "\\<with\\>"
-    "\\<let\\>" "\\<in\\>" "\\<rec\\>" "\\<inherit\\>" "\\<or\\>"
-    ("\\<true\\>" . font-lock-builtin-face)
-    ("\\<false\\>" . font-lock-builtin-face)
-    ("\\<null\\>" . font-lock-builtin-face)
-    ("\\<import\\>" . font-lock-builtin-face)
-    ("\\<derivation\\>" . font-lock-builtin-face)
-    ("\\<baseNameOf\\>" . font-lock-builtin-face)
-    ("\\<toString\\>" . font-lock-builtin-face)
-    ("\\<isNull\\>" . font-lock-builtin-face)
-    ("[a-zA-Z][a-zA-Z0-9\\+-\\.]*:[a-zA-Z0-9%/\\?:@&=\\+\\$,_\\.!~\\*'-]+"
-     . font-lock-constant-face)
-    ("\\<\\([a-zA-Z_][a-zA-Z0-9_'\-\.]*\\)[ \t]*="
-     (1 font-lock-variable-name-face nil nil))
-    ("<[a-zA-Z0-9._\\+-]+\\(/[a-zA-Z0-9._\\+-]+\\)*>"
-     . font-lock-constant-face)
-    ("[a-zA-Z0-9._\\+-]*\\(/[a-zA-Z0-9._\\+-]+\\)+"
-     . font-lock-constant-face)))
-
-
-(defvar nix-mode-syntax-table nil
-  "Syntax table for Nix mode.")
-
-(if nix-mode-syntax-table
-    nil
-    (progn
-      (setq nix-mode-syntax-table (make-syntax-table))
-      (modify-syntax-entry ?/ ". 14" nix-mode-syntax-table)
-      (modify-syntax-entry ?* ". 23" nix-mode-syntax-table)
-      (modify-syntax-entry ?# "< b" nix-mode-syntax-table)
-      (modify-syntax-entry ?\n "> b" nix-mode-syntax-table)))
-
-
-(defun nix-indent-line ()
-  "Indent current line in a Nix expression."
-  (interactive)
-  (indent-relative-maybe))
-
-
-(setq auto-mode-alist (cons '("\\.nix\\'" . nix-mode) auto-mode-alist))
-(setq auto-mode-alist (cons '("\\.nix.in\\'" . nix-mode) auto-mode-alist))
+;;;###autoload
+(progn
+  (add-to-list 'auto-mode-alist '("\\.nix\\'" . nix-mode))
+  (add-to-list 'auto-mode-alist '("\\.nix.in\\'" . nix-mode)))
 
 (provide 'nix-mode)
 


### PR DESCRIPTION
- Use define-derived-mode to declare nix-mode
- Use autoloads to ensure nix-mode is usable (and enabled) without needing `require`
- Use set + make-local-variable instead of longer 2-step equivalent

(Background: I was handling this [request to add nix-mode to MELPA](https://github.com/milkypostman/melpa/pull/1751) and thought I'd send these fixes.)
