### PR TITLE
print_nix_grammar: helper to print Nix grammar summary

### DIFF
--- a/scripts/print_nix_grammar.sh
+++ b/scripts/print_nix_grammar.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Print a BNF-like grammar summary of the Nix language
+
+case "$0" in
+  /*) me="$0" ;;
+  *) me=$PWD/"$0" ;;
+esac
+mydir=$(dirname "$me")
+syntax="$mydir/../src/libexpr/parser.y"
+
+if [ ! -r "$syntax" ]; then
+  echo "Can't find libexpr/parser.y" >&2
+  exit 1
+fi
+
+nix-shell -p bison --pure --command "
+  dir=\$(mktemp -d /tmp/parserXXX)
+  [ \$? -eq 0 ] || exit 1
+
+  cd \"\$dir\"
+  if bison -v \"$syntax\"; then
+    awk 'n==2&&\$1==\"Terminals,\"{n=0; exit 0}n==1&&\$1>=1{n=2}n==2{print substr(\$0,7)}\$0==\"Grammar\"{n=1}' parser.output
+  fi
+  cd
+  rm -r \"\$dir\"
+"


### PR DESCRIPTION
This adds a script that uses `bison -v` to print a summary of the Nix grammar, to e.g. include in the docs.

Example output:

```
start: expr

expr: expr_function

expr_function: ID ':' expr_function
             | '{' formals '}' ':' expr_function
             | '{' formals '}' '@' ID ':' expr_function
             | ID '@' '{' formals '}' ':' expr_function
             | ASSERT expr ';' expr_function
             | WITH expr ';' expr_function
             | LET binds IN expr_function
             | expr_if

expr_if: IF expr THEN expr ELSE expr
       | expr_op

expr_op: '!' expr_op
       | '-' expr_op
       | expr_op EQ expr_op
       | expr_op NEQ expr_op
       | expr_op '<' expr_op
       | expr_op LEQ expr_op
       | expr_op '>' expr_op
       | expr_op GEQ expr_op
       | expr_op AND expr_op
       | expr_op OR expr_op
       | expr_op IMPL expr_op
       | expr_op UPDATE expr_op
       | expr_op '?' attrpath
       | expr_op '+' expr_op
       | expr_op '-' expr_op
       | expr_op '*' expr_op
       | expr_op '/' expr_op
       | expr_op CONCAT expr_op
       | expr_app

expr_app: expr_app expr_select
        | expr_select

expr_select: expr_simple '.' attrpath
           | expr_simple '.' attrpath OR_KW expr_select
           | expr_simple OR_KW
           | expr_simple

expr_simple: ID
           | INT
           | '"' string_parts '"'
           | IND_STRING_OPEN ind_string_parts IND_STRING_CLOSE
           | PATH
           | SPATH
           | URI
           | '(' expr ')'
           | LET '{' binds '}'
           | REC '{' binds '}'
           | '{' binds '}'
           | '[' expr_list ']'

string_parts: STR
            | string_parts_interpolated
            | %empty

string_parts_interpolated: string_parts_interpolated STR
                         | string_parts_interpolated DOLLAR_CURLY expr '}'
                         | STR DOLLAR_CURLY expr '}'
                         | DOLLAR_CURLY expr '}'

ind_string_parts: ind_string_parts IND_STR
                | ind_string_parts DOLLAR_CURLY expr '}'
                | %empty

binds: binds attrpath '=' expr ';'
     | binds INHERIT attrs ';'
     | binds INHERIT '(' expr ')' attrs ';'
     | %empty

attrs: attrs attr
     | attrs string_attr
     | %empty

attrpath: attrpath '.' attr
        | attrpath '.' string_attr
        | attr
        | string_attr

attr: ID
    | OR_KW

string_attr: '"' string_parts '"'
           | DOLLAR_CURLY expr '}'

expr_list: expr_list expr_select
         | %empty

formals: formal ',' formals
       | formal
       | %empty
       | ELLIPSIS

formal: ID
      | ID '?' expr
```
