### PR TITLE
Fix forward-decl of Bindings as "class", match definition.

### DIFF
--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -6,7 +6,7 @@
 namespace nix {
 
 struct Value;
-struct Bindings;
+class Bindings;
 class EvalState;
 
 /* A command is an argument parser that can be executed by calling its


### PR DESCRIPTION
(appease clang -Wmismatched-tags warning)

NFCI.