### PR TITLE
nix: allow using --file - to read from stdin

### DIFF
--- a/src/libexpr/common-eval-args.cc
+++ b/src/libexpr/common-eval-args.cc
@@ -45,8 +45,6 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
 
 Path lookupFileArg(EvalState & state, string s)
 {
-    if (s == "-")
-        return "-";
     if (isUri(s)) {
         CachedDownloadRequest request(s);
         request.unpack = true;

--- a/src/libexpr/common-eval-args.cc
+++ b/src/libexpr/common-eval-args.cc
@@ -45,6 +45,8 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
 
 Path lookupFileArg(EvalState & state, string s)
 {
+    if (s == "-")
+        return "-";
     if (isUri(s)) {
         CachedDownloadRequest request(s);
         request.unpack = true;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -728,50 +728,51 @@ Value * ExprPath::maybeThunk(EvalState & state, Env & env)
 
 void EvalState::evalFile(const Path & path_, Value & v)
 {
-    if (path_ == "-") {
-        Expr * e = parseStdin();
-        try {
-            eval(e, v);
-        } catch (Error & e) {
-            addErrorPrefix(e, "while evaluating %1%:\n", "<stdin>");
-            throw;
-        }
-    } else {
-        auto path = checkSourcePath(path_);
+    auto path = checkSourcePath(path_);
 
-        FileEvalCache::iterator i;
-        if ((i = fileEvalCache.find(path)) != fileEvalCache.end()) {
-            v = i->second;
-            return;
-        }
+    FileEvalCache::iterator i;
+    if ((i = fileEvalCache.find(path)) != fileEvalCache.end()) {
+        v = i->second;
+        return;
+    }
 
-        Path path2 = resolveExprPath(path);
-        if ((i = fileEvalCache.find(path2)) != fileEvalCache.end()) {
-            v = i->second;
-            return;
-        }
+    Path path2 = resolveExprPath(path);
+    if ((i = fileEvalCache.find(path2)) != fileEvalCache.end()) {
+        v = i->second;
+        return;
+    }
 
-        printTalkative("evaluating file '%1%'", path2);
-        Expr * e = nullptr;
+    printTalkative("evaluating file '%1%'", path2);
+    Expr * e = nullptr;
 
-        auto j = fileParseCache.find(path2);
-        if (j != fileParseCache.end())
-            e = j->second;
+    auto j = fileParseCache.find(path2);
+    if (j != fileParseCache.end())
+        e = j->second;
 
-        if (!e)
-            e = parseExprFromFile(checkSourcePath(path2));
+    if (!e)
+        e = parseExprFromFile(checkSourcePath(path2));
 
-        fileParseCache[path2] = e;
+    fileParseCache[path2] = e;
 
-        try {
-            eval(e, v);
-        } catch (Error & e) {
-            addErrorPrefix(e, "while evaluating the file '%1%':\n", path2);
-            throw;
-        }
+    try {
+        eval(e, v);
+    } catch (Error & e) {
+        addErrorPrefix(e, "while evaluating the file '%1%':\n", path2);
+        throw;
+    }
 
-        fileEvalCache[path2] = v;
-        if (path != path2) fileEvalCache[path] = v;
+    fileEvalCache[path2] = v;
+    if (path != path2) fileEvalCache[path] = v;
+}
+
+void EvalState::evalStdin(Value & v)
+{
+    Expr * e = parseStdin();
+    try {
+        eval(e, v);
+    } catch (Error & e) {
+        addErrorPrefix(e, "while evaluating %1%:\n", "<stdin>");
+        throw;
     }
 }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -149,6 +149,10 @@ public:
        form. */
     void evalFile(const Path & path, Value & v);
 
+
+    /* Evaluate an expression from stdin. */
+    void evalStdin(Value & v);
+
     void resetFileCache();
 
     /* Look up a file in the search path. */

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -30,10 +30,12 @@ Value * SourceExprCommand::getSourceExpr(EvalState & state)
 
     vSourceExpr = state.allocValue();
 
-    if (file != "")
-        state.evalFile(lookupFileArg(state, file), *vSourceExpr);
-
-    else {
+    if (file != "") {
+        if (file == "-")
+            state.evalStdin(*vSourceExpr);
+        else
+            state.evalFile(lookupFileArg(state, file), *vSourceExpr);
+    } else {
 
         /* Construct the installation source from $NIX_PATH. */
 

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -1,0 +1,5 @@
+{
+  int = 123;
+  str = "foo";
+  attr.foo = "bar";
+}

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -1,0 +1,18 @@
+source common.sh
+
+clearStore
+
+nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
+[[ $(nix-instantiate -A int --eval "./eval.nix") == 123 ]]
+[[ $(nix-instantiate -A str --eval "./eval.nix") == '"foo"' ]]
+[[ $(nix-instantiate -A attr --eval "./eval.nix") == '{ foo = "bar"; }' ]]
+[[ $(nix-instantiate -A attr --eval --json "./eval.nix") == '{"foo":"bar"}' ]]
+[[ $(nix-instantiate -A int --eval - < "./eval.nix") == 123 ]]
+
+nix eval '(assert 1 + 2 == 3; true)'
+[[ $(nix eval int -f "./eval.nix") == 123 ]]
+[[ $(nix eval str -f "./eval.nix") == '"foo"' ]]
+[[ $(nix eval str --raw -f "./eval.nix") == 'foo' ]]
+[[ $(nix eval attr -f "./eval.nix") == '{ foo = "bar"; }' ]]
+[[ $(nix eval attr --json -f "./eval.nix") == '{"foo":"bar"}' ]]
+[[ $(nix eval int -f - < "./eval.nix") == 123 ]]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -2,7 +2,7 @@ check:
 	@echo "Warning: Nix has no 'make check'. Please install Nix and run 'make installcheck' instead."
 
 nix_tests = \
-  init.sh hash.sh lang.sh add.sh simple.sh dependencies.sh \
+  init.sh eval.sh hash.sh lang.sh add.sh simple.sh dependencies.sh \
   gc.sh gc-concurrent.sh \
   referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \
   gc-runtime.sh check-refs.sh filter-source.sh \


### PR DESCRIPTION
Brings the `nix-instantiate -` functionality to all the new nix commands that take the --file argument.

	$ echo '{ foo = 1 + 1; }' | nix eval -f - foo
	2