### PR TITLE
Added builtins.intern primop (WIP)

### DIFF
--- a/tests/lang/eval-okay-intern.nix
+++ b/tests/lang/eval-okay-intern.nix
@@ -1,0 +1,1 @@
+builtins.intern ./eval-okay-intern.nix


### PR DESCRIPTION
NOTE: this is a work in progress; in particular, it is untested

This commit adds a new `builtins.intern` primop that allows a fixed-output Nix store path to be made from any given path, as long as it exists. In other words, this primop allows you to do something similar to Nix path references (like `src = ./.;`), except that the given path could already be in the Nix store.

Without an intensional store, this is necessary to make incremental builds work in Nix. You can make a hacky alternative without it -- `(path: with builtins; toFile (basename path) (readFile path))` -- but since `builtins.readFile` fails on binary files, it cannot be used in all cases.