### PR TITLE
rename the url attribute to instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ GSYMS
 GTAGS
 
 nix-rust/target
+result*/

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -357,6 +357,9 @@ public:
     Setting<std::string> githubAccessToken{this, "", "github-access-token",
         "GitHub access token to get access to GitHub data through the GitHub API for github:<..> flakes."};
 
+    Setting<std::string> giteaAccessToken{this, "", "gitea-access-token",
+        "Gitea access token to get access to Gitea data through the gitea API for gitea:<..> flakes."};
+
     Setting<Strings> experimentalFeatures{this, {}, "experimental-features",
         "Experimental Nix features to enable."};
 


### PR DESCRIPTION
This renames the url attribute created in #3660 and adds a url info to the output of `nix flake info`

~~~
./result/bin/nix flake info gitlab:kloenk/dwarffs\?instance=git.thevillage.chat
Resolved URL:  gitlab:kloenk/dwarffs?instance=git.thevillage.chat
Locked URL:    gitlab:kloenk/dwarffs/799b8e0abc624e440bc35c38f4b5a08ce981df4a?instance=git.thevillage.chat
Description:   A filesystem that fetches DWARF debug info from the Internet on demand
Path:          /nix/store/v6xvpisgmnp2qwjbcl5xl735g7md2c6l-source
Revision:      799b8e0abc624e440bc35c38f4b5a08ce981df4a
Last modified: 2020-05-11 19:41:56
~~~