### PR TITLE
Prelink static libraries into an object file

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -125,7 +125,8 @@ define build-library
     $(1)_PATH := $$(_d)/$$($(1)_NAME).a
 
     $$($(1)_PATH): $$($(1)_OBJS) | $$(_d)/
-	$(trace-ar) $(AR) crs $$@ $$?
+	$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$?
+	$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
 
     $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS)
 


### PR DESCRIPTION
This combines the *.o into a big .o producing one translation unit.
This preserve our unused static initializers, as specified in the C++
standard:

  If no variable or function is odr-used from a given translation
  unit, the non-local variables defined in that translation unit may
  never be initialized (this models the behavior of an on-demand
  dynamic library).

Note that this is very similar to how the --whole-archive flag works.
One advantage of this approach is that users of the final .a library don’t have
to worry about specifying --whole-archive, or that we have unused
static initializers at all!

related to #2698 and #3511.