### PR TITLE
Convert short nix options to long ones

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -318,7 +318,7 @@ flag, e.g. <literal>--option gc-keep-outputs false</literal>.</para>
     Nix will write the build log of a derivation (i.e. the standard
     output and error of its builder) to the directory
     <filename>/nix/var/log/nix/drvs</filename>.  The build log can be
-    retrieved using the command <command>nix-store -l
+    retrieved using the command <command>nix-store --read-log
     <replaceable>path</replaceable></command>.</para></listitem>
 
   </varlistentry>

--- a/doc/manual/command-ref/nix-build.xml
+++ b/doc/manual/command-ref/nix-build.xml
@@ -142,7 +142,7 @@ also <xref linkend="sec-common-options" />.</phrase></para>
 <refsection><title>Examples</title>
 
 <screen>
-$ nix-build '&lt;nixpkgs>' -A firefox
+$ nix-build '&lt;nixpkgs>' --attr firefox
 store derivation is /nix/store/qybprl8sz2lc...-firefox-1.5.0.7.drv
 /nix/store/d18hyl92g30l...-firefox-1.5.0.7
 
@@ -156,7 +156,7 @@ firefox  firefox-config</screen>
 <command>nix-build</command> will build the default (first) output.
 You can also build all outputs:
 <screen>
-$ nix-build '&lt;nixpkgs>' -A openssl.all
+$ nix-build '&lt;nixpkgs>' --attr openssl.all
 </screen>
 This will create a symlink for each output named
 <filename>result-<replaceable>outputname</replaceable></filename>.
@@ -168,14 +168,14 @@ So if <literal>openssl</literal> has outputs <literal>out</literal>,
 <literal>result-man</literal>.  It’s also possible to build a specific
 output:
 <screen>
-$ nix-build '&lt;nixpkgs>' -A openssl.man
+$ nix-build '&lt;nixpkgs>' --attr openssl.man
 </screen>
 This will create a symlink <literal>result-man</literal>.</para>
 
 <para>Build a Nix expression given on the command line:
 
 <screen>
-$ nix-build -E 'with import &lt;nixpkgs> { }; runCommand "foo" { } "echo bar > $out"'
+$ nix-build --expr 'with import &lt;nixpkgs> { }; runCommand "foo" { } "echo bar > $out"'
 $ cat ./result
 bar
 </screen>
@@ -186,7 +186,7 @@ bar
 master branch of Nixpkgs:
 
 <screen>
-$ nix-build https://github.com/NixOS/nixpkgs/archive/master.tar.gz -A hello
+$ nix-build https://github.com/NixOS/nixpkgs/archive/master.tar.gz --attr hello
 </screen>
 
 </para>

--- a/doc/manual/command-ref/nix-channel.xml
+++ b/doc/manual/command-ref/nix-channel.xml
@@ -107,18 +107,18 @@ an update.</para>
 <screen>
 $ nix-channel --add https://nixos.org/channels/nixpkgs-unstable
 $ nix-channel --update
-$ nix-env -iA nixpkgs.hello</screen>
+$ nix-env --install --attr nixpkgs.hello</screen>
 
 <para>You can revert channel updates using <option>--rollback</option>:</para>
 
 <screen>
-$ nix-instantiate --eval -E '(import &lt;nixpkgs> {}).lib.nixpkgsVersion'
+$ nix-instantiate --eval --expr '(import &lt;nixpkgs> {}).lib.nixpkgsVersion'
 "14.04.527.0e935f1"
 
 $ nix-channel --rollback
 switching from generation 483 to 482
 
-$ nix-instantiate --eval -E '(import &lt;nixpkgs> {}).lib.nixpkgsVersion'
+$ nix-instantiate --eval --expr '(import &lt;nixpkgs> {}).lib.nixpkgsVersion'
 "14.04.526.dbadfad"
 </screen>
 

--- a/doc/manual/command-ref/nix-copy-closure.xml
+++ b/doc/manual/command-ref/nix-copy-closure.xml
@@ -163,7 +163,7 @@ user environment:
 <screen>
 $ nix-copy-closure --from alice@itchy.labs \
     /nix/store/0dj0503hjxy5mbwlafv1rsbdiyx1gkdy-subversion-1.4.4
-$ nix-env -i /nix/store/0dj0503hjxy5mbwlafv1rsbdiyx1gkdy-subversion-1.4.4
+$ nix-env --install /nix/store/0dj0503hjxy5mbwlafv1rsbdiyx1gkdy-subversion-1.4.4
 </screen>
 
 </para>

--- a/doc/manual/command-ref/nix-env.xml
+++ b/doc/manual/command-ref/nix-env.xml
@@ -70,8 +70,8 @@ be performed.  These are documented below.</para>
 
 <refsection><title>Selectors</title>
 
