### PR TITLE
Support extra compatible architectures

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -254,6 +254,25 @@ false</literal>.</para>
   </varlistentry>
 
 
+  <varlistentry><term><literal>extra-platforms</literal></term>
+
+    <listitem><para>Platforms other than the native one which
+    this machine is capable of building for. This can be useful for
+    supporting additional architectures on compatible machines:
+    i686-linux can be built on x86_64-linux machines (and the default
+    for this setting reflects this); armv7 is backwards-compatible with
+    armv6 and armv5tel; some aarch64 machines can also natively run
+    32-bit ARM code; and qemu-user may be used to support non-native
+    platforms (though this may be slow and buggy). Most values for this
+    are not enabled by default because build systems will often
+    misdetect the target platform and generate incompatible code, so you
+    may wish to cross-check the results of using this option against
+    proper natively-built versions of your
+    derivations.</para></listitem>
+
+  </varlistentry>
+
+
   <varlistentry><term><literal>extra-substituters</literal></term>
 
     <listitem><para>Additional binary caches appended to those

--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -98,7 +98,9 @@ int main (int argc, char * * argv)
             source >> drvPath;
             auto requiredFeatures = readStrings<std::set<std::string>>(source);
 
-            auto canBuildLocally = amWilling && (neededSystem == settings.thisSystem);
+            auto canBuildLocally = amWilling
+                &&  (  neededSystem == settings.thisSystem
+                    || settings.extraPlatforms.get().count(neededSystem) > 0);
 
             /* Error ignored here, will be caught later */
             mkdir(currentLoad.c_str(), 0777);

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2491,6 +2491,10 @@ void setupSeccomp()
         seccomp_arch_add(ctx, SCMP_ARCH_X32) != 0)
         throw SysError("unable to add X32 seccomp architecture");
 
+    if (settings.thisSystem == "aarch64-linux" &&
+        seccomp_arch_add(ctx, SCMP_ARCH_ARM) != 0)
+        printError("unsable to add ARM seccomp architecture; this may result in spurious build failures if running 32-bit ARM processes.");
+
     /* Prevent builders from creating setuid/setgid binaries. */
     for (int perm : { S_ISUID, S_ISGID }) {
         if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(chmod), 1,

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -57,16 +57,8 @@ bool BasicDerivation::isBuiltin() const
 bool BasicDerivation::canBuildLocally() const
 {
     return platform == settings.thisSystem
-        || isBuiltin()
-#if __linux__
-        || (platform == "i686-linux" && settings.thisSystem == "x86_64-linux")
-        || (platform == "armv6l-linux" && settings.thisSystem == "armv7l-linux")
-        || (platform == "armv5tel-linux" && (settings.thisSystem == "armv7l-linux" || settings.thisSystem == "armv6l-linux"))
-#elif __FreeBSD__
-        || (platform == "i686-linux" && settings.thisSystem == "x86_64-freebsd")
-        || (platform == "i686-linux" && settings.thisSystem == "i686-freebsd")
-#endif
-        ;
+        || settings.extraPlatforms.get().count(platform) > 0
+        || isBuiltin();
 }
 
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -295,6 +295,9 @@ public:
         "Nix store has a valid signature (that is, one signed using a key "
         "listed in 'trusted-public-keys'."};
 
+    Setting<StringSet> extraPlatforms{this, StringSet{}, "build-extra-platforms",
+        "Additional platforms that can be built on the local system, e.g. using qemu-user."};
+
     Setting<Strings> substituters{this,
         nixStore == "/nix/store" ? Strings{"https://cache.nixos.org/"} : Strings(),
         "substituters",

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -295,8 +295,12 @@ public:
         "Nix store has a valid signature (that is, one signed using a key "
         "listed in 'trusted-public-keys'."};
 
-    Setting<StringSet> extraPlatforms{this, StringSet{}, "build-extra-platforms",
-        "Additional platforms that can be built on the local system, e.g. using qemu-user."};
+    Setting<StringSet> extraPlatforms{this,
+        SYSTEM == "x86_64-linux" ? StringSet{"i686-linux"} : StringSet{},
+        "extra-platforms",
+        "Additional platforms that can be built on the local system. "
+        "These may be supported natively (e.g. armv7 on some aarch64 CPUs "
+        "or using hacks like qemu-user."};
 
     Setting<Strings> substituters{this,
         nixStore == "/nix/store" ? Strings{"https://cache.nixos.org/"} : Strings(),


### PR DESCRIPTION
This is based on @cleverca22's patch (cleverca22/nix-misc). It allows building for additional architectures locally. This can be useful with binfmt-misc or compatible architectures (e.g. ARM32-capable aarch64 machines). Additionally, it enables 32-bit ARM seccomp support.

Questions:
 - Thoughts on disabling i686-linux on x86_64-linux by default?
 - What about the seccomp setting? I experienced crashes caused by seccomp while testing on an ARM32-capable aarch64 machine, but I'm not sure how this will behave on non-ARM32-capable ones — in case it fails, I didn't throw an error. I'm not sure if this is appropriate, feedback would be appreciated.