### PR TITLE
documentation: mention substituter precedence

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -888,7 +888,7 @@ password <replaceable>my-password</replaceable>
   <varlistentry xml:id="conf-substituters"><term><literal>substituters</literal></term>
 
     <listitem><para>A list of URLs of substituters, separated by
-    whitespace.  The default is
+    whitespace.  The substituters are queried from left to right.  The default is
     <literal>https://cache.nixos.org</literal>.</para></listitem>
 
   </varlistentry>


### PR DESCRIPTION
Mentions the order in which substituters are queried.