### PR TITLE
add support for specifying 'compression-level' for NAR's

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -170,7 +170,7 @@ void BinaryCacheStore::addToStore(const ValidPathInfo & info, const ref<std::str
     /* Compress the NAR. */
     narInfo->compression = compression;
     auto now1 = std::chrono::steady_clock::now();
-    auto narCompressed = compress(compression, *nar, parallelCompression);
+    auto narCompressed = compress(compression, *nar, parallelCompression, compressionLevel);
     auto now2 = std::chrono::steady_clock::now();
     narInfo->fileHash = hashString(htSHA256, *narCompressed);
     narInfo->fileSize = narCompressed->size();

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -20,7 +20,11 @@ public:
     const Setting<Path> secretKeyFile{this, "", "secret-key", "path to secret key used to sign the binary cache"};
     const Setting<Path> localNarCache{this, "", "local-nar-cache", "path to a local cache of NARs"};
     const Setting<bool> parallelCompression{this, false, "parallel-compression",
-        "enable multi-threading compression, available for xz only currently"};
+        "enable multi-threading compression for NARs, available for xz only currently"};
+    const Setting<int> compressionLevel{this, -1, "compression-level",
+        "specify 'preset level' of compression to be used with NARs: "
+        "meaning and accepted range of values depends on compression method selected, "
+        "other than -1 which we reserve to indicate Nix defaults should be used"};
 
 private:
 

--- a/src/libutil/compression.hh
+++ b/src/libutil/compression.hh
@@ -17,9 +17,9 @@ ref<std::string> decompress(const std::string & method, const std::string & in);
 
 ref<CompressionSink> makeDecompressionSink(const std::string & method, Sink & nextSink);
 
-ref<std::string> compress(const std::string & method, const std::string & in, const bool parallel = false);
+ref<std::string> compress(const std::string & method, const std::string & in, const bool parallel = false, int level = -1);
 
-ref<CompressionSink> makeCompressionSink(const std::string & method, Sink & nextSink, const bool parallel = false);
+ref<CompressionSink> makeCompressionSink(const std::string & method, Sink & nextSink, const bool parallel = false, int level  = -1);
 
 MakeError(UnknownCompressionMethod, Error);
 


### PR DESCRIPTION
As requested on #2255.

-----

Lightly tested, but could probably use a bit more vetting :).

-----

May be useful to also add:

* [ ] Documentation
* [ ] New tests

I'll probably put together at least some test for this,
but help with documentation (what/where/how?) would be appreciated.

-----

As an aside, as I was writing the "description" for Setting's that
are part of BinaryCacheStore I wondered:

Are these flags visible somewhere to the user? I couldn't find any way
to get the store-oriented flags to be listed (with or without descriptions/values),
is this currently possible?