### PR TITLE
use std::tuple for ValueMap allocator

### DIFF
--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -256,7 +256,7 @@ size_t valueSize(Value & v);
 
 #if HAVE_BOEHMGC
 typedef std::vector<Value *, gc_allocator<Value *> > ValueVector;
-typedef std::map<Symbol, Value *, std::less<Symbol>, gc_allocator<Value *> > ValueMap;
+typedef std::map<Symbol, Value *, std::less<Symbol>, gc_allocator<std::pair<const Symbol, Value *> > > ValueMap;
 #else
 typedef std::vector<Value *> ValueVector;
 typedef std::map<Symbol, Value *> ValueMap;


### PR DESCRIPTION
Use std::tuple for ValueMap allocator to fix building with clang / libc++4

Fixes https://github.com/NixOS/nix/issues/1288.