### PR TITLE
nix-daemon: allow setting builders to "" by any user (untrusted)

### DIFF
--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -557,7 +557,8 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                     ;
                 else if (trusted
                     || name == settings.buildTimeout.name
-                    || name == "connect-timeout")
+                    || name == "connect-timeout"
+                    || (name == "builders" && value == ""))
                     settings.set(name, value);
                 else if (setSubstituters(settings.substituters))
                     ;


### PR DESCRIPTION
It'd be even better to accept a subset of builders, but this is still
a big win IMHO for making it easy to disable distributed builds from normal accounts.