### PR TITLE
Allow local networking in the darwin sandbox to appease tests

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2323,6 +2323,9 @@ void DerivationGoal::runChild()
             /* Enables getpwuid (used by git and others) */
             sandboxProfile += "(allow mach-lookup (global-name \"com.apple.system.notification_center\") (global-name \"com.apple.system.opendirectoryd.libinfo\"))\n";
 
+            /* Allow local networking operations, mostly because lots of test suites use it and it seems mostly harmless */
+            sandboxProfile += "(allow network* (local ip) (remote unix-socket))";
+
 
             /* Our rwx outputs */
             sandboxProfile += "(allow file-read* file-write* process-exec\n";


### PR DESCRIPTION
Lots of test suites (including Nix's own!) like to open up small local network connections and are currently failing with "operation not permitted". This should fix most instances of that, for both TCP and AF_UNIX sockets.