### PR TITLE
Add unit tests for rust-ffi

### DIFF
--- a/src/libutil/tests/local.mk
+++ b/src/libutil/tests/local.mk
@@ -10,6 +10,6 @@ libutil-tests_SOURCES := $(wildcard $(d)/*.cc)
 
 libutil-tests_CXXFLAGS += -I src/libutil
 
-libutil-tests_LIBS = libutil
+libutil-tests_LIBS = libutil libnixrust
 
 libutil-tests_LDFLAGS := $(GTEST_LIBS)

--- a/src/libutil/tests/rust-ffi.cc
+++ b/src/libutil/tests/rust-ffi.cc
@@ -1,0 +1,52 @@
+#include "rust-ffi.hh"
+#include <gtest/gtest.h>
+#include <sstream>
+
+namespace rust {
+
+    /* ----------------------------------------------------------------------------
+     * String
+     * --------------------------------------------------------------------------*/
+
+    TEST(RustString, constructString) {
+        String s("afsjdkljfhreajkthawklfjrektghaekjfjhrgklhreak;rjwaeuifhasuifh");
+        std::string_view v(s);
+        ASSERT_EQ(v, "afsjdkljfhreajkthawklfjrektghaekjfjhrgklhreak;rjwaeuifhasuifh");
+    }
+
+    TEST(RustString, writeToStream) {
+        String s("nlvkhrtiluwaejklfkjdthaewojfrldhnguirdag");
+        std::string_view v(s);
+        std::stringstream out;
+
+        String s2(v);
+        out << s2;
+
+        ASSERT_EQ(out.str(), "nlvkhrtiluwaejklfkjdthaewojfrldhnguirdag");
+    }
+
+    /* ----------------------------------------------------------------------------
+     * Result
+     * --------------------------------------------------------------------------*/
+
+    TEST(RustResult, resultCanBeUnwrapped) {
+        Result<int> r;
+        r.tag = Result<int>::Ok;
+        r.data = 1;
+
+        ASSERT_EQ(r.unwrap(), 1);
+    }
+
+    ///XXX: This is *NOT* what we want. We should be able
+    //to set exc to an exception object here and then do
+    //an ASSER_THROW(r.unwrap(), Error)
+    TEST(RustResult, cannotUnwrapErrResult) {
+        Result<int> r;
+        r.tag = Result<int>::Err;
+        r.exc = NULL;
+
+        ASSERT_DEATH(r.unwrap(), "");
+
+    }
+
+}


### PR DESCRIPTION
Adds very simple tests for String and Result from rust-ffi.h

**Note**: The `Result` test case for Err values should be adjusted such
that it carries an actual exception. I failed to get that done however.

@edolstra Maybe you know how to do this.