### PR TITLE
Introduce printItemsSep

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1015,26 +1015,11 @@ template StringSet tokenizeString(const string & s, const string & separators);
 template vector<string> tokenizeString(const string & s, const string & separators);
 
 
-string concatStringsSep(const string & sep, const Strings & ss)
-{
-    string s;
-    for (auto & i : ss) {
-        if (s.size() != 0) s += sep;
-        s += i;
-    }
-    return s;
-}
+template std::string concatStringsSep(const std::string & sep, const Strings & ss);
+template std::string concatStringsSep(const std::string & sep, const StringSet & ss);
 
-
-string concatStringsSep(const string & sep, const StringSet & ss)
-{
-    string s;
-    for (auto & i : ss) {
-        if (s.size() != 0) s += sep;
-        s += i;
-    }
-    return s;
-}
+template std::ostream& printItemsSep(std::ostream& stream, const std::string& sep, Strings::const_iterator begin, Strings::const_iterator end);
+template std::ostream& printItemsSep(std::ostream& stream, const std::string& sep, StringSet::const_iterator begin, StringSet::const_iterator end);
 
 
 string chomp(const string & s)

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -295,12 +295,31 @@ MakeError(Interrupted, BaseError)
 /* String tokenizer. */
 template<class C> C tokenizeString(const string & s, const string & separators = " \t\n\r");
 
+/* concatenate the items with a separator in between and print to stream */
+template <typename Iter>
+std::ostream& printItemsSep(std::ostream& stream, const std::string& sep, Iter begin, Iter end)
+{
+    if (begin == end)
+      return stream;
+
+    stream << *begin;
+    begin++;
+    for (; begin != end; ++begin) {
+        stream << sep;
+        stream << *begin;
+    }
+    return stream;
+}
 
 /* Concatenate the given strings with a separator between the
    elements. */
-string concatStringsSep(const string & sep, const Strings & ss);
-string concatStringsSep(const string & sep, const StringSet & ss);
-
+template<typename C>
+std::string concatStringsSep(const std::string & sep, const C & ss)
+{
+    std::ostringstream os;
+    printItemsSep(os, sep, ss.begin(), ss.end());
+    return os.str();
+}
 
 /* Remove trailing whitespace from a string. */
 string chomp(const string & s);

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -120,9 +120,9 @@ struct CmdPathInfo : StorePathsCommand
 
             for (auto storePath : storePaths) {
                 auto info = store->queryPathInfo(storePath);
-                storePath = info->path; // FIXME: screws up padding
+                storePath = info->path;
 
-                std::cout << storePath << std::string(std::max(0, (int) pathLen - (int) storePath.size()), ' ');
+                std::cout << std::left << std::setw(pathLen) << storePath << std::right;
 
                 if (showSize)
                     std::cout << '\t' << std::setw(11) << info->narSize;

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -135,8 +135,8 @@ struct CmdPathInfo : StorePathsCommand
                     Strings ss;
                     if (info->ultimate) ss.push_back("ultimate");
                     if (info->ca != "") ss.push_back("ca:" + info->ca);
-                    for (auto & sig : info->sigs) ss.push_back(sig);
-                    std::cout << concatStringsSep(" ", ss);
+                    ss.insert(ss.end(), info->sigs.begin(), info->sigs.end());
+                    printItemsSep(std::cout, " ", ss.begin(), ss.end());
                 }
 
                 std::cout << std::endl;


### PR DESCRIPTION
This adds a new template function that prints items with a given seperator to a given output stream.
It's basically what `concatStringsSep` does, only generalized for any container type and any printable object type (needs overloaded `operator<<` for ostream). Reimplementing `concatStringsSep` with the new function was tivial.

The last change resolves the `FIXME`. I'm not sure why it was there, because it works for me this way...?
