### PR TITLE
Allow PS1 to be customized in nix-shell

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -432,7 +432,7 @@ static void _main(int argc, char * * argv)
                 "PATH=\"%4%:$PATH\"; "
                 "SHELL=%5%; "
                 "set +e; "
-                R"s([ -n "$PS1" ] && PS1='\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '; )s"
+                R"s([ -n "$PS1" ] && PS1=${NIX_SHELL_PS1:-'\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '}; )s"
                 "if [ \"$(type -t runHook)\" = function ]; then runHook shellHook; fi; "
                 "unset NIX_ENFORCE_PURITY; "
                 "shopt -u nullglob; "


### PR DESCRIPTION
Currently there's no way to customize the `nix-shell` prompt permanently. This change allows the variable `NIX_SHELL_PS1` to be set (not exported) in `.bashrc` and it will then be used to set `PS1` in `nix-shell`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nix/3349)
<!-- Reviewable:end -->
