### PR TITLE
build: remove warning when in sandboxing test mode

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3464,7 +3464,6 @@ void DerivationGoal::runChild()
                 }
                 args.push_back(drv->builder);
             } else {
-                printError("warning: running in sandboxing test mode, sandbox disabled");
                 builder = drv->builder.c_str();
                 args.push_back(std::string(baseNameOf(drv->builder)));
             }


### PR DESCRIPTION
Introduced in 66fccd5832d125e9162abc5ed351aa37708e9623, but somehow breaks the secure-drv-outputs test.

/cc @edolstra