### PR TITLE
Add missing `#include <regex>`

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -7,6 +7,7 @@
 #include "hash.hh"
 #include "config.hh"
 
+#include <regex>
 #include <map>
 #include <optional>
 #include <unordered_map>


### PR DESCRIPTION
The build without precompiled headers broke again. 