### PR TITLE
Manual: Passing an env var to a pure nix shell with getEnv

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -558,7 +558,20 @@ builtins.genList (x: x * x) 5
     locate the file <filename>~/.nixpkgs/config.nix</filename>, which
     contains user-local settings for Nix Packages.  (That is, it does
     a <literal>getEnv "HOME"</literal> to locate the user’s home
-    directory.)</para></listitem>
+    directory.)</para>
+
+    <para>You can use <function>getEnv</function> to pass additional
+    environment variables to a derivation that is (exclusively) used
+    with <literal>nix-shell --pure</literal>, for example to pass the
+    SSH authentication socket:
+
+<programlisting>
+derivation {
+  …
+  SSH_AUTH_SOCK = builtins.getEnv "SSH_AUTH_SOCK";
+}
+</programlisting>
+    </para></listitem>
 
   </varlistentry>
 


### PR DESCRIPTION
Describe a practical use of `builtins.getEnv` with `nix-shell`
that is not directly obvious.

Rendered: 
![screenshot](https://user-images.githubusercontent.com/3153638/44917121-caade280-ad37-11e8-9441-dd3869c3cd66.png)
