### PR TITLE
Pack nix::Value on 2 words instead of 3.

### DIFF
--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -60,7 +60,7 @@ Value * findAlongAttrPath(EvalState & state, const string & attrPath,
 
         if (apType == apAttr) {
 
-            if (v->type != tAttrs)
+            if (v->type() != Value::tAttrs)
                 throw TypeError(
                     format("the expression selected by the selection path ‘%1%’ should be a set but is %2%")
                     % attrPath % showType(*v));
@@ -68,8 +68,8 @@ Value * findAlongAttrPath(EvalState & state, const string & attrPath,
             if (attr.empty())
                 throw Error(format("empty attribute name in selection path ‘%1%’") % attrPath);
 
-            Bindings::iterator a = v->attrs->find(state.symbols.create(attr));
-            if (a == v->attrs->end())
+            Bindings::iterator a = v->asAttrs()->find(state.symbols.create(attr));
+            if (a == v->asAttrs()->end())
                 throw Error(format("attribute ‘%1%’ in selection path ‘%2%’ not found") % attr % attrPath);
             v = &*a->value;
         }
@@ -81,10 +81,11 @@ Value * findAlongAttrPath(EvalState & state, const string & attrPath,
                     format("the expression selected by the selection path ‘%1%’ should be a list but is %2%")
                     % attrPath % showType(*v));
 
-            if (attrIndex >= v->listSize())
+            Value::asList list(v);
+            if (attrIndex >= list.length())
                 throw Error(format("list index %1% in selection path ‘%2%’ is out of range") % attrIndex % attrPath);
 
-            v = v->listElems()[attrIndex];
+            v = list[attrIndex];
         }
 
     }

--- a/src/libexpr/attr-set.cc
+++ b/src/libexpr/attr-set.cc
@@ -35,9 +35,7 @@ void EvalState::mkAttrs(Value & v, unsigned int capacity)
         v = vEmptySet;
         return;
     }
-    clearValue(v);
-    v.type = tAttrs;
-    v.attrs = allocBindings(capacity);
+    v.setAttrs(allocBindings(capacity));
     nrAttrsets++;
     nrAttrsInAttrsets += capacity;
 }
@@ -49,7 +47,7 @@ void EvalState::mkAttrs(Value & v, unsigned int capacity)
 Value * EvalState::allocAttr(Value & vAttrs, const Symbol & name)
 {
     Value * v = allocValue();
-    vAttrs.attrs->push_back(Attr(name, v));
+    vAttrs.asAttrs()->push_back(Attr(name, v));
     return v;
 }
 

--- a/src/libexpr/common-opts.cc
+++ b/src/libexpr/common-opts.cc
@@ -34,7 +34,7 @@ Bindings * evalAutoArgs(EvalState & state, std::map<string, string> & in)
         if (i.second[0] == 'E')
             state.mkThunk_(*v, state.parseExprFromString(string(i.second, 1), absPath(".")));
         else
-            mkString(*v, string(i.second, 1));
+            v->setString(string(i.second, 1));
         res->push_back(Attr(state.symbols.create(i.first), v));
     }
     res->sort();

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -42,8 +42,6 @@ struct Env
 };
 
 
-void mkString(Value & v, const string & s, const PathSet & context = PathSet());
-
 void copyContext(const Value & v, PathSet & context);
 
 

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -72,8 +72,9 @@ static void parseJSON(EvalState & state, const char * & s, Value & v)
         }
         s++;
         state.mkList(v, values.size());
+        Value::asMutableList list(v);
         for (size_t n = 0; n < values.size(); ++n)
-            v.listElems()[n] = values[n];
+            list[n] = values[n];
     }
 
     else if (*s == '{') {
@@ -96,13 +97,13 @@ static void parseJSON(EvalState & state, const char * & s, Value & v)
         }
         state.mkAttrs(v, attrs.size());
         for (auto & i : attrs)
