### PR TITLE
Document path-searching behaviour

### DIFF
--- a/doc/manual/expressions/language-values.xml
+++ b/doc/manual/expressions/language-values.xml
@@ -167,7 +167,16 @@ stdenv.mkDerivation {
   user's home directory. e.g. <filename>~/foo</filename> would be
   equivalent to <filename>/home/edolstra/foo</filename> for a user
   whose home directory is <filename>/home/edolstra</filename>.
-  </para></listitem>
+  </para>
+
+  <para>Paths can also be specified between angle brackets, e.g.
+  <literal>&lt;nixpkgs&gt;</literal>. This means that the directories
+  listed in the environment variable
+  <envar linkend="env-NIX_PATH">NIX_PATH</envar> will be searched
+  for the given file or directory name.
+  </para>
+
+  </listitem>
 
   <listitem><para><emphasis>Booleans</emphasis> with values
   <literal>true</literal> and

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation {
         customMemoryManagement = false;
       })
       autoreconfHook
+      perlPackages.DBDSQLite
     ];
 
   configureFlags =


### PR DESCRIPTION
Clarifies how things like `<nixpkgs>` are handled.

Also threw in a change to shell.nix, without which I couldn't run `./configure` in a nix-shell.