### PR TITLE
installer: also test for xz to unpack

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -36,6 +36,7 @@ tarball="$tmpDir/$(basename "$tmpDir/nix-@nixVersion@-$system.tar.xz")"
 
 require_util curl "download the binary tarball"
 require_util tar "unpack the binary tarball"
+require_util xz "unpack the binary tarball"
 
 echo "downloading Nix @nixVersion@ binary tarball for $system from '$url' to '$tmpDir'..."
 curl -L "$url" -o "$tarball" || oops "failed to download '$url'"


### PR DESCRIPTION
As mentioned in #3430, we are checking for `tar`, and then use `-J` to unpack the `xz` file. But this needs `xz`, too!