### PR TITLE
POSIX compliant directory access (fixes build on Solaris)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,7 @@ test "$localstatedir" = '${prefix}/var' && localstatedir=/nix/var
 
 
 # Solaris-specific stuff.
+AC_STRUCT_DIRENT_D_TYPE
 if test "$sys_name" = sunos; then
     # Solaris requires -lsocket -lnsl for network functions
     LIBS="-lsocket -lnsl $LIBS"

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -232,7 +232,11 @@ DirEntries readDirectory(const Path & path)
         checkInterrupt();
         string name = dirent->d_name;
         if (name == "." || name == "..") continue;
+#ifdef HAVE_STRUCT_DIRENT_D_TYPE
         entries.emplace_back(name, dirent->d_ino, dirent->d_type);
+#else
+        entries.emplace_back(name, dirent->d_ino, getFileType(absPath(name, path)));
+#endif
     }
     if (errno) throw SysError(format("reading directory ‘%1%’") % path);
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -232,11 +232,7 @@ DirEntries readDirectory(const Path & path)
         checkInterrupt();
         string name = dirent->d_name;
         if (name == "." || name == "..") continue;
-#ifdef HAVE_STRUCT_DIRENT_D_TYPE
-        entries.emplace_back(name, dirent->d_ino, dirent->d_type);
-#else
-        entries.emplace_back(name, dirent->d_ino, getFileType(absPath(name, path)));
-#endif
+        entries.emplace_back(name, dirent->d_ino, #ifdef HAVE_STRUCT_DIRENT_D_TYPE dirent->d_type #else DT_UNKNOWN #endif);
     }
     if (errno) throw SysError(format("reading directory ‘%1%’") % path);
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -11,6 +11,12 @@
 
 #include <cstdio>
 
+#ifndef HAVE_STRUCT_DIRENT_D_TYPE
+#define DT_UNKNOWN 0
+#define DT_REG 1
+#define DT_LNK 2
+#define DT_DIR 3
+#endif
 
 namespace nix {
 


### PR DESCRIPTION
d_type is not part of the POSIX spec unfortunately.

Patch was based on this article: http://grep.be/blog//en/computer/nbd/Not_using_adirent/