### PR TITLE
Make subcommand construction in MultiCommand lazy

### DIFF
--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -192,7 +192,12 @@ public:
    run() method. */
 struct Command : virtual Args
 {
-    virtual std::string name() = 0;
+private:
+    std::string _name;
+
+public:
+    std::string name() { return _name; }
+
     virtual void prepare() { };
     virtual void run() = 0;
 
@@ -209,7 +214,7 @@ struct Command : virtual Args
     void printHelp(const string & programName, std::ostream & out) override;
 };
 
-typedef std::map<std::string, ref<Command>> Commands;
+typedef std::map<std::string, std::function<ref<Command>()>> Commands;
 
 /* An argument parser that supports multiple subcommands,
    i.e. ‘<command> <subcommand>’. */
@@ -220,7 +225,7 @@ public:
 
     std::shared_ptr<Command> command;
 
-    MultiCommand(const std::vector<ref<Command>> & commands);
+    MultiCommand(const Commands & commands);
 
     void printHelp(const string & programName, std::ostream & out) override;
 

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -22,11 +22,6 @@ struct CmdAddToStore : MixDryRun, StoreCommand
             .dest(&namePart);
     }
 
-    std::string name() override
-    {
-        return "add-to-store";
-    }
-
     std::string description() override
     {
         return "add a path to the Nix store";
@@ -58,4 +53,4 @@ struct CmdAddToStore : MixDryRun, StoreCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdAddToStore>());
+static auto r1 = registerCommand<CmdAddToStore>("add-to-store");

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -25,11 +25,6 @@ struct CmdBuild : MixDryRun, InstallablesCommand
             .set(&outLink, Path(""));
     }
 
-    std::string name() override
-    {
-        return "build";
-    }
-
     std::string description() override
     {
         return "build a derivation or fetch a store path";
@@ -72,4 +67,4 @@ struct CmdBuild : MixDryRun, InstallablesCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdBuild>());
+static auto r1 = registerCommand<CmdBuild>("build");

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -28,11 +28,6 @@ struct CmdCatStore : StoreCommand, MixCat
         expectArg("path", &path);
     }
 
-    std::string name() override
-    {
-        return "cat-store";
-    }
-
     std::string description() override
     {
         return "print the contents of a store file on stdout";
@@ -54,11 +49,6 @@ struct CmdCatNar : StoreCommand, MixCat
         expectArg("path", &path);
     }
 
-    std::string name() override
-    {
-        return "cat-nar";
-    }
-
     std::string description() override
     {
         return "print the contents of a file inside a NAR file";
@@ -70,5 +60,5 @@ struct CmdCatNar : StoreCommand, MixCat
     }
 };
 
-static RegisterCommand r1(make_ref<CmdCatStore>());
-static RegisterCommand r2(make_ref<CmdCatNar>());
+static auto r1 = registerCommand<CmdCatStore>("cat-store");
+static auto r2 = registerCommand<CmdCatNar>("cat-nar");

