### PR TITLE
doc: fixed nix-instantiate --find-file

### DIFF
--- a/doc/manual/command-ref/nix-instantiate.xml
+++ b/doc/manual/command-ref/nix-instantiate.xml
@@ -45,7 +45,7 @@
     <arg choice='plain' rep='repeat'><replaceable>files</replaceable></arg>
     <sbr/>
     <command>nix-instantiate</command>
-    <arg choice='plain'><option>--file-file</option></arg>
+    <arg choice='plain'><option>--find-file</option></arg>
     <arg choice='plain' rep='repeat'><replaceable>files</replaceable></arg>
   </cmdsynopsis>
 </refsynopsisdiv>


### PR DESCRIPTION
The manual said --file-file, which should be --find-file.
