### PR TITLE
use /nix/var/tmp as default tmpRoot

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -375,7 +375,7 @@ void deletePath(const Path & path, unsigned long long & bytesFreed)
 static Path tempName(Path tmpRoot, const Path & prefix, bool includePid,
     int & counter)
 {
-    tmpRoot = canonPath(tmpRoot.empty() ? getEnv("TMPDIR", "/tmp") : tmpRoot, true);
+    tmpRoot = canonPath(tmpRoot.empty() ? getEnv("NIX_TMPDIR", "/nix/var/tmp") : tmpRoot, true);
     if (includePid)
         return (format("%1%/%2%-%3%-%4%") % tmpRoot % prefix % getpid() % counter++).str();
     else


### PR DESCRIPTION
the default TMPDIR on OSX is set to a pretty long path in /var/folders
this causes unit tests that try to create unix domain sockets in the
build directory or a TMPDIR to fail.

This change uses `/nix/var/tmp` by default even if `TMPDIR` is set, but it's still overridable with `NIX_TMPDIR`

This still builds with this change for example: https://gist.github.com/LnL7/cdf69b7f231bdedfef5c11ce0c276c7f
