### PR TITLE
Set $MANPATH

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -81,6 +81,10 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         export SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
     fi
 
+    if [ -n ${MANPATH} ]; then
+        export MANPATH="$NIX_LINK/share/man:$MANPATH"
+    fi
+
     export PATH="$NIX_LINK/bin:$NIX_LINK/sbin:$__savedpath"
     unset __savedpath NIX_LINK NIX_USER_PROFILE_DIR NIX_PROFILES
 fi


### PR DESCRIPTION
Currently, man has issues finding man pages for Nix-installed
application (also, `nix-env --help` doesn't work). The issue is caused
by custom `$MANPATH` set by my system. That makes man use it instead of
searching in default location.

Either of next lines workaround the issue:
```sh
unset MANPATH

export MANPATH=$HOME/.nix-profile/share/man:$MANPATH
```

This patch adds the later line to the `nix-profile.sh` if user has
`MANPATH` set. (Not clearing `MANPATH` as that would be disrespect of
user's preferences.)

As a side-effect, host's man might find man pages installed by Nix.