### PR TITLE
nix-daemon: emit a warning if untrusted user tries to set build parameters

### DIFF
--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -566,7 +566,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                 else if (setSubstituters(settings.extraSubstituters))
                     ;
                 else
-                    debug("ignoring untrusted setting '%s'", name);
+                    warn("ignoring untrusted setting '%s'", name);
             } catch (UsageError & e) {
                 warn(e.what());
             }


### PR DESCRIPTION
It's documented in the NixOS wiki that untrusted users can't set build
machines using `--builders` or `--option builders`[1]. This should cause
a warning at least to avoid confusion why the options won't take any
effect.

This applies to all options except `connect-timeout`, `timeout` and
`builders` if the value is empty.

[1] https://nixos.wiki/wiki/Distributed_build


---

I tested the behavior with the following VM declaration built from the nixpkgs master:

``` nix
{
  nixpatch = { pkgs, ... }: {
    nix.package = pkgs.nix.overrideAttrs (old: {
      patches = [ ../nix/0001-nix-daemon-emit-a-warning-if-untrusted-user-tries-to.patch ];
    });

    users.extraUsers.vm = {
      password = "vm";
      isNormalUser = true;
    };
  };
}
```