### PR TITLE
nix-shell: provide fake $out

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -400,7 +400,9 @@ static void _main(int argc, char * * argv)
                 Path p = (Path) tmpDir + "/" + fn;
                 writeFile(p, var.second);
                 env[var.first + "Path"] = p;
-            } else
+            } else if (var.first == "out")          // 'nix-shell' usualy has no permission to write to nix store, so 'installPhase' fails.
+                env[var.first] = absPath(outLink);  // this overrides derivation's $out with path passed in -o switch (or ./result by default).
+              else                                  // while in 'nix-build' ./result is a symlink to nix store path, in 'nix-shell' it is a real output path
                 env[var.first] = var.second;
 
         restoreAffinity();


### PR DESCRIPTION
`nix-shell` is usually run under user account which has no write permissions to nix store.
It results in `installPhase` failure and impossibility to run `fuxupPhase` and `installCheckPhase`

This overrides $out with the path provided as -o command line switch (which defaults to `./result`), so `nix-shell` can "install" packages to a user-controlled directory

---

For example this compiles `htop` to `./result` without touching nix store
```
TMPDIR=$(mktemp -d) \
 nix-shell -E '(import <nixpkgs> {}).htop' --run 'cd $NIX_BUILD_TOP; genericBuild'
```

---

A developer workflow using stock .nix files, without writing special ones for `nix-shell`
1
```bash
mkdir $(pwd)/working-dir
TMPDIR=$(pwd)/working-dir nix-shell -E '(import <nixpkgs> {}).htop' \
  --run 'cd $NIX_BUILD_TOP; unpackPhase; cd htop*; patchPhase && configurePhase'
```

2.
```bash
TMPDIR=$(pwd)/working-dir nix-shell -E '(import <nixpkgs> {}).htop' \
  --run 'cd $NIX_BUILD_TOP/htop*; buildPhase && installPhase && fixupPhase'
```

4. run `result/bin/htop` to see how it works and what to change

5. change sources in `$(pwd)/working-dir` and goto `2`, where only changed sources will be recompiled.
