### PR TITLE
Implementation of a CAS store

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1226,6 +1226,9 @@ void DerivationGoal::outputsSubstituted()
 {
     trace("all outputs substituted (maybe)");
 
+    if (useDerivation)
+        worker.store.resolveDerivation(*(dynamic_cast<Derivation *>(drv.get())));
+
     if (nrFailed > 0 && nrFailed > nrNoSubstituters + nrIncompleteClosure && !settings.tryFallback) {
         done(BuildResult::TransientFailure,
             fmt("some substitutes for the outputs of derivation '%s' failed (usually happens due to networking issues); try '--fallback' to build derivation from source ",

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -4243,10 +4243,14 @@ StorePathSet DerivationGoal::checkPathValidity(bool returnValid, bool checkHash)
     StorePathSet result;
     for (auto & i : drv->outputs) {
         if (!wantOutput(i.first, wantedOutputs)) continue;
+        StorePath outPath = worker.store.queryOutPath(
+            DrvOutputId{ drvPath, i.first },
+            *(drv.get())
+          );
         bool good =
-            worker.store.isValidPath(i.second.path) &&
-            (!checkHash || worker.pathContentsGood(i.second.path));
-        if (good == returnValid) result.insert(i.second.path);
+            worker.store.isValidPath(outPath) &&
+            (!checkHash || worker.pathContentsGood(outPath));
+        if (good == returnValid) result.insert(outPath);
     }
     return result;
 }

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1360,8 +1360,14 @@ void DerivationGoal::inputsRealised()
 {
     trace("all inputs realised");
 
-    if (useDerivation)
-        worker.store.resolveDerivation(*(dynamic_cast<Derivation *>(drv.get())));
+    if (useDerivation) {
+        bool isModified = worker.store.resolveDerivation(*(dynamic_cast<Derivation *>(drv.get())));
+        if (isModified) {
+            debug("Trying the substitution again");
+            haveDerivation();
+            return;
+        }
+    }
 
     if (nrFailed != 0) {
         if (!useDerivation)

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -809,6 +809,9 @@ private:
     /* Whether this is a fixed-output derivation. */
     bool fixedOutput;
 
+    /* Whether this is a content adressed derivation */
+    bool contentAddressed = false;
+
     /* Whether to run the build in a private network namespace. */
     bool privateNetwork = false;
 
@@ -1194,6 +1197,14 @@ void DerivationGoal::haveDerivation()
     }
 
     parsedDrv = std::make_unique<ParsedDerivation>(drvPath, *drv);
+
+    contentAddressed = parsedDrv->contentAddressed();
+
+    if (this->contentAddressed) {
+        settings.requireExperimentalFeature("content-addressed-paths");
+        throw Error("content-addressed-paths isn't implemented yet");
+    }
+
 
     /* We are first going to try to create the invalid output paths
        through substitutes.  If that doesn't work, we'll build

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1226,9 +1226,6 @@ void DerivationGoal::outputsSubstituted()
 {
     trace("all outputs substituted (maybe)");
 
-    if (useDerivation)
-        worker.store.resolveDerivation(*(dynamic_cast<Derivation *>(drv.get())));
-
     if (nrFailed > 0 && nrFailed > nrNoSubstituters + nrIncompleteClosure && !settings.tryFallback) {
         done(BuildResult::TransientFailure,
             fmt("some substitutes for the outputs of derivation '%s' failed (usually happens due to networking issues); try '--fallback' to build derivation from source ",
@@ -1358,6 +1355,9 @@ void DerivationGoal::closureRepaired()
 void DerivationGoal::inputsRealised()
 {
     trace("all inputs realised");
+
+    if (useDerivation)
+        worker.store.resolveDerivation(*(dynamic_cast<Derivation *>(drv.get())));
 
     if (nrFailed != 0) {
         if (!useDerivation)

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -753,6 +753,16 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case wopQueryOutPath: {
+        auto deriver = store->parseStorePath(readString(from));
+        auto outputName = readString(from);
+        logger->startWork();
+        auto outPath = store->queryOutPath(DrvOutputId{ std::move(deriver), outputName });
+        logger->stopWork();
+        to << store->printStorePath(outPath);
+        break;
+    }
+
     default:
         throw Error("invalid operation %1%", op);
     }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -586,7 +586,7 @@ void LocalStore::resolveDerivation(Derivation & drv) {
     DerivationInputs newInputs;
 
     for (auto & input : drv.inputDrvs) {
-        auto inputDrv = readDerivation(*this, printStorePath(input.first));
+        auto inputDrv = readDerivation(input.first);
         StringSet newOutputNames;
         for (auto & outputName : input.second) {
             DrvOutputId outputId { input.first.clone(), outputName };

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -607,7 +607,6 @@ void LocalStore::resolveDerivation(Derivation & drv) {
     }
     drv.inputDrvs = std::move(newInputs);
     rewriteDerivation(*this, drv, inputRewrites);
-    debug(drv.unparse(*this, false));
 }
 
 uint64_t LocalStore::addValidPath(State & state,

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -589,8 +589,8 @@ void LocalStore::resolveDerivation(Derivation & drv) {
         auto inputDrv = readDerivation(input.first);
         StringSet newOutputNames;
         for (auto & outputName : input.second) {
-            DrvOutputId outputId { input.first.clone(), outputName };
-            auto actualPath = queryOutPath(outputId);
+            DrvOutputId outputId { input.first, outputName };
+            auto actualPath = queryOutPath(outputId, inputDrv);
             if (actualPath != drv.findOutput(outputName)) {
                 inputRewrites.emplace(
                         printStorePath(inputDrv.outputs.at(outputName).path),
@@ -936,7 +936,7 @@ StorePath LocalStore::queryOutPath(const DrvOutputId & outputId) {
     return queryOutPath(outputId, derivationFromPath(outputId.deriver));
 }
 
-StorePath LocalStore::queryOutPath(const DrvOutputId & outputId, const Derivation & drv) {
+StorePath LocalStore::queryOutPath(const DrvOutputId & outputId, const BasicDerivation & drv) {
 
     auto dbQuery = retrySQLite<std::optional<StorePath>>([&]() -> std::optional<StorePath> {
         auto state(_state.lock());

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -591,7 +591,7 @@ void LocalStore::resolveDerivation(Derivation & drv) {
         for (auto & outputName : input.second) {
             DrvOutputId outputId { input.first, outputName };
             auto actualPath = queryOutPath(outputId, inputDrv);
-            if (actualPath != drv.findOutput(outputName)) {
+            if (actualPath != inputDrv.findOutput(outputName)) {
                 inputRewrites.emplace(
                         printStorePath(inputDrv.outputs.at(outputName).path),
                         printStorePath(actualPath)

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -579,7 +579,7 @@ void LocalStore::checkDerivationOutputs(const StorePath & drvPath, const Derivat
     }
 }
 
-void LocalStore::resolveDerivation(Derivation & drv) {
+bool LocalStore::resolveDerivation(Derivation & drv) {
     // Input paths that we'll want to rewrite in the derivation
     std::map<Path, Path> inputRewrites;
 
@@ -607,6 +607,8 @@ void LocalStore::resolveDerivation(Derivation & drv) {
     }
     drv.inputDrvs = std::move(newInputs);
     rewriteDerivation(*this, drv, inputRewrites);
+
+    return (! inputRewrites.empty());
 }
 
 uint64_t LocalStore::addValidPath(State & state,

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -933,7 +933,7 @@ void LocalStore::registerOutputMappings(const OutputMappings & mappings)
 }
 
 StorePath LocalStore::queryOutPath(const DrvOutputId & outputId) {
-  return queryOutPath(outputId, derivationFromPath(outputId.deriver));
+    return queryOutPath(outputId, derivationFromPath(outputId.deriver));
 }
 
 StorePath LocalStore::queryOutPath(const DrvOutputId & outputId, const Derivation & drv) {

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -213,8 +213,8 @@ public:
 
     void registerOutputMappings(const OutputMappings & outputMappings);
 
-    StorePath queryOutPath(const DrvOutputId & outputId);
     StorePath queryOutPath(const DrvOutputId & outputId, const Derivation & drv);
+    StorePath queryOutPath(const DrvOutputId & outputId);
 
     unsigned int getProtocol() override;
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -303,6 +303,10 @@ private:
 
     void createUser(const std::string & userName, uid_t userId) override;
 
+    /* Rewrite a derivation by replacing its input derivations by their actual
+       store path */
+    void resolveDerivation(Derivation & drv);
+
     friend class DerivationGoal;
     friend class SubstitutionGoal;
 };

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -305,8 +305,11 @@ private:
     void createUser(const std::string & userName, uid_t userId) override;
 
     /* Rewrite a derivation by replacing its input derivations by their actual
-       store path */
-    void resolveDerivation(Derivation & drv);
+       store path.
+
+       Return `true` iff the derivation has been modified in the process
+    */
+    bool resolveDerivation(Derivation & drv);
 
     friend class DerivationGoal;
     friend class SubstitutionGoal;

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -50,6 +50,8 @@ private:
         SQLiteStmt stmtRegisterValidPath;
         SQLiteStmt stmtUpdatePathInfo;
         SQLiteStmt stmtAddReference;
+        SQLiteStmt stmtRegisterPathOf;
+        SQLiteStmt stmtGetPathOf;
         SQLiteStmt stmtQueryPathInfo;
         SQLiteStmt stmtQueryReferences;
         SQLiteStmt stmtQueryReferrers;
@@ -209,6 +211,10 @@ public:
 
     void registerValidPaths(const ValidPathInfos & infos);
 
+    void registerOutputMappings(const OutputMappings & outputMappings);
+
+    std::optional<StorePath> queryOutPath(const DrvOutputId & outputId);
+
     unsigned int getProtocol() override;
 
     void vacuumDB();
@@ -290,6 +296,8 @@ private:
     /* Add signatures to a ValidPathInfo using the secret keys
        specified by the ‘secret-key-files’ option. */
     void signPathInfo(ValidPathInfo & info);
+
+    void makeContentAddressed(ValidPathInfo & info);
 
     Path getRealStoreDir() override { return realStoreDir; }
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -213,7 +213,8 @@ public:
 
     void registerOutputMappings(const OutputMappings & outputMappings);
 
-    std::optional<StorePath> queryOutPath(const DrvOutputId & outputId);
+    StorePath queryOutPath(const DrvOutputId & outputId);
+    StorePath queryOutPath(const DrvOutputId & outputId, const Derivation & drv);
 
     unsigned int getProtocol() override;
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -213,7 +213,7 @@ public:
 
     void registerOutputMappings(const OutputMappings & outputMappings);
 
-    StorePath queryOutPath(const DrvOutputId & outputId, const Derivation & drv);
+    StorePath queryOutPath(const DrvOutputId & outputId, const BasicDerivation & drv);
     StorePath queryOutPath(const DrvOutputId & outputId);
 
     unsigned int getProtocol() override;

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -108,6 +108,15 @@ void Store::computeFSClosure(const StorePath & startPath,
 }
 
 
+StorePath Store::queryOutPath(const DrvOutputId & outputId) {
+    return queryOutPath(outputId, derivationFromPath(outputId.deriver));
+}
+
+StorePath Store::queryOutPath(const DrvOutputId & outputId, const Derivation & drv) {
+    return drv.findOutput(outputId.outputName).clone();
+}
+
+
 void Store::queryMissing(const std::vector<StorePathWithOutputs> & targets,
     StorePathSet & willBuild_, StorePathSet & willSubstitute_, StorePathSet & unknown_,
     unsigned long long & downloadSize_, unsigned long long & narSize_)

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -112,8 +112,8 @@ StorePath Store::queryOutPath(const DrvOutputId & outputId) {
     return queryOutPath(outputId, derivationFromPath(outputId.deriver));
 }
 
-StorePath Store::queryOutPath(const DrvOutputId & outputId, const Derivation & drv) {
-    return drv.findOutput(outputId.outputName).clone();
+StorePath Store::queryOutPath(const DrvOutputId & outputId, const BasicDerivation & drv) {
+    return drv.findOutput(outputId.outputName);
 }
 
 

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -205,10 +205,14 @@ void Store::queryMissing(const std::vector<StorePathWithOutputs> & targets,
             ParsedDerivation parsedDrv(StorePath(path.path), *drv);
 
             PathSet invalid;
-            for (auto & j : drv->outputs)
+            for (auto & j : drv->outputs) {
+                auto outPath = queryOutPath(
+                  DrvOutputId { path.path, j.first }
+                );
                 if (wantOutput(j.first, path.outputs)
-                    && !isValidPath(j.second.path))
-                    invalid.insert(printStorePath(j.second.path));
+                    && !isValidPath(outPath))
+                    invalid.insert(printStorePath(outPath));
+            }
             if (invalid.empty()) return;
 
             if (settings.useSubstitutes && parsedDrv.substitutesAllowed()) {

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -117,4 +117,9 @@ bool ParsedDerivation::substitutesAllowed() const
     return getBoolAttr("allowSubstitutes", true);
 }
 
+bool ParsedDerivation::contentAddressed() const
+{
+    return getBoolAttr("__contentAddressed", false);
+}
+
 }

--- a/src/libstore/parsed-derivations.hh
+++ b/src/libstore/parsed-derivations.hh
@@ -34,6 +34,8 @@ public:
     bool willBuildLocally() const;
 
     bool substitutesAllowed() const;
+
+    bool contentAddressed() const;
 };
 
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -388,6 +388,17 @@ void RemoteStore::queryPathInfoUncached(const StorePath & path,
     } catch (...) { callback.rethrow(); }
 }
 
+StorePath RemoteStore::queryOutPath(const DrvOutputId & outputId, const BasicDerivation & _drv) {
+    return queryOutPath(outputId);
+}
+
+StorePath RemoteStore::queryOutPath(const DrvOutputId & outputId) {
+    auto conn(getConnection());
+    conn->to << wopQueryOutPath << printStorePath(outputId.deriver) << outputId.outputName;
+    conn.processStderr();
+    return parseStorePath(readString(conn->from));
+}
+
 
 void RemoteStore::queryReferrers(const StorePath & path,
     StorePathSet & referrers)

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -47,6 +47,9 @@ public:
 
     void queryReferrers(const StorePath & path, StorePathSet & referrers) override;
 
+    StorePath queryOutPath(const DrvOutputId & outputId);
+    StorePath queryOutPath(const DrvOutputId & outputId, const BasicDerivation & drv);
+
     StorePathSet queryValidDerivers(const StorePath & path) override;
 
     StorePathSet queryDerivationOutputs(const StorePath & path) override;

--- a/src/libstore/rewrite-derivation.cc
+++ b/src/libstore/rewrite-derivation.cc
@@ -1,0 +1,60 @@
+#include "rewrite-derivation.hh"
+#include "parsed-derivations.hh"
+#include "util.hh"
+
+namespace nix {
+
+void recomputeOutputs(Store & store, Derivation & drv) {
+    DerivationOutputs oldOutputs = std::move(drv.outputs);
+
+    for (auto & i : drv.outputs) {
+        auto outputEnvVar = drv.env.find(i.first);
+        if (outputEnvVar != drv.env.end())
+            outputEnvVar->second = "";
+    }
+
+    /* Use the masked derivation expression to compute the output
+        path. */
+    Hash h = hashDerivationModulo(store, drv, true);
+
+    for (auto & i : drv.outputs)
+        if (i.second.path == StorePath::dummy) {
+            // XXX: There's certainly a better and less error-prone way
+            // of getting the name than to look it up in the drv environment
+            string name = ParsedDerivation(StorePath::dummy.clone(), drv).getStringAttr("name").value_or("");
+            StorePath outPath = store.makeOutputPath(i.first, h, name);
+            auto outputEnvVar = drv.env.find(i.first);
+            if (outputEnvVar != drv.env.end())
+                outputEnvVar->second = store.printStorePath(outPath);
+            debug(format("Rewrote output %1% to %2%")
+                % store.printStorePath(oldOutputs.at(i.first).path)
+                % store.printStorePath(outPath));
+            i.second.path = std::move(outPath);
+        }
+}
+
+void rewriteDerivation(Store & store, Derivation & drv, const StringMap & rewrites) {
+
+    for (auto &rewrite: rewrites) {
+        debug("rewriting %s as %s", rewrite.first, rewrite.second);
+    }
+
+    drv.builder = rewriteStrings(drv.builder, rewrites);
+    for (auto & arg: drv.args) {
+        arg = rewriteStrings(arg, rewrites);
+    }
+
+    StringPairs newEnv;
+    for (auto & envVar: drv.env) {
+        auto envName = rewriteStrings(envVar.first, rewrites);
+        auto envValue = rewriteStrings(envVar.second, rewrites);
+        newEnv.emplace(envName, envValue);
+    }
+    drv.env = newEnv;
+
+    if (!drv.isFixedOutput()) {
+        recomputeOutputs(store, drv);
+    }
+}
+
+}

--- a/src/libstore/rewrite-derivation.hh
+++ b/src/libstore/rewrite-derivation.hh
@@ -1,0 +1,14 @@
+#include "derivations.hh"
+#include "store-api.hh"
+#include "types.hh"
+#include "path.hh"
+
+namespace nix {
+
+/**
+ * Replace all occurences of a path in `keys(pathRewrites)` in the derivation
+ * by its associated value.
+ */
+void rewriteDerivation(Store & store, Derivation & drv, const StringMap & pathRewrites);
+
+}

--- a/src/libstore/schema.sql
+++ b/src/libstore/schema.sql
@@ -39,4 +39,10 @@ create table if not exists DerivationOutputs (
     foreign key (drv) references ValidPaths(id) on delete cascade
 );
 
+create table if not exists PathOf (
+    drv integer not null,
+    output text not null,
+    path integer not null
+);
+
 create index if not exists IndexDerivationOutputs on DerivationOutputs(path);

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -336,8 +336,8 @@ public:
     /* Get the out path for the given DrvOutputId.
      * XXX: The implementation is only valid atm for `LocalStore`
      */
-    StorePath queryOutPath(const DrvOutputId & outputId);
-    StorePath queryOutPath(const DrvOutputId & outputId, const BasicDerivation & drv);
+    virtual StorePath queryOutPath(const DrvOutputId & outputId);
+    virtual StorePath queryOutPath(const DrvOutputId & outputId, const BasicDerivation & drv);
 
     /* Return true if ‘path’ is in the Nix store (but not the Nix
        store itself). */

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -198,6 +198,20 @@ struct ValidPathInfo
 
 typedef list<ValidPathInfo> ValidPathInfos;
 
+/*
+ * Unique identifier for a specific output of a specific derivation
+ */
+struct DrvOutputId {
+    StorePath deriver;
+    string outputName;
+
+    bool operator < (const DrvOutputId & other) const
+    {
+        return deriver < other.deriver && outputName < other.outputName;
+    }
+};
+
+typedef std::map<DrvOutputId, StorePath> OutputMappings;
 
 enum BuildMode { bmNormal, bmRepair, bmCheck };
 

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -337,7 +337,7 @@ public:
      * XXX: The implementation is only valid atm for `LocalStore`
      */
     StorePath queryOutPath(const DrvOutputId & outputId);
-    StorePath queryOutPath(const DrvOutputId & outputId, const Derivation & drv);
+    StorePath queryOutPath(const DrvOutputId & outputId, const BasicDerivation & drv);
 
     /* Return true if ‘path’ is in the Nix store (but not the Nix
        store itself). */

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -333,6 +333,12 @@ public:
        and separated by commas). */
     std::string showPaths(const StorePathSet & paths);
 
