### PR TITLE
Bring nix-profile.sh in line with NixOS

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,24 +1,71 @@
-if [ -n "$HOME" ]; then
-    NIX_LINK="$HOME/.nix-profile"
+if [ -n "$HOME" ] && [ -n "$USER" ]; then
+    __savedpath="$PATH"
+    export PATH=@coreutils@
 
-    # Set the default profile.
-    if ! [ -L "$NIX_LINK" ]; then
-        echo "creating $NIX_LINK" >&2
-        _NIX_DEF_LINK=@localstatedir@/nix/profiles/default
-        @coreutils@/ln -s "$_NIX_DEF_LINK" "$NIX_LINK"
+    # Set up the per-user profile.
+    # This part should be kept in sync with nixpkgs:nixos/modules/programs/shell.nix
+
+    : ${NIX_LINK:=$HOME/.nix-profile}
+
+    : ${NIX_USER_PROFILE_DIR:=@localstatedir@/nix/profiles/per-user/$USER}
+
+    mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
+
+    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
+        echo "Nix: WARNING: bad ownership on "$NIX_USER_PROFILE_DIR", should be $(id -u)" >&2
     fi
 
-    export PATH=$NIX_LINK/bin:$NIX_LINK/sbin:$PATH
+    if [ -w "$HOME" ]; then
+        if ! [ -L "$NIX_LINK" ]; then
+            echo "Nix: creating $NIX_LINK" >&2
+            if [ "$USER" != root ]; then
+                if ! ln -s "$NIX_USER_PROFILE_DIR"/profile "$NIX_LINK"; then
+                    echo "Nix: WARNING: could not create $NIX_LINK -> $NIX_USER_PROFILE_DIR/profile" >&2
+                fi
+            else
+                # Root installs in the system-wide profile by default.
+                ln -s @localstatedir@/nix/profiles/default "$NIX_LINK"
+            fi
+        fi
 
-    # Subscribe the user to the Nixpkgs channel by default.
-    if [ ! -e "$HOME/.nix-channels" ]; then
-        echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
+        # Subscribe the user to the unstable Nixpkgs channel by default.
+        if [ ! -e "$HOME/.nix-channels" ]; then
+            echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
+        fi
+
+        # Create the per-user garbage collector roots directory.
+        __user_gcroots=@localstatedir@/nix/gcroots/per-user/"$USER"
+        mkdir -m 0755 -p "$__user_gcroots"
+        if [ "$(stat --printf '%u' "$__user_gcroots")" != "$(id -u)" ]; then
+            echo "Nix: WARNING: bad ownership on $__user_gcroots, should be $(id -u)" >&2
+        fi
+        unset __user_gcroots
+
+        # Set up a default Nix expression from which to install stuff.
+        __nix_defexpr="$HOME"/.nix-defexpr
+        [ -L "$__nix_defexpr" ] && rm -f "$__nix_defexpr"
+        mkdir -m 0755 -p "$__nix_defexpr"
+        if [ "$USER" != root ] && [ ! -L "$__nix_defexpr"/channels_root ]; then
+            ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root
+        fi
+        unset __nix_defexpr
     fi
 
     # Append ~/.nix-defexpr/channels/nixpkgs to $NIX_PATH so that
     # <nixpkgs> paths work when the user has fetched the Nixpkgs
     # channel.
-    export NIX_PATH=${NIX_PATH:+$NIX_PATH:}nixpkgs=$HOME/.nix-defexpr/channels/nixpkgs
+    export NIX_PATH="${NIX_PATH:+$NIX_PATH:}nixpkgs=$HOME/.nix-defexpr/channels/nixpkgs"
+
+    # Set up environment.
+    # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
+    export NIX_USER_PROFILE_DIR
+    export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_USER_PROFILE_DIR"
+
+    for i in $NIX_PROFILES; do
+        if [ -d "$i/lib/aspell" ]; then
+            export ASPELL_CONF="dict-dir $i/lib/aspell"
+        fi
+    done
 
     # Set $SSL_CERT_FILE so that Nixpkgs applications like curl work.
     if [ -e /etc/ssl/certs/ca-certificates.crt ]; then # NixOS, Ubuntu, Debian, Gentoo, Arch
@@ -34,4 +81,7 @@ if [ -n "$HOME" ]; then
     elif [ -e "$NIX_LINK/etc/ca-bundle.crt" ]; then # old cacert in Nix profile
         export SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
     fi
+
+    export PATH="$NIX_LINK/bin:$NIX_LINK/sbin:$__savedpath"
+    unset __savedpath
 fi


### PR DESCRIPTION
Use the same logic as NixOS' profile and environment setup. Closes #414 and paves the way for enabling multi-user setups from a single-user nix install.