### PR TITLE
nix repl: add :edit command

### DIFF
--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -103,6 +103,8 @@ Pos findDerivationFilename(EvalState & state, Value & v, std::string what)
         throw Error("package '%s' has no source location information", what);
     }
 
+    // FIXME: is it possible to extract the Pos object instead of doing this
+    //        toString + parsing?
     auto pos = state.forceString(*v2);
 
     auto colon = pos.rfind(':');

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -93,7 +93,7 @@ Value * findAlongAttrPath(EvalState & state, const string & attrPath,
 }
 
 
-std::tuple<std::string, int> findDerivationFilename(EvalState & state, Value & v, std::string what)
+Pos findDerivationFilename(EvalState & state, Value & v, std::string what)
 {
     Value * v2;
     try {
@@ -110,14 +110,16 @@ std::tuple<std::string, int> findDerivationFilename(EvalState & state, Value & v
         throw Error("cannot parse meta.position attribute '%s'", pos);
 
     std::string filename(pos, 0, colon);
-    int lineno;
+    unsigned int lineno;
     try {
         lineno = std::stoi(std::string(pos, colon + 1));
     } catch (std::invalid_argument & e) {
         throw Error("cannot parse line number '%s'", pos);
     }
 
-    return std::make_tuple(filename, lineno);
+    Symbol file = state.symbols.create(filename);
+
+    return { file, lineno, 0 };
 }
 
 

--- a/src/libexpr/attr-path.hh
+++ b/src/libexpr/attr-path.hh
@@ -4,10 +4,15 @@
 
 #include <string>
 #include <map>
+#include <tuple>
 
 namespace nix {
 
 Value * findAlongAttrPath(EvalState & state, const string & attrPath,
     Bindings & autoArgs, Value & vIn);
+
+/* Heuristic to find the filename and lineno or a derivation. */
+std::tuple<std::string, int> findDerivationFilename(EvalState & state,
+    Value & v, std::string what);
 
 }

--- a/src/libexpr/attr-path.hh
+++ b/src/libexpr/attr-path.hh
@@ -4,15 +4,13 @@
 
 #include <string>
 #include <map>
-#include <tuple>
 
 namespace nix {
 
 Value * findAlongAttrPath(EvalState & state, const string & attrPath,
     Bindings & autoArgs, Value & vIn);
 
-/* Heuristic to find the filename and lineno or a derivation. */
-std::tuple<std::string, int> findDerivationFilename(EvalState & state,
-    Value & v, std::string what);
+/* Heuristic to find the filename and lineno or a nix value. */
+Pos findDerivationFilename(EvalState & state, Value & v, std::string what);
 
 }

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -178,16 +178,16 @@ Strings argvToStrings(int argc, char * * argv)
     return args;
 }
 
-Strings editorFor(std::string filename, int lineno)
+Strings editorFor(Pos pos)
 {
     auto editor = getEnv("EDITOR", "cat");
     auto args = tokenizeString<Strings>(editor);
-    if (lineno > 0 && (
+    if (pos.line > 0 && (
         editor.find("emacs") != std::string::npos ||
         editor.find("nano") != std::string::npos ||
         editor.find("vim") != std::string::npos))
-        args.push_back(fmt("+%d", lineno));
-    args.push_back(filename);
+        args.push_back(fmt("+%d", pos.line));
+    args.push_back(pos.file);
     return args;
 }
 

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -178,6 +178,19 @@ Strings argvToStrings(int argc, char * * argv)
     return args;
 }
 
+Strings editorFor(std::string filename, int lineno)
+{
+    auto editor = getEnv("EDITOR", "cat");
+    auto args = tokenizeString<Strings>(editor);
+    if (lineno > 0 && (
+        editor.find("emacs") != std::string::npos ||
+        editor.find("nano") != std::string::npos ||
+        editor.find("vim") != std::string::npos))
+        args.push_back(fmt("+%d", lineno));
+    args.push_back(filename);
+    return args;
+}
+
 std::string renderLabels(const Strings & labels)
 {
     std::string res;

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "util.hh"
+#include "nixexpr.hh"
 
 namespace nix {
 
@@ -191,7 +192,7 @@ public:
 Strings argvToStrings(int argc, char * * argv);
 
 /* Helper function to generate args that invoke $EDITOR on filename:lineno */
-Strings editorFor(std::string filename, int lineno);
+Strings editorFor(Pos pos);
 
 /* Helper function for rendering argument labels. */
 std::string renderLabels(const Strings & labels);

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -190,6 +190,9 @@ public:
 
 Strings argvToStrings(int argc, char * * argv);
 
+/* Helper function to generate args that invoke $EDITOR on filename:lineno */
+Strings editorFor(std::string filename, int lineno);
+
 /* Helper function for rendering argument labels. */
 std::string renderLabels(const Strings & labels);
 

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -59,22 +59,15 @@ struct CmdEdit : InstallableCommand
             throw Error("cannot parse line number '%s'", pos);
         }
 
-        auto editor = getEnv("EDITOR", "cat");
-
-        auto args = tokenizeString<Strings>(editor);
-
-        if (editor.find("emacs") != std::string::npos ||
-            editor.find("nano") != std::string::npos ||
-            editor.find("vim") != std::string::npos)
-            args.push_back(fmt("+%d", lineno));
-
-        args.push_back(filename);
-
         stopProgressBar();
+
+        auto args = editorFor(filename, lineno);
 
         execvp(args.front().c_str(), stringsToCharPtrs(args).data());
 
-        throw SysError("cannot run editor '%s'", editor);
+        std::string command;
+        for (const auto &arg : args) command += " '" + arg + "'";
+        throw SysError("cannot run command%s", command);
     }
 };
 

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -36,28 +36,9 @@ struct CmdEdit : InstallableCommand
 
         auto v = installable->toValue(*state);
 
-        Value * v2;
-        try {
-            auto dummyArgs = state->allocBindings(0);
-            v2 = findAlongAttrPath(*state, "meta.position", *dummyArgs, *v);
-        } catch (Error &) {
-            throw Error("package '%s' has no source location information", installable->what());
-        }
-
-        auto pos = state->forceString(*v2);
-        debug("position is %s", pos);
-
-        auto colon = pos.rfind(':');
-        if (colon == std::string::npos)
-            throw Error("cannot parse meta.position attribute '%s'", pos);
-
-        std::string filename(pos, 0, colon);
+        std::string filename;
         int lineno;
-        try {
-            lineno = std::stoi(std::string(pos, colon + 1));
-        } catch (std::invalid_argument & e) {
-            throw Error("cannot parse line number '%s'", pos);
-        }
+        std::tie(filename, lineno) = findDerivationFilename(*state, *v, installable->what());
 
         stopProgressBar();
 

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -36,9 +36,9 @@ struct CmdEdit : InstallableCommand
 
         auto v = installable->toValue(*state);
 
-        std::string filename;
-        int lineno;
-        std::tie(filename, lineno) = findDerivationFilename(*state, *v, installable->what());
+        Pos pos = findDerivationFilename(*state, *v, installable->what());
+        std::string filename(pos.file);
+        int lineno(pos.line);
 
         stopProgressBar();
 

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -37,12 +37,10 @@ struct CmdEdit : InstallableCommand
         auto v = installable->toValue(*state);
 
         Pos pos = findDerivationFilename(*state, *v, installable->what());
-        std::string filename(pos.file);
-        int lineno(pos.line);
 
         stopProgressBar();
 
-        auto args = editorFor(filename, lineno);
+        auto args = editorFor(pos);
 
         execvp(args.front().c_str(), stringsToCharPtrs(args).data());
 

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -481,28 +481,7 @@ bool NixRepl::processLine(string line)
             lineno = 0;
         } else {
             // assume it's a derivation
-            Value * v2;
-            try {
-                auto dummyArgs = state.allocBindings(0);
-                v2 = findAlongAttrPath(state, "meta.position", *dummyArgs, v);
-            } catch (Error &) {
-                throw Error("package '%s' has no source location information", arg);
-            }
-
-            auto pos = state.forceString(*v2);
-            debug("position is %s", pos);
-
-            auto colon = pos.rfind(':');
-            if (colon == std::string::npos)
-                throw Error("cannot parse meta.position attribute '%s'", pos);
-
-            filename = std::string(pos, 0, colon);
-            try {
-                lineno = std::stoi(std::string(pos, colon + 1));
-            } catch (std::invalid_argument & e) {
-                throw Error("cannot parse line number '%s'", pos);
-            }
-
+            std::tie(filename, lineno) = findDerivationFilename(state, v, arg);
         }
 
         // Open in EDITOR

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -478,6 +478,8 @@ bool NixRepl::processLine(string line)
             PathSet context;
             auto filename = state.coerceToString(noPos, v, context);
             pos.file = state.symbols.create(filename);
