### PR TITLE
WIP: Add Store API-based HashedMirrors

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -263,7 +263,7 @@ void BinaryCacheStore::addToStore(const ValidPathInfo & info, Source & narSource
     stats.narInfoWrite++;
 }
 
-bool BinaryCacheStore::isValidPathUncached(const StorePath & storePath)
+bool BinaryCacheStore::isValidPathUncached(const StorePath & storePath, const std::string ca)
 {
     // FIXME: this only checks whether a .narinfo with a matching hash
     // part exists. So ‘f4kb...-foo’ matches ‘f4kb...-bar’, even
@@ -271,7 +271,7 @@ bool BinaryCacheStore::isValidPathUncached(const StorePath & storePath)
     return fileExists(narInfoFileFor(storePath));
 }
 
-void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
+void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink, const std::string ca)
 {
     auto info = queryPathInfo(storePath).cast<const NarInfo>();
 
@@ -298,7 +298,7 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
 }
 
 void BinaryCacheStore::queryPathInfoUncached(const StorePath & storePath,
-    Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
+    Callback<std::shared_ptr<const ValidPathInfo>> callback, const std::string ca) noexcept
 {
     auto uri = getUri();
     auto storePathS = printStorePath(storePath);

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -66,10 +66,11 @@ private:
 
 public:
 
-    bool isValidPathUncached(const StorePath & path) override;
+    bool isValidPathUncached(const StorePath & path, const std::string ca) override;
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback,
+        const std::string ca) noexcept override;
 
     std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override
     { unsupported("queryPathFromHashPart"); }
@@ -85,7 +86,7 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
-    void narFromPath(const StorePath & path, Sink & sink) override;
+    void narFromPath(const StorePath & path, Sink & sink, const std::string ca) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
         BuildMode buildMode) override

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2703,7 +2703,7 @@ struct RestrictedStore : public LocalFSStore
     }
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override
+        Callback<std::shared_ptr<const ValidPathInfo>> callback, const std::string ca) noexcept override
     {
         if (goal.isAllowed(path)) {
             try {
@@ -2762,11 +2762,11 @@ struct RestrictedStore : public LocalFSStore
         return path;
     }
 
-    void narFromPath(const StorePath & path, Sink & sink) override
+    void narFromPath(const StorePath & path, Sink & sink, std::string ca) override
     {
         if (!goal.isAllowed(path))
             throw InvalidPath("cannot dump unknown path '%s' in recursive Nix", printStorePath(path));
-        LocalFSStore::narFromPath(path, sink);
+        LocalFSStore::narFromPath(path, sink, ca);
     }
 
     void ensurePath(const StorePath & path) override

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -58,20 +58,6 @@ void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
         }
     };
 
-    /* Try the hashed mirrors first. */
-    if (getAttr("outputHashMode") == "flat")
-        for (auto hashedMirror : settings.hashedMirrors.get())
-            try {
-                if (!hasSuffix(hashedMirror, "/")) hashedMirror += '/';
-                auto ht = parseHashType(getAttr("outputHashAlgo"));
-                auto h = Hash(getAttr("outputHash"), ht);
-                fetch(hashedMirror + printHashType(h.type) + "/" + h.to_string(Base16, false));
-                return;
-            } catch (Error & e) {
-                debug(e.what());
-            }
-
-    /* Otherwise try the specified URL. */
     fetch(mainUrl);
 }
 

--- a/src/libstore/hashed-mirror-store.cc
+++ b/src/libstore/hashed-mirror-store.cc
@@ -182,6 +182,10 @@ public:
         }
     }
 
