### PR TITLE
Improve error message for conflicting priorities

### DIFF
--- a/src/buildenv/buildenv.cc
+++ b/src/buildenv/buildenv.cc
@@ -74,10 +74,11 @@ static void createLinks(const Path & srcDir, const Path & dstDir, int priority)
                     auto prevPriority = priorities[dstFile];
                     if (prevPriority == priority)
                         throw Error(format(
-                                "collision between '%1%' and '%2%'; "
-                                "use 'nix-env --set-flag priority NUMBER PKGNAME' "
+                                "Packages '%1%' and '%2%' have the same priority '%3%'"
+                                "use 'nix-env --set-flag priority NUMBER INSTALLED_PKGNAME' "
                                 "to change the priority of one of the conflicting packages"
-                                ) % srcFile % target);
+                                " ('0' being the highest priority)"
+                                ) % srcFile % target % priority);
                     if (prevPriority < priority)
                         continue;
                     if (unlink(dstFile.c_str()) == -1)


### PR DESCRIPTION
I find the error message 'nix-env --set-flag priority NUMBER PKGNAME'
not as helpful as it could be :
- doesn't share the current priorities
- doesn't say that the command must be run on the already installed
PKGNAME (which is confusing the first time)
- the doc needs careful reading:
"If there are multiple derivations matching a name in args that have the same name (e.g., gcc-3.3.6 and gcc-4.1.1), then the derivation with the highest priority is used."
if one stops reading there, he is screwed. Salvation comes with reading "A derivation can define a priority by declaring the meta.priority attribute. This attribute should be a number, with a higher value denoting a lower priority. The default priority is 0."
To sum it up, lower number wins. I tried to convey this idea in the
message too.

I haven't used this in production because nixUnstable tends to break my install and I wanted to check for agreement first.