### PR TITLE
release.nix: Allow to override inNixShell

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,7 @@
 { nix ? { outPath = ./.; revCount = 1234; shortRev = "abcdef"; }
 , nixpkgs ? { outPath = <nixpkgs>; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
+, shell ? (import <nixpkgs/lib>).inNixShell
 }:
 
 let
@@ -20,7 +21,7 @@ let
         name = "nix-tarball";
         version = builtins.readFile ./version;
         versionSuffix = if officialRelease then "" else "pre${toString nix.revCount}_${nix.shortRev}";
-        src = if lib.inNixShell then null else nix;
+        src = if shell then null else nix;
         inherit officialRelease;
 
         buildInputs =
@@ -28,7 +29,7 @@ let
             pkgconfig sqlite libsodium
             docbook5 docbook5_xsl
             autoconf-archive
-          ] ++ lib.optional (!lib.inNixShell) git;
+          ] ++ lib.optional (!shell) git;
 
         configureFlags = ''
           --with-dbi=${perlPackages.DBI}/${perl.libPrefix}


### PR DESCRIPTION
If we want to start up a `nix-shell` for another derivation referencing the `release.nix`, `inNixShell` is also `true` for the `release.nix` in Nix itself and the build will fail.

The `inNixShell` helper checks for an environment variable `IN_NIX_SHELL` at evaluation time, so there is not an easy way (except very hack ones) to have that set _only_ for the final derivation in the graph (the one we want to have a shell environment for).

So unless we have found a good option which _really_ fixes this, let's at least have a way to force deactivating `nix-shell` specific stuff in `release.nix`.
