### PR TITLE
binary download: Use $NIX_CURL_FLAGS

### DIFF
--- a/scripts/download-from-binary-cache.pl.in
+++ b/scripts/download-from-binary-cache.pl.in
@@ -546,7 +546,7 @@ sub downloadBinary {
         die if $requireSignedBinaryCaches && !defined $info->{signedBy};
         print STDERR "\n*** Downloading ‘$url’ ", ($requireSignedBinaryCaches ? "(signed by ‘$info->{signedBy}’) " : ""), "to ‘$storePath’...\n";
         checkURL $url;
-        if (system("$Nix::Config::curl --fail --location --insecure --connect-timeout $curlConnectTimeout '$url' $decompressor | $Nix::Config::binDir/nix-store --restore $destPath") != 0) {
+        if (system("$Nix::Config::curl --fail --location --insecure --connect-timeout $curlConnectTimeout $NIX_CURL_FLAGS '$url' $decompressor | $Nix::Config::binDir/nix-store --restore $destPath") != 0) {
             warn "download of ‘$url’ failed" . ($! ? ": $!" : "") . "\n";
             next;
         }


### PR DESCRIPTION
As in https://github.com/NixOS/nixpkgs/blob/5c0816567d6b99bd2ef7c8ae5744f80a6a0372c4/pkgs/build-support/fetchurl/builder.sh#L17
