### PR TITLE
Fix missing $DESTDIR when installing programs and BUILD_SHARED_LIBS=0

### DIFF
--- a/mk/programs.mk
+++ b/mk/programs.mk
@@ -51,7 +51,7 @@ define build-program
   else
 
     $(DESTDIR)$$($(1)_INSTALL_PATH): $$($(1)_PATH) | $(DESTDIR)$$($(1)_INSTALL_DIR)/
-	install -t $$($(1)_INSTALL_DIR) $$<
+	install -t $(DESTDIR)$$($(1)_INSTALL_DIR) $$<
 
   endif
 


### PR DESCRIPTION
The rule target and dependencies properly use `$(DESTDIR)`, but the `install` command didn't when `BUILD_SHARED_LIBS` was false.  This commit adds it.  I'm successfully able to run a build using `DESTDIR=/path` after this patch.