### PR TITLE
nix copy: add an example with S3

### DIFF
--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -67,6 +67,12 @@ struct CmdCopy : StorePathsCommand
                 "To copy a closure from another machine via SSH:",
                 "nix copy --from ssh://server /nix/store/a6cnl93nk1wxnq84brbbwr6hxw9gp2w9-blender-2.79-rc2"
             },
+#ifdef ENABLE_S3
+            Example{
+                "To populate the current folder build output to a S3 binary cache:",
+                "nix copy --to s3://my-bucket?region=eu-west-1"
+            },
+#endif
         };
     }
 


### PR DESCRIPTION
I couldn't find a good example how to use it with non-us-east-1 buckets.

I think these options should be documented more thoroughly but I didn't find the right place to do it. If you point me to the right place I'm happy to write some more docs.