### PR TITLE
Allow builtins.pathExists to check the existence of /nix/store paths

### DIFF
--- a/tests/import-derivation.nix
+++ b/tests/import-derivation.nix
@@ -10,7 +10,10 @@ let
       '';
   };
 
-  value = import bar;
+  value =
+    # Test that pathExists can check the existence of /nix/store paths
+    assert builtins.pathExists bar;
+    import bar;
 
 in
 


### PR DESCRIPTION
This makes it consitent with `builtins.readDir`.