### PR TITLE
Print path names built by nix build

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -55,14 +55,17 @@ struct CmdBuild : MixDryRun, InstallablesCommand
         for (size_t i = 0; i < buildables.size(); ++i) {
             auto & b(buildables[i]);
 
-            if (outLink != "")
-                for (auto & output : b.outputs)
+            for (auto & output : b.outputs) {
+                std::cout << output.second << std::endl;
+                if (outLink != "") {
                     if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>()) {
                         std::string symlink = outLink;
                         if (i) symlink += fmt("-%d", i);
                         if (output.first != "out") symlink += fmt("-%s", output.first);
                         store2->addPermRoot(output.second, absPath(symlink), true);
                     }
+                }
+            }
         }
     }
 };


### PR DESCRIPTION
When building with `nix build --no-link`, there is otherwise no way to know the store path that was built.