### PR TITLE
nix-channel: remind user to update after adding

### DIFF
--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -50,6 +50,7 @@ static void addChannel(const string & url, const string & name)
     readChannels();
     channels[name] = url;
     writeChannels();
+    std::cerr << "Remember to run nix-channel --update to apply the changes!\n";
 }
 
 static auto profile = Path{};


### PR DESCRIPTION
This reduces the likelihood of a common pitfall; I've often forgotten to run --update after adding a channel or changing a channel URL.