### PR TITLE
Document import <path> syntax

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -733,21 +733,13 @@ builtins.genList (x: x * x) 5
   <varlistentry xml:id='builtin-import'>
     <term><function>import</function>
     <replaceable>path</replaceable></term>
-    <term><function>import</function>
-    <replaceable>&lt;path&gt;</replaceable></term>
     <term><function>builtins.import</function>
     <replaceable>path</replaceable></term>
-    <term><function>builtins.import</function>
-    <replaceable>&lt;path&gt;</replaceable></term>
 
     <listitem><para>Load, parse and return the Nix expression in the
     file <replaceable>path</replaceable>.  If <replaceable>path
     </replaceable> is a directory, the file <filename>default.nix
-    </filename> in that directory is loaded.  If the <replaceable>
-    &lt;path&gt;</replaceable> syntax is used, the path will be resolved
-    relative to those listed in the <envar>NIX_PATH</envar> environment
-    variable (see the section on <envar linkend="env-NIX_PATH">NIX_PATH</envar>
-    for details on how the resolution works). Evaluation aborts if the
+    </filename> in that directory is loaded.  Evaluation aborts if the
     file doesn’t exist or contains an incorrect Nix expression.
     <function>import</function> implements Nix’s module system: you
     can put any Nix expression (such as a set or a function) in a

--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -733,13 +733,21 @@ builtins.genList (x: x * x) 5
   <varlistentry xml:id='builtin-import'>
     <term><function>import</function>
     <replaceable>path</replaceable></term>
+    <term><function>import</function>
+    <replaceable>&lt;path&gt;</replaceable></term>
     <term><function>builtins.import</function>
     <replaceable>path</replaceable></term>
+    <term><function>builtins.import</function>
+    <replaceable>&lt;path&gt;</replaceable></term>
 
     <listitem><para>Load, parse and return the Nix expression in the
     file <replaceable>path</replaceable>.  If <replaceable>path
     </replaceable> is a directory, the file <filename>default.nix
-    </filename> in that directory is loaded.  Evaluation aborts if the
+    </filename> in that directory is loaded.  If the <replaceable>
+    &lt;path&gt;</replaceable> syntax is used, the path will be resolved
+    relative to those listed in the <envar>NIX_PATH</envar> environment
+    variable (see the section on <envar linkend="env-NIX_PATH">NIX_PATH</envar>
+    for details on how the resolution works). Evaluation aborts if the
     file doesn’t exist or contains an incorrect Nix expression.
     <function>import</function> implements Nix’s module system: you
     can put any Nix expression (such as a set or a function) in a

--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -747,7 +747,8 @@ builtins.genList (x: x * x) 5
     files.</para>
 
     <note><para>Unlike some languages, <function>import</function> is a regular
-    function in Nix. Paths using the angle bracket syntax (e.g., <function>import</function> <replaceable>&lt;foo&gt;</replaceable>) are normal
+    function in Nix. Paths using the angle bracket syntax (e.g., <function>
+    import</function> <replaceable>&lt;foo&gt;</replaceable>) are normal path
     values (see <xref linkend='ssec-values' />).</para></note>
 
     <para>A Nix expression loaded by <function>import</function> must

--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -746,6 +746,10 @@ builtins.genList (x: x * x) 5
     separate file, and use it from Nix expressions in other
     files.</para>
 
+    <note><para>Unlike some languages, <function>import</function> is a regular
+    function in Nix. Paths using the angle bracket syntax (e.g., <function>import</function> <replaceable>&lt;foo&gt;</replaceable>) are normal
+    values (see <xref linkend='ssec-values' />).</para></note>
+
     <para>A Nix expression loaded by <function>import</function> must
     not contain any <emphasis>free variables</emphasis> (identifiers
     that are not defined in the Nix expression itself and are not


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/338 by changing the start of the manual section on `builtins.import` to the following:

**import _path_, import _&lt;path&gt;_, builtins.import _path_, builtins.import _&lt;path&gt;_**

Load, parse and return the Nix expression in the file _path_. If path is a directory, the file default.nix in that directory is loaded. If the _&lt;path&gt;_ syntax is used, the path will be resolved relative to those listed in the NIX_PATH environment variable (see the section on NIX_PATH for details on how the resolution works). Evaluation aborts if the file doesn’t exist or contains an incorrect Nix expression. import implements Nix’s module system: you can put any Nix expression (such as a set or a function) in a separate file, and use it from Nix expressions in other files.