### PR TITLE
download: make hash mismatch error consistent with fetchurl

### DIFF
--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -730,8 +730,8 @@ Path Downloader::downloadCached(ref<Store> store, const string & url_, bool unpa
         Hash gotHash = unpack
             ? hashPath(expectedHash.type, store->toRealPath(storePath)).first
             : hashFile(expectedHash.type, store->toRealPath(storePath));
-        throw nix::Error("hash mismatch in file downloaded from '%s': expected hash '%s', got '%s'",
-            url, expectedHash.to_string(), gotHash.to_string());
+        throw nix::Error("hash mismatch in file downloaded from '%s': got hash '%s' instead of the expected hash '%s'",
+            url, gotHash.to_string(), expectedHash.to_string());
     }
 
     return store->toRealPath(storePath);


### PR DESCRIPTION
Currently the hash mismatch from nix shows the expected/actual hashes in a different order than eg. fetchurl from nixpkgs.

---

error: hash mismatch in file downloaded from 'http://ftpmirror.gnu.org/hello/hello-2.10.tar.gz': expected hash 'sha256:0000000000000000000000000000000000000000000000000000', got 'sha256:0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i'

vs

fixed-output derivation produced path '/nix/store/3x7dwzq014bblazs7kq20p9hyzz0qh8g-hello-2.10.tar.gz' with sha256 hash '0ssi1wpaf7plaswqqjwigppsg5fyh99vdlb9kzl7c9lng89ndq1i' instead of the expected hash '0000000000000000000000000000000000000000000000000000'