### PR TITLE
backport: manual: builtins.fromJSON: floats

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -479,8 +479,7 @@ builtins.fromJSON ''{"x": [1, 2, 3], "y": null}''
 </programlisting>
 
     returns the value <literal>{ x = [ 1 2 3 ]; y = null;
-    }</literal>. Floating point numbers are not
-    supported.</para></listitem>
+    }</literal>.</para></listitem>
 
   </varlistentry>
 


### PR DESCRIPTION
floating-point numbers are supported now, including the fromJSON
builtin. Reported on IRC by inquisitiv3

(cherry picked from commit 17bc7579809e2afa3870ac1d85f7027d3681f506)