### PR TITLE
Make function arguments retain position info

### DIFF
--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -209,9 +209,10 @@ struct ExprList : Expr
 
 struct Formal
 {
+    Pos pos;
     Symbol name;
     Expr * def;
-    Formal(const Symbol & name, Expr * def) : name(name), def(def) { };
+    Formal(const Pos & pos, const Symbol & name, Expr * def) : pos(pos), name(name), def(def) { };
 };
 
 struct Formals

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -531,8 +531,8 @@ formals
   ;
 
 formal
-  : ID { $$ = new Formal(data->symbols.create($1), 0); }
-  | ID '?' expr { $$ = new Formal(data->symbols.create($1), $3); }
+  : ID { $$ = new Formal(CUR_POS, data->symbols.create($1), 0); }
+  | ID '?' expr { $$ = new Formal(CUR_POS, data->symbols.create($1), $3); }
   ;
 
 %%

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1354,9 +1354,12 @@ static void prim_functionArgs(EvalState & state, const Pos & pos, Value * * args
     }
 
     state.mkAttrs(v, args[0]->lambda.fun->formals->formals.size());
-    for (auto & i : args[0]->lambda.fun->formals->formals)
+    for (auto & i : args[0]->lambda.fun->formals->formals) {
         // !!! should optimise booleans (allocate only once)
-        mkBool(*state.allocAttr(v, i.name), i.def);
+        Value * value = state.allocValue();
+        v.attrs->push_back(Attr(i.name, value, &i.pos));
+        mkBool(*value, i.def);
+    }
     v.attrs->sort();
 }
 

--- a/tests/lang/eval-okay-getattrpos-functionargs.exp
+++ b/tests/lang/eval-okay-getattrpos-functionargs.exp
@@ -1,0 +1,1 @@
+{ column = 11; file = "eval-okay-getattrpos-functionargs.nix"; line = 2; }

--- a/tests/lang/eval-okay-getattrpos-functionargs.nix
+++ b/tests/lang/eval-okay-getattrpos-functionargs.nix
@@ -1,0 +1,4 @@
+let
+  fun = { foo }: {};
+  pos = builtins.unsafeGetAttrPos "foo" (builtins.functionArgs fun);
+in { inherit (pos) column line; file = baseNameOf pos.file; }


### PR DESCRIPTION
This allows querying the location of function arguments. E.g.

```nix
builtins.unsafeGetAttrPos "x" (builtins.functionArgs ({ x }: null))

-> { column = 57; file = "/home/infinisil/src/nix/inst/test.nix"; line = 1; }
```

I'll be able to use this in https://github.com/NixOS/nixpkgs/pull/79877 for better error messages