### PR TITLE
Missing `#include <cassert>` in `lru-cache.hh`

### DIFF
--- a/src/libutil/lru-cache.hh
+++ b/src/libutil/lru-cache.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <map>
 #include <list>
 #include <optional>


### PR DESCRIPTION
This was a latent bug that just appeared because of the tests that were
added. Remember to wait for CI! :)