### PR TITLE
Fix progress bar when nix-prefetch-url is piped.

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1467,7 +1467,7 @@ static Sync<std::pair<unsigned short, unsigned short>> windowSize{{0, 0}};
 static void updateWindowSize()
 {
     struct winsize ws;
-    if (ioctl(1, TIOCGWINSZ, &ws) == 0) {
+    if (ioctl(2, TIOCGWINSZ, &ws) == 0) {
         auto windowSize_(windowSize.lock());
         windowSize_->first = ws.ws_row;
         windowSize_->second = ws.ws_col;

--- a/src/nix/progress-bar.cc
+++ b/src/nix/progress-bar.cc
@@ -341,7 +341,7 @@ public:
         }
 
         auto width = getWindowSize().second;
-        if (width <= 0) std::numeric_limits<decltype(width)>::max();
+        if (width <= 0) width = std::numeric_limits<decltype(width)>::max();
 
         writeToStderr("\r" + filterANSIEscapes(line, false, width) + "\e[K");
     }


### PR DESCRIPTION
The intent of the code was that if the window size cannot be determined,
it would be treated as having the maximum possible size. Because of a
missing assignment, it was actually treated as having a width of 0.

The reason the width could not be determined was because it was obtained
from stdout, not stderr, even though the printing was done to stderr.

This commit addresses both issues.