### PR TITLE
Makefile.config.in: drop unused bsddiff_compat_include

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -14,7 +14,6 @@ LIBLZMA_LIBS = @LIBLZMA_LIBS@
 SQLITE3_LIBS = @SQLITE3_LIBS@
 bash = @bash@
 bindir = @bindir@
-bsddiff_compat_include = @bsddiff_compat_include@
 curl = @curl@
 datadir = @datadir@
 datarootdir = @datarootdir@


### PR DESCRIPTION
bsddiff_compat_include configure.ac substitution
was removed in commit 16d9c872e41eb39248d88a3ba7c5706267676153

Signed-off-by: Sergei Trofimovich <siarheit@google.com>