### PR TITLE
musl compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_ARG_WITH(system, AC_HELP_STRING([--with-system=SYSTEM],
    esac
 
    case "$host_os" in
-     linux-gnu*)
+     linux-gnu*|linux-musl*)
         # For backward compatibility, strip the `-gnu' part.
         system="$machine_name-linux";;
      *)

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -52,7 +52,6 @@
 #include <sys/param.h>
 #include <sys/mount.h>
 #include <sys/syscall.h>
-#include <linux/fs.h>
 #define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
 #endif
 


### PR DESCRIPTION
This allows Nix to compile against musl libc.
Fixes #469.