### PR TITLE
Fix `builtins.path` error handling

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -422,10 +422,13 @@ Path RemoteStore::addToStore(const string & name, const Path & _srcPath,
 {
     if (repair) throw Error("repairing is not supported when building through the Nix daemon");
 
-    auto conn(connections->get());
-
     Path srcPath(absPath(_srcPath));
 
+    struct stat st;
+    if (lstat(srcPath.c_str(), &st))
+        throw SysError(format("getting attributes of path '%1%'") % srcPath);
+
+    auto conn(connections->get());
     conn->to << wopAddToStore << name
        << ((hashAlgo == htSHA256 && recursive) ? 0 : 1) /* backwards compatibility hack */
        << (recursive ? 1 : 0)


### PR DESCRIPTION
Fixes #2075

# Before

```
nix-repl> builtins.path { path = "/home/kmicklas/bar"; }
error: getting attributes of path '/home/kmicklas/bar': No such file or directory

nix-repl> builtins.path { path = "/home/kmicklas/foo"; }
error: bad archive: expected open tag

nix-repl> builtins.path { path = "/home/kmicklas/foo"; }
error: bad archive: expected open tag

nix-repl> builtins.path { path = "/home/kmicklas/foo"; }
error: unexpected end-of-file

nix-repl> builtins.path { path = "/home/kmicklas/foo"; }
"/nix/store/avva3pijyyj4bgrj1vcl3sj6hiadjxlj-foo"

```
# After
```
nix-repl> builtins.path { path = "/home/minoulefou/bar"; }                                                  
error: getting attributes of path '/home/minoulefou/bar': No such file or directory

nix-repl> builtins.path { path = "/home/minoulefou/foo"; }                                                           

"/nix/store/avva3pijyyj4bgrj1vcl3sj6hiadjxlj-foo"
```

The nix-store client was basically sending an incomplete message. This PR adds an extra check before sending anything to the daemon's socket sink.