### PR TITLE
Minor updates to inline comments

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -45,9 +45,7 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
 
         if (!clean) {
 
-            /* This is an unclean working tree. So copy all tracked
-               files. */
-
+            /* This is an unclean working tree. So copy all tracked files. */
             GitInfo gitInfo;
             gitInfo.rev = "0000000000000000000000000000000000000000";
             gitInfo.shortRev = std::string(gitInfo.rev, 0, 7);

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3264,8 +3264,7 @@ void DerivationGoal::registerOutputs()
             i.second.parseHashInfo(recursive, h);
 
             if (!recursive) {
-                /* The output path should be a regular file without
-                   execute permission. */
+                /* The output path should be a regular file without execute permission. */
                 if (!S_ISREG(st.st_mode) || (st.st_mode & S_IXUSR) != 0)
                     throw BuildError(
                         format("output path '%1%' should be a non-executable regular file") % path);
@@ -3343,8 +3342,7 @@ void DerivationGoal::registerOutputs()
                         % drvPath % path);
             }
 
-            /* Since we verified the build, it's now ultimately
-               trusted. */
+            /* Since we verified the build, it's now ultimately trusted. */
             if (!info.ultimate) {
                 info.ultimate = true;
                 worker.store.signPathInfo(info);
@@ -3354,8 +3352,7 @@ void DerivationGoal::registerOutputs()
             continue;
         }
 
-        /* For debugging, print out the referenced and unreferenced
-           paths. */
+        /* For debugging, print out the referenced and unreferenced paths. */
         for (auto & i : inputPaths) {
             PathSet::iterator j = references.find(i);
             if (j == references.end())
@@ -3413,8 +3410,7 @@ void DerivationGoal::registerOutputs()
             }
     }
 
-    /* If this is the first round of several, then move the output out
-       of the way. */
+    /* If this is the first round of several, then move the output out of the way. */
     if (nrRounds > 1 && curRound == 1 && curRound < nrRounds && keepPreviousRound) {
         for (auto & i : drv->outputs) {
             Path prev = i.second.path + checkSuffix;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -937,8 +937,7 @@ void LocalStore::registerValidPaths(const ValidPathInfos & infos)
            not be valid yet. */
         for (auto & i : infos)
             if (isDerivation(i.path)) {
-                // FIXME: inefficient; we already loaded the
-                // derivation in addValidPath().
+                // FIXME: inefficient; we already loaded the derivation in addValidPath().
                 Derivation drv = readDerivation(realStoreDir + "/" + baseNameOf(i.path));
                 checkDerivationOutputs(i.path, drv);
             }

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -632,8 +632,7 @@ static void opDelete(Strings opFlags, Strings opArgs)
 }
 
 
-/* Dump a path as a Nix archive.  The archive is written to standard
-   output. */
+/* Dump a path as a Nix archive.  The archive is written to stdout */
 static void opDump(Strings opFlags, Strings opArgs)
 {
     if (!opFlags.empty()) throw UsageError("unknown flag");
@@ -646,8 +645,7 @@ static void opDump(Strings opFlags, Strings opArgs)
 }
 
 
-/* Restore a value from a Nix archive.  The archive is read from
-   standard input. */
+/* Restore a value from a Nix archive.  The archive is read from stdin. */
 static void opRestore(Strings opFlags, Strings opArgs)
 {
     if (!opFlags.empty()) throw UsageError("unknown flag");

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -34,7 +34,7 @@ struct Command : virtual Args
 
 class Store;
 
-/* A command that require a Nix store. */
+/* A command that requires a Nix store. */
 struct StoreCommand : virtual Command
 {
     StoreCommand();
@@ -115,6 +115,7 @@ private:
     std::vector<std::string> _installables;
 };
 
+/* A command that operates on exactly one "installable" */
 struct InstallableCommand : virtual Args, SourceExprCommand
 {
     std::shared_ptr<Installable> installable;


### PR DESCRIPTION
Add missing docstring on InstallableCommand. Also, some of these were wrapped
when they're right next to a line longer than the unwrapped line, so we can just
unwrap them to save vertical space.