### PR TITLE
armv5tel can be built by armv6l and armv7l

### DIFF
--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -61,6 +61,7 @@ bool BasicDerivation::canBuildLocally() const
 #if __linux__
         || (platform == "i686-linux" && settings.thisSystem == "x86_64-linux")
         || (platform == "armv6l-linux" && settings.thisSystem == "armv7l-linux")
+        || (platform == "armv5tel-linux" && (settings.thisSystem == "armv7l-linux" || settings.thisSystem == "armv6l-linux"))
 #elif __FreeBSD__
         || (platform == "i686-linux" && settings.thisSystem == "x86_64-freebsd")
         || (platform == "i686-linux" && settings.thisSystem == "i686-freebsd")


### PR DESCRIPTION
I've used this successfully on armv7 to build armv5. I'm pretty sure it will also work on armv6j, since armv5tel is always softfloat.