### PR TITLE
add a filter function argument to builtins.fetchGit

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -385,6 +385,16 @@ stdenv.mkDerivation { … }
             <para>
               The URL of the repo.
             </para>
+            <para>
+              Note that the <literal>url</literal> attribute can also be a path to a
+              local git repository in which case the files in the git index
+              (files which are either committed or staged) will be copied to the
+              store.
+            </para>
+            <para>
+              Note that only files which satisfy the optional
+              <literal>filter</literal> function are copied to the store.
+            </para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -419,6 +429,18 @@ stdenv.mkDerivation { … }
               with <literal>refs/heads/</literal>. As of Nix 2.3.0
               Nix will not prefix <literal>refs/heads/</literal> if
               <varname>ref</varname> starts with <literal>refs/</literal>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>filter</term>
+          <listitem>
+            <para>
+              A function to filter the resulting git checkout. Its type is the
+              same type as expected by <link
+              linkend="builtin-filterSource">builtins.filterSource</link>, with
+              the same semantics except that the path is always relative to the
+              git checkout.
             </para>
           </listitem>
         </varlistentry>
@@ -506,6 +528,28 @@ stdenv.mkDerivation { … }
   ref = "master";
 }</programlisting>
       </example>
+
+      <example>
+        <title>Fetching a local git repository and using a filter to only
+        include sub directories</title>
+        <para>
+          The following function is useful when working with a monorepo
+          containing multiple projects in sub directories. In such a setup each
+          sub directory typically has its own derivation. The
+          <literal>src</literal> attribute of each derivation can then be set to
+          the output of this function. This ensures that local nix builds are
+          reproducible on CI.
+        </para>
+        <programlisting><![CDATA[let fetchGitSubDir = url: subdir: builtins.fetchGit {
+  inherit url;
+  filter = path: type:
+    (lib.hasPrefix (subdir + "/") path) ||
+                   (type == "directory" && path == subdir);
+};
+in fetchGitSubDir ./my-repo "my-sub-project"
+]]></programlisting>
+      </example>
+
     </listitem>
   </varlistentry>
 

--- a/tests/fetchGit-subdir.nix
+++ b/tests/fetchGit-subdir.nix
@@ -1,0 +1,10 @@
+url: subdir: with builtins;
+let
+  hasPrefix  = pref: str: substring 0 (stringLength pref) str == pref;
+in
+builtins.fetchGit {
+  inherit url;
+  filter = path: type:
+    (hasPrefix (subdir + "/") path) ||
+               (type == "directory" && path == subdir);
+}

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -81,6 +81,11 @@ path2=$(nix eval --raw "(builtins.fetchGit $repo).outPath")
 
 [[ $(nix eval --raw "(builtins.fetchGit $repo).rev") = 0000000000000000000000000000000000000000 ]]
 
+# Check whether filtering an unclean tree works
+dir1=$(nix eval --raw "(import ./fetchGit-subdir.nix $repo \"dir1\").outPath")
+[   -e $dir1/dir1/foo ]
+[ ! -e $dir1/dir2 ]
+
 # ... unless we're using an explicit ref or rev.
 path3=$(nix eval --raw "(builtins.fetchGit { url = $repo; ref = \"master\"; }).outPath")
 [[ $path = $path3 ]]
@@ -93,6 +98,11 @@ git -C $repo commit -m 'Bla3' -a
 
 path4=$(nix eval --tarball-ttl 0 --raw "(builtins.fetchGit file://$repo).outPath")
 [[ $path2 = $path4 ]]
+
+# Check whether filtering a clean tree procudes the same result as an unclean tree
+dir1=$(nix eval --raw "(import ./fetchGit-subdir.nix $repo \"dir1\").outPath")
+[   -e $dir1/dir1/foo ]
+[ ! -e $dir1/dir2 ]
 
 # tarball-ttl should be ignored if we specify a rev
 echo delft > $repo/hello


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nix/issues/2944.

When working with monorepos containing projects in sub directories
each sub project typically has a derivation where the `src` attribute
is set to the path of the sub directory.

That setup is not ideal since all files below that sub directory,
including build artefacts, temporary files or even secrets, will be
copied to the store. Ideally only files added to the git repository
should be copied to the store to ensure local nix builds are
reproducible on CI.

Note that `builtins.fetchGit` can be used to copy a local git
repository to the store. This commit extends `builtins.fetchGit` with
a filter function argument which can be used to only include a sub
directory.

The filter function has the same type as expected by
`builtins.filterSource` and has the same semantics except that the
path is relative to the git checkout.

@edolstra at NixCon you mentioned we should possibly think about a more compositional API since most builtin fetch functions now take a filter argument. However this addition provides in a common need and prevents users from IFD. Let me know what you think.