### PR TITLE
don't copy path if it's already a (top-level) store path.

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1542,7 +1542,10 @@ string EvalState::copyPathToStore(PathSet & context, const Path & path)
         throwEvalError("file names are not allowed to end in '%1%'", drvExtension);
 
     Path dstPath;
-    if (srcToStore[path] != "")
+    if (store->isStorePath(path))
+        /* Already a store path. */
+        dstPath = path;
+    else if (srcToStore[path] != "")
         dstPath = srcToStore[path];
     else {
         dstPath = settings.readOnlyMode


### PR DESCRIPTION
Fixes #1728

Assuming there's no reason to do the extra copy.

```
$ nix repl
nix-repl> "${/nix/store/6vjwsyv4il8f9jm3wylbzmbbsa70qc33-hello-2.10}"
"/nix/store/6vjwsyv4il8f9jm3wylbzmbbsa70qc33-hello-2.10"
nix-repl> "${/nix/store/6vjwsyv4il8f9jm3wylbzmbbsa70qc33-hello-2.10/bin/hello}"
"/nix/store/xh98c1bv1fjrggl36dpj3j0wnsay94wp-hello"
```