-            v.attrs->push_back(Attr(i.first, i.second));
-        v.attrs->sort();
+            v.asAttrs()->push_back(Attr(i.first, i.second));
+        v.asAttrs()->sort();
         s++;
     }
 
     else if (*s == '"') {
-        mkString(v, parseJSONString(s));
+        v.setString(parseJSONString(s));
     }
 
     else if (isdigit(*s) || *s == '-') {
@@ -115,22 +116,22 @@ static void parseJSON(EvalState & state, const char * & s, Value & v)
         // FIXME: detect overflow
         while (isdigit(*s)) n = n * 10 + (*s++ - '0');
         if (*s == '.' || *s == 'e') throw JSONParseError("floating point JSON numbers are not supported");
-        mkInt(v, neg ? -n : n);
+        v.setInt(neg ? -n : n);
     }
 
     else if (strncmp(s, "true", 4) == 0) {
         s += 4;
-        mkBool(v, true);
+        v.setBool(true);
     }
 
     else if (strncmp(s, "false", 5) == 0) {
         s += 5;
-        mkBool(v, false);
+        v.setBool(false);
     }
 
     else if (strncmp(s, "null", 4) == 0) {
         s += 4;
-        mkNull(v);
+        v.setNull();
     }
 
     else throw JSONParseError("unrecognised JSON value");

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -93,7 +93,7 @@ struct ExprInt : Expr
 {
     NixInt n;
     Value v;
-    ExprInt(NixInt n) : n(n) { mkInt(v, n); };
+    ExprInt(NixInt n) : n(n) { v.setInt(n); };
     COMMON_METHODS
     Value * maybeThunk(EvalState & state, Env & env);
 };
@@ -102,7 +102,7 @@ struct ExprString : Expr
 {
     Symbol s;
     Value v;
-    ExprString(const Symbol & s) : s(s) { mkString(v, s); };
+    ExprString(const Symbol & s) : s(s) { v.setString(s); };
     COMMON_METHODS
     Value * maybeThunk(EvalState & state, Env & env);
 };
@@ -118,7 +118,7 @@ struct ExprPath : Expr
 {
     string s;
     Value v;
-    ExprPath(const string & s) : s(s) { mkPathNoCopy(v, this->s.c_str()); };
+    ExprPath(const string & s) : s(s) { v.setPathNoCopy(this->s.c_str()); };
     COMMON_METHODS
     Value * maybeThunk(EvalState & state, Env & env);
 };

