### PR TITLE
nix-hash: Add sentence and example for nix-prefetch-url hash

### DIFF
--- a/doc/manual/command-ref/nix-hash.xml
+++ b/doc/manual/command-ref/nix-hash.xml
@@ -44,7 +44,9 @@
 cryptographic hash of the contents of each
 <replaceable>path</replaceable> and prints it on standard output.  By
 default, it computes an MD5 hash, but other hash algorithms are
-available as well.  The hash is printed in hexadecimal.</para>
+available as well.  The hash is printed in hexadecimal.  To generate
+the same hash as <command>nix-prefetch-url</command> you have to
+specify multiple arguments, see below for an example.</para>
 
 <para>The hash is computed over a <emphasis>serialisation</emphasis>
 of each path: a dump of the file system tree rooted at the path.  This
@@ -121,6 +123,15 @@ cryptographic hash as <literal>nix-store --dump
 
 
 <refsection><title>Examples</title>
+
+<para>Computing the same hash as <command>nix-prefetch-url</command>:
+<screen>
+$ nix-prefetch-url file://<(echo test)
+1lkgqb6fclns49861dwk9rzb6xnfkxbpws74mxnx01z9qyv1pjpj
+$ nix-hash --type sha256 --flat --base32 <(echo test)
+1lkgqb6fclns49861dwk9rzb6xnfkxbpws74mxnx01z9qyv1pjpj
+</screen>
+</para>
 
 <para>Computing hashes:
 


### PR DESCRIPTION
I recently had the problem that I couldn't easily figure out, why `nix-hash` and `nix-prefetch-url` result in different hashes.  Turns out, that there are multiple flags you have to specify, which is not well documented (or at least I could not find it).

Because of that, I added an sentence to the nix-hash documentation and an example as well.

---
### 24 Pull Requests (https://24pullrequests.com) ###
![https://24pullrequests.com](https://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png
)
