### PR TITLE
Expose lastModified attribute

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -19,7 +19,8 @@ let
       releaseTools.sourceTarball {
         name = "nix-tarball";
         version = builtins.readFile ./.version;
-        versionSuffix = if officialRelease then "" else "pre${toString nix.revCount or 0}_${nix.shortRev or "0000000"}";
+        versionSuffix = if officialRelease then "" else
+          "pre${if nix ? lastModified then builtins.substring 0 8 nix.lastModified else toString nix.revCount or 0}_${nix.shortRev or "0000000"}";
         src = nix;
         inherit officialRelease;
 

--- a/src/libexpr/primops/fetchGit.hh
+++ b/src/libexpr/primops/fetchGit.hh
@@ -12,6 +12,7 @@ struct GitInfo
     std::string ref;
     Hash rev{htSHA1};
     uint64_t revCount;
+    time_t lastModified;
 };
 
 GitInfo exportGit(ref<Store> store, std::string uri,

--- a/src/libexpr/primops/flake.cc
+++ b/src/libexpr/primops/flake.cc
@@ -265,6 +265,7 @@ static SourceInfo fetchFlake(EvalState & state, const FlakeRef & flakeRef, bool 
         request.unpack = true;
         request.name = "source";
         request.ttl = resolvedRef.rev ? 1000000000 : settings.tarballTtl;
+        request.getLastModified = true;
         auto result = getDownloader()->downloadCached(state.store, request);
 
         if (!result.etag)
@@ -278,6 +279,7 @@ static SourceInfo fetchFlake(EvalState & state, const FlakeRef & flakeRef, bool 
         SourceInfo info(ref);
         info.storePath = result.storePath;
         info.narHash = state.store->queryPathInfo(info.storePath)->narHash;
+        info.lastModified = result.lastModified;
 
         return info;
     }

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -81,10 +81,22 @@ void writeRegistry(const FlakeRegistry &, const Path &);
 
 struct SourceInfo
 {
+    // Immutable flakeref that this source tree was obtained from.
     FlakeRef resolvedRef;
+
     Path storePath;
+
+    // Number of ancestors of the most recent commit.
     std::optional<uint64_t> revCount;
-    Hash narHash; // store path hash
+
+    // NAR hash of the store path.
+    Hash narHash;
+
+    // A stable timestamp of this source tree. For Git and GitHub
+    // flakes, the commit date (not author date!) of the most recent
+    // commit.
+    std::optional<time_t> lastModified;
+
     SourceInfo(const FlakeRef & resolvRef) : resolvedRef(resolvRef) {};
 };
 

--- a/src/libstore/download.hh
+++ b/src/libstore/download.hh
@@ -49,6 +49,7 @@ struct CachedDownloadRequest
     Hash expectedHash;
     unsigned int ttl = settings.tarballTtl;
     bool gcRoot = false;
+    bool getLastModified = false;
 
     CachedDownloadRequest(const std::string & uri)
         : uri(uri) { }
@@ -62,6 +63,7 @@ struct CachedDownloadResult
     Path path;
     std::optional<std::string> etag;
     std::string effectiveUri;
+    std::optional<time_t> lastModified;
 };
 
 class Store;

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -22,6 +22,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #ifdef __APPLE__
@@ -552,20 +553,31 @@ Paths createDirs(const Path & path)
 }
 
 
-void createSymlink(const Path & target, const Path & link)
+void createSymlink(const Path & target, const Path & link,
+    std::optional<time_t> mtime)
 {
     if (symlink(target.c_str(), link.c_str()))
         throw SysError(format("creating symlink from '%1%' to '%2%'") % link % target);
+    if (mtime) {
+        struct timeval times[2];
+        times[0].tv_sec = *mtime;
+        times[0].tv_usec = 0;
+        times[1].tv_sec = *mtime;
+        times[1].tv_usec = 0;
+        if (lutimes(link.c_str(), times))
+            throw SysError("setting time of symlink '%s'", link);
+    }
 }
 
 
