### PR TITLE
Get relative path of NIX_DATA_DIR

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -33,7 +33,7 @@ static GlobalConfig::Register r1(&settings);
 Settings::Settings()
     : nixPrefix(NIX_PREFIX)
     , nixStore(canonPath(getEnv("NIX_STORE_DIR", getEnv("NIX_STORE", NIX_STORE_DIR))))
-    , nixDataDir(canonPath(getEnv("NIX_DATA_DIR", NIX_DATA_DIR)))
+    , nixDataDir(canonPath(absPath(getEnv("NIX_DATA_DIR", NIX_DATA_DIR))))
     , nixLogDir(canonPath(getEnv("NIX_LOG_DIR", NIX_LOG_DIR)))
     , nixStateDir(canonPath(getEnv("NIX_STATE_DIR", NIX_STATE_DIR)))
     , nixConfDir(canonPath(getEnv("NIX_CONF_DIR", NIX_CONF_DIR)))


### PR DESCRIPTION
This is useful when you want Nix to look in a relative path at
runtime. For instance, you can make Nix work without a Nix store dir
by building like this:

$ make datadir=./share

and you just need “share” to be in the same directory as the Nix
binary. If statically linked properly, no references to $prefix should
remain.