### PR TITLE
Make nix-daemon.plist less fragile on macOS

### DIFF
--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -17,7 +17,7 @@
     <array>
       <string>/bin/sh</string>
       <string>-c</string>
-      <string>/bin/wait4path @bindir@/nix-daemon &amp;&amp; /nix/var/nix/profiles/default/bin/nix-daemon</string>
+      <string>/bin/wait4path /nix/var/nix/profiles/default/bin/nix-daemon &amp;&amp; /nix/var/nix/profiles/default/bin/nix-daemon</string>
     </array>
     <key>StandardErrorPath</key>
     <string>/var/log/nix-daemon.log</string>


### PR DESCRIPTION
We're calling `wait4path` on the full, resolved `@bindir@/nix-daemon` path.

That means we're hardcoding something like:

    /bin/wait4path /nix/store/zs9c5xhp3zv9p23qnjxp87nl5injsi1i-nix-2.3/bin/nix-daemon &amp;&amp; /nix/var/nix/profiles/default/bin/nix-daemon

That seems unnecessarily fragile.

It might be better to just wait4path on `/nix/store/`

This is a follow-up to #3128 and is related to #3125. cc: @matthewbauer @edolstra 