### PR TITLE
fetchgit: Remove incomplete/unneeded ref check.

### DIFF
--- a/src/libexpr/primops/fetchgit.cc
+++ b/src/libexpr/primops/fetchgit.cc
@@ -22,11 +22,6 @@ Path exportGit(ref<Store> store, const std::string & uri,
             throw Error("invalid Git revision '%s'", rev);
     }
 
-    // FIXME: too restrictive, but better safe than sorry.
-    std::regex refRegex("^[0-9a-zA-Z][0-9a-zA-Z.-]+$");
-    if (!std::regex_match(ref, refRegex))
-        throw Error("invalid Git ref '%s'", ref);
-
     Path cacheDir = getCacheDir() + "/nix/git";
 
     if (!pathExists(cacheDir)) {


### PR DESCRIPTION
This check fails for tags and branches, and is made redundant by the
checks git itself will do when fetching the repo.