### PR TITLE
Escape square brackets in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,7 @@ test "$prefix" = NONE && prefix=$ac_default_prefix
 test "$exec_prefix" = NONE && exec_prefix='${prefix}'
 for name in $ac_subst_vars; do
     for _ in 1 2 3; do
-    if printf '%s' "${name}" | egrep '^[_[:alpha:]][_[:alnum:]]*$'
+    if printf '%s' "${name}" | egrep '^[[_[[:alpha:]]]][[_[[:alnum:]]]]*$'
     then
         eval "${name}"="$(eval echo "\${${name}}")"
     fi


### PR DESCRIPTION
This patch attempts to solve the regression introduced in e8b0efdc
(#2607).

It wasn't detected by me before the previous commit because GNU grep behaviour for `egrep '^_[:alpha:]_[:alnum:]*$'` varies across versions:
- grep (GNU grep) 2.5.1-FreeBSD does not report any issues
- grep (GNU grep) 3.3 prints the following message:

    >     /bin/grep: character class syntax is [[:space:]], not [:space:]

