### PR TITLE
nix-install-package: follow symlinks

### DIFF
--- a/scripts/nix-install-package.in
+++ b/scripts/nix-install-package.in
@@ -71,7 +71,7 @@ sub barf {
 my $pkgFile = $source;
 if ($fromURL) {
     $pkgFile = "$tmpDir/tmp.nixpkg";
-    system("@curl@", "--silent", $source, "-o", $pkgFile) == 0
+    system("@curl@", "-L", "--silent", $source, "-o", $pkgFile) == 0
         or barf "curl failed: $?";
 }
 


### PR DESCRIPTION
This is needed if you want to install latest packages from hydra urls like `http://hydra.x-truder.net/job/euganke/package/app.x86_64-linux/latest/nix/pkg/*`