### PR TITLE
Disable extra-platforms = i686-linux on wsl1

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -271,7 +271,7 @@ public:
         "listed in 'trusted-public-keys'."};
 
     Setting<StringSet> extraPlatforms{this,
-        std::string{SYSTEM} == "x86_64-linux" ? StringSet{"i686-linux"} : StringSet{},
+        std::string{SYSTEM} == "x86_64-linux" && !isWSL1() ? StringSet{"i686-linux"} : StringSet{},
         "extra-platforms",
         "Additional platforms that can be built on the local system. "
         "These may be supported natively (e.g. armv7 on some aarch64 CPUs "


### PR DESCRIPTION
WSL1 doesn’t support i686-linux emulation, see https://github.com/microsoft/wsl/issues/2468