### PR TITLE
baseNameOf: Don't copy paths to the store first

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -730,7 +730,7 @@ static void prim_pathExists(EvalState & state, const Pos & pos, Value * * args, 
 static void prim_baseNameOf(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     PathSet context;
-    mkString(v, baseNameOf(state.coerceToString(pos, *args[0], context)), context);
+    mkString(v, baseNameOf(state.coerceToString(pos, *args[0], context, false, false)), context);
 }
 
 

--- a/tests/lang/eval-okay-context.nix
+++ b/tests/lang/eval-okay-context.nix
@@ -1,4 +1,4 @@
-let s = "foo ${builtins.substring 33 100 (baseNameOf ./eval-okay-context.nix)} bar";
+let s = "foo ${builtins.substring 33 100 (baseNameOf "${./eval-okay-context.nix}")} bar";
 in
   if s != "foo eval-okay-context.nix bar"
   then abort "context not discarded"


### PR DESCRIPTION
This is technically a breaking change, but I doubt anyone relies on the existing semantics. I'd expect `baseNameOf ./foo` to be `"foo"`, not `"somehash-foo"`. Currently I'm doing `baseNameOf (toString ./foo)` everywhere I need `baseNameOf`.