### PR TITLE
nix-daemon.sh: Export MANPATH

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -52,3 +52,7 @@ fi
 export NIX_SSL_CERT_FILE="@localstatedir@/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
 export NIX_PATH="@localstatedir@/nix/profiles/per-user/root/channels"
 export PATH="$HOME/.nix-profile/bin:$HOME/.nix-profile/lib/kde4/libexec:@localstatedir@/nix/profiles/default/bin:@localstatedir@/nix/profiles/default:@localstatedir@/nix/profiles/default/lib/kde4/libexec:$PATH"
+
+if [ -n $MANPATH ]; then
+    export MANPATH="$HOME/.nix-profile/share/man:@localstatedir@/nix/var/nix/profiles/default/share/man:$MANPATH"
+fi


### PR DESCRIPTION
As Darwin installation defaults to multi-user, `nix-daemon.sh` is sourced instead of `nix.sh`. However MANPATHs are not exported, causing not-found failures when invoking `nix-env --help` (or other `nix-*` commands) and `man <cmd>` where `<cmd>` is any program installed via nix. Related issue [here](https://github.com/NixOS/nixpkgs/issues/23601#issuecomment-355757630).

Suggestions welcome as I am currently just starting out with nix :)