### PR TITLE
install symlink to nix-daemon.8.gz

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -51,6 +51,8 @@ $(firstword $(man-pages)): $(d)/manual.xmli $(d)/manual.is-valid
 
 $(wordlist 2, $(words $(man-pages)), $(man-pages)): $(firstword $(man-pages))
 
+$(eval $(call install-symlink, nix-daemon.8.gz, $(mandir)/man8/nix-worker.8.gz))
+
 clean-files += $(d)/*.1 $(d)/*.5 $(d)/*.8
 
 dist-files += $(man-pages)


### PR DESCRIPTION
Since nix-worker is just a symlink to nix-daemon but missing a manpage.