### PR TITLE
installables: resolve derivation outputs

### DIFF
--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -96,7 +96,15 @@ struct InstallableStorePath : Installable
 
     Buildables toBuildables() override
     {
-        return {{isDerivation(storePath) ? storePath : "", {{"out", storePath}}}};
+        if (isDerivation(storePath)) {
+            std::map<std::string, Path> outputs;
+            auto drv = readDerivation(storePath);
+            for (auto & output : drv.outputs)
+                outputs.emplace(output.first, output.second.path);
+            return {{storePath, outputs}};
+        }
+        else
+            return {{"", {{"out", storePath}}}};
     }
 };
 


### PR DESCRIPTION
When converting a drv path to an installable the buildables would
contain `{"out", "/nix/store/<path>.drv"}` as outputs instead of the
actual outputs from the derivation.

This makes sure the result symblinks created `nix build` point to the
outputs instead of the drv file that was built.