### PR TITLE
docs: xref doesn't render in title

### DIFF
--- a/doc/manual/advanced-topics/post-build-hook.xml
+++ b/doc/manual/advanced-topics/post-build-hook.xml
@@ -5,7 +5,7 @@
       version="5.0"
       >
 
-<title>Using the <xref linkend="conf-post-build-hook" /></title>
+<title>Using the <option linkend="conf-post-build-hook">post-build-hook</option></title>
 <subtitle>Uploading to an S3-compatible binary cache after each build</subtitle>
 
 


### PR DESCRIPTION
The `post-build-hook` text currently appears in the index, but not on the actual title line of the section, this follows the pattern used in a previous section to get a reference into a title for `diff-hook`.

Unrelated, the subtitle on the next line is one of two in the doc besides the version line at the top of the documentation. The other is also in the advanced features section and it renders strangely in the html, it's as large as the title itself, but italic and below the title underline. Is there any general or project specific guidance of how to use docbook for this project?