### PR TITLE
rand() -> random(), since we use srandom().

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1458,7 +1458,7 @@ void replaceValidPath(const Path & storePath, const Path tmpPath)
        tmpPath (the replacement), so we have to move it out of the
        way first.  We'd better not be interrupted here, because if
        we're repairing (say) Glibc, we end up with a broken system. */
-    Path oldPath = (format("%1%.old-%2%-%3%") % storePath % getpid() % rand()).str();
+    Path oldPath = (format("%1%.old-%2%-%3%") % storePath % getpid() % random()).str();
     if (pathExists(storePath))
         rename(storePath.c_str(), oldPath.c_str());
     if (rename(tmpPath.c_str(), storePath.c_str()) == -1)

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -59,7 +59,7 @@ static void makeSymlink(const Path & link, const Path & target)
 
     /* Create the new symlink. */
     Path tempLink = (format("%1%.tmp-%2%-%3%")
-        % link % getpid() % rand()).str();
+        % link % getpid() % random()).str();
     createSymlink(target, tempLink);
 
     /* Atomically replace the old one. */

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -213,7 +213,7 @@ void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
     MakeReadOnly makeReadOnly(mustToggle ? dirOf(path) : "");
 
     Path tempLink = (format("%1%/.tmp-link-%2%-%3%")
-        % realStoreDir % getpid() % rand()).str();
+        % realStoreDir % getpid() % random()).str();
 
     if (link(linkPath.c_str(), tempLink.c_str()) == -1) {
         if (errno == EMLINK) {


### PR DESCRIPTION
rand() requires we call srand() instead,
but might as well use random().

-----------------

As-is, all threads will have the same seed and
(in some cases)  quickly encounter problems when
they generate the same temporary link names in the same order.

Looking at the glibc source, it appears to implement
rand() using random() which is why this didn't cause
bigger problems previously.

Note that "random()" does return "long int" instead
of the "int" returned by "rand()" but that seems okay:
either they're the same size or the larger type
results in slightly longer names for our temporary
links bringing with it a corresponding reduction
in chance of collision between threads.