### PR TITLE
replace in-memory nar caching with on-disk nar caching when >256MB

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -280,21 +280,16 @@ Path BinaryCacheStore::addToStore(const string & name, const Path & srcPath,
     /* Read the whole path into memory. This is not a very scalable
        method for very large paths, but `copyPath' is mainly used for
        small files. */
-    StringSink sink;
+    HashedBufferSink sink(hashAlgo);
     Hash h;
-    if (recursive) {
-        dumpPath(srcPath, sink, filter);
-        h = hashString(hashAlgo, *sink.s);
-    } else {
-        auto s = readFile(srcPath);
-        dumpString(s, sink);
-        h = hashString(hashAlgo, s);
-    }
+    // todo: assert regular
+    dumpPath(srcPath, sink, filter);
 
     ValidPathInfo info;
-    info.path = makeFixedOutputPath(recursive, h, name);
+    info.path = makeFixedOutputPath(recursive, sink.toHash().first, name);
 
-    addToStore(info, sink.s, repair, CheckSigs, nullptr);
+    // todo: fix toString
+    addToStore(info, sink.toString(), repair, CheckSigs, nullptr);
 
     return info.path;
 }

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -62,8 +62,6 @@ public:
 
 private:
 
-    std::string narMagic;
-
     std::string narInfoFileFor(const Path & storePath);
 
     void writeNarInfo(ref<NarInfo> narInfo);
@@ -80,9 +78,11 @@ public:
 
     bool wantMassQuery() override { return wantMassQuery_; }
 
+    void addToStore(const ValidPathInfo & info, HashResult hash, Source & source,
+        RepairFlag repair, CheckSigsFlag checkSigs);
+
     void addToStore(const ValidPathInfo & info, const ref<std::string> & nar,
-        RepairFlag repair, CheckSigsFlag checkSigs,
-        std::shared_ptr<FSAccessor> accessor) override;
+        RepairFlag repair, CheckSigsFlag checkSigs) override;
 
     Path addToStore(const string & name, const Path & srcPath,
         bool recursive, HashType hashAlgo,

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -35,7 +35,7 @@ public:
     virtual bool fileExists(const std::string & path) = 0;
 
     virtual void upsertFile(const std::string & path,
-        const std::string & data,
+        const std::string_view data,
         const std::string & mimeType) = 0;
 
     /* Note: subclasses must implement at least one of the two

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2092,10 +2092,7 @@ void DerivationGoal::startBuilder()
                        --optimise'. */
                     if (errno != EMLINK)
                         throw SysError(format("linking '%1%' to '%2%'") % p % i);
-                    StringSink sink;
-                    dumpPath(r, sink);
-                    StringSource source(*sink.s);
-                    restorePath(p, source);
+                    restorePath(p, *sinkToSource([&](Sink & s) { dumpPath(r, s); }));
                 }
             }
         }

--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -92,8 +92,6 @@ Paths Store::importPaths(Source & source, CheckSigsFlag checkSigs)
         if (readInt(source) == 1)
             readString(source);
 
-        LambdaSink voidsink([](const unsigned char*, size_t){});
-        tee.source.drain(voidsink);
         HashResult hash = tee.source.sink.toHash();
         info.narHash = hash.first;
         info.narSize = hash.second;

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -98,7 +98,7 @@ protected:
     }
 
     void upsertFile(const std::string & path,
-        const std::string & data,
+        const std::string_view data,
         const std::string & mimeType) override
     {
         auto req = DownloadRequest(cacheUri + "/" + path);

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -124,8 +124,7 @@ struct LegacySSHStore : public Store
     }
 
     void addToStore(const ValidPathInfo & info, Source & source,
-        RepairFlag repair, CheckSigsFlag checkSigs,
-        std::shared_ptr<FSAccessor> accessor) override
+        RepairFlag repair, CheckSigsFlag checkSigs) override
     {
         debug("adding path '%s' to remote host '%s'", info.path, host);
 

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -31,7 +31,7 @@ protected:
     bool fileExists(const std::string & path) override;
 
     void upsertFile(const std::string & path,
-        const std::string & data,
+        const std::string_view data,
         const std::string & mimeType) override;
 
     void getFile(const std::string & path, Sink & sink) override
@@ -66,7 +66,7 @@ void LocalBinaryCacheStore::init()
     BinaryCacheStore::init();
 }
 
