### PR TITLE
serialise.cc: remove pessimising move

### DIFF
--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -185,7 +185,7 @@ std::unique_ptr<Source> sinkToSource(std::function<void(Sink &)> fun)
 
             if (pos == cur.size()) {
                 if (!cur.empty()) coro();
-                cur = std::move(coro.get());
+                cur = coro.get();
                 pos = 0;
             }
 


### PR DESCRIPTION
from clang6:

src/libutil/serialise.cc:189:23: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]