### PR TITLE
install: configure and bootstrap synthetic.conf on darwin

### DIFF
--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -230,8 +230,10 @@ LABEL=Nix\040Store /nix apfs rw
       </para>
 
       <para>
-        This new volume also won't be encrypted by default, and enabling is
-        only possible interactively?
+        This new volume also won't be encrypted by default, and enabling it
+        requires extra setup.  For machines with a <link xlink:href="https://www.apple.com/euro/mac/shared/docs/Apple_T2_Security_Chip_Overview.pdf">T2 chip</link>
+        all data is already entrypted at rest, older hardware won't even when
+        FileVault is enabled for the rest of the system.
       </para>
 
 <screen>

--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -136,6 +136,109 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
 
 </section>
 
+<section xml:id="sect-apfs-volume-installation">
+  <title>APFS Volume Installation</title>
+
+  <para>
+    The root filesystem is read-only as of macOS 10.15 Catalina, all writable
+    paths to a separate data volume.  This means creating or writing to <filename>/nix</filename>
+    is not allowed.  While changing the default prefix would be possible, it's
+    a very intrusive change that has side effects we want to avoid for now.
+  </para>
+
+  <para>
+    For common writable locations <literal>firmlinks</literal> where introduced,
+    described by Apple as a "bi-directional wormhole" between two filesystems.
+    Essentially a bind mount for APFS volumes.  However this is (currently) not
+    user configurable and only available for paths like <filename>/Users</filename>.
+  </para>
+
+  <para>
+    For special cases like NFS mount points or package manager roots <link xlink:href="https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man5/synthetic.conf.5.html">synthetic.conf(5)</link>
+    provides a mechanism for some limited, user-controlled file-creation at <filename>/</filename>.
+    This only applies on a reboot, but <command>apfs.util</command> can be used
+    to trigger the creation (not deletion) of new entries.
+  </para>
+
+<screen>
+alice$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B
+</screen>
+
+  <itemizedlist>
+    <listitem>
+      <para>
+        The simplest solution is creating a symlink with <filename>/etc/synthetic.conf</filename>
+        to the data volume. (not recommended)
+      </para>
+
+<screen>
+nix    /System/Volumes/Data/nix
+</screen>
+
+<screen>
+alice$ ls -l /
+lrwxr-xr-x   1 root  wheel    25 Jan  1  2019 nix -> /System/Volumes/Data/nix
+</screen>
+
+      <para>
+        However builds that detect or resolve this symlink will leak the canonical
+        location or even fail in certain cases, making this approach undesirable.
+      </para>
+    </listitem>
+
+    <listitem>
+      <para>
+        An empty directory can also be created using <filename>/etc/synthetic.conf</filename>,
+        this won't be writable but can be used as a mount point.  And with
+        <literal>APFS</literal> it's relatively easy to create an separate
+        volume for nix instead.
+      </para>
+
+<screen>
+nix
+</screen>
+
+<screen>
+alice$ sudo diskutil apfs addVolume diskX APFS 'Nix Store' -mountpoint /nix
+alice$ mount
+/dev/disk1s6 on /nix (apfs, local, journaled)
+</screen>
+
+      <para>
+        This does make the installation more complicated, requiring both
+        <filename>/etc/synthetic.conf</filename> as well as <filename>/etc/fstab</filename>
+      </para>
+
+<screen>
+#
+# Warning - this file should only be modified with vifs(8)
+#
+# Failure to do so is unsupported and may be destructive.
+#
+LABEL=Nix\040Store /nix apfs rw
+</screen>
+
+      <para>
+        On macOS volumes are also mounted quite late, launchd services or other
+        things that start during login will start before our volume is mounted.
+        For these cases eg. <command>wait4path</command> must be used for
+        things that depend on <filename>/nix</filename>.
+      </para>
+
+      <para>
+        This new volume also won't be encrypted by default, and enabling is
+        only possible interactively?
+      </para>
+
+<screen>
+diskutil apfs enableFileVault /nix -user disk
+</screen>
+
+    </listitem>
+  </itemizedlist>
+
+</section>
+
 <section xml:id="sect-nix-install-pinned-version-url">
   <title>Installing a pinned Nix version from a URL</title>
 

--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -199,6 +199,7 @@ nix
 </screen>
 
 <screen>
+alice$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B
 alice$ sudo diskutil apfs addVolume diskX APFS 'Nix Store' -mountpoint /nix
 alice$ mount
 /dev/disk1s6 on /nix (apfs, local, journaled)
