### PR TITLE
release.nix: don't try to use nix-2.0 branch, no longer exists

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,5 @@
 { nix ? builtins.fetchGit ./.
-, nixpkgs ? builtins.fetchGit { url = https://github.com/NixOS/nixpkgs.git; ref = "nix-2.0"; }
+, nixpkgs ? builtins.fetchGit https://github.com/NixOS/nixpkgs.git
 , officialRelease ? false
 , systems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ]
 }:


### PR DESCRIPTION
Probably should point at the 18.03 release branch once that's made.

Currently evaluating this throws an error.