### PR TITLE
Changes to make Nix output more informative errors

### DIFF
--- a/doc/manual/expressions/language-constructs.xml
+++ b/doc/manual/expressions/language-constructs.xml
@@ -56,6 +56,28 @@ evaluates to <literal>"foobar"</literal>.
 
 </para>
 
+<para>The syntax
+
+<programlisting>
+let {
+  x = "foo";
+  y = "bar";
+  body = x + y;
+}
+</programlisting>
+
+is also allowed; it is syntactic sugar for
+
+<programlisting>
+(rec {
+  x = "foo";
+  y = "bar";
+  body = x + y;
+}).body
+</programlisting>
+
+</para>
+
 </simplesect>
 
 

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -53,7 +53,7 @@ Value * findAlongAttrPath(EvalState & state, const string & attrPath,
         Value * vNew = state.allocValue();
         state.autoCallFunction(autoArgs, *v, *vNew);
         v = vNew;
-        state.forceValue(*v);
+        state.forceValue(*v, noPos);
 
         /* It should evaluate to either a set or an expression,
            according to what is specified in the attrPath. */

--- a/src/libexpr/attr-set.cc
+++ b/src/libexpr/attr-set.cc
@@ -46,10 +46,10 @@ void EvalState::mkAttrs(Value & v, unsigned int capacity)
 /* Create a new attribute named 'name' on an existing attribute set stored
    in 'vAttrs' and return the newly allocated Value which is associated with
    this attribute. */
-Value * EvalState::allocAttr(Value & vAttrs, const Symbol & name)
+Value * EvalState::allocAttr(Value & vAttrs, const Symbol & name, const Pos* pos)
 {
     Value * v = allocValue();
-    vAttrs.attrs->push_back(Attr(name, v));
+    vAttrs.attrs->push_back(Attr(name, v, pos));
     return v;
 }
 

--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -16,10 +16,10 @@ struct Attr
 {
     Symbol name;
     Value * value;
-    Pos * pos;
-    Attr(Symbol name, Value * value, Pos * pos = &noPos)
+    const Pos * pos;
+    Attr(Symbol name, Value * value, const Pos * pos)
         : name(name), value(value), pos(pos) { };
-    Attr() : pos(&noPos) { };
+    Attr(const Pos * pos) : pos(pos) { };
     bool operator < (const Attr & a) const
     {
         return name < a.name;
@@ -57,7 +57,7 @@ public:
 
     iterator find(const Symbol & name)
     {
-        Attr key(name, 0);
+        Attr key(name, 0, 0);
         iterator i = std::lower_bound(begin(), end(), key);
         if (i != end() && i->name == name) return i;
         return end();

--- a/src/libexpr/common-opts.cc
+++ b/src/libexpr/common-opts.cc
@@ -35,7 +35,7 @@ Bindings * evalAutoArgs(EvalState & state, std::map<string, string> & in)
             state.mkThunk_(*v, state.parseExprFromString(string(i.second, 1), absPath(".")));
         else
             mkString(*v, string(i.second, 1));
-        res->push_back(Attr(state.symbols.create(i.first), v));
+        res->push_back(Attr(state.symbols.create(i.first), v, &noPos));
     }
     res->sort();
     return res;
@@ -58,7 +58,7 @@ Path lookupFileArg(EvalState & state, string s)
         return downloadFileCached(s, true);
     else if (s.size() > 2 && s.at(0) == '<' && s.at(s.size() - 1) == '>') {
         Path p = s.substr(1, s.size() - 2);
-        return state.findFile(p);
+        return state.findFile(p, noPos);
     } else
         return absPath(s);
 }

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -6,6 +6,8 @@ namespace nix {
 
 void EvalState::forceValue(Value & v, const Pos & pos)
 {
+    if(!(v.pos))
+        v.pos = pos;
     if (v.type == tThunk) {
         Env * env = v.thunk.env;
         Expr * expr = v.thunk.expr;
@@ -14,10 +16,10 @@ void EvalState::forceValue(Value & v, const Pos & pos)
             //checkInterrupt();
             expr->eval(*this, *env, v);
         } catch (Error & e) {
+            addErrorPrefix(e, "while evaluating %1%%2%:\n", v, (v.pos == pos) ? noPos : pos);
             v.type = tThunk;
             v.thunk.env = env;
             v.thunk.expr = expr;
-            addErrorPrefix(e, "while evaluating value%1%:\n", pos);
             throw;
         }
     }

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -2,27 +2,7 @@
 
 #include "eval.hh"
 
-#define LocalNoInline(f) static f __attribute__((noinline)); f
-#define LocalNoInlineNoReturn(f) static f __attribute__((noinline, noreturn)); f
-
 namespace nix {
-
-LocalNoInlineNoReturn(void throwEvalError(const char * s, const Pos & pos))
-{
-    throw EvalError(format(s) % pos);
-}
-
-LocalNoInlineNoReturn(void throwTypeError(const char * s, const Value & v))
-{
-    throw TypeError(format(s) % showType(v));
-}
-
-
-LocalNoInlineNoReturn(void throwTypeError(const char * s, const Value & v, const Pos & pos))
-{
-    throw TypeError(format(s) % showType(v) % pos);
-}
-
 
 void EvalState::forceValue(Value & v, const Pos & pos)
 {
@@ -37,45 +17,30 @@ void EvalState::forceValue(Value & v, const Pos & pos)
             v.type = tThunk;
             v.thunk.env = env;
             v.thunk.expr = expr;
+            addErrorPrefix(e, "while evaluating value%1%:\n", pos);
             throw;
         }
     }
     else if (v.type == tApp)
-        callFunction(*v.app.left, *v.app.right, v, noPos);
+        callFunction(*v.app.left, *v.app.right, v, pos);
     else if (v.type == tBlackhole)
-        throwEvalError("infinite recursion encountered, at %1%", pos);
-}
-
-
-inline void EvalState::forceAttrs(Value & v)
-{
-    forceValue(v);
-    if (v.type != tAttrs)
-        throwTypeError("value is %1% while a set was expected", v);
+        throwEvalError("infinite recursion encountered%1%", pos);
 }
 
 
 inline void EvalState::forceAttrs(Value & v, const Pos & pos)
 {
-    forceValue(v);
+    forceValue(v, pos);
     if (v.type != tAttrs)
-        throwTypeError("value is %1% while a set was expected, at %2%", v, pos);
-}
-
-
-inline void EvalState::forceList(Value & v)
-{
-    forceValue(v);
-    if (!v.isList())
-        throwTypeError("value is %1% while a list was expected", v);
+        throwTypeError("value is %1% while a set was expected%2%", v, pos);
 }
 
 
 inline void EvalState::forceList(Value & v, const Pos & pos)
 {
-    forceValue(v);
+    forceValue(v, pos);
     if (!v.isList())
-        throwTypeError("value is %1% while a list was expected, at %2%", v, pos);
+        throwTypeError("value is %1% while a list was expected%2%", v, pos);
 }
 
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -293,6 +293,7 @@ void realiseContext(const PathSet & context);
 
 LocalNoInline(void addErrorPrefix(Error & e, const char * s, const ExprLambda & fun, const Pos & pos));
 LocalNoInline(void addErrorPrefix(Error & e, const char * s, const Pos & pos));
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, const Value & v, const Pos & pos));
 LocalNoInline(void addErrorPrefix(Error & e, const char * s, const string & s2));
 LocalNoInline(void addErrorPrefix(Error & e, const char * s, const string & s2, const Pos & pos));
 LocalNoInline(void addErrorPrefix(Error & e, const char * s, unsigned int s2, const Pos & pos));
