### PR TITLE
build: don't log raw stderr

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -4132,13 +4132,9 @@ void DerivationGoal::flushLine()
         ;
 
     else {
-        if (settings.verboseBuild &&
-            (settings.printRepeatedBuilds || curRound == 1))
-            printError(currentLogLine);
-        else {
-            logTail.push_back(currentLogLine);
-            if (logTail.size() > settings.logLines) logTail.pop_front();
-        }
+        logTail.push_back(currentLogLine);
+        if (logTail.size() > settings.logLines)
+            logTail.pop_front();
 
         act->result(resBuildLogLine, currentLogLine);
     }

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -63,6 +63,16 @@ public:
         writeToStderr(prefix + filterANSIEscapes(fs.s, !tty) + "\n");
     }
 
+    void result(ActivityId act, ResultType type, const std::vector<Field> & fields) override
+    {
+        if (type == resBuildLogLine || type == resPostBuildLogLine) {
+            assert(0 < fields.size());
+            assert(fields[0].type == Logger::Field::tString);
+            auto lastLine = fields[0].s;
+            log(lvlInfo, lastLine);
+        }
+    }
+
     void startActivity(ActivityId act, Verbosity lvl, ActivityType type,
         const std::string & s, const Fields & fields, ActivityId parent)
         override


### PR DESCRIPTION
Second attempt, this time removing raw stderr from the build side instead of trying to determine what to show on the client.