### PR TITLE
nix-collect-garbage: Fix deleting old generations

### DIFF
--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -6,7 +6,7 @@
 
 using namespace nix;
 
-std::string gen = "";
+std::string gen = "old";
 bool dryRun = false;
 
 void runProgramSimple(Path program, const Strings & args)


### PR DESCRIPTION
The call to nix-env expects a string which represents how old the
derivations are or just "old" which means any generations other than
the current one in use. Currently nix-collect-garbage passes an empty
string to nix-env when using the -d option. This patch corrects the call
to nix-env such that it follows the old behavior.