### PR TITLE
Add environment variable to enable verbose CURL output

### DIFF
--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -217,6 +217,9 @@ struct CurlDownloader : public Downloader
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0);
             }
 
+            if(getEnv("NIX_CURL_VERBOSE", "") != "")
+                curl_easy_setopt(req, CURLOPT_VERBOSE, 1);
+
             result.data = std::make_shared<std::string>();
         }
 


### PR DESCRIPTION
Helped me to debug https://github.com/NixOS/nix/issues/1181, may be handy for others.