### PR TITLE
Fix comments parsing

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -189,7 +189,7 @@ or          { return OR_KW; }
 
 [ \t\r\n]+    /* eat up whitespace */
 \#[^\r\n]*    /* single-line comments */
-\/\*([^*]|\*[^\/])*\*\/  /* long comments */
+\/\*([^*]|\*+[^*/])*\*+\/  /* long comments */
 
 .           return yytext[0];
 

--- a/tests/lang/eval-okay-comments.exp
+++ b/tests/lang/eval-okay-comments.exp
@@ -1,0 +1,1 @@
+"abcdefghijklmnopqrstuvwxyz"

--- a/tests/lang/eval-okay-comments.nix
+++ b/tests/lang/eval-okay-comments.nix
@@ -1,0 +1,59 @@
+# A simple comment
+"a"+ # And another
+## A double comment
+"b"+  ## And another
+# Nested # comments #
+"c"+   # and # some # other #
+# An empty line, following here:
+
+"d"+      # and a comment not starting the line !
+
+"e"+
+/* multiline comments */
+"f" +
+/* multiline
+   comments,
+   on
+   multiple
+   lines
+*/
+"g" +
+# Small, tricky comments
+/**/ "h"+ /*/*/ "i"+ /***/ "j"+ /* /*/ "k"+ /*/* /*/ "l"+
+# Comments with an even number of ending '*' used to fail:
+"m"+
+/* */ /* **/ /* ***/ /* ****/ "n"+
+/* */ /** */ /*** */ /**** */ "o"+
+/** **/ /*** ***/ /**** ****/ "p"+
+/* * ** *** **** ***** */     "q"+
+# Random comments
+/* ***** ////// * / * / /* */ "r"+
+# Mixed comments
+/* # */
+"s"+
+# /* #
+"t"+
+# /* # */
+"u"+
+# /*********/
+"v"+
+## */*
+"w"+
+/*
+ * Multiline, decorated comments
+ * # This ain't a nest'd comm'nt
+ */
+"x"+
+''${/** with **/"y"
+  # real
+  /* comments
+     inside ! # */
+
+  # (and empty lines)
+
+}''+          /* And a multiline comment,
+                 on the same line,
+                 after some spaces
+*/             # followed by a one-line comment
+"z"
+/* EOF */


### PR DESCRIPTION
Fixed the parsing of multiline strings ending with an even number of
stars, like /** this **/.
Added test cases for comments.

Strange thing is, there is of course no occurence of that bug in nixpkgs,
but there is a `/*** deprecated stuff ***/` line added in 523e3283 by @zimbatm.
I wonder if he encountered the bug, and used three stars to work around it :-D.

- [X] Tested properly on NixOS