### PR TITLE
buildenv: remove darwin sandbox profile

### DIFF
--- a/corepkgs/buildenv.nix
+++ b/corepkgs/buildenv.nix
@@ -25,20 +25,5 @@ derivation {
   # Also don't bother substituting.
   allowSubstitutes = false;
 
-  __sandboxProfile = ''
-    (allow sysctl-read)
-    (allow file-read*
-           (literal "/usr/lib/libSystem.dylib")
-           (literal "/usr/lib/libSystem.B.dylib")
-           (literal "/usr/lib/libobjc.A.dylib")
-           (literal "/usr/lib/libobjc.dylib")
-           (literal "/usr/lib/libauto.dylib")
-           (literal "/usr/lib/libc++abi.dylib")
-           (literal "/usr/lib/libc++.1.dylib")
-           (literal "/usr/lib/libDiagnosticMessagesClient.dylib")
-           (subpath "/usr/lib/system")
-           (subpath "/dev"))
-  '';
-
   inherit chrootDeps;
 }


### PR DESCRIPTION
This shouldn't be necessary anymore and it breaks nix-env/nix-channel
when non 'relaxed' sandboxing is enabled.