### PR TITLE
nix-shell: fix --expr

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -164,7 +164,7 @@ for (my $n = 0; $n < scalar @ARGV; $n++) {
     }
 }
 
-if ($packages) {
+if ($packages || $fromArgs) {
     push @instArgs, "--expr";
     @exprs = (
         'with import <nixpkgs> { }; runCommand "shell" { buildInputs = [ '


### PR DESCRIPTION
Before this change, --expr arguments would only work in the presence of
a -p argument.

Fixes #454