--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -4,7 +4,7 @@
 
 namespace nix {
 
-std::vector<ref<Command>> * RegisterCommand::commands = 0;
+Commands * RegisterCommand::commands = nullptr;
 
 StoreCommand::StoreCommand()
 {

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -190,14 +190,21 @@ struct StorePathCommand : public InstallablesCommand
 /* A helper class for registering commands globally. */
 struct RegisterCommand
 {
-    static std::vector<ref<Command>> * commands;
+    static Commands * commands;
 
-    RegisterCommand(ref<Command> command)
+    RegisterCommand(const std::string & name,
+        std::function<ref<Command>()> command)
     {
-        if (!commands) commands = new std::vector<ref<Command>>;
-        commands->push_back(command);
+        if (!commands) commands = new Commands;
+        commands->emplace(name, command);
     }
 };
+
+template<class T>
+static RegisterCommand registerCommand(const std::string & name)
+{
+    return RegisterCommand(name, [](){ return make_ref<T>(); });
+}
 
 Buildables build(ref<Store> store, RealiseMode mode,
     std::vector<std::shared_ptr<Installable>> installables);

--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -42,11 +42,6 @@ struct CmdCopy : StorePathsCommand
             .set(&substitute, Substitute);
     }
 
-    std::string name() override
-    {
-        return "copy";
-    }
-
     std::string description() override
     {
         return "copy paths between Nix stores";
@@ -97,4 +92,4 @@ struct CmdCopy : StorePathsCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdCopy>());
+static auto r1 = registerCommand<CmdCopy>("copy");

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -20,11 +20,6 @@ struct CmdDoctor : StoreCommand
 {
     bool success = true;
 
-    std::string name() override
-    {
-        return "doctor";
-    }
-
     std::string description() override
     {
         return "check your system for potential problems";
@@ -121,4 +116,4 @@ struct CmdDoctor : StoreCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdDoctor>());
+static auto r1 = registerCommand<CmdDoctor>("doctore");

--- a/src/nix/dump-path.cc
+++ b/src/nix/dump-path.cc
@@ -5,11 +5,6 @@ using namespace nix;
 
 struct CmdDumpPath : StorePathCommand
 {
-    std::string name() override
-    {
-        return "dump-path";
-    }
-
     std::string description() override
     {
         return "dump a store path to stdout (in NAR format)";
@@ -33,4 +28,4 @@ struct CmdDumpPath : StorePathCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdDumpPath>());
+static auto r1 = registerCommand<CmdDumpPath>("dump-path");

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -10,11 +10,6 @@ using namespace nix;
 
 struct CmdEdit : InstallableCommand
 {
-    std::string name() override
-    {
-        return "edit";
-    }
-
     std::string description() override
     {
         return "open the Nix expression of a Nix package in $EDITOR";
@@ -78,4 +73,4 @@ struct CmdEdit : InstallableCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdEdit>());
+static auto r1 = registerCommand<CmdEdit>("edit");

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -18,11 +18,6 @@ struct CmdEval : MixJSON, InstallableCommand
         mkFlag(0, "raw", "print strings unquoted", &raw);
     }
 
-    std::string name() override
-    {
-        return "eval";
-    }
-
     std::string description() override
     {
         return "evaluate a Nix expression";
@@ -74,4 +69,4 @@ struct CmdEval : MixJSON, InstallableCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdEval>());
+static auto r1 = registerCommand<CmdEval>("eval");

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -49,11 +49,6 @@ public:
 
 struct CmdFlakeList : EvalCommand
 {
-    std::string name() override
-    {
-        return "list";
-    }
-
     std::string description() override
     {
         return "list available Nix flakes";
@@ -133,11 +128,6 @@ static void printNonFlakeInfo(const NonFlake & nonFlake)
 // FIXME: merge info CmdFlakeInfo?
 struct CmdFlakeDeps : FlakeCommand
 {
-    std::string name() override
-    {
-        return "deps";
-    }
-
     std::string description() override
     {
         return "list informaton about dependencies";
@@ -171,11 +161,6 @@ struct CmdFlakeDeps : FlakeCommand
 
 struct CmdFlakeUpdate : FlakeCommand
 {
-    std::string name() override
-    {
-        return "update";
-    }
-
     std::string description() override
     {
         return "update flake lock file";
@@ -209,11 +194,6 @@ static void enumerateOutputs(EvalState & state, Value & vFlake,
 
 struct CmdFlakeInfo : FlakeCommand, MixJSON
 {
-    std::string name() override
-    {
-        return "info";
-    }
-
     std::string description() override
     {
         return "list info about a given flake";
@@ -267,11 +247,6 @@ struct CmdFlakeCheck : FlakeCommand, MixJSON
             .longName("no-build")
             .description("do not build checks")
             .set(&build, false);
-    }
-
-    std::string name() override
-    {
-        return "check";
     }
 
     std::string description() override
@@ -383,11 +358,6 @@ struct CmdFlakeAdd : MixEvalArgs, Command
     FlakeUri alias;
     FlakeUri uri;
 
-    std::string name() override
-    {
-        return "add";
-    }
-
     std::string description() override
     {
         return "upsert flake in user flake registry";
@@ -414,11 +384,6 @@ struct CmdFlakeRemove : virtual Args, MixEvalArgs, Command
 {
     FlakeUri alias;
 
-    std::string name() override
-    {
-        return "remove";
-    }
-
     std::string description() override
     {
         return "remove flake from user flake registry";
@@ -441,11 +406,6 @@ struct CmdFlakeRemove : virtual Args, MixEvalArgs, Command
 struct CmdFlakePin : virtual Args, EvalCommand
 {
     FlakeUri alias;
-
-    std::string name() override
-    {
-        return "pin";
-    }
 
     std::string description() override
     {
@@ -482,11 +442,6 @@ struct CmdFlakePin : virtual Args, EvalCommand
 
 struct CmdFlakeInit : virtual Args, Command
 {
-    std::string name() override
-    {
-        return "init";
-    }
-
     std::string description() override
     {
         return "create a skeleton 'flake.nix' file in the current directory";
@@ -514,11 +469,6 @@ struct CmdFlakeClone : FlakeCommand
 {
     Path destDir;
 
-    std::string name() override
-    {
-        return "clone";
-    }
-
     std::string description() override
     {
         return "clone flake repository";
@@ -541,23 +491,18 @@ struct CmdFlakeClone : FlakeCommand
 struct CmdFlake : virtual MultiCommand, virtual Command
 {
     CmdFlake()
-        : MultiCommand({make_ref<CmdFlakeList>()
-            , make_ref<CmdFlakeUpdate>()
-            , make_ref<CmdFlakeInfo>()
-            , make_ref<CmdFlakeCheck>()
-            //, make_ref<CmdFlakeDeps>()
-            , make_ref<CmdFlakeAdd>()
-            , make_ref<CmdFlakeRemove>()
-            , make_ref<CmdFlakePin>()
-            , make_ref<CmdFlakeInit>()
-            , make_ref<CmdFlakeClone>()
-          })
+        : MultiCommand({
+                {"list", []() { return make_ref<CmdFlakeList>(); }},
+                {"update", []() { return make_ref<CmdFlakeUpdate>(); }},
+                {"info", []() { return make_ref<CmdFlakeInfo>(); }},
+                {"check", []() { return make_ref<CmdFlakeCheck>(); }},
+                {"add", []() { return make_ref<CmdFlakeAdd>(); }},
+                {"remove", []() { return make_ref<CmdFlakeRemove>(); }},
+                {"pin", []() { return make_ref<CmdFlakePin>(); }},
+                {"init", []() { return make_ref<CmdFlakeInit>(); }},
+                {"clone", []() { return make_ref<CmdFlakeClone>(); }},
+            })
     {
-    }
-
-    std::string name() override
-    {
-        return "flake";
     }
 
     std::string description() override
@@ -578,4 +523,4 @@ struct CmdFlake : virtual MultiCommand, virtual Command
     }
 };
 
-static RegisterCommand r1(make_ref<CmdFlake>());
+static auto r1 = registerCommand<CmdFlake>("flake");

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -26,11 +26,6 @@ struct CmdHash : Command
         expectArgs("paths", &paths);
     }
 
-    std::string name() override
-    {
-        return mode == mFile ? "hash-file" : "hash-path";
-    }
-
     std::string description() override
     {
         return mode == mFile
@@ -49,8 +44,8 @@ struct CmdHash : Command
     }
 };
 
-static RegisterCommand r1(make_ref<CmdHash>(CmdHash::mFile));
-static RegisterCommand r2(make_ref<CmdHash>(CmdHash::mPath));
+static RegisterCommand r1("hash-file", [](){ return make_ref<CmdHash>(CmdHash::mFile); });
+static RegisterCommand r2("hash-path", [](){ return make_ref<CmdHash>(CmdHash::mPath); });
 
 struct CmdToBase : Command
 {
@@ -64,15 +59,6 @@ struct CmdToBase : Command
             .longName("type")
             .mkHashTypeFlag(&ht);
         expectArgs("strings", &args);
-    }
-
-    std::string name() override
-    {
-        return
-            base == Base16 ? "to-base16" :
-            base == Base32 ? "to-base32" :
-            base == Base64 ? "to-base64" :
-            "to-sri";
     }
 
     std::string description() override
@@ -91,10 +77,10 @@ struct CmdToBase : Command
     }
 };
 
-static RegisterCommand r3(make_ref<CmdToBase>(Base16));
-static RegisterCommand r4(make_ref<CmdToBase>(Base32));
-static RegisterCommand r5(make_ref<CmdToBase>(Base64));
-static RegisterCommand r6(make_ref<CmdToBase>(SRI));
+static RegisterCommand r3("to-base16", [](){ return make_ref<CmdToBase>(Base16); });
+static RegisterCommand r4("to-base32", [](){ return make_ref<CmdToBase>(Base32); });
+static RegisterCommand r5("to-base64", [](){ return make_ref<CmdToBase>(Base64); });
+static RegisterCommand r6("to-sri", [](){ return make_ref<CmdToBase>(SRI); });
 
 /* Legacy nix-hash command. */
 static int compatNixHash(int argc, char * * argv)

--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -8,15 +8,6 @@ using namespace nix;
 
 struct CmdLog : InstallableCommand
 {
-    CmdLog()
-    {
-    }
-
-    std::string name() override
-    {
-        return "log";
-    }
-
     std::string description() override
     {
         return "show the build log of the specified packages or paths, if available";
@@ -68,4 +59,4 @@ struct CmdLog : InstallableCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdLog>());
+static auto r1 = registerCommand<CmdLog>("log");

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -100,11 +100,6 @@ struct CmdLsStore : StoreCommand, MixLs
         };
     }
 
-    std::string name() override
-    {
-        return "ls-store";
-    }
-
     std::string description() override
     {
         return "show information about a store path";
@@ -136,11 +131,6 @@ struct CmdLsNar : Command, MixLs
         };
     }
 
-    std::string name() override
-    {
-        return "ls-nar";
-    }
-
     std::string description() override
     {
         return "show information about the contents of a NAR file";
@@ -152,5 +142,5 @@ struct CmdLsNar : Command, MixLs
     }
 };
 
-static RegisterCommand r1(make_ref<CmdLsStore>());
-static RegisterCommand r2(make_ref<CmdLsNar>());
+static auto r1 = registerCommand<CmdLsStore>("ls-store");
+static auto r2 = registerCommand<CmdLsNar>("ls-nar");

--- a/src/nix/optimise-store.cc
+++ b/src/nix/optimise-store.cc
@@ -8,15 +8,6 @@ using namespace nix;
 
 struct CmdOptimiseStore : StoreCommand
 {
-    CmdOptimiseStore()
-    {
-    }
-
-    std::string name() override
-    {
-        return "optimise-store";
-    }
-
     std::string description() override
     {
         return "replace identical files in the store by hard links";
@@ -38,4 +29,4 @@ struct CmdOptimiseStore : StoreCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdOptimiseStore>());
+static auto r1 = registerCommand<CmdOptimiseStore>("optimise-store");

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -24,11 +24,6 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
         mkFlag(0, "sigs", "show signatures", &showSigs);
     }
 
-    std::string name() override
-    {
-        return "path-info";
-    }
-
     std::string description() override
     {
         return "query information about store paths";
@@ -130,4 +125,4 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
     }
 };
 
-static RegisterCommand r1(make_ref<CmdPathInfo>());
+static auto r1 = registerCommand<CmdPathInfo>("path-info");

--- a/src/nix/ping-store.cc
+++ b/src/nix/ping-store.cc
@@ -6,11 +6,6 @@ using namespace nix;
 
 struct CmdPingStore : StoreCommand
 {
-    std::string name() override
-    {
-        return "ping-store";
-    }
-
     std::string description() override
     {
         return "test whether a store can be opened";
@@ -32,4 +27,4 @@ struct CmdPingStore : StoreCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdPingStore>());
+static auto r1 = registerCommand<CmdPingStore>("ping-store");

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -764,8 +764,6 @@ struct CmdRepl : StoreCommand, MixEvalArgs
         expectArgs("files", &files);
     }
 
-    std::string name() override { return "repl"; }
-
     std::string description() override
     {
         return "start an interactive environment for evaluating Nix expressions";
@@ -779,6 +777,6 @@ struct CmdRepl : StoreCommand, MixEvalArgs
     }
 };
 
-static RegisterCommand r1(make_ref<CmdRepl>());
+static auto r1 = registerCommand<CmdRepl>("repl");
 
 }

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -99,11 +99,6 @@ struct CmdRun : InstallablesCommand, RunCommon
             .handler([&](std::vector<std::string> ss) { unset.insert(ss.front()); });
     }
 
-    std::string name() override
-    {
-        return "run";
-    }
-
     std::string description() override
     {
         return "run a shell in which the specified packages are available";
@@ -192,7 +187,7 @@ struct CmdRun : InstallablesCommand, RunCommon
     }
 };
 
-static RegisterCommand r1(make_ref<CmdRun>());
+static auto r1 = registerCommand<CmdRun>("run");
 
 struct CmdApp : InstallableCommand, RunCommon
 {
@@ -201,11 +196,6 @@ struct CmdApp : InstallableCommand, RunCommon
     CmdApp()
     {
         expectArgs("args", &args);
-    }
-
-    std::string name() override
-    {
-        return "app";
     }
 
     std::string description() override
@@ -248,7 +238,7 @@ struct CmdApp : InstallableCommand, RunCommon
     }
 };
 
-static RegisterCommand r2(make_ref<CmdApp>());
+static auto r2 = registerCommand<CmdApp>("app");
 
 void chrootHelper(int argc, char * * argv)
 {

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -52,11 +52,6 @@ struct CmdSearch : SourceExprCommand, MixJSON
             .handler([&]() { writeCache = false; useCache = false; });
     }
 
-    std::string name() override
-    {
-        return "search";
-    }
-
     std::string description() override
     {
         return "query available packages";
@@ -282,4 +277,4 @@ struct CmdSearch : SourceExprCommand, MixJSON
     }
 };
 
-static RegisterCommand r1(make_ref<CmdSearch>());
+static auto r1 = registerCommand<CmdSearch>("search");

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -177,12 +177,6 @@ struct Common : InstallableCommand
 
 struct CmdDevShell : Common
 {
-
-    std::string name() override
-    {
-        return "dev-shell";
-    }
-
     std::string description() override
     {
         return "run a bash shell that provides the build environment of a derivation";
@@ -240,12 +234,6 @@ struct CmdDevShell : Common
 
 struct CmdPrintDevEnv : Common
 {
-
-    std::string name() override
-    {
-        return "print-dev-env";
-    }
-
     std::string description() override
     {
         return "print shell code that can be sourced by bash to reproduce the build environment of a derivation";
@@ -279,5 +267,5 @@ struct CmdPrintDevEnv : Common
     }
 };
 
-static RegisterCommand r1(make_ref<CmdPrintDevEnv>());
-static RegisterCommand r2(make_ref<CmdDevShell>());
+static auto r1 = registerCommand<CmdPrintDevEnv>("print-dev-env");
+static auto r2 = registerCommand<CmdDevShell>("dev-shell");

--- a/src/nix/show-config.cc
+++ b/src/nix/show-config.cc
@@ -8,15 +8,6 @@ using namespace nix;
 
 struct CmdShowConfig : Command, MixJSON
 {
-    CmdShowConfig()
-    {
-    }
-
-    std::string name() override
-    {
-        return "show-config";
-    }
-
     std::string description() override
     {
         return "show the Nix configuration";
@@ -37,4 +28,4 @@ struct CmdShowConfig : Command, MixJSON
     }
 };
 
-static RegisterCommand r1(make_ref<CmdShowConfig>());
+static auto r1 = registerCommand<CmdShowConfig>("show-config");

--- a/src/nix/show-derivation.cc
+++ b/src/nix/show-derivation.cc
@@ -22,11 +22,6 @@ struct CmdShowDerivation : InstallablesCommand
             .set(&recursive, true);
     }
 
-    std::string name() override
-    {
-        return "show-derivation";
-    }
-
     std::string description() override
     {
         return "show the contents of a store derivation";
@@ -116,4 +111,4 @@ struct CmdShowDerivation : InstallablesCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdShowDerivation>());
+static auto r1 = registerCommand<CmdShowDerivation>("show-derivation");

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -22,11 +22,6 @@ struct CmdCopySigs : StorePathsCommand
             .handler([&](std::vector<std::string> ss) { substituterUris.push_back(ss[0]); });
     }
 
-    std::string name() override
-    {
-        return "copy-sigs";
-    }
-
     std::string description() override
     {
         return "copy path signatures from substituters (like binary caches)";
@@ -93,7 +88,7 @@ struct CmdCopySigs : StorePathsCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdCopySigs>());
+static auto r1 = registerCommand<CmdCopySigs>("copy-sigs");
 
 struct CmdSignPaths : StorePathsCommand
 {
@@ -107,11 +102,6 @@ struct CmdSignPaths : StorePathsCommand
             .label("file")
             .description("file containing the secret signing key")
             .dest(&secretKeyFile);
-    }
-
-    std::string name() override
-    {
-        return "sign-paths";
     }
 
     std::string description() override
@@ -146,4 +136,4 @@ struct CmdSignPaths : StorePathsCommand
     }
 };
 
-static RegisterCommand r3(make_ref<CmdSignPaths>());
+static auto r2 = registerCommand<CmdSignPaths>("sign-paths");

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -30,11 +30,6 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
             .dest(&storePathsUrl);
     }
 
-    std::string name() override
-    {
-        return "upgrade-nix";
-    }
-
     std::string description() override
     {
         return "upgrade Nix to the latest stable version";
@@ -157,4 +152,4 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdUpgradeNix>());
+static auto r1 = registerCommand<CmdUpgradeNix>("upgrade-nix");

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -29,11 +29,6 @@ struct CmdVerify : StorePathsCommand
         mkIntFlag('n', "sigs-needed", "require that each path has at least N valid signatures", &sigsNeeded);
     }
 
-    std::string name() override
-    {
-        return "verify";
-    }
-
     std::string description() override
     {
         return "verify the integrity of store paths";
@@ -175,4 +170,4 @@ struct CmdVerify : StorePathsCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdVerify>());
+static auto r1 = registerCommand<CmdVerify>("verify");

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -44,11 +44,6 @@ struct CmdWhyDepends : SourceExprCommand
             .set(&all, true);
     }
 
-    std::string name() override
-    {
-        return "why-depends";
-    }
-
     std::string description() override
     {
         return "show why a package has another package in its closure";
@@ -264,4 +259,4 @@ struct CmdWhyDepends : SourceExprCommand
     }
 };
 
-static RegisterCommand r1(make_ref<CmdWhyDepends>());
+static auto r1 = registerCommand<CmdWhyDepends>("why-depends");


### PR DESCRIPTION
This makes things a bit faster (we're not constructing Commands we don't need) and ensures that `Command` destructors are executed.