### PR TITLE
Make Debian package depend on libcurl3-nss

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -302,7 +302,7 @@ let
       src = jobs.tarball;
       diskImage = (diskImageFun vmTools.diskImageFuns)
         { extraPackages =
-            [ "libdbd-sqlite3-perl" "libsqlite3-dev" "libbz2-dev" "libwww-curl-perl" "libcurl-dev" "libssl-dev" "liblzma-dev" ]
+            [ "libdbd-sqlite3-perl" "libsqlite3-dev" "libbz2-dev" "libwww-curl-perl" "libcurl-dev" "libcurl3-nss" "libssl-dev" "liblzma-dev" ]
             ++ extraPackages; };
       memSize = 1024;
       meta.schedulingPriority = 50;


### PR DESCRIPTION
I [downloaded](http://hydra.nixos.org/release/nix/nix-1.10) the Nix debian package for amd64 jessie.  After installing it, `nix-env` fails to start:

```
$ /usr/bin/nix-env
/usr/bin/nix-env: error while loading shared libraries: libcurl-nss.so.4: cannot open shared object file: No such file or directory
```

Installing `libcurl3-nss` fixed it, but it really ought to be listed as a dependency in `release.nix`.  It seems this package exists for all supported Debian and Ubuntu versions, so I *think* it's safe to depend on it everywhere.