### PR TITLE
Allow multiple search experssions in nix search

### DIFF
--- a/tests/search.sh
+++ b/tests/search.sh
@@ -29,6 +29,11 @@ clearCache
 # Check search that matches nothing
 (( $(nix search nosuchpackageexists | wc -l) == 0 ))
 
+# Search for multiple arguments
+(( $(nix search hello empty | wc -l) == 5 ))
+
+# Multiple arguments will not exist
+(( $(nix search hello broken | wc -l) == 0 ))
 
 ## Search expressions
 


### PR DESCRIPTION
The common use case is to search for packages containing multiple words
like a "git" "frontend". Having only one expressions makes this simple regular
use case very complicated. Instead, search accepts multiple regular epressions
which all need to match.

nix search git 'gui|frontend'

returns a list of all git uis for example