### PR TITLE
nix doctor: add command

### DIFF
--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -303,6 +303,12 @@ struct LegacySSHStore : public Store
     {
         auto conn(connections->get());
     }
+
+    unsigned int getProtocol() override
+    {
+        auto conn(connections->get());
+        return conn->remoteVersion;
+    }
 };
 
 static RegisterStoreImplementation regStore([](

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1332,6 +1332,12 @@ void LocalStore::verifyPath(const Path & path, const PathSet & store,
 }
 
 
+unsigned int LocalStore::getProtocol()
+{
+    return PROTOCOL_VERSION;
+}
+
+
 #if defined(FS_IOC_SETFLAGS) && defined(FS_IOC_GETFLAGS) && defined(FS_IMMUTABLE_FL)
 
 static void makeMutable(const Path & path)

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -209,6 +209,8 @@ public:
 
     void registerValidPaths(const ValidPathInfos & infos);
 
+    unsigned int getProtocol() override;
+
     void vacuumDB();
 
     /* Repair the contents of the given path by redownloading it using

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -646,6 +646,13 @@ void RemoteStore::connect()
 }
 
 
+unsigned int RemoteStore::getProtocol()
+{
+    auto conn(connections->get());
+    return conn->daemonVersion;
+}
+
+
 void RemoteStore::flushBadConnections()
 {
     connections->flushBad();

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -97,6 +97,8 @@ public:
 
     void connect() override;
 
+    unsigned int getProtocol() override;
+
     void flushBadConnections();
 
 protected:

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -598,6 +598,12 @@ public:
        a notion of connection. Otherwise this is a no-op. */
     virtual void connect() { };
 
+    /* Get the protocol version of this store or it's connection. */
+    virtual unsigned int getProtocol()
+    {
+        return 0;
+    };
+
     /* Get the priority of the store, used to order substituters. In
        particular, binary caches can specify a priority field in their
        "nix-cache-info" file. Lower value means higher priority. */

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -33,7 +33,24 @@ struct CmdDoctor : StoreCommand
         std::cout << "Store uri: " << store->getUri() << std::endl;
         std::cout << std::endl;
 
+        checkNixInPath();
         checkStoreProtocol(store->getProtocol());
+    }
+
+    void checkNixInPath() {
+        PathSet dirs;
+
+        for (auto & dir : tokenizeString<Strings>(getEnv("PATH"), ":"))
+            if (pathExists(dir + "/nix-env"))
+                dirs.insert(dirOf(canonPath(dir + "/nix-env", true)));
+
+        if (dirs.size() != 1) {
+            std::cout << "Warning: multiple versions of nix found in PATH." << std::endl;
+            std::cout << std::endl;
+            for (auto & dir : dirs)
+                std::cout << "  " << dir << std::endl;
+            std::cout << std::endl;
+        }
     }
 
     void checkStoreProtocol(unsigned int storeProto) {

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -1,4 +1,5 @@
 #include "command.hh"
+#include "serve-protocol.hh"
 #include "shared.hh"
 #include "store-api.hh"
 #include "worker-protocol.hh"
@@ -35,14 +36,18 @@ struct CmdDoctor : StoreCommand
         checkStoreProtocol(store->getProtocol());
     }
 
-    void checkStoreProtocol(unsigned int proto) {
-        if (PROTOCOL_VERSION != proto) {
+    void checkStoreProtocol(unsigned int storeProto) {
+        auto clientProto = GET_PROTOCOL_MAJOR(SERVE_PROTOCOL_VERSION) == GET_PROTOCOL_MAJOR(storeProto)
+            ? SERVE_PROTOCOL_VERSION
+            : PROTOCOL_VERSION;
+
+        if (clientProto != storeProto) {
             std::cout << "Warning: protocol version of this client does not match the store." << std::endl;
             std::cout << "While this is not necessarily a problem it's recommended to keep the client in" << std::endl;
             std::cout << "sync with the daemon." << std::endl;
             std::cout << std::endl;
-            std::cout << "Client protocol: " << formatProtocol(PROTOCOL_VERSION) << std::endl;
-            std::cout << "Store protocol: " << formatProtocol(proto) << std::endl;
+            std::cout << "Client protocol: " << formatProtocol(clientProto) << std::endl;
+            std::cout << "Store protocol: " << formatProtocol(storeProto) << std::endl;
             std::cout << std::endl;
         }
     }

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -1,8 +1,19 @@
 #include "command.hh"
 #include "shared.hh"
 #include "store-api.hh"
+#include "worker-protocol.hh"
 
 using namespace nix;
+
+std::string formatProtocol(unsigned int proto)
+{
+    if (proto) {
+        auto major = GET_PROTOCOL_MAJOR(proto) >> 8;
+        auto minor = GET_PROTOCOL_MINOR(proto);
+        return (format("%1%.%2%") % major % minor).str();
+    }
+    return "unknown";
+}
 
 struct CmdDoctor : StoreCommand
 {
@@ -19,8 +30,22 @@ struct CmdDoctor : StoreCommand
     void run(ref<Store> store) override
     {
         std::cout << "Store uri: " << store->getUri() << std::endl;
+        std::cout << std::endl;
+
+        checkStoreProtocol(store->getProtocol());
+    }
+
+    void checkStoreProtocol(unsigned int proto) {
+        if (PROTOCOL_VERSION != proto) {
+            std::cout << "Warning: protocol version of this client does not match the store." << std::endl;
+            std::cout << "While this is not necessarily a problem it's recommended to keep the client in" << std::endl;
+            std::cout << "sync with the daemon." << std::endl;
+            std::cout << std::endl;
+            std::cout << "Client protocol: " << formatProtocol(PROTOCOL_VERSION) << std::endl;
+            std::cout << "Store protocol: " << formatProtocol(proto) << std::endl;
+            std::cout << std::endl;
+        }
     }
 };
 
 static RegisterCommand r1(make_ref<CmdDoctor>());
-

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -1,0 +1,26 @@
+#include "command.hh"
+#include "shared.hh"
+#include "store-api.hh"
+
+using namespace nix;
+
+struct CmdDoctor : StoreCommand
+{
+    std::string name() override
+    {
+        return "doctor";
+    }
+
+    std::string description() override
+    {
+        return "check your system for potential problems";
+    }
+
+    void run(ref<Store> store) override
+    {
+        std::cout << "Store uri: " << store->getUri() << std::endl;
+    }
+};
+
+static RegisterCommand r1(make_ref<CmdDoctor>());
+

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -33,8 +33,12 @@ struct CmdDoctor : StoreCommand
         std::cout << "Store uri: " << store->getUri() << std::endl;
         std::cout << std::endl;
 
-        checkNixInPath();
-        checkProfileRoots(store);
+        auto type = getStoreType();
+
+        if (type < tOther) {
+            checkNixInPath();
+            checkProfileRoots(store);
+        }
         checkStoreProtocol(store->getProtocol());
     }
 
@@ -56,7 +60,6 @@ struct CmdDoctor : StoreCommand
 
     void checkProfileRoots(ref<Store> store) {
         PathSet dirs;
-
         Roots roots = store->findRoots();
 
         for (auto & dir : tokenizeString<Strings>(getEnv("PATH"), ":"))


### PR DESCRIPTION
This command performs a bunch of sanity checks on the nix installation, most of these are not necceceraly a problem but can be very useful when debugging an issue. Most notably a way to detect worker/serve protocol mismatches in various conditions. This also works in combination with `--store ssh://host` to help debug eg. nix-copy-closure issues like https://github.com/NixOS/nix/pull/2383.

TODO: also include the details `nix-info` generates?

The code probably also needs a bit of cleanup.

---

```
$ nix doctor
Store uri: daemon

Warning: multiple versions of nix found in PATH.

  /nix/store/1wgsprdh6lafnqf8iddnm01k9kxvx5xv-nix-2.0.4/bin
  /src/nix/inst/bin

Warning: found profiles outside of /nix/var/nix/profiles.
The generation this profile points to might not have a gcroot and could be
garbage collected, resulting in broken symlinks.

  /tmp/foo/bin

Warning: protocol version of this client does not match the store.
While this is not necessarily a problem it's recommended to keep the client in
sync with the daemon.

Client protocol: 1.21
Store protocol: 1.20
```