### PR TITLE
Fix issues in systemv init script

### DIFF
--- a/misc/systemv/nix-daemon
+++ b/misc/systemv/nix-daemon
@@ -9,12 +9,13 @@
 # pidfile:     /var/run/nix/nix-daemon.pid
 
 ### BEGIN INIT INFO
-# Required-Start:    
-# Required-Stop:     
+# Provides:          nix-daemon
+# Required-Start:    $local_fs
+# Required-Stop:     $local_fs
 # Should-Start:      
 # Should-Stop:       
-# Default-Start:     3 4 5
-# Default-Stop:      0 1 2 6
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
 # Short-Description: Starts the nix daemon
 # Description:       This is a daemon which enable the multi-user mode 
 #                     of the nix package manager.
@@ -93,7 +94,7 @@ case "$1" in
         status -p ${PIDFILE} $NIX_DAEMON_BIN
             RETVAL=$?
     ;;
-  restart)
+  restart|force-reload)
         restart
     ;;
   reload)


### PR DESCRIPTION
This commit fixes some issues reported by [lintian][1]:

- [init.d-script-missing-lsb-keyword][2]
- [init.d-script-missing-start][3]
- [init.d-script-missing-dependency-on-local_fs][4]
- [init.d-script-does-not-implement-required-option][5]

[1]: https://lintian.debian.org/
[2]: https://lintian.debian.org/tags/init.d-script-missing-lsb-keyword.html
[3]: https://lintian.debian.org/tags/init.d-script-missing-start.html
[4]: https://lintian.debian.org/tags/init.d-script-missing-dependency-on-local_fs.html
[5]: https://lintian.debian.org/tags/init.d-script-does-not-implement-required-option.html