### PR TITLE
Manual: Updates install notes for one-liner

### DIFF
--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -6,11 +6,47 @@
 
 <title>Installing a Binary Distribution</title>
 
+<section>
+<title>Installing using the one-liner</title>
+
 <para>If you are using Linux or macOS, the easiest way to install
 Nix is to run the following command:
 
 <screen>
-$ bash &lt;(curl https://nixos.org/nix/install)
+$ curl https://nixos.org/nix/install | sh
+</screen>
+
+This will perform a default installation of Nix for your platform.
+
+<segmentedlist>
+	<?dbhtml list-presentation="table"?>
+	<?dbfo   list-presentation="table"?>
+	<title>System differences</title>
+	<segtitle>System</segtitle>
+	<segtitle>Default installation</segtitle>
+	<seglistitem>
+		<seg>Linux</seg>
+		<seg>Defaults to a single-user install</seg>
+	</seglistitem>
+	<seglistitem>
+		<seg>macOS</seg>
+		<seg>Defaults to a multi-user install</seg>
+	</seglistitem>
+</segmentedlist>
+
+It is possible to pass additional parameters to the installer using the
+following form.
+
+<screen>
+$ curl https://nixos.org/nix/install | sh -s -- [--daemon --no-daemon]
+</screen>
+</para>
+
+<section>
+<title>Single-user install</title>
+<para>
+<screen>
+$ curl https://nixos.org/nix/install | sh -s -- --no-daemon
 </screen>
 
 This will perform a single-user installation of Nix, meaning that
@@ -29,12 +65,61 @@ $ chown alice /nix
 The install script will modify the first writable file from amongst
 <filename>.bash_profile</filename>, <filename>.bash_login</filename>
 and <filename>.profile</filename> to source
-<filename>~/.nix-profile/etc/profile.d/nix.sh</filename>. You can set
+<filename>~/.nix-profile/etc/profile.d/nix.sh</filename>.  You can set
 the <command>NIX_INSTALLER_NO_MODIFY_PROFILE</command> environment
 variable before executing the install script to disable this
 behaviour.
 
 </para>
+</section>
+
+<section>
+<title>Multi-user install</title>
+<screen>
+$ curl https://nixos.org/nix/install | sh -s -- --daemon
+</screen>
+<para>
+The exact steps taken by the installer are different depending of the
+target platform.  The multi-user installation will explain what it will
+do before doing it to the system.
+</para>
+<para>
+It will
+<orderedlist>
+	<listitem><para>
+Make sure your computer doesn't already have Nix.  If it does, I
+will show you instructions on how to clean up your old one.
+	</para></listitem>
+
+	<listitem><para>
+Show you what we are going to install and where.  Then we will ask
+if you are ready to continue.
+	</para></listitem>
+
+	<listitem><para>
+Create the system users and groups that the Nix daemon uses to run
+builds.
+	</para></listitem>
+
+	<listitem><para>
+Perform the basic installation of the Nix files daemon.
+	</para></listitem>
+
+	<listitem><para>
+Configure your shell to import special Nix Profile files, so you
+can use Nix.
+	</para></listitem>
+
+	<listitem><para>
+Start the Nix daemon.
+	</para></listitem>
+</orderedlist>
+</para>
+</section>
+</section>
+
+<section>
+<title>Installing from a binary tarball</title>
 
 <para>You can also download a binary tarball that contains Nix and all
 its dependencies.  (This is what the install script at
@@ -59,5 +144,6 @@ $ rm -rf /nix
 </screen>
 
 </para>
+</section>
 
 </chapter>

--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -36,33 +36,6 @@ behaviour.
 
 </para>
 
-<!--
-<para>You can also manually download and install a binary package.
-Binary packages of the latest stable release are available for Fedora,
-Debian, Ubuntu, macOS and various other systems from the <link
-xlink:href="http://nixos.org/nix/download.html">Nix homepage</link>.
-You can also get builds of the latest development release from our
-<link
-xlink:href="http://hydra.nixos.org/job/nix/master/release/latest-finished#tabs-constituents">continuous
-build system</link>.</para>
-
-<para>For Fedora, RPM packages are available.  These can be installed
-or upgraded using <command>rpm -U</command>.  For example,
-
-<screen>
-$ rpm -U nix-1.8-1.i386.rpm</screen>
-
-</para>
-
-<para>For Debian and Ubuntu, you can download a Deb package and
-install it like this:
-
-<screen>
-$ dpkg -i nix_1.8-1_amd64.deb</screen>
-
-</para>
--->
-
 <para>You can also download a binary tarball that contains Nix and all
 its dependencies.  (This is what the install script at
 <uri>https://nixos.org/nix/install</uri> does automatically.)  You


### PR DESCRIPTION
The previous instructions did not account for the fact that:
  * macOS now defaults to *multi-user*.
  * it is possible to override installation type.

Furthermore, older commented-out deb/rpm instructions were removed as they are code-rotting.

I think this should be safe to also merge in maintenance (hoping this would also reach the website).

* * *

@grahamc please review for the details about the single/multi user installation.

* * *

~~There is one issue which I'm still looking into: will the `<segmentedlist>` cause issues on the website. I will update this PR once determined. If it does, I will either change to whatever a docbook-knowing contributor suggests, and/or fix the CSS for the website manual accordingly.~~ See my following comment.