### PR TITLE
Print stats in more programs

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -305,6 +305,8 @@ void mainWrapped(int argc, char * * argv)
         }
     }
 
+    state->printStats();
+
     auto buildPaths = [&](const PathSet & paths) {
         /* Note: we do this even when !printMissing to efficiently
            fetch binary cache data. */
@@ -495,7 +497,6 @@ void mainWrapped(int argc, char * * argv)
 
         for (auto & path : outPaths)
             std::cout << path << '\n';
-        state->printStats();
     }
 }
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -495,6 +495,7 @@ void mainWrapped(int argc, char * * argv)
 
         for (auto & path : outPaths)
             std::cout << path << '\n';
+        state->printStats();
     }
 }
 


### PR DESCRIPTION
works on failed builds:

```
[nix-shell:~/projects/nix]$ NIX_SHOW_STATS=1 ./inst/bin/nix-build ../test.nix 
evaluation statistics:
  time elapsed: 0.090999
  size of a value: 24
  size of an attr: 24
  environments allocated count: 4811
  environments allocated bytes: 135936
  list elements count: 3770
  list elements bytes: 30160
  list concatenations: 17
  values allocated count: 26697
  values allocated bytes: 640728
  sets allocated: 2034 (2094960 bytes)
  right-biased unions: 251
  values copied in right-biased unions: 63015
  symbols in symbol table: 12782
  size of symbol table: 156784
  number of thunks: 23295
  number of thunks avoided: 6495
  number of attr lookups: 906
  number of primop calls: 2480
  number of function calls: 4284
  total allocations: 2901784 bytes
  current Boehm heap size: 402718720 bytes
  total Boehm heap allocations: 3186896 bytes
these derivations will be built:
  /nix/store/d2vrs4sgs3caxv2pldy0gli6l20lk50i-hi.drv
building '/nix/store/d2vrs4sgs3caxv2pldy0gli6l20lk50i-hi.drv'...
builder for '/nix/store/d2vrs4sgs3caxv2pldy0gli6l20lk50i-hi.drv' failed to produce output path '/nix/store/2sznz356r0j7215srdppwzi830v98hd5-hi'
error: build of '/nix/store/d2vrs4sgs3caxv2pldy0gli6l20lk50i-hi.drv' failed
```

nix shell:

```
$ NIX_SHOW_STATS=1 ./inst/bin/nix-shell ../test.nix -A a
evaluation statistics:
  time elapsed: 0.091844
  size of a value: 24
  size of an attr: 24
  environments allocated count: 4831
  environments allocated bytes: 136856
  list elements count: 3772
  list elements bytes: 30176
  list concatenations: 17
  values allocated count: 26751
  values allocated bytes: 642024
  sets allocated: 2054 (2101552 bytes)
  right-biased unions: 261
  values copied in right-biased unions: 63223
  symbols in symbol table: 12782
  size of symbol table: 156774
  number of thunks: 23345
  number of thunks avoided: 6539
  number of attr lookups: 917
  number of primop calls: 2485
  number of function calls: 4300
  total allocations: 2910608 bytes
  current Boehm heap size: 402718720 bytes
  total Boehm heap allocations: 3197488 bytes

```

dry runs:

```
]$ NIX_SHOW_STATS=1 ./inst/bin/nix-build ../test.nix  -A a --dry-run
evaluation statistics:
  time elapsed: 0.091129
  size of a value: 24
  size of an attr: 24
  environments allocated count: 4831
  environments allocated bytes: 136856
  list elements count: 3772
  list elements bytes: 30176
  list concatenations: 17
  values allocated count: 26751
  values allocated bytes: 642024
  sets allocated: 2054 (2101552 bytes)
  right-biased unions: 261
  values copied in right-biased unions: 63223
  symbols in symbol table: 12782
  size of symbol table: 156774
  number of thunks: 23345
  number of thunks avoided: 6539
  number of attr lookups: 917
  number of primop calls: 2485
  number of function calls: 4300
  total allocations: 2910608 bytes
  current Boehm heap size: 402718720 bytes
  total Boehm heap allocations: 3197488 bytes
these derivations will be built:
  /nix/store/ndig663m5626mlqfkr1i0bgnlmv3kg3m-hi.drv

```

successfull builds:

```
$ NIX_SHOW_STATS=1 ./inst/bin/nix-build  ../test.nix
evaluation statistics:
  time elapsed: 0.094896
  size of a value: 24
  size of an attr: 24
  environments allocated count: 4811
  environments allocated bytes: 135936
  list elements count: 3770
  list elements bytes: 30160
  list concatenations: 17
  values allocated count: 26698
  values allocated bytes: 640752
  sets allocated: 2035 (2094992 bytes)
  right-biased unions: 251
  values copied in right-biased unions: 63015
  symbols in symbol table: 12783
  size of symbol table: 156799
  number of thunks: 23296
  number of thunks avoided: 6495
  number of attr lookups: 906
  number of primop calls: 2480
  number of function calls: 4284
  total allocations: 2901840 bytes
  current Boehm heap size: 402718720 bytes
  total Boehm heap allocations: 3186896 bytes
these derivations will be built:
  /nix/store/70dbsncklmss52zl050j35m0d3z0gvkr-hi.drv
building '/nix/store/70dbsncklmss52zl050j35m0d3z0gvkr-hi.drv'...
/nix/store/zc95dfzrlf12dk4pvapnj427qa599sdl-hi
```

helpful for debugging big evals in nixops according to @cleverca22.