### PR TITLE
libexpr: add sha256 noop argument to fetch

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1709,6 +1709,8 @@ void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
             string n(attr.name);
             if (n == "url")
                 url = state.forceStringNoCtx(*attr.value, *attr.pos);
+            else if (n == "sha256")
+                // noop, added for forward-compatiblity
             else if (n == "name")
                 name = state.forceStringNoCtx(*attr.value, *attr.pos);
             else

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1711,6 +1711,8 @@ void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
                 url = state.forceStringNoCtx(*attr.value, *attr.pos);
             else if (n == "sha256")
                 // noop, added for forward-compatiblity
+                static bool haveWarned = false;
+                warnOnce(haveWarned, "the fetchurl/fetchTarball sha256 argument is currently ignored. Upgrade to Nix 1.12 to support this feature.");
             else if (n == "name")
                 name = state.forceStringNoCtx(*attr.value, *attr.pos);
             else


### PR DESCRIPTION
Nix 1.12 is going to support that argument fully. This addition is only
there to allow forward-compatibility.