### PR TITLE
Backport SSL_CERT_FILE -> NIX_SSL_CERT_FILE

### DIFF
--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -14,10 +14,10 @@ ONBUILD ENV \
     ENV=/etc/profile \
     PATH=/root/.nix-profile/bin:/root/.nix-profile/sbin:/bin:/sbin:/usr/bin:/usr/sbin \
     GIT_SSL_CAINFO=/root/.nix-profile/etc/ca-bundle.crt \
-    SSL_CERT_FILE=/root/.nix-profile/etc/ca-bundle.crt
+    NIX_SSL_CERT_FILE=/root/.nix-profile/etc/ca-bundle.crt
 
 ENV \
     ENV=/etc/profile \
     PATH=/root/.nix-profile/bin:/root/.nix-profile/sbin:/bin:/sbin:/usr/bin:/usr/sbin \
     GIT_SSL_CAINFO=/root/.nix-profile/etc/ca-bundle.crt \
-    SSL_CERT_FILE=/root/.nix-profile/etc/ca-bundle.crt
+    NIX_SSL_CERT_FILE=/root/.nix-profile/etc/ca-bundle.crt

--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -14,7 +14,7 @@
     <string>/dev/null</string>
     <key>EnvironmentVariables</key>
     <dict>
-      <key>SSL_CERT_FILE</key>
+      <key>NIX_SSL_CERT_FILE</key>
       <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
     </dict>
   </dict>

--- a/scripts/download-from-binary-cache.pl.in
+++ b/scripts/download-from-binary-cache.pl.in
@@ -41,7 +41,7 @@ my $activeRequests = 0;
 my $curlIdCount = 1;
 my %requests;
 my %scheduled;
-my $caBundle = $ENV{"SSL_CERT_FILE"} // $ENV{"CURL_CA_BUNDLE"} // $ENV{"OPENSSL_X509_CERT_FILE"};
+my $caBundle = $ENV{"NIX_SSL_CERT_FILE"} // $ENV{"CURL_CA_BUNDLE"} // $ENV{"OPENSSL_X509_CERT_FILE"};
 $caBundle = "/etc/ssl/certs/ca-bundle.crt" if !$caBundle && -f "/etc/ssl/certs/ca-bundle.crt";
 $caBundle = "/etc/ssl/certs/ca-certificates.crt" if !$caBundle && -f "/etc/ssl/certs/ca-certificates.crt";
 

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -73,9 +73,9 @@ if ! $nix/bin/nix-env -i "$nix"; then
 fi
 
 # Install an SSL certificate bundle.
-if [ -z "$SSL_CERT_FILE" -o ! -f "$SSL_CERT_FILE" ]; then
+if [ -z "$NIX_SSL_CERT_FILE" -o ! -f "$NIX_SSL_CERT_FILE" ]; then
     $nix/bin/nix-env -i "$cacert"
-    export SSL_CERT_FILE="$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt"
+    export NIX_SSL_CERT_FILE="$HOME/.nix-profile/etc/ssl/certs/ca-bundle.crt"
 fi
 
 # Subscribe the user to the Nixpkgs channel and fetch it.

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -20,16 +20,16 @@ if [ -n "$HOME" ]; then
     # channel.
     export NIX_PATH=${NIX_PATH:+$NIX_PATH:}nixpkgs=$HOME/.nix-defexpr/channels/nixpkgs
 
-    # Set $SSL_CERT_FILE so that Nixpkgs applications like curl work.
+    # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
     if [ -e /etc/ssl/certs/ca-certificates.crt ]; then # NixOS, Ubuntu, Debian, Gentoo, Arch
-        export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+        export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     elif [ -e /etc/ssl/certs/ca-bundle.crt ]; then # Old NixOS
-        export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+        export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
     elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
-        export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+        export NIX_SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
     elif [ -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" ]; then # fall back to cacert in Nix profile
-        export SSL_CERT_FILE="$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+        export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
     elif [ -e "$NIX_LINK/etc/ca-bundle.crt" ]; then # old cacert in Nix profile
-        export SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
+        export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
     fi
 fi

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -129,7 +129,7 @@ struct Curl
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 
         if (options.verifyTLS)
-            curl_easy_setopt(curl, CURLOPT_CAINFO, getEnv("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt").c_str());
+            curl_easy_setopt(curl, CURLOPT_CAINFO, getEnv("NIX_SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt").c_str());
         else {
             curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
             curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
This prevents collisions with the "native" OpenSSL, in particular on
OS X.

Fixes #1219.
Backports: fb2dd321 ('SSL_CERT_FILE -> NIX_SSL_CERT_FILE')