### PR TITLE
anchor vtables of exceptions, helps throwing across DSO boundaries

### DIFF
--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -4,6 +4,7 @@
 
 namespace nix {
 
+void JSONParseError::anchor() {}
 
 static void skipWhitespace(const char * & s)
 {

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -7,6 +7,16 @@
 
 namespace nix {
 
+// anchor vtables
+void EvalError::anchor() {}
+void ParseError::anchor() {}
+void IncompleteParseError::anchor() {}
+void AssertionError::anchor() {}
+void ThrownError::anchor() {}
+void Abort::anchor() {}
+void TypeError::anchor() {}
+void UndefinedVarError::anchor() {}
+void RestrictedPathError::anchor() {}
 
 /* Displaying abstract syntax trees. */
 

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1473,6 +1473,7 @@ void replaceValidPath(const Path & storePath, const Path tmpPath)
 
 
 MakeError(NotDeterministic, BuildError)
+void NotDeterministic::anchor() {}
 
 
 void DerivationGoal::buildDone()

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -29,6 +29,8 @@ using namespace std::string_literals;
 
 namespace nix {
 
+void DownloadError::anchor() {}
+
 double getTime()
 {
     struct timeval tv;

--- a/src/libstore/download.hh
+++ b/src/libstore/download.hh
@@ -73,6 +73,8 @@ public:
     DownloadError(Downloader::Error error, const FormatOrString & fs)
         : Error(fs), error(error)
     { }
+private:
+    void anchor() override;
 };
 
 bool isUri(const string & s);

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -7,6 +7,8 @@ namespace nix {
 
 MakeError(UploadToHTTP, Error);
 
+void UploadToHTTP::anchor() {}
+
 class HttpBinaryCacheStore : public BinaryCacheStore
 {
 private:

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -39,6 +39,7 @@
 
 namespace nix {
 
+void PathInUse::anchor() {}
 
 LocalStore::LocalStore(const Params & params)
     : Store(params)

--- a/src/libstore/pathlocks.cc
+++ b/src/libstore/pathlocks.cc
@@ -12,6 +12,7 @@
 
 namespace nix {
 
+void AlreadyLocked::anchor() {}
 
 AutoCloseFD openLockFile(const Path & path, bool create)
 {

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -7,6 +7,9 @@
 
 namespace nix {
 
+void SQLiteError::anchor() {}
+void SQLiteBusy::anchor() {}
+
 [[noreturn]] void throwSQLiteError(sqlite3 * db, const FormatOrString & fs)
 {
     int err = sqlite3_errcode(db);

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -12,6 +12,10 @@
 
 namespace nix {
 
+void SubstError::anchor() {}
+void BuildError::anchor() {}
+void InvalidPath::anchor() {}
+void Unsupported::anchor() {}
 
 bool Store::isInStore(const Path & path) const
 {

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -3,6 +3,8 @@
 
 namespace nix {
 
+void UsageError::anchor() {}
+
 Args::FlagMaker Args::mkFlag()
 {
     return FlagMaker(*this);

--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -33,6 +33,9 @@ static void decompressNone(Source & source, Sink & sink)
     }
 }
 
+void UnknownCompressionMethod::anchor() {}
+void CompressionError::anchor() {}
+
 static void decompressXZ(Source & source, Sink & sink)
 {
     lzma_stream strm(LZMA_STREAM_INIT);

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -15,6 +15,7 @@
 
 namespace nix {
 
+void BadHash::anchor() {}
 
 void Hash::init()
 {

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -10,6 +10,7 @@
 
 namespace nix {
 
+void SerialisationError::anchor() {}
 
 void BufferedSink::operator () (const unsigned char * data, size_t len)
 {

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -3,6 +3,8 @@
 
 namespace nix {
 
+void ThreadPoolShutDown::anchor() {}
+
 ThreadPool::ThreadPool(size_t _maxThreads)
     : maxThreads(_maxThreads)
 {

--- a/src/libutil/types.hh
+++ b/src/libutil/types.hh
@@ -109,6 +109,8 @@ public:
     const string & msg() const { return err; }
     const string & prefix() const { return prefix_; }
     BaseError & addPrefix(const FormatOrString & fs);
+private:
+    virtual void anchor();
 };
 
 #define MakeError(newClass, superClass) \
@@ -116,6 +118,8 @@ public:
     {                                                   \
     public:                                             \
         using superClass::superClass;                   \
+    private:                                            \
+        void anchor() override;                         \
     };
 
 MakeError(Error, BaseError)
@@ -133,6 +137,7 @@ public:
 private:
 
     std::string addErrno(const std::string & s);
+    void anchor() override;
 };
 
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -58,6 +58,14 @@ string getEnv(const string & key, const string & def)
     return value ? string(value) : def;
 }
 
+void Error::anchor() {}
+void BaseError::anchor() {}
+void SysError::anchor() {}
+void ExecError::anchor() {}
+void EndOfFile::anchor() {}
+void Interrupted::anchor() {}
+void FormatError::anchor() {}
+
 
 std::map<std::string, std::string> getEnv()
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -284,6 +284,8 @@ public:
     ExecError(int status, Args... args)
         : Error(args...), status(status)
     { }
+private:
+    void anchor() override;
 };
 
 /* Convert a list of strings to a null-terminated vector of char


### PR DESCRIPTION
At least it does on my special platform :).

As-is the vtables will be anchored in every translation unit that
includes them, so this should reduce size a bit everywhere.