### PR TITLE
Store SourceInfo in Flake/NonFlake

### DIFF
--- a/src/libexpr/primops/flake.cc
+++ b/src/libexpr/primops/flake.cc
@@ -397,13 +397,17 @@ LockFile entryToLockFile(const LockFile::FlakeEntry & entry)
 
 LockFile::FlakeEntry dependenciesToFlakeEntry(const ResolvedFlake & resolvedFlake)
 {
-    LockFile::FlakeEntry entry(resolvedFlake.flake.resolvedRef, resolvedFlake.flake.sourceInfo.narHash);
+    LockFile::FlakeEntry entry(
+        resolvedFlake.flake.sourceInfo.resolvedRef,
+        resolvedFlake.flake.sourceInfo.narHash);
 
     for (auto & info : resolvedFlake.flakeDeps)
         entry.flakeEntries.insert_or_assign(info.first.to_string(), dependenciesToFlakeEntry(info.second));
 
     for (auto & nonFlake : resolvedFlake.nonFlakeDeps) {
-        LockFile::NonFlakeEntry nonEntry(nonFlake.resolvedRef, nonFlake.sourceInfo.narHash);
+        LockFile::NonFlakeEntry nonEntry(
+            nonFlake.sourceInfo.resolvedRef,
+            nonFlake.sourceInfo.narHash);
         entry.nonFlakeEntries.insert_or_assign(nonFlake.alias, nonEntry);
     }
 
@@ -540,11 +544,11 @@ void callFlake(EvalState & state, const ResolvedFlake & resFlake, Value & v)
     state.store->isValidPath(path);
     mkString(*state.allocAttr(v, state.sOutPath), path, {path});
 
-    if (resFlake.flake.resolvedRef.rev) {
+    if (resFlake.flake.sourceInfo.resolvedRef.rev) {
         mkString(*state.allocAttr(v, state.symbols.create("rev")),
-            resFlake.flake.resolvedRef.rev->gitRev());
+            resFlake.flake.sourceInfo.resolvedRef.rev->gitRev());
         mkString(*state.allocAttr(v, state.symbols.create("shortRev")),
-            resFlake.flake.resolvedRef.rev->gitShortRev());
+            resFlake.flake.sourceInfo.resolvedRef.rev->gitShortRev());
     }
 
     if (resFlake.flake.sourceInfo.revCount)

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -22,28 +22,28 @@ struct LockFile
     struct NonFlakeEntry
     {
         FlakeRef ref;
-        Hash contentHash;
-        NonFlakeEntry(const FlakeRef & flakeRef, const Hash & hash) : ref(flakeRef), contentHash(hash) {};
+        Hash narHash;
+        NonFlakeEntry(const FlakeRef & flakeRef, const Hash & hash) : ref(flakeRef), narHash(hash) {};
 
         bool operator ==(const NonFlakeEntry & other) const
         {
-            return ref == other.ref && contentHash == other.contentHash;
+            return ref == other.ref && narHash == other.narHash;
         }
     };
 
     struct FlakeEntry
     {
         FlakeRef ref;
-        Hash contentHash;
+        Hash narHash;
         std::map<FlakeRef, FlakeEntry> flakeEntries;
         std::map<FlakeAlias, NonFlakeEntry> nonFlakeEntries;
-        FlakeEntry(const FlakeRef & flakeRef, const Hash & hash) : ref(flakeRef), contentHash(hash) {};
+        FlakeEntry(const FlakeRef & flakeRef, const Hash & hash) : ref(flakeRef), narHash(hash) {};
 
         bool operator ==(const FlakeEntry & other) const
         {
             return
                 ref == other.ref
-                && contentHash == other.contentHash
+                && narHash == other.narHash
                 && flakeEntries == other.flakeEntries
                 && nonFlakeEntries == other.nonFlakeEntries;
         }

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -92,7 +92,6 @@ struct Flake
 {
     FlakeId id;
     FlakeRef originalRef;
-    FlakeRef resolvedRef;
     std::string description;
     SourceInfo sourceInfo;
     std::vector<FlakeRef> requires;
@@ -100,18 +99,17 @@ struct Flake
     Value * vProvides; // FIXME: gc
     unsigned int epoch;
 
-    Flake(const FlakeRef & origRef, const SourceInfo & sourceInfo) : originalRef(origRef),
-        resolvedRef(sourceInfo.resolvedRef), sourceInfo(sourceInfo) {};
+    Flake(const FlakeRef & origRef, const SourceInfo & sourceInfo)
+        : originalRef(origRef), sourceInfo(sourceInfo) {};
 };
 
 struct NonFlake
 {
     FlakeAlias alias;
     FlakeRef originalRef;
-    FlakeRef resolvedRef;
     SourceInfo sourceInfo;
-    NonFlake(const FlakeRef & origRef, const SourceInfo & sourceInfo) :
-        originalRef(origRef), resolvedRef(sourceInfo.resolvedRef), sourceInfo(sourceInfo) {};
+    NonFlake(const FlakeRef & origRef, const SourceInfo & sourceInfo)
+        : originalRef(origRef), sourceInfo(sourceInfo) {};
 };
 
 Flake getFlake(EvalState &, const FlakeRef &, bool impureIsAllowed);

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -94,17 +94,15 @@ struct Flake
     FlakeRef originalRef;
     FlakeRef resolvedRef;
     std::string description;
-    std::optional<uint64_t> revCount;
-    Path storePath;
+    SourceInfo sourceInfo;
     Hash hash; // content hash
     std::vector<FlakeRef> requires;
     std::map<FlakeAlias, FlakeRef> nonFlakeRequires;
     Value * vProvides; // FIXME: gc
-    // date
     unsigned int epoch;
 
     Flake(const FlakeRef & origRef, const SourceInfo & sourceInfo) : originalRef(origRef),
-        resolvedRef(sourceInfo.resolvedRef), revCount(sourceInfo.revCount), storePath(sourceInfo.storePath) {};
+        resolvedRef(sourceInfo.resolvedRef), sourceInfo(sourceInfo) {};
 };
 
 struct NonFlake
