### PR TITLE
Update multi-user.xml

### DIFF
--- a/doc/manual/installation/multi-user.xml
+++ b/doc/manual/installation/multi-user.xml
@@ -91,7 +91,7 @@ done
 started as follows (as <literal>root</literal>):
 
 <screen>
-$ nix-daemon</screen>
+$ /root/.nix-profile/bin/nix-daemon</screen>
 
 You’ll want to put that line somewhere in your system’s boot
 scripts.</para>


### PR DESCRIPTION
I may be wrong here (first day playing with nix) with the path, but since /usr/local/bin (or normal system PATH) does not by default hold nix-daemon (or any nix package) the docs should talk about how to create new profiles for users, and how to get the full path to nix-daemon to run.
