### PR TITLE
nix repl: Provide documentation from comment when evaluating to lambda

### DIFF
--- a/src/nix/comment.cc
+++ b/src/nix/comment.cc
@@ -1,0 +1,231 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <regex>
+#include <climits>
+#include <algorithm>
+
+#include "comment.hh"
+#include "util.hh"
+
+/* This module looks for documentation comments in the source code.
+
+   Documentation is not retained during parsing, and it should not be,
+   for performance reasons. Because of this the code has to jump
+   through some hoops, to perform its task.
+
+   Adapting the parser was not considered an option, so this code
+   parses the comments from scratch, using regular expressions. These
+   do not support all syntactic constructs, so in rare cases, they
+   will fail and the code will report no documentation.
+
+   One such situation is where documentation is requested for a
+   partially applied function, where the outer lambda pattern
+   matches an attribute set. This is not supported in the regexes
+   because it potentially requires (almost?) the entire grammar.
+
+   This module has been designed not to report the wrong
+   documentation; considering that the wrong documentation is worse
+   than no documentation. The regular expressions will only match
+   simple, well understood syntactic structures, or not match at all.
+
+   This approach to finding documentation does not cause extra runtime
+   overhead, until used.
+
+   This module does not support tab ('\t') characters. In some places
+   they are treated as single spaces. They should be avoided.
+*/
+namespace nix::Comment {
+
+struct Doc emptyDoc("", "", "", 0);
+
+/* parseDoc will try to recover a Doc by looking at the text that leads up to a term
+   definition.*/
+static struct Doc parseDoc(std::string sourcePrefix);
+
+/* stripComment unpacks a comment, by unindenting and stripping " * " prefixes as
+   applicable. The argument should include any preceding whitespace. */
+static std::string stripComment(std::string rawComment);
+
+/* Consistent unindenting. It will only remove entire columns. */
+static std::string unindent(std::string s);
+
+static std::string trimUnindent(std::string s) {
+    return trim(unindent(s));
+}
+
+static std::string stripPrefix(std::string prefix, std::string s) {
+    std::string::size_type index = s.find(prefix);
+    return (index == 0) ? s.erase(0, prefix.length()) : s;
+}
+
+static std::string readFileUpToPos(const Pos & pos) {
+
+    std::ifstream ifs(static_cast<const std::string>(pos.file));
+    std::stringstream ret;
+    size_t lineNum = 1;
+    std::string line;
+
+    while (getline(ifs, line) && lineNum <= pos.line) {
+        if (lineNum < pos.line) {
+            ret << line << "\n";
+        } else if (lineNum == pos.line) {
+            ret << line.substr(0, pos.column-1);
+        }
+        lineNum++;
+    }
+
+    return ret.str();
+}
+
+struct Doc lookupDoc(const Pos & pos) {
+    try {
+        return parseDoc(readFileUpToPos(pos));
+    } catch (std::exception e) {
+        ignoreException();
+        return emptyDoc;
+    }
+}
+
+/* See lambdas in parseDoc */
+static int countLambdas(std::string piece) {
+    return std::count(piece.begin(), piece.end(), ':');
+}
+
+/* Try to recover a Doc by looking at the text that leads up to a term
+   definition */
+static struct Doc parseDoc(std::string sourcePrefix) {
+
+    std::string wss("[ \t\r\n]*");
+    std::string spaces("[ \t]*");
+
+    std::string singleLineComment(spaces + "#[^\r\n]*(?:\n|\r\n)");
+    std::string multiSingleLineComment("(?:" + singleLineComment + ")*");
+    std::string multiLineComment("\\/\\*(?:[^*]|\\*+[^*/])*\\*+\\/");
+    std::string commentUnit("(" + multiSingleLineComment + "|" + spaces + multiLineComment + ")" + wss);
+
+    std::string ident("[a-zA-Z_][a-zA-Z0-9_'-]*" + wss);
+    std::string identKeep("([a-zA-Z_][a-zA-Z0-9_'-]*)" + wss);
+
+    /* lvalue for nested attrset construction, but not matching
+       quoted identifiers or ${...} or comments inbetween etc */
+    std::string simplePath("(?:" + wss + ident + "\\.)*" + identKeep);
+
+    std::string lambda(ident + wss + ":" + wss);
+
+    /* see countLambdas */
+    std::string lambdas("((:?" + lambda + ")*)");
+
+    std::string assign("=" + wss);
+
+    std::string re(commentUnit + simplePath + assign + lambdas + "$");
+    std::regex e(re);
+
+    #define REGEX_GROUP_COMMENT 1
+    #define REGEX_GROUP_NAME 2
+    #define REGEX_GROUP_LAMBDAS 3
+    #define REGEX_GROUP_MAX 4
+
+    std::smatch matches;
+    regex_search(sourcePrefix, matches, e);
+
+    std::stringstream buffer;
+    if (matches.length() < REGEX_GROUP_MAX) {
+        return emptyDoc;
+    }
+
+    std::string rawComment = matches[REGEX_GROUP_COMMENT];
+    std::string name = matches[REGEX_GROUP_NAME];
+    int timesApplied = countLambdas(matches[REGEX_GROUP_LAMBDAS]);
+    return Doc(rawComment, stripComment(rawComment), name, timesApplied);
+}
+
+static std::string stripComment(std::string rawComment) {
+    rawComment.erase(rawComment.find_last_not_of("\n")+1);
+
+    std::string s(trimUnindent(rawComment));
+
+    if (s[0] == '/' && s[1] == '*') {
+        // Remove the "/*"
+        // Indentation will be removed consistently later on
+        s[0] = ' ';
+        s[1] = ' ';
+
+        // Remove the "*/"
+        if (!s.empty() && *(--s.end()) == '/')
+            s.pop_back();
+        if (!s.empty() && *(--s.end()) == '*')
+            s.pop_back();
+
+        s = trimUnindent(s);
+
+        std::istringstream inStream(s);
+        std::ostringstream stripped;
+
+        std::string line;
+
+        /* at first, we assume a comment
+         * that is formatted like this
+         * with '*' characters at the beginning
+         * of the line.
+         */
+        bool hasStars = true;
+
+        while(std::getline(inStream,line,'\n')){
+            if (hasStars && (
+                    (!line.empty() && line[0] == '*')
+                 || (line.length() >= 2 && line[0] == ' ' && line[1] == '*')
+                    )) {
+                if (line[0] == ' ') {
+                    line = stripPrefix(" *", line);
+                } else {
+                    line = stripPrefix("*", line);
+                }
+            } else {
+                hasStars = false;
+            }
+
+            stripped << line << std::endl;
+        }
+        return trimUnindent(stripped.str());
+    }
+    else {
+        std::istringstream inStream(s);
+        std::ostringstream stripped;
+
+        std::string line;
+        while(std::getline(inStream, line, '\n')) {
+            line.erase(0, line.find("#") + 1);
+            stripped << line << std::endl;
+        }
+        return trimUnindent(stripped.str());
+    }
+}
+
+static std::string unindent(std::string s) {
+    size_t maxIndent = 1000;
+    {
+        std::istringstream inStream(s);
+        for (std::string line; std::getline(inStream, line); ) {
+            size_t firstNonWS = line.find_first_not_of(" \t\r\n");
+            if (firstNonWS != std::string::npos) {
+                maxIndent = std::min(firstNonWS, maxIndent);
+            }
+        }
+    }
+
+    std::ostringstream unindentedStream;
+    {
+        std::istringstream inStream(s);
+        for (std::string line; std::getline(inStream, line); ) {
+            if (line.length() >= maxIndent) {
+                unindentedStream << line.substr(maxIndent) << std::endl;
+            } else {
+                unindentedStream << std::endl;
+            }
+        }
+    }
+    return unindentedStream.str();
+}
+
+}

