### PR TITLE
launchd: enable keepalive for the nix-daemon service

### DIFF
--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -4,6 +4,8 @@
   <dict>
     <key>Label</key>
     <string>org.nixos.nix-daemon</string>
+    <key>KeepAlive</key>
+    <true/>
     <key>RunAtLoad</key>
     <true/>
     <key>Program</key>


### PR DESCRIPTION
Without this the daemon won't be restarted if the process ever dies, for
example when sending a SIGHUP to reload nix.conf.