### PR TITLE
repl: disable progress-bar explicitly, fix drawing regression

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -14,6 +14,7 @@
 #include "globals.hh"
 #include "command.hh"
 #include "finally.hh"
+#include "progress-bar.hh"
 
 #include "src/linenoise/linenoise.h"
 
@@ -693,6 +694,7 @@ struct CmdRepl : StoreCommand, MixEvalArgs
 
     void run(ref<Store> store) override
     {
+        stopProgressBar();
         auto repl = std::make_unique<NixRepl>(searchPath, openStore());
         repl->mainLoop(files);
     }


### PR DESCRIPTION
Fixes 'nix repl' having prompt drawn-over after
44de71a39624d86d6744062ee36f57170024c9a0.

Apparently repl has ProgressBar enabled like other nix commands,
so after that change after 1 sec an empty line (at least at first)
would be drawn over the prompt, which is of course no good.

AFAICT builds from repl didn't actually use the progress bar anyway
since builds are done in a child via `nix-store -r`.
Accordingly the easy fix is to disable progress bar for the repl,
but we may want to revisit as progress bar would be nifty
to have for builds done from repl :).


-------

Apologies for the breakage and for not noticing this sooner.