### PR TITLE
Print out the path to the user-environment for each generation.

### DIFF
--- a/doc/manual/nix-env.xml
+++ b/doc/manual/nix-env.xml
@@ -1138,10 +1138,10 @@ generation.</para>
 
 <screen>
 $ nix-env --list-generations
-  95   2004-02-06 11:48:24
-  96   2004-02-06 11:49:01
-  97   2004-02-06 16:22:45
-  98   2004-02-06 16:24:33   (current)</screen>
+  42   2014-08-15 08:30:27               /nix/store/4fkx4zss4p6y6jwww8qblscf5bya9ga6-user-environment
+  43   2014-08-15 08:30:59               /nix/store/pbf9mxzcddj2fl6f1mjabdvwc82an3yf-user-environment
+  44   2014-08-15 08:33:00               /nix/store/swg3rl88avk9hp3bfk437frwm8c7nkyp-user-environment
+  45   2014-08-15 08:33:08   (current)   /nix/store/pbf9mxzcddj2fl6f1mjabdvwc82an3yf-user-environment</screen>
 
 </refsection>
 

--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -204,6 +204,7 @@ foreach my $expr (@exprs) {
             or die "$0: failed to build all dependencies\n";
 
         # Set the environment.
+        my $tmp = $ENV{"TMPDIR"} // $ENV{"XDG_RUNTIME_DIR"} // "/tmp";
         if ($pure) {
             foreach my $name (keys %ENV) {
                 next if grep { $_ eq $name } ("HOME", "USER", "LOGNAME", "DISPLAY", "PATH", "TERM", "IN_NIX_SHELL", "TZ", "PAGER");
@@ -212,7 +213,7 @@ foreach my $expr (@exprs) {
             # NixOS hack: prevent /etc/bashrc from sourcing /etc/profile.
             $ENV{'__ETC_PROFILE_SOURCED'} = 1;
         }
-        $ENV{'NIX_BUILD_TOP'} = $ENV{'TMPDIR'} = $ENV{'TEMPDIR'} = $ENV{'TMP'} = $ENV{'TEMP'} = $ENV{'TMPDIR'} // "/tmp";
+        $ENV{'NIX_BUILD_TOP'} = $ENV{'TMPDIR'} = $ENV{'TEMPDIR'} = $ENV{'TMP'} = $ENV{'TEMP'} = $tmp;
         $ENV{'NIX_STORE'} = $Nix::Config::storeDir;
         $ENV{$_} = $drv->{env}->{$_} foreach keys %{$drv->{env}};
 

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1249,11 +1249,12 @@ static void opListGenerations(Globals & globals, Strings opFlags, Strings opArgs
     for (Generations::iterator i = gens.begin(); i != gens.end(); ++i) {
         tm t;
         if (!localtime_r(&i->creationTime, &t)) throw Error("cannot convert time");
-        cout << format("%|4|   %|4|-%|02|-%|02| %|02|:%|02|:%|02|   %||\n")
+        cout << format("%|4|   %|4|-%|02|-%|02| %|02|:%|02|:%|02|   %||   %s\n")
             % i->number
             % (t.tm_year + 1900) % (t.tm_mon + 1) % t.tm_mday
             % t.tm_hour % t.tm_min % t.tm_sec
-            % (i->number == curGen ? "(current)" : "");
+            % (i->number == curGen ? "(current)" : "         ")
+            % readLink(i->path);
     }
 }
 


### PR DESCRIPTION
Example:
$ nix-env --list-generations
  42   2014-08-15 08:30:27               /nix/store/4fkx4zss4p6y6jwww8qblscf5bya9ga6-user-environment

Use case:
When I roll back and forth between generation, I record the uniq hash for identification. This helps with the release process.
