### PR TITLE
Use nixpkgs#bashInteractive for dev-shell

### DIFF
--- a/src/nix/dev-shell.cc
+++ b/src/nix/dev-shell.cc
@@ -6,9 +6,6 @@
 #include "derivations.hh"
 #include "affinity.hh"
 #include "progress-bar.hh"
-#include "attr-path.hh"
-#include "eval-cache.hh"
-#include "flake/flake.hh"
 
 #include <regex>
 

--- a/src/nix/dev-shell.cc
+++ b/src/nix/dev-shell.cc
@@ -286,9 +286,8 @@ struct CmdDevShell : Common, MixEnvironment
 
     std::string getBashPath(ref<Store> store)
     {
-        auto flakeRef = FlakeRef::fromAttrs({{"type","indirect"}, {"id", "nixpkgs"}});
         auto state = getEvalState();
-        auto lockedFlake = std::make_shared<flake::LockedFlake>(lockFlake(*state, flakeRef, lockFlags));
+        auto lockedFlake = std::make_shared<flake::LockedFlake>(lockFlake(*state, installable->nixpkgsFlakeRef(), lockFlags));
         auto cache = openEvalCache(*state, lockedFlake, true);
         auto root = cache->getRoot();
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -408,8 +408,7 @@ ref<eval_cache::EvalCache> openEvalCache(
 std::tuple<std::string, FlakeRef, InstallableValue::DerivationInfo> InstallableFlake::toDerivation()
 {
 
-    auto lockedFlake = std::make_shared<flake::LockedFlake>(
-        lockFlake(*state, flakeRef, lockFlags));
+    auto lockedFlake = getLockedFlake();
 
     auto cache = openEvalCache(*state, lockedFlake, true);
     auto root = cache->getRoot();
@@ -455,9 +454,9 @@ std::vector<InstallableValue::DerivationInfo> InstallableFlake::toDerivations()
 
 std::pair<Value *, Pos> InstallableFlake::toValue(EvalState & state)
 {
-    auto lockedFlake = lockFlake(state, flakeRef, lockFlags);
+    auto lockedFlake = getLockedFlake();
 
-    auto vOutputs = getFlakeOutputs(state, lockedFlake);
+    auto vOutputs = getFlakeOutputs(state, *lockedFlake);
 
     auto emptyArgs = state.allocBindings(0);
 
@@ -493,12 +492,19 @@ InstallableFlake::getCursor(EvalState & state, bool useEvalCache)
     return res;
 }
 
+std::shared_ptr<flake::LockedFlake> InstallableFlake::getLockedFlake() const
+{
+    if (!_lockedFlake)
+        _lockedFlake = std::make_shared<flake::LockedFlake>(lockFlake(*state, flakeRef, lockFlags));
+    return _lockedFlake;
+}
+
 FlakeRef InstallableFlake::nixpkgsFlakeRef() const
 {
-    auto lockedFlake = lockFlake(*(cmd.getEvalState()), flakeRef, cmd.lockFlags);
+    auto lockedFlake = getLockedFlake();
 
-    auto nixpkgsInput = lockedFlake.flake.inputs.find("nixpkgs");
-    if (nixpkgsInput != lockedFlake.flake.inputs.end()) {
+    auto nixpkgsInput = lockedFlake->flake.inputs.find("nixpkgs");
+    if (nixpkgsInput != lockedFlake->flake.inputs.end()) {
         return std::move(nixpkgsInput->second.ref);
     }
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -493,6 +493,18 @@ InstallableFlake::getCursor(EvalState & state, bool useEvalCache)
     return res;
 }
 
+FlakeRef InstallableFlake::nixpkgsFlakeRef() const
+{
+    auto lockedFlake = lockFlake(*(cmd.getEvalState()), flakeRef, cmd.lockFlags);
+
+    auto nixpkgsInput = lockedFlake.flake.inputs.find("nixpkgs");
+    if (nixpkgsInput != lockedFlake.flake.inputs.end()) {
+        return std::move(nixpkgsInput->second.ref);
+    }
+
+    return Installable::nixpkgsFlakeRef();
+}
+
 std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
     ref<Store> store, std::vector<std::string> ss)
 {

--- a/src/nix/installables.hh
+++ b/src/nix/installables.hh
@@ -57,6 +57,11 @@ struct Installable
 
     virtual std::vector<std::pair<std::shared_ptr<eval_cache::AttrCursor>, std::string>>
     getCursor(EvalState & state, bool useEvalCache);
+
+    virtual FlakeRef nixpkgsFlakeRef() const
+    {
+        return std::move(FlakeRef::fromAttrs({{"type","indirect"}, {"id", "nixpkgs"}}));
+    }
 };
 
 struct InstallableValue : Installable
@@ -104,6 +109,8 @@ struct InstallableFlake : InstallableValue
 
     std::vector<std::pair<std::shared_ptr<eval_cache::AttrCursor>, std::string>>
     getCursor(EvalState & state, bool useEvalCache) override;
+
+    FlakeRef nixpkgsFlakeRef() const override;
 };
 
 ref<eval_cache::EvalCache> openEvalCache(

--- a/src/nix/installables.hh
+++ b/src/nix/installables.hh
@@ -88,6 +88,7 @@ struct InstallableFlake : InstallableValue
     Strings attrPaths;
     Strings prefixes;
     const flake::LockFlags & lockFlags;
+    mutable std::shared_ptr<flake::LockedFlake> _lockedFlake;
 
     InstallableFlake(ref<EvalState> state, FlakeRef && flakeRef,
         Strings && attrPaths, Strings && prefixes, const flake::LockFlags & lockFlags)
@@ -109,6 +110,8 @@ struct InstallableFlake : InstallableValue
 
     std::vector<std::pair<std::shared_ptr<eval_cache::AttrCursor>, std::string>>
     getCursor(EvalState & state, bool useEvalCache) override;
+
+    std::shared_ptr<flake::LockedFlake> getLockedFlake() const;
 
     FlakeRef nixpkgsFlakeRef() const override;
 };


### PR DESCRIPTION
Instead of using system bash for dev-shell, uses nixpkgs#bashInteractive as discussed in https://github.com/NixOS/nix/pull/3107#issuecomment-535981016. If dev-shell is used for a flake with a toplevel nixpkgs input, it uses that nixpkgs per https://github.com/NixOS/nix/pull/3107#issuecomment-536957104.

Reused a lot of code from InstallableFlake - seems like that should maybe get factored out?

@matthewbauer 