### PR TITLE
libexpr: remove unused attrError

### DIFF
--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -37,9 +37,6 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attr
 {
     Strings tokens = parseAttrPath(attrPath);
 
-    Error attrError =
-        Error(format("attribute selection path '%1%' does not match expression") % attrPath);
-
     Value * v = &vIn;
     Pos pos = noPos;
 


### PR DESCRIPTION
The attrError variable is no longer used but still allocated on every
call to the findAlongAttrPath function.