### PR TITLE
Document the <nixpkgs> notation for nix-shell.

### DIFF
--- a/doc/manual/command-ref/nix-shell.xml
+++ b/doc/manual/command-ref/nix-shell.xml
@@ -69,6 +69,12 @@ unpacked to a temporary location. The tarball must include a single
 top-level directory containing at least a file named
 <filename>default.nix</filename>.</para>
 
+<para>If <replaceable>path</replaceable> is of the form
+<literal>&lt;<replaceable>foo</replaceable>&gt;</literal>, it is
+replaced with the definition of <replaceable>foo</replaceable> as set
+in the environment variable <envar>NIX_PATH</envar> or by the
+<option>-I</option> option.</para>
+
 <para>If the derivation defines the variable
 <varname>shellHook</varname>, it will be evaluated after
 <literal>$stdenv/setup</literal> has been sourced.  Since this hook is


### PR DESCRIPTION
I was very confused about the examples in the documentation that use `<nixpkgs>` paths, because that is not documented in the manpage.  After asking on #nixos, I was pointed at [this Nix pill](https://nixos.org/nixos/nix-pills/nix-search-paths.html) that seems to explain what is going on.  I'm still not sure I get all the subtleties, though.