### PR TITLE
handle empty SANDBOX_SHELL

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -64,7 +64,8 @@ Settings::Settings()
     }
 
 #if defined(__linux__) && defined(SANDBOX_SHELL)
-    sandboxPaths = tokenizeString<StringSet>("/bin/sh=" SANDBOX_SHELL);
+    if (SANDBOX_SHELL[0] != '\0')
+        sandboxPaths = tokenizeString<StringSet>("/bin/sh=" SANDBOX_SHELL);
 #endif
 
     allowedImpureHostPrefixes = tokenizeString<StringSet>(DEFAULT_ALLOWED_IMPURE_PREFIXES);


### PR DESCRIPTION
`nix-build --sandbox ....` sometimes fails with
`error: while setting up the build environment: getting attributes of path '': No such file or directory`

Fixes https://github.com/NixOS/nix/issues/2673