### PR TITLE
Add git to source tarball buildInputs

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -23,7 +23,7 @@ let
 
         buildInputs =
           [ curl bison flex libxml2 libxslt
-            bzip2 xz brotli
+            bzip2 xz brotli git
             pkgconfig sqlite libsodium boehmgc
             docbook5 docbook5_xsl
             autoconf-archive


### PR DESCRIPTION
Fixes

```
$ nix build binaryTarball.x86_64-linux -f release.nix
builder for
'/nix/store/kmybvm9zzd3wyxwdklmxqwnbf88zagfg-nix-tarball-1.12pre5779_cd74a55.drv'
failed with exit code 2; last 10 log lines:
    INST   /build/tmp_prefix/share/man/man1/nix-copy-closure.1
    MKDIR  /build/tmp_prefix/share/man/man5/
    INST   /build/tmp_prefix/share/man/man5/nix.conf.5
    MKDIR  /build/tmp_prefix/share/man/man8/
    INST   /build/tmp_prefix/share/man/man8/nix-daemon.8
  /bin/sh: git: command not found
    GEN    src/libstore/schema.sql.gen.hh
    GEN    nix.spec
  make: *** No rule to make target 'src/nlohmann/json.hpp', needed by
'nix-1.12pre5779_cd74a55.tar.bz2'.  Stop.
  build time elapsed:  0m0.267s 0m0.476s 0m19.914s 0m7.074s
cannot build derivation
'/nix/store/5fv03zrnipjn07kqlzccjncjv552r319-nix-1.12pre5779_cd74a55.drv':
1 dependencies couldn't be built
cannot build derivation
'/nix/store/hlip12bv0byrwcwfh22ss03vgm9iyps3-nix-binary-tarball-1.12pre5779_cd74a55.drv':
1 dependencies couldn't be built
[0 built (1 failed), 17 copied (22.5 MiB), 13.2 MiB DL]
error: build of
'/nix/store/hlip12bv0byrwcwfh22ss03vgm9iyps3-nix-binary-tarball-1.12pre5779_cd74a55.drv'
failed
```