### PR TITLE
release-common: use shell from nixpkgs, provide fallback for compat

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -1,7 +1,9 @@
 { pkgs }:
 
 rec {
-  sh = pkgs.busybox.override {
+  # Use "busybox-sandbox-shell" if present,
+  # if not (legacy) fallback and hope it's sufficient.
+  sh = pkgs.busybox-sandbox-shell or (pkgs.busybox.override {
     useMusl = true;
     enableStatic = true;
     enableMinimal = true;
@@ -11,7 +13,7 @@ rec {
       CONFIG_ASH_TEST y
       CONFIG_ASH_OPTIMIZE_FOR_SIZE y
     '';
-  };
+  });
 
   configureFlags =
     [ "--disable-init-state"


### PR DESCRIPTION
Somewhat of an alternative to #1842.

Instead of maintaining two definitions of "basic static shell sufficient to be used as /bin/sh"
(which may change moving forward across nixpkgs versions)
have the nixpkgs we're building against define what this means and use that by default.

As a fallback provide our own definition, which this PR leaves alone but we may want to one-time
update to include the changes in #1842 .

Hopefully this avoids having to update this in two places, as well as somewhat making things slightly
forward-compatible should nixpkgs change what we use for our basic shell.

This relies on https://github.com/dtzWill/nixpkgs/tree/feature/busybox-sandbox-shell which I haven't issued a PR for yet.

Does this seem like an improvement / good way to go?