### PR TITLE
Only call grantpt on MacOS systems

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2250,10 +2250,13 @@ void DerivationGoal::startBuilder()
 
         if (chown(slaveName.c_str(), buildUser->getUID(), 0))
             throw SysError("changing owner of pseudoterminal slave");
-    } else {
+    }
+#if __APPLE__
+    else {
         if (grantpt(builderOut.readSide.get()))
             throw SysError("granting access to pseudoterminal slave");
     }
+#endif
 
     #if 0
     // Mount the pt in the sandbox so that the "tty" command works.


### PR DESCRIPTION
The commit 3cc1125595d97b4ab7369e37e4ad22f4cfecb8b2 adds a `grantpt`
call on the builder pseudo terminal fd. This call is actually only
required for MacOS, but it however requires a RW access to /dev/pts
which is only RO bindmounted in the Bazel Linux sandbox. So, Nix can
not be actually run in the Bazel Linux sandbox for unneeded reasons.

Note, on a Linux systems with a mono user Nix installation, the grantpt
call removes the write permission to the group `tty` on the pseudo
terminal file.