### PR TITLE
Fix typo in "allowedRequisites"

### DIFF
--- a/doc/manual/expressions/advanced-attributes.xml
+++ b/doc/manual/expressions/advanced-attributes.xml
@@ -40,7 +40,7 @@ allowedReferences = [];
     recursively.  For example,
 
 <programlisting>
-allowedReferences = [ foobar ];
+allowedRequisites = [ foobar ];
 </programlisting>
 
     enforces that the output of a derivation cannot have any other


### PR DESCRIPTION
Fix typo (assuming this is a typo)
`allowedRequisites` mentions `allowedReferences` in code example