### PR TITLE
nix/main: Set `verboseBuild` to `args.printBuildLogs`

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -143,11 +143,11 @@ void mainWrapped(int argc, char * * argv)
     }
 
     verbosity = lvlWarn;
-    settings.verboseBuild = false;
 
     NixArgs args;
 
     args.parseCmdline(argvToStrings(argc, argv));
+    settings.verboseBuild = args.printBuildLogs;
 
     settings.requireExperimentalFeature("nix-command");
 


### PR DESCRIPTION
When running `nix build -L`, it's slightly confusing to get the last 10
loglines again after the log-output.