### PR TITLE
Fix adding paths to the store (try 3)

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1098,13 +1098,12 @@ Path LocalStore::addToStore(const string & name, const Path & _srcPath,
             copyPath(srcPath, dstPath, filter, recursive);
 
             canonicalisePathMetaData(dstPath, -1);
-            HashResult hash = hashPath(htSHA256, dstPath);
             optimisePath(dstPath); // FIXME: combine with hashPath()
 
             ValidPathInfo info;
             info.path = dstPath;
-            info.narHash = hash.first;
-            info.narSize = hash.second;
+            info.narHash = h.first;
+            info.narSize = h.second;
             registerValidPath(info);
         }
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1017,13 +1017,31 @@ void LocalStore::addToStore(const ValidPathInfo & info, const ref<std::string> &
 }
 
 
-Path LocalStore::addToStoreFromDump(const string & dump, const string & name,
-    bool recursive, HashType hashAlgo, RepairFlag repair)
+struct HashAndReadSource : Source
 {
-    Hash h = hashString(hashAlgo, dump);
+    Source & readSource;
+    HashSink hashSink;
+    bool hashing;
+    HashAndReadSource(Source & readSource) : readSource(readSource), hashSink(htSHA256)
+    {
+        hashing = true;
+    }
+    size_t read(unsigned char * data, size_t len)
+    {
+        size_t n = readSource.read(data, len);
+        if (hashing) hashSink(data, n);
+        return n;
+    }
+    HashResult finish()
+    {
+        hashing = false;
+        return hashSink.finish();
+    }
+};
 
