### PR TITLE
.dir-locals.el: Set additional lambda indentation to zero

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -13,4 +13,5 @@
   (eval . (c-set-offset 'arglist-cont-nonempty '+))
   (eval . (c-set-offset 'substatement-open 0))
   (eval . (c-set-offset 'access-label '-))
+  (eval . (c-set-offset 'inlambda 0))
   )))


### PR DESCRIPTION
To allow emacs to handle the currently used lambda indentation correctly.