### PR TITLE
Fix nix-instantiate manpage indentation

### DIFF
--- a/doc/manual/command-ref/nix-instantiate.xml
+++ b/doc/manual/command-ref/nix-instantiate.xml
@@ -43,7 +43,8 @@
       <arg choice='plain'><option>-E</option></arg>
     </group>
     <arg choice='plain' rep='repeat'><replaceable>files</replaceable></arg>
-    <sbr/>
+  </cmdsynopsis>
+  <cmdsynopsis>
     <command>nix-instantiate</command>
     <arg choice='plain'><option>--find-file</option></arg>
     <arg choice='plain' rep='repeat'><replaceable>files</replaceable></arg>

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -1,7 +1,5 @@
 set -e
 
-datadir="@datadir@"
-
 export TEST_ROOT=$(realpath ${TMPDIR:-/tmp}/nix-test)
 export NIX_STORE_DIR
 if ! NIX_STORE_DIR=$(readlink -f $TEST_ROOT/store 2> /dev/null); then


### PR DESCRIPTION
The second command variant is now its own cmdsynopsis, which ensures it's not indented as was the case using sbrk.

I also included a trivial cleanup commit I made while debugging a local build issue -- would you prefer I put this in a separate PR?

Before:

```
       nix-instantiate [--parse | --eval [--strict] [--xml] ]
                                      [--read-write-mode] [--arg name value]
                                      [{--attr | -A} attrPath]
                                      [--add-root path] [--indirect] {--expr |
                                      -E} files...
                                      nix-instantiate --find-file files...
```

After:

```
       nix-instantiate [--parse | --eval [--strict] [--xml] ]
                       [--read-write-mode] [--arg name value]
                       [{--attr | -A} attrPath] [--add-root path] [--indirect]
                       {--expr | -E} files...

       nix-instantiate --find-file files...
 ```
