### PR TITLE
ssh-ng: Don't forward options to the daemon.

### DIFF
--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -122,11 +122,12 @@ protected:
 
     ref<Pool<Connection>> connections;
 
+    virtual void setOptions(Connection & conn);
+
 private:
 
     std::atomic_bool failed{false};
 
-    void setOptions(Connection & conn);
 };
 
 class UDSRemoteStore : public LocalFSStore, public RemoteStore

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -51,6 +51,16 @@ private:
     std::string host;
 
     SSHMaster master;
+
+    void setOptions(RemoteStore::Connection & conn) override
+    {
+        /* TODO Add a way to explicitly ask for some options to be
+           forwarded. One option: A way to query the daemon for its
+           settings, and then a series of params to SSHStore like
+           forward-cores or forward-overridden-cores that only
+           override the requested settings.
+        */
+    };
 };
 
 


### PR DESCRIPTION
This can be iterated on and currently leaves out settings we know we
want to forward, but it fixes #1713 and fixes #1935 and isn't
fundamentally broken like the status quo. Future changes are suggested
in a comment.