### PR TITLE
tests.setuid: only on i686 and x86_64 linuxs

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -225,10 +225,12 @@ let
       nix = build.x86_64-linux; system = "x86_64-linux";
     });
 
-    tests.setuid = pkgs.lib.genAttrs (pkgs.lib.filter (pkgs.lib.hasSuffix "-linux") systems) (system:
-      import ./tests/setuid.nix rec {
-        nix = build.${system}; inherit system;
-      });
+    tests.setuid = pkgs.lib.genAttrs
+      (pkgs.lib.filter (system: system == "x86_64-linux" || system == "i686-linux") systems)
+      (system:
+        import ./tests/setuid.nix rec {
+          nix = build.${system}; inherit system;
+        });
 
     tests.binaryTarball =
       with import <nixpkgs> { system = "x86_64-linux"; };


### PR DESCRIPTION
Please backport to 1.11 as well.