### PR TITLE
Update nix eval --help msg to not include deprecated command

### DIFF
--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -41,7 +41,7 @@ struct CmdEval : MixJSON, InstallableCommand
             },
             Example{
                 "To get the current version of Nixpkgs:",
-                "nix eval --raw nixpkgs.lib.nixpkgsVersion"
+                "nix eval --raw nixpkgs.lib.version"
             },
             Example{
                 "To print the store path of the Hello package:",


### PR DESCRIPTION
Don't know if there's a reason to include the deprecated command as per https://github.com/NixOS/nixpkgs/blob/8252861507ef85b45f739c63f27d4e9a80b31b31/lib/trivial.nix#L199