### PR TITLE
Generic shell completion support for the 'nix' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ makefiles = \
   src/resolve-system-dependencies/local.mk \
   scripts/local.mk \
   corepkgs/local.mk \
+  misc/bash/local.mk \
   misc/systemd/local.mk \
   misc/launchd/local.mk \
   misc/upstart/local.mk \

--- a/misc/bash/completion.sh
+++ b/misc/bash/completion.sh
@@ -1,6 +1,14 @@
 function _complete_nix {
+    local have_type
     while IFS= read -r line; do
-        COMPREPLY+=("$line")
+        if [[ -z $have_type ]]; then
+            have_type=1
+            if [[ $line = filenames ]]; then
+                compopt -o filenames
+            fi
+        else
+            COMPREPLY+=("$line")
+        fi
     done < <(NIX_GET_COMPLETIONS=$COMP_CWORD "${COMP_WORDS[@]}")
 }
 

--- a/misc/bash/completion.sh
+++ b/misc/bash/completion.sh
@@ -1,4 +1,7 @@
 function _complete_nix {
+    local -a words
+    local cword cur
+    _get_comp_words_by_ref -n ':=&' words cword cur
     local have_type
     while IFS= read -r line; do
         if [[ -z $have_type ]]; then
@@ -9,7 +12,8 @@ function _complete_nix {
         else
             COMPREPLY+=("$line")
         fi
-    done < <(NIX_GET_COMPLETIONS=$COMP_CWORD "${COMP_WORDS[@]}")
+    done < <(NIX_GET_COMPLETIONS=$cword "${words[@]}")
+    __ltrim_colon_completions "$cur"
 }
 
 complete -F _complete_nix nix

--- a/misc/bash/completion.sh
+++ b/misc/bash/completion.sh
@@ -1,0 +1,7 @@
+function _complete_nix {
+    while IFS= read -r line; do
+        COMPREPLY+=("$line")
+    done < <(NIX_GET_COMPLETIONS=$COMP_CWORD "${COMP_WORDS[@]}")
+}
+
+complete -F _complete_nix nix

--- a/misc/bash/local.mk
+++ b/misc/bash/local.mk
@@ -1,0 +1,1 @@
+$(eval $(call install-file-as, $(d)/completion.sh, $(datarootdir)/bash-completion/completions/_nix3, 0644))

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -155,7 +155,7 @@ void overrideRegistry(
 static std::shared_ptr<Registry> getGlobalRegistry(ref<Store> store)
 {
     static auto reg = [&]() {
-        auto path = settings.flakeRegistry;
+        auto path = settings.flakeRegistry.get();
 
         if (!hasPrefix(path, "/")) {
             auto storePath = downloadFile(store, path, "flake-registry.json", false).storePath;

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -31,9 +31,17 @@ MixCommonArgs::MixCommonArgs(const string & programName)
         .labels = {"name", "value"},
         .handler = {[](std::string name, std::string value) {
             try {
+                if (auto prefix = needsCompletion(name)) {
+                    std::map<std::string, Config::SettingInfo> settings;
+                    globalConfig.getSettings(settings);
+                    for (auto & s : settings)
+                        if (hasPrefix(s.first, *prefix))
+                            completions->insert(s.first);
+                }
                 globalConfig.set(name, value);
             } catch (UsageError & e) {
-                warn(e.what());
+                if (!completions)
+                    warn(e.what());
             }
         }},
     });

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -31,19 +31,21 @@ MixCommonArgs::MixCommonArgs(const string & programName)
         .labels = {"name", "value"},
         .handler = {[](std::string name, std::string value) {
             try {
-                if (auto prefix = needsCompletion(name)) {
-                    std::map<std::string, Config::SettingInfo> settings;
-                    globalConfig.getSettings(settings);
-                    for (auto & s : settings)
-                        if (hasPrefix(s.first, *prefix))
-                            completions->insert(s.first);
-                }
                 globalConfig.set(name, value);
             } catch (UsageError & e) {
                 if (!completions)
                     warn(e.what());
             }
         }},
+        .completer = [](size_t index, std::string_view prefix) {
+            if (index == 0) {
+                std::map<std::string, Config::SettingInfo> settings;
+                globalConfig.getSettings(settings);
+                for (auto & s : settings)
+                    if (hasPrefix(s.first, prefix))
+                        completions->insert(s.first);
+            }
+        }
     });
 
     addFlag({

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -41,6 +41,7 @@ void Args::parseCmdline(const Strings & _cmdline)
         assert(n > 0 && n <= cmdline.size());
         *std::next(cmdline.begin(), n - 1) += completionMarker;
         completions = std::make_shared<decltype(completions)::element_type>();
+        verbosity = lvlError;
     }
 
     for (auto pos = cmdline.begin(); pos != cmdline.end(); ) {

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -220,15 +220,25 @@ Args::Flag Args::Flag::mkHashTypeFlag(std::string && longName, HashType * ht)
     };
 }
 
-void completePath(size_t, std::string_view prefix)
+static void completePath(std::string_view prefix, int flags)
 {
     pathCompletions = true;
     glob_t globbuf;
-    if (glob((std::string(prefix) + "*").c_str(), GLOB_NOESCAPE | GLOB_TILDE, nullptr, &globbuf) == 0) {
+    if (glob((std::string(prefix) + "*").c_str(), GLOB_NOESCAPE | GLOB_TILDE | flags, nullptr, &globbuf) == 0) {
         for (size_t i = 0; i < globbuf.gl_pathc; ++i)
             completions->insert(globbuf.gl_pathv[i]);
         globfree(&globbuf);
     }
+}
+
+void completePath(size_t, std::string_view prefix)
+{
+    completePath(prefix, 0);
+}
+
+void completeDir(size_t, std::string_view prefix)
+{
+    completePath(prefix, GLOB_ONLYDIR);
 }
 
 Strings argvToStrings(int argc, char * * argv)

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -256,4 +256,8 @@ typedef std::vector<std::pair<std::string, std::string>> Table2;
 
 void printTable(std::ostream & out, const Table2 & table);
 
+extern std::shared_ptr<std::set<std::string>> completions;
+
+std::optional<std::string> needsCompletion(std::string_view s);
+
 }

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -277,4 +277,6 @@ std::optional<std::string> needsCompletion(std::string_view s);
 
 void completePath(size_t, std::string_view prefix);
 
+void completeDir(size_t, std::string_view prefix);
+
 }

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -83,6 +83,7 @@ protected:
         std::string category;
         Strings labels;
         Handler handler;
