### PR TITLE
build: add setting to extend the default darwin sandbox profile

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2867,6 +2867,11 @@ void DerivationGoal::runChild()
                 if (fixedOutput)
                     sandboxProfile += "(import \"sandbox-network.sb\")\n";
 
+                auto extraFile = settings.darwinExtraSandboxProfile;
+                trim(extraFile);
+                if (extraFile != "")
+                    sandboxProfile += (format("(import \"%1%\")\n") % extraFile).str();
+
                 /* Our rwx outputs */
                 sandboxProfile += "(allow file-read* file-write* process-exec\n";
                 for (auto & i : missingPaths) {

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -231,6 +231,9 @@ public:
 #if __APPLE__
     Setting<bool> darwinLogSandboxViolations{this, false, "darwin-log-sandbox-violations",
         "Whether to log Darwin sandbox access violations to the system log."};
+
+    Setting<std::string> darwinExtraSandboxProfile{this, "", "darwin-extra-sandbox-profile",
+        "Additional sandbox profile to import after the defaults."};
 #endif
 
     Setting<bool> runDiffHook{this, false, "run-diff-hook",


### PR DESCRIPTION
This makes the default profile configurable with extra capabilities
using nix.conf without having to resort to relaxed mode and expressions
using `__sandboxProfile`. eg.

	(allow ipc-sysv-shm ipc-sysv-sem)