-<para>Several commands, such as <command>nix-env -q</command> and
-<command>nix-env -i</command>, take a list of arguments that specify
+<para>Several commands, such as <command>nix-env --query</command> and
+<command>nix-env --install</command>, take a list of arguments that specify
 the packages on which to operate. These are extended regular
 expressions that must match the entire name of the package. (For
 details on regular expressions, see
@@ -329,7 +329,7 @@ number of possible ways:
 
   <para>You can force the installation of multiple derivations with
   the same name by being specific about the versions.  For instance,
-  <literal>nix-env -i gcc-3.3.6 gcc-4.1.1</literal> will install both
+  <literal>nix-env --install gcc-3.3.6 gcc-4.1.1</literal> will install both
   version of GCC (and will probably cause a user environment
   conflict!).</para></listitem>
 
@@ -339,7 +339,7 @@ number of possible ways:
   <emphasis>attribute paths</emphasis> that select attributes from the
   top-level Nix expression.  This is faster than using derivation
   names and unambiguous.  To find out the attribute paths of available
-  packages, use <literal>nix-env -qaP</literal>.</para></listitem>
+  packages, use <literal>nix-env --query --available --attr-path</literal>.</para></listitem>
 
   <listitem><para>If <option>--from-profile</option>
   <replaceable>path</replaceable> is given,
@@ -407,7 +407,7 @@ number of possible ways:
     <term><option>-r</option></term>
 
     <listitem><para>Remove all previously installed packages first.
-    This is equivalent to running <literal>nix-env -e '.*'</literal>
+    This is equivalent to running <literal>nix-env --uninstall '.*'</literal>
     first, except that everything happens in a single
     transaction.</para></listitem>
 
@@ -442,15 +442,15 @@ installing `gcc-3.3.2'</screen>
 <para>To install using a specific attribute:
 
 <screen>
-$ nix-env -i -A gcc40mips
-$ nix-env -i -A xorg.xorgserver</screen>
+$ nix-env --install --attr gcc40mips
+$ nix-env --install --attr xorg.xorgserver</screen>
 
 </para>
 
 <para>To install all derivations in the Nix expression <filename>foo.nix</filename>:
 
 <screen>
-$ nix-env -f ~/foo.nix -i '.*'</screen>
+$ nix-env --file ~/foo.nix --install '.*'</screen>
 
 </para>
 
@@ -458,7 +458,7 @@ $ nix-env -f ~/foo.nix -i '.*'</screen>
 from another profile:
 
 <screen>
-$ nix-env -i --from-profile /nix/var/nix/profiles/foo -i gcc</screen>
+$ nix-env --install --from-profile /nix/var/nix/profiles/foo --install gcc</screen>
 
 </para>
 
@@ -466,21 +466,21 @@ $ nix-env -i --from-profile /nix/var/nix/profiles/foo -i gcc</screen>
 <command>nix-instantiate</command>):
 
 <screen>
-$ nix-env -i /nix/store/fibjb1bfbpm5mrsxc4mh2d8n37sxh91i-gcc-3.4.3.drv</screen>
+$ nix-env --install /nix/store/fibjb1bfbpm5mrsxc4mh2d8n37sxh91i-gcc-3.4.3.drv</screen>
 
 </para>
 
 <para>To install a specific output path:
 
 <screen>
-$ nix-env -i /nix/store/y3cgx0xj1p4iv9x0pnnmdhr8iyg741vk-gcc-3.4.3</screen>
+$ nix-env --install /nix/store/y3cgx0xj1p4iv9x0pnnmdhr8iyg741vk-gcc-3.4.3</screen>
 
 </para>
 
 <para>To install from a Nix expression specified on the command-line:
 
 <screen>
-$ nix-env -f ./foo.nix -i -E \
+$ nix-env --file ./foo.nix --install --expr \
     'f: (f {system = "i686-linux";}).subversionWithJava'</screen>
 
 I.e., this evaluates to <literal>(f: (f {system =
@@ -493,7 +493,7 @@ set returned by calling the function defined in
 source:
 
 <screen>
-$ nix-env -f '&lt;nixpkgs>' -iA hello --dry-run
+$ nix-env --file '&lt;nixpkgs>' --install --attr hello --dry-run
 (dry run; not doing anything)
 installing ‘hello-2.10’
 these paths will be fetched (0.04 MiB download, 0.19 MiB unpacked):
@@ -506,7 +506,7 @@ these paths will be fetched (0.04 MiB download, 0.19 MiB unpacked):
 14.12 channel:
 
 <screen>
-$ nix-env -f https://github.com/NixOS/nixpkgs-channels/archive/nixos-14.12.tar.gz -iA firefox
+$ nix-env --file https://github.com/NixOS/nixpkgs-channels/archive/nixos-14.12.tar.gz --install --attr firefox
 </screen>
 
 (The GitHub repository <literal>nixpkgs-channels</literal> is updated
@@ -618,13 +618,13 @@ linkend="rsec-nix-env-install">--install</option>.</para>
 $ nix-env --upgrade gcc
 upgrading `gcc-3.3.1' to `gcc-3.4'
 
-$ nix-env -u gcc-3.3.2 --always <lineannotation>(switch to a specific version)</lineannotation>
+$ nix-env --upgrade gcc-3.3.2 --always <lineannotation>(switch to a specific version)</lineannotation>
 upgrading `gcc-3.4' to `gcc-3.3.2'
 
 $ nix-env --upgrade pan
 <lineannotation>(no upgrades available, so nothing happens)</lineannotation>
 
-$ nix-env -u <lineannotation>(try to upgrade everything)</lineannotation>
+$ nix-env --upgrade <lineannotation>(try to upgrade everything)</lineannotation>
 upgrading `hello-2.1.2' to `hello-2.1.3'
 upgrading `mozilla-1.2' to `mozilla-1.4'</screen>
 
@@ -711,7 +711,7 @@ paths designated by the symbolic names
 
 <screen>
 $ nix-env --uninstall gcc
-$ nix-env -e '.*' <lineannotation>(remove everything)</lineannotation></screen>
+$ nix-env --uninstall '.*' <lineannotation>(remove everything)</lineannotation></screen>
 
 </refsection>
 
@@ -747,7 +747,7 @@ The following updates a profile such that its current generation will contain
 just Firefox:
 
 <screen>
-$ nix-env -p /nix/var/nix/profiles/browser --set firefox</screen>
+$ nix-env --profile /nix/var/nix/profiles/browser --set firefox</screen>
 
 </para>
 
@@ -819,16 +819,16 @@ script:
 <screen>
 $ nix-env --set-flag keep true firefox</screen>
 
-After this, <command>nix-env -u</command> will ignore Firefox.</para>
+After this, <command>nix-env --upgrade</command> will ignore Firefox.</para>
 
 <para>To disable the currently installed Firefox, then install a new
 Firefox while the old remains part of the profile:
 
 <screen>
-$ nix-env -q
+$ nix-env --query
 firefox-2.0.0.9 <lineannotation>(the current one)</lineannotation>
 
-$ nix-env --preserve-installed -i firefox-2.0.0.11
+$ nix-env --preserve-installed --install firefox-2.0.0.11
 installing `firefox-2.0.0.11'
 building path(s) `/nix/store/myy0y59q3ig70dgq37jqwg1j0rsapzsl-user-environment'
 collision between `/nix/store/<replaceable>...</replaceable>-firefox-2.0.0.11/bin/firefox'
@@ -838,10 +838,10 @@ collision between `/nix/store/<replaceable>...</replaceable>-firefox-2.0.0.11/bi
 $ nix-env --set-flag active false firefox
 setting flag on `firefox-2.0.0.9'
 
-$ nix-env --preserve-installed -i firefox-2.0.0.11
+$ nix-env --preserve-installed --install firefox-2.0.0.11
 installing `firefox-2.0.0.11'
 
-$ nix-env -q
+$ nix-env --query
 firefox-2.0.0.11 <lineannotation>(the enabled one)</lineannotation>
 firefox-2.0.0.9 <lineannotation>(the disabled one)</lineannotation></screen>
 
@@ -1150,7 +1150,7 @@ user environment elements, etc. -->
 <para>To show installed packages:
 
 <screen>
-$ nix-env -q
+$ nix-env --query
 bison-1.875c
 docbook-xml-4.2
 firefox-1.0.4
@@ -1164,7 +1164,7 @@ ORBit2-2.8.3
 <para>To show available packages:
 
 <screen>
-$ nix-env -qa
+$ nix-env --query --available
 firefox-1.0.7
 GConf-2.4.0.1
 MPlayer-1.0pre7
@@ -1177,7 +1177,7 @@ ORBit2-2.8.3
 <para>To show the status of available packages:
 
 <screen>
-$ nix-env -qas
+$ nix-env --query --available --status
 -P- firefox-1.0.7   <lineannotation>(not installed but present)</lineannotation>
 --S GConf-2.4.0.1   <lineannotation>(not present, but there is a substitute for fast installation)</lineannotation>
 --S MPlayer-1.0pre3 <lineannotation>(i.e., this is not the installed MPlayer, even though the version is the same!)</lineannotation>
@@ -1190,7 +1190,7 @@ IP- ORBit2-2.8.3    <lineannotation>(installed and by definition present)</linea
 <para>To show available packages in the Nix expression <filename>foo.nix</filename>:
 
 <screen>
-$ nix-env -f ./foo.nix -qa
+$ nix-env --file ./foo.nix --query --available
 foo-1.2.3
 </screen>
 
@@ -1199,7 +1199,7 @@ foo-1.2.3
 <para>To compare installed versions to what’s available:
 
 <screen>
-$ nix-env -qc
+$ nix-env --query --compare-versions
 <replaceable>...</replaceable>
 acrobat-reader-7.0 - ?      <lineannotation>(package is not available at all)</lineannotation>
 autoconf-2.59      = 2.59   <lineannotation>(same version)</lineannotation>
@@ -1212,7 +1212,7 @@ firefox-1.0.4      &lt; 1.0.7  <lineannotation>(a more recent version is availab
 <para>To show all packages with “<literal>zip</literal>” in the name:
 
 <screen>
-$ nix-env -qa '.*zip.*'
+$ nix-env --query --available '.*zip.*'
 bzip2-1.0.6
 gzip-1.6
 zip-3.0
@@ -1225,7 +1225,7 @@ zip-3.0
 “<literal>chromium</literal>” in the name:
 
 <screen>
-$ nix-env -qa '.*(firefox|chromium).*'
+$ nix-env --query --available '.*(firefox|chromium).*'
 chromium-37.0.2062.94
 chromium-beta-38.0.2125.24
 firefox-32.0.3
@@ -1239,7 +1239,7 @@ firefox-with-plugins-13.0.1
 repository:
 
 <screen>
-$ nix-env -f https://github.com/NixOS/nixpkgs/archive/master.tar.gz -qa
+$ nix-env --file https://github.com/NixOS/nixpkgs/archive/master.tar.gz --query --available
 </screen>
 
 </para>
@@ -1280,7 +1280,7 @@ profile for the user.  That is, the symlink
 <refsection><title>Examples</title>
 
 <screen>
-$ nix-env -S ~/my-profile</screen>
+$ nix-env --switch-profile ~/my-profile</screen>
 
 </refsection>
 
@@ -1363,7 +1363,7 @@ $ nix-env --delete-generations 3 4 8
 
 $ nix-env --delete-generations 30d
 
-$ nix-env -p other_profile --delete-generations old</screen>
+$ nix-env --profile other_profile --delete-generations old</screen>
 
 </refsection>
 
@@ -1410,7 +1410,7 @@ store.</para>
 <refsection><title>Examples</title>
 
 <screen>
-$ nix-env -G 42
+$ nix-env --switch-generation 42
 switching from generation 50 to 42</screen>
 
 </refsection>

--- a/doc/manual/command-ref/nix-instantiate.xml
+++ b/doc/manual/command-ref/nix-instantiate.xml
@@ -178,7 +178,7 @@ building them using <command>nix-store</command>:
 $ nix-instantiate test.nix <lineannotation>(instantiate)</lineannotation>
 /nix/store/cigxbmvy6dzix98dxxh9b6shg7ar5bvs-perl-BerkeleyDB-0.26.drv
 
-$ nix-store -r $(nix-instantiate test.nix) <lineannotation>(build)</lineannotation>
+$ nix-store --realise $(nix-instantiate test.nix) nix-instantiate test.nix) <lineannotation>(build)</lineannotation>
 <replaceable>...</replaceable>
 /nix/store/qhqk4n8ci095g3sdp93x7rgwyh9rdvgk-perl-BerkeleyDB-0.26 <lineannotation>(output path)</lineannotation>
 
@@ -191,14 +191,14 @@ dr-xr-xr-x    2 eelco    users        4096 1970-01-01 01:00 lib
 <para>You can also give a Nix expression on the command line:
 
 <screen>
-$ nix-instantiate -E 'with import &lt;nixpkgs> { }; hello'
+$ nix-instantiate --expr 'with import &lt;nixpkgs> { }; hello'
 /nix/store/j8s4zyv75a724q38cb0r87rlczaiag4y-hello-2.8.drv
 </screen>
 
 This is equivalent to:
 
 <screen>
-$ nix-instantiate '&lt;nixpkgs>' -A hello
+$ nix-instantiate '&lt;nixpkgs>' --attr hello
 </screen>
 
 </para>
@@ -206,13 +206,13 @@ $ nix-instantiate '&lt;nixpkgs>' -A hello
 <para>Parsing and evaluating Nix expressions:
 
 <screen>
-$ nix-instantiate --parse -E '1 + 2'
+$ nix-instantiate --parse --expr '1 + 2'
 1 + 2
 
-$ nix-instantiate --eval -E '1 + 2'
+$ nix-instantiate --eval --expr '1 + 2'
 3
 
-$ nix-instantiate --eval --xml -E '1 + 2'
+$ nix-instantiate --eval --xml --expr '1 + 2'
 <![CDATA[<?xml version='1.0' encoding='utf-8'?>
 <expr>
   <int value="3" />
@@ -223,7 +223,7 @@ $ nix-instantiate --eval --xml -E '1 + 2'
 <para>The difference between non-strict and strict evaluation:
 
 <screen>
-$ nix-instantiate --eval --xml -E 'rec { x = "foo"; y = x; }'
+$ nix-instantiate --eval --xml --expr 'rec { x = "foo"; y = x; }'
 <replaceable>...</replaceable><![CDATA[
   <attr name="x">
     <string value="foo" />
@@ -237,7 +237,7 @@ Note that <varname>y</varname> is left unevaluated (the XML
 representation doesn’t attempt to show non-normal forms).
 
 <screen>
-$ nix-instantiate --eval --xml --strict -E 'rec { x = "foo"; y = x; }'
+$ nix-instantiate --eval --xml --strict --expr 'rec { x = "foo"; y = x; }'
 <replaceable>...</replaceable><![CDATA[
   <attr name="x">
     <string value="foo" />

--- a/doc/manual/command-ref/nix-shell.xml
+++ b/doc/manual/command-ref/nix-shell.xml
@@ -149,7 +149,7 @@ also <xref linkend="sec-common-options" />.</phrase></para>
     <listitem><para>Set up an environment in which the specified
     packages are present.  The command line arguments are interpreted
     as attribute names inside the Nix Packages collection.  Thus,
-    <literal>nix-shell -p libjpeg openjdk</literal> will start a shell
+    <literal>nix-shell --packages libjpeg openjdk</literal> will start a shell
     in which the packages denoted by the attribute names
     <varname>libjpeg</varname> and <varname>openjdk</varname> are
     present.</para></listitem>
@@ -198,7 +198,7 @@ also <xref linkend="sec-common-options" />.</phrase></para>
 interactive shell in which to build it:
 
 <screen>
-$ nix-shell '&lt;nixpkgs>' -A pan
+$ nix-shell '&lt;nixpkgs>' --attr pan
 [nix-shell]$ unpackPhase
 [nix-shell]$ cd pan-*
 [nix-shell]$ configurePhase
@@ -210,7 +210,7 @@ To clear the environment first, and do some additional automatic
 initialisation of the interactive shell:
 
 <screen>
-$ nix-shell '&lt;nixpkgs>' -A pan --pure \
+$ nix-shell '&lt;nixpkgs>' --attr pan --pure \
     --command 'export NIX_DEBUG=1; export NIX_CORES=8; return'
 </screen>
 
@@ -219,13 +219,13 @@ the following starts a shell containing the packages
 <literal>sqlite</literal> and <literal>libX11</literal>:
 
 <screen>
-$ nix-shell -E 'with import &lt;nixpkgs> { }; runCommand "dummy" { buildInputs = [ sqlite xorg.libX11 ]; } ""'
+$ nix-shell --expr 'with import &lt;nixpkgs> { }; runCommand "dummy" { buildInputs = [ sqlite xorg.libX11 ]; } ""'
 </screen>
 
 A shorter way to do the same is:
 
 <screen>
-$ nix-shell -p sqlite xorg.libX11
+$ nix-shell --packages sqlite xorg.libX11
 [nix-shell]$ echo $NIX_LDFLAGS
 … -L/nix/store/j1zg5v…-sqlite-3.8.0.2/lib -L/nix/store/0gmcz9…-libX11-1.6.1/lib …
 </screen>
@@ -236,7 +236,7 @@ path. You can override it by passing <option>-I</option> or setting
 containing the Pan package from a specific revision of Nixpkgs:
 
 <screen>
-$ nix-shell -p pan -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/8a3eea054838b55aca962c3fbde9c83c102b8bf2.tar.gz
+$ nix-shell --packages pan -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/8a3eea054838b55aca962c3fbde9c83c102b8bf2.tar.gz
 
 [nix-shell:~]$ pan --version
 Pan 0.139
@@ -276,7 +276,7 @@ the <literal>prettytable</literal> package:
 
 <programlisting>
 #! /usr/bin/env nix-shell
-#! nix-shell -i python -p python pythonPackages.prettytable
+#! nix-shell -i python --packages python pythonPackages.prettytable
 
 import prettytable
 
@@ -294,7 +294,7 @@ requires Perl and the <literal>HTML::TokeParser::Simple</literal> and
 
 <programlisting>
 #! /usr/bin/env nix-shell
-#! nix-shell -i perl -p perl perlPackages.HTMLTokeParserSimple perlPackages.LWP
+#! nix-shell -i perl --packages perl perlPackages.HTMLTokeParserSimple perlPackages.LWP
 
 use HTML::TokeParser::Simple;
 
@@ -314,7 +314,7 @@ Nixpkgs/NixOS (the 14.12 stable branch):
 
 <programlisting><![CDATA[
 #! /usr/bin/env nix-shell
-#! nix-shell -i runghc -p haskellPackages.ghc haskellPackages.HTTP haskellPackages.tagsoup
+#! nix-shell -i runghc --packages haskellPackages.ghc haskellPackages.HTTP haskellPackages.tagsoup
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-14.12.tar.gz
 
 import Network.HTTP

--- a/doc/manual/command-ref/nix-store.xml
+++ b/doc/manual/command-ref/nix-store.xml
@@ -92,7 +92,7 @@ options.</phrase></para>
     <filename>/nix/var/nix/gcroots/auto/</filename>.  For instance,
 
     <screen>
-$ nix-store --add-root /home/eelco/bla/result --indirect -r <replaceable>...</replaceable>
+$ nix-store --add-root /home/eelco/bla/result --indirect --realise <replaceable>...</replaceable>
 
 $ ls -l /nix/var/nix/gcroots/auto
 lrwxrwxrwx    1 ... 2005-03-13 21:10 dn54lcypm8f8... -> /home/eelco/bla/result
@@ -225,7 +225,7 @@ produced by <link
 linkend="sec-nix-instantiate"><command>nix-instantiate</command></link>:
 
 <screen>
-$ nix-store -r $(nix-instantiate ./test.nix)
+$ nix-store --realise $(nix-instantiate ./test.nix)nix-instantiate ./test.nix)
 /nix/store/31axcgrlbfsxzmfff1gyj1bf62hvkby2-aterm-2.3.1</screen>
 
 This is essentially what <link
@@ -234,7 +234,7 @@ linkend="sec-nix-build"><command>nix-build</command></link> does.</para>
 <para>To test whether a previously-built derivation is deterministic:
 
 <screen>
-$ nix-build -r '&lt;nixpkgs>' -A hello --check -K
+$ nix-build -r '&lt;nixpkgs>' --attr hello --check --keep-failed
 </screen>
 
 </para>
@@ -727,7 +727,7 @@ query is applied to the target of the symlink.</para>
 <command>svn</command> program in the current user environment:
 
 <screen>
-$ nix-store -qR $(which svn)
+$ nix-store --query --requisites $(which svn)
 /nix/store/5mbglq5ldqld8sj57273aljwkfvj22mc-subversion-1.1.4
 /nix/store/9lz9yc6zgmc0vlqmn2ipcpkjlmbi51vv-glibc-2.3.4
 <replaceable>...</replaceable></screen>
@@ -737,7 +737,7 @@ $ nix-store -qR $(which svn)
 <para>Print the build-time dependencies of <command>svn</command>:
 
 <screen>
-$ nix-store -qR $(nix-store -qd $(which svn))
+$ nix-store --query --requisites $(nix-store --query d $(which svn))nix-store --query d $(which svn))
 /nix/store/02iizgn86m42q905rddvg4ja975bk2i4-grep-2.5.1.tar.bz2.drv
 /nix/store/07a2bzxmzwz5hp58nf03pahrv2ygwgs3-gcc-wrapper.sh
 /nix/store/0ma7c9wsbaxahwwl04gbw3fcd806ski4-glibc-2.3.4.drv
@@ -750,7 +750,7 @@ path that contains <command>svn</command>.</para>
 <para>Show the build-time dependencies as a tree:
 
 <screen>
-$ nix-store -q --tree $(nix-store -qd $(which svn))
+$ nix-store --query --tree $(nix-store --query d $(which svn))nix-store --query d $(which svn))
 /nix/store/7i5082kfb6yjbqdbiwdhhza0am2xvh6c-subversion-1.1.4.drv
 +---/nix/store/d8afh10z72n8l1cr5w42366abiblgn54-builder.sh
 +---/nix/store/fmzxmpjx2lh849ph0l36snfj9zdibw67-bash-3.0.drv
@@ -764,7 +764,7 @@ $ nix-store -q --tree $(nix-store -qd $(which svn))
 <command>svn</command>:
 
 <screen>
-$ nix-store -q --referrers $(nix-store -q --binding openssl $(nix-store -qd $(which svn)))
+$ nix-store --query --referrers $(nix-store --query --binding openssl $(nix-store --query d $(which svn)))nix-store --query --binding openssl $(nix-store --query d $(which svn)))nix-store --query d $(which svn)))
 /nix/store/23ny9l9wixx21632y2wi4p585qhva1q8-sylpheed-1.0.0
 /nix/store/5mbglq5ldqld8sj57273aljwkfvj22mc-subversion-1.1.4
 /nix/store/dpmvp969yhdqs7lm2r1a3gng7pyq6vy4-subversion-1.1.3
@@ -776,7 +776,7 @@ $ nix-store -q --referrers $(nix-store -q --binding openssl $(nix-store -qd $(wh
 (C library) used by <command>svn</command>:
 
 <screen>
-$ nix-store -q --referrers-closure $(ldd $(which svn) | grep /libc.so | awk '{print $3}')
+$ nix-store --query --referrers-closure $(ldd $(which svn) | grep /libc.so | awk '{print $3}')
 /nix/store/034a6h4vpz9kds5r6kzb9lhh81mscw43-libgnomeprintui-2.8.2
 /nix/store/15l3yi0d45prm7a82pcrknxdh6nzmxza-gawk-3.1.4
 <replaceable>...</replaceable></screen>
@@ -788,7 +788,7 @@ dynamic libraries used by an ELF executable.</para>
 user environment:
 
 <screen>
-$ nix-store -q --graph ~/.nix-profile | dot -Tps > graph.ps
+$ nix-store --query --graph ~/.nix-profile | dot -Tps > graph.ps
 $ gv graph.ps</screen>
 
 </para>
@@ -797,7 +797,7 @@ $ gv graph.ps</screen>
 that depends on <command>svn</command>:
 
 <screen>
-$ nix-store -q --roots $(which svn)
+$ nix-store --query --roots $(which svn)
 /nix/var/nix/profiles/default-81-link
 /nix/var/nix/profiles/default-82-link
 /nix/var/nix/profiles/per-user/eelco/profile-97-link
@@ -956,7 +956,7 @@ otherwise.</para>
 <para>To verify the integrity of the <command>svn</command> command and all its dependencies:
 
 <screen>
-$ nix-store --verify-path $(nix-store -qR $(which svn))
+$ nix-store --verify-path $(nix-store --query --requisites $(which svn))nix-store --query --requisites $(which svn))
 </screen>
 
 </para>
@@ -1045,7 +1045,7 @@ directory entries are always sorted so that the actual on-disk order
 doesn’t influence the result.  This means that the cryptographic hash
 of a NAR dump of a path is usable as a fingerprint of the contents of
 the path.  Indeed, the hashes of store paths stored in Nix’s database
-(see <link linkend="refsec-nix-store-query"><literal>nix-store -q
+(see <link linkend="refsec-nix-store-query"><literal>nix-store --query
 --hash</literal></link>) are SHA-256 hashes of the NAR dump of each
 store path.</para>
 
@@ -1118,7 +1118,7 @@ that are missing in the target Nix store, the import will fail.  To
 copy a whole closure, do something like:
 
 <screen>
-$ nix-store --export $(nix-store -qR <replaceable>paths</replaceable>) > out</screen>
+$ nix-store --export $(nix-store --query --requisites nix-store --query --requisites <replaceable>paths</replaceable>) > out</screen>
 
 To import the whole closure again, run:
 
@@ -1243,7 +1243,7 @@ a substitute, then the log is unavailable.</para>
 <refsection><title>Example</title>
 
 <screen>
-$ nix-store -l $(which ktorrent)
+$ nix-store --read-log $(which ktorrent)
 building /nix/store/dhc73pvzpnzxhdgpimsd9sw39di66ph1-ktorrent-2.2.1
 unpacking sources
 unpacking source archive /nix/store/p8n1jpqs27mgkjw07pb5269717nzf5f8-ktorrent-2.2.1.tar.gz
@@ -1330,7 +1330,7 @@ variable <envar>_args</envar>.</para>
 <refsection><title>Example</title>
 
 <screen>
-$ nix-store --print-env $(nix-instantiate '&lt;nixpkgs>' -A firefox)
+$ nix-store --print-env $(nix-instantiate '&lt;nixpkgs>' --attr firefox)nix-instantiate '&lt;nixpkgs>' --attr firefox)
 <replaceable>…</replaceable>
 export src; src='/nix/store/plpj7qrwcz94z2psh6fchsi7s8yihc7k-firefox-12.0.source.tar.bz2'
 export stdenv; stdenv='/nix/store/7c8asx3yfrg5dg1gzhzyq2236zfgibnn-stdenv'

--- a/doc/manual/command-ref/opt-common.xml
+++ b/doc/manual/command-ref/opt-common.xml
@@ -246,11 +246,11 @@
 }: <replaceable>...</replaceable></programlisting>
 
   So if you call this Nix expression (e.g., when you do
-  <literal>nix-env -i <replaceable>pkgname</replaceable></literal>),
+  <literal>nix-env --install <replaceable>pkgname</replaceable></literal>),
   the function will be called automatically using the value <link
   linkend='builtin-currentSystem'><literal>builtins.currentSystem</literal></link>
   for the <literal>system</literal> argument.  You can override this
-  using <option>--arg</option>, e.g., <literal>nix-env -i
+  using <option>--arg</option>, e.g., <literal>nix-env --install
   <replaceable>pkgname</replaceable> --arg system
   \"i686-freebsd\"</literal>.  (Note that since the argument is a Nix
   string literal, you have to escape the quotes.)</para></listitem>

--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -909,7 +909,7 @@ builtins.substring 0 3 "nixos"
 
     <listitem><para>Throw an error message
     <replaceable>s</replaceable>.  This usually aborts Nix expression
-    evaluation, but in <command>nix-env -qa</command> and other
+    evaluation, but in <command>nix-env --query --available</command> and other
     commands that try to evaluate a set of derivations to get
     information about those derivations, a derivation that throws an
     error is silently skipped (which is not the case for

--- a/doc/manual/expressions/debug-build.xml
+++ b/doc/manual/expressions/debug-build.xml
@@ -16,7 +16,7 @@ can go to the output directory and <quote>switch</quote> to the
 environment of the builder:
 
 <screen>
-$ nix-build -K ./foo.nix
+$ nix-build --keep-failed ./foo.nix
 ... fails, keeping build directory `/tmp/nix-1234-0'
 
 $ cd /tmp/nix-1234-0

--- a/doc/manual/expressions/simple-building-testing.xml
+++ b/doc/manual/expressions/simple-building-testing.xml
@@ -7,14 +7,14 @@
 <title>Building and Testing</title>
 
 <para>You can now try to build Hello.  Of course, you could do
-<literal>nix-env -i hello</literal>, but you may not want to install a
+<literal>nix-env --install hello</literal>, but you may not want to install a
 possibly broken package just yet.  The best way to test the package is by
 using the command <command linkend="sec-nix-build">nix-build</command>,
 which builds a Nix expression and creates a symlink named
 <filename>result</filename> in the current directory:
 
 <screen>
-$ nix-build -A hello
+$ nix-build --attr hello
 building path `/nix/store/632d2b22514d...-hello-2.1.1'
 hello-2.1.1/
 hello-2.1.1/intl/
@@ -67,7 +67,7 @@ block (or perform other derivations if available) until the build
 finishes:
 
 <screen>
-$ nix-build -A hello
+$ nix-build --attr hello
 waiting for lock on `/nix/store/0h5b7hp8d4hqfrw8igvx97x1xawrjnac-hello-2.1.1x'</screen>
 
 So it is always safe to run multiple instances of Nix in parallel

--- a/doc/manual/hacking.xml
+++ b/doc/manual/hacking.xml
@@ -14,7 +14,7 @@ $ cd nix
 
 <para>To build it and its dependencies:
 <screen>
-$ nix-build release.nix -A build.x86_64-linux
+$ nix-build release.nix --attr build.x86_64-linux
 </screen>
 </para>
 

--- a/doc/manual/introduction/about-nix.xml
+++ b/doc/manual/introduction/about-nix.xml
@@ -211,7 +211,7 @@ xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/netwo
 Nix expression</link>:</para>
 
 <screen>
-$ nix-shell '&lt;nixpkgs>' -A pan
+$ nix-shell '&lt;nixpkgs>' --attr pan
 </screen>
 
 <para>You’re then dropped into a shell where you can edit, build and test

--- a/doc/manual/introduction/quick-start.xml
+++ b/doc/manual/introduction/quick-start.xml
@@ -27,7 +27,7 @@ methods, see <xref linkend="chap-installation"/>.)</para></step>
 in the channel:
 
 <screen>
-$ nix-env -qa
+$ nix-env --query --available
 docbook-xml-4.3
 docbook-xml-4.5
 firefox-33.0.2
@@ -40,7 +40,7 @@ libxslt-1.1.28
 <step><para>Install some packages from the channel:
 
 <screen>
-$ nix-env -i hello <replaceable>...</replaceable> </screen>
+$ nix-env --install hello <replaceable>...</replaceable> </screen>
 
 This should download pre-built packages; it should not build them
 locally (if it does, something went wrong).</para></step>
@@ -59,14 +59,14 @@ Hello, world!
 <step><para>Uninstall a package:
 
 <screen>
-$ nix-env -e hello</screen>
+$ nix-env --uninstall hello</screen>
 
 </para></step>
 
 <step><para>You can also test a package without installing it:
 
 <screen>
-$ nix-shell -p hello
+$ nix-shell --packages hello
 </screen>
 
 This builds or downloads GNU Hello and its dependencies, then drops
@@ -89,7 +89,7 @@ hello: command not found
 
 <screen>
 $ nix-channel --update nixpkgs
-$ nix-env -u '*'</screen>
+$ nix-env --upgrade '*'</screen>
 
 The latter command will upgrade each installed package for which there
 is a “newer” version (as determined by comparing the version

--- a/doc/manual/packages/basic-package-mgmt.xml
+++ b/doc/manual/packages/basic-package-mgmt.xml
@@ -57,7 +57,7 @@ succeed.</para></note>
 <para>You can view the set of available packages in Nixpkgs:
 
 <screen>
-$ nix-env -qa
+$ nix-env --query --available
 aterm-2.2
 bash-3.0
 binutils-2.15
@@ -74,7 +74,7 @@ then you need to pass the path to your Nixpkgs tree using the
 <option>-f</option> flag:
 
 <screen>
-$ nix-env -qaf <replaceable>/path/to/nixpkgs</replaceable>
+$ nix-env --query --available --file <replaceable>/path/to/nixpkgs</replaceable>
 </screen>
 
 where <replaceable>/path/to/nixpkgs</replaceable> is where you’ve
@@ -83,7 +83,7 @@ unpacked or checked out Nixpkgs.</para>
 <para>You can select specific packages by name:
 
 <screen>
-$ nix-env -qa firefox
+$ nix-env --query --available firefox
 firefox-34.0.5
 firefox-with-plugins-34.0.5
 </screen>
@@ -91,7 +91,7 @@ firefox-with-plugins-34.0.5
 and using regular expressions:
 
 <screen>
-$ nix-env -qa 'firefox.*'
+$ nix-env --query --available 'firefox.*'
 </screen>
 
 </para>
@@ -101,7 +101,7 @@ available packages, i.e., whether they are installed into the user
 environment and/or present in the system:
 
 <screen>
-$ nix-env -qas
+$ nix-env --query --available --status
 …
 -PS bash-3.0
 --S binutils-2.15
@@ -119,11 +119,11 @@ just means that Nix knows that it can fetch a pre-built package from
 somewhere (typically a network server) instead of building it
 locally.</para>
 
-<para>You can install a package using <literal>nix-env -i</literal>.
+<para>You can install a package using <literal>nix-env --install</literal>.
 For instance,
 
 <screen>
-$ nix-env -i subversion</screen>
+$ nix-env --install subversion</screen>
 
 will install the package called <literal>subversion</literal> (which
 is, of course, the <link
@@ -150,7 +150,7 @@ Nixpkgs tree), you will get binaries for most packages.</para></note>
 <para>Naturally, packages can also be uninstalled:
 
 <screen>
-$ nix-env -e subversion</screen>
+$ nix-env --uninstall subversion</screen>
 
 </para>
 
@@ -158,7 +158,7 @@ $ nix-env -e subversion</screen>
 release of Nix Packages, you can do:
 
 <screen>
-$ nix-env -u subversion</screen>
+$ nix-env --upgrade subversion</screen>
 
 This will <emphasis>only</emphasis> upgrade Subversion if there is a
 “newer” version in the new set of Nix expressions, as
@@ -173,17 +173,17 @@ whatever version is already installed.</para>
 versions:
 
 <screen>
-$ nix-env -u</screen>
+$ nix-env --upgrade</screen>
 
 </para>
 
 <para>Sometimes it’s useful to be able to ask what
 <command>nix-env</command> would do, without actually doing it.  For
 instance, to find out what packages would be upgraded by
-<literal>nix-env -u</literal>, you can do
+<literal>nix-env --upgrade</literal>, you can do
 
 <screen>
-$ nix-env -u --dry-run
+$ nix-env --upgrade --dry-run
 (dry run; not doing anything)
 upgrading `libxslt-1.1.0' to `libxslt-1.1.10'
 upgrading `graphviz-1.10' to `graphviz-1.12'

--- a/doc/manual/packages/binary-cache-substituter.xml
+++ b/doc/manual/packages/binary-cache-substituter.xml
@@ -17,7 +17,7 @@ mechanism that Nix usually uses to fetch pre-built binaries from
 you can install it from Nixpkgs:
 
 <screen>
-$ nix-env -i nix-serve
+$ nix-env --install nix-serve
 </screen>
 
 You can then start the server, listening for HTTP connections on
@@ -47,7 +47,7 @@ Priority: 30
 using <option>--option extra-binary-caches</option>, e.g.:
 
 <screen>
-$ nix-env -i firefox --option extra-binary-caches http://avalon:8080/
+$ nix-env --install firefox --option extra-binary-caches http://avalon:8080/
 </screen>
 
 The option <option>extra-binary-caches</option> tells Nix to use this

--- a/doc/manual/packages/channels.xml
+++ b/doc/manual/packages/channels.xml
@@ -49,7 +49,7 @@ default to <command>nix-env</command> operations (via the symlink
 then say
 
 <screen>
-$ nix-env -u</screen>
+$ nix-env --upgrade</screen>
 
 to upgrade all packages in your profile to the latest versions
 available in the subscribed channels.</para>

--- a/doc/manual/packages/copy-closure.xml
+++ b/doc/manual/packages/copy-closure.xml
@@ -26,7 +26,7 @@ dependencies) to a file, and then unpack that file into another Nix
 store.  For example,
 
 <screen>
-$ nix-store --export $(nix-store -qR $(type -p firefox)) > firefox.closure</screen>
+$ nix-store --export $(nix-store --query --requisites $(type -p firefox)) > firefox.closurenix-store --query --requisites $(type -p firefox)) > firefox.closure</screen>
 
 writes the closure of Firefox to a file.  You can then copy this file
 to another machine and install the closure:
@@ -40,7 +40,7 @@ another command, e.g. to copy and install a closure directly to/on
 another machine:
 
 <screen>
-$ nix-store --export $(nix-store -qR $(type -p firefox)) | bzip2 | \
+$ nix-store --export $(nix-store --query --requisites $(type -p firefox))nix-store --query --requisites $(type -p firefox)) | bzip2 | \
     ssh alice@itchy.example.org "bunzip2 | nix-store --import"</screen>
 
 However, <command>nix-copy-closure</command> is generally more

--- a/doc/manual/packages/profiles.xml
+++ b/doc/manual/packages/profiles.xml
@@ -56,7 +56,7 @@ contains a symlink to just Subversion 1.1.2 (arrows in the figure
 indicate symlinks).  This would be what we would obtain if we had done
 
 <screen>
-$ nix-env -i subversion</screen>
+$ nix-env --install subversion</screen>
 
 on a set of Nix expressions that contained Subversion 1.1.2.</para>
 
@@ -73,7 +73,7 @@ generated based on the current one.  For instance, generation 43 was
 created from generation 42 when we did
 
 <screen>
-$ nix-env -i subversion firefox</screen>
+$ nix-env --install subversion firefox</screen>
 
 on a set of Nix expressions that contained Firefox and a new version
 of Subversion.</para>
@@ -150,7 +150,7 @@ this using the <option>--profile</option> option (abbreviation
 <option>-p</option>):
 
 <screen>
-$ nix-env -p /nix/var/nix/profiles/other-profile -i subversion</screen>
+$ nix-env --profile /nix/var/nix/profiles/other-profile --install subversion</screen>
 
 This will <emphasis>not</emphasis> change the
 <command>~/.nix-profile</command> symlink.</para>

--- a/doc/manual/packages/ssh-substituter.xml
+++ b/doc/manual/packages/ssh-substituter.xml
@@ -12,7 +12,7 @@ automatically fetching any store paths in Firefox’s closure if they
 are available on the server <literal>avalon</literal>:
 
 <screen>
-$ nix-env -i firefox --option ssh-substituter-hosts alice@avalon
+$ nix-env --install firefox --option ssh-substituter-hosts alice@avalon
 </screen>
 
 This works similar to the binary cache substituter that Nix usually
@@ -31,7 +31,7 @@ an SSH passphrase interactively. Therefore, you should use
 installing it into your profile, e.g.
 
 <screen>
-$ nix-store -r /nix/store/m85bxg…-firefox-34.0.5 --option ssh-substituter-hosts alice@avalon
+$ nix-store --realise /nix/store/m85bxg…-firefox-34.0.5 --option ssh-substituter-hosts alice@avalon
 </screen>
 
 This is essentially equivalent to doing

--- a/doc/manual/release-notes/rl-0.10.xml
+++ b/doc/manual/release-notes/rl-0.10.xml
@@ -36,16 +36,16 @@ irreversible.</para></warning>
       --query</command> to allow you to compare installed versions of
       packages to available versions, or vice versa.  An easy way to
       see if you are up to date with what’s in your subscribed
-      channels is <literal>nix-env -qc \*</literal>.</para></listitem>
+      channels is <literal>nix-env --query --compare-versions \*</literal>.</para></listitem>
 
       <listitem><para><literal>nix-env --query</literal> now takes as
       arguments a list of package names about which to show
       information, just like <option>--install</option>, etc.: for
-      example, <literal>nix-env -q gcc</literal>.  Note that to show
+      example, <literal>nix-env --query gcc</literal>.  Note that to show
       all derivations, you need to specify
       <literal>\*</literal>.</para></listitem>
 
-      <listitem><para><literal>nix-env -i
+      <listitem><para><literal>nix-env --install
       <replaceable>pkgname</replaceable></literal> will now install
       the highest available version of
       <replaceable>pkgname</replaceable>, rather than installing all
@@ -56,7 +56,7 @@ irreversible.</para></warning>
       shows exactly which missing paths will be built or
       substituted.</para></listitem>
 
-      <listitem><para><literal>nix-env -qa --description</literal>
+      <listitem><para><literal>nix-env --query --available --description</literal>
       shows human-readable descriptions of packages, provided that
       they have a <literal>meta.description</literal> attribute (which
       most packages in Nixpkgs don’t have yet).</para></listitem>
@@ -134,7 +134,7 @@ irreversible.</para></warning>
 
     <itemizedlist>
 
-      <listitem><para><literal>nix-env -q --xml</literal> prints the
+      <listitem><para><literal>nix-env --query --xml</literal> prints the
       installed or available packages in an XML representation for
       easy processing by other tools.</para></listitem>
 
@@ -163,7 +163,7 @@ irreversible.</para></warning>
   attribute set are unique.)  For instance, a quick way to perform a
   test build of a package in Nixpkgs is <literal>nix-build
   pkgs/top-level/all-packages.nix -A
