### PR TITLE
manual: import needs root or trusted signature

### DIFF
--- a/doc/manual/command-ref/nix-store.xml
+++ b/doc/manual/command-ref/nix-store.xml
@@ -1123,7 +1123,7 @@ $ nix-store --export $(nix-store -qR <replaceable>paths</replaceable>) > out</sc
 To import the whole closure again, run:
 
 <screen>
-$ nix-store --import &lt; out</screen>
+# nix-store --import &lt; out</screen>
 
 </para>
 
@@ -1154,6 +1154,11 @@ standard input and adds those store paths to the Nix store.  Paths
 that already exist in the Nix store are ignored.  If a path refers to
 another path that doesn’t exist in the Nix store, the import
 fails.</para>
+
+<para>
+Note: this needs to be either run as root, or on a seralization with
+signatures from a trusted cache.
+</para>
 
 </refsection>
 

--- a/doc/manual/packages/copy-closure.xml
+++ b/doc/manual/packages/copy-closure.xml
@@ -32,7 +32,7 @@ writes the closure of Firefox to a file.  You can then copy this file
 to another machine and install the closure:
 
 <screen>
-$ nix-store --import &lt; firefox.closure</screen>
+# nix-store --import &lt; firefox.closure</screen>
 
 Any store paths in the closure that are already present in the target
 store are ignored.  It is also possible to pipe the export into


### PR DESCRIPTION
`nix-store --import` needs to be either run as root, or on a
closure that's been signed by a trusted cache.

Currently this is mentioned nowhere in the manual, so this
makes it explicit