### PR TITLE
scripts/nix-copy-closure.in: Automatically flush STDERR handle

### DIFF
--- a/scripts/nix-copy-closure.in
+++ b/scripts/nix-copy-closure.in
@@ -7,8 +7,10 @@ use Nix::Config;
 use Nix::Store;
 use Nix::CopyClosure;
 use List::Util qw(sum);
+use IO::Handle;
 
 binmode STDERR, ":encoding(utf8)";
+STDERR->autoflush(1);
 
 if (scalar @ARGV < 1) {
     print STDERR <<EOF


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixops/issues/455