### PR TITLE
repl: give user the choice between libeditline and libreadline

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -204,8 +204,6 @@ void NixRepl::mainLoop(const std::vector<std::string> & files)
     createDirs(dirOf(historyFile));
     el_hist_size = 1000;
     read_history(historyFile.c_str());
-    // rl_initialize();
-    // linenoiseSetCompletionCallback(completionCallback);
     curRepl = this;
     rl_set_complete_func(completionCallback);
     rl_set_list_possib_func(listPossibleCallback);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -5,7 +5,12 @@
 
 #include <setjmp.h>
 
+#ifdef READLINE
+#include <readline/history.h>
+#include <readline/readline.h>
+#else
 #include <editline.h>
+#endif
 
 #include "shared.hh"
 #include "eval.hh"
@@ -202,11 +207,15 @@ void NixRepl::mainLoop(const std::vector<std::string> & files)
     // Allow nix-repl specific settings in .inputrc
     rl_readline_name = "nix-repl";
     createDirs(dirOf(historyFile));
+#ifndef READLINE
     el_hist_size = 1000;
+#endif
     read_history(historyFile.c_str());
     curRepl = this;
+#ifndef READLINE
     rl_set_complete_func(completionCallback);
     rl_set_list_possib_func(listPossibleCallback);
+#endif
 
     std::string input;
 


### PR DESCRIPTION
The goal is to support libeditline AND libreadline and let the user
decide at compile time which one to use.

Add a compile time option to use libreadline instead of
libeditline. If compiled against libreadline completion functionality
is lost because of a incompatibility between libeditlines and
libreadlines completion function. Completion with libreadline is
possible and can be added later.

To use libreadline instead of libeditline the environment
variables 'EDITLINE_LIBS' and 'EDITLINE_CFLAGS' have to been set
during the ./configure step.

Example:

  EDITLINE_LIBS="/usr/lib/x86_64-linux-gnu/libhistory.so /usr/lib/x86_64-linux-gnu/libreadline.so"
  EDITLINE_CFLAGS="-DREADLINE"

The reason for this change is that for example on Debian already three
different editline libraries exist but none of those is compatible the
flavor used by nix. My hope is that with this change it would be
easier to port nix to systems that have already libreadline available.