### PR TITLE
Add --whole-archive to include all store implementations (when BUILD_SHARED_LIBS=false)

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -127,7 +127,7 @@ define build-library
     $$($(1)_PATH): $$($(1)_OBJS) | $$(_d)/
 	$(trace-ar) $(AR) crs $$@ $$?
 
-    $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS)
+    $(1)_LDFLAGS_USE += -Wl,--whole-archive $$($(1)_PATH) -Wl,--no-whole-archive $$($(1)_LDFLAGS)
 
     $(1)_INSTALL_PATH := $$(libdir)/$$($(1)_NAME).a
 

--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -50,6 +50,11 @@ endif
 #   target andwill not be listed in the make help output. This is
 #   useful for libraries built solely for testing, for example.
 #
+# - $(1)_WHOLE_ARCHIVE: if defined, the whole archive of the static
+#   library will be used. This is necessary when using global
+#   constructors such as setting up a RegisterStoreImplementation.
+#   Only applies when BUILD_SHARED_LIBS=0.
+#
 # - BUILD_SHARED_LIBS: if equal to ‘1’, a dynamic library will be
 #   built, otherwise a static library.
 define build-library
@@ -136,16 +141,20 @@ define build-library
     # -force_load that seems to work similarly, but takes one argument
     # instead of a group of arguments.
 
-    ifeq ($(OS), Linux)
-      $(1)_LDFLAGS_USE += -Wl,--whole-archive
-    else ifeq ($(OS), Darwin)
-      $(1)_LDFLAGS_USE += -Wl,-force_load
+    ifdef $(1)_WHOLE_ARCHIVE
+      ifeq ($(OS), Linux)
+        $(1)_LDFLAGS_USE += -Wl,--whole-archive
+      else ifeq ($(OS), Darwin)
+        $(1)_LDFLAGS_USE += -Wl,-force_load
+      endif
     endif
 
     $(1)_LDFLAGS_USE += $$($(1)_PATH)
 
-    ifeq ($(OS), Linux)
-      $(1)_LDFLAGS_USE += -Wl,--no-whole-archive
+    ifdef $(1)_WHOLE_ARCHIVE
+      ifeq ($(OS), Linux)
+        $(1)_LDFLAGS_USE += -Wl,--no-whole-archive
+      endif
     endif
 
     $(1)_LDFLAGS_USE += $$($(1)_LDFLAGS)

--- a/src/libexpr/local.mk
+++ b/src/libexpr/local.mk
@@ -15,6 +15,8 @@ ifneq ($(OS), FreeBSD)
  libexpr_LDFLAGS += -ldl
 endif
 
+libexpr_WHOLE_ARCHIVE = 1
+
 # The dependency on libgc must be propagated (i.e. meaning that
 # programs/libraries that use libexpr must explicitly pass -lgc),
 # because inline functions in libexpr's header files call libgc.

--- a/src/libfetchers/local.mk
+++ b/src/libfetchers/local.mk
@@ -9,3 +9,6 @@ libfetchers_SOURCES := $(wildcard $(d)/*.cc)
 libfetchers_CXXFLAGS += -I src/libutil -I src/libstore
 
 libfetchers_LIBS = libutil libstore libnixrust
+
+libfetchers_WHOLE_ARCHIVE = 1
+

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -13,6 +13,8 @@ ifneq ($(OS), FreeBSD)
  libstore_LDFLAGS += -ldl
 endif
 
+libstore_WHOLE_ARCHIVE = 1
+
 ifeq ($(OS), Darwin)
 libstore_FILES = sandbox-defaults.sb sandbox-minimal.sb sandbox-network.sb
 endif


### PR DESCRIPTION
When statically linking, symbols that are not referenced are not
included in the final executable. Usually, this is an okay
optimization, but sometimes can cause unexpected issues.

In this case, statically linked Nix was not finding the
HttpBinaryCacheStore class and the RegisterStoreImplementation that
comes with it. This is because the resulting binary would not run all
of the store registration at initialization time. Some of the store
registrations were still heppning like in the S3 case, but only
because another symbol in s3-binary-cache-store.o was being used
elsewhere in Nix. This linking behavior caused static Nix to have
errors like:

  don't know how to open Nix store ‘https://...’

Adding --whole-archive forces the linker to include these archives.
This is just applied to the local Nix libraries, and not external
libraries. As a side effect we might get some symbols that we don’t
actually need, but that is the same case as with dynamically linked
Nix.

You can try out my statically built pr here:

https://github.com/NixOS/nixpkgs/pull/56281
