### PR TITLE
Always use "bash" for dev-shell

### DIFF
--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -245,7 +245,7 @@ struct CmdDevShell : Common
 
         stopProgressBar();
 
-        auto shell = getEnv("SHELL", "bash");
+        auto shell = string("bash");
 
         auto args = Strings{baseNameOf(shell), "--rcfile", rcFilePath};
 


### PR DESCRIPTION
Unfortunately zshell does not support the --rcfile arg. Best to
hardcode bash here. Fixes #2965