### PR TITLE
Fix #3369: verify output hash in nix-build --check

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3673,7 +3673,7 @@ void DerivationGoal::registerOutputs()
 
                 Path actualDest = worker.store.toRealPath(worker.store.printStorePath(dest));
 
-                if (worker.store.isValidPath(dest))
+                if (worker.store.isValidPath(dest) || buildMode == bmCheck)
                     std::rethrow_exception(delayedException);
 
                 if (actualPath != actualDest) {


### PR DESCRIPTION
`nix-build --check` (or `nix-store --realise --check`) behaves differently
depending on whether expected output of fixed-output derivation was
built (and registered) before or not.

Throw an exception in case of hash mismatch when `--check` flag is
specified even if the expected output wasn't registered before.

Help to check and detect cases when output of fixed-output derivation is
changed however outputHash doesn't change and so matches the output
built before.