### PR TITLE
Rewrite builtin:fetchurl output paths

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -337,7 +337,8 @@ Path EvalState::checkSourcePath(const Path & path_)
 {
     if (!allowedPaths) return path_;
 
-    auto doThrow = [&]() [[noreturn]] {
+    // This originally had [[noreturn]] on it, but clang barfs on that, so we'll get a warning until it learns
+    auto doThrow = [&]() {
         throw RestrictedPathError("access to path '%1%' is forbidden in restricted mode", path_);
     };
 

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2933,8 +2933,11 @@ void DerivationGoal::runChild()
         if (drv->isBuiltin()) {
             try {
                 logger = makeJSONLogger(*logger);
-                if (drv->builder == "builtin:fetchurl")
-                    builtinFetchurl(*drv, netrcData);
+                if (drv->builder == "builtin:fetchurl") {
+                    /* fetchurl might need to rewrite its outputs, so let's pass in a closure to rewrite anythings */
+                    auto rewriter = [&](const std::string & in) { return rewriteStrings(in, inputRewrites); };
+                    builtinFetchurl(*drv, netrcData, rewriter);
+                }
                 else
                     throw Error(format("unsupported builtin function '%1%'") % string(drv->builder, 8));
                 _exit(0);

--- a/src/libstore/builtins.cc
+++ b/src/libstore/builtins.cc
@@ -6,7 +6,7 @@
 
 namespace nix {
 
-void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
+void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData, std::function<std::string(const std::string &)> rewriteStrings)
 {
     /* Make the host's netrc data available. Too bad curl requires
        this to be stored in a file. It would be nice if we could just
@@ -52,7 +52,7 @@ void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
 
     if (!data) data = fetch(getAttr("url"));
 
-    Path storePath = getAttr("out");
+    Path storePath = rewriteStrings(getAttr("out"));
 
     auto unpack = drv.env.find("unpack");
     if (unpack != drv.env.end() && unpack->second == "1") {

--- a/src/libstore/builtins.hh
+++ b/src/libstore/builtins.hh
@@ -4,6 +4,6 @@
 
 namespace nix {
 
-void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData);
+void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData, std::function<std::string(const std::string &)> rewriteStrings);
 
 }


### PR DESCRIPTION
This was failing when it needed redirected outputs, such as when calling a build with --check on a fixed-output derivation that used the builtin fetchurl.

Fixes #1803 

cc @edolstra @shlevy @domenkozar 