### PR TITLE
doc/manual/command-ref/nix-collect-garbage.xml: document --max-freed option

### DIFF
--- a/doc/manual/command-ref/nix-collect-garbage.xml
+++ b/doc/manual/command-ref/nix-collect-garbage.xml
@@ -28,6 +28,7 @@
       <arg choice='plain'><option>--print-dead</option></arg>
       <arg choice='plain'><option>--delete</option></arg>
     </group>
+    <arg><option>--max-freed</option> <replaceable>bytes</replaceable></arg>
     <arg><option>--dry-run</option></arg>
   </cmdsynopsis>
 </refsynopsisdiv>


### PR DESCRIPTION
Mention the `--max-freed` option in the `nix-collect-garbage` man page. Related to https://github.com/NixOS/nix/issues/609.