### PR TITLE
add gitlab auth token

### DIFF
--- a/src/libexpr/common-eval-args.cc
+++ b/src/libexpr/common-eval-args.cc
@@ -76,7 +76,7 @@ Path lookupFileArg(EvalState & state, string s)
     if (isUri(s)) {
         return state.store->toRealPath(
             fetchers::downloadTarball(
-                state.store, resolveUri(s), "source", false).first.storePath);
+                state.store, resolveUri(s), std::nullopt, "source", false).first.storePath);
     } else if (s.size() > 2 && s.at(0) == '<' && s.at(s.size() - 1) == '>') {
         Path p = s.substr(1, s.size() - 2);
         return state.findFile(p);

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -689,7 +689,7 @@ std::pair<bool, std::string> EvalState::resolveSearchPathElem(const SearchPathEl
     if (isUri(elem.second)) {
         try {
             res = { true, store->toRealPath(fetchers::downloadTarball(
-                        store, resolveUri(elem.second), "source", false).first.storePath) };
+                        store, resolveUri(elem.second), std::nullopt, "source", false).first.storePath) };
         } catch (FileTransferError & e) {
             printError(format("warning: Nix search path entry '%1%' cannot be downloaded, ignoring") % elem.second);
             res = { false, "" };

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -141,8 +141,8 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
 
     auto storePath =
         unpack
-        ? fetchers::downloadTarball(state.store, *url, name, (bool) expectedHash).first.storePath
-        : fetchers::downloadFile(state.store, *url, name, (bool) expectedHash).storePath;
+        ? fetchers::downloadTarball(state.store, *url, std::nullopt, name, (bool) expectedHash).first.storePath
+        : fetchers::downloadFile(state.store, *url, std::nullopt, name, (bool) expectedHash).storePath;
 
     auto path = state.store->toRealPath(storePath);
 

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -119,12 +119,14 @@ struct DownloadFileResult
 DownloadFileResult downloadFile(
     ref<Store> store,
     const std::string & url,
+    const std::optional<std::map<std::string, std::string>> & headers,
     const std::string & name,
     bool immutable);
 
 std::pair<Tree, time_t> downloadTarball(
     ref<Store> store,
     const std::string & url,
+    const std::optional<std::map<std::string, std::string>> & headers,
     const std::string & name,
     bool immutable);
 

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -145,7 +145,7 @@ static std::shared_ptr<Registry> getGlobalRegistry(ref<Store> store)
         auto path = settings.flakeRegistry.get();
 
         if (!hasPrefix(path, "/")) {
-            auto storePath = downloadFile(store, path, "flake-registry.json", false).storePath;
+            auto storePath = downloadFile(store, path, std::nullopt, "flake-registry.json", false).storePath;
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
                 store2->addPermRoot(storePath, getCacheDir() + "/nix/flake-registry.json", true);
             path = store->toRealPath(storePath);

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -100,6 +100,9 @@ struct curlFileTransfer : public FileTransfer
                 requestHeaders = curl_slist_append(requestHeaders, ("If-None-Match: " + request.expectedETag).c_str());
             if (!request.mimeType.empty())
                 requestHeaders = curl_slist_append(requestHeaders, ("Content-Type: " + request.mimeType).c_str());
+            for (const auto & header: request.headers) {
+                requestHeaders = curl_slist_append(requestHeaders, (header.first + ": " + header.second).c_str());
+            }
         }
 
         ~TransferItem()

--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -37,6 +37,7 @@ struct FileTransferRequest
 {
     std::string uri;
     std::string expectedETag;
+    std::map<std::string, std::string> headers;
     bool verifyTLS = true;
     bool head = false;
     size_t tries = fileTransferSettings.tries;
@@ -49,6 +50,11 @@ struct FileTransferRequest
 
     FileTransferRequest(const std::string & uri)
         : uri(uri), parentAct(getCurActivity()) { }
+
+    FileTransferRequest(const std::string & uri, const std::optional<std::map<std::string, std::string>> & headers)
+        : uri(uri), parentAct(getCurActivity()) {
+            if (headers) this->headers = *headers;
+        }
 
     std::string verb()
     {

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -357,6 +357,9 @@ public:
     Setting<std::string> githubAccessToken{this, "", "github-access-token",
         "GitHub access token to get access to GitHub data through the GitHub API for github:<..> flakes."};
 
+    Setting<std::string> gitLabbAccessToken{this, "", "gitlab-access-token",
+        "GitLab access token to get access to GitLab data through the GitLab API for gitlab:<..> flakes."};
+
     Setting<Strings> experimentalFeatures{this, {}, "experimental-features",
         "Experimental Nix features to enable."};
 

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -87,7 +87,7 @@ static void update(const StringSet & channelNames)
         // We want to download the url to a file to see if it's a tarball while also checking if we
         // got redirected in the process, so that we can grab the various parts of a nix channel
         // definition from a consistent location if the redirect changes mid-download.
-        auto result = fetchers::downloadFile(store, url, std::string(baseNameOf(url)), false);
+        auto result = fetchers::downloadFile(store, url, std::nullopt, std::string(baseNameOf(url)), false);
         auto filename = store->toRealPath(result.storePath);
         url = result.effectiveUrl;
 
@@ -112,9 +112,9 @@ static void update(const StringSet & channelNames)
         if (!unpacked) {
             // Download the channel tarball.
             try {
-                filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.xz", "nixexprs.tar.xz", false).storePath);
+                filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.xz", std::nullopt, "nixexprs.tar.xz", false).storePath);
             } catch (FileTransferError & e) {
-                filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.bz2", "nixexprs.tar.bz2", false).storePath);
+                filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.bz2", std::nullopt, "nixexprs.tar.bz2", false).storePath);
             }
         }
 


### PR DESCRIPTION
This adds the possibility to set own headers in `fetchers::downloadFile` and `fetchers::downloadTarball`. which is needed for the access of private repos on gitlab.