### PR TITLE
build: fix sandboxing on darwin

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -443,7 +443,7 @@ void LocalStore::findRuntimeRoots(Roots & roots, bool censor)
     // lsof is really slow on OS X. This actually causes the gc-concurrent.sh test to fail.
     // See: https://github.com/NixOS/nix/issues/3011
     // Because of this we disable lsof when running the tests.
-    if (getEnv("_NIX_TEST_NO_LSOF") == "") {
+    if (getEnv("_NIX_TEST_NO_LSOF") != "1") {
         try {
             std::regex lsofRegex(R"(^n(/.*)$)");
             auto lsofLines =

--- a/src/nix-prefetch-url/nix-prefetch-url.cc
+++ b/src/nix-prefetch-url/nix-prefetch-url.cc
@@ -53,7 +53,7 @@ static int _main(int argc, char * * argv)
     {
         HashType ht = htSHA256;
         std::vector<string> args;
-        bool printPath = getEnv("PRINT_PATH") != "";
+        bool printPath = getEnv("PRINT_PATH") == "1";
         bool fromExpr = false;
         string attrPath;
         bool unpack = false;


### PR DESCRIPTION
Starting ba87b08f8529e4d9f8c58d8c625152058ceadb75 getEnv now returns an
std::optional which means these getEnv() != "" conditions no longer happen
if the variables are not defined.

