### PR TITLE
Add a 5 seconds of timeout to connecting to S3.

### DIFF
--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -126,6 +126,7 @@ ref<Aws::Client::ClientConfiguration> S3Helper::makeConfig(const string & region
         res->endpointOverride = endpoint;
     }
     res->requestTimeoutMs = 600 * 1000;
+    res->connectTimeoutMs = 5 * 1000;
     res->retryStrategy = std::make_shared<RetryStrategy>();
     res->caFile = settings.caFile;
     return res;


### PR DESCRIPTION
The default is 1000ms, but we can hit it a lot of we don't have direct
link to AWS (e.g. using VPN).
Steps to reproduce this:

` sudo tc qdisc add dev wlp1s0 root netem delay 3000ms` This will add 3 seconds of delays to your network. 
If you try to realize a store path from an S3 binary cache, you will get this error
```
AWS error '' (Unable to connect to endpoint), will retry in 0 ms                
AWS error '' (Unable to connect to endpoint), will retry in 50 ms                                                                                                                                                                              
AWS error '' (Unable to connect to endpoint), will retry in 100 ms                                                                                                                                                                             
AWS error '' (Unable to connect to endpoint), will retry in 200 ms                                                                                                                                                                             
AWS error '' (Unable to connect to endpoint), will retry in 400 ms                  
AWS error '' (Unable to connect to endpoint), will retry in 800 ms                                                
AWS error '' (Unable to connect to endpoint), will retry in 1600 ms                 
AWS error '' (Unable to connect to endpoint), will retry in 3200 ms                                                                                               
AWS error '' (Unable to connect to endpoint), will retry in 6400 ms                                                                                               
AWS error '' (Unable to connect to endpoint), will retry in 12800 ms  
```

To delete the delay that you added previously.

`sudo  tc qdisc del dev wlp1s0 root `