### PR TITLE
nix ls-nar: allow reading from FIFOs

### DIFF
--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -148,7 +148,7 @@ struct CmdLsNar : Command, MixLs
 
     void run() override
     {
-        list(makeNarAccessor(make_ref<std::string>(readFile(narPath))));
+        list(makeNarAccessor(make_ref<std::string>(readFile(narPath, true))));
     }
 };
 


### PR DESCRIPTION
fixes #2528

cc @cleverca22 