### PR TITLE
nix ls: support '/' for the root directory

### DIFF
--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -61,6 +61,10 @@ struct MixLs : virtual Args
                 showFile(curPath, relPath);
         };
 
+        if (path == "/") {
+            path = "";
+        }
+
         auto st = accessor->stat(path);
         if (st.type == FSAccessor::Type::tMissing)
             throw Error(format("path ‘%1%’ does not exist") % path);


### PR DESCRIPTION
This makes the command `nix ls-nar -R xxx.nar /` work (to achieve the same functionality before, you had to use the unintuitive command `nix ls-nar -R xxx.nar ""`)