### PR TITLE
Always allow builds to use unix domain sockets in Darwin sandbox

### DIFF
--- a/src/libstore/sandbox-defaults.sb
+++ b/src/libstore/sandbox-defaults.sb
@@ -22,7 +22,14 @@
 (allow signal (target same-sandbox))
 
 ; Access to /tmp.
-(allow file* process-exec (literal "/tmp") (subpath TMPDIR))
+; The network-outbound/network-inbound ones are for unix domain sockets, which
+; we allow access to in TMPDIR (but if we allow them more broadly, you could in
+; theory escape the sandbox)
+(allow file* process-exec network-outbound network-inbound
+       (literal "/tmp") (subpath TMPDIR))
+
+; Always allow unix domain sockets, since they can't hurt purity or security
+
 
 ; Some packages like to read the system version.
 (allow file-read* (literal "/System/Library/CoreServices/SystemVersion.plist"))


### PR DESCRIPTION
No reason not to allow this, and quite a few test suites use unix sockets