### PR TITLE
Add tests for "nix build --dry-run" issues, fix one.

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -52,6 +52,8 @@ struct CmdBuild : MixDryRun, InstallablesCommand
     {
         auto buildables = toBuildables(store, dryRun ? DryRun : Build, installables);
 
+        if (dryRun) return;
+
         for (size_t i = 0; i < buildables.size(); ++i) {
             auto & b(buildables[i]);
 

--- a/tests/build-dry.sh
+++ b/tests/build-dry.sh
@@ -1,0 +1,49 @@
+source common.sh
+
+###################################################
+# Check that --dry-run isn't confused with read-only mode
+# https://github.com/NixOS/nix/issues/1795
+
+clearStore
+clearCache
+
+# Ensure this builds successfully first
+nix build -f dependencies.nix
+
+clearStore
+clearCache
+
+# Try --dry-run using old command first
+nix-build dependencies.nix --dry-run 2>&1 | grep "will be built"
+# Now new command:
+nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
+
+clearStore
+clearCache
+
+# Try --dry-run using new command first
+nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
+# Now old command:
+nix-build dependencies.nix --dry-run 2>&1 | grep "will be built"
+
+
+###################################################
+# Check --dry-run doesn't create links with --dry-run
+# https://github.com/NixOS/nix/issues/1849
+clearStore
+clearCache
+
+RESULT=$TEST_ROOT/result-link
+rm -f $RESULT
+
+nix-build dependencies.nix -o $RESULT --dry-run
+
+[[ ! -h $RESULT ]] || fail "nix-build --dry-run created output link"
+
+nix build -f dependencies.nix -o $RESULT --dry-run
+
+[[ ! -h $RESULT ]] || fail "nix build --dry-run created output link"
+
+nix build -f dependencies.nix -o $RESULT
+
+[[ -h $RESULT ]]

--- a/tests/build-dry.sh
+++ b/tests/build-dry.sh
@@ -18,6 +18,9 @@ nix-build dependencies.nix --dry-run 2>&1 | grep "will be built"
 # Now new command:
 nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
 
+# TODO: XXX: FIXME: #1793
+# Disable this part of the test until the problem is resolved:
+if [ -n "$ISSUE_1795_IS_FIXED" ]; then
 clearStore
 clearCache
 
@@ -25,7 +28,7 @@ clearCache
 nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
 # Now old command:
 nix-build dependencies.nix --dry-run 2>&1 | grep "will be built"
-
+fi
 
 ###################################################
 # Check --dry-run doesn't create links with --dry-run

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -13,6 +13,7 @@ nix_tests = \
   check-reqs.sh pass-as-file.sh tarball.sh restricted.sh \
   placeholders.sh nix-shell.sh \
   linux-sandbox.sh \
+  build-dry.sh \
   build-remote.sh \
   nar-access.sh \
   structured-attrs.sh \


### PR DESCRIPTION
Keep the code testing the unfixed issue,
but disable it to prevent tests failing for now.

Builds on top of #1851 so that tests pass.