### PR TITLE
Run builds in a pseudo-terminal

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2443,6 +2443,9 @@ void DerivationGoal::initEnv()
        may change that in the future. So tell the builder which file
        descriptor to use for that. */
     env["NIX_LOG_FD"] = "2";
+
+    /* Trigger colored output in various tools. */
+    env["TERM"] = "xterm-256color";
 }
 
 

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2196,6 +2196,9 @@ void DerivationGoal::startBuilder()
 
         if (chown(slaveName.c_str(), buildUser->getUID(), 0))
             throw SysError("changing owner of pseudoterminal slave");
+    } else {
+        if (grantpt(builderOut.readSide.get()))
+            throw SysError("granting access to pseudoterminal slave");
     }
 
     #if 0

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2190,11 +2190,13 @@ void DerivationGoal::startBuilder()
 
     std::string slaveName(ptsname(builderOut.readSide.get()));
 
-    if (chmod(slaveName.c_str(), 0600))
-        throw SysError("changing mode of pseudoterminal slave");
+    if (buildUser) {
+        if (chmod(slaveName.c_str(), 0600))
+            throw SysError("changing mode of pseudoterminal slave");
 
-    if (buildUser && chown(slaveName.c_str(), buildUser->getUID(), 0))
-        throw SysError("changing owner of pseudoterminal slave");
+        if (chown(slaveName.c_str(), buildUser->getUID(), 0))
+            throw SysError("changing owner of pseudoterminal slave");
+    }
 
     #if 0
     // Mount the pt in the sandbox so that the "tty" command works.


### PR DESCRIPTION
This allows many programs (e.g. gcc, clang, cmake) to print colorized log output (assuming `$TERM` is set to a value like `xterm`).

There are other ways to get colors, in particular setting `CLICOLOR_FORCE`, but they're less widely supported and can break programs that parse tool output.

Example output:

![nix-colors](https://user-images.githubusercontent.com/1148549/57956605-d4916900-78f9-11e9-90c8-3864192a2fd0.png)
