### PR TITLE
Place global lock on fetchGit

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -28,6 +28,9 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
     std::experimental::optional<std::string> ref, std::string rev,
     const std::string & name)
 {
+    Path gitLockFile = getCacheDir() + "/nix/git.lock";
+    PathLocks gitLock({gitLockFile}, "waiting for Git fetch...");
+
     if (evalSettings.pureEval && rev == "")
         throw Error("in pure evaluation mode, 'fetchGit' requires a Git revision");
 


### PR DESCRIPTION
We use `fetchGit` in CI, and lack of a lock causes irrecoverable issues once in a while: https://gist.github.com/serokell-bot/081bc82276e227fe0f34fdb3cfcf3361

There are many things that can go wrong prior to `storeLinkLock`, so this places global lock on `fetchGit`.