### PR TITLE
Add `--json` argument to `nix-instantiate`

### DIFF
--- a/doc/manual/nix-instantiate.xml
+++ b/doc/manual/nix-instantiate.xml
@@ -124,6 +124,15 @@ input.</para>
 
   </varlistentry>
 
+  <varlistentry><term><option>--json</option></term>
+
+    <listitem><para>When used with <option>--parse</option> and
+    <option>--eval</option>, print the resulting expression as an
+    JSON representation of the abstract syntax tree rather than as an
+    ATerm.</para></listitem>
+
+  </varlistentry>
+
   <varlistentry><term><option>--strict</option></term>
 
     <listitem><para>When used with <option>--eval</option>,


### PR DESCRIPTION
This is complementary to `--xml` and uses already existing functionality.

I think it's useful for using with external tools, i.e. to convert _nix_ to json, and parse with json parser. (BTW, works well with `json_pp`, or does _nix_ has pretty-printer of it's own?)
