### PR TITLE
Fix for `unknown serve command 13`

### DIFF
--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -179,6 +179,36 @@ struct TeeSource : Source
     }
 };
 
+/* A reader that consumes the original Source until 'size'. */
+struct SizedSource : Source
+{
+    Source & orig;
+    size_t remain;
+    SizedSource(Source & orig, size_t size)
+        : orig(orig), remain(size) { }
+    size_t read(unsigned char * data, size_t len)
+    {
+        if (this->remain <= 0) {
+            throw EndOfFile("sized: unexpected end-of-file");
+        }
+        len = std::min(len, this->remain);
+        size_t n = this->orig.read(data, len);
+        this->remain -= n;
+        return n;
+    }
+
+    /* Consume the original source until no remain data is left to consume. */
+    size_t drainAll()
+    {
+        std::vector<unsigned char> buf(8192);
+        size_t sum = 0;
+        while (this->remain > 0) {
+            size_t n = read(buf.data(), buf.size());
+            sum += n;
+        }
+        return sum;
+    }
+};
 
 /* Convert a function into a sink. */
 struct LambdaSink : Sink


### PR DESCRIPTION
Fixes #3039 

`libstore->addToStore(ValidPathInfo & info, Source & source, ...)` can exit early if the path already exists into the store. It's an optimization. The source doesn't need to be read and is left untouched.

Unfortunately, the remote store protocols assume that the while NAR file will be send. So when that happens the protocol gets out of sync.

This PR introduces a `SizedSource(Source & source, size_t size)` which reads the `source` until `size` is reached. That way we can wrap the source and make sure it's read until `narSize` is reached. And then nix-store and nix-daemon are patched to use that new source.

If the NAR file is not consumed by `addToStore` the protocol gets out of sync. This introduces a new SizedReader that we can drain at the end in order to keep the protocol in sync. It means that