### PR TITLE
Use shellwords for nix-shell shebang

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -6,6 +6,7 @@ use Nix::Config;
 use Nix::Store;
 use Nix::Utils;
 use File::Basename;
+use Text::ParseWords;
 use Cwd;
 
 binmode STDERR, ":encoding(utf8)";
@@ -56,7 +57,7 @@ if ($runEnv && defined $ARGV[0] && $ARGV[0] !~ /nix-shell/) {
             while (<SCRIPT>) {
                 chomp;
                 if (/^\#\!\s*nix-shell (.*)$/) {
-                    push @ARGV, split(/ /, $1);
+                    push @ARGV, shellwords(/ /, $1);
                 }
             }
         }


### PR DESCRIPTION
Previously we can't have quoted arguments.

This now allows us to use things like `ghcWithPackages`