### PR TITLE
nix-daemon: Don't splice with len=SIZE_MAX

### DIFF
--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -23,6 +23,7 @@
 #include <pwd.h>
 #include <grp.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #if __APPLE__ || __FreeBSD__
 #include <sys/ucred.h>
@@ -967,14 +968,14 @@ int main(int argc, char * * argv)
                     if (select(nfds, &fds, nullptr, nullptr, nullptr) == -1)
                         throw SysError("waiting for data from client or server");
                     if (FD_ISSET(s, &fds)) {
-                        auto res = splice(s, nullptr, STDOUT_FILENO, nullptr, SIZE_MAX, SPLICE_F_MOVE);
+                        auto res = splice(s, nullptr, STDOUT_FILENO, nullptr, SSIZE_MAX, SPLICE_F_MOVE);
                         if (res == -1)
                             throw SysError("splicing data from daemon socket to stdout");
                         else if (res == 0)
                             throw EndOfFile("unexpected EOF from daemon socket");
                     }
                     if (FD_ISSET(STDIN_FILENO, &fds)) {
-                        auto res = splice(STDIN_FILENO, nullptr, s, nullptr, SIZE_MAX, SPLICE_F_MOVE);
+                        auto res = splice(STDIN_FILENO, nullptr, s, nullptr, SSIZE_MAX, SPLICE_F_MOVE);
                         if (res == -1)
                             throw SysError("splicing data from stdin to daemon socket");
                         else if (res == 0)


### PR DESCRIPTION
Currently, 'nix-daemon --stdio' is always failing for me, due to the
splice call always failing with (on a 32-bit system):

````
splice(0, NULL, 3, NULL, 4294967295, SPLICE_F_MOVE) = -1 EINVAL (Invalid argument)
````

With a bit of ftracing (and luck) the problem seems to be that splice()
always fails with EINVAL if the len cast as ssize_t is negative:
http://lxr.free-electrons.com/source/fs/read_write.c?v=4.4#L384

So use SSIZE_MAX instead of SIZE_MAX.

cc @shlevy who wrote the code.

Noticed this when trying `nix copy --from ssh://host`. Though even with this fix it `nix copy` doesn't work for me over ssh, I get either:

````
error: hash mismatch importing path ‘/nix/store/28xfqm556mjlkzw28ab92dzzsj96g3gz-linux-config-4.5.7’; expected hash ‘sha256:0dc87m5qgfm0vmarrb3xxnb33kkiyryyrvj41j09xrj07ahpdjjp’, got ‘sha256:05sdp58zvsnahgjg9lhnj2y03zm9qgivy869qplwwfrl8ns9lhw7’
````

or

````
error: path ‘/nix/store/1rzzq2wdn5vfgbp5y9613jpdkf8i9ag6-coreutils-8.26’ is not valid
````