@@ -303,6 +304,9 @@ LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2));
 LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2, const Pos & pos));
 LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2, const string & s3));
 LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2, const string & s3, const Pos & pos));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const Value & v, const Pos & pos));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const Value & v, const Value & v2, const Pos & pos));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const Value & v, const string & s2, const Pos & pos));
 LocalNoInlineNoReturn(void throwTypeError(const char * s, const ExprLambda & fun, const Symbol & s2, const Pos & pos));
 LocalNoInlineNoReturn(void throwTypeError(const char * s, const Pos & pos));
 LocalNoInlineNoReturn(void throwTypeError(const char * s, const Value & v));

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -119,8 +119,8 @@ public:
     void resetFileCache();
 
     /* Look up a file in the search path. */
-    Path findFile(const string & path);
-    Path findFile(SearchPath & searchPath, const string & path, const Pos & pos = noPos);
+    Path findFile(const string & path, const Pos & pos);
+    Path findFile(SearchPath & searchPath, const string & path, const Pos & pos);
 
     /* Evaluate an expression to normal form, storing the result in
        value `v'. */
@@ -128,31 +128,28 @@ public:
 
     /* Evaluation the expression, then verify that it has the expected
        type. */
-    inline bool evalBool(Env & env, Expr * e);
     inline bool evalBool(Env & env, Expr * e, const Pos & pos);
