### PR TITLE
SourceExprCommand: allocate the vSourceExpr via uncollectable memory

### DIFF
--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -41,7 +41,7 @@ private:
 
     std::shared_ptr<EvalState> evalState;
 
-    Value * vSourceExpr = 0;
+    std::shared_ptr<Value> vSourceExpr;
 };
 
 enum RealiseMode { Build, NoBuild, DryRun };


### PR DESCRIPTION
Previously the memory would occasionally be collected during eval since
the GC doesn't consider the member variable as alive / doesn't scan the
region of memory where the pointer lives.

By using the traceable_allocator<T> allocator provided by Boehm GC we
can ensure the memory isn't collected. It should be properly freed when
SourceExprCommand goes out of scope.

Related to #3475 


I've been running my reproducer for  >20min. Usually it would trigger the error within a few minutes. So far it looks very stable. Having spent some time on reading through the code  and the various GC docs I believe this might be the correct fix (or approach).

The `vSourceExpr` will be released when the current command (`CmdBulid`) goes out of scope. That is probably fine as that is basically the same as the lifetime of the entire program.


I would appreciate if we could get this into a stable (v2.3-branch) release.