### PR TITLE
Sandbox: Allow reading system ICU data

### DIFF
--- a/src/libstore/sandbox-defaults.sb.in
+++ b/src/libstore/sandbox-defaults.sb.in
@@ -11,7 +11,8 @@
        (literal "/private/etc/protocols")
        (literal "/private/var/tmp")
        (literal "/private/var/db")
-       (subpath "/private/var/db/mds"))
+       (subpath "/private/var/db/mds")
+       (subpath "/usr/share/icu"))
 
 (allow file-write*
        (literal "/dev/tty")


### PR DESCRIPTION
As far as I can tell, the CoreFoundation function `CFNumberFormatterCopyProperty` segfaults if the directory added in this pull request is not readable. This change allows openjdk-darwin to build in the sandbox.

@shlevy @edolstra 