### PR TITLE
Improve 'waiting for' message by supplying a reason for the message

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1469,7 +1469,7 @@ void DerivationGoal::tryToBuild()
             case rpPostpone:
                 /* Not now; wait until at least one child finishes or
                    the wake-up timeout expires. */
-                worker.waitForAWhile(shared_from_this(), "build hook");
+                worker.waitForAWhile(shared_from_this(), "a build hook");
                 outputLocks.unlock();
                 return;
             case rpDecline:
@@ -4456,7 +4456,7 @@ void SubstitutionGoal::tryToRun()
        a substituter to run.  This is because substitutions cannot be
        distributed to another machine via the build hook. */
     if (worker.getNrLocalBuilds() >= std::max(1U, (unsigned int) settings.maxBuildJobs)) {
-        worker.waitForBuildSlot(shared_from_this(), "substitution slot");
+        worker.waitForBuildSlot(shared_from_this(), "a substitution slot");
         return;
     }
 

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -4721,11 +4721,12 @@ void Worker::updateBlockingResourceName(string resourceName) {
 void Worker::waitForBuildSlot(GoalPtr goal, string resourceName)
 {
     debug("wait for build slots");
-    updateBlockingResourceName(resourceName);
     if (getNrLocalBuilds() < settings.maxBuildJobs)
         wakeUp(goal); /* we can do it right away */
-    else
+    else {
         addToWeakGoals(wantingToBuild, goal);
+        updateBlockingResourceName(resourceName);
+    }
 }
 
 


### PR DESCRIPTION
Resolves #2069 by allowing to pass the reason for which we are waiting to `Worker::wait*` functions.

Implementation details: stores the latest reason for which some `DerivationGoal` is sleeping in `Worker`, and if a `wait*` function is called with a reason different from the previous one, that reason is printed to stderr. Example output:

```
$ nix build -f test-nix.nix --max-jobs 8 --no-substitute
waiting for build slots...
```