### PR TITLE
Don't stop user from installing the nix store on an unencrypted volume

### DIFF
--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -161,11 +161,12 @@ main() {
                 echo "         is only encrypted at rest." >&2
                 echo "         See https://nixos.org/nix/manual/#sect-macos-installation" >&2
             else
-                echo "error: refusing to create Nix store volume because the boot volume is" >&2
-                echo "       FileVault encrypted, but encryption-at-rest is not available." >&2
-                echo "       Manually create a volume for the store and re-run this script." >&2
-                echo "       See https://nixos.org/nix/manual/#sect-macos-installation" >&2
-                exit 1
+                echo "warning: boot volume is FileVault-encrypted, but encryption-at-rest is not available." >&2
+                echo "         This means any software installed with nix will be stored unencrypted on your hard drive." >&2
+                echo "         After nix is installed, you can manually add encryption to the store volume using Finder (Right click -> Encrypt)." >&2
+                echo "         For alternative solutions, see https://nixos.org/nix/manual/#sect-macos-installation\n\n" >&2
+                echo "         Because the --darwin-use-unencrypted-nix-store-volume option is given, we asume you" >&2
+                echo "         are ok with using an unencrypted store volume and therefore proceeding." >&2
             fi
         fi
 


### PR DESCRIPTION
Right now the nix installer will abort on macOS when the installation will result in an unencrypted store volume being created. This problem affects lots of common mac hardware like 13-inch 2017 Macbook Pro. It leads to the following unhelpful error message being printed:

```
error: refusing to create Nix store volume because the boot volume is
       FileVault encrypted, but encryption-at-rest is not available.
       Manually create a volume for the store and re-run this script.
       See https://nixos.org/nix/manual/#sect-macos-installation
```

After that the installer exits with an error code.

This will block certain people from adopting nix (e.g. https://github.com/digitallyinduced/ihp/issues/93). 

Users should be able to make the tradeoff themselves. By passing `--darwin-use-unencrypted-nix-store-volume` they already give consent that they are ok with using an unencrypted store volume. Therefore we should not exit the installer and instead just warn the user.