### PR TITLE
structured-attrs: chown .attrs.* files to builder

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2579,6 +2579,7 @@ void DerivationGoal::writeStructuredAttrs()
     }
 
     writeFile(tmpDir + "/.attrs.json", rewriteStrings(json.dump(), inputRewrites));
+    chownToBuilder(tmpDir + "/.attrs.json");
 
     /* As a convenience to bash scripts, write a shell file that
        maps all attributes that are representable in bash -
@@ -2647,6 +2648,7 @@ void DerivationGoal::writeStructuredAttrs()
     }
 
     writeFile(tmpDir + "/.attrs.sh", rewriteStrings(jsonSh, inputRewrites));
+    chownToBuilder(tmpDir + "/.attrs.sh");
 }
 
 


### PR DESCRIPTION
Otherwise `chmod .`'ing the build directory doesn't work anymore, which
is done in nixpkgs if sourceRoot is set to '.'.

cc @edolstra @Ericson2314 @jtojnar @Ma27 