### PR TITLE
parser.y: fix assoc of -> and < > <= >=

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -273,7 +273,7 @@ void yyerror(YYLTYPE * loc, yyscan_t scanner, ParseData * data, const char * err
 %token IND_STRING_OPEN IND_STRING_CLOSE
 %token ELLIPSIS
 
-%left IMPL
+%right IMPL
 %left OR
 %left AND
 %nonassoc EQ NEQ

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -273,11 +273,11 @@ void yyerror(YYLTYPE * loc, yyscan_t scanner, ParseData * data, const char * err
 %token IND_STRING_OPEN IND_STRING_CLOSE
 %token ELLIPSIS
 
-%nonassoc IMPL
+%left IMPL
 %left OR
 %left AND
 %nonassoc EQ NEQ
-%left '<' '>' LEQ GEQ
+%nonassoc '<' '>' LEQ GEQ
 %right UPDATE
 %left NOT
 %left '+' '-'


### PR DESCRIPTION
The parser allowed senseless `a > b > c` but disallowed valid `a -> b -> c`
It might be a typo