### PR TITLE
libexpr: add position to builtins.trace

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -498,9 +498,9 @@ static void prim_trace(EvalState & state, const Pos & pos, Value * * args, Value
 {
     state.forceValue(*args[0]);
     if (args[0]->type == tString)
-        printError(format("trace: %1%") % args[0]->string.s);
+        printError(format("trace: %1% at %2%") % args[0]->string.s % pos);
     else
-        printError(format("trace: %1%") % *args[0]);
+        printError(format("trace: %1% at %2%") % *args[0] % pos);
     state.forceValue(*args[1]);
     v = *args[1];
 }


### PR DESCRIPTION
Let the user know where the trace was produced by adding the filename
and lineno from where that function was called.

/cc happy birthday @domenkozar :p