### PR TITLE
WIP: deterministic evaluation of expressions/derivations

### DIFF
--- a/corepkgs/local.mk
+++ b/corepkgs/local.mk
@@ -1,4 +1,4 @@
-corepkgs_FILES = nar.nix buildenv.nix buildenv.pl unpack-channel.nix derivation.nix fetchurl.nix imported-drv-to-derivation.nix
+corepkgs_FILES = nar.nix buildenv.nix buildenv.pl unpack-channel.nix derivation.nix fetchurl.nix imported-drv-to-derivation.nix reproducable-derivation.nix
 
 $(foreach file,config.nix $(corepkgs_FILES),$(eval $(call install-data-in,$(d)/$(file),$(datadir)/nix/corepkgs)))
 

--- a/corepkgs/reproducable-derivation.nix
+++ b/corepkgs/reproducable-derivation.nix
@@ -6,9 +6,7 @@ derivation {
   args = ["-e" (__toFile "name" ''
     #!/bin/bash
     ${coreutils}/mkdir -p $out/nix-support
-    ${coreutils}/cat << EOF > $out/nix-support/source
-    ${result}
-    EOF
+    ${coreutils}/cp ${__toFile "result" result} $out/nix-support/source
     '')];
   system = builtins.currentSystem;
 }

--- a/corepkgs/reproducable-derivation.nix
+++ b/corepkgs/reproducable-derivation.nix
@@ -1,0 +1,14 @@
+result:
+with import ./config.nix;
+derivation {
+  name = "source-closure";
+  builder = shell;
+  args = ["-e" (__toFile "name" ''
+    #!/bin/bash
+    ${coreutils}/mkdir -p $out/nix-support
+    ${coreutils}/cat << EOF > $out/nix-support/source
+    ${result}
+    EOF
+    '')];
+  system = builtins.currentSystem;
+}

