### PR TITLE
Allow empty hashes

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -201,6 +201,10 @@ Hash::Hash(const std::string & s, HashType type)
         memcpy(hash, d.data(), hashSize);
     }
 
+    else if (s == "") {
+        printError("warning: found empty hash, assuming you wanted '%s'", this->to_string());
+    }
+
     else
         throw BadHash("hash '%s' has wrong length for hash type '%s'", s, printHashType(type));
 }


### PR DESCRIPTION
This allows hash="" so that it can be used for debugging purposes. For
instance, this gives you an error message like:

warning: found empty hash, assuming you wanted 'sha256:0000000000000000000000000000000000000000000000000000'
hash mismatch in fixed-output derivation '/nix/store/jx3gikmipizpk181cgfa1l4wwcamy6p0-nixpkgs':
  wanted: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
  got:    sha256-Wm7FDDnzNteClYOn+LRCtPNcK9wjEtpj+k9IIfygD7o=