### PR TITLE
Throw SysError if the buildHook file does not exist

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -597,7 +597,7 @@ HookInstance::HookInstance()
     buildHook = canonPath(buildHook);
 
     if (!pathExists(buildHook))
-        throw SysError(format("NIX_BUILD_HOOK '%1%' does not exist" % buildHook));
+        throw SysError(format("NIX_BUILD_HOOK '%1%' does not exist") % buildHook);
 
     /* Create a pipe to get the output of the child. */
     fromHook.create();

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -597,7 +597,7 @@ HookInstance::HookInstance()
     buildHook = canonPath(buildHook);
 
     if (!pathExists(buildHook))
-        throw SysError(format("NIX_BUILD_HOOK does not exist"));
+        throw SysError(format("NIX_BUILD_HOOK '%1%' does not exist" % buildHook));
 
     /* Create a pipe to get the output of the child. */
     fromHook.create();

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -596,6 +596,9 @@ HookInstance::HookInstance()
     if (string(buildHook, 0, 1) != "/") buildHook = settings.nixLibexecDir + "/nix/" + buildHook;
     buildHook = canonPath(buildHook);
 
+    if (!pathExists(buildHook))
+        throw SysError(format("NIX_BUILD_HOOK does not exist"));
+
     /* Create a pipe to get the output of the child. */
     fromHook.create();
 


### PR DESCRIPTION
A follow-up to #957 .

---

**Please note**: This is the very first piece of C++ code I write outside of university. I hope the place is appropriate and everything.

I did not yet test this, I first wanted to get feedback whether this change is appropriate at all...
