### PR TITLE
Nix hangs on network errors when downloading files

### DIFF
--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -376,7 +376,7 @@ struct CurlDownloader : public Downloader
             auto sleepTimeMs =
                 nextWakeup != std::chrono::steady_clock::time_point()
                 ? std::max(0, (int) std::chrono::duration_cast<std::chrono::milliseconds>(nextWakeup - std::chrono::steady_clock::now()).count())
-                : 1000000000;
+                : 3000;
             //printMsg(lvlVomit, format("download thread waiting for %d ms") % sleepTimeMs);
             mc = curl_multi_wait(curlm, extraFDs, 1, sleepTimeMs, &numfds);
             if (mc != CURLM_OK)


### PR DESCRIPTION
For some reason the default timeout when calling curl is 11.5 days, effectively infinite. This means that in case of network errors nix-shell or nix-build will hang forever trying to download files.

Changed the default timeout to 3 seconds.

