### PR TITLE
libstore: ssh-ng: forward the default setOptions

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -172,6 +172,12 @@ void RemoteStore::initConnection(Connection & conn)
 }
 
 
+/* TODO Add a way to explicitly ask for some options to be
+        forwarded. One option: A way to query the daemon for its
+        settings, and then a series of params to SSHStore like
+        forward-cores or forward-overridden-cores that only
+        override the requested settings.
+*/
 void RemoteStore::setOptions(Connection & conn)
 {
     conn.to << wopSetOptions

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -51,16 +51,6 @@ private:
     std::string host;
 
     SSHMaster master;
-
-    void setOptions(RemoteStore::Connection & conn) override
-    {
-        /* TODO Add a way to explicitly ask for some options to be
-           forwarded. One option: A way to query the daemon for its
-           settings, and then a series of params to SSHStore like
-           forward-cores or forward-overridden-cores that only
-           override the requested settings.
-        */
-    };
 };
 
 void SSHStore::narFromPath(const Path & path, Sink & sink)


### PR DESCRIPTION
Without these options it's not possible to forward build timeout options
for example. The TODO is probably applicable to all the remote stores.