### PR TITLE
Support parameters in S3 URLs

### DIFF
--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -620,8 +620,8 @@ struct CurlDownloader : public Downloader
         auto [path, params] = splitUriAndParams(uri);
 
         auto slash = path.find('/', 5); // 5 is the length of "s3://" prefix
-           if (slash == std::string::npos)
-               throw nix::Error("bad S3 URI '%s'", path);
+            if (slash == std::string::npos)
+                throw nix::Error("bad S3 URI '%s'", path);
 
         std::string bucketName(path, 5, slash - 5);
         std::string key(path, slash + 1);

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -639,7 +639,14 @@ struct CurlDownloader : public Downloader
             try {
 #ifdef ENABLE_S3
                 auto [bucketName, key, params] = parseS3Uri(request.uri);
-                S3Helper s3Helper("", Aws::Region::US_EAST_1, "", ""); // FIXME: make configurable
+
+                std::string profile = get(params, "profile", "");
+                std::string region = get(params, "region", Aws::Region::US_EAST_1);
+                std::string scheme = get(params, "scheme", "");
+                std::string endpoint = get(params, "endpoint", "");
+
+                S3Helper s3Helper(profile, region, scheme, endpoint);
+
                 // FIXME: implement ETag
                 auto s3Res = s3Helper.getObject(bucketName, key);
                 DownloadResult res;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -798,4 +798,8 @@ ValidPathInfo decodeValidPathInfo(std::istream & str,
    for paths created by makeFixedOutputPath() / addToStore(). */
 std::string makeFixedOutputCA(bool recursive, const Hash & hash);
 
+
+/* Split URI into protocol+hierarchy part and its parameter set. */
+std::pair<std::string, Store::Params> splitUriAndParams(const std::string & uri);
+
 }


### PR DESCRIPTION
This pull request adds proper support for S3 URL parameters.

Currently, an attempt to download artifacts with fetchTarball or fetchUrl fails for buckets residing in regions other than us-east-1. Nix manual states explicitly that, when using another region, the "region"
parameter should be passed. Which doesn't work since us-east-1 is hardcoded.

