### PR TITLE
Derive Emacs nix-mode from prog-mode.

### DIFF
--- a/misc/emacs/nix-mode.el
+++ b/misc/emacs/nix-mode.el
@@ -45,7 +45,7 @@
 
 
 ;;;###autoload
-(define-derived-mode nix-mode fundamental-mode "Nix"
+(define-derived-mode nix-mode prog-mode "Nix"
   "Major mode for editing Nix expressions.
 
 The following commands may be useful:


### PR DESCRIPTION
[Emacs 24.1](https://www.gnu.org/software/emacs/news/NEWS.24.1) introduced the notion of "basic major modes" and among these is `prog-mode`, see section [23.2.5 Basic Major Modes](https://www.gnu.org/software/emacs/manual/html_node/elisp/Basic-Major-Modes.html) in the Emacs manual. The `prog-mode` basic major mode is recommended as a base for derived major modes that are intended for editing source code.

Deriving from `prog-mode` is quite nice since we then can use the `prog-mode-hook` to run code for all programming modes, see description on [Emacs Redux](http://emacsredux.com/blog/2013/04/05/prog-mode-the-parent-of-all-programming-modes/), for example.

Note, this breaks compatibility with Emacs versions prior to 24.1 and if this is a concern I can update the pull request to add backwards support.
