### PR TITLE
Print total space saved on nix-store --optimise #2288

### DIFF
--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -231,6 +231,14 @@ private:
 
     void makeStoreWritable();
 
+    struct HardLinkStats {
+        unsigned long long actualSize = 0;
+        unsigned long long unsharedSize = 0;
+        unsigned long long overhead = 0;
+    };
+
+    void getHardLinkSavings(HardLinkStats & linkStats);
+
     uint64_t queryValidPathId(State & state, const Path & path);
 
     uint64_t addValidPath(State & state, const ValidPathInfo & info, bool checkOutputs = true);


### PR DESCRIPTION
This PR attempts to provide the functionality requested in #2288. I opted to follow the code used i `nix-collect-garbage` but factored it into a private method on `LocalStorage` to avoid cluttering `optimiseStore`.

I do have one question that might impact this PR beyond any organizational or stylistic blunders: How accurately is accurate enough for on disk storage? `nix-collect-garbage` uses `st_blocks * 512ULL`, which will be accurate for the usual case. `optimiseStore` uses `st_size`, which will be similar (though possibly less honest about the disk usage). 

In a case with a block size that isn't the usual 512 (i.e. networked storages, etc.), the reported number could not reflect the actual size on disk well at all, which would beg for a query to `st_blksize`

For now, I used `st_size` to be consistent within `optimise-store.cc`, which means it gives a slightly different answer than the same text in used in `gc.cc`.

Happy to make any changes and correct rookie mistakes.

