### PR TITLE
WIP: Coverage per-platform

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -231,8 +231,9 @@ let
         '');
 
 
-    coverage =
-      with pkgs;
+    coverage = pkgs.lib.genAttrs systems (system:
+
+      let pkgs = import nixpkgs { inherit system; }; in with pkgs;
 
       with import ./release-common.nix { inherit pkgs; };
 
@@ -257,7 +258,7 @@ let
 
         # To test building without precompiled headers.
         makeFlagsArray = [ "PRECOMPILE_HEADERS=0" ];
-      };
+      });
 
 
     # System tests.


### PR DESCRIPTION
I was quite confused in https://github.com/NixOS/nix/pull/3315#issuecomment-574312784 (sorry!) but shouldn't we do the coverage test on more platforms than just Linux? Say a missing header bug is Darwin (or Windows!) only?