### PR TITLE
Make `functionArgs` primitive accept primops (fix #3624)

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1346,6 +1346,10 @@ static void prim_catAttrs(EvalState & state, const Pos & pos, Value * * args, Va
 static void prim_functionArgs(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
+    if (args[0]->type == tPrimOpApp || args[0]->type == tPrimOp) {
+        state.mkAttrs(v, 0);
+        return;
+    }
     if (args[0]->type != tLambda)
         throw TypeError(format("'functionArgs' requires a function, at %1%") % pos);
 


### PR DESCRIPTION
Hi!

I ran into the bug I documented in #3624, that is `functionArgs` not accepting `primop`s or partial applications or `primop`s.
This PR just makes `functionArgs` returns `{}` when a primitive operation is given.

It compiles properly for me, and as expected, evaluating `(import <nixpkgs>).lib.functionArgs map` indeed yields `{}`.