--- a/src/nix/comment.hh
+++ b/src/nix/comment.hh
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "nixexpr.hh"
+
+namespace nix::Comment {
+
+struct Doc {
+
+    // Name that the term is assigned to
+    std::string name;
+
+    std::string rawComment;
+    std::string comment;
+
+    // Number of times the curried function must be applied to get the value
+    // that this structure documents.
+    //
+    // This is useful when showing the documentation for a partially applied
+    // curried function. The documentation is for the unapplied function, so
+    // this is crucial information.
+    int timesApplied;
+
+    Doc(std::string rawComment, std::string comment, std::string name, int timesApplied) {
+        this->name = name;
+        this->rawComment = rawComment;
+        this->comment = comment;
+        this->timesApplied = timesApplied;
+    }
+
+};
+
+extern struct Doc emptyDoc;
+
+// lookupDoc will try to recover a Doc. This will perform perform I/O,
+// because documentation is not retained by the parser.
+//
+// Will return empty values if nothing can be found.
+// For its limitations, see the docs of the implementation.
+struct Doc lookupDoc(const Pos & pos);
+
+}

--- a/tests/comments.nix
+++ b/tests/comments.nix
@@ -1,0 +1,97 @@
+{
+  # Just a function.
+  f = x: x;
+
+  # Just a function in an attrset.
+  nested.f = x: x;
+
+  /* A nice function.
+   */
+  g = x: x;
+
+  # FOO
+  /* A somewhat nice function.
+   */
+  h = x: x;
+
+  /*
+   * A nice function.
+   */
+  i = x: x;
+
+  /*
+   *
+   * A nice function.
+   *
+   */
+  j = x: x;
+
+  /*
+   
+    A nice function.
+   
+  */
+  k = x: x;
+
+  /*
+   
+ A nice function.
+   
+  */
+  l = x: x;
+
+    /*
+   
+     	    A nice function.
+   
+  */
+  m = x: x;
+
+  /* One
+     Two
+  */
+  n = x: x;
+  
+  /*
+    Bullets:
+
+     * Are lethal.
+     * Are made of metal.
+
+  */
+  o = x: x;
+  
+  /*
+   * Bullets:
+   *
+   *  * Are lethal.
+   *  * Are made of metal.
+   *
+   */
+  p = x: x;
+
+  # Implementation detail
+
+  # Useful stuff
+  q = x: x;
+
+  # Useful
+  # stuff
+  r = x: x;
+
+  /* ßuper toll.
+   */
+  unicode1 = x: x;
+
+  /* 🤢
+   */
+  unicode2 = x: x;
+
+  /* Apply me twice.
+   */
+  curried = x: y: x;
+
+  /* You can give 3 arguments.
+   */
+  curried2 = x: y: z: x;
+}

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -2,6 +2,7 @@ check:
 	@echo "Warning: Nix has no 'make check'. Please install Nix and run 'make installcheck' instead."
 
 nix_tests = \
