### PR TITLE
Reintroduce host deps in tandem with sandbox profiles

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -97,7 +97,7 @@ let
 
         enableParallelBuilding = true;
 
-        __sandboxProfile = lib.sandbox.allowFileRead [
+        sandboxProfile = lib.sandbox.allowFileRead [
           "/etc" "/etc/nix/nix.conf" "/private/etc/nix/nix.conf"
         ];
 

--- a/scripts/resolve-system-dependencies.pl.in
+++ b/scripts/resolve-system-dependencies.pl.in
@@ -113,7 +113,7 @@ if (defined $ARGV[0]) {
     my $depset = reduce { union($a, $b) } (map { resolve_tree($_, $depcache) } @files);
     print "extra-chroot-dirs\n";
     print join("\n", keys %$depset);
-    print "\n\n";
+    print "\n";
   }
   lock_store($DEPS, $cache);
 } else {

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1927,7 +1927,7 @@ void DerivationGoal::startBuilder()
 
 #if SANDBOX_ENABLED
         additionalSandboxProfile = get(drv->env, "__sandboxProfile");
-#else
+#endif
         string allowed = settings.get("allowed-impure-host-deps", string(DEFAULT_ALLOWED_IMPURE_PREFIXES));
         PathSet allowedPaths = tokenizeString<StringSet>(allowed);
 
@@ -1953,7 +1953,6 @@ void DerivationGoal::startBuilder()
 
             dirsInChroot[i] = i;
         }
-#endif
 
 #if CHROOT_ENABLED
         /* Create a temporary directory in which we set up the chroot


### PR DESCRIPTION
@shlevy @edolstra 

Reintroduces the functionality that allows the baked-in pre-build-hook to find framework dependencies