### PR TITLE
Handle SIGWINCH in main thread

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -125,8 +125,14 @@ void initNix()
     act.sa_handler = sigHandler;
     if (sigaction(SIGUSR1, &act, 0)) throw SysError("handling SIGUSR1");
 
-    /* Make sure SIGWINCH is handled as well. */
-    if (sigaction(SIGWINCH, &act, 0)) throw SysError("handling SIGWINCH");
+#if __APPLE__
+    /* HACK: on darwin, we need can’t use sigprocmask with SIGWINCH.
+     * Instead, add a dummy sigaction handler, and signalHandlerThread
+     * can handle the rest. */
+    struct sigaction sa;
+    sa.sa_handler = sigHandler;
+    if (sigaction(SIGWINCH, &sa, 0)) throw SysError("handling SIGWINCH");
+#endif
 
     /* Register a SIGSEGV handler to detect stack overflows. */
     detectStackOverflow();

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -125,6 +125,9 @@ void initNix()
     act.sa_handler = sigHandler;
     if (sigaction(SIGUSR1, &act, 0)) throw SysError("handling SIGUSR1");
 
+    /* Make sure SIGWINCH is handled as well. */
+    if (sigaction(SIGWINCH, &act, 0)) throw SysError("handling SIGWINCH");
+
     /* Register a SIGSEGV handler to detect stack overflows. */
     detectStackOverflow();
 


### PR DESCRIPTION
For the SIGWINCH signal to be caught, it needs to be set in sigaction
on the main thread. Previously, this was broken, and updateWindowSize
was never being called. Tested on macOS 10.14.