### PR TITLE
installer: don't require xz on darwin

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -36,7 +36,9 @@ tarball="$tmpDir/$(basename "$tmpDir/nix-@nixVersion@-$system.tar.xz")"
 
 require_util curl "download the binary tarball"
 require_util tar "unpack the binary tarball"
-require_util xz "unpack the binary tarball"
+if [ "$(uname -s)" != "Darwin" ]; then
+    require_util xz "unpack the binary tarball"
+fi
 
 echo "downloading Nix @nixVersion@ binary tarball for $system from '$url' to '$tmpDir'..."
 curl -L "$url" -o "$tarball" || oops "failed to download '$url'"


### PR DESCRIPTION
On macOS the system tar has builtin support for lzma while xz isn't
available as a separate binary.  There's no builtin package manager
there available either so having to install lzma (without nix) would be
rather painful.

Alternative to adding this condition would be to revert #3431, in which case potentially more works out of the box but with the downside of worse error handling.

/cc @domenkozar