### PR TITLE
nix-shell: unset IN_NIX_SHELL for nested nix commands

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -264,6 +264,8 @@ static void _main(int argc, char * * argv)
 
     if (runEnv)
         setenv("IN_NIX_SHELL", pure ? "pure" : "impure", 1);
+    else
+        unsetenv("IN_NIX_SHELL");
 
     DrvInfos drvs;
 

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1401,6 +1401,8 @@ static int _main(int argc, char * * argv)
 
         initPlugins();
 
+        unsetenv("IN_NIX_SHELL");
+
         if (!op) throw UsageError("no operation specified");
 
         auto store = openStore();

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -151,6 +151,8 @@ static int _main(int argc, char * * argv)
 
         initPlugins();
 
+        unsetenv("IN_NIX_SHELL");
+
         if (evalOnly && !wantsReadWrite)
             settings.readOnlyMode = true;
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -94,6 +94,8 @@ void mainWrapped(int argc, char * * argv)
 
     initPlugins();
 
+    unsetenv("IN_NIX_SHELL");
+
     if (!args.command) args.showHelpAndExit();
 
     Finally f([]() { stopProgressBar(); });

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -3,6 +3,8 @@
 with import ./config.nix;
 
 let pkgs = rec {
+  inNixShell = builtins.getEnv "IN_NIX_SHELL" != "";
+
   setupSh = builtins.toFile "setup" ''
     export VAR_FROM_STDENV_SETUP=foo
     for pkg in $buildInputs; do


### PR DESCRIPTION
This fixes the unexpected behaviour of `lib.inNixShell` from nixpkgs. With this it only evaluates to true if the current command is nix-shell.