### PR TITLE
keep-paths: keep store paths alive without touching the filesystem.

### DIFF
--- a/src/nix/keep-paths.cc
+++ b/src/nix/keep-paths.cc
@@ -1,0 +1,48 @@
+#include "command.hh"
+#include "util.hh"
+#include "store-api.hh"
+
+using namespace nix;
+
+struct CmdKeepPaths : StoreCommand
+{
+    std::string name() override
+    {
+        return "keep-paths";
+    }
+
+    std::string description() override
+    {
+        return "keeps store paths alive as long as nix keep-paths is alive";
+    }
+
+    void printHelp(const string & programName, std::ostream & out) override
+    {
+        StoreCommand::printHelp(programName, out);
+
+        out << "\n";
+        out << "Reads in newline-separated store-paths over stdin.\n";
+        out << "A newline is printed after the path is registered.\n";
+    }
+
+    void run(ref<Store> store) override
+    {
+        try {
+            while (true) {
+                const auto s = readLine(0);
+                if (s.empty())
+                    continue;
+                if (!store->isStorePath(s)) {
+                    throw Error("%s is not a store path", s);
+                }
+
+                store->addTempRoot(s);
+                writeLine(1, "");
+            }
+        } catch (EndOfFile & e) {
+            return;
+        }
+    }
+};
+
+static RegisterCommand r1(make_ref<CmdKeepPaths>());

--- a/tests/gc.sh
+++ b/tests/gc.sh
@@ -34,6 +34,14 @@ if test -e $drvPath; then false; fi
 
 rm "$NIX_STATE_DIR"/gcroots/foo
 
+coproc nix keep-paths
+echo "$outPath" >&${COPROC[1]}
+read <&${COPROC[0]}
+if nix-store --delete $outPath; then false; fi
+test -e $outPath
+exec {COPROC[1]}>&- {COPROC[0]}<&-
+wait $COPROC_pid
+
 nix-collect-garbage
 
 # Check that the output has been GC'd.


### PR DESCRIPTION
Before this, scripts that do a nix build whose validity needn't extend
past the script's lifetime would have to either hope there was no
garbage collection between the build and the usage of it or create a
temporary directory and manage cleanup. With nix keep-paths, path
lifetimes can track script lifetimes (or shorter) without any races or
possibly interrupted cleanup steps.