### PR TITLE
Add inNixShell = true to nix-shell auto-call

### DIFF
--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -7,9 +7,9 @@ export IMPURE_VAR=foo
 export SELECTED_IMPURE_VAR=baz
 export NIX_BUILD_SHELL=$SHELL
 output=$(nix-shell --pure shell.nix -A shellDrv --run \
-    'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX"')
+    'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX - $TEST_inNixShell"')
 
-[ "$output" = " - foo - bar" ]
+[ "$output" = " - foo - bar - true" ]
 
 # Test --keep
 output=$(nix-shell --pure --keep SELECTED_IMPURE_VAR shell.nix -A shellDrv --run \
@@ -19,10 +19,10 @@ output=$(nix-shell --pure --keep SELECTED_IMPURE_VAR shell.nix -A shellDrv --run
 
 # Test nix-shell on a .drv
 [[ $(nix-shell --pure $(nix-instantiate shell.nix -A shellDrv) --run \
-    'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX"') = " - foo - bar" ]]
+    'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX - $TEST_inNixShell"') = " - foo - bar - false" ]]
 
 [[ $(nix-shell --pure $(nix-instantiate shell.nix -A shellDrv) --run \
-    'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX"') = " - foo - bar" ]]
+    'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX - $TEST_inNixShell"') = " - foo - bar - false" ]]
 
 # Test nix-shell on a .drv symlink
 

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,4 +1,4 @@
-{ }:
+{ inNixShell ? false }:
 
 with import ./config.nix;
 
@@ -22,6 +22,7 @@ let pkgs = rec {
     name = "shellDrv";
     builder = "/does/not/exist";
     VAR_FROM_NIX = "bar";
+    TEST_inNixShell = if inNixShell then "true" else "false";
     inherit stdenv;
   };
 


### PR DESCRIPTION
This is an alternative to the IN_NIX_SHELL environment variable,
allowing the expression to adapt itself to nix-shell without
triggering those adaptations when used as a dependency of another
shell.

Closes #3147