### PR TITLE
fix git cache 'corruption' when git not available, breaks all future use of fetchGit

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -85,7 +85,6 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
     Path cacheDir = getCacheDir() + "/nix/git";
 
     if (!pathExists(cacheDir)) {
-        createDirs(cacheDir);
         runProgram("git", true, { "init", "--bare", cacheDir });
     }
 

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -119,3 +119,16 @@ path4=$(nix eval --raw "(builtins.fetchGit $repo).outPath")
 # Confirm same as 'dev' branch
 path5=$(nix eval --raw "(builtins.fetchGit { url = $repo; ref = \"dev\"; }).outPath")
 [[ $path3 = $path5 ]]
+
+
+# Nuke the cache
+rm -rf $TEST_HOME/.cache/nix/git
+
+# Try again, but without 'git' on PATH
+NIX=$(command -v nix)
+# This should fail
+(! PATH= $NIX eval --raw "(builtins.fetchGit { url = $repo; ref = \"dev\"; }).outPath" )
+
+# Try again, with 'git' available.  This should work.
+path5=$(nix eval --raw "(builtins.fetchGit { url = $repo; ref = \"dev\"; }).outPath")
+[[ $path3 = $path5 ]]


### PR DESCRIPTION
There's no guarantee `git` exists anywhere on the system-- I ran into this yesterday while trying to use 1.12 on a fresh server, for example.

Before this fix (see test) attempts to use `fetchGit` create broken `cache` directory and caused all subsequent invocations involving `fetchGit`--after installing git-- to fail until I nuked the cache.