### PR TITLE
release.nix: ncurses-bin is no longer required on debian

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -335,7 +335,7 @@ let
       src = jobs.tarball;
       diskImage = (diskImageFun vmTools.diskImageFuns)
         { extraPackages =
-            [ "libsqlite3-dev" "libbz2-dev" "libcurl-dev" "libcurl3-nss" "libssl-dev" "liblzma-dev" "libseccomp-dev" "ncurses-bin" ]
+            [ "libsqlite3-dev" "libbz2-dev" "libcurl-dev" "libcurl3-nss" "libssl-dev" "liblzma-dev" "libseccomp-dev" ]
             ++ extraPackages; };
       memSize = 1024;
       meta.schedulingPriority = 50;


### PR DESCRIPTION
see https://github.com/NixOS/nix/commit/fd10f6f2414521947ca60b9d1508d909f50e9faa#commitcomment-25601381