### PR TITLE
launchd: enable keepalive for the nix-daemon service

### DIFF
--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -4,6 +4,8 @@
   <dict>
     <key>Label</key>
     <string>org.nixos.nix-daemon</string>
+    <key>KeepAlive</key>
+    <true/>
     <key>RunAtLoad</key>
     <true/>
     <key>Program</key>


### PR DESCRIPTION
This should fix #1980 when 2.0.1 is released.

(cherry picked from commit 05cb8e5c5a954fa999ac5156cdf19148a05fdb2b)