### PR TITLE
Fix Darwin build

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -1,5 +1,3 @@
-#define _XOPEN_SOURCE 600
-
 #include "config.h"
 
 #include <cerrno>

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -444,13 +444,11 @@ int main(int argc, char ** argv)
                 for (auto & i : env)
                     envStrs.push_back(i.first + "=" + i.second);
 
-                auto args = interactive
-                    ? Strings{"bash", "--rcfile", rcfile}
-                    : Strings{"bash", rcfile};
-
-                execvpe(getEnv("NIX_BUILD_SHELL", "bash").c_str(),
-                        stringsToCharPtrs(args).data(),
-                        stringsToCharPtrs(envStrs).data());
+                if (interactive) {
+                    execle(getEnv("NIX_BUILD_SHELL", "bash").c_str(), "bash", "--rcfile", rcfile.c_str(), NULL, stringsToCharPtrs(envStrs).data());
+                } else {
+                    execle(getEnv("NIX_BUILD_SHELL", "bash").c_str(), "bash", rcfile.c_str(), NULL, stringsToCharPtrs(envStrs).data());
+                }
 
                 throw SysError("executing shell");
             }


### PR DESCRIPTION
This should fix #1091, #1092, and #1013. 

`make installcheck` shows that 10 tests failed, so this is effectively untested and I don't know whether that's expected. I don't really have a last known good state to check against.

@edolstra @shlevy can you give some guidance on how to test this properly? Are all tests expected to pass on Darwin?

Also, I'd prefer to delete the `_XOPEN_SOURCE` altogether if possible, but if we keep it, it should be 700.