### PR TITLE
Fix for builds with system libcurl < 7.30

### DIFF
--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -369,11 +369,13 @@ struct CurlDownloader : public Downloader
 
         curlm = curl_multi_init();
 
-        #if LIBCURL_VERSION_NUM >= 0x072b00 // correct?
+        #if LIBCURL_VERSION_NUM >= 0x072b00 // Multiplex requires >= 7.43.0
         curl_multi_setopt(curlm, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
         #endif
+        #if LIBCURL_VERSION_NUM >= 0x071e00 // Max connections requires >= 7.30.0
         curl_multi_setopt(curlm, CURLMOPT_MAX_TOTAL_CONNECTIONS,
             settings.binaryCachesParallelConnections.get());
+        #endif
 
         enableHttp2 = settings.enableHttp2;
 


### PR DESCRIPTION
CentOS 7.4 and RHEL 7.4 ship with `libcurl-devel-7.29.0-42.el7.x86_64`; this flag
was added in 7.30.0
https://curl.haxx.se/libcurl/c/CURLMOPT_MAX_TOTAL_CONNECTIONS.html

Tangentially related to https://github.com/NixOS/nixpkgs/issues/32320, which tracks some efforts to get the latest Nix working on CentOS 7.4.  To fully get there we need to figure out what to do with c++14 and libsodium, but in the meantime this is a generic fix for any enterprise distribution maintaining an older libcurl for binary compatibility.