### PR TITLE
fetchGit: allow fetching revs which are not ancestors of HEAD without specifying a ref

### DIFF
--- a/doc/manual/expressions/builtins.xml
+++ b/doc/manual/expressions/builtins.xml
@@ -422,6 +422,28 @@ stdenv.mkDerivation { … }
             </para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term>fetchRevInsteadOfRef</term>
+          <listitem>
+            <para>
+              Defaults to <literal>false</literal>.
+            </para>
+
+            <para>
+              When set to <literal>true</literal> the specified
+              <varname>rev</varname> is fetched <emphasis>directly</emphasis>
+              instead of fetching the <varname>ref</varname> (which defaults to
+              <literal>HEAD</literal> when not specified). This is useful in
+              case a <varname>ref</varname> is not available.
+            </para>
+
+            <para>
+              Do note that git servers by default <link
+              xlink:href="https://www.git-scm.com/docs/git-config/2.25.1#Documentation/git-config.txt-uploadpackallowAnySHA1InWant">don't allow fetching revisions directly</link>
+              (GitHub does allow it).
+            </para>
+          </listitem>
+        </varlistentry>
       </variablelist>
 
       <example>


### PR DESCRIPTION
Note that `builtins.fetchGit` defaults `ref` to `HEAD` when not specified. This is problematic when fetching a `rev` which is not an ancestor of `HEAD` when no `ref` is available:

```
nix-instantiate -v --eval -E \
'builtins.fetchGit { 
  url = "https://github.com/.../..."; 
  rev = "9ec3a6973f6a17dc4b2566520253fc6203f75ac6"; 
}'
evaluating file '/nix/store/lrnvapsqmf0ja6zfyx4cpxr7ahdr7f9b-nix-2.3.3/share/nix/corepkgs/derivation.nix'
fetching Git repository 'https://github.com/.../...'...
using revision 9ec3a6973f6a17dc4b2566520253fc6203f75ac6 of repo 'https://github.com/.../...'
fatal: not a tree object: 9ec3a6973f6a17dc4b2566520253fc6203f75ac6
error: program 'git' failed with exit code 128
```

This error occurs because `rev` is never fetched since it's not an ancestor of the ref `HEAD` which is fetched.

This commit introduces the `fetchRevInsteadOfRef` argument to `builtins.fetchGit` which when `true` fetches the `rev` directly instead of fetching `HEAD`.

`fetchRevInsteadOfRef` defaults to `false` to keep backwards compatibility and since git servers by default [don't allow fetching revisions directly](https://www.git-scm.com/docs/git-config/2.25.1#Documentation/git-config.txt-uploadpackallowAnySHA1InWant) (Note that GitHub does allow this).

This commit now also checks whether `rev` is an ancestor of `ref` when the latter is specified.

