### PR TITLE
Don't hardcode docbook XSL namespace URL

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -10,7 +10,7 @@ XSLTPROC = $(xsltproc) --nonet $(xmlflags) \
   --stringparam generate.toc "book toc" \
   --param keep.relative.image.uris 0
 
-docbookxsl = http://docbook.sourceforge.net/release/xsl-ns/1.78.1
+docbookxsl = http://docbook.sourceforge.net/release/xsl-ns/current
 docbookrng = http://docbook.org/xml/5.0/rng/docbook.rng
 
 MANUAL_SRCS := $(call rwildcard, $(d), *.xml)


### PR DESCRIPTION
Docbook XSL got updated to version `1.79.1` in NixOS/nixpkgs@fb893a8 and we're still referring to the hardcoded previous version.

So instead of just updating this to `1.79.1` we're going to use `current` in the hope that this won't happen again.

I have tested this by building the manual under Nix(OS) but I haven't tested this in a non-Nix environment, so I'm not sure whether this could have implications.

Cc: @edolstra