### PR TITLE
install script: remove unportable command check, fixup errant escape

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -11,14 +11,14 @@ oops() {
 }
 
 tmpDir="$(mktemp -d -t nix-binary-tarball-unpack.XXXXXXXXXX || \
-          oops "Can\'t create temporary directory for downloading the Nix binary tarball")"
+          oops "Can't create temporary directory for downloading the Nix binary tarball")"
 cleanup() {
     rm -rf "$tmpDir"
 }
 trap cleanup EXIT INT QUIT TERM
 
 require_util() {
-    type "$1" > /dev/null 2>&1 || which "$1" > /dev/null 2>&1 ||
+    type "$1" > /dev/null 2>&1 || command -v "$1" > /dev/null 2>&1 ||
         oops "you do not have '$1' installed, which I need to $2"
 }
 


### PR DESCRIPTION
`which` isn't necessarily portable, but `command -v` is an equivalent form.

Additionally, the `\'` is not necessary, as it is already quoted by `"`.

Ideally backported too, since I patch the Install script on every update to be shellcheck-compliant.