### PR TITLE
Fix build --repeat with -K to use real paths

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2567,10 +2567,9 @@ void LocalDerivationGoal::registerOutputs()
     /* If this is the first round of several, then move the output out of the way. */
     if (nrRounds > 1 && curRound == 1 && curRound < nrRounds && keepPreviousRound) {
         for (auto & [_, outputStorePath] : finalOutputs) {
-            auto path = worker.store.printStorePath(outputStorePath);
-            Path prev = path + checkSuffix;
-            deletePath(prev);
+            auto path = worker.store.toRealPath(outputStorePath);
             Path dst = path + checkSuffix;
+            deletePath(dst);
             if (rename(path.c_str(), dst.c_str()))
                 throw SysError("renaming '%s' to '%s'", path, dst);
         }
@@ -2585,7 +2584,7 @@ void LocalDerivationGoal::registerOutputs()
        if the result was not determistic? */
     if (curRound == nrRounds) {
         for (auto & [_, outputStorePath] : finalOutputs) {
-            Path prev = worker.store.printStorePath(outputStorePath) + checkSuffix;
+            Path prev = worker.store.toRealPath(outputStorePath) + checkSuffix;
             deletePath(prev);
         }
     }

--- a/tests/linux-sandbox.sh
+++ b/tests/linux-sandbox.sh
@@ -29,6 +29,11 @@ nix store cat $outPath/foobar | grep FOOBAR
 # Test --check without hash rewriting.
 nix-build dependencies.nix --no-out-link --check --sandbox-paths /nix/store
 
+# Make sure we rename build with .check suffix in correct store
+(! nix-build check.nix -A nondeterministic --sandbox-paths /nix/store --no-out-link --repeat 2 -K 2> $TEST_ROOT/log)
+if grep 'error: renaming' $TEST_ROOT/log; then false; fi
+grep -q 'differs from previous round' $TEST_ROOT/log
+
 # Test that sandboxed builds with --check and -K can move .check directory to store
 nix-build check.nix -A nondeterministic --sandbox-paths /nix/store --no-out-link
 


### PR DESCRIPTION
Use toRealPath() to map store paths correctly for builds with the
--keep-failed (-K) and --repeat options. This fixes an issue where
the rename of a build output with a .check suffix fails due to
having the wrong store paths.

Added test of build --repeat with --keep-failed to demonstrate
issue and prevent regressions.

Fixes #4617