+        } else if (v.type == tLambda) {
+            pos = v.lambda.fun->pos;
         } else {
             // assume it's a derivation
             pos = findDerivationFilename(state, v, arg);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -472,22 +472,19 @@ bool NixRepl::processLine(string line)
         Value v;
         evalString(arg, v);
 
-        std::string filename;
-        int lineno = 0;
+        Pos pos;
 
         if (v.type == tPath || v.type == tString) {
             PathSet context;
-            filename = state.coerceToString(noPos, v, context);
-            lineno = 0;
+            auto filename = state.coerceToString(noPos, v, context);
+            pos.file = state.symbols.create(filename);
         } else {
             // assume it's a derivation
-            Pos pos = findDerivationFilename(state, v, arg);
-            filename = pos.file;
-            lineno = pos.line;
+            pos = findDerivationFilename(state, v, arg);
         }
 
         // Open in EDITOR
-        auto args = editorFor(filename, lineno);
+        auto args = editorFor(pos);
         auto editor = args.front();
         args.pop_front();
         runProgram(editor, args);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -481,7 +481,9 @@ bool NixRepl::processLine(string line)
             lineno = 0;
         } else {
             // assume it's a derivation
-            std::tie(filename, lineno) = findDerivationFilename(state, v, arg);
+            Pos pos = findDerivationFilename(state, v, arg);
+            filename = pos.file;
+            lineno = pos.line;
         }
 
         // Open in EDITOR

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -506,15 +506,8 @@ bool NixRepl::processLine(string line)
         }
 
         // Open in EDITOR
-        auto editor = getEnv("EDITOR", "cat");
-        auto args = tokenizeString<Strings>(editor);
-        if (lineno > 0 && (
-            editor.find("emacs") != std::string::npos ||
-            editor.find("nano") != std::string::npos ||
-            editor.find("vim") != std::string::npos))
-            args.push_back(fmt("+%d", lineno));
-        args.push_back(filename);
-        editor = args.front();
+        auto args = editorFor(filename, lineno);
+        auto editor = args.front();
         args.pop_front();
         runProgram(editor, args);
 


### PR DESCRIPTION
This allows to have a repl-centric workflow to working on nixpkgs.

Usage:

    :edit <package> - heuristic that find the package file path

    :edit <path> - just open the editor on the file path

Once invoked, `nix repl` will open $EDITOR on that file path. Once the
editor exits, `nix repl` will automatically reload itself.