### PR TITLE
Remove unused decodeOctalEscaped

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1140,21 +1140,6 @@ std::string toLower(const std::string & s)
 }
 
 
-string decodeOctalEscaped(const string & s)
-{
-    string r;
-    for (string::const_iterator i = s.begin(); i != s.end(); ) {
-        if (*i != '\\') { r += *i++; continue; }
-        unsigned char c = 0;
-        ++i;
-        while (i != s.end() && *i >= '0' && *i < '8')
-            c = c * 8 + (*i++ - '0');
-        r += c;
-    }
-    return r;
-}
-
-
 void ignoreException()
 {
     try {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -349,12 +349,6 @@ bool hasSuffix(const string & s, const string & suffix);
 std::string toLower(const std::string & s);
 
 
-/* Escape a string that contains octal-encoded escape codes such as
-   used in /etc/fstab and /proc/mounts (e.g. "foo\040bar" decodes to
-   "foo bar"). */
-string decodeOctalEscaped(const string & s);
-
-
 /* Exception handling in destructors: print an error message, then
    ignore the exception. */
 void ignoreException();


### PR DESCRIPTION
Besides being unused, this function has a bug that it will incorrectly
decode the path component Ubuntu\04016.04.2\040LTS\040amd64 as
"Ubuntu.04.2 LTS amd64" instead of "Ubuntu 16.04.2 LTS amd64".

Found because Guix's copy of nix-daemon still used this function.