### PR TITLE
local-store: do not remove system.nfs4_acl

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -462,7 +462,7 @@ static void canonicalisePathMetaData_(const Path & path, uid_t fromUid, InodesSe
         for (auto & eaName: tokenizeString<Strings>(std::string(eaBuf.data(), eaSize), std::string("\000", 1))) {
             /* Ignore SELinux security labels since these cannot be
                removed even by root. */
-            if (eaName == "security.selinux") continue;
+            if (eaName == "security.selinux" || eaName == "system.nfs4_acl") continue;
             if (lremovexattr(path.c_str(), eaName.c_str()) == -1)
                 throw SysError("removing extended attribute '%s' from '%s'", eaName, path);
         }


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/29778

Removal of this ACL breaks nix if the store resides on an
NFSv 4.1 mount.