### PR TITLE
nix why-depends: render output into $PAGER

### DIFF
--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -2,6 +2,7 @@
 #include "store-api.hh"
 #include "progress-bar.hh"
 #include "fs-accessor.hh"
+#include "shared.hh"
 
 #include <queue>
 
@@ -237,6 +238,7 @@ struct CmdWhyDepends : SourceExprCommand
 
             visitPath(node.path);
 
+            RunPager pager;
             for (auto & ref : refs) {
                 auto hash = storePathToHash(ref.second->path);
 


### PR DESCRIPTION
This makes the output e.g. searchable and nothing will be dropped due to scrollback limits in case of bigger closure sizes.