### PR TITLE
nix-profile.sh.in: quote use of $HOME in shell arguments

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -11,8 +11,8 @@ if [ -n "$HOME" ]; then
     export PATH=$NIX_LINK/bin:$NIX_LINK/sbin:$PATH
 
     # Subscribe the user to the Nixpkgs channel by default.
-    if [ ! -e $HOME/.nix-channels ]; then
-        echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > $HOME/.nix-channels
+    if [ ! -e "$HOME/.nix-channels" ]; then
+        echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
     fi
 
     # Append ~/.nix-defexpr/channels/nixpkgs to $NIX_PATH so that


### PR DESCRIPTION
All other places in the script do this already, so let's be consistent.