### PR TITLE
anchor nix::Exit exception

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -369,5 +369,6 @@ PrintFreed::~PrintFreed()
             % showBytes(results.bytesFreed);
 }
 
+Exit::~Exit() { }
 
 }

--- a/src/libmain/shared.hh
+++ b/src/libmain/shared.hh
@@ -17,6 +17,7 @@ public:
     int status;
     Exit() : status(0) { }
     Exit(int status) : status(status) { }
+    virtual ~Exit();
 };
 
 int handleExceptions(const string & programName, std::function<void()> fun);


### PR DESCRIPTION
Fixes problem in my toolchain and generally helps compatibility
to anchor into a single place so there is only 1 typeinfo when throwing cross-DSO.