### PR TITLE
nix-collect-garbage: print warning when we can't remove old generations

### DIFF
--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -19,7 +19,10 @@ bool dryRun = false;
 
 void removeOldGenerations(std::string dir)
 {
-    if (access(dir.c_str(), R_OK) != 0) return;
+    if (access(dir.c_str(), R_OK) != 0) {
+        printError(format("warning: could not remove generations in: %1%") % dir);
+        return;
+    }
 
     bool canWrite = access(dir.c_str(), W_OK) == 0;
 


### PR DESCRIPTION
I ran into https://github.com/NixOS/nix/issues/1492 recently and figured that it'd be nice to print a warning here.

cc @dtzWill @chris-martin @cleverca22 