### PR TITLE
nix: allow top-level installables

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -45,6 +45,10 @@ struct CmdBuild : MixDryRun, InstallablesCommand
                 "To build the build.x86_64-linux attribute from release.nix:",
                 "nix build -f release.nix build.x86_64-linux"
             },
+            Example{
+                "To build a top-level derivation:"
+                "nix build -f default.nix ."
+            },
         };
     }
 

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -47,6 +47,10 @@ struct CmdEval : MixJSON, InstallableCommand
                 "To print the store path of the Hello package:",
                 "nix eval --raw nixpkgs.hello"
             },
+            Example{
+                "To print the top-level attribute:",
+                "nix eval -f default.nix ."
+            },
         };
     }
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -189,7 +189,7 @@ struct InstallableAttrPath : InstallableValue
 
 // FIXME: extend
 std::string attrRegex = R"([A-Za-z_][A-Za-z0-9-_+]*)";
-static std::regex attrPathRegex(fmt(R"(%1%(\.%1%)*)", attrRegex));
+static std::regex attrPathRegex(fmt(R"(\.|%1%(\.%1%)*)", attrRegex));
 
 static std::vector<std::shared_ptr<Installable>> parseInstallables(
     SourceExprCommand & cmd, ref<Store> store, std::vector<std::string> ss, bool useDefaultInstallables)
@@ -203,6 +203,7 @@ static std::vector<std::shared_ptr<Installable>> parseInstallables(
     }
 
     for (auto & s : ss) {
+        if (s == ".") s = "";
 
         if (s.compare(0, 1, "(") == 0)
             result.push_back(std::make_shared<InstallableExpr>(cmd, s));


### PR DESCRIPTION
This brings a missing feature from the v1 CLI.

Old syntax: `nix-build default.nix`

New syntax: `nix build -f default.nix .`

Currently the v2 CLI can only build installables if they are part of a returnd attribute set, like nixpkgs.