### PR TITLE
Create version.nix containing used nixos version

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,5 @@
 { nix ? builtins.fetchGit ./.
-, nixpkgs ? builtins.fetchGit { url = https://github.com/NixOS/nixpkgs-channels.git; ref = "nixos-18.09"; }
+, nixpkgs ? ./version.nix
 , officialRelease ? false
 , systems ? [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" ]
 }:

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { useClang ? false }:
 
-with import (builtins.fetchGit { url = https://github.com/NixOS/nixpkgs-channels.git; ref = "nixos-18.09"; }) {};
+with import ./version.nix {};
 
 with import ./release-common.nix { inherit pkgs; };
 

--- a/version.nix
+++ b/version.nix
@@ -1,0 +1,1 @@
+import (builtins.fetchGit { url = https://github.com/NixOS/nixpkgs-channels.git; ref = "nixos-18.09"; })


### PR DESCRIPTION
This ensures, that `release.nix` and `shell.nix` always use the same version
of nixos. See https://github.com/NixOS/nix/pull/2506#issuecomment-435047869.