### PR TITLE
builtins.tryEval: catch EvalError

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -388,7 +388,7 @@ static void prim_tryEval(EvalState & state, const Pos & pos, Value * * args, Val
         state.forceValue(*args[0]);
         v.attrs->push_back(Attr(state.sValue, args[0]));
         mkBool(*state.allocAttr(v, state.symbols.create("success")), true);
-    } catch (AssertionError & e) {
+    } catch (EvalError & e) {
         mkBool(*state.allocAttr(v, state.sValue), false);
         mkBool(*state.allocAttr(v, state.symbols.create("success")), false);
     }


### PR DESCRIPTION
Make `tryEval` catch all `EvalError`s.