### PR TITLE
Default to 5 download retries

### DIFF
--- a/src/libstore/download.hh
+++ b/src/libstore/download.hh
@@ -15,7 +15,7 @@ struct DownloadRequest
     bool verifyTLS = true;
     enum { yes, no, automatic } showProgress = yes;
     bool head = false;
-    size_t tries = 1;
+    size_t tries = 5;
     unsigned int baseRetryTimeMs = 250;
 
     DownloadRequest(const std::string & uri) : uri(uri) { }


### PR DESCRIPTION
This should help certain downloaders that don't request anything special for the number of retries, like nix-channel.

(Partially addresses #1311 , specifically [this comment](https://github.com/NixOS/nix/issues/1311#issuecomment-292722476) in there)