### PR TITLE
Fix typos

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -319,7 +319,7 @@ public:
         "A program to run just before a build to set derivation-specific build settings."};
 
     Setting<std::string> postBuildHook{this, "", "post-build-hook",
-        "A program to run just after each succesful build."};
+        "A program to run just after each successful build."};
 
     Setting<std::string> netrcFile{this, fmt("%s/%s", nixConfDir, "netrc"), "netrc-file",
         "Path to the netrc file used to obtain usernames/passwords for downloads."};

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -569,7 +569,7 @@ public:
         unsigned long long & downloadSize, unsigned long long & narSize);
 
     /* Sort a set of paths topologically under the references
-       relation.  If p refers to q, then p preceeds q in this list. */
+       relation.  If p refers to q, then p precedes q in this list. */
     Paths topoSortPaths(const PathSet & paths);
 
     /* Export multiple paths in the format expected by ‘nix-store


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.