### PR TITLE
Add CentOS 7.4 builds for 1.11-maintenance nix

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -76,17 +76,3 @@ all: $(d)/manual.html
 clean-files += $(d)/manual.html
 
 dist-files += $(d)/manual.html
-
-
-# Generate the PDF manual.
-$(d)/manual.pdf: $(d)/manual.xml $(MANUAL_SRCS) $(d)/manual.is-valid
-	$(trace-gen) if test "$(dblatex)" != ""; then \
-		cd doc/manual && $(XSLTPROC) --xinclude --stringparam profile.condition manual \
-		  $(docbookxsl)/profiling/profile.xsl manual.xml | \
-		  $(dblatex) -o $(notdir $@) $(dblatex_opts) -; \
-	else \
-		echo "Please install dblatex and rerun configure."; \
-		exit 1; \
-	fi
-
-clean-files += $(d)/manual.pdf

--- a/nix.spec.in
+++ b/nix.spec.in
@@ -6,7 +6,7 @@ Name: nix
 Version: @PACKAGE_VERSION@
 Release: 2%{?dist}
 License: LGPLv2+
-%if 0%{?rhel}
+%if 0%{?rhel} && 0%{?rhel} < 7
 Group: Applications/System
 %endif
 URL: http://nixos.org/
@@ -43,7 +43,7 @@ it can be used equally well under other Unix systems.
 
 %package        devel
 Summary:        Development files for %{name}
-%if 0%{?rhel}
+%if 0%{?rhel} && 0%{?rhel} < 7
 Group:          Development/Libraries
 %endif
 Requires:       %{name}%{?_isa} = %{version}-%{release}
@@ -55,7 +55,7 @@ developing applications that use %{name}.
 
 %package doc
 Summary:        Documentation files for %{name}
-%if 0%{?rhel}
+%if 0%{?rhel} && 0%{?rhel} < 7
 Group:          Documentation
 %endif
 BuildArch:      noarch
@@ -158,7 +158,7 @@ done
 %post
 chgrp %{nixbld_group} /nix/store
 chmod 1775 /nix/store
-%if ! 0%{?rhel}
+%if ! 0%{?rhel} || 0%{?rhel} >= 7
 # Enable and start Nix worker
 systemctl enable nix-daemon.socket nix-daemon.service
 systemctl start  nix-daemon.socket
@@ -170,7 +170,7 @@ systemctl start  nix-daemon.socket
 %{perl_vendorarch}/*
 %exclude %dir %{perl_vendorarch}/auto/
 %{_prefix}/libexec/*
-%if ! 0%{?rhel}
+%if ! 0%{?rhel} || 0%{?rhel} >= 7
 %{_prefix}/lib/systemd/system/nix-daemon.socket
 %{_prefix}/lib/systemd/system/nix-daemon.service
 %endif

--- a/release.nix
+++ b/release.nix
@@ -188,6 +188,7 @@ let
         FONTCONFIG_FILE = texFunctions.fontsConf;
       };
 
+    rpm_centos74x86_64 = makeRPM_x86_64 (diskImageFunsFun: diskImageFunsFun.centos74x86_64) [];
 
     rpm_fedora19i386 = makeRPM_i686 (diskImageFuns: diskImageFuns.fedora19i386) [];
     rpm_fedora19x86_64 = makeRPM_x86_64 (diskImageFunsFun: diskImageFunsFun.fedora19x86_64) [];
@@ -288,6 +289,7 @@ let
           deb_ubuntu1404x86_64 # LTS
           deb_ubuntu1504i386
           deb_ubuntu1504x86_64
+          rpm_centos74x86_64
           rpm_fedora20i386
           rpm_fedora20x86_64
           rpm_fedora21i386

--- a/release.nix
+++ b/release.nix
@@ -25,7 +25,7 @@ let
 
         buildInputs =
           [ curl bison flex perl libxml2 libxslt bzip2 xz
-            dblatex (dblatex.tex or tetex) nukeReferences pkgconfig sqlite libsodium
+            pkgconfig sqlite libsodium
             docbook5 docbook5_xsl
           ] ++ lib.optional stdenv.isLinux libseccomp
           ++ lib.optional (!lib.inNixShell) git;
@@ -58,20 +58,7 @@ let
 
         preDist = ''
           make install docdir=$out/share/doc/nix makefiles=doc/manual/local.mk
-
-          make doc/manual/manual.pdf
-          cp doc/manual/manual.pdf $out/manual.pdf
-
-          # The PDF containes filenames of included graphics (see
-          # http://www.tug.org/pipermail/pdftex/2007-August/007290.html).
-          # This causes a retained dependency on dblatex, which Hydra
-          # doesn't like (the output of the tarball job is distributed
-          # to Windows and Macs, so there should be no Linux binaries
-          # in the closure).
-          nuke-refs $out/manual.pdf
-
           echo "doc manual $out/share/doc/nix/manual" >> $out/nix-support/hydra-build-products
-          echo "doc-pdf manual $out/manual.pdf" >> $out/nix-support/hydra-build-products
         '';
       };
 


### PR DESCRIPTION
Now that we have a [Centos 7.4 VM image](https://github.com/NixOS/nixpkgs/pull/32278), a handful of contributors have started a wider effort to get the [master nix packaged for enterprise linux](https://github.com/NixOS/nixpkgs/issues/32900).  

While that's a non-trivial effort and may even be fundamentally misguided given that the resulting RPM will have dependencies on other package distributions and a different ABI, in the meantime it turns out that the stable branch of nix builds on RHEL/CentOS 7.4 without any necessary modifications, aside from a minor backport of the RPM macro logic update to distinguish el6 from el7.  Fortunately it was just a light touch, since eventually this will all be replaced with @abbradar's [nice work cleaning up the RPM packaging](https://github.com/NixOS/nix/pull/1141).

This at least lets us get some coverage on Hydra build products for users interested in using nix in enterprise environments.  I'm not sure if it's standard practice to add new releases to a maintenance branch (I see @grahamc added `aarch64` last week, but I'd imagine that's atypical).  Either way this PR at least shows users that it's not hard to build a nix RPM for `el7`.


Builds with nixpkgs from before the [dblatex update last week](https://github.com/NixOS/nixpkgs/pull/30332); as it currently stands stable nix's documentation does not build with master nixpkgs until we [upgrade dblatex](https://github.com/NixOS/nixpkgs/pull/32989).

```
$ nix-build release.nix -A rpm_centos74x86_64
...
[  251.473427] reboot: Power down
/nix/store/5vaa1pvbn0gy9pkqn00ff2f9wpj24ic3-nix-rpm-centos-7.4-x86_64-1.11.17pre1234_abcdef
$ tree result
result
├── nix-support
│   ├── full-name
│   └── hydra-build-products
└── rpms
    └── centos-7.4-x86_64
        ├── emacs-nix-1.11.17pre1234_abcdef-2.el7.centos.noarch.rpm
        ├── emacs-nix-el-1.11.17pre1234_abcdef-2.el7.centos.noarch.rpm
        ├── nix-1.11.17pre1234_abcdef-2.el7.centos.src.rpm
        ├── nix-1.11.17pre1234_abcdef-2.el7.centos.x86_64.rpm
        ├── nix-debuginfo-1.11.17pre1234_abcdef-2.el7.centos.x86_64.rpm
        ├── nix-devel-1.11.17pre1234_abcdef-2.el7.centos.x86_64.rpm
        └── nix-doc-1.11.17pre1234_abcdef-2.el7.centos.noarch.rpm

3 directories, 9 files
```