### PR TITLE
manual: distributed-builds: Mention - as default

### DIFF
--- a/doc/manual/advanced-topics/distributed-builds.xml
+++ b/doc/manual/advanced-topics/distributed-builds.xml
@@ -81,6 +81,7 @@ or a newline, e.g.
 
 <para>Each machine specification consists of the following elements,
 separated by spaces. Only the first element is required.
+To leave a field at its default, set it to <literal>-</literal>.
 
 <orderedlist>
 


### PR DESCRIPTION
nh2:

> how to set the 6th field without having to give all the fields in the middle?

sphalerite:

> I think you can put "-" as the value for any of them to make it use the default
> must have got lost when the docs got reshuffled to reflect it being in the builders option now
> it's used in `tests/build-remote.sh` as well though so I'm pretty sure it's an intended feature

https://github.com/NixOS/nix/blob/d73e881c81a8bf0522fbd026ddf44a7e1adcb81f/tests/build-remote.sh#L14