### PR TITLE
Installables refactor

### DIFF
--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -179,27 +179,6 @@ struct InstallableStorePath : Installable
     }
 };
 
-std::vector<InstallableValue::DerivationInfo> InstallableAttrPath::toDerivations()
-{
-    auto v = toValue(*state).first;
-
-    Bindings & autoArgs = *cmd.getAutoArgs(*state);
-
-    DrvInfos drvInfos;
-    getDerivations(*state, *v, "", autoArgs, drvInfos, false);
-
-    std::vector<DerivationInfo> res;
-    for (auto & drvInfo : drvInfos) {
-        res.push_back({
-            state->store->parseStorePath(drvInfo.queryDrvPath()),
-            state->store->parseStorePath(drvInfo.queryOutPath()),
-            drvInfo.queryOutputName()
-        });
-    }
-
-    return res;
-}
-
 Buildables InstallableValue::toBuildables()
 {
     Buildables res;
@@ -254,6 +233,27 @@ struct InstallableAttrPath : InstallableValue
 
     virtual std::vector<InstallableValue::DerivationInfo> toDerivations() override;
 };
+
+std::vector<InstallableValue::DerivationInfo> InstallableAttrPath::toDerivations()
+{
+    auto v = toValue(*state).first;
+
+    Bindings & autoArgs = *cmd.getAutoArgs(*state);
+
+    DrvInfos drvInfos;
+    getDerivations(*state, *v, "", autoArgs, drvInfos, false);
+
+    std::vector<DerivationInfo> res;
+    for (auto & drvInfo : drvInfos) {
+        res.push_back({
+            state->store->parseStorePath(drvInfo.queryDrvPath()),
+            state->store->parseStorePath(drvInfo.queryOutPath()),
+            drvInfo.queryOutputName()
+        });
+    }
+
+    return res;
+}
 
 std::vector<std::string> InstallableFlake::getActualAttrPaths()
 {

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -237,23 +237,6 @@ Buildables InstallableValue::toBuildables()
         return res;
 }
 
-struct InstallableExpr : InstallableValue
-{
-    std::string text;
-
-    InstallableExpr(SourceExprCommand & cmd, const std::string & text)
-         : InstallableValue(cmd), text(text) { }
-
-    std::string what() override { return text; }
-
-    std::pair<Value *, Pos> toValue(EvalState & state) override
-    {
-        auto v = state.allocValue();
-        state.eval(state.parseExprFromString(text, absPath(".")), *v);
-        return {v, noPos};
-    }
-};
-
 struct InstallableAttrPath : InstallableValue
 {
     RootValue v;

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -336,7 +336,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
                 Activity act(*logger, lvlChatty, actUnknown,
                     fmt("checking '%s' for updates", element.source->attrPath));
 
-                InstallableFlake installable(*this, FlakeRef(element.source->originalRef), {element.source->attrPath}, {});
+                InstallableFlake installable(getEvalState(), FlakeRef(element.source->originalRef), {element.source->attrPath}, {}, lockFlags);
 
                 auto [attrPath, resolvedRef, drv] = installable.toDerivation();
 


### PR DESCRIPTION
Simplifies the inheritance structure for Installables, so that parent classes only contain functionality used by all children. Makes Installables less interdependent with commands, and helps #3565