+        std::function<void(size_t, std::string_view)> completer;
 
         static Flag mkHashTypeFlag(std::string && longName, HashType * ht);
     };
@@ -98,8 +99,8 @@ protected:
     struct ExpectedArg
     {
         std::string label;
-        size_t arity; // 0 = any
-        bool optional;
+        size_t arity = 0; // 0 = any
+        bool optional = false;
         std::function<void(std::vector<std::string>)> handler;
     };
 
@@ -182,6 +183,8 @@ public:
         }});
     }
 
+    void expectPathArg(const std::string & label, string * dest, bool optional = false);
+
     /* Expect 0 or more arguments. */
     void expectArgs(const std::string & label, std::vector<std::string> * dest)
     {
@@ -189,6 +192,8 @@ public:
             *dest = std::move(ss);
         }});
     }
+
+    void expectPathArgs(const std::string & label, std::vector<std::string> * dest);
 
     friend class MultiCommand;
 };
@@ -257,7 +262,10 @@ typedef std::vector<std::pair<std::string, std::string>> Table2;
 void printTable(std::ostream & out, const Table2 & table);
 
 extern std::shared_ptr<std::set<std::string>> completions;
+extern bool pathCompletions;
 
 std::optional<std::string> needsCompletion(std::string_view s);
+
+void completePath(size_t, std::string_view s);
 
 }

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -16,6 +16,9 @@
 namespace nix {
 
 
+std::set<std::string> hashTypes = { "md5", "sha1", "sha256", "sha512" };
+
+
 void Hash::init()
 {
     if (type == htMD5) hashSize = md5HashSize;

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -18,6 +18,8 @@ const int sha1HashSize = 20;
 const int sha256HashSize = 32;
 const int sha512HashSize = 64;
 
+extern std::set<std::string> hashTypes;
+
 extern const string base32Chars;
 
 enum Base : int { Base64, Base32, Base16, SRI };

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1330,7 +1330,7 @@ bool statusOk(int status)
 }
 
 
-bool hasPrefix(const string & s, const string & prefix)
+bool hasPrefix(std::string_view s, std::string_view prefix)
 {
     return s.compare(0, prefix.size(), prefix) == 0;
 }

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -431,7 +431,7 @@ template<class N> bool string2Float(const string & s, N & n)
 
 
 /* Return true iff `s' starts with `prefix'. */
-bool hasPrefix(const string & s, const string & prefix);
+bool hasPrefix(std::string_view s, std::string_view prefix);
 
 
 /* Return true iff `s' ends in `suffix'. */

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -18,6 +18,7 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixProfile
             .description = "path of the symlink to the build result",
             .labels = {"path"},
             .handler = {&outLink},
+            .completer = completePath
         });
 
         addFlag({

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -25,7 +25,11 @@ struct CmdCatStore : StoreCommand, MixCat
 {
     CmdCatStore()
     {
-        expectPathArg("path", &path);
+        expectArgs({
+            .label = "path",
+            .handler = {&path},
+            .completer = completePath
+        });
     }
 
     std::string description() override
@@ -47,7 +51,11 @@ struct CmdCatNar : StoreCommand, MixCat
 
     CmdCatNar()
     {
-        expectPathArg("nar", &narPath);
+        expectArgs({
+            .label = "nar",
+            .handler = {&narPath},
+            .completer = completePath
+        });
         expectArg("path", &path);
     }
 

--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -25,7 +25,7 @@ struct CmdCatStore : StoreCommand, MixCat
 {
     CmdCatStore()
     {
-        expectArg("path", &path);
+        expectPathArg("path", &path);
     }
 
     std::string description() override
@@ -47,7 +47,7 @@ struct CmdCatNar : StoreCommand, MixCat
 
     CmdCatNar()
     {
-        expectArg("nar", &narPath);
+        expectPathArg("nar", &narPath);
         expectArg("path", &path);
     }
 

--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -108,6 +108,7 @@ MixProfile::MixProfile()
         .description = "profile to update",
         .labels = {"path"},
         .handler = {&profile},
+        .completer = completePath
     });
 }
 

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -38,6 +38,8 @@ struct EvalCommand : virtual StoreCommand, MixEvalArgs
     ref<EvalState> getEvalState();
 
     std::shared_ptr<EvalState> evalState;
+
+    void completeFlakeRef(std::string_view prefix);
 };
 
 struct MixFlakeOptions : virtual Args

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -73,10 +73,7 @@ struct InstallablesCommand : virtual Args, SourceExprCommand
 {
     std::vector<std::shared_ptr<Installable>> installables;
 
-    InstallablesCommand()
-    {
-        expectArgs("installables", &_installables);
-    }
+    InstallablesCommand();
 
     void prepare() override;
 

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -63,6 +63,8 @@ struct SourceExprCommand : virtual Args, EvalCommand, MixFlakeOptions
     virtual Strings getDefaultFlakeAttrPaths();
 
     virtual Strings getDefaultFlakeAttrPathPrefixes();
+
+    void completeInstallable(std::string_view prefix);
 };
 
 enum RealiseMode { Build, NoBuild, DryRun };
