### PR TITLE
Link directly to local libraries

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -96,7 +96,9 @@ define build-library
     ifneq ($(OS), Darwin)
       $(1)_LDFLAGS_USE += -Wl,-rpath,$$(abspath $$(_d))
     endif
-    $(1)_LDFLAGS_USE += -L$$(_d) -l$$(patsubst lib%,%,$$(strip $$($(1)_NAME)))
+    # -L and -l might conflict with previously-installed libraries. Instead
+    #  pass the file directly to the linker.
+    $(1)_LDFLAGS_USE += -Wl,$$(_d)/$$($(1)_NAME).$(SO_EXT)
 
     $(1)_INSTALL_PATH := $(DESTDIR)$$($(1)_INSTALL_DIR)/$$($(1)_NAME).$(SO_EXT)
 
@@ -107,7 +109,7 @@ define build-library
     $$($(1)_INSTALL_PATH): $$($(1)_OBJS) $$(_libs_final) | $(DESTDIR)$$($(1)_INSTALL_DIR)/
 	$$(trace-ld) $(CXX) -o $$@ -shared $$(LDFLAGS) $$(GLOBAL_LDFLAGS) $$($(1)_OBJS) $$($(1)_LDFLAGS) $$($(1)_LDFLAGS_PROPAGATED) $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LDFLAGS_USE_INSTALLED))
 
-    $(1)_LDFLAGS_USE_INSTALLED += -L$$(DESTDIR)$$($(1)_INSTALL_DIR) -l$$(patsubst lib%,%,$$(strip $$($(1)_NAME)))
+    $(1)_LDFLAGS_USE_INSTALLED += -Wl,$$(DESTDIR)$$($(1)_INSTALL_DIR)/$$($(1)_NAME).$(SO_EXT)
     ifneq ($(OS), Darwin)
       ifeq ($(SET_RPATH_TO_LIBS), 1)
         $(1)_LDFLAGS_USE_INSTALLED += -Wl,-rpath,$$($(1)_INSTALL_DIR)


### PR DESCRIPTION
Otherwise previous -L flags could cause the linker to use globally
installed versions of libraries instead of the ones that were just
compiled.

Fix https://github.com/NixOS/nix/issues/3087