### PR TITLE
Remove quotes on hash errors

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2739,7 +2739,7 @@ void DerivationGoal::registerOutputs()
             } else {
                 if (h != h2)
                     throw BuildError(
-                        format("output path ‘%1%’ has %2% hash ‘%3%’ when ‘%4%’ was expected")
+                        format("output path %1% has %2% hash %3% when %4% was expected")
                         % path % i.second.hashAlgo % printHash16or32(h2) % printHash16or32(h));
             }
         }


### PR DESCRIPTION
This makes copying hashes from terminals a bit easier (at least for me).