+    /* Get the out path for the given DrvOutputId.
+     * XXX: The implementation is only valid atm for `LocalStore`
+     */
+    StorePath queryOutPath(const DrvOutputId & outputId);
+    StorePath queryOutPath(const DrvOutputId & outputId, const Derivation & drv);
+
     /* Return true if ‘path’ is in the Nix store (but not the Nix
        store itself). */
     bool isInStore(const Path & path) const;

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -49,6 +49,7 @@ typedef enum {
     wopNarFromPath = 38,
     wopAddToStoreNar = 39,
     wopQueryMissing = 40,
+    wopQueryOutPath = 41,
 } WorkerOp;
 
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -508,12 +508,8 @@ static void _main(int argc, char * * argv)
             auto outputName = drvInfo.queryOutputName();
             auto drvPath = drvInfo.queryDrvPath();
 
-            string rawOutPath = drvInfo.queryOutPath();
-            auto store2 = store.dynamic_pointer_cast<LocalStore>();
-            if (store2) {
-              auto outPath = store2->queryOutPath(DrvOutputId{ store->parseStorePath(drvPath), outputName});
-              rawOutPath = store2->printStorePath(outPath);
-            }
+            auto outPath = store->queryOutPath(DrvOutputId{ store->parseStorePath(drvPath), outputName});
+            string rawOutPath = store->printStorePath(outPath);
 
             std::string drvPrefix;
             auto i = drvPrefixes.find(drvPath);

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -507,8 +507,9 @@ static void _main(int argc, char * * argv)
         for (auto & drvInfo : drvs) {
             auto outputName = drvInfo.queryOutputName();
             auto drvPath = drvInfo.queryDrvPath();
-
             auto outPath = store->queryOutPath(DrvOutputId{ store->parseStorePath(drvPath), outputName});
+            if (auto store2 = store.dynamic_pointer_cast<LocalStore>())
+                outPath = store2->queryOutPath(DrvOutputId{ store->parseStorePath(drvPath), outputName});
             string rawOutPath = store->printStorePath(outPath);
 
             std::string drvPrefix;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -507,9 +507,8 @@ static void _main(int argc, char * * argv)
         for (auto & drvInfo : drvs) {
             auto outputName = drvInfo.queryOutputName();
             auto drvPath = drvInfo.queryDrvPath();
+
             auto outPath = store->queryOutPath(DrvOutputId{ store->parseStorePath(drvPath), outputName});
-            if (auto store2 = store.dynamic_pointer_cast<LocalStore>())
-                outPath = store2->queryOutPath(DrvOutputId{ store->parseStorePath(drvPath), outputName});
             string rawOutPath = store->printStorePath(outPath);
 
             std::string drvPrefix;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -512,9 +512,7 @@ static void _main(int argc, char * * argv)
             auto store2 = store.dynamic_pointer_cast<LocalStore>();
             if (store2) {
               auto outPath = store2->queryOutPath(DrvOutputId{ store->parseStorePath(drvPath), outputName});
-              if (outPath) {
-                rawOutPath = store2->printStorePath(*outPath);
-              }
+              rawOutPath = store2->printStorePath(outPath);
             }
 
             std::string drvPrefix;

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -76,9 +76,9 @@ static PathSet realisePath(StorePathWithOutputs path, bool build = true)
             DerivationOutputs::iterator i = drv.outputs.find(j);
             if (i == drv.outputs.end())
                 throw Error("derivation '%s' does not have an output named '%s'",
-                    store2->printStorePath(path.path), j);
-            auto outPath = store2->printStorePath(
-                store2->queryOutPath(DrvOutputId{ path.path.clone(), j})
+                    store->printStorePath(path.path), j);
+            auto outPath = store->printStorePath(
+                store->queryOutPath(DrvOutputId{ path.path, j})
             );
             if (store2) {
                 if (gcRoot == "")

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -61,7 +61,7 @@ static StorePath useDeriver(const StorePath & path)
    other paths it means ensure their validity. */
 static PathSet realisePath(StorePathWithOutputs path, bool build = true)
 {
-    auto store2 = std::dynamic_pointer_cast<LocalStore>(store);
+    auto store2 = std::dynamic_pointer_cast<LocalFSStore>(store);
 
     if (path.path.isDerivation()) {
         if (build) store->buildPaths({path});
@@ -77,9 +77,10 @@ static PathSet realisePath(StorePathWithOutputs path, bool build = true)
             if (i == drv.outputs.end())
                 throw Error("derivation '%s' does not have an output named '%s'",
                     store2->printStorePath(path.path), j);
-            auto outPath = store2->printStorePath(i->second.path);
+            auto outPath = store2->printStorePath(
+                store2->queryOutPath(DrvOutputId{ path.path.clone(), j})
+            );
             if (store2) {
-                outPath = store2->printStorePath(store2->queryOutPath(DrvOutputId{ path.path.clone(), j}));
                 if (gcRoot == "")
                     printGCWarning();
                 else {
@@ -218,7 +219,6 @@ static StorePathSet maybeUseOutputs(const StorePath & storePath, bool useOutput,
     if (forceRealise) realisePath({storePath});
     if (useOutput && storePath.isDerivation()) {
         auto drv = store->derivationFromPath(storePath);
-        auto store2 = std::dynamic_pointer_cast<LocalStore>(store);
         StorePathSet outputs;
         for (auto & i : drv.outputs) {
             auto outPath = i.second.path.clone();

--- a/tests/content-addressed.nix
+++ b/tests/content-addressed.nix
@@ -7,11 +7,14 @@ rec {
   # but the output will always be the same
   contentAddressed = mkDerivation {
     name = "simple-content-addressed";
-    builder = ./simple.builder.sh;
-    PATH = "";
-    goodPath = "${path}:${toString seed}";
+    buildCommand = ''
+      set -x
+      echo "Building a CA derivation"
+      echo "The seed is ${toString seed}"
+      mkdir -p $out
+      echo "Hello World" > $out/hello
+    '';
     __contentAddressed = true;
-    MSG = "Hello from ${placeholder "out"}";
   };
   dependent = mkDerivation {
     name = "dependent";

--- a/tests/content-addressed.nix
+++ b/tests/content-addressed.nix
@@ -1,0 +1,32 @@
+with import ./config.nix;
+
+{ seed ? 0 }:
+rec {
+  # A simple content-addressed derivation.
+  # The derivation can be arbitrarily modified by passing a different `seed`,
+  # but the output will always be the same
+  contentAddressed = mkDerivation {
+    name = "simple-content-addressed";
+    builder = ./simple.builder.sh;
+    PATH = "";
+    goodPath = "${path}:${toString seed}";
+    __contentAddressed = true;
+    MSG = "Hello from ${placeholder "out"}";
+  };
+  dependent = mkDerivation {
+    name = "dependent";
+    buildCommand = ''
+      echo "building a dependent derivation"
+      mkdir -p $out
+      echo ${contentAddressed}/hello > $out/dep
+    '';
+  };
+  transitivelyDependent = mkDerivation {
+    name = "transitively-dependent";
+    buildCommand = ''
+      echo "building transitively-dependent"
+      cat ${dependent}/dep
+      echo ${dependent} > $out
+    '';
+  };
+}

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -7,10 +7,18 @@ clearCache
 
 export REMOTE_STORE=file://$cacheDir
 
-out1=$(nix-build ./content-addressed.nix -A dependent --arg seed 1 -vvv)
-out2=$(nix-build ./content-addressed.nix -A dependent --arg seed 2 -vvv)
+checkBuild () {
+    drvToBuild="$1"
 
-test $out1 == $out2
+    out1=$(nix-build ./content-addressed.nix -A "$drvToBuild" --arg seed 1 -vvv)
+    out2=$(nix-build ./content-addressed.nix -A "$drvToBuild" --arg seed 2 -vvv)
+
+    test $out1 == $out2
+}
+
+checkBuild contentAddressed
+checkBuild dependent
+checkBuild transitivelyDependent
 
 # nix-build ./content-addressed.nix --arg seed 3 |& (! grep -q "building transitively-dependent")
 

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -7,8 +7,8 @@ clearCache
 
 export REMOTE_STORE=file://$cacheDir
 
-out1=$(nix-build ./content-addressed.nix -A contentAddressed --arg seed 1 -vvv)
-out2=$(nix-build ./content-addressed.nix -A contentAddressed --arg seed 2 -vvv)
+out1=$(nix-build ./content-addressed.nix -A dependent --arg seed 1 -vvv)
+out2=$(nix-build ./content-addressed.nix -A dependent --arg seed 2 -vvv)
 
 test $out1 == $out2
 

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -16,9 +16,24 @@ checkBuild () {
     test $out1 == $out2
 }
 
-checkBuild contentAddressed
-checkBuild dependent
-checkBuild transitivelyDependent
+checkAll () {
+    checkBuild contentAddressed
+    checkBuild dependent
+    checkBuild transitivelyDependent
+    # Ensure that in addition to the out paths being the same, we don't rebuild
+    # the derivations that don't need it
+    nix-build ./content-addressed.nix --arg seed 3 |& (! grep -q "building transitively-dependent")
+}
+
+# Ensure that everything works locally
+checkAll
+
+# Same thing, but with the daemon
+clearStore
+startDaemon
+checkAll
+killDaemon
+unset NIX_REMOTE
 
 # nix-build ./content-addressed.nix --arg seed 3 |& (! grep -q "building transitively-dependent")
 

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+clearStore
+clearCache
+
+export REMOTE_STORE=file://$cacheDir
+
+out1=$(nix-build ./content-addressed.nix -A contentAddressed --arg seed 1 -vvv)
+out2=$(nix-build ./content-addressed.nix -A contentAddressed --arg seed 2 -vvv)
+
+test $out1 == $out2
+
+# nix-build ./content-addressed.nix --arg seed 3 |& (! grep -q "building transitively-dependent")
+
+# clearStore
+
+# nix-build ./content-addressed.nix --arg seed 1 \
+#   --substituters "file://$cacheDir" \
+#   --no-require-sigs \
+#   --max-jobs 0


### PR DESCRIPTION
New implementation of NixOS/rfcs#62 (replaces the old prototype from https://github.com/NixOS/nix/pull/3262)

Currently at a very early stage:

- Building a cas derivation locally works
- Derivations can depend (transitively) on CAS derivations and the cutoff will be correctly done when possible
- Most tests fail, probably just because the output path returned by most commands isn't the right one anymore
- Nothing is implemented on the remote {building,caching} side

/cc @edolstra @Ericson2314 @layus 