### PR TITLE
Shift Darwin sandbox to separate installed files

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2774,14 +2774,10 @@ void DerivationGoal::runChild()
                     sandboxProfile += "(deny default (with no-log))\n";
                 }
 
-                sandboxProfile +=
-                    #include "sandbox-defaults.sb.gen.hh"
-                    ;
+                sandboxProfile += "(import \"sandbox-defaults.sb\")";
 
                 if (fixedOutput)
-                    sandboxProfile +=
-                        #include "sandbox-network.sb.gen.hh"
-                        ;
+                    sandboxProfile += "(import \"sandbox-network.sb\")";
 
                 /* Our rwx outputs */
                 sandboxProfile += "(allow file-read* file-write* process-exec\n";
@@ -2824,9 +2820,7 @@ void DerivationGoal::runChild()
 
                 sandboxProfile += additionalSandboxProfile;
             } else
-                sandboxProfile +=
-                    #include "sandbox-minimal.sb.gen.hh"
-                    ;
+                sandboxProfile += "(import \"sandbox-minimal.sb\")";
 
             debug("Generated sandbox profile:");
             debug(sandboxProfile);
@@ -2848,6 +2842,8 @@ void DerivationGoal::runChild()
             args.push_back(sandboxFile);
             args.push_back("-D");
             args.push_back("_GLOBAL_TMP_DIR=" + globalTmpDir);
+            args.push_back("-D");
+            args.push_back("IMPORT_DIR=" + settings.nixDataDir + "/nix/sandbox/");
             args.push_back(drv->builder);
         }
 #endif

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -10,6 +10,10 @@ libstore_LIBS = libutil libformat
 
 libstore_LDFLAGS = $(SQLITE3_LIBS) -lbz2 $(LIBCURL_LIBS) $(SODIUM_LIBS) -pthread
 
+libstore_FILES = sandbox-defaults.sb sandbox-minimal.sb sandbox-network.sb
+
+$(foreach file,$(libstore_FILES),$(eval $(call install-data-in,$(d)/$(file),$(datadir)/nix/sandbox)))
+
 ifeq ($(ENABLE_S3), 1)
 	libstore_LDFLAGS += -laws-cpp-sdk-s3 -laws-cpp-sdk-core
 endif
@@ -36,9 +40,7 @@ libstore_CXXFLAGS = \
 
 $(d)/local-store.cc: $(d)/schema.sql.gen.hh
 
-sandbox-headers = $(d)/sandbox-defaults.sb.gen.hh $(d)/sandbox-network.sb.gen.hh $(d)/sandbox-minimal.sb.gen.hh
-
-$(d)/build.cc: $(sandbox-headers)
+$(d)/build.cc:
 
 %.gen.hh: %
 	@echo 'R"foo(' >> $@.tmp
@@ -46,6 +48,6 @@ $(d)/build.cc: $(sandbox-headers)
 	@echo ')foo"' >> $@.tmp
 	@mv $@.tmp $@
 
-clean-files += $(d)/schema.sql.gen.hh $(sandbox-headers)
+clean-files += $(d)/schema.sql.gen.hh
 
 $(eval $(call install-file-in, $(d)/nix-store.pc, $(prefix)/lib/pkgconfig, 0644))


### PR DESCRIPTION
This makes it slightly more manageable to see at a glance what in a build's sandbox profile is unique to the build and what is standard. Also a first step to factoring more of our Darwin logic into scheme functions that will allow us a bit more flexibility. And of course less of that nasty codegen in C++! 😀

cc @edolstra @shlevy @domenkozar @LnL7