### PR TITLE
Improve error message on trailing path slashes

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -87,8 +87,8 @@ static Expr * unescapeStr(SymbolTable & symbols, const char * s)
 ID          [a-zA-Z\_][a-zA-Z0-9\_\'\-]*
 INT         [0-9]+
 FLOAT       (([1-9][0-9]*\.[0-9]*)|(0?\.[0-9]+))([Ee][+-]?[0-9]+)?
-PATH        [a-zA-Z0-9\.\_\-\+]*(\/[a-zA-Z0-9\.\_\-\+]+)+
-HPATH       \~(\/[a-zA-Z0-9\.\_\-\+]+)+
+PATH        [a-zA-Z0-9\.\_\-\+]*(\/[a-zA-Z0-9\.\_\-\+]+)+\/?
+HPATH       \~(\/[a-zA-Z0-9\.\_\-\+]+)+\/?
 SPATH       \<[a-zA-Z0-9\.\_\-\+]+(\/[a-zA-Z0-9\.\_\-\+]+)*\>
 URI         [a-zA-Z][a-zA-Z0-9\+\-\.]*\:[a-zA-Z0-9\%\/\?\:\@\&\=\+\$\,\-\_\.\!\~\*\']+
 
@@ -182,8 +182,16 @@ or          { return OR_KW; }
 
 <INITIAL,INSIDE_DOLLAR_CURLY>{
 
-{PATH}      { yylval->path = strdup(yytext); return PATH; }
-{HPATH}     { yylval->path = strdup(yytext); return HPATH; }
+{PATH}      { if (yytext[yyleng-1] == '/')
+                  throw ParseError(format("Invalid path '%1%'; trailing slashes are not allowed in paths") % yytext);
+              yylval->path = strdup(yytext);
+              return PATH;
+            }
+{HPATH}     { if (yytext[yyleng-1] == '/')
+                  throw ParseError(format("Invalid path '%1%'; trailing slashes are not allowed in paths") % yytext);
+              yylval->path = strdup(yytext);
+              return HPATH;
+            }
 {SPATH}     { yylval->path = strdup(yytext); return SPATH; }
 {URI}       { yylval->uri = strdup(yytext); return URI; }
 

--- a/tests/lang/eval-fail-path-slash.nix
+++ b/tests/lang/eval-fail-path-slash.nix
@@ -1,0 +1,6 @@
+# Trailing slashes in paths are not allowed.
+# This restriction could be lifted sometime,
+# for example if we make '/' a path concatenation operator.
+# See https://github.com/NixOS/nix/issues/1138
+# and http://lists.science.uu.nl/pipermail/nix-dev/2016-June/020829.html
+/nix/store/


### PR DESCRIPTION
See http://lists.science.uu.nl/pipermail/nix-dev/2016-June/thread.html#20809 for detailed issue info.

Fixes #1138.
