### PR TITLE
manual: builtins.fromJSON: remove the claim that floats are not allowed

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -509,8 +509,7 @@ builtins.fromJSON ''{"x": [1, 2, 3], "y": null}''
 </programlisting>
 
     returns the value <literal>{ x = [ 1 2 3 ]; y = null;
-    }</literal>. Floating point numbers are not
-    supported.</para></listitem>
+    }</literal>.</para></listitem>
 
   </varlistentry>
 


### PR DESCRIPTION
floating-point numbers are supported now, including the fromJSON
builtin. Reported on IRC by inquisitiv3