-    Path dstPath = makeFixedOutputPath(recursive, h, name);
-
+Path LocalStore::addToStoreFromDump(Source & source, const Path & dstPath,
+    bool recursive, bool repair)
+{
     addTempRoot(dstPath);
 
     if (repair || !isValidPath(dstPath)) {
@@ -1041,32 +1059,17 @@ Path LocalStore::addToStoreFromDump(const string & dump, const string & name,
 
             autoGC();
 
-            if (recursive) {
-                StringSource source(dump);
-                restorePath(realPath, source);
-            } else
-                writeFile(realPath, dump);
-
+            HashAndReadSource hashSource(source);
+            restorePath(realPath, hashSource, recursive);
+            HashResult hash = hashSource.finish();
             canonicalisePathMetaData(realPath, -1);
-
-            /* Register the SHA-256 hash of the NAR serialisation of
-               the path in the database.  We may just have computed it
-               above (if called with recursive == true and hashAlgo ==
-               sha256); otherwise, compute it here. */
-            HashResult hash;
-            if (recursive) {
-                hash.first = hashAlgo == htSHA256 ? h : hashString(htSHA256, dump);
-                hash.second = dump.size();
-            } else
-                hash = hashPath(htSHA256, realPath);
-
             optimisePath(realPath); // FIXME: combine with hashPath()
 
             ValidPathInfo info;
             info.path = dstPath;
             info.narHash = hash.first;
             info.narSize = hash.second;
-            info.ca = makeFixedOutputCA(recursive, h);
+            info.ca = makeFixedOutputCA(recursive, hash.first);
             registerValidPath(info);
         }
 
@@ -1081,17 +1084,34 @@ Path LocalStore::addToStore(const string & name, const Path & _srcPath,
     bool recursive, HashType hashAlgo, PathFilter & filter, RepairFlag repair)
 {
     Path srcPath(absPath(_srcPath));
+    Hash h = recursive ? hashPath(hashAlgo, srcPath, filter).first : hashFile(hashAlgo, srcPath);
+    Path dstPath = makeFixedOutputPath(recursive, h, name);
+    addTempRoot(dstPath);
+    if (repair || !isValidPath(dstPath)) {
 
-    /* Read the whole path into memory. This is not a very scalable
-       method for very large paths, but `copyPath' is mainly used for
-       small files. */
-    StringSink sink;
-    if (recursive)
-        dumpPath(srcPath, sink, filter);
-    else
-        sink.s = make_ref<std::string>(readFile(srcPath));
+        PathLocks outputLock({dstPath});
 
-    return addToStoreFromDump(*sink.s, name, recursive, hashAlgo, repair);
+        if (repair || !isValidPath(dstPath)) {
+
+            if (pathExists(dstPath)) deletePath(dstPath);
+
+            copyPath(srcPath, dstPath, filter, recursive);
+
+            canonicalisePathMetaData(dstPath, -1);
+            HashResult hash = hashPath(htSHA256, dstPath);
+            optimisePath(dstPath); // FIXME: combine with hashPath()
+
+            ValidPathInfo info;
+            info.path = dstPath;
+            info.narHash = hash.first;
+            info.narSize = hash.second;
+            registerValidPath(info);
+        }
+
+        outputLock.setDeletion(true);
+    }
+
+    return dstPath;
 }
 
 
@@ -1139,7 +1159,6 @@ Path LocalStore::addTextToStore(const string & name, const string & s,
 
     return dstPath;
 }
-
 
 /* Create a temporary directory in the store that won't be
    garbage-collected. */

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -152,8 +152,8 @@ public:
        in `dump', which is either a NAR serialisation (if recursive ==
        true) or simply the contents of a regular file (if recursive ==
        false). */
-    Path addToStoreFromDump(const string & dump, const string & name,
-        bool recursive = true, HashType hashAlgo = htSHA256, RepairFlag repair = NoRepair);
+    Path addToStoreFromDump(Source& dump, const Path& dstPath,
+        bool recursive = true, bool repair = false);
 
     Path addTextToStore(const string & name, const string & s,
         const PathSet & references, RepairFlag repair) override;

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -6,7 +6,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION 0x114
+#define PROTOCOL_VERSION 0x115
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -253,7 +253,7 @@ static void parse(ParseSink & sink, Source & source, const Path & path)
                             names[name] = 0;
                     }
                 } else if (s == "node") {
-                    if (s.empty()) throw badArchive("entry name missing");
+                    if (name.empty()) throw badArchive("entry name missing");
                     parse(sink, source, path + "/" + name);
                 } else
                     throw badArchive("unknown field " + s);
@@ -289,10 +289,17 @@ void parseDump(ParseSink & sink, Source & source)
 struct RestoreSink : ParseSink
 {
     Path dstPath;
+    bool recursive;
     AutoCloseFD fd;
+
+    RestoreSink(const Path& dstPath, bool recursive)
+     : dstPath(dstPath), recursive(recursive)
+    {
+    }
 
     void createDirectory(const Path & path)
     {
+        if(!recursive) throw Error("regular file expected");
         Path p = dstPath + path;
         if (mkdir(p.c_str(), 0777) == -1)
             throw SysError(format("creating directory '%1%'") % p);
@@ -336,18 +343,121 @@ struct RestoreSink : ParseSink
 
     void createSymlink(const Path & path, const string & target)
     {
+        if(!recursive) throw Error("regular file expected");
         Path p = dstPath + path;
         nix::createSymlink(target, p);
     }
 };
 
 
-void restorePath(const Path & path, Source & source)
+void restorePath(const Path & path, Source & source, bool recursive)
 {
-    RestoreSink sink;
-    sink.dstPath = path;
+    RestoreSink sink(path, recursive);
     parseDump(sink, source);
 }
 
+static void copyContents(const Path & srcPath, const AutoCloseFD& ofd, size_t size)
+{
+#if HAVE_POSIX_FALLOCATE
+    if (size) {
+        errno = posix_fallocate(ofd.get(), 0, size);
+        /* Note that EINVAL may indicate that the underlying
+            filesystem doesn't support preallocation (e.g. on
+            OpenSolaris).  Since preallocation is just an
+            optimisation, ignore it. */
+        if (errno && errno != EINVAL)
+            throw SysError(format("preallocating file of %1% bytes") % size);
+    }
+#endif
+
+    AutoCloseFD fd = open(srcPath.c_str(), O_RDONLY);
+    if (!fd) throw SysError(format("opening file ‘%1%’") % srcPath);
+
+    // TODO: use sendfile(2) / sendfile64(2) on Linux
+
+    unsigned char buf[65536];
+    size_t left = size;
+
+    while (left > 0) {
+        checkInterrupt();
+        size_t n = left > sizeof(buf) ? sizeof(buf) : left;
+        readFull(fd.get(), buf, n);
+        writeFull(ofd.get(), buf, n);
+        left -= n;
+    }
+}
+
+void copyPath(const Path & srcPath, const Path & dstPath, PathFilter & filter, bool recursive)
+{
+    struct stat st;
+    if (lstat(srcPath.c_str(), &st))
+        throw SysError(format("getting attributes of path ‘%1%’") % srcPath);
+
+    if (S_ISREG(st.st_mode)) {
+        AutoCloseFD ofd = open(dstPath.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0666);
+        if (!ofd) throw SysError(format("creating file ‘%1%’") % dstPath);
+        if (st.st_mode & S_IXUSR) {
+            struct stat ost;
+            if (fstat(ofd.get(), &ost) == -1)
+                throw SysError("fstat");
+            if (fchmod(ofd.get(), ost.st_mode | (S_IXUSR | S_IXGRP | S_IXOTH)) == -1)
+                throw SysError("fchmod");
+        }
+        copyContents(srcPath, ofd.get(), (size_t) st.st_size);
+    }
+    else if (S_ISDIR(st.st_mode)) {
+        if(!recursive) throw Error("regular file expected");
+        if (mkdir(dstPath.c_str(), 0777) == -1)
+            throw SysError(format("creating directory ‘%1%’") % dstPath);
+        /* If we're on a case-insensitive system like Mac OS X, undo
+           the case hack applied by restorePath(). */
+        if (useCaseHack) {
+            std::map<string, string> unhacked;
+            for (auto & i : readDirectory(srcPath)) {
+                string name(i.name);
+                size_t pos = i.name.find(caseHackSuffix);
+                if (pos != string::npos) {
+                    printMsg(lvlDebug, format("removing case hack suffix from ‘%1%’") % (srcPath + "/" + i.name));
+                    name.erase(pos);
+                }
+                if (unhacked.find(name) != unhacked.end())
+                    throw Error(format("file name collision in between ‘%1%’ and ‘%2%’")
+                        % (srcPath + "/" + unhacked[name]) % (srcPath + "/" + i.name));
+                unhacked[name] = i.name;
+            }
+
+            std::map<Path, int, CaseInsensitiveCompare> names;
+            for (auto & i : unhacked)
+                if (filter(srcPath + "/" + i.first)) {
+                    string name = i.first;
+                    if (name.empty() || name.find('/') != string::npos || name.find((char) 0) != string::npos)
+                        throw Error(format("Directory contains invalid file name ‘%1%’") % name);
+                    auto i = names.find(name);
+                    if (i != names.end()) {
+                        printMsg(lvlDebug, format("case collision between ‘%1%’ and ‘%2%’") % i->first % name);
+                        name += caseHackSuffix;
+                        name += std::to_string(++i->second);
+                    } else
+                        names[name] = 0;
+                    copyPath(srcPath + "/" + name, dstPath + "/" + name, filter, recursive);
+                }
+        } else {
+            for (auto & i : readDirectory(srcPath)) {
+                if (filter(srcPath + "/" + i.name)) {
+                    string name = i.name;
+                    if (name.empty() || name.find('/') != string::npos || name.find((char) 0) != string::npos)
+                        throw Error(format("Directory contains invalid file name ‘%1%’") % name);
+                    copyPath(srcPath + "/" + name, dstPath + "/" + name, filter, recursive);
+                }
+            }
+        }
+    }
+    else if (S_ISLNK(st.st_mode)) {
+        if(!recursive) throw Error("regular file expected");
+        Path target = readLink(srcPath);
+        nix::createSymlink(target, dstPath);
+    }
+    else throw Error(format("file ‘%1%’ has an unsupported type") % srcPath);
+}
 
 }

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -72,8 +72,10 @@ struct TeeSink : ParseSink
 
 void parseDump(ParseSink & sink, Source & source);
 
-void restorePath(const Path & path, Source & source);
+void restorePath(const Path & path, Source & source, bool recursive = true);
 
+void copyPath(const Path & srcPath, const Path & dstPath,
+    PathFilter & filter = defaultPathFilter, bool recursive = true);
 
 // FIXME: global variables are bad m'kay.
 extern bool useCaseHack;

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -193,6 +193,12 @@ inline Sink & operator << (Sink & sink, uint64_t n)
     return sink;
 }
 
+
+template< unsigned N >
+Sink & operator << (Sink & sink, const char (&s)[N]) {
+    writeString((const unsigned char*)s, N-1, sink);
+    return sink;
+}
 Sink & operator << (Sink & sink, const string & s);
 Sink & operator << (Sink & sink, const Strings & s);
 Sink & operator << (Sink & sink, const StringSet & s);


### PR DESCRIPTION
This is a rebased version of the patch originally authored by @Mathnerd314 and proposed for merge in #619. It refactors the `addToStore` logic to stream data from the file system, avoiding the need to read potentially large files into memory. Note that this patch, unlike the version initially put forth in #619, incurs no dependency on Boost.

So far this is only build tested. However, I would like review on the overall idea.