### PR TITLE
nix-shell: use appropriate prompt terminator

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -438,7 +438,7 @@ int main(int argc, char ** argv)
                         "[ -e $stdenv/setup ] && source $stdenv/setup; "
                         "%3%"
                         "set +e; "
-                        "[ -n \"$PS1\" ] && PS1=\"\\n\\[\\033[1;32m\\][nix-shell:\\w]$\\[\\033[0m\\] \"; "
+                        "[ -n \"$PS1\" ] && PS1=\"\\n\\[\\033[1;32m\\][nix-shell:\\w]\\$\\[\\033[0m\\] \"; "
                         "if [ \"$(type -t runHook)\" = function ]; then runHook shellHook; fi; "
                         "unset NIX_ENFORCE_PURITY; "
                         "unset NIX_INDENT_MAKE; "


### PR DESCRIPTION
If running nix-shell as root, the terminator should be # and not $.