### PR TITLE
parse $ followed by a ' inside ind_string

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -167,8 +167,10 @@ or          { return OR_KW; }
                  }
 <IND_STRING>\$\{ { PUSH_STATE(INSIDE_DOLLAR_CURLY); return DOLLAR_CURLY; }
 <IND_STRING>\'\' { POP_STATE(); return IND_STRING_CLOSE; }
-<IND_STRING>\'   {
-                   yylval->e = new ExprIndStr("'");
+<IND_STRING>(\'|\$) {
+                   char str[2] = "'";
+                   str[0] = yytext[0];
+                   yylval->e = new ExprIndStr(str);
                    return IND_STR;
                  }
 <IND_STRING>.    return yytext[0]; /* just in case: shouldn't be reached */

--- a/tests/lexer.nix
+++ b/tests/lexer.nix
@@ -1,2 +1,5 @@
 let const = a: "const"; in
-''${ const { x = "q"; }}''
+''${ const { x = "q"; }}'' +
+''
+   we now allow the literal $' inside strings
+''


### PR DESCRIPTION
Previously, e. g. ''$'' or '' $' '' would fail with 'unexpected $undefined, expecting IND_STR or DOLLAR_CURLY or IND_STRING_CLOSE'
This fixes #772
