### PR TITLE
buildenv: Read muliple lines in propagated-user-env-packages

### DIFF
--- a/src/buildenv/buildenv.cc
+++ b/src/buildenv/buildenv.cc
@@ -114,9 +114,9 @@ static void addPkg(const Path & pkgDir, int priority)
                 return;
             throw SysError(format("opening ‘%1%’") % propagatedFN);
         }
-        propagated = readLine(fd.get());
+        propagated = readFile(fd.get());
     }
-    for (const auto & p : tokenizeString<std::vector<string>>(propagated, " "))
+    for (const auto & p : tokenizeString<std::vector<string>>(propagated, " \n"))
         if (done.find(p) == done.end())
             postponed.insert(p);
 }


### PR DESCRIPTION
For comparability with old and new nixpkgs, either ' ' or '\n' can serve as a delimiter between entries. I'll rewrite for the existing `11.x` perl version next.

See https://github.com/NixOS/nixpkgs/pull/27427 for background. 

@ttuegel I wrote it this way not because I disagree with making Nix and Nixpkgs share a buildenv, but because this is the simpler change. Also, it is unclear to me whether the `nix-support/*` files are a Nix interface or Nixpkgs interface---seems to very case to case.

Do not merge just yet---I only built it and did not test it yet.