### PR TITLE
Switch to std::uncaught_exceptions

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -218,6 +218,7 @@ struct ConnectionHandle
 {
     Pool<RemoteStore::Connection>::Handle handle;
     bool daemonException = false;
+    int uncaught_exceptions = std::uncaught_exceptions();
 
     ConnectionHandle(Pool<RemoteStore::Connection>::Handle && handle)
         : handle(std::move(handle))
@@ -229,7 +230,7 @@ struct ConnectionHandle
 
     ~ConnectionHandle()
     {
-        if (!daemonException && std::uncaught_exception()) {
+        if (!daemonException && std::uncaught_exceptions() != uncaught_exceptions) {
             handle.markBad();
             debug("closing daemon connection because of an exception");
         }

--- a/src/libutil/json.cc
+++ b/src/libutil/json.cc
@@ -173,7 +173,7 @@ JSONObject JSONPlaceholder::object()
 
 JSONPlaceholder::~JSONPlaceholder()
 {
-    assert(!first || std::uncaught_exception());
+    assert(!first || std::uncaught_exceptions() != uncaught_exceptions);
 }
 
 }

--- a/src/libutil/json.hh
+++ b/src/libutil/json.hh
@@ -150,6 +150,8 @@ private:
     friend class JSONList;
     friend class JSONObject;
 
+    int uncaught_exceptions = std::uncaught_exceptions();
+
     JSONPlaceholder(JSONState * state)
         : JSONWriter(state)
     {

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1181,7 +1181,7 @@ void _interrupted()
     /* Block user interrupts while an exception is being handled.
        Throwing an exception while another exception is being handled
        kills the program! */
-    if (!interruptThrown && !std::uncaught_exception()) {
+    if (!interruptThrown && std::uncaught_exceptions() == 0) {
         interruptThrown = true;
         throw Interrupted("interrupted by the user");
     }


### PR DESCRIPTION
This returns the number of uncaught exceptions. std::uncaught_exception
just returned whether there were any uncaught exceptions. c++17
deprecated it and c++20 will remove it. GCC 9 warns that the function is
deprecated.

std::uncaught_exceptions() can be > 1 if all exceptions are caught
before they propagate to a stack unwind. E.g. if a first exception
occurs and a destructor runs as part of the stack unwind, then that
destructor may cause additional exceptions to be thrown as long as they
are caught before that destructor returns.

I'm unsure if this can occur in nix, but I handled it by recording the
first count in the constructor and comparing it to the count in the
destructor. That way the object can determine whether the exception was
thrown during its lifetime.