### PR TITLE
libstore: Verify and repair path metadata on `nix-store --verify --check-contents'

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3080,7 +3080,7 @@ void DerivationGoal::registerOutputs()
             /* Canonicalise first.  This ensures that the path we're
                rewriting doesn't contain a hard link to /etc/shadow or
                something like that. */
-            canonicalisePathMetaData(actualPath, buildUser ? buildUser->getUID() : -1, inodesSeen);
+            canonicalisePathMetaData(actualPath, buildUser ? buildUser->getUID() : -1, inodesSeen, false);
 
             /* FIXME: this is in-memory. */
             StringSink sink;
@@ -3147,7 +3147,7 @@ void DerivationGoal::registerOutputs()
         /* Get rid of all weird permissions.  This also checks that
            all files are owned by the build user, if applicable. */
         canonicalisePathMetaData(actualPath,
-            buildUser && !rewritten ? buildUser->getUID() : -1, inodesSeen);
+            buildUser && !rewritten ? buildUser->getUID() : -1, inodesSeen, false);
 
         /* For this output path, find the references to other paths
            contained in it.  Compute the SHA-256 NAR hash at the same

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -308,9 +308,14 @@ typedef set<Inode> InodesSeen;
    - the permissions are set of 444 or 555 (i.e., read-only with or
      without execute permission; setuid bits etc. are cleared)
    - the owner and group are set to the Nix user and group, if we're
-     running as root. */
-void canonicalisePathMetaData(const Path & path, uid_t fromUid, InodesSeen & inodesSeen);
-void canonicalisePathMetaData(const Path & path, uid_t fromUid);
+     running as root.
+
+  If @complain is true, additionally print a message for each metadata being
+  fixed (for use by `nix-store --verify --check-contents'), otherwise the
+  operation is silent.
+*/
+void canonicalisePathMetaData(const Path & path, uid_t fromUid, InodesSeen & inodesSeen, bool complain);
+void canonicalisePathMetaData(const Path & path, uid_t fromUid, bool complain);
 
 void canonicaliseTimestampAndPermissions(const Path & path);
 

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -502,7 +502,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
         if (!store->isValidPath(info.path) || reregister) {
             /* !!! races */
             if (canonicalise)
-                canonicalisePathMetaData(info.path, -1);
+                canonicalisePathMetaData(info.path, -1, false);
             if (!hashGiven) {
                 HashResult hash = hashPath(htSHA256, info.path);
                 info.narHash = hash.first;


### PR DESCRIPTION
Currently, if you somehow end up with store paths that contain an
invalid permission (i.e. not 444 or 555) or mtime (i.e. not 1),
figuring out the problem and fixing it is quite difficult. (See e.g.
NixOS/nixpkgs#32242).

Fortunately, this is quite simple to fix by calling
canonicalisePathMetaData() in --check-contents handling, just need to
add some prints to show when problems are getting repaired.