### PR TITLE
EvalState::resetFileCache: clear parse cache as well as eval cache

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -757,6 +757,7 @@ void EvalState::evalFile(const Path & path_, Value & v)
 void EvalState::resetFileCache()
 {
     fileEvalCache.clear();
+    fileParseCache.clear();
 }
 
 


### PR DESCRIPTION
Fixes #2546.

(at least the basic reproduction I've been testing)

-----------------

Seems safe since this method isn't used for anything else locally,
but I haven't checked the possible impact on hydra or anything else.