### PR TITLE
libstore: improve hash mismatch error messages

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3129,8 +3129,8 @@ void DerivationGoal::registerOutputs()
                 /* Throw an error after registering the path as
                    valid. */
                 delayedException = std::make_exception_ptr(
-                    BuildError("fixed-output derivation produced path '%s' with %s hash '%s' instead of the expected hash '%s'",
-                        dest, printHashType(h.type), printHash16or32(h2), printHash16or32(h)));
+                    BuildError("hash mismatch in fixed-output derivation '%s':\n  wanted: %s\n  got:    %s",
+                        dest, h.to_string(), h2.to_string()));
 
                 Path actualDest = worker.store.toRealPath(dest);
 

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -881,8 +881,8 @@ Path Downloader::downloadCached(ref<Store> store, const string & url_, bool unpa
         Hash gotHash = unpack
             ? hashPath(expectedHash.type, store->toRealPath(storePath)).first
             : hashFile(expectedHash.type, store->toRealPath(storePath));
-        throw nix::Error("hash mismatch in file downloaded from '%s': got hash '%s' instead of the expected hash '%s'",
-            url, gotHash.to_string(), expectedHash.to_string());
+        throw nix::Error("hash mismatch in file downloaded from '%s':\n  wanted: %s\n  got:    %s",
+            url, expectedHash.to_string(), gotHash.to_string());
     }
 
     return store->toRealPath(storePath);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1022,11 +1022,11 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
             auto hashResult = hashSink.finish();
 
             if (hashResult.first != info.narHash)
-                throw Error("hash mismatch importing path '%s'; expected hash '%s', got '%s'",
+                throw Error("hash mismatch importing path '%s';\n  wanted: %s\n  got:    %s",
                     info.path, info.narHash.to_string(), hashResult.first.to_string());
 
             if (hashResult.second != info.narSize)
-                throw Error("size mismatch importing path '%s'; expected %s, got %s",
+                throw Error("size mismatch importing path '%s';\n  wanted: %s\n  got:   %s",
                     info.path, info.narSize, hashResult.second);
 
             autoGC();


### PR DESCRIPTION
Use the same output ordering and format everywhere.

This is such a common issue that we trade the single-line error message for
more readability.

Old message:
```
fixed-output derivation produced path '/nix/store/d4nw9x2sy9q3r32f3g5l5h1k833c01vq-example.com' with sha256 hash '08y4734bm2zahw75b16bcmcg587vvyvh0n11gwiyir70divwp1rm' instead of the expected hash '1xzwnipjd54wl8g93vpw6hxnpmdabq0wqywriiwmh7x8k0lvpq5m'
```

New message:
```
hash mismatch in fixed-output derivation '/nix/store/d4nw9x2sy9q3r32f3g5l5h1k833c01vq-example.com':
  wanted: sha256:1xzwnipjd54wl8g93vpw6hxnpmdabq0wqywriiwmh7x8k0lvpq5m
  got:    sha256:08y4734bm2zahw75b16bcmcg587vvyvh0n11gwiyir70divwp1rm
```