### PR TITLE
Don't activate Nix if the user's profile is not owned by that user

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -6,39 +6,39 @@ export NIX_USER_PROFILE_DIR="@localstatedir@/nix/profiles/per-user/$USER"
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
 # Set up the per-user profile.
-mkdir -m 0755 -p $NIX_USER_PROFILE_DIR
+mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
 if ! test -O "$NIX_USER_PROFILE_DIR"; then
     echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
 fi
 
-if test -w $HOME; then
-  if ! test -L $HOME/.nix-profile; then
+if test -w "$HOME"; then
+  if ! test -L "$HOME/.nix-profile"; then
       if test "$USER" != root; then
-          ln -s $NIX_USER_PROFILE_DIR/profile $HOME/.nix-profile
+          ln -s "$NIX_USER_PROFILE_DIR/profile" "$HOME/.nix-profile"
       else
           # Root installs in the system-wide profile by default.
-          ln -s @localstatedir@/nix/profiles/default $HOME/.nix-profile
+          ln -s @localstatedir@/nix/profiles/default "$HOME/.nix-profile"
       fi
   fi
 
   # Subscribe the root user to the NixOS channel by default.
-  if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
-      echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > $HOME/.nix-channels
+  if [ "$USER" = root -a ! -e "$HOME/.nix-channels" ]; then
+      echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
   fi
 
   # Create the per-user garbage collector roots directory.
-  NIX_USER_GCROOTS_DIR=@localstatedir@/nix/gcroots/per-user/$USER
-  mkdir -m 0755 -p $NIX_USER_GCROOTS_DIR
+  NIX_USER_GCROOTS_DIR="@localstatedir@/nix/gcroots/per-user/$USER"
+  mkdir -m 0755 -p "$NIX_USER_GCROOTS_DIR"
   if ! test -O "$NIX_USER_GCROOTS_DIR"; then
       echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
   fi
 
   # Set up a default Nix expression from which to install stuff.
-  if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
-      rm -f $HOME/.nix-defexpr
-      mkdir -p $HOME/.nix-defexpr
+  if [ ! -e "$HOME/.nix-defexpr" -o -L "$HOME/.nix-defexpr" ]; then
+      rm -f "$HOME/.nix-defexpr"
+      mkdir -p "$HOME/.nix-defexpr"
       if [ "$USER" != root ]; then
-          ln -s @localstatedir@/nix/profiles/per-user/root/channels $HOME/.nix-defexpr/channels_root
+          ln -s @localstatedir@/nix/profiles/per-user/root/channels "$HOME/.nix-defexpr/channels_root"
       fi
   fi
 fi
@@ -58,8 +58,8 @@ elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
 else
   # Fall back to what is in the nix profiles, favouring whatever is defined last.
   for i in $NIX_PROFILES; do
-    if [ -e $i/etc/ssl/certs/ca-bundle.crt ]; then
-      export NIX_SSL_CERT_FILE=$i/etc/ssl/certs/ca-bundle.crt
+    if [ -e "$i/etc/ssl/certs/ca-bundle.crt" ]; then
+      export NIX_SSL_CERT_FILE="$i/etc/ssl/certs/ca-bundle.crt"
     fi
   done
 fi

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -15,7 +15,8 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
         echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)," >&2
-        echo "              please delete '$NIX_USER_PROFILE_DIR'." >&2
+        echo "              please delete '$NIX_USER_PROFILE_DIR'. The current ownership" >&2
+        echo "              allows other users to install software for you." >&2
         __safe=1
     fi
 
@@ -55,7 +56,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
             if [ "$(stat --printf '%u' @localstatedir@/nix/profiles/per-user/root)" -eq 0 ]; then
                 if [ "$USER" != root ] && [ ! -L "$__nix_defexpr"/channels_root ]; then
                     if [ -d @localstatedir@/nix/profiles/per-user/root ]; then
-                        ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root # !!! is this safe?
+                        ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root
                     fi
                 fi
             else

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,6 +1,6 @@
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
     # __safe: if it is safe to "activate" Nix. 0 is safe, 1 is unsafe
