### PR TITLE
emacs: remove '*' as punctuation

### DIFF
--- a/misc/emacs/nix-mode.el
+++ b/misc/emacs/nix-mode.el
@@ -47,7 +47,6 @@
 (defvar nix-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?/ ". 14" table)
-    (modify-syntax-entry ?* ". 23" table)
     (modify-syntax-entry ?# "< b" table)
     (modify-syntax-entry ?\n "> b" table)
     table)


### PR DESCRIPTION
From what I can tell, the `*` character is no longer used in nix syntax. Leaving it there throws off some highlighting like in `nixpkgs/pkgs/development/libraries/v8/default.nix`.