### PR TITLE
libstore/gc.cc: ignore ESRCH when reading symlinks in /proc

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -365,7 +365,7 @@ try_again:
     char buf[bufsiz];
     auto res = readlink(file.c_str(), buf, bufsiz);
     if (res == -1) {
-        if (errno == ENOENT || errno == EACCES)
+        if (errno == ENOENT || errno == EACCES || errno == ESRCH)
             return;
         throw SysError("reading symlink");
     }


### PR DESCRIPTION
It seems readlink is also affected by the problem fixed for regular files in #2223 
I just encountered `error: reading symlink: No such process`.