### PR TITLE
install-darwin-multi-user: relax assumption check

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -318,7 +318,7 @@ EOF
 
     for file in ~/.bash_profile ~/.bash_login ~/.profile ~/.zshenv ~/.zprofile ~/.zshrc ~/.zlogin; do
         if [ -f "$file" ]; then
-            if grep -l ".nix-profile" "$file"; then
+            if grep -l "^[^#].*.nix-profile" "$file"; then
                 failure <<EOF
 I found a reference to a ".nix-profile" in $file.
 This has a high chance of breaking a new nix installation. It was most


### PR DESCRIPTION
The installer will error out if a user's shell configuration includes any mention of `nix-profile`, even if this is in a comment. This change is designed to do the bare minimum to ignore lines beginning with a `#`.