### PR TITLE
nix: trivial instantiation timing experiment

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -9,6 +9,7 @@
 #include "json.hh"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <unistd.h>
 #include <sys/time.h>
@@ -1504,9 +1505,17 @@ bool EvalState::isFunctor(Value & fun)
 
 void EvalState::forceFunction(Value & v, const Pos & pos)
 {
+    auto start = std::chrono::high_resolution_clock::now();
+
     forceValue(v);
     if (v.type != tLambda && v.type != tPrimOp && v.type != tPrimOpApp && !isFunctor(v))
         throwTypeError("value is %1% while a function was expected, at %2%", v, pos);
+
+    auto finish = std::chrono::high_resolution_clock::now();
+
+    auto duration = finish - start;
+    auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+    debug(":clock: %1% %2%", pos, nanoseconds.count());
 }
 
 


### PR DESCRIPTION
Some trivial experiment with timing. This is probably wrong in MANY ways.

cc @zimbatm 

after `make install`:

    ./inst/bin/nix-instantiate '<nixpkgs/pkgs/top-level/release.nix>' \
        -A unstable -vvvvvv 2>&1 > log

    cat log | grep ':clock:' | sort \
        | awk '
            { sums[$2] += $3; calls[$2] += 1; }
            END {
                for (category in sums) {
                    print category, sums[category], calls[category],
                          sums[category] / calls[category];
                }
            }'

showed me:

| function-position                                                                                                               | ns      | calls |
|---------------------------------------------------------------------------------------------------------------------------------|---------|-------|
| /nix/store/xnjvl3lnbl729hsi585v5075fqsgijl9-nixos-19.03.172138.5c52b25283a/nixos/pkgs/stdenv/generic/make-derivation.nix:108:33 | 437582  | 8981  |
| /nix/store/xnjvl3lnbl729hsi585v5075fqsgijl9-nixos-19.03.172138.5c52b25283a/nixos/pkgs/stdenv/generic/check-meta.nix:22:5        | 503557  | 14230 |
| /nix/store/xnjvl3lnbl729hsi585v5075fqsgijl9-nixos-19.03.172138.5c52b25283a/nixos/pkgs/stdenv/generic/check-meta.nix:214:9       | 2817229 | 5093  |

and:

| function-position                                                                                                               | ns      | calls | ns/call |
|---------------------------------------------------------------------------------------------------------------------------------|---------|-------|---------|
| /nix/store/xnjvl3lnbl729hsi585v5075fqsgijl9-nixos-19.03.172138.5c52b25283a/nixos/pkgs/development/compilers/ghc/8.6.4.nix:20:27 | 3309    | 3     | 1103    |
| /nix/var/nix/profiles/per-user/root/channels/nixos/pkgs/top-level/release-lib.nix:83:9                                          | 272303  | 195   | 1396.43 |
| /nix/var/nix/profiles/per-user/root/channels/nixos/lib/systems/parse.nix:174:12                                                 | 10180   | 6     | 1696.67 |