### PR TITLE
Revamp README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ make
 - [Nix jobsets on hydra.nixos.org](https://hydra.nixos.org/project/nix)
 - [Nix - A One Pager](https://github.com/tazjin/nix-1p)
 - [NixOS Discourse](https://discourse.nixos.org/)
-- #nix / #nixos on irc.freenode.net
+- [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,55 @@
+# Nix
+
 [![Open Collective supporters](https://opencollective.com/nixos/tiers/supporter/badge.svg?label=Supporters&color=brightgreen)](https://opencollective.com/nixos)
 [![Test](https://github.com/NixOS/nix/workflows/Test/badge.svg)](https://github.com/NixOS/nix/actions)
 
-Nix, the purely functional package manager
-------------------------------------------
+Nix is a powerful package manager for Linux and other Unix systems that makes package
+management reliable and reproducible. Please refer to the [Nix manual](https://nixos.org/nix/manual)
+for more details.
 
-Nix is a new take on package management that is fairly unique. Because of its
-purity aspects, a lot of issues found in traditional package managers don't
-appear with Nix.
+## Installation
 
-To find out more about the tool, usage and installation instructions, please
-read the manual, which is available on the Nix website at
-<https://nixos.org/nix/manual>.
+On Linux and macOS the easiest way to Install Nix is to run the following shell command
+(as a user other than root):
 
-## Contributing
+```
+$ curl -L https://nixos.org/nix/install | sh
+```
 
-Take a look at the [Hacking Section](https://nixos.org/nix/manual/#chap-hacking)
-of the manual. It helps you to get started with building Nix from source.
+Information on additional installation methods is available on the [Nix download page](https://nixos.org/download.html).
+
+## Building And Developing
+
+### Building Nix
+
+You can build Nix via Nix via one of the targets provided by [release.nix](./release.nix):
+
+```
+$ nix-build ./release.nix -A build.aarch64-linux
+$ nix-build ./release.nix -A build.x86_64-darwin
+$ nix-build ./release.nix -A build.i686-linux
+$ nix-build ./release.nix -A build.x86_64-linux
+```
+
+### Development Environment
+
+You can use the provided `shell.nix` to easily bootstrap working development environment:
+
+```
+$ nix-shell
+$ ./bootstrap.sh
+$ ./configure
+$ make
+```
+
+## Additional Resources
+
+- [Nix manual](https://nixos.org/nix/manual)
+- [Nix jobs on nixos.hydra.org](https://hydra.nixos.org/project/nix)
+- [Nix - A One Pager](https://github.com/tazjin/nix-1p)
+- [NixOS Discourse](https://discourse.nixos.org/)
+- #nix / #nixos on irc.freenode.net
 
 ## License
 
-Nix is released under the LGPL v2.1
+Nix is released under the [LGPL v2.1](./COPYING)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ nix-build ./release.nix -A build.x86_64-linux
 
 ### Development Environment
 
-You can use the provided `shell.nix` to easily bootstrap working development environment:
+You can use the provided `shell.nix` to easily bootstrap a working development environment:
 
 ```
 $ nix-shell

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ make
 ## Additional Resources
 
 - [Nix manual](https://nixos.org/nix/manual)
-- [Nix jobs on nixos.hydra.org](https://hydra.nixos.org/project/nix)
+- [Nix jobsets on hydra.nixos.org](https://hydra.nixos.org/project/nix)
 - [Nix - A One Pager](https://github.com/tazjin/nix-1p)
 - [NixOS Discourse](https://discourse.nixos.org/)
 - #nix / #nixos on irc.freenode.net


### PR DESCRIPTION
The current README looks a bit lackluster and almost exclusively relays to nixos.org/nix for all information. While I understand and accept that we should not duplicate a lot of information these changes introduce *very* manageable redundancy while still providing the info that is most relevant:

- how do i install this?
- how do i build this?
- how do I develop this?
- where can i find related information?

The https://github.com/tazjin/nix-1p article is the least official part of the external resources that I linked. If that is a concern i could just remove it again. If there are other suggestions for external resources i'm all ears!