### PR TITLE
Assertion syntax in error in the manual?

### DIFF
--- a/doc/manual/expressions/language-constructs.xml
+++ b/doc/manual/expressions/language-constructs.xml
@@ -271,7 +271,7 @@ evaluate to a Boolean value (<literal>true</literal> or
 on or between features and dependencies hold.  They look like this:
 
 <programlisting>
-assert <replaceable>e1</replaceable>; <replaceable>e2</replaceable></programlisting>
+assert <replaceable>e1</replaceable> -> <replaceable>e2</replaceable></programlisting>
 
 where <replaceable>e1</replaceable> is an expression that should
 evaluate to a Boolean value.  If it evaluates to


### PR DESCRIPTION
I'm a complete neophyte to Nix, but based on the example in the manual and looking in `nixpkgs` a bit it seems like the actual `assert` syntax is `assert e1 -> e2`  not `assert e1; e2`.  If I've got this garbled, please ignore of course, but even if so I think it's still worth pointing out that for a new learner this explanation and example _seem_ contradictory as written and could probably be clarified.