### PR TITLE
Install from closure: wording and fallback using .bash_profile

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -90,43 +90,37 @@ if [ -z "$_NIX_INSTALLER_TEST" ]; then
 fi
 
 added=
+
+# Make the shell source nix.sh during login.
+p=$HOME/.nix-profile/etc/profile.d/nix.sh
+
 if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
-
-    # Make the shell source nix.sh during login.
-    p=$HOME/.nix-profile/etc/profile.d/nix.sh
-
     for i in .bash_profile .bash_login .profile; do
         fn="$HOME/$i"
         if [ -w "$fn" ]; then
             if ! grep -q "$p" "$fn"; then
-                echo "modifying $fn..." >&2
+                echo "$0: modifying $fn..." >&2
                 echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
             fi
             added=1
             break
         fi
     done
-
 fi
 
 if [ -z "$added" ]; then
-    cat >&2 <<EOF
-
-Installation finished!  To ensure that the necessary environment
-variables are set, please add the line
-
-  . $p
-
-to your shell profile (e.g. ~/.profile).
-EOF
-else
-    cat >&2 <<EOF
-
-Installation finished!  To ensure that the necessary environment
-variables are set, either log in again, or type
-
-  . $p
-
-in your shell.
-EOF
+  echo "$0: creating ~/.bash_profile ..." >&2
+  touch ~/.bash_profile
+  chmod +x ~/.bash_profile
+  echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> /.bash_profile
 fi
+
+cat >&2 <<EOF
+
+Installation has finished successfully.
+
+To start using Nix, execute in your shell:
+
+ $ source $p
+
+EOF


### PR DESCRIPTION
- use empty `~/.bash_profile` if it's not there
- use `source` instead of vague `.`
- make it more explicit how to start using Nix after installation