### PR TITLE
Enable custom nix-shell prompts

### DIFF
--- a/doc/manual/command-ref/nix-shell.xml
+++ b/doc/manual/command-ref/nix-shell.xml
@@ -366,9 +366,15 @@ runCommand "dummy" { buildInputs = [ python pythonPackages.prettytable ]; } ""
 
 <variablelist>
   <xi:include href="env-common.xml#xmlns(db=http://docbook.org/ns/docbook)xpointer(//db:variablelist[@xml:id='env-common']/*)" />
+
+<varlistentry><term><envar>NIX_SHELL_PS1</envar></term>
+
+  <listitem><para>Overrides the prompt in a nix-shell.
+  </para></listitem>
+
+</varlistentry>
 </variablelist>
 
 </refsection>
-
 
 </refentry>

--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -270,7 +270,7 @@ foreach my $expr (@exprs) {
         my $tmp = $ENV{"TMPDIR"} // $ENV{"XDG_RUNTIME_DIR"} // "/tmp";
         if ($pure) {
             foreach my $name (keys %ENV) {
-                next if grep { $_ eq $name } ("HOME", "USER", "LOGNAME", "DISPLAY", "PATH", "TERM", "IN_NIX_SHELL", "TZ", "PAGER", "NIX_BUILD_SHELL");
+                next if grep { $_ eq $name } ("HOME", "USER", "LOGNAME", "DISPLAY", "PATH", "TERM", "IN_NIX_SHELL", "TZ", "PAGER", "NIX_BUILD_SHELL", "NIX_SHELL_PS1");
                 delete $ENV{$name};
             }
             # NixOS hack: prevent /etc/bashrc from sourcing /etc/profile.
@@ -289,13 +289,16 @@ foreach my $expr (@exprs) {
             $rcfile,
             "rm -rf '$tmpDir'; " .
             'unset BASH_ENV; ' .
+            '[ -v NIX_SHELL_PS1 ] && NIX_SHELL_LOCAL_PS1="$NIX_SHELL_PS1"; ' .
             '[ -n "$PS1" ] && [ -e ~/.bashrc ] && source ~/.bashrc; ' .
             ($pure ? '' : 'p=$PATH; ' ) .
             'dontAddDisableDepTrack=1; ' .
             '[ -e $stdenv/setup ] && source $stdenv/setup; ' .
             ($pure ? '' : 'PATH=$PATH:$p; unset p; ') .
             'set +e; ' .
-            '[ -n "$PS1" ] && PS1="\n\[\033[1;32m\][nix-shell:\w]$\[\033[0m\] "; ' .
+            '[ -n "$PS1" ] && if [ -v NIX_SHELL_LOCAL_PS1 ] ; then PS1="$NIX_SHELL_LOCAL_PS1"; ' .
+            'elif [ -v NIX_SHELL_PS1 ] ; then PS1="$NIX_SHELL_PS1"; ' .
+            'else PS1="\n\[\033[1;32m\][nix-shell:\w]$\[\033[0m\] "; fi; ' .
             'if [ "$(type -t runHook)" = function ]; then runHook shellHook; fi; ' .
             'unset NIX_ENFORCE_PURITY; ' .
             'unset NIX_INDENT_MAKE; ' .


### PR DESCRIPTION
Allow overriding the nix-shell prompt by setting NIX_SHELL_PS1.

My use-case: I often switch workspaces after firing off a long-running process, and it's nice to be notified when the process completes. So I have a bell character in my PS1, which, through a chain of triggers, highlights the workspace in my status bar. This pull request lets me do the same with and within `nix-shell`.
