### PR TITLE
Fix potential crash/wrong result two hashes of unequal length are compared

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -54,6 +54,8 @@ bool Hash::operator != (const Hash & h2) const
 
 bool Hash::operator < (const Hash & h) const
 {
+    if (hashSize < h.hashSize) return true;
+    if (hashSize > h.hashSize) return false;
     for (unsigned int i = 0; i < hashSize; i++) {
         if (hash[i] < h.hash[i]) return true;
         if (hash[i] > h.hash[i]) return false;


### PR DESCRIPTION
Just found this reading through the code.

(Note I didn't compile this, I cherry-picked it from my 1.11.8 branch.)