### PR TITLE
nix-env command line: forbid -A before -q

### DIFF
--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1316,6 +1316,7 @@ int main(int argc, char * * argv)
         initGC();
 
         Strings opFlags, opArgs, searchPath;
+        int opFlagsToDoubleCheck = 0;
         std::map<string, string> autoArgs_;
         Operation op = 0;
         bool repair = false;
@@ -1355,8 +1356,10 @@ int main(int argc, char * * argv)
                 op = opSetFlag;
             else if (*arg == "--set")
                 op = opSet;
-            else if (*arg == "--query" || *arg == "-q")
+            else if (*arg == "--query" || *arg == "-q") {
                 op = opQuery;
+                opFlagsToDoubleCheck = opFlags.size();
+            }
             else if (*arg == "--profile" || *arg == "-p")
                 globals.profile = absPath(getArg(*arg, arg, end));
             else if (*arg == "--file" || *arg == "-f")
@@ -1398,6 +1401,20 @@ int main(int argc, char * * argv)
         });
 
         if (!op) throw UsageError("no operation specified");
+
+        for(Strings::iterator arg=opFlags.begin();opFlagsToDoubleCheck>0;) {
+            if(*arg == "--from-profile") {
+                opFlagsToDoubleCheck--;
+                arg++;
+            }
+            else if(*arg == "-A")
+                throw UsageError("‘-A’ can only be specified after ‘-q’");
+            else if(*arg == "--attr")
+                throw UsageError("‘--attr’ can only be specified after ‘-q’");
+
+            opFlagsToDoubleCheck--;
+            arg++;
+        }
 
         auto store = openStore();
 


### PR DESCRIPTION
-A before -q on nix-env command line leads to weird error messages and weirder behaviour. This pull request makes it an error.

Weird error message:

```
$ nix-env -A cabal2nix -q                                          
error: ‘-A’ requires an argument 
```

Weird behaviour:

```
$ nix-env -qa -f ~/nixpkgs -A cabal2nix                            
cabal2nix  cabal2nix-2.0.1                                                                                       
$ nix-env  -A cabal2nix -qa -f ~/nixpkgs                          
0  cabal2nix-2.0
```

The latter command lists the installed derivation, not the available one, because the flag "-a" gets interpreted as the argument to "-A".
