### PR TITLE
resolve-system-dependencies.pl hanging

### DIFF
--- a/scripts/resolve-system-dependencies.pl.in
+++ b/scripts/resolve-system-dependencies.pl.in
@@ -87,16 +87,24 @@ sub cache_insert($) {
 
 sub find_deps($) {
   my $lib = shift;
+
+  my $ok = 0;
+  my @libs;
+
   my($chld_in, $chld_out, $chld_err);
   my $pid = open3($chld_in, $chld_out, $chld_err, "@otool@", "-L", "-arch", "x86_64", $lib);
-  waitpid($pid, 0);
   my $line = readline $chld_out;
-  if($? == 0 and $line !~ /not an object file/) {
-    my @libs;
+  if($line !~ /not an object file/) {
     while(<$chld_out>) {
       my $dep = (split /\s+/)[1];
       push @libs, $dep unless $dep eq $lib or $dep =~ /\@rpath/;
     }
+    waitpid($pid, 0);
+    if ($? == 0) {
+      $ok = 1;
+    }
+  }
+  if ($ok) {
     @libs
   } elsif (-l $lib) {
     (realpath($lib))


### PR DESCRIPTION
This is OS X 10.11.5.

~~~~
› rm /nix/var/nix/dependency-maps/x86_64-Darwin-15.5.0.map
› nix-env --option use-binary-caches false -iA nixpkgs.hello
installing ‘hello-2.10’
these derivations will be built:
  /nix/store/ww4k3h185z98n1xqh3izx9a1da950dqa-hello-2.10.tar.gz.drv
  /nix/store/x5dj533g2wx8c64l6kx67ic4yd8x22q3-hello-2.10.drv
building path(s) ‘/nix/store/3x7dwzq014bblazs7kq20p9hyzz0qh8g-hello-2.10.tar.gz’
Finding dependencies for /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation...
^C|   killing process 13685
error: interrupted by the user
~~~~

The problem is [here](https://github.com/NixOS/nix/blob/279fa8f618ff22cc71bf902a65cc29c04af6e01f/scripts/resolve-system-dependencies.pl.in#L92). It totally seems to me that `otool` is not willing to output anything unless someone is actually reading its output. If I execute that same `otool` command line myself, everything works fine; but if I run `resolve-system-dependencies.pl` the `otool` process hangs.

I’m as far from being a Perl guru as it gets, so I made a quick and dirty adjustment: I made it first read all the output and only then `waitpid` and check the exit status. (Not showing the code here as it is extremely ugly.) This helped.