### PR TITLE
nix run: put installables in env var

### DIFF
--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -127,6 +127,12 @@ struct CmdRun : InstallablesCommand
                 unixPath.push_front(path + "/bin");
         setenv("PATH", concatStringsSep(":", unixPath).c_str(), 1);
 
+        auto allInstallables = tokenizeString<Strings>(getEnv("NIX_RUN_INSTALLABLES"), " ");
+        for (auto inst : installables) {
+            allInstallables.push_front(inst->what());
+        }
+        setenv("NIX_RUN_INSTALLABLES", concatStringsSep(" ", allInstallables).c_str(), 1);
+
         std::string cmd = *command.begin();
         Strings args;
         for (auto & arg : command) args.push_back(arg);


### PR DESCRIPTION
This can be useful for providing information on the available packages
to child processes, e.g. for displaying in the shell prompt.

I'm not 100% sure whether this is a good idea/implementation, particularly with respect to installables like `(import ./. {})` that contain spaces, so feedback on this and how it might be done better would be appreciated.