### PR TITLE
Expand tilde to home directory in NIX_PATH

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -663,7 +663,7 @@ std::pair<bool, std::string> EvalState::resolveSearchPathElem(const SearchPathEl
             res = { false, "" };
         }
     } else {
-        auto path = absPath(elem.second);
+        auto path = absPath(expandTilde(elem.second));
         if (pathExists(path))
             res = { true, path };
         else {

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -453,6 +453,14 @@ static Lazy<Path> getHome2([]() {
 
 Path getHome() { return getHome2(); }
 
+Path expandTilde(const Path & path)
+{
+    if (path == "~")
+        return getHome();
+    if (path.compare(0, 2, "~/") == 0)
+        return getHome() + "/" + path.substr(2);
+    return path;
+}
 
 Path getCacheDir()
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -121,6 +121,9 @@ Path createTempDir(const Path & tmpRoot = "", const Path & prefix = "nix",
 /* Return $HOME or the user's home directory from /etc/passwd. */
 Path getHome();
 
+/* Expand a leading '~' in a path to the user's home directory. */
+Path expandTilde(const Path & path);
+
 /* Return $XDG_CACHE_HOME or $HOME/.cache. */
 Path getCacheDir();
 


### PR DESCRIPTION
Given that Nix path expressions can start with a tilde, allow the same for NIX_PATH entries.

This is needed for fixing https://github.com/NixOS/nixpkgs/issues/40165 (or well, my suggestion in https://github.com/NixOS/nixpkgs/issues/40165#issuecomment-387512180 depends on that) so this should be picked to the 2.0.x branch as well.