### PR TITLE
Allow building ARMv6 stuff on ARMv7

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1192,6 +1192,7 @@ static bool canBuildLocally(const string & platform)
     return platform == settings.thisSystem
 #if __linux__
         || (platform == "i686-linux" && settings.thisSystem == "x86_64-linux")
+        || (platform == "armv6l-linux" && settings.thisSystem == "armv7l-linux")
 #endif
         ;
 }


### PR DESCRIPTION
I successfully built an Raspberry Pi SD image with this change on my ARMv7 Jetson TK1 board, and it booted.
