### PR TITLE
Add --no-net flag

### DIFF
--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -1,5 +1,6 @@
 #include "common-args.hh"
 #include "globals.hh"
+#include "download.hh"
 
 namespace nix {
 
@@ -33,6 +34,16 @@ MixCommonArgs::MixCommonArgs(const string & programName)
             } catch (UsageError & e) {
                 warn(e.what());
             }
+        });
+
+    mkFlag()
+        .longName("no-net")
+        .description("disable substituters and consider all previously downloaded files up-to-date")
+        .handler([]() {
+            settings.useSubstitutes = false;
+            settings.tarballTtl = std::numeric_limits<unsigned int>::max();
+            downloadSettings.tries = 0;
+            downloadSettings.connectTimeout = 1;
         });
 
     std::string cat = "config";

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -1,6 +1,5 @@
 #include "common-args.hh"
 #include "globals.hh"
-#include "download.hh"
 
 namespace nix {
 
@@ -34,16 +33,6 @@ MixCommonArgs::MixCommonArgs(const string & programName)
             } catch (UsageError & e) {
                 warn(e.what());
             }
-        });
-
-    mkFlag()
-        .longName("no-net")
-        .description("disable substituters and consider all previously downloaded files up-to-date")
-        .handler([]() {
-            settings.useSubstitutes = false;
-            settings.tarballTtl = std::numeric_limits<unsigned int>::max();
-            downloadSettings.tries = 0;
-            downloadSettings.connectTimeout = 1;
         });
 
     std::string cat = "config";

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -30,23 +30,7 @@ using namespace std::string_literals;
 
 namespace nix {
 
-struct DownloadSettings : Config
-{
-    Setting<bool> enableHttp2{this, true, "http2",
-        "Whether to enable HTTP/2 support."};
-
-    Setting<std::string> userAgentSuffix{this, "", "user-agent-suffix",
-        "String appended to the user agent in HTTP requests."};
-
-    Setting<size_t> httpConnections{this, 25, "http-connections",
-        "Number of parallel HTTP connections.",
-        {"binary-caches-parallel-connections"}};
-
-    Setting<unsigned long> connectTimeout{this, 0, "connect-timeout",
-        "Timeout for connecting to servers during downloads. 0 means use curl's builtin default."};
-};
-
-static DownloadSettings downloadSettings;
+DownloadSettings downloadSettings;
 
 static GlobalConfig::Register r1(&downloadSettings);
 

--- a/src/libstore/download.hh
+++ b/src/libstore/download.hh
@@ -9,13 +9,34 @@
 
 namespace nix {
 
+struct DownloadSettings : Config
+{
+    Setting<bool> enableHttp2{this, true, "http2",
+        "Whether to enable HTTP/2 support."};
+
+    Setting<std::string> userAgentSuffix{this, "", "user-agent-suffix",
+        "String appended to the user agent in HTTP requests."};
+
+    Setting<size_t> httpConnections{this, 25, "http-connections",
+        "Number of parallel HTTP connections.",
+        {"binary-caches-parallel-connections"}};
+
+    Setting<unsigned long> connectTimeout{this, 0, "connect-timeout",
+        "Timeout for connecting to servers during downloads. 0 means use curl's builtin default."};
+
+    Setting<unsigned int> tries{this, 5, "download-attempts",
+        "How often Nix will attempt to download a file before giving up."};
+};
+
+extern DownloadSettings downloadSettings;
+
 struct DownloadRequest
 {
     std::string uri;
     std::string expectedETag;
     bool verifyTLS = true;
     bool head = false;
-    size_t tries = 5;
+    size_t tries = downloadSettings.tries;
     unsigned int baseRetryTimeMs = 250;
     ActivityId parentAct;
     bool decompress = true;

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -255,7 +255,7 @@ public:
         "Secret keys with which to sign local builds."};
 
     Setting<unsigned int> tarballTtl{this, 60 * 60, "tarball-ttl",
-        "How soon to expire files fetched by builtins.fetchTarball and builtins.fetchurl."};
+        "How long downloaded files are considered up-to-date."};
 
     Setting<bool> requireSigs{this, true, "require-sigs",
         "Whether to check that any non-content-addressed path added to the "

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -84,7 +84,6 @@ protected:
         try {
             DownloadRequest request(cacheUri + "/" + path);
             request.head = true;
-            request.tries = 5;
             getDownloader()->download(request);
             return true;
         } catch (DownloadError & e) {

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -21,7 +21,7 @@ Logger * logger = makeDefaultLogger();
 
 void Logger::warn(const std::string & msg)
 {
-    log(lvlInfo, ANSI_RED "warning:" ANSI_NORMAL " " + msg);
+    log(lvlWarn, ANSI_RED "warning:" ANSI_NORMAL " " + msg);
 }
 
 class SimpleLogger : public Logger
@@ -46,6 +46,7 @@ public:
             char c;
             switch (lvl) {
             case lvlError: c = '3'; break;
+            case lvlWarn: c = '4'; break;
             case lvlInfo: c = '5'; break;
             case lvlTalkative: case lvlChatty: c = '6'; break;
             default: c = '7';

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -6,6 +6,7 @@ namespace nix {
 
 typedef enum {
     lvlError = 0,
+    lvlWarn,
     lvlInfo,
     lvlTalkative,
     lvlChatty,

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -411,7 +411,7 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
                 bool static warned;
                 warnOnce(warned, "the syntax 'nixpkgs.<attr>' is deprecated; use 'nixpkgs:<attr>' instead");
                 result.push_back(std::make_shared<InstallableFlake>(*this, FlakeRef("nixpkgs"),
-                        Strings{"packages." + std::string(s, 8)}));
+                        Strings{"legacyPackages." + std::string(s, 8)}));
             }
 
             else if (auto flakeRef = parseFlakeRef(s, true))

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -102,7 +102,7 @@ void mainWrapped(int argc, char * * argv)
         if (legacy) return legacy(argc, argv);
     }
 
-    verbosity = lvlError;
+    verbosity = lvlWarn;
     settings.verboseBuild = false;
     evalSettings.pureEval = true;
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -8,7 +8,13 @@
 #include "shared.hh"
 #include "store-api.hh"
 #include "progress-bar.hh"
+#include "download.hh"
 #include "finally.hh"
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
 
 extern std::string chrootHelperName;
 
@@ -16,11 +22,38 @@ void chrootHelper(int argc, char * * argv);
 
 namespace nix {
 
+/* Check if we have a non-loopback/link-local network interface. */
+static bool haveInternet()
+{
+    struct ifaddrs * addrs;
+
+    if (getifaddrs(&addrs))
+        return true;
+
+    Finally free([&]() { freeifaddrs(addrs); });
+
+    for (auto i = addrs; i; i = i->ifa_next) {
+        if (!i->ifa_addr) continue;
+        if (i->ifa_addr->sa_family == AF_INET) {
+            if (ntohl(((sockaddr_in *) i->ifa_addr)->sin_addr.s_addr) != INADDR_LOOPBACK) {
+                return true;
+            }
+        } else if (i->ifa_addr->sa_family == AF_INET6) {
+            if (!IN6_IS_ADDR_LOOPBACK(((sockaddr_in6 *) i->ifa_addr)->sin6_addr.s6_addr) &&
+                !IN6_IS_ADDR_LINKLOCAL(((sockaddr_in6 *) i->ifa_addr)->sin6_addr.s6_addr))
+                return true;
+        }
+    }
+
+    return false;
+}
+
 std::string programPath;
 
 struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
 {
     bool printBuildLogs = false;
+    bool useNet = true;
 
     NixArgs() : MultiCommand(*RegisterCommand::commands), MixCommonArgs("nix")
     {
@@ -52,6 +85,11 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
             .longName("version")
             .description("show version information")
             .handler([&]() { printVersion(programName); });
+
+        mkFlag()
+            .longName("no-net")
+            .description("disable substituters and consider all previously downloaded files up-to-date")
+            .handler([&]() { useNet = false; });
     }
 
     void printFlags(std::ostream & out) override
@@ -117,6 +155,23 @@ void mainWrapped(int argc, char * * argv)
     Finally f([]() { stopProgressBar(); });
 
     startProgressBar(args.printBuildLogs);
+
+    if (args.useNet && !haveInternet()) {
+        warn("you don't have Internet access; disabling some network-dependent features");
+        args.useNet = false;
+    }
+
+    if (!args.useNet) {
+        // FIXME: should check for command line overrides only.
+        if (!settings.useSubstitutes.overriden)
+            settings.useSubstitutes = false;
+        if (!settings.tarballTtl.overriden)
+            settings.tarballTtl = std::numeric_limits<unsigned int>::max();
+        if (!downloadSettings.tries.overriden)
+            downloadSettings.tries = 0;
+        if (!downloadSettings.connectTimeout.overriden)
+            downloadSettings.connectTimeout = 1;
+    }
 
     args.command->prepare();
     args.command->run();


### PR DESCRIPTION
This flag

* Disables substituters.

* Sets the `tarball-ttl` to infinity (ensuring e.g. that the flake registry and any downloaded flakes are considered current).

* Disables retrying downloads and sets the connection timeout to the minimum. (So it doesn't completely disable downloads at the moment.)

`--no-net` is implied if there are no configured non-loopback/link-local IPv4/v6 addresses.