### PR TITLE
Also set CURLOPT_SSL_VERIFYHOST=0 when "verify-https-binary-caches" is false

### DIFF
--- a/scripts/download-from-binary-cache.pl.in
+++ b/scripts/download-from-binary-cache.pl.in
@@ -80,7 +80,12 @@ sub addRequest {
     $curl->setopt(CURLOPT_WRITEDATA, $fh);
     $curl->setopt(CURLOPT_FOLLOWLOCATION, 1);
     $curl->setopt(CURLOPT_CAINFO, $caBundle) if defined $caBundle;
-    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0) unless isTrue($Nix::Config::config{"verify-https-binary-caches"} // "1");
+
+    unless (isTrue($Nix::Config::config{"verify-https-binary-caches"} // "1")) {
+        $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);
+        $curl->setopt(CURLOPT_SSL_VERIFYHOST, 0);
+    }
+
     $curl->setopt(CURLOPT_USERAGENT, $userAgent);
     $curl->setopt(CURLOPT_NOBODY, 1) if $head;
     $curl->setopt(CURLOPT_FAILONERROR, 1);


### PR DESCRIPTION
This makes that option even more insecure, by also not checking the SSL host.

But without this parameter, one can still get SSL errors even when
"verify-https-binary-caches" is false, which is unexpected in my opinion.