### PR TITLE
Installation: allow profile modification to be skipped

### DIFF
--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -26,6 +26,14 @@ $ mkdir /nix
 $ chown alice /nix
 </screen>
 
+The install script will modify the first writable file from amongst
+<filename>.bash_profile</filename>, <filename>.bash_login</filename>
+and <filename>.profile</filename> to source
+<filename>~/.nix-profile/etc/profile.d/nix.sh</filename>. You can set
+the <command>NIX_INSTALLER_NO_MODIFY_PROFILE</command> environment
+variable before executing the install script to disable this
+behaviour.
+
 </para>
 
 <!--

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -89,21 +89,25 @@ if [ -z "$_NIX_INSTALLER_TEST" ]; then
     $nix/bin/nix-channel --update nixpkgs
 fi
 
-# Make the shell source nix.sh during login.
-p=$HOME/.nix-profile/etc/profile.d/nix.sh
-
 added=
-for i in .bash_profile .bash_login .profile; do
-    fn="$HOME/$i"
-    if [ -w "$fn" ]; then
-        if ! grep -q "$p" "$fn"; then
-            echo "modifying $fn..." >&2
-            echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> $fn
+if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
+
+    # Make the shell source nix.sh during login.
+    p=$HOME/.nix-profile/etc/profile.d/nix.sh
+
+    for i in .bash_profile .bash_login .profile; do
+        fn="$HOME/$i"
+        if [ -w "$fn" ]; then
+            if ! grep -q "$p" "$fn"; then
+                echo "modifying $fn..." >&2
+                echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> $fn
+            fi
+            added=1
+            break
         fi
-        added=1
-        break
-    fi
-done
+    done
+
+fi
 
 if [ -z "$added" ]; then
     cat >&2 <<EOF


### PR DESCRIPTION
The current behaviour modifies the first writeable file from amongst
.bash_profile, .bash_login and .profile.  So .bash_profile (if it is
writable) would be modified even if a user has already sourced nix.sh
in, say, .profile.

This commit introduces a new environment variable,
NIX_INSTALLER_NO_MODIFY_PROFILE.  If this is set during installation,
then the modifications are unconditionally skipped.

This is useful for users who have a manually curated set of dotfiles
that they are porting to a new machine. In such scenarios, nix.sh is
already sourced at a place where the user prefers.  Without this
change, the nix installer would insist on modifying .bash_profile if
it exists.

This commit also add documentations for both the current behaviour and
the new override.
