### PR TITLE
Remove the --delete option for --gc. Fixes #3343

### DIFF
--- a/doc/manual/command-ref/nix-store.xml
+++ b/doc/manual/command-ref/nix-store.xml
@@ -360,7 +360,6 @@ EOF
     <arg choice='plain'><option>--print-roots</option></arg>
     <arg choice='plain'><option>--print-live</option></arg>
     <arg choice='plain'><option>--print-dead</option></arg>
-    <arg choice='plain'><option>--delete</option></arg>
   </group>
   <arg><option>--max-freed</option> <replaceable>bytes</replaceable></arg>
 </cmdsynopsis>
@@ -407,14 +406,6 @@ the Nix store not reachable via file system references from a set of
 
   </varlistentry>
 
-  <varlistentry><term><option>--delete</option></term>
-
-    <listitem><para>This operation performs an actual garbage
-    collection.  All dead paths are removed from the
-    store.  This is the default.</para></listitem>
-
-  </varlistentry>
-
 </variablelist>
 
 <para>By default, all unreachable paths are deleted.  The following
@@ -444,10 +435,10 @@ and <link
 linkend="conf-keep-derivations"><literal>keep-derivations</literal></link>
 variables in the Nix configuration file.</para>
 
-<para>With <option>--delete</option>, the collector prints the total
-number of freed bytes when it finishes (or when it is interrupted).
-With <option>--print-dead</option>, it prints the number of bytes that
-would be freed.</para>
+<para>By default, the collector prints the total number of freed bytes
+when it finishes (or when it is interrupted). With
+<option>--print-dead</option>, it prints the number of bytes that would
+be freed.</para>
 
 </refsection>
 

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -577,7 +577,6 @@ static void opGC(Strings opFlags, Strings opArgs)
         if (*i == "--print-roots") printRoots = true;
         else if (*i == "--print-live") options.action = GCOptions::gcReturnLive;
         else if (*i == "--print-dead") options.action = GCOptions::gcReturnDead;
-        else if (*i == "--delete") options.action = GCOptions::gcDeleteDead;
         else if (*i == "--max-freed") {
             long long maxFreed = getIntArg<long long>(*i, i, opFlags.end(), true);
             options.maxFreed = maxFreed >= 0 ? maxFreed : 0;


### PR DESCRIPTION
Running `nix-store --gc --delete` will, as of Nix 2.3.3, simply fail because the `--delete` option conflicts with the --delete operation.

    $ nix-store --gc --delete
    error: only one operation may be specified
    Try 'nix-store --help' for more information.

Furthermore, it has been broken since at least Nix 0.16 (which was released sometime in 2010), which means that any scripts which depend on it should have been broken at least nine years ago. This commit simply formally removes the option. There should be no actual difference in behaviour as far as the user is concerned: it errors with the exact same error message. The manual has been edited to remove any references to the (now gone) `--delete` option.

The alternative is renaming the `--delete` option to something else or making `nix-build` able to tell the difference between the two uses of `--delete`, but since it's clearly not in use, it shouldn't matter.

See #3343 for more information.

Other information:
* Path for Nix 0.16 used:
  /nix/store/rp3sgmskn0p0pj1ia2qwd5al6f6pinz4-nix-0.16
* The `--delete` option is actually not ever used in Nixpkgs (according to `grep`)

Edit: Fixes #3343