+  nix-repl.sh \
   init.sh hash.sh lang.sh add.sh simple.sh dependencies.sh \
   gc.sh gc-concurrent.sh \
   referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \

--- a/tests/nix-repl.sh
+++ b/tests/nix-repl.sh
@@ -1,0 +1,187 @@
+source common.sh
+
+strip_colors() {
+    sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
+}
+
+check() {
+    exp="$1"
+
+    (
+        tmp=$(mktemp)
+        cleanup() {
+            rm "$tmp"
+        }
+        trap cleanup EXIT
+
+        ( echo "$exp"
+          echo ":q"
+        ) | nix repl \
+          | grep '|' \
+          | strip_colors \
+                >"$tmp"
+
+        diff -U10 - "$tmp"
+    )
+}
+
+check "(import ./comments.nix).f" <<EOF
+| f
+| -
+| 
+| Just a function.
+EOF
+
+check "(import ./comments.nix).nested.f" <<EOF
+| f
+| -
+| 
+| Just a function in an attrset.
+EOF
+
+check "(import ./comments.nix).g" <<EOF
+| g
+| -
+| 
+| A nice function.
+EOF
+
+check "(import ./comments.nix).h" <<EOF
+| h
+| -
+| 
+| A somewhat nice function.
+EOF
+
+check "(import ./comments.nix).i" <<EOF
+| i
+| -
+| 
+| A nice function.
+EOF
+
+check "(import ./comments.nix).j" <<EOF
+| j
+| -
+| 
+| A nice function.
+EOF
+
+check "(import ./comments.nix).k" <<EOF
+| k
+| -
+| 
+| A nice function.
+EOF
+
+check "(import ./comments.nix).l" <<EOF
+| l
+| -
+| 
+| A nice function.
+EOF
+
+check "(import ./comments.nix).m" <<EOF
+| m
+| -
+| 
+| A nice function.
+EOF
+
+check "(import ./comments.nix).n" <<EOF
+| n
+| -
+| 
+| One
+| Two
+EOF
+
+check "(import ./comments.nix).o" <<EOF
+| o
+| -
+| 
+| Bullets:
+| 
+|  * Are lethal.
+|  * Are made of metal.
+EOF
+
+check "(import ./comments.nix).p" <<EOF
+| p
+| -
+| 
+| Bullets:
+| 
+|  * Are lethal.
+|  * Are made of metal.
+EOF
+
+check "(import ./comments.nix).q" <<EOF
+| q
+| -
+| 
+| Useful stuff
+EOF
+
+
+check "(import ./comments.nix).r" <<EOF
+| r
+| -
+| 
+| Useful
+| stuff
+EOF
+
+check "(import ./comments.nix).unicode1" <<EOF
+| unicode1
+| --------
+| 
+| ßuper toll.
+EOF
+
+check "(import ./comments.nix).unicode2" <<EOF
+| unicode2
+| --------
+| 
+| 🤢
+EOF
+
+check "(import ./comments.nix).curried" <<EOF
+| curried
+| -------
+| 
+| Apply me twice.
+EOF
+
+check "(import ./comments.nix).curried true" <<EOF
+| curried
+| -------
+| 
+| NOTE: This function has already been applied!
+|       You should ignore the first 1 parameter(s) in this documentation,
+|       because they have already been applied.
+|
+| Apply me twice.
+EOF
+
+check "(import ./comments.nix).curried2 true false" <<EOF
+| curried2
+| --------
+| 
+| NOTE: This function has already been applied!
+|       You should ignore the first 2 parameter(s) in this documentation,
+|       because they have already been applied.
+|
+| You can give 3 arguments.
+EOF
+
+check "(import ./comments.nix).curried2 true" <<EOF
+| curried2
+| --------
+| 
+| NOTE: This function has already been applied!
+|       You should ignore the first 1 parameter(s) in this documentation,
+|       because they have already been applied.
+|
+| You can give 3 arguments.
+EOF


