### PR TITLE
nix-shell: don't use XDG_RUNTIME_DIR if TMPDIR is unset

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -370,7 +370,7 @@ static void _main(int argc, char * * argv)
         // Set the environment.
         auto env = getEnv();
 
-        auto tmp = getEnv("TMPDIR", getEnv("XDG_RUNTIME_DIR", "/tmp"));
+        auto tmp = getEnv("TMPDIR", "/tmp");
 
         if (pure) {
             decltype(env) newEnv;


### PR DESCRIPTION
XDG_RUNTIME_DIR isn't meant for possibly-large build processes; it's
mostly meant for small sockets, named pipes, and other IPC
mechanisms. As a result it's limited in size on many systems, and so
using it as a temporary directory (by setting TMPDIR to it) will cause
some test and build processes to fail when they try to use more space
than is available in XDG_RUNTIME_DIR.

For example, XDG_RUNTIME_DIR is limited to 100MB on an older Debian
system, and some build and test processes try to use several GB of
space for temporary artifacts; these failures are spurious, and can be
avoided if we just default directly to /tmp instead of trying to
default to XDG_RUNTIME_DIR first.