### PR TITLE
Binary cache - improve error message when trying to copy partial closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Makefile.config
 perl/Makefile.config
+.vscode
 
 # /
 /aclocal.m4

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -123,7 +123,8 @@ void BinaryCacheStore::addToStore(const ValidPathInfo & info, const ref<std::str
             if (ref != info.path)
                 queryPathInfo(ref);
         } catch (InvalidPath &) {
-            throw Error(format("cannot add '%s' to the binary cache because the reference '%s' is not valid")
+            throw Error(format("cannot add '%s' to the binary cache because the reference '%s' is missing. "
+                               "Copying a partial closure isn't supported (the reference should be in the cache).")
                 % info.path % ref);
         }
 


### PR DESCRIPTION
Since https://github.com/NixOS/nix/commit/0207272b28f1dad119b418dfafcfb18d22b6d3f6#diff-4fb7d3254df1c8894c7014adc990dfa1 copying a partial closure isn't allowed, but the error message is a bit misleading: "the reference is not valid" might mean that there's something wrong on the local store (missing path, invalid signature, ...).

Just out of curiosity, why isn't it possible to partially copy a closure to a binary cache? Shouldn't nix be able to pull a closure from different substituters? Isn't this a bit at odd with the `nix copy --no-recursive` option?