### PR TITLE
Detect and disallow base32 hash overflow

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -165,7 +165,13 @@ Hash parseHash32(HashType ht, const string & s)
         unsigned int i = b / 8;
         unsigned int j = b % 8;
         hash.hash[i] |= digit << j;
-        if (i < hash.hashSize - 1) hash.hash[i + 1] |= digit >> (8 - j);
+
+        if (i < hash.hashSize - 1) {
+            hash.hash[i + 1] |= digit >> (8 - j);
+        } else {
+            if (digit >> (8 - j))
+                throw BadHash(format("invalid base-32 hash ‘%1%’") % s);
+        }
     }
 
     return hash;


### PR DESCRIPTION
Example (before this commit):
```
$ nix-hash --type sha256 --to-base16 4n0igfxbd3kqvvj2k2xgysrp63l4v2gd110fwkk4apfpm0hvzwh0 \
    | xargs nix-hash --type sha256 --to-base32
0n0igfxbd3kqvvj2k2xgysrp63l4v2gd110fwkk4apfpm0hvzwh0
```

It's a real-life example:
https://github.com/NixOS/nixpkgs/pull/20208/files#r86695567
Best pick this to the stable version, too, if planning to have more maintenance releases. Feel free to change code-style etc.