### PR TITLE
Gracefully handle exceptions from stoi

### DIFF
--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -106,10 +106,16 @@ static void parseJSON(EvalState & state, const char * & s, Value & v)
             tmp_number += *s++;
         }
 
-        if (number_type == tFloat)
-            mkFloat(v, stod(tmp_number));
-        else
-            mkInt(v, stoi(tmp_number));
+        try {
+            if (number_type == tFloat)
+                mkFloat(v, stod(tmp_number));
+            else
+                mkInt(v, stoi(tmp_number));
+        } catch (std::invalid_argument e) {
+            throw JSONParseError("invalid JSON number");
+        } catch (std::out_of_range e) {
+            throw JSONParseError("out-of-range JSON number");
+        }
     }
 
     else if (strncmp(s, "true", 4) == 0) {

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -52,7 +52,12 @@ struct CmdEdit : InstallableCommand
             throw Error("cannot parse meta.position attribute '%s'", pos);
 
         std::string filename(pos, 0, colon);
-        int lineno = std::stoi(std::string(pos, colon + 1));
+        int lineno;
+        try {
+            lineno = std::stoi(std::string(pos, colon + 1));
+        } catch (std::invalid_argument e) {
+            throw Error("cannot parse line number '%s'", pos);
+        }
 
         auto editor = getEnv("EDITOR", "cat");
 


### PR DESCRIPTION
I encountered an exception from `stoi` which I believe was from the JSON parser.