### PR TITLE
Print license information on '--xml --meta'

### DIFF
--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1140,7 +1140,19 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                                         attrs3["value"] = v->listElems()[j]->string.s;
                                         xml.writeEmptyElement("string", attrs3);
                                     }
+                              } else if (v->type == tAttrs) {
+                                  attrs2["type"] = "strings";
+                                  XMLOpenElement m(xml, "meta", attrs2);
+                                  Bindings & attrs = *v->attrs;
+                                  for (auto &i : attrs) {
+                                      Attr & a(*attrs.find(i.name));
+                                      if(a.value->type != tString) continue;
+                                      XMLAttrs attrs3;
+                                      attrs3["type"] = i.name;
+                                      attrs3["value"] = a.value->string.s;
+                                      xml.writeEmptyElement("string", attrs3);
                                 }
+                              }
                             }
                         }
                     }


### PR DESCRIPTION
The nixpkgs manual prescribes the use of values from stdenv.lib.licenses
for the meta.license attribute. Those values are attribute sets and
currently skipped when running nix-env with '--xml --meta'. This has the
consequence that also nixpkgs-lint will report missing licenses.

With this commit nix-env with '--xml --meta' will print all attributes
of an attribute set that are of type tString. For example the output for
the package nixpkgs.hello is

    <meta name="license" type="strings">
      <string type="url" value="http://spdx.org/licenses/GPL-3.0+" />
      <string type="shortName" value="gpl3Plus" />
      <string type="fullName" value="GNU General Public License v3.0 or later" />
      <string type="spdxId" value="GPL-3.0+" />
    </meta>

This commit fixes nixpkgs-lint, too.

Closes #288, https://github.com/NixOS/nixpkgs/issues/9966 and is also relevant for the "automatic linter" mentioned in https://github.com/NixOS/nixpkgs/issues/11166.