### PR TITLE
Add special devices to sandbox-defaults

### DIFF
--- a/src/libstore/sandbox-defaults.sb.in
+++ b/src/libstore/sandbox-defaults.sb.in
@@ -35,7 +35,10 @@
        (literal "/private/var/run/resolv.conf"))
 
 ; some builders use filehandles other than stdin/stdout
-(allow file* (subpath "/dev/fd"))
+(allow file*
+        (subpath "/dev/fd")
+        (literal "/dev/ptmx")
+        (regex #"^/dev/[pt]ty.*$"))
 
 ; allow everything inside TMP
 (allow file* process-exec


### PR DESCRIPTION
@shlevy @edolstra This is required for perlPackages.IOTty and, by extension, mosh