### PR TITLE
corepkgs.fetchurl: comment typo

### DIFF
--- a/corepkgs/fetchurl.nix
+++ b/corepkgs/fetchurl.nix
@@ -1,6 +1,6 @@
 { system ? "" # obsolete
 , url
-, hash ? "" # an SRI ash
+, hash ? "" # an SRI hash
 
 # Legacy hash specification
 , md5 ? "", sha1 ? "", sha256 ? "", sha512 ? ""


### PR DESCRIPTION
Hello,

I'm trying to understand the internals and was reading through the core packages. I noticed this typo but I'd also like to know if these are correct:

https://github.com/NixOS/nix/blob/master/corepkgs/fetchurl.nix#L9-L10
```
, outputHashAlgo ?
    if hash != "" then "" else if sha512 != "" then "sha512" else if sha1 != "" then "sha1" else if md5 != "" then "md5" else "sha256"
```

Shouldn't it be `if hash != "" then hash`?