### PR TITLE
Add nix profile suitable for using the daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Makefile.config
 
 # /scripts/
 /scripts/nix-profile.sh
+/scripts/nix-profile-daemon.sh
 /scripts/nix-pull
 /scripts/nix-push
 /scripts/nix-switch

--- a/scripts/local.mk
+++ b/scripts/local.mk
@@ -20,6 +20,7 @@ nix_noinst_scripts := \
   $(d)/resolve-system-dependencies.pl \
   $(d)/nix-http-export.cgi \
   $(d)/nix-profile.sh \
+  $(d)/nix-profile-daemon.sh \
   $(d)/nix-reduce-build \
   $(nix_substituters)
 
@@ -28,6 +29,7 @@ noinst-scripts += $(nix_noinst_scripts)
 profiledir = $(sysconfdir)/profile.d
 
 $(eval $(call install-file-as, $(d)/nix-profile.sh, $(profiledir)/nix.sh, 0644))
+$(eval $(call install-file-as, $(d)/nix-profile-daemon.sh, $(profiledir)/nix-daemon.sh, 0644))
 $(eval $(call install-program-in, $(d)/find-runtime-roots.pl, $(libexecdir)/nix))
 $(eval $(call install-program-in, $(d)/build-remote.pl, $(libexecdir)/nix))
 $(eval $(call install-program-in, $(d)/resolve-system-dependencies.pl, $(libexecdir)/nix))

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -1,0 +1,54 @@
+# Only execute this file once per shell.
+if [ -n "$__ETC_PROFILE_NIX_SOURCED" ]; then return; fi
+__ETC_PROFILE_NIX_SOURCED=1
+
+# Set up secure multi-user builds: non-root users build through the
+# Nix daemon.
+if [ "$USER" != root -o ! -w @localstatedir@/nix/db ]; then
+    export NIX_REMOTE=daemon
+fi
+
+export NIX_USER_PROFILE_DIR="@localstatedir@/nix/profiles/per-user/$USER"
+export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+
+# Set up the per-user profile.
+mkdir -m 0755 -p $NIX_USER_PROFILE_DIR
+if test "$(stat -f '%u' $NIX_USER_PROFILE_DIR)" != "$(id -u)"; then
+    echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
+fi
+
+if test -w $HOME; then
+  if ! test -L $HOME/.nix-profile; then
+      if test "$USER" != root; then
+          ln -s $NIX_USER_PROFILE_DIR/profile $HOME/.nix-profile
+      else
+          # Root installs in the system-wide profile by default.
+          ln -s @localstatedir@/nix/profiles/default $HOME/.nix-profile
+      fi
+  fi
+
+  # Subscribe the root user to the NixOS channel by default.
+  if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
+      echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > $HOME/.nix-channels
+  fi
+
+  # Create the per-user garbage collector roots directory.
+  NIX_USER_GCROOTS_DIR=@localstatedir@/nix/gcroots/per-user/$USER
+  mkdir -m 0755 -p $NIX_USER_GCROOTS_DIR
+  if test "$(stat -f '%u' $NIX_USER_GCROOTS_DIR)" != "$(id -u)"; then
+      echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
+  fi
+
+  # Set up a default Nix expression from which to install stuff.
+  if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
+      rm -f $HOME/.nix-defexpr
+      mkdir -p $HOME/.nix-defexpr
+      if [ "$USER" != root ]; then
+          ln -s @localstatedir@/nix/profiles/per-user/root/channels $HOME/.nix-defexpr/channels_root
+      fi
+  fi
+fi
+
+export NIX_SSL_CERT_FILE="@localstatedir@/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+export NIX_PATH="@localstatedir@/nix/profiles/per-user/root/channels"
+export PATH="$HOME/.nix-profile/bin:$HOME/.nix-profile/sbin:$HOME/.nix-profile/lib/kde4/libexec:@localstatedir@/nix/profiles/default/bin:@localstatedir@/nix/profiles/default/sbin:@localstatedir@/nix/profiles/default/lib/kde4/libexec:$PATH"


### PR DESCRIPTION
In order for the Mac installer to use the daemon by default, we must first release a Nix through the `nixpkgs-unstable` channel which contains this PR.  See: https://github.com/NixOS/nix/pull/1453#issuecomment-313939878