### PR TITLE
remote-store.hh: ConnectionHandle is struct, minor fix warning

### DIFF
--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -127,7 +127,7 @@ protected:
 
     ConnectionHandle getConnection();
 
-    friend class ConnectionHandle;
+    friend struct ConnectionHandle;
 
 private:
 


### PR DESCRIPTION
Makes clang happy, that's the main benefit :).