-void replaceSymlink(const Path & target, const Path & link)
+void replaceSymlink(const Path & target, const Path & link,
+    std::optional<time_t> mtime)
 {
     for (unsigned int n = 0; true; n++) {
         Path tmp = canonPath(fmt("%s/.%d_%s", dirOf(link), n, baseNameOf(link)));
 
         try {
-            createSymlink(target, tmp);
+            createSymlink(target, tmp, mtime);
         } catch (SysError & e) {
             if (e.errNo == EEXIST) continue;
             throw;

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -142,10 +142,12 @@ Path getDataDir();
 Paths createDirs(const Path & path);
 
 /* Create a symlink. */
-void createSymlink(const Path & target, const Path & link);
+void createSymlink(const Path & target, const Path & link,
+    std::optional<time_t> mtime = {});
 
 /* Atomically create or replace a symlink. */
-void replaceSymlink(const Path & target, const Path & link);
+void replaceSymlink(const Path & target, const Path & link,
+    std::optional<time_t> mtime = {});
 
 
 /* Wrappers arount read()/write() that read/write exactly the

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -7,6 +7,7 @@
 
 #include <nlohmann/json.hpp>
 #include <queue>
+#include <iomanip>
 
 using namespace nix;
 
@@ -72,14 +73,17 @@ struct CmdFlakeList : EvalCommand
 
 static void printSourceInfo(const SourceInfo & sourceInfo)
 {
-    std::cout << fmt("URI:         %s\n", sourceInfo.resolvedRef.to_string());
+    std::cout << fmt("URI:           %s\n", sourceInfo.resolvedRef.to_string());
     if (sourceInfo.resolvedRef.ref)
-        std::cout << fmt("Branch:      %s\n",*sourceInfo.resolvedRef.ref);
+        std::cout << fmt("Branch:        %s\n",*sourceInfo.resolvedRef.ref);
     if (sourceInfo.resolvedRef.rev)
-        std::cout << fmt("Revision:    %s\n", sourceInfo.resolvedRef.rev->to_string(Base16, false));
+        std::cout << fmt("Revision:      %s\n", sourceInfo.resolvedRef.rev->to_string(Base16, false));
     if (sourceInfo.revCount)
-        std::cout << fmt("Revcount:    %s\n", *sourceInfo.revCount);
-    std::cout << fmt("Path:        %s\n", sourceInfo.storePath);
+        std::cout << fmt("Revisions:     %s\n", *sourceInfo.revCount);
+    if (sourceInfo.lastModified)
+        std::cout << fmt("Last modified: %s\n",
+            std::put_time(std::localtime(&*sourceInfo.lastModified), "%F %T"));
+    std::cout << fmt("Path:          %s\n", sourceInfo.storePath);
 }
 
 static void sourceInfoToJson(const SourceInfo & sourceInfo, nlohmann::json & j)
@@ -91,14 +95,16 @@ static void sourceInfoToJson(const SourceInfo & sourceInfo, nlohmann::json & j)
         j["revision"] = sourceInfo.resolvedRef.rev->to_string(Base16, false);
     if (sourceInfo.revCount)
         j["revCount"] = *sourceInfo.revCount;
+    if (sourceInfo.lastModified)
+        j["lastModified"] = *sourceInfo.lastModified;
     j["path"] = sourceInfo.storePath;
 }
 
 static void printFlakeInfo(const Flake & flake)
 {
-    std::cout << fmt("ID:          %s\n", flake.id);
-    std::cout << fmt("Description: %s\n", flake.description);
-    std::cout << fmt("Epoch:       %s\n", flake.epoch);
+    std::cout << fmt("ID:            %s\n", flake.id);
+    std::cout << fmt("Description:   %s\n", flake.description);
+    std::cout << fmt("Epoch:         %s\n", flake.epoch);
     printSourceInfo(flake.sourceInfo);
 }
 
@@ -114,7 +120,7 @@ static nlohmann::json flakeToJson(const Flake & flake)
 
 static void printNonFlakeInfo(const NonFlake & nonFlake)
 {
-    std::cout << fmt("ID:          %s\n", nonFlake.alias);
+    std::cout << fmt("ID:            %s\n", nonFlake.alias);
     printSourceInfo(nonFlake.sourceInfo);
 }
 

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -124,6 +124,7 @@ nix flake info --flake-registry $registry $flake1Dir | grep -q 'ID: *flake1'
 json=$(nix flake info --flake-registry $registry flake1 --json | jq .)
 [[ $(echo "$json" | jq -r .description) = 'Bla bla' ]]
 [[ -d $(echo "$json" | jq -r .path) ]]
+[[ $(echo "$json" | jq -r .lastModified) = $(git -C $flake1Dir log -n1 --format=%ct) ]]
 
 # Test 'nix build' on a flake.
 nix build -o $TEST_ROOT/result --flake-registry $registry flake1:foo


### PR DESCRIPTION
The `lastModified` attribute of a flake is the timestamp of the last commit. This is primarily useful for generating version strings, since unlike `revCount`, it's supported for both git and github flakes. For example:
```
name = "dwarffs-0.1.${substring 0 8 deps.self.lastModified}";
```
produces a name like `dwarffs-0.1.20190528`.

It's also visible in `nix flake info`:
```
$ nix flake info nixpkgs
ID:            nixpkgs
...
Revision:      a4d896e89932e873c4117908d558db6210fa3b56
Last modified: 2019-04-19 14:48:40
```