### PR TITLE
FlakeCommand improvements

### DIFF
--- a/src/libexpr/primops/flake.cc
+++ b/src/libexpr/primops/flake.cc
@@ -482,9 +482,8 @@ ResolvedFlake resolveFlake(EvalState & state, const FlakeRef & topRef, HandleLoc
     return resFlake;
 }
 
-void updateLockFile(EvalState & state, const FlakeUri & flakeUri, bool recreateLockFile)
+void updateLockFile(EvalState & state, const FlakeRef & flakeRef, bool recreateLockFile)
 {
-    FlakeRef flakeRef(flakeUri);
     resolveFlake(state, flakeRef, recreateLockFile ? RecreateLockFile : UpdateLockFile);
 }
 
@@ -551,10 +550,8 @@ static void prim_getFlake(EvalState & state, const Pos & pos, Value * * args, Va
 
 static RegisterPrimOp r2("getFlake", 1, prim_getFlake);
 
-void gitCloneFlake (std::string flakeUri, EvalState & state, Registries registries,
-    Path endDirectory)
+void gitCloneFlake(FlakeRef flakeRef, EvalState & state, Registries registries, const Path & destDir)
 {
-    FlakeRef flakeRef(flakeUri);
     flakeRef = lookupFlake(state, flakeRef, registries);
 
     std::string uri;
@@ -576,8 +573,8 @@ void gitCloneFlake (std::string flakeUri, EvalState & state, Registries registri
         }
     }
 
-    if (endDirectory != "")
-        args.push_back(endDirectory);
+    if (destDir != "")
+        args.push_back(destDir);
 
     runProgram("git", true, args);
 }

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -133,7 +133,8 @@ struct ResolvedFlake
 
 ResolvedFlake resolveFlake(EvalState &, const FlakeRef &, HandleLockFile);
 
-void updateLockFile(EvalState &, const FlakeUri &, bool recreateLockFile);
+void updateLockFile(EvalState &, const FlakeRef & flakeRef, bool recreateLockFile);
 
-void gitCloneFlake (std::string flakeUri, EvalState &, Registries, Path);
+void gitCloneFlake(FlakeRef flakeRef, EvalState &, Registries, const Path & destDir);
+
 }

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -64,7 +64,7 @@ typedef std::vector<std::shared_ptr<FlakeRegistry>> Registries;
 
 Path getUserRegistryPath();
 
-enum HandleLockFile
+enum HandleLockFile : unsigned int
     { AllPure // Everything is handled 100% purely
     , TopRefUsesRegistries // The top FlakeRef uses the registries, apart from that, everything happens 100% purely
     , UpdateLockFile // Update the existing lockfile and write it to file

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -11,8 +11,8 @@ extern std::string programPath;
 struct Value;
 class Bindings;
 class EvalState;
-
 class Store;
+enum HandleLockFile : unsigned int;
 
 /* A command that require a Nix store. */
 struct StoreCommand : virtual Command
@@ -61,17 +61,24 @@ private:
     std::shared_ptr<EvalState> evalState;
 };
 
-struct SourceExprCommand : virtual Args, EvalCommand
+struct MixFlakeOptions : virtual Args
 {
-    std::optional<Path> file;
-
-    SourceExprCommand();
-
     bool recreateLockFile = false;
 
     bool saveLockFile = true;
 
-    bool noRegistries = false;
+    bool useRegistries = true;
+
+    MixFlakeOptions();
+
+    HandleLockFile getLockFileMode();
+};
+
+struct SourceExprCommand : virtual Args, EvalCommand, MixFlakeOptions
+{
+    std::optional<Path> file;
+
+    SourceExprCommand();
 
     std::vector<std::shared_ptr<Installable>> parseInstallables(
         ref<Store> store, std::vector<std::string> ss);

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -35,26 +35,6 @@ struct Buildable
 
 typedef std::vector<Buildable> Buildables;
 
-struct GitRepoCommand : virtual Args
-{
-    std::string gitPath = absPath(".");
-
-    GitRepoCommand ()
-    {
-        expectArg("git-path", &gitPath, true);
-    }
-};
-
-struct FlakeCommand : virtual Args
-{
-    std::string flakeUri;
-
-    FlakeCommand()
-    {
-        expectArg("flake-uri", &flakeUri);
-    }
-};
-
 struct Installable
 {
     virtual std::string what() = 0;
@@ -72,7 +52,16 @@ struct Installable
     }
 };
 
-struct SourceExprCommand : virtual Args, StoreCommand, MixEvalArgs
+struct EvalCommand : virtual StoreCommand, MixEvalArgs
+{
+    ref<EvalState> getEvalState();
+
+private:
+
+    std::shared_ptr<EvalState> evalState;
+};
+
+struct SourceExprCommand : virtual Args, EvalCommand
 {
     std::optional<Path> file;
 
@@ -84,8 +73,6 @@ struct SourceExprCommand : virtual Args, StoreCommand, MixEvalArgs
 
     bool noRegistries = false;
 
-    ref<EvalState> getEvalState();
-
     std::vector<std::shared_ptr<Installable>> parseInstallables(
         ref<Store> store, std::vector<std::string> ss);
 
@@ -96,10 +83,6 @@ struct SourceExprCommand : virtual Args, StoreCommand, MixEvalArgs
     {
         return {"defaultPackage"};
     }
-
-private:
-
-    std::shared_ptr<EvalState> evalState;
 };
 
 enum RealiseMode { Build, NoBuild, DryRun };

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -38,7 +38,7 @@ SourceExprCommand::SourceExprCommand()
         .set(&noRegistries, true);
 }
 
-ref<EvalState> SourceExprCommand::getEvalState()
+ref<EvalState> EvalCommand::getEvalState()
 {
     if (!evalState)
         evalState = std::make_shared<EvalState>(searchPath, getStore());

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -104,6 +104,11 @@ EOF
 # Test 'nix flake info'.
 nix flake info --flake-registry $registry flake1 | grep -q 'ID: *flake1'
 
+# Test 'nix flake info' on a local flake.
+(cd $flake1Dir && nix flake info) | grep -q 'ID: *flake1'
+(cd $flake1Dir && nix flake info .) | grep -q 'ID: *flake1'
+nix flake info $flake1Dir | grep -q 'ID: *flake1'
+
 # Test 'nix flake info --json'.
 json=$(nix flake info --flake-registry $registry flake1 --json | jq .)
 [[ $(echo "$json" | jq -r .description) = 'Bla bla' ]]


### PR DESCRIPTION
It now handles commonality like calling `getFlake()`, resolving relative local flake refs, and creating/updating a lockfile.

Also fixes #2822. All `nix flake` subcommands now work on relative directories and use `.` if no argument is given.