### PR TITLE
Add `src/libutil/tests/libutil-tests` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ perl/Makefile.config
 # /src/libstore/
 *.gen.*
 
+# /src/libutil/
+/src/libutil/tests/libutil-tests
+
 /src/nix/nix
 
 # /src/nix-env/


### PR DESCRIPTION
I gather this comes from the new unit tests.