### PR TITLE
Add unit tests for xml-writer

### DIFF
--- a/src/libutil/tests/xml-writer.cc
+++ b/src/libutil/tests/xml-writer.cc
@@ -1,0 +1,105 @@
+#include "xml-writer.hh"
+#include <gtest/gtest.h>
+#include <sstream>
+
+namespace nix {
+
+    /* ----------------------------------------------------------------------------
+     * XMLWriter
+     * --------------------------------------------------------------------------*/
+
+    TEST(XMLWriter, emptyObject) {
+        std::stringstream out;
+        {
+            XMLWriter t(false, out);
+        }
+
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n");
+    }
+
+    TEST(XMLWriter, objectWithEmptyElement) {
+        std::stringstream out;
+        {
+            XMLWriter t(false, out);
+            t.openElement("foobar");
+        }
+
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar></foobar>");
+    }
+
+    TEST(XMLWriter, objectWithElementWithAttrs) {
+        std::stringstream out;
+        {
+            XMLWriter t(false, out);
+            XMLAttrs attrs = {
+                { "foo", "bar" }
+            };
+            t.openElement("foobar", attrs);
+        }
+
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar foo=\"bar\"></foobar>");
+    }
+
+    TEST(XMLWriter, objectWithElementWithEmptyAttrs) {
+        std::stringstream out;
+        {
+            XMLWriter t(false, out);
+            XMLAttrs attrs = {};
+            t.openElement("foobar", attrs);
+        }
+
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar></foobar>");
+    }
+
+    TEST(XMLWriter, objectWithElementWithAttrsEscaping) {
+        std::stringstream out;
+        {
+            XMLWriter t(false, out);
+            XMLAttrs attrs = {
+                { "<key>", "<value>" }
+            };
+            t.openElement("foobar", attrs);
+        }
+
+        // XXX: While "<value>" is escaped, "<key>" isn't which I think is a bug.
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar <key>=\"&lt;value&gt;\"></foobar>");
+    }
+
+    TEST(XMLWriter, objectWithElementWithAttrsIndented) {
+        std::stringstream out;
+        {
+            XMLWriter t(true, out);
+            XMLAttrs attrs = {
+                { "foo", "bar" }
+            };
+            t.openElement("foobar", attrs);
+        }
+
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar foo=\"bar\">\n</foobar>\n");
+    }
+
+    TEST(XMLWriter, writeEmptyElement) {
+        std::stringstream out;
+        {
+            XMLWriter t(false, out);
+            t.writeEmptyElement("foobar");
+        }
+
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar />");
+    }
+
+    TEST(XMLWriter, writeEmptyElementWithAttributes) {
+        std::stringstream out;
+        {
+            XMLWriter t(false, out);
+            XMLAttrs attrs = {
+                { "foo", "bar" }
+            };
+            t.writeEmptyElement("foobar", attrs);
+
+        }
+
+        ASSERT_EQ(out.str(), "<?xml version='1.0' encoding='utf-8'?>\n<foobar foo=\"bar\" />");
+    }
+
+}


### PR DESCRIPTION
**Summary**:
Add unit tests for `xml-writer.cc`

**Notes**:
Small surface and just some basic tests to establish/document functionality. I did notice one thing though:

When providing attributes <key,value> only the value is escaped, the key isn't. ~Meaning it's possible to write invalid xml. I'll let the unit test encode the current state and open an issue when this is merged. Fixing this in `XMLWriter::writeAttrs(const XMLAttrs & attrs)` should be easy enough and I can do that as a follow-up.~ From what I can tell attribute names cannot be escaped so this would have to throw instead.