### PR TITLE
release-common: prefer utillinuxMinimal to reduce compile-time deps

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -57,7 +57,7 @@ rec {
       git
       mercurial
     ]
-    ++ lib.optionals stdenv.isLinux [libseccomp utillinux]
+    ++ lib.optionals stdenv.isLinux [libseccomp utillinuxMinimal]
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin)
       (aws-sdk-cpp.override {


### PR DESCRIPTION
Honestly could probably use busybox here instead, but at least
with utillinuxMinimal there's no build-time dependency on systemd.