### PR TITLE
nix search --json: Don’t fail for empty result set

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -263,8 +263,12 @@ struct CmdSearch : SourceExprCommand, MixJSON
                 throw SysError("cannot rename '%s' to '%s'", tmpFile, jsonCacheFileName);
         }
 
-        if (results.size() == 0)
+        if (results.size() == 0 && !json) {
             throw Error("no results for the given search term(s)!");
+        }
+        if (json) {
+            return;
+        }
 
         RunPager pager;
         for (auto el : results) std::cout << el.second << "\n";


### PR DESCRIPTION
I'm using `nix search --json` to generate a list of all the packages available for installation. I noticed that I cannot test this command for failure, because...it always fails.

Specifically, it always outputs "no results for the given search term(s)", even after outputting a huge list of packages, and it always results in an exit code of 1.

Is this intentional? I see two cases to handle here:

1. The user doesn't provide a search string, so `nix search` or `nix search --json`. This is valid and even an example in the manpage. In this case, I think you never want to fail.
2. The user provides a search string, and nothing is found. In this case, failing (and outputting a message on stderr) is good behavior when `--json` isn't provided. If it is, I think it's a matter of preference. I personally wouldn't let it fail. The script you're writing can process the JSON and check for emptiness.

Regarding the code: Since `results` is apparently not filled in json mode, testing it for emptiness doesn't make much sense. This PR only tests this in plain-text mode as a first fix to the problem.