### PR TITLE
Ensure that curSchema is set before opening the DB

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -225,6 +225,7 @@ LocalStore::LocalStore(bool reserveSpace)
     schemaPath = settings.nixDBPath + "/schema";
 
     if (settings.readOnlyMode) {
+        curSchema = getSchema();
         openDB(false);
         return;
     }
@@ -309,6 +310,7 @@ LocalStore::LocalStore(bool reserveSpace)
     } catch (SysError & e) {
         if (e.errNo != EACCES) throw;
         settings.readOnlyMode = true;
+        curSchema = getSchema();
         openDB(false);
         return;
     }


### PR DESCRIPTION
Without this, it's possible to get `curSchema = 0` which then causes us not to trigger the branch that maintains forward compatibility with the 1.12 schema.

Fixes #1332

P.S: I'm not convinced that the "I wasn't able to acquire the lock so I silently revert to read-only mode" is a good user experience, but I figured this isn't the right place to change that.