### PR TITLE
unpack-channel.nix: fix 'mv' corner case

### DIFF
--- a/corepkgs/unpack-channel.nix
+++ b/corepkgs/unpack-channel.nix
@@ -15,7 +15,9 @@ let
       else
         ${bzip2} -d < $src | ${tar} xf - ${tarFlags}
       fi
-      mv * $out/$channelName
+      if [ * != $channelName ]; then
+        mv * $out/$channelName
+      fi
       if [ -n "$binaryCacheURL" ]; then
         mkdir $out/binary-caches
         echo -n "$binaryCacheURL" > $out/binary-caches/$channelName


### PR DESCRIPTION
unpack-channel.nix fails if the tarball contains a directory named the
same as the channel:

```
  mv: cannot move 'nixpkgs' to a subdirectory of itself, '.../nixpkgs'
```

This commit fixes that by not moving the directory if it already has the
correct name.