### PR TITLE
Handle circular flake dependencies in list-inputs

### DIFF
--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -661,3 +661,6 @@ sed -i $flakeB/flake.nix -e 's/456/789/'
 git -C $flakeB commit -a -m 'Foo'
 
 [[ $(nix eval --update-input b $flakeA#foo) = 1912 ]]
+
+# Test list-inputs with circular dependencies
+nix flake list-inputs $flakeA


### PR DESCRIPTION
`nix flake list-inputs` currently segfaults for circular flake dependencies. This PR keeps track of visited nodes and only visits them once. Second commit adds a test that currently segfaults.