-  <replaceable>foo</replaceable></literal>.  <literal>nix-env -q
+  <replaceable>foo</replaceable></literal>.  <literal>nix-env --query
   --attr</literal> shows the attribute names corresponding to each
   derivation.</para></listitem>
 
@@ -191,7 +191,7 @@ irreversible.</para></warning>
   variables.</para></listitem>
 
 
-  <listitem><para><literal>nix-build -o
+  <listitem><para><literal>nix-build --out-link
   <replaceable>symlink</replaceable></literal> allows the symlink to
   the build result to be named something other than
   <literal>result</literal>.</para></listitem>
@@ -284,7 +284,7 @@ irreversible.</para></warning>
   4.3.</para></listitem>
 
   <listitem><para>Substantial performance improvements in expression
-  evaluation and <literal>nix-env -qa</literal>, all thanks to <link
+  evaluation and <literal>nix-env --query --available</literal>, all thanks to <link
   xlink:href="http://valgrind.org/">Valgrind</link>.  Memory use has
   been reduced by a factor 8 or so.  Big speedup by memoisation of
   path hashing.</para></listitem>
@@ -303,7 +303,7 @@ irreversible.</para></warning>
       (<literal>NIX-7</literal>).</para></listitem>
 
       <listitem><para>Removed misleading messages from
