### PR TITLE
do not make Thunks for ExprLambda

### DIFF
--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -241,6 +241,7 @@ struct ExprLambda : Expr
     void setName(Symbol & name);
     string showNamePos() const;
     COMMON_METHODS
+    virtual Value * maybeThunk(EvalState & state, Env & env) { return eval(state, env); }
 };
 
 struct ExprLet : Expr


### PR DESCRIPTION
It is senseless to make Thunks for ExprLambda, as a Lambda Value does nothing else than a Thunk Value: it stores pointers to Expr and Env.
Eager evaluation of ExprLambda saves some memory and CPU clocks.