### PR TITLE
nixexpr grammar: optional semicolon at the end

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -8,7 +8,7 @@
 %parse-param { nix::ParseData * data }
 %lex-param { void * scanner }
 %lex-param { nix::ParseData * data }
-%expect 1
+%expect 2
 %expect-rr 1
 
 %code requires {
@@ -292,7 +292,12 @@ void yyerror(YYLTYPE * loc, yyscan_t scanner, ParseData * data, const char * err
 
 start: expr { data->result = $1; };
 
-expr: expr_function;
+expr
+  : expr_function optional_semicolon;
+
+optional_semicolon
+  :
+  | ';';
 
 expr_function
   : ID ':' expr_function


### PR DESCRIPTION
In daily nixexpr programming one often forgets to remove a semicolon at
the end of a file, be it by copying, by deleting a surrounding attrset
or simply by not noticing the difference between a let-binding, an
attrset and the last expression in a file.

This change to the grammar adds the possibility of having a last
semicolon.
Semantically, nothing changes.
No existing nixexprs are affected.
Removing this rule again would be a breaking change, so it should be
discussed first.

This change improves the user experience by making nixexprs more
forgiving (i.e. less frustrating).

cc @edolstra