-    __safe=0
+    __safe=1
     __savedpath="$PATH"
     export PATH=@coreutils@
 
@@ -13,11 +13,12 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
 
-    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
+    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" -eq "$(id -u)" ]; then
+        __safe=0
+    else
         echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)," >&2
         echo "              please delete '$NIX_USER_PROFILE_DIR'. The current ownership" >&2
         echo "              allows other users to install software for you." >&2
-        __safe=1
     fi
 
     if [ -w "$HOME" ]; then

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -13,7 +13,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
 
-    if [ "$(stat --printf '%u' "$NIX_USER _PROFILE_DIR")" != "$(id -u)" ]; then
+    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
         echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)," >&2
         echo "              please delete '$NIX_USER_PROFILE_DIR'." >&2
         __safe=1

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -11,16 +11,16 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
 
-    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
-        echo "Nix: WARNING: bad ownership on "$NIX_USER_PROFILE_DIR", should be $(id -u)" >&2
+    if [ "$(stat --printf '%u' "$NIX_USER _PROFILE_DIR")" != "$(id -u)" ]; then
+        echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)" >&2
     fi
 
     if [ -w "$HOME" ]; then
         if ! [ -L "$NIX_LINK" ]; then
-            echo "Nix: creating $NIX_LINK" >&2
+            echo "Nix: creating '$NIX_LINK'" >&2
             if [ "$USER" != root ]; then
                 if ! ln -s "$NIX_USER_PROFILE_DIR"/profile "$NIX_LINK"; then
-                    echo "Nix: WARNING: could not create $NIX_LINK -> $NIX_USER_PROFILE_DIR/profile" >&2
+                    echo "Nix: WARNING: could not link '$NIX_LINK' to '$NIX_USER_PROFILE_DIR/profile'" >&2
                 fi
             else
                 # Root installs in the system-wide profile by default.
@@ -37,7 +37,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         __user_gcroots=@localstatedir@/nix/gcroots/per-user/"$USER"
         mkdir -m 0755 -p "$__user_gcroots"
         if [ "$(stat --printf '%u' "$__user_gcroots")" != "$(id -u)" ]; then
-            echo "Nix: WARNING: bad ownership on $__user_gcroots, should be $(id -u)" >&2
+            echo "Nix: WARNING: bad ownership on '$__user_gcroots', should be $(id -u)" >&2
         fi
         unset __user_gcroots
 

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -44,7 +44,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         if [ "$(stat --printf '%u' "$__user_gcroots")" != "$(id -u)" ]; then
             echo "Nix: WARNING: bad ownership on '$__user_gcroots', should be $(id -u)," >&2
             echo "              please delete '$__user_gcroots'." >&2
-            __safe=1
         fi
         unset __user_gcroots
 

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -52,18 +52,19 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         __nix_defexpr="$HOME"/.nix-defexpr
         [ -L "$__nix_defexpr" ] && rm -f "$__nix_defexpr"
         mkdir -m 0755 -p "$__nix_defexpr"
-        if [ "$USER" != root ] && [ ! -L "$__nix_defexpr"/channels_root ]; then
-            if [ -d @localstatedir@/nix/profiles/per-user/root ]; then
-                if [ "$(stat --printf '%u' @localstatedir@/nix/profiles/per-user/root)" -eq 0 ]; then
-                    # This runs if we are not root, the channels_root symlink doesn't already exist,
-                    # and the root per-user profile is actually owned by root.
-                    ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root # !!! is this safe?
-                else
-                    echo "Nix: WARNING: bad ownership on '@localstatedir@/nix/profiles/per-user/root',"
-                    echo "              the root user should own it."
+        if [ -d @localstatedir@/nix/profiles/per-user/root ]; then
+            if [ "$(stat --printf '%u' @localstatedir@/nix/profiles/per-user/root)" -eq 0 ]; then
+                if [ "$USER" != root ] && [ ! -L "$__nix_defexpr"/channels_root ]; then
+                    if [ -d @localstatedir@/nix/profiles/per-user/root ]; then
+                        ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root # !!! is this safe?
+                    fi
                 fi
