### PR TITLE
WIP nix-shell: Use bashInteractive from <nixpkgs>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,8 @@ if test "$gc" = yes; then
 fi
 
 
-# Check for the required Perl dependencies (DBI, DBD::SQLite and WWW::Curl).
+# Check for the required Perl dependencies (DBI, DBD::SQLite, WWW::Curl, and
+# Try::Tiny).
 perlFlags="-I$perllibdir"
 
 AC_ARG_WITH(dbi, AC_HELP_STRING([--with-dbi=PATH],
@@ -233,6 +234,10 @@ AC_ARG_WITH(www-curl, AC_HELP_STRING([--with-www-curl=PATH],
   [prefix of the Perl WWW::Curl library]),
   perlFlags="$perlFlags -I$withval")
 
+AC_ARG_WITH(try-tiny, AC_HELP_STRING([--with-www-tiny=PATH],
+  [prefix of the Perl Try::Tiny library]),
+  perlFlags="$perlFlags -I$withval")
+
 AC_MSG_CHECKING([whether DBD::SQLite works])
 if ! $perl $perlFlags -e 'use DBI; use DBD::SQLite;' 2>&5; then
     AC_MSG_RESULT(no)
@@ -244,6 +249,13 @@ AC_MSG_CHECKING([whether WWW::Curl works])
 if ! $perl $perlFlags -e 'use WWW::Curl;' 2>&5; then
     AC_MSG_RESULT(no)
     AC_MSG_FAILURE([The Perl module WWW::Curl is missing.])
+fi
+AC_MSG_RESULT(yes)
+
+AC_MSG_CHECKING([whether Try::Tiny works])
+if ! $perl $perlFlags -e 'use Try::Tiny;' 2>&5; then
+    AC_MSG_RESULT(no)
+    AC_MSG_FAILURE([The Perl module Try::Tiny is missing.])
 fi
 AC_MSG_RESULT(yes)
 

--- a/doc/manual/installation/prerequisites-source.xml
+++ b/doc/manual/installation/prerequisites-source.xml
@@ -30,8 +30,8 @@
   or higher.  If your distribution does not provide it, please install
   it from <link xlink:href="http://www.sqlite.org/" />.</para></listitem>
 
-  <listitem><para>The Perl DBI, DBD::SQLite, and WWW::Curl libraries, which are
-  available from <link
+  <listitem><para>The Perl DBI, DBD::SQLite, WWW::Curl, and Try::Tiny
+  libraries, which are available from <link
   xlink:href="http://search.cpan.org/">CPAN</link> if your
   distribution does not provide them.</para></listitem>
 

--- a/nix.spec.in
+++ b/nix.spec.in
@@ -18,6 +18,7 @@ BuildRequires: perl(DBD::SQLite)
 BuildRequires: perl(DBI)
 BuildRequires: perl(WWW::Curl)
 BuildRequires: perl(ExtUtils::ParseXS)
+BuildRequires: perl(Try::Tiny)
 Requires: /usr/bin/perl
 Requires: curl
 Requires: perl-DBD-SQLite

--- a/release.nix
+++ b/release.nix
@@ -34,6 +34,7 @@ let
           --with-dbi=${perlPackages.DBI}/${perl.libPrefix}
           --with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}
           --with-www-curl=${perlPackages.WWWCurl}/${perl.libPrefix}
+          --with-try-tiny=${perlPackages.TryTiny}/${perl.libPrefix}
         '';
 
         postUnpack = ''

--- a/scripts/nix-build.in
+++ b/scripts/nix-build.in
@@ -7,6 +7,7 @@ use Nix::Store;
 use Nix::Utils;
 use File::Basename;
 use Text::ParseWords;
+use Try::Tiny;
 use Cwd;
 
 binmode STDERR, ":encoding(utf8)";
@@ -302,7 +303,29 @@ foreach my $expr (@exprs) {
             'shopt -u nullglob; ' .
             'unset TZ; ' . (defined $ENV{'TZ'} ? "export TZ='${ENV{'TZ'}}'; " : '') .
             $envCommand);
-        my @args = ($ENV{NIX_BUILD_SHELL} // "bash");
+        my $buildShell = $ENV{NIX_BUILD_SHELL} // "";
+        if ($buildShell eq "") {
+            try {
+                # !!! would prefer the perl 5.8.0 pipe open feature here.
+                my $pid = open(SHELLPATH, "-|") || exec
+                    "$Nix::Config::binDir/nix-instantiate",
+                    "-E", "(import <nixpkgs> {}).bashInteractive";
+                $buildShell = <DRVPATHS>;
+                if (!close DRVPATHS) {
+                    die "nix-instantiate killed by signal " . ($? & 127) . "\n"
+                        if ($? & 127);
+                }
+                chomp $buildShell;
+                $buildShell += "/bin/bash";
+                if (! -x $buildShell) {
+                    die "expected shell ‘$buildShell’ to exist, but it doesn't";
+                }
+            } catch {
+                warn "$_; will use bash from your environment";
+                $buildShell = "bash";
+            };
+        }
+        my @args = ($buildShell);
         push @args, "--rcfile" if $interactive;
         push @args, $rcfile;
         exec @args;


### PR DESCRIPTION
Backport of c94f3d5575d7af5403274d1e9e2f3c9d72989751. Hopefully the extra dependency is no big deal--it is supposed to be minimal and Perl is going away soon anyways.

Don't merge yet because I still need to test.

CC @domenkozar 