### PR TITLE
Always try next substituter

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3683,18 +3683,12 @@ void SubstitutionGoal::tryNext()
         tryNext();
         return;
     } catch (SubstituterDisabled &) {
-        if (settings.tryFallback) {
-            tryNext();
-            return;
-        }
-        throw;
+        tryNext();
+        return;
     } catch (Error & e) {
-        if (settings.tryFallback) {
-            printError(e.what());
-            tryNext();
-            return;
-        }
-        throw;
+        printError(e.what());
+        tryNext();
+        return;
     }
 
     /* Update the total expected download size. */

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -882,10 +882,7 @@ void LocalStore::querySubstitutablePathInfos(const PathSet & paths,
             } catch (InvalidPath) {
             } catch (SubstituterDisabled) {
             } catch (Error & e) {
-                if (settings.tryFallback)
-                    printError(e.what());
-                else
-                    throw;
+                printError(e.what());
             }
         }
     }


### PR DESCRIPTION
This is related to #1990.
The current behaviour is counter-intuitive and conflicts with the
documentation of --fallback which states that the option is used to
build derivations locally if they fail to download.