--- a/src/libexpr/value.cc
+++ b/src/libexpr/value.cc
@@ -1,0 +1,83 @@
+#include "value.hh"
+#include "util.hh"
+
+#include <new>
+
+#include <algorithm>
+#include <cstring>
+#include <unistd.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#if HAVE_BOEHMGC
+
+#include <gc/gc.h>
+#include <gc/gc_cpp.h>
+
+#define NEW new (UseGC)
+
+#else
+
+#define NEW new
+
+#endif
+
+
+namespace nix {
+
+
+static char * dupString(const char * s)
+{
+    char * t;
+#if HAVE_BOEHMGC
+    t = GC_strdup(s);
+#else
+    t = strdup(s);
+#endif
+    if (!t) throw std::bad_alloc();
+    return t;
+}
+
+
+static void * allocBytes(size_t n)
+{
+    void * p;
+#if HAVE_BOEHMGC
+    p = GC_malloc(n);
+#else
+    p = malloc(n);
+#endif
+    if (!p) throw std::bad_alloc();
+    return p;
+}
+
+
+void Value::setString(const char * s)
+{
+    setStringNoCopy(dupString(s), nullptr);
+}
+
+
+void Value::setString(const string & s, const PathSet & context)
+{
+    const char * str = dupString(s.c_str());
+    const char * * ctx = nullptr;
+    if (!context.empty()) {
+        unsigned int n = 0;
+        ctx = (const char * *)
+            allocBytes((context.size() + 1) * sizeof(char *));
+        for (auto & i : context)
+            ctx[n++] = dupString(i.c_str());
+        ctx[n] = nullptr;
+    }
+    setStringNoCopy(str, ctx);
+}
+
+
+void Value::setPath(const char * s)
+{
+    setPathNoCopy(dupString(s));
+}
+
+
+}

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -5,26 +5,6 @@
 namespace nix {
 
 
-typedef enum {
-    tInt = 1,
-    tBool,
-    tString,
-    tPath,
-    tNull,
-    tAttrs,
-    tList1,
-    tList2,
-    tListN,
-    tThunk,
-    tApp,
-    tLambda,
-    tBlackhole,
-    tPrimOp,
-    tPrimOpApp,
-    tExternal,
-} ValueType;
-
-
 class Bindings;
 struct Env;
 struct Expr;
@@ -84,152 +64,445 @@ class ExternalValueBase
 
 std::ostream & operator << (std::ostream & str, const ExternalValueBase & v);
 
-
 struct Value
 {
-    ValueType type;
-    union
-    {
-        NixInt integer;
-        bool boolean;
-
-        /* Strings in the evaluator carry a so-called `context' which
-           is a list of strings representing store paths.  This is to
-           allow users to write things like
-
-             "--with-freetype2-library=" + freetype + "/lib"
-
-           where `freetype' is a derivation (or a source to be copied
-           to the store).  If we just concatenated the strings without
-           keeping track of the referenced store paths, then if the
-           string is used as a derivation attribute, the derivation
-           will not have the correct dependencies in its inputDrvs and
-           inputSrcs.
-
-           The semantics of the context is as follows: when a string
-           with context C is used as a derivation attribute, then the
-           derivations in C will be added to the inputDrvs of the
-           derivation, and the other store paths in C will be added to
-           the inputSrcs of the derivations.
-
-           For canonicity, the store paths should be in sorted order. */
-        struct {
-            const char * s;
-            const char * * context; // must be in sorted order
-        } string;
-
-        const char * path;
-        Bindings * attrs;
-        struct {
-            unsigned int size;
-            Value * * elems;
-        } bigList;
-        Value * smallList[2];
-        struct {
-            Env * env;
-            Expr * expr;
-        } thunk;
-        struct {
-            Value * left, * right;
-        } app;
-        struct {
-            Env * env;
-            ExprLambda * fun;
-        } lambda;
-        PrimOp * primOp;
-        struct {
-            Value * left, * right;
-        } primOpApp;
-        ExternalValueBase * external;
+private:
+    struct Storage {
+        uintptr_t first;
+        uintptr_t second;
     };
 
-    bool isList() const
-    {
-        return type == tList1 || type == tList2 || type == tListN;
+    Storage raw;
+
+    /* In order to avoid having too many tagged pointers, we tag both the first pointer and the second pointer. */
+    enum LowFirstTag {
+        /* First is a GC pointer */
+        LFT_0 = 0,
+        LFT_1 = 1,
+        LFT_2 = 2, /* unused */
+
+        /* constant value, or single value stored in the second member. */
+        LFT_3 = 3, /* not a GC pointer */
+
+        /* Meta */
+        LFT_MASK = 3,
+        LFT_MAX = 4
+    };
+
+    enum HighFirstTag {
+        HFT_Blackhole = 0,
+        HFT_Null,
+        HFT_Int,
+        HFT_Bool,
+        HFT_Path,
+        HFT_Attrs,
+        HFT_List0,
+        HFT_List1,
+        HFT_PrimOp,
+        HFT_External,
+
+        HFT_NotAValue,
+    };
+
+    enum LowSecondTag {
+        /* LFT_0 */
+        LST_PrimOpApp = 0,
+        LST_App = 1,
+        LST_List2 = 2,
+        LST_ListN = 3,
+
+        /* LFT_1 */
+        LST_String = 0,
+        LST_Thunk = 1,
+        LST_Lambda = 2,
+        /* unused */
+
+        /* LFT_2 */
+        /* unused */
+        /* unused */
+        /* unused */
+        /* unused */
+
+        /* Meta */
+        LST_MASK = 3,
+        LST_MAX = 4
+    };
+
+    template <typename T>
+    void setFirst(LowFirstTag low, const T& val) {
+        uintptr_t ival = uintptr_t(val);
+        assert((ival & LFT_MASK) == 0);
+        /* If the following assertion fails, then we should change the
+           initGC function, to register more known displacements. */
+        assert(!std::is_pointer<T>::value || uintptr_t(low) <= 2);
+        raw.first = low | ival;
+    }
+    void setFirstHigh(enum HighFirstTag val) {
+        setFirst(LFT_3, uintptr_t(val) * LFT_MAX);
+    }
+    template <typename T>
+    T getFirst(LowFirstTag low) const {
+        assert((raw.first & LFT_MASK) == low);
+        return T(raw.first & ~LFT_MASK);
     }
 
-    Value * * listElems()
-    {
-        return type == tList1 || type == tList2 ? smallList : bigList.elems;
+    template <typename T>
+    void setSecond(const T& val) {
+        raw.second = uintptr_t(val);
+    }
+    template <typename T>
+    void setSecond(LowSecondTag low, const T& val) {
+        uintptr_t ival = uintptr_t(val);
+        assert((ival & LFT_MASK) == 0);
+        /* If the following assertion fails, then we should change the
+           initGC function, to register more known displacements. */
+        assert(!std::is_pointer<T>::value || uintptr_t(low) <= 2);
+        raw.second = low | ival;
+    }
+    template <typename T>
+    T getSecond() const {
+        return T(raw.second);
+    }
+    template <typename T>
+    T getSecond(LowSecondTag low) const {
+        assert((raw.second & LST_MASK) == low);
+        return T(raw.second & ~LST_MASK);
+    }
+    template <typename T>
+    T getSecondUnchecked() const {
+        return T(raw.second & ~LST_MASK);
     }
 
-    const Value * const * listElems() const
-    {
-        return type == tList1 || type == tList2 ? smallList : bigList.elems;
+public:
+    /* The current packing scheme implies that we have to accept inner
+       pointers with offsets 1 and 2. The low bits of the first and second
+       value are reserved to identify the type of the value. As we have to
+       inform the GC about known inner pointers, we reserve the low bits
+       between 0 and 2 for GC pointers. */
+    enum Type {
+        /* First is a GC pointer. */
+        tPrimOpApp = LFT_0 | LFT_MAX * LST_PrimOpApp,
+        tApp       = LFT_0 | LFT_MAX * LST_App,
+        tList2     = LFT_0 | LFT_MAX * LST_List2,
+        tListN     = LFT_0 | LFT_MAX * LST_ListN,
+
+        tString    = LFT_1 | LFT_MAX * LST_String,
+        tThunk     = LFT_1 | LFT_MAX * LST_Thunk,
+        tLambda    = LFT_1 | LFT_MAX * LST_Lambda,
+        /* unused */
+
+        /* unused */
+        /* unused */
+        /* unused */
+        /* unused */
+
+        tHighFirstTag = LFT_MAX | LFT_MAX * LST_MAX,
+
+        /* First is not a GC pointer. */
+        tBlackhole = HFT_Blackhole + tHighFirstTag,
+        tNull      = HFT_Null + tHighFirstTag,
+        tInt       = HFT_Int + tHighFirstTag,
+        tBool      = HFT_Bool + tHighFirstTag,
+        tPath      = HFT_Path + tHighFirstTag,
+        tAttrs     = HFT_Attrs + tHighFirstTag,
+        tList0     = HFT_List0 + tHighFirstTag,
+        tList1     = HFT_List1 + tHighFirstTag,
+        tPrimOp    = HFT_PrimOp + tHighFirstTag,
+        tExternal  = HFT_External + tHighFirstTag,
+
+        /* tNotAValue = HFT_NotAValue + tHighFirstTag, */
+    };
+
+    Type type() const {
+        if ((raw.first & LFT_MASK) == LFT_3)
+            return Type(raw.first / LFT_MAX + tHighFirstTag);
+        return Type((raw.first & LFT_MASK) | LFT_MAX * (raw.second & LST_MASK));
+    }
+    bool isList() const {
+        Type t = type();
+        return t == tList0 || t == tList1 || t == tList2 || t == tListN;
     }
 
-    unsigned int listSize() const
-    {
-        return type == tList1 ? 1 : type == tList2 ? 2 : bigList.size;
+    void setInt(NixInt integer) {
+        setFirstHigh(HFT_Int);
+        setSecond(integer);
+        assert(type() == tInt);
+    }
+    NixInt asInt() const {
+        assert(type() == tInt);
+        return getSecond<NixInt>();
+    }
+
+    void setBool(bool boolean) {
+        setFirstHigh(HFT_Bool);
+        setSecond(boolean);
+        assert(type() == tBool);
+    }
+    bool asBool() const {
+        assert(type() == tBool);
+        return getSecond<bool>();
+    }
+
+    /* Strings in the evaluator carry a so-called `context' which
+       is a list of strings representing store paths.  This is to
+       allow users to write things like
+
+         "--with-freetype2-library=" + freetype + "/lib"
+
+         where `freetype' is a derivation (or a source to be copied
+         to the store).  If we just concatenated the strings without
+         keeping track of the referenced store paths, then if the
+         string is used as a derivation attribute, the derivation
+         will not have the correct dependencies in its inputDrvs and
+         inputSrcs.
+
+         The semantics of the context is as follows: when a string
+         with context C is used as a derivation attribute, then the
+         derivations in C will be added to the inputDrvs of the
+         derivation, and the other store paths in C will be added to
+         the inputSrcs of the derivations.
+
+         For canonicity, the store paths should be in sorted order. */
+    void setStringNoCopy(const char * str, const char * * context) {
+        setFirst(LFT_1, str);
+        setSecond(LST_String, context);
+        assert(type() == tString);
+    }
+    void setString(const Symbol & s) {
+        setStringNoCopy(((const string &) s).c_str(), nullptr);
+    }
+    void setString(const char * str);
+    void setString(const string & s) {
+        setString(s.c_str());
+    }
+    void setString(const string & s, const PathSet & context);
+    const char * asString() const {
+        assert(type() == tString);
+        return getFirst<const char *>(LFT_1);
+    }
+    const char * * asStringContext() const {
+        assert(type() == tString);
+        return getSecond<const char * *>(LST_String);
+    }
+
+    void setPathNoCopy(const char * path) {
+        setFirstHigh(HFT_Path);
+        setSecond(path);
+        assert(type() == tPath);
+    }
+    void setPath(const char * path);
+    const char * asPath() const {
+        assert(type() == tPath);
+        return getSecond<const char *>();
+    }
+
+    void setAttrs(Bindings * attrs) {
+        setFirstHigh(HFT_Attrs);
+        setSecond(attrs);
+        assert(type() == tAttrs);
+    }
+    Bindings * asAttrs() const {
+        assert(type() == tAttrs);
+        return getSecond<Bindings *>();
+    }
+
+    void setList() {
+        setFirstHigh(HFT_List0);
+        assert(type() == tList0);
+    }
+    void setList(Value * e0) {
+        setFirstHigh(HFT_List1);
+        setSecond(e0);
+        assert(type() == tList1);
+    }
+    void setList(Value * e0, Value * e1) {
+        setFirst(LFT_0, e0);
+        setSecond(LST_List2, e1);
+        assert(type() == tList2);
+    }
+    void setList(Value * * elems, size_t size) {
+        setFirst(LFT_0, elems);
+        setSecond(LST_ListN, size * LST_MAX);
+        assert(type() == tListN);
+    }
+
+    class asList {
+    protected:
+        Value * * list_;
+        size_t length_;
+        Value * smallList_[2];
+
+        void init(const Value * v) {
+            Type t = v->type();
+            if (t == tList0) {
+                length_ = 0;
+                list_ = smallList_;
+            } else if (t == tList1) {
+                length_ = 1;
+                list_ = smallList_;
+                smallList_[0] = v->getSecond<Value *>();
+            } else if (t == tList2) {
+                length_ = 2;
+                list_ = smallList_;
+                smallList_[0] = v->getFirst<Value *>(LFT_0);
+                smallList_[1] = v->getSecond<Value *>(LST_List2);
+            } else {
+                assert(t == tListN);
+                length_ = v->getSecond<size_t>(LST_ListN) / LST_MAX;;
+                list_ = v->getFirst<Value * *>(LFT_0);
+            }
+        }
+
+    public:
+        asList(const Value * v) {
+            init(v);
+        }
+        asList(const Value & v) {
+            init(&v);
+        }
+        ~asList() {
+        }
+
+        size_t length() const {
+            return length_;
+        }
+        const Value * const * begin() const {
+            return list_;
+        }
+        Value * * begin() {
+            return list_;
+        }
+        const Value * const * end() const {
+            return list_ + length_;
+        }
+        Value * * end() {
+            return list_ + length_;
+        }
+
+        const Value * operator[] (size_t i) const {
+            return list_[i];
+        }
+        Value * & operator[] (size_t i) {
+            return list_[i];
+        }
+    };
+    friend class asList;
+
+    class asMutableList : public asList {
+        Value * v_;
+
+    public:
+        asMutableList(Value * v)
+          : asList(v),
+            v_(v)
+        {
+#ifdef DEBUG
+            v->setBlackhole()
+#endif
+        }
+        asMutableList(Value & v)
+          : asList(&v),
+            v_(&v)
+        {
+#ifdef DEBUG
+            v.setBlackhole()
+#endif
+        }
+        ~asMutableList() {
+            synchronizeValueContent();
+        }
+
+        void synchronizeValueContent() {
+            if (length_ == 1)
+                v_->setList(list_[0]);
+            else if (length_ == 2)
+                v_->setList(list_[0], list_[1]);
+#ifdef DEBUG
+            /* If we are not in debug mode, then the content would be the
+               same as before. */
+            else if (length_ == 0)
+                setList();
+            else
+                setList(list_, length_);
+#endif
+        }
+    };
+
+    void setPrimOpApp(Value * left, Value * right) {
+        setFirst(LFT_0, left);
+        setSecond(LST_PrimOpApp, right);
+        assert(type() == tPrimOpApp);
+    }
+    void setApp(Value & left, Value & right) {
+        setFirst(LFT_0, &left);
+        setSecond(LST_App, &right);
+        assert(type() == tApp);
+    }
+    Value * asAppLeft() const {
+        assert(type() == tApp || type() == tPrimOpApp);
+        return getFirst<Value *>(LFT_0);
+    }
+    Value * asAppRight() const {
+        assert(type() == tApp || type() == tPrimOpApp);
+        return getSecondUnchecked<Value *>();
+    }
+
+    void setThunk(Env * env, Expr * expr) {
+        setFirst(LFT_1, env);
+        setSecond(LST_Thunk, expr);
+        assert(type() == tThunk);
+    }
+    void setLambda(Env * env, ExprLambda * fun) {
+        setFirst(LFT_1, env);
+        setSecond(LST_Lambda, fun);
+        assert(type() == tLambda);
+    }
+    Env * asExprEnv() const {
+        assert(type() == tThunk || type() == tLambda);
+        return getFirst<Env *>(LFT_1);
+    }
+    Expr * asThunk() const {
+        assert(type() == tThunk);
+        return getSecond<Expr *>(LST_Thunk);
+    }
+    ExprLambda * asLambda() const {
+        assert(type() == tLambda);
+        return getSecond<ExprLambda *>(LST_Lambda);
+    }
+
+    void setPrimOp(PrimOp * primop) {
+        setFirstHigh(HFT_PrimOp);
+        setSecond(primop);
+        assert(type() == tPrimOp);
+    }
+    PrimOp * asPrimOp() const {
+        assert(type() == tPrimOp);
+        return getSecond<PrimOp *>();
+    }
+
+    void setExternal(ExternalValueBase * external) {
+        setFirstHigh(HFT_External);
+        setSecond(external);
+        assert(type() == tExternal);
+    }
+    ExternalValueBase * asExternal() const {
+        assert(type() == tExternal);
+        return getSecond<ExternalValueBase *>();
+    }
+
+    void setBlackhole() {
+        setFirstHigh(HFT_Blackhole);
+        assert(type() == tBlackhole);
+    }
+    void setNull() {
+        setFirstHigh(HFT_Null);
+        assert(type() == tNull);
+    }
+
+    void clear() {
+        setFirstHigh(HFT_NotAValue);
     }
 };
-
-
-/* After overwriting an app node, be sure to clear pointers in the
-   Value to ensure that the target isn't kept alive unnecessarily. */
-static inline void clearValue(Value & v)
-{
-    v.app.left = v.app.right = 0;
-}
-
-
-static inline void mkInt(Value & v, NixInt n)
-{
-    clearValue(v);
-    v.type = tInt;
-    v.integer = n;
-}
-
-
-static inline void mkBool(Value & v, bool b)
-{
-    clearValue(v);
-    v.type = tBool;
-    v.boolean = b;
-}
-
-
-static inline void mkNull(Value & v)
-{
-    clearValue(v);
-    v.type = tNull;
-}
-
-
-static inline void mkApp(Value & v, Value & left, Value & right)
-{
-    v.type = tApp;
-    v.app.left = &left;
-    v.app.right = &right;
-}
-
-
-static inline void mkStringNoCopy(Value & v, const char * s)
-{
-    v.type = tString;
-    v.string.s = s;
-    v.string.context = 0;
-}
-
-
-static inline void mkString(Value & v, const Symbol & s)
-{
-    mkStringNoCopy(v, ((const string &) s).c_str());
-}
-
-
-void mkString(Value & v, const char * s);
-
-
-static inline void mkPathNoCopy(Value & v, const char * s)
-{
-    clearValue(v);
-    v.type = tPath;
-    v.path = s;
-}
-
-
-void mkPath(Value & v, const char * s);
 
 
 /* Compute the size in bytes of the given value, including all values


### PR DESCRIPTION
This patch change the `nix::Value` representation to use a packed representation which use tagged pointers to mix the type information with the values.

To be able to do so, we have to register in GC that we keep inner pointers with known offsets.  To minimize the known offsets (0, 1, 2), the types are stored across the 2 words which are in the values, except when these values can be represented in one word, in which case we use the high part of the first word to fully describe the content of the second word if any.

On the following command:

```
$ nix-instantiate '<nixos/release.nix>' -A tests.kde4
```

The `time` command reports an improvement of 45 MB on the max resident size, from 336 MB to 291 MB.

cc @edolstra 
