### PR TITLE
Make --arg work for undeclared arguments

### DIFF
--- a/tests/lang/eval-okay-autoargs.exp
+++ b/tests/lang/eval-okay-autoargs.exp
@@ -1,1 +1,1 @@
-"xyzzy!xyzzy!foobar"
+"xyzzy!xyzzy!foobarhaah"

--- a/tests/lang/eval-okay-autoargs.flags
+++ b/tests/lang/eval-okay-autoargs.flags
@@ -1,1 +1,1 @@
---arg lib import(lang/lib.nix) --argstr xyzzy xyzzy! -A result
+--arg lib import(lang/lib.nix) --argstr xyzzy xyzzy! --arg abc "haah" -A result

--- a/tests/lang/eval-okay-autoargs.nix
+++ b/tests/lang/eval-okay-autoargs.nix
@@ -8,8 +8,9 @@ in
 , xyzzy ? "blaat" # will be overridden by --argstr
 , fb ? foobar
 , lib # will be set by --arg
-}:
+, ...
+}@args: # args.abc will be set by --arg too
 
 {
-  result = lib.concat [xyzzy xyzzy2 fb];
+  result = lib.concat [xyzzy xyzzy2 fb args.abc];
 }


### PR DESCRIPTION
Make the `--arg` and `--argstr` cli options work even if
the evaluated function doesn't explicitly declare this argument.

For example `nix-instantiate --eval -E "{...}@args: args.foo" --arg foo
1` now apply the function with the argument `{ foo = 1 }` (thus returns
`1`) instead of quietly ignoring the `arg foo 1` option (and returning
`<LAMBDA>`):

`nix-instantiate --eval -E "args: args.foo" --arg foo 1` now also returns `1`.

I assumed that the actual behavior (`--arg` argument dropped when the
corresponding argument isn't explicitly declared) isn't intended and is a bug,
let me know if it isn't.

This should fix #1360