### PR TITLE
globals.hh: don't use '==' to compare string literals

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -296,7 +296,7 @@ public:
         "listed in 'trusted-public-keys'."};
 
     Setting<StringSet> extraPlatforms{this,
-        SYSTEM == "x86_64-linux" ? StringSet{"i686-linux"} : StringSet{},
+        std::string{SYSTEM} == "x86_64-linux" ? StringSet{"i686-linux"} : StringSet{},
         "extra-platforms",
         "Additional platforms that can be built on the local system. "
         "These may be supported natively (e.g. armv7 on some aarch64 CPUs "


### PR DESCRIPTION
Saw this in logs, also reported here:

https://github.com/NixOS/nix/commit/8e6108ff71caae180d764ab9e9bff5593724655c#r28707288