### PR TITLE
Remove world-writability from {profiles,gcroots}/per-user 

### DIFF
--- a/nix.spec.in
+++ b/nix.spec.in
@@ -106,7 +106,7 @@ chmod 1775 $RPM_BUILD_ROOT/nix/store
 for d in profiles gcroots;
 do
   mkdir -p $RPM_BUILD_ROOT/nix/var/nix/$d/per-user
-  chmod 1777 $RPM_BUILD_ROOT/nix/var/nix/$d/per-user
+  chmod 755 $RPM_BUILD_ROOT/nix/var/nix/$d/per-user
 done
 
 # fix permission of nix profile

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -437,16 +437,15 @@ create_build_users() {
 }
 
 create_directories() {
+    # FIXME: remove all of this because it duplicates LocalStore::LocalStore().
+
     _sudo "to make the basic directory structure of Nix (part 1)" \
-          mkdir -pv -m 0755 /nix /nix/var /nix/var/log /nix/var/log/nix /nix/var/log/nix/drvs /nix/var/nix{,/db,/gcroots,/profiles,/temproots,/userpool}
+          mkdir -pv -m 0755 /nix /nix/var /nix/var/log /nix/var/log/nix /nix/var/log/nix/drvs /nix/var/nix{,/db,/gcroots,/profiles,/temproots,/userpool} /nix/var/nix/{gcroots,profiles}/per-user
 
     _sudo "to make the basic directory structure of Nix (part 2)" \
-          mkdir -pv -m 1777 /nix/var/nix/{gcroots,profiles}/per-user
-
-    _sudo "to make the basic directory structure of Nix (part 3)" \
           mkdir -pv -m 1775 /nix/store
 
-    _sudo "to make the basic directory structure of Nix (part 4)" \
+    _sudo "to make the basic directory structure of Nix (part 3)" \
           chgrp "$NIX_BUILD_GROUP_NAME" /nix/store
 
     _sudo "to set up the root user's profile (part 1)" \

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -490,7 +490,7 @@ EOF
 We will:
 
  - make sure your computer doesn't already have Nix files
-   (if it does, I  will tell you how to clean them up.)
+   (if it does, I will tell you how to clean them up.)
  - create local users (see the list above for the users we'll make)
  - create a local group ($NIX_BUILD_GROUP_NAME)
  - install Nix in to $NIX_ROOT

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -448,12 +448,6 @@ create_directories() {
     _sudo "to make the basic directory structure of Nix (part 3)" \
           chgrp "$NIX_BUILD_GROUP_NAME" /nix/store
 
-    _sudo "to set up the root user's profile (part 1)" \
-          mkdir -pv -m 0755 /nix/var/nix/profiles/per-user/root
-
-    _sudo "to set up the root user's profile (part 2)" \
-          mkdir -pv -m 0700 "$ROOT_HOME/.nix-defexpr"
-
     _sudo "to place the default nix daemon configuration (part 1)" \
           mkdir -pv -m 0555 /etc/nix
 }

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -5,18 +5,6 @@ __ETC_PROFILE_NIX_SOURCED=1
 export NIX_USER_PROFILE_DIR="@localstatedir@/nix/profiles/per-user/$USER"
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
-if test -w $HOME; then
-  # Set up a default Nix expression from which to install stuff.
-  if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
-      rm -f $HOME/.nix-defexpr
-      mkdir -p $HOME/.nix-defexpr
-      if [ "$USER" != root ]; then
-          ln -s @localstatedir@/nix/profiles/per-user/root/channels $HOME/.nix-defexpr/channels_root
-      fi
-  fi
-fi
-
-
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
 if [ ! -z "${NIX_SSL_CERT_FILE:-}" ]; then
     : # Allow users to override the NIX_SSL_CERT_FILE

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -6,15 +6,6 @@ export NIX_USER_PROFILE_DIR="@localstatedir@/nix/profiles/per-user/$USER"
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
 if test -w $HOME; then
-  if ! test -L $HOME/.nix-profile; then
-      if test "$USER" != root; then
-          ln -s $NIX_USER_PROFILE_DIR/profile $HOME/.nix-profile
-      else
-          # Root installs in the system-wide profile by default.
-          ln -s @localstatedir@/nix/profiles/default $HOME/.nix-profile
-      fi
-  fi
-
   # Set up a default Nix expression from which to install stuff.
   if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
       rm -f $HOME/.nix-defexpr

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -15,11 +15,6 @@ if test -w $HOME; then
       fi
   fi
 
-  # Subscribe the root user to the NixOS channel by default.
-  if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
-      echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > $HOME/.nix-channels
-  fi
-
   # Set up a default Nix expression from which to install stuff.
   if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
       rm -f $HOME/.nix-defexpr

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -5,12 +5,6 @@ __ETC_PROFILE_NIX_SOURCED=1
 export NIX_USER_PROFILE_DIR="@localstatedir@/nix/profiles/per-user/$USER"
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
-# Set up the per-user profile.
-mkdir -m 0755 -p $NIX_USER_PROFILE_DIR
-if ! test -O "$NIX_USER_PROFILE_DIR"; then
-    echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
-fi
-
 if test -w $HOME; then
   if ! test -L $HOME/.nix-profile; then
       if test "$USER" != root; then
@@ -24,13 +18,6 @@ if test -w $HOME; then
   # Subscribe the root user to the NixOS channel by default.
   if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
       echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > $HOME/.nix-channels
-  fi
-
-  # Create the per-user garbage collector roots directory.
-  NIX_USER_GCROOTS_DIR=@localstatedir@/nix/gcroots/per-user/$USER
-  mkdir -m 0755 -p $NIX_USER_GCROOTS_DIR
-  if ! test -O "$NIX_USER_GCROOTS_DIR"; then
-      echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
   fi
 
   # Set up a default Nix expression from which to install stuff.

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -10,18 +10,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     NIX_USER_PROFILE_DIR=@localstatedir@/nix/profiles/per-user/$USER
 
     if [ -w "$HOME" ]; then
-        if ! [ -L "$NIX_LINK" ]; then
-            echo "Nix: creating $NIX_LINK" >&2
-            if [ "$USER" != root ]; then
-                if ! ln -s "$NIX_USER_PROFILE_DIR"/profile "$NIX_LINK"; then
-                    echo "Nix: WARNING: could not create $NIX_LINK -> $NIX_USER_PROFILE_DIR/profile" >&2
-                fi
-            else
-                # Root installs in the system-wide profile by default.
-                ln -s @localstatedir@/nix/profiles/default "$NIX_LINK"
-            fi
-        fi
-
         # Set up a default Nix expression from which to install stuff.
         __nix_defexpr="$HOME"/.nix-defexpr
         [ -L "$__nix_defexpr" ] && rm -f "$__nix_defexpr"

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -22,11 +22,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
             fi
         fi
 
-        # Subscribe the user to the unstable Nixpkgs channel by default.
-        if [ ! -e "$HOME/.nix-channels" ]; then
-            echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
-        fi
-
         # Set up a default Nix expression from which to install stuff.
         __nix_defexpr="$HOME"/.nix-defexpr
         [ -L "$__nix_defexpr" ] && rm -f "$__nix_defexpr"

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -9,12 +9,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     NIX_USER_PROFILE_DIR=@localstatedir@/nix/profiles/per-user/$USER
 
-    mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
-
-    if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
-        echo "Nix: WARNING: bad ownership on "$NIX_USER_PROFILE_DIR", should be $(id -u)" >&2
-    fi
-
     if [ -w "$HOME" ]; then
         if ! [ -L "$NIX_LINK" ]; then
             echo "Nix: creating $NIX_LINK" >&2
@@ -32,14 +26,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         if [ ! -e "$HOME/.nix-channels" ]; then
             echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
         fi
-
-        # Create the per-user garbage collector roots directory.
-        __user_gcroots=@localstatedir@/nix/gcroots/per-user/"$USER"
-        mkdir -m 0755 -p "$__user_gcroots"
-        if [ "$(stat --printf '%u' "$__user_gcroots")" != "$(id -u)" ]; then
-            echo "Nix: WARNING: bad ownership on $__user_gcroots, should be $(id -u)" >&2
-        fi
-        unset __user_gcroots
 
         # Set up a default Nix expression from which to install stuff.
         __nix_defexpr="$HOME"/.nix-defexpr

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,6 +1,4 @@
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
-    __savedpath="$PATH"
-    export PATH=@coreutils@
 
     # Set up the per-user profile.
     # This part should be kept in sync with nixpkgs:nixos/modules/programs/shell.nix
@@ -47,6 +45,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         export MANPATH="$NIX_LINK/share/man:$MANPATH"
     fi
 
-    export PATH="$NIX_LINK/bin:$__savedpath"
-    unset __savedpath NIX_LINK NIX_USER_PROFILE_DIR
+    export PATH="$NIX_LINK/bin:$PATH"
+    unset NIX_LINK NIX_USER_PROFILE_DIR
 fi

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -7,17 +7,6 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     NIX_USER_PROFILE_DIR=@localstatedir@/nix/profiles/per-user/$USER
 
-    if [ -w "$HOME" ]; then
-        # Set up a default Nix expression from which to install stuff.
-        __nix_defexpr="$HOME"/.nix-defexpr
-        [ -L "$__nix_defexpr" ] && rm -f "$__nix_defexpr"
-        mkdir -m 0755 -p "$__nix_defexpr"
-        if [ "$USER" != root ] && [ ! -L "$__nix_defexpr"/channels_root ]; then
-            ln -s @localstatedir@/nix/profiles/per-user/root/channels "$__nix_defexpr"/channels_root
-        fi
-        unset __nix_defexpr
-    fi
-
     # Append ~/.nix-defexpr/channels to $NIX_PATH so that <nixpkgs>
     # paths work when the user has fetched the Nixpkgs channel.
     export NIX_PATH=${NIX_PATH:+$NIX_PATH:}$HOME/.nix-defexpr/channels

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -70,16 +70,17 @@ LocalStore::LocalStore(const Params & params)
         createSymlink(profilesDir, gcRootsDir + "/profiles");
     }
 
+    for (auto & perUserDir : {profilesDir + "/per-user", gcRootsDir + "/per-user"}) {
+        createDirs(perUserDir);
+        if (chmod(perUserDir.c_str(), 0755) == -1)
+            throw SysError("could not set permissions on '%s' to 755", perUserDir);
+    }
+
+    createUser(getUserName(), getuid());
+
     /* Optionally, create directories and set permissions for a
        multi-user install. */
     if (getuid() == 0 && settings.buildUsersGroup != "") {
-
-        for (auto & perUserDir : {profilesDir + "/per-user", gcRootsDir + "/per-user"}) {
-            createDirs(perUserDir);
-            if (chmod(perUserDir.c_str(), 0755) == -1)
-                throw SysError("could not set permissions on '%s' to 755", perUserDir);
-        }
-
         mode_t perm = 01775;
 
         struct group * gr = getgrnam(settings.buildUsersGroup.get().c_str());

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1441,7 +1441,7 @@ void LocalStore::createUser(const std::string & userName, uid_t userId)
         fmt("%s/gcroots/per-user/%s", stateDir, userName)
     }) {
         createDirs(dir);
-        if (chmod(dir.c_str(), 0700) == -1)
+        if (chmod(dir.c_str(), 0755) == -1)
             throw SysError("changing permissions of directory '%s'", dir);
         if (chown(dir.c_str(), userId, -1) == -1)
             throw SysError("changing owner of directory '%s'", dir);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1443,7 +1443,7 @@ void LocalStore::createUser(const std::string & userName, uid_t userId)
         createDirs(dir);
         if (chmod(dir.c_str(), 0755) == -1)
             throw SysError("changing permissions of directory '%s'", dir);
-        if (chown(dir.c_str(), userId, -1) == -1)
+        if (chown(dir.c_str(), userId, 0) == -1)
             throw SysError("changing owner of directory '%s'", dir);
     }
 }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -74,10 +74,11 @@ LocalStore::LocalStore(const Params & params)
        multi-user install. */
     if (getuid() == 0 && settings.buildUsersGroup != "") {
 
-        Path perUserDir = profilesDir + "/per-user";
-        createDirs(perUserDir);
-        if (chmod(perUserDir.c_str(), 01777) == -1)
-            throw SysError(format("could not set permissions on '%1%' to 1777") % perUserDir);
+        for (auto & perUserDir : {profilesDir + "/per-user", gcRootsDir + "/per-user"}) {
+            createDirs(perUserDir);
+            if (chmod(perUserDir.c_str(), 0755) == -1)
+                throw SysError("could not set permissions on '%s' to 755", perUserDir);
+        }
 
         mode_t perm = 01775;
 
@@ -1428,6 +1429,21 @@ void LocalStore::signPathInfo(ValidPathInfo & info)
     for (auto & secretKeyFile : secretKeyFiles.get()) {
         SecretKey secretKey(readFile(secretKeyFile));
         info.sign(secretKey);
+    }
+}
+
+
+void LocalStore::createUser(const std::string & userName, uid_t userId)
+{
+    for (auto & dir : {
+        fmt("%s/profiles/per-user/%s", stateDir, userName),
+        fmt("%s/gcroots/per-user/%s", stateDir, userName)
+    }) {
+        createDirs(dir);
+        if (chmod(dir.c_str(), 0700) == -1)
+            throw SysError("changing permissions of directory '%s'", dir);
+        if (chown(dir.c_str(), userId, -1) == -1)
+            throw SysError("changing owner of directory '%s'", dir);
     }
 }
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -293,6 +293,8 @@ private:
 
     Path getRealStoreDir() override { return realStoreDir; }
 
