### PR TITLE
install-nix: Advancement of destination folder creation means

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -78,7 +78,7 @@ else
     # if dest still not created (with user or sudo) - use su to access root
     if [ ! -d "$dest" ] ; then
         echo "Trying to get privileges using su and root password"
-        if ! su root 'sh -c "$cmd"' && echo "Exiting priviliged mode."; then
+        if ! su root sh -c "$cmd" && echo "Exiting priviliged mode."; then
             # all means failed, Exit!
             echo "$0: Can't get root access to create $dest folder. All variants failed. Exiting..." >&2
             exit 1

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -76,9 +76,9 @@ else
     fi
 
     # if dest still not created (with user or sudo) - use su to access root
-    if [ -d "$dest" ] ; then
+    if [ ! -d "$dest" ] ; then
         echo "Trying to get privileges using su and root password"
-        if ! su sh -c "$cmd" && echo "Exiting priviliged mode."; then
+        if ! su root 'sh -c "$cmd"' && echo "Exiting priviliged mode."; then
             # all means failed, Exit!
             echo "$0: Can't get root access to create $dest folder. All variants failed. Exiting..." >&2
             exit 1


### PR DESCRIPTION
This commit concentrates on streamlining `/nix` folder creation.

As Nix installation can be launched from any user, on any distro, with `sudo` or not - here is universal code.

1. At first it tries to create folder from current user. If it is root, or user can create directory - no need to use sudo or su or disturb user with additional messages.
2. Detects does `sudo` installed. Before this we could not distinct when `sudo` access failed itself and when `sudo` is not installed. And now we can say that we looked and `sudo` is not installed, and it is understandable why we ask him root password itself.
3. Looks does `sudo` access is passwordless, or not.
3a. Passwordless: we can inform user that we used `sudo`.
3b. With password: we explain to user why we need sudo access, and ask to enter password for that.
4. If `sudo` fails, we mention that it also can be due to user has no sudoers access. Nowadays `sudo` pretends that password do not match, while in reality user has no sudoers access. The One `sudo` developer, - millert - made that change years ago to not inform hackers that user has no `sudo` access, but those reports is written to logs. But admins/users also can be puzzled by that, especially if passwords/infrastructure is complex.
5. If folder still not created - use `su`.
5a.And big volume of clean distributions (minimalist ones) doesn't have `sudo` supplied with a distro (Alpine, Arch, even Debian I think).
5a. And we explain why installer asks for root password itself.
6. Without informing user when root access closed - he doesn't sure how many operations was under root after he gave access, and what Nix beast will do with his system. We now inform user, in both sudo and su, when we closed root assess, that he kindly entrusted to us.
7. Script errors only when all merits was used - only then. So user has less hassle, we are trying in his benefit.
8. More vocal installation process overall. Which is important for smooth experience and good impression.
9. Yes, I also changed:
```sh
if ! [ -e $dest ]; then # it can also be file or link to file.
# to
if ! [ -d $dest ]; then # it can be only directory/link to directory
```

And, yes; solves #539. Now script not falls because `sudo` is not present, - it uses root, user rights or `su`.
I looked though all 'install' bugs and that's all I found related, but I by the way triaged a handful for people bugs, old ones also.