### PR TITLE
extend NIX_PATH in nix-daemon.sh

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -50,5 +50,5 @@ if test -w $HOME; then
 fi
 
 export NIX_SSL_CERT_FILE="@localstatedir@/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
-export NIX_PATH="@localstatedir@/nix/profiles/per-user/root/channels"
-export PATH="$HOME/.nix-profile/bin:$HOME/.nix-profile/sbin:$HOME/.nix-profile/lib/kde4/libexec:@localstatedir@/nix/profiles/default/bin:@localstatedir@/nix/profiles/default/sbin:@localstatedir@/nix/profiles/default/lib/kde4/libexec:$PATH"
+export NIX_PATH="${NIX_PATH:+$NIX_PATH:}@localstatedir@/nix/profiles/per-user/root/channels"
+export PATH="$HOME/.nix-profile/bin:$HOME/.nix-profile/sbin:$HOME/.nix-profile/lib/kde4/libexec:@localstatedir@/nix/profiles/default/bin:@localstatedir@/nix/profiles/default/sbin:@localstatedir@/nix/profiles/default/lib/kde4/libexec:${PATH:+:$PATH}"


### PR DESCRIPTION
The current `nix-daemon.sh` assumes it's loaded first, but that's not necessary the case.
Since the new installer sources this at the end of `/etc/profile` it will run after `/etc/bashrc`.

I'm also not sure why it's loaded in both profile and bashrc. /cc @grahamc