### PR TITLE
Offline flakes

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -139,7 +139,12 @@ GitInfo exportGit(ref<Store> store, std::string uri,
 
             // FIXME: git stderr messes up our progress indicator, so
             // we're using --quiet for now. Should process its stderr.
-            runProgram("git", true, { "-C", repoDir, "fetch", "--quiet", "--force", "--", uri, fmt("%s:%s", *ref, *ref) });
+            try {
+                runProgram("git", true, { "-C", repoDir, "fetch", "--quiet", "--force", "--", uri, fmt("%s:%s", *ref, *ref) });
+            } catch (Error & e) {
+                if (!pathExists(localRefFile)) throw;
+                warn("could not update local clone of Git repository '%s'; continuing with the most recent version", uri);
+            }
 
             struct timeval times[2];
             times[0].tv_sec = now;

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -132,6 +132,8 @@ struct ResolvedFlake
 
 ResolvedFlake resolveFlake(EvalState &, const FlakeRef &, HandleLockFile);
 
+void callFlake(EvalState & state, const ResolvedFlake & resFlake, Value & v);
+
 void updateLockFile(EvalState &, const FlakeRef & flakeRef, bool recreateLockFile);
 
 void gitCloneFlake(FlakeRef flakeRef, EvalState &, Registries, const Path & destDir);

--- a/src/libexpr/primops/flakeref.cc
+++ b/src/libexpr/primops/flakeref.cc
@@ -194,6 +194,8 @@ std::string FlakeRef::to_string() const
 
     else abort();
 
+    assert(FlakeRef(string) == *this);
+
     return string;
 }
 


### PR DESCRIPTION
This makes `nix build flake:...` etc. register the downloaded flake source trees as a GC root to ensure that they won't be garbage collected, which would be bad if you're offline. Also, `fetchGit` now works offline; if it can't fetch the latest version, it just continues with the most recently fetched version.

TODO: add some commands for manually adding / releasing GC roots? (E.g. `nix flake keep nixpkgs`.)

Fixes #2868.
