### PR TITLE
remote-store: don't log raw stderr by default

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -779,8 +779,10 @@ std::exception_ptr RemoteStore::Connection::processStderr(Sink * sink, Source * 
             return std::make_exception_ptr(Error(status, error));
         }
 
-        else if (msg == STDERR_NEXT)
-            printError(chomp(readString(from)));
+        else if (msg == STDERR_NEXT) {
+            string s = chomp(readString(from));
+            printMsg(lvlVomit, "stderr %s", s);
+        }
 
         else if (msg == STDERR_START_ACTIVITY) {
             auto act = readNum<ActivityId>(from);

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -63,6 +63,16 @@ public:
         writeToStderr(prefix + filterANSIEscapes(fs.s, !tty) + "\n");
     }
 
+    void result(ActivityId act, ResultType type, const std::vector<Field> & fields) override
+    {
+        if (type == resBuildLogLine || type == resPostBuildLogLine) {
+            assert(0 < fields.size());
+            assert(fields[0].type == Logger::Field::tString);
+            auto lastLine = fields[0].s;
+            log(lvlInfo, lastLine);
+        }
+    }
+
     void startActivity(ActivityId act, Verbosity lvl, ActivityType type,
         const std::string & s, const Fields & fields, ActivityId parent)
         override


### PR DESCRIPTION
For remote stores the log messages are already forwarded as structured
STDERR_RESULT messages so the old format is duplicate information.  But
still included with -vvv since it could be useful for debugging
problems.

    $ nix build -L /nix/store/nl71b2niws857ffiaggyrkjwgx9jjzc0-foo.drv --store ssh-ng://localhost
    Hello World!
    foo> Hello World!
    [1/0/1 built] building foo

Fixes #3556