### PR TITLE
install-nix: Solve #971 USER == NULL

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -20,13 +20,9 @@ fi
 # in case if USER not set
 if [ -z "$userID" ]; then
     echo "$0: Environment variable USER is not set" >&2
-    echo "$0: Detecting userID from UID=$(id -u)" >&2
-    userID="$(getent passwd | cut -d: -f1,3 | grep "$(id -u)" | cut -d: -f1)"    # Taking username from  UID requires some reverse-engineering.
-    if [ "$(id -u "$userID")" -ne "$(id -u)" ]; then
-        echo "$0: test: Detected userID is wrong."  >&2
-        echo "$0: Please set proper USER environment variable. Exiting..." >&2
-        exit 1
-    fi
+    echo "$0: Detecting username from UID=$(id -u)" >&2
+    userID="$(id -u -n)"    # Taking username from  UID
+    echo "$0: Username: $userID" >&2
 fi
 
 if [ -z "$HOME" ]; then

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -7,22 +7,17 @@ readonly dest="/nix"
 readonly self="$(dirname "$0")"
 readonly nix="@nix@"
 readonly cacert="@cacert@"
-readonly USER
-
-# Global declaration block
-userID="$USER" # for the case when USER not set (root in some environments, environment not gone through login shell (Docker)). Guessing username from UID needed.
-
 
 if ! [ -e "$self/.reginfo" ]; then
     echo "$0: incomplete installer (.reginfo is missing)" >&2
 fi
 
 # in case if USER not set
-if [ -z "$userID" ]; then
+if [ -z "$USER" ]; then
     echo "$0: Environment variable USER is not set" >&2
-    echo "$0: Detecting username from UID=$(id -u)" >&2
-    userID="$(id -u -n)"    # Taking username from  UID
-    echo "$0: Username: $userID" >&2
+    echo "$0: Detected username from UID=$(id -u)" >&2
+    USER="$(whoami)"    # Taking username from  UID
+    echo "$0: Username: $USER" >&2
 fi
 
 if [ -z "$HOME" ]; then
@@ -49,7 +44,7 @@ fi
 echo "performing a single-user installation of Nix..." >&2
 
 if ! [ -e $dest ]; then
-    cmd="mkdir -m 0755 $dest && chown $userID $dest"
+    cmd="mkdir -m 0755 $dest && chown $USER $dest"
     echo "directory $dest does not exist; creating it by running '$cmd' using sudo" >&2
     if ! sudo sh -c "$cmd"; then
         echo "$0: please manually run '$cmd' as root to create $dest" >&2
@@ -58,7 +53,7 @@ if ! [ -e $dest ]; then
 fi
 
 if ! [ -w $dest ]; then
-    echo "$0: directory $dest exists, but is not writable by you. This could indicate that another user has already performed a single-user installation of Nix on this system. If you wish to enable multi-user support see http://nixos.org/nix/manual/#ssec-multi-user. If you wish to continue with a single-user install for $userID please run 'chown -R $userID $dest' as root." >&2
+    echo "$0: directory $dest exists, but is not writable by you. This could indicate that another user has already performed a single-user installation of Nix on this system. If you wish to enable multi-user support see http://nixos.org/nix/manual/#ssec-multi-user. If you wish to continue with a single-user install for $USER please run 'chown -R $USER $dest' as root." >&2
     exit 1
 fi
 

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -15,9 +15,8 @@ fi
 # in case if USER not set
 if [ -z "$USER" ]; then
     echo "$0: Environment variable USER is not set" >&2
-    echo "$0: Detected username from UID=$(id -u)" >&2
     USER="$(whoami)"    # Taking username from  UID
-    echo "$0: Username: $USER" >&2
+    echo "$0: Detected username: $USER" >&2
 fi
 
 if [ -z "$HOME" ]; then


### PR DESCRIPTION
This addresses #971.

Which also encountered by me:

```bash
docker run -it alpine env
docker run -it alpine /bin/sh -c 'echo "$USER <-this" ; whoami'
docker run -it ubuntu /bin/sh -c 'echo "$USER <-this" ; whoami'
docker run -it base/archlinux /bin/sh -c 'echo "$USER <-this" ; whoami'
docker run -it nixos/nix /bin/sh -c 'echo "$USER <-this" ; whoami'
```

This is because Docker env not goes through `login` and login shell, so shell not sources login config, so shell not defined that env variables.

We touch `USER` only when it is not defined. And as it is shell, anyway it is a copy variable in scope of this script.