### PR TITLE
manual: fix the hacking section

### DIFF
--- a/doc/manual/hacking.xml
+++ b/doc/manual/hacking.xml
@@ -27,7 +27,7 @@ $ nix-shell
 To build Nix itself in this shell:
 <screen>
 [nix-shell]$ ./bootstrap.sh
-[nix-shell]$ configurePhase
+[nix-shell]$ ./configure
 [nix-shell]$ make
 </screen>
 To install it in <literal>$(pwd)/inst</literal> and test it:


### PR DESCRIPTION
The hacking section of the manual says to run `configurePhase` before running make, but configurePhase does not exist. Running `./configure` without any arguments worked for me.