### PR TITLE
Search: remove no output error on json

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -164,6 +164,7 @@ struct CmdSearch : SourceExprCommand, MixJSON
                     }
 
                     if (found == res.size()) {
+			// output in json format
                         if (json) {
 
                             auto jsonElem = jsonOut->object(attrPath);
@@ -271,7 +272,8 @@ struct CmdSearch : SourceExprCommand, MixJSON
                 throw SysError("cannot rename '%s' to '%s'", tmpFile, jsonCacheFileName);
         }
 
-        if (results.size() == 0)
+	// json uses jsonElem instead of results but that's not in this scope
+        if (!json && (results.size() == 0))
             throw Error("no results for the given search term(s)!");
 
         RunPager pager;


### PR DESCRIPTION
Don't warn about no results when using json output.
Addresses #2474 