### PR TITLE
importPaths: Don't copy imported NAR into memory.

### DIFF
--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -70,6 +70,13 @@ struct TeeSink : ParseSink
     TeeSink(Source & source) : source(source) { }
 };
 
+struct FdTeeSink : ParseSink
+{
+    FdTeeSource source;
+
+    FdTeeSink(Source & source, int fd) : source(source, fd) { }
+};
+
 void parseDump(ParseSink & sink, Source & source);
 
 void restorePath(const Path & path, Source & source);

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -180,6 +180,22 @@ struct TeeSource : Source
 };
 
 
+/* Adapter class of a Source that saves all data read to the given FD. */
+struct FdTeeSource : Source
+{
+    Source & orig;
+    FdSink fdSink;
+    FdTeeSource(Source & orig, int fd)
+        : orig(orig), fdSink(fd) { }
+    size_t read(unsigned char * data, size_t len)
+    {
+        size_t n = orig.read(data, len);
+        fdSink.write(data, n);
+        return n;
+    }
+};
+
+
 /* Convert a function into a sink. */
 struct LambdaSink : Sink
 {


### PR DESCRIPTION
Fixes `error: out of memory` of `nix-store --serve --write`
when receiving packages via SSH (and perhaps other sources).

See #1681 #1969 #1988 NixOS/nixpkgs#38808.

Performance improvement on `nix-store --import` of a 2.2 GB cudatoolkit closure:

```
When the store path already exists:
  Before:
    10.82user 2.66system 0:20.14elapsed 66%CPU (0avgtext+0avgdata   12556maxresident)k
  After:
    11.43user 2.94system 0:16.71elapsed 86%CPU (0avgtext+0avgdata 4204664maxresident)k
When the store path doesn't yet exist (after `nix-store --delete`):
  Before:
    11.15user 2.09system 0:13.26elapsed 99%CPU (0avgtext+0avgdata 4204732maxresident)k
  After:
     5.27user 1.48system 0:06.80elapsed 99%CPU (0avgtext+0avgdata   12032maxresident)k
```

The reduction is 4200 MB -> 12 MB RAM usage, and it also takes less time.