### PR TITLE
Option to make sandbox work in Docker with its default seccomp filter

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -700,6 +700,20 @@ password <replaceable>my-password</replaceable>
   </varlistentry>
 
 
+  <varlistentry xml:id="conf-sandbox-use-pivot_root">
+    <term><literal>sandbox-use-pivot_root</literal></term>
+
+    <listitem><para>Whether to use the <literal>pivot_root</literal>
+    system call, which is safer than plain <literal>chroot</literal> when
+    establishing the sandbox.</para>
+    <para>This option has the safe default <literal>true</literal>,
+    but needs to be set to <literal>false</literal> when running the
+    sandbox inside a container.</para>
+    </listitem>
+
+  </varlistentry>
+
+
   <varlistentry xml:id="conf-secret-key-files"><term><literal>secret-key-files</literal></term>
 
     <listitem><para>A whitespace-separated list of files containing

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -205,6 +205,9 @@ public:
         "Whether to enable sandboxed builds. Can be \"true\", \"false\" or \"relaxed\".",
         {"build-use-chroot", "build-use-sandbox"}};
 
+    Setting<bool> sandboxUsePivotRoot{this, true, "sandbox-use-pivot_root",
+        "Whether to use pivot_root when sandboxing is enabled. This is safer than plain chroot, but not supported when running the sandbox in a container."};
+
     Setting<PathSet> sandboxPaths{this, {}, "sandbox-paths",
         "The paths to make available inside the build sandbox.",
         {"build-chroot-dirs", "build-sandbox-paths"}};


### PR DESCRIPTION
 - Fall back to bind-mounting proc (required because of `MNT_LOCKED`)
 - Allow skipping pivot_root, which is not allowed in containers
