### PR TITLE
Check shell profile is writeable before modifying

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -92,7 +92,7 @@ p=$NIX_LINK/etc/profile.d/nix.sh
 added=
 for i in .bash_profile .bash_login .profile; do
     fn="$HOME/$i"
-    if [ -e "$fn" ]; then
+    if [ -w "$fn" ]; then
         if ! grep -q "$p" "$fn"; then
             echo "modifying $fn..." >&2
             echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> $fn


### PR DESCRIPTION
The `set -e` at the top of the script causes the installation to fail to complete if the shell profile is not writeable. Checking file existence only is not enough.

I use a shell configuration tool, [fresh](http://freshshell.com/), to build my setup. The `.bash_profile` present in my home directory is actually a symlink to a composed file managed by fresh. It's not writeable by the user running the nix install script and this was causing the install to fail abruptly when attempting to modify it. The installer assumed that testing file existence was enough to ensure writing to it was possible.