### PR TITLE
progress-bar: refresh occasionally even if no updates are received

### DIFF
--- a/src/libutil/sync.hh
+++ b/src/libutil/sync.hh
@@ -57,11 +57,11 @@ public:
         }
 
         template<class Rep, class Period>
-        void wait_for(std::condition_variable & cv,
+        std::cv_status wait_for(std::condition_variable & cv,
             const std::chrono::duration<Rep, Period> & duration)
         {
             assert(s);
-            cv.wait_for(lk, duration);
+            return cv.wait_for(lk, duration);
         }
 
         template<class Rep, class Period, class Predicate>

--- a/src/nix/progress-bar.cc
+++ b/src/nix/progress-bar.cc
@@ -75,9 +75,10 @@ public:
         updateThread = std::thread([&]() {
             auto state(state_.lock());
             while (state->active) {
-                state.wait(updateCV);
+                auto r = state.wait_for(updateCV, std::chrono::seconds(1));
                 draw(*state);
-                state.wait_for(quitCV, std::chrono::milliseconds(50));
+                if (r == std::cv_status::no_timeout)
+                  state.wait_for(quitCV, std::chrono::milliseconds(50));
             }
         });
     }


### PR DESCRIPTION
(if updates are far apart don't wait indefinitely to redraw/check for quit)