### PR TITLE
passAsFile: leave out the hash prefix

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2460,7 +2460,7 @@ void DerivationGoal::initTmpDir() {
                 env[i.first] = i.second;
             } else {
                 auto hash = hashString(htSHA256, i.first);
-                string fn = ".attr-" + hash.to_string();
+                string fn = ".attr-" + hash.to_string(Base32, false);
                 Path p = tmpDir + "/" + fn;
                 writeFile(p, i.second);
                 chownToBuilder(p);

--- a/tests/pass-as-file.sh
+++ b/tests/pass-as-file.sh
@@ -10,6 +10,7 @@ mkDerivation {
   passAsFile = [ \"foo\" ];
   foo = [ \"xyzzy\" ];
   builder = builtins.toFile \"builder.sh\" ''
+    [ \"\$(basename \$fooPath)\" = .attr-1bp7cri8hplaz6hbz0v4f0nl44rl84q1sg25kgwqzipzd1mv89ic ]
     [ \"\$(cat \$fooPath)\" = xyzzy ]
     touch \$out
   '';


### PR DESCRIPTION
Having a colon in the path may cause issues, and having the hash
function indicated isn't actually necessary. We now verify the path 
format in the tests to prevent regressions.