+            else
+                echo "Nix: WARNING: bad ownership on '@localstatedir@/nix/profiles/per-user/root':"
+                echo "              the root user should own it."
             fi
         fi
+
         unset __nix_defexpr
     fi
 

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -100,5 +100,5 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
         export PATH="$NIX_LINK/bin:$__savedpath"
     fi
-    unset __unsafe __savedpath NIX_LINK NIX_USER_PROFILE_DIR
+    unset __safe __savedpath NIX_LINK NIX_USER_PROFILE_DIR
 fi

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -12,7 +12,8 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
 
     if [ "$(stat --printf '%u' "$NIX_USER _PROFILE_DIR")" != "$(id -u)" ]; then
-        echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)" >&2
+        echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)," >&2
+        echo "              please delete '$NIX_USER_PROFILE_DIR'." >&2
     fi
 
     if [ -w "$HOME" ]; then
@@ -37,7 +38,8 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         __user_gcroots=@localstatedir@/nix/gcroots/per-user/"$USER"
         mkdir -m 0755 -p "$__user_gcroots"
         if [ "$(stat --printf '%u' "$__user_gcroots")" != "$(id -u)" ]; then
-            echo "Nix: WARNING: bad ownership on '$__user_gcroots', should be $(id -u)" >&2
+            echo "Nix: WARNING: bad ownership on '$__user_gcroots', should be $(id -u)," >&2
+            echo "              please delete '$__user_gcroots'." >&2
         fi
         unset __user_gcroots
 

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,6 +1,6 @@
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
     # __safe: if it is safe to "activate" Nix. 0 is safe, 1 is unsafe
-    __safe=1
+    __safe=0
     __savedpath="$PATH"
     export PATH=@coreutils@
 
@@ -13,12 +13,11 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
 
-    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" -eq "$(id -u)" ]; then
-        __safe=0
-    else
+    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" -ne "$(id -u)" ]; then
         echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)," >&2
         echo "              please delete '$NIX_USER_PROFILE_DIR'. The current ownership" >&2
         echo "              allows other users to install software for you." >&2
+        __safe=1
     fi
 
     if [ -w "$HOME" ]; then
@@ -63,13 +62,14 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
             else
                 echo "Nix: WARNING: bad ownership on '@localstatedir@/nix/profiles/per-user/root':"
                 echo "              the root user should own it."
+                __safe=1
             fi
         fi
 
         unset __nix_defexpr
     fi
 
-    if [ "$__safe" -eq 1 ]; then
+    if [ "$__safe" -ne 0 ]; then
         echo "Nix: WARNING: Not activating due to the above warnings." >&2
     else
         # Append ~/.nix-defexpr/channels to $NIX_PATH so that <nixpkgs>

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,4 +1,6 @@
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
+    # __safe: if it is safe to "activate" Nix. 0 is safe, 1 is unsafe
+    __safe=0
     __savedpath="$PATH"
     export PATH=@coreutils@
 
@@ -14,6 +16,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     if [ "$(stat --printf '%u' "$NIX_USER _PROFILE_DIR")" != "$(id -u)" ]; then
         echo "Nix: WARNING: bad ownership on '$NIX_USER_PROFILE_DIR', should be $(id -u)," >&2
         echo "              please delete '$NIX_USER_PROFILE_DIR'." >&2
+        __safe=1
     fi
 
     if [ -w "$HOME" ]; then
@@ -25,6 +28,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
                 fi
             else
                 # Root installs in the system-wide profile by default.
+                # nix/profiles is not writable by arbitrary users
                 ln -s @localstatedir@/nix/profiles/default "$NIX_LINK"
             fi
         fi
@@ -40,6 +44,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         if [ "$(stat --printf '%u' "$__user_gcroots")" != "$(id -u)" ]; then
             echo "Nix: WARNING: bad ownership on '$__user_gcroots', should be $(id -u)," >&2
             echo "              please delete '$__user_gcroots'." >&2
+            __safe=1
         fi
         unset __user_gcroots
 
