### PR TITLE
libstore/ssh: Improve error message on failing `execvp`

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -47,10 +47,13 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string
             throw SysError("duping over stderr");
 
         Strings args;
+        const char * execInto;
 
         if (fakeSSH) {
+            execInto = "bash";
             args = { "bash", "-c" };
         } else {
+            execInto = "ssh";
             args = { "ssh", host.c_str(), "-x", "-a" };
             addCommonSSHOpts(args);
             if (socketPath != "")
@@ -62,7 +65,8 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string
         args.push_back(command);
         execvp(args.begin()->c_str(), stringsToCharPtrs(args).data());
 
-        throw SysError("executing '%s' on '%s'", command, host);
+        // could not exec ssh/bash
+        throw SysError("Failed to exec into %s. Is it in PATH?", execInto);
     });
 
 
@@ -108,7 +112,7 @@ Path SSHMaster::startMaster()
         addCommonSSHOpts(args);
         execvp(args.begin()->c_str(), stringsToCharPtrs(args).data());
 
-        throw SysError("starting SSH master");
+        throw SysError("Failed to exec into ssh. Is it in PATH?");
     });
 
     out.writeSide = -1;


### PR DESCRIPTION
If the `throw` is reached, this means that execvp into `ssh` wasn’t
successful. We can hint at a usual problem, which is a missing `ssh`
executable.

Test with:

```
env PATH= ./result/bin/nix-copy-closure --builders '' unusedhost
```

and the bash version with

```
env PATH= ./result/bin/nix-copy-closure --builders '' localhost
```