### PR TITLE
Disable use-sqlite-wal under WSL

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -117,6 +117,15 @@ void Settings::requireExperimentalFeature(const std::string & name)
         throw Error("experimental Nix feature '%s' is disabled", name);
 }
 
+bool Settings::isWSL1()
+{
+    struct utsname utsbuf;
+    uname(&utsbuf);
+    // WSL1 uses -Microsoft suffix
+    // WSL2 uses -microsoft-standard suffix
+    return hasSuffix(utsbuf.release, "-Microsoft");
+}
+
 const string nixVersion = PACKAGE_VERSION;
 
 template<> void BaseSetting<SandboxMode>::set(const std::string & str)

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -34,6 +34,8 @@ class Settings : public Config {
 
     StringSet getDefaultSystemFeatures();
 
+    bool isWSL1();
+
 public:
 
     Settings();
@@ -130,7 +132,7 @@ public:
     Setting<bool> fsyncMetadata{this, true, "fsync-metadata",
         "Whether SQLite should use fsync()."};
 
-    Setting<bool> useSQLiteWAL{this, true, "use-sqlite-wal",
+    Setting<bool> useSQLiteWAL{this, !isWSL1(), "use-sqlite-wal",
         "Whether SQLite should use WAL mode."};
 
     Setting<bool> syncBeforeRegistering{this, false, "sync-before-registering",


### PR DESCRIPTION
Before:

    $ nix-channel --update
    unpacking channels...
    warning: SQLite database '/nix/var/nix/db/db.sqlite' is busy (SQLITE_PROTOCOL)
    warning: SQLite database '/nix/var/nix/db/db.sqlite' is busy (SQLITE_PROTOCOL)
    warning: SQLite database '/nix/var/nix/db/db.sqlite' is busy (SQLITE_PROTOCOL)
    warning: SQLite database '/nix/var/nix/db/db.sqlite' is busy (SQLITE_PROTOCOL)
    warning: SQLite database '/nix/var/nix/db/db.sqlite' is busy (SQLITE_PROTOCOL)

After:

    $ inst/bin/nix-channel --update
    unpacking channels...
    created 1 symlinks in user environment

I've seen complaints that "sandbox" caused problems under WSL but I'm
having no problems. I think recent changes could have fixed the issue.