### PR TITLE
Don't depend on .git/ when generating source tarball

### DIFF
--- a/local.mk
+++ b/local.mk
@@ -1,5 +1,5 @@
 ifeq ($(MAKECMDGOALS), dist)
-  dist-files += $(shell git ls-files)
+  dist-files += $(shell cat dist-files)
 endif
 
 dist-files += configure config.h.in nix.spec

--- a/release.nix
+++ b/release.nix
@@ -36,7 +36,12 @@ let
 
         postUnpack = ''
           # Clean up when building from a working tree.
-          (cd $sourceRoot && (git ls-files -o | xargs -r rm -v))
+          if [[ -d $sourceRoot/.git ]]; then
+            (cd $sourceRoot && (git ls-files -o | xargs -r rm -v))
+          fi
+
+          # Store initial files in ./dist-files
+          (cd $sourceRoot && find * -type f > dist-files)
         '';
 
         preConfigure = ''


### PR DESCRIPTION
We were using nix inside a submodule, and since it's git folder resides on parent repository, the build fails. This patch removes that dependency on .git folder.