### PR TITLE
Fix Fedora 25 i386 RPM build

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -313,7 +313,8 @@ let
         { extraPackages =
             [ "sqlite" "sqlite-devel" "bzip2-devel" "libcurl-devel" "openssl-devel" "xz-devel" "libseccomp-devel" ]
             ++ extraPackages; };
-      memSize = 2048;
+      # At most 2047MB can be simulated in qemu-system-i386
+      memSize = 2047;
       meta.schedulingPriority = 50;
       postRPMInstall = "cd /tmp/rpmout/BUILD/nix-* && make installcheck";
       #enableParallelBuilding = true;


### PR DESCRIPTION
In PR #1773, we fixed the RPM build for Fedora x86_64, and for the first time in many weeks it suceeded on Hydra!
https://hydra.nixos.org/job/nix/master/rpm_fedora25x86_64

However, this broke the 32-bit build, since QEMU can only simulate up to 2047MB.
https://hydra.nixos.org/build/67176958/nixlog/1

Tested this time with:
```
$ nix-build release.nix -A rpm_fedora25x86_64 
$ nix-build release.nix -A rpm_fedora25i386
```
both of which now succeed.