### PR TITLE
Pass through http proxy env vars in pure shell

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -97,7 +97,11 @@ static void _main(int argc, char * * argv)
     std::string outLink = "./result";
 
     // List of environment variables kept for --pure
-    std::set<string> keepVars{"HOME", "USER", "LOGNAME", "DISPLAY", "PATH", "TERM", "IN_NIX_SHELL", "TZ", "PAGER", "NIX_BUILD_SHELL", "SHLVL"};
+    std::set<string> keepVars{
+        "HOME", "USER", "LOGNAME", "DISPLAY", "PATH", "TERM",
+        "IN_NIX_SHELL", "TZ", "PAGER", "NIX_BUILD_SHELL", "SHLVL",
+        "http_proxy", "https_proxy", "ftp_proxy", "all_proxy", "no_proxy"
+    };
 
     Strings args;
     for (int i = 1; i < argc; ++i)


### PR DESCRIPTION
Allow a pure nix-shell to inherit environment variables to signal some programs (such as `curl`) to use a proxy. This is quite common in eg corporate environments. 

Issue arises for me whilst using `stack`, I opened a PR over there as well, but maybe here it can be solved in a more general way. Reference: https://github.com/commercialhaskell/stack/pull/5171. As mentioned there, possible solutions are to add those variables to something like `~/.bashrc`, which is totally fine too of course. However, maybe these vars are prevalent enough to warrant their inclusion in a pure nix shell.  