### PR TITLE
release.nix: Use $sourceRoot instead of hardcoded source directory

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -28,8 +28,8 @@ let
         configureFlags = "--enable-gc";
 
         postUnpack = ''
-          (cd source && find . -type f) | cut -c3- > source/.dist-files
-          cat source/.dist-files
+          (cd $sourceRoot && find . -type f) | cut -c3- > $sourceRoot/.dist-files
+          cat $sourceRoot/.dist-files
         '';
 
         preConfigure = ''


### PR DESCRIPTION
On my fresh Hydra install, the source root here ends up at git-export/ instead of source/, which causes all the builds to fail.