### PR TITLE
Add 32bit linux clause to dev-shell

### DIFF
--- a/dev-shell
+++ b/dev-shell
@@ -11,7 +11,7 @@ exec $s release.nix -A tarball --command "
     export NIX_PATH='$NIX_PATH'
     export NIX_BUILD_SHELL=$(type -p bash)
     export c=\$configureFlags
-    exec $s release.nix -A build.$(if [ $(uname -s) = Darwin ]; then echo x86_64-darwin; else echo x86_64-linux; fi) --exclude tarball --command '
+    exec $s release.nix -A build.$(if [ $(uname -s) = Darwin ]; then echo x86_64-darwin; elif [[ $(uname -m) =~ ^i[3456]86$ ]]; then echo i686-linux; else echo x86_64-linux; fi) --exclude tarball --command '
         configureFlags+=\" \$c --prefix=$(pwd)/inst --sysconfdir=$(pwd)/inst/etc\"
         return
     '" \


### PR DESCRIPTION
This prevents my 32bit linux NixOS machine from using 64bit packages when following the [hacking guide](http://nixos.org/nix/manual/#chap-hacking)

Fixes https://github.com/NixOS/nix/issues/857