@@ -112,12 +110,10 @@ struct NonFlake
     FlakeAlias alias;
     FlakeRef originalRef;
     FlakeRef resolvedRef;
-    std::optional<uint64_t> revCount;
+    SourceInfo sourceInfo;
     Hash hash;
-    Path storePath;
-    // date
-    NonFlake(const FlakeRef & origRef, const SourceInfo & sourceInfo) : originalRef(origRef),
-        resolvedRef(sourceInfo.resolvedRef), revCount(sourceInfo.revCount), storePath(sourceInfo.storePath) {};
+    NonFlake(const FlakeRef & origRef, const SourceInfo & sourceInfo) :
+        originalRef(origRef), resolvedRef(sourceInfo.resolvedRef), sourceInfo(sourceInfo) {};
 };
 
 Flake getFlake(EvalState &, const FlakeRef &, bool impureIsAllowed);

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -84,7 +84,7 @@ struct SourceInfo
     FlakeRef resolvedRef;
     Path storePath;
     std::optional<uint64_t> revCount;
-    // date
+    Hash narHash; // store path hash
     SourceInfo(const FlakeRef & resolvRef) : resolvedRef(resolvRef) {};
 };
 
@@ -95,7 +95,6 @@ struct Flake
     FlakeRef resolvedRef;
     std::string description;
     SourceInfo sourceInfo;
-    Hash hash; // content hash
     std::vector<FlakeRef> requires;
     std::map<FlakeAlias, FlakeRef> nonFlakeRequires;
     Value * vProvides; // FIXME: gc
@@ -111,7 +110,6 @@ struct NonFlake
     FlakeRef originalRef;
     FlakeRef resolvedRef;
     SourceInfo sourceInfo;
