### PR TITLE
nix-shell: don't check for "nix-shell" in shebang script name

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -106,7 +106,7 @@ static void _main(int argc, char * * argv)
     // Heuristic to see if we're invoked as a shebang script, namely,
     // if we have at least one argument, it's the name of an
     // executable file, and it starts with "#!".
-    if (runEnv && argc > 1 && !std::regex_search(argv[1], std::regex("nix-shell"))) {
+    if (runEnv && argc > 1) {
         script = argv[1];
         try {
             auto lines = tokenizeString<Strings>(readFile(script), "\n");


### PR DESCRIPTION
Fix bug: if the path to the nix-shell shebang script contains `"nix-shell"`, it won't run properly.

```sh
$ cat a-script-that-should-be-run-in-nix-shell.sh
#! /usr/bin/env nix-shell
#! nix-shell -p hello -i sh
hello

$ ./a-script-that-should-be-run-in-nix-shell.sh
error: undefined variable 'hello' at /tmp/a-script-that-should-be-run-in-nix-shell.sh:3:1

$ mv a-script-that-should-be-run-in-nix-shell.sh a-script.sh

$ ./a-script.sh
Hello, world!
```

Probably this check was relevant when nix-build [was a perl script](https://github.com/NixOS/nix/commit/80ebc553eca19dafc64c47420cd49ddd506bc9b7) (as perl handles `argv` differently than C++).
