### PR TITLE
tests: more robust check for user namespaces availability (canUseSand…

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -57,7 +57,7 @@ rec {
       git
       mercurial
     ]
-    ++ lib.optional stdenv.isLinux [libseccomp utillinux]
+    ++ lib.optionals stdenv.isLinux [libseccomp utillinux]
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin)
       (aws-sdk-cpp.override {

--- a/release-common.nix
+++ b/release-common.nix
@@ -57,7 +57,7 @@ rec {
       git
       mercurial
     ]
-    ++ lib.optional stdenv.isLinux libseccomp
+    ++ lib.optional stdenv.isLinux [libseccomp pkgs.utillinux]
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin)
       (aws-sdk-cpp.override {

--- a/release-common.nix
+++ b/release-common.nix
@@ -57,7 +57,7 @@ rec {
       git
       mercurial
     ]
-    ++ lib.optional stdenv.isLinux [libseccomp pkgs.utillinux]
+    ++ lib.optional stdenv.isLinux [libseccomp utillinux]
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin)
       (aws-sdk-cpp.override {

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -94,11 +94,9 @@ canUseSandbox() {
         return 1
     fi
 
-    if [ -e /proc/sys/kernel/unprivileged_userns_clone ]; then
-        if [ "$(cat /proc/sys/kernel/unprivileged_userns_clone)" != 1 ]; then
-            echo "Unprivileged user namespaces disabled by sysctl, skipping this test..."
-            return 1
-        fi
+    if ! unshare --user true ; then
+        echo "Unprivileged user namespaces disabled by sysctl, skipping this test..."
+        return 1
     fi
 
     return 0


### PR DESCRIPTION
…box)

Fixes https://github.com/NixOS/nix/issues/2165

`unshare`-utility way as suggested by @veprbl 

Two things to pay attention to
- Works for me but requires testing on Debian/Ubuntu with user namespaces turned on/off
- Introduced dependency could be an overkill