### PR TITLE
Add builtins.concatStringSep to the manual

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -134,6 +134,14 @@ if builtins ? getEnv then builtins.getEnv "PATH" else ""</programlisting>
 
   </varlistentry>
 
+  <varlistentry><term><function>builtins.concatStringsSep</function>
+  <replaceable>separator</replaceable> <replaceable>list</replaceable></term>
+
+    <listitem><para>Concatenate a list of strings with a separator
+    between each element, e.g. <literal>concatStringsSep "/"
+    ["usr" "local" "bin"] == "usr/local/bin"</literal></para></listitem>
+
+  </varlistentry>
 
   <varlistentry
   xml:id='builtin-currentSystem'><term><varname>builtins.currentSystem</varname></term>


### PR DESCRIPTION
This addresses at least part of #1653, though I can't say whether any other builtins are missing from the manual.

The text is directly from nixpkgs. https://github.com/NixOS/nixpkgs/blob/41371512e2da3cf8d98d79fcca4649a976e9f52b/lib/strings.nix#L49-L54