### PR TITLE
Add "nix flake check"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,12 @@
       nixpkgs = deps.nixpkgs;
     };
 
-    checks.binaryTarball = hydraJobs.binaryTarball.x86_64-linux;
+    checks = {
+      binaryTarball = hydraJobs.binaryTarball.x86_64-linux;
+      perlBindings = hydraJobs.perlBindings.x86_64-linux;
+      inherit (hydraJobs.tests) remoteBuilds nix-copy-closure;
+      setuid = hydraJobs.tests.setuid.x86_64-linux;
+    };
 
     packages = {
       nix = hydraJobs.build.x86_64-linux;

--- a/flake.nix
+++ b/flake.nix
@@ -14,13 +14,17 @@
       nixpkgs = deps.nixpkgs;
     };
 
-    packages.nix = hydraJobs.build.x86_64-linux;
+    checks.binaryTarball = hydraJobs.binaryTarball.x86_64-linux;
+
+    packages = {
+      nix = hydraJobs.build.x86_64-linux;
+      nix-perl-bindings = hydraJobs.perlBindings.x86_64-linux;
+    };
 
     defaultPackage = packages.nix;
 
     devShell = import ./shell.nix {
       nixpkgs = deps.nixpkgs;
     };
-
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 , nixpkgs ? builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
 }:
 
-with import (builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz) { system = builtins.currentSystem or "x86_64-linux"; };
+with import nixpkgs { system = builtins.currentSystem or "x86_64-linux"; };
 
 with import ./release-common.nix { inherit pkgs; };
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -17,7 +17,10 @@ namespace nix {
 class Store;
 class EvalState;
 enum RepairFlag : bool;
+
+namespace flake {
 struct FlakeRegistry;
+}
 
 
 typedef void (* PrimOpFun) (EvalState & state, const Pos & pos, Value * * args, Value & v);
@@ -323,12 +326,12 @@ private:
 
 public:
 
-    const std::vector<std::shared_ptr<FlakeRegistry>> getFlakeRegistries();
+    const std::vector<std::shared_ptr<flake::FlakeRegistry>> getFlakeRegistries();
 
-    std::shared_ptr<FlakeRegistry> getGlobalFlakeRegistry();
+    std::shared_ptr<flake::FlakeRegistry> getGlobalFlakeRegistry();
 
 private:
-    std::shared_ptr<FlakeRegistry> _globalFlakeRegistry;
+    std::shared_ptr<flake::FlakeRegistry> _globalFlakeRegistry;
     std::once_flag _globalFlakeRegistryInit;
 };
 

--- a/src/libexpr/primops/flake.cc
+++ b/src/libexpr/primops/flake.cc
@@ -566,18 +566,11 @@ void callFlake(EvalState & state, const ResolvedFlake & resFlake, Value & v)
     v.attrs->sort();
 }
 
-// Return the `provides` of the top flake, while assigning to `v` the provides
-// of the dependencies as well.
-void makeFlakeValue(EvalState & state, const FlakeRef & flakeRef, HandleLockFile handle, Value & v)
-{
-    callFlake(state, resolveFlake(state, flakeRef, handle), v);
-}
-
 // This function is exposed to be used in nix files.
 static void prim_getFlake(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
-    makeFlakeValue(state, state.forceStringNoCtx(*args[0], pos),
-        evalSettings.pureEval ? AllPure : UseUpdatedLockFile, v);
+    callFlake(state, resolveFlake(state, state.forceStringNoCtx(*args[0], pos),
+            evalSettings.pureEval ? AllPure : UseUpdatedLockFile), v);
 }
 
 static RegisterPrimOp r2("getFlake", 1, prim_getFlake);

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -5,12 +5,14 @@
 
 namespace nix {
 
+struct Value;
+class EvalState;
+
+namespace flake {
+
 static const size_t FLAG_REGISTRY = 0;
 static const size_t USER_REGISTRY = 1;
 static const size_t GLOBAL_REGISTRY = 2;
-
-struct Value;
-class EvalState;
 
 struct FlakeRegistry
 {
@@ -141,5 +143,7 @@ void callFlake(EvalState & state, const ResolvedFlake & resFlake, Value & v);
 void updateLockFile(EvalState &, const FlakeRef & flakeRef, bool recreateLockFile);
 
 void gitCloneFlake(FlakeRef flakeRef, EvalState &, Registries, const Path & destDir);
+
+}
 
 }

--- a/src/libexpr/primops/flake.hh
+++ b/src/libexpr/primops/flake.hh
@@ -75,8 +75,6 @@ enum HandleLockFile : unsigned int
     , UseNewLockFile // `RecreateLockFile` without writing to file
     };
 
-void makeFlakeValue(EvalState &, const FlakeRef &, HandleLockFile, Value &);
-
 std::shared_ptr<FlakeRegistry> readRegistry(const Path &);
 
 void writeRegistry(const FlakeRegistry &, const Path &);

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -12,7 +12,10 @@ struct Value;
 class Bindings;
 class EvalState;
 class Store;
+
+namespace flake {
 enum HandleLockFile : unsigned int;
+}
 
 /* A command that require a Nix store. */
 struct StoreCommand : virtual Command
