### PR TITLE
Set GCROOT to store path to prevent garbage collection

### DIFF
--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -279,7 +279,7 @@ struct CmdDevShell : Common, MixEnvironment
 
         setEnviron();
         // prevent garbage collection until shell exits
-        setenv("GCROOT", gcroot.data(), 1);
+        setenv("NIX_GCROOT", gcroot.data(), 1);
 
         auto args = Strings{std::string(baseNameOf(shell)), "--rcfile", rcFilePath};
 

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -200,13 +200,15 @@ struct Common : InstallableCommand, MixProfile
         }
     }
 
-    BuildEnvironment getBuildEnvironment(ref<Store> store)
+    std::pair<BuildEnvironment, std::string> getBuildEnvironment(ref<Store> store)
     {
         auto shellOutPath = getShellOutPath(store);
 
+        auto strPath = store->printStorePath(shellOutPath);
+
         updateProfile(shellOutPath);
 
-        return readEnvironment(store->printStorePath(shellOutPath));
+        return {readEnvironment(strPath), strPath};
     }
 };
 
@@ -253,7 +255,7 @@ struct CmdDevShell : Common, MixEnvironment
 
     void run(ref<Store> store) override
     {
-        auto buildEnvironment = getBuildEnvironment(store);
+        auto [buildEnvironment, gcroot] = getBuildEnvironment(store);
 
         auto [rcFileFd, rcFilePath] = createTempFile("nix-shell");
 
@@ -276,6 +278,7 @@ struct CmdDevShell : Common, MixEnvironment
         auto shell = getEnv("SHELL").value_or("bash");
 
         setEnviron();
+        setenv("GCROOT", gcroot.data(), 1);
 
         auto args = Strings{std::string(baseNameOf(shell)), "--rcfile", rcFilePath};
 
@@ -307,7 +310,7 @@ struct CmdPrintDevEnv : Common
 
     void run(ref<Store> store) override
     {
-        auto buildEnvironment = getBuildEnvironment(store);
+        auto buildEnvironment = getBuildEnvironment(store).first;
 
         stopProgressBar();
 

--- a/src/nix/shell.cc
+++ b/src/nix/shell.cc
@@ -278,6 +278,7 @@ struct CmdDevShell : Common, MixEnvironment
         auto shell = getEnv("SHELL").value_or("bash");
 
         setEnviron();
+        // prevent garbage collection until shell exits
         setenv("GCROOT", gcroot.data(), 1);
 
         auto args = Strings{std::string(baseNameOf(shell)), "--rcfile", rcFilePath};


### PR DESCRIPTION
Running `nix-collect-garbage` messes up a `nix dev-shell`. For example in `nix dev-shell nixpkgs.hello`, patchelf is gone after garbage collection.

nix-shell leaves buildInputs in an environment variable, which prevents garbage collection. `nix-store --gc --print-roots` shows `/proc/*/environ`

This PR adds something similar for dev-shell