### PR TITLE
add --pure option to dev-shell

### DIFF
--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -229,14 +229,15 @@ struct Common : InstallableCommand, MixProfile
 
 struct CmdDevShell : Common
 {
-    bool pure = false;
+    bool ignoreEnvironment = false;
 
     CmdDevShell()
     {
         mkFlag()
-            .longName("pure")
+            .longName("ignore-environment")
+            .shortName('i')
             .description("clear almost all environment variables")
-            .set(&pure, true);
+            .set(&ignoreEnvironment, true);
     }
 
     std::string description() override
@@ -288,7 +289,7 @@ struct CmdDevShell : Common
         restoreAffinity();
         restoreSignals();
 
-        if (pure) {
+        if (ignoreEnvironment) {
             Strings envVars;
             for (auto var : keepVars) {
                 auto val = getEnv(var, "");

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -291,7 +291,7 @@ struct CmdDevShell : Common
 
         if (ignoreEnvironment) {
             Strings envVars;
-            for (auto var : keepVars) {
+            for (const auto & var : keepVars) {
                 auto val = getEnv(var, "");
                 if (!val.empty()) {
                     envVars.emplace_back(fmt("%s=%s", var, val));


### PR DESCRIPTION
Fixes #2813 

If --pure is passed to dev-shell, call execvpe with only the variables in keepVars