### PR TITLE
port nix.sh to the fish shell

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -92,15 +92,21 @@ fi
 added=
 if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
 
-    # Make the shell source nix.sh during login.
+    # Make the shell source nix.sh/nix.fish during login.
     p=$HOME/.nix-profile/etc/profile.d/nix.sh
+    pfish=$HOME/.nix-profile/etc/profile.d/nix.fish
 
-    for i in .bash_profile .bash_login .profile; do
+    for i in .bash_profile .bash_login .profile .config/fish/config.fish; do
         fn="$HOME/$i"
         if [ -w "$fn" ]; then
-            if ! grep -q "$p" "$fn"; then
-                echo "modifying $fn..." >&2
-                echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> $fn
+            if [ "$fn" = "$HOME/.config/fish/config.fish" ]; then
+                if ! grep -q "$pfish" "$fn"; then
+                    echo "modifying $fn..." >&2
+                    echo "if [ -e $p ]; source $pfish; end # added by Nix installer" >> $fn
+                fi
+            else if ! grep -q "$p" "$fn"; then
+                    echo "modifying $fn..." >&2
+                    echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> $fn
             fi
             added=1
             break
@@ -118,6 +124,12 @@ variables are set, please add the line
   . $p
 
 to your shell profile (e.g. ~/.profile).
+
+For the fish shell, please add the line
+
+  source $pfish
+
+to your fish config file (~/.config/fish/config.fish).
 EOF
 else
     cat >&2 <<EOF
@@ -126,6 +138,12 @@ Installation finished!  To ensure that the necessary environment
 variables are set, either log in again, or type
 
   . $p
+
+in your shell.
+
+For the fish shell, please type
+
+  source $pfish
 
 in your shell.
 EOF

--- a/scripts/local.mk
+++ b/scripts/local.mk
@@ -14,6 +14,7 @@ noinst-scripts += $(nix_noinst_scripts)
 profiledir = $(sysconfdir)/profile.d
 
 $(eval $(call install-file-as, $(d)/nix-profile.sh, $(profiledir)/nix.sh, 0644))
+$(eval $(call install-file-as, $(d)/nix-profile.fish, $(profiledir)/nix.fish, 0644))
 $(eval $(call install-program-in, $(d)/build-remote.pl, $(libexecdir)/nix))
 
 clean-files += $(nix_bin_scripts) $(nix_noinst_scripts)

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,0 +1,87 @@
+if set -q HOME USER
+    set -l __savedpath "$PATH"
+    set -x PATH @coreutils@
+
+    # Set up the per-user profile.
+    # This part should be kept in sync with nixpkgs:nixos/modules/programs/shell.nix
+
+    set -l NIX_LINK "$HOME"/.nix-profile
+
+    set -l NIX_USER_PROFILE_DIR @localstatedir@/nix/profiles/per-user/"$USER"
+
+    mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
+
+    if [ (stat --printf '%u' "$NIX_USER_PROFILE_DIR") != (id -u) ]
+        echo Nix: WARNING: bad ownership on "$NIX_USER_PROFILE_DIR", should be (id -u) >&2
+    end
+
+    if [ -w "$HOME" ]
+        if not [ -L "$NIX_LINK" ]
+            echo Nix: creating "$NIX_LINK" >&2
+            if [ "$USER" != root ]
+                if not ln -s "$NIX_USER_PROFILE_DIR"/profile "$NIX_LINK"
+                    echo Nix: WARNING: could not create "$NIX_LINK" -> "$NIX_USER_PROFILE_DIR"/profile >&2
+                end
+            else
+                # Root installs in the system-wide profile by default.
+                ln -s @localstatedir@/nix/profiles/default "$NIX_LINK"
+            end
+        end
+
+        # Subscribe the user to the unstable Nixpkgs channel by default.
+        if not [ -e "$HOME"/.nix-channels ]
+            echo 'https://nixos.org/channels/nixpkgs-unstable nixpkgs' > "$HOME"/.nix-channels
+        end
+
+        # Create the per-user garbage collector roots directory.
+        set -l __user_gcroots @localstatedir@/nix/gcroots/per-user/"$USER"
+        mkdir -m 0755 -p "$__user_gcroots"
+        if [ (stat --printf '%u' "$__user_gcroots") != (id -u) ]
+            echo Nix: WARNING: bad ownership on "$__user_gcroots", should be (id -u) >&2
+        end
+
+        # Set up a default Nix expression from which to install stuff.
+        set -l __nix_defexpr "$HOME"/.nix-defexpr
+        [ -L "$__nix_defexpr" ]; and rm -f "$__nix_defexpr"
+        mkdir -m 0755 -p "$__nix_defexpr"
+        if [ "$USER" != root ]; and; not [ -L "$__nix_defexpr"/channels_root ]
+            ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root
+        end
+    end
+
+    # Append ~/.nix-defexpr/channels/nixpkgs to $NIX_PATH so that
+    # <nixpkgs> paths work when the user has fetched the Nixpkgs
+    # channel.
+    set -x NIX_PATH (string join : (echo -n "$NIX_PATH") nixpkgs="$HOME"/.nix-defexpr/channels/nixpkgs)
+
+    # Set up environment.
+    # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
+    set -l NIX_PROFILES "@localstatedir@/nix/profiles/default $NIX_USER_PROFILE_DIR"
+
+    for i in $NIX_PROFILES
+        if [ -d "$i"/lib/aspell ]
+            set -x ASPELL_CONF "dict-dir $i/lib/aspell"
+        end
+    end
+
+    # Set $SSL_CERT_FILE so that Nixpkgs applications like curl work.
+    if [ -e /etc/ssl/certs/ca-certiendcates.crt ] # NixOS, Ubuntu, Debian, Gentoo, Arch
+        set -x SSL_CERT_FILE /etc/ssl/certs/ca-certiendcates.crt
+    else if [ -e /etc/ssl/ca-bundle.pem ] # openSUSE Tumbleweed
+        set -x SSL_CERT_FILE /etc/ssl/ca-bundle.pem
+    else if [ -e /etc/ssl/certs/ca-bundle.crt ] # Old NixOS
+        set -x SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
+    else if [ -e /etc/pki/tls/certs/ca-bundle.crt ] # Fedora, CentOS
+        set -x SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
+    else if [ -e "$NIX_LINK"/etc/ssl/certs/ca-bundle.crt ] # fall back to cacert in Nix profile
+        set -x SSL_CERT_FILE "$NIX_LINK"/etc/ssl/certs/ca-bundle.crt
+    else if [ -e "$NIX_LINK"/etc/ca-bundle.crt ] # old cacert in Nix profile
+        set -x SSL_CERT_FILE "$NIX_LINK"/etc/ca-bundle.crt
+    end
+
+    if set -q MANPATH
+        set -x MANPATH "$NIX_LINK"/share/man $MANPATH
+    end
+
+    set -x PATH "$NIX_LINK"/bin "$NIX_LINK"/sbin $__savedpath
+end


### PR DESCRIPTION
Builds off of #626 

I haven't been able to test it because I cannot get nix to build on macOS Sierra. Using my system nix, I've installed the automake, autoconf and pkg-config packages already.

I get the error "configure.ac:78: error: possibly undefined macro: AC_DEFINE".
