### PR TITLE
Add 'nix app' command

### DIFF
--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -72,6 +72,14 @@ public:
         return {};
     }
 
+    Attr & need(const Symbol & name, const Pos & pos = noPos)
+    {
+        auto a = get(name);
+        if (!a)
+            throw Error("attribute '%s' missing, at %s", name, pos);
+        return **a;
+    }
+
     iterator begin() { return &attrs[0]; }
     iterator end() { return &attrs[size_]; }
 

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -38,6 +38,13 @@ struct Buildable
 
 typedef std::vector<Buildable> Buildables;
 
+struct App
+{
+    PathSet context;
+    Path program;
+    // FIXME: add args, sandbox settings, metadata, ...
+};
+
 struct Installable
 {
     virtual std::string what() = 0;
@@ -48,6 +55,8 @@ struct Installable
     }
 
     Buildable toBuildable();
+
+    App toApp(EvalState & state);
 
     virtual Value * toValue(EvalState & state)
     {


### PR DESCRIPTION
This is like `nix run`, except that the command to execute is defined in a flake output, e.g.

```nix
  defaultApp = {
    type = "app";
    program = "${packages.blender_2_80}/bin/blender";
  };
```

Thus you can do

```
  $ nix app blender-bin
```

to start Blender from the `blender-bin` flake.

In the future, we can extend this with sandboxing. (For example we would want to be able to specify that Blender should not have network access by default and should only have access to certain paths in the user's home directory.)