### PR TITLE
doc: Adds `--quiet` to the common options.

### DIFF
--- a/doc/manual/command-ref/opt-common-syn.xml
+++ b/doc/manual/command-ref/opt-common-syn.xml
@@ -9,6 +9,9 @@
   </group>
 </arg>
 <arg>
+  <arg choice='plain'><option>--quiet</option></arg>
+</arg>
+<arg>
   <group choice='plain'>
     <arg choice='plain'><option>--no-build-output</option></arg>
     <arg choice='plain'><option>-Q</option></arg>

--- a/doc/manual/command-ref/opt-common.xml
+++ b/doc/manual/command-ref/opt-common.xml
@@ -75,6 +75,23 @@
 </varlistentry>
 
 
+<varlistentry><term><option>--quiet</option></term>
+
+  <listitem>
+
+  <para>Decreases the level of verbosity of diagnostic messages
+  printed on standard error.  This is the inverse option to
+  <option>-v</option> / <option>--verbose</option>.
+  </para>
+
+  <para>This option may be specified repeatedly.  See the previous
+  verbosity levels list.</para>
+
+  </listitem>
+
+</varlistentry>
+
+
 <varlistentry><term><option>--no-build-output</option> / <option>-Q</option></term>
 
   <listitem><para>By default, output written by builders to standard


### PR DESCRIPTION
Fixes #1298 

* * *

Adds `--quiet` to the synopsis and to the description text in the common options.

Verified in `man ./doc/manual/nix-store.1` and in `manual.html`.

```
SYNOPSIS
       nix-store [--help] [--version] [{--verbose | -v}...] [--quiet]
                 [--no-build-output | -Q] [{--max-jobs | -j} number]

...

       --verbose / -v
           Increases the level of verbosity of diagnostic messages printed on
           standard error. For each Nix operation, the information printed on
           standard output is well-defined; any diagnostic information is printed
           on standard error, never on standard output.

           This option may be specified repeatedly. Currently, the following
           verbosity levels exist:

           0
               “Errors only”: only print messages explaining why the Nix
               invocation failed.

           1
               “Informational”: print useful messages about what Nix is doing.
               This is the default.

           2
               “Talkative”: print more informational messages.

           3
               “Chatty”: print even more informational messages.

           4
               “Debug”: print debug information.

           5
               “Vomit”: print vast amounts of debug information.

       --quiet
           Decreases the level of verbosity of diagnostic messages printed on
           standard error. This is the inverse option to -v / --verbose.

           This option may be specified repeatedly. See the previous verbosity
           levels list.

```