### PR TITLE
[do not merge] tarball: Workaround bad branch names

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -228,7 +228,14 @@
             buildInputs = tarballDeps ++ buildDeps ++ propagatedDeps;
 
             postUnpack = ''
-              (cd $sourceRoot && find . -type f) | cut -c3- > $sourceRoot/.dist-files
+              (cd $sourceRoot && find . -type f) | grep -v '\$' | cut -c3- > $sourceRoot/.dist-files
+              #                                    ------------   --------
+              #                                        \              \
+              #                                         \       Strips the ./ prefix
+              #                                          \
+              #               Ensures we don't get files that would get wrongly expanded by make
+              #                   this is the case if there is e.g. the mojave-$HOME branch.
+
               cat $sourceRoot/.dist-files
             '';
 


### PR DESCRIPTION
Currently, from a git checkout, using `nix-build` fails like this for
me:

```
[...]
  GEN    nix-2.4pre0_dirty.tar.bz2
tar: .git/logs/refs/remotes/origin/mojave-/homeless-shelter: Cannot stat: No such file or directory
tar: .git/refs/remotes/origin/mojave-/homeless-shelter: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
make: *** [mk/dist.mk:8: nix-2.4pre0_dirty.tar.bz2] Error 2
```

As can be deduced from the two `No such file or directory`, the files
listing in `.dist-files` gets expanded once used by `tar`.

The branch name is `mojave-$HOME`.

This is a *dumb workaround* rather than a proper fix.

Fixing this by escaping using `sed` to double-up the `$` fails like this:

```
make: *** No rule to make target '.git/logs/refs/remotes/origin/mojave-$$HOME', needed by 'nix-2.4pre0_dirty.tar.bz2'.  Stop.
```

And trying to escape it as `\$` fails like this:

```
make: *** No rule to make target '.git/logs/refs/remotes/origin/mojave-\$HOME', needed by 'nix-2.4pre0_dirty.tar.bz2'.  Stop.
```