### PR TITLE
release-common: fix build with `config.allowAliases = false`

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -42,7 +42,7 @@ rec {
       libxml2
       libxslt
       docbook5
-      docbook5_xsl
+      docbook_xsl_ns
       autoconf-archive
       autoreconfHook
     ];


### PR DESCRIPTION
```sh
> nix build -f release.nix build.x86_64-linux
error: undefined variable 'docbook5_xsl' at /vcs/nix/release-common.nix:45:7
```