-    Hash hash;
     NonFlake(const FlakeRef & origRef, const SourceInfo & sourceInfo) :
         originalRef(origRef), resolvedRef(sourceInfo.resolvedRef), sourceInfo(sourceInfo) {};
 };

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -74,12 +74,12 @@ void printFlakeInfo(const Flake & flake, bool json) {
     if (json) {
         nlohmann::json j;
         j["id"] = flake.id;
-        j["uri"] = flake.resolvedRef.to_string();
+        j["uri"] = flake.sourceInfo.resolvedRef.to_string();
         j["description"] = flake.description;
-        if (flake.resolvedRef.ref)
-            j["branch"] = *flake.resolvedRef.ref;
-        if (flake.resolvedRef.rev)
-            j["revision"] = flake.resolvedRef.rev->to_string(Base16, false);
+        if (flake.sourceInfo.resolvedRef.ref)
+            j["branch"] = *flake.sourceInfo.resolvedRef.ref;
+        if (flake.sourceInfo.resolvedRef.rev)
+            j["revision"] = flake.sourceInfo.resolvedRef.rev->to_string(Base16, false);
         if (flake.sourceInfo.revCount)
             j["revCount"] = *flake.sourceInfo.revCount;
         j["path"] = flake.sourceInfo.storePath;
@@ -87,12 +87,12 @@ void printFlakeInfo(const Flake & flake, bool json) {
         std::cout << j.dump(4) << std::endl;
     } else {
         std::cout << "ID:          " << flake.id << "\n";
-        std::cout << "URI:         " << flake.resolvedRef.to_string() << "\n";
+        std::cout << "URI:         " << flake.sourceInfo.resolvedRef.to_string() << "\n";
         std::cout << "Description: " << flake.description << "\n";
-        if (flake.resolvedRef.ref)
-            std::cout << "Branch:      " << *flake.resolvedRef.ref << "\n";
-        if (flake.resolvedRef.rev)
-            std::cout << "Revision:    " << flake.resolvedRef.rev->to_string(Base16, false) << "\n";
+        if (flake.sourceInfo.resolvedRef.ref)
+            std::cout << "Branch:      " << *flake.sourceInfo.resolvedRef.ref << "\n";
+        if (flake.sourceInfo.resolvedRef.rev)
+            std::cout << "Revision:    " << flake.sourceInfo.resolvedRef.rev->to_string(Base16, false) << "\n";
         if (flake.sourceInfo.revCount)
             std::cout << "Revcount:    " << *flake.sourceInfo.revCount << "\n";
         std::cout << "Path:        " << flake.sourceInfo.storePath << "\n";
@@ -104,22 +104,22 @@ void printNonFlakeInfo(const NonFlake & nonFlake, bool json) {
     if (json) {
         nlohmann::json j;
         j["id"] = nonFlake.alias;
-        j["uri"] = nonFlake.resolvedRef.to_string();
-        if (nonFlake.resolvedRef.ref)
-            j["branch"] = *nonFlake.resolvedRef.ref;
-        if (nonFlake.resolvedRef.rev)
-            j["revision"] = nonFlake.resolvedRef.rev->to_string(Base16, false);
+        j["uri"] = nonFlake.sourceInfo.resolvedRef.to_string();
+        if (nonFlake.sourceInfo.resolvedRef.ref)
+            j["branch"] = *nonFlake.sourceInfo.resolvedRef.ref;
+        if (nonFlake.sourceInfo.resolvedRef.rev)
+            j["revision"] = nonFlake.sourceInfo.resolvedRef.rev->to_string(Base16, false);
         if (nonFlake.sourceInfo.revCount)
             j["revCount"] = *nonFlake.sourceInfo.revCount;
         j["path"] = nonFlake.sourceInfo.storePath;
         std::cout << j.dump(4) << std::endl;
     } else {
         std::cout << "ID:          " << nonFlake.alias << "\n";
-        std::cout << "URI:         " << nonFlake.resolvedRef.to_string() << "\n";
-        if (nonFlake.resolvedRef.ref)
-            std::cout << "Branch:      " << *nonFlake.resolvedRef.ref;
-        if (nonFlake.resolvedRef.rev)
-            std::cout << "Revision:    " << nonFlake.resolvedRef.rev->to_string(Base16, false) << "\n";
+        std::cout << "URI:         " << nonFlake.sourceInfo.resolvedRef.to_string() << "\n";
+        if (nonFlake.sourceInfo.resolvedRef.ref)
+            std::cout << "Branch:      " << *nonFlake.sourceInfo.resolvedRef.ref;
+        if (nonFlake.sourceInfo.resolvedRef.rev)
+            std::cout << "Revision:    " << nonFlake.sourceInfo.resolvedRef.rev->to_string(Base16, false) << "\n";
         if (nonFlake.sourceInfo.revCount)
             std::cout << "Revcount:    " << *nonFlake.sourceInfo.revCount << "\n";
         std::cout << "Path:        " << nonFlake.sourceInfo.storePath << "\n";
@@ -295,13 +295,13 @@ struct CmdFlakePin : virtual Args, EvalCommand
         FlakeRegistry userRegistry = *readRegistry(userRegistryPath);
         auto it = userRegistry.entries.find(FlakeRef(alias));
         if (it != userRegistry.entries.end()) {
-            it->second = getFlake(*evalState, it->second, true).resolvedRef;
+            it->second = getFlake(*evalState, it->second, true).sourceInfo.resolvedRef;
             writeRegistry(userRegistry, userRegistryPath);
         } else {
             std::shared_ptr<FlakeRegistry> globalReg = evalState->getGlobalFlakeRegistry();
             it = globalReg->entries.find(FlakeRef(alias));
             if (it != globalReg->entries.end()) {
-                FlakeRef newRef = getFlake(*evalState, it->second, true).resolvedRef;
+                auto newRef = getFlake(*evalState, it->second, true).sourceInfo.resolvedRef;
                 userRegistry.entries.insert_or_assign(alias, newRef);
                 writeRegistry(userRegistry, userRegistryPath);
             } else

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -125,7 +125,7 @@ static void printNonFlakeInfo(const NonFlake & nonFlake, bool json)
 }
 
 // FIXME: merge info CmdFlakeInfo?
-struct CmdFlakeDeps : FlakeCommand, MixJSON
+struct CmdFlakeDeps : FlakeCommand
 {
     std::string name() override
     {
@@ -152,10 +152,10 @@ struct CmdFlakeDeps : FlakeCommand, MixJSON
             todo.pop();
 
             for (auto & nonFlake : resFlake.nonFlakeDeps)
-                printNonFlakeInfo(nonFlake, json);
+                printNonFlakeInfo(nonFlake, false);
 
             for (auto & info : resFlake.flakeDeps) {
-                printFlakeInfo(info.second.flake, json);
+                printFlakeInfo(info.second.flake, false);
                 todo.push(info.second);
             }
         }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -72,14 +72,14 @@ struct CmdFlakeList : EvalCommand
 
 static void printSourceInfo(const SourceInfo & sourceInfo)
 {
-    std::cout << "URI:         " << sourceInfo.resolvedRef.to_string() << "\n";
+    std::cout << fmt("URI:         %s\n", sourceInfo.resolvedRef.to_string());
     if (sourceInfo.resolvedRef.ref)
-        std::cout << "Branch:      " << *sourceInfo.resolvedRef.ref;
+        std::cout << fmt("Branch:      %s\n",*sourceInfo.resolvedRef.ref);
     if (sourceInfo.resolvedRef.rev)
-        std::cout << "Revision:    " << sourceInfo.resolvedRef.rev->to_string(Base16, false) << "\n";
+        std::cout << fmt("Revision:    %s\n", sourceInfo.resolvedRef.rev->to_string(Base16, false));
     if (sourceInfo.revCount)
-        std::cout << "Revcount:    " << *sourceInfo.revCount << "\n";
-    std::cout << "Path:        " << sourceInfo.storePath << "\n";
+        std::cout << fmt("Revcount:    %s\n", *sourceInfo.revCount);
+    std::cout << fmt("Path:        %s\n", sourceInfo.storePath);
 }
 
 static void sourceInfoToJson(const SourceInfo & sourceInfo, nlohmann::json & j)
@@ -96,9 +96,9 @@ static void sourceInfoToJson(const SourceInfo & sourceInfo, nlohmann::json & j)
 
 static void printFlakeInfo(const Flake & flake)
 {
-    std::cout << "ID:          " << flake.id << "\n";
-    std::cout << "Description: " << flake.description << "\n";
-    std::cout << "Epoch:       " << flake.epoch << "\n";
+    std::cout << fmt("ID:          %s\n", flake.id);
+    std::cout << fmt("Description: %s\n", flake.description);
+    std::cout << fmt("Epoch:       %s\n", flake.epoch);
     printSourceInfo(flake.sourceInfo);
 }
 
@@ -114,7 +114,7 @@ static nlohmann::json flakeToJson(const Flake & flake)
 
 static void printNonFlakeInfo(const NonFlake & nonFlake)
 {
-    std::cout << "ID:          " << nonFlake.alias << "\n";
+    std::cout << fmt("ID:          %s\n", nonFlake.alias);
     printSourceInfo(nonFlake.sourceInfo);
 }
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -80,9 +80,9 @@ void printFlakeInfo(const Flake & flake, bool json) {
             j["branch"] = *flake.resolvedRef.ref;
         if (flake.resolvedRef.rev)
             j["revision"] = flake.resolvedRef.rev->to_string(Base16, false);
-        if (flake.revCount)
-            j["revCount"] = *flake.revCount;
-        j["path"] = flake.storePath;
+        if (flake.sourceInfo.revCount)
+            j["revCount"] = *flake.sourceInfo.revCount;
+        j["path"] = flake.sourceInfo.storePath;
         j["epoch"] = flake.epoch;
         std::cout << j.dump(4) << std::endl;
     } else {
@@ -93,9 +93,9 @@ void printFlakeInfo(const Flake & flake, bool json) {
             std::cout << "Branch:      " << *flake.resolvedRef.ref << "\n";
         if (flake.resolvedRef.rev)
             std::cout << "Revision:    " << flake.resolvedRef.rev->to_string(Base16, false) << "\n";
-        if (flake.revCount)
-            std::cout << "Revcount:    " << *flake.revCount << "\n";
-        std::cout << "Path:        " << flake.storePath << "\n";
+        if (flake.sourceInfo.revCount)
+            std::cout << "Revcount:    " << *flake.sourceInfo.revCount << "\n";
+        std::cout << "Path:        " << flake.sourceInfo.storePath << "\n";
         std::cout << "Epoch:       " << flake.epoch << "\n";
     }
 }
@@ -109,9 +109,9 @@ void printNonFlakeInfo(const NonFlake & nonFlake, bool json) {
             j["branch"] = *nonFlake.resolvedRef.ref;
         if (nonFlake.resolvedRef.rev)
             j["revision"] = nonFlake.resolvedRef.rev->to_string(Base16, false);
-        if (nonFlake.revCount)
-            j["revCount"] = *nonFlake.revCount;
-        j["path"] = nonFlake.storePath;
+        if (nonFlake.sourceInfo.revCount)
+            j["revCount"] = *nonFlake.sourceInfo.revCount;
+        j["path"] = nonFlake.sourceInfo.storePath;
         std::cout << j.dump(4) << std::endl;
     } else {
         std::cout << "ID:          " << nonFlake.alias << "\n";
@@ -120,9 +120,9 @@ void printNonFlakeInfo(const NonFlake & nonFlake, bool json) {
             std::cout << "Branch:      " << *nonFlake.resolvedRef.ref;
         if (nonFlake.resolvedRef.rev)
             std::cout << "Revision:    " << nonFlake.resolvedRef.rev->to_string(Base16, false) << "\n";
-        if (nonFlake.revCount)
-            std::cout << "Revcount:    " << *nonFlake.revCount << "\n";
-        std::cout << "Path:        " << nonFlake.storePath << "\n";
+        if (nonFlake.sourceInfo.revCount)
+            std::cout << "Revcount:    " << *nonFlake.sourceInfo.revCount << "\n";
+        std::cout << "Path:        " << nonFlake.sourceInfo.storePath << "\n";
     }
 }
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -147,6 +147,8 @@ struct CmdFlakeDeps : FlakeCommand, MixJSON
         std::queue<ResolvedFlake> todo;
         todo.push(resolveFlake());
 
+        stopProgressBar();
+
         while (!todo.empty()) {
             auto resFlake = std::move(todo.front());
             todo.pop();
@@ -204,6 +206,7 @@ struct CmdFlakeInfo : FlakeCommand, MixJSON
     void run(nix::ref<nix::Store> store) override
     {
         auto flake = getFlake();
+        stopProgressBar();
         printFlakeInfo(flake, json);
     }
 };

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -70,59 +70,57 @@ struct CmdFlakeList : EvalCommand
     }
 };
 
-void printFlakeInfo(const Flake & flake, bool json) {
+static void printSourceInfo(const SourceInfo & sourceInfo)
+{
+    std::cout << "URI:         " << sourceInfo.resolvedRef.to_string() << "\n";
+    if (sourceInfo.resolvedRef.ref)
+        std::cout << "Branch:      " << *sourceInfo.resolvedRef.ref;
+    if (sourceInfo.resolvedRef.rev)
+        std::cout << "Revision:    " << sourceInfo.resolvedRef.rev->to_string(Base16, false) << "\n";
+    if (sourceInfo.revCount)
+        std::cout << "Revcount:    " << *sourceInfo.revCount << "\n";
+    std::cout << "Path:        " << sourceInfo.storePath << "\n";
+}
+
+static void sourceInfoToJson(const SourceInfo & sourceInfo, nlohmann::json & j)
+{
+    j["uri"] = sourceInfo.resolvedRef.to_string();
+    if (sourceInfo.resolvedRef.ref)
+        j["branch"] = *sourceInfo.resolvedRef.ref;
+    if (sourceInfo.resolvedRef.rev)
+        j["revision"] = sourceInfo.resolvedRef.rev->to_string(Base16, false);
+    if (sourceInfo.revCount)
+        j["revCount"] = *sourceInfo.revCount;
+    j["path"] = sourceInfo.storePath;
+}
+
+static void printFlakeInfo(const Flake & flake, bool json)
+{
     if (json) {
         nlohmann::json j;
         j["id"] = flake.id;
-        j["uri"] = flake.sourceInfo.resolvedRef.to_string();
         j["description"] = flake.description;
-        if (flake.sourceInfo.resolvedRef.ref)
-            j["branch"] = *flake.sourceInfo.resolvedRef.ref;
-        if (flake.sourceInfo.resolvedRef.rev)
-            j["revision"] = flake.sourceInfo.resolvedRef.rev->to_string(Base16, false);
-        if (flake.sourceInfo.revCount)
-            j["revCount"] = *flake.sourceInfo.revCount;
-        j["path"] = flake.sourceInfo.storePath;
         j["epoch"] = flake.epoch;
+        sourceInfoToJson(flake.sourceInfo, j);
         std::cout << j.dump(4) << std::endl;
     } else {
         std::cout << "ID:          " << flake.id << "\n";
-        std::cout << "URI:         " << flake.sourceInfo.resolvedRef.to_string() << "\n";
         std::cout << "Description: " << flake.description << "\n";
-        if (flake.sourceInfo.resolvedRef.ref)
-            std::cout << "Branch:      " << *flake.sourceInfo.resolvedRef.ref << "\n";
-        if (flake.sourceInfo.resolvedRef.rev)
-            std::cout << "Revision:    " << flake.sourceInfo.resolvedRef.rev->to_string(Base16, false) << "\n";
-        if (flake.sourceInfo.revCount)
-            std::cout << "Revcount:    " << *flake.sourceInfo.revCount << "\n";
-        std::cout << "Path:        " << flake.sourceInfo.storePath << "\n";
         std::cout << "Epoch:       " << flake.epoch << "\n";
+        printSourceInfo(flake.sourceInfo);
     }
 }
 
-void printNonFlakeInfo(const NonFlake & nonFlake, bool json) {
+static void printNonFlakeInfo(const NonFlake & nonFlake, bool json)
+{
     if (json) {
         nlohmann::json j;
         j["id"] = nonFlake.alias;
-        j["uri"] = nonFlake.sourceInfo.resolvedRef.to_string();
-        if (nonFlake.sourceInfo.resolvedRef.ref)
-            j["branch"] = *nonFlake.sourceInfo.resolvedRef.ref;
-        if (nonFlake.sourceInfo.resolvedRef.rev)
-            j["revision"] = nonFlake.sourceInfo.resolvedRef.rev->to_string(Base16, false);
-        if (nonFlake.sourceInfo.revCount)
-            j["revCount"] = *nonFlake.sourceInfo.revCount;
-        j["path"] = nonFlake.sourceInfo.storePath;
+        printSourceInfo(nonFlake.sourceInfo);
         std::cout << j.dump(4) << std::endl;
     } else {
         std::cout << "ID:          " << nonFlake.alias << "\n";
-        std::cout << "URI:         " << nonFlake.sourceInfo.resolvedRef.to_string() << "\n";
-        if (nonFlake.sourceInfo.resolvedRef.ref)
-            std::cout << "Branch:      " << *nonFlake.sourceInfo.resolvedRef.ref;
-        if (nonFlake.sourceInfo.resolvedRef.rev)
-            std::cout << "Revision:    " << nonFlake.sourceInfo.resolvedRef.rev->to_string(Base16, false) << "\n";
-        if (nonFlake.sourceInfo.revCount)
-            std::cout << "Revcount:    " << *nonFlake.sourceInfo.revCount << "\n";
-        std::cout << "Path:        " << nonFlake.sourceInfo.storePath << "\n";
+        printSourceInfo(nonFlake.sourceInfo);
     }
 }
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -177,7 +177,7 @@ void makeFlakeClosureGCRoot(Store & store, const FlakeRef & origFlakeRef, const 
         const ResolvedFlake & flake = queue.front();
         queue.pop();
         if (!std::get_if<FlakeRef::IsPath>(&flake.flake.resolvedRef.data))
-            closure.insert(flake.flake.storePath);
+            closure.insert(flake.flake.sourceInfo.storePath);
         for (const auto & dep : flake.flakeDeps)
             queue.push(dep.second);
     }

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -176,7 +176,7 @@ void makeFlakeClosureGCRoot(Store & store, const FlakeRef & origFlakeRef, const 
     while (!queue.empty()) {
         const ResolvedFlake & flake = queue.front();
         queue.pop();
-        if (!std::get_if<FlakeRef::IsPath>(&flake.flake.resolvedRef.data))
+        if (!std::get_if<FlakeRef::IsPath>(&flake.flake.sourceInfo.resolvedRef.data))
             closure.insert(flake.flake.sourceInfo.storePath);
         for (const auto & dep : flake.flakeDeps)
             queue.push(dep.second);


### PR DESCRIPTION
This stores a `SourceInfo` in `Flake` and `NonFlake`, rather than duplicating a bunch of fields (e.g. `storePath`, `revCount`). This simplifies some common code. For example, `callFlake` now emits source info attributes for non-flake dependencies.