### PR TITLE
Nix repl does not interrupt partially typed in expressions on Ctrl-C

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -189,6 +189,7 @@ bool NixRepl::getLine(string & input, const std::string &prompt)
     if (!s) {
       switch (auto type = linenoiseKeyType()) {
         case 1: // ctrl-C
+          input = "";
           return true;
         case 2: // ctrl-D
           return false;


### PR DESCRIPTION
This is a one liner fixing #2076 .

```
nix-repl> let
          a = "oops"
          ^C

nix-repl> 
```