### PR TITLE
Better error message: Also show types when nix cannot compare values of different types

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -248,7 +248,7 @@ struct CompareValues
     bool operator () (const Value * v1, const Value * v2) const
     {
         if (v1->type != v2->type)
-            throw EvalError("cannot compare values of different types");
+            throw EvalError(format("cannot compare %1% with %2%") % showType(*v1) % showType(*v2));
         switch (v1->type) {
             case tInt:
                 return v1->integer < v2->integer;


### PR DESCRIPTION
Also show types when nix cannot compare values of different types.
This is also more consistent since types are already shown when comparing values of the same not comparable type.

This is slightly unaesthetic since the error message is duplicated, the alternatives would be to create the EvalError object unconditionally (then showType would always be called if C++ isn't clever enough to optimize it away) or using a lambda. I think this it is good enough like this since the code duplication is very  local.