### PR TITLE
builtins.currentSystem: document system/--system

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -208,7 +208,10 @@ if builtins ? getEnv then builtins.getEnv "PATH" else ""</programlisting>
     evaluates to the Nix platform identifier for the Nix installation
     on which the expression is being evaluated, such as
     <literal>"i686-linux"</literal> or
-    <literal>"x86_64-darwin"</literal>.</para></listitem>
+    <literal>"x86_64-darwin"</literal>.</para><para>The value is
+    automatically detected by default. The <xref linkend="conf-system" />
+    configuration setting and the corresponding <parameter>--system</parameter>
+    argument overrides the default.</para></listitem>
 
   </varlistentry>
 


### PR DESCRIPTION
Add a note to the builtins.currentSystem entry that `--system` and the `system` params change the detected value.

Closes #3029.