-      <literal>nix-env -i</literal> (e.g., <literal>installing
+      <literal>nix-env --install</literal> (e.g., <literal>installing
       `foo'</literal> followed by <literal>uninstalling
       `foo'</literal>) (<literal>NIX-17</literal>).</para></listitem>
 

--- a/doc/manual/release-notes/rl-0.11.xml
+++ b/doc/manual/release-notes/rl-0.11.xml
@@ -43,7 +43,7 @@ on Nix.  Here is an (incomplete) list:</para>
   <listitem><para><command>nix-env</command> <option>--set</option>
   modifies the current generation of a profile so that it contains
   exactly the specified derivation, and nothing else.  For example,
-  <literal>nix-env -p /nix/var/nix/profiles/browser --set
+  <literal>nix-env --profile /nix/var/nix/profiles/browser --set
   firefox</literal> lets the profile named
   <filename>browser</filename> contain just Firefox.</para></listitem>
 
@@ -52,7 +52,7 @@ on Nix.  Here is an (incomplete) list:</para>
   meta-information about installed packages in profiles.  The
   meta-information is the contents of the <varname>meta</varname>
   attribute of derivations, such as <varname>description</varname> or
-  <varname>homepage</varname>.  The command <literal>nix-env -q --xml
+  <varname>homepage</varname>.  The command <literal>nix-env --query --xml
   --meta</literal> shows all meta-information.</para></listitem>
 
 
@@ -68,7 +68,7 @@ on Nix.  Here is an (incomplete) list:</para>
   environment.</para></listitem>
 
 
-  <listitem><para><command>nix-env -i / -u</command>: instead of
+  <listitem><para><command>nix-env --install / --upgrade</command>: instead of
   breaking package ties by version, break them by priority and version
   number.  That is, if there are multiple packages with the same name,
   then pick the package with the highest priority, and only use the
@@ -80,7 +80,7 @@ on Nix.  Here is an (incomplete) list:</para>
   be a beta version of some package (e.g.,
   <literal>gcc-4.2.0rc1</literal>) which should not be installed even
   though it is the highest version, except when it is explicitly
-  selected (e.g., <literal>nix-env -i
+  selected (e.g., <literal>nix-env --install
   gcc-4.2.0rc1</literal>).</para></listitem>
 
 
@@ -112,14 +112,14 @@ on Nix.  Here is an (incomplete) list:</para>
   </para></listitem>
 
 
-  <listitem><para><command>nix-env -q</command> now has a flag
+  <listitem><para><command>nix-env --query</command> now has a flag
   <option>--prebuilt-only</option> (<option>-b</option>) that causes
   <command>nix-env</command> to show only those derivations whose
   output is already in the Nix store or that can be substituted (i.e.,
   downloaded from somewhere).  In other words, it shows the packages
   that can be installed “quickly”, i.e., don’t need to be built from
   source.  The <option>-b</option> flag is also available in
-  <command>nix-env -i</command> and <command>nix-env -u</command> to
+  <command>nix-env --install</command> and <command>nix-env --upgrade</command> to
   filter out derivations for which no pre-built binary is
   available.</para></listitem>
 
@@ -152,7 +152,7 @@ on Nix.  Here is an (incomplete) list:</para>
 
   <!-- foo
   <listitem><para>TODO: option <option>- -reregister</option> in
-  <command>nix-store - -register-validity</command>.</para></listitem>
+  <command>nix-store - --realise egister-validity</command>.</para></listitem>
   -->
 
 

--- a/doc/manual/release-notes/rl-0.12.xml
+++ b/doc/manual/release-notes/rl-0.12.xml
@@ -74,14 +74,14 @@ $ rm __db* log.* derivers references referrers reserved validpaths DB_CONFIG</sc
   be deleted.  For instance,
 
     <screen>
-    $ nix-store --gc -v --max-atime $(date +%s -d "2 months ago")</screen>
+    $ nix-store --gc --verbose --max-atime $(date +%s -d "2 months ago")</screen>
 
   deletes everything that hasn’t been accessed in two months.</para></listitem>
 
   <listitem><para><command>nix-env</command> now uses optimistic
   profile locking when performing an operation like installing or
   upgrading, instead of setting an exclusive lock on the profile.
-  This allows multiple <command>nix-env -i / -u / -e</command>
+  This allows multiple <command>nix-env --install / --upgrade / --uninstall</command>
   operations on the same profile in parallel.  If a
   <command>nix-env</command> operation sees at the end that the profile
   was changed in the meantime by another process, it will just
@@ -89,13 +89,13 @@ $ rm __db* log.* derivers references referrers reserved validpaths DB_CONFIG</sc
   still in the Nix store.</para></listitem>
 
   <listitem><para>The option <option>--dry-run</option> is now
-  supported by <command>nix-store -r</command> and
+  supported by <command>nix-store --realise</command> and
   <command>nix-build</command>.</para></listitem>
 
   <listitem><para>The information previously shown by
   <option>--dry-run</option> (i.e., which derivations will be built
   and which paths will be substituted) is now always shown by
-  <command>nix-env</command>, <command>nix-store -r</command> and
+  <command>nix-env</command>, <command>nix-store --realise</command> and
   <command>nix-build</command>.  The total download size of
   substitutable paths is now also shown.  For instance, a build will
   show something like
@@ -163,7 +163,7 @@ the following paths will be downloaded/copied (30.02 MiB):
   <command>nix-pack-closure</command> and
   <command>nix-unpack-closure</command>.   You can do almost the same
   thing but much more efficiently by doing <literal>nix-store --export
-  $(nix-store -qR <replaceable>paths</replaceable>) > closure</literal> and
+  $(nix-store --query --requisites <replaceable>paths</replaceable>) > closure</literal> and
   <literal>nix-store --import &lt;
   closure</literal>.</para></listitem>
 

--- a/doc/manual/release-notes/rl-0.16.xml
+++ b/doc/manual/release-notes/rl-0.16.xml
@@ -42,7 +42,7 @@
   </listitem>
 
   <listitem>
-    <para><command>nix-store -q</command> now supports XML output
+    <para><command>nix-store --query</command> now supports XML output
     through the <option>--xml</option> flag.</para>
   </listitem>
 

--- a/doc/manual/release-notes/rl-0.8.xml
+++ b/doc/manual/release-notes/rl-0.8.xml
@@ -59,25 +59,25 @@ xlink:href='http://catamaran.labs.cs.uu.nl/dist/nix/channels-v3/nixpkgs-unstable
   <para>For instance, given any store path, you can query its closure:
 
   <screen>
-$ nix-store -qR $(which firefox)
+$ nix-store --query --requisites $(which firefox)
 ... lots of paths ...</screen>
 
   Also, Nix now remembers for each store path the derivation that
   built it (the “deriver”):
 
   <screen>
-$ nix-store -qR $(which firefox)
+$ nix-store --query --requisites $(which firefox)
 /nix/store/4b0jx7vq80l9aqcnkszxhymsf1ffa5jd-firefox-1.0.1.drv</screen>
 
   So to see the build-time dependencies, you can do
 
   <screen>
-$ nix-store -qR $(nix-store -qd $(which firefox))</screen>
+$ nix-store --query --requisites $(nix-store --query d $(which firefox))nix-store --query d $(which firefox))</screen>
 
   or, in a nicer format:
 
   <screen>
-$ nix-store -q --tree $(nix-store -qd $(which firefox))</screen>
+$ nix-store --query --tree $(nix-store --query d $(which firefox))nix-store --query d $(which firefox))</screen>
 
   </para>
 
@@ -86,7 +86,7 @@ $ nix-store -q --tree $(nix-store -qd $(which firefox))</screen>
   certain Glibc:
 
   <screen>
-$ nix-store -q --referrers-closure \
+$ nix-store --query --referrers-closure \
     /nix/store/8lz9yc6zgmc0vlqmn2ipcpkjlmbi51vv-glibc-2.3.4</screen>
 
   </para>
@@ -117,7 +117,7 @@ $ nix-store -q --referrers-closure \
   just want to install some specific application, this is easier than
   subscribing to a channel.</para></listitem>
 
-  <listitem><para><command>nix-store -r
+  <listitem><para><command>nix-store --realise
   <replaceable>PATHS</replaceable></command> now builds all the
   derivations PATHS in parallel.  Previously it did them sequentially
   (though exploiting possible parallelism between subderivations).
@@ -135,7 +135,7 @@ $ nix-store -q --referrers-closure \
     <listitem><para>Copy from another user environment:
 
     <screen>
-$ nix-env -i --from-profile .../other-profile firefox</screen>
+$ nix-env --install --from-profile .../other-profile firefox</screen>
 
     </para></listitem>
 
@@ -143,7 +143,7 @@ $ nix-env -i --from-profile .../other-profile firefox</screen>
     Nix expression language entirely):
 
     <screen>
