### PR TITLE
install-nix: Adding HOME checks

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -22,6 +22,31 @@ if [ -z "$HOME" ]; then
     exit 1
 fi
 
+if [ ! -e "$HOME" ]; then
+    echo "$0: Home directory $HOME does not exist" >&2
+    exit 1
+fi
+
+if [ ! -d "$HOME" ]; then
+    echo "$0: Home directory $HOME is not a directory" >&2
+    exit 1
+fi
+
+if [ ! -w "$HOME" ]; then
+    echo "$0: Home directory $HOME is not writable for user $USER. No deal" >&2
+    exit 1
+fi
+
+if [ ! -O "$HOME" ]; then
+    echo "$0: Home directory $HOME is not owned by user $USER, users HOME probably must be owned by user" >&2
+    exit 1
+fi
+
+if [ ! -x "$HOME" ]; then
+    echo "$0: Home directory $HOME is not marked as executable for user $USER, how we are going to go into it?" >&2
+    exit 1
+fi
+
 # macOS support for 10.10 or higher
 if [ "$(uname -s)" = "Darwin" ]; then
     if [ $(($(sw_vers -productVersion | cut -d '.' -f 2))) -lt 10 ]; then


### PR DESCRIPTION
### Core part: It is possible HOME can be set even by system config, but there can be no directory in reality.
I found no bugreports. But I solve error I did couple of times myself through years. And making installation robust by enabling requirement checks for the right installation process is a great idea. I try to not interfere with any functional use cases.

How HOME var can be set, but directory not exist:
Example, admin in `adduser` don't provided '-m' key.
```
man adduser
...
-d, --home HOME_DIR
    ... The directory HOME_DIR does not have to exist but will not be created if it is missing.
...
-m, --create-home
    Create the user's home directory if it does not exist.
```

This is possible to mixup, because `usermod -d` creates HOME directories, but `adduser -d` - not.

### `echo` messages - self-explanatory of checks they do.

In this same script we do:
use HOME - so it needs to exist, be directory, and be executable
create $HOME/.nix-profile - so it needs to be writable
since script is `echo "performing a single-user installation of Nix..." >&2` - we can require that HOME is user owned.
in 99% read permissions also needed, but technically it is possible to operate and have a case when HOME can not have read permissions for user though (if admin not trust even user itself). HOME -wx is enough to go to known path ($HOME/.nix-profile) and it should have rwx for user, so user can operate as long, as he knows path.