### PR TITLE
Remove #[macro_use]

### DIFF
--- a/nix-rust/src/lib.rs
+++ b/nix-rust/src/lib.rs
@@ -1,14 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
-
-#[cfg(test)]
-#[macro_use]
-extern crate proptest;
-
 #[cfg(not(test))]
 mod c;
 mod error;

--- a/nix-rust/src/store/path.rs
+++ b/nix-rust/src/store/path.rs
@@ -138,6 +138,7 @@ impl fmt::Display for StorePathName {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
 
     #[test]
     fn test_parse() {

--- a/nix-rust/src/util/base32.rs
+++ b/nix-rust/src/util/base32.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use lazy_static::lazy_static;
 
 pub fn encoded_len(input_len: usize) -> usize {
     if input_len == 0 {
@@ -87,7 +88,9 @@ pub fn decode(input: &str) -> Result<Vec<u8>, crate::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
     use hex;
+    use proptest::proptest;
 
     #[test]
     fn test_encode() {


### PR DESCRIPTION
As of Rust 2018, `#[macro_use]` is no longer required in most circumstances, we can just `use` macros the same way as functions. I think it is generally a good idea to remove `#[macro_use]` when not needed, to stop macros from polluting the crate's global namespace.

https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html#macro_rules-style-macros