### PR TITLE
Cache tree in fetchOrSubstituteTree

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -117,7 +117,7 @@ std::pair<Tree, Input> Input::fetch(ref<Store> store) const
 
             auto actualPath = store->toRealPath(storePath);
 
-            return {fetchers::Tree { .actualPath = actualPath, .storePath = std::move(storePath) }, *this};
+            return {fetchers::Tree(std::move(actualPath), std::move(storePath)), *this};
         } catch (Error & e) {
             debug("substitution of input '%s' failed: %s", to_string(), e.what());
         }

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -16,6 +16,8 @@ struct Tree
 {
     Path actualPath;
     StorePath storePath;
+    Tree(Path && actualPath, StorePath && storePath) : actualPath(actualPath), storePath(std::move(storePath)) {}
+    Tree (const Tree & rhs) : actualPath(rhs.actualPath), storePath(rhs.storePath.clone()) {}
 };
 
 struct InputScheme;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -189,10 +189,7 @@ struct GitInputScheme : InputScheme
                 input.attrs.insert_or_assign("revCount", getIntAttr(infoAttrs, "revCount"));
             input.attrs.insert_or_assign("lastModified", getIntAttr(infoAttrs, "lastModified"));
             return {
-                Tree {
-                    .actualPath = store->toRealPath(storePath),
-                    .storePath = std::move(storePath),
-                },
+                Tree(store->toRealPath(storePath), std::move(storePath)),
                 input
             };
         };
@@ -273,10 +270,8 @@ struct GitInputScheme : InputScheme
                     haveCommits ? std::stoull(runProgram("git", true, { "-C", actualUrl, "log", "-1", "--format=%ct", "HEAD" })) : 0);
 
                 return {
-                    Tree {
-                        .actualPath = store->printStorePath(storePath),
-                        .storePath = std::move(storePath),
-                    }, input
+                    Tree(store->printStorePath(storePath), std::move(storePath)),
+                    input
                 };
             }
         }

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -140,10 +140,7 @@ struct GitArchiveInputScheme : InputScheme
         if (auto res = getCache()->lookup(store, immutableAttrs)) {
             input.attrs.insert_or_assign("lastModified", getIntAttr(res->first, "lastModified"));
             return {
-                Tree{
-                    .actualPath = store->toRealPath(res->second),
-                    .storePath = std::move(res->second),
-                },
+                Tree(store->toRealPath(res->second), std::move(res->second)),
                 input
             };
         }

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -164,10 +164,10 @@ struct MercurialInputScheme : InputScheme
 
                 auto storePath = store->addToStore("source", actualUrl, true, htSHA256, filter);
 
-                return {Tree {
-                    .actualPath = store->printStorePath(storePath),
-                    .storePath = std::move(storePath),
-                }, input};
+                return {
+                    Tree(store->printStorePath(storePath), std::move(storePath)),
+                    input
+                };
             }
         }
 
@@ -189,10 +189,7 @@ struct MercurialInputScheme : InputScheme
             assert(!_input.getRev() || _input.getRev() == input.getRev());
             input.attrs.insert_or_assign("revCount", getIntAttr(infoAttrs, "revCount"));
             return {
-                Tree{
-                    .actualPath = store->toRealPath(storePath),
-                    .storePath = std::move(storePath),
-                },
+                Tree(store->toRealPath(storePath), std::move(storePath)),
                 input
             };
         };

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -96,10 +96,7 @@ struct PathInputScheme : InputScheme
             storePath = store->addToStore("source", path);
 
         return {
-            Tree {
-                .actualPath = store->toRealPath(*storePath),
-                .storePath = std::move(*storePath),
-            },
+            Tree(store->toRealPath(*storePath), std::move(*storePath)),
             input
         };
     }

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -117,10 +117,7 @@ std::pair<Tree, time_t> downloadTarball(
 
     if (cached && !cached->expired)
         return {
-            Tree {
-                .actualPath = store->toRealPath(cached->storePath),
-                .storePath = std::move(cached->storePath),
-            },
+            Tree(store->toRealPath(cached->storePath), std::move(cached->storePath)),
             getIntAttr(cached->infoAttrs, "lastModified")
         };
 
@@ -157,10 +154,7 @@ std::pair<Tree, time_t> downloadTarball(
         immutable);
 
     return {
-        Tree {
-            .actualPath = store->toRealPath(*unpackedStorePath),
-            .storePath = std::move(*unpackedStorePath),
-        },
+        Tree(store->toRealPath(*unpackedStorePath), std::move(*unpackedStorePath)),
         lastModified,
     };
 }


### PR DESCRIPTION
Caches tree in addition to lockedRef, and explicitly writes out the logic for different combinations of cached/uncached flakes and indirect/resolved/locked flakes. This eliminates uneccessary calls to lookupInFlakeCache, fetchTree, maybeLookupFlake, and flakeCache.push_back