### PR TITLE
Downloader: Log configured CA file

### DIFF
--- a/src/libstore/download.cc
+++ b/src/libstore/download.cc
@@ -285,6 +285,7 @@ struct CurlDownloader : public Downloader
             }
 
             if (request.verifyTLS) {
+                debug("verify TLS: Nix CA file = '%s'", settings.caFile);
                 if (settings.caFile != "")
                     curl_easy_setopt(req, CURLOPT_CAINFO, settings.caFile.c_str());
             } else {


### PR DESCRIPTION
*Update*: Rescoped PR to only debug print configured CA file to address concerns by @edolstra.

It seems like a good idea to warn if no trusted CA's has been configured, to help narrow down issues like https://github.com/NixOS/nixpkgs/issues/70939.

*Update*: CA files may come from different sources if e.g. Curl or the TLS library is used from the system and not Nix. Therefore it might be misleading to warn.

In addition I added a `debug` print of the configured CA file for the same reason.

Tested on CentOS and looks like this:
```sh
$ nix-env -i firefox -vvv
...
downloading 'https://cache.nixos.org/nar/0wpvc57l0sv8jxfylfyfwrkxzij6fxvakk4k3zd11iiaanwx8viy.nar.xz'...
starting download of https://cache.nixos.org/nar/0wpvc57l0sv8jxfylfyfwrkxzij6fxvakk4k3zd11iiaanwx8viy.nar.xz
verify TLS: Nix CA file = ''
finished download of 'https://cache.nixos.org/nar/0wpvc57l0sv8jxfylfyfwrkxzij6fxvakk4k3zd11iiaanwx8viy.nar.xz'; curl status = 60, HTTP status = 0, body = 0 bytes
warning: unable to download 'https://cache.nixos.org/nar/0wpvc57l0sv8jxfylfyfwrkxzij6fxvakk4k3zd11iiaanwx8viy.nar.xz': SSL peer certificate or SSH remote key was not OK (60); retrying in 274 ms
