### PR TITLE
configure.ac: do more checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,6 +298,34 @@ fi
 AC_SUBST(tarFlags)
 
 
+# Additional checks
+AC_CHECK_FUNCS([dup2 fchdir getcwd gettimeofday localtime_r memset mkdir regcomp select setenv sethostname socket strcasecmp strchr strdup strerror strtol uname])
+AC_CHECK_HEADERS([fcntl.h limits.h sys/ioctl.h sys/socket.h sys/statvfs.h sys/time.h utime.h])
+AC_CHECK_HEADER_STDBOOL
+AC_CHECK_TYPES([ptrdiff_t])
+AC_C_INLINE
+AC_FUNC_CHOWN
+AC_FUNC_ERROR_AT_LINE
+AC_FUNC_FORK
+AC_FUNC_FSEEKO
+AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
+AC_FUNC_MALLOC
+AC_PREREQ
+AC_PROG_INSTALL
+AC_PROG_LN_S
+AC_STRUCT_ST_BLOCKS
+AC_TYPE_MODE_T
+AC_TYPE_OFF_T
+AC_TYPE_PID_T
+AC_TYPE_SIZE_T
+AC_TYPE_SSIZE_T
+AC_TYPE_UID_T
+AC_TYPE_UINT16_T
+AC_TYPE_UINT32_T
+AC_TYPE_UINT64_T
+AC_TYPE_UINT8_T
+
+
 # Expand all variables in config.status.
 test "$prefix" = NONE && prefix=$ac_default_prefix
 test "$exec_prefix" = NONE && exec_prefix='${prefix}'


### PR DESCRIPTION
Those additional checks were taken from running `autoscan` inside the build directory:

```
configure.ac: warning: missing AC_CHECK_FUNCS([dup2]) wanted by: src/libmain/shared.cc:312
configure.ac: warning: missing AC_CHECK_FUNCS([fchdir]) wanted by: src/libstore/remote-store.cc:125
configure.ac: warning: missing AC_CHECK_FUNCS([getcwd]) wanted by: src/libutil/util.cc:68
configure.ac: warning: missing AC_CHECK_FUNCS([gettimeofday]) wanted by: src/libmain/shared.cc:155
configure.ac: warning: missing AC_CHECK_FUNCS([localtime_r]) wanted by: src/nix-env/nix-env.cc:1253
configure.ac: warning: missing AC_CHECK_FUNCS([memset]) wanted by: src/libutil/serialise.cc:141
configure.ac: warning: missing AC_CHECK_FUNCS([mkdir]) wanted by: src/libutil/util.cc:363
configure.ac: warning: missing AC_CHECK_FUNCS([regcomp]) wanted by: src/libutil/regex.cc:11
configure.ac: warning: missing AC_CHECK_FUNCS([select]) wanted by: src/libstore/local-store.cc:1150
configure.ac: warning: missing AC_CHECK_FUNCS([setenv]) wanted by: src/libmain/shared.cc:315
configure.ac: warning: missing AC_CHECK_FUNCS([sethostname]) wanted by: src/libstore/build.cc:1991
configure.ac: warning: missing AC_CHECK_FUNCS([socket]) wanted by: src/libstore/build.cc:1978
configure.ac: warning: missing AC_CHECK_FUNCS([strcasecmp]) wanted by: src/libutil/archive.cc:177
configure.ac: warning: missing AC_CHECK_FUNCS([strchr]) wanted by: src/nix-log2xml/log2xml.cc:148
configure.ac: warning: missing AC_CHECK_FUNCS([strdup]) wanted by: src/libexpr/lexer.l:112
configure.ac: warning: missing AC_CHECK_FUNCS([strerror]) wanted by: src/libutil/util.cc:48
configure.ac: warning: missing AC_CHECK_FUNCS([strtol]) wanted by: src/libexpr/lexer.l:114
configure.ac: warning: missing AC_CHECK_FUNCS([uname]) wanted by: src/libstore/build.cc:2102
configure.ac: warning: missing AC_CHECK_HEADERS([fcntl.h]) wanted by: src/bsdiff-4.3/bspatch.c:38
configure.ac: warning: missing AC_CHECK_HEADERS([limits.h]) wanted by: src/libstore/build.cc:16
configure.ac: warning: missing AC_CHECK_HEADERS([sys/ioctl.h]) wanted by: src/libstore/local-store.cc:33
configure.ac: warning: missing AC_CHECK_HEADERS([sys/socket.h]) wanted by: src/libstore/build.cc:54
configure.ac: warning: missing AC_CHECK_HEADERS([sys/statvfs.h]) wanted by: src/libstore/local-store.cc:27
configure.ac: warning: missing AC_CHECK_HEADERS([sys/time.h]) wanted by: src/libexpr/eval.cc:12
configure.ac: warning: missing AC_CHECK_HEADERS([utime.h]) wanted by: src/libstore/local-store.cc:18
configure.ac: warning: missing AC_CHECK_HEADER_STDBOOL wanted by: src/nix-env/profiles.cc:15
configure.ac: warning: missing AC_CHECK_TYPES([ptrdiff_t]) wanted by: src/libmain/stack.cc:31
configure.ac: warning: missing AC_C_INLINE wanted by: src/libexpr/eval.cc:387
configure.ac: warning: missing AC_FUNC_CHOWN wanted by: src/libstore/local-store.cc:269
configure.ac: warning: missing AC_FUNC_ERROR_AT_LINE wanted by: src/libexpr/common-opts.cc:15
configure.ac: warning: missing AC_FUNC_FORK wanted by: src/libutil/util.cc:875
configure.ac: warning: missing AC_FUNC_FSEEKO wanted by: src/bsdiff-4.3/bspatch.c:133
configure.ac: warning: missing AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK wanted by: src/nix-env/profiles.cc:52
configure.ac: warning: missing AC_FUNC_MALLOC wanted by: src/bsdiff-4.3/bspatch.c:155
configure.ac: warning: missing AC_PREREQ wanted by: autoscan
configure.ac: warning: missing AC_PROG_INSTALL wanted by: scripts/install-nix-from-closure.sh:71
configure.ac: warning: missing AC_PROG_LN_S wanted by: scripts/nix-profile.sh.in:8
configure.ac: warning: missing AC_STRUCT_ST_BLOCKS wanted by: src/libstore/optimise-store.cc:211
configure.ac: warning: missing AC_TYPE_MODE_T wanted by: src/libstore/local-store.cc:517
configure.ac: warning: missing AC_TYPE_OFF_T wanted by: src/bsdiff-4.3/bspatch.c:41
configure.ac: warning: missing AC_TYPE_PID_T wanted by: src/libstore/build.cc:206
configure.ac: warning: missing AC_TYPE_SIZE_T wanted by: src/bsdiff-4.3/bspatch.c:61
configure.ac: warning: missing AC_TYPE_SSIZE_T wanted by: src/bsdiff-4.3/bspatch.c:64
configure.ac: warning: missing AC_TYPE_UID_T wanted by: src/libstore/local-store.cc:596
configure.ac: warning: missing AC_TYPE_UINT16_T wanted by: src/libexpr/value-to-json.cc:21
configure.ac: warning: missing AC_TYPE_UINT32_T wanted by: src/libexpr/eval.hh:39
configure.ac: warning: missing AC_TYPE_UINT64_T wanted by: src/libexpr/eval.cc:1463
configure.ac: warning: missing AC_TYPE_UINT8_T wanted by: src/libutil/sha1.h:17
```

It works well on Ubuntu 14.04.