### PR DESCRIPTION
This provides limited support for python-like docstrings in the `nix repl`. When the user evaluates an expression to a lambda, `nix repl` will now print the contents of a documentation comment, as long the comment written right before the attribute, and the attribute value is an actual lambda.

Current limitations:
 - Overriding the documentation requires redundant lambdas (eta abstraction to be precise)
 - No docstring support for anything other than functions

Demo:

```
nix-repl> pkgs.lib.concatMapStringsSep ":"
«lambda @ /nix/store/ksi72626r14035xkndbn584pmb7l703r-nixos-17.09.1535.1fdca25ee8/nixos/lib/strings.nix:64:30»

| concatMapStringsSep
| -------------------
| 
| NOTE: This function has already been applied!
|       You should ignore the first 1 parameter(s) in this documentation,
|       because they have already been applied.
|
| First maps over the list and then concatenates it.
| 
| Example:
|    concatMapStringsSep "-" (x: toUpper x)  ["foo" "bar" "baz"]
|    => "FOO-BAR-BAZ"


nix-repl>
```

Changes:
 - A new test set, `nix-repl.sh`
 - A new module, `comment.cc` for the documentation retrieval logic
 - Additions to `repl.cc`

Todo:
 - [ ] choose a comment syntax
 - [ ] hide the documentation behind a hint that `:doc` displays the documentation for the function

