### PR TITLE
Do not override environment CFLAGS and CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,6 @@ if test "$sys_name" = sunos; then
 fi
 
 
-CFLAGS=
-CXXFLAGS=
 AC_PROG_CC
 AC_PROG_CXX
 


### PR DESCRIPTION
Looks like 5a05cf4063fc6ea666f3e24c60bd2e9e5526ef4e removed usage of
environment CFLAGS and CXXFLAGS by mistake. That change broke building
of nix on fedora core 23.