### PR TITLE
libstore/build.cc: more explicit error about form of output

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3679,7 +3679,7 @@ void DerivationGoal::registerOutputs()
                 if (!S_ISREG(st.st_mode) || (st.st_mode & S_IXUSR) != 0)
                     throw BuildError(
                         format("output path '%1%' should be a non-executable regular file "
-                               "since recursive hashing is not enabled (outputHashMode=flat).") % path);
+                               "since recursive hashing is not enabled (outputHashMode=flat)") % path);
             }
 
             /* Check the hash. In hash mode, move the path produced by

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -3678,7 +3678,8 @@ void DerivationGoal::registerOutputs()
                 /* The output path should be a regular file without execute permission. */
                 if (!S_ISREG(st.st_mode) || (st.st_mode & S_IXUSR) != 0)
                     throw BuildError(
-                        format("output path '%1%' should be a non-executable regular file") % path);
+                        format("output path '%1%' should be a non-executable regular file "
+                               "since recursive hashing is not enabled (outputHashMode=flat).") % path);
             }
 
             /* Check the hash. In hash mode, move the path produced by


### PR DESCRIPTION
Be more explicit about why we expect a regular file as output
when outputHashMode=flat for a fixed output derivation.