@@ -231,7 +232,7 @@ LABEL=Nix\040Store /nix apfs rw
       </para>
 
 <screen>
-diskutil apfs enableFileVault /nix -user disk
+alice$ diskutil apfs enableFileVault /nix -user disk
 </screen>
 
     </listitem>

--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -6,16 +6,30 @@
 
 <title>Installing a Binary Distribution</title>
 
-<para>If you are using Linux or macOS, the easiest way to install Nix
-is to run the following command:
+<para>
+  If you are using Linux or macOS versions up to 10.14 (Mojave), the
+  easiest way to install Nix is to run the following command:
+</para>
 
 <screen>
   $ sh &lt;(curl https://nixos.org/nix/install)
 </screen>
 
-As of Nix 2.1.0, the Nix installer will always default to creating a
-single-user installation, however opting in to the multi-user
-installation is highly recommended.
+<para>
+  If you're using macOS 10.15 (Catalina) or newer, consult
+  <link linkend="sect-macos-installation">the macOS installation instructions</link>
+  before installing.
+</para>
+
+<para>
+  As of Nix 2.1.0, the Nix installer will always default to creating a
+  single-user installation, however opting in to the multi-user
+  installation is highly recommended.
+  <!-- TODO: this explains *neither* why the default version is
+  single-user, nor why we'd recommend multi-user over the default.
+  True prospective users don't have much basis for evaluating this.
+  What's it to me? Who should pick which? Why? What if I pick wrong?
+  -->
 </para>
 
 <section xml:id="sect-single-user-installation">
@@ -36,7 +50,7 @@ run this under your usual user account, <emphasis>not</emphasis> as
 root.  The script will invoke <command>sudo</command> to create
 <filename>/nix</filename> if it doesn’t already exist.  If you don’t
 have <command>sudo</command>, you should manually create
-<command>/nix</command> first as root, e.g.:
+<filename>/nix</filename> first as root, e.g.:
 
 <screen>
 $ mkdir /nix
@@ -47,7 +61,7 @@ The install script will modify the first writable file from amongst
 <filename>.bash_profile</filename>, <filename>.bash_login</filename>
 and <filename>.profile</filename> to source
 <filename>~/.nix-profile/etc/profile.d/nix.sh</filename>. You can set
-the <command>NIX_INSTALLER_NO_MODIFY_PROFILE</command> environment
+the <envar>NIX_INSTALLER_NO_MODIFY_PROFILE</envar> environment
 variable before executing the install script to disable this
 behaviour.
 </para>
@@ -81,11 +95,9 @@ $ rm -rf /nix
   <para>
     You can instruct the installer to perform a multi-user
     installation on your system:
-
-    <screen>
-  sh &lt;(curl https://nixos.org/nix/install) --daemon
-</screen>
   </para>
+
+  <screen>sh &lt;(curl https://nixos.org/nix/install) --daemon</screen>
 
   <para>
     The multi-user installation of Nix will create build users between
@@ -136,82 +148,253 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
 
 </section>
 
-<section xml:id="sect-apfs-volume-installation">
-  <title>APFS Volume Installation</title>
+<section xml:id="sect-macos-installation">
+  <title>macOS Installation</title>
 
   <para>
-    The root filesystem is read-only as of macOS 10.15 Catalina, all writable
-    paths were moved to a separate data volume.  This means creating or writing
-    to <filename>/nix</filename> is not allowed.  While changing the default prefix
-    would be possible, it's a very intrusive change that has side effects we want to
-    avoid for now.
+    Starting with macOS 10.15 (Catalina), the root filesystem is read-only.
+    This means <filename>/nix</filename> can no longer live on your system
+    volume, and that you'll need a workaround to install Nix.
   </para>
 
   <para>
-    For common writable locations <literal>firmlinks</literal> were introduced,
-    described by Apple as a "bi-directional wormhole" between two filesystems.
-    Essentially a bind mount for APFS volumes.  However this is (currently) not
-    user configurable and only available for paths like <filename>/Users</filename>.
+    The recommended approach, which creates an unencrypted APFS volume
+    for your Nix store and a "synthetic" empty directory to mount it
+    over at <filename>/nix</filename>, is least likely to impair Nix
+    or your system.
   </para>
+
+  <note><para>
+    With all separate-volume approaches, it's possible something on
+    your system (particularly daemons/services and restored apps) may
+    need access to your Nix store before the volume is mounted. Adding
+    additional encryption makes this more likely.
+  </para></note>
 
   <para>
-    For special cases like NFS mount points or package manager roots <link xlink:href="https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man5/synthetic.conf.5.html">synthetic.conf(5)</link>
-    provides a mechanism for some limited, user-controlled file-creation at <filename>/</filename>.
-    This only applies at boot time, however <command>apfs.util</command> can be used
-    to trigger the creation (not deletion) of new entries without a reboot.
-    It would be ideal if this could create firmlinks, however a symlink or mountpoint
-    are the only options.
+    If you're using a recent Mac with a
+    <link xlink:href="https://www.apple.com/euro/mac/shared/docs/Apple_T2_Security_Chip_Overview.pdf">T2 chip</link>,
+    your drive will still be encrypted at rest (in which case "unencrypted"
+    is a bit of a misnomer). To use this approach, just install Nix with:
   </para>
 
-<screen>
-alice$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B
-</screen>
+  <screen>$ sh &lt;(curl https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume</screen>
 
-  <itemizedlist>
-    <listitem>
-      <para>
-        The simplest solution is creating a symlink with <filename>/etc/synthetic.conf</filename>
-        to the data volume. (not recommended)
-      </para>
+  <para>
+    If you don't like the sound of this, you'll want to weigh the
+    other approaches and tradeoffs detailed in this section.
+  </para>
 
-<screen>
-nix    /System/Volumes/Data/nix
-</screen>
+  <note>
+    <title>Eventual solutions?</title>
+    <para>
+      All of the known workarounds have drawbacks, but we hope
+      better solutions will be available in the future. Some that
+      we have our eye on are:
+    </para>
+    <orderedlist>
+      <listitem>
+        <para>
+          A true firmlink would enable the Nix store to live on the
+          primary data volume without the build problems caused by
+          the symlink approach. End users cannot currently
+          create true firmlinks.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          If the Nix store volume shared FileVault encryption
+          with the primary data volume (probably by using the same
+          volume group and role), FileVault encryption could be
+          easily supported by the installer without requiring
+          manual setup by each user.
+        </para>
+      </listitem>
+    </orderedlist>
+  </note>
 
-<screen>
-alice$ ls -l /
-lrwxr-xr-x   1 root  wheel    25 Jan  1  2019 nix -> /System/Volumes/Data/nix
-</screen>
+  <section xml:id="sect-macos-installation-change-store-prefix">
+    <title>Change the Nix store path prefix</title>
+    <para>
+      Changing the default prefix for the Nix store is a simple
+      approach which enables you to leave it on your root volume,
+      where it can take full advantage of FileVault encryption if
+      enabled. Unfortunately, this approach also opts your device out
+      of some benefits that are enabled by using the same prefix
+      across systems:
 
-      <para>
-        However builds that detect or resolve this symlink will leak the canonical
-        location or even fail in certain cases, making this approach undesirable.
-      </para>
-    </listitem>
+      <itemizedlist>
+        <listitem>
+          <para>
+            Your system won't be able to take advantage of the binary
+            cache (unless someone is able to stand up and support
+            duplicate caching infrastructure), which means you'll
+            spend more time waiting for builds.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            It's harder to build and deploy packages to Linux systems.
+          </para>
+        </listitem>
+        <!-- TODO: may be more here -->
+      </itemizedlist>
 
-    <listitem>
-      <para>
-        An empty directory can also be created using <filename>/etc/synthetic.conf</filename>,
-        this won't be writable but can be used as a mount point.  And with
-        <literal>APFS</literal> it's relatively easy to create an separate
-        volume for nix instead.
-      </para>
+      <!-- TODO: Yes, but how?! -->
 
-<screen>
-nix
-</screen>
+      It would also possible (and often requested) to just apply this
+      change ecosystem-wide, but it's an intrusive process that has
+      side effects we want to avoid for now.
+      <!-- magnificent hand-wavy gesture -->
+    </para>
+    <para>
+    </para>
+  </section>
 
-<screen>
-alice$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B
-alice$ sudo diskutil apfs addVolume diskX APFS 'Nix Store' -mountpoint /nix
-alice$ mount
-/dev/disk1s6 on /nix (apfs, local, journaled)
-</screen>
+  <section xml:id="sect-macos-installation-encrypted-volume">
+    <title>Use a separate encrypted volume</title>
+    <para>
+      If you like, you can also add encryption to the recommended
+      approach taken by the installer. You can do this by pre-creating
+      an encrypted volume before you run the installer--or you can
+      run the installer and encrypt the volume it creates later.
+      <!-- TODO: see later note about whether this needs both add-encryption and from-scratch directions -->
+    </para>
+    <para>
+      In either case, adding encryption to a second volume isn't quite
+      as simple as enabling FileVault for your boot volume. Before you
+      dive in, there are a few things to weigh:
+    </para>
+    <orderedlist>
+      <listitem>
+        <para>
+          The additional volume won't be encrypted with your existing
+          FileVault key, so you'll need another mechanism to decrypt
+          the volume.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          You can store the password in Keychain to automatically
+          decrypt the volume on boot--but it'll have to wait on Keychain
+          and may not mount before your GUI apps restore. If any of
+          your launchd agents or apps depend on Nix-installed software
+          (for example, if you use a Nix-installed login shell), the
+          restore may fail or break.
+        </para>
+        <para>
+          On a case-by-case basis, you may be able to work around this
+          problem by using <command>wait4path</command> to block
+          execution until your executable is available.
+        </para>
+        <para>
+          It's also possible to decrypt and mount the volume earlier
+          with a login hook--but this mechanism appears to be
+          deprecated and its future is unclear.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          You can hard-code the password in the clear, so that your
+          store volume can be decrypted before Keychain is available.
+        </para>
+      </listitem>
+    </orderedlist>
+    <para>
+      If you are comfortable navigating these tradeoffs, you can encrypt the volume with
+      something along the lines of:
+      <!-- TODO:
+      I don't know if this also needs from-scratch instructions?
+      can we just recommend use-the-installer-and-then-encrypt?
+      -->
+    </para>
+    <!--
+    TODO: it looks like this option can be encryptVolume|encrypt|enableFileVault
 
-      <para>
-        This does make the installation more complicated, requiring both
-        <filename>/etc/synthetic.conf</filename> as well as <filename>/etc/fstab</filename>
-      </para>
+    It may be more clear to use encryptVolume, here? FileVault seems
+    heavily associated with the boot-volume behavior; I worry
+    a little that it can mislead here, especially as it gets
+    copied around minus doc context...?
+    -->
+    <screen>alice$ diskutil apfs enableFileVault /nix -user disk</screen>
+
+    <!-- TODO: and then go into detail on the mount/decrypt approaches? -->
+  </section>
+
+  <section xml:id="sect-macos-installation-symlink">
+    <!--
+    Maybe a good razor is: if we'd hate having to support someone who
+    installed Nix this way, it shouldn't even be detailed?
+    -->
+    <title>Symlink the Nix store to a custom location</title>
+    <para>
+      Another simple approach is using <filename>/etc/synthetic.conf</filename>
+      to symlink the Nix store to the data volume. This option also
+      enables your store to share any configured FileVault encryption.
+      Unfortunately, builds that resolve the symlink may leak the
+      canonical path or even fail.
+    </para>
+    <para>
+      Because of these downsides, we can't recommend this approach.
+    </para>
+    <!-- Leaving out instructions for this one. -->
+  </section>
+
+  <section xml:id="sect-macos-installation-recommended-notes">
+    <title>Notes on the recommended approach</title>
+    <para>
+      This section goes into a little more detail on the recommended
+      approach. You don't need to understand it to run the installer,
+      but it can serve as a helpful reference if you run into trouble.
+    </para>
+    <orderedlist>
+      <listitem>
+        <para>
+          In order to compose user-writable locations into the new
+          read-only system root, Apple introduced a new concept called
+          <literal>firmlinks</literal>, which it describes as a
+          "bi-directional wormhole" between two filesystems. You can
+          see the current firmlinks in <filename>/usr/share/firmlinks</filename>.
+          Unfortunately, firmlinks aren't (currently?) user-configurable.
+        </para>
+
+        <para>
+          For special cases like NFS mount points or package manager roots,
+          <link xlink:href="https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man5/synthetic.conf.5.html">synthetic.conf(5)</link>
+          supports limited user-controlled file-creation (of symlinks,
+          and synthetic empty directories) at <filename>/</filename>.
+          To create a synthetic empty directory for mounting at <filename>/nix</filename>,
+          add the following line to <filename>/etc/synthetic.conf</filename>
+          (create it if necessary):
+        </para>
+
+        <screen>nix</screen>
+      </listitem>
+
+      <listitem>
+        <para>
+          This configuration is applied at boot time, but you can use
+          <command>apfs.util</command> to trigger creation (not deletion)
+          of new entries without a reboot:
+        </para>
+
+        <screen>alice$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B</screen>
+      </listitem>
+
+      <listitem>
+        <para>
+          Create the new APFS volume with diskutil:
+        </para>
+
+        <screen>alice$ sudo diskutil apfs addVolume diskX APFS 'Nix Store' -mountpoint /nix</screen>
+      </listitem>
+
+      <listitem>
+        <para>
+          Using <command>vifs</command>, add the new mount to
+          <filename>/etc/fstab</filename>. If it doesn't already have
+          other entries, it should look something like:
+        </para>
 
 <screen>
 #
@@ -219,29 +402,16 @@ alice$ mount
 #
 # Failure to do so is unsupported and may be destructive.
 #
-LABEL=Nix\040Store /nix apfs rw
+LABEL=Nix\040Store /nix apfs rw,nobrowse
 </screen>
 
-      <para>
-        On macOS volumes are also mounted quite late, launchd services or other
-        things that start during login will start before our volume is mounted.
-        For these cases eg. <command>wait4path</command> must be used for
-        things that depend on <filename>/nix</filename>.
-      </para>
-
-      <para>
-        This new volume also won't be encrypted by default, and enabling it
-        requires extra setup.  For machines with a <link xlink:href="https://www.apple.com/euro/mac/shared/docs/Apple_T2_Security_Chip_Overview.pdf">T2 chip</link>
-        all data is already entrypted at rest, older hardware won't even when
-        FileVault is enabled for the rest of the system.
-      </para>
-
-<screen>
-alice$ diskutil apfs enableFileVault /nix -user disk
-</screen>
-
-    </listitem>
-  </itemizedlist>
+        <para>
+          The nobrowse setting will keep Spotlight from indexing this
+          volume, and keep it from showing up on your desktop.
+        </para>
+      </listitem>
+    </orderedlist>
+  </section>
 
 </section>
 

--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -141,13 +141,14 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
 
   <para>
     The root filesystem is read-only as of macOS 10.15 Catalina, all writable
-    paths to a separate data volume.  This means creating or writing to <filename>/nix</filename>
-    is not allowed.  While changing the default prefix would be possible, it's
-    a very intrusive change that has side effects we want to avoid for now.
+    paths were moved to a separate data volume.  This means creating or writing
+    to <filename>/nix</filename> is not allowed.  While changing the default prefix
+    would be possible, it's a very intrusive change that has side effects we want to
+    avoid for now.
   </para>
 
   <para>
-    For common writable locations <literal>firmlinks</literal> where introduced,
+    For common writable locations <literal>firmlinks</literal> were introduced,
     described by Apple as a "bi-directional wormhole" between two filesystems.
     Essentially a bind mount for APFS volumes.  However this is (currently) not
     user configurable and only available for paths like <filename>/Users</filename>.
@@ -156,8 +157,10 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
   <para>
     For special cases like NFS mount points or package manager roots <link xlink:href="https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man5/synthetic.conf.5.html">synthetic.conf(5)</link>
     provides a mechanism for some limited, user-controlled file-creation at <filename>/</filename>.
-    This only applies on a reboot, but <command>apfs.util</command> can be used
-    to trigger the creation (not deletion) of new entries.
+    This only applies at boot time, however <command>apfs.util</command> can be used
+    to trigger the creation (not deletion) of new entries without a reboot.
+    It would be ideal if this could create firmlinks, however a symlink or mountpoint
+    are the only options.
   </para>
 
 <screen>

--- a/release.nix
+++ b/release.nix
@@ -177,10 +177,10 @@ let
         }
         ''
           cp ${installerClosureInfo}/registration $TMPDIR/reginfo
+          cp ${./scripts/create-darwin-volume.sh} $TMPDIR/create-darwin-volume.sh
           substitute ${./scripts/install-nix-from-closure.sh} $TMPDIR/install \
             --subst-var-by nix ${toplevel} \
             --subst-var-by cacert ${cacert}
-
           substitute ${./scripts/install-darwin-multi-user.sh} $TMPDIR/install-darwin-multi-user.sh \
             --subst-var-by nix ${toplevel} \
             --subst-var-by cacert ${cacert}
@@ -195,6 +195,7 @@ let
             # SC1090: Don't worry about not being able to find
             #         $nix/etc/profile.d/nix.sh
             shellcheck --exclude SC1090 $TMPDIR/install
+            shellcheck $TMPDIR/create-darwin-volume.sh
             shellcheck $TMPDIR/install-darwin-multi-user.sh
             shellcheck $TMPDIR/install-systemd-multi-user.sh
 
@@ -210,6 +211,7 @@ let
           fi
 
           chmod +x $TMPDIR/install
+          chmod +x $TMPDIR/create-darwin-volume.sh
           chmod +x $TMPDIR/install-darwin-multi-user.sh
           chmod +x $TMPDIR/install-systemd-multi-user.sh
           chmod +x $TMPDIR/install-multi-user
@@ -222,11 +224,15 @@ let
             --absolute-names \
             --hard-dereference \
             --transform "s,$TMPDIR/install,$dir/install," \
+            --transform "s,$TMPDIR/create-darwin-volume.sh,$dir/create-darwin-volume.sh," \
             --transform "s,$TMPDIR/reginfo,$dir/.reginfo," \
             --transform "s,$NIX_STORE,$dir/store,S" \
-            $TMPDIR/install $TMPDIR/install-darwin-multi-user.sh \
+            $TMPDIR/install \
+            $TMPDIR/create-darwin-volume.sh \
+            $TMPDIR/install-darwin-multi-user.sh \
             $TMPDIR/install-systemd-multi-user.sh \
-            $TMPDIR/install-multi-user $TMPDIR/reginfo \
+            $TMPDIR/install-multi-user \
+            $TMPDIR/reginfo \
             $(cat ${installerClosureInfo}/store-paths)
         '');
 

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-root_disks() {
-    diskutil list -plist /
+root_disk() {
+    diskutil info -plist /
 }
 
 apfs_volumes_for() {
@@ -11,7 +11,7 @@ apfs_volumes_for() {
 }
 
 disk_identifier() {
-    xpath "/plist/dict/key[text()='WholeDisks']/following-sibling::array[1]/string/text()" 2>/dev/null
+    xpath "/plist/dict/key[text()='ParentWholeDisk']/following-sibling::string[1]/text()" 2>/dev/null
 }
 
 volume_get() {
@@ -81,7 +81,7 @@ main() {
         sudo mkdir /nix
     fi
 
-    disk=$(root_disks | disk_identifier)
+    disk=$(root_disk | disk_identifier)
     volume=$(find_nix_volume "$disk")
     if [ -z "$volume" ]; then
         echo "Creating a Nix Store volume..." >&2

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -94,7 +94,7 @@ main() {
     if ! test_fstab; then
         echo "Configuring /etc/fstab..." >&2
         label=$(echo "$volume" | sed 's/ /\\040/g')
-        printf "\$a\nLABEL=%s /nix apfs rw\n.\nwq\n" "$label" | EDITOR=ed sudo vifs
+        printf "\$a\nLABEL=%s /nix apfs rw,nobrowse\n.\nwq\n" "$label" | EDITOR=ed sudo vifs
     fi
 
     echo "The following options can be enabled to disable spotlight indexing" >&2

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -39,11 +39,15 @@ find_nix_volume() {
 }
 
 test_fstab() {
-    grep -q "/nix" /etc/fstab 2>/dev/null
+    grep -q "/nix apfs rw" /etc/fstab 2>/dev/null
+}
+
+test_nix_symlink() {
+    [ -L "/nix" ] || grep -q "^nix." /etc/synthetic.conf 2>/dev/null
 }
 
 test_synthetic_conf() {
-    grep -q "^nix" /etc/synthetic.conf 2>/dev/null
+    grep -q "^nix$" /etc/synthetic.conf 2>/dev/null
 }
 
 test_nix() {
@@ -60,12 +64,12 @@ main() {
         echo ""
         echo "  1. Remove the entry from fstab using 'sudo vifs'"
         echo "  2. Destroy the data volume using 'diskutil apfs deleteVolume'"
-        echo "  3. Delete /etc/synthetic.conf"
+        echo "  3. Remove the 'nix' line from /etc/synthetic.conf or the file"
         echo ""
     ) >&2
 
-    if [ -L "/nix" ]; then
-        echo "error: /nix is a symlink, please remove it or edit synthetic.conf (requires reboot)" >&2
+    if test_nix_symlink; then
+        echo "error: /nix is a symlink, please remove it and make sure it's not in synthetic.conf (in which case a reboot is required)" >&2
         echo "  /nix -> $(readlink "/nix")" >&2
         exit 2
     fi

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+set -e
+
+root_disks() {
+    diskutil list -plist /
+}
+
+apfs_volumes_for() {
+    disk=$1
+    diskutil apfs list -plist "$disk"
+}
+
+disk_identifier() {
+    xpath "/plist/dict/key[text()='WholeDisks']/following-sibling::array[1]/string/text()" 2>/dev/null
+}
+
+volume_get() {
+    key=$1 i=$2
+    xpath "/plist/dict/array/dict/key[text()='Volumes']/following-sibling::array/dict[$i]/key[text()='$key']/following-sibling::string[1]/text()" 2> /dev/null
+}
+
+find_nix_volume() {
+    disk=$1
+    i=1
+    volumes=$(apfs_volumes_for "$disk")
+    while true; do
+        name=$(echo "$volumes" | volume_get "Name" "$i")
+        if [ -z "$name" ]; then
+            break
+        fi
+        case "$name" in
+            [Nn]ix*)
+                echo "$name"
+                break
+                ;;
+        esac
+        i=$((i+1))
+    done
+}
+
+test_fstab() {
+    grep -q "/nix" /etc/fstab 2>/dev/null
+}
+
+test_synthetic_conf() {
+    grep -q "^nix" /etc/synthetic.conf 2>/dev/null
+}
+
+test_nix() {
+    test -d "/nix"
+}
+
+main() {
+    (
+        echo ""
+        echo "     ------------------------------------------------------------------ "
+        echo "    | This installer will create a volume for the nix store and        |"
+        echo "    | configure it to mount at /nix.  Follow these steps to uninstall. |"
+        echo "     ------------------------------------------------------------------ "
+        echo ""
+        echo "  1. Remove the entry from fstab using 'sudo vifs'"
+        echo "  2. Destroy the data volume using 'diskutil apfs deleteVolume'"
+        echo "  3. Delete /etc/synthetic.conf"
+        echo ""
+    ) >&2
+
+    if [ -L "/nix" ]; then
+        echo "error: /nix is a symlink, please remove it or edit synthetic.conf (requires reboot)" >&2
+        echo "  /nix -> $(readlink "/nix")" >&2
+        exit 2
+    fi
+
+    if ! test_synthetic_conf; then
+        echo "Configuring /etc/synthetic.conf..." >&2
+        echo nix | sudo tee /etc/synthetic.conf
+        /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B
+    fi
+
+    if ! test_nix; then
+        echo "Creating mountpoint for /nix..." >&2
+        sudo mkdir /nix
+    fi
+
+    disk=$(root_disks | disk_identifier)
+    volume=$(find_nix_volume "$disk")
+    if [ -z "$volume" ]; then
+        echo "Creating a Nix Store volume..." >&2
+        sudo diskutil apfs addVolume "$disk" APFS 'Nix Store' -mountpoint /nix
+        volume="Nix Store"
+    else
+        echo "Using existing '$volume' volume" >&2
+    fi
+
+    if ! test_fstab; then
+        echo "Configuring /etc/fstab..." >&2
+        label=$(echo "$volume" | sed 's/ /\\040/g')
+        printf "\$a\nLABEL=%s /nix apfs rw\n.\nwq\n" "$label" | EDITOR=ed sudo vifs
+    fi
+
+    echo "The following options can be enabled to disable spotlight indexing" >&2
+    echo "of the volume, which might be desirable." >&2
+    echo "" >&2
+    echo "   $ mdutil -i off /nix" >&2
+    echo "" >&2
+}
+
+main "$@"

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -15,7 +15,7 @@ disk_identifier() {
 }
 
 volume_list_true() {
-    key=$1 t=$2
+    key=$1
     xpath "/plist/dict/array/dict/key[text()='Volumes']/following-sibling::array/dict/key[text()='$key']/following-sibling::true[1]" 2> /dev/null
 }
 

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -122,7 +122,7 @@ main() {
 
     if ! test_synthetic_conf; then
         echo "Configuring /etc/synthetic.conf..." >&2
-        echo nix | sudo tee /etc/synthetic.conf
+        echo nix | sudo tee -a /etc/synthetic.conf
         if ! test_synthetic_conf; then
             echo "error: failed to configure synthetic.conf;" >&2
             suggest_report_error

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -82,7 +82,7 @@ while [ $# -gt 0 ]; do
                     echo " --create-volume: Create an APFS volume for the store and create the /nix"
                     echo "                  mountpoint for it using synthetic.conf."
                     echo "                  (required on macOS >=10.15)"
-                    echo "                  See https://nixos.org/nix/manual/#sect-darwin-apfs-volume"
+                    echo "                  See https://nixos.org/nix/manual/#sect-apfs-volume-installation"
                     echo ""
                 ) >&2
             fi
@@ -102,10 +102,11 @@ if [ "$(uname -s)" = "Darwin" ]; then
         (
             echo ""
             echo "Installing on macOS >=10.15 requires relocating the store to an apfs volume."
-            echo "Use --create-volume or run the preparation steps manually."
-            echo "See https://nixos.org/nix/manual/#sect-darwin-apfs-volume."
+            echo "Use sh <(curl https://nixos.org/nix/install) --create-volume or run the preparation steps manually."
+            echo "See https://nixos.org/nix/manual/#sect-apfs-volume-installation"
             echo ""
         ) >&2
+        exit 1
     fi
 fi
 

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -197,6 +197,17 @@ if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
             break
         fi
     done
+    for i in .zshenv .zshrc; do
+        fn="$HOME/$i"
+        if [ -w "$fn" ]; then
+            if ! grep -q "$p" "$fn"; then
+                echo "modifying $fn..." >&2
+                echo "if [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
+            fi
+            added=1
+            break
+        fi
+    done
 fi
 
 if [ -z "$added" ]; then

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -52,7 +52,7 @@ while [ $# -gt 0 ]; do
             NIX_INSTALLER_NO_CHANNEL_ADD=1;;
         --no-modify-profile)
             NIX_INSTALLER_NO_MODIFY_PROFILE=1;;
-        --create-volume)
+        --darwin-use-unencrypted-nix-store-volume)
             CREATE_DARWIN_VOLUME=1;;
         *)
             (
@@ -77,12 +77,13 @@ while [ $# -gt 0 ]; do
                 echo ""
             ) >&2
 
-            if [ "$(uname -s)" = "Darwin" ]; then
+            # darwin and Catalina+
+            if [ "$(uname -s)" = "Darwin" ] && [ "$macos_major" -gt 14 ]; then
                 (
-                    echo " --create-volume: Create an APFS volume for the store and create the /nix"
-                    echo "                  mountpoint for it using synthetic.conf."
-                    echo "                  (required on macOS >=10.15)"
-                    echo "                  See https://nixos.org/nix/manual/#sect-apfs-volume-installation"
+                    echo " --darwin-use-unencrypted-nix-store-volume: Create an APFS volume for the Nix"
+                    echo "              store and mount it at /nix. This is the recommended way to create"
+                    echo "              /nix with a read-only / on macOS >=10.15."
+                    echo "              See: https://nixos.org/nix/manual/#sect-macos-installation"
                     echo ""
                 ) >&2
             fi
@@ -98,12 +99,12 @@ if [ "$(uname -s)" = "Darwin" ]; then
     fi
 
     info=$(diskutil info -plist / | xpath "/plist/dict/key[text()='Writable']/following-sibling::true[1]" 2> /dev/null)
-    if ! [ -e $dest ] && [ -n "$info" ]; then
+    if ! [ -e $dest ] && [ -n "$info" ] && [ "$macos_major" -gt 14 ]; then
         (
             echo ""
             echo "Installing on macOS >=10.15 requires relocating the store to an apfs volume."
-            echo "Use sh <(curl https://nixos.org/nix/install) --create-volume or run the preparation steps manually."
-            echo "See https://nixos.org/nix/manual/#sect-apfs-volume-installation"
+            echo "Use sh <(curl https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume or run the preparation steps manually."
+            echo "See https://nixos.org/nix/manual/#sect-macos-installation"
             echo ""
         ) >&2
         exit 1


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/2925.

Here's some preliminary documentation for the [apfs volume creation](https://dgn9s9wft3u6a.cloudfront.net/store/4iwvbj92fc10yyxla50an3vghajikwbl-manual/manual.html#sect-macos-installation) section.

Updated to create an apfs volume instead of using the symlink approach. This works on a clean install but I expect there are other corner cases that are not covered. More testing is probably required.

~Using a symlink instead of a separate volume is the most straightforward approach which relies less on darwin specific tools. However it does have some disadvantages, especially if this has to be changed in the future. Also the new location should be avoided for official infrastructure (at least for a while) so installation using an apfs volume should probably also be implemented somewhere.~

From my testing it looks like `apfs.util` works properly now, unless this breaks again a reboot can be bypassed for both mountpoints and symlinks.