### PR TITLE
 Add setPathName primop to copy paths to the store with a given name.

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -84,7 +84,11 @@ static void printValue(std::ostream & str, std::set<const Value *> & active, con
         str << "\"";
         break;
     case tPath:
-        str << v.path; // !!! escaping?
+        if (v.path.name)
+            str << "(builtins.setPathName ";
+        str << v.path.p; // !!! escaping?
+        if (v.path.name)
+            str << " " << v.path.name << ")";
         break;
     case tNull:
         str << "null";
@@ -1488,8 +1492,11 @@ string EvalState::coerceToString(const Pos & pos, Value & v, PathSet & context,
     }
 
     if (v.type == tPath) {
-        Path path(canonPath(v.path));
-        return copyToStore ? copyPathToStore(context, path) : path;
+        return copyToStore
+            ? copyPathToStore(context, v.path.p, v.path.name
+                ? v.path.name
+                : baseNameOf(v.path.p))
+            : v.path.p;
     }
 
     if (v.type == tAttrs) {
@@ -1536,19 +1543,20 @@ string EvalState::coerceToString(const Pos & pos, Value & v, PathSet & context,
 }
 
 
-string EvalState::copyPathToStore(PathSet & context, const Path & path)
+string EvalState::copyPathToStore(PathSet & context, const Path & path, const string & name)
 {
-    if (nix::isDerivation(path))
+    if (nix::isDerivation(name))
         throwEvalError("file names are not allowed to end in '%1%'", drvExtension);
 
     Path dstPath;
-    if (srcToStore[path] != "")
-        dstPath = srcToStore[path];
+    auto cacheKey = std::pair<Path, string>(path, name);
+    if (srcToStore[cacheKey] != "")
+        dstPath = srcToStore[cacheKey];
     else {
         dstPath = settings.readOnlyMode
-            ? store->computeStorePathForPath(checkSourcePath(path)).first
-            : store->addToStore(baseNameOf(path), checkSourcePath(path), true, htSHA256, defaultPathFilter, repair);
-        srcToStore[path] = dstPath;
+            ? store->computeStorePathForPath(checkSourcePath(path), name).first
+            : store->addToStore(name, checkSourcePath(path), true, htSHA256, defaultPathFilter, repair);
+        srcToStore[cacheKey] = dstPath;
         printMsg(lvlChatty, format("copied source '%1%' -> '%2%'")
             % path % dstPath);
     }
@@ -1598,7 +1606,23 @@ bool EvalState::eqValues(Value & v1, Value & v2)
             return strcmp(v1.string.s, v2.string.s) == 0;
 
         case tPath:
-            return strcmp(v1.path, v2.path) == 0;
+            if (strcmp(v1.path.p, v2.path.p) == 0) {
+                if (v1.path.name) {
+                    if (v2.path.name) {
+                        return strcmp(v1.path.name, v2.path.name) == 0;
+                    } else {
+                        return v1.path.name == baseNameOf(v2.path.p);
+                    }
+                } else {
+                    if (v2.path.name) {
+                        return v2.path.name == baseNameOf(v1.path.p);
+                    } else {
+                        return true;
+                    }
+                }
+            } else {
+                return false;
+            }
 
         case tNull:
             return true;
@@ -1749,7 +1773,9 @@ size_t valueSize(Value & v)
                     sz += doString(*p);
             break;
         case tPath:
-            sz += doString(v.path);
+            sz += doString(v.path.p);
+            if (v.path.name)
+                sz += doString(v.path.name);
             break;
         case tAttrs:
             if (seen.find(v.attrs) == seen.end()) {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -47,7 +47,7 @@ void copyContext(const Value & v, PathSet & context);
 
 /* Cache for calls to addToStore(); maps source paths to the store
    paths. */
-typedef std::map<Path, Path> SrcToStore;
+typedef std::map<std::pair<Path, std::string>, Path> SrcToStore;
 
 
 std::ostream & operator << (std::ostream & str, const Value & v);
@@ -179,7 +179,7 @@ public:
     string coerceToString(const Pos & pos, Value & v, PathSet & context,
         bool coerceMore = false, bool copyToStore = true);
 
-    string copyPathToStore(PathSet & context, const Path & path);
+    string copyPathToStore(PathSet & context, const Path & path, const string & name);
 
     /* Path coercion.  Converts strings, paths and derivations to a
        path.  The result is guaranteed to be a canonicalised, absolute

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -376,7 +376,7 @@ expr_simple
       $$ = stripIndentation(CUR_POS, data->symbols, *$2);
   }
   | PATH { $$ = new ExprPath(absPath($1, data->basePath)); }
-  | HPATH { $$ = new ExprPath(getHome() + string{$1 + 1}); }
+  | HPATH { $$ = new ExprPath(canonPath(getHome() + string{$1 + 1})); }
   | SPATH {
       string path($1 + 1, strlen($1) - 2);
       $$ = new ExprApp(CUR_POS,

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -32,7 +32,9 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
 
         case tPath:
-            out.write(state.copyPathToStore(context, v.path));
+            out.write(state.copyPathToStore(context, v.path.p, v.path.name
+                    ? v.path.name
+                    : baseNameOf(v.path.p)));
             break;
 
         case tNull:

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -75,8 +75,15 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
             break;
 
         case tPath:
-            doc.writeEmptyElement("path", singletonAttrs("value", v.path));
+        {
+            XMLAttrs attrs;
+            attrs["value"] = v.path.p;
+            if (v.path.name) {
+                attrs["name"] = v.path.name;
+            }
+            doc.writeEmptyElement("path", attrs);
             break;
+        }
 
         case tNull:
             doc.writeEmptyElement("null");

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -126,7 +126,10 @@ struct Value
             const char * * context; // must be in sorted order
         } string;
 
-        const char * path;
+        struct {
+            const char * p;
+            const char * name; // If null, use p's basename
+        } path;
         Bindings * attrs;
         struct {
             unsigned int size;
@@ -251,7 +254,8 @@ static inline void mkPathNoCopy(Value & v, const char * s)
     assert(s == canonPath(s));
     clearValue(v);
     v.type = tPath;
-    v.path = s;
+    v.path.p = s;
+    v.path.name = nullptr;
 }
 
 

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "symbol-table.hh"
+#include "util.hh"
 
 #if HAVE_BOEHMGC
 #include <gc/gc_allocator.h>
@@ -247,6 +248,7 @@ void mkString(Value & v, const char * s);
 
 static inline void mkPathNoCopy(Value & v, const char * s)
 {
+    assert(s == canonPath(s));
     clearValue(v);
     v.type = tPath;
     v.path = s;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -223,10 +223,10 @@ Path Store::makeTextPath(const string & name, const Hash & hash,
 
 
 std::pair<Path, Hash> Store::computeStorePathForPath(const Path & srcPath,
+    const string & name,
     bool recursive, HashType hashAlgo, PathFilter & filter) const
 {
     Hash h = recursive ? hashPath(hashAlgo, srcPath, filter).first : hashFile(hashAlgo, srcPath);
-    string name = baseNameOf(srcPath);
     Path dstPath = makeFixedOutputPath(recursive, h, name);
     return std::pair<Path, Hash>(dstPath, h);
 }

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -306,6 +306,7 @@ public:
        store path to which srcPath is to be copied.  Returns the store
        path and the cryptographic hash of the contents of srcPath. */
     std::pair<Path, Hash> computeStorePathForPath(const Path & srcPath,
+        const string & name,
         bool recursive = true, HashType hashAlgo = htSHA256,
         PathFilter & filter = defaultPathFilter) const;
 

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -554,7 +554,13 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         break;
 
     case tPath:
-        str << ESC_GRE << v.path << ESC_END; // !!! escaping?
+        str << ESC_GRE;
+        if (v.path.name)
+            str << "(builtins.setPathName ";
+        str << v.path.p; // !!! escaping?
+        if (v.path.name)
+            str << " " << v.path.name << ")";
+        str << ESC_END;
         break;
 
     case tNull:

--- a/tests/lang/eval-okay-setPathName.nix
+++ b/tests/lang/eval-okay-setPathName.nix
@@ -1,0 +1,2 @@
+let path = ./. + "/setPathName@invalid-name";
+in "${builtins.setPathName path "valid-name"}"


### PR DESCRIPTION
In some situations, relative paths in nix expressions resolve to paths
with names that are uninformative or, worse, unrepresentable in the
nix store. For example, one jenkins plugin for parallel building
starts each build in a directory named like `foo@1`, which then can't
causes nix to fail to add the path to the store when referenced with
`./.`. With setPathName, this can be fixed without modifying the
surrounding build infrastructure.