### PR TITLE
build: fix path repairing with the darwin sandbox

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1513,8 +1513,10 @@ void replaceValidPath(const Path & storePath, const Path tmpPath)
     Path oldPath = (format("%1%.old-%2%-%3%") % storePath % getpid() % random()).str();
     if (pathExists(storePath))
         rename(storePath.c_str(), oldPath.c_str());
-    if (rename(tmpPath.c_str(), storePath.c_str()) == -1)
+    if (rename(tmpPath.c_str(), storePath.c_str()) == -1) {
+        rename(oldPath.c_str(), storePath.c_str()); // attempt to recover
         throw SysError("moving '%s' to '%s'", tmpPath, storePath);
+    }
     deletePath(oldPath);
 }
 


### PR DESCRIPTION
Handle store path repairing on darwin when sandboxing is enabled. Unlike
on linux sandboxing on darwin still requires hash rewriting.

Follow up on #2775, which only fixed the `--check` case properly.