### PR TITLE
Fix library ordering in Makefiles

### DIFF
--- a/src/build-remote/local.mk
+++ b/src/build-remote/local.mk
@@ -4,6 +4,6 @@ build-remote_DIR := $(d)
 
 build-remote_INSTALL_DIR := $(libexecdir)/nix
 
-build-remote_LIBS = libmain libutil libformat libstore
+build-remote_LIBS = libmain libformat libstore libutil
 
 build-remote_SOURCES := $(d)/build-remote.cc

--- a/src/nix-channel/local.mk
+++ b/src/nix-channel/local.mk
@@ -2,6 +2,6 @@ programs += nix-channel
 
 nix-channel_DIR := $(d)
 
-nix-channel_LIBS = libmain libutil libformat libstore
+nix-channel_LIBS = libmain libformat libstore libutil
 
 nix-channel_SOURCES := $(d)/nix-channel.cc

--- a/src/nix-copy-closure/local.mk
+++ b/src/nix-copy-closure/local.mk
@@ -2,6 +2,6 @@ programs += nix-copy-closure
 
 nix-copy-closure_DIR := $(d)
 
-nix-copy-closure_LIBS = libmain libutil libformat libstore
+nix-copy-closure_LIBS = libmain libformat libstore libutil
 
 nix-copy-closure_SOURCES := $(d)/nix-copy-closure.cc


### PR DESCRIPTION
The existing ordering linked `libutil` before `libstore`, which causes
link failures when building statically. This is due to `libstore` using
functions from `libutil`, and the fact that symbol resolution works
"forward" - i.e. if you pass `-lfoo -lbar -lbaz`, any symbols that
`libbar` uses from `libbaz` will be resolved, but symbols from `libfoo`
will not since it comes first in the command line.

All this to say: this commit reorders the libraries which fixes the link
errors.