-    inline void evalAttrs(Env & env, Expr * e, Value & v);
+    inline void evalAttrs(Env & env, Expr * e, Value & v, const Pos & pos);
 
     /* If `v' is a thunk, enter it and overwrite `v' with the result
        of the evaluation of the thunk.  If `v' is a delayed function
        application, call the function and overwrite `v' with the
        result.  Otherwise, this is a no-op. */
-    inline void forceValue(Value & v, const Pos & pos = noPos);
+    inline void forceValue(Value & v, const Pos & pos);
 
     /* Force a value, then recursively force list elements and
        attributes. */
-    void forceValueDeep(Value & v);
+    void forceValueDeep(Value & v, const Pos & pos);
 
     /* Force `v', and then verify that it has the expected type. */
     NixInt forceInt(Value & v, const Pos & pos);
-    bool forceBool(Value & v);
-    inline void forceAttrs(Value & v);
+    bool forceBool(Value & v, const Pos & pos);
     inline void forceAttrs(Value & v, const Pos & pos);
-    inline void forceList(Value & v);
     inline void forceList(Value & v, const Pos & pos);
     void forceFunction(Value & v, const Pos & pos); // either lambda or primop
-    string forceString(Value & v, const Pos & pos = noPos);
-    string forceString(Value & v, PathSet & context, const Pos & pos = noPos);
-    string forceStringNoCtx(Value & v, const Pos & pos = noPos);
+    string forceString(Value & v, const Pos & pos);
+    string forceString(Value & v, PathSet & context, const Pos & pos);
+    string forceStringNoCtx(Value & v, const Pos & pos);
 
     /* Return true iff the value `v' denotes a derivation (i.e. a
        set with attribute `type = "derivation"'). */
@@ -211,7 +208,7 @@ public:
 
     /* Do a deep equality test between two values.  That is, list
        elements and attributes are compared recursively. */
-    bool eqValues(Value & v1, Value & v2);
+    bool eqValues(Value & v1, Value & v2, const Pos & pos);
 
     void callFunction(Value & fun, Value & arg, Value & v, const Pos & pos);
     void callPrimOp(Value & fun, Value & arg, Value & v, const Pos & pos);
@@ -224,14 +221,14 @@ public:
     Value * allocValue();
     Env & allocEnv(unsigned int size);
 
-    Value * allocAttr(Value & vAttrs, const Symbol & name);
+    Value * allocAttr(Value & vAttrs, const Symbol & name, const Pos* pos);
 
     Bindings * allocBindings(Bindings::size_t capacity);
 
     void mkList(Value & v, unsigned int length);
     void mkAttrs(Value & v, unsigned int capacity);
     void mkThunk_(Value & v, Expr * expr);
-    void mkPos(Value & v, Pos * pos);
+    void mkPos(Value & v, const Pos * pos);
 
     void concatLists(Value & v, unsigned int nrLists, Value * * lists, const Pos & pos);
 
@@ -290,5 +287,27 @@ struct InvalidPathError : EvalError
 
 /* Realise all paths in `context' */
 void realiseContext(const PathSet & context);
