### PR TITLE
src/libstore/build.cc: clarify error message for hash mismatches

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2708,7 +2708,7 @@ void DerivationGoal::registerOutputs()
             Hash h2 = recursive ? hashPath(ht, actualPath).first : hashFile(ht, actualPath);
             if (h != h2)
                 throw BuildError(
-                    format("output path ‘%1%’ should have %2% hash ‘%3%’, instead has ‘%4%’")
+                    format("Nix expects output path ‘%1%’ to have %2% hash ‘%3%’, instead it has ‘%4%’")
                     % path % i.second.hashAlgo % printHash16or32(h) % printHash16or32(h2));
         }
 


### PR DESCRIPTION
Nix reports a hash mismatch saying:

> output path ‘foo’ should have sha256 hash ‘abc’, instead has ‘xyz’

That message is slightly ambiguous and some people read that statement
to mean the exact opposite of what it is supposed to mean. After this
patch, the message will be:

> Nix expects output path ‘foo’ to have sha256 hash ‘abc’, instead it has ‘xyz’