### PR TITLE
Fix `??` in Nix warning message

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -25,7 +25,7 @@ echo "performing a single-user installation of Nix..." >&2
 
 if ! [ -e $dest ]; then
     cmd="mkdir -m 0755 $dest && chown $USER $dest"
-    echo "directory $dest does not exist; creating it by running ‘$cmd’ using sudo" >&2
+    echo "directory $dest does not exist; creating it by running '$cmd' using sudo" >&2
     if ! sudo sh -c "$cmd"; then
         echo "$0: please manually run ‘$cmd’ as root to create $dest" >&2
         exit 1


### PR DESCRIPTION
Nix sometimes outputs a warning message like this:

```
directory /nix does not exist; creating it by running ‘?? using sudo
```

... when it really meant to output something that looked like this:

```
directory /nix does not exist; creating it by running 'mkdir -m 0755 /nix && chown gabriel /nix' using sudo
```

The reason why is due to some bizarre behavior in Bash where it will translate anything of the form `$x’` to `??`, leading to the incorrect warning message.  I don't know what is the origin of this Bash behavior, but the easiest fix is to just use ASCII quotes instead of unicode quotes.