### PR TITLE
pathlocks: add include to fcntl.h for O_CLOEXEC

### DIFF
--- a/src/libstore/pathlocks.cc
+++ b/src/libstore/pathlocks.cc
@@ -5,6 +5,7 @@
 #include <cerrno>
 #include <cstdlib>
 
+#include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/file.h>


### PR DESCRIPTION
Fixes build w/musl, also is where glibc defines it.