### PR TITLE
add support for queryPathFromFileHash

### DIFF
--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -79,6 +79,9 @@ public:
     Path queryPathFromHashPart(const string & hashPart) override
     { unsupported("queryPathFromHashPart"); }
 
+    Path queryPathFromFileHash(const string & fileHash) override
+    { unsupported("queryPathFromFileHash"); }
+
     bool wantMassQuery() override { return wantMassQuery_; }
 
     void addToStore(const ValidPathInfo & info, const ref<std::string> & nar,

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -190,6 +190,10 @@ struct LegacySSHStore : public Store
     Path queryPathFromHashPart(const string & hashPart) override
     { unsupported("queryPathFromHashPart"); }
 
+    Path queryPathFromFileHash(const string & fileHash) override
+    { unsupported("queryPathFromFileHash"); }
+
+
     Path addToStore(const string & name, const Path & srcPath,
         bool recursive, HashType hashAlgo,
         PathFilter & filter, RepairFlag repair) override

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -5,6 +5,7 @@
 #include "worker-protocol.hh"
 #include "derivations.hh"
 #include "nar-info.hh"
+#include "nar-info-disk-cache.hh"
 
 #include <iostream>
 #include <algorithm>
@@ -829,6 +830,11 @@ Path LocalStore::queryPathFromHashPart(const string & hashPart)
         const char * s = (const char *) sqlite3_column_text(state->stmtQueryPathFromHashPart, 0);
         return s && prefix.compare(0, prefix.size(), s, prefix.size()) == 0 ? s : "";
     });
+}
+
+Path LocalStore::queryPathFromFileHash(const string & fileHash)
+{
+    return getNarInfoDiskCache()->queryPathFromFileHash(fileHash);
 }
 
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -139,6 +139,8 @@ public:
 
     Path queryPathFromHashPart(const string & hashPart) override;
 
+    Path queryPathFromFileHash(const string & fileHash) override;
+
     PathSet querySubstitutablePaths(const PathSet & paths) override;
 
     void querySubstitutablePathInfos(const PathSet & paths,

--- a/src/libstore/nar-info-disk-cache.hh
+++ b/src/libstore/nar-info-disk-cache.hh
@@ -19,6 +19,8 @@ public:
     virtual std::pair<Outcome, std::shared_ptr<NarInfo>> lookupNarInfo(
         const std::string & uri, const std::string & hashPart) = 0;
 
+    virtual Path queryPathFromFileHash(const std::string & fileHash) = 0;
+
     virtual void upsertNarInfo(
         const std::string & uri, const std::string & hashPart,
         std::shared_ptr<ValidPathInfo> info) = 0;

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -693,6 +693,16 @@ void RemoteStore::queryMissing(const PathSet & targets,
         unknown, downloadSize, narSize);
 }
 
+Path RemoteStore::queryPathFromFileHash(const string & fileHash)
+{
+    auto conn(getConnection());
+    conn->to << wopQueryPathFromFileHash << fileHash;
+    conn.processStderr();
+    Path path = readString(conn->from);
+    if (!path.empty()) assertStorePath(path);
+    return path;
+}
+
 
 void RemoteStore::connect()
 {

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -53,6 +53,8 @@ public:
 
     Path queryPathFromHashPart(const string & hashPart) override;
 
+    Path queryPathFromFileHash(const string & fileHash) override;
+
     PathSet querySubstitutablePaths(const PathSet & paths) override;
 
     void querySubstitutablePathInfos(const PathSet & paths,

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -392,6 +392,10 @@ public:
        path, or "" if the path doesn't exist. */
     virtual Path queryPathFromHashPart(const string & hashPart) = 0;
 
+    /* Query the full store path given the hash of a file hash,
+     * or "" if the path doesn't exist. */
+    virtual Path queryPathFromFileHash(const string & fileHash) = 0;
+
     /* Query which of the given paths have substitutes. */
     virtual PathSet querySubstitutablePaths(const PathSet & paths) { return {}; };
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -49,6 +49,7 @@ typedef enum {
     wopNarFromPath = 38,
     wopAddToStoreNar = 39,
     wopQueryMissing = 40,
+    wopQueryPathFromFileHash = 41,
 } WorkerOp;
 
 

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -736,6 +736,15 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case wopQueryPathFromFileHash: {
+        string fileHash = readString(from);
+        logger->startWork();
+        Path path = store->queryPathFromFileHash(fileHash);
+        logger->stopWork();
+        to << path;
+        break;
+    }
+
     default:
         throw Error(format("invalid operation %1%") % op);
     }


### PR DESCRIPTION
This is useful if you want to know what store path a nar archive was
generated from. The lookup obviously only works for paths that have been
downloaded from the binary cache and not for those that were build
locally.

With this new piece of information it is possible to serve NAR files
from the local nix store as if they came from the binary cache.
Re-serving files is useful in multiple situations for example in
scenarios where the bandwidth to the binary cache is limited. The part
of actually providing the HTTP interface and exporting the archives in
the correct format are still out of scope for this change but should be
straight forward.

In the mean time I have implemented an avahi discovery based proxy for (re-)serving content that was downloaded from the binary cache: https://github.com/andir/local-nix-cache
