### PR TITLE
Doc: NIX_REMOTE_SYSTEMS path must be absolute

### DIFF
--- a/doc/manual/advanced-topics/distributed-builds.xml
+++ b/doc/manual/advanced-topics/distributed-builds.xml
@@ -44,7 +44,8 @@ outputs and perform the remote build.  To use it, you should set
 <envar>NIX_BUILD_HOOK</envar> to
 <filename><replaceable>prefix</replaceable>/libexec/nix/build-remote.pl</filename>.
 You should also define a list of available build machines and point
-the environment variable <envar>NIX_REMOTE_SYSTEMS</envar> to it.  An
+the environment variable <envar>NIX_REMOTE_SYSTEMS</envar> to it (the
+path has to be absolute, otherwise nix will fail to distribute the build).  An
 example configuration is shown in <xref linkend='ex-remote-systems'
 />.  Each line in the file specifies a machine, with the following
 bits of information:


### PR DESCRIPTION
Once upon a time, I wrote my bachelors thesis about functional
deployment mechanisms.

I had to evaluate several szenarios where package management and
deployment were relevant. One szenario was to do distributed builds
over several machines.

I told myself: Weee, nix can do this! And with nix, this is actually
save, as you do not have side effects when building!

So I started. I use a cloud to set up four virtual machines where I
wanted to do the build. A fifth machine was used as master to distribute
the builds. All was good.

I created the necessary SSH keys, made sure every machine was reachable
by the master and configured the build in my remotes.conf.

When I started to try to build weechat from source, the build failed. It
failed, telling me

    error: unable to start any build; either increase ‘--max-jobs’ or enable distributed builds

And I started to dig around. I digged long and good. But I wasn't able
to find the issue.

I double and triple checked my environment variables, my settings, the
SSH key and everything.

I reached out to fellow Nixers by asking on the nixos IRC channel. And I
got help. But we weren't able to find the issue, either.

So I became frustrated. I re-did all the environment variables.

And suddenly,... it worked! What did I change? Well... I made the
environment variables which contained pathes contain absolute pathes
rather than relatives.

And because I like to share my knowledge, this should be put into the
documentation, so others do not bang their heads against the wall
because something is not documented somewhere.