### PR TITLE
improve toFile error message when containing potential drv path

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1021,7 +1021,9 @@ static void prim_toFile(EvalState & state, const Pos & pos, Value * * args, Valu
 
     for (auto path : context) {
         if (path.at(0) != '/')
-            throw EvalError(format("in 'toFile': the file '%1%' cannot refer to derivation outputs, at %2%") % name % pos);
+            throw EvalError(format(
+                "in 'toFile': the file named '%1%' must not contain a reference "
+                "to a derivation but contains (%2%), at %3%") % name % path % pos);
         refs.insert(state.store->parseStorePath(path));
     }
 


### PR DESCRIPTION
closes https://github.com/NixOS/nix/issues/2274

In case a potential derivation path is found in the content passed to `toFile`, the new error message will be:
`
error: in 'toFile': the file named 'test-file' must not contain a sub-string referring to a potential derivation path (!out!/nix/store/h24qmnnbcbj84pimrg55pd3yjq0gpfra-python3-3.7.5.drv), at /home/user/some_expr.nix:3:1
`