### PR TITLE
fetchGit: Remove unneeded call to git

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -108,21 +108,9 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
 
     Path localRefFile = cacheDir + "/refs/heads/" + localRef;
 
-    bool doFetch;
     time_t now = time(0);
-    /* If a rev was specified, we need to fetch if it's not in the
-       repo. */
-    if (rev != "") {
-        doFetch = !isRevInCache(rev, cacheDir);
-    } else {
-        /* If the local ref is older than ‘tarball-ttl’ seconds, do a
-           git fetch to update the local ref to the remote ref. */
-        struct stat st;
-        doFetch = stat(localRefFile.c_str(), &st) != 0 ||
-            st.st_mtime + settings.tarballTtl <= now;
-    }
-    if (doFetch)
-    {
+
+    auto fetchRepo = [&]() {
         Activity act(*logger, lvlTalkative, actUnknown, fmt("fetching Git repository '%s'", uri));
 
         // FIXME: git stderr messes up our progress indicator, so
@@ -136,11 +124,24 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
         times[1].tv_usec = 0;
 
         utimes(localRefFile.c_str(), times);
+    };
+
+    if (rev == "") {
+        /* No explicit rev given, so make sure the local ref file
+           which contains the rev exists and is up to date.
+           Update if the local ref is older than ‘tarball-ttl’ seconds. */
+        struct stat st;
+        if (stat(localRefFile.c_str(), &st) != 0 ||
+            st.st_mtime + settings.tarballTtl <= now)
+        {
+            fetchRepo();
+        }
+        rev = chomp(readFile(localRefFile));
     }
 
     // FIXME: check whether rev is an ancestor of ref.
     GitInfo gitInfo;
-    gitInfo.rev = rev != "" ? rev : chomp(readFile(localRefFile));
+    gitInfo.rev = rev;
     gitInfo.shortRev = std::string(gitInfo.rev, 0, 7);
 
     printTalkative("using revision %s of repo '%s'", gitInfo.rev, uri);
@@ -163,6 +164,10 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
 
     } catch (SysError & e) {
         if (e.errNo != ENOENT) throw;
+    }
+
+    if (!isRevInCache(rev, cacheDir)) {
+        fetchRepo();
     }
 
     // FIXME: should pipe this, or find some better way to extract a


### PR DESCRIPTION
Originally, I wrote this to fix a nix performance issue, which turned out to have other causes specific to my setup.

This patch might still be useful as it saves a needless call to git in the common case where a rev is given that is already in `/nix/store`.
In this case, now only `~/.cache/nix/git` and `/nix/store` are queried and no subprocesses are started.
