### PR TITLE
Fix early removal of nix-shell rc-file

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -295,7 +295,6 @@ foreach my $expr (@exprs) {
         writeFile(
             $rcfile,
             "rm -rf '$tmpDir'; " .
-            'unset BASH_ENV; ' .
             '[ -n "$PS1" ] && [ -e ~/.bashrc ] && source ~/.bashrc; ' .
             ($pure ? '' : 'p=$PATH; ' ) .
             'dontAddDisableDepTrack=1; ' .
@@ -309,7 +308,6 @@ foreach my $expr (@exprs) {
             'shopt -u nullglob; ' .
             'unset TZ; ' . (defined $ENV{'TZ'} ? "export TZ='${ENV{'TZ'}}'; " : '') .
             $envCommand);
-        $ENV{BASH_ENV} = $rcfile;
         my @args = ($ENV{NIX_BUILD_SHELL} // "bash");
         push @args, "--rcfile" if $interactive;
         push @args, $rcfile;


### PR DESCRIPTION
`BASH_ENV` causes all non-interactive shells called via eg. /etc/bashrc to
remove the rc-file before the main shell gets to run it. Completion
scripts will often do this. Fixes #976.

Looking at the blame information it seems that there's no reason `$ENV{BASH_ENV} = $rcfile` would cause trouble if removed. It was introduced to [support the `--command` flag](https://github.com/NixOS/nix/commit/4ea034a5c56a60ae0ceedf18a066c428a963c836/), but [a later commit](https://github.com/NixOS/nix/commit/128538ef06aa1075b82a1c559e11f6e445514858/) makes non-interactive scripts run the rcfile directly, ie. `bash $rcfile`.

The same bug is present in the c++ rewrite I believe.