### PR TITLE
`nix run` using $SHELL as default command

### DIFF
--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -59,14 +59,14 @@ struct RunCommon : virtual Command
 
 struct CmdRun : InstallablesCommand, RunCommon, MixEnvironment
 {
-    std::vector<std::string> command = { "bash" };
+    std::vector<std::string> command = { getEnv("SHELL").value_or("bash") };
 
     CmdRun()
     {
         mkFlag()
             .longName("command")
             .shortName('c')
-            .description("command and arguments to be executed; defaults to 'bash'")
+            .description("command and arguments to be executed; defaults to '$SHELL'")
             .labels({"command", "args"})
             .arity(ArityAny)
             .handler([&](std::vector<std::string> ss) {


### PR DESCRIPTION
Since `nix run` just sets the `PATH`, I think it makes sense to use `$SHELL` as the default command for a more fluent workflow.

Additionally, the `nix dev-shell` uses option `--rcfile`, which is not compatible with all mainstream shells(I think zsh is one of the mainstream shell, is it?), and the rcfile usually contains bash-specific content, I think it is better to just use "bash" in dev-shell instead of "$SHELL". What's your opinion? Just discussion though, this is not part of this pr.