### PR TITLE
don't allow uris inside ${ ... } blocks

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -180,12 +180,13 @@ or          { return OR_KW; }
                  }
 <IND_STRING>.    return yytext[0]; /* just in case: shouldn't be reached */
 
+<INITIAL>{URI}       { yylval->uri = strdup(yytext); return URI; }
+
 <INITIAL,INSIDE_DOLLAR_CURLY>{
 
 {PATH}      { yylval->path = strdup(yytext); return PATH; }
 {HPATH}     { yylval->path = strdup(yytext); return HPATH; }
 {SPATH}     { yylval->path = strdup(yytext); return SPATH; }
-{URI}       { yylval->uri = strdup(yytext); return URI; }
 
 [ \t\r\n]+    /* eat up whitespace */
 \#[^\r\n]*    /* single-line comments */


### PR DESCRIPTION
this fixes #1017
also related to #836
evaluating `nix-env -qa` worked (modulo some typo problem) so this doesn't seem to be used inside nixpkgs.
this is a non-backward-compatible change though, 3rd party code could break because of this.