--- a/corepkgs/reproducable-derivation.nix
+++ b/corepkgs/reproducable-derivation.nix
@@ -1,4 +1,4 @@
-result:
+{ recording, expressions}:
 with import ./config.nix;
 derivation {
   name = "source-closure";
@@ -6,7 +6,10 @@ derivation {
   args = ["-e" (__toFile "name" ''
     #!/bin/bash
     ${coreutils}/mkdir -p $out/nix-support
-    ${coreutils}/cp ${__toFile "result" result} $out/nix-support/source
+    ${coreutils}/cp ${__toFile "deterministic-recording" recording} $out/nix-support/recording.nix
+    ${coreutils}/cp ${__toFile "expressions" expressions} $out/nix-support/expressions.nix
+    echo "__playback { sources = { \"$out\" = ./.; }; functions = []; }" > $out/default.nix
+    echo "(__playback (import ./nix-support/recording.nix) (import ./nix-support/expressions.nix))" >> $out/default.nix
     '')];
   system = builtins.currentSystem;
 }

--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -18,6 +18,7 @@ my $pure = 0;
 my $fromArgs = 0;
 my $packages = 0;
 my $interactive = 1;
+my $playback = 0;
 
 my @instArgs = ();
 my @buildArgs = ();
@@ -124,6 +125,17 @@ for (my $n = 0; $n < scalar @ARGV; $n++) {
         $n += 2;
     }
 
+    elsif ($arg eq "--playback") {
+        die "$0: '$arg' requires an argument\n" unless $n + 1 < scalar @ARGV;
+        push @instArgs, ($arg, $ARGV[$n + 1]);
+        $playback = 1;
+        $n++;
+    }
+    
+    elsif ($arg eq "--record") {
+        push @instArgs, $arg;
+    }
+    
     elsif ($arg eq "--max-jobs" || $arg eq "-j" || $arg eq "--max-silent-time" || $arg eq "--log-type" || $arg eq "--cores" || $arg eq "--timeout" || $arg eq '--add-root') {
         $n++;
         die "$0: ‘$arg’ requires an argument\n" unless $n < scalar @ARGV;
@@ -219,6 +231,7 @@ for (my $n = 0; $n < scalar @ARGV; $n++) {
 }
 
 die "$0: ‘-p’ and ‘-E’ are mutually exclusive\n" if $packages && $fromArgs;
+die "$0: with --playback you can't supply expressions\n" if $playback && (scalar @exprs > 0 || $packages);
 
 if ($packages) {
     push @instArgs, "--expr";
@@ -243,8 +256,9 @@ foreach my $expr (@exprs) {
         $expr = dirname(Cwd::abs_path($script)) . "/" . $expr
             if $inShebang && !$packages && $expr !~ /^\//;
 
+        my @expression = $playback ? () : ($expr);
         # !!! would prefer the perl 5.8.0 pipe open feature here.
-        my $pid = open(DRVPATHS, "-|") || exec "$Nix::Config::binDir/nix-instantiate", "--add-root", $drvLink, "--indirect", @instArgs, $expr;
+        my $pid = open(DRVPATHS, "-|") || exec "$Nix::Config::binDir/nix-instantiate", "--add-root", $drvLink, "--indirect", @instArgs, @expression;
         while (<DRVPATHS>) {chomp; push @drvPaths, $_;}
         if (!close DRVPATHS) {
             die "nix-instantiate killed by signal " . ($? & 127) . "\n" if ($? & 127);

--- a/src/libexpr/common-opts.cc
+++ b/src/libexpr/common-opts.cc
@@ -52,7 +52,7 @@ bool parseSearchPathArg(Strings::iterator & i,
 }
 
 
-Path lookupFileArg(EvalState & state, string s)
+Path lookupFileArg(EvalState & state, string s, string currentPath)
 {
     if (isUri(s))
         return downloadFileCached(s, true);
@@ -60,7 +60,7 @@ Path lookupFileArg(EvalState & state, string s)
         Path p = s.substr(1, s.size() - 2);
         return state.findFile(p);
     } else
-        return absPath(s);
+        return absPath(s, currentPath);
 }
 
 

--- a/src/libexpr/common-opts.hh
+++ b/src/libexpr/common-opts.hh
@@ -13,6 +13,6 @@ Bindings * evalAutoArgs(EvalState & state, std::map<string, string> & in);
 bool parseSearchPathArg(Strings::iterator & i,
     const Strings::iterator & argsEnd, Strings & searchPath);
 
-Path lookupFileArg(EvalState & state, string s);
+Path lookupFileArg(EvalState & state, string s, string currentPath = "");
 
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -346,6 +346,40 @@ EvalState::EvalState(const Strings & _searchPath)
 EvalState::~EvalState()
 {
     fileEvalCache.clear();
+
+    if (evalMode == Record) { 
+	std::fstream out(recordFileName, std::fstream::out);
+	out << "{\"functions\": [\n";
+	bool isThisTheFirstTime = true;
+	
+	for (auto kv : recording) {
+	  std::cout << "?";	
+	  if (!isThisTheFirstTime) out << ",";
+	  isThisTheFirstTime = false;
+	  
+	  out << "{ \"name\": \"" << kv.first.first << "\", \"parameters\": [";
+	  
+	  bool isThisTheFirstTime2 = true;
+	  for (auto parameter: kv.first.second) {
+	    if (!isThisTheFirstTime2) out << ", ";
+	    isThisTheFirstTime2 = false;
+	    out << parameter;	
+	  }
+	  out << "], \"result\": " << valueToJSON(kv.second) << "}\n";
+	}
+	    
+	out << "], \"sources\": {";
+	
+	bool isThisTheFirstTime3 = true;
+	for (auto path : srcToStore) {
+	  if (!isThisTheFirstTime3) out << ", ";
+      isThisTheFirstTime3 = false;
+	  out << "\"" << path.first << "\": \"" << path.second << "\"";
+	}
+	std::cout << "\\";
+	out << "}}";
+	out.close();
+    }
 }
 
 
@@ -709,43 +743,9 @@ void EvalState::getAttr(Value & attrSet, const char *attr, Value & v) {
     v = *i->value;
 }
 
-void EvalState::eval(Expr * e, Value & v)
-{  
+void EvalState::eval(Expr* e, Value& v)
+{
     e->eval(*this, baseEnv, v);
-
-    if (evalMode == Record) { 
-	std::fstream out(recordFileName, std::fstream::out);
-	out << "{\"functions\": [\n";
-	bool isThisTheFirstTime = true;
-	
-	for (auto kv : recording) {
-	  std::cout << "?";	
-	  if (!isThisTheFirstTime) out << ",";
-	  isThisTheFirstTime = false;
-	  
-	  out << "{ \"name\": \"" << kv.first.first << "\", \"parameters\": [";
-	  
-	  bool isThisTheFirstTime2 = true;
-	  for (auto parameter: kv.first.second) {
-	    if (!isThisTheFirstTime2) out << ", ";
-	    isThisTheFirstTime2 = false;
-	    out << parameter;	
-	  }
-	  out << "], \"result\": " << valueToJSON(kv.second) << "}\n";
-	}
-	    
-	out << "], \"sources\": {";
-	
-	bool isThisTheFirstTime3 = true;
-	for (auto path : srcToStore) {
-	  if (!isThisTheFirstTime3) out << ", ";
-      isThisTheFirstTime3 = false;
-	  out << "\"" << path.first << "\": \"" << path.second << "\"";
-	}
-	std::cout << "\\";
-	out << "}}";
-	out.close();
-    }
 }
 
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -421,44 +421,6 @@ std::string EvalState::valueToJSON(Value & value) {
     return out.str();
 }
 
-void EvalState::addImpurePrimOp(const string & name,
-    unsigned int arity, PrimOpFun primOp)
-{
-  std::cout << "IMPURE " << name << std::endl;
-  
-    if (evalMode == Record) {
-        PrimOpLambdaFun foo = [this, name, primOp, arity] (EvalState & state, const Pos & pos, Value * * args, Value & v) {
-            std::list<string> argList;
-            for (int i = 0; i < arity; i++) {
-                argList.push_back(valueToJSON(*args[i]));
-            }
-            std::cout << "Record " << name << std::endl;
-            primOp(state, pos, args, v);
-            recording[std::make_pair(name, argList)] = v;
-        };
-        addPrimOpLambda(name, arity, foo);
-    } else if (evalMode == Playback) {
-	PrimOpLambdaFun foo = [this, name, primOp, arity] (EvalState & state, const Pos & pos, Value * * args, Value & v) {
-            std::list<string> argList;
-            for (int i = 0; i < arity; i++) {
-                argList.push_back(valueToJSON(*args[i]));
-            }
-            std::cout << "Playback " << name << std::endl;
-            auto result = recording.find(std::make_pair(name, argList));
-	    if (result == recording.end()) {
-	      std::string errorMsg("wanted to call ");
-	      errorMsg +=name;
-	      throw EvalError(errorMsg.c_str());
-	    }
-	    else {
-	      v = result->second;
-	    }
-	};
-        addPrimOpLambda(name, arity, foo);
-    } else {
-        addPrimOp(name, arity, primOp);
-    }
-}
 
 void EvalState::getBuiltin(const string & name, Value & v)
 {

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -455,7 +455,6 @@ void EvalState::addImpureConstant(const string & name, Value & v, Value * consta
     left->primOpApp.right = allocValue();
     mkString(*left->primOpApp.right, name);
     wrappedConstant->primOpApp.right = v2;
-    forceValue(*wrappedConstant);
     addToBaseEnv(name, wrappedConstant);
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -336,16 +336,14 @@ void EvalState::initializePlayback()
         std::list<std::string> parameterList;
         forceList(parameters);
         for (unsigned int j = 0; j < parameters.listSize(); ++j) {
-            parameterList.push_back(valueToJSON(*parameters.listElems()[j]));
+            parameterList.push_back(valueToJSON(*parameters.listElems()[j], false));
         }
         recording[std::make_pair(nameString, parameterList)] = result;
     }
     Value sources;
     getAttr(top, sourcesSymbol, sources);
     forceAttrs(sources);
-    std::cout << sources.attrs->size() << std::endl;
     for (auto it = sources.attrs->begin(); it != sources.attrs->end(); ++it) {
-        std::cout << it->name << " -> " << forceStringNoCtx(*it->value) << std::endl;
         srcToStore[it->name] = forceStringNoCtx(*it->value);
     }
 }
@@ -378,7 +376,7 @@ void EvalState::finalizeRecord()
             isThisTheFirstTime2 = false;
             out << parameter;   
         }
-        out << "], \"result\": " << valueToJSON(kv.second) << "}\n";
+        out << "], \"result\": " << valueToJSON(kv.second, false) << "}\n";
     }
         
     out << "], \"sources\": {";
@@ -484,10 +482,10 @@ void EvalState::addPrimOp(const string & name,
     addToBaseEnv(name, v, sym);
 }
 
-std::string EvalState::valueToJSON(Value & value) {
+std::string EvalState::valueToJSON(Value & value, bool copyToStore) {
     std::ostringstream out;
     PathSet context;
-    printValueAsJSON(*this, true, value, out, context);
+    printValueAsJSON(*this, true, value, out, context, copyToStore);
     return out.str();
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -455,21 +455,23 @@ void EvalState::finalizeRecording(Value & result)
     for (auto autoArg: recordingExpression.autoArgs) {
         if (!isThisTheFirstTime0) out << ",";
         isThisTheFirstTime0 = false;
-        out << "\"" << autoArg.first << "\":\"" << autoArg.second << "\""; 
+        escapeJSON (out, autoArg.first);
+        out << ":";
+        escapeJSON(out, autoArg.second); 
     }
     out << "},\"attributes\":[";
     isThisTheFirstTime0 = true;
     for (auto attr: recordingExpression.attrPaths) {
         if (!isThisTheFirstTime0) out << ",";
         isThisTheFirstTime0 = false;
-        out << "\"" << attr << "\""; 
+        escapeJSON(out, attr);
     }
     out << "],\"files\":[";
     isThisTheFirstTime0 = true;
     for (auto file: recordingExpression.files) {
         if (!isThisTheFirstTime0) out << ",";
         isThisTheFirstTime0 = false;
-        out << "\"" << resolveExprPath(lookupFileArg(*this, file)) << "\"";
+        escapeJSON(out, recordingExpression.fromArgs ? file : resolveExprPath(lookupFileArg(*this, file)));
     }
     out << "],\"currentDir\":\"" << recordingExpression.currentDir << "\"},\"functions\": [\n";
    
@@ -478,13 +480,15 @@ void EvalState::finalizeRecording(Value & result)
         if (!isThisTheFirstTime) out << ",";
         isThisTheFirstTime = false;
         
-        out << "{ \"name\": \"" << kv.first.first << "\", \"parameters\": [";
+        out << "{ \"name\":";
+        escapeJSON(out, kv.first.first);
+        out << ", \"parameters\": [";
         
         bool isThisTheFirstTime2 = true;
         for (auto parameter: kv.first.second) {
             if (!isThisTheFirstTime2) out << ", ";
             isThisTheFirstTime2 = false;
-            out << parameter;   
+            out << parameter;
         }
         out << "], \"result\": " << valueToJSON(kv.second, false) << "}\n";
     }
@@ -496,7 +500,9 @@ void EvalState::finalizeRecording(Value & result)
         if (!isThisTheFirstTime3) out << ", ";
         isThisTheFirstTime3 = false;
         context.insert(path.second);
-        out << "\"" << path.first << "\": \"" << path.second << "\"";
+        escapeJSON(out, path.first);
+        out << ":";
+        escapeJSON(out, path.second);
     }
     out << "}}";
     mkString(result, out.str(), context);

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -584,7 +584,7 @@ Value * EvalState::getImpureConstantPrimop()
     if (evalMode == Normal) return 0;
     Value * result = allocValue();
     result->type = tPrimOp;
-    result->primOp = NEW PrimOp(transformPrimOp<__impureConstant, 2, prim_impureConstant>(), 2, symbols.create("impureConstant"));
+    result->primOp = NEW PrimOp(transformPrimOp<__impureConstant, 2, prim_impureConstant, onlyPos<0> >(), 2, symbols.create("impureConstant"));
     return result;
 }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -183,7 +183,7 @@ public:
     string coerceToString(const Pos & pos, Value & v, PathSet & context,
         bool coerceMore = false, bool copyToStore = true);
 
-    string copyPathToStore(PathSet & context, const Path & path);
+    string copyPathToStore(PathSet & context, const Path & path, bool ignoreReadOnly = false);
 
     /* Path coercion.  Converts strings, paths and derivations to a
        path.  The result is guaranteed to be a canonicalised, absolute

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -109,6 +109,7 @@ private:
     SearchPath searchPath;
 
     EvalMode evalMode;
+    const char * recordFileName;
 
     std::map<std::pair<string, std::list<string>>, Value> recording;
 
@@ -298,6 +299,7 @@ private:
     friend struct ExprOpConcatLists;
     friend struct ExprSelect;
     friend void prim_getAttr(EvalState & state, const Pos & pos, Value * * args, Value & v);
+    void getAttr(Value & top, const char* arg2, Value & v);
 };
 
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -26,7 +26,7 @@ typedef enum {
 } EvalMode;
 
 typedef void (* PrimOpFun) (EvalState & state, const Pos & pos, Value * * args, Value & v);
-typedef std::function<void(EvalState & state, const Pos & pos, Value * * args, Value & v)> PrimOpLambdaFun;
+
 
 struct PrimOp
 {
@@ -37,14 +37,6 @@ struct PrimOp
         : fun(fun), arity(arity), name(name) { }
 };
 
-struct PrimOpLambda
-{
-    PrimOpLambdaFun fun;
-    unsigned int arity;
-    Symbol name;
-    PrimOpLambda(PrimOpLambdaFun fun, unsigned int arity, Symbol name)
-        : fun(fun), arity(arity), name(name) { }
-};
 
 struct Env
 {
@@ -112,6 +104,7 @@ private:
     EvalMode evalMode;
     const char * recordFileName;
 
+    //TODO: use some other structure, maybe a hashmap
     std::map<std::pair<string, std::list<string>>, Value> recording;
 
 public:
@@ -211,14 +204,8 @@ private:
     void addPrimOp(const string & name,
         unsigned int arity, PrimOpFun primOp);
 
-    void addPrimOpLambda(const string & name,
-        unsigned int arity, PrimOpLambdaFun primOp);
-
-
-
     std::string valueToJSON(Value & value);
-
-    
+  
     template< PrimOpFun primOp, const char *name, unsigned int arity>
       static void recordPrimOp(EvalState & state, const Pos & pos, Value * * args, Value & v)
       {
@@ -263,11 +250,6 @@ private:
 	  addPrimOp(name, arity, primOp);
       }      
     }
-
-      
-      
-
-    
     
 public:
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -220,9 +220,6 @@ private:
 
     
     template< PrimOpFun primOp, const char *name, unsigned int arity>
-    class WrapPrimOp
-    {
-    public:
       static void recordPrimOp(EvalState & state, const Pos & pos, Value * * args, Value & v)
       {
 	  std::list<string> argList;
@@ -234,6 +231,7 @@ private:
 	  state.recording[std::make_pair(name, argList)] = v;
       }
 	
+    template< PrimOpFun primOp, const char *name, unsigned int arity>
     static void playbackPrimOp(EvalState & state, const Pos & pos, Value * * args, Value & v)
     {	
 	  std::list<string> argList;
@@ -252,17 +250,15 @@ private:
 	  }     	
     }
     
-    };
-    
     template< const char *name, unsigned int arity, PrimOpFun primOp>
     void addImpurePrimOp() 
     {      
       if (evalMode == Record) {
-	  PrimOpFun wrapped = WrapPrimOp<primOp, name, arity>::recordPrimOp;
+	  PrimOpFun wrapped = recordPrimOp<primOp, name, arity>;
 	  addPrimOp(name, arity, wrapped);
       } else if (evalMode == Playback) {
-	    PrimOpFun wrapped = WrapPrimOp<primOp, name, arity>::playbackPrimOp;
-	    addPrimOp(name, arity, wrapped	);
+	    PrimOpFun wrapped = playbackPrimOp<primOp, name, arity>;
+	    addPrimOp(name, arity, wrapped);
       } else {
 	  addPrimOp(name, arity, primOp);
       }      

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -26,7 +26,6 @@ typedef enum {
 
 typedef void (* PrimOpFun) (EvalState & state, const Pos & pos, Value * * args, Value & v);
 
-
 struct PrimOp
 {
     PrimOpFun fun;
@@ -102,14 +101,23 @@ private:
 
     DeterministicEvaluationMode evalMode;
     const char * recordFileName;
+    Value * playbackJson;
 
     //TODO: use some other structure, maybe a hashmap
     //since comparing strings with long same prefixes is slow
     std::map<std::pair<string, std::list<string>>, Value> recording;
-
+    struct RecordingExpression {
+        bool fromArgs;
+        std::map<string,string> autoArgs;
+        Strings attrPaths;
+        Strings files;
+        string currentDir;
+        RecordingExpression() : fromArgs(false) {}
+    } recordingExpression;
+    
 public:
 
-    EvalState(const Strings & _searchPath);
+    EvalState(const Strings & _searchPath, DeterministicEvaluationMode evalMode = Normal, const char * evalModeFile = nullptr);
     ~EvalState();
 
     void addToSearchPath(const string & s, bool warn = false);
@@ -275,6 +283,8 @@ private:
     }
 
 public:
+    void getRecordingInfo(bool & fromArgs, std::map<string, string> & autoArgs_, Strings & attrPaths, Strings & files, string & currentDir);
+    void setRecordingInfo(bool fromArgs, std::map<string, string> autoArgs_, Strings attrPaths, Strings files, string currentDir);
 
     void getBuiltin(const string & name, Value & v);
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -217,7 +217,8 @@ private:
     void getAttr(Value & top, const Symbol & arg2, Value & v);
     void initializeDeterministicEvaluationMode();
     void initializePlayback();
-    void finalizeRecord();
+    void finalizeRecording (Value & result);
+    void writeRecordingIntoStore (Value & result);
  
     template< const char * name, unsigned int arity, PrimOpFun primOp>
     static void recordPrimOp(EvalState & state, const Pos & pos, Value * * args, Value & v)

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -205,7 +205,7 @@ private:
     void addPrimOp(const string & name,
         unsigned int arity, PrimOpFun primOp);
 
-    std::string valueToJSON(Value & value);
+    std::string valueToJSON(Value & value, bool copyToStore);
     void getAttr(Value & top, const Symbol & arg2, Value & v);
     void initializeDeterministicEvaluationMode();
     void initializePlayback();
@@ -216,7 +216,7 @@ private:
     {
         std::list<string> argList;
         for (unsigned int i = 0; i < arity; i++) {
-            argList.push_back(state.valueToJSON(*args[i]));
+            argList.push_back(state.valueToJSON(*args[i], false));
         }
         primOp(state, pos, args, v);
         state.recording[std::make_pair(name, argList)] = v;
@@ -227,7 +227,7 @@ private:
     {
         std::list<string> argList;
         for (unsigned int i = 0; i < arity; i++) {
-            argList.push_back(state.valueToJSON(*args[i]));
+            argList.push_back(state.valueToJSON(*args[i], false));
         }
         auto result = state.recording.find(std::make_pair(name, argList));
         if (result == state.recording.end()) {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -88,7 +88,8 @@ public:
 
 private:
     SrcToStore srcToStore;
-
+    SrcToStore srcToStoreForPlayback;
+    
     /* A cache from path names to values. */
 #if HAVE_BOEHMGC
     typedef std::map<Path, Value, std::less<Path>, traceable_allocator<std::pair<const Path, Value> > > FileEvalCache;
@@ -367,6 +368,7 @@ private:
     void addToBaseEnv(const string & name, Value * v, Symbol sym);
     void addToBaseEnv(const string & name, Value * v);
     Value * getImpureConstantPrimop();
+    Path copyPathToStoreIfItsNotAlreadyThere(PathSet context, Path path);
 };
 
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -106,7 +106,6 @@ private:
     //TODO: use some other structure, maybe a hashmap
     //since comparing strings with long same prefixes is slow
     std::map<std::pair<string, std::list<string>>, Value> recording;
-    Expr * recordingExpression;
     
 public:
     bool isInPlaybackMode() {
@@ -126,7 +125,9 @@ public:
     /* Parse a Nix expression from the specified file. */
     Expr * parseExprFromFile(const Path & path);
     Expr * parseExprFromFile(const Path & path, StaticEnv & staticEnv);
-
+    Expr * parseExprFromFileWithoutRecording(const Path & path);
+    Expr * parseExprFromFileWithoutRecording(const Path & path, StaticEnv &);
+    
     /* Parse a Nix expression from the specified string. */
     Expr * parseExprFromString(const string & s, const Path & basePath, StaticEnv & staticEnv);
     Expr * parseExprFromString(const string & s, const Path & basePath);
@@ -219,8 +220,6 @@ private:
     string parameterValue(Value & value);
     void getAttr(Value & top, const Symbol & arg2, Value & v);
     void initializeDeterministicEvaluationMode();
-    void finalizeRecording (Value & result);
-    void writeRecordingIntoStore (Value & result);
  
     static bool constTrue(unsigned int arg) { return true; }
     template< int argumentPos >
@@ -300,7 +299,8 @@ private:
     }
 
 public:
-    void setRecordingInfo(Expr *);
+    void finalizeRecording (Value & result, Expr * recordingExpressions);
+    Path writeRecordingIntoStore (Value & result, bool buildStorePath);
 
     void getBuiltin(const string & name, Value & v);
 

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -21,6 +21,8 @@
 #include "nixexpr.hh"
 #include "eval.hh"
 
+#include <iostream>
+
 namespace nix {
 
     struct ParseData
@@ -574,7 +576,15 @@ Expr * EvalState::parseExprFromFile(const Path & path)
 
 Expr * EvalState::parseExprFromFile(const Path & path, StaticEnv & staticEnv)
 {
-    return parse(readFile(path).c_str(), path, dirOf(path), staticEnv);
+    Path actualPath;
+    if (evalMode == Record || evalMode == Playback) {
+      PathSet context;
+      actualPath = copyPathToStore(context, path, true);
+      std::cout << "parseExprFromFile(" << path << ") = " << actualPath << "\n";
+    } else {
+      actualPath = path;
+    }
+    return parse(readFile(actualPath).c_str(), path, dirOf(path), staticEnv);
 }
 
 

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -577,7 +577,7 @@ Expr * EvalState::parseExprFromFile(const Path & path, StaticEnv & staticEnv)
     Path actualPath;
     if (evalMode == Record || evalMode == Playback) {
         PathSet context;
-        actualPath = copyPathToStore(context, path, true);
+        actualPath = copyPathToStoreIfItsNotAlreadyThere(context, path);
     } else {
         actualPath = path;
     }

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -576,10 +576,10 @@ Expr * EvalState::parseExprFromFile(const Path & path, StaticEnv & staticEnv)
 {
     Path actualPath;
     if (evalMode == Record || evalMode == Playback) {
-      PathSet context;
-      actualPath = copyPathToStore(context, path, true);
+        PathSet context;
+        actualPath = copyPathToStore(context, path, true);
     } else {
-      actualPath = path;
+        actualPath = path;
     }
     return parse(readFile(actualPath).c_str(), path, dirOf(path), staticEnv);
 }

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -21,8 +21,6 @@
 #include "nixexpr.hh"
 #include "eval.hh"
 
-#include <iostream>
-
 namespace nix {
 
     struct ParseData
@@ -580,7 +578,6 @@ Expr * EvalState::parseExprFromFile(const Path & path, StaticEnv & staticEnv)
     if (evalMode == Record || evalMode == Playback) {
       PathSet context;
       actualPath = copyPathToStore(context, path, true);
-      std::cout << "parseExprFromFile(" << path << ") = " << actualPath << "\n";
     } else {
       actualPath = path;
     }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1770,14 +1770,14 @@ void EvalState::createBaseEnv()
     addPrimOp("__valueSize", 1, prim_valueSize);
 
     // Paths
-    addPrimOp("__toPath", 1, prim_toPath);
-    addPrimOp("__storePath", 1, prim_storePath);
-    addPrimOp("__pathExists", 1, prim_pathExists);
+    addImpurePrimOp("__toPath", 1, prim_toPath);
+    addImpurePrimOp("__storePath", 1, prim_storePath);
+    addImpurePrimOp("__pathExists", 1, prim_pathExists);
     addPrimOp("baseNameOf", 1, prim_baseNameOf);
     addPrimOp("dirOf", 1, prim_dirOf);
-    addPrimOp("__readFile", 1, prim_readFile);
-    addPrimOp("__readDir", 1, prim_readDir);
-    addPrimOp("__findFile", 2, prim_findFile);
+    addImpurePrimOp("__readFile", 1, prim_readFile);
+    addImpurePrimOp("__readDir", 1, prim_readDir);
+    addImpurePrimOp("__findFile", 2, prim_findFile);
 
     // Creating files
     addPrimOp("__toXML", 1, prim_toXML);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1747,7 +1747,7 @@ void EvalState::createBaseEnv()
     forceValue(v);
     addConstant("import", v);
     if (settings.enableImportNative)
-        addPrimOp("__importNative", 2, prim_importNative);
+        addImpurePrimOp("__importNative", 2, prim_importNative);
     addPrimOp("__typeOf", 1, prim_typeOf);
     addPrimOp("isNull", 1, prim_isNull);
     addPrimOp("__isFunction", 1, prim_isFunction);
@@ -1759,7 +1759,7 @@ void EvalState::createBaseEnv()
     addPrimOp("throw", 1, prim_throw);
     addPrimOp("__addErrorContext", 2, prim_addErrorContext);
     addPrimOp("__tryEval", 1, prim_tryEval);
-    addPrimOp("__getEnv", 1, prim_getEnv);
+    addImpurePrimOp("__getEnv", 1, prim_getEnv);
 
     // Strictness
     addPrimOp("__seq", 2, prim_seq);
@@ -1770,7 +1770,7 @@ void EvalState::createBaseEnv()
     addPrimOp("__valueSize", 1, prim_valueSize);
 
     // Paths
-    addImpurePrimOp("__toPath", 1, prim_toPath);
+    addPrimOp("__toPath", 1, prim_toPath);
     addImpurePrimOp("__storePath", 1, prim_storePath);
     addImpurePrimOp("__pathExists", 1, prim_pathExists);
     addPrimOp("baseNameOf", 1, prim_baseNameOf);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1790,7 +1790,7 @@ void EvalState::createBaseEnv()
     addPrimOp("dirOf", 1, prim_dirOf);
     addImpurePrimOp<__readFile, 1, prim_readFile>();
     addImpurePrimOp<__readDir, 1, prim_readDir>();
-    addImpurePrimOp<__findFile, 2, prim_findFile>();
+    addImpurePrimOp<__findFile, 2, prim_findFile, onlyPos<1>>();
 
     // Creating files
     addPrimOp("__toXML", 1, prim_toXML);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1708,8 +1708,6 @@ extern const char __pathExists[] = "__pathExists";
 extern const char __readFile[] = "__readFile";
 
 
-
-
 void EvalState::createBaseEnv()
 {
     baseEnv.up = 0;
@@ -1794,6 +1792,8 @@ void EvalState::createBaseEnv()
     addPrimOp("__toJSON", 1, prim_toJSON);
     addPrimOp("__fromJSON", 1, prim_fromJSON);
     addPrimOp("__toFile", 2, prim_toFile);
+
+    //TODO: filter source is an impure primop too
     addPrimOp("__filterSource", 2, prim_filterSource);
 
     // Sets

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1699,6 +1699,16 @@ static void prim_fetchTarball(EvalState & state, const Pos & pos, Value * * args
  * Primop registration
  *************************************************************/
 
+extern const char __importNative[] = "__importNative";
+extern const char __findFile[] = "__findFile";
+extern const char __readDir[] = "__readDir";
+extern const char __getEnv[] = "__getEnv";
+extern const char __storePath[] = "__storePath";
+extern const char __pathExists[] = "__pathExists";
+extern const char __readFile[] = "__readFile";
+
+
+
 
 void EvalState::createBaseEnv()
 {
@@ -1747,7 +1757,7 @@ void EvalState::createBaseEnv()
     forceValue(v);
     addConstant("import", v);
     if (settings.enableImportNative)
-        addImpurePrimOp("__importNative", 2, prim_importNative);
+        addImpurePrimOp<__importNative, 2, prim_importNative>();
     addPrimOp("__typeOf", 1, prim_typeOf);
     addPrimOp("isNull", 1, prim_isNull);
     addPrimOp("__isFunction", 1, prim_isFunction);
@@ -1759,7 +1769,7 @@ void EvalState::createBaseEnv()
     addPrimOp("throw", 1, prim_throw);
     addPrimOp("__addErrorContext", 2, prim_addErrorContext);
     addPrimOp("__tryEval", 1, prim_tryEval);
-    addImpurePrimOp("__getEnv", 1, prim_getEnv);
+    addImpurePrimOp<__getEnv, 1, prim_getEnv>();
 
     // Strictness
     addPrimOp("__seq", 2, prim_seq);
@@ -1771,13 +1781,13 @@ void EvalState::createBaseEnv()
 
     // Paths
     addPrimOp("__toPath", 1, prim_toPath);
-    addImpurePrimOp("__storePath", 1, prim_storePath);
-    addImpurePrimOp("__pathExists", 1, prim_pathExists);
+    addImpurePrimOp<__storePath, 1, prim_storePath>();
+    addImpurePrimOp<__pathExists, 1, prim_pathExists>();
     addPrimOp("baseNameOf", 1, prim_baseNameOf);
     addPrimOp("dirOf", 1, prim_dirOf);
-    addImpurePrimOp("__readFile", 1, prim_readFile);
-    addImpurePrimOp("__readDir", 1, prim_readDir);
-    addImpurePrimOp("__findFile", 2, prim_findFile);
+    addImpurePrimOp<__readFile, 1, prim_readFile>();
+    addImpurePrimOp<__readDir, 1, prim_readDir>();
+    addImpurePrimOp<__findFile, 2, prim_findFile>();
 
     // Creating files
     addPrimOp("__toXML", 1, prim_toXML);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1706,6 +1706,7 @@ extern const char __getEnv[] = "__getEnv";
 extern const char __storePath[] = "__storePath";
 extern const char __pathExists[] = "__pathExists";
 extern const char __readFile[] = "__readFile";
+extern const char __filterSource[] = "__filterSource";
 
 
 void EvalState::createBaseEnv()
@@ -1792,9 +1793,7 @@ void EvalState::createBaseEnv()
     addPrimOp("__toJSON", 1, prim_toJSON);
     addPrimOp("__fromJSON", 1, prim_fromJSON);
     addPrimOp("__toFile", 2, prim_toFile);
-
-    //TODO: filter source is an impure primop too
-    addPrimOp("__filterSource", 2, prim_filterSource);
+    addUnsupportedImpurePrimOp<__filterSource>(2, prim_filterSource);
 
     // Sets
     addPrimOp("__attrNames", 1, prim_attrNames);
@@ -1851,8 +1850,8 @@ void EvalState::createBaseEnv()
     addPrimOp("derivationStrict", 1, prim_derivationStrict);
 
     // Networking
-    addPrimOp("__fetchurl", 1, prim_fetchurl);
-    addPrimOp("fetchTarball", 1, prim_fetchTarball);
+    addImpurePrimOp("__fetchurl", 1, prim_fetchurl);
+    addImpurePrimOp("fetchTarball", 1, prim_fetchTarball);
 
     /* Add a wrapper around the derivation primop that computes the
        `drvPath' and `outPath' attributes lazily. */

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1699,6 +1699,7 @@ static void prim_fetchTarball(EvalState & state, const Pos & pos, Value * * args
  * Primop registration
  *************************************************************/
 
+
 extern const char __importNative[] = "__importNative";
 extern const char __findFile[] = "__findFile";
 extern const char __readDir[] = "__readDir";
@@ -1707,7 +1708,8 @@ extern const char __storePath[] = "__storePath";
 extern const char __pathExists[] = "__pathExists";
 extern const char __readFile[] = "__readFile";
 extern const char __filterSource[] = "__filterSource";
-
+extern const char __fetchurl[] = "__fetchurl";
+extern const char fetchTarball[] = "fetchTarball";
 
 void EvalState::createBaseEnv()
 {
@@ -1728,18 +1730,20 @@ void EvalState::createBaseEnv()
 
     mkNull(v);
     addConstant("null", v);
+    
+    Value * impureConstantPrimop = getImpureConstantPrimop();
 
     mkInt(v, time(0));
-    addConstant("__currentTime", v);
+    addImpureConstant("__currentTime", v, impureConstantPrimop);
 
     mkString(v, settings.thisSystem);
-    addConstant("__currentSystem", v);
+    addImpureConstant("__currentSystem", v, impureConstantPrimop);
 
     mkString(v, nixVersion);
-    addConstant("__nixVersion", v);
+    addImpureConstant("__nixVersion", v, impureConstantPrimop);
 
     mkString(v, settings.nixStore);
-    addConstant("__storeDir", v);
+    addImpureConstant("__storeDir", v, impureConstantPrimop);
 
     /* Language version.  This should be increased every time a new
        language feature gets added.  It's not necessary to increase it
@@ -1850,8 +1854,8 @@ void EvalState::createBaseEnv()
     addPrimOp("derivationStrict", 1, prim_derivationStrict);
 
     // Networking
-    addImpurePrimOp("__fetchurl", 1, prim_fetchurl);
-    addImpurePrimOp("fetchTarball", 1, prim_fetchTarball);
+    addImpurePrimOp<__fetchurl, 1, prim_fetchurl>();
+    addImpurePrimOp<fetchTarball, 1, prim_fetchTarball>();
 
     /* Add a wrapper around the derivation primop that computes the
        `drvPath' and `outPath' attributes lazily. */

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -25,7 +25,7 @@ void escapeJSON(std::ostream & str, const string & s)
 
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, std::ostream & str, PathSet & context)
+    Value & v, std::ostream & str, PathSet & context, bool copyPathToStore)
 {
     checkInterrupt();
 
@@ -47,9 +47,13 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
 
         case tPath:
-            escapeJSON(str, state.copyPathToStore(context, v.path));
+            if(copyPathToStore) {
+                escapeJSON(str, state.copyPathToStore(context, v.path));
+            }
+            else {
+                escapeJSON(str, v.path);
+            }
             break;
-
         case tNull:
             str << "null";
             break;

--- a/src/libexpr/value-to-json.hh
+++ b/src/libexpr/value-to-json.hh
@@ -9,7 +9,7 @@
 namespace nix {
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, std::ostream & out, PathSet & context);
+    Value & v, std::ostream & out, PathSet & context, bool copyPathToStore = true);
 
 void escapeJSON(std::ostream & str, const string & s);
 

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -20,6 +20,7 @@ typedef enum {
     tLambda,
     tBlackhole,
     tPrimOp,
+    tPrimOpLambda,
     tPrimOpApp,
     tExternal,
 } ValueType;
@@ -30,7 +31,7 @@ struct Env;
 struct Expr;
 struct ExprLambda;
 struct PrimOp;
-struct PrimOp;
+struct PrimOpLambda;
 class Symbol;
 struct Pos;
 class EvalState;
@@ -137,6 +138,7 @@ struct Value
             ExprLambda * fun;
         } lambda;
         PrimOp * primOp;
+        PrimOpLambda * primOpLambda;
         struct {
             Value * left, * right;
         } primOpApp;

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "symbol-table.hh"
+#include <functional>
 
 namespace nix {
 
@@ -36,6 +37,7 @@ class Symbol;
 struct Pos;
 class EvalState;
 class XMLWriter;
+struct ConstantWithSideEffect;
 
 
 typedef long NixInt;
@@ -139,7 +141,8 @@ struct Value
         } lambda;
         PrimOp * primOp;
         PrimOpLambda * primOpLambda;
-        struct {
+        ConstantWithSideEffect * constantWithSideEffect;
+	struct {
             Value * left, * right;
         } primOpApp;
         ExternalValueBase * external;

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "symbol-table.hh"
-#include <functional>
 
 namespace nix {
 
@@ -21,7 +20,6 @@ typedef enum {
     tLambda,
     tBlackhole,
     tPrimOp,
-    tPrimOpLambda,
     tPrimOpApp,
     tExternal,
 } ValueType;
@@ -32,12 +30,10 @@ struct Env;
 struct Expr;
 struct ExprLambda;
 struct PrimOp;
-struct PrimOpLambda;
 class Symbol;
 struct Pos;
 class EvalState;
 class XMLWriter;
-struct ConstantWithSideEffect;
 
 
 typedef long NixInt;
@@ -140,9 +136,7 @@ struct Value
             ExprLambda * fun;
         } lambda;
         PrimOp * primOp;
-        PrimOpLambda * primOpLambda;
-        ConstantWithSideEffect * constantWithSideEffect;
-	struct {
+        struct {
             Value * left, * right;
         } primOpApp;
         ExternalValueBase * external;

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -163,8 +163,10 @@ int main(int argc, char * * argv)
                 settings.readOnlyMode = true;
             else if (*arg == "--playback")
                 playback = true;
-            else if (*arg == "--record")
+            else if (*arg == "--record") {
                 record = true;
+                wantsReadWrite = true;
+            }
             else if (*arg != "" && arg->at(0) == '-')
                 return false;
             else


### PR DESCRIPTION
This pull request introduces an option to nix-instantiate and nix-env to record all impure dependencies of a nix expression and save it in a json file, thus getting a "pure" nix expression, so it can later be replayed.
This is originally from #553 and a discussion on nixconf with @copumpkin.
We later started hacking this on the following sprint with help from @edolstra.
## Usage

Currently, it can be invoked for example like this:

```
nix-build --record
```

Then an additional derivation /nix/store/...-source-closure gets build which contains a json file consisting of all impurities associated with this build including a closure of all used build files. For example `nix-build --record -A vim "<nixpkgs>"` results in [the following json file](https://gist.github.com/fkz/78675c003d7708888671) (pretty printed with python -m 'tool.json').
With `nix-store --export $(nix-store -qR /nix/store/5wxzlhm2s98rq97ml96bsb0j4d2ydy3k-source-closure)` we can then bundle the complete source closure. (the dependencies can be seen with `nix-store -q --tree /nix/store/...-source-closure/`)

In the json file, there are basically the command line arguments to nix-instantiate, calls of impure functions with results (so they can be replayed) and a mapping from paths to store-paths for included files (like .nix, .patch etc.), the closure consists of all the filepaths which are values in the sources map (the keys are not needed).
This should then be reproducable with

```
nix-build --replay /nix/store/...-source-closure/nix-support/source
```

This command should currently be usable with nix-instantiate, nix-build and nix-shell; nix-env is not yet covered.

Furthermore, you could alter some things in the json file to create a different, but still reproducable behavior (currently the replay fails when the program wants to access anything else, we could add a mode which generates a new json file with additional sources/impurities though).
## TODO

The basic playback works, there are a few things that still need to be done
### Important
- [ ] add tests
- [ ] add documentation
### Nice to have
- [ ] support ~ -paths
- [x] support for nix-build, nix-shell
- [ ] support for nix-env
- [x] writing the .json output to the nix store with its proper dependency clojure
- [ ] save a mapping source-closure -> drv (maybe in the metadata of nix?)
- not adding every file on its own to the store, instead recognize when one is already in the store and then use that (for example nixpkgs would only get one source mapping like this). We may somehow detect, how high we should go in the directory tree, e. g. :
  - [x] if it's already in the store, we can go to /nix/store/`<hash`>-`<name`> (*)
  - [ ] find a .git, .gitrevision or other special files
- [ ] since the __filterSource primop is currently not supported, some derivations are not recordable.
- [x] It would be great if these were composable. I.e. import /nix/store/....-source-closure in nix-exprs work. Nix would warn/error if the keys were mapped to different values in the referenced source closures. [N.B. this totally resembles mixing binary caches with the intensional store, and I think the similarity should be explored for maximum code/idea reuse.] 
  **Update**: just implemented this with a refactoring to produce nix-files instead of json-files
### Bugs
- [x] when using `nix-instantiate --eval`, no derivations are build, so the source clojure isn't build either (and there's an error message: cannot build missing derivation)
### Further ideas
- [ ] There's also a problem with imports from derivations since we get a dependency on the generated file (with the last point, this might actually be huge since we'd depend on the whole output of the derivation), so this isn't strictly a source closure anymore.
- [ ] creating the option to include it in the output of the derivation (since we don't want to change the output of a derivation depending on changes in nix files, we'd have to create a symlink tree of the .json file and the derivation output; this would be the derivation including its source clojure) so we get an output which also depends on the source clojure.
