### PR TITLE
Make the default impure prefix include all of /System/Library

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -56,7 +56,7 @@
 /* chroot-like behavior from Apple's sandbox */
 #if __APPLE__
     #define SANDBOX_ENABLED 1
-    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library/Frameworks /usr/lib /dev /bin/sh"
+    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library /usr/lib /dev /bin/sh"
 #else
     #define SANDBOX_ENABLED 0
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/bin" "/usr/bin"


### PR DESCRIPTION
We also want PrivateFrameworks from there and (briefly) TextEncodings, and who knows what else. Yay infectious impurities?