### PR TITLE
[WIP] add --root-realisations to nix-instantiate

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1742,6 +1742,11 @@ bool EvalState::eqValues(Value & v1, Value & v2)
     }
 }
 
+PathSet const & EvalState::realisedDerivations() const
+{
+    return realisedPaths;
+}
+
 void EvalState::printStats()
 {
     bool showStats = getEnv("NIX_SHOW_STATS", "0") != "0";

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -280,7 +280,11 @@ public:
 
     void realiseContext(const PathSet & context);
 
+    PathSet const & realisedDerivations() const;
+
 private:
+
+    PathSet realisedPaths;
 
     unsigned long nrEnvs = 0;
     unsigned long nrValuesInEnvs = 0;


### PR DESCRIPTION
Currently using IFD (or similar mechanisms such as readFile from a derivation) together with garbage collection is a bad experience, since all derivations required for evaluation will have to be completely rebuilt after each run.

This PR adds an option `--root-realisations` to `nix-instantiate` which mirrors `--add-root` but creates a GC root for derivations used for evaluation instead of those that are the result of the evaluation.

There is some duplication of  code with `--add-root`, but abstracting over both is complicated by `--add--root` using successive numbering for results instead of putting them in a folder and it outputting paths to the GC roots instead of the store paths.

At this point, especially since this is my first PR to Nix, and I'm not really familiar with C++, I'm mostly looking for general feedback on chance of this feature in the abstract being merged, whether to change `--add-root` behavior (numbered outputs have always seemed strange to me since there's potentially garbage left over with successive invocations), and general direction of implementation.