### PR TITLE
nix-shell: improve shebang recognition

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -56,7 +56,7 @@ if ($runEnv && defined $ARGV[0] && $ARGV[0] !~ /nix-shell/) {
             @ARGV = ();
             while (<SCRIPT>) {
                 chomp;
-                if (/^\#\!\s*nix-shell (.*)$/) {
+                if (/^.*\s*nix-shell (.*)$/) {
                     push @ARGV, shellwords($1);
                 }
             }


### PR DESCRIPTION
Some languages don’t accept shebangs that are more than one line, e.g.
lua. This patch laxes the restriction that the second line needs to
start with `#!`, it can now start with any string instead.

E.g. in lua one can now use the comment symbols:

``` lua
 #!/usr/bin/env nix-shell
 -- nix-shell -i …
```
