### PR TITLE
Tell user why a given path is live when it can't be deleted 

### DIFF
--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -551,6 +551,9 @@ public:
        relation.  If p refers to q, then p preceeds q in this list. */
     Paths topoSortPaths(const PathSet & paths);
 
+    string printTree(const Path & path, const string & firstPad,
+        const string & tailPad, PathSet & done, std::function<Paths(const Path&)> getChildren); 
+
     /* Export multiple paths in the format expected by ‘nix-store
        --import’. */
     void exportPaths(const Paths & paths, Sink & sink);


### PR DESCRIPTION
Hello,

This PR changes the error message displayed while trying to remove a path from the store still referenced by a GC root.

```
$ nix-store --delete /nix/store/73h7ybrxngp9vd22jgixksy8rcidxqp0-firefox-59.0.1/
  error: cannot delete path /nix/store/73h7ybrxngp9vd22jgixksy8rcidxqp0-firefox-59.0.1' since it is still alive
```

To:
```
$ nix-store --delete /nix/store/73h7ybrxngp9vd22jgixksy8rcidxqp0-firefox-59.0.1/
  error: cannot delete path '/nix/store/73h7ybrxngp9vd22jgixksy8rcidxqp0-firefox-59.0.1': it is still needed by '/nix/store/xqkhb8hcjj7hns6qphz7zgmnvpk2rlqm-system-path'
```

This pull request fixes #1810.

Note: this is my first contribution to Nix, I'm not familiar with the code-base yet, I guess you should be extra-cautious while reviewing this.