### PR TITLE
fetchGit: Fix handling of local repo when not using 'master' branch

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -23,7 +23,7 @@ struct GitInfo
 };
 
 GitInfo exportGit(ref<Store> store, const std::string & uri,
-    std::experimental::optional<std::string> ref, const std::string & rev,
+    std::experimental::optional<std::string> ref, std::string rev,
     const std::string & name)
 {
     if (!ref && rev == "" && hasPrefix(uri, "/") && pathExists(uri + "/.git")) {
@@ -68,6 +68,10 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
 
             return gitInfo;
         }
+
+        // clean working tree, but no ref or rev specified.  Use 'HEAD'.
+        rev = chomp(runProgram("git", true, { "-C", uri, "rev-parse", "HEAD" }));
+        ref = "HEAD"s;
     }
 
     if (!ref) ref = "master"s;


### PR DESCRIPTION
Add tests checking this behavior.

Currently, `fetchGit` behavior does the following when working on a local git checkout (with branches "master" and "dev"):

* `fetchGit ./.`, HEAD=master, clean: -> master
* `fetchGit ./.`, HEAD=master, dirty -> master+changes to tracked files
* `fetchGit ./.`, HEAD=dev, clean -> master **(!!)**
* `fetchGit ./.`, HEAD=dev, dirty -> dev+changes to tracked files

This PR changes behavior so that the item marked **(!!)** above follows the pattern and uses "dev" instead of "master".

This is particularly relevant as of `6d8087083278b078d0db6238fb16929163388acd`: cloning nix, checking out a branch, committing changes, and then using release.nix to test it.... results in building 'master' instead! :confused: 