### PR TITLE
Fix unset variable in installer

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -141,11 +141,9 @@ if [ -z "$_NIX_INSTALLER_TEST" ]; then
 fi
 
 added=
+p=$HOME/.nix-profile/etc/profile.d/nix.sh
 if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
-
     # Make the shell source nix.sh during login.
-    p=$HOME/.nix-profile/etc/profile.d/nix.sh
-
     for i in .bash_profile .bash_login .profile; do
         fn="$HOME/$i"
         if [ -w "$fn" ]; then
@@ -157,7 +155,6 @@ if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
             break
         fi
     done
-
 fi
 
 if [ -z "$added" ]; then


### PR DESCRIPTION
The `p` variable in the install script is not defined when `NIX_INSTALLER_NO_MODIFY_PROFILE` is set.

There is no error but the file to source after "please add the line" is empty:

```
$ NIX_INSTALLER_NO_MODIFY_PROFILE=y sh <(curl -s https://nixos.org/nix/install) --no-daemon
downloading Nix 2.3.1 binary tarball for x86_64-darwin from 'https://nixos.org/releases/nix/nix-2.3.1/nix-2.3.1-x86_64-darwin.tar.xz' to '/var/folders/5p/pg4tt29543q9myxxt9j1528m0000gn/T/nix-binary-tarball-unpack.mDl1TE2hFV'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17.1M  100 17.1M    0     0   331k      0  0:00:53  0:00:53 --:--:--  593k
Note: a multi-user installation is possible. See https://nixos.org/nix/manual/#sect-multi-user-installation
performing a single-user installation of Nix...
copying Nix to /nix/store........................................
replacing old 'nix-2.3.1'
installing 'nix-2.3.1'
unpacking channels...

Installation finished!  To ensure that the necessary environment
variables are set, please add the line

  .

to your shell profile (e.g. ~/.profile).
```

Perhaps should also consider `set -eu` rather than just `set -e` at the top of the file? It doesn't seem to present any portability difficulties.