### PR TITLE
Set nixpkgs= in nix-profile.sh

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -51,9 +51,9 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         unset __nix_defexpr
     fi
 
-    # Append ~/.nix-defexpr/channels to $NIX_PATH so that <nixpkgs>
-    # paths work when the user has fetched the Nixpkgs channel.
-    export NIX_PATH=${NIX_PATH:+$NIX_PATH:}$HOME/.nix-defexpr/channels
+    # Append ~/.nix-defexpr/channels/nixpkgs to $NIX_PATH so that
+    # <nixpkgs> paths work when the user has fetched the Nixpkgs channel.
+    export NIX_PATH="${NIX_PATH:+$NIX_PATH:}nixpkgs=$HOME/.nix-defexpr/channels/nixpkgs:$HOME/.nix-defexpr/channels"
 
     # Set up environment.
     # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix


### PR DESCRIPTION
Setting nixpkgs is necessary for the new commands to resolve. Otherwise things like `nix search` do not work in a new install.

Related issues:

- #3119
- #1892
- #1865

Also see discussion in https://github.com/NixOS/nix/commit/b6eb8a2d7e2ea8b083fdac15f537679ffe633183#diff-5bffa5f8b1fe4444a3db1c0f9f8a7a47

and in https://github.com/LnL7/nix-darwin/issues/140