### PR TITLE
Upgrading docs: easier to copy + link to issue

### DIFF
--- a/doc/manual/installation/upgrading.xml
+++ b/doc/manual/installation/upgrading.xml
@@ -8,7 +8,7 @@
 
   <para>
     Multi-user Nix users on macOS can upgrade Nix by running this:
-    <command>$ sudo -i sh -c 'nix-channel --update &amp;&amp; nix-env
+    <command>sudo -i sh -c 'nix-channel --update &amp;&amp; nix-env
       -iA nixpkgs.nix'; sudo launchctl stop org.nixos.nix-daemon; sudo
       launchctl start org.nixos.nix-daemon</command>
   </para>

--- a/doc/manual/installation/upgrading.xml
+++ b/doc/manual/installation/upgrading.xml
@@ -7,15 +7,21 @@
   <title>Upgrading Nix</title>
 
   <para>
-    Multi-user Nix users on macOS can upgrade Nix by running
-    <command>sudo -i sh -c 'nix-channel --update &amp;&amp; nix-env
-    -iA nixpkgs.nix'; sudo launchctl stop org.nixos.nix-daemon; sudo
-    launchctl start org.nixos.nix-daemon</command>.
+    Multi-user Nix users on macOS can upgrade Nix by running this:
+    <screen>$ sudo -i sh -c 'nix-channel --update &amp;&amp; nix-env
+      -iA nixpkgs.nix'; sudo launchctl stop org.nixos.nix-daemon; sudo
+      launchctl start org.nixos.nix-daemon</screen>
+  </para>
+
+
+  <para>
+    Single-user installations of Nix should run this:
+    <screen>$ nix-channel
+      --update; nix-env -iA nixpkgs.nix</screen>
   </para>
 
   <para>
-    Single-user installations of Nix should run <command>nix-channel
-    --update; nix-env -iA nixpkgs.nix</command>.
+    For more information, see <link xlink:href="https://github.com/NixOS/nix/issues/2410">Issue #2410</link>.
   </para>
 
 </chapter>

--- a/doc/manual/installation/upgrading.xml
+++ b/doc/manual/installation/upgrading.xml
@@ -8,16 +8,16 @@
 
   <para>
     Multi-user Nix users on macOS can upgrade Nix by running this:
-    <screen>$ sudo -i sh -c 'nix-channel --update &amp;&amp; nix-env
+    <command>$ sudo -i sh -c 'nix-channel --update &amp;&amp; nix-env
       -iA nixpkgs.nix'; sudo launchctl stop org.nixos.nix-daemon; sudo
-      launchctl start org.nixos.nix-daemon</screen>
+      launchctl start org.nixos.nix-daemon</command>
   </para>
 
 
   <para>
     Single-user installations of Nix should run this:
-    <screen>$ nix-channel
-      --update; nix-env -iA nixpkgs.nix</screen>
+    <command>nix-channel
+      --update; nix-env -iA nixpkgs.nix</command>
   </para>
 
   <para>


### PR DESCRIPTION
With `command`, it's easy for users to accidentally copy the period after the command.