### PR TITLE
Allow root uid/gid (0) in sandbox userns when allowNewPrivileges

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2243,11 +2243,13 @@ void DerivationGoal::startBuilder()
         uid_t hostGid = buildUser ? buildUser->getGID() : getgid();
 
         writeFile("/proc/" + std::to_string(pid) + "/uid_map",
+            (settings.allowNewPrivileges ? "0 0 1\n" : "") +
             (format("%d %d 1") % sandboxUid % hostUid).str());
 
         writeFile("/proc/" + std::to_string(pid) + "/setgroups", "deny");
 
         writeFile("/proc/" + std::to_string(pid) + "/gid_map",
+            (settings.allowNewPrivileges ? "0 0 1\n" : "") +
             (format("%d %d 1") % sandboxGid % hostGid).str());
 
         /* Signal the builder that we've updated its user


### PR DESCRIPTION
If Nix is run with the `--allow-new-privileges` option then it should be possible to run setuid binaries to gain root access. However, this did not work in practice because the root user/group did not exist in the sandbox due to exclusion from the kernel user-namespace. The uid would always be nixbld (1000) even when executing a setuid-root binary.

This change adds uid/gid 0 to the sandbox userns only when `--allow-new-privileges` is enabled and makes setuid work as expected.

Note: This makes it effective to *run* setuid executables but it does not make it possible to create them. This means that in practice to gain root in the sandbox you must both provide `--allow-new-privileges` and also add a suitable binary to the Nix sandbox path.

Resolves nixos/nix#2522.