### PR TITLE
release-common: Fix busybox builtins (busybox >= 1.27)

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -7,8 +7,8 @@ rec {
     enableMinimal = true;
     extraConfig = ''
       CONFIG_ASH y
-      CONFIG_ASH_BUILTIN_ECHO y
-      CONFIG_ASH_BUILTIN_TEST y
+      CONFIG_ASH_ECHO y
+      CONFIG_ASH_TEST y
       CONFIG_ASH_OPTIMIZE_FOR_SIZE y
     '';
   };


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/28261

If this is fixed here, it should be fixed in nixpkgs as well.