### PR TITLE
nix-daemon: allow more safe settings by "untrusted" users.

### DIFF
--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -567,7 +567,17 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                 else if (trusted
                     || name == settings.buildTimeout.name
                     || name == "connect-timeout"
-                    || (name == "builders" && value == ""))
+                    || (name == "builders" && value == "") // "build locally, no remote builders"
+                    || (name == "max-jobs" && value == "0") // "build remotely, no local builders"
+                    || name == "show-trace" // eval-time tracing doesn't require trust
+                    || name == "log-lines" // log output size doesn't require trust
+                    || name == "print-missing" // behavioral, no trust required
+                    // TTL-related settings are useful, shouldn't require trust and are useful if you just updated cache
+                    || name == "tarball-ttl"
+                    || name == "narinfo-cache-negative-ttl"
+                    || name == "narinfo-cache-positive-ttl"
+                    // useful for big builds that might encounter a failure, useful for CI-esque cases
+                    || name == "keep-going")
                     settings.set(name, value);
                 else if (setSubstituters(settings.substituters))
                     ;


### PR DESCRIPTION
These options are mostly selected based on my usage
and judging each to only change "superficial" properties
of the build or output printed.

I particularly find it useful to ask builds to only
use remote builders (when on laptop, esp battery),
hence the `--max-jobs 0` whitelisting.

TTL settings can be useful when debugging either
a build cache (mostly forcing re-fetching)
or fetching latest copy of a URL such as
https://github.com/NixOS/nixpkgs/archive/master.tar.gz
(most commonly I used this to ensure my NixOps deployments
use latest version of branch they're pointed at, for
faster/sane change/deploy cycles).

I think setting `show-trace` is safe,
assuming the eval is performed by the user
and so any increased memory usage is theirs.

I don't think we are concerned about tracing
exposing (or being disabled to "hide") information
from untrusted users, but LMK if that's not right.

In the future it might be nice to add alias options
`--remote-only` or `--local-only` or something,
but for now don't reject the current method for
requesting the behavior.