### PR TITLE
Kaiha/pr/readline

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -329,6 +329,11 @@ bool NixRepl::getLine(string & input, const std::string &prompt)
 
     if (!s)
       return false;
+#ifdef READLINE
+    if (*s) {
+        add_history(s);
+    }
+#endif
     input += s;
     input += '\n';
     return true;


### PR DESCRIPTION
Implement completion and history for `nix repl` when compiled against _libreadline_ instead of _libeditline_.