### PR TITLE
Drop Store::addToStore taking a string.

### DIFF
--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -80,7 +80,7 @@ public:
 
     bool wantMassQuery() override { return wantMassQuery_; }
 
-    void addToStore(const ValidPathInfo & info, const ref<std::string> & nar,
+    void addToStore(const ValidPathInfo & info, Source& narSource,
         RepairFlag repair, CheckSigsFlag checkSigs,
         std::shared_ptr<FSAccessor> accessor) override;
 

--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -878,7 +878,8 @@ CachedDownloadResult Downloader::downloadCached(
                 info.narHash = hashString(htSHA256, *sink.s);
                 info.narSize = sink.s->size();
                 info.ca = makeFixedOutputCA(false, hash);
-                store->addToStore(info, sink.s, NoRepair, NoCheckSigs);
+                StringSource source(*sink.s);
+                store->addToStore(info, source, NoRepair, NoCheckSigs);
                 storePath = info.path;
             }
 

--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -95,7 +95,7 @@ Paths Store::importPaths(Source & source, std::shared_ptr<FSAccessor> accessor, 
         if (readInt(source) == 1)
             readString(source);
 
-        addToStore(info, tee.source.data, NoRepair, checkSigs, accessor);
+        addToStore(info, tee.source, NoRepair, checkSigs, accessor);
 
         res.push_back(info.path);
     }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -821,22 +821,6 @@ std::string makeFixedOutputCA(bool recursive, const Hash & hash)
     return "fixed:" + (recursive ? (std::string) "r:" : "") + hash.to_string();
 }
 
-
-void Store::addToStore(const ValidPathInfo & info, Source & narSource,
-    RepairFlag repair, CheckSigsFlag checkSigs,
-    std::shared_ptr<FSAccessor> accessor)
-{
-    addToStore(info, make_ref<std::string>(narSource.drain()), repair, checkSigs, accessor);
-}
-
-void Store::addToStore(const ValidPathInfo & info, const ref<std::string> & nar,
-    RepairFlag repair, CheckSigsFlag checkSigs,
-    std::shared_ptr<FSAccessor> accessor)
-{
-    StringSource source(*nar);
-    addToStore(info, source, repair, checkSigs, accessor);
-}
-
 }
 
 

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -406,12 +406,7 @@ public:
     /* Import a path into the store. */
     virtual void addToStore(const ValidPathInfo & info, Source & narSource,
         RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs,
-        std::shared_ptr<FSAccessor> accessor = 0);
-
-    // FIXME: remove
-    virtual void addToStore(const ValidPathInfo & info, const ref<std::string> & nar,
-        RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs,
-        std::shared_ptr<FSAccessor> accessor = 0);
+        std::shared_ptr<FSAccessor> accessor = 0) = 0;
 
     /* Copy the contents of a path to the store and register the
        validity the resulting path.  The resulting path is returned.

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -51,8 +51,10 @@ struct CmdAddToStore : MixDryRun, StoreCommand
         info.path = store->makeFixedOutputPath(true, info.narHash, *namePart);
         info.ca = makeFixedOutputCA(true, info.narHash);
 
-        if (!dryRun)
-            store->addToStore(info, sink.s);
+        if (!dryRun) {
+          StringSource source(*sink.s);
+          store->addToStore(info, source);
+        }
 
         std::cout << fmt("%s\n", info.path);
     }


### PR DESCRIPTION
This removes all uses of this function, in most cases wrapping
previously-provided string with a StringSource.

@edolstra There are couple of places where, I am moving data from a `StringSink` to a `Source` via `StringSource source(sink.s)`. It is not clear to me if this is the best way. This is my first contribution, so please bear with me. My long-term goal is to investigate the Nix code base enough to look into implementing the intentional store capability.