### PR TITLE
Do not try to fill fd_set with fd>=FD_SETSIZE

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3835,6 +3835,9 @@ void Worker::waitForInput()
     int fdMax = 0;
     for (auto & i : children) {
         for (auto & j : i.fds) {
+            if (j >= FD_SETSIZE) {
+                throw BuildError("reached FD_SETSIZE limit");
+            }
             FD_SET(j, &fds);
             if (j >= fdMax) fdMax = j + 1;
         }


### PR DESCRIPTION
This is UB and causes buffer overflow and crash on linux.

## Test case:
**default.nix**
```Nix
builtins.genList (i: derivation { name = "test-${toString i}"; builder = ./builder.sh; system = "x86_64-linux"; allowSubstitutes = false; }) 1000
```
**builder.sh**
```
#!/bin/sh

/bin/sleep 100
/bin/touch $out
```
```
nix-build -j 1000
```