### PR TITLE
Fix attr path to nixpkgs flake in flake template

### DIFF
--- a/src/nix/flake-template.nix
+++ b/src/nix/flake-template.nix
@@ -5,7 +5,7 @@
 
   outputs = { self, nixpkgs }: {
 
-    packages.x86_64-linux.hello = nixpkgs.packages.x86_64-linux.hello;
+    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
 
   };
 }


### PR DESCRIPTION
This doesn't work anymore since `packages` was removed from the
`nixpkgs`-fork with flake support[1], now it's only possible to refer to
pkgs via `legacyPackages`.

[1] https://github.com/edolstra/nixpkgs/commit/49c9b71e4ca98722cecd64ce8d53c1a4b9c46b64