### PR TITLE
Fix log-prefix of `nix build -L`

### DIFF
--- a/src/nix/progress-bar.cc
+++ b/src/nix/progress-bar.cc
@@ -157,10 +157,12 @@ public:
             auto name = storePathToName(getS(fields, 0));
             if (hasSuffix(name, ".drv"))
                 name = name.substr(0, name.size() - 4);
-            i->s = fmt("building " ANSI_BOLD "%s" ANSI_NORMAL, name);
             auto machineName = getS(fields, 1);
-            if (machineName != "")
-                i->s += fmt(" on " ANSI_BOLD "%s" ANSI_NORMAL, machineName);
+            i->s = fmt(
+                "building " ANSI_BOLD "%s" ANSI_NORMAL "%s",
+                name,
+                machineName != "" ? fmt(" on " ANSI_BOLD "%s" ANSI_NORMAL, machineName) : ""
+            );
             auto curRound = getI(fields, 2);
             auto nrRounds = getI(fields, 3);
             if (nrRounds != 1)


### PR DESCRIPTION
While playing around with Nix master, I realized that the log-prefix is
broken when building a derivation on a remote builder:

```
~/nixpkgs → ../nix/inst/bin/nix build --experimental-features 'nix-command flakes'  -L -f . hello
lder0> unpacking sources
lder0> unpacking source archive /nix/store/3x7dwzq014bblazs7kq20p9hyzz0qh8g-hello-2.10.tar.gz
lder0> source root is hello-2.10
lder0> setting SOURCE_DATE_EPOCH to timestamp 1416139241 of file hello-2.10/ChangeLog
lder0> patching sources
lder0> configuring
lder0> configure flags: --disable-dependency-tracking --prefix=/nix/store/55xlqch5wdc3vbkjl3v47bn5if63n65c-hello-2.10
[1/0/1 built]
error: interrupted by the user
```

It seems as the five chars of the string `hello` have been replaced by
the builder's name (ssh://builder). I suspect that this is related to
`fmt` taking `args` as reference[1].

I'm not sure why, but this can be avoided by not appending another
formatted string to `i->s`. I worked around this by modifying `i->s`
only once.

I can reproduce this on a recent `master`[2] and on a recent `flakes`[3]. In
the latter case, e.g. `nix flake check -L` is also affected.

[1] 334b8f8af1c47970e6cdf3ca6f45dfb8cd8e7938
[2] bfa1acd85c4d15c5ea95337138f47672659e2a9e
[3] 81cafda306e7257d0d77a20b9bde45049abaa52a