### PR TITLE
nix-env: validate json outputsToInstall

### DIFF
--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -117,7 +117,7 @@ DrvInfo::Outputs DrvInfo::queryOutputs(bool onlyOutputsToInstall)
     /* Check for `meta.outputsToInstall` and return `outputs` reduced to that. */
     const Value * outTI = queryMeta("outputsToInstall");
     if (!outTI) return outputs;
-    const auto errMsg = Error("this derivation has bad 'meta.outputsToInstall'");
+    const auto errMsg = Error("derivation '%s' has bad 'meta.outputsToInstall'", name);
         /* ^ this shows during `nix-env -i` right under the bad derivation */
     if (!outTI->isList()) throw errMsg;
     Outputs result;

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -867,8 +867,12 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems)
         pkgObj.attr("system", i.querySystem());
 
         JSONObject metaObj = pkgObj.object("meta");
+
         StringSet metaNames = i.queryMetaNames();
         for (auto & j : metaNames) {
+            if (j == "outputsToInstall")
+                continue;
+
             auto placeholder = metaObj.placeholder(j);
             Value * v = i.queryMeta(j);
             if (!v) {
@@ -879,6 +883,11 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems)
                 printValueAsJSON(*globals.state, true, *v, placeholder, context);
             }
         }
+
+        DrvInfo::Outputs outputs = i.queryOutputs(true);
+        auto placeholder = metaObj.list("outputsToInstall");
+        for (auto & j : outputs)
+            placeholder.elem(j.first);
     }
 }
 


### PR DESCRIPTION
This isn't particularly useful since the json output already includes
metadata.  However the evaluation behaves differently, in this case
`meta.outputsToInstall` is also validated.  The same is done by the
channel index generation but it's currently not exposed in a way other
tools like ofborg could use it.

https://github.com/NixOS/nixos-channel-scripts/blob/7a681103b2b3ce150f7f96394f19aa0ad4797ca1/generate-programs-index.cc#L110


If this flag is added to the ofborg evaluation checks it should catch problems like https://github.com/NixOS/nixpkgs/pull/87138 in the future.

/cc @grahamc @cole-h