### PR TITLE
src/libmain/stack.cc: fix 'ucontext' usage on glibc-2.26

### DIFF
--- a/src/libmain/stack.cc
+++ b/src/libmain/stack.cc
@@ -18,9 +18,9 @@ static void sigsegvHandler(int signo, siginfo_t * info, void * ctx)
     bool haveSP = true;
     char * sp = 0;
 #if defined(__x86_64__) && defined(REG_RSP)
-    sp = (char *) ((ucontext *) ctx)->uc_mcontext.gregs[REG_RSP];
+    sp = (char *) ((ucontext_t *) ctx)->uc_mcontext.gregs[REG_RSP];
 #elif defined(REG_ESP)
-    sp = (char *) ((ucontext *) ctx)->uc_mcontext.gregs[REG_ESP];
+    sp = (char *) ((ucontext_t *) ctx)->uc_mcontext.gregs[REG_ESP];
 #else
     haveSP = false;
 #endif


### PR DESCRIPTION
Build fails as:

```
$ make
  CXX    src/libmain/stack.o
src/libmain/stack.cc: In function 'void nix::sigsegvHandler(int, siginfo_t*, void*)':
src/libmain/stack.cc:21:21: error: 'ucontext' was not declared in this scope
     sp = (char *) ((ucontext *) ctx)->uc_mcontext.gregs[REG_RSP];
                     ^~~~~~~~
src/libmain/stack.cc:21:21: note: suggested alternative: 'ucontext_t'
     sp = (char *) ((ucontext *) ctx)->uc_mcontext.gregs[REG_RSP];
                     ^~~~~~~~
                     ucontext_t
```

It's caused by upstream rename:
https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=251287734e89a52da3db682a8241eb6bccc050c9

which basically changes
```
    typedef struct ucontext {} ucontext_t;
```
to
```
    typedef struct ucontext_t {} ucontext_t;
```
The change uses ucontext_t.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>