### PR TITLE
only send overridden settings to the remote store

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -221,6 +221,10 @@ let
       nix = build.x86_64-linux; system = "x86_64-linux";
     });
 
+    tests.sshStoreBuilds = (import ./tests/ssh-store-builds.nix rec {
+      nix = build.x86_64-linux; system = "x86_64-linux";
+    });
+
     tests.nix-copy-closure = (import ./tests/nix-copy-closure.nix rec {
       nix = build.x86_64-linux; system = "x86_64-linux";
     });

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -664,7 +664,8 @@ HookInstance::HookInstance()
     toHook.readSide = -1;
 
     sink = FdSink(toHook.writeSide.get());
-    for (auto & setting : settings.getSettings())
+    /* Send overridden settings. */
+    for (auto & setting : settings.getSettings(true))
         sink << 1 << setting.first << setting.second;
     sink << 0;
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -159,6 +159,9 @@ void RemoteStore::initConnection(Connection & conn)
 
 void RemoteStore::setOptions(Connection & conn)
 {
+    printMsg(lvlVomit, format("sending options to remote store, verbosity = '%1%'")
+        % verbosity);
+
     conn.to << wopSetOptions
        << settings.keepFailed
        << settings.keepGoing
@@ -175,9 +178,15 @@ void RemoteStore::setOptions(Connection & conn)
 
     if (GET_PROTOCOL_MINOR(conn.daemonVersion) >= 12) {
         auto overrides = settings.getSettings(true);
+        // Don't override the store uri on the remote side.
+        overrides.erase(settings.storeUri.name);
+
         conn.to << overrides.size();
-        for (auto & i : overrides)
+        for (auto & i : overrides) {
+            printMsg(lvlVomit, format("sending setting, %1% = '%2%'")
+                % i.first % i.second);
             conn.to << i.first << i.second;
+        }
     }
 
     conn.processStderr();

--- a/tests/ssh-store-builds.nix
+++ b/tests/ssh-store-builds.nix
@@ -1,0 +1,76 @@
+# Test Nix's remote build feature.
+
+{ system, nix }:
+
+with import <nixpkgs/nixos/lib/testing.nix> { inherit system; };
+
+makeTest (
+
+let
+
+  # Trivial Nix expression to build remotely.
+  expr = config: nr: pkgs.writeText "expr.nix"
+    ''
+      let utils = builtins.storePath ${config.system.build.extraUtils}; in
+      derivation {
+        name = "hello-${toString nr}";
+        system = "i686-linux";
+        PATH = "''${utils}/bin";
+        builder = "''${utils}/bin/sh";
+        args = [ "-c" "if [ ${toString nr} = 5 ]; then echo FAIL; exit 1; fi; echo Hello; mkdir $out $foo; cat /proc/sys/kernel/hostname > $out/host; ln -s $out $foo/bar; sleep 10" ];
+        outputs = [ "out" "foo" ];
+      }
+    '';
+
+in
+
+{
+
+  nodes =
+    { slave =
+        { config, pkgs, ... }:
+        { services.openssh.enable = true;
+          virtualisation.writableStore = true;
+          virtualisation.pathsInNixDB = [ config.system.build.extraUtils ];
+          nix.package = nix;
+          nix.binaryCaches = [ ];
+          nix.useSandbox = true;
+        };
+
+      client =
+        { config, pkgs, ... }:
+        { environment.variables.NIX_REMOTE = "ssh-ng://root@slave?ssh-key=/root/.ssh/id_rsa";
+          virtualisation.writableStore = true;
+          nix.package = nix;
+          nix.binaryCaches = [ ];
+          programs.ssh.extraConfig = "ConnectTimeout 30";
+        };
+    };
+
+  testScript = { nodes }:
+    ''
+      startAll;
+
+      # Create an SSH key on the client.
+      my $key = `${pkgs.openssh}/bin/ssh-keygen -t dsa -f key -N ""`;
+      $client->succeed("mkdir -p -m 700 /root/.ssh");
+      $client->copyFileFromHost("key", "/root/.ssh/id_dsa");
+      $client->succeed("chmod 600 /root/.ssh/id_dsa");
+
+      # Install the SSH key on the slaves.
+      $client->waitForUnit("network.target");
+      $slave->succeed("mkdir -p -m 700 /root/.ssh");
+      $slave->copyFileFromHost("key.pub", "/root/.ssh/authorized_keys");
+      $slave->waitForUnit("sshd");
+      $client->succeed("ssh -o StrictHostKeyChecking=no " . $slave->name() . " 'echo hello world'");
+
+      # Perform a build and check that it was performed on the slave.
+      my $out = $client->succeed(
+        "nix-build ${expr nodes.client.config 1} 2> build-output",
+        "grep -q Hello build-output"
+      );
+      $slave->succeed("test -e $out");
+      $client->succeed("! test -e $out");
+    '';
+
+})


### PR DESCRIPTION
Sending all settings breaks builders with another platform,
since that includes 'system' and other local settings like
'sandbox-paths' that might be different.

Explicit overrides like `nix-build --store ssh-ng://foo --option build-use-sandbox true` still work.