### PR TITLE
install-multi-user: fail only if /nix is not empty

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -324,7 +324,7 @@ EOF
         fi
     done
 
-    if [ -d /nix ]; then
+    if [ -e /nix/store -o -e /nix/var ]; then
         failure <<EOF
 There are some relics of a previous installation of Nix at /nix, and
 this scripts assumes Nix is _not_ yet installed. Please delete the old


### PR DESCRIPTION
This will allow having /nix on a separate partition. Fixes #2042 and #2407.