### PR TITLE
gc.cc: Ignore hidden files in temproots

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -202,6 +202,11 @@ void LocalStore::findTempRoots(FDs & fds, Roots & tempRoots, bool censor)
     /* Read the `temproots' directory for per-process temporary root
        files. */
     for (auto & i : readDirectory(tempRootsDir)) {
+        if (i.name[0] == '.') {
+            // Ignore hidden files. Some package managers (notably portage) create
+            // those to keep the directory alive.
+            continue;
+        }
         Path path = tempRootsDir + "/" + i.name;
 
         pid_t pid = std::stoi(i.name);


### PR DESCRIPTION
While trying out Nix on Gentoo, I noticed that `nix-collect-garbage` failed, outputting simply `error: stoi`. Investigating a bit, I noticed that in `/nix/var/nix/temproots`, there was a file called `.keep_sys-apps_nix-0`, which Nix tried to interpret as a process ID (and failed, of course). Apparently, Gentoo puts such files in directories in order to remember if any package wants this directory there (even if might be currently empty). If the file's not there, Gentoo will delete the directory.

Since *creating* the temproots directory dynamically seemed a bit "unsafe", I changed the GC code so that hidden files are ignored. I'm not sure myself if that's a good solution, to be honest. But it does improve interoperability with other package managers, apparently.