### PR TITLE
scripts: remove default 'sandbox = false' from multi-user installer

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -747,7 +747,6 @@ build-users-group = $NIX_BUILD_GROUP_NAME
 
 max-jobs = $NIX_USER_COUNT
 cores = 1
-sandbox = false
 EOF
     _sudo "to place the default nix daemon configuration (part 2)" \
           install -m 0664 "$SCRATCH/nix.conf" /etc/nix/nix.conf


### PR DESCRIPTION
The multi-user installer script set `sandbox = false` unilaterally, overriding the new default configuration of `true` for Linux. Removing it allows the platform default to kick in.