### PR TITLE
install-multi-user: reduce max-jobs from 32 to 1

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -742,7 +742,7 @@ place_nix_configuration() {
     cat <<EOF > "$SCRATCH/nix.conf"
 build-users-group = $NIX_BUILD_GROUP_NAME
 
-max-jobs = $NIX_USER_COUNT
+max-jobs = 1
 cores = 1
 EOF
     _sudo "to place the default nix daemon configuration (part 2)" \

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -741,9 +741,6 @@ setup_default_profile() {
 place_nix_configuration() {
     cat <<EOF > "$SCRATCH/nix.conf"
 build-users-group = $NIX_BUILD_GROUP_NAME
-
-max-jobs = 1
-cores = 1
 EOF
     _sudo "to place the default nix daemon configuration (part 2)" \
           install -m 0664 "$SCRATCH/nix.conf" /etc/nix/nix.conf


### PR DESCRIPTION
And follow up by removing settings that are set to the same value as Nix' built-in defaults.