### PR TITLE
Use nativeBuildInputs for nix-shell

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -249,7 +249,7 @@ static void _main(int argc, char * * argv)
 
     if (packages) {
         std::ostringstream joined;
-        joined << "with import <nixpkgs> { }; (pkgs.runCommandCC or pkgs.runCommand) \"shell\" { buildInputs = [ ";
+        joined << "with import <nixpkgs> { }; (pkgs.runCommandCC or pkgs.runCommand) \"shell\" { nativeBuildInputs = [ ";
         for (const auto & i : left)
             joined << '(' << i << ") ";
         joined << "]; } \"\"";


### PR DESCRIPTION
Now the nix-shell will generate a nix expression that looks like this:

```
with import <nixpkgs> {};
runCommand "shell" {
  nativeBuildInputs = [
    (...)
    (...)
    (...)
  ];
}
```

from

$ nix-shell --packages ... ... ...

Fixes the issue described in https://github.com/NixOS/nixpkgs/issues/38657.