### PR TITLE
travis: enable linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
-os: osx
-script: ./tests/install-darwin.sh
+matrix:
+  include:
+    - language: osx
+      script: ./tests/install-darwin.sh
+    - language: nix
+      script: nix-build release.nix -A build.x86_64-linux
+notifications:
+  email: false


### PR DESCRIPTION
Also disable email to not notify the whole NixOS community about build failures