### PR TITLE
libexpr: Don't create lots of temporary strings in Bindings::lexicographicOrder

### DIFF
--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -83,7 +83,7 @@ public:
         for (size_t n = 0; n < size_; n++)
             res.emplace_back(&attrs[n]);
         std::sort(res.begin(), res.end(), [](const Attr * a, const Attr * b) {
-            return (string) a->name < (string) b->name;
+            return (const string &) a->name < (const string &) b->name;
         });
         return res;
     }


### PR DESCRIPTION
Avoids ~180,000 string temporaries created when evaluating a headless
NixOS system.