### PR TITLE
Pass --no-net to improve race condition in gc-concurrent

### DIFF
--- a/tests/gc-auto.sh
+++ b/tests/gc-auto.sh
@@ -30,7 +30,7 @@ EOF
 )
 
 nix build -o $TEST_ROOT/result-A -L "($expr)" \
-    --min-free 1000 --max-free 2000 --min-free-check-interval 1 &
+    --no-net --min-free 1000 --max-free 2000 --min-free-check-interval 1 &
 pid=$!
 
 expr2=$(cat <<EOF
@@ -51,7 +51,7 @@ EOF
 )
 
 nix build -o $TEST_ROOT/result-B -L "($expr2)" \
-    --min-free 1000 --max-free 2000 --min-free-check-interval 1
+    --no-net --min-free 1000 --max-free 2000 --min-free-check-interval 1
 
 wait "$pid"
 


### PR DESCRIPTION
It looks like the no-net option broke the gc-concurrent tests inside a nix build. 
this ... seems ... to fix it.

```

++ nix add-to-store --name garbage1 ./tarball.sh
--

```
