### PR TITLE
run.sh: include lib64 in sandbox-paths to fix on ubuntu 16.XX

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,10 +18,10 @@ if [[ $(uname) = Linux ]]; then
     # Note: we need the sandbox paths to ensure that the shell is
     # visible in the sandbox.
     nix run --sandbox-build-dir /build-tmp \
-        --sandbox-paths '/nix? /bin? /lib? /usr?' \
+        --sandbox-paths '/nix? /bin? /lib? /lib64? /usr?' \
         --store $TEST_ROOT/store0 -f run.nix hello -c hello | grep 'Hello World'
 
-    path2=$(nix run --sandbox-paths '/nix? /bin? /lib? /usr?' --store $TEST_ROOT/store0 -f run.nix hello -c $SHELL -c 'type -p hello')
+    path2=$(nix run --sandbox-paths '/nix? /bin? /lib? /lib64? /usr?' --store $TEST_ROOT/store0 -f run.nix hello -c $SHELL -c 'type -p hello')
 
     [[ $path/bin/hello = $path2 ]]
 


### PR DESCRIPTION
(cc #1769)

Without this, build fails because /bin/bash uses interpreter from /lib64:

```
$ file /bin/bash
/bin/bash: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=82a83d5728a8d493dd12d951144cf6554b075068, stripped
```