### PR TITLE
[WIP] Add a compatibility shim for non-flake nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,58 @@
+let
+  # Fields we care about when parsing, in order they'll be merged.
+  flakeFields = [
+    "info"
+    "inputs"
+    "locked"
+    "original"
+  ];
+
+  # The lock information.
+  flakeLockInfos = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  # This is a watered-down version of flake.lock parsing.
+  # This is probably somewhat wrong.
+  inputsInfo = builtins.mapAttrs (input: data:
+    let
+      # Ensure we have at least empty attrsets for each fields.
+      data' = (
+        (builtins.listToAttrs (builtins.map (name: { inherit name; value = {}; }) flakeFields))
+        // data
+      );
+    in
+    builtins.foldl' (coll: next: coll // next) {}
+      (builtins.map (attrname: data'.${attrname}) flakeFields)
+  ) flakeLockInfos.inputs;
+
+  # Here we apply the parsed data.
+  # This is definitely naïve and simplistic.
+  inputs = builtins.mapAttrs (name: info:
+    let
+      # FIXME: extremely assumes all github.com inputs
+      path = fetchTarball {
+        url = "https://github.com/${info.owner}/${info.repo}/archive/${info.rev}.tar.gz";
+        sha256 = info.narHash;
+      };
+      self =
+        { __toString = _: path; } //
+        info //
+        # Should a more generic shim pass the parameters the function wants?
+        # (Here nixpkgs.outputs only wants `self`.)
+        ((import (path + "/flake.nix")).outputs) ({ inherit self; })
+      ;
+    in self
+  ) inputsInfo;
+
+  # This is the current flake.
+  self =
+    let source = builtins.fetchGit ./.; in
+    {
+      __toString = _: source;
+      lastModified = "0";
+    } // source // (import (source + "/flake.nix")).outputs (inputs // {
+    inherit self;
+  });
+in
+  builtins.trace
+  "\n\nWarning: Using the flake mechanism with this repository is encouraged.\nThis build is being made using a compatibility shim.\n"
+  self

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./default.nix).devShell.${builtins.currentSystem}


### PR DESCRIPTION
This compatibility shim uses an extremely naïve parsing of `flake.lock`
to get the dependencies.

It then uses a naïve implementation of flakes to produce the build.

* * *

## Intent

I am sharing the current state of the shim, half-expecting that there are things to fix.

With a flakes-free nix, this handles:

 * using `nix build` or `nix-build` to build.
 * using `nix-shell`.

It is my opinion that this, or another implementation of such a shim, should be present in the flakes branch, and *then* in the master branch, up until a full release cycle of nix has had flakes enabled by default.

Not doing so makes for a confusing experience for getting started in looking at the flakes branch, at first. Then, allowing this for one full release might not be as useful at that point, but will allow laggards to at least be able to use this repository with `nix v"flakes-1"`.

I would recommend, once flakes get into master, assuming there is such a shim, that the warning documents that this is going to be dropped in `nix v"next release"`, also linking to a proper location for upgrades instructions.

## Implementation details

This implementation is probably wrong in some ways. It does work for nix, but I wouldn't assume it works for all flakes. Surely, it would be helpful to include such a shim in all "core" flakes around the NixOS organization, if it can be fixed to be good enough for all of our flakes.

I am open to critique, rework, everything to make this better for inclusion in nix. Tell me what I did wrong, I'll be glad to get it sorted out.