### PR TITLE
Improve command not found errors

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1041,9 +1041,10 @@ void runProgram2(const RunOptions & options)
 
         restoreSignals();
 
-        if (options.searchPath)
+        if (options.searchPath) {
             execvp(options.program.c_str(), stringsToCharPtrs(args_).data());
-        else
+            _exit(127);
+        } else
             execv(options.program.c_str(), stringsToCharPtrs(args_).data());
 
         throw SysError("executing '%1%'", options.program);


### PR DESCRIPTION
Improves error message when git/mercurial are not available. eg.

```
error: program 'git' failed with exit code 127
The program 'git' is currently not installed. It is required for builtins.fetchGit
You can install it by running the following:
nix-env -f '<nixpkgs>' -iA git
```