### PR TITLE
make single installable argument optional, allowing `nix log`

### DIFF
--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -121,10 +121,12 @@ struct InstallableCommand : virtual Args, SourceExprCommand
 
     InstallableCommand()
     {
-        expectArg("installable", &_installable);
+        expectArg("installable", &_installable, useDefaultInstallable());
     }
 
     void prepare() override;
+
+    virtual bool useDefaultInstallable() { return true; }
 
 private:
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -320,7 +320,7 @@ void InstallablesCommand::prepare()
 
 void InstallableCommand::prepare()
 {
-    installable = parseInstallable(*this, getStore(), _installable, false);
+    installable = parseInstallable(*this, getStore(), _installable, useDefaultInstallable());
 }
 
 }


### PR DESCRIPTION
Previously in Nix commands like log always required an argument. This was confusing, because it is often used in combination with `nix build`, but does not expect the same arguments:

```
$ nix build
$ nix log
error: more arguments are required
Try 'nix --help' for more information.
```

A workaround was to use `""` as argument, since that same value is used by default for the build command:

```
$ nix build
$ nix log ""
```

This is because `nix log` has the following usage:

```
Usage: nix log <FLAGS>... <INSTALLABLE>
```

whereas `nix build` has:

```
Usage: nix build <FLAGS>... <INSTALLABLES>...
```

This PR will make the INSTALLABLE of `nix log`, `nix eval` and `nix edit` optional. That makes the usage as follows:

```
Usage: nix log <FLAGS>... <INSTALLABLE>?
```

Solves #2332 #2066
Partially solves #2078