### PR TITLE
docs: Update installation location on the hacking section

### DIFF
--- a/doc/manual/hacking.xml
+++ b/doc/manual/hacking.xml
@@ -30,7 +30,7 @@ To build Nix itself in this shell:
 [nix-shell]$ configurePhase
 [nix-shell]$ make
 </screen>
-To install it in <literal>$(pwd)/nix</literal> and test it:
+To install it in <literal>$(pwd)/inst</literal> and test it:
 <screen>
 [nix-shell]$ make install
 [nix-shell]$ make installcheck


### PR DESCRIPTION
I followed the docs and noticed that `make install` will install nix in under `$(pwd)/inst` and not `$(pwd)/nix` as the docs currently state 😄 