+    bool supportsOtherStoreDir() {
+        return true;
+    }
+
 };
 
 static RegisterStoreImplementation regStore([](

--- a/src/libstore/hashed-mirror-store.cc
+++ b/src/libstore/hashed-mirror-store.cc
@@ -1,0 +1,198 @@
+#include "binary-cache-store.hh"
+#include "filetransfer.hh"
+#include "globals.hh"
+#include "archive.hh"
+
+namespace nix {
+
+class HashedMirrorStore : public Store
+{
+private:
+
+    Path cacheUri;
+    Path cacheDir;
+
+public:
+
+    HashedMirrorStore(
+        const Params & params, const Path & _cacheUri)
+        : Store(params)
+        , cacheUri(_cacheUri)
+    {
+        if (hasPrefix(cacheUri, "hashed-mirror+"))
+            cacheUri = cacheUri.substr(14);
+
+        if (cacheUri.back() == '/')
+            cacheUri.pop_back();
+
+        if (!hasPrefix(cacheUri, "file://"))
+            throw Error("only file:// cache is currently supported in hashed mirror store");
+
+        cacheDir = cacheUri.substr(7);
+    }
+
+    std::string getUri() override
+    {
+        return cacheUri;
+    }
+
+    void init()
+    {
+    }
+
+    void narFromPath(const StorePath & storePath, Sink & sink, const std::string ca) override
+    {
+        dumpPath(cacheDir + getPath(ca), sink);
+    }
+
+    static Hash getHash(std::string ca)
+    {
+        if (ca == "")
+            throw Error("ca cannot be empty in hashed mirror store");
+
+        if (!hasPrefix(ca, "fixed:"))
+            throw Error("hashed mirror must be fixed-output");
+
+        ca = ca.substr(6);
+
+        if (hasPrefix(ca, "r:"))
+            throw Error("hashed mirror cannot be recursive");
+
+        return Hash(ca);
+    }
+
+    static std::string getPath(std::string ca)
+    {
+        Hash h = getHash(ca);
+
+        return "/" + printHashType(h.type) + "/" + h.to_string(Base16, false);
+    }
+
+    bool isValidPathUncached(const StorePath & storePath, std::string ca) override
+    {
+        return fileExists(getPath(ca));
+    }
+
+    void queryPathInfoUncached(const StorePath & path,
+        Callback<std::shared_ptr<const ValidPathInfo>> callback, const std::string ca) noexcept override
+    {
+        auto info = std::make_shared<ValidPathInfo>(path.clone());
+
+        // not efficient!
+        StringSink sink;
+        dumpPath(cacheDir + getPath(ca), sink);
+        info->narHash = hashString(htSHA256, *sink.s);
+        info->narSize = sink.s->size();
+
+        info->ca = ca;
+        callback(std::move(info));
+    }
+
+    std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override
+    {
+        unsupported("queryPathFromHashPart");
+    }
+
+    void addToStore(const ValidPathInfo & info, Source & source,
+        RepairFlag repair, CheckSigsFlag checkSigs, std::shared_ptr<FSAccessor> accessor) override
+    {
+        if (info.references.size() > 0)
+            throw Error("references are not supported in a hashed mirror store");
+
+        auto dirname = std::string(dirOf(cacheDir + getPath(info.ca)));
+        if (!pathExists(dirname))
+            if (mkdir(dirname.c_str(), 0777) == -1)
+                throw SysError(format("creating directory '%1%'") % dirname);
+
+        auto path = cacheDir + getPath(info.ca);
+        restorePath(path, source);
+
+        Hash h(info.ca.substr(6));
+
+        HashSink hashSink(h.type);
+        readFile(path, hashSink);
+
+        Hash gotHash = hashSink.finish().first;
+        if (gotHash != h)
+            throw Error("path '%s' does not have correct hash: expected %s, got %s", path, h.to_string(), gotHash.to_string());
+    }
+
+    StorePath addToStore(const string & name, const Path & srcPath,
+        FileIngestionMethod method, HashType hashAlgo,
+        PathFilter & filter, RepairFlag repair) override
+    {
+        unsupported("addToStore");
+    }
+
+    void ensurePath(const StorePath & path) override
+    {
+        unsupported("ensurePath");
+    }
+
+    StorePath addTextToStore(const string & name, const string & s,
+        const StorePathSet & references, RepairFlag repair = NoRepair) override
+    { unsupported("addTextToStore"); }
+
+    BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
+        BuildMode buildMode = bmNormal) override
+    { unsupported("buildDerivation"); }
+
+    StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute, std::map<std::string, std::string> pathsInfo) override
+    {
+        StorePathSet res;
+        for (auto & i : paths) {
+            auto ca = pathsInfo.find(printStorePath(i));
+            if (isValidPath(i, ca != pathsInfo.end() ? ca->second : ""))
+                res.insert(i.clone());
+        }
+        return res;
+    }
+
+    // Taken from local-binary-cache.cc, should make this also support http
+
+    static void atomicWrite(const Path & path, const std::string & s)
+    {
+        Path tmp = path + ".tmp." + std::to_string(getpid());
+        AutoDelete del(tmp, false);
+        writeFile(tmp, s);
+        if (rename(tmp.c_str(), path.c_str()))
+            throw SysError(format("renaming '%1%' to '%2%'") % tmp % path);
+        del.cancel();
+    }
+
+    bool fileExists(const std::string & path)
+    {
+        return pathExists(cacheDir + "/" + path);
+    }
+
+    void upsertFile(const std::string & path,
+        const std::string & data,
+        const std::string & mimeType)
+    {
+        atomicWrite(cacheDir + "/" + path, data);
+    }
+
+    void getFile(const std::string & path, Sink & sink)
+    {
+        try {
+            readFile(cacheDir + "/" + path, sink);
+        } catch (SysError & e) {
+            if (e.errNo == ENOENT)
+                throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache", path);
+        }
+    }
+
+};
+
+static RegisterStoreImplementation regStore([](
+    const std::string & uri, const Store::Params & params)
+    -> std::shared_ptr<Store>
+{
+    if (std::string(uri, 0, 14) != "hashed-mirror+")
+        return 0;
+    auto store = std::make_shared<HashedMirrorStore>(params, uri);
+    store->init();
+    return store;
+});
+
+}

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -88,7 +88,8 @@ struct LegacySSHStore : public Store
     }
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override
+        Callback<std::shared_ptr<const ValidPathInfo>> callback,
+        const std::string ca) noexcept override
     {
         try {
             auto conn(connections->get());
@@ -182,7 +183,7 @@ struct LegacySSHStore : public Store
             throw Error("failed to add path '%s' to remote host '%s'", printStorePath(info.path), host);
     }
 
-    void narFromPath(const StorePath & path, Sink & sink) override
+    void narFromPath(const StorePath & path, Sink & sink, const std::string ca) override
     {
         auto conn(connections->get());
 
@@ -260,7 +261,8 @@ struct LegacySSHStore : public Store
     }
 
     StorePathSet queryValidPaths(const StorePathSet & paths,
-        SubstituteFlag maybeSubstitute = NoSubstitute) override
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        std::map<std::string, std::string> pathsInfo = {}) override
     {
         auto conn(connections->get());
 

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -77,7 +77,7 @@ ref<FSAccessor> LocalFSStore::getFSAccessor()
             std::dynamic_pointer_cast<LocalFSStore>(shared_from_this())));
 }
 
