### PR TITLE
Remove the tarball job

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -34,7 +34,7 @@ rec {
       "--with-sandbox-shell=${sh}/bin/busybox"
     ];
 
-  tarballDeps =
+  buildDeps =
     [ bison
       flex
       libxml2
@@ -43,10 +43,8 @@ rec {
       docbook_xsl_ns
       autoconf-archive
       autoreconfHook
-    ];
 
-  buildDeps =
-    [ curl
+      curl
       bzip2 xz brotli zlib editline
       openssl pkgconfig sqlite
       libarchive

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ with import ./release-common.nix { inherit pkgs; };
 (if useClang then clangStdenv else stdenv).mkDerivation {
   name = "nix";
 
-  buildInputs = buildDeps ++ propagatedDeps ++ tarballDeps ++ perlDeps ++ [ pkgs.rustfmt ];
+  buildInputs = buildDeps ++ propagatedDeps ++ perlDeps ++ [ pkgs.rustfmt ];
 
   inherit configureFlags;
 


### PR DESCRIPTION
Source tarballs are not very useful anymore. People who want to build from source can also just build from the Git repository. Once upon a time, the source tarball also saved users from needing a few dependencies (e.g. bison and flex) but those are dwarfed by the other dependencies, so it's no longer worth it.