### PR TITLE
Fix adding large paths to the store

### DIFF
--- a/dev-shell
+++ b/dev-shell
@@ -11,6 +11,7 @@ exec $s release.nix -A tarball --command "
     export NIX_PATH='$NIX_PATH'
     export NIX_BUILD_SHELL=$(type -p bash)
     export c=\$configureFlags
+    PATH=\"$(pwd)/inst/bin:\$PATH\"
     exec $s release.nix -A build.$(if [ $(uname -s) = Darwin ]; then echo x86_64-darwin; else echo x86_64-linux; fi) --exclude tarball --command '
         configureFlags+=\" \$c --prefix=$(pwd)/inst --sysconfdir=$(pwd)/inst/etc\"
         return

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -138,8 +138,8 @@ public:
        in `dump', which is either a NAR serialisation (if recursive ==
        true) or simply the contents of a regular file (if recursive ==
        false). */
-    Path addToStoreFromDump(const string & dump, const string & name,
-        bool recursive = true, HashType hashAlgo = htSHA256, bool repair = false);
+    Path addToStoreFromDump(Source& dump, const Path& dstPath,
+        bool recursive = true, bool repair = false);
 
     Path addTextToStore(const string & name, const string & s,
         const PathSet & references, bool repair = false);

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -6,7 +6,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION 0x10e
+#define PROTOCOL_VERSION 0x10f
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -69,8 +69,10 @@ struct ParseSink
 
 void parseDump(ParseSink & sink, Source & source);
 
-void restorePath(const Path & path, Source & source);
+void restorePath(const Path & path, Source & source, bool recursive = true);
 
+void copyPath(const Path & srcPath, const Path & dstPath,
+    PathFilter & filter = defaultPathFilter, bool recursive = true);
 
 // FIXME: global variables are bad m'kay.
 extern bool useCaseHack;

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -130,6 +130,12 @@ inline Sink & operator << (Sink & sink, uint64_t n)
     return sink;
 }
 
+
+template< unsigned N >
+Sink & operator << (Sink & sink, const char (&s)[N]) {
+    writeString((const unsigned char*)s, N-1, sink);
+    return sink;
+}
 Sink & operator << (Sink & sink, const string & s);
 Sink & operator << (Sink & sink, const Strings & s);
 Sink & operator << (Sink & sink, const StringSet & s);


### PR DESCRIPTION
This requires a patched version of the latest boost (sed 's|explicit basic_format|basic_format|' boost/format_class.hpp) compiled with -std=c++14.
