### PR TITLE
Use fragment size for autoGC capacity calculation

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -889,7 +889,7 @@ void LocalStore::autoGC(bool sync)
         if (statvfs(realStoreDir.c_str(), &st))
             throw SysError("getting filesystem info about '%s'", realStoreDir);
 
-        return (uint64_t) st.f_bavail * st.f_bsize;
+        return (uint64_t) st.f_bavail * st.f_frsize;
     };
 
     std::shared_future<void> future;


### PR DESCRIPTION
Our Darwin builders at work weren't running auto-GC despite being configured to, so I had to step in here and figure out what's going on.

Turns out that in `struct statvfs`, `f_bsize` and `f_frsize` are basically always the same on Linux, while on macOS, `f_bsize` measures a *completely* different statistic (optimal I/O read size), see the man page [here](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/statvfs.3.html).

On my relatively new MBP running Catalina on APFS, `f_bsize` is 1MB while `f_frsize` is 4KB (the actual block size). Since we use `f_bsize` in the size calculation requirement, the capacity checks Nix does on Darwin are off by a factor of 256, and since we had `max-free` configured, the machine was always considered to have ample space.

The `gc-auto.sh` test can't catch this since it stubs the reported FS capacity, and also I don't think there's any reasonable way for us to catch this in a test.

I don't think there should be anything wrong with using `f_frsize` for both platforms since the two fields seem to always be the same on Linux, see [StackOverflow](https://stackoverflow.com/questions/54823541/what-do-f-bsize-and-f-frsize-in-struct-statvfs-stand-for).