### PR TITLE
nix-channel: error out if direct tarball unpack fails.

### DIFF
--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -103,12 +103,9 @@ static void update(const StringSet & channelNames)
 
         auto unpacked = false;
         if (std::regex_search(filename, std::regex("\\.tar\\.(gz|bz2|xz)$"))) {
-            try {
-                runProgram(settings.nixBinDir + "/nix-build", false, { "--no-out-link", "--expr", "import <nix/unpack-channel.nix> "
-                            "{ name = \"" + cname + "\"; channelName = \"" + name + "\"; src = builtins.storePath \"" + filename + "\"; }" });
-                unpacked = true;
-            } catch (ExecError & e) {
-            }
+            runProgram(settings.nixBinDir + "/nix-build", false, { "--no-out-link", "--expr", "import <nix/unpack-channel.nix> "
+                        "{ name = \"" + cname + "\"; channelName = \"" + name + "\"; src = builtins.storePath \"" + filename + "\"; }" });
+            unpacked = true;
         }
 
         if (!unpacked) {


### PR DESCRIPTION
It's very unlikely a path ending in .tar.gz is a directory

Fixes #1318