### PR TITLE
Moves runHook to a later execution position

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -278,10 +278,10 @@ foreach my $expr (@exprs) {
             ($pure ? '' : 'p=$PATH; ' ) .
             'dontAddDisableDepTrack=1; ' .
             '[ -e $stdenv/setup ] && source $stdenv/setup; ' .
-            'if [ "$(type -t runHook)" = function ]; then runHook shellHook; fi; ' .
             ($pure ? '' : 'PATH=$PATH:$p; unset p; ') .
             'set +e; ' .
             '[ -n "$PS1" ] && PS1="\n\[\033[1;32m\][nix-shell:\w]$\[\033[0m\] "; ' .
+            'if [ "$(type -t runHook)" = function ]; then runHook shellHook; fi; ' .
             'unset NIX_ENFORCE_PURITY; ' .
             'unset NIX_INDENT_MAKE; ' .
             'shopt -u nullglob; ' .


### PR DESCRIPTION
It moves runHook to a later position in the rcfile. After that we are
able to set the PS1 environment-variable for a nix-shell environment
e.g.:

  # turn the color of the prompt to blue
  shellHook = ''
    export PS1="\n\[\033[1;34m\][\u@\h:\w]$\[\033[0m\] ";
  '';