### PR TITLE
nix-prefetch-url: progressbar

### DIFF
--- a/src/nix-prefetch-url/nix-prefetch-url.cc
+++ b/src/nix-prefetch-url/nix-prefetch-url.cc
@@ -7,6 +7,8 @@
 #include "common-eval-args.hh"
 #include "attr-path.hh"
 #include "legacy.hh"
+#include "finally.hh"
+#include "progress-bar.hh"
 
 #include <iostream>
 
@@ -95,6 +97,11 @@ static int _main(int argc, char * * argv)
 
         if (args.size() > 2)
             throw UsageError("too many arguments");
+
+        Finally f([]() { stopProgressBar(); });
+
+        if (isatty(STDERR_FILENO))
+          startProgressBar();
 
         auto store = openStore();
         auto state = std::make_unique<EvalState>(myArgs.searchPath, store);


### PR DESCRIPTION
Requires #2485 to be built (as does master).

Small thing I tried a while back but didn't work out
because progress-bar definition in the `nix` tools
not in any library `nix-prefetch-url` could use.

However after recent change combining the tools
this works and is a nice usability improvement
over the current behavior of silence.