### PR TITLE
Add Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
-os: osx
-script: ./tests/install-darwin.sh
+sudo: required
+os:
+  - osx
+  - linux
+language: nix
+script: scripts/ci.sh

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Tests to be run during PRs
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "--- Unshallow"
+
+# Travis-CI only does a shallow copy.
+# release.nix is using fetchGit which depends on a full history.
+git pull --unshallow
+
+echo "--- Testing build"
+
+nix-build release.nix -A coverage
+
+if [[ $(uname) = Darwin ]]; then
+  echo "--- Testing installation"
+
+  ./tests/install-darwin.sh
+fi


### PR DESCRIPTION
This is a work-in-progress so PRs can be tested for compilation success. Once that's working we can start thinking of adding static analysis tools like coverity to the mix.

Right now the issue is that Travis only provides GCC 4.8.4 and Clang 3.5.0. Both fail on the `std::regex_replace` usage as it's probably too new[1]. I think it's important for nix to be compatible with older C++ implementations as it's necessary to bootstrap on older linux distributions.

[1]: https://travis-ci.org/zimbatm/nix/builds/182907114