### PR TITLE
Add perl packages as a buildInput and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Makefile.config
 /scripts/build-remote.pl
 /scripts/nix-reduce-build
 /scripts/nix-http-export.cgi
+/scripts/resolve-system-dependencies.pl
 
 # /src/libexpr/
 /src/libexpr/lexer-tab.cc
@@ -57,9 +58,11 @@ Makefile.config
 /src/libexpr/parser-tab.hh
 /src/libexpr/parser-tab.output
 /src/libexpr/nix.tbl
+/src/libexpr/libnixexpr.dylib
 
 # /src/libstore/
 /src/libstore/schema.sql.hh
+/src/libstore/libnixstore.dylib
 
 # /src/nix-env/
 /src/nix-env/nix-env
@@ -76,6 +79,24 @@ Makefile.config
 # /src/download-via-ssh/
 /src/download-via-ssh/download-via-ssh
 
+# /src/nix/
+/src/nix/nix
+
+# /src/libmain/
+/src/libmain/libnixmain.dylib
+
+# /src/libutil/
+/src/libutil/libnixutil.dylib
+
+# /src/boost/format/
+/src/boost/format/libnixformat.dylib
+
+# /src/nix-prefetch-url/
+/src/nix-prefetch-url/nix-prefetch-url
+
+# /src/nix-collect-garbage/
+/src/nix-collect-garbage/nix-collect-garbage
+
 # /tests/
 /tests/test-tmp
 /tests/common.sh
@@ -89,6 +110,7 @@ Makefile.config
 
 /perl/lib/Nix/Config.pm
 /perl/lib/Nix/Store.cc
+/perl/lib/Nix/Store.dylib
 
 /misc/systemd/nix-daemon.service
 /misc/systemd/nix-daemon.socket

--- a/release.nix
+++ b/release.nix
@@ -28,6 +28,7 @@ let
             pkgconfig sqlite libsodium
             docbook5 docbook5_xsl
             autoconf-archive
+            perlPackages.DBI perlPackages.DBDSQLite perlPackages.WWWCurl
           ] ++ lib.optional (!lib.inNixShell) git;
 
         configureFlags = ''


### PR DESCRIPTION
I'm not sure if this was intentionally left out but "dev-shell" was failing for me because of the missing perl requirements from the configure script.

I've got a gitignore update attached but feel free to cherry pick accordingly.