@@ -48,38 +53,51 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         [ -L "$__nix_defexpr" ] && rm -f "$__nix_defexpr"
         mkdir -m 0755 -p "$__nix_defexpr"
         if [ "$USER" != root ] && [ ! -L "$__nix_defexpr"/channels_root ]; then
-            ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root
+            if [ -d @localstatedir@/nix/profiles/per-user/root ]; then
+                if [ "$(stat --printf '%u' @localstatedir@/nix/profiles/per-user/root)" -eq 0 ]; then
+                    # This runs if we are not root, the channels_root symlink doesn't already exist,
+                    # and the root per-user profile is actually owned by root.
+                    ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root # !!! is this safe?
+                else
+                    echo "Nix: WARNING: bad ownership on '@localstatedir@/nix/profiles/per-user/root',"
+                    echo "              the root user should own it."
+                fi
+            fi
         fi
         unset __nix_defexpr
     fi
 
-    # Append ~/.nix-defexpr/channels to $NIX_PATH so that <nixpkgs>
-    # paths work when the user has fetched the Nixpkgs channel.
-    export NIX_PATH=${NIX_PATH:+$NIX_PATH:}$HOME/.nix-defexpr/channels
+    if [ "$__safe" -eq 1 ]; then
+        echo "Nix: WARNING: Not activating due to the above warnings." >&2
+    else
+        # Append ~/.nix-defexpr/channels to $NIX_PATH so that <nixpkgs>
+        # paths work when the user has fetched the Nixpkgs channel.
+        export NIX_PATH=${NIX_PATH:+$NIX_PATH:}$HOME/.nix-defexpr/channels
 
-    # Set up environment.
-    # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
-    export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+        # Set up environment.
+        # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
+        export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
-    # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
-    if [ -e /etc/ssl/certs/ca-certificates.crt ]; then # NixOS, Ubuntu, Debian, Gentoo, Arch
-        export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-    elif [ -e /etc/ssl/ca-bundle.pem ]; then # openSUSE Tumbleweed
-        export NIX_SSL_CERT_FILE=/etc/ssl/ca-bundle.pem
-    elif [ -e /etc/ssl/certs/ca-bundle.crt ]; then # Old NixOS
-        export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
-    elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
-        export NIX_SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
-    elif [ -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" ]; then # fall back to cacert in Nix profile
-        export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
-    elif [ -e "$NIX_LINK/etc/ca-bundle.crt" ]; then # old cacert in Nix profile
-        export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
+        # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
+        if [ -e /etc/ssl/certs/ca-certificates.crt ]; then # NixOS, Ubuntu, Debian, Gentoo, Arch
+            export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+        elif [ -e /etc/ssl/ca-bundle.pem ]; then # openSUSE Tumbleweed
+            export NIX_SSL_CERT_FILE=/etc/ssl/ca-bundle.pem
+        elif [ -e /etc/ssl/certs/ca-bundle.crt ]; then # Old NixOS
+            export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+        elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
+            export NIX_SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+        elif [ -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" ]; then # fall back to cacert in Nix profile
+            export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+        elif [ -e "$NIX_LINK/etc/ca-bundle.crt" ]; then # old cacert in Nix profile
+            export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
+        fi
+
+        if [ -n "${MANPATH-}" ]; then
+            export MANPATH="$NIX_LINK/share/man:$MANPATH"
+        fi
+
+        export PATH="$NIX_LINK/bin:$__savedpath"
     fi
-
-    if [ -n "${MANPATH-}" ]; then
-        export MANPATH="$NIX_LINK/share/man:$MANPATH"
-    fi
-
-    export PATH="$NIX_LINK/bin:$__savedpath"
-    unset __savedpath NIX_LINK NIX_USER_PROFILE_DIR
+    unset __unsafe __savedpath NIX_LINK NIX_USER_PROFILE_DIR
 fi


### PR DESCRIPTION
re https://www.openwall.com/lists/oss-security/2019/10/09/4

My deepest apologies on dropping the ball on this changeset. I don't remember what happened, but I completely forgot to continue this patchset and get it released.

I believe the multi-user profile still needs to be updated.

I would like to work to improve our handling of security matters to ensure they don't get delayed like this again.