### PR TITLE
Unbreak build without pch

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -7,6 +7,7 @@
 #include <map>
 #include <thread>
 #include <dlfcn.h>
+#include <sys/utsname.h>
 
 
 namespace nix {


### PR DESCRIPTION
The change for WSL relied on `#include <sys/utsname.h>` being included everywhere. Also change `release.nix` so we build both builds in hydra/ofborg, preventing such regressions in the future.