### PR TITLE
Nix install script failed when "cd" printed to stdout.

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -41,7 +41,7 @@ mkdir -p $dest/store
 
 echo -n "copying Nix to $dest/store..." >&2
 
-for i in $(cd $self/store && echo *); do
+for i in $(cd $self/store >/dev/null && echo *); do
     echo -n "." >&2
     i_tmp="$dest/store/$i.$$"
     if [ -e "$i_tmp" ]; then


### PR DESCRIPTION
In some cases the bash builtin command "cd" can print the variable $CWD
to stdout.  This caused the install script to fail while copying files
because the source path was wrong.

Fixes #476.