+
+#define LocalNoInline(f) f __attribute__((noinline)); f
+#define LocalNoInlineNoReturn(f) f __attribute__((noinline, noreturn)); f
+
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, const ExprLambda & fun, const Pos & pos));
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, const Pos & pos));
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, const string & s2));
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, const string & s2, const Pos & pos));
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, unsigned int s2, const Pos & pos));
+LocalNoInlineNoReturn(void throwAssertionError(const char * s, const Pos & pos));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const Pos & pos));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const Symbol & sym, const Pos & p1, const Pos & p2));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2, const Pos & pos));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2, const string & s3));
+LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2, const string & s3, const Pos & pos));
+LocalNoInlineNoReturn(void throwTypeError(const char * s, const ExprLambda & fun, const Symbol & s2, const Pos & pos));
+LocalNoInlineNoReturn(void throwTypeError(const char * s, const Pos & pos));
+LocalNoInlineNoReturn(void throwTypeError(const char * s, const Value & v));
+LocalNoInlineNoReturn(void throwTypeError(const char * s, const Value & v, const Pos & pos));
+LocalNoInlineNoReturn(void throwTypeError(const char * s, const string & s1));
+LocalNoInlineNoReturn(void throwUndefinedVarError(const char * s, const string & s1, const Pos & pos));
 
 }

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -28,7 +28,7 @@ private:
 
     Bindings * getMeta();
 
-    bool checkMeta(Value & v);
+    bool checkMeta(Value & v, const Pos& pos);
 
 public:
     string name;

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -96,7 +96,7 @@ static void parseJSON(EvalState & state, const char * & s, Value & v)
         }
         state.mkAttrs(v, attrs.size());
         for (auto & i : attrs)
-            v.attrs->push_back(Attr(i.first, i.second));
+            v.attrs->push_back(Attr(i.first, i.second, &noPos));
         v.attrs->sort();
         s++;
     }

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -185,13 +185,16 @@ void ExprPos::show(std::ostream & str)
     str << "__curPos";
 }
 
+string showPos(const Pos & pos, const string& locType) {
+    if (!pos)
+      return "";
+    else
+      return (format("%6%" ANSI_BOLD "%1%" ANSI_NORMAL ":%2%:%3%-%4%:%5%") % (string) pos.file % pos.firstline % pos.firstcolumn % pos.lastline % pos.lastcolumn % locType).str();
+}
 
 std::ostream & operator << (std::ostream & str, const Pos & pos)
 {
-    if (!pos)
-        str << "undefined position";
-    else
-        str << (format(ANSI_BOLD "%1%" ANSI_NORMAL ":%2%:%3%") % (string) pos.file % pos.line % pos.column).str();
+    str << showPos(pos, " at ");
     return str;
 }
 
@@ -257,7 +260,7 @@ void ExprVar::bindVars(const StaticEnv & env)
     /* Otherwise, the variable must be obtained from the nearest
        enclosing `with'.  If there is no `with', then we can issue an
        "undefined variable" error now. */
-    if (withLevel == -1) throw UndefinedVarError(format("undefined variable ‘%1%’ at %2%") % name % pos);
+    if (withLevel == -1) throw UndefinedVarError(format("undefined variable ‘%1%’%2%") % name % pos);
 
     fromWith = true;
     this->level = withLevel;
@@ -409,7 +412,7 @@ void ExprLambda::setName(Symbol & name)
 
 string ExprLambda::showNamePos() const
 {
-    return (format("%1% at %2%") % (name.set() ? "‘" + (string) name + "’" : "anonymous function") % pos).str();
+    return (format("%1%%2%") % (name.set() ? "‘" + (string) name + "’" : "anonymous function") % pos).str();
 }
 
 

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -19,38 +19,6 @@ MakeError(UndefinedVarError, Error)
 MakeError(RestrictedPathError, Error)
 
 
