### PR TITLE
Wait for build users when none are available

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -4830,7 +4830,7 @@ void Worker::waitForInput()
     if (!waitingForAWhile.empty()) {
         useTimeout = true;
         if (lastWokenUp == steady_time_point::min())
-            printError("waiting for locks or build slots...");
+            printError("waiting for locks, build slots or build users...");
         if (lastWokenUp == steady_time_point::min() || lastWokenUp > before) lastWokenUp = before;
         timeout = std::max(1L,
             (long) std::chrono::duration_cast<std::chrono::seconds>(


### PR DESCRIPTION
Solves #1216  

Descriptions from there:
>It would be nice to have the option of waiting for a build user to become free instead of failing to build.
>I'm talking about this error: error: all build users are currently in use; consider creating additional users and adding them to the ‘nixbld’ group
>Is there ever a case where failing is the preferred option to waiting? Hopefully waiting can become the default behaviour.

Additional implementation details: when build users are available, the behavior is exactly the same as before (choose the first available user, take a lock on it, use it). However, when no build users are available at the moment, repeat the search every two seconds. Whenever a build user becomes available, choose it and continue as usual. Previous behavior was to error out.

Tested on:
- [x] NixOS
- [ ] Non-NixOS Linux
- [ ] Darwin
- [ ] other platforms.

_Note:_
I have tried implementing a more "proper" solution with `libfswatch` (to only check the userpool when it changes), but for some reason the callback didn't trigger when lock files were released. If you believe that my work on implementing this with `libfswatch` is of interest, I can publish it.