### PR TITLE
Clearer error message when regex exceeds space limit

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1734,8 +1734,13 @@ static void prim_match(EvalState & state, const Pos & pos, Value * * args, Value
                 mkString(*(v.listElems()[i] = state.allocValue()), match[i + 1].str().c_str());
         }
 
-    } catch (std::regex_error &) {
-        throw EvalError("invalid regular expression ‘%s’, at %s", re, pos);
+    } catch (std::regex_error &e) {
+        if (e.code() == std::regex_constants::error_space) {
+          // limit is _GLIBCXX_REGEX_STATE_LIMIT for libstdc++
+          throw EvalError("memory limit exceeded by regular expression ‘%s’, at %s", re, pos);
+        } else {
+          throw EvalError("invalid regular expression ‘%s’, at %s", re, pos);
+        }
     }
 }
 


### PR DESCRIPTION
While investigating why [nixpkgs-mozilla stopped working on our Hydra instance](https://github.com/mozilla/nixpkgs-mozilla/issues/40), I discovered that there's an upper limit to the size of a regular expression. This took quite a while, because Nix reported "invalid regular expression" when the limit was exceeded but the expression seemed syntactically valid.

This PR improves the error message in this specific case. I tried using `e.what()` but the resulting message was very unhelpful (literally `regex_error`).