### PR TITLE
nix-daemon.service: fix startup

### DIFF
--- a/misc/systemd/nix-daemon.service.in
+++ b/misc/systemd/nix-daemon.service.in
@@ -8,3 +8,4 @@ ConditionPathIsReadWrite=@localstatedir@/nix/daemon-socket
 ExecStart=@@bindir@/nix-daemon nix-daemon --daemon
 KillMode=process
 Environment=XDG_CACHE_HOME=/root/.cache
+Environment=XDG_CONFIG_HOME=/root/.config


### PR DESCRIPTION
Otherwise starting nix-daemon fails

● nix-daemon.service - Nix Daemon
   Loaded: loaded
(/nix/store/mnf00a6gc55xl47smk0b32gmi7xpvlfp-nix-1.12pre5308_2f21d522/lib/systemd/system/nix-daemon.service;
enabled; vendor preset: enabled)
  Drop-In:
/nix/store/m2rgjp71n4kyp8j5fxgbrlv13scd5vvv-system-units/nix-daemon.service.d
           └─overrides.conf
   Active: failed (Result: exit-code) since Sat 2017-04-29 11:29:21
CEST; 9s ago
  Process: 7299 ExecStart=nix-daemon --daemon (code=exited, status=1/FAILURE)
 Main PID: 7299 (code=exited, status=1/FAILURE)
      CPU: 19ms

... systemd[1]: Started Nix Daemon.
... nix-daemon[7299]: error: $XDG_CONFIG_HOME and $HOME are not set
... systemd[1]: nix-daemon.service: Main process exited, code=exited, status=1/FAILURE
... systemd[1]: nix-daemon.service: Unit entered failed state.
... systemd[1]: nix-daemon.service: Failed with result 'exit-code'.
... systemd[1]: nix-daemon.service: Start request repeated too quickly.
... systemd[1]: Failed to start Nix Daemon.
... systemd[1]: nix-daemon.service: Failed with result 'exit-code'.