### PR TITLE
search: Don't omit version info when package name is matched

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -178,7 +178,7 @@ struct CmdSearch : SourceExprCommand, MixJSON
                             results[attrPath] = fmt(
                                 "* %s (%s)\n  %s\n",
                                 wrap("\e[0;1m", hilite(attrPath, attrPathMatch, "\e[0;1m")),
-                                wrap("\e[0;2m", hilite(name, nameMatch, "\e[0;2m")),
+                                wrap("\e[0;2m", name),
                                 hilite(description, descriptionMatch, ANSI_NORMAL));
                         }
                     }


### PR DESCRIPTION
The `name` variable already includes highlighting in addition to the version info, so with the old code it would print the version info only if `nameMatch` is empty.

Fixes #2778.