### PR TITLE
OS X sandbox: Store .sb file in $TMPDIR rather than the Nix store

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -778,7 +778,6 @@ private:
 #if __APPLE__
     typedef string SandboxProfile;
     SandboxProfile additionalSandboxProfile;
-    AutoDelete autoDelSandbox;
 #endif
 
     /* Hash rewriting. */
@@ -2633,9 +2632,7 @@ void DerivationGoal::runChild()
             debug("Generated sandbox profile:");
             debug(sandboxProfile);
 
-            Path sandboxFile = drvPath + ".sb";
-            if (pathExists(sandboxFile)) deletePath(sandboxFile);
-            autoDelSandbox.reset(sandboxFile, false);
+            Path sandboxFile = tmpDir + "/.sandbox.sb";
 
             writeFile(sandboxFile, sandboxProfile);
 


### PR DESCRIPTION
This fix was already in master, just applying it to 1.11.

See issue #1526