### PR TITLE
Make fetchGit do full checkout if ref = "*"

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -120,6 +120,13 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
     {
         Activity act(*logger, lvlTalkative, actUnknown, fmt("fetching Git repository '%s'", uri));
 
+        if (ref == "*"s) {
+          /* Do full checkout. */
+          runProgram("git", true, { "-C", cacheDir, "fetch", "--quiet", "--force", "--", uri, "+refs/heads/*:refs/heads/*" });
+
+          ref = "HEAD"s;
+        }
+
         // FIXME: git stderr messes up our progress indicator, so
         // we're using --quiet for now. Should process its stderr.
         runProgram("git", true, { "-C", cacheDir, "fetch", "--quiet", "--force", "--", uri, *ref + ":" + localRef });


### PR DESCRIPTION
Sometimes one might want to fetch a rev without knowing the ref. In this case, full repo clone is usually required. This commit adds a special case to ref handling, so that when `ref = "*"`, `fetchGit` fetches all refs prior to fetching the rev.

Usage example:

```
let
 repo = fetchGit {
   url = "https://github.com/serokell/nixage.git";
   ref = "*";
   rev = "4b83ae894ab99b55c67b6629058b3a4fdd8ba0c2";
 };
in

builtins.trace repo repo
```