-static void atomicWrite(const Path & path, const std::string & s)
+static void atomicWrite(const Path & path, const std::string_view s)
 {
     Path tmp = path + ".tmp." + std::to_string(getpid());
     AutoDelete del(tmp, false);
@@ -82,7 +82,7 @@ bool LocalBinaryCacheStore::fileExists(const std::string & path)
 }
 
 void LocalBinaryCacheStore::upsertFile(const std::string & path,
-    const std::string & data,
+    const std::string_view data,
     const std::string & mimeType)
 {
     atomicWrite(binaryCacheDir + "/" + path, data);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -979,7 +979,7 @@ const PublicKeys & LocalStore::getPublicKeys()
 
 
 void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
-    RepairFlag repair, CheckSigsFlag checkSigs, std::shared_ptr<FSAccessor> accessor)
+    RepairFlag repair, CheckSigsFlag checkSigs)
 {
     if (!info.narHash)
         throw Error("cannot add path '%s' because it lacks a hash", info.path);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1110,17 +1110,13 @@ Path LocalStore::addToStore(const string & name, const Path & _srcPath,
 {
     Path srcPath(absPath(_srcPath));
 
-    /* Read the whole path into memory. This is not a very scalable
-       method for very large paths, but `copyPath' is mainly used for
-       small files. */
-    // TODO: if too big, first copy to tmp, then hash, then addToStore
-    StringSink sink;
+    HashedBufferSink sink(hashAlgo);
     if (recursive)
         dumpPath(srcPath, sink, filter);
     else
-        sink.s = make_ref<std::string>(readFile(srcPath));
+        readFile(srcPath, sink);
 
-    return addToStoreFromDump(*sink.s, name, recursive, hashAlgo, repair);
+    return addToStoreFromDump(sink.toHash().first, sink.toSource(), name, recursive, repair);
 }
 
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1096,13 +1096,6 @@ Path LocalStore::addToStoreFromDump(const Hash & h, Source & source,
 
     return dstPath;
 }
-Path LocalStore::addToStoreFromDump(const string & dump, const string & name,
-    bool recursive, HashType hashAlgo, RepairFlag repair)
-{
-    Hash h = hashString(hashAlgo, dump);
-    StringSource source(dump);
-    return addToStoreFromDump(h, source, name, recursive, repair);
-}
 
 
 Path LocalStore::addToStore(const string & name, const Path & _srcPath,

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -158,6 +158,10 @@ public:
        false). */
     Path addToStoreFromDump(const string & dump, const string & name,
         bool recursive = true, HashType hashAlgo = htSHA256, RepairFlag repair = NoRepair);
+    /* addToStoreFromDump variant that works on a source and a hash, if
+       a hash is already available. */
+    Path addToStoreFromDump(const Hash & h, Source & source,
+        const string & name, bool recursive = true, RepairFlag repair = NoRepair);
 
     Path addTextToStore(const string & name, const string & s,
         const PathSet & references, RepairFlag repair) override;

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -155,10 +155,6 @@ public:
        in `dump', which is either a NAR serialisation (if recursive ==
        true) or simply the contents of a regular file (if recursive ==
        false). */
-    Path addToStoreFromDump(const string & dump, const string & name,
-        bool recursive = true, HashType hashAlgo = htSHA256, RepairFlag repair = NoRepair);
-    /* addToStoreFromDump variant that works on a source and a hash, if
-       a hash is already available. */
     Path addToStoreFromDump(const Hash & h, Source & source,
         const string & name, bool recursive = true,
         RepairFlag repair = NoRepair);

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -145,8 +145,7 @@ public:
         SubstitutablePathInfos & infos) override;
 
     void addToStore(const ValidPathInfo & info, Source & source,
-        RepairFlag repair, CheckSigsFlag checkSigs,
-        std::shared_ptr<FSAccessor> accessor) override;
+        RepairFlag repair, CheckSigsFlag checkSigs) override;
 
     Path addToStore(const string & name, const Path & srcPath,
         bool recursive, HashType hashAlgo,
@@ -161,7 +160,8 @@ public:
     /* addToStoreFromDump variant that works on a source and a hash, if
        a hash is already available. */
     Path addToStoreFromDump(const Hash & h, Source & source,
-        const string & name, bool recursive = true, RepairFlag repair = NoRepair);
+        const string & name, bool recursive = true,
+        RepairFlag repair = NoRepair);
 
     Path addTextToStore(const string & name, const string & s,
         const PathSet & references, RepairFlag repair) override;

--- a/src/libstore/nar-accessor.hh
+++ b/src/libstore/nar-accessor.hh
@@ -3,12 +3,14 @@
 #include <functional>
 
 #include "fs-accessor.hh"
+#include "serialise.hh"
 
 namespace nix {
 
 /* Return an object that provides access to the contents of a NAR
    file. */
 ref<FSAccessor> makeNarAccessor(ref<const std::string> nar);
+ref<FSAccessor> makeNarAccessor(Source & nar);
 
 /* Create a NAR accessor from a NAR listing (in the format produced by
    listNar()). The callback getNarBytes(offset, length) is used by the

--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -22,7 +22,7 @@ Path RemoteFSAccessor::makeCacheFile(const Path & storePath, const std::string &
     return fmt("%s/%s.%s", cacheDir, storePathToHash(storePath), ext);
 }
 
-void RemoteFSAccessor::addToCache(const Path & storePath, const std::string & nar,
+void RemoteFSAccessor::addToCache(const Path & storePath, Source & nar,
     ref<FSAccessor> narAccessor)
 {
     nars.emplace(storePath, narAccessor);

--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -96,6 +96,9 @@ std::pair<ref<FSAccessor>, Path> RemoteFSAccessor::fetch(const Path & path_)
         } catch (SysError &) { }
     }
 
+    // FIXME: This loads the nar in-memory.
+    // Hard to fix because it leaks a reference to the entire file contents
+    // via the nar accessor
     store->narFromPath(storePath, sink);
     auto narAccessor = makeNarAccessor(sink.s);
     addToCache(storePath, *sink.s, narAccessor);

--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -35,6 +35,7 @@ void RemoteFSAccessor::addToCache(const Path & storePath, Source & nar,
             writeFile(makeCacheFile(storePath, "ls"), str.str());
 
             /* FIXME: do this asynchronously. */
+            // fixme: link from FS if possible
             writeFile(makeCacheFile(storePath, "nar"), nar);
 
         } catch (...) {
@@ -101,7 +102,8 @@ std::pair<ref<FSAccessor>, Path> RemoteFSAccessor::fetch(const Path & path_)
     // via the nar accessor
     store->narFromPath(storePath, sink);
     auto narAccessor = makeNarAccessor(sink.s);
-    addToCache(storePath, *sink.s, narAccessor);
+    StringSource src(*sink.s);
+    addToCache(storePath, src, narAccessor);
     return {narAccessor, restPath};
 }
 

--- a/src/libstore/remote-fs-accessor.hh
+++ b/src/libstore/remote-fs-accessor.hh
@@ -20,8 +20,7 @@ class RemoteFSAccessor : public FSAccessor
 
     Path makeCacheFile(const Path & storePath, const std::string & ext);
 
-    void addToCache(const Path & storePath, const std::string & nar,
-        ref<FSAccessor> narAccessor);
+    void addToCache(const Path & storePath, Source & nar, ref<FSAccessor> narAccessor);
 
 public:
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -429,7 +429,7 @@ Path RemoteStore::queryPathFromHashPart(const string & hashPart)
 
 
 void RemoteStore::addToStore(const ValidPathInfo & info, Source & source,
-    RepairFlag repair, CheckSigsFlag checkSigs, std::shared_ptr<FSAccessor> accessor)
+    RepairFlag repair, CheckSigsFlag checkSigs)
 {
     auto conn(getConnection());
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -59,8 +59,7 @@ public:
         SubstitutablePathInfos & infos) override;
 
     void addToStore(const ValidPathInfo & info, Source & nar,
-        RepairFlag repair, CheckSigsFlag checkSigs,
-        std::shared_ptr<FSAccessor> accessor) override;
+        RepairFlag repair, CheckSigsFlag checkSigs) override;
 
     Path addToStore(const string & name, const Path & srcPath,
         bool recursive = true, HashType hashAlgo = htSHA256,

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -257,7 +257,7 @@ struct S3BinaryCacheStoreImpl : public S3BinaryCacheStore
     std::shared_ptr<TransferManager> transferManager;
     std::once_flag transferManagerCreated;
 
-    void uploadFile(const std::string & path, const std::string & data,
+    void uploadFile(const std::string & path, const std::string_view data,
         const std::string & mimeType,
         const std::string & contentEncoding)
     {
@@ -350,7 +350,7 @@ struct S3BinaryCacheStoreImpl : public S3BinaryCacheStore
         stats.put++;
     }
 
-    void upsertFile(const std::string & path, const std::string & data,
+    void upsertFile(const std::string & path, const std::string_view data,
         const std::string & mimeType) override
     {
         if (narinfoCompression != "" && hasSuffix(path, ".narinfo"))

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -827,18 +827,16 @@ std::string makeFixedOutputCA(bool recursive, const Hash & hash)
 
 
 void Store::addToStore(const ValidPathInfo & info, Source & narSource,
-    RepairFlag repair, CheckSigsFlag checkSigs,
-    std::shared_ptr<FSAccessor> accessor)
+    RepairFlag repair, CheckSigsFlag checkSigs)
 {
-    addToStore(info, make_ref<std::string>(narSource.drain()), repair, checkSigs, accessor);
+    addToStore(info, make_ref<std::string>(narSource.drain()), repair, checkSigs);
 }
 
 void Store::addToStore(const ValidPathInfo & info, const ref<std::string> & nar,
-    RepairFlag repair, CheckSigsFlag checkSigs,
-    std::shared_ptr<FSAccessor> accessor)
+    RepairFlag repair, CheckSigsFlag checkSigs)
 {
     StringSource source(*nar);
-    addToStore(info, source, repair, checkSigs, accessor);
+    addToStore(info, source, repair, checkSigs);
 }
 
 }

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -571,10 +571,8 @@ public:
     void exportPath(const Path & path, Sink & sink);
 
     /* Import a sequence of NAR dumps created by exportPaths() into
-       the Nix store. Optionally, the contents of the NARs are
-       preloaded into the specified FS accessor to speed up subsequent
-       access. */
-    Paths importPaths(Source & source, std::shared_ptr<FSAccessor> accessor,
+       the Nix store. */
+    Paths importPaths(Source & source,
         CheckSigsFlag checkSigs = CheckSigs);
 
     struct Stats

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -405,13 +405,11 @@ public:
 
     /* Import a path into the store. */
     virtual void addToStore(const ValidPathInfo & info, Source & narSource,
-        RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs,
-        std::shared_ptr<FSAccessor> accessor = 0);
+        RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs);
 
     // FIXME: remove
     virtual void addToStore(const ValidPathInfo & info, const ref<std::string> & nar,
-        RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs,
-        std::shared_ptr<FSAccessor> accessor = 0);
+        RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs);
 
     /* Copy the contents of a path to the store and register the
        validity the resulting path.  The resulting path is returned.

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -63,11 +63,13 @@ struct ParseSink
     virtual void createSymlink(const Path & path, const string & target) { };
 };
 
+template<class S>
 struct TeeSink : ParseSink
 {
-    TeeSource source;
+    TeeSource<S> source;
 
-    TeeSink(Source & source) : source(source) { }
+    template<typename... Args>
+    TeeSink(Source & source, Args... args) : source(source, args...) { }
 };
 
 void parseDump(ParseSink & sink, Source & source);

--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -420,7 +420,7 @@ ref<CompressionSink> makeCompressionSink(const std::string & method, Sink & next
         throw UnknownCompressionMethod(format("unknown compression method '%s'") % method);
 }
 
-ref<std::string> compress(const std::string & method, const std::string & in, const bool parallel)
+ref<std::string> compress(const std::string & method, const std::string_view in, const bool parallel)
 {
     StringSink ssink;
     auto sink = makeCompressionSink(method, ssink, parallel);

--- a/src/libutil/compression.hh
+++ b/src/libutil/compression.hh
@@ -17,7 +17,7 @@ ref<std::string> decompress(const std::string & method, const std::string & in);
 
 ref<CompressionSink> makeDecompressionSink(const std::string & method, Sink & nextSink);
 
-ref<std::string> compress(const std::string & method, const std::string & in, const bool parallel = false);
+ref<std::string> compress(const std::string & method, const std::string_view in, const bool parallel = false);
 
 ref<CompressionSink> makeCompressionSink(const std::string & method, Sink & nextSink, const bool parallel = false);
 

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -366,12 +366,13 @@ void HashedBufferSink::upgrade() {
     newchild(*(oldchild->s));
     child = std::move(newchild);
 }
-extern size_t threshold;
+
+extern size_t large_dump_threshold;
 void HashedBufferSink::operator () ( const unsigned char * data, size_t len)
 {
     assert(!finished);
     if (auto strs = std::get_if<StringSink>(&child)) {
-        if (strs->s->size() + len > threshold)
+        if (strs->s->size() + len > large_dump_threshold)
             upgrade();
     }
     hashsink(data, len);

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -378,7 +378,7 @@ void HashedBufferSink::operator () ( const unsigned char * data, size_t len)
     std::visit([&](Sink& s) { s(data, len); }, child);
 }
 void HashedBufferSink::finish() {
-    if (!finished) return;
+    if (finished) return;
     if (std::holds_alternative<FdSink>(child)) {
         std::get<FdSink>(child).flush();
         fd.reset();

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -134,7 +134,9 @@ private:
     std::unique_ptr<AutoDelete> tmpDir;
     std::unique_ptr<AutoCloseFD> fd;
     std::unique_ptr<Source> src;
+    std::shared_ptr<void> mmapped;
     std::variant<StringSink, FdSink> child;
+    HashResult hash;
     Path tmpFile;
     HashSink hashsink;
     bool finished = false;
@@ -144,7 +146,7 @@ public:
     HashResult toHash();
     Source& toSource();
     void finish();
-    ref<std::string> toString();
+    std::string_view toStringView();
     void upgrade();
 };
 

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -2,7 +2,7 @@
 
 #include "types.hh"
 #include "serialise.hh"
-
+#include <variant>
 
 namespace nix {
 
@@ -131,16 +131,15 @@ public:
 struct HashedBufferSink : Sink
 {
 private:
-    std::unique_ptr<Sink> child;
     std::unique_ptr<AutoDelete> tmpDir;
     std::unique_ptr<AutoCloseFD> fd;
     std::unique_ptr<Source> src;
+    std::variant<StringSink, FdSink> child;
     Path tmpFile;
     HashSink hashsink;
     bool finished = false;
-    bool upgraded = false;
 public:
-    HashedBufferSink(HashType ht) : child(new StringSink()), hashsink(ht) {}
+    HashedBufferSink(HashType ht) : hashsink(ht) {}
     void operator () (const unsigned char * data, size_t len) override;
     HashResult toHash();
     Source& toSource();

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -128,4 +128,25 @@ public:
 };
 
 
+struct HashedBufferSink : Sink
+{
+private:
+    std::unique_ptr<Sink> child;
+    std::unique_ptr<AutoDelete> tmpDir;
+    std::unique_ptr<AutoCloseFD> fd;
+    std::unique_ptr<Source> src;
+    Path tmpFile;
+    HashSink hashsink;
+    bool finished = false;
+    bool upgraded = false;
+public:
+    HashedBufferSink(HashType ht) : child(new StringSink()), hashsink(ht) {}
+    void operator () (const unsigned char * data, size_t len) override;
+    HashResult toHash();
+    Source& toSource();
+    void finish();
+    ref<std::string> toString();
+    void upgrade();
+};
+
 }

--- a/src/libutil/istringstream_nocopy.hh
+++ b/src/libutil/istringstream_nocopy.hh
@@ -8,11 +8,11 @@
 #include <string>
 #include <iostream>
 
-template <class CharT, class Traits = std::char_traits<CharT>, class Allocator = std::allocator<CharT>>
+template <class CharT, class Traits = std::char_traits<CharT>>
 class basic_istringbuf_nocopy : public std::basic_streambuf<CharT, Traits>
 {
 public:
-    typedef std::basic_string<CharT, Traits, Allocator> string_type;
+    typedef std::basic_string_view<CharT> string_type;
 
     typedef typename std::basic_streambuf<CharT, Traits>::off_type off_type;
 
@@ -23,12 +23,12 @@ public:
     typedef typename std::basic_streambuf<CharT, Traits>::traits_type traits_type;
 
 private:
-    const string_type & s;
+    const string_type s;
 
     off_type off;
 
 public:
-    basic_istringbuf_nocopy(const string_type & s) : s{s}, off{0}
+    basic_istringbuf_nocopy(const string_type s) : s{s}, off{0}
     {
     }
 
@@ -79,10 +79,10 @@ private:
 
 };
 
-template <class CharT, class Traits = std::char_traits<CharT>, class Allocator = std::allocator<CharT>>
+template <class CharT, class Traits = std::char_traits<CharT>>
 class basic_istringstream_nocopy : public std::basic_iostream<CharT, Traits>
 {
-    typedef basic_istringbuf_nocopy<CharT, Traits, Allocator> buf_type;
+    typedef basic_istringbuf_nocopy<CharT, Traits> buf_type;
     buf_type buf;
 public:
     basic_istringstream_nocopy(const typename buf_type::string_type & s) :

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -117,6 +117,7 @@ size_t BufferedSource::read(unsigned char * data, size_t len)
     size_t n = len > bufPosIn - bufPosOut ? bufPosIn - bufPosOut : len;
     memcpy(data, buffer.get() + bufPosOut, n);
     bufPosOut += n;
+    totalRead += n;
     if (bufPosIn == bufPosOut) bufPosIn = bufPosOut = 0;
     return n;
 }
@@ -205,6 +206,9 @@ std::unique_ptr<Source> sinkToSource(
             pos += n;
 
             return n;
+        }
+        size_t total_read() const override {
+            return pos;
         }
     };
 

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -48,7 +48,7 @@ FdSink::~FdSink()
 }
 
 
-size_t threshold = 256 * 1024 * 1024;
+size_t large_dump_threshold = 256 * 1024 * 1024;
 
 static void warnLargeDump()
 {
@@ -61,7 +61,7 @@ void FdSink::write(const unsigned char * data, size_t len)
     written += len;
     static bool warned = false;
     if (warn && !warned) {
-        if (written > threshold) {
+        if (written > large_dump_threshold) {
             warnLargeDump();
             warned = true;
         }
@@ -316,7 +316,7 @@ template PathSet readStrings(Source & source);
 void StringSink::operator () (const unsigned char * data, size_t len)
 {
     static bool warned = false;
-    if (!warned && s->size() > threshold) {
+    if (!warned && s->size() > large_dump_threshold) {
         warnLargeDump();
         warned = true;
     }

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -89,6 +89,19 @@ void Source::operator () (unsigned char * data, size_t len)
     }
 }
 
+void Source::drain(Sink& s)
+{
+    std::vector<unsigned char> buf(8192);
+    while (true) {
+        size_t n;
+        try {
+            n = read(buf.data(), buf.size());
+            s((const unsigned char *) buf.data(), n);
+        } catch (EndOfFile &) {
+            break;
+        }
+    }
+}
 
 std::string Source::drain()
 {

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -323,5 +323,4 @@ void StringSink::operator () (const unsigned char * data, size_t len)
     s->append((const char *) data, len);
 }
 
-
 }

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -16,7 +16,7 @@ struct Sink
     virtual void operator () (const unsigned char * data, size_t len) = 0;
     virtual bool good() { return true; }
 
-    void operator () (const std::string & s)
+    void operator () (const std::string_view s)
     {
         (*this)((const unsigned char *) s.data(), s.size());
     }
@@ -34,7 +34,7 @@ struct BufferedSink : Sink
 
     void operator () (const unsigned char * data, size_t len) override;
 
-    void operator () (const std::string & s)
+    void operator () (const std::string_view s)
     {
         Sink::operator()(s);
     }

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -64,6 +64,7 @@ struct Source
     virtual size_t total_read() const = 0;
 
     std::string drain();
+    void drain(Sink& s);
 };
 
 

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -158,7 +158,7 @@ struct StringSink : Sink
 };
 
 
-/* A source that reads data from a string. */
+/* A source that reads data from a string/fd. */
 struct StringSource : Source
 {
     const string & s;
@@ -177,8 +177,8 @@ struct TeeSource : Source
 {
     Source & orig;
     S sink;
-    template<typename... Args> TeeSource(Source & orig, Args... args)
-        : orig(orig), sink(args...) { }
+    template<typename... Args> TeeSource(Source & orig, Args&&... args)
+        : orig(orig), sink(std::forward<Args>(args)...) { }
     size_t read(unsigned char * data, size_t len)
     {
         size_t n = orig.read(data, len);

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -323,7 +323,7 @@ void readFile(const Path & path, Sink & sink)
 }
 
 
-void writeFile(const Path & path, const string & s, mode_t mode)
+void writeFile(const Path & path, const std::string_view s, mode_t mode)
 {
     AutoCloseFD fd = open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, mode);
     if (!fd)
@@ -600,7 +600,7 @@ void writeFull(int fd, const unsigned char * buf, size_t count, bool allowInterr
 }
 
 
-void writeFull(int fd, const string & s, bool allowInterrupts)
+void writeFull(int fd, const std::string_view s, bool allowInterrupts)
 {
     writeFull(fd, (const unsigned char *) s.data(), s.size(), allowInterrupts);
 }

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -105,7 +105,7 @@ string readFile(const Path & path, bool drain = false);
 void readFile(const Path & path, Sink & sink);
 
 /* Write a string to a file. */
-void writeFile(const Path & path, const string & s, mode_t mode = 0666);
+void writeFile(const Path & path, const std::string_view s, mode_t mode = 0666);
 
 void writeFile(const Path & path, Source & source, mode_t mode = 0666);
 
@@ -156,7 +156,7 @@ void replaceSymlink(const Path & target, const Path & link);
    requested number of bytes. */
 void readFull(int fd, unsigned char * buf, size_t count);
 void writeFull(int fd, const unsigned char * buf, size_t count, bool allowInterrupts = true);
-void writeFull(int fd, const string & s, bool allowInterrupts = true);
+void writeFull(int fd, const std::string_view s, bool allowInterrupts = true);
 
 MakeError(EndOfFile, Error)
 

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -401,8 +401,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     case wopImportPaths: {
         logger->startWork();
         TunnelSource source(from);
-        Paths paths = store->importPaths(source, nullptr,
-            trusted ? NoCheckSigs : CheckSigs);
+        Paths paths = store->importPaths(source, trusted ? NoCheckSigs : CheckSigs);
         logger->stopWork();
         to << paths;
         break;
@@ -721,7 +720,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
 
         // FIXME: race if addToStore doesn't read source?
         store->addToStore(info, *source, (RepairFlag) repair,
-            dontCheckSigs ? NoCheckSigs : CheckSigs, nullptr);
+            dontCheckSigs ? NoCheckSigs : CheckSigs);
 
         logger->stopWork();
         break;

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -681,7 +681,7 @@ static void opImport(Strings opFlags, Strings opArgs)
     if (!opArgs.empty()) throw UsageError("no arguments expected");
 
     FdSource source(STDIN_FILENO);
-    Paths paths = store->importPaths(source, nullptr, NoCheckSigs);
+    Paths paths = store->importPaths(source, NoCheckSigs);
 
     for (auto & i : paths)
         cout << format("%1%\n") % i << std::flush;
@@ -877,7 +877,7 @@ static void opServe(Strings opFlags, Strings opArgs)
 
             case cmdImportPaths: {
                 if (!writeAllowed) throw Error("importing paths is not allowed");
-                store->importPaths(in, nullptr, NoCheckSigs); // FIXME: should we skip sig checking?
+                store->importPaths(in, NoCheckSigs); // FIXME: should we skip sig checking?
                 out << 1; // indicate success
                 break;
             }

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -42,19 +42,16 @@ struct CmdAddToStore : MixDryRun, StoreCommand
     {
         if (!namePart) namePart = baseNameOf(path);
 
-        StringSink sink;
-        dumpPath(path, sink);
+        if (!dryRun) {
+            const string result = store->addToStore(*namePart, path);
+            std::cout << fmt("%s\n", result);
+        }
+        else {
+            const Hash narHash = hashPath(htSHA256, path).first;
+            const string result = store->makeFixedOutputPath(true, narHash, *namePart);
 
-        ValidPathInfo info;
-        info.narHash = hashString(htSHA256, *sink.s);
-        info.narSize = sink.s->size();
-        info.path = store->makeFixedOutputPath(true, info.narHash, *namePart);
-        info.ca = makeFixedOutputCA(true, info.narHash);
-
-        if (!dryRun)
-            store->addToStore(info, sink.s);
-
-        std::cout << fmt("%s\n", info.path);
+            std::cout << fmt("%s\n", result);
+        }
     }
 };
 


### PR DESCRIPTION
Nix runs out of memory when dumping large files on systems without enough ram, and the whole saving and hashing is not as efficient as it could be (multiple passes through files, multiple copies). I'm out of time for now, but this fixes all the main problematic cases. It would be very cool to just pass FD's over to the nix daemon where possible, zero-copying into the nix store on filesystems with reflinks.

The one in `RemoteFSAccessor::fetch` still remains.

In more detail, this introduces a `HashedBufferSink` sink that buffers data in memory, then switches to a file when the data gets too big. Afterwards, it can be converted to a Source. It also keeps a hash of the data. It also switches some of the code to `std::string_view`, so we can use file-backed memory via mmap there. 
There also seemed to be an `accessor` argument to `addToStore` that was never actually used and complicated the `BinaryCacheStore` code quite a bit, I've removed that.
These changes do not seem to be covered well by the tests, but I've run some builds and `nix add-to-store`'s to verify the output and behavior is the same (minus the running out of memory).

cc @Pitometsu