### PR TITLE
Don't throw in destructor, happens in nix-daemon when client disappears.

### DIFF
--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -221,4 +221,12 @@ bool handleJSONLogMessage(const std::string & msg,
     return true;
 }
 
+Activity::~Activity() {
+    try {
+        logger.stopActivity(id);
+    } catch (...) {
+        ignoreException();
+    }
+}
+
 }

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -94,8 +94,7 @@ struct Activity
 
     Activity(const Activity & act) = delete;
 
-    ~Activity()
-    { logger.stopActivity(id); }
+    ~Activity();
 
     void progress(uint64_t done = 0, uint64_t expected = 0, uint64_t running = 0, uint64_t failed = 0) const
     { result(resProgress, done, expected, running, failed); }


### PR DESCRIPTION
Wasn't sure how to best handle the ignoreException decl re:layering.