@@ -89,10 +91,7 @@ struct InstallableCommand : virtual Args, SourceExprCommand
 {
     std::shared_ptr<Installable> installable;
 
-    InstallableCommand()
-    {
-        expectArg("installable", &_installable, true);
-    }
+    InstallableCommand();
 
     void prepare() override;
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -28,7 +28,14 @@ public:
 
     FlakeCommand()
     {
-        expectArg("flake-url", &flakeUrl, true);
+        expectArgs({
+            .label = "flake-url",
+            .optional = true,
+            .handler = {&flakeUrl},
+            .completer = {[&](size_t, std::string_view prefix) {
+                completeFlakeRef(prefix);
+            }}
+        });
     }
 
     FlakeRef getFlakeRef()

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -31,7 +31,7 @@ struct CmdHash : Command
             .labels({"modulus"})
             .dest(&modulus);
         #endif
-        expectArgs("paths", &paths);
+        expectPathArgs("paths", &paths);
     }
 
     std::string description() override

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -31,7 +31,11 @@ struct CmdHash : Command
             .labels({"modulus"})
             .dest(&modulus);
         #endif
-        expectPathArgs("paths", &paths);
+        expectArgs({
+            .label = "paths",
+            .handler = {&paths},
+            .completer = completePath
+        });
     }
 
     std::string description() override

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -571,6 +571,14 @@ StorePathSet toDerivations(ref<Store> store,
     return drvPaths;
 }
 
