### PR TITLE
nix log: use pager

### DIFF
--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -50,6 +50,7 @@ struct CmdLog : InstallableCommand
 
         auto b = installable->toBuildable();
 
+        RunPager pager;
         for (auto & sub : subs) {
             auto log = b.drvPath != "" ? sub->getBuildLog(b.drvPath) : nullptr;
             for (auto & output : b.outputs) {


### PR DESCRIPTION
Matches what `nix-store -l` does, and is rather convenient :).

Also A+ for a codebase where making this change is so easy :+1:.