### PR TITLE
Propagate NIX_BUILD_CORES to nix-shell environments

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -406,6 +406,7 @@ int main(int argc, char ** argv)
 
                 env["NIX_BUILD_TOP"] = env["TMPDIR"] = env["TEMPDIR"] = env["TMP"] = env["TEMP"] = tmp;
                 env["NIX_STORE"] = store->storeDir;
+                env["NIX_BUILD_CORES"] = settings.buildCores;
 
                 for (auto & var : drv.env)
                     env[var.first] = var.second;


### PR DESCRIPTION
This probably fixes #1025 which has annoyed me for some time.

I wasn't sure how best to test this, since the code on `master` isn't in production yet, so this is a tentative fix. My PR for the 1.11 series is #1313.