### PR TITLE
repl: don't add trailing spaces to history lines

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -173,9 +173,12 @@ void NixRepl::mainLoop(const std::vector<std::string> & files)
             printMsg(lvlError, format(error + "%1%%2%") % (settings.showTrace ? e.prefix() : "") % e.msg());
         }
 
+        // Remove trailing newline before adding to history
+        input.erase(input.size() - 1);
+        linenoiseHistoryAdd(input.c_str());
+
         // We handled the current input fully, so we should clear it
         // and read brand new input.
-        linenoiseHistoryAdd(input.c_str());
         input.clear();
         std::cout << std::endl;
     }


### PR DESCRIPTION
This fixes #2314.

I tested this manually and confirmed that a trailing space is no longer present when hitting `Up` to get a previous line, and that multi-line input still works.

Sidenote: I had to revert 7de3e00ad905bba85abadd86b83973fdba8d0dfd to build nix with nixpkgs master because the aws-sdk-cpp patch failed to apply.