### PR TITLE
release.nix: use 'nixpkgs' argument, even if nixpkgs in NIX_PATH

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,7 +6,7 @@
 
 let
 
-  pkgs = import <nixpkgs> {};
+  pkgs = import nixpkgs {};
 
   jobs = rec {
 
@@ -62,7 +62,7 @@ let
 
     build = pkgs.lib.genAttrs systems (system:
 
-      with import <nixpkgs> { inherit system; };
+      with import nixpkgs { inherit system; };
 
       with import ./release-common.nix { inherit pkgs; };
 
@@ -105,7 +105,7 @@ let
 
     perlBindings = pkgs.lib.genAttrs systems (system:
 
-      let pkgs = import <nixpkgs> { inherit system; }; in with pkgs;
+      let pkgs = import nixpkgs { inherit system; }; in with pkgs;
 
       releaseTools.nixBuild {
         name = "nix-perl";
@@ -131,7 +131,7 @@ let
     binaryTarball = pkgs.lib.genAttrs systems (system:
 
       # FIXME: temporarily use a different branch for the Darwin build.
-      with import <nixpkgs> { inherit system; };
+      with import nixpkgs { inherit system; };
 
       let
         toplevel = builtins.getAttr system jobs.build;
@@ -174,7 +174,7 @@ let
 
 
     coverage =
-      with import <nixpkgs> { system = "x86_64-linux"; };
+      with import nixpkgs { system = "x86_64-linux"; };
 
       releaseTools.coverageAnalysis {
         name = "nix-build";
@@ -231,7 +231,7 @@ let
       });
 
     tests.binaryTarball =
-      with import <nixpkgs> { system = "x86_64-linux"; };
+      with import nixpkgs { system = "x86_64-linux"; };
       vmTools.runInLinuxImage (runCommand "nix-binary-tarball-test"
         { diskImage = vmTools.diskImages.ubuntu1204x86_64;
         }
@@ -250,7 +250,7 @@ let
         ''); # */
 
     tests.evalNixpkgs =
-      import <nixpkgs/pkgs/top-level/make-tarball.nix> {
+      import "${nixpkgs}/pkgs/top-level/make-tarball.nix" {
         inherit nixpkgs;
         inherit pkgs;
         nix = build.x86_64-linux;
@@ -304,7 +304,7 @@ let
   makeRPM =
     system: diskImageFun: extraPackages:
 
-    with import <nixpkgs> { inherit system; };
+    with import nixpkgs { inherit system; };
 
     releaseTools.rpmBuild rec {
       name = "nix-rpm";
@@ -326,7 +326,7 @@ let
   makeDeb =
     system: diskImageFun: extraPackages: extraDebPackages:
 
-    with import <nixpkgs> { inherit system; };
+    with import nixpkgs { inherit system; };
 
     releaseTools.debBuild {
       name = "nix-deb";


### PR DESCRIPTION
When trying to use custom Nix (upstream with my outstanding PR's optimistically merged),
I noticed that overriding the `nixpkgs` argument to `release.nix` doesn't seem to have any impact.
At least not if `nixpkgs` is on `NIX_PATH` (which it usually isn't on Hydra).

Concretely this caused Nix to fail to build since my system's `nixpkgs` doesn't have the new aws bits (I'm on 17.09).

The default value for the argument reads from NIX_PATH and seems to work (happily no recursive definition problems?),
so thought I'd submit it to y'all in case it seems like a good change.
