### PR TITLE
Include missing <cstdlib> for abort()

### DIFF
--- a/src/libutil/sync.hh
+++ b/src/libutil/sync.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdlib>
 #include <mutex>
 #include <condition_variable>
 #include <cassert>


### PR DESCRIPTION
This is needed to get Nix compiled using Android NDK.