### PR TITLE
Add netrc-file support

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -430,6 +430,21 @@ flag, e.g. <literal>--option gc-keep-outputs false</literal>.</para>
   </varlistentry>
 
 
+  <varlistentry><term><literal>netrc-file</literal></term>
+
+    <listitem><para>If set to an absolute path to a <filename>netrc</filename>
+    file, Nix will use the HTTP authentication credentials in this file when
+    trying to download from a remote host through HTTP or HTTPS. Defaults to
+    <filename>$NIX_CONF_DIR/netrc</filename>.</para>
+
+    <para>The <filename>netrc</filename> file consists of zero or more lines
+    like: <literal>machine <replaceable>my-machine</replaceable> login
+    <replaceable>my-username</replaceable> password
+    <replaceable>my-password</replaceable></literal>.</para></listitem>
+
+  </varlistentry>
+
+
   <varlistentry><term><literal>system</literal></term>
 
     <listitem><para>This option specifies the canonical Nix system

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -230,6 +230,11 @@ struct CurlDownloader : public Downloader
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0);
             }
 
+            Path netrcFile = settings.get("netrc-file",
+               (format("%1%/%2%") % settings.nixConfDir % "netrc").str());
+            curl_easy_setopt(req, CURLOPT_NETRC_FILE, netrcFile.c_str());
+            curl_easy_setopt(req, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+
             result.data = std::make_shared<std::string>();
         }
 

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -230,8 +230,11 @@ struct CurlDownloader : public Downloader
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0);
             }
 
+            /* If no file exist in the specified path, curl continues to work
+             * anyway as if netrc support was disabled. */
             Path netrcFile = settings.get("netrc-file",
                (format("%1%/%2%") % settings.nixConfDir % "netrc").str());
+            /* Curl copies the given C string, so the following call is safe. */
             curl_easy_setopt(req, CURLOPT_NETRC_FILE, netrcFile.c_str());
             curl_easy_setopt(req, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
 


### PR DESCRIPTION
From the `nix.conf` docs:

> `netrc-file`:
>
>    If set to an absolute path to a `netrc` file, Nix will use the HTTP authentication credentials in this file when trying to download from a remote host through HTTP or HTTPS. Defaults to `$NIX_CONF_DIR/netrc`.
>   The netrc file consists of zero or more lines like: `machine $my-machine login $my-username password $my-password`. 

This allows us to use HTTP/HTTPS binary caches behind HTTP basic authentication without having to use an URL like `https://user:password@example.com` which forces us to write `user` and `password` in `configuration.nix` (in NixOS), and leaks these credentials to the logs when displaying URLs.

If the default `$NIX_CONF_DIR/netrc` file is missing, curl continues doing its work without complaining, making this change backwards compatible. The reason for providing a default value for `netrc-file` in the first place is so that we can have a predictable place where credentials are stored (otherwise people have to needlessly figure out the best place to put this file). 

If using `nix-daemon`, then this `netrc` file can be made readable only to the user running `nix-daemon` and it will still work for all users accessing `nix-daemon` without exposing the credentials.

Fixes #950 


