### PR TITLE
Add --include-ifd option to nix-instantiate

### DIFF
--- a/doc/manual/command-ref/nix-instantiate.xml
+++ b/doc/manual/command-ref/nix-instantiate.xml
@@ -162,6 +162,13 @@ input.</para>
 
   </varlistentry>
 
+  <varlistentry><term><option>--include-ifd</option></term>
+
+    <listitem><para>Print all imported derivations along with the
+    final derivation.</para></listitem>
+
+  </varlistentry>
+
 </variablelist>
 
 <variablelist condition="manpage">

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -88,6 +88,9 @@ public:
 
     const ref<Store> store;
 
+    /* List of derivations that got imported. */
+    std::list<std::pair<string, string>> importedDrvs;
+
 private:
     SrcToStore srcToStore;
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -55,6 +55,9 @@ void EvalState::realiseContext(const PathSet & context)
         auto ctx = store->parseStorePath(decoded.first);
         if (!store->isValidPath(ctx))
             throw InvalidPathError(store->printStorePath(ctx));
+        if (ctx.isDerivation()) {
+            importedDrvs.push_back(decoded);
+        }
         if (!decoded.second.empty() && ctx.isDerivation()) {
             drvs.push_back(StorePathWithOutputs{ctx.clone(), {decoded.second}});
 

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -28,7 +28,7 @@ enum OutputKind { okPlain, okXML, okJSON };
 
 void processExpr(EvalState & state, const Strings & attrPaths,
     bool parseOnly, bool strict, Bindings & autoArgs,
-    bool evalOnly, OutputKind output, bool location, Expr * e)
+    bool evalOnly, OutputKind output, bool location, bool includeIfd, Expr * e)
 {
     if (parseOnly) {
         std::cout << format("%1%\n") % *e;
@@ -79,6 +79,11 @@ void processExpr(EvalState & state, const Strings & attrPaths,
                 }
                 std::cout << fmt("%s%s\n", drvPath, (outputName != "out" ? "!" + outputName : ""));
             }
+            if (includeIfd) {
+                for (auto & i : state.importedDrvs) {
+                    std::cout << fmt("%s%s\n", i.first, (i.second != "out" ? "!" + i.second : ""));
+                }
+            }
         }
     }
 }
@@ -96,6 +101,7 @@ static int _main(int argc, char * * argv)
         OutputKind outputKind = okPlain;
         bool xmlOutputSourceLocation = true;
         bool strict = false;
+        bool includeIfd = false;
         Strings attrPaths;
         bool wantsReadWrite = false;
         RepairFlag repair = NoRepair;
@@ -140,6 +146,8 @@ static int _main(int argc, char * * argv)
                 repair = Repair;
             else if (*arg == "--dry-run")
                 settings.readOnlyMode = true;
+            else if (*arg == "--include-ifd")
+                includeIfd = true;
             else if (*arg != "" && arg->at(0) == '-')
                 return false;
             else
@@ -175,7 +183,7 @@ static int _main(int argc, char * * argv)
         if (readStdin) {
             Expr * e = state->parseStdin();
             processExpr(*state, attrPaths, parseOnly, strict, autoArgs,
-                evalOnly, outputKind, xmlOutputSourceLocation, e);
+                evalOnly, outputKind, xmlOutputSourceLocation, includeIfd, e);
         } else if (files.empty() && !fromArgs)
             files.push_back("./default.nix");
 
@@ -184,7 +192,7 @@ static int _main(int argc, char * * argv)
                 ? state->parseExprFromString(i, absPath("."))
                 : state->parseExprFromFile(resolveExprPath(state->checkSourcePath(lookupFileArg(*state, i))));
             processExpr(*state, attrPaths, parseOnly, strict, autoArgs,
-                evalOnly, outputKind, xmlOutputSourceLocation, e);
+                evalOnly, outputKind, xmlOutputSourceLocation, includeIfd, e);
         }
 
         state->printStats();


### PR DESCRIPTION
This allows use you to get all drvs that your Nix expression
references. Output looks like this:

```
  $ nix-instantiate --include-ifd
  warning: you did not specify '--add-root'; the result might be removed by the garbage collector
  /nix/store/xvplw4i56ys3j1lk4bxnr8r4725rb6c8-bauer-1.5.0.drv
  /nix/store/nk7j41ldlq39lmmsg5v1mlwwwpnqnbgk-README.drv
  /nix/store/pp84r1z7j7aqqarbwkq55h5asy35rs15-package-list.drv
```

This can be put into nix-store to get all paths that will be needed to build the Nix expression:

```
  $ nix-store -qR --include-outputs $(nix-instantiate --include-ifd) | grep -v \.drv$
  /nix/store/00crwk6z71l36av0gspzi0z410h8fq1r-libXtst-1.2.3.tar.bz2
  /nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh
  /nix/store/c0sr4qdy8halrdrh5dpm7hj05c6hyssa-unpack-bootstrap-tools.sh
  ...
```

Comes from discussion in https://github.com/NixOS/nix/pull/3494.

/cc @domenkozar @Ericson2314 