### PR TITLE
release: access fetchGit from builtins to fix parsing w/1.11 (<1.12)

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,4 @@
-{ nix ? fetchGit ./.
+{ nix ? builtins.fetchGit ./.
 , nixpkgs ? fetchTarball channel:nixos-17.09
 , officialRelease ? false
 , systems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ]


### PR DESCRIPTION
Currently nix "stable" (tested with 1.11.16) aborts when trying to process release.nix:

```
$ nix-instantiate --parse-only release.nix
error: undefined variable ‘fetchGit’ at /path/to/nix/src/release.nix:1:9
```

This PR accesses `fetchGit` through `builtins` so that `release.nix` parses,
and can be evaluated with 1.11 if proper `nix` and `nixpkgs` arguments are provided.