### PR TITLE
travis: run release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
-os: osx
-script: ./tests/install-darwin.sh
+language: nix
+before_install:
+- git fetch --unshallow
+matrix:
+  include:
+  - script:
+    - nix-build ./release.nix -A build.x86_64-linux
+  - os: osx
+    script:
+    - nix-build ./release.nix -A build.x86_64-darwin
+    # - ./tests/install-darwin.sh


### PR DESCRIPTION
Prompted by https://github.com/NixOS/nix/commit/7becb1bf1c2ec1544a5374580a97b36273506baf#r33450554. This should test both the build as well as the install tests that also run with the expression in nixpkgs, adding some extra validation for merge requests.

https://travis-ci.org/LnL7/nix/jobs/529534826