### PR TITLE
Try to substitute tree for all uses of fetchTree instead of just in flakes

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -53,37 +53,6 @@ static std::tuple<fetchers::Tree, FlakeRef, FlakeRef> fetchOrSubstituteTree(
     bool allowLookup,
     FlakeCache & flakeCache)
 {
-    /* The tree may already be in the Nix store, or it could be
-       substituted (which is often faster than fetching from the
-       original source). So check that. */
-    if (treeInfo && originalRef.input->isDirect() && originalRef.input->isImmutable()) {
-        try {
-            auto storePath = treeInfo->computeStorePath(*state.store);
-
-            state.store->ensurePath(storePath);
-
-            debug("using substituted/cached input '%s' in '%s'",
-                originalRef, state.store->printStorePath(storePath));
-
-            auto actualPath = state.store->toRealPath(storePath);
-
-            if (state.allowedPaths)
-                state.allowedPaths->insert(actualPath);
-
-            return {
-                Tree {
-                    .actualPath = actualPath,
-                    .storePath = std::move(storePath),
-                    .info = *treeInfo,
-                },
-                originalRef,
-                originalRef
-            };
-        } catch (Error & e) {
-            debug("substitution of input '%s' failed: %s", originalRef, e.what());
-        }
-    }
-
     auto resolvedRef = lookupInFlakeCache(flakeCache,
         maybeLookupFlake(state.store,
             lookupInFlakeCache(flakeCache, originalRef), allowLookup));

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -83,7 +83,6 @@ static void prim_fetchTree(EvalState & state, const Pos & pos, Value * * args, V
     if (evalSettings.pureEval && !input->isImmutable())
         throw Error("in pure evaluation mode, 'fetchTree' requires an immutable input, at %s", pos);
 
-    // FIXME: use fetchOrSubstituteTree
     auto [tree, input2] = input->fetchTree(state.store);
 
     if (state.allowedPaths)

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -55,6 +55,11 @@ struct Input : std::enable_shared_from_this<Input>
 
     Attrs toAttrs() const;
 
+    /* The tree may already be in the Nix store, or it could be
+       substituted (which is often faster than fetching from the
+       original source). */
+    Tree substituteTree(ref<Store> store) const;
+
     std::pair<Tree, std::shared_ptr<const Input>> fetchTree(ref<Store> store) const;
 
     virtual std::shared_ptr<const Input> applyOverrides(


### PR DESCRIPTION
Trying to fix the FIXME in fetchTree.cc:86

Wasn't quite sure how having a nar hash interacts with resolved refs. Since narHash is optional, a resolved ref could be immutable, but then possibly not locked? But then it doesn't make sense to assume that fetchOrSubstituteTree returns a lockedRef:
https://github.com/NixOS/nix/blob/8c75621da6260d92459e105892751457e1659741/src/libexpr/flake/flake.cc#L210

Should that be treated as an immutable ref but not locked? Or should substitute only occur for locked refs?