### PR TITLE
Ensure enough space in attrset bindings

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -875,7 +875,7 @@ void ExprAttrs::eval(EvalState & state, Env & env, Value & v)
         if (hasOverrides) {
             Value * vOverrides = (*v.attrs)[overrides->second.displ].value;
             state.forceAttrs(*vOverrides);
-            Bindings * newBnds = state.allocBindings(v.attrs->size() + vOverrides->attrs->size());
+            Bindings * newBnds = state.allocBindings(v.attrs->capacity() + vOverrides->attrs->size());
             for (auto & i : *v.attrs)
                 newBnds->push_back(i);
             for (auto & i : *vOverrides->attrs) {

--- a/tests/lang/eval-okay-attrs6.exp
+++ b/tests/lang/eval-okay-attrs6.exp
@@ -1,0 +1,1 @@
+{ __overrides = { bar = "qux"; }; bar = "qux"; foo = "bar"; }

--- a/tests/lang/eval-okay-attrs6.nix
+++ b/tests/lang/eval-okay-attrs6.nix
@@ -1,0 +1,4 @@
+rec {
+  "${"foo"}" = "bar";
+   __overrides = { bar = "qux"; };
+}


### PR DESCRIPTION
When allocating bindings for attrset when using __overrides, we need to use the capacity of the original attrs, otherwise there's no space for dynamic attributes.

```nix
(rec { "${"foo"}" = 5; __overrides = { b = 5; }; }.foo)
```