### PR TITLE
Set NIX_REMOTE to unix-socket path; fixes #2372

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -5,7 +5,7 @@ __ETC_PROFILE_NIX_SOURCED=1
 # Set up secure multi-user builds: non-root users build through the
 # Nix daemon.
 if [ "$USER" != root -o ! -w @localstatedir@/nix/db ]; then
-    export NIX_REMOTE=daemon
+    export NIX_REMOTE=unix://@localstatedir@/nix/daemon-socket/socket
 fi
 
 export NIX_USER_PROFILE_DIR="@localstatedir@/nix/profiles/per-user/$USER"


### PR DESCRIPTION
The socket of the nix-daemon is located in `@localstatedir@/nix/daemon-socket/socket`. Therefore setting the environment variable `NIX_REMOTE` to this path, so that programs that need to communicate with nix-daemon know where to find the socket.