### PR TITLE
fixed typo in nix-env documentation

### DIFF
--- a/doc/manual/nix-env.xml
+++ b/doc/manual/nix-env.xml
@@ -880,7 +880,7 @@ user environment elements, etc. -->
 
   <varlistentry><term><option>--json</option></term>
 
-    <listitem><para>Print the result in a JSON representation suitable
+    <listitem><para>Print the result in JSON representation suitable
     for automatic processing by other tools.</para></listitem>
 
   </varlistentry>


### PR DESCRIPTION
I'm currently working on zsh completion for nix commands and encountered a typo in the nix-env manpage.

Best,
Sven
