### PR TITLE
Add XDG_DATA_DIRS to nix-profile.sh

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -78,6 +78,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     if [ -n "${MANPATH}" ]; then
         export MANPATH="$NIX_LINK/share/man:$MANPATH"
     fi
+    export XDG_DATA_DIRS="$NIX_LINK/share:$XDG_DATA_DIRS"
 
     export PATH="$NIX_LINK/bin:$__savedpath"
     unset __savedpath NIX_LINK NIX_USER_PROFILE_DIR NIX_PROFILES


### PR DESCRIPTION
This is helpful for locating resources with Nix, especially in
unmanaged situations like on macOS or non-NixOS Linux. ~Like MANPATH,
it should be harmless to have these set when the directory doesn’t
exist. If anyone knows of other variables like this, please mention them
here! We should include as many as possible so things work out-of-the-box.~
