### PR TITLE
Fix nix-build --check -K in sandbox w/o root

### DIFF
--- a/tests/check.sh
+++ b/tests/check.sh
@@ -49,13 +49,8 @@ checkBuildTempDirRemoved $TEST_ROOT/log
 
 nix-build check.nix -A nondeterministic --argstr checkBuildId $checkBuildId \
     --no-out-link --check --keep-failed 2> $TEST_ROOT/log || status=$?
-
-# The above nix-build fails with status=1 on darwin (not sure why)
-# ...but the primary purpose of the test case is to verify the temp directory is retained
-if [ "$(uname -s)" != "Darwin" ]; then
 grep 'may not be deterministic' $TEST_ROOT/log
 [ "$status" = "104" ]
-fi
 if checkBuildTempDirRemoved $TEST_ROOT/log; then false; fi
 
 clearStore

--- a/tests/linux-sandbox.sh
+++ b/tests/linux-sandbox.sh
@@ -28,3 +28,10 @@ nix cat-store $outPath/foobar | grep FOOBAR
 
 # Test --check without hash rewriting.
 nix-build dependencies.nix --no-out-link --check --sandbox-paths /nix/store
+
+# Test that sandboxed builds with --check and -K can move .check directory to store
+nix-build check.nix -A nondeterministic --sandbox-paths /nix/store --no-out-link
+
+(! nix-build check.nix -A nondeterministic --sandbox-paths /nix/store --no-out-link --check -K 2> $TEST_ROOT/log)
+if grep -q 'error: renaming' $TEST_ROOT/log; then false; fi
+grep -q 'may not be deterministic' $TEST_ROOT/log


### PR DESCRIPTION
Temporarily add user-write permission to build directory so that it
can be moved out of the sandbox to the store with a .check suffix.

This is necessary because the build directory has already had its
permissions set read-only, but write permission is required
to update the directory's parent link to move it out of the sandbox.

Updated the related --check "derivation may not be deterministic"
messages to consistently use the real store paths.

Added test for non-root sandbox nix-build --check -K to demonstrate
issue and help prevent regressions.