### PR TITLE
nix-collect-garbage: fix documentation to not mention options like --print-dead

### DIFF
--- a/doc/manual/command-ref/nix-collect-garbage.xml
+++ b/doc/manual/command-ref/nix-collect-garbage.xml
@@ -22,12 +22,6 @@
     <arg><option>--delete-old</option></arg>
     <arg><option>-d</option></arg>
     <arg><option>--delete-older-than</option> <replaceable>period</replaceable></arg>
-    <group choice='opt'>
-      <arg choice='plain'><option>--print-roots</option></arg>
-      <arg choice='plain'><option>--print-live</option></arg>
-      <arg choice='plain'><option>--print-dead</option></arg>
-      <arg choice='plain'><option>--delete</option></arg>
-    </group>
     <arg><option>--max-freed</option> <replaceable>bytes</replaceable></arg>
     <arg><option>--dry-run</option></arg>
   </cmdsynopsis>


### PR DESCRIPTION
I installed Nix 2.0.1 the other day and I saw that the man page for `nix-collect-garbage` list some options that aren't actually recognized, like `--print-dead`.

Pull request #1648 was supposed to fix the documentation by removing unsupported options, but I think it got merged into the  wrong branch.  I cherry-picked the one commit from there.  

I've confirmed that all four options being removed from the documentation in this pull request are indeed not recognized.