### PR TITLE
nix-shell: Fixes use with ruby shebangs.

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -212,7 +212,7 @@ void mainWrapped(int argc, char * * argv)
                 // read the shebang to understand which packages to read from. Since
                 // this is handled via nix-shell -p, we wrap our ruby script execution
                 // in ruby -e 'load' which ignores the shebangs.
-                envCommand = (format("exec %1% %2% -e 'load(\"%3%\") -- %4%") % execArgs % interpreter % script % joined.str()).str();
+                envCommand = (format("exec %1% %2% -e 'load(\"%3%\")' -- %4%") % execArgs % interpreter % script % joined.str()).str();
             } else {
                 envCommand = (format("exec %1% %2% %3% %4%") % execArgs % interpreter % script % joined.str()).str();
             }

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -39,3 +39,12 @@ chmod a+rx $TEST_ROOT/shell.shebang.sh
 
 output=$($TEST_ROOT/shell.shebang.sh abc def)
 [ "$output" = "foo bar abc def" ]
+
+# Test nix-shell shebang mode for ruby
+# This uses a fake interpreter that returns the arguments passed
+# This, in turn, verifies the `rc` script is valid and the `load()` script (given using `-e`) is as expected.
+sed -e "s|@ENV_PROG@|$(type -p env)|" shell.shebang.rb > $TEST_ROOT/shell.shebang.rb
+chmod a+rx $TEST_ROOT/shell.shebang.rb
+
+output=$($TEST_ROOT/shell.shebang.rb abc ruby)
+[ "$output" = '-e load("'"$TEST_ROOT"'/shell.shebang.rb") -- abc ruby' ]

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -43,7 +43,7 @@ output=$($TEST_ROOT/shell.shebang.sh abc def)
 # Test nix-shell shebang mode for ruby
 # This uses a fake interpreter that returns the arguments passed
 # This, in turn, verifies the `rc` script is valid and the `load()` script (given using `-e`) is as expected.
-sed -e "s|@ENV_PROG@|$(type -p env)|" shell.shebang.rb > $TEST_ROOT/shell.shebang.rb
+sed -e "s|@SHELL_PROG@|$(type -p nix-shell)|" shell.shebang.rb > $TEST_ROOT/shell.shebang.rb
 chmod a+rx $TEST_ROOT/shell.shebang.rb
 
 output=$($TEST_ROOT/shell.shebang.rb abc ruby)

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -45,5 +45,12 @@ let pkgs = rec {
 
   bash = shell;
 
+  # ruby "interpreter" that outputs "$@"
+  ruby = runCommand "ruby" {} ''
+    mkdir -p $out/bin
+    echo 'printf -- "$*"' > $out/bin/ruby
+    chmod a+rx $out/bin/ruby
+  '';
+
   inherit pkgs;
 }; in pkgs

--- a/tests/shell.shebang.rb
+++ b/tests/shell.shebang.rb
@@ -1,0 +1,7 @@
+#! @ENV_PROG@ nix-shell
+#! ruby
+#! nix-shell -I nixpkgs=shell.nix --no-substitute
+#! nix-shell --pure -p ruby -i ruby
+
+# Contents doesn't matter.
+abort("This shouldn't be executed.")

--- a/tests/shell.shebang.rb
+++ b/tests/shell.shebang.rb
@@ -1,4 +1,4 @@
-#! @ENV_PROG@ nix-shell
+#! @SHELL_PROG@
 #! ruby
 #! nix-shell -I nixpkgs=shell.nix --no-substitute
 #! nix-shell --pure -p ruby -i ruby


### PR DESCRIPTION
The ported code in 80ebc553eca19dafc64c47420cd49ddd506bc9b7 was incorrectly ported.

```
-            $envCommand = "exec $execArgs $interpreter -e 'load(\"$script\")' -- ${\(join ' ', (map shellEscape, @savedArgs))}";
...
+                    envCommand = (format("exec %1% %2% -e 'load(\"%3%\") -- %4%") % execArgs % interpreter % script % joined.str()).str();
```

The single-quote finishing the small ruby snippet was lost in
translation.

* * *

Symptoms:

```
/tmp/nix-shell-1953-0/rc: line 1: unexpected EOF while looking for matching `''
/tmp/nix-shell-1953-0/rc: line 2: syntax error: unexpected end of file
```

* * *

~~In addition, I will be looking at how tests work, but I would really like to add a test for this regression. Any help is welcome.~~