### PR TITLE
ExprApp::eval: A reference to the function might be held if it's a functor, so allocate vFun

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -940,10 +940,9 @@ void ExprLambda::eval(EvalState & state, Env & env, Value & v)
 
 void ExprApp::eval(EvalState & state, Env & env, Value & v)
 {
-    /* FIXME: vFun prevents GCC from doing tail call optimisation. */
-    Value vFun;
-    e1->eval(state, env, vFun);
-    state.callFunction(vFun, *(e2->maybeThunk(state, env)), v, pos);
+    Value * vFun = state.allocValue();
+    e1->eval(state, env, *vFun);
+    state.callFunction(*vFun, *(e2->maybeThunk(state, env)), v, pos);
 }
 
 


### PR DESCRIPTION

Fixes #1045