### PR TITLE
build.cc: fix bind-mount of /dev/{pts,ptmx} fallback

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2699,8 +2699,8 @@ void DerivationGoal::runChild()
                 } else {
                     if (errno != EINVAL)
                         throw SysError("mounting /dev/pts");
-                    doBind("/dev/pts", "/dev/pts");
-                    doBind("/dev/ptmx", "/dev/ptmx");
+                    doBind("/dev/pts", chrootRootDir + "/dev/pts");
+                    doBind("/dev/ptmx", chrootRootDir + "/dev/ptmx");
                 }
             }
 


### PR DESCRIPTION
Don't bind-mount these to themselves,
mount them into the chroot directory.

Fixes pty issues when using sandbox on CentOS 7.4.
(build of perlPackages.IOTty fails before this change)

(see chat on IRC for a bit more background)