### PR TITLE
fix `error: unknown serve command 9`

### DIFF
--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -131,7 +131,7 @@ struct LegacySSHStore : public Store
 
         auto conn(connections->get());
 
-        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 4) {
+        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 5) {
 
             conn->to
                 << cmdAddToStoreNar


### PR DESCRIPTION
this appears to be a typo when checking the remote store version, and the end-result is sending serve commands the remote end cant support