### PR TITLE
lexer: restrict escape sequences to only meaningful ones

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -64,7 +64,7 @@ static Expr * unescapeStr(SymbolTable & symbols, const char * s, size_t length)
             else if (c == 'r') t += '\r';
             else if (c == 't') t += '\t';
             else {
-                assert(c == '"' || c == '\\' || c == '$');
+                assert(c == '"' || c == '\\' || c == '$' || c == '\n');
                 t += c;
             }
         }
@@ -154,8 +154,8 @@ or          { return OR_KW; }
 \{          { PUSH_STATE(DEFAULT); return '{'; }
 
 \"          { PUSH_STATE(STRING); return '"'; }
-<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$]|\$\\["ntr\\$])*\$/\" |
-<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$]|\$\\["ntr\\$])+ {
+<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$\n]|\$\\["ntr\\$\n])*\$/\" |
+<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$\n]|\$\\["ntr\\$\n])+ {
                 /* It is impossible to match strings ending with '$' with one
                    regex because trailing contexts are only valid at the end
                    of a rule. (A sane but undocumented limitation.) */

--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -66,7 +66,7 @@ static Expr * unescapeStr(YYLTYPE * loc, SymbolTable & symbols, const char * s, 
             else if (c == 't') t += '\t';
             else {
               if (!(c == '"' || c == '\\' || c == '$' || c == '\n'))
-                std::cerr << "meaningful escape sequence \"\\" << c << "\" at " << loc->last_line << ":" << loc->last_column << std::endl;
+                std::cerr << "meaningless escape sequence \"\\" << c << "\" at " << loc->last_line << ":" << loc->last_column << std::endl;
               t += c;
             }
         }

--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -63,7 +63,10 @@ static Expr * unescapeStr(SymbolTable & symbols, const char * s, size_t length)
             if (c == 'n') t += '\n';
             else if (c == 'r') t += '\r';
             else if (c == 't') t += '\t';
-            else t += c;
+            else {
+                assert(c == '"' || c == '\\' || c == '$');
+                t += c;
+            }
         }
         else if (c == '\r') {
             /* Normalise CR and CR/LF into LF. */
@@ -151,8 +154,8 @@ or          { return OR_KW; }
 \{          { PUSH_STATE(DEFAULT); return '{'; }
 
 \"          { PUSH_STATE(STRING); return '"'; }
-<STRING>([^\$\"\\]|\$[^\{\"\\]|\\{ANY}|\$\\{ANY})*\$/\" |
-<STRING>([^\$\"\\]|\$[^\{\"\\]|\\{ANY}|\$\\{ANY})+ {
+<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$]|\$\\["ntr\\$])*\$/\" |
+<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$]|\$\\["ntr\\$])+ {
                 /* It is impossible to match strings ending with '$' with one
                    regex because trailing contexts are only valid at the end
                    of a rule. (A sane but undocumented limitation.) */

--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -61,16 +61,14 @@ static Expr * unescapeStr(YYLTYPE * loc, SymbolTable & symbols, const char * s, 
         if (c == '\\') {
             assert(*s);
             c = *s++;
-            if (c == 'n') t += '\n';
-            else if (c == 'r') t += '\r';
-            else if (c == 't') t += '\t';
-            else {
-              if (!(c == '"' || c == '\\' || c == '$' || c == '\n'))
+            if (c == 'n') { t += '\n'; continue; }
+            if (c == 'r') { t += '\r'; continue; }
+            if (c == 't') { t += '\t'; continue; }
+            if (!(c == '"' || c == '\\' || c == '$' || c == '\n'))
                 std::cerr << "meaningless escape sequence \"\\" << c << "\" at " << loc->last_line << ":" << loc->last_column << std::endl;
-              t += c;
-            }
+           /* fall through */
         }
-        else if (c == '\r') {
+        if (c == '\r') {
             /* Normalise CR and CR/LF into LF. */
             t += '\n';
             if (*s == '\n') s++; /* cr/lf */

--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -13,6 +13,7 @@
 
 %{
 #include <boost/lexical_cast.hpp>
+#include <iostream>
 
 #include "nixexpr.hh"
 #include "parser-tab.hh"
@@ -51,7 +52,7 @@ static void adjustLoc(YYLTYPE * loc, const char * s, size_t len)
 }
 
 
-static Expr * unescapeStr(SymbolTable & symbols, const char * s, size_t length)
+static Expr * unescapeStr(YYLTYPE * loc, SymbolTable & symbols, const char * s, size_t length)
 {
     string t;
     t.reserve(length);
@@ -64,8 +65,9 @@ static Expr * unescapeStr(SymbolTable & symbols, const char * s, size_t length)
             else if (c == 'r') t += '\r';
             else if (c == 't') t += '\t';
             else {
-                assert(c == '"' || c == '\\' || c == '$' || c == '\n');
-                t += c;
+              if (!(c == '"' || c == '\\' || c == '$' || c == '\n'))
+                std::cerr << "meaningful escape sequence \"\\" << c << "\" at " << loc->last_line << ":" << loc->last_column << std::endl;
+              t += c;
             }
         }
         else if (c == '\r') {
@@ -154,12 +156,12 @@ or          { return OR_KW; }
 \{          { PUSH_STATE(DEFAULT); return '{'; }
 
 \"          { PUSH_STATE(STRING); return '"'; }
-<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$\n]|\$\\["ntr\\$\n])*\$/\" |
-<STRING>([^\$\"\\]|\$[^\{\"\\]|\\["ntr\\$\n]|\$\\["ntr\\$\n])+ {
+<STRING>([^\$\"\\]|\$[^\{\"\\]|\\{ANY}|\$\\{ANY})*\$/\" |
+<STRING>([^\$\"\\]|\$[^\{\"\\]|\\{ANY}|\$\\{ANY})+ {
                 /* It is impossible to match strings ending with '$' with one
                    regex because trailing contexts are only valid at the end
                    of a rule. (A sane but undocumented limitation.) */
-                yylval->e = unescapeStr(data->symbols, yytext, yyleng);
+                yylval->e = unescapeStr(yylloc, data->symbols, yytext, yyleng);
                 return STR;
               }
 <STRING>\$\{  { PUSH_STATE(DEFAULT); return DOLLAR_CURLY; }
@@ -187,7 +189,7 @@ or          { return OR_KW; }
                    return IND_STR;
                  }
 <IND_STRING>\'\'\\{ANY} {
-                   yylval->e = unescapeStr(data->symbols, yytext + 2, yyleng - 2);
+                   yylval->e = unescapeStr(yylloc, data->symbols, yytext + 2, yyleng - 2);
                    return IND_STR;
                  }
 <IND_STRING>\$\{ { PUSH_STATE(DEFAULT); return DOLLAR_CURLY; }


### PR DESCRIPTION
Nix parser is very relaxing and allows any character after `\` in strings
When the character following `\` is not one of the six which require escaping (`"` `r` `n` `$` `\` `t`) then `\` is silently skipped

so `"\1"` is the same as just`"1"`

This makes writing string constants which have `\` character (regular expressions, etc) challenging and error-prone.

There are few places in `nixpkgs` (https://github.com/NixOS/nixpkgs/pull/68946) where people write "\1" expecting "\1" , etc