### PR TITLE
configure.ac: define HAVE_SECCOMP macro when using seccomp, fix build/tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,7 @@ if test "$sys_name" = linux; then
     PKG_CHECK_MODULES([LIBSECCOMP], [libseccomp],
                       [CXXFLAGS="$LIBSECCOMP_CFLAGS $CXXFLAGS"])
     have_seccomp=1
+    AC_DEFINE([HAVE_SECCOMP], [1], [Whether seccomp is available and should be used for sandboxing.])
   else
     have_seccomp=
   fi


### PR DESCRIPTION
Happily the failing tests should prevent anyone from using such a Nix
in situations where they expect sandboxing to be on,
which would otherwise be a risk.