### PR TITLE
Reduce default value for "binary-caches-parallel-connections" from 150 to 50

### DIFF
--- a/scripts/download-from-binary-cache.pl.in
+++ b/scripts/download-from-binary-cache.pl.in
@@ -21,7 +21,7 @@ Nix::Config::readConfig;
 my @caches;
 my $gotCaches = 0;
 
-my $maxParallelRequests = int($Nix::Config::config{"binary-caches-parallel-connections"} // 150);
+my $maxParallelRequests = int($Nix::Config::config{"binary-caches-parallel-connections"} // 50);
 $maxParallelRequests = 1 if $maxParallelRequests < 1;
 
 my $ttlNegative = 24 * 3600; # when to purge negative lookups from the database


### PR DESCRIPTION
This patch fixes https://github.com/NixOS/nixpkgs/issues/9453.