### PR TITLE
Add "arx" scripts to release

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -124,19 +124,12 @@ let
         }
         ''
           cp ${installerClosureInfo}/registration $TMPDIR/reginfo
-          substitute ${./scripts/install-nix-from-closure.sh} $TMPDIR/install \
-            --subst-var-by nix ${toplevel} \
-            --subst-var-by cacert ${cacert}
+          (echo "nix=${toplevel}"; echo "cacert=${cacert}") > $TMPDIR/hashes-${system}
 
-          substitute ${./scripts/install-darwin-multi-user.sh} $TMPDIR/install-darwin-multi-user.sh \
-            --subst-var-by nix ${toplevel} \
-            --subst-var-by cacert ${cacert}
-          substitute ${./scripts/install-systemd-multi-user.sh} $TMPDIR/install-systemd-multi-user.sh \
-            --subst-var-by nix ${toplevel} \
-            --subst-var-by cacert ${cacert}
-          substitute ${./scripts/install-multi-user.sh} $TMPDIR/install-multi-user \
-            --subst-var-by nix ${toplevel} \
-            --subst-var-by cacert ${cacert}
+          cp ${./scripts/install-nix-from-closure.sh} $TMPDIR/install
+          cp ${./scripts/install-darwin-multi-user.sh} $TMPDIR/install-darwin-multi-user.sh
+          cp ${./scripts/install-systemd-multi-user.sh} $TMPDIR/install-systemd-multi-user.sh
+          cp ${./scripts/install-multi-user.sh} $TMPDIR/install-multi-user
 
           if type -p shellcheck; then
             # SC1090: Don't worry about not being able to find

--- a/release.nix
+++ b/release.nix
@@ -124,6 +124,8 @@ let
         }
         ''
           cp ${installerClosureInfo}/registration $TMPDIR/reginfo
+
+          # TODO should be able to use reginfo instead of this
           (echo "nix=${toplevel}"; echo "cacert=${cacert}") > $TMPDIR/hashes-${system}
 
           cp ${./scripts/install-nix-from-closure.sh} $TMPDIR/install

--- a/release.nix
+++ b/release.nix
@@ -216,6 +216,14 @@ let
     deb_ubuntu1710x86_64 = makeDeb_x86_64 (diskImageFuns: diskImageFuns.ubuntu1710x86_64) [ ] [ "libsodium18" "libboost-context1.62.0" ];
 
 
+    arx = with pkgs; lib.genAttrs systems (system:
+      runCommand "nix-arx-${tarball.version}.sh" {
+        buildInputs = [ haskellPackages.arx ];
+      } ''
+        arx tmpx --shared -o $out ${binaryTarball.${system}}/*.tar.bz2 // \
+          'cd * && sh install'
+      '');
+
     # System tests.
     tests.remoteBuilds = (import ./tests/remote-builds.nix rec {
       inherit nixpkgs;

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -1,16 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -e
 
 dest="/nix"
 self="$(dirname "$0")"
-nix="@nix@"
-cacert="@cacert@"
-
 
 if ! [ -e "$self/.reginfo" ]; then
     echo "$0: incomplete installer (.reginfo is missing)" >&2
 fi
+
+system=$(uname -m | sed s,i.86,i686,)-$(uname -s | tr '[:upper:]' '[:lower:]')
+source $self/hashes-$system
 
 if [ -z "$USER" ]; then
     echo "$0: \$USER is not set" >&2


### PR DESCRIPTION
This was suggested in https://github.com/NixOS/nixos-homepage/pull/215 & seems like a good idea.

"arx" is a Haskell tool to generate self-extracting shell scripts. It is fairly straightforward to integrate into release.nix. Eventually I want to use these scripts in ```https://nixos.org/nix/install``` but for now just want to get these included in the release jobset. You will be able to run these .sh files using the standard ```curl | sh``` model:

```
curl https://nixos.org/releases/nix/nix-2.0.1/nix-2.0.1-x86_64-linux.sh | sh -s optional args go here
```