### PR TITLE
More elegant test output

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -7,20 +7,38 @@ define run-install-test
 
 endef
 
+# Color code from https://unix.stackexchange.com/a/10065
 installcheck:
-	@total=0; failed=0; for i in $(_installcheck-list); do \
+	@total=0; failed=0; \
+	pad="                           "; \
+	red=""; \
+	green=""; \
+	normal=""; \
+	if [ -t 1 ]; then \
+		ncolors="$$(tput colors)"; \
+		if [[ -n "$$ncolors" && $$ncolors -ge 8 ]]; then \
+			red="$$(tput setaf 1)"; \
+			green="$$(tput setaf 2)"; \
+			normal="$$(tput sgr0)"; \
+		fi; \
+	fi; \
+	for i in $(_installcheck-list); do \
 	  total=$$((total + 1)); \
-	  echo "running test $$i"; \
-	  if (cd $$(dirname $$i) && $(tests-environment) $$(basename $$i)); then \
-	    echo "PASS: $$i"; \
+	  printf "running test $$i... $${pad:$${#i}}"; \
+	  log="$$(cd $$(dirname $$i) && $(tests-environment) $$(basename $$i) 2>&1)"; \
+	  if [ $$? == 0 ]; then \
+	    echo "[$${green}PASS$$normal]"; \
 	  else \
-	    echo "FAIL: $$i"; \
+	    echo "[$${red}FAIL$$normal]"; \
+	    echo "$$log" | sed 's/^/    /'; \
 	    failed=$$((failed + 1)); \
 	  fi; \
 	done; \
 	if [ "$$failed" != 0 ]; then \
-	  echo "$$failed out of $$total tests failed "; \
+	  echo "$${red}$$failed out of $$total tests failed $$normal"; \
 	  exit 1; \
+	else \
+		echo "$${green}All tests succeeded"; \
 	fi
 
 .PHONY: check installcheck


### PR DESCRIPTION
I got sick of trying to find the failures in the sea of debug output, so we now:

- Hide test output unless it fails
- Sprinkle in some simple color if we're in a terminal that supports it (so Hydra/CI doesn't get cluttered up with escape codes)
- Pad results for a more tabular look

If Nix is getting a more friendly user interface, we might as well get a friendlier developer interface, right? :)

I realize we don't want to add a dependency on a third-party test framework so I figured a few lines of make/bash could make this a lot more pleasant to work with.

Fixes #880 

cc @edolstra @domenkozar @shlevy 