### PR TITLE
Show an example default.nix that calls hello.nix

### DIFF
--- a/doc/manual/expressions/arguments-variables.xml
+++ b/doc/manual/expressions/arguments-variables.xml
@@ -113,7 +113,7 @@ hello = callPackage ../applications/misc/hello/ex-1 { stdenv = myStdenv; };
     <filename>default.nix</filename> as follows:</para>
 
 <programlisting>
-(import <nixpkgs> {}).callPackage ./hello.nix {}
+(import &lt;nixpkgs&gt; {}).callPackage ./hello.nix {}
 </programlisting>
 
     <para>This infrastructure allows you to build it as a local

--- a/doc/manual/expressions/arguments-variables.xml
+++ b/doc/manual/expressions/arguments-variables.xml
@@ -105,7 +105,23 @@ hello = callPackage ../applications/misc/hello/ex-1 { };
 hello = callPackage ../applications/misc/hello/ex-1 { stdenv = myStdenv; };
 </programlisting>
 
-    </para></note>
+    </para>
+
+    <para>A useful way to use the callPackage function would be to
+    change the name of the above <filename>default.nix</filename>
+    to <filename>hello.nix</filename> and create a new
+    <filename>default.nix</filename> as follows:</para>
+
+<programlisting>
+(import <nixpkgs> {}).callPackage ./hello.nix {}
+</programlisting>
+
+    <para>This infrastructure allows you to build it as a local
+    package simply by running <literal>nix-build</literal> or drop
+    into a build environment shell with
+    <literal>nix-shell</literal></para>
+
+    </note>
 
   </callout>
 


### PR DESCRIPTION
The existing hello example nix expression shows how to modify `all-packages.nix` to build the package.  I more frequently find myself wanting to build a local package without having to modify `all-packages.nix` in order to accomplish that.  I couldn't figure it out from reading the manual and had to ask on IRC.  It seems like this is probably a common thing, so I thought it would be worth adding to the manual.