### PR TITLE
nix/search: no error for empty search results if json is enabled

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -180,7 +180,7 @@ struct CmdSearch : InstallableCommand, MixJSON
         for (auto & [cursor, prefix] : installable->getCursor(*state, true))
             visit(*cursor, parseAttrPath(*state, prefix));
 
-        if (!results)
+        if (!json && !results)
             throw Error("no results for the given search term(s)!");
     }
 };


### PR DESCRIPTION
- result list will be always empty if --json is passed
- for scripts an empty search result is not really an error,
  we rather want to distinguish between evaluation errors and empty results

(cherry picked from commit e60dc42caa659985aa689958c656f26dc51eae56)