### PR TITLE
shared: improve the help message

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -288,8 +288,8 @@ int handleExceptions(const string & programName, std::function<void()> fun)
         return e.status;
     } catch (UsageError & e) {
         printError(
-            format(error + "%1%\nTry '%2% --help' for more information.")
-            % e.what() % programName);
+            format(error + "%1%\nAdd '--help' to the command for usage information.")
+            % e.what());
         return 1;
     } catch (BaseError & e) {
         printError(format(error + "%1%%2%") % (settings.showTrace ? e.prefix() : "") % e.msg());


### PR DESCRIPTION
For subcommands, the default message was confusing. It directs the user to the top-level help which is not what the user wants.

Ideally the message would be `Try 'nix <sub-command> --help' for more information.` but that would require some more refactoring.

Before:

    $ nix repl --wrong --help
    error: unrecognised flag '--wrong'
    Try 'nix --help' for more information.

After:

    $ nix repl --wrong
    error: unrecognised flag '--wrong'
    Add '--help' to the command for usage information.