### PR TITLE
Retry in all error cases but a few

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,16 +99,20 @@ perl/Makefile.config
 /misc/systemd/nix-daemon.socket
 /misc/upstart/nix-daemon.conf
 
+/src/resolve-system-dependencies/resolve-system-dependencies
+
 inst/
 
 *.a
 *.o
 *.so
+*.dylib
 *.dll
 *.exe
 *.dep
 *~
 *.pc
+*.plist
 
 # GNU Global
 GPATH


### PR DESCRIPTION
~~I could make this optional but it doesn't seem like too weird of a thing to enable in general.~~

As we discussed on IRC

This is what I'm currently running into in #1573, even though it no longer causes deadlocks. I'm honestly not sure if it was what was causing deadlocks before, but since updating Nix I'm now getting timeout errors with the same frequency as I was getting deadlocks before.

I'm unsure what to do about timeouts. The behavior in this PR will retry on curl connect timeouts (which happens to be the behavior I want, since I'm getting occasional timeouts from dud S3 backend servers), but that doesn't seem like something everyone would want.

cc @edolstra 