### PR TITLE
environment fixes in run

### DIFF
--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -159,7 +159,7 @@ void MixEnvironment::setEnviron() {
 
         for (const auto & var : keep) {
             auto val = getenv(var.c_str());
-            if (val) stringEnv.emplace_back(fmt("%s=%s", var.c_str(), val));
+            if (val) stringsEnv.emplace_back(fmt("%s=%s", var.c_str(), val));
         }
         vectorEnv = stringsToCharPtrs(stringsEnv);
         environ = vectorEnv.data();

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -194,4 +194,17 @@ struct MixDefaultProfile : MixProfile
     MixDefaultProfile();
 };
 
+struct MixEnvironment : virtual Args {
+
+    StringSet keep, unset;
+    Strings stringsEnv;
+    std::vector<char*> vectorEnv;
+    bool ignoreEnvironment;
+
+    MixEnvironment();
+
+    /* Modify global environ based on ignoreEnvironment, keep, and unset. It's expected that exec will be called before this class goes out of scope, otherwise environ will become invalid. */
+    void setEnviron();
+};
+
 }

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -229,7 +229,7 @@ struct Common : InstallableCommand, MixProfile
     }
 };
 
-struct CmdDevShell : Common
+struct CmdDevShell : Common, MixEnvironment
 {
     std::string description() override
     {
@@ -274,6 +274,8 @@ struct CmdDevShell : Common
         stopProgressBar();
 
         auto shell = getEnv("SHELL", "bash");
+
+        setEnviron();
 
         auto args = Strings{baseNameOf(shell), "--rcfile", rcFilePath};
 


### PR DESCRIPTION
Code in #3172 which adds --ignore-environment to dev-shell is redundant because --ignore-environment is already implemented for run. I moved the related code in run to a separate function. If doing it this way works, I was thinking I could move it to a common class that both run and dev-shell can inherit from.

I also changed the way ignore environment is handled, creating a new char* array if ignoreEnvironment is set rather than calling clearEnv. The previous way of doing it had to getenv, clearenv, and setenv for every kept variable, and clearenv for all variables, so it seems like creating a new array might be a better way of doing it that just does one getenv for kept variables. Not sure if it makes the call to runProgram and handling of PATH too complicated.