### PR TITLE
HttpBinaryCacheStore: Support upsertFile with PUT.

### DIFF
--- a/src/libstore/download.hh
+++ b/src/libstore/download.hh
@@ -18,9 +18,11 @@ struct DownloadRequest
     unsigned int baseRetryTimeMs = 250;
     ActivityId parentAct;
     bool decompress = true;
+    std::shared_ptr<std::string> data;
+    std::string mimeType;
 
-    DownloadRequest(const std::string & uri)
-        : uri(uri), parentAct(curActivity) { }
+    DownloadRequest(const std::string & uri, std::shared_ptr<std::string> data = nullptr, std::string mimeType = "")
+        : uri(uri), parentAct(curActivity), data(std::move(data)), mimeType(std::move(mimeType)) { }
 };
 
 struct DownloadResult

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -67,7 +67,13 @@ protected:
         const std::string & data,
         const std::string & mimeType) override
     {
-        throw UploadToHTTP("uploading to an HTTP binary cache is not supported");
+        auto data_ = std::make_shared<string>(data);
+        auto req = DownloadRequest(cacheUri + "/" + path, data_, mimeType);
+        try {
+            getDownloader()->download(req);
+        } catch (DownloadError & e) {
+            throw UploadToHTTP(format("uploading to HTTP binary cache at %1% not supported: %2%") % cacheUri % e.msg());
+        }
     }
 
     void getFile(const std::string & path,


### PR DESCRIPTION
Some servers, such as Artifactory, allow uploading with PUT and BASIC
auth. This allows nix copy to work to upload binaries to those
servers.

Worked on together with @adelbertc