### PR TITLE
Store the schema version in the database.

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -150,12 +150,9 @@ LocalStore::LocalStore(const Params & params)
 
     /* Check the current database schema and if necessary do an
        upgrade.  */
-    int curSchema = getSchema();
-    if (curSchema > nixSchemaVersion)
-        throw Error(format("current Nix store schema is version %1%, but I only support %2%")
-            % curSchema % nixSchemaVersion);
+    int curSchema = getSchema(*state, false);
 
-    else if (curSchema == 0) { /* new store */
+    if (curSchema == 0) { /* new store */
         curSchema = nixSchemaVersion;
         openDB(*state, true);
         writeFile(schemaPath, (format("%1%") % nixSchemaVersion).str());
@@ -181,37 +178,36 @@ LocalStore::LocalStore(const Params & params)
 
         /* Get the schema version again, because another process may
            have performed the upgrade already. */
-        curSchema = getSchema();
+        curSchema = getSchema(*state, true);
 
         if (curSchema < 7) { upgradeStore7(); }
-
-        openDB(*state, false);
 
         if (curSchema < 8) {
             SQLiteTxn txn(state->db);
             state->db.exec("alter table ValidPaths add column ultimate integer");
             state->db.exec("alter table ValidPaths add column sigs text");
+            state->db.exec("pragma user_version = 8");
             txn.commit();
         }
 
         if (curSchema < 9) {
             SQLiteTxn txn(state->db);
             state->db.exec("drop table FailedPaths");
+            state->db.exec("pragma user_version = 9");
             txn.commit();
         }
 
         if (curSchema < 10) {
             SQLiteTxn txn(state->db);
             state->db.exec("alter table ValidPaths add column ca text");
+            state->db.exec("pragma user_version = 10");
             txn.commit();
         }
 
-        writeFile(schemaPath, (format("%1%") % nixSchemaVersion).str());
+        writeFile(schemaPath, (format("%1%") % nixSchemaVersion).str(), 0666, true);
 
         lockFile(globalLock.get(), ltRead, true);
     }
-
-    else openDB(*state, false);
 
     /* Prepare SQL statements. */
     state->stmtRegisterValidPath.create(state->db,
@@ -275,13 +271,28 @@ std::string LocalStore::getUri()
 }
 
 
-int LocalStore::getSchema()
+int LocalStore::getSchema(State & state, bool dbOpen)
 {
     int curSchema = 0;
     if (pathExists(schemaPath)) {
         string s = readFile(schemaPath);
         if (!string2Int(s, curSchema))
             throw Error(format("'%1%' is corrupt") % schemaPath);
+    }
+    if (curSchema > nixSchemaVersion)
+        throw Error(format("current Nix store schema is version %1%, but I only support %2%")
+            % curSchema % nixSchemaVersion);
+    if (curSchema >= 6) {
+        if (!dbOpen)
+            openDB(state, false);
+        SQLiteStmt schemaQuery;
+        schemaQuery.create(state.db, "pragma user_version;");
+        if (sqlite3_step(schemaQuery) != SQLITE_ROW)
+            throwSQLiteError(state.db, "querying nix schema version");
+        int curSchema_ = sqlite3_column_int(schemaQuery, 0);
+        curSchema = curSchema_ ?
+            curSchema_ :
+            curSchema;
     }
     return curSchema;
 }

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -222,7 +222,7 @@ public:
 
 private:
 
-    int getSchema();
+    int getSchema(State & state, bool dbOpen);
 
     void openDB(State & state, bool create);
 

--- a/src/libstore/schema.sql
+++ b/src/libstore/schema.sql
@@ -1,3 +1,5 @@
+pragma user_version = 10;
+
 create table if not exists ValidPaths (
     id               integer primary key autoincrement not null,
     path             text unique not null,

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -310,12 +310,14 @@ string readFile(const Path & path, bool drain)
 }
 
 
-void writeFile(const Path & path, const string & s, mode_t mode)
+void writeFile(const Path & path, const string & s, mode_t mode, bool sync)
 {
     AutoCloseFD fd = open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, mode);
     if (!fd)
         throw SysError(format("opening file '%1%'") % path);
     writeFull(fd.get(), s);
+    if (sync)
+        fsync(fd.get());
 }
 
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -99,7 +99,7 @@ string readFile(int fd);
 string readFile(const Path & path, bool drain = false);
 
 /* Write a string to a file. */
-void writeFile(const Path & path, const string & s, mode_t mode = 0666);
+void writeFile(const Path & path, const string & s, mode_t mode = 0666, bool sync = false);
 
 /* Read a line from a file descriptor. */
 string readLine(int fd);


### PR DESCRIPTION
Before this, there was a gap between the database update and changes
to the schema version file, leading to #1954. Now database changes and
schema bumps happen in a single transaction.

To avoid gratuitous backwards incompatibility, we still write 10 to
the old version file, and will write 11 on the next schema bump. We
won't write 12 to it unless we're moving away from storing the schema
in the database.

Fixes #1954.