### PR TITLE
Add a --keep-successful flag to nix-build.

### DIFF
--- a/doc/manual/command-ref/opt-common-syn.xml
+++ b/doc/manual/command-ref/opt-common-syn.xml
@@ -44,6 +44,12 @@
 </arg>
 <arg>
   <group choice='plain'>
+    <arg choice='plain'><option>--keep-successful</option></arg>
+    <arg choice='plain'><option>-S</option></arg>
+  </group>
+</arg>
+<arg>
+  <group choice='plain'>
     <arg choice='plain'><option>--keep-failed</option></arg>
     <arg choice='plain'><option>-K</option></arg>
   </group>

--- a/doc/manual/command-ref/opt-common.xml
+++ b/doc/manual/command-ref/opt-common.xml
@@ -181,6 +181,17 @@
 </varlistentry>
 
 
+<varlistentry><term><option>--keep-successful</option> / <option>-K</option></term>
+
+  <listitem><para>Specifies that in case of a build success, the
+  temporary directory (usually in <filename>/tmp</filename>) in which
+  the build takes place should not be deleted.  The path of the build
+  directory is printed as an informational message.
+    </para>
+  </listitem>
+</varlistentry>
+
+
 <varlistentry><term><option>--fallback</option></term>
 
   <listitem>

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -159,6 +159,12 @@ LegacyArgs::LegacyArgs(const std::string & programName,
         .set(&settings.verboseBuild, false);
 
     mkFlag()
+        .longName("keep-successful")
+        .shortName('S')
+        .description("keep temporary directories of successful builds")
+        .set(&(bool&) settings.keepSuccessful, true);
+
+    mkFlag()
         .longName("keep-failed")
         .shortName('K')
         .description("keep temporary directories of failed builds")

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3372,7 +3372,7 @@ void DerivationGoal::deleteTmpDir(bool force)
     if (tmpDir != "") {
         /* Don't keep temporary directories for builtins because they
            might have privileged stuff (like a copy of netrc). */
-        if (settings.keepFailed && !force && !drv->isBuiltin()) {
+        if (((settings.keepFailed && !force) || (settings.keepSuccessful && force)) && !drv->isBuiltin()) {
             printError(
                 format("note: keeping build directory '%2%'")
                 % drvPath % tmpDir);

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -69,6 +69,9 @@ public:
     Setting<std::string> storeUri{this, getEnv("NIX_REMOTE", "auto"), "store",
         "The default Nix store to use."};
 
+    Setting<bool> keepSuccessful{this, false, "keep-successful",
+        "Whether to keep temporary directories of successful builds."};
+
     Setting<bool> keepFailed{this, false, "keep-failed",
         "Whether to keep temporary directories of failed builds."};
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -175,6 +175,7 @@ void RemoteStore::initConnection(Connection & conn)
 void RemoteStore::setOptions(Connection & conn)
 {
     conn.to << wopSetOptions
+       << settings.keepSuccessful
        << settings.keepFailed
        << settings.keepGoing
        << settings.tryFallback

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -506,6 +506,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     }
 
     case wopSetOptions: {
+        settings.keepSuccessful = readInt(from);
         settings.keepFailed = readInt(from);
         settings.keepGoing = readInt(from);
         settings.tryFallback = readInt(from);


### PR DESCRIPTION
The new flag mirrors the --keep-failed flag; it keeps the temporary build directory when the build is successful instead of removing it.