### PR TITLE
Drop misleading ellipses

### DIFF
--- a/doc/manual/introduction/quick-start.xml
+++ b/doc/manual/introduction/quick-start.xml
@@ -40,7 +40,7 @@ libxslt-1.1.28
 <step><para>Install some packages from the channel:
 
 <screen>
-$ nix-env -i hello <replaceable>...</replaceable> </screen>
+$ nix-env -i hello</screen>
 
 This should download pre-built packages; it should not build them
 locally (if it does, something went wrong).</para></step>


### PR DESCRIPTION
This portion of the quick start guide may lead to confusion for newcomers to Nix.  This change clarifies the example to one that can be copied in its entirety.