### PR TITLE
Fix macOS installation when umask disallow public read (solves #1582)

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -695,7 +695,7 @@ install_from_extracted_nix() {
         cd "$EXTRACTED_NIX_PATH"
 
         _sudo "to copy the basic Nix files to the new store at $NIX_ROOT/store" \
-              rsync -rlpt "$(pwd)/store/" "$NIX_ROOT/store/"
+              rsync -rlpt ./store/* "$NIX_ROOT/store/"
 
         if [ -d "$NIX_INSTALLED_NIX" ]; then
             echo "      Alright! We have our first nix at $NIX_INSTALLED_NIX"


### PR DESCRIPTION
#1582 happens when the user running the install has an umask that disallows public read (eg: `umask 0027`).

`/nix/store` is created  with `mkdir -pv -m 1775 /nix/store`, but then `rsync -rlpt "$(pwd)/store/" "$NIX_ROOT/store/"` syncs the permissions on `/nix/store` to those of `$(pwd)/store/`.

Replacing `rsync -rlpt "$(pwd)/store/" "$NIX_ROOT/store/"` with `rsync -rlpt ./store/* "$NIX_ROOT/store/"` solves the issue by syncing the *contents* of `./store` instead of the folder itself (of course `.` is the same as `$(pwd)`, just clearer imho).
