### PR TITLE
Clarify error message for hash mismatches (again)

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2736,8 +2736,8 @@ void DerivationGoal::registerOutputs()
             Hash h2 = recursive ? hashPath(ht, actualPath).first : hashFile(ht, actualPath);
             if (h != h2)
                 throw BuildError(
-                    format("Nix expects output path ‘%1%’ to have %2% hash ‘%3%’, instead it has ‘%4%’")
-                    % path % i.second.hashAlgo % printHash16or32(h) % printHash16or32(h2));
+                    format("output path ‘%1%’ has %2% hash ‘%3%’ when ‘%4%’ was expected")
+                    % path % i.second.hashAlgo % printHash16or32(h2) % printHash16or32(h));
         }
 
         /* Get rid of all weird permissions.  This also checks that


### PR DESCRIPTION
This is arguably nitpicky, but I think this new formulation is even
clearer. My thinking is that it's easier to comprehend when the
calculated hash value is displayed close to the output path. (I think it
is somewhat similar to eliminating double negatives in logic
statements.)

The formulation is inspired / copied from the OpenEmbedded build tool,
bitbake.