### PR TITLE
Handle ARM triples without an endianness suffix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,8 @@ AC_ARG_WITH(system, AC_HELP_STRING([--with-system=SYSTEM],
         machine_name="i686";;
      amd64)
         machine_name="x86_64";;
+     armv6|armv7)
+        machine_name="${host_cpu}l";;
      *)
         machine_name="$host_cpu";;
    esac


### PR DESCRIPTION
Alpine seems to use this, and it results in a wrong
builtins.currentSystem. Big-endian ARM systems have triples starting
with armv6eb- or armv7eb-, so this doesn't change any systems that
already worked.