### PR TITLE
Don't depend on .git/ when generating source tarball V2

### DIFF
--- a/local.mk
+++ b/local.mk
@@ -1,5 +1,6 @@
 ifeq ($(MAKECMDGOALS), dist)
-  dist-files += $(shell git ls-files)
+  # Make sure we are in repo root with `--git-dir`
+  dist-files += $(shell git --git-dir=.git ls-files || find * -type f)
 endif
 
 dist-files += configure config.h.in nix.spec

--- a/release.nix
+++ b/release.nix
@@ -36,7 +36,9 @@ let
 
         postUnpack = ''
           # Clean up when building from a working tree.
-          git -C $sourceRoot clean -fd
+          if [[ -d $sourceRoot/.git ]]; then
+            git -C $sourceRoot clean -fd
+          fi
         '';
 
         preConfigure = ''

--- a/release.nix
+++ b/release.nix
@@ -36,7 +36,7 @@ let
 
         postUnpack = ''
           # Clean up when building from a working tree.
-          (cd $sourceRoot && (git ls-files -o | xargs -r rm -v))
+          git -C $sourceRoot clean -fd
         '';
 
         preConfigure = ''


### PR DESCRIPTION
Variant of #663 to address @edolstra's concerns.
@edolstra how does this look?

cc @utdemir