### PR TITLE
List the features a derivation requires when it cannot be built locally

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1786,9 +1786,24 @@ void DerivationGoal::startBuilder()
 {
     /* Right platform? */
     if (!drv->canBuildLocally()) {
-        throw Error(
-            format("a '%1%' is required to build '%3%', but I am a '%2%'")
-            % drv->platform % settings.thisSystem % drvPath);
+        Strings features = tokenizeString<Strings>(get(drv->env, "requiredSystemFeatures"));
+
+        if (features.size() == 1) {
+            throw Error(
+                "a '%s' system with the feature '%s' is required to build '%s'",
+                drv->platform, concatStringsSep("', '", features), drvPath
+                );
+        } else if (features.size() > 1) {
+            throw Error(
+                "a '%s' system with the features '%s' is required to build '%s'",
+                drv->platform, concatStringsSep("', '", features), drvPath
+                );
+        } else {
+            throw Error(
+                "a '%s' system is required to build '%s'",
+                drv->platform, drvPath
+                );
+        }
     }
 
     if (drv->isBuiltin())

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -25,6 +25,7 @@ nix_tests = \
   pure-eval.sh \
   check.sh \
   plugins.sh \
+  missing-features.sh \
   search.sh
   # parallel.sh
 

--- a/tests/missing-features.nix
+++ b/tests/missing-features.nix
@@ -1,0 +1,36 @@
+{
+  zero = derivation {
+    name = "testing-absent-features";
+    system = "x86_64-bogus";
+    builder = "/bogus";
+    args = [];
+
+    foo = builtins.currentTime;
+
+    meta_description = "Testing multiple absent features";
+  };
+
+  one = derivation {
+    name = "testing-absent-features";
+    system = "x86_64-bogus";
+    builder = "/bogus";
+    args = [];
+
+    foo = builtins.currentTime;
+
+    meta_description = "Testing multiple absent features";
+    requiredSystemFeatures = [ "bogus" ];
+  };
+
+  multiple = derivation {
+    name = "testing-absent-features";
+    system = "x86_64-bogus";
+    builder = "/bogus";
+    args = [];
+
+    foo = builtins.currentTime;
+
+    meta_description = "Testing multiple absent features";
+    requiredSystemFeatures = [ "bogus" "feature" ];
+  };
+}

--- a/tests/missing-features.sh
+++ b/tests/missing-features.sh
@@ -1,0 +1,33 @@
+source common.sh
+
+clearStore
+
+expectFailureMsg() {
+    expect=$1
+    shift
+    if output=$("$@" 2>&1); then
+        echo "Running '" "$@" "' succeeded, but it should not have!"
+        exit 1
+    fi
+
+    echo "Expecting:"
+    echo "$expect"
+    echo ""
+    echo "Received:"
+    echo "$output"
+
+
+    echo "$output" | grep "$expect"
+}
+
+expectFailureMsg \
+    "a 'x86_64-bogus' system is required to build" \
+    nix-build ./missing-features.nix -A zero
+
+expectFailureMsg \
+    "a 'x86_64-bogus' system with the feature 'bogus' is required to build" \
+    nix-build ./missing-features.nix -A one
+
+expectFailureMsg \
+    "a 'x86_64-bogus' system with the features 'bogus', 'feature' is required to build" \
+    nix-build ./missing-features.nix -A multiple


### PR DESCRIPTION
> error: a 'aarch64-linux' is required to build '/nix/store/2r9r8m2pf8j0kjwfxk02gx5siyl4m9ks-hello-2.10.drv', but I am a 'x86_64-linux'

okay .... but ...

```
$ cat /etc/nix/machines
root@myaarch64 aarch64-linux /root/foobar 96 1 big-parallel
```

_applies patch_

> error: a 'aarch64-linux' with the system feature 'magic-pixie-dust' is required to build '/nix/store/2r9r8m2pf8j0kjwfxk02gx5siyl4m9ks-hello-2.10.drv', but I am a 'x86_64-linux'

ah ha!