### PR TITLE
[WIP] +RFC fixing arguments parsing and documentation for nix-build and nix-shell

### DIFF
--- a/doc/manual/command-ref/nix-build.xml
+++ b/doc/manual/command-ref/nix-build.xml
@@ -22,6 +22,12 @@
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="opt-common-syn.xml#xmlns(db=http://docbook.org/ns/docbook)xpointer(/db:nop/*)" />
     <arg><option>--arg</option> <replaceable>name</replaceable> <replaceable>value</replaceable></arg>
     <arg><option>--argstr</option> <replaceable>name</replaceable> <replaceable>value</replaceable></arg>
+    <arg><option>--check</option></arg>
+    <arg><option>--dry-run</option></arg>
+    <group>
+      <arg choice='plain'><option>--expr</option></arg>
+      <arg choice='plain'><option>-E</option></arg>
+    </group>
     <arg>
       <group choice='req'>
         <arg choice='plain'><option>--attr</option></arg>

--- a/doc/manual/command-ref/nix-shell.xml
+++ b/doc/manual/command-ref/nix-shell.xml
@@ -19,6 +19,7 @@
 <refsynopsisdiv>
   <cmdsynopsis>
     <command>nix-shell</command>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="opt-common-syn.xml#xmlns(db=http://docbook.org/ns/docbook)xpointer(/db:nop/*)" />
     <arg><option>--arg</option> <replaceable>name</replaceable> <replaceable>value</replaceable></arg>
     <arg><option>--argstr</option> <replaceable>name</replaceable> <replaceable>value</replaceable></arg>
     <arg><option>--check</option></arg>

--- a/doc/manual/command-ref/nix-shell.xml
+++ b/doc/manual/command-ref/nix-shell.xml
@@ -21,6 +21,12 @@
     <command>nix-shell</command>
     <arg><option>--arg</option> <replaceable>name</replaceable> <replaceable>value</replaceable></arg>
     <arg><option>--argstr</option> <replaceable>name</replaceable> <replaceable>value</replaceable></arg>
+    <arg><option>--check</option></arg>
+    <arg><option>--dry-run</option></arg>
+    <group>
+      <arg choice='plain'><option>--expr</option></arg>
+      <arg choice='plain'><option>-E</option></arg>
+    </group>
     <arg>
       <group choice='req'>
         <arg choice='plain'><option>--attr</option></arg>

--- a/doc/manual/command-ref/opt-common-syn.xml
+++ b/doc/manual/command-ref/opt-common-syn.xml
@@ -59,6 +59,9 @@
   <replaceable>name</replaceable>
   <replaceable>value</replaceable>
 </arg>
+<arg>
+  <arg choice='plain'><option>--repair</option></arg>
+</arg>
 <sbr />
 
 </nop>


### PR DESCRIPTION
`nix-build` and `nix-shell` are both implemented in the same multi-call binary.

The current implementation for arguments parsing makes them share arguments. This can lead to surprising behaviour (or lack thereof) when accidentally using a non-shared parameter.

Abridged list of nonsensical invocations:

 * `nix-build --command "foo" ./release.nix`
 * `nix-build --impure ./release.nix -A build.x86_64-linux`
 * `nix-shell --out-link "foo" ./shell.nix`

There are a couple more that could be added.

This PR intends to fix the behaviour by segregating the arguments parsing using an `if` conditional. That is, unless a better method is suggested.

Additionally, this PR adds the missing documentation for a couple of options, since while checking for the "owner" of the parameters, I realized that a couple options weren't documented.

#### Expectations

I am expecting a bit of push-back from "simply removing" the options. That is, it technically breaks backwards-compatibility with (wrong) usage of the 2.x series for nix-build and nix-shell. This has to be kept in mind.

If it is judged better to keep the non-sensical options, it may be preferred to keep them segregated in their respective binaries, turned into no-ops in the other and documented as such.

#### RFC stdin

I find the `-` (stdin) behaviour surprising with regards to `nix-shell`.

 * `nix-shell ./shell.nix` != `echo 'import ./shell.nix' | nix-shell -`

As for `nix-build` it seems the behaviour is fine.

I am probably overlooking something with the semantics of it. Though, the way it's implemented it may be better to drop this flag in `nix-shell`? The only documentation for `-` as standard input is [for nix-instantiate](https://nixos.org/nix/manual/#description-39), and there are no mention of it in neither the `nix-build` nor the `nix-shell` manuals. (They mention `nix-instantiate.` only for `--arg | --attr | -A`.

* * *

I may split this PR into a documentation-only one that can be fast-tracked. I may also split this PR furthermore while it's WIP.

* * *

Furthermore, this *will* (still a WIP) try to address #1982 and #2208 by actually implementing the flag.