### PR TITLE
Build 1.11 on aarch64-linux

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -7,7 +7,7 @@ let
 
   pkgs = import <nixpkgs> {};
 
-  systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" /* "x86_64-freebsd" "i686-freebsd" */ ];
+  systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" /* "x86_64-freebsd" "i686-freebsd" */ ];
 
 
   jobs = rec {


### PR DESCRIPTION
This way we can start updating the website to include install instructions for 1.11. I tested the build, it worked  just fine :)

(cherry picked from commit da76c72bc9b247092e68411f0bd91ca37c176d0a)