### PR TITLE
shellcheck scripts/install-nix-from-closure.sh

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -7,7 +7,7 @@ self="$(dirname "$0")"
 nix="@nix@"
 cacert="@cacert@"
 
-if ! [ -e $self/.reginfo ]; then
+if ! [ -e "$self/.reginfo" ]; then
     echo "$0: incomplete installer (.reginfo is missing)" >&2
     exit 1
 fi
@@ -39,10 +39,10 @@ fi
 
 mkdir -p $dest/store
 
-echo -n "copying Nix to $dest/store..." >&2
+printf "copying Nix to %s..." "${dest}/store" >&2
 
-for i in $(cd $self/store >/dev/null && echo *); do
-    echo -n "." >&2
+for i in $(cd "$self/store" >/dev/null && echo ./*); do
+    printf "." >&2
     i_tmp="$dest/store/$i.$$"
     if [ -e "$i_tmp" ]; then
         rm -rf "$i_tmp"
@@ -63,20 +63,20 @@ if ! $nix/bin/nix-store --init; then
     exit 1
 fi
 
-if ! $nix/bin/nix-store --load-db < $self/.reginfo; then
+if ! "$nix/bin/nix-store" --load-db < "$self/.reginfo"; then
     echo "$0: unable to register valid paths" >&2
     exit 1
 fi
 
-. $nix/etc/profile.d/nix.sh
+. "$nix/etc/profile.d/nix.sh"
 
-if ! $nix/bin/nix-env -i "$nix"; then
+if ! "$nix/bin/nix-env" -i "$nix"; then
     echo "$0: unable to install Nix into your default profile" >&2
     exit 1
 fi
 
 # Install an SSL certificate bundle.
-if [ -z "$NIX_SSL_CERT_FILE" -o ! -f "$NIX_SSL_CERT_FILE" ]; then
+if [ -z "$NIX_SSL_CERT_FILE" ] || ! [ -f "$NIX_SSL_CERT_FILE" ]; then
     $nix/bin/nix-env -i "$cacert"
     export NIX_SSL_CERT_FILE="$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt"
 fi
@@ -100,7 +100,7 @@ if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
         if [ -w "$fn" ]; then
             if ! grep -q "$p" "$fn"; then
                 echo "modifying $fn..." >&2
-                echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> $fn
+                echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
             fi
             added=1
             break


### PR DESCRIPTION
Shellcheck this file.

Opinionated change: 's/"echo -n"/"echo"' to avoid changing the shebang to be non-posix. Alternative: use /bin/bash

after:
```
In scripts/install-nix-from-closure.sh line 71:
. "$nix/etc/profile.d/nix.sh"
^-- SC1090: Can't follow non-constant source. Use a directive to specify location.
```

before
```
In scripts/install-nix-from-closure.sh line 10:
if ! [ -e $self/.reginfo ]; then
          ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/install-nix-from-closure.sh line 42:
echo -n "copying Nix to $dest/store..." >&2
     ^-- SC2039: In POSIX sh, echo flags are undefined.


In scripts/install-nix-from-closure.sh line 44:
for i in $(cd $self/store >/dev/null && echo *); do
              ^-- SC2086: Double quote to prevent globbing and word splitting.
                                             ^-- SC2035: Use ./*glob* or -- *glob* so names with dashes won't become options.


In scripts/install-nix-from-closure.sh line 45:
    echo -n "." >&2
         ^-- SC2039: In POSIX sh, echo flags are undefined.


In scripts/install-nix-from-closure.sh line 66:
if ! $nix/bin/nix-store --load-db < $self/.reginfo; then
                                    ^-- SC2086: Double quote to prevent globbing and word splitting.


In scripts/install-nix-from-closure.sh line 71:
. $nix/etc/profile.d/nix.sh
^-- SC1090: Can't follow non-constant source. Use a directive to specify location.


In scripts/install-nix-from-closure.sh line 79:
if [ -z "$NIX_SSL_CERT_FILE" -o ! -f "$NIX_SSL_CERT_FILE" ]; then
                             ^-- SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.


In scripts/install-nix-from-closure.sh line 103:
                echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> $fn
                                                                               ^-- SC2086: Double quote to prevent globbing and word splitting.
```