### PR TITLE
Fix displaying error-position in `builtins.fetch{Tree,Tarball}`

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -108,7 +108,7 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
                 name = state.forceStringNoCtx(*attr.value, *attr.pos);
             else
                 throw EvalError("unsupported argument '%s' to '%s', at %s",
-                    attr.name, who, attr.pos);
+                    attr.name, who, *attr.pos);
         }
 
         if (!url)


### PR DESCRIPTION
Without dereferencing this pointer, you'd get an error like this:

```
error: unsupported argument 'abc' to 'fetchTarball', at 0x13627e8
```

----
cc @edolstra 