### PR TITLE
nix-env --upgrade improvements

### DIFF
--- a/doc/manual/command-ref/nix-env.xml
+++ b/doc/manual/command-ref/nix-env.xml
@@ -378,7 +378,7 @@ number of possible ways:
 
 <variablelist>
 
-  <varlistentry><term><option>--prebuild-only</option> / <option>-b</option></term>
+  <varlistentry><term><option>--prebuilt-only</option> / <option>-b</option></term>
 
     <listitem><para>Use only derivations for which a substitute is
     registered, i.e., there is a pre-built binary available that can
@@ -1012,7 +1012,7 @@ user environment elements, etc. -->
 
   </varlistentry>
 
-  <varlistentry><term><option>--prebuild-only</option> / <option>-b</option></term>
+  <varlistentry><term><option>--prebuilt-only</option> / <option>-b</option></term>
 
     <listitem><para>Show only derivations for which a substitute is
     registered, i.e., there is a pre-built binary available that can

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -570,14 +570,16 @@ static void upgradeDerivations(Globals & globals,
                    constraints specified by upgradeType.  If there are
                    multiple matches, take the one with the highest
                    priority.  If there are still multiple matches,
-                   take the one with the highest version. */
+                   take the one with the highest version.
+                   Do not upgrade if it would decrease the priority. */
                 DrvInfos::iterator bestElem = availElems.end();
-                DrvName bestName;
+                string bestVersion;
                 for (auto j = availElems.begin(); j != availElems.end(); ++j) {
+                    if (comparePriorities(*globals.state, i, *j) > 0)
+                        continue;
                     DrvName newName(j->name);
                     if (newName.name == drvName.name) {
-                        int d = comparePriorities(*globals.state, i, *j);
-                        if (d == 0) d = compareVersions(drvName.version, newName.version);
+                        int d = compareVersions(drvName.version, newName.version);
                         if ((upgradeType == utLt && d < 0) ||
                             (upgradeType == utLeq && d <= 0) ||
                             (upgradeType == utEq && d == 0) ||
@@ -586,11 +588,11 @@ static void upgradeDerivations(Globals & globals,
                             int d2 = -1;
                             if (bestElem != availElems.end()) {
                                 d2 = comparePriorities(*globals.state, *bestElem, *j);
-                                if (d2 == 0) d2 = compareVersions(bestName.version, newName.version);
+                                if (d2 == 0) d2 = compareVersions(bestVersion, newName.version);
                             }
                             if (d2 < 0 && (!globals.prebuiltOnly || isPrebuilt(*globals.state, *j))) {
                                 bestElem = j;
-                                bestName = newName;
+                                bestVersion = newName.version;
                             }
                         }
                     }

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -602,9 +602,11 @@ static void upgradeDerivations(Globals & globals,
                     i.queryOutPath() !=
                     bestElem->queryOutPath())
                 {
+                    const char * action = compareVersions(drvName.version, bestVersion) <= 0
+                        ? "upgrading" : "downgrading";
                     printMsg(lvlInfo,
-                        format("upgrading ‘%1%’ to ‘%2%’")
-                        % i.name % bestElem->name);
+                        format("%1% ‘%2%’ to ‘%3%’")
+                        % action % i.name % bestElem->name);
                     newElems.push_back(*bestElem);
                 } else newElems.push_back(i);
 


### PR DESCRIPTION
The main thing is 64f9b511b to avoid unexpected downgrades (https://github.com/NixOS/nixpkgs/issues/9758):

Until now, if one explicitly installed a low-priority version, nix-env --upgrade would downgrade it by default, even with --leq.  Let's never accept an upgrade with version not matching the upgradeType. Additionally, let's never decrease the priority of an installed package; you can use --install to force that.

Tested the effects are now what is described. Pending `release.nix -A tests`.