### PR TITLE
Promote verbose-build and log-lines

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -82,9 +82,9 @@ public:
     /* Whether to show build log output in real time. */
     bool verboseBuild = true;
 
-    /* If verboseBuild is false, the number of lines of the tail of
-       the log to show if a build fails. */
-    size_t logLines = 10;
+    Setting<size_t> logLines{this, 10, "log-lines",
+        "If verbose-build is false, the number of lines of the tail of "
+        "the log to show if a build fails."};
 
     MaxBuildJobsSetting maxBuildJobs{this, 1, "max-jobs",
         "Maximum number of parallel build jobs. \"auto\" means use number of cores.",


### PR DESCRIPTION
These are now fully-qualified options, allowing commands like

```
nix build --verbose-build nixpkgs.hello
nix build --log-lines 30 nixpkgs.hello
```

In order to obtain more information in case of a failure.

cc @colemickens who was asking about this on IRC, @gilligan who was asking about this on twitter :)