### PR TITLE
nix-profile.sh: remove sbin from PATH

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -85,6 +85,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         export MANPATH="$NIX_LINK/share/man:$MANPATH"
     fi
 
-    export PATH="$NIX_LINK/bin:$NIX_LINK/sbin:$__savedpath"
+    export PATH="$NIX_LINK/bin:$__savedpath"
     unset __savedpath NIX_LINK NIX_USER_PROFILE_DIR NIX_PROFILES
 fi


### PR DESCRIPTION
sbin is a symlink to bin. 
profiles only contains packages, which have this symlink. 
It is a subset of bin.

related to https://github.com/NixOS/nixpkgs/pull/25550