### PR TITLE
Add a new option to disable documentation generation at configure time

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -33,5 +33,6 @@ pkglibdir = $(libdir)/$(PACKAGE_NAME)
 prefix = @prefix@
 storedir = @storedir@
 sysconfdir = @sysconfdir@
+doc_generate = @doc_generate@
 xmllint = @xmllint@
 xsltproc = @xsltproc@

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,13 @@ AC_ARG_ENABLE(init-state, AC_HELP_STRING([--disable-init-state],
 #AM_CONDITIONAL(INIT_STATE, test "$init_state" = "yes")
 
 
+# documentation generation switch
+AC_ARG_ENABLE(doc-gen, AC_HELP_STRING([--disable-doc-gen],
+  [disable documentation generation]),
+  doc_generate=$enableval, doc_generate=yes)
+AC_SUBST(doc_generate)
+
+
 # Setuid installations.
 AC_CHECK_FUNCS([setresuid setreuid lchown])
 

--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -1,3 +1,6 @@
+
+ifeq ($(doc_generate),yes)
+
 XSLTPROC = $(xsltproc) --nonet $(xmlflags) \
   --param section.autolabel 1 \
   --param section.label.includes.component.label 1 \
@@ -71,8 +74,14 @@ $(foreach file, $(wildcard $(d)/images/callouts/*.gif), $(eval $(call install-da
 
 $(eval $(call install-symlink, manual.html, $(docdir)/manual/index.html))
 
+
 all: $(d)/manual.html
+
+
 
 clean-files += $(d)/manual.html
 
 dist-files += $(d)/manual.html
+
+
+endif


### PR DESCRIPTION
Add a new option to configure script ( --disable-doc-gen ) to disable the documentation generation step.

This is particularly useful when trying to bootstrap Nix on platforms that do not have an XSLT / XML installation with all the necessary spreadsheet / DTDs.

This is often the case on non-NixOS machines (cf here #967, here #506 or here #542 ) or on old machines.

