### PR TITLE
add ability to change name of user-environment

### DIFF
--- a/corepkgs/buildenv.nix
+++ b/corepkgs/buildenv.nix
@@ -1,9 +1,9 @@
 with import <nix/config.nix>;
 
-{ derivations, manifest }:
+{ derivations, manifest, name ? "user-environment" }:
 
 derivation {
-  name = "user-environment";
+  inherit name;
   system = builtins.currentSystem;
   builder = perl;
   args = [ "-w" ./buildenv.pl ];


### PR DESCRIPTION
If we made this change, would I be able to pass the name tag from `<nixpkgs>` ?

Any reasons we should not do this? I would like to include git commit id of `<nixpkgs>` in the name of my `user-environment`.
