### PR TITLE
mention `nix-store --query --roots` when a path cannot be deleted

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -791,7 +791,11 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
             assertStorePath(i);
             tryToDelete(state, i);
             if (state.dead.find(i) == state.dead.end())
-                throw Error(format("cannot delete path '%1%' since it is still alive") % i);
+                throw Error(format(
+                    "cannot delete path '%1%' since it is still alive. "
+                    "To find out why use: "
+                    "nix-store --query --roots"
+                    ) % i);
         }
 
     } else if (options.maxFreed > 0) {


### PR DESCRIPTION
As a follow-up on the discussions on PR #2046, this PR will mention the usage of
`nix-store --query --roots` whenever `nix-store` cannot delete a path due to it
still being alive.

This was suggested by @edolstra, because it is not straightforward
whether a path is alive due to it being referred to by a GC root, it being a GC root or
it being referred to by GC in-memory.