### PR TITLE
Make the TTL for disk cache configurable

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -788,6 +788,30 @@ password <replaceable>my-password</replaceable>
 
   </varlistentry>
 
+  <varlistentry xml:id="conf-negative-disk-cache-ttl"><term><literal>negative-disk-cache-ttl</literal></term>
+
+    <listitem>
+
+      <para>The TTL in seconds for negative lookups. If a store path is queried from a substituer but
+      was not found, there will be a negative lookup cached in the local disk cache database for the specified
+      duration.</para>
+
+    </listitem>
+
+  </varlistentry>
+
+  <varlistentry xml:id="conf-positive-disk-cache-ttl"><term><literal>positive-disk-cache-ttl</literal></term>
+
+    <listitem>
+
+      <para>The TTL in seconds for positive lookups. If a store path is queried from a substituer, the result of
+      the query will be cached in the local disk cache database including some of the NAR metadata. Setting a TTL
+      for positive lookups can be useful in case of builds that aren't reproducible, in which case having a more
+      frequent cache invalidation would prevent hash mismatch issues.</para>
+
+    </listitem>
+
+  </varlistentry>
 
 </variablelist>
 

--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -456,7 +456,7 @@ builtins.fetchurl {
 
   </varlistentry>
 
-  <varlistentry xml:id="conf-negative-disk-cache-ttl"><term><literal>negative-disk-cache-ttl</literal></term>
+  <varlistentry xml:id="conf-narinfo-cache-negative-ttl"><term><literal>narinfo-cache-negative-ttl</literal></term>
 
     <listitem>
 
@@ -464,6 +464,24 @@ builtins.fetchurl {
       queried from a substituter but was not found, there will be a
       negative lookup cached in the local disk cache database for the
       specified duration.</para>
+
+    </listitem>
+
+  </varlistentry>
+
+  <varlistentry xml:id="conf-narinfo-cache-positive-ttl"><term><literal>narinfo-cache-positive-ttl</literal></term>
+
+    <listitem>
+
+      <para>The TTL in seconds for positive lookups. If a store path is
+      queried from a substituter, the result of the query will be cached
+      in the local disk cache database including some of the NAR
+      metadata. The default TTL is a month, setting a shorter TTL for
+      positive lookups can be useful for binary caches that have
+      frequent garbage collection, in which case having a more frequent
+      cache invalidation would prevent trying to pull the path again and
+      failing with a hash mismatch if the build isn't reproducible.
+      </para>
 
     </listitem>
 
@@ -519,24 +537,6 @@ password <replaceable>my-password</replaceable>
         If an entry in the list is a directory, all files in the
         directory are loaded as plugins (non-recursively).
       </para>
-    </listitem>
-
-  </varlistentry>
-
-  <varlistentry xml:id="conf-positive-disk-cache-ttl"><term><literal>positive-disk-cache-ttl</literal></term>
-
-    <listitem>
-
-      <para>The TTL in seconds for positive lookups. If a store path is
-      queried from a substituter, the result of the query will be cached
-      in the local disk cache database including some of the NAR
-      metadata. The default TTL is a month, setting a shorter TTL for
-      positive lookups can be useful for binary caches that have
-      frequent garbage collection, in which case having a more frequent
-      cache invalidation would prevent trying to pull the path again and
-      failing with a hash mismatch if the build isn't reproducible.
-      </para>
-
     </listitem>
 
   </varlistentry>

--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -456,6 +456,18 @@ builtins.fetchurl {
 
   </varlistentry>
 
+  <varlistentry xml:id="conf-negative-disk-cache-ttl"><term><literal>negative-disk-cache-ttl</literal></term>
+
+    <listitem>
+
+      <para>The TTL in seconds for negative lookups. If a store path is
+      queried from a substituter but was not found, there will be a
+      negative lookup cached in the local disk cache database for the
+      specified duration.</para>
+
+    </listitem>
+
+  </varlistentry>
 
   <varlistentry xml:id="conf-netrc-file"><term><literal>netrc-file</literal></term>
 
@@ -511,6 +523,23 @@ password <replaceable>my-password</replaceable>
 
   </varlistentry>
 
+  <varlistentry xml:id="conf-positive-disk-cache-ttl"><term><literal>positive-disk-cache-ttl</literal></term>
+
+    <listitem>
+
+      <para>The TTL in seconds for positive lookups. If a store path is
+      queried from a substituter, the result of the query will be cached
+      in the local disk cache database including some of the NAR
+      metadata. The default TTL is a month, setting a shorter TTL for
+      positive lookups can be useful for binary caches that have
+      frequent garbage collection, in which case having a more frequent
+      cache invalidation would prevent trying to pull the path again and
+      failing with a hash mismatch if the build isn't reproducible.
+      </para>
+
+    </listitem>
+
+  </varlistentry>
 
   <varlistentry xml:id="conf-pre-build-hook"><term><literal>pre-build-hook</literal></term>
 
@@ -783,31 +812,6 @@ password <replaceable>my-password</replaceable>
       <option>sandbox-paths</option> and thereby obtain read access to
       directories that are otherwise inacessible to
       them.</para></warning>
-
-    </listitem>
-
-  </varlistentry>
-
-  <varlistentry xml:id="conf-negative-disk-cache-ttl"><term><literal>negative-disk-cache-ttl</literal></term>
-
-    <listitem>
-
-      <para>The TTL in seconds for negative lookups. If a store path is queried from a substituer but
-      was not found, there will be a negative lookup cached in the local disk cache database for the specified
-      duration.</para>
-
-    </listitem>
-
-  </varlistentry>
-
-  <varlistentry xml:id="conf-positive-disk-cache-ttl"><term><literal>positive-disk-cache-ttl</literal></term>
-
-    <listitem>
-
-      <para>The TTL in seconds for positive lookups. If a store path is queried from a substituer, the result of
-      the query will be cached in the local disk cache database including some of the NAR metadata. Setting a TTL
-      for positive lookups can be useful in case of builds that aren't reproducible, in which case having a more
-      frequent cache invalidation would prevent hash mismatch issues.</para>
 
     </listitem>
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -310,14 +310,16 @@ public:
         "Disabled substituters that may be enabled via the substituters option by untrusted users.",
         {"trusted-binary-caches"}};
 
-    Setting<int> ttlNegativeDiskCache{this, 3600, "negative-disk-cache-ttl",
-        "The TTL in seconds for negative lookups in the disk cache."};
-
-    Setting<int> ttlPositiveDiskCache{this, 30 * 24 * 3600, "positive-disk-cache-ttl",
-        "The TTL in seconds for positive lookups in the disk cache."};
-
     Setting<Strings> trustedUsers{this, {"root"}, "trusted-users",
         "Which users or groups are trusted to ask the daemon to do unsafe things."};
+
+    Setting<unsigned int> ttlNegativeDiskCache{this, 3600, "negative-disk-cache-ttl",
+        "The TTL in seconds for negative lookups in the disk cache i.e binary cache lookups that "
+        "return an invalid path result"};
+
+    Setting<unsigned int> ttlPositiveDiskCache{this, 30 * 24 * 3600, "positive-disk-cache-ttl",
+        "The TTL in seconds for positive lookups in the disk cache i.e binary cache lookups that "
+        "return a valid path result."};
 
     /* ?Who we trust to use the daemon in safe ways */
     Setting<Strings> allowedUsers{this, {"*"}, "allowed-users",

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -313,11 +313,11 @@ public:
     Setting<Strings> trustedUsers{this, {"root"}, "trusted-users",
         "Which users or groups are trusted to ask the daemon to do unsafe things."};
 
-    Setting<unsigned int> ttlNegativeDiskCache{this, 3600, "negative-disk-cache-ttl",
+    Setting<unsigned int> ttlNegativeNarInfoCache{this, 3600, "narinfo-cache-negative-ttl",
         "The TTL in seconds for negative lookups in the disk cache i.e binary cache lookups that "
         "return an invalid path result"};
 
-    Setting<unsigned int> ttlPositiveDiskCache{this, 30 * 24 * 3600, "positive-disk-cache-ttl",
+    Setting<unsigned int> ttlPositiveNarInfoCache{this, 30 * 24 * 3600, "narinfo-cache-positive-ttl",
         "The TTL in seconds for positive lookups in the disk cache i.e binary cache lookups that "
         "return a valid path result."};
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -310,6 +310,12 @@ public:
         "Disabled substituters that may be enabled via the substituters option by untrusted users.",
         {"trusted-binary-caches"}};
 
+    Setting<int> ttlNegativeDiskCache{this, 3600, "negative-disk-cache-ttl",
+        "The TTL in seconds for negative lookups in the disk cache."};
+
+    Setting<int> ttlPositiveDiskCache{this, 30 * 24 * 3600, "positive-disk-cache-ttl",
+        "The TTL in seconds for positive lookups in the disk cache."};
+
     Setting<Strings> trustedUsers{this, {"root"}, "trusted-users",
         "Which users or groups are trusted to ask the daemon to do unsafe things."};
 

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -113,8 +113,8 @@ public:
                 SQLiteStmt(state->db,
                     "delete from NARs where ((present = 0 and timestamp < ?) or (present = 1 and timestamp < ?))")
                     .use()
-                    (now - settings.ttlNegativeDiskCache)
-                    (now - settings.ttlPositiveDiskCache)
+                    (now - settings.ttlNegativeNarInfoCache)
+                    (now - settings.ttlPositiveNarInfoCache)
                     .exec();
 
                 debug("deleted %d entries from the NAR info disk cache", sqlite3_changes(state->db));
@@ -183,8 +183,8 @@ public:
             auto queryNAR(state->queryNAR.use()
                 (cache.id)
                 (hashPart)
-                (now - settings.ttlNegativeDiskCache)
-                (now - settings.ttlPositiveDiskCache));
+                (now - settings.ttlNegativeNarInfoCache)
+                (now - settings.ttlPositiveNarInfoCache));
 
             if (!queryNAR.next())
                 return {oUnknown, 0};

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -1,6 +1,7 @@
 #include "nar-info-disk-cache.hh"
 #include "sync.hh"
 #include "sqlite.hh"
+#include "globals.hh"
 
 #include <sqlite3.h>
 
@@ -46,10 +47,6 @@ create table if not exists LastPurge (
 class NarInfoDiskCacheImpl : public NarInfoDiskCache
 {
 public:
-
-    /* How long negative and positive lookups are valid. */
-    const int ttlNegative = 3600;
-    const int ttlPositive = 30 * 24 * 3600;
 
     /* How often to purge expired entries from the cache. */
     const int purgeInterval = 24 * 3600;
@@ -116,8 +113,8 @@ public:
                 SQLiteStmt(state->db,
                     "delete from NARs where ((present = 0 and timestamp < ?) or (present = 1 and timestamp < ?))")
                     .use()
-                    (now - ttlNegative)
-                    (now - ttlPositive)
+                    (now - settings.ttlNegativeDiskCache)
+                    (now - settings.ttlPositiveDiskCache)
                     .exec();
 
                 debug("deleted %d entries from the NAR info disk cache", sqlite3_changes(state->db));
@@ -186,8 +183,8 @@ public:
             auto queryNAR(state->queryNAR.use()
                 (cache.id)
                 (hashPart)
-                (now - ttlNegative)
-                (now - ttlPositive));
+                (now - settings.ttlNegativeDiskCache)
+                (now - settings.ttlPositiveDiskCache));
 
             if (!queryNAR.next())
                 return {oUnknown, 0};


### PR DESCRIPTION
This should allow modifying the disk cache TTL or completely disabling it to force another binary cache query.