### PR TITLE
Subdirectory improvements

### DIFF
--- a/src/libexpr/primops/flake.cc
+++ b/src/libexpr/primops/flake.cc
@@ -482,9 +482,12 @@ ResolvedFlake resolveFlake(EvalState & state, const FlakeRef & topRef, HandleLoc
     Flake flake = getFlake(state, topRef, allowedToUseRegistries(handleLockFile, true));
     LockFile oldLockFile;
 
-    if (!recreateLockFile (handleLockFile)) {
+    if (!recreateLockFile(handleLockFile)) {
         // If recreateLockFile, start with an empty lockfile
-        oldLockFile = readLockFile(flake.sourceInfo.storePath + "/flake.lock"); // FIXME: symlink attack
+        // FIXME: symlink attack
+        oldLockFile = readLockFile(
+            state.store->toRealPath(flake.sourceInfo.storePath)
+            + "/" + flake.sourceInfo.resolvedRef.subdir + "/flake.lock");
     }
 
     LockFile lockFile(oldLockFile);

--- a/src/libexpr/primops/flake.cc
+++ b/src/libexpr/primops/flake.cc
@@ -121,7 +121,7 @@ nlohmann::json flakeEntryToJson(const LockFile::FlakeEntry & entry)
     return json;
 }
 
-void writeLockFile(const LockFile & lockFile, const Path & path)
+std::ostream & operator <<(std::ostream & stream, const LockFile & lockFile)
 {
     nlohmann::json json;
     json["version"] = 1;
@@ -133,8 +133,14 @@ void writeLockFile(const LockFile & lockFile, const Path & path)
     json["inputs"] = nlohmann::json::object();
     for (auto & x : lockFile.flakeEntries)
         json["inputs"][x.first.to_string()] = flakeEntryToJson(x.second);
+    stream << json.dump(4); // '4' = indentation in json file
+    return stream;
+}
+
+void writeLockFile(const LockFile & lockFile, const Path & path)
+{
     createDirs(dirOf(path));
-    writeFile(path, json.dump(4) + "\n"); // '4' = indentation in json file
+    writeFile(path, fmt("%s\n", lockFile));
 }
 
 Path getUserRegistryPath()

--- a/src/libexpr/primops/flakeref.hh
+++ b/src/libexpr/primops/flakeref.hh
@@ -180,4 +180,9 @@ struct FlakeRef
 
 std::ostream & operator << (std::ostream & str, const FlakeRef & flakeRef);
 
+MakeError(BadFlakeRef, Error);
+
+std::optional<FlakeRef> parseFlakeRef(
+    const std::string & uri, bool allowRelative = false);
+
 }

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3170,7 +3170,7 @@ void DerivationGoal::registerOutputs()
                    valid. */
                 delayedException = std::make_exception_ptr(
                     BuildError("hash mismatch in fixed-output derivation '%s':\n  wanted: %s\n  got:    %s",
-                        dest, h.to_string(), h2.to_string()));
+                        dest, h.to_string(SRI), h2.to_string(SRI)));
 
                 Path actualDest = worker.store.toRealPath(dest);
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -314,6 +314,10 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
                         Strings{"packages." + std::string(s, 8)}));
             }
 
+            else if (auto flakeRef = parseFlakeRef(s, true))
+                result.push_back(std::make_shared<InstallableFlake>(*this, s,
+                        getDefaultFlakeAttrPaths()));
+
             else if ((colon = s.rfind(':')) != std::string::npos) {
                 auto flakeRef = std::string(s, 0, colon);
                 auto attrPath = std::string(s, colon + 1);
@@ -331,10 +335,6 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
                     result.push_back(std::make_shared<InstallableFlake>(*this, FlakeRef(s, true),
                             getDefaultFlakeAttrPaths()));
             }
-
-            else if (auto flakeRef = parseFlakeRef(s, true))
-                result.push_back(std::make_shared<InstallableFlake>(*this, s,
-                        getDefaultFlakeAttrPaths()));
 
             else
                 result.push_back(std::make_shared<InstallableFlake>(*this, FlakeRef("nixpkgs"), s));

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -315,7 +315,7 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
             }
 
             else if (auto flakeRef = parseFlakeRef(s, true))
-                result.push_back(std::make_shared<InstallableFlake>(*this, s,
+                result.push_back(std::make_shared<InstallableFlake>(*this, std::move(*flakeRef),
                         getDefaultFlakeAttrPaths()));
 
             else if ((colon = s.rfind(':')) != std::string::npos) {

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -332,6 +332,10 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
                             getDefaultFlakeAttrPaths()));
             }
 
+            else if (auto flakeRef = parseFlakeRef(s, true))
+                result.push_back(std::make_shared<InstallableFlake>(*this, s,
+                        getDefaultFlakeAttrPaths()));
+
             else
                 result.push_back(std::make_shared<InstallableFlake>(*this, FlakeRef("nixpkgs"), s));
         }

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -131,7 +131,7 @@ nix build -o $TEST_ROOT/result --flake-registry $registry flake1:foo
 [[ -e $TEST_ROOT/result/hello ]]
 
 # Test defaultPackage.
-nix build -o $TEST_ROOT/result --flake-registry $registry flake1:
+nix build -o $TEST_ROOT/result --flake-registry $registry flake1
 [[ -e $TEST_ROOT/result/hello ]]
 
 # Building a flake with an unlocked dependency should fail in pure mode.

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -134,6 +134,9 @@ nix build -o $TEST_ROOT/result --flake-registry $registry flake1:foo
 nix build -o $TEST_ROOT/result --flake-registry $registry flake1
 [[ -e $TEST_ROOT/result/hello ]]
 
+nix build -o $TEST_ROOT/result --flake-registry $registry $flake1Dir
+nix build -o $TEST_ROOT/result --flake-registry $registry file://$flake1Dir
+
 # Building a flake with an unlocked dependency should fail in pure mode.
 (! nix eval "(builtins.getFlake "$flake2Dir")")
 


### PR DESCRIPTION
You can now use `dir` and other parameters in path flakes (e.g. `nix build /path/to/repo?dir=bla`). Also, `dir` can be determined automatically (i.e. `nix build /path/to/repo/bla`).

Also, you can now use bare flakerefs as installables (e.g. `nix build dwarffs`), so you don't need a colon at the end anymore.

This PR also fixes a bug in reading lockfiles from subdirectories.