-void LocalFSStore::narFromPath(const StorePath & path, Sink & sink)
+void LocalFSStore::narFromPath(const StorePath & path, Sink & sink, const std::string)
 {
     if (!isValidPath(path))
         throw Error("path '%s' is not valid", printStorePath(path));

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -835,7 +835,7 @@ StorePathSet LocalStore::querySubstitutablePaths(const StorePathSet & paths)
 
     for (auto & sub : getDefaultSubstituters()) {
         if (remaining.empty()) break;
-        if (sub->storeDir != storeDir) continue;
+        if (sub->storeDir != storeDir && !sub->supportsOtherStoreDir()) continue;
         if (!sub->wantMassQuery) continue;
 
         auto valid = sub->queryValidPaths(remaining);
@@ -859,7 +859,7 @@ void LocalStore::querySubstitutablePathInfos(const StorePathSet & paths,
 {
     if (!settings.useSubstitutes) return;
     for (auto & sub : getDefaultSubstituters()) {
-        if (sub->storeDir != storeDir) continue;
+        if (sub->storeDir != storeDir && sub->supportsOtherStoreDir()) continue;
         for (auto & path : paths) {
             if (infos.count(path)) continue;
             debug("checking substituter '%s' for path '%s'", sub->getUri(), printStorePath(path));

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -25,6 +25,7 @@ const int nixSchemaVersion = 10;
 
 struct Derivation;
 
+class HashedMirrorStore;
 
 struct OptimiseStats
 {

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -119,15 +119,17 @@ public:
 
     std::string getUri() override;
 
-    bool isValidPathUncached(const StorePath & path) override;
+    bool isValidPathUncached(const StorePath & path, const std::string ca) override;
 
     StorePathSet queryValidPaths(const StorePathSet & paths,
-        SubstituteFlag maybeSubstitute = NoSubstitute) override;
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        std::map<std::string, std::string> pathsInfo = {}) override;
 
     StorePathSet queryAllValidPaths() override;
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback,
+        const std::string ca) noexcept override;
 
     void queryReferrers(const StorePath & path, StorePathSet & referrers) override;
 
@@ -142,7 +144,8 @@ public:
     StorePathSet querySubstitutablePaths(const StorePathSet & paths) override;
 
     void querySubstitutablePathInfos(const StorePathSet & paths,
-        SubstitutablePathInfos & infos) override;
+        SubstitutablePathInfos & infos,
+        std::map<std::string, Derivation> drvs = {}) override;
 
     void addToStore(const ValidPathInfo & info, Source & source,
         RepairFlag repair, CheckSigsFlag checkSigs,

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -159,7 +159,8 @@ void Store::queryMissing(const std::vector<StorePathWithOutputs> & targets,
         SubstitutablePathInfos infos;
         StorePathSet paths; // FIXME
         paths.insert(outPath.clone());
-        querySubstitutablePathInfos(paths, infos);
+
+        querySubstitutablePathInfos(paths, infos, { {outPathS, Derivation(*drv) } });
 
         if (infos.empty()) {
             drvState_->lock()->done = true;

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -253,7 +253,7 @@ ConnectionHandle RemoteStore::getConnection()
 }
 
 
-bool RemoteStore::isValidPathUncached(const StorePath & path)
+bool RemoteStore::isValidPathUncached(const StorePath & path, const std::string ca)
 {
     auto conn(getConnection());
     conn->to << wopIsValidPath << printStorePath(path);
@@ -262,7 +262,7 @@ bool RemoteStore::isValidPathUncached(const StorePath & path)
 }
 
 
-StorePathSet RemoteStore::queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute)
+StorePathSet RemoteStore::queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute, std::map<std::string, std::string> pathsInfo)
 {
     auto conn(getConnection());
     if (GET_PROTOCOL_MINOR(conn->daemonVersion) < 12) {
@@ -309,7 +309,7 @@ StorePathSet RemoteStore::querySubstitutablePaths(const StorePathSet & paths)
 
 
 void RemoteStore::querySubstitutablePathInfos(const StorePathSet & paths,
-    SubstitutablePathInfos & infos)
+    SubstitutablePathInfos & infos, std::map<std::string, Derivation> drvs)
 {
     if (paths.empty()) return;
 
@@ -353,7 +353,8 @@ void RemoteStore::querySubstitutablePathInfos(const StorePathSet & paths,
 
 
 void RemoteStore::queryPathInfoUncached(const StorePath & path,
-    Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
+    Callback<std::shared_ptr<const ValidPathInfo>> callback,
+    const std::string ca) noexcept
 {
     try {
         std::shared_ptr<ValidPathInfo> info;

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -35,15 +35,17 @@ public:
 
     /* Implementations of abstract store API methods. */
 
-    bool isValidPathUncached(const StorePath & path) override;
+    bool isValidPathUncached(const StorePath & path, const std::string ca) override;
 
     StorePathSet queryValidPaths(const StorePathSet & paths,
-        SubstituteFlag maybeSubstitute = NoSubstitute) override;
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        std::map<std::string, std::string> pathsInfo = {}) override;
 
     StorePathSet queryAllValidPaths() override;
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback,
+        const std::string ca) noexcept override;
 
     void queryReferrers(const StorePath & path, StorePathSet & referrers) override;
 
@@ -58,7 +60,7 @@ public:
     StorePathSet querySubstitutablePaths(const StorePathSet & paths) override;
 
     void querySubstitutablePathInfos(const StorePathSet & paths,
-        SubstitutablePathInfos & infos) override;
+        SubstitutablePathInfos & infos, std::map<std::string, Derivation> drvs = {}) override;
 
     void addToStore(const ValidPathInfo & info, Source & nar,
         RepairFlag repair, CheckSigsFlag checkSigs,

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -223,7 +223,7 @@ struct S3BinaryCacheStoreImpl : public S3BinaryCacheStore
        fetches the .narinfo file, rather than first checking for its
        existence via a HEAD request. Since .narinfos are small, doing
        a GET is unlikely to be slower than HEAD. */
-    bool isValidPathUncached(const StorePath & storePath) override
+    bool isValidPathUncached(const StorePath & storePath, const std::string ca) override
     {
         try {
             queryPathInfo(storePath);

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -40,7 +40,7 @@ public:
     bool sameMachine() override
     { return false; }
 
-    void narFromPath(const StorePath & path, Sink & sink) override;
+    void narFromPath(const StorePath & path, Sink & sink, const std::string ca) override;
 
     ref<FSAccessor> getFSAccessor() override;
 
@@ -68,7 +68,7 @@ private:
     };
 };
 
-void SSHStore::narFromPath(const StorePath & path, Sink & sink)
+void SSHStore::narFromPath(const StorePath & path, Sink & sink, const std::string ca)
 {
     auto conn(connections->get());
     conn->to << wopNarFromPath << printStorePath(path);

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -948,6 +948,10 @@ std::list<ref<Store>> getDefaultSubstituters()
         for (auto uri : settings.extraSubstituters.get())
             addStore(uri);
 
+        for (auto uri : settings.hashedMirrors.get()) {
+            addStore("hashed-mirror+" + uri);
+        }
+
         stores.sort([](ref<Store> & a, ref<Store> & b) {
             return a->priority < b->priority;
         });

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -379,18 +379,19 @@ public:
         const StorePathSet & references) const;
 
     /* Check whether a path is valid. */
-    bool isValidPath(const StorePath & path);
+    bool isValidPath(const StorePath & path, const std::string ca = "");
 
 protected:
 
-    virtual bool isValidPathUncached(const StorePath & path);
+    virtual bool isValidPathUncached(const StorePath & path, const std::string ca = "");
 
 public:
 
     /* Query which of the given paths is valid. Optionally, try to
        substitute missing paths. */
     virtual StorePathSet queryValidPaths(const StorePathSet & paths,
-        SubstituteFlag maybeSubstitute = NoSubstitute);
+        SubstituteFlag maybeSubstitute = NoSubstitute,
+        std::map<std::string, std::string> pathsInfo = {});
 
     /* Query the set of all valid paths. Note that for some store
        backends, the name part of store paths may be omitted
@@ -402,16 +403,16 @@ public:
 
     /* Query information about a valid path. It is permitted to omit
        the name part of the store path. */
-    ref<const ValidPathInfo> queryPathInfo(const StorePath & path);
+    ref<const ValidPathInfo> queryPathInfo(const StorePath & path, const std::string ca = "");
 
     /* Asynchronous version of queryPathInfo(). */
     void queryPathInfo(const StorePath & path,
-        Callback<ref<const ValidPathInfo>> callback) noexcept;
+        Callback<ref<const ValidPathInfo>> callback, const std::string ca = "") noexcept;
 
 protected:
 
     virtual void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept = 0;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback, const std::string ca = "") noexcept = 0;
 
 public:
 
@@ -445,7 +446,7 @@ public:
        sizes) of a set of paths.  If a path does not have substitute
        info, it's omitted from the resulting ‘infos’ map. */
     virtual void querySubstitutablePathInfos(const StorePathSet & paths,
-        SubstitutablePathInfos & infos) { return; };
+        SubstitutablePathInfos & infos, std::map<std::string, Derivation> drvs = {}) { return; };
 
     /* Import a path into the store. */
     virtual void addToStore(const ValidPathInfo & info, Source & narSource,
@@ -473,7 +474,7 @@ public:
         const StorePathSet & references, RepairFlag repair = NoRepair) = 0;
 
     /* Write a NAR dump of a store path. */
-    virtual void narFromPath(const StorePath & path, Sink & sink) = 0;
+    virtual void narFromPath(const StorePath & path, Sink & sink, std::string ca = "") = 0;
 
     /* For each path, if it's a derivation, build it.  Building a
        derivation means ensuring that the output paths are valid.  If
@@ -713,7 +714,7 @@ public:
 
     LocalFSStore(const Params & params);
 
-    void narFromPath(const StorePath & path, Sink & sink) override;
+    void narFromPath(const StorePath & path, Sink & sink, std::string ca) override;
     ref<FSAccessor> getFSAccessor() override;
 
     /* Register a permanent GC root. */

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -298,6 +298,8 @@ public:
 
     virtual std::string getUri() = 0;
 
+    virtual bool supportsOtherStoreDir() { return false; };
+
     StorePath parseStorePath(std::string_view path) const;
 
     std::optional<StorePath> maybeParseStorePath(std::string_view path) const;


### PR DESCRIPTION
This is a replacement for “hashed-mirrors” which provide a way to
supply fixed output, flat store objects. An advantage of
hashed-mirrors over other substituters is that we can use them in
multiple store directories. HashedMirrorStore succeeds hashed mirror,
but now uses the store api.

url format for HashedMirrorStore looks like:

  - hashed-mirror+file://
  - hashed-mirror+http://

The hashed-mirrors option still works, it just rewrites them as
substituters for the above.

Currently only file:// is implemented, http:// still needs to be
added.

@edolstra Does this make sense to you? Specifically, I'm wondering if adding `ca` here breaks any assumptions we have in the store api. Leaving this partially unfinished (no http support) to wait for some feedback.