### PR TITLE
Warn about using the cache only when its older

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -231,6 +231,15 @@ struct stat lstat(const Path & path)
 }
 
 
+struct timespec now()
+{
+    struct timespec time;
+    if (timespec_get(&time, TIME_UTC) == 0)
+        throw SysError("getting current time");
+    return time;
+}
+
+
 bool pathExists(const Path & path)
 {
     int res;

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -9,6 +9,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <signal.h>
+#include <time.h>
 
 #include <functional>
 #include <limits>
@@ -74,6 +75,9 @@ bool isDirOrInDir(const Path & path, const Path & dir);
 
 /* Get status of `path'. */
 struct stat lstat(const Path & path);
+
+/* Get current time. */
+struct timespec now();
 
 /* Return true iff the given path exists. */
 bool pathExists(const Path & path);


### PR DESCRIPTION
The age of the cache is determined by the date it was last modified from the filesystem.

---

This PR addresses #3554. See that issue for motivation.