### PR TITLE
nix-env.cc: make `--query` evaluate `.outPath`s

### DIFF
--- a/doc/manual/command-ref/nix-env.xml
+++ b/doc/manual/command-ref/nix-env.xml
@@ -877,11 +877,6 @@ $ nix-env --set-flag priority 10 gcc</screen>
     <arg choice='plain'><option>--available</option></arg>
     <arg choice='plain'><option>-a</option></arg>
   </group>
-  <group choice='opt'>
-    <arg choice='plain'><option>--all</option></arg>
-    <arg choice='plain'><option>--approximate</option></arg>
-    <arg choice='plain'><option>--strict</option></arg>
-  </group>
 
   <sbr />
 

--- a/doc/manual/command-ref/nix-env.xml
+++ b/doc/manual/command-ref/nix-env.xml
@@ -877,6 +877,11 @@ $ nix-env --set-flag priority 10 gcc</screen>
     <arg choice='plain'><option>--available</option></arg>
     <arg choice='plain'><option>-a</option></arg>
   </group>
+  <group choice='opt'>
+    <arg choice='plain'><option>--all</option></arg>
+    <arg choice='plain'><option>--approximate</option></arg>
+    <arg choice='plain'><option>--strict</option></arg>
+  </group>
 
   <sbr />
 

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -464,6 +464,9 @@ static void installDerivations(Globals & globals,
 
     StringSet newNames;
     for (auto & i : newElems) {
+        /* Evaluate (and possibly fail) now before giving any mixed signals to the user. */
+        i.queryOutPath();
+
         /* `forceName' is a hack to get package names right in some
            one-click installs, namely those where the name used in the
            path is not the one we want (e.g., `java-front' versus


### PR DESCRIPTION
NixOS/nixpkgs#33057 delays `stdenv.mkDerivation` derivation checks (e.g.
meta, brokennes, etc) to `.drvPath` and `.outPath` evaluation leaving
other fields accessible. That has a side-effect of making `nix-env -qa`
list broken packages.

This patch forces those checks.