### PR TITLE
Add uname and misc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Makefile.config
 /scripts/build-remote.pl
 /scripts/nix-reduce-build
 /scripts/nix-http-export.cgi
+/scripts/resolve-system-dependencies.pl
 
 # /src/libexpr/
 /src/libexpr/lexer-tab.cc
@@ -57,9 +58,11 @@ Makefile.config
 /src/libexpr/parser-tab.hh
 /src/libexpr/parser-tab.output
 /src/libexpr/nix.tbl
+/src/libexpr/libnixexpr.dylib
 
 # /src/libstore/
 /src/libstore/schema.sql.hh
+/src/libstore/libnixstore.dylib
 
 # /src/nix-env/
 /src/nix-env/nix-env
@@ -76,6 +79,24 @@ Makefile.config
 # /src/download-via-ssh/
 /src/download-via-ssh/download-via-ssh
 
+# /src/nix/
+/src/nix/nix
+
+# /src/libmain/
+/src/libmain/libnixmain.dylib
+
+# /src/libutil/
+/src/libutil/libnixutil.dylib
+
+# /src/boost/format/
+/src/boost/format/libnixformat.dylib
+
+# /src/nix-prefetch-url/
+/src/nix-prefetch-url/nix-prefetch-url
+
+# /src/nix-collect-garbage/
+/src/nix-collect-garbage/nix-collect-garbage
+
 # /tests/
 /tests/test-tmp
 /tests/common.sh
@@ -89,6 +110,7 @@ Makefile.config
 
 /perl/lib/Nix/Config.pm
 /perl/lib/Nix/Store.cc
+/perl/lib/Nix/Store.dylib
 
 /misc/systemd/nix-daemon.service
 /misc/systemd/nix-daemon.socket

--- a/release.nix
+++ b/release.nix
@@ -28,6 +28,7 @@ let
             pkgconfig sqlite libsodium
             docbook5 docbook5_xsl
             autoconf-archive
+            perlPackages.DBI perlPackages.DBDSQLite perlPackages.WWWCurl
           ] ++ lib.optional (!lib.inNixShell) git;
 
         configureFlags = ''

--- a/src/nix/uname.cc
+++ b/src/nix/uname.cc
@@ -1,0 +1,24 @@
+#include "command.hh"
+#include "globals.hh"
+
+using namespace nix;
+
+struct CmdUname : Command
+{
+    std::string name() override
+    {
+        return "uname";
+    }
+
+    std::string description() override
+    {
+        return "print canonical Nix system name";
+    }
+
+    void run() override
+    {
+        std::cout << format("%1%\n") % settings.thisSystem;
+    }
+};
+
+static RegisterCommand r1(make_ref<CmdUname>());


### PR DESCRIPTION
This is my proposal for a "uname" command for the new Nix CLI. For instance, the "dev-shell" script has this line:

``` sh
nix-shell release.nix -A build.$(if [ $(uname -s) = Darwin ]; then echo x86_64-darwin; elif [[ $(uname -m) =~ ^i[3456]86$ ]]; then echo i686-linux; else echo x86_64-linux; fi)
```

This could be replaced in the new Nix CLI with:

``` sh
nix shell -f release.nix build.$(nix uname)
```

I'm open to any discussion or suggestions especially regarding changing the name of the command.

I've also got two minor commits that can be cherry picked off if they're not useful.
