### PR TITLE
Fix tests using user namespaces on kernels that don't have it

### DIFF
--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -2,7 +2,7 @@ source common.sh
 
 clearStore
 
-if [[ $(uname) != Linux ]]; then exit; fi
+if ! canUseSandbox; then exit; fi
 if [[ ! $SHELL =~ /nix/store ]]; then exit; fi
 
 chmod -R u+w $TEST_ROOT/store0 || true

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -87,6 +87,24 @@ killDaemon() {
     trap "" EXIT
 }
 
+canUseSandbox() {
+    if [[ $(uname) != Linux ]]; then return 1; fi
+
+    if [ ! -L /proc/self/ns/user ]; then
+        echo "Kernel doesn't support user namespaces, skipping this test..."
+        return 1
+    fi
+
+    if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
+        if [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" != 1 ]; then
+            echo "Unprivileged user namespaces disabled by sysctl, skipping this test..."
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
 fail() {
     echo "$1"
     exit 1

--- a/tests/linux-sandbox.sh
+++ b/tests/linux-sandbox.sh
@@ -2,7 +2,7 @@ source common.sh
 
 clearStore
 
-if [[ $(uname) != Linux ]]; then exit; fi
+if ! canUseSandbox; then exit; fi
 
 # Note: we need to bind-mount $SHELL into the chroot. Currently we
 # only support the case where $SHELL is in the Nix store, because

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,24 +6,23 @@ clearCache
 nix run -f run.nix hello -c hello | grep 'Hello World'
 nix run -f run.nix hello -c hello NixOS | grep 'Hello NixOS'
 
-if [[ $(uname) = Linux ]]; then
+if ! canUseSandbox; then exit; fi
 
-    chmod -R u+w $TEST_ROOT/store0 || true
-    rm -rf $TEST_ROOT/store0
+chmod -R u+w $TEST_ROOT/store0 || true
+rm -rf $TEST_ROOT/store0
 
-    clearStore
+clearStore
 
-    path=$(nix eval --raw -f run.nix hello)
+path=$(nix eval --raw -f run.nix hello)
 
-    # Note: we need the sandbox paths to ensure that the shell is
-    # visible in the sandbox.
-    nix run --sandbox-build-dir /build-tmp \
-        --sandbox-paths '/nix? /bin? /lib? /lib64? /usr?' \
-        --store $TEST_ROOT/store0 -f run.nix hello -c hello | grep 'Hello World'
+# Note: we need the sandbox paths to ensure that the shell is
+# visible in the sandbox.
+nix run --sandbox-build-dir /build-tmp \
+    --sandbox-paths '/nix? /bin? /lib? /lib64? /usr?' \
+    --store $TEST_ROOT/store0 -f run.nix hello -c hello | grep 'Hello World'
 
-    path2=$(nix run --sandbox-paths '/nix? /bin? /lib? /lib64? /usr?' --store $TEST_ROOT/store0 -f run.nix hello -c $SHELL -c 'type -p hello')
+path2=$(nix run --sandbox-paths '/nix? /bin? /lib? /lib64? /usr?' --store $TEST_ROOT/store0 -f run.nix hello -c $SHELL -c 'type -p hello')
 
-    [[ $path/bin/hello = $path2 ]]
+[[ $path/bin/hello = $path2 ]]
 
-    [[ -e $TEST_ROOT/store0/nix/store/$(basename $path)/bin/hello ]]
-fi
+[[ -e $TEST_ROOT/store0/nix/store/$(basename $path)/bin/hello ]]


### PR DESCRIPTION
Disable various tests if the kernel doesn't support unprivileged user
namespaces (e.g. Arch Linux disables them) or disable them via a sysctl
(Debian, Ubuntu).

Fixes #1521
Fixes #1625