### PR TITLE
Test to see if nix-daemon is running already

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -300,6 +300,19 @@ $(uninstall_directions)
 EOF
     fi
 
+    if pgrep nix-daemon 2> /dev/null >&2; then
+        failure <<EOF
+Nix seems to be partially installed, because the nix-daemon is
+currently running. It may be in a launchd service. Please stop the
+the old nix-daemon, and try again.
+
+If you have an existing launchd plist for nix-daemon, please delete
+it.
+
+$(uninstall_directions)
+EOF
+    fi
+
     if [ "${NIX_REMOTE:-}" != "" ]; then
         failure <<EOF
 For some reason, \$NIX_REMOTE is set. It really should not be set


### PR DESCRIPTION
A user had an install, uninstalled it via the instructions, and found their nix broken.

The issue was based around nix-daemon already running.

I tried to be very smart around searching their launchctl files:

  $ grep -ri nix-daemon  ~/Library/LaunchAgents /Library/LaunchAgents /Library/LaunchDaemons /System/Library/LaunchAgents /System/Library/LaunchDaemons

but then couldn't figure out how to write out (nicely) commands for uninstalling
or unloading them based on their name, and also couching the instrunctions in a
bit of doubt so we don't piss off some poor mac admin because their users just
deleted some important launchd files.