### PR TITLE
Sort directory entries after they are returned by readdir

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -5,6 +5,7 @@
 #include "finally.hh"
 #include "serialise.hh"
 
+#include <algorithm>
 #include <cctype>
 #include <cerrno>
 #include <cstdio>
@@ -274,6 +275,11 @@ DirEntries readDirectory(const Path & path)
         );
     }
     if (errno) throw SysError(format("reading directory '%1%'") % path);
+
+    std::sort(entries.begin(), entries.end(),
+        [](const DirEntry & a, const DirEntry & b) {
+            return a.name < b.name;
+    });
 
     return entries;
 }


### PR DESCRIPTION
The readdir syscall does not guarantee a consistent order between calls and on some
file systems this will result in non deterministic store paths for the
same collections of files.