### PR TITLE
Allow using /bin and /usr/bin as impure prefixes on non-darwin by default

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -56,7 +56,7 @@
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library/Frameworks /usr/lib /dev /bin/sh"
 #else
     #define SANDBOX_ENABLED 0
-    #define DEFAULT_ALLOWED_IMPURE_PREFIXES ""
+    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/bin" "/usr/bin"
 #endif
 
 #if CHROOT_ENABLED


### PR DESCRIPTION
These directories are generally world-readable anyway, and give us the two
most common linux impurities (env and sh)