### PR TITLE
Propagate path context via builtins.readFile

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -765,7 +765,7 @@ static void prim_readFile(EvalState & state, const Pos & pos, Value * * args, Va
     string s = readFile(state.checkSourcePath(path));
     if (s.find((char) 0) != string::npos)
         throw Error(format("the contents of the file ‘%1%’ cannot be represented as a Nix string") % path);
-    mkString(v, s.c_str());
+    mkString(v, s.c_str(), context);
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/833