### PR TITLE
Remove superfluous IAM action for S3 cache

### DIFF
--- a/doc/manual/packages/s3-substituter.xml
+++ b/doc/manual/packages/s3-substituter.xml
@@ -159,7 +159,6 @@ the S3 URL:</para>
         "s3:ListBucket",
         "s3:ListBucketMultipartUploads",
         "s3:ListMultipartUploadParts",
-        "s3:ListObjects",
         "s3:PutObject"
       ],
       "Resource": [


### PR DESCRIPTION
`s3:ListObjects` isn't a real IAM action, but _is_ the name of an S3 API method. `s3:ListBucket` is the relevant action for that method.

https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html