### PR TITLE
Document that autoconf is a dependency

### DIFF
--- a/doc/manual/installation/prerequisites-source.xml
+++ b/doc/manual/installation/prerequisites-source.xml
@@ -8,6 +8,14 @@
 
 <itemizedlist>
 
+  <listitem><para>GNU Autoconf
+  (<link xlink:href="https://www.gnu.org/software/autoconf/"/>)
+  and the autoconf-archive macro collection
+  (<link xlink:href="https://www.gnu.org/software/autoconf-archive/"/>).
+  These are only needed to run the bootstrap script, and are not necessary
+  if your source distribution came with a pre-built
+  <literal>./configure</literal> script.</para></listitem>
+
   <listitem><para>GNU Make.</para></listitem>
   
   <listitem><para>Bash Shell. The <literal>./configure</literal> script


### PR DESCRIPTION
I was recently tripped up by the fact that autoconf-archive is not listed in the dependency lists. (More info: https://github.com/NixOS/nix/issues/3113#issuecomment-578563519).

Please let me know if I missed any other obvious dependencies (m4? automake?), or if the formatting for this XML blurb is wrong.