### PR TITLE
Fix errors when eval path contains whitespace

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,9 +313,9 @@ AC_SUBST(tarFlags)
 test "$prefix" = NONE && prefix=$ac_default_prefix
 test "$exec_prefix" = NONE && exec_prefix='${prefix}'
 for name in $ac_subst_vars; do
-    declare $name="$(eval echo "${!name}")"
-    declare $name="$(eval echo "${!name}")"
-    declare $name="$(eval echo "${!name}")"
+    declare $name="$(eval 'echo "${!name}"')"
+    declare $name="$(eval 'echo "${!name}"')"
+    declare $name="$(eval 'echo "${!name}"')"
 done
 
 rm -f Makefile.config


### PR DESCRIPTION
This fixes the following error when running ./configure under cygwin:

The eval command dislikes the whitespace of my path unless I add the additional single quotes.

```
checking if you have a recent GNU tar... yes
./configure: eval: line 6188: syntax error near unexpected token `('
./configure: eval: line 6188: `echo /cygdrive/c/Program Files (x86)/Git/bin/openssl'
./configure: line 6188: warning: syntax errors in . or eval will cause future versions of the shell to abort as Posix requires
./configure: eval: line 6188: syntax error near unexpected token `('
./configure: eval: line 6188: `echo /cygdrive/c/Program Files (x86)/Git/bin/bison'
./configure: line 6188: warning: syntax errors in . or eval will cause future versions of the shell to abort as Posix requires
./configure: eval: line 6188: syntax error near unexpected token `('
./configure: eval: line 6188: `echo /cygdrive/c/Program Files (x86)/Git/bin/flex'
./configure: line 6188: warning: syntax errors in . or eval will cause future versions of the shell to abort as Posix requires
./configure: eval: line 6188: syntax error near unexpected token `('
./configure: eval: line 6188: `echo /cygdrive/c/Program Files (x86)/Git/bin/patch'
./configure: line 6188: warning: syntax errors in . or eval will cause future versions of the shell to abort as Posix requires
configure: creating ./config.status
config.status: creating config.h
config.status: config.h is unchanged
```