### PR TITLE
Add missing header <sstream>

### DIFF
--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -13,6 +13,7 @@
 #include <limits>
 #include <cstdio>
 #include <map>
+#include <sstream>
 
 #ifndef HAVE_STRUCT_DIRENT_D_TYPE
 #define DT_UNKNOWN 0


### PR DESCRIPTION
Add missing header <sstream> related to the usage of std::istringstream in util.hh

Without that, the inclusion of the store-api.hh return an error at compile time.

due to line 315 in utils.hh

    if (string(s, 0, 1) == "-" && !std::numeric_limits<N>::is_signed)
        return false;
    std::istringstream str(s);
    str >> n;

