### PR TITLE
Revert "progress-bar: re-draw last update if nothing new for 1sec."

### DIFF
--- a/src/nix/progress-bar.cc
+++ b/src/nix/progress-bar.cc
@@ -75,10 +75,9 @@ public:
         updateThread = std::thread([&]() {
             auto state(state_.lock());
             while (state->active) {
-                auto r = state.wait_for(updateCV, std::chrono::seconds(1));
+                state.wait(updateCV);
                 draw(*state);
-                if (r == std::cv_status::no_timeout)
-                  state.wait_for(quitCV, std::chrono::milliseconds(50));
+                state.wait_for(quitCV, std::chrono::milliseconds(50));
             }
         });
     }


### PR DESCRIPTION
Not ready for this yet, causes the prompt to disappear in nix repl
and more generally can overwrite non-progress-bar messages.

This reverts commit 44de71a39624d86d6744062ee36f57170024c9a0.