### PR TITLE
Port nix.sh to the fish shell

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -91,6 +91,7 @@ fi
 
 # Make the shell source nix.sh during login.
 p=$HOME/.nix-profile/etc/profile.d/nix.sh
+pfish=$HOME/.nix-profile/etc/profile.d/nix.fish
 
 added=
 for i in .bash_profile .bash_login .profile; do
@@ -114,6 +115,13 @@ variables are set, please add the line
   . $p
 
 to your shell profile (e.g. ~/.profile).
+
+For the fish shell, please add the line
+
+  source $pfish
+
+to your fish config file (~/.config/fish/config.fish).
+
 EOF
 else
     cat >&2 <<EOF
@@ -122,6 +130,12 @@ Installation finished!  To ensure that the necessary environment
 variables are set, either log in again, or type
 
   . $p
+
+in your shell.
+
+For the fish shell, please type
+
+  source $pfish
 
 in your shell.
 EOF

--- a/scripts/local.mk
+++ b/scripts/local.mk
@@ -14,6 +14,7 @@ noinst-scripts += $(nix_noinst_scripts)
 profiledir = $(sysconfdir)/profile.d
 
 $(eval $(call install-file-as, $(d)/nix-profile.sh, $(profiledir)/nix.sh, 0644))
+$(eval $(call install-file-as, $(d)/nix-profile.fish, $(profiledir)/nix.fish, 0644))
 $(eval $(call install-program-in, $(d)/build-remote.pl, $(libexecdir)/nix))
 
 clean-files += $(nix_bin_scripts) $(nix_noinst_scripts)

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,0 +1,35 @@
+if test -n $HOME
+    set NIX_LINK $HOME/.nix-profile
+
+    # Set the default profile.
+    if not test -L "$NIX_LINK"
+        echo "creating $NIX_LINK" >&2
+        set _NIX_DEF_LINK @localstatedir@/nix/profiles/default
+        @coreutils@/ln -s $_NIX_DEF_LINK $NIX_LINK
+    end
+
+    set PATH $NIX_LINK/bin $NIX_LINK/sbin $PATH
+
+    # Subscribe the user to the Nixpkgs channel by default.
+    if not test -e $HOME/.nix-channels
+        echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > $HOME/.nix-channels
+    end
+
+    # Append ~/.nix-defexpr/channels/nixpkgs to $NIX_PATH so that
+    # <nixpkgs> paths work when the user has fetched the Nixpkgs
+    # channel.
+    set -xg NIX_PATH $NIX_PATH:$HOME/.nix-defexpr/channels/nixpkgs
+
+    # Set $SSL_CERT_FILE so that Nixpkgs applications like curl work.
+    if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
+        set -xg SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+    else if test -e /etc/ssl/certs/ca-bundle.crt # Old NixOS
+         set -xg SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
+    else if test -e /etc/pki/tls/certs/ca-bundle.crt # Fedora, CentOS
+        set -xg SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
+    else if test -e $NIX_LINK/etc/ssl/certs/ca-bundle.crt # fall back to cacert in Nix profile
+        set -xg SSL_CERT_FILE $NIX_LINK/etc/ssl/certs/ca-bundle.crt
+    else if test -e $NIX_LINK/etc/ca-bundle.crt # old cacert in Nix profile
+        set -xg SSL_CERT_FILE $NIX_LINK/etc/ca-bundle.crt
+    end
+end


### PR DESCRIPTION
Sourcing nix.sh won't work on fish shell since it doesn't use the same syntax. This patch adds a new nix.fish that can be sourced from fish.
