### PR TITLE
darwin: allow reading system locale and zoneinfo

### DIFF
--- a/src/libstore/sandbox-defaults.sb.in
+++ b/src/libstore/sandbox-defaults.sb.in
@@ -15,7 +15,7 @@
 
 (allow file-read*
        (subpath "/usr/share/icu")
-       (subpath "/usr/share/locale"))
+       (subpath "/usr/share/locale")
        (subpath "/usr/share/zoneinfo"))
 
 (allow file-write*

--- a/src/libstore/sandbox-defaults.sb.in
+++ b/src/libstore/sandbox-defaults.sb.in
@@ -11,8 +11,12 @@
        (literal "/private/etc/protocols")
        (literal "/private/var/tmp")
        (literal "/private/var/db")
-       (subpath "/private/var/db/mds")
-       (subpath "/usr/share/icu"))
+       (subpath "/private/var/db/mds"))
+
+(allow file-read*
+       (subpath "/usr/share/icu")
+       (subpath "/usr/share/locale"))
+       (subpath "/usr/share/zoneinfo"))
 
 (allow file-write*
        (literal "/dev/tty")


### PR DESCRIPTION
@shlevy Please review.

Pardon me if this seems ridiculous, but I asked in the IRC channel what we do on non-Linux systems to get locales and there didn't seem to be a solution in place. I made this change for two reasons:

1. Darwin's locale data doesn't appear to be open source
2. Privileged processes will always use `/usr/share/locale` regardless of environment variables

This change will fix the `argh` Python package.