### PR TITLE
[WIP] Add multi-output reference checks

### DIFF
--- a/tests/check-refs.nix
+++ b/tests/check-refs.nix
@@ -67,4 +67,97 @@ rec {
     disallowedReferences = [test5];
   };
 
+  test11 = makeTest 11 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    allowedReferences = [];
+  };
+
+  test12 = makeTest 12 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    allowedReferences = [];
+  };
+
+  test13 = makeTest 13 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $two; ln -s $dep $out";
+    outputs = ["out" "two"];
+    inherit dep;
+    allowedReferences = [dep];
+  };
+
+  test14 = makeTest 14 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $out";
+    outputs = ["out" "two"];
+    inherit dep;
+    allowedReferences.out = [dep];
+  };
+
+  test15 = makeTest 15 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $out; ln -s $dep $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    allowedReferences.out = [dep];
+  };
+
+  test16 = makeTest 16 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $out; ln -s $dep $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    allowedReferences.out = [dep];
+    allowedReferences.two = [dep];
+  };
+
+  test17 = makeTest 17 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $out; ln -s $dep $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    disallowedReferences.out = [];
+    disallowedReferences.two = [];
+  };
+
+  test18 = makeTest 18 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $out; ln -s $dep $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    disallowedReferences.out = [dep];
+  };
+
+  test19 = makeTest 19 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    disallowedReferences.out = [dep];
+  };
+
+  test20 = makeTest 20 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    disallowedReferences.out = [dep];
+    disallowedReferences.two = [dep];
+  };
+
+  test21 = makeTest 21 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    disallowedReferences.two = [dep "out"];
+  };
+
+  test22 = makeTest 22 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $out $two";
+    outputs = ["out" "two"];
+    inherit dep;
+    disallowedReferences.two = [dep "out"];
+  };
+
+  test90 = makeTest 90 {
+    builder = builtins.toFile "builder.sh" "mkdir $out; mkdir $two; ln -s $dep $out; ln -s $dep $two";
+    outputs = ["out" "two"];
+    inherit dep;
+  };
+
 }

--- a/tests/check-refs.sh
+++ b/tests/check-refs.sh
@@ -38,3 +38,39 @@ nix-build -o $RESULT check-refs.nix -A test7
 
 # test10 should succeed (no disallowed references).
 nix-build -o $RESULT check-refs.nix -A test10
+
+# test11 should succeed (no allowed references).
+nix-build -o $RESULT check-refs.nix -A test11
+
+# test12 should fail (no allowed references).
+(! nix-build -o $RESULT check-refs.nix -A test12)
+
+# test13 should succeed (one allowed reference).
+nix-build -o $RESULT check-refs.nix -A test13
+
+# test14 should succeed (one allowed reference in out).
+nix-build -o $RESULT check-refs.nix -A test14
+
+# test15 should fail (one allowed reference in out).
+(! nix-build -o $RESULT check-refs.nix -A test15)
+
+# test16 should succeed (one allowed reference in out and two).
+nix-build -o $RESULT check-refs.nix -A test16
+
+# test17 should succeed (no disallowed references in out and two).
+nix-build -o $RESULT check-refs.nix -A test17
+
+# test18 should fail (one disallowed references in out).
+(! nix-build -o $RESULT check-refs.nix -A test18)
+
+# test19 should succeed (one disallowed references in out).
+nix-build -o $RESULT check-refs.nix -A test19
+
+# test20 should succeed (one disallowed references in out and two).
+nix-build -o $RESULT check-refs.nix -A test20
+
+# test21 should succeed (two disallows reference to one).
+nix-build -o $RESULT check-refs.nix -A test20
+
+# test22 should fail (two disallows reference to one).
+(! nix-build -o $RESULT check-refs.nix -A test21)


### PR DESCRIPTION
This patchset adds support for nix applying reference checks per output in a multiple output build. This allows us to constrain each output independently. Most importantly allowing us to prevent one output from referencing other outputs.
