### PR TITLE
install-multi-user: allow overriding user count

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -20,7 +20,9 @@ readonly GREEN='\033[32m'
 readonly GREEN_UL='\033[4;32m'
 readonly RED='\033[31m'
 
-readonly NIX_USER_COUNT="32"
+# installer allows overriding build user count to speed up installation
+# as creating each user takes non-trivial amount of time on macos
+readonly NIX_USER_COUNT=${NIX_USER_COUNT:-32}
 readonly NIX_BUILD_GROUP_ID="30000"
 readonly NIX_BUILD_GROUP_NAME="nixbld"
 readonly NIX_FIRST_BUILD_UID="30001"

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -50,6 +50,9 @@ while [ $# -gt 0 ]; do
             INSTALL_MODE=no-daemon;;
         --no-channel-add)
             NIX_INSTALLER_NO_CHANNEL_ADD=1;;
+        --daemon-user-count)
+            NIX_USER_COUNT=$2
+            shift;;
         --no-modify-profile)
             NIX_INSTALLER_NO_MODIFY_PROFILE=1;;
         --darwin-use-unencrypted-nix-store-volume)


### PR DESCRIPTION
Motivation at https://github.com/cachix/install-nix-action/issues/13

Open question is if it should have been a flag like `--daemon` and if it needs to be documented somewhere.