### PR TITLE
nix-daemon.service: add install section.

### DIFF
--- a/misc/systemd/nix-daemon.service.in
+++ b/misc/systemd/nix-daemon.service.in
@@ -7,3 +7,6 @@ ConditionPathIsReadWrite=@localstatedir@/nix/daemon-socket
 [Service]
 ExecStart=@@bindir@/nix-daemon nix-daemon --daemon
 KillMode=process
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The systemd software suite requires the install section to enable a service. Without this section, it's not possible to enable nix-daemon service. The multi-user seems to be a good target for nix-daemon.

Signed-off-by: Piotr Szubiakowski <pszubiak@eso.org>