### PR TITLE
Add support for the curl netrc file in nix-channel/nix-pull.

### DIFF
--- a/scripts/nix-channel.in
+++ b/scripts/nix-channel.in
@@ -32,6 +32,9 @@ mkpath(dirname $profile, 0, 0755);
 
 my %channels;
 
+my $netrcFile = $Nix::Config::config{"netrc-file"} //
+    "$Nix::Config::confDir/netrc";
+
 
 # Reads the list of channels.
 sub readChannels {
@@ -104,7 +107,7 @@ sub update {
         # definition from a consistent location if the redirect changes mid-download.
         my $tmpdir = tempdir( CLEANUP => 1 );
         my $filename;
-        ($url, $filename) = `cd $tmpdir && $Nix::Config::curl $Nix::Config::curlCaFlag --silent --write-out '%{url_effective}\n%{filename_effective}' -L '$url' -O`;
+        ($url, $filename) = `cd $tmpdir && $Nix::Config::curl $Nix::Config::curlCaFlag --netrc-file $netrcFile --netrc-optional --silent --write-out '%{url_effective}\n%{filename_effective}' -L '$url' -O`;
         chomp $url;
         die "$0: unable to check ‘$url’\n" if $? != 0;
 
@@ -131,7 +134,7 @@ sub update {
         my $extraAttrs = "";
         if ($ret != 0) {
             # Check if the channel advertises a binary cache.
-            my $binaryCacheURL = `$Nix::Config::curl $Nix::Config::curlCaFlag --silent '$url'/binary-cache-url`;
+            my $binaryCacheURL = `$Nix::Config::curl $Nix::Config::curlCaFlag --netrc-file $netrcFile --netrc-optional  --silent '$url'/binary-cache-url`;
             my $getManifest = ($Nix::Config::config{"force-manifest"} // "false") eq "true";
             if ($? == 0 && $binaryCacheURL ne "") {
                 $extraAttrs .= "binaryCacheURL = \"$binaryCacheURL\"; ";
@@ -151,7 +154,7 @@ sub update {
 
             # Download the channel tarball.
             my $fullURL = "$url/nixexprs.tar.xz";
-            system("$Nix::Config::curl $Nix::Config::curlCaFlag --fail --silent --head '$fullURL' > /dev/null") == 0 or
+            system("$Nix::Config::curl $Nix::Config::curlCaFlag --netrc-file $netrcFile --netrc-optional  --fail --silent --head '$fullURL' > /dev/null") == 0 or
                 $fullURL = "$url/nixexprs.tar.bz2";
             print STDERR "downloading Nix expressions from ‘$fullURL’...\n";
             (my $hash, $path) = `PRINT_PATH=1 QUIET=1 $Nix::Config::binDir/nix-prefetch-url '$fullURL'`;

--- a/scripts/nix-pull.in
+++ b/scripts/nix-pull.in
@@ -8,7 +8,8 @@ use Nix::Manifest;
 binmode STDERR, ":encoding(utf8)";
 
 my $manifestDir = $Nix::Config::manifestDir;
-
+my $netrcFile = $Nix::Config::config{"netrc-file"} //
+    "$Nix::Config::confDir/netrc";
 
 # Prevent access problems in shared-stored installations.
 umask 0022;
@@ -51,7 +52,7 @@ sub processURL {
     my $origUrl = $ENV{'NIX_ORIG_URL'} || $url;
 
     # First see if a bzipped manifest is available.
-    if (system("$Nix::Config::curl $Nix::Config::curlCaFlag --fail --silent --location --head '$url'.bz2 > /dev/null") == 0) {
+    if (system("$Nix::Config::curl $Nix::Config::curlCaFlag --netrc-file $netrcFile --netrc-optional --fail --silent --location --head '$url'.bz2 > /dev/null") == 0) {
         print "fetching list of Nix archives at ‘$url.bz2’...\n";
         $manifest = downloadFile "$url.bz2";
     }


### PR DESCRIPTION
Based on the implementation in download-from-binary-cache.pl.in.

Complements PR #1215