### PR TITLE
Fix sandbox permissions for Darwin builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,6 +261,23 @@ AC_MSG_RESULT(yes)
 AC_SUBST(perlFlags)
 
 
+# Check for otool, an optional dependency on Darwin.
+AC_PATH_PROG(otool, otool)
+AC_MSG_CHECKING([that otool works])
+case $host_os in
+  darwin*)
+    if test -z "$otool" || ! $otool --version 2>/dev/null; then
+      AC_MSG_RESULT(no)
+      AC_MSG_ERROR([Can't get version from otool; do you need to install developer tools?])
+    fi
+    AC_MSG_RESULT(yes)
+    ;;
+  *)
+    AC_MSG_RESULT(not needed)
+    ;;
+esac
+
+
 # Whether to build the Perl bindings
 AC_MSG_CHECKING([whether to build the Perl bindings])
 AC_ARG_ENABLE(perl-bindings, AC_HELP_STRING([--enable-perl-bindings],

--- a/corepkgs/buildenv.nix
+++ b/corepkgs/buildenv.nix
@@ -25,13 +25,6 @@ derivation {
 
   __impureHostDeps = [
     "/usr/lib/libSystem.dylib"
-    "/usr/lib/libSystem.B.dylib"
-    "/usr/lib/libobjc.A.dylib"
-    "/usr/lib/libobjc.dylib"
-    "/usr/lib/libauto.dylib"
-    "/usr/lib/libc++abi.dylib"
-    "/usr/lib/libc++.1.dylib"
-    "/usr/lib/libDiagnosticMessagesClient.dylib"
     "/usr/lib/system"
   ];
 

--- a/corepkgs/buildenv.nix
+++ b/corepkgs/buildenv.nix
@@ -23,5 +23,17 @@ derivation {
   # network traffic, so don't do that.
   preferLocalBuild = true;
 
+  __impureHostDeps = [
+    "/usr/lib/libSystem.dylib"
+    "/usr/lib/libSystem.B.dylib"
+    "/usr/lib/libobjc.A.dylib"
+    "/usr/lib/libobjc.dylib"
+    "/usr/lib/libauto.dylib"
+    "/usr/lib/libc++abi.dylib"
+    "/usr/lib/libc++.1.dylib"
+    "/usr/lib/libDiagnosticMessagesClient.dylib"
+    "/usr/lib/system"
+  ];
+
   inherit chrootDeps;
 }

--- a/scripts/local.mk
+++ b/scripts/local.mk
@@ -17,6 +17,7 @@ nix_substituters := \
 nix_noinst_scripts := \
   $(d)/build-remote.pl \
   $(d)/find-runtime-roots.pl \
+  $(d)/resolve-system-dependencies.pl \
   $(d)/nix-http-export.cgi \
   $(d)/nix-profile.sh \
   $(d)/nix-reduce-build \
@@ -29,6 +30,7 @@ profiledir = $(sysconfdir)/profile.d
 $(eval $(call install-file-as, $(d)/nix-profile.sh, $(profiledir)/nix.sh, 0644))
 $(eval $(call install-program-in, $(d)/find-runtime-roots.pl, $(libexecdir)/nix))
 $(eval $(call install-program-in, $(d)/build-remote.pl, $(libexecdir)/nix))
+$(eval $(call install-program-in, $(d)/resolve-system-dependencies.pl, $(libexecdir)/nix))
 $(foreach prog, $(nix_substituters), $(eval $(call install-program-in, $(prog), $(libexecdir)/nix/substituters)))
 $(eval $(call install-symlink, nix-build, $(bindir)/nix-shell))
 

--- a/scripts/resolve-system-dependencies.pl.in
+++ b/scripts/resolve-system-dependencies.pl.in
@@ -4,6 +4,7 @@ use utf8;
 use strict;
 use warnings;
 use Cwd qw(realpath);
+use Errno;
 use File::Basename qw(dirname);
 use File::Path qw(make_path);
 use File::Spec::Functions qw(catfile);
@@ -24,10 +25,14 @@ make_path dirname($cache);
 our $DEPS;
 eval {
   $DEPS = lock_retrieve($cache);
-} or do {
+};
+
+if($!{ENOENT}) {
   lock_store {}, $cache;
   $DEPS = {};
-};
+} elsif($@) {
+  die "Unable to obtain a lock on dependency-map file $cache: $@";
+}
 
 sub mkset(@) {
   my %set;

--- a/scripts/resolve-system-dependencies.pl.in
+++ b/scripts/resolve-system-dependencies.pl.in
@@ -1,0 +1,123 @@
+#! @perl@ -w @perlFlags@
+
+use utf8;
+use strict;
+use warnings;
+use Cwd qw(realpath);
+use File::Basename qw(dirname);
+use File::Path qw(make_path);
+use File::Spec::Functions qw(catfile);
+use List::Util qw(reduce);
+use IPC::Open3;
+use Nix::Config;
+use Nix::Store qw(derivationFromPath);
+use POSIX qw(uname);
+use Storable qw(lock_retrieve lock_store);
+
+my ($sysname, undef, $version, undef, $machine) = uname;
+$sysname =~ /Darwin/ or die "This tool is only meant to be used on Darwin systems.";
+
+my $cache = "$Nix::Config::stateDir/dependency-maps/$machine-$sysname-$version.map";
+
+make_path dirname($cache);
+
+our $DEPS;
+eval {
+  $DEPS = lock_retrieve($cache);
+} or do {
+  lock_store {}, $cache;
+  $DEPS = {};
+};
+
+sub mkset(@) {
+  my %set;
+  @set{@_} = ();
+  \%set
+}
+
+sub union($$) {
+  my ($set1, $set2) = @_;
+  my $new = {};
+  foreach my $key (keys %$set1) {
+    $new->{$key} = $set1->{$key};
+  }
+  foreach my $key (keys %$set2) {
+    $new->{$key} = $set2->{$key};
+  }
+  $new
+}
+
+sub cache_filepath($) {
+  my $fp = shift;
+  $fp =~ s/-/--/g;
+  $fp =~ s/\//-/g;
+  $fp =~ s/^-//g;
+  catfile $cache, $fp
+}
+
+sub resolve_tree {
+  sub resolve_tree_inner {
+    my ($lib, $TREE) = @_;
+    return if (defined $TREE->{$lib});
+    $TREE->{$lib} = mkset(@{cache_get($lib)});
+    foreach my $dep (keys %{$TREE->{$lib}}) {
+      resolve_tree_inner($dep, $TREE);
+    }
+    values %$TREE
+  }
+
+  reduce { union($a, $b) } {}, resolve_tree_inner(@_)
+}
+
+sub cache_get {
+  my $key = shift;
+  if (defined $DEPS->{$key}) {
+    $DEPS->{$key}
+  } else {
+    cache_insert($key);
+    cache_get($key)
+  }
+}
+
+sub cache_insert($) {
+  my $key = shift;
+  print STDERR "Finding dependencies for $key...\n";
+  my @deps = find_deps($key);
+  $DEPS->{$key} = \@deps;
+}
+
+sub find_deps($) {
+  my $lib = shift;
+  my($chld_in, $chld_out, $chld_err);
+  my $pid = open3($chld_in, $chld_out, $chld_err, "@otool@", "-L", "-arch", "x86_64", $lib);
+  waitpid($pid, 0);
+  my $line = readline $chld_out;
+  if($? == 0 and $line !~ /not an object file/) {
+    my @libs;
+    while(<$chld_out>) {
+      my $dep = (split /\s+/)[1];
+      push @libs, $dep unless $dep eq $lib or $dep =~ /\@rpath/;
+    }
+    @libs
+  } elsif (-l $lib) {
+    (realpath($lib))
+  } else {
+    ()
+  }
+}
+
+if (defined $ARGV[0]) {
+  my $deps = derivationFromPath($ARGV[0])->{"env"}->{"__impureHostDeps"};
+  if (defined $deps) {
+    my @files = split(/\s+/, $deps);
+    my $depcache = {};
+    my $depset = reduce { union($a, $b) } (map { resolve_tree($_, $depcache) } @files);
+    print "extra-chroot-dirs\n";
+    print join("\n", keys %$depset);
+    print "\n\n";
+  }
+  lock_store($DEPS, $cache);
+} else {
+  print STDERR "Usage: $0 path/to/derivation.drv\n";
+  exit 1
+}

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -59,8 +59,8 @@
 /* chroot-like behavior from Apple's sandbox */
 #if __APPLE__
     #define SANDBOX_ENABLED 1
-    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library /usr /dev /bin/sh"
     #define DARWIN_PREBUILD 1
+    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library /usr/lib /dev /bin/sh"
 #else
     #define SANDBOX_ENABLED 0
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/bin" "/usr/bin"

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2488,7 +2488,11 @@ void DerivationGoal::runChild()
             sandboxProfile += ")\n";
 
             /* Our ancestry. N.B: this uses literal on folders, instead of subpath. Without that,
-               you open up the entire filesystem because you end up with (subpath "/") */
+               you open up the entire filesystem because you end up with (subpath "/")
+               Note: file-read-metadata* is not sufficiently permissive for GHC. file-read* is but may
+               be a security hazard.
+               TODO: figure out a more appropriate directive.
+             */
             sandboxProfile += "(allow file-read*\n";
             for (auto & i : ancestry) {
                 sandboxProfile += (format("\t(literal \"%1%\")\n") % i.c_str()).str();

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -59,12 +59,10 @@
 /* chroot-like behavior from Apple's sandbox */
 #if __APPLE__
     #define SANDBOX_ENABLED 1
-    #define DARWIN_PREBUILD 1
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library /usr/lib /dev /bin/sh"
 #else
     #define SANDBOX_ENABLED 0
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/bin" "/usr/bin"
-    #define DARWIN_PREBUILD 0
 #endif
 
 #if CHROOT_ENABLED
@@ -2046,11 +2044,6 @@ void DerivationGoal::startBuilder()
                     redirectedBadOutputs.insert(i);
                 }
     }
-
-#if DARWIN_PREBUILD
-    if (settings.preBuildHook == "")
-      settings.preBuildHook = settings.nixLibexecDir + "/nix/resolve-system-dependencies.pl";
-#endif
 
     if (settings.preBuildHook != "") {
         printMsg(lvlChatty, format("executing pre-build hook ‘%1%’")

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2460,7 +2460,6 @@ void DerivationGoal::runChild()
             sandboxProfile += "(allow file-read*\n"
                 "\t(literal \"/dev/dtracehelper\")\n"
                 "\t(literal \"/dev/tty\")\n"
-                "\t(literal \"/System/Library/CoreServices/SystemVersion.plist\")\n"
                 "\t(literal \"/dev/autofs_nowait\")\n"
                 "\t(literal \"/private/var/run/systemkeychaincheck.done\")\n"
                 "\t(literal \"/private/etc/protocols\")\n"

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -59,7 +59,7 @@
 /* chroot-like behavior from Apple's sandbox */
 #if __APPLE__
     #define SANDBOX_ENABLED 1
-    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/"
+    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library /usr /dev /bin/sh"
 #else
     #define SANDBOX_ENABLED 0
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/bin" "/usr/bin"

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -60,9 +60,11 @@
 #if __APPLE__
     #define SANDBOX_ENABLED 1
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library /usr /dev /bin/sh"
+    #define DARWIN_PREBUILD 1
 #else
     #define SANDBOX_ENABLED 0
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/bin" "/usr/bin"
+    #define DARWIN_PREBUILD 0
 #endif
 
 #if CHROOT_ENABLED
@@ -2044,6 +2046,11 @@ void DerivationGoal::startBuilder()
                     redirectedBadOutputs.insert(i);
                 }
     }
+
+#if DARWIN_PREBUILD
+    if (settings.preBuildHook == "")
+      settings.preBuildHook = settings.nixLibexecDir + "/nix/resolve-system-dependencies.pl";
+#endif
 
     if (settings.preBuildHook != "") {
         printMsg(lvlChatty, format("executing pre-build hook ‘%1%’")

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2059,7 +2059,7 @@ void DerivationGoal::startBuilder()
         auto lastPos = std::string::size_type{0};
         for (auto nlPos = lines.find('\n'); nlPos != string::npos;
                 nlPos = lines.find('\n', lastPos)) {
-            auto line = std::string{lines, lastPos, nlPos};
+            auto line = std::string{lines, lastPos, nlPos - lastPos};
             lastPos = nlPos + 1;
             if (state == stBegin) {
                 if (line == "extra-chroot-dirs") {

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -59,7 +59,7 @@
 /* chroot-like behavior from Apple's sandbox */
 #if __APPLE__
     #define SANDBOX_ENABLED 1
-    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/System/Library /usr/lib /dev /bin/sh"
+    #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/"
 #else
     #define SANDBOX_ENABLED 0
     #define DEFAULT_ALLOWED_IMPURE_PREFIXES "/bin" "/usr/bin"
@@ -2451,7 +2451,7 @@ void DerivationGoal::runChild()
 
             sandboxProfile += "(allow file-read* file-write-data (literal \"/dev/null\"))\n";
 
-            sandboxProfile += "(allow ipc-posix-shm*)\n";
+            sandboxProfile += "(allow ipc-posix-shm* ipc-posix-sem)\n";
 
             sandboxProfile += "(allow mach-lookup\n"
                 "\t(global-name \"com.apple.SecurityServer\")\n"

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2442,7 +2442,7 @@ void DerivationGoal::runChild()
             /* This has to appear before import statements */
             sandboxProfile += "(version 1)\n";
 
-            sandboxProfile += (format("(import \"%1%/share/nix/sandbox-defaults.sb\")\n") % NIX_PREFIX).str();
+            sandboxProfile += (format("(import \"%1%/nix/sandbox-defaults.sb\")\n") % settings.nixDataDir).str();
 
             /* Violations will go to the syslog if you set this. Unfortunately the destination does not appear to be configurable */
             if (settings.get("darwin-log-sandbox-violations", false)) {

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -77,6 +77,11 @@ void Settings::processEnvironment()
     nixLibexecDir = canonPath(getEnv("NIX_LIBEXEC_DIR", NIX_LIBEXEC_DIR));
     nixBinDir = canonPath(getEnv("NIX_BIN_DIR", NIX_BIN_DIR));
     nixDaemonSocketFile = canonPath(nixStateDir + DEFAULT_SOCKET_PATH);
+
+    // should be set with the other config options, but depends on nixLibexecDir
+#ifdef __APPLE__
+    preBuildHook = nixLibexecDir + "/nix/resolve-system-dependencies.pl";
+#endif
 }
 
 

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -33,4 +33,4 @@ $(d)/local-store.cc: $(d)/schema.sql.hh
 clean-files += $(d)/schema.sql.hh
 
 $(eval $(call install-file-in, $(d)/nix-store.pc, $(prefix)/lib/pkgconfig, 0644))
-$(eval $(call install-file-in, $(d)/sandbox-defaults.sb, $(prefix)/share/nix, 0644))
+$(eval $(call install-file-in, $(d)/sandbox-defaults.sb, $(datadir)/nix, 0644))

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -33,3 +33,4 @@ $(d)/local-store.cc: $(d)/schema.sql.hh
 clean-files += $(d)/schema.sql.hh
 
 $(eval $(call install-file-in, $(d)/nix-store.pc, $(prefix)/lib/pkgconfig, 0644))
+$(eval $(call install-file-in, $(d)/sandbox-defaults.sb, $(prefix)/share/nix, 0644))

--- a/src/libstore/sandbox-defaults.sb.in
+++ b/src/libstore/sandbox-defaults.sb.in
@@ -6,6 +6,7 @@
        (literal "/dev/dtracehelper")
        (literal "/dev/tty")
        (literal "/dev/autofs_nowait")
+       (literal "/System/Library/CoreServices/SystemVersion.plist")
        (literal "/private/var/run/systemkeychaincheck.done")
        (literal "/private/etc/protocols")
        (literal "/private/var/tmp")

--- a/src/libstore/sandbox-defaults.sb.in
+++ b/src/libstore/sandbox-defaults.sb.in
@@ -1,0 +1,56 @@
+(allow file-read* file-write-data (literal "/dev/null"))
+(allow ipc-posix*)
+(allow mach-lookup (global-name "com.apple.SecurityServer"))
+
+(allow file-read*
+       (literal "/dev/dtracehelper")
+       (literal "/dev/tty")
+       (literal "/dev/autofs_nowait")
+       (literal "/private/var/run/systemkeychaincheck.done")
+       (literal "/private/etc/protocols")
+       (literal "/private/var/tmp")
+       (subpath "/usr/share/locale")
+       (subpath "/usr/share/zoneinfo")
+       (literal "/private/var/db")
+       (subpath "/private/var/db/mds"))
+
+(allow file-write*
+       (literal "/dev/tty")
+       (literal "/dev/dtracehelper")
+       (literal "/mds"))
+
+(allow file-ioctl (literal "/dev/dtracehelper"))
+
+(allow file-read-metadata
+       (literal "/var")
+       (literal "/tmp")
+       ; symlinks
+       (literal "@sysconfdir@")
+       (literal "@sysconfdir@/nix")
+       (literal "@sysconfdir@/nix/nix.conf")
+       (literal "/etc/resolv.conf")
+       (literal "/private/etc/resolv.conf"))
+
+(allow file-read*
+       (literal "/private@sysconfdir@/nix/nix.conf")
+       (literal "/private/var/run/resolv.conf"))
+
+; some builders use filehandles other than stdin/stdout
+(allow file* (subpath "/dev/fd"))
+
+; allow everything inside TMP
+(allow file* process-exec
+       (subpath (param "_GLOBAL_TMP_DIR"))
+       (subpath "/private/tmp"))
+
+(allow process-fork)
+(allow sysctl-read)
+(allow signal (target same-sandbox))
+
+; allow getpwuid (for git and other packages)
+(allow mach-lookup
+       (global-name "com.apple.system.notification_center")
+       (global-name "com.apple.system.opendirectoryd.libinfo"))
+
+; allow local networking
+(allow network* (local ip) (remote unix-socket))

--- a/src/libstore/sandbox-defaults.sb.in
+++ b/src/libstore/sandbox-defaults.sb.in
@@ -10,8 +10,6 @@
        (literal "/private/var/run/systemkeychaincheck.done")
        (literal "/private/etc/protocols")
        (literal "/private/var/tmp")
-       (subpath "/usr/share/locale")
-       (subpath "/usr/share/zoneinfo")
        (literal "/private/var/db")
        (subpath "/private/var/db/mds"))
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -167,11 +167,10 @@ string baseNameOf(const Path & path)
 
 bool isInDir(const Path & path, const Path & dir)
 {
-    return dir == "/"
-        || (path[0] == '/'
-            && string(path, 0, dir.size()) == dir
-            && path.size() >= dir.size() + 2
-            && path[dir.size()] == '/');
+    return path[0] == '/'
+        && string(path, 0, dir.size()) == dir
+        && path.size() >= dir.size() + 2
+        && path[dir.size()] == '/';
 }
 
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -167,10 +167,11 @@ string baseNameOf(const Path & path)
 
 bool isInDir(const Path & path, const Path & dir)
 {
-    return path[0] == '/'
-        && string(path, 0, dir.size()) == dir
-        && path.size() >= dir.size() + 2
-        && path[dir.size()] == '/';
+    return dir == "/"
+        || (path[0] == '/'
+            && string(path, 0, dir.size()) == dir
+            && path.size() >= dir.size() + 2
+            && path[dir.size()] == '/');
 }
 
 


### PR DESCRIPTION
This allows a few different things to work that didn't before, such as tests that `cabal-install` runs (before it would get `dist/build: permission denied` during the test phase) and `security-tool` being able to read the system certificate store. (I don't see us being able to purely replicate the Apple certificate ecosystem anytime soon).