### PR TITLE
execl: cast NULL sentinel to (char *), per man page and compiler warning

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -263,7 +263,7 @@ void showManPage(const string & name)
 {
     restoreSignals();
     setenv("MANPATH", settings.nixManDir.c_str(), 1);
-    execlp("man", "man", name.c_str(), NULL);
+    execlp("man", "man", name.c_str(), (char *)NULL);
     throw SysError(format("command 'man %1%' failed") % name.c_str());
 }
 
@@ -325,10 +325,10 @@ RunPager::RunPager()
             setenv("LESS", "FRSXMK", 1);
         restoreSignals();
         if (pager)
-            execl("/bin/sh", "sh", "-c", pager, NULL);
-        execlp("pager", "pager", NULL);
-        execlp("less", "less", NULL);
-        execlp("more", "more", NULL);
+            execl("/bin/sh", "sh", "-c", pager, (char *)NULL);
+        execlp("pager", "pager", (char *)NULL);
+        execlp("less", "less", (char *)NULL);
+        execlp("more", "more", (char *)NULL);
         throw SysError(format("executing '%1%'") % pager);
     });
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -263,7 +263,7 @@ void showManPage(const string & name)
 {
     restoreSignals();
     setenv("MANPATH", settings.nixManDir.c_str(), 1);
-    execlp("man", "man", name.c_str(), (char *)NULL);
+    execlp("man", "man", name.c_str(), nullptr);
     throw SysError(format("command 'man %1%' failed") % name.c_str());
 }
 
@@ -325,10 +325,10 @@ RunPager::RunPager()
             setenv("LESS", "FRSXMK", 1);
         restoreSignals();
         if (pager)
-            execl("/bin/sh", "sh", "-c", pager, (char *)NULL);
-        execlp("pager", "pager", (char *)NULL);
-        execlp("less", "less", (char *)NULL);
-        execlp("more", "more", (char *)NULL);
+            execl("/bin/sh", "sh", "-c", pager, nullptr);
+        execlp("pager", "pager", nullptr);
+        execlp("less", "less", nullptr);
+        execlp("more", "more", nullptr);
         throw SysError(format("executing '%1%'") % pager);
     });
 


### PR DESCRIPTION
From exec(3):

> The list of arguments must be terminated by a null pointer, and, since these
> are variadic functions, this pointer must be cast (char *) NULL