### PR TITLE
Provide better error message when hash type is unknown

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -201,6 +201,9 @@ Hash::Hash(const std::string & s, HashType type)
         memcpy(hash, d.data(), hashSize);
     }
 
+    else if (type == htUnknown)
+        throw BadHash("cannot determine hash type for '%s'", s);
+
     else
         throw BadHash("hash '%s' has wrong length for hash type '%s'", s, printHashType(type));
 }


### PR DESCRIPTION
Previously this would abort on printHashType. This shows a better
error message so that you can see what hash value Nix is actually
seeing.