### PR TITLE
nar-accessor: use tree, fixes readDirectory missing children

### DIFF
--- a/src/libstore/nar-accessor.cc
+++ b/src/libstore/nar-accessor.cc
@@ -28,7 +28,6 @@ struct NarIndexer : ParseSink, StringSource
     NarMember root;
     std::stack<NarMember*> parents;
 
-    std::string currentName;
     std::string currentStart;
     bool isExec = false;
 
@@ -56,7 +55,7 @@ struct NarIndexer : ParseSink, StringSource
 
     void createDirectory(const Path & path) override
     {
-        createMember(path, {FSAccessor::Type::tDirectory, false, 0, 0 }); 
+        createMember(path, {FSAccessor::Type::tDirectory, false, 0, 0 });
     }
 
     void createRegularFile(const Path & path) override

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -13,7 +13,8 @@ nix_tests = \
   check-reqs.sh pass-as-file.sh tarball.sh restricted.sh \
   placeholders.sh nix-shell.sh \
   linux-sandbox.sh \
-  build-remote.sh
+  build-remote.sh \
+  nar-index.sh
   # parallel.sh
 
 install-tests += $(foreach x, $(nix_tests), tests/$(x))

--- a/tests/nar-index.nix
+++ b/tests/nar-index.nix
@@ -1,0 +1,23 @@
+with import ./config.nix;
+
+rec {
+    a = mkDerivation {
+        name = "nar-index-a";
+        builder = builtins.toFile "builder.sh"
+      ''
+        mkdir $out
+        mkdir $out/foo
+        touch $out/foo-x
+        touch $out/foo/bar
+        touch $out/foo/baz
+        touch $out/qux
+        mkdir $out/zyx
+
+        cat >$out/foo/data <<EOF
+        lasjdöaxnasd
+asdom 12398
+ä"§Æẞ¢«»”alsd
+EOF
+      '';
+    };
+}

--- a/tests/nar-index.sh
+++ b/tests/nar-index.sh
@@ -1,0 +1,23 @@
+source common.sh
+
+echo "building test path"
+storePath="$(nix-build nar-index.nix -A a --no-out-link)"
+
+cd "$TEST_ROOT"
+
+echo "dumping path to nar"
+narFile="$TEST_ROOT/path.nar"
+nix-store --dump $storePath > $narFile
+
+echo "check that find and ls-nar match"
+( cd $storePath; find . | sort ) > files.find
+nix ls-nar -R -d $narFile "" | sort > files.ls-nar
+diff -u files.find files.ls-nar
+
+echo "check that file contents of data match"
+nix cat-nar $narFile /foo/data > data.cat-nar
+diff -u data.cat-nar $storePath/foo/data
+
+echo "check that file contents of baz match"
+nix cat-nar $narFile /foo/baz > baz.cat-nar
+diff -u baz.cat-nar $storePath/foo/baz


### PR DESCRIPTION
Previously, if a directory `foo` existed and a file `foo-` (where `-` is any character that is sorted before `/`), then  `readDirectory` would return an empty list.

To fix this, we now use a tree where we can just access the children of the node, and do not need to rely on sorting behavior to list the contents of a directory.

Here's the diff for https://cache.nixos.org/nar/0iganlam4ism8v20n41rsw3x1mjwh9hmpgikj6iaikwis20n0qmw.nar (path `/nix/store/cpprsynaygxhx5xw30m0g873yy3v5mpm-glibc-2.25-dev`):

```
--- before	2017-05-15 10:21:00.850022680 +0200
+++ after	2017-05-15 10:21:45.346690356 +0200
@@ -133,6 +133,15 @@
 ./include/bits/timerfd.h
 ./include/bits/timex.h
 ./include/bits/types
+./include/bits/types/clock_t.h
+./include/bits/types/clockid_t.h
+./include/bits/types/struct_itimerspec.h
+./include/bits/types/struct_osockaddr.h
+./include/bits/types/struct_timespec.h
+./include/bits/types/struct_timeval.h
+./include/bits/types/struct_tm.h
+./include/bits/types/time_t.h
+./include/bits/types/timer_t.h
 ./include/bits/types.h
 ./include/bits/typesizes.h
 ./include/bits/uintn-identity.h
@@ -179,6 +188,11 @@
 ./include/getopt.h
 ./include/glob.h
 ./include/gnu
+./include/gnu/lib-names-32.h
+./include/gnu/lib-names.h
+./include/gnu/libc-version.h
+./include/gnu/stubs-32.h
+./include/gnu/stubs.h
 ./include/gnu-versions.h
 ./include/grp.h
 ./include/gshadow.h
```