### PR TITLE
Build tarball per system

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -268,7 +268,9 @@ let
       name = "nix-${tarball."x86_64-linux".version}";
       meta.description = "Release-critical builds";
       constituents =
-        [ tarball
+        [ tarball.x86_64-linux
+          tarball.x86_64-darwin
+          tarball.i686-linux
           build.i686-linux
           build.x86_64-darwin
           build.x86_64-linux

--- a/release.nix
+++ b/release.nix
@@ -71,7 +71,7 @@ let
 
       releaseTools.nixBuild {
         name = "nix";
-        src = tarball.${system};
+        src = tarball."x86_64-linux";
 
         buildInputs =
           [ curl
@@ -109,7 +109,7 @@ let
 
       releaseTools.nixBuild {
         name = "nix-perl";
-        src = tarball.${system};
+        src = tarball."x86_64-linux";
 
         buildInputs =
           [ (builtins.getAttr system jobs.build) curl bzip2 xz pkgconfig pkgs.perl ]
@@ -170,7 +170,7 @@ let
 
       releaseTools.coverageAnalysis {
         name = "nix-build";
-        src = tarball.${system};
+        src = tarball."x86_64-linux";
 
         buildInputs =
           [ curl bzip2 openssl pkgconfig sqlite xz libsodium libseccomp
@@ -302,7 +302,7 @@ let
 
     releaseTools.rpmBuild rec {
       name = "nix-rpm";
-      src = jobs.tarball.${system};
+      src = jobs.tarball."x86_64-linux";
       diskImage = (diskImageFun vmTools.diskImageFuns)
         { extraPackages =
             [ "sqlite" "sqlite-devel" "bzip2-devel" "emacs" "libcurl-devel" "openssl-devel" "xz-devel" "libseccomp-devel" ]
@@ -324,7 +324,7 @@ let
 
     releaseTools.debBuild {
       name = "nix-deb";
-      src = jobs.tarball.${system};
+      src = jobs.tarball."x86_64-linux";
       diskImage = (diskImageFun vmTools.diskImageFuns)
         { extraPackages =
             [ "libsqlite3-dev" "libbz2-dev" "libcurl-dev" "libcurl3-nss" "libssl-dev" "liblzma-dev" "libseccomp-dev" ]

--- a/release.nix
+++ b/release.nix
@@ -5,7 +5,7 @@
 
 let
 
-  pkgs = import <nixpkgs> {};
+  pkgs = import nixpkgs {};
 
   systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ];
 
@@ -14,7 +14,7 @@ let
 
 
     tarball = pkgs.lib.genAttrs systems (system:
-      with import <nixpkgs> { inherit system; };
+      with import nixpkgs { inherit system; };
 
       releaseTools.sourceTarball {
         name = "nix-tarball";
@@ -65,7 +65,7 @@ let
 
     build = pkgs.lib.genAttrs systems (system:
 
-      with import <nixpkgs> { inherit system; };
+      with import nixpkgs { inherit system; };
 
       with import ./release-common.nix { inherit pkgs; };
 
@@ -105,7 +105,7 @@ let
 
     perlBindings = pkgs.lib.genAttrs systems (system:
 
-      let pkgs = import <nixpkgs> { inherit system; }; in with pkgs;
+      let pkgs = import nixpkgs { inherit system; }; in with pkgs;
 
       releaseTools.nixBuild {
         name = "nix-perl";
@@ -131,7 +131,7 @@ let
     binaryTarball = pkgs.lib.genAttrs systems (system:
 
       # FIXME: temporarily use a different branch for the Darwin build.
-      with import <nixpkgs> { inherit system; };
+      with import nixpkgs { inherit system; };
 
       let
         toplevel = builtins.getAttr system jobs.build;
@@ -166,7 +166,7 @@ let
 
 
     coverage =
-      with import <nixpkgs> { system = "x86_64-linux"; };
+      with import nixpkgs { system = "x86_64-linux"; };
 
       releaseTools.coverageAnalysis {
         name = "nix-build";
@@ -225,7 +225,7 @@ let
       });
 
     tests.binaryTarball =
-      with import <nixpkgs> { system = "x86_64-linux"; };
+      with import nixpkgs { system = "x86_64-linux"; };
       vmTools.runInLinuxImage (runCommand "nix-binary-tarball-test"
         { diskImage = vmTools.diskImages.ubuntu1204x86_64;
         }
@@ -298,7 +298,7 @@ let
   makeRPM =
     system: diskImageFun: extraPackages:
 
-    with import <nixpkgs> { inherit system; };
+    with import nixpkgs { inherit system; };
 
     releaseTools.rpmBuild rec {
       name = "nix-rpm";
@@ -320,7 +320,7 @@ let
   makeDeb =
     system: diskImageFun: extraPackages: extraDebPackages:
 
-    with import <nixpkgs> { inherit system; };
+    with import nixpkgs { inherit system; };
 
     releaseTools.debBuild {
       name = "nix-deb";


### PR DESCRIPTION
This catches any build failures that otherwise users might encounter on non-linux.

For example libseccomp package doesn't build on darwin.