### PR TITLE
Allow empty hash in derivations

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1131,9 +1131,14 @@ static void prim_path(EvalState & state, const Pos & pos, Value * * args, Value 
             filterFun = attr.value;
         } else if (n == "recursive")
             method = FileIngestionMethod { state.forceBool(*attr.value, *attr.pos) };
-        else if (n == "sha256")
-            expectedHash = Hash(state.forceStringNoCtx(*attr.value, *attr.pos), htSHA256);
-        else
+        else if (n == "sha256") {
+            auto hashStr = state.forceStringNoCtx(*attr.value, *attr.pos);
+            if (hashStr == "") {
+                expectedHash = Hash(htSHA256);
+                printError("warning: found empty hash, assuming you wanted '%s'", expectedHash.to_string());
+            } else
+                expectedHash = Hash(hashStr, htSHA256);
+        } else
             throw EvalError(format("unsupported argument '%1%' to 'addPath', at %2%") % attr.name % *attr.pos);
     }
     if (path.empty())

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -719,7 +719,13 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
             throw Error(format("multiple outputs are not supported in fixed-output derivations, at %1%") % posDrvName);
 
         HashType ht = outputHashAlgo.empty() ? htUnknown : parseHashType(outputHashAlgo);
-        Hash h(*outputHash, ht);
+
+        Hash h;
+        if (outputHash->empty()) {
+            h = Hash(ht);
+            printError("warning: found empty hash, assuming you wanted '%s'", h.to_string());
+        } else
+            h = Hash(*outputHash, ht);
 
         auto outPath = state.store->makeFixedOutputPath(ingestionMethod, h, drvName);
         if (!jsonObject) drv.env["out"] = state.store->printStorePath(outPath);

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -102,14 +102,9 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
             string n(attr.name);
             if (n == "url")
                 url = state.forceStringNoCtx(*attr.value, *attr.pos);