+InstallablesCommand::InstallablesCommand()
+{
+    expectArgs({
+        .label = "installables",
+        .handler = {&_installables},
+    });
+}
+
 void InstallablesCommand::prepare()
 {
     if (_installables.empty() && useDefaultInstallables())

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -109,7 +109,7 @@ Strings SourceExprCommand::getDefaultFlakeAttrPathPrefixes()
 
 void SourceExprCommand::completeInstallable(std::string_view prefix)
 {
-    completePath(0, prefix);
+    completeDir(0, prefix);
 
     if (file) return; // FIXME
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -109,8 +109,6 @@ Strings SourceExprCommand::getDefaultFlakeAttrPathPrefixes()
 
 void SourceExprCommand::completeInstallable(std::string_view prefix)
 {
-    completeDir(0, prefix);
-
     if (file) return; // FIXME
 
     /* Look for flake output attributes that match the
@@ -176,6 +174,23 @@ void SourceExprCommand::completeInstallable(std::string_view prefix)
         warn(e.msg());
     }
 
+    completeFlakeRef(prefix);
+}
+
+ref<EvalState> EvalCommand::getEvalState()
+{
+    if (!evalState)
+        evalState = std::make_shared<EvalState>(searchPath, getStore());
+    return ref<EvalState>(evalState);
+}
+
+void EvalCommand::completeFlakeRef(std::string_view prefix)
+{
+    if (prefix == "")
+        completions->insert(".");
+
+    completeDir(0, prefix);
+
     /* Look for registry entries that match the prefix. */
     for (auto & registry : fetchers::getRegistries(getStore())) {
         for (auto & entry : registry->entries) {
@@ -190,13 +205,6 @@ void SourceExprCommand::completeInstallable(std::string_view prefix)
             }
         }
     }
-}
-
-ref<EvalState> EvalCommand::getEvalState()
-{
-    if (!evalState)
-        evalState = std::make_shared<EvalState>(searchPath, getStore());
-    return ref<EvalState>(evalState);
 }
 
 Buildable Installable::toBuildable()

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -689,6 +689,7 @@ InstallableCommand::InstallableCommand()
 {
     expectArgs({
         .label = "installable",
+        .optional = true,
         .handler = {&_installable},
         .completer = {[&](size_t, std::string_view prefix) {
             completeInstallable(prefix);

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -77,7 +77,8 @@ SourceExprCommand::SourceExprCommand()
         .shortName = 'f',
         .description = "evaluate FILE rather than the default",
         .labels = {"file"},
-        .handler = {&file}
+        .handler = {&file},
+        .completer = completePath
     });
 
     addFlag({

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -85,7 +85,7 @@ struct CmdLsStore : StoreCommand, MixLs
 {
     CmdLsStore()
     {
-        expectArg("path", &path);
+        expectPathArg("path", &path);
     }
 
     Examples examples() override
@@ -117,7 +117,7 @@ struct CmdLsNar : Command, MixLs
 
     CmdLsNar()
     {
-        expectArg("nar", &narPath);
+        expectPathArg("nar", &narPath);
         expectArg("path", &path);
     }
 

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -85,7 +85,11 @@ struct CmdLsStore : StoreCommand, MixLs
 {
     CmdLsStore()
     {
-        expectPathArg("path", &path);
+        expectArgs({
+            .label = "path",
+            .handler = {&path},
+            .completer = completePath
+        });
     }
 
     Examples examples() override
@@ -117,7 +121,11 @@ struct CmdLsNar : Command, MixLs
 
     CmdLsNar()
     {
-        expectPathArg("nar", &narPath);
+        expectArgs({
+            .label = "nar",
+            .handler = {&narPath},
+            .completer = completePath
+        });
         expectArg("path", &path);
     }
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -166,7 +166,21 @@ void mainWrapped(int argc, char * * argv)
 
     NixArgs args;
 
-    args.parseCmdline(argvToStrings(argc, argv));
+    Finally printCompletions([&]()
+    {
+        if (completions) {
+            for (auto & s : *completions)
+                std::cout << s << "\n";
+        }
+    });
+
+    try {
+        args.parseCmdline(argvToStrings(argc, argv));
+    } catch (UsageError &) {
+        if (!completions) throw;
+    }
+
+    if (completions) return;
 
     settings.requireExperimentalFeature("nix-command");
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -68,7 +68,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
         addFlag({
             .longName = "help",
             .description = "show usage information",
-            .handler = {[&]() { showHelpAndExit(); }},
+            .handler = {[&]() { if (!completions) showHelpAndExit(); }},
         });
 
         addFlag({
@@ -96,7 +96,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
         addFlag({
             .longName = "version",
             .description = "show version information",
-            .handler = {[&]() { printVersion(programName); }},
+            .handler = {[&]() { if (!completions) printVersion(programName); }},
         });
 
         addFlag({
@@ -169,6 +169,7 @@ void mainWrapped(int argc, char * * argv)
     Finally printCompletions([&]()
     {
         if (completions) {
+            std::cout << (pathCompletions ? "filenames\n" : "no-filenames\n");
             for (auto & s : *completions)
                 std::cout << s << "\n";
         }

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -767,7 +767,7 @@ struct CmdRepl : StoreCommand, MixEvalArgs
 
     CmdRepl()
     {
-        expectArgs("files", &files);
+        expectPathArgs("files", &files);
     }
 
     std::string description() override

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -767,7 +767,11 @@ struct CmdRepl : StoreCommand, MixEvalArgs
 
     CmdRepl()
     {
-        expectPathArgs("files", &files);
+        expectArgs({
+            .label = "files",
+            .handler = {&files},
+            .completer = completePath
+        });
     }
 
     std::string description() override

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -149,7 +149,11 @@ struct CmdRun : InstallableCommand, RunCommon
 
     CmdRun()
     {
-        expectPathArgs("args", &args);
+        expectArgs({
+            .label = "args",
+            .handler = {&args},
+            .completer = completePath
+        });
     }
 
     std::string description() override

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -149,7 +149,7 @@ struct CmdRun : InstallableCommand, RunCommon
 
     CmdRun()
     {
-        expectArgs("args", &args);
+        expectPathArgs("args", &args);
     }
 
     std::string description() override

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -105,7 +105,8 @@ struct CmdSignPaths : StorePathsCommand
             .shortName = 'k',
             .description = "file containing the secret signing key",
             .labels = {"file"},
-            .handler = {&secretKeyFile}
+            .handler = {&secretKeyFile},
+            .completer = completePath
         });
     }
 


### PR DESCRIPTION
This adds completion support for the `nix` command. For example:
```
$ nix build nixpkgs#thunderb<TAB>
nixpkgs#thunderbird      nixpkgs#thunderbird-bin  nixpkgs#thunderbolt
```

This is mostly shell-independent: the bash completion script just runs the `nix` command with the environment variable `NIX_GET_COMPLETIONS` set. `nix` then prints the completions on stdout. So it shouldn't be hard to enable support for other shells.

Any flag / argument can get custom completion by setting a `completer` function.