### PR TITLE
Pass -J to tar for xz decompression

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -56,7 +56,7 @@ fi
 
 unpack=$tmpDir/unpack
 mkdir -p "$unpack"
-tar -xf "$tarball" -C "$unpack" || oops "failed to unpack '$url'"
+tar -xJf "$tarball" -C "$unpack" || oops "failed to unpack '$url'"
 
 script=$(echo "$unpack"/*/install)
 


### PR DESCRIPTION
Some tar implementations can't auto-detect compression formats, so
they must be specified explicitly.