### PR TITLE
build-remote: Fix missing log output

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -177,7 +177,7 @@ int main (int argc, char * * argv)
                     Activity act(*logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", bestMachine->storeUri));
 
                     Store::Params storeParams;
-                    if (hasPrefix(storeUri, "ssh://")) {
+                    if (hasPrefix(bestMachine->storeUri, "ssh://")) {
                         storeParams["max-connections"] ="1";
                         storeParams["log-fd"] = "4";
                         if (bestMachine->sshKey != "")

--- a/tests/remote-builds.nix
+++ b/tests/remote-builds.nix
@@ -85,7 +85,10 @@ in
       }
 
       # Perform a build and check that it was performed on the slave.
-      my $out = $client->succeed("nix-build ${expr nodes.client.config 1}");
+      my $out = $client->succeed(
+        "nix-build ${expr nodes.client.config 1} 2> build-output",
+        "grep -q Hello build-output"
+      );
       $slave1->succeed("test -e $out");
 
       # And a parallel build.


### PR DESCRIPTION
The `storeUri` variable in the build-remote hook is declared very much to the start of the `main` function and a bunch of lines later, the same variable gets checked via `hasPrefix()` but it gets assigned *after* that check when the most suitable machine for the build was choosen.
    
So I guess this was just a typo in d16fd2497374671c92cb877f9570d65783a7 and what we really want is to either check the prefix *after* assigning `storeUri` or use `bestMachine->storeUri` directly.
    
I choose the latter, because the former could introduce even more regressions if the try block where the variable gets assigned terminates early.
    
Nevertheless, the reason why the log output didn't work is because `hasPrefix()` checked for `ssh://` in front of `storeUri`, but if the `storeUri` isn't set correctly (or at all), we don't get the log file descriptor set up properly, leading to no log output.
    
I've adjusted the remote-builds test to include a regression test for this, so that we can make sure we get a build output when using remote builds.
    
In addition to that I've tested this with two of my build farms and the build logs are emitted correctly again.