### PR TITLE
nix-shell: Fix 'nix-shell --command' doing nothing without TTY (stable backport)

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -17,7 +17,8 @@ my $runEnv = $0 =~ /nix-shell$/;
 my $pure = 0;
 my $fromArgs = 0;
 my $packages = 0;
-my $interactive = 1;
+# Same condition as bash uses for interactive shells
+my $interactive = -t STDIN && -t STDERR;
 
 my @instArgs = ();
 my @buildArgs = ();


### PR DESCRIPTION
Regression from 8bddc3d4 ("Fix early removal of rc-file for nix-shell").
The removal of BASH_ENV causes nothing to be executed by bash if it
detects itself in a non-interactive context. Instead, just
use the same condition used by bash to launch bash differently.

According to bash sources, the condition (stdin and stder both
must be TTYs) is specified by POSIX so this should be pretty
safe to rely on.

Fixes #1171 on 1.11.