### PR TITLE
Support custom shell in nix-shell/nix run

### DIFF
--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -21,7 +21,7 @@ std::string chrootHelperName = "__run_in_chroot";
 
 struct CmdRun : InstallablesCommand
 {
-    std::vector<std::string> command = { "bash" };
+    std::vector<std::string> command;
     StringSet keep, unset;
     bool ignoreEnvironment = false;
 
@@ -30,7 +30,8 @@ struct CmdRun : InstallablesCommand
         mkFlag()
             .longName("command")
             .shortName('c')
-            .description("command and arguments to be executed; defaults to 'bash'")
+            .description("command and arguments to be executed; defaults to "
+                "\"$NIX_RUN_INTERACTIVE_SHELL\" if set, otherwise to 'bash'")
             .labels({"command", "args"})
             .arity(ArityAny)
             .handler([&](std::vector<std::string> ss) {
@@ -146,6 +147,11 @@ struct CmdRun : InstallablesCommand
         }
 
         setenv("PATH", concatStringsSep(":", unixPath).c_str(), 1);
+
+        if (command.empty()) {
+            auto interactiveShell = getenv("NIX_RUN_INTERACTIVE_SHELL");
+            command = { interactiveShell ? interactiveShell : "bash" };
+        }
 
         std::string cmd = *command.begin();
         Strings args;


### PR DESCRIPTION
_EDIT: Any changes to `nix-shell` have been removed from the PR. Only `nix run` is now affected._

* ~Use `$NIX_SHELL_INTERACTIVE_SHELL` (if present) as interactive shell for `nix-shell`~
* Use `$NIX_RUN_INTERACTIVE_SHELL` (if present) as interactive shell for `nix run`

If ~`--run`~, `--command` or `-c` are given, then bash is still used.

One could also consider those environment variables to be arbitrary default commands that are executed when ~`nix-shell`~/`nix run` are ran interactive and without a command. However, I think the most common use case (by far) is to set them to a shell, hence the name `[...]_INTERACTIVE_SHELL`.

~Tests:~

~I was unsuccessful adding tests to *tests/nix-shell.sh*. Any non-interactive test doesn't trigger the feature since it's only triggered in interactive shells.~

Previous work:

Issue #419 (nix-shell ignoring SHELL enviroment variable) proposed to use `$SHELL` as interactive shell for `nix-shell`. This is of course not desirable if people depend on `nix-shell` always using bash. ~With this change however, the feature is optional since it uses previously unused environment variables.~