@@ -71,7 +74,7 @@ struct MixFlakeOptions : virtual Args
 
     MixFlakeOptions();
 
-    HandleLockFile getLockFileMode();
+    flake::HandleLockFile getLockFileMode();
 };
 
 struct SourceExprCommand : virtual Args, EvalCommand, MixFlakeOptions

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -10,6 +10,7 @@
 #include <iomanip>
 
 using namespace nix;
+using namespace nix::flake;
 
 class FlakeCommand : virtual Args, public EvalCommand, public MixFlakeOptions
 {
@@ -33,12 +34,12 @@ public:
     Flake getFlake()
     {
         auto evalState = getEvalState();
-        return nix::getFlake(*evalState, getFlakeRef(), useRegistries);
+        return flake::getFlake(*evalState, getFlakeRef(), useRegistries);
     }
 
     ResolvedFlake resolveFlake()
     {
-        return nix::resolveFlake(*getEvalState(), getFlakeRef(), getLockFileMode());
+        return flake::resolveFlake(*getEvalState(), getFlakeRef(), getLockFileMode());
     }
 };
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -259,6 +259,8 @@ struct CmdFlakeCheck : FlakeCommand, MixJSON
 
     void run(nix::ref<nix::Store> store) override
     {
+        settings.readOnlyMode = !build;
+
         auto state = getEvalState();
         auto flake = resolveFlake();
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -32,8 +32,9 @@ MixFlakeOptions::MixFlakeOptions()
         .set(&useRegistries, false);
 }
 
-HandleLockFile MixFlakeOptions::getLockFileMode()
+flake::HandleLockFile MixFlakeOptions::getLockFileMode()
 {
+    using namespace flake;
     return
         useRegistries
         ? recreateLockFile
@@ -163,18 +164,20 @@ struct InstallableAttrPath : InstallableValue
     }
 };
 
-void makeFlakeClosureGCRoot(Store & store, const FlakeRef & origFlakeRef, const ResolvedFlake & resFlake)
+void makeFlakeClosureGCRoot(Store & store,
+    const FlakeRef & origFlakeRef,
+    const flake::ResolvedFlake & resFlake)
 {
     if (std::get_if<FlakeRef::IsPath>(&origFlakeRef.data)) return;
 
     /* Get the store paths of all non-local flakes. */
     PathSet closure;
 
-    std::queue<std::reference_wrapper<const ResolvedFlake>> queue;
+    std::queue<std::reference_wrapper<const flake::ResolvedFlake>> queue;
     queue.push(resFlake);
 
     while (!queue.empty()) {
-        const ResolvedFlake & flake = queue.front();
+        const flake::ResolvedFlake & flake = queue.front();
         queue.pop();
         if (!std::get_if<FlakeRef::IsPath>(&flake.flake.sourceInfo.resolvedRef.data))
             closure.insert(flake.flake.sourceInfo.storePath);

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -236,10 +236,21 @@ struct InstallableFlake : InstallableValue
 
         auto emptyArgs = state.allocBindings(0);
 
-        // As a convenience, look for the attribute in
-        // 'provides.packages'.
         if (searchPackages) {
+            // As a convenience, look for the attribute in
+            // 'provides.packages'.
             if (auto aPackages = *vProvides->attrs->get(state.symbols.create("packages"))) {
+                try {
+                    auto * v = findAlongAttrPath(state, *attrPaths.begin(), *emptyArgs, *aPackages->value);
+                    state.forceValue(*v);
+                    return v;
+                } catch (AttrPathNotFound & e) {
+                }
+            }
+
+            // As a temporary hack until Nixpkgs is properly converted
+            // to provide a clean 'packages' set, look in 'legacyPackages'.
+            if (auto aPackages = *vProvides->attrs->get(state.symbols.create("legacyPackages"))) {
                 try {
                     auto * v = findAlongAttrPath(state, *attrPaths.begin(), *emptyArgs, *aPackages->value);
                     state.forceValue(*v);


### PR DESCRIPTION
`nix flake check` evaluates the known "provides" of a flake (e.g. `packages`, `devShell`, `checks`). It also builds the derivations in the `checks` provide. For example:
```
$ nix flake check
[147 built, 36 copied (281.5 MiB), 116.3 MiB DL]
```

This PR also extends `nix flake info --json` to provide info about the `provides`, for example:
```

  $ nix flake info --json | jq
  {
    "branch": "HEAD",
    "description": "The purely functional package manager",
    "epoch": 2019,
    "id": "nix",
    "lastModified": 1559161142,
    "path": "/nix/store/2w2qla8735dbxah8gai8r1nsbf5x4f5d-source",
    "provides": {
      "checks": {
        "binaryTarball": {},
        "nix-copy-closure": {},
        "perlBindings": {},
        "remoteBuilds": {},
        "setuid": {}
      },
      "defaultPackage": {},
      "devShell": {},
      "hydraJobs": {},
      "packages": {
        "nix": {},
        "nix-perl-bindings": {}
      }
    },
    "revCount": 6955,
    "revision": "8cb24e04e8b6cc60e2504733afe78e0eadafcd98",
    "uri": "/home/eelco/Dev/nix"
  }
```