### PR TITLE
Allow channelName matching top directory in nixexprs.tar

### DIFF
--- a/corepkgs/unpack-channel.nix
+++ b/corepkgs/unpack-channel.nix
@@ -15,7 +15,8 @@ let
       else
         ${bzip2} -d < $src | ${tar} xf - ${tarFlags}
       fi
-      mv * $out/$channelName
+      shopt -s nullglob
+      test * == "$channelName" || mv * $out/$channelName
       if [ -n "$binaryCacheURL" ]; then
         mkdir $out/binary-caches
         echo -n "$binaryCacheURL" > $out/binary-caches/$channelName


### PR DESCRIPTION
I was trying to make a channel and ran across the case where nixexprs.tar.xz's top-level dir had the same name as the channel, so `mv * $out/$channelName` would fail with err 1, because src and dest were the same.