### PR TITLE
1.11 backport: buildenv: Read muliple lines in propagated-user-env-packages

### DIFF
--- a/corepkgs/buildenv.pl
+++ b/corepkgs/buildenv.pl
@@ -110,10 +110,10 @@ sub addPkg {
     my $propagatedFN = "$pkgDir/nix-support/propagated-user-env-packages";
     if (-e $propagatedFN) {
         open PROP, "<$propagatedFN" or die;
+        local $/;
         my $propagated = <PROP>;
         close PROP;
-        my @propagated = split ' ', $propagated;
-        foreach my $p (@propagated) {
+        foreach my $p (split ' ', $propagated) {
             $postponed{$p} = 1 unless defined $done{$p};
         }
     }


### PR DESCRIPTION
For compatability with current and future nixpkgs, either `' '` or `'\n'` can serve as a delimiter between entries. Trailing empty entries are also skipped.

See https://github.com/NixOS/nixpkgs/pull/27427 for background, and #1480 for the master version.

I tested the parsing logic in a standalone script, but not buildenv yet.