### PR TITLE
Don’t override system PATH in nix-profile.sh

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,6 +1,6 @@
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
     __savedpath="$PATH"
-    export PATH=@coreutils@
+    export PATH=@coreutils@:$PATH
 
     # Set up the per-user profile.
     # This part should be kept in sync with nixpkgs:nixos/modules/programs/shell.nix


### PR DESCRIPTION
Sometimes --with-coreutils-bin= will be set to something like /bin or
/usr/bin. This usually works out okay, but on some systems the
different coreutils commands are in different directories. We don’t
really know what these directories will look like ahead of time, so
need to be a little more forgiving in the profile script. To avoid
causing issues, we can just prefix system PATH instead of overwriting
it altogether. This should help with #3127.