### PR TITLE
tests: Fix wrong channel name in nix-channel.sh.

### DIFF
--- a/tests/nix-channel.sh
+++ b/tests/nix-channel.sh
@@ -49,7 +49,7 @@ clearManifests
 rm -f $TEST_ROOT/.nix-channels
 
 # Test updating from a tarball
-nix-channel --add file://$TEST_ROOT/foo/nixexprs.tar.bz2
+nix-channel --add file://$TEST_ROOT/foo/nixexprs.tar.bz2 foo
 nix-channel --update
 
 # Do a query.


### PR DESCRIPTION
The `$channelName` variable passed to the channel builder is the last portion of the URL and while that works in the previous test for channels prior to #519, it doesn't work if the last portion is `nixexprs.tar.bz2`.