-            else if (n == "sha256") {
-                auto hashStr = state.forceStringNoCtx(*attr.value, *attr.pos);
-                if (hashStr == "") {
-                    expectedHash = Hash(htSHA256);
-                    printError("warning: found empty hash, assuming you wanted '%s'", expectedHash->to_string());
-                } else
-                    expectedHash = Hash(hashStr, htSHA256);
-            } else if (n == "name")
+            else if (n == "sha256")
+                expectedHash = newHashAllowEmpty(state.forceStringNoCtx(*attr.value, *attr.pos), htSHA256);
+            else if (n == "name")
                 name = state.forceStringNoCtx(*attr.value, *attr.pos);
             else
                 throw EvalError("unsupported argument '%s' to '%s', at %s",

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -102,9 +102,14 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
             string n(attr.name);
             if (n == "url")
                 url = state.forceStringNoCtx(*attr.value, *attr.pos);
-            else if (n == "sha256")
-                expectedHash = Hash(state.forceStringNoCtx(*attr.value, *attr.pos), htSHA256);
-            else if (n == "name")
+            else if (n == "sha256") {
+                auto hashStr = state.forceStringNoCtx(*attr.value, *attr.pos);
+                if (hashStr == "") {
+                    expectedHash = Hash(htSHA256);
+                    printError("warning: found empty hash, assuming you wanted '%s'", expectedHash->to_string());
+                } else
+                    expectedHash = Hash(hashStr, htSHA256);
+            } else if (n == "name")
                 name = state.forceStringNoCtx(*attr.value, *attr.pos);
             else
                 throw EvalError("unsupported argument '%s' to '%s', at %s",

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -34,9 +34,14 @@ std::unique_ptr<Input> inputFromAttrs(const Attrs & attrs)
     for (auto & inputScheme : *inputSchemes) {
         auto res = inputScheme->inputFromAttrs(attrs2);
         if (res) {
-            if (auto narHash = maybeGetStrAttr(attrs, "narHash"))
-                // FIXME: require SRI hash.
-                res->narHash = Hash(*narHash);
+            if (auto narHash = maybeGetStrAttr(attrs, "narHash")) {
+                if (narHash->empty()) {
+                    res->narHash = Hash(htUnknown);
+                    printError("warning: found empty hash, assuming you wanted '%s'", res->narHash->to_string());
+                } else
+                    // FIXME: require SRI hash.
+                    res->narHash = Hash(*narHash);
+            }
             return res;
         }
     }

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -34,14 +34,9 @@ std::unique_ptr<Input> inputFromAttrs(const Attrs & attrs)
     for (auto & inputScheme : *inputSchemes) {
         auto res = inputScheme->inputFromAttrs(attrs2);
         if (res) {
-            if (auto narHash = maybeGetStrAttr(attrs, "narHash")) {
-                if (narHash->empty()) {
-                    res->narHash = Hash(htUnknown);
-                    printError("warning: found empty hash, assuming you wanted '%s'", res->narHash->to_string());
-                } else
-                    // FIXME: require SRI hash.
-                    res->narHash = Hash(*narHash);
-            }
+            if (auto narHash = maybeGetStrAttr(attrs, "narHash"))
+                // FIXME: require SRI hash.
+                res->narHash = newHashAllowEmpty(*narHash, htUnknown);
             return res;
         }
     }

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -263,14 +263,8 @@ struct TarballInputScheme : InputScheme
                 throw Error("unsupported tarball input attribute '%s'", name);
 
         auto input = std::make_unique<TarballInput>(parseURL(getStrAttr(attrs, "url")));
-        if (auto hash = maybeGetStrAttr(attrs, "hash")) {
-            if (hash->empty()) {
-                input->hash = Hash(htUnknown);
-                printError("warning: found empty hash, assuming you wanted '%s'", input->hash->to_string());
-            } else
-                // FIXME: require SRI hash.
-                input->hash = Hash(*hash);
-        }
+        if (auto hash = maybeGetStrAttr(attrs, "hash"))
+            input->hash = newHashAllowEmpty(*hash, htUnknown);
 
         return input;
     }

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -263,9 +263,14 @@ struct TarballInputScheme : InputScheme
                 throw Error("unsupported tarball input attribute '%s'", name);
 
         auto input = std::make_unique<TarballInput>(parseURL(getStrAttr(attrs, "url")));
-        if (auto hash = maybeGetStrAttr(attrs, "hash"))
-            // FIXME: require SRI hash.
-            input->hash = Hash(*hash);
+        if (auto hash = maybeGetStrAttr(attrs, "hash")) {
+            if (hash->empty()) {
+                input->hash = Hash(htUnknown);
+                printError("warning: found empty hash, assuming you wanted '%s'", input->hash->to_string());
+            } else
+                // FIXME: require SRI hash.
+                input->hash = Hash(*hash);
+        }
 
         return input;
     }

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -210,7 +210,7 @@ Hash newHashAllowEmpty(std::string hashStr, HashType ht)
     if (hashStr.empty())
     {
         Hash h(ht);
-        warn("found empty hash, assuming you wanted '%s'", h.to_string());
+        warn("found empty hash, assuming you wanted '%s'", h.to_string(SRI));
     } else
         return Hash(hashStr, ht);
 }

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -205,6 +205,16 @@ Hash::Hash(const std::string & s, HashType type)
         throw BadHash("hash '%s' has wrong length for hash type '%s'", s, printHashType(type));
 }
 
+Hash newHashAllowEmpty(std::string hashStr, HashType ht)
+{
+    if (hashStr.empty())
+    {
+        Hash h(ht);
+        warn("found empty hash, assuming you wanted '%s'", h.to_string());
+    } else
+        return Hash(hashStr, ht);
+}
+
 
 union Ctx
 {

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -94,6 +94,8 @@ struct Hash
     }
 };
 
+/* Helper that defaults empty hashes to the 0 hash. */
+Hash newHashAllowEmpty(std::string hashStr, HashType ht);
 
 /* Print a hash in base-16 if it's MD5, or base-32 otherwise. */
 string printHash16or32(const Hash & hash);


### PR DESCRIPTION
follow up of https://github.com/NixOS/nix/pull/3544

This allows hash="" so that it can be used for debugging purposes. For
instance, this gives you an error message like:

  warning: found empty hash, assuming you wanted 'sha256:0000000000000000000000000000000000000000000000000000'
  hash mismatch in fixed-output derivation '/nix/store/asx6qw1r1xk6iak6y6jph4n58h4hdmbm-nix':
    wanted: sha256:0000000000000000000000000000000000000000000000000000
    got:    sha256:0fpfhipl9v1mfzw2ffmxiyyzqwlkvww22bh9wcy4qrfslb4jm429

this only effects "derivations" with outputHash set.