### PR TITLE
download: fix size reported to progress bar

### DIFF
--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -345,7 +345,7 @@ struct CurlDownloader : public Downloader
                 done = true;
 
                 try {
-                    act.progress(result.data->size(), result.data->size());
+                    act.progress(result.bodySize, result.bodySize);
                     callback(std::move(result));
                 } catch (...) {
                     done = true;


### PR DESCRIPTION
Can be seen in progress bar "restarting" from zero repeatedly,
and final DL total either claimed to be 0 or omitted.

Watch the `/11.9` counter in these, for example:

Before: https://asciinema.org/a/ZLEHRkOlSAgF7jB6FEV0KqJVl
After: https://asciinema.org/a/BwqDZV6hGtcRBiARnVU3SUZ3T