### PR TITLE
Set environment variable NIX_SHELL_NAME to derivation name

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -446,6 +446,7 @@ void mainWrapped(int argc, char * * argv)
 
         restoreSignals();
 
+        setenv("NIX_SHELL_NAME", drvInfo.queryName().c_str(), 1);
         execvp(shell.c_str(), argPtrs.data());
 
         throw SysError("executing shell '%s'", shell);


### PR DESCRIPTION
When in a nix-shell environment, I like to have the derivation name exposed on my prompt.
At the moment this is a bit tricky to do, thus this change introduces an environment variable that exports the derivation name.