### PR TITLE
Use wait4path on org.nixos.nix-daemon.plist

### DIFF
--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -13,10 +13,9 @@
     <true/>
     <key>RunAtLoad</key>
     <true/>
-    <key>Program</key>
-    <string>/bin/sh</string>
     <key>ProgramArguments</key>
     <array>
+      <string>/bin/sh</string>
       <string>-c</string>
       <string>/bin/wait4path @bindir@/nix-daemon &amp;&amp; @bindir@/nix-daemon</string>
     </array>

--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -14,7 +14,12 @@
     <key>RunAtLoad</key>
     <true/>
     <key>Program</key>
-    <string>@bindir@/nix-daemon</string>
+    <string>/bin/sh</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>-c</string>
+      <string>/bin/wait4path @bindir@/nix-daemon &amp;&amp; @bindir@/nix-daemon</string>
+    </array>
     <key>StandardErrorPath</key>
     <string>/var/log/nix-daemon.log</string>
     <key>StandardOutPath</key>


### PR DESCRIPTION
When using a volume, the nix-daemon path may not exist. To avoid this
issue, we must use the wait4path tool. This should solve one of the
issues in multi-user on macOS Catalina. It also doesn't hurt on other systems.