-$ nix-env -i /nix/store/z58v41v21xd3...-aterm-2.3.1.drv</screen>
+$ nix-env --install /nix/store/z58v41v21xd3...-aterm-2.3.1.drv</screen>
 
     (This is used to implement <command>nix-install-package</command>,
     which is therefore immune to evolution in the Nix expression
@@ -152,7 +152,7 @@ $ nix-env -i /nix/store/z58v41v21xd3...-aterm-2.3.1.drv</screen>
     <listitem><para>Install an already built store path directly:
 
     <screen>
-$ nix-env -i /nix/store/hsyj5pbn0d9i...-aterm-2.3.1</screen>
+$ nix-env --install /nix/store/hsyj5pbn0d9i...-aterm-2.3.1</screen>
 
     </para></listitem>
 
@@ -160,7 +160,7 @@ $ nix-env -i /nix/store/hsyj5pbn0d9i...-aterm-2.3.1</screen>
     as a command-line argument:
 
     <screen>
-$ nix-env -f .../i686-linux.nix -i -E 'x: x.firefoxWrapper'</screen>
+$ nix-env --file .../i686-linux.nix --install --expr 'x: x.firefoxWrapper'</screen>
 
     The difference with the normal installation mode is that
     <option>-E</option> does not use the <varname>name</varname>

--- a/doc/manual/release-notes/rl-0.9.xml
+++ b/doc/manual/release-notes/rl-0.9.xml
@@ -44,8 +44,8 @@ attrs // {
   where <function>derivation!</function> is a primop that does the
   actual derivation instantiation (i.e., it does what
   <function>derivation</function> used to do).  The advantage is that
-  it allows commands such as <command>nix-env -qa</command> and
-  <command>nix-env -i</command> to be much faster since they no longer
+  it allows commands such as <command>nix-env --query --available</command> and
+  <command>nix-env --install</command> to be much faster since they no longer
   need to instantiate all derivations, just the
   <varname>name</varname> attribute.</para>
 

--- a/doc/manual/release-notes/rl-1.1.xml
+++ b/doc/manual/release-notes/rl-1.1.xml
@@ -92,7 +92,7 @@
 
   <listitem>
     <para>When using the Nix daemon, the <option>-s</option> flag in
-    <command>nix-env -qa</command> is now much faster.</para>
+    <command>nix-env --query --available</command> is now much faster.</para>
   </listitem>
 
 </itemizedlist>

--- a/doc/manual/release-notes/rl-1.11.xml
+++ b/doc/manual/release-notes/rl-1.11.xml
@@ -23,7 +23,7 @@ $ nix-prefetch-url -A hello.src
     <function>fetchurl</function> call in the attribute
     <literal>hello.src</literal> from the Nix expression in the
     current directory, and print the cryptographic hash of the
-    resulting file on stdout. This differs from <literal>nix-build -A
+    resulting file on stdout. This differs from <literal>nix-build --attr
     hello.src</literal> in that it doesn't verify the hash, and is
     thus useful when you’re updating a Nix expression.</para>
 
@@ -87,7 +87,7 @@ $ nix-prefetch-url -A nix-repl.src
       like <command>diffoscope</command>, e.g.,
 
 <screen>
-$ nix-build pkgs/stdenv/linux -A stage1.pkgs.zlib --check -K
+$ nix-build pkgs/stdenv/linux --attr stage1.pkgs.zlib --check --keep-failed
 error: derivation ‘/nix/store/l54i8wlw2265…-zlib-1.2.8.drv’ may not
 be deterministic: output ‘/nix/store/11a27shh6n2i…-zlib-1.2.8’
 differs from ‘/nix/store/11a27shh6n2i…-zlib-1.2.8-check’
@@ -110,7 +110,7 @@ $ diffoscope /nix/store/11a27shh6n2i…-zlib-1.2.8 /nix/store/11a27shh6n2i…-zl
   </listitem>
 
   <listitem>
-    <para><command>nix-env -qa --xml --meta</command> now prints
+    <para><command>nix-env --query --available --xml --meta</command> now prints
     license information.</para>
   </listitem>
 

--- a/doc/manual/release-notes/rl-1.2.xml
+++ b/doc/manual/release-notes/rl-1.2.xml
@@ -19,7 +19,7 @@
     configuration setting <option>binary-caches</option> contains a
     list of URLs of binary caches.  For instance, doing
 <screen>
-$ nix-env -i thunderbird --option binary-caches http://cache.nixos.org
+$ nix-env --install thunderbird --option binary-caches http://cache.nixos.org
 </screen>
     will install Thunderbird and its dependencies, using the available
     pre-built binaries in <uri>http://cache.nixos.org</uri>.

--- a/doc/manual/release-notes/rl-1.6.xml
+++ b/doc/manual/release-notes/rl-1.6.xml
@@ -40,12 +40,12 @@ features:</para>
   <listitem>
     <para><command>nix-env</command> no longer requires a
     <literal>*</literal> argument to match all packages, so
-    <literal>nix-env -qa</literal> is equivalent to <literal>nix-env
+    <literal>nix-env --query --available</literal> is equivalent to <literal>nix-env
     -qa '*'</literal>.</para>
   </listitem>
 
   <listitem>
-    <para><command>nix-env -i</command> has a new flag
+    <para><command>nix-env --install</command> has a new flag
     <option>--remove-all</option> (<option>-r</option>) to remove all
     previous packages from the profile.  This makes it easier to do
     declarative package management similar to NixOS’s
@@ -63,7 +63,7 @@ with import &lt;nixpkgs> {};
     then after any change to this file, you can run:
 
 <screen>
-$ nix-env -f my-packages.nix -ir
+$ nix-env --file my-packages.nix --install --remove-all
 </screen>
 
     to update your profile to match the specification.</para>

--- a/doc/manual/release-notes/rl-1.7.xml
+++ b/doc/manual/release-notes/rl-1.7.xml
@@ -40,7 +40,7 @@ following new features:</para>
   </listitem>
 
   <listitem>
-    <para><command>nix-store -r</command> and
+    <para><command>nix-store --realise</command> and
     <command>nix-build</command> have a new flag,
     <option>--check</option>, that builds a previously built
     derivation again, and prints an error message if the output is not
@@ -48,9 +48,9 @@ following new features:</para>
     truly deterministic.  For example:
 
 <screen>
-$ nix-build '&lt;nixpkgs>' -A patchelf
+$ nix-build '&lt;nixpkgs>' --attr patchelf
 <replaceable>…</replaceable>
-$ nix-build '&lt;nixpkgs>' -A patchelf --check
+$ nix-build '&lt;nixpkgs>' --attr patchelf --check
 <replaceable>…</replaceable>
 error: derivation `/nix/store/1ipvxs…-patchelf-0.6' may not be deterministic:
   hash mismatch in output `/nix/store/4pc1dm…-patchelf-0.6.drv'
@@ -72,7 +72,7 @@ error: derivation `/nix/store/1ipvxs…-patchelf-0.6' may not be deterministic:
     <command>nix-build</command> and <command>nix-shell</command> now
     have a flag <option>--expr</option> (or <option>-E</option>) that
     allows you to specify the expression to be evaluated as a command
-    line argument.  For instance, <literal>nix-instantiate --eval -E
+    line argument.  For instance, <literal>nix-instantiate --eval --expr
     '1 + 2'</literal> will print <literal>3</literal>.</para>
   </listitem>
 
@@ -88,7 +88,7 @@ error: derivation `/nix/store/1ipvxs…-patchelf-0.6' may not be deterministic:
         the command
 
 <screen>
-$ nix-shell -p sqlite xorg.libX11 hello
+$ nix-shell --packages sqlite xorg.libX11 hello
 </screen>
 
         will start a shell in which the given packages are
@@ -142,7 +142,7 @@ $ nix-shell -p sqlite xorg.libX11 hello
   </listitem>
 
   <listitem>
-    <para><command>nix-env -q</command> has a new flag
+    <para><command>nix-env --query</command> has a new flag
     <option>--json</option> to print a JSON representation of the
     installed or available packages.</para>
   </listitem>
@@ -157,7 +157,7 @@ $ nix-shell -p sqlite xorg.libX11 hello
     dots in them, e.g.
 
 <screen>
-$ nix-instantiate --eval '&lt;nixos>' -A 'config.systemd.units."nscd.service".text'
+$ nix-instantiate --eval '&lt;nixos>' --attr 'config.systemd.units."nscd.service".text'
 </screen>
 
     </para>
@@ -198,7 +198,7 @@ $ nix-instantiate --eval '&lt;nixos>' -A 'config.systemd.units."nscd.service".te
     information in error messages, e.g.
 
 <screen>
-$ nix-build '&lt;nixpkgs>' -A libreoffice --argstr system x86_64-darwin
+$ nix-build '&lt;nixpkgs>' --attr libreoffice --argstr system x86_64-darwin
 error: the package ‘libreoffice-4.0.5.2’ in ‘.../applications/office/libreoffice/default.nix:263’
   is not supported on ‘x86_64-darwin’
 </screen>

--- a/doc/manual/release-notes/rl-1.8.xml
+++ b/doc/manual/release-notes/rl-1.8.xml
@@ -21,7 +21,7 @@
   expressions. For instance, you can do
 
 <screen>
-$ nix-env -qa '.*zip.*'
+$ nix-env --query --available '.*zip.*'
 </screen>
 
   to query all packages with a name containing
@@ -29,7 +29,7 @@ $ nix-env -qa '.*zip.*'
 
   <listitem><para><command>nix-store --read-log</command> can now
   fetch remote build logs. If a build log is not available locally,
-  then ‘nix-store -l’ will now try to download it from the servers
+  then ‘nix-store --read-log ’ will now try to download it from the servers
   listed in the ‘log-servers’ option in nix.conf. For instance, if you
   have the configuration option
 
@@ -42,7 +42,7 @@ then it will try to get logs from
 store path</replaceable></literal>. This allows you to do things like:
 
 <screen>
-$ nix-store -l $(which xterm)
+$ nix-store --read-log $(which xterm)
 </screen>
 
   and get a log even if <command>xterm</command> wasn't built

--- a/doc/manual/release-notes/rl-1.9.xml
+++ b/doc/manual/release-notes/rl-1.9.xml
@@ -45,7 +45,7 @@ binary-cache-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFG
       <listitem><para>In <command>nix-env</command>:
 
 <screen>
-$ nix-env -f https://github.com/NixOS/nixpkgs-channels/archive/nixos-14.12.tar.gz -iA firefox
+$ nix-env --file https://github.com/NixOS/nixpkgs-channels/archive/nixos-14.12.tar.gz --install --attr firefox
 </screen>
 
       This installs Firefox from the latest tested and built revision
@@ -55,7 +55,7 @@ $ nix-env -f https://github.com/NixOS/nixpkgs-channels/archive/nixos-14.12.tar.g
       <command>nix-shell</command>:
 
 <screen>
-$ nix-build https://github.com/NixOS/nixpkgs/archive/master.tar.gz -A hello
+$ nix-build https://github.com/NixOS/nixpkgs/archive/master.tar.gz --attr hello
 </screen>
 
       This builds GNU Hello from the latest revision of the Nixpkgs
@@ -67,7 +67,7 @@ $ nix-build https://github.com/NixOS/nixpkgs/archive/master.tar.gz -A hello
       of Nixpkgs:
 
 <screen>
-$ nix-shell -p pan -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/8a3eea054838b55aca962c3fbde9c83c102b8bf2.tar.gz
+$ nix-shell --packages pan -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/8a3eea054838b55aca962c3fbde9c83c102b8bf2.tar.gz
 </screen>
 
       </para></listitem>
@@ -114,7 +114,7 @@ with import (fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixo
 
 <programlisting>
 #! /usr/bin/env nix-shell
-#! nix-shell -i runghc -p haskellPackages.ghc haskellPackages.HTTP
+#! nix-shell -i runghc --packages haskellPackages.ghc haskellPackages.HTTP
 
 import Network.HTTP
 

--- a/doc/manual/troubleshooting/collisions-nixenv.xml
+++ b/doc/manual/troubleshooting/collisions-nixenv.xml
@@ -9,7 +9,7 @@
 <para>Symptom: when installing or upgrading, you get an error message such as
 
 <screen>
-$ nix-env -i docbook-xml
+$ nix-env --install docbook-xml
 ...
 adding /nix/store/s5hyxgm62gk2...-docbook-xml-4.2
 collision between `/nix/store/s5hyxgm62gk2...-docbook-xml-4.2/xml/dtd/docbook/calstblx.dtd'
@@ -24,14 +24,14 @@ have overlapping filenames (e.g.,
 happens when you accidentally try to install two versions of the same
 package.  For instance, in the example above, the Nix Packages
 collection contains two versions of <literal>docbook-xml</literal>, so
-<command>nix-env -i</command> will try to install both.  The default
+<command>nix-env --install</command> will try to install both.  The default
 user environment builder has no way to way to resolve such conflicts,
 so it just gives up.</para>
 
 <para>Solution: remove one of the offending packages from the user
 environment (if already installed) using <command>nix-env
 -e</command>, or specify exactly which version should be installed
-(e.g., <literal>nix-env -i docbook-xml-4.2</literal>).</para>
+(e.g., <literal>nix-env --install docbook-xml-4.2</literal>).</para>
 
 <!-- FIXME: describe priorities -->
 


### PR DESCRIPTION
e.g. nix-env -e subversion => nix-env --uninstall subversion

The aim is to make the documention less cryptic for newcomers and the long
options are more self-documenting.

The change was made with the following script:

<https://github.com/aschmolck/convert-short-nix-opts-to-long-ones>

and sanity checked visually.