### PR TITLE
build: disallow root without build users

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -528,7 +528,8 @@ public:
 
 UserLock::UserLock()
 {
-    assert(settings.buildUsersGroup != "");
+    if(settings.buildUsersGroup == "")
+        throw Error("the 'build-users-group' option is required for security reasons");
 
     /* Get the members of the build-users-group. */
     struct group * gr = getgrnam(settings.buildUsersGroup.get().c_str());
@@ -1943,7 +1944,7 @@ void DerivationGoal::startBuilder()
 
     /* If `build-users-group' is not empty, then we have to build as
        one of the members of that group. */
-    if (settings.buildUsersGroup != "" && getuid() == 0) {
+    if (getuid() == 0) {
 #if defined(__linux__) || defined(__APPLE__)
         buildUser = std::make_unique<UserLock>();
 

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3334,6 +3334,10 @@ void DerivationGoal::runChild()
                 throw SysError("setuid failed");
         }
 
+        /* Prevent users from doing something very dangerous. */
+        if (geteuid() == 0 || getegid() == 0)
+            throw Error("build seems to be running as root, refusing");
+
         /* Fill in the arguments. */
         Strings args;
 


### PR DESCRIPTION
Currently nix enforces build user separation for root by setting `build-users-group = nixbld` [by default](https://github.com/NixOS/nix/commit/ada3e3fa15bc14aebb2bafd1240c15cf1fd99351) in this case. However there's no validation allowing the user to disable it. For nix-daemon specifically there used to be a check that ensured builds would not run as root, however that was also removed in https://github.com/NixOS/nix/commit/98968fbb63a1a049b2439bfc2a7d53e5b51471e3.

A bunch of issues mention this bug as a "workaround" for root installations which is pretty 
bad IMHO. And it looks like there are also things in nix that don't account for this behaviour, making it only partially functional.

```
suspicious ownership or permission on '...'; rejecting this build output
```


- https://github.com/NixOS/nix/issues/697
- https://github.com/NixOS/nix/issues/1559
- https://github.com/NixOS/nix/issues/936#issuecomment-475795730
- https://github.com/NixOS/nixpkgs/issues/82357