### PR TITLE
Use pivot_root in addition to chroot when possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,7 @@ AC_CHECK_HEADERS([sys/mount.h], [], [],
 # include <sys/param.h>
 # endif
 ])
+AC_CHECK_HEADERS([sys/syscall.h])
 
 
 # Check for lutimes, optionally used for changing the mtime of


### PR DESCRIPTION
As brought up [earlier on the mailing list](http://lists.science.uu.nl/pipermail/nix-dev/2014-December/015089.html), here is a request to make Nix use pivot_root on Linux. I missed that the sandbox support mentioned in that thread that I was waiting for already got accepted in Nix. There does not appear to be any overlap with my proposed change.

chroot only changes the process root directory, not the mount namespace root directory, and it is well-known that any process with chroot capability can break out of a chroot "jail". By using pivot_root as well, and unmounting the original mount namespace root directory, breaking out becomes impossible.

Non-root processes typically have no ability to use chroot() anyway, but they can gain that capability through the use of clone() or unshare(). For security reasons, these syscalls are limited in functionality when used inside a normal chroot environment. Using pivot_root() this way does allow those syscalls to be put to their full use.

I've tested this change with my own packages as well as nixpkgs, inside a chroot and outside. For nixpkgs, there are no issues. It doesn't matter whether Nix itself is running in a chroot, the packages in nixpkgs build without any issues. For my own packages, as long as Nix itself is not run in a chroot, clone()/unshare() are fully functional. If Nix itself is running in a chroot, this is not sufficient to get them to work, but that is not something I'm trying to make work either.

On the mailing list, an alternative suggestion of the equivalent of mount --move was brought up. I gave that a shot, but couldn't get it working. After mount-moving /dir to /, / still referred to the original root in my testing, and following that by chroot (if the current directory was /dir) was insufficient to make clone()/unshare() work the way I wanted them to.