+    void createUser(const std::string & userName, uid_t userId) override;
+
     friend class DerivationGoal;
     friend class SubstitutionGoal;
 };

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -628,6 +628,9 @@ public:
         return storePath;
     }
 
+    virtual void createUser(const std::string & userName, uid_t userId)
+    { }
+
 protected:
 
     Stats stats;

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -475,6 +475,16 @@ Path createTempDir(const Path & tmpRoot, const Path & prefix,
 }
 
 
+std::string getUserName()
+{
+    auto pw = getpwuid(geteuid());
+    std::string name = pw ? pw->pw_name : getEnv("USER", "");
+    if (name.empty())
+        throw Error("cannot figure out user name");
+    return name;
+}
+
+
 static Lazy<Path> getHome2([]() {
     Path homeDir = getEnv("HOME");
     if (homeDir.empty()) {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -126,6 +126,8 @@ void deletePath(const Path & path, unsigned long long & bytesFreed);
 Path createTempDir(const Path & tmpRoot = "", const Path & prefix = "nix",
     bool includePid = true, bool useGlobalCounter = true, mode_t mode = 0755);
 
+std::string getUserName();
+
 /* Return $HOME or the user's home directory from /etc/passwd. */
 Path getHome();
 

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -159,13 +159,7 @@ static int _main(int argc, char ** argv)
         nixDefExpr = home + "/.nix-defexpr";
 
         // Figure out the name of the channels profile.
-        ;
-        auto pw = getpwuid(geteuid());
-        std::string name = pw ? pw->pw_name : getEnv("USER", "");
-        if (name.empty())
-            throw Error("cannot figure out user name");
-        profile = settings.nixStateDir + "/profiles/per-user/" + name + "/channels";
-        createDirs(dirOf(profile));
+        profile = fmt("%s/profiles/per-user/%s/channels", settings.nixStateDir, getUserName());
 
         enum {
             cNone,

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -742,7 +742,8 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
 }
 
 
-static void processConnection(bool trusted)
+static void processConnection(bool trusted,
+    const std::string & userName, uid_t userId)
 {
     MonitorFdHup monitor(from.fd);
 
@@ -792,6 +793,8 @@ static void processConnection(bool trusted)
         // Disable caching since the client already does that.
         params["path-info-cache-size"] = "0";
         auto store = openStore(settings.storeUri, params);
+
+        store->createUser(userName, userId);
 
         tunnelLogger->stopWork();
         to.flush();
@@ -1053,7 +1056,7 @@ static void daemonLoop(char * * argv)
                 /* Handle the connection. */
                 from.fd = remote.get();
                 to.fd = remote.get();
-                processConnection(trusted);
+                processConnection(trusted, user, peer.uid);
 
                 exit(0);
             }, options);
@@ -1133,7 +1136,7 @@ static int _main(int argc, char * * argv)
                     }
                 }
             } else {
-                processConnection(true);
+                processConnection(true, "root", 0);
             }
         } else {
             daemonLoop(argv);

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1422,9 +1422,14 @@ static int _main(int argc, char * * argv)
 
         if (globals.profile == "") {
             Path profileLink = getHome() + "/.nix-profile";
-            globals.profile = pathExists(profileLink)
-                ? absPath(readLink(profileLink), dirOf(profileLink))
-                : canonPath(settings.nixStateDir + "/profiles/default");
+            if (!pathExists(profileLink)) {
+                replaceSymlink(
+                    getuid() == 0
+                    ? settings.nixStateDir + "/profiles/default"
+                    : fmt("%s/profiles/per-user/%s/profile", settings.nixStateDir, getUserName()),
+                    profileLink);
+            }
+            globals.profile = absPath(readLink(profileLink), dirOf(profileLink));
         }
 
         op(globals, opFlags, opArgs);

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -192,12 +192,6 @@ static void loadDerivations(EvalState & state, Path nixExprPath,
 }
 
 
-static Path getDefNixExprPath()
-{
-    return getHome() + "/.nix-defexpr";
-}
-
-
 static long getPriority(EvalState & state, DrvInfo & drv)
 {
     return drv.queryMetaInt("priority", 0);
@@ -1327,8 +1321,19 @@ static int _main(int argc, char * * argv)
         Globals globals;
 
         globals.instSource.type = srcUnknown;
-        globals.instSource.nixExprPath = getDefNixExprPath();
+        globals.instSource.nixExprPath = getHome() + "/.nix-defexpr";
         globals.instSource.systemFilter = "*";
+
+        if (!pathExists(globals.instSource.nixExprPath)) {
+            createDirs(globals.instSource.nixExprPath);
+            replaceSymlink(
+                fmt("%s/profiles/per-user/%s/channels", settings.nixStateDir, getUserName()),
+                globals.instSource.nixExprPath + "/channels");
+            if (getuid() != 0)
+                replaceSymlink(
+                    fmt("%s/profiles/per-user/root/channels", settings.nixStateDir),
+                    globals.instSource.nixExprPath + "/channels_root");
+        }
 
         globals.dryRun = false;
         globals.preserveInstalled = false;

--- a/tests/nix-channel.sh
+++ b/tests/nix-channel.sh
@@ -36,7 +36,7 @@ grep -q 'item.*attrPath="foo".*name="dependencies"' $TEST_ROOT/meta.xml
 
 # Do an install.
 nix-env -i dependencies
-[ -e $TEST_ROOT/var/nix/profiles/default/foobar ]
+[ -e $TEST_HOME/.nix-profile/foobar ]
 
 clearProfiles
 rm -f $TEST_HOME/.nix-channels
@@ -55,5 +55,5 @@ grep -q 'item.*attrPath="foo".*name="dependencies"' $TEST_ROOT/meta.xml
 
 # Do an install.
 nix-env -i dependencies
-[ -e $TEST_ROOT/var/nix/profiles/default/foobar ]
+[ -e $TEST_HOME/.nix-profile/foobar ]
 

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -9,4 +9,3 @@ USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh; set"
 USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh" # test idempotency
 
 [ -L $TEST_HOME/.nix-profile ]
-[ -e $TEST_HOME/.nix-channels ]

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -10,5 +10,3 @@ USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh" # test idempotency
 
 [ -L $TEST_HOME/.nix-profile ]
 [ -e $TEST_HOME/.nix-channels ]
-[ -e $TEST_ROOT/profile-var/nix/gcroots/per-user/$user ]
-[ -e $TEST_ROOT/profile-var/nix/profiles/per-user/$user ]

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -7,5 +7,3 @@ rm -rf $TEST_HOME $TEST_ROOT/profile-var
 mkdir -p $TEST_HOME
 USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh; set"
 USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh" # test idempotency
-
-[ -L $TEST_HOME/.nix-profile ]

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -13,3 +13,7 @@ cmp $TEST_ROOT/d1 $TEST_ROOT/d2
 nix-store --gc --max-freed 1K
 
 killDaemon
+
+user=$(whoami)
+[ -e $NIX_STATE_DIR/gcroots/per-user/$user ]
+[ -e $NIX_STATE_DIR/profiles/per-user/$user ]

--- a/tests/user-envs.sh
+++ b/tests/user-envs.sh
@@ -20,7 +20,7 @@ drvPath10=$(nix-env -f ./user-envs.nix -qa --drv-path --no-name '*' | grep foo-1
 
 # Query descriptions.
 nix-env -f ./user-envs.nix -qa '*' --description | grep -q silly
-rm -f $HOME/.nix-defexpr
+rm -rf $HOME/.nix-defexpr
 ln -s $(pwd)/user-envs.nix $HOME/.nix-defexpr
 nix-env -qa '*' --description | grep -q silly
 


### PR DESCRIPTION
These directories are now created on demand by the daemon.

Also some simplifications to the profile scripts.

Alternative to #3134, #3135.