### PR TITLE
Propagate NIX_BUILD_CORES to nix-shell environments

### DIFF
--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -11,6 +11,8 @@ use Cwd;
 
 binmode STDERR, ":encoding(utf8)";
 
+Nix::Config::readConfig;
+
 my $dryRun = 0;
 my $verbose = 0;
 my $runEnv = $0 =~ /nix-shell$/;
@@ -279,6 +281,9 @@ foreach my $expr (@exprs) {
         }
         $ENV{'NIX_BUILD_TOP'} = $ENV{'TMPDIR'} = $ENV{'TEMPDIR'} = $ENV{'TMP'} = $ENV{'TEMP'} = $tmp;
         $ENV{'NIX_STORE'} = $Nix::Config::storeDir;
+        if (defined $Nix::Config::config{"build-cores"}) {
+            $ENV{'NIX_BUILD_CORES'} = $Nix::Config::config{"build-cores"};
+        }
         $ENV{$_} = $drv->{env}->{$_} foreach keys %{$drv->{env}};
 
         # Run a shell using the derivation's environment.  For


### PR DESCRIPTION
This fixes #1025 which has annoyed me for some time.

I've tested it it by using a patch override in `~/.nixpkgs/config.nix` and then installing `nix` with `nix-env -i nix`. I'm on NixOS 16.09 (`16.09.1914.cbf3d03`). Here's the override I used:

```Diff
diff --git a/config.nix b/config.nix
index b7754a4..7cadb3a 100644
--- a/config.nix
+++ b/config.nix
@@ -44,6 +44,9 @@
         buildInputs = [ super.ncurses super.perl ];
         patches = [ ./inetutils.patch ];
     });
+    nix = super.stdenv.lib.overrideDerivation super.nix (oldAttrs : {
+        patches = [ ./Propagate-NIX_BUILD_CORES-to-nix-shell-environments.patch ];
+    });
 
     # Customized packages
     texlive = super.texlive.combine {
```

I also wrote a fix for the same issue in the C++ implementation on master, but wasn't sure how best to test it. I'll submit a different PR for that.