### PR TITLE
Fix RPM builds by increasing VM memory size

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -313,7 +313,7 @@ let
         { extraPackages =
             [ "sqlite" "sqlite-devel" "bzip2-devel" "libcurl-devel" "openssl-devel" "xz-devel" "libseccomp-devel" ]
             ++ extraPackages; };
-      memSize = 1024;
+      memSize = 2048;
       meta.schedulingPriority = 50;
       postRPMInstall = "cd /tmp/rpmout/BUILD/nix-* && make installcheck";
       #enableParallelBuilding = true;


### PR DESCRIPTION
The VM was running out of RAM while handling debug symbols, which caused `eu-strip` to fail while separating debug symbols.

```
$ nix-build -A rpm_fedora25x86_64
```
now succeeds!