-/* Position objects. */
-
-struct Pos
-{
-    Symbol file;
-    unsigned int firstline, firstcolumn, lastline, lastcolumn;
-    Pos() : firstline(0), firstcolumn(0), lastline(-1),lastcolumn(-1) { };
-    Pos(const Symbol & file, unsigned int firstline, unsigned int firstcolumn, unsigned int lastline, unsigned int lastcolumn)
-        : file(file), firstline(firstline), firstcolumn(firstcolumn), lastline(lastline), lastcolumn(lastcolumn) { };
-    operator bool() const
-    {
-        return firstline != 0;
-    }
-    bool operator < (const Pos & p2) const
-    {
-        if (!firstline) return p2.firstline;
-        if (!p2.firstline) return false;
-        int d = ((string) file).compare((string) p2.file);
-        if (d < 0) return true;
-        if (d > 0) return false;
-        if (firstline < p2.firstline) return true;
-        if (firstline > p2.firstline) return false;
-        if (firstcolumn < p2.firstcolumn) return true;
-        if (firstcolumn > p2.firstcolumn) return false;
-        if (lastline < p2.lastline) return true;
-        if (lastline > p2.lastline) return false;
-        return lastcolumn < p2.lastcolumn;
-    }
-};
-
-extern Pos noPos;
-
 string showPos(const Pos& pos, const string& locType);
 std::ostream & operator << (std::ostream & str, const Pos & pos);
 

--- a/src/libexpr/symbol-table.hh
+++ b/src/libexpr/symbol-table.hh
@@ -79,4 +79,36 @@ public:
     size_t totalSize() const;
 };
 
+/* Position objects. */
+
+struct Pos
+{
+    Symbol file;
+    unsigned int firstline, firstcolumn, lastline, lastcolumn;
+    Pos() : firstline(0), firstcolumn(0), lastline(-1),lastcolumn(-1) { };
+    Pos(const Symbol & file, unsigned int firstline, unsigned int firstcolumn, unsigned int lastline, unsigned int lastcolumn)
+        : file(file), firstline(firstline), firstcolumn(firstcolumn), lastline(lastline), lastcolumn(lastcolumn) { };
+    operator bool() const
+    {
+        return firstline != 0;
+    }
+    bool operator < (const Pos & p2) const
+    {
+        if (!firstline) return p2.firstline;
+        if (!p2.firstline) return false;
+        int d = ((string) file).compare((string) p2.file);
+        if (d < 0) return true;
+        if (d > 0) return false;
+        if (firstline < p2.firstline) return true;
+        if (firstline > p2.firstline) return false;
+        if (firstcolumn < p2.firstcolumn) return true;
+        if (firstcolumn > p2.firstcolumn) return false;
+        if (lastline < p2.lastline) return true;
+        if (lastline > p2.lastline) return false;
+        return lastcolumn < p2.lastcolumn;
+    }
+};
+
+extern Pos noPos;
+
 }

--- a/src/libexpr/value-to-json.hh
+++ b/src/libexpr/value-to-json.hh
@@ -9,7 +9,7 @@
 namespace nix {
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, std::ostream & out, PathSet & context);
+    Value & v, std::ostream & out, PathSet & context, const Pos & pos);
 
 void escapeJSON(std::ostream & str, const string & s);
 

