### PR TITLE
binary-cache-store: add setting to disable local narinfo caching

### DIFF
--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -23,6 +23,8 @@ private:
 
 public:
 
+    const Setting<bool> cache{this, true, "cache", "Whether to cache narinfo metadata for this binary cache."};
+
     HttpBinaryCacheStore(
         const Params & params, const Path & _cacheUri)
         : BinaryCacheStore(params)
@@ -31,7 +33,10 @@ public:
         if (cacheUri.back() == '/')
             cacheUri.pop_back();
 
-        diskCache = getNarInfoDiskCache();
+        if (cache)
+            diskCache = getNarInfoDiskCache();
+        else
+            printTalkative(format("skipping local narinfo cache for '%1%'") % cacheUri);
     }
 
     std::string getUri() override
@@ -42,7 +47,7 @@ public:
     void init() override
     {
         // FIXME: do this lazily?
-        if (!diskCache->cacheExists(cacheUri, wantMassQuery_, priority)) {
+        if (diskCache && !diskCache->cacheExists(cacheUri, wantMassQuery_, priority)) {
             try {
                 BinaryCacheStore::init();
             } catch (UploadToHTTP &) {


### PR DESCRIPTION
This is nice for debugging since the cache can have some unintended side
effects when, eg. paths are removed but not invalidated.

```
$ nix path-info --store 's3://test?cache=0' /nix/store/6j01qy6rj13q5nibm4gpmlv6x7sfgim8-foo
skipping local narinfo cache for 's3://test'
querying info about '/nix/store/6j01qy6rj13q5nibm4gpmlv6x7sfgim8-foo' on 's3://test'...
downloaded 's3://nix/6j01qy6rj13q5nibm4gpmlv6x7sfgim8.narinfo' (392 bytes) in 21 ms
querying foo on s3://nix
/nix/store/6j01qy6rj13q5nibm4gpmlv6x7sfgim8-foo
```