### PR TITLE
nix-shell: Don't overwrite PS1.

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -440,7 +440,7 @@ int main(int argc, char ** argv)
                         "[ -e $stdenv/setup ] && source $stdenv/setup; "
                         "%3%"
                         "set +e; "
-                        R"s([ -n "$PS1" ] && PS1='\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '; )s"
+                        R"s([ -z "$PS1" ] && PS1='\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '; )s"
                         "if [ \"$(type -t runHook)\" = function ]; then runHook shellHook; fi; "
                         "unset NIX_ENFORCE_PURITY; "
                         "unset NIX_INDENT_MAKE; "


### PR DESCRIPTION
Set PS1 only when it's not already set, not when it's set.