--- a/src/libexpr/value-to-xml.hh
+++ b/src/libexpr/value-to-xml.hh
@@ -9,6 +9,6 @@
 namespace nix {
 
 void printValueAsXML(EvalState & state, bool strict, bool location,
-    Value & v, std::ostream & out, PathSet & context);
+    Value & v, std::ostream & out, PathSet & context, const Pos& pos);
     
 }

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -87,6 +87,7 @@ std::ostream & operator << (std::ostream & str, const ExternalValueBase & v);
 
 struct Value
 {
+    Pos pos = noPos;
     ValueType type;
     union
     {

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -205,6 +205,8 @@ void parseCmdLine(int argc, char * * argv,
             settings.keepFailed = true;
         else if (arg == "--keep-going" || arg == "-k")
             settings.keepGoing = true;
+        else if (arg == "--color" || arg == "-C")
+            useColor = true;
         else if (arg == "--fallback")
             settings.set("build-fallback", "true");
         else if (arg == "--max-jobs" || arg == "-j")

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -435,6 +435,7 @@ void replaceSymlink(const Path & target, const Path & link)
 
 LogType logType = ltPretty;
 Verbosity verbosity = lvlInfo;
+bool useColor = false;
 
 static int nestingLevel = 0;
 
@@ -505,7 +506,7 @@ void printMsg_(Verbosity level, const FormatOrString & fs)
     }
 
     string s = (format("%1%%2%\n") % prefix % fs.s).str();
-    if (!isatty(STDERR_FILENO)) s = filterANSIEscapes(s);
+    if (!isatty(STDERR_FILENO) && !useColor) s = filterANSIEscapes(s);
     writeToStderr(s);
 }
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -128,6 +128,7 @@ typedef enum {
 
 extern LogType logType;
 extern Verbosity verbosity; /* suppress msgs > this */
+extern bool useColor;
 
 class Nest
 {

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -134,7 +134,7 @@ static void getAllExprs(EvalState & state,
             mkString(vArg, path2);
             if (v.attrs->size() == v.attrs->capacity())
                 throw Error(format("too many Nix expressions in directory ‘%1%’") % path);
-            mkApp(*state.allocAttr(v, state.symbols.create(attrName)), vFun, vArg);
+            mkApp(*state.allocAttr(v, state.symbols.create(attrName), &noPos), vFun, vArg);
         }
         else if (S_ISDIR(st.st_mode))
             /* `path2' is a directory (with no default.nix in it);
@@ -163,7 +163,7 @@ static void loadSourceExpr(EvalState & state, const Path & path, Value & v)
        directory). */
     if (S_ISDIR(st.st_mode)) {
         state.mkAttrs(v, 1024);
-        state.mkList(*state.allocAttr(v, state.symbols.create("_combineChannels")), 0);
+        state.mkList(*state.allocAttr(v, state.symbols.create("_combineChannels"), &noPos), 0);
         StringSet attrs;
         getAllExprs(state, path, attrs, v);
         v.attrs->sort();
@@ -873,7 +873,7 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems)
                 cout << "null";
             } else {
                 PathSet context;
-                printValueAsJSON(*globals.state, true, *v, cout, context);
+                printValueAsJSON(*globals.state, true, *v, cout, context, noPos);
             }
         }
     }

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -47,7 +47,7 @@ void processExpr(EvalState & state, const Strings & attrPaths,
 
     for (auto & i : attrPaths) {
         Value & v(*findAlongAttrPath(state, i, autoArgs, vRoot));
-        state.forceValue(v);
+        state.forceValue(v, noPos);
 
         PathSet context;
         if (evalOnly) {
@@ -57,11 +57,11 @@ void processExpr(EvalState & state, const Strings & attrPaths,
             else
                 state.autoCallFunction(autoArgs, v, vRes);
             if (output == okXML)
-                printValueAsXML(state, strict, location, vRes, std::cout, context);
+                printValueAsXML(state, strict, location, vRes, std::cout, context, noPos);
             else if (output == okJSON)
-                printValueAsJSON(state, strict, vRes, std::cout, context);
+                printValueAsJSON(state, strict, vRes, std::cout, context, noPos);
             else {
-                if (strict) state.forceValueDeep(vRes);
+                if (strict) state.forceValueDeep(vRes, noPos);
                 std::cout << vRes << std::endl;
             }
         } else {
@@ -176,7 +176,7 @@ int main(int argc, char * * argv)
 
         if (findFile) {
             for (auto & i : files) {
-                Path p = state.findFile(i);
+                Path p = state.findFile(i, noPos);
                 if (p == "") throw Error(format("unable to find ‘%1%’") % i);
                 std::cout << p << std::endl;
             }


### PR DESCRIPTION
- Output several more locations during --show-trace
- Option -C / --color for use with less -r
- nix-instantiate respects '-k' by continuing evaluation after errors (only with derivations)
