### PR TITLE
Add NIX_FORCE_COLOR env variable to skip removal of ANSI escapes

### DIFF
--- a/doc/manual/command-ref/env-common.xml
+++ b/doc/manual/command-ref/env-common.xml
@@ -196,6 +196,15 @@ $ mount -o bind /mnt/otherdisk/nix /nix</screen>
 </varlistentry>
 
 
+<varlistentry><term><envar>NIX_FORCE_COLOR</envar></term>
+
+ <listitem><para>Forces the Nix process to not strip any ANSI sequences
+ from the output to <literal>stderr</literal>. Especially helpful for a
+ <command>nix-daemon</command> on a remote builder.</para></listitem>
+
+</varlistentry>
+
+
 </variablelist>
 
 

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -54,7 +54,7 @@ public:
             prefix = std::string("<") + c + ">";
         }
 
-        writeToStderr(prefix + filterANSIEscapes(fs.s, !tty) + "\n");
+        writeToStderr(prefix + filterANSIEscapes(fs.s, !tty && (getEnv("NIX_FORCE_COLOR") != "1")) + "\n");
     }
 
     void startActivity(ActivityId act, Verbosity lvl, ActivityType type,


### PR DESCRIPTION
Currently the build log from a remote builder isn't colorful as usually
no TTY is allocated when accessing the remote machine with SSH. However
using a TTY (e.g. by setting `RequestTTY force`) doesn't work either:

```
cannot build on 'ssh://builder': serialised integer 6791531838262124011 is too large for type 'j'
```

This patch allows to skip the removal of escape sequences by adding the env var
`NIX_FORCE_COLOR=1` (e.g. in `nix.envVars` in the NixOS configuration).