### PR TITLE
Fix "Unexpected EOF reading a line" error

### DIFF
--- a/src/buildenv/buildenv.cc
+++ b/src/buildenv/buildenv.cc
@@ -115,9 +115,9 @@ static void addPkg(const Path & pkgDir, int priority)
                 return;
             throw SysError(format("opening '%1%'") % propagatedFN);
         }
-        propagated = readLine(fd.get());
+        propagated = readFile(fd.get());
     }
-    for (const auto & p : tokenizeString<std::vector<string>>(propagated, " "))
+    for (const auto & p : tokenizeString<std::vector<string>>(propagated, " \n"))
         if (done.find(p) == done.end())
             postponed.insert(p);
 }


### PR DESCRIPTION
Fixes #1674.

propagated-user-env-packages files in nixpkgs aren't all terminated by
newlines, as buildenv expected. Now it does not require a terminating
newline; note that this introduces a behaviour change: propagated user
env packages may now be spread across multiple lines. However, nix
1.11.x still expects them to be on a single line so this shouldn't be
used in nixpkgs for now.