### PR TITLE
manual: "sandbox" option default is "true" on Linux

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -657,7 +657,8 @@ password <replaceable>my-password</replaceable>
     <varname>__noChroot</varname> attribute set to
     <literal>true</literal> do not run in sandboxes.</para>
 
-    <para>The default is <literal>false</literal>.</para>
+    <para>The default is <literal>true</literal> on Linux and
+    <literal>false</literal> on all other platforms.</para>
 
     </listitem>
 


### PR DESCRIPTION
Manual needs to be updated after https://github.com/NixOS/nix/commit/812e39313c2bcf8909b83e1e8bc548a85dcd626c