### PR TITLE
Process nix.conf options in "new" commands, add test

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -42,6 +42,7 @@ void mainWrapped(int argc, char * * argv)
     NixArgs args;
 
     args.parseCmdline(argvToStrings(argc, argv));
+    settings.update();
 
     assert(args.command);
 

--- a/tests/timeout.nix
+++ b/tests/timeout.nix
@@ -5,6 +5,7 @@ with import ./config.nix;
   infiniteLoop = mkDerivation {
     name = "timeout";
     buildCommand = ''
+      touch $out
       echo "‘timeout’ builder entering an infinite loop"
       while true ; do echo -n .; done
     '';
@@ -13,6 +14,7 @@ with import ./config.nix;
   silent = mkDerivation {
     name = "silent";
     buildCommand = ''
+      touch $out
       sleep 60
     '';
   };
@@ -20,6 +22,7 @@ with import ./config.nix;
   closeLog = mkDerivation {
     name = "silent";
     buildCommand = ''
+      touch $out
       exec > /dev/null 2>&1
       sleep 1000000000
     '';

--- a/tests/timeout.sh
+++ b/tests/timeout.sh
@@ -29,3 +29,8 @@ if nix-build timeout.nix -A closeLog; then
     echo "build should have failed"
     exit 1
 fi
+
+if nix build -f timeout.nix silent --option build-max-silent-time 2; then
+    echo "build should have failed"
+    exit 1
+fi


### PR DESCRIPTION
Without this (minor) change, the options set using "--option"
or read from nix.conf were parsed but not used.

Also touchup the timeout test derivations so they don't trivially fail
by not creating any outputs.