### PR TITLE
Update prerequisites-source.xml

### DIFF
--- a/doc/manual/installation/prerequisites-source.xml
+++ b/doc/manual/installation/prerequisites-source.xml
@@ -30,7 +30,7 @@
   or higher.  If your distribution does not provide it, please install
   it from <link xlink:href="http://www.sqlite.org/" />.</para></listitem>
 
-  <listitem><para>The Perl DBI and DBD::SQLite libraries, which are
+  <listitem><para>The Perl DBI, DBD::SQLite, and WWW::Curl libraries, which are
   available from <link
   xlink:href="http://search.cpan.org/">CPAN</link> if your
   distribution does not provide them.</para></listitem>


### PR DESCRIPTION
The Perl WWW::Curl bindings are required to build Nix.