### PR TITLE
manual: Make it clear that 'nix-shell -p' installs build-time and runtime dependencies.

### DIFF
--- a/doc/manual/command-ref/nix-shell.xml
+++ b/doc/manual/command-ref/nix-shell.xml
@@ -152,7 +152,8 @@ also <xref linkend="sec-common-options" />.</phrase></para>
     <literal>nix-shell -p libjpeg openjdk</literal> will start a shell
     in which the packages denoted by the attribute names
     <varname>libjpeg</varname> and <varname>openjdk</varname> are
-    present.</para></listitem>
+    present, along with all their build-time and runtime dependencies.
+    </para></listitem>
 
   </varlistentry>
 

--- a/doc/manual/introduction/quick-start.xml
+++ b/doc/manual/introduction/quick-start.xml
@@ -69,9 +69,10 @@ $ nix-env -e hello</screen>
 $ nix-shell -p hello
 </screen>
 
-This builds or downloads GNU Hello and its dependencies, then drops
-you into a Bash shell where the <command>hello</command> command is
-present, all without affecting your normal environment:
+This builds or downloads GNU Hello and its build-time and runtime
+dependencies, then drops you into a Bash shell where the
+<command>hello</command> command is present, all without affecting
+your normal environment:
 
 <screen>
 [nix-shell:~]$ hello


### PR DESCRIPTION
I'm pretty new to Nix, and while I was going through the Quick Start section of the manual I was kind of confused about why `nix-shell -p hello` took so much longer than `nix-env -i hello`.  It sounded like `nix-shell -p hello` was supposed to be a _fast_ way to try out packages, but really since it installs all the build-time dependencies, it can be a lot slower.  I thought adding a few words to the documentation could clarify what is going on.  (I hope I got it right!)

Here are some shell sessions demonstrating the difference between `nix-shell -p` and `nix-env -i`:

https://gist.github.com/DavidEGrayson/ac7598d80dc756c9263eb9297fb8d72f
