### PR TITLE
repl: use `nix build` for building instead of `nix-store -r`

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -385,7 +385,7 @@ bool NixRepl::processLine(string line)
             /* We could do the build in this process using buildPaths(),
                but doing it in a child makes it easier to recover from
                problems / SIGINT. */
-            if (runProgram(settings.nixBinDir + "/nix-store", Strings{"-r", drvPath}) == 0) {
+            if (runProgram(settings.nixBinDir + "/nix", Strings{"build", drvPath}) == 0) {
                 Derivation drv = readDerivation(drvPath);
                 std::cout << std::endl << "this derivation produced the following outputs:" << std::endl;
                 for (auto & i : drv.outputs)


### PR DESCRIPTION
progress bar!

----

Recommended to test using/on-top-of fix from #2249.

Seems to work for me? :D