### PR TITLE
nix-shell: Fix 'nix-shell --command' doing nothing without TTY

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -81,7 +81,8 @@ int main(int argc, char ** argv)
         auto pure = false;
         auto fromArgs = false;
         auto packages = false;
-        auto interactive = true;
+        // Same condition as bash uses for interactive shells
+        auto interactive = isatty(STDIN_FILENO) && isatty(STDERR_FILENO);
 
         Strings instArgs;
         Strings buildArgs;


### PR DESCRIPTION
Regression from a5f2750e ("Fix early removal of rc-file for nix-shell").
The removal of BASH_ENV causes nothing to be executed by bash if it
detects itself in a non-interactive context. Instead, just
use the same condition used by bash to launch bash differently.

According to bash sources, the condition (stdin and stder both
must be TTYs) is specified by POSIX so this should be pretty
safe to rely on.

Fixes #1171 on master, needs a backport to the Perl code in 1.11.