### PR TITLE
eval.cc: add message to static_assert, message can be omitted w/c++17

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -307,7 +307,7 @@ EvalState::EvalState(const Strings & _searchPath, ref<Store> store)
 
     assert(gcInitialised);
 
-    static_assert(sizeof(Env) == 16);
+    static_assert(sizeof(Env) == 16, "environment must be 16 bytes");
 
     /* Initialise the Nix expression search path. */
     if (!settings.pureEval) {


### PR DESCRIPTION
Doesn't seem to cause problems anywhere, but just in case :).