### PR TITLE
Manual: update appendix on nar production/consumption

### DIFF
--- a/doc/manual/glossary/glossary.xml
+++ b/doc/manual/glossary/glossary.xml
@@ -186,8 +186,8 @@
   <emphasis>AR</emphasis>chive.  This is a serialisation of a path in
   the Nix store.  It can contain regular files, directories and
   symbolic links.  NARs are generated and unpacked using
-  <command>nix-store --dump</command> and <command>nix-store
-  --restore</command>.</para></glossdef>
+  <command>nix-store --export</command> and <command>nix-store
+  --import</command>.</para></glossdef>
 
 </glossentry>
 


### PR DESCRIPTION
The NAR produced by `--export` seems to work juts as well as the NAR produced by
`--dump`, except that it can *also* be safely imported into an existing nix
store and update the sqlite metadata. This commit changes the manual to
reference export/import by default.

See #3183 for a potential followup pending discussion.