### PR TITLE
nix-upgrade: resolve profile symlinks

### DIFF
--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -1,4 +1,5 @@
 #include "command.hh"
+#include "common-args.hh"
 #include "store-api.hh"
 #include "download.hh"
 #include "eval.hh"
@@ -6,7 +7,7 @@
 
 using namespace nix;
 
-struct CmdUpgradeNix : StoreCommand
+struct CmdUpgradeNix : MixDryRun, StoreCommand
 {
     Path profileDir;
 
@@ -61,21 +62,25 @@ struct CmdUpgradeNix : StoreCommand
 
         {
             Activity act(*logger, lvlInfo, actUnknown, fmt("downloading '%s'...", storePath));
-            store->ensurePath(storePath);
+            if (!dryRun)
+                store->ensurePath(storePath);
         }
 
         {
             Activity act(*logger, lvlInfo, actUnknown, fmt("verifying that '%s' works...", storePath));
-            auto program = storePath + "/bin/nix-env";
-            auto s = runProgram(program, false, {"--version"});
-            if (s.find("Nix") == std::string::npos)
-                throw Error("could not verify that '%s' works", program);
+            if (!dryRun) {
+                auto program = storePath + "/bin/nix-env";
+                auto s = runProgram(program, false, {"--version"});
+                if (s.find("Nix") == std::string::npos)
+                    throw Error("could not verify that '%s' works", program);
+            }
         }
 
         {
             Activity act(*logger, lvlInfo, actUnknown, fmt("installing '%s' into profile '%s'...", storePath, profileDir));
-            runProgram(settings.nixBinDir + "/nix-env", false,
-                {"--profile", profileDir, "-i", storePath, "--no-sandbox"});
+            if (!dryRun)
+                runProgram(settings.nixBinDir + "/nix-env", false,
+                    {"--profile", profileDir, "-i", storePath, "--no-sandbox"});
         }
     }
 


### PR DESCRIPTION
The profile present in PATH is not necessarily the actual profile
location. User profiles are generally added as $HOME/.nix-profile
in which case the indirect profile link needs to be resolved first.

```
/home/user/.nix-profile -> /nix/var/nix/profiles/per-user/user/profile
/nix/var/nix/profiles/per-user/user/profile -> profile-15-link
/nix/var/nix/profiles/per-user/user/profile-14-link -> /nix/store/hyi4kkjh3bwi2z3wfljrkfymz9904h62-user-environment
/nix/var/nix/profiles/per-user/user/profile-15-link -> /nix/store/6njpl3qvihz46vj911pwx7hfcvwhifl9-user-environment
```

To upgrade nix here we want /nix/var/nix/profiles/per-user/user/profile-16-link
instead of /home/user/.nix-profile-1-link. The latter is not a gcroot
and would be garbage collected, resulting in a broken profile.

Fixes #2175