### PR TITLE
Show users how to source the profile, to get a working Nix.

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -259,8 +259,13 @@ function finish_success {
     ok "Alright! We're done!"
     cat <<EOF
 
-Before Nix will work in your existing shells, you'll need to close
-them and open them again. Other than that, you should be ready to go.
+Before Nix will work in your existing shells, you'll need to either
+run:
+
+  $ source $PROFILE_NIX_FILE
+
+or close them and open them again. Other than that, you should be
+ready to go.
 
 Try it! Open a new terminal, and type:
 


### PR DESCRIPTION
This was the final feedback from @domenkozar. I don't have a mac I can test with physically, but TravisCI thinks I haven't broken it: https://travis-ci.org/grahamc/nix/builds/254421969

Log output shows:

```
Alright! We're done!

Before Nix will work in your existing shells, you'll need to either
run:

  $ source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh

or close them and open them again. Other than that, you should be
ready to go.

Try it! Open a new terminal, and type:

  $ nix-shell -p figlet -p lolcat --run "echo 'nix rules' | figlet | lolcat"

Thank you for using this installer. If you have any feedback, don't
hesitate:

We'd love to help if you need it.

If you can, open an issue at https://github.com/nixos/nix/issues

Or feel free to contact the team,
 - on IRC #nixos on irc.freenode.net
 - on twitter @nixos_org
```