### PR TITLE
WIP: Use std::string_view everywhere

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -38,7 +38,7 @@ static AutoCloseFD openSlotLock(const Machine & m, unsigned long long slot)
     return openLockFile(fmt("%s/%s-%d", currentLoad, escapeUri(m.storeUri), slot), true);
 }
 
-static bool allSupportedLocally(const std::set<std::string>& requiredFeatures) {
+static bool allSupportedLocally(const std::set<std::string, std::less<>>& requiredFeatures) {
     for (auto & feature : requiredFeatures)
         if (!settings.systemFeatures.get().count(feature)) return false;
     return true;
@@ -101,7 +101,7 @@ static int _main(int argc, char * * argv)
             auto amWilling = readInt(source);
             auto neededSystem = readString(source);
             drvPath = store->parseStorePath(readString(source));
-            auto requiredFeatures = readStrings<std::set<std::string>>(source);
+            auto requiredFeatures = readStrings<std::set<std::string, std::less<>>>(source);
 
              auto canBuildLocally = amWilling
                  &&  (  neededSystem == settings.thisSystem

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -10,7 +10,7 @@ static Strings parseAttrPath(std::string_view s)
 {
     Strings res;
     string cur;
-    string::const_iterator i = s.begin();
+	std::string_view::const_iterator i = s.begin();
     while (i != s.end()) {
         if (*i == '.') {
             res.push_back(cur);

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -10,7 +10,7 @@ static Strings parseAttrPath(std::string_view s)
 {
     Strings res;
     string cur;
-	std::string_view::const_iterator i = s.begin();
+    std::string_view::const_iterator i = s.begin();
     while (i != s.end()) {
         if (*i == '.') {
             res.push_back(cur);

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -6,7 +6,7 @@
 namespace nix {
 
 
-static Strings parseAttrPath(const string & s)
+static Strings parseAttrPath(std::string_view s)
 {
     Strings res;
     string cur;
@@ -32,7 +32,7 @@ static Strings parseAttrPath(const string & s)
 }
 
 
-std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attrPath,
+std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, std::string_view attrPath,
     Bindings & autoArgs, Value & vIn)
 {
     Strings tokens = parseAttrPath(attrPath);

--- a/src/libexpr/attr-path.hh
+++ b/src/libexpr/attr-path.hh
@@ -10,7 +10,7 @@ namespace nix {
 MakeError(AttrPathNotFound, Error);
 MakeError(NoPositionInfo, Error);
 
-std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attrPath,
+std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, std::string_view attrPath,
     Bindings & autoArgs, Value & vIn);
 
 /* Heuristic to find the filename and lineno or a nix value. */

--- a/src/libexpr/attr-set.cc
+++ b/src/libexpr/attr-set.cc
@@ -43,7 +43,7 @@ Value * EvalState::allocAttr(Value & vAttrs, const Symbol & name)
 }
 
 
-Value * EvalState::allocAttr(Value & vAttrs, const std::string & name)
+Value * EvalState::allocAttr(Value & vAttrs, std::string_view name)
 {
     return allocAttr(vAttrs, symbols.create(name));
 }

--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -104,7 +104,7 @@ public:
         for (size_t n = 0; n < size_; n++)
             res.emplace_back(&attrs[n]);
         std::sort(res.begin(), res.end(), [](const Attr * a, const Attr * b) {
-            return (const string &) a->name < (const string &) b->name;
+            return (std::string_view) a->name < (std::string_view) b->name;
         });
         return res;
     }

--- a/src/libexpr/common-eval-args.cc
+++ b/src/libexpr/common-eval-args.cc
@@ -39,7 +39,7 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
     for (auto & i : autoArgs) {
         Value * v = state.allocValue();
         if (i.second[0] == 'E')
-            state.mkThunk_(*v, state.parseExprFromString(string(i.second, 1), absPath(".")));
+            state.mkThunk_(*v, state.parseExprFromString(string(i.second, 1), absCWD()));
         else
             mkString(*v, string(i.second, 1));
         res->push_back(Attr(state.symbols.create(i.first), v));
@@ -58,7 +58,7 @@ Path lookupFileArg(EvalState & state, std::string_view s)
         PathView p = s.substr(1, s.size() - 2);
         return state.findFile(p);
     } else
-        return absPath(Path { s });
+        return absPath(s);
 }
 
 }

--- a/src/libexpr/common-eval-args.cc
+++ b/src/libexpr/common-eval-args.cc
@@ -48,17 +48,17 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
     return res;
 }
 
-Path lookupFileArg(EvalState & state, string s)
+Path lookupFileArg(EvalState & state, std::string_view s)
 {
     if (isUri(s)) {
         return state.store->toRealPath(
             fetchers::downloadTarball(
                 state.store, resolveUri(s), "source", false).storePath);
     } else if (s.size() > 2 && s.at(0) == '<' && s.at(s.size() - 1) == '>') {
-        Path p = s.substr(1, s.size() - 2);
+        PathView p = s.substr(1, s.size() - 2);
         return state.findFile(p);
     } else
-        return absPath(s);
+        return absPath(Path { s });
 }
 
 }

--- a/src/libexpr/common-eval-args.hh
+++ b/src/libexpr/common-eval-args.hh
@@ -21,6 +21,6 @@ private:
     std::map<std::string, std::string> autoArgs;
 };
 
-Path lookupFileArg(EvalState & state, string s);
+Path lookupFileArg(EvalState & state, std::string_view s);
 
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -377,7 +377,7 @@ Path EvalState::checkSourcePath(PathView path_)
 {
     if (!allowedPaths) return Path { path_ };
 
-	// No smart lookup with std::unordered_map, sadly.
+    // No smart lookup with std::unordered_map, sadly.
     auto i = resolvedPaths.find(Path { path_ });
     if (i != resolvedPaths.end())
         return i->second;
@@ -463,7 +463,7 @@ Value * EvalState::addConstant(std::string_view name, Value & v)
     *v2 = v;
     staticBaseEnv.vars[symbols.create(name)] = baseEnvDispl;
     baseEnv.values[baseEnvDispl++] = v2;
-	std::string_view name2 = name.substr(0, 2) == "__" ? name.substr(2) : name;
+    std::string_view name2 = name.substr(0, 2) == "__" ? name.substr(2) : name;
     baseEnv.values[0]->attrs->push_back(Attr(symbols.create(name2), v2));
     return v2;
 }
@@ -478,7 +478,7 @@ Value * EvalState::addPrimOp(std::string_view name,
         return addConstant(name, v);
     }
     Value * v = allocValue();
-	std::string_view name2 = name.substr(0, 2) == "__" ? name.substr(2) : name;
+    std::string_view name2 = name.substr(0, 2) == "__" ? name.substr(2) : name;
     Symbol sym = symbols.create(name2);
     v->type = tPrimOp;
     v->primOp = new PrimOp(primOp, arity, sym);

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -261,7 +261,7 @@ void initGC()
 
 /* Very hacky way to parse $NIX_PATH, which is colon-separated, but
    can contain URLs (e.g. "nixpkgs=https://bla...:foo=https://"). */
-static Strings parseNixPath(const string & s)
+static Strings parseNixPath(std::string_view s)
 {
     Strings res;
 
@@ -373,7 +373,7 @@ EvalState::~EvalState()
 }
 
 
-Path EvalState::checkSourcePath(const Path & path_)
+Path EvalState::checkSourcePath(PathView path_)
 {
     if (!allowedPaths) return path_;
 
@@ -414,7 +414,7 @@ Path EvalState::checkSourcePath(const Path & path_)
 }
 
 
-void EvalState::checkURI(const std::string & uri)
+void EvalState::checkURI(std::string_view uri)
 {
     if (!evalSettings.restrictEval) return;
 
@@ -446,7 +446,7 @@ void EvalState::checkURI(const std::string & uri)
 }
 
 
-Path EvalState::toRealPath(const Path & path, const PathSet & context)
+Path EvalState::toRealPath(PathView path, const PathSet & context)
 {
     // FIXME: check whether 'path' is in 'context'.
     return
@@ -456,7 +456,7 @@ Path EvalState::toRealPath(const Path & path, const PathSet & context)
 }
 
 
-Value * EvalState::addConstant(const string & name, Value & v)
+Value * EvalState::addConstant(std::string_view name, Value & v)
 {
     Value * v2 = allocValue();
     *v2 = v;
@@ -468,7 +468,7 @@ Value * EvalState::addConstant(const string & name, Value & v)
 }
 
 
-Value * EvalState::addPrimOp(const string & name,
+Value * EvalState::addPrimOp(std::string_view name,
     size_t arity, PrimOpFun primOp)
 {
     if (arity == 0) {
@@ -488,7 +488,7 @@ Value * EvalState::addPrimOp(const string & name,
 }
 
 
-Value & EvalState::getBuiltin(const string & name)
+Value & EvalState::getBuiltin(std::string_view name)
 {
     return *baseEnv.values[0]->attrs->find(symbols.create(name))->value;
 }
@@ -499,12 +499,12 @@ Value & EvalState::getBuiltin(const string & name)
    evaluator.  So here are some helper functions for throwing
    exceptions. */
 
-LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2))
+LocalNoInlineNoReturn(void throwEvalError(const char * s, std::string_view s2))
 {
     throw EvalError(s, s2);
 }
 
-LocalNoInlineNoReturn(void throwEvalError(const Pos & pos, const char * s, const string & s2))
+LocalNoInlineNoReturn(void throwEvalError(const Pos & pos, const char * s, std::string_view s2))
 {
     throw EvalError({
         .hint = hintfmt(s, s2),
@@ -512,12 +512,12 @@ LocalNoInlineNoReturn(void throwEvalError(const Pos & pos, const char * s, const
     });
 }
 
-LocalNoInlineNoReturn(void throwEvalError(const char * s, const string & s2, const string & s3))
+LocalNoInlineNoReturn(void throwEvalError(const char * s, std::string_view s2, std::string_view s3))
 {
     throw EvalError(s, s2, s3);
 }
 
-LocalNoInlineNoReturn(void throwEvalError(const Pos & pos, const char * s, const string & s2, const string & s3))
+LocalNoInlineNoReturn(void throwEvalError(const Pos & pos, const char * s, std::string_view s2, std::string_view s3))
 {
     throw EvalError({
         .hint = hintfmt(s, s2, s3),
@@ -542,7 +542,7 @@ LocalNoInlineNoReturn(void throwTypeError(const Pos & pos, const char * s))
     });
 }
 
-LocalNoInlineNoReturn(void throwTypeError(const char * s, const string & s1))
+LocalNoInlineNoReturn(void throwTypeError(const char * s, std::string_view s1))
 {
     throw TypeError(s, s1);
 }
@@ -555,7 +555,7 @@ LocalNoInlineNoReturn(void throwTypeError(const Pos & pos, const char * s, const
     });
 }
 
-LocalNoInlineNoReturn(void throwAssertionError(const Pos & pos, const char * s, const string & s1))
+LocalNoInlineNoReturn(void throwAssertionError(const Pos & pos, const char * s, std::string_view s1))
 {
     throw AssertionError({
         .hint = hintfmt(s, s1),
@@ -563,7 +563,7 @@ LocalNoInlineNoReturn(void throwAssertionError(const Pos & pos, const char * s, 
     });
 }
 
-LocalNoInlineNoReturn(void throwUndefinedVarError(const Pos & pos, const char * s, const string & s1))
+LocalNoInlineNoReturn(void throwUndefinedVarError(const Pos & pos, const char * s, std::string_view s1))
 {
     throw UndefinedVarError({
         .hint = hintfmt(s, s1),
@@ -571,7 +571,7 @@ LocalNoInlineNoReturn(void throwUndefinedVarError(const Pos & pos, const char * 
     });
 }
 
-LocalNoInline(void addErrorPrefix(Error & e, const char * s, const string & s2))
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, std::string_view s2))
 {
     e.addPrefix(format(s) % s2);
 }
@@ -581,7 +581,7 @@ LocalNoInline(void addErrorPrefix(Error & e, const char * s, const ExprLambda & 
     e.addPrefix(format(s) % fun.showNamePos() % pos);
 }
 
-LocalNoInline(void addErrorPrefix(Error & e, const char * s, const string & s2, const Pos & pos))
+LocalNoInline(void addErrorPrefix(Error & e, const char * s, std::string_view s2, const Pos & pos))
 {
     e.addPrefix(format(s) % s2 % pos);
 }
@@ -766,7 +766,7 @@ Value * ExprPath::maybeThunk(EvalState & state, Env & env)
 }
 
 
-void EvalState::evalFile(const Path & path_, Value & v)
+void EvalState::evalFile(PathView path_, Value & v)
 {
     auto path = checkSourcePath(path_);
 
@@ -1679,7 +1679,7 @@ string EvalState::coerceToString(const Pos & pos, Value & v, PathSet & context,
 }
 
 
-string EvalState::copyPathToStore(PathSet & context, const Path & path)
+string EvalState::copyPathToStore(PathSet & context, PathView path)
 {
     if (nix::isDerivation(path))
         throwEvalError("file names are not allowed to end in '%1%'", drvExtension);
@@ -1878,11 +1878,11 @@ void EvalState::printStats()
                 for (auto & i : functionCalls) {
                     auto obj = list.object();
                     if (i.first->name.set())
-                        obj.attr("name", (const string &) i.first->name);
+                        obj.attr("name", (std::string_view) i.first->name);
                     else
                         obj.attr("name", nullptr);
                     if (i.first->pos) {
-                        obj.attr("file", (const string &) i.first->pos.file);
+                        obj.attr("file", (std::string_view) i.first->pos.file);
                         obj.attr("line", i.first->pos.line);
                         obj.attr("column", i.first->pos.column);
                     }
@@ -1894,7 +1894,7 @@ void EvalState::printStats()
                 for (auto & i : attrSelects) {
                     auto obj = list.object();
                     if (i.first) {
-                        obj.attr("file", (const string &) i.first.file);
+                        obj.attr("file", (std::string_view) i.first.file);
                         obj.attr("line", i.first.line);
                         obj.attr("column", i.first.column);
                     }
@@ -1905,7 +1905,7 @@ void EvalState::printStats()
 
         if (getEnv("NIX_SHOW_SYMBOLS").value_or("0") != "0") {
             auto list = topObj.list("symbols");
-            symbols.dump([&](const std::string & s) { list.elem(s); });
+            symbols.dump([&](std::string_view s) { list.elem(s); });
         }
     }
 }
@@ -1940,7 +1940,7 @@ EvalSettings::EvalSettings()
 Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;
-    auto add = [&](const Path & p) { if (pathExists(p)) { res.push_back(p); } };
+    auto add = [&](PathView p) { if (pathExists(p)) { res.push_back(p); } };
     add(getHome() + "/.nix-defexpr/channels");
     add("nixpkgs=" + settings.nixStateDir + "/nix/profiles/per-user/root/channels/nixpkgs");
     add(settings.nixStateDir + "/nix/profiles/per-user/root/channels");

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -304,7 +304,7 @@ private:
 
     bool countCalls;
 
-    typedef std::map<Symbol, size_t, std::less> PrimOpCalls;
+    typedef std::map<Symbol, size_t, std::less<>> PrimOpCalls;
     PrimOpCalls primOpCalls;
 
     typedef std::map<ExprLambda *, size_t, std::less<>> FunctionCalls;
@@ -312,7 +312,7 @@ private:
 
     void incrFunctionCall(ExprLambda * fun);
 
-    typedef std::map<Pos, size_t, std::les<>> AttrSelects;
+    typedef std::map<Pos, size_t, std::less<>> AttrSelects;
     AttrSelects attrSelects;
 
     friend struct ExprOpUpdate;
@@ -328,7 +328,7 @@ string showType(const Value & v);
 
 /* Decode a context string ‘!<name>!<path>’ into a pair <path,
    name>. */
-std::pair<string, string> decodeContext(std::string_view s);
+std::pair<std::string_view, std::string_view> decodeContext(std::string_view s);
 
 /* If `path' refers to a directory, then append "/default.nix". */
 Path resolveExprPath(Path path);

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -51,7 +51,7 @@ void copyContext(const Value & v, PathSet & context);
 
 /* Cache for calls to addToStore(); maps source paths to the store
    paths. */
-typedef std::map<Path, StorePath> SrcToStore;
+typedef std::map<Path, StorePath, std::less<>> SrcToStore;
 
 
 std::ostream & operator << (std::ostream & str, const Value & v);
@@ -96,7 +96,7 @@ private:
 #if HAVE_BOEHMGC
     typedef std::map<Path, Expr *, std::less<Path>, traceable_allocator<std::pair<const Path, Expr *> > > FileParseCache;
 #else
-    typedef std::map<Path, Expr *> FileParseCache;
+    typedef std::map<Path, Expr *, std::less<Path>> FileParseCache;
 #endif
     FileParseCache fileParseCache;
 
@@ -104,7 +104,7 @@ private:
 #if HAVE_BOEHMGC
     typedef std::map<Path, Value, std::less<Path>, traceable_allocator<std::pair<const Path, Value> > > FileEvalCache;
 #else
-    typedef std::map<Path, Value> FileEvalCache;
+    typedef std::map<Path, Value, std::less<Path>> FileEvalCache;
 #endif
     FileEvalCache fileEvalCache;
 
@@ -304,15 +304,15 @@ private:
 
     bool countCalls;
 
-    typedef std::map<Symbol, size_t> PrimOpCalls;
+    typedef std::map<Symbol, size_t, std::less> PrimOpCalls;
     PrimOpCalls primOpCalls;
 
-    typedef std::map<ExprLambda *, size_t> FunctionCalls;
+    typedef std::map<ExprLambda *, size_t, std::less<>> FunctionCalls;
     FunctionCalls functionCalls;
 
     void incrFunctionCall(ExprLambda * fun);
 
-    typedef std::map<Pos, size_t> AttrSelects;
+    typedef std::map<Pos, size_t, std::les<>> AttrSelects;
     AttrSelects attrSelects;
 
     friend struct ExprOpUpdate;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -123,13 +123,13 @@ public:
     EvalState(const Strings & _searchPath, ref<Store> store);
     ~EvalState();
 
-    void addToSearchPath(const string & s);
+    void addToSearchPath(std::string_view s);
 
     SearchPath getSearchPath() { return searchPath; }
 
-    Path checkSourcePath(const Path & path);
+    Path checkSourcePath(PathView path);
 
-    void checkURI(const std::string & uri);
+    void checkURI(std::string_view uri);
 
     /* When using a diverted store and 'path' is in the Nix store, map
        'path' to the diverted location (e.g. /nix/store/foo is mapped
@@ -138,27 +138,27 @@ public:
        probably trying to read from the actual /nix/store. This is
        intended to distinguish between import-from-derivation and
        sources stored in the actual /nix/store. */
-    Path toRealPath(const Path & path, const PathSet & context);
+    Path toRealPath(PathView path, const PathSet & context);
 
     /* Parse a Nix expression from the specified file. */
-    Expr * parseExprFromFile(const Path & path);
-    Expr * parseExprFromFile(const Path & path, StaticEnv & staticEnv);
+    Expr * parseExprFromFile(PathView path);
+    Expr * parseExprFromFile(PathView path, StaticEnv & staticEnv);
 
     /* Parse a Nix expression from the specified string. */
-    Expr * parseExprFromString(std::string_view s, const Path & basePath, StaticEnv & staticEnv);
-    Expr * parseExprFromString(std::string_view s, const Path & basePath);
+    Expr * parseExprFromString(std::string_view s, PathView basePath, StaticEnv & staticEnv);
+    Expr * parseExprFromString(std::string_view s, PathView basePath);
 
     Expr * parseStdin();
 
     /* Evaluate an expression read from the given file to normal
        form. */
-    void evalFile(const Path & path, Value & v);
+    void evalFile(PathView path, Value & v);
 
     void resetFileCache();
 
     /* Look up a file in the search path. */
-    Path findFile(const string & path);
-    Path findFile(SearchPath & searchPath, const string & path, const Pos & pos = noPos);
+    Path findFile(std::string_view path);
+    Path findFile(SearchPath & searchPath, std::string_view path, const Pos & pos = noPos);
 
     /* If the specified search path element is a URI, download it. */
     std::pair<bool, std::string> resolveSearchPathElem(const SearchPathElem & elem);
@@ -210,7 +210,7 @@ public:
     string coerceToString(const Pos & pos, Value & v, PathSet & context,
         bool coerceMore = false, bool copyToStore = true);
 
-    string copyPathToStore(PathSet & context, const Path & path);
+    string copyPathToStore(PathSet & context, PathView path);
 
     /* Path coercion.  Converts strings, paths and derivations to a
        path.  The result is guaranteed to be a canonicalised, absolute
@@ -232,14 +232,14 @@ private:
 
     void createBaseEnv();
 
-    Value * addConstant(const string & name, Value & v);
+    Value * addConstant(std::string_view name, Value & v);
 
-    Value * addPrimOp(const string & name,
+    Value * addPrimOp(std::string_view name,
         size_t arity, PrimOpFun primOp);
 
 public:
 
-    Value & getBuiltin(const string & name);
+    Value & getBuiltin(std::string_view name);
 
 private:
 
@@ -249,8 +249,8 @@ private:
     friend struct ExprAttrs;
     friend struct ExprLet;
 
-    Expr * parse(const char * text, const Path & path,
-        const Path & basePath, StaticEnv & staticEnv);
+    Expr * parse(const char * text, PathView path,
+        PathView basePath, StaticEnv & staticEnv);
 
 public:
 
@@ -272,7 +272,7 @@ public:
     Env & allocEnv(size_t size);
 
     Value * allocAttr(Value & vAttrs, const Symbol & name);
-    Value * allocAttr(Value & vAttrs, const std::string & name);
+    Value * allocAttr(Value & vAttrs, std::string_view name);
 
     Bindings * allocBindings(size_t capacity);
 
@@ -328,7 +328,7 @@ string showType(const Value & v);
 
 /* Decode a context string ‘!<name>!<path>’ into a pair <path,
    name>. */
-std::pair<string, string> decodeContext(const string & s);
+std::pair<string, string> decodeContext(std::string_view s);
 
 /* If `path' refers to a directory, then append "/default.nix". */
 Path resolveExprPath(Path path);
@@ -336,7 +336,7 @@ Path resolveExprPath(Path path);
 struct InvalidPathError : EvalError
 {
     Path path;
-    InvalidPathError(const Path & path);
+    InvalidPathError(PathView path);
 #ifdef EXCEPTION_NEEDS_THROW_SPEC
     ~InvalidPathError() throw () { };
 #endif

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -307,7 +307,9 @@ std::optional<DrvInfo> getDerivation(EvalState & state, Value & v,
 
 static string addToPath(std::string_view s1, std::string_view s2)
 {
-    return s1.empty() ? s2 : s1 + "." + s2;
+    return s1.empty()
+    	? std::string { s2 }
+        : std::string { s1 } << "." << s2;
 }
 
 

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -308,7 +308,7 @@ std::optional<DrvInfo> getDerivation(EvalState & state, Value & v,
 static string addToPath(std::string_view s1, std::string_view s2)
 {
     return s1.empty()
-    	? std::string { s2 }
+        ? std::string { s2 }
         : std::string { s1 } << "." << s2;
 }
 

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -10,13 +10,13 @@
 namespace nix {
 
 
-DrvInfo::DrvInfo(EvalState & state, const string & attrPath, Bindings * attrs)
+DrvInfo::DrvInfo(EvalState & state, std::string_view attrPath, Bindings * attrs)
     : state(&state), attrs(attrs), attrPath(attrPath)
 {
 }
 
 
-DrvInfo::DrvInfo(EvalState & state, ref<Store> store, const std::string & drvPathWithOutputs)
+DrvInfo::DrvInfo(EvalState & state, ref<Store> store, std::string_view drvPathWithOutputs)
     : state(&state), attrs(nullptr), attrPath("")
 {
     auto [drvPath, selectedOutputs] = store->parsePathWithOutputs(drvPathWithOutputs);
@@ -183,7 +183,7 @@ bool DrvInfo::checkMeta(Value & v)
 }
 
 
-Value * DrvInfo::queryMeta(const string & name)
+Value * DrvInfo::queryMeta(std::string_view name)
 {
     if (!getMeta()) return 0;
     Bindings::iterator a = meta->find(state->symbols.create(name));
@@ -192,7 +192,7 @@ Value * DrvInfo::queryMeta(const string & name)
 }
 
 
-string DrvInfo::queryMetaString(const string & name)
+string DrvInfo::queryMetaString(std::string_view name)
 {
     Value * v = queryMeta(name);
     if (!v || v->type != tString) return "";
@@ -200,7 +200,7 @@ string DrvInfo::queryMetaString(const string & name)
 }
 
 
-NixInt DrvInfo::queryMetaInt(const string & name, NixInt def)
+NixInt DrvInfo::queryMetaInt(std::string_view name, NixInt def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
@@ -214,7 +214,7 @@ NixInt DrvInfo::queryMetaInt(const string & name, NixInt def)
     return def;
 }
 
-NixFloat DrvInfo::queryMetaFloat(const string & name, NixFloat def)
+NixFloat DrvInfo::queryMetaFloat(std::string_view name, NixFloat def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
@@ -229,7 +229,7 @@ NixFloat DrvInfo::queryMetaFloat(const string & name, NixFloat def)
 }
 
 
-bool DrvInfo::queryMetaBool(const string & name, bool def)
+bool DrvInfo::queryMetaBool(std::string_view name, bool def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
@@ -244,7 +244,7 @@ bool DrvInfo::queryMetaBool(const string & name, bool def)
 }
 
 
-void DrvInfo::setMeta(const string & name, Value * v)
+void DrvInfo::setMeta(std::string_view name, Value * v)
 {
     getMeta();
     Bindings * old = meta;
@@ -268,7 +268,7 @@ typedef set<Bindings *> Done;
    The result boolean indicates whether it makes sense
    for the caller to recursively search for derivations in `v'. */
 static bool getDerivation(EvalState & state, Value & v,
-    const string & attrPath, DrvInfos & drvs, Done & done,
+    std::string_view attrPath, DrvInfos & drvs, Done & done,
     bool ignoreAssertionFailures)
 {
     try {
@@ -305,7 +305,7 @@ std::optional<DrvInfo> getDerivation(EvalState & state, Value & v,
 }
 
 
-static string addToPath(const string & s1, const string & s2)
+static string addToPath(std::string_view s1, std::string_view s2)
 {
     return s1.empty() ? s2 : s1 + "." + s2;
 }
@@ -315,7 +315,7 @@ static std::regex attrRegex("[A-Za-z_][A-Za-z0-9-_+]*");
 
 
 static void getDerivations(EvalState & state, Value & vIn,
-    const string & pathPrefix, Bindings & autoArgs,
+    std::string_view pathPrefix, Bindings & autoArgs,
     DrvInfos & drvs, Done & done,
     bool ignoreAssertionFailures)
 {
@@ -368,7 +368,7 @@ static void getDerivations(EvalState & state, Value & vIn,
 }
 
 
-void getDerivations(EvalState & state, Value & v, const string & pathPrefix,
+void getDerivations(EvalState & state, Value & v, std::string_view pathPrefix,
     Bindings & autoArgs, DrvInfos & drvs, bool ignoreAssertionFailures)
 {
     Done done;

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -36,8 +36,8 @@ public:
     string attrPath; /* path towards the derivation */
 
     DrvInfo(EvalState & state) : state(&state) { };
-    DrvInfo(EvalState & state, const string & attrPath, Bindings * attrs);
-    DrvInfo(EvalState & state, ref<Store> store, const std::string & drvPathWithOutputs);
+    DrvInfo(EvalState & state, std::string_view attrPath, Bindings * attrs);
+    DrvInfo(EvalState & state, ref<Store> store, std::string_view drvPathWithOutputs);
 
     string queryName() const;
     string querySystem() const;
@@ -48,21 +48,21 @@ public:
     Outputs queryOutputs(bool onlyOutputsToInstall = false);
 
     StringSet queryMetaNames();
-    Value * queryMeta(const string & name);
-    string queryMetaString(const string & name);
-    NixInt queryMetaInt(const string & name, NixInt def);
-    NixFloat queryMetaFloat(const string & name, NixFloat def);
-    bool queryMetaBool(const string & name, bool def);
-    void setMeta(const string & name, Value * v);
+    Value * queryMeta(std::string_view name);
+    string queryMetaString(std::string_view name);
+    NixInt queryMetaInt(std::string_view name, NixInt def);
+    NixFloat queryMetaFloat(std::string_view name, NixFloat def);
+    bool queryMetaBool(std::string_view name, bool def);
+    void setMeta(std::string_view name, Value * v);
 
     /*
     MetaInfo queryMetaInfo(EvalState & state) const;
-    MetaValue queryMetaInfo(EvalState & state, const string & name) const;
+    MetaValue queryMetaInfo(EvalState & state, std::string_view name) const;
     */
 
-    void setName(const string & s) { name = s; }
-    void setDrvPath(const string & s) { drvPath = s; }
-    void setOutPath(const string & s) { outPath = s; }
+    void setName(std::string_view s) { name = s; }
+    void setDrvPath(std::string_view s) { drvPath = s; }
+    void setOutPath(std::string_view s) { outPath = s; }
 
     void setFailed() { failed = true; };
     bool hasFailed() { return failed; };
@@ -81,7 +81,7 @@ typedef list<DrvInfo> DrvInfos;
 std::optional<DrvInfo> getDerivation(EvalState & state,
     Value & v, bool ignoreAssertionFailures);
 
-void getDerivations(EvalState & state, Value & v, const string & pathPrefix,
+void getDerivations(EvalState & state, Value & v, std::string_view pathPrefix,
     Bindings & autoArgs, DrvInfos & drvs,
     bool ignoreAssertionFailures);
 

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -12,7 +12,7 @@ namespace nix {
 struct DrvInfo
 {
 public:
-    typedef std::map<string, Path> Outputs;
+    typedef std::map<string, Path, std::less<>> Outputs;
 
 private:
     EvalState * state;

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -149,7 +149,7 @@ public:
     }
 };
 
-void parseJSON(EvalState & state, const string & s_, Value & v)
+void parseJSON(EvalState & state, std::string_view s_, Value & v)
 {
     JSONSax parser(state, v);
     bool res = json::sax_parse(s_, &parser);

--- a/src/libexpr/json-to-value.hh
+++ b/src/libexpr/json-to-value.hh
@@ -8,6 +8,6 @@ namespace nix {
 
 MakeError(JSONParseError, EvalError);
 
-void parseJSON(EvalState & state, const string & s, Value & v);
+void parseJSON(EvalState & state, std::string_view s, Value & v);
 
 }

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -16,7 +16,7 @@ std::ostream & operator << (std::ostream & str, const Expr & e)
     return str;
 }
 
-static void showString(std::ostream & str, const string & s)
+static void showString(std::ostream & str, std::string_view s)
 {
     str << '"';
     for (auto c : (string) s)
@@ -28,7 +28,7 @@ static void showString(std::ostream & str, const string & s)
     str << '"';
 }
 
-static void showId(std::ostream & str, const string & s)
+static void showId(std::ostream & str, std::string_view s)
 {
     if (s.empty())
         str << "\"\"";

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -187,7 +187,7 @@ struct ExprAttrs : Expr
             : inherited(inherited), e(e), pos(pos) { };
         AttrDef() { };
     };
-    typedef std::map<Symbol, AttrDef> AttrDefs;
+    typedef std::map<Symbol, AttrDef, std::less<>> AttrDefs;
     AttrDefs attrs;
     struct DynamicAttrDef {
         Expr * nameExpr, * valueExpr;
@@ -338,7 +338,7 @@ struct StaticEnv
 {
     bool isWith;
     const StaticEnv * up;
-    typedef std::map<Symbol, unsigned int> Vars;
+    typedef std::map<Symbol, unsigned int, std::less<>> Vars;
     Vars vars;
     StaticEnv(bool isWith, const StaticEnv * up) : isWith(isWith), up(up) { };
 };

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -121,14 +121,14 @@ struct ExprString : Expr
 struct ExprIndStr : Expr
 {
     string s;
-    ExprIndStr(const string & s) : s(s) { };
+    ExprIndStr(std::string_view s) : s(s) { };
 };
 
 struct ExprPath : Expr
 {
     string s;
     Value v;
-    ExprPath(const string & s) : s(s) { mkPathNoCopy(v, this->s.c_str()); };
+    ExprPath(std::string_view s) : s(s) { mkPathNoCopy(v, this->s.c_str()); };
     COMMON_METHODS
     Value * maybeThunk(EvalState & state, Env & env);
 };

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -405,7 +405,7 @@ expr_simple
   | IND_STRING_OPEN ind_string_parts IND_STRING_CLOSE {
       $$ = stripIndentation(CUR_POS, data->symbols, *$2);
   }
-  | PATH { $$ = new ExprPath(absPath($1, data->basePath)); }
+  | PATH { $$ = new ExprPath(absPath(Path { $1 }, data->basePath)); }
   | HPATH { $$ = new ExprPath(getHome() + string{$1 + 1}); }
   | SPATH {
       string path($1 + 1, strlen($1) - 2);
@@ -644,7 +644,7 @@ Expr * EvalState::parseExprFromString(std::string_view s, PathView basePath)
 Expr * EvalState::parseStdin()
 {
     //Activity act(*logger, lvlTalkative, format("parsing standard input"));
-    return parseExprFromString(drainFD(0), absPath("."));
+    return parseExprFromString(drainFD(0), absCWD());
 }
 
 
@@ -717,7 +717,7 @@ std::pair<bool, std::string> EvalState::resolveSearchPathElem(const SearchPathEl
             res = { false, "" };
         }
     } else {
-        auto path = absPath(Path { elem.second });
+        auto path = absPath(elem.second);
         if (pathExists(path))
             res = { true, path };
         else {

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -570,7 +570,7 @@ namespace nix {
 
 
 Expr * EvalState::parse(const char * text,
-    const Path & path, const Path & basePath, StaticEnv & staticEnv)
+    PathView path, PathView basePath, StaticEnv & staticEnv)
 {
     yyscan_t scanner;
     ParseData data(*this);
@@ -617,25 +617,25 @@ Path resolveExprPath(Path path)
 }
 
 
-Expr * EvalState::parseExprFromFile(const Path & path)
+Expr * EvalState::parseExprFromFile(PathView path)
 {
     return parseExprFromFile(path, staticBaseEnv);
 }
 
 
-Expr * EvalState::parseExprFromFile(const Path & path, StaticEnv & staticEnv)
+Expr * EvalState::parseExprFromFile(PathView path, StaticEnv & staticEnv)
 {
     return parse(readFile(path).c_str(), path, dirOf(path), staticEnv);
 }
 
 
-Expr * EvalState::parseExprFromString(std::string_view s, const Path & basePath, StaticEnv & staticEnv)
+Expr * EvalState::parseExprFromString(std::string_view s, PathView basePath, StaticEnv & staticEnv)
 {
     return parse(s.data(), "(string)", basePath, staticEnv);
 }
 
 
-Expr * EvalState::parseExprFromString(std::string_view s, const Path & basePath)
+Expr * EvalState::parseExprFromString(std::string_view s, PathView basePath)
 {
     return parseExprFromString(s, basePath, staticBaseEnv);
 }
@@ -648,7 +648,7 @@ Expr * EvalState::parseStdin()
 }
 
 
-void EvalState::addToSearchPath(const string & s)
+void EvalState::addToSearchPath(std::string_view s)
 {
     size_t pos = s.find('=');
     string prefix;
@@ -664,13 +664,13 @@ void EvalState::addToSearchPath(const string & s)
 }
 
 
-Path EvalState::findFile(const string & path)
+Path EvalState::findFile(std::string_view path)
 {
     return findFile(searchPath, path);
 }
 
 
-Path EvalState::findFile(SearchPath & searchPath, const string & path, const Pos & pos)
+Path EvalState::findFile(SearchPath & searchPath, std::string_view path, const Pos & pos)
 {
     for (auto & i : searchPath) {
         std::string suffix;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2176,7 +2176,7 @@ static void prim_compareVersions(EvalState & state, const Pos & pos, Value * * a
 static void prim_splitVersion(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     string _version = state.forceStringNoCtx(*args[0], pos);
-	std::string_view version { _version };
+    std::string_view version { _version };
     auto iter = version.cbegin();
     Strings components;
     while (iter != version.cend()) {

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -82,7 +82,7 @@ static void prim_getContext(EvalState & state, const Pos & pos, Value * * args, 
             drv = string(p, 1);
             path = &drv;
         } else if (p.at(0) == '!') {
-            std::pair<string, string> ctx = decodeContext(p);
+            std::pair<std::string_view, std::string_view> ctx = decodeContext(p);
             drv = ctx.first;
             output = ctx.second;
             path = &drv;

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -90,7 +90,7 @@ static void prim_fetchTree(EvalState & state, const Pos & pos, Value * * args, V
 static RegisterPrimOp r("fetchTree", 1, prim_fetchTree);
 
 static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
-    const string & who, bool unpack, std::string name)
+    std::string_view who, bool unpack, std::string name)
 {
     std::optional<std::string> url;
     std::optional<Hash> expectedHash;

--- a/src/libexpr/symbol-table.hh
+++ b/src/libexpr/symbol-table.hh
@@ -38,7 +38,7 @@ public:
         return s < s2.s;
     }
 
-    operator const std::string & () const
+    operator std::string_view () const
     {
         return *s;
     }
@@ -68,7 +68,7 @@ private:
     Symbols symbols;
 
 public:
-    Symbol create(const string & s)
+    Symbol create(std::string_view s)
     {
         std::pair<Symbols::iterator, bool> res = symbols.insert(s);
         return Symbol(&*res.first);

--- a/src/libexpr/symbol-table.hh
+++ b/src/libexpr/symbol-table.hh
@@ -43,7 +43,7 @@ public:
         return *s;
     }
 
-    operator const std::string_view () const
+    operator const std::string & () const
     {
         return *s;
     }
@@ -70,7 +70,7 @@ private:
 public:
     Symbol create(std::string_view s)
     {
-        std::pair<Symbols::iterator, bool> res = symbols.insert(s);
+        std::pair<Symbols::iterator, bool> res = symbols.insert(std::string { s });
         return Symbol(&*res.first);
     }
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -32,7 +32,7 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
 
         case tPath:
-            out.write(state.copyPathToStore(context, v.path));
+            out.write(PathView { state.copyPathToStore(context, v.path) });
             break;
 
         case tNull:
@@ -42,7 +42,7 @@ void printValueAsJSON(EvalState & state, bool strict,
         case tAttrs: {
             auto maybeString = state.tryAttrsToString(noPos, v, context, false, false);
             if (maybeString) {
-                out.write(*maybeString);
+                out.write(std::string_view { *maybeString });
                 break;
             }
             auto i = v.attrs->find(state.sOutPath);

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -12,7 +12,7 @@ namespace nix {
 static XMLAttrs singletonAttrs(std::string_view name, std::string_view value)
 {
     XMLAttrs attrs;
-    attrs[name] = value;
+    attrs[std::string { name } ] = value;
     return attrs;
 }
 

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -9,7 +9,7 @@
 namespace nix {
 
 
-static XMLAttrs singletonAttrs(const string & name, const string & value)
+static XMLAttrs singletonAttrs(std::string_view name, std::string_view value)
 {
     XMLAttrs attrs;
     attrs[name] = value;

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -257,7 +257,7 @@ typedef std::vector<Value *, traceable_allocator<Value *> > ValueVector;
 typedef std::map<Symbol, Value *, std::less<Symbol>, traceable_allocator<std::pair<const Symbol, Value *> > > ValueMap;
 #else
 typedef std::vector<Value *> ValueVector;
-typedef std::map<Symbol, Value *> ValueMap;
+typedef std::map<Symbol, Value *, std::less<Symbol>> ValueMap;
 #endif
 
 

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -234,7 +234,7 @@ static inline void mkStringNoCopy(Value & v, const char * s)
 
 static inline void mkString(Value & v, const Symbol & s)
 {
-    mkStringNoCopy(v, ((const string &) s).c_str());
+    mkStringNoCopy(v, ((std::string_view) s).c_str());
 }
 
 

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -234,7 +234,7 @@ static inline void mkStringNoCopy(Value & v, const char * s)
 
 static inline void mkString(Value & v, const Symbol & s)
 {
-    mkStringNoCopy(v, ((std::string_view) s).c_str());
+    mkStringNoCopy(v, ((const std::string &) s).c_str());
 }
 
 

--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -38,7 +38,7 @@ nlohmann::json attrsToJson(const Attrs & attrs)
     return json;
 }
 
-std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::string & name)
+std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, std::string_view name)
 {
     auto i = attrs.find(name);
     if (i == attrs.end()) return {};
@@ -47,7 +47,7 @@ std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::strin
     throw Error("input attribute '%s' is not a string %s", name, attrsToJson(attrs).dump());
 }
 
-std::string getStrAttr(const Attrs & attrs, const std::string & name)
+std::string getStrAttr(const Attrs & attrs, std::string_view name)
 {
     auto s = maybeGetStrAttr(attrs, name);
     if (!s)
@@ -55,7 +55,7 @@ std::string getStrAttr(const Attrs & attrs, const std::string & name)
     return *s;
 }
 
-std::optional<int64_t> maybeGetIntAttr(const Attrs & attrs, const std::string & name)
+std::optional<int64_t> maybeGetIntAttr(const Attrs & attrs, std::string_view name)
 {
     auto i = attrs.find(name);
     if (i == attrs.end()) return {};
@@ -64,7 +64,7 @@ std::optional<int64_t> maybeGetIntAttr(const Attrs & attrs, const std::string & 
     throw Error("input attribute '%s' is not an integer", name);
 }
 
-int64_t getIntAttr(const Attrs & attrs, const std::string & name)
+int64_t getIntAttr(const Attrs & attrs, std::string_view name)
 {
     auto s = maybeGetIntAttr(attrs, name);
     if (!s)
@@ -72,7 +72,7 @@ int64_t getIntAttr(const Attrs & attrs, const std::string & name)
     return *s;
 }
 
-std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, const std::string & name)
+std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, std::string_view name)
 {
     auto i = attrs.find(name);
     if (i == attrs.end()) return {};
@@ -81,7 +81,7 @@ std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, const std::string & na
     throw Error("input attribute '%s' is not a Boolean", name);
 }
 
-bool getBoolAttr(const Attrs & attrs, const std::string & name)
+bool getBoolAttr(const Attrs & attrs, std::string_view name)
 {
     auto s = maybeGetBoolAttr(attrs, name);
     if (!s)

--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -89,9 +89,9 @@ bool getBoolAttr(const Attrs & attrs, std::string_view name)
     return *s;
 }
 
-std::map<std::string, std::string> attrsToQuery(const Attrs & attrs)
+std::map<std::string, std::string, std::less<>> attrsToQuery(const Attrs & attrs)
 {
-    std::map<std::string, std::string> query;
+    std::map<std::string, std::string, std::less<>> query;
     for (auto & attr : attrs) {
         if (auto v = std::get_if<int64_t>(&attr.second)) {
             query.insert_or_assign(attr.first, fmt("%d", *v));

--- a/src/libfetchers/attrs.hh
+++ b/src/libfetchers/attrs.hh
@@ -34,6 +34,6 @@ std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, std::string_view name)
 
 bool getBoolAttr(const Attrs & attrs, std::string_view name);
 
-std::map<std::string, std::string> attrsToQuery(const Attrs & attrs);
+std::map<std::string, std::string, std::less<>> attrsToQuery(const Attrs & attrs);
 
 }

--- a/src/libfetchers/attrs.hh
+++ b/src/libfetchers/attrs.hh
@@ -22,17 +22,17 @@ Attrs jsonToAttrs(const nlohmann::json & json);
 
 nlohmann::json attrsToJson(const Attrs & attrs);
 
-std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::string & name);
+std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, std::string_view name);
 
-std::string getStrAttr(const Attrs & attrs, const std::string & name);
+std::string getStrAttr(const Attrs & attrs, std::string_view name);
 
-std::optional<int64_t> maybeGetIntAttr(const Attrs & attrs, const std::string & name);
+std::optional<int64_t> maybeGetIntAttr(const Attrs & attrs, std::string_view name);
 
-int64_t getIntAttr(const Attrs & attrs, const std::string & name);
+int64_t getIntAttr(const Attrs & attrs, std::string_view name);
 
-std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, const std::string & name);
+std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, std::string_view name);
 
-bool getBoolAttr(const Attrs & attrs, const std::string & name);
+bool getBoolAttr(const Attrs & attrs, std::string_view name);
 
 std::map<std::string, std::string> attrsToQuery(const Attrs & attrs);
 

--- a/src/libfetchers/attrs.hh
+++ b/src/libfetchers/attrs.hh
@@ -16,7 +16,7 @@ struct Explicit {
 };
 
 typedef std::variant<std::string, int64_t, Explicit<bool>> Attr;
-typedef std::map<std::string, Attr> Attrs;
+typedef std::map<std::string, Attr, std::less<>> Attrs;
 
 Attrs jsonToAttrs(const nlohmann::json & json);
 

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -22,7 +22,7 @@ std::unique_ptr<Input> inputFromURL(const ParsedURL & url)
     throw Error("input '%s' is unsupported", url.url);
 }
 
-std::unique_ptr<Input> inputFromURL(const std::string & url)
+std::unique_ptr<Input> inputFromURL(std::string_view url)
 {
     return inputFromURL(parseURL(url));
 }

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -75,7 +75,7 @@ struct InputScheme
 
 std::unique_ptr<Input> inputFromURL(const ParsedURL & url);
 
-std::unique_ptr<Input> inputFromURL(const std::string & url);
+std::unique_ptr<Input> inputFromURL(std::string_view url);
 
 std::unique_ptr<Input> inputFromAttrs(const Attrs & attrs);
 
@@ -90,14 +90,14 @@ struct DownloadFileResult
 
 DownloadFileResult downloadFile(
     ref<Store> store,
-    const std::string & url,
-    const std::string & name,
+    std::string_view url,
+    std::string_view name,
     bool immutable);
 
 Tree downloadTarball(
     ref<Store> store,
-    const std::string & url,
-    const std::string & name,
+    std::string_view url,
+    std::string_view name,
     bool immutable);
 
 }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -10,12 +10,12 @@ using namespace std::string_literals;
 
 namespace nix::fetchers {
 
-static std::string readHead(const Path & path)
+static std::string readHead(PathView path)
 {
     return chomp(runProgram("git", true, { "-C", path, "rev-parse", "--abbrev-ref", "HEAD" }));
 }
 
-static bool isNotDotGitDirectory(const Path & path)
+static bool isNotDotGitDirectory(PathView path)
 {
     static const std::regex gitDirRegex("^(?:.*/)?\\.git$");
 
@@ -180,7 +180,7 @@ struct GitInput : Input
                 auto files = tokenizeString<std::set<std::string>>(
                     runProgram("git", true, gitOpts), "\0"s);
 
-                PathFilter filter = [&](const Path & p) -> bool {
+                PathFilter filter = [&](PathView p) -> bool {
                     assert(hasPrefix(p, actualUrl));
                     std::string file(p, actualUrl.size() + 1);
 

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -99,7 +99,7 @@ struct MercurialInput : Input
                 auto files = tokenizeString<std::set<std::string>>(
                     runProgram("hg", true, { "status", "-R", actualUrl, "--clean", "--modified", "--added", "--no-status", "--print0" }), "\0"s);
 
-                PathFilter filter = [&](const Path & p) -> bool {
+                PathFilter filter = [&](PathView p) -> bool {
                     assert(hasPrefix(p, actualUrl));
                     std::string file(p, actualUrl.size() + 1);
 

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -96,17 +96,17 @@ struct MercurialInput : Input
 
                 input->ref = chomp(runProgram("hg", true, { "branch", "-R", actualUrl }));
 
-                auto files = tokenizeString<std::set<std::string>>(
+                auto files = tokenizeString<std::set<std::string, std::less<>>>(
                     runProgram("hg", true, { "status", "-R", actualUrl, "--clean", "--modified", "--added", "--no-status", "--print0" }), "\0"s);
 
                 PathFilter filter = [&](PathView p) -> bool {
                     assert(hasPrefix(p, actualUrl));
-                    std::string file(p, actualUrl.size() + 1);
+                    std::string_view file = p.substr(actualUrl.size() + 1);
 
                     auto st = lstat(p);
 
                     if (S_ISDIR(st.st_mode)) {
-                        auto prefix = file + "/";
+                        auto prefix = Path { file } << "/";
                         auto i = files.lower_bound(prefix);
                         return i != files.end() && hasPrefix(*i, prefix);
                     }

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -18,8 +18,8 @@ DownloadFileResult downloadFile(
 
     Attrs inAttrs({
         {"type", "file"},
-        {"url", url},
-        {"name", name},
+        {"url", std::string { url }},
+        {"name", std::string { name }},
     });
 
     auto cached = getCache()->lookupExpired(store, inAttrs);
@@ -88,8 +88,8 @@ DownloadFileResult downloadFile(
             store,
             {
                 {"type", "file"},
-                {"url", res.effectiveUri},
-                {"name", name},
+                {"url", std::string { res.effectiveUri }},
+                {"name", std::string { name }},
             },
             infoAttrs,
             *storePath,
@@ -110,8 +110,8 @@ Tree downloadTarball(
 {
     Attrs inAttrs({
         {"type", "tarball"},
-        {"url", url},
-        {"name", name},
+        {"url", std::string { url }},
+        {"name", std::string { name }},
     });
 
     auto cached = getCache()->lookupExpired(store, inAttrs);

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -10,8 +10,8 @@ namespace nix::fetchers {
 
 DownloadFileResult downloadFile(
     ref<Store> store,
-    const std::string & url,
-    const std::string & name,
+    std::string_view url,
+    std::string_view name,
     bool immutable)
 {
     // FIXME: check store
@@ -104,8 +104,8 @@ DownloadFileResult downloadFile(
 
 Tree downloadTarball(
     ref<Store> store,
-    const std::string & url,
-    const std::string & name,
+    std::string_view url,
+    std::string_view name,
     bool immutable)
 {
     Attrs inAttrs({

--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -4,7 +4,7 @@
 
 namespace nix {
 
-MixCommonArgs::MixCommonArgs(const string & programName)
+MixCommonArgs::MixCommonArgs(std::string_view programName)
     : programName(programName)
 {
     addFlag({

--- a/src/libmain/common-args.hh
+++ b/src/libmain/common-args.hh
@@ -7,7 +7,7 @@ namespace nix {
 struct MixCommonArgs : virtual Args
 {
     string programName;
-    MixCommonArgs(const string & programName);
+    MixCommonArgs(std::string_view programName);
 };
 
 struct MixDryRun : virtual Args

--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -5,7 +5,7 @@ namespace nix {
 
 LogFormat defaultLogFormat = LogFormat::raw;
 
-LogFormat parseLogFormat(const std::string & logFormatStr) {
+LogFormat parseLogFormat(std::string_view logFormatStr) {
     if (logFormatStr == "raw")
         return LogFormat::raw;
     else if (logFormatStr == "raw-with-logs")
@@ -36,7 +36,7 @@ Logger * makeDefaultLogger() {
     }
 }
 
-void setLogFormat(const std::string & logFormatStr) {
+void setLogFormat(std::string_view logFormatStr) {
     setLogFormat(parseLogFormat(logFormatStr));
 }
 

--- a/src/libmain/loggers.hh
+++ b/src/libmain/loggers.hh
@@ -12,7 +12,7 @@ enum class LogFormat {
   barWithLogs,
 };
 
-void setLogFormat(const std::string & logFormatStr);
+void setLogFormat(std::string_view logFormatStr);
 void setLogFormat(const LogFormat & logFormat);
 
 void createDefaultLogger();

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -136,7 +136,7 @@ public:
         log(*state, ei.level, oss.str());
     }
 
-    void log(State & state, Verbosity lvl, const std::string & s)
+    void log(State & state, Verbosity lvl, std::string_view s)
     {
         if (state.active) {
             writeToStderr("\r\e[K" + filterANSIEscapes(s, !isTTY) + ANSI_NORMAL "\n");
@@ -149,7 +149,7 @@ public:
     }
 
     void startActivity(ActivityId act, Verbosity lvl, ActivityType type,
-        const std::string & s, const Fields & fields, ActivityId parent) override
+        std::string_view s, const Fields & fields, ActivityId parent) override
     {
         auto state(state_.lock());
 
@@ -371,7 +371,7 @@ public:
 
         std::string res;
 
-        auto renderActivity = [&](ActivityType type, const std::string & itemFmt, const std::string & numberFmt = "%d", double unit = 1) {
+        auto renderActivity = [&](ActivityType type, std::string_view itemFmt, std::string_view numberFmt = "%d", double unit = 1) {
             auto & act = state.activitiesByType[type];
             uint64_t done = act.done, expected = act.done, running = 0, failed = act.failed;
             for (auto & j : act.its) {
@@ -410,7 +410,7 @@ public:
             return s;
         };
 
-        auto showActivity = [&](ActivityType type, const std::string & itemFmt, const std::string & numberFmt = "%d", double unit = 1) {
+        auto showActivity = [&](ActivityType type, std::string_view itemFmt, std::string_view numberFmt = "%d", double unit = 1) {
             auto s = renderActivity(type, itemFmt, numberFmt, unit);
             if (s.empty()) return;
             if (!res.empty()) res += ", ";

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -142,7 +142,7 @@ public:
             writeToStderr("\r\e[K" + filterANSIEscapes(s, !isTTY) + ANSI_NORMAL "\n");
             draw(state);
         } else {
-            auto s2 = s + ANSI_NORMAL "\n";
+            auto s2 = std::string { s } << ANSI_NORMAL "\n";
             if (!isTTY) s2 = filterANSIEscapes(s2, true);
             writeToStderr(s2);
         }
@@ -154,7 +154,7 @@ public:
         auto state(state_.lock());
 
         if (lvl <= verbosity && !s.empty() && type != actBuildWaiting)
-            log(*state, lvl, s + "...");
+            log(*state, lvl, std::string { s } << "...");
 
         state->activities.emplace_back(ActInfo());
         auto i = std::prev(state->activities.end());
@@ -388,19 +388,19 @@ public:
             if (running || done || expected || failed) {
                 if (running)
                     if (expected != 0)
-                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" ANSI_GREEN + numberFmt + ANSI_NORMAL "/" + numberFmt,
+                        s = fmt(std::string { ANSI_BLUE } << numberFmt << ANSI_NORMAL "/" ANSI_GREEN << numberFmt << ANSI_NORMAL "/" << numberFmt,
                             running / unit, done / unit, expected / unit);
                     else
-                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" ANSI_GREEN + numberFmt + ANSI_NORMAL,
+                        s = fmt(std::string { ANSI_BLUE } << numberFmt << ANSI_NORMAL "/" ANSI_GREEN << numberFmt << ANSI_NORMAL,
                             running / unit, done / unit);
                 else if (expected != done)
                     if (expected != 0)
-                        s = fmt(ANSI_GREEN + numberFmt + ANSI_NORMAL "/" + numberFmt,
+                        s = fmt(std::string { ANSI_GREEN } << numberFmt << ANSI_NORMAL "/" << numberFmt,
                             done / unit, expected / unit);
                     else
-                        s = fmt(ANSI_GREEN + numberFmt + ANSI_NORMAL, done / unit);
+                        s = fmt(std::string { ANSI_GREEN } << numberFmt << ANSI_NORMAL, done / unit);
                 else
-                    s = fmt(done ? ANSI_GREEN + numberFmt + ANSI_NORMAL : numberFmt, done / unit);
+                    s = fmt(done ? std::string { ANSI_GREEN } << numberFmt << ANSI_NORMAL : numberFmt, done / unit);
                 s = fmt(itemFmt, s);
 
                 if (failed)

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -281,7 +281,7 @@ void showManPage(std::string_view name)
 {
     restoreSignals();
     setenv("MANPATH", settings.nixManDir.c_str(), 1);
-    execlp("man", "man", name.c_str(), nullptr);
+    execlp("man", "man", std::string { name }.c_str(), nullptr);
     throw SysError("command 'man %1%' failed", name.c_str());
 }
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -72,7 +72,7 @@ void printMissing(ref<Store> store, const StorePathSet & willBuild,
 }
 
 
-string getArg(const string & opt,
+string getArg(std::string_view opt,
     Strings::iterator & i, const Strings::iterator & end)
 {
     ++i;
@@ -162,7 +162,7 @@ void initNix()
 }
 
 
-LegacyArgs::LegacyArgs(const std::string & programName,
+LegacyArgs::LegacyArgs(std::string_view programName,
     std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg)
     : MixCommonArgs(programName), parseArg(parseArg)
 {
@@ -193,8 +193,8 @@ LegacyArgs::LegacyArgs(const std::string & programName,
         .handler = {&(bool&) settings.tryFallback, true},
     });
 
-    auto intSettingAlias = [&](char shortName, const std::string & longName,
-        const std::string & description, const std::string & dest) {
+    auto intSettingAlias = [&](char shortName, std::string_view longName,
+        std::string_view description, std::string_view dest) {
         mkFlag<unsigned int>(shortName, longName, description, [=](unsigned int n) {
             settings.set(dest, std::to_string(n));
         });
@@ -247,14 +247,14 @@ void parseCmdLine(int argc, char * * argv,
 }
 
 
-void parseCmdLine(const string & programName, const Strings & args,
+void parseCmdLine(std::string_view programName, const Strings & args,
     std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg)
 {
     LegacyArgs(programName, parseArg).parseCmdline(args);
 }
 
 
-void printVersion(const string & programName)
+void printVersion(std::string_view programName)
 {
     std::cout << format("%1% (Nix) %2%") % programName % nixVersion << std::endl;
     if (verbosity > lvlInfo) {
@@ -277,7 +277,7 @@ void printVersion(const string & programName)
 }
 
 
-void showManPage(const string & name)
+void showManPage(std::string_view name)
 {
     restoreSignals();
     setenv("MANPATH", settings.nixManDir.c_str(), 1);
@@ -286,7 +286,7 @@ void showManPage(const string & name)
 }
 
 
-int handleExceptions(const string & programName, std::function<void()> fun)
+int handleExceptions(std::string_view programName, std::function<void()> fun)
 {
     ReceiveInterrupts receiveInterrupts; // FIXME: need better place for this
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -282,7 +282,7 @@ void showManPage(std::string_view name)
     restoreSignals();
     setenv("MANPATH", settings.nixManDir.c_str(), 1);
     execlp("man", "man", std::string { name }.c_str(), nullptr);
-    throw SysError("command 'man %1%' failed", name.c_str());
+    throw SysError("command 'man %s' failed", name);
 }
 
 

--- a/src/libmain/shared.hh
+++ b/src/libmain/shared.hh
@@ -21,7 +21,7 @@ public:
     virtual ~Exit();
 };
 
-int handleExceptions(const string & programName, std::function<void()> fun);
+int handleExceptions(std::string_view programName, std::function<void()> fun);
 
 /* Don't forget to call initPlugins() after settings are initialized! */
 void initNix();
@@ -29,10 +29,10 @@ void initNix();
 void parseCmdLine(int argc, char * * argv,
     std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg);
 
-void parseCmdLine(const string & programName, const Strings & args,
+void parseCmdLine(std::string_view programName, const Strings & args,
     std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg);
 
-void printVersion(const string & programName);
+void printVersion(std::string_view programName);
 
 /* Ugh.  No better place to put this. */
 void printGCWarning();
@@ -49,10 +49,10 @@ void printMissing(ref<Store> store, const StorePathSet & willBuild,
     const StorePathSet & willSubstitute, const StorePathSet & unknown,
     unsigned long long downloadSize, unsigned long long narSize, Verbosity lvl = lvlInfo);
 
-string getArg(const string & opt,
+string getArg(std::string_view opt,
     Strings::iterator & i, const Strings::iterator & end);
 
-template<class N> N getIntArg(const string & opt,
+template<class N> N getIntArg(std::string_view opt,
     Strings::iterator & i, const Strings::iterator & end, bool allowUnit)
 {
     ++i;
@@ -81,7 +81,7 @@ struct LegacyArgs : public MixCommonArgs
 {
     std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg;
 
-    LegacyArgs(const std::string & programName,
+    LegacyArgs(std::string_view programName,
         std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg);
 
     bool processFlag(Strings::iterator & pos, Strings::iterator end) override;
@@ -91,7 +91,7 @@ struct LegacyArgs : public MixCommonArgs
 
 
 /* Show the manual page for the specified program. */
-void showManPage(const string & name);
+void showManPage(std::string_view name);
 
 /* The constructor of this class starts a pager if stdout is a
    terminal and $PAGER is set. Stdout is redirected to the pager. */

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -24,7 +24,7 @@ BinaryCacheStore::BinaryCacheStore(const Params & params)
     : Store(params)
 {
     if (secretKeyFile != "")
-        secretKey = std::unique_ptr<SecretKey>(new SecretKey(readFile(secretKeyFile)));
+        secretKey = std::unique_ptr<SecretKey>(new SecretKey(readFile(PathView { secretKeyFile })));
 
     StringSink sink;
     sink << narVersionMagic1;
@@ -57,7 +57,7 @@ void BinaryCacheStore::init()
     }
 }
 
-void BinaryCacheStore::getFile(const std::string & path,
+void BinaryCacheStore::getFile(std::string_view path,
     Callback<std::shared_ptr<std::string>> callback) noexcept
 {
     try {
@@ -65,7 +65,7 @@ void BinaryCacheStore::getFile(const std::string & path,
     } catch (...) { callback.rethrow(); }
 }
 
-void BinaryCacheStore::getFile(const std::string & path, Sink & sink)
+void BinaryCacheStore::getFile(std::string_view path, Sink & sink)
 {
     std::promise<std::shared_ptr<std::string>> promise;
     getFile(path,
@@ -80,7 +80,7 @@ void BinaryCacheStore::getFile(const std::string & path, Sink & sink)
     sink((unsigned char *) data->data(), data->size());
 }
 
-std::shared_ptr<std::string> BinaryCacheStore::getFile(const std::string & path)
+std::shared_ptr<std::string> BinaryCacheStore::getFile(std::string_view path)
 {
     StringSink sink;
     try {
@@ -303,7 +303,7 @@ void BinaryCacheStore::queryPathInfoUncached(const StorePath & storePath,
     auto uri = getUri();
     auto storePathS = printStorePath(storePath);
     auto act = std::make_shared<Activity>(*logger, lvlTalkative, actQueryPathInfo,
-        fmt("querying info about '%s' on '%s'", storePathS, uri), Logger::Fields{storePathS, uri});
+        fmt("querying info about '%s' on '%s'", storePathS, uri), Logger::Fields{ storePathS, uri });
     PushActivity pact(act->id);
 
     auto narInfoFile = narInfoFileFor(storePath);
@@ -329,7 +329,7 @@ void BinaryCacheStore::queryPathInfoUncached(const StorePath & storePath,
         }});
 }
 
-StorePath BinaryCacheStore::addToStore(const string & name, const Path & srcPath,
+StorePath BinaryCacheStore::addToStore(std::string_view name, PathView srcPath,
     FileIngestionMethod method, HashType hashAlgo, PathFilter & filter, RepairFlag repair)
 {
     // FIXME: some cut&paste from LocalStore::addToStore().
@@ -356,7 +356,7 @@ StorePath BinaryCacheStore::addToStore(const string & name, const Path & srcPath
     return std::move(info.path);
 }
 
-StorePath BinaryCacheStore::addTextToStore(const string & name, const string & s,
+StorePath BinaryCacheStore::addTextToStore(std::string_view name, std::string_view s,
     const StorePathSet & references, RepairFlag repair)
 {
     ValidPathInfo info(computeStorePathForText(name, s, references));

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -33,24 +33,24 @@ protected:
 
 public:
 
-    virtual bool fileExists(const std::string & path) = 0;
+    virtual bool fileExists(std::string_view path) = 0;
 
-    virtual void upsertFile(const std::string & path,
-        const std::string & data,
-        const std::string & mimeType) = 0;
+    virtual void upsertFile(std::string_view path,
+        std::string_view data,
+        std::string_view mimeType) = 0;
 
     /* Note: subclasses must implement at least one of the two
        following getFile() methods. */
 
     /* Dump the contents of the specified file to a sink. */
-    virtual void getFile(const std::string & path, Sink & sink);
+    virtual void getFile(std::string_view path, Sink & sink);
 
     /* Fetch the specified file and call the specified callback with
        the result. A subclass may implement this asynchronously. */
-    virtual void getFile(const std::string & path,
+    virtual void getFile(std::string_view path,
         Callback<std::shared_ptr<std::string>> callback) noexcept;
 
-    std::shared_ptr<std::string> getFile(const std::string & path);
+    std::shared_ptr<std::string> getFile(std::string_view path);
 
 public:
 
@@ -71,18 +71,18 @@ public:
     void queryPathInfoUncached(const StorePath & path,
         Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
 
-    std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override
+    std::optional<StorePath> queryPathFromHashPart(std::string_view hashPart) override
     { unsupported("queryPathFromHashPart"); }
 
     void addToStore(const ValidPathInfo & info, Source & narSource,
         RepairFlag repair, CheckSigsFlag checkSigs,
         std::shared_ptr<FSAccessor> accessor) override;
 
-    StorePath addToStore(const string & name, const Path & srcPath,
+    StorePath addToStore(std::string_view name, PathView srcPath,
         FileIngestionMethod method, HashType hashAlgo,
         PathFilter & filter, RepairFlag repair) override;
 
-    StorePath addTextToStore(const string & name, const string & s,
+    StorePath addTextToStore(std::string_view name, std::string_view s,
         const StorePathSet & references, RepairFlag repair) override;
 
     void narFromPath(const StorePath & path, Sink & sink) override;

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -100,7 +100,7 @@ typedef set<GoalPtr, CompareGoalPtrs> Goals;
 typedef list<WeakGoalPtr> WeakGoals;
 
 /* A map of paths to goals (and the other way around). */
-typedef std::map<StorePath, WeakGoalPtr> WeakGoalMap;
+typedef std::map<StorePath, WeakGoalPtr, std::less<>> WeakGoalMap;
 
 
 
@@ -859,7 +859,7 @@ private:
        building multiple times. Since this contains the hash, it
        allows us to compare whether two rounds produced the same
        result. */
-    std::map<Path, ValidPathInfo> prevInfos;
+    std::map<Path, ValidPathInfo, std::less<>> prevInfos;
 
     const uid_t sandboxUid = 1000;
     const gid_t sandboxGid = 100;
@@ -984,7 +984,7 @@ private:
     /* Check that an output meets the requirements specified by the
        'outputChecks' attribute (or the legacy
        '{allowed,disallowed}{References,Requisites}' attributes). */
-    void checkOutputs(const std::map<std::string, ValidPathInfo> & outputs);
+    void checkOutputs(const std::map<std::string, ValidPathInfo, std::less<>> & outputs);
 
     /* Open a log file and a pipe to it. */
     Path openLogFile();
@@ -1216,9 +1216,9 @@ void DerivationGoal::outputsSubstituted()
     trace("all outputs substituted (maybe)");
 
     if (nrFailed > 0 && nrFailed > nrNoSubstituters + nrIncompleteClosure && !settings.tryFallback) {
-        done(BuildResult::TransientFailure,
-            fmt("some substitutes for the outputs of derivation '%s' failed (usually happens due to networking issues); try '--fallback' to build derivation from source ",
-                worker.store.printStorePath(drvPath)));
+        done(BuildResult::TransientFailure,Error(
+            "some substitutes for the outputs of derivation '%s' failed (usually happens due to networking issues); try '--fallback' to build derivation from source ",
+            worker.store.printStorePath(drvPath)));
         return;
     }
 
@@ -3612,7 +3612,7 @@ void DerivationGoal::registerOutputs()
         if (allValid) return;
     }
 
-    std::map<std::string, ValidPathInfo> infos;
+    std::map<std::string, ValidPathInfo, std::less<>> infos;
 
     /* Set of inodes seen during calls to canonicalisePathMetaData()
        for this build's outputs.  This needs to be shared between
@@ -3919,9 +3919,9 @@ void DerivationGoal::registerOutputs()
 }
 
 
-void DerivationGoal::checkOutputs(const std::map<Path, ValidPathInfo> & outputs)
+void DerivationGoal::checkOutputs(const std::map<Path, ValidPathInfo, std::less<>> & outputs)
 {
-    std::map<Path, const ValidPathInfo &> outputsByPath;
+    std::map<Path, const ValidPathInfo &, std::less<>> outputsByPath;
     for (auto & output : outputs)
         outputsByPath.emplace(worker.store.printStorePath(output.second.path), output.second);
 

--- a/src/libstore/builtins.hh
+++ b/src/libstore/builtins.hh
@@ -5,7 +5,7 @@
 namespace nix {
 
 // TODO: make pluggable.
-void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData);
+void builtinFetchurl(const BasicDerivation & drv, std::string_view netrcData);
 void builtinUnpackChannel(const BasicDerivation & drv);
 
 }

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -35,8 +35,8 @@ static void createLinks(State & state, PathView srcDir, PathView dstDir, int pri
         if (ent.name[0] == '.')
             /* not matched by glob */
             continue;
-        auto srcFile = srcDir + "/" + ent.name;
-        auto dstFile = dstDir + "/" + ent.name;
+        auto srcFile = Path { srcDir } << "/" << ent.name;
+        auto dstFile = Path { dstDir } << "/" << ent.name;
 
         struct stat srcSt;
         try {
@@ -125,12 +125,12 @@ void buildProfile(PathView out, Packages && pkgs)
     std::set<Path> done, postponed;
 
     auto addPkg = [&](PathView pkgDir, int priority) {
-        if (!done.insert(pkgDir).second) return;
+        if (!done.insert(Path { pkgDir }).second) return;
         createLinks(state, pkgDir, out, priority);
 
         try {
             for (const auto & p : tokenizeString<std::vector<string>>(
-                    readFile(pkgDir + "/nix-support/propagated-user-env-packages"), " \n"))
+                    readFile(Path { pkgDir } + "/nix-support/propagated-user-env-packages"), " \n"))
                 if (!done.count(p))
                     postponed.insert(p);
         } catch (SysError & e) {

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -14,7 +14,7 @@ struct State
 };
 
 /* For each activated package, create symlinks */
-static void createLinks(State & state, const Path & srcDir, const Path & dstDir, int priority)
+static void createLinks(State & state, PathView srcDir, PathView dstDir, int priority)
 {
     DirEntries srcFiles;
 
@@ -118,13 +118,13 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
     }
 }
 
-void buildProfile(const Path & out, Packages && pkgs)
+void buildProfile(PathView out, Packages && pkgs)
 {
     State state;
 
     std::set<Path> done, postponed;
 
-    auto addPkg = [&](const Path & pkgDir, int priority) {
+    auto addPkg = [&](PathView pkgDir, int priority) {
         if (!done.insert(pkgDir).second) return;
         createLinks(state, pkgDir, out, priority);
 
@@ -167,7 +167,7 @@ void buildProfile(const Path & out, Packages && pkgs)
 
 void builtinBuildenv(const BasicDerivation & drv)
 {
-    auto getAttr = [&](const string & name) {
+    auto getAttr = [&](std::string_view name) {
         auto i = drv.env.find(name);
         if (i == drv.env.end()) throw Error("attribute '%s' missing", name);
         return i->second;

--- a/src/libstore/builtins/buildenv.hh
+++ b/src/libstore/builtins/buildenv.hh
@@ -14,7 +14,7 @@ struct Package {
 
 typedef std::vector<Package> Packages;
 
-void buildProfile(const Path & out, Packages && pkgs);
+void buildProfile(PathView out, Packages && pkgs);
 
 void builtinBuildenv(const BasicDerivation & drv);
 

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -6,7 +6,7 @@
 
 namespace nix {
 
-void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
+void builtinFetchurl(const BasicDerivation & drv, std::string_view netrcData)
 {
     /* Make the host's netrc data available. Too bad curl requires
        this to be stored in a file. It would be nice if we could just
@@ -16,7 +16,7 @@ void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
         writeFile(settings.netrcFile, netrcData, 0600);
     }
 
-    auto getAttr = [&](const string & name) {
+    auto getAttr = [&](std::string_view name) {
         auto i = drv.env.find(name);
         if (i == drv.env.end()) throw Error("attribute '%s' missing", name);
         return i->second;
@@ -30,7 +30,7 @@ void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
        a forked process. */
     auto fileTransfer = makeFileTransfer();
 
-    auto fetch = [&](const std::string & url) {
+    auto fetch = [&](std::string_view url) {
 
         auto source = sinkToSource([&](Sink & sink) {
 

--- a/src/libstore/builtins/unpack-channel.cc
+++ b/src/libstore/builtins/unpack-channel.cc
@@ -5,7 +5,7 @@ namespace nix {
 
 void builtinUnpackChannel(const BasicDerivation & drv)
 {
-    auto getAttr = [&](const string & name) {
+    auto getAttr = [&](std::string_view name) {
         auto i = drv.env.find(name);
         if (i == drv.env.end()) throw Error("attribute '%s' missing", name);
         return i->second;

--- a/src/libstore/crypto.cc
+++ b/src/libstore/crypto.cc
@@ -8,7 +8,7 @@
 
 namespace nix {
 
-static std::pair<std::string, std::string> split(const string & s)
+static std::pair<std::string, std::string> split(std::string_view s)
 {
     size_t colon = s.find(':');
     if (colon == std::string::npos || colon == 0)
@@ -16,7 +16,7 @@ static std::pair<std::string, std::string> split(const string & s)
     return {std::string(s, 0, colon), std::string(s, colon + 1)};
 }
 
-Key::Key(const string & s)
+Key::Key(std::string_view s)
 {
     auto ss = split(s);
 
@@ -29,7 +29,7 @@ Key::Key(const string & s)
     key = base64Decode(key);
 }
 
-SecretKey::SecretKey(const string & s)
+SecretKey::SecretKey(std::string_view s)
     : Key(s)
 {
 #if HAVE_SODIUM
@@ -45,7 +45,7 @@ SecretKey::SecretKey(const string & s)
 }
 #endif
 
-std::string SecretKey::signDetached(const std::string & data) const
+std::string SecretKey::signDetached(std::string_view data) const
 {
 #if HAVE_SODIUM
     unsigned char sig[crypto_sign_BYTES];
@@ -69,7 +69,7 @@ PublicKey SecretKey::toPublicKey() const
 #endif
 }
 
-PublicKey::PublicKey(const string & s)
+PublicKey::PublicKey(std::string_view s)
     : Key(s)
 {
 #if HAVE_SODIUM
@@ -78,7 +78,7 @@ PublicKey::PublicKey(const string & s)
 #endif
 }
 
-bool verifyDetached(const std::string & data, const std::string & sig,
+bool verifyDetached(std::string_view data, std::string_view sig,
     const PublicKeys & publicKeys)
 {
 #if HAVE_SODIUM

--- a/src/libstore/crypto.cc
+++ b/src/libstore/crypto.cc
@@ -8,12 +8,12 @@
 
 namespace nix {
 
-static std::pair<std::string, std::string> split(std::string_view s)
+static std::pair<std::string_view, std::string_view> split(std::string_view s)
 {
     size_t colon = s.find(':');
     if (colon == std::string::npos || colon == 0)
         return {"", ""};
-    return {std::string(s, 0, colon), std::string(s, colon + 1)};
+    return {s.substr(0, colon), s.substr(colon + 1)};
 }
 
 Key::Key(std::string_view s)

--- a/src/libstore/crypto.hh
+++ b/src/libstore/crypto.hh
@@ -13,10 +13,10 @@ struct Key
 
     /* Construct Key from a string in the format
        ‘<name>:<key-in-base64>’. */
-    Key(const std::string & s);
+    Key(std::string_view s);
 
 protected:
-    Key(const std::string & name, const std::string & key)
+    Key(std::string_view name, std::string_view key)
         : name(name), key(key) { }
 };
 
@@ -24,20 +24,20 @@ struct PublicKey;
 
 struct SecretKey : Key
 {
-    SecretKey(const std::string & s);
+    SecretKey(std::string_view s);
 
     /* Return a detached signature of the given string. */
-    std::string signDetached(const std::string & s) const;
+    std::string signDetached(std::string_view s) const;
 
     PublicKey toPublicKey() const;
 };
 
 struct PublicKey : Key
 {
-    PublicKey(const std::string & data);
+    PublicKey(std::string_view data);
 
 private:
-    PublicKey(const std::string & name, const std::string & key)
+    PublicKey(std::string_view name, std::string_view key)
         : Key(name, key) { }
     friend struct SecretKey;
 };
@@ -46,7 +46,7 @@ typedef std::map<std::string, PublicKey> PublicKeys;
 
 /* Return true iff ‘sig’ is a correct signature over ‘data’ using one
    of the given public keys. */
-bool verifyDetached(const std::string & data, const std::string & sig,
+bool verifyDetached(std::string_view data, std::string_view sig,
     const PublicKeys & publicKeys);
 
 PublicKeys getDefaultPublicKeys();

--- a/src/libstore/crypto.hh
+++ b/src/libstore/crypto.hh
@@ -42,7 +42,7 @@ private:
     friend struct SecretKey;
 };
 
-typedef std::map<std::string, PublicKey> PublicKeys;
+typedef std::map<std::string, PublicKey, std::less<>> PublicKeys;
 
 /* Return true iff ‘sig’ is a correct signature over ‘data’ using one
    of the given public keys. */

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -122,8 +122,8 @@ struct TunnelLogger : public Logger
     {
         if (GET_PROTOCOL_MINOR(clientVersion) < 20) {
             if (!s.empty()){
-				log(lvl, std::string { s } + "...");
-			};
+                log(lvl, std::string { s } + "...");
+            };
             return;
         }
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -8,6 +8,7 @@
 #include "archive.hh"
 #include "derivations.hh"
 #include "args.hh"
+#include "util.hh"
 
 namespace nix::daemon {
 
@@ -61,7 +62,7 @@ struct TunnelLogger : public Logger
                 throw;
             }
         } else
-            state->pendingMsgs.push_back(s);
+            state->pendingMsgs.push_back(std::string { s });
     }
 
     void log(Verbosity lvl, const FormatOrString & fs) override
@@ -120,8 +121,9 @@ struct TunnelLogger : public Logger
         std::string_view s, const Fields & fields, ActivityId parent) override
     {
         if (GET_PROTOCOL_MINOR(clientVersion) < 20) {
-            if (!s.empty())
-                log(lvl, s + "...");
+            if (!s.empty()){
+				log(lvl, std::string { s } + "...");
+			};
             return;
         }
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -45,7 +45,7 @@ struct TunnelLogger : public Logger
     TunnelLogger(FdSink & to, unsigned int clientVersion)
         : to(to), clientVersion(clientVersion) { }
 
-    void enqueueMsg(const std::string & s)
+    void enqueueMsg(std::string_view s)
     {
         auto state(state_.lock());
 
@@ -102,7 +102,7 @@ struct TunnelLogger : public Logger
 
     /* stopWork() means that we're done; stop sending stderr to the
        client. */
-    void stopWork(bool success = true, const string & msg = "", unsigned int status = 0)
+    void stopWork(bool success = true, std::string_view msg = "", unsigned int status = 0)
     {
         auto state(state_.lock());
 
@@ -117,7 +117,7 @@ struct TunnelLogger : public Logger
     }
 
     void startActivity(ActivityId act, Verbosity lvl, ActivityType type,
-        const std::string & s, const Fields & fields, ActivityId parent) override
+        std::string_view s, const Fields & fields, ActivityId parent) override
     {
         if (GET_PROTOCOL_MINOR(clientVersion) < 20) {
             if (!s.empty())
@@ -182,7 +182,7 @@ struct RetrieveRegularNARSink : ParseSink
 
     RetrieveRegularNARSink() : regular(true) { }
 
-    void createDirectory(const Path & path)
+    void createDirectory(PathView path)
     {
         regular = false;
     }
@@ -192,7 +192,7 @@ struct RetrieveRegularNARSink : ParseSink
         s.append((const char *) data, len);
     }
 
-    void createSymlink(const Path & path, const string & target)
+    void createSymlink(PathView path, std::string_view target)
     {
         regular = false;
     }
@@ -766,7 +766,7 @@ void processConnection(
     FdSink & to,
     TrustedFlag trusted,
     RecursiveFlag recursive,
-    const std::string & userName,
+    std::string_view userName,
     uid_t userId)
 {
     auto monitor = !recursive ? std::make_unique<MonitorFdHup>(from.fd) : nullptr;

--- a/src/libstore/daemon.hh
+++ b/src/libstore/daemon.hh
@@ -12,7 +12,7 @@ void processConnection(
     FdSink & to,
     TrustedFlag trusted,
     RecursiveFlag recursive,
-    const std::string & userName,
+    std::string_view userName,
     uid_t userId);
 
 }

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -270,7 +270,7 @@ static void printUnquotedStrings(string & res, ForwardIterator i, ForwardIterato
 
 
 string Derivation::unparse(const Store & store, bool maskOutputs,
-    std::map<std::string, StringSet> * actualInputs) const
+    std::map<std::string, StringSet, std::less<>> * actualInputs) const
 {
     string s;
     s.reserve(65536);
@@ -378,7 +378,7 @@ Hash hashDerivationModulo(Store & store, const Derivation & drv, bool maskOutput
 
     /* For other derivations, replace the inputs paths with recursive
        calls to this function.*/
-    std::map<std::string, StringSet> inputs2;
+    std::map<std::string, StringSet, std::less<>> inputs2;
     for (auto & i : drv.inputDrvs) {
         auto h = drvHashes.find(i.first);
         if (h == drvHashes.end()) {
@@ -401,7 +401,7 @@ std::string StorePathWithOutputs::to_string(const Store & store) const
 }
 
 
-bool wantOutput(std::string_view output, const std::set<string> & wanted)
+bool wantOutput(std::string_view output, const std::set<string, std::less<>> & wanted)
 {
     return wanted.empty() || wanted.find(output) != wanted.end();
 }
@@ -468,7 +468,7 @@ void writeDerivation(Sink & out, const Store & store, const BasicDerivation & dr
 std::string hashPlaceholder(std::string_view outputName)
 {
     // FIXME: memoize?
-    return "/" + hashString(htSHA256, "nix-output:" + outputName).to_string(Base32, false);
+    return "/" + hashString(htSHA256, "nix-output:" << outputName).to_string(Base32, false);
 }
 
 

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -49,7 +49,7 @@ Derivation::Derivation(const Derivation & other)
 }
 
 
-const StorePath & BasicDerivation::findOutput(const string & id) const
+const StorePath & BasicDerivation::findOutput(std::string_view id) const
 {
     auto i = outputs.find(id);
     if (i == outputs.end())
@@ -82,7 +82,7 @@ StorePath writeDerivation(ref<Store> store,
 
 
 /* Read string `s' from stream `str'. */
-static void expect(std::istream & str, const string & s)
+static void expect(std::istream & str, std::string_view s)
 {
     char s2[s.size()];
     str.read(s2, s.size());
@@ -142,7 +142,7 @@ static StringSet parseStrings(std::istream & str, bool arePaths)
 }
 
 
-static Derivation parseDerivation(const Store & store, const string & s)
+static Derivation parseDerivation(const Store & store, std::string_view s)
 {
     Derivation drv;
     istringstream_nocopy str(s);
@@ -191,7 +191,7 @@ static Derivation parseDerivation(const Store & store, const string & s)
 }
 
 
-Derivation readDerivation(const Store & store, const Path & drvPath)
+Derivation readDerivation(const Store & store, PathView drvPath)
 {
     try {
         return parseDerivation(store, readFile(drvPath));
@@ -328,7 +328,7 @@ string Derivation::unparse(const Store & store, bool maskOutputs,
 
 
 // FIXME: remove
-bool isDerivation(const string & fileName)
+bool isDerivation(std::string_view fileName)
 {
     return hasSuffix(fileName, drvExtension);
 }
@@ -401,7 +401,7 @@ std::string StorePathWithOutputs::to_string(const Store & store) const
 }
 
 
-bool wantOutput(const string & output, const std::set<string> & wanted)
+bool wantOutput(std::string_view output, const std::set<string> & wanted)
 {
     return wanted.empty() || wanted.find(output) != wanted.end();
 }
@@ -465,7 +465,7 @@ void writeDerivation(Sink & out, const Store & store, const BasicDerivation & dr
 }
 
 
-std::string hashPlaceholder(const std::string & outputName)
+std::string hashPlaceholder(std::string_view outputName)
 {
     // FIXME: memoize?
     return "/" + hashString(htSHA256, "nix-output:" + outputName).to_string(Base32, false);

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -48,7 +48,7 @@ struct BasicDerivation
 
     /* Return the path corresponding to the output identifier `id' in
        the given derivation. */
-    const StorePath & findOutput(const std::string & id) const;
+    const StorePath & findOutput(std::string_view id) const;
 
     bool isBuiltin() const;
 
@@ -84,10 +84,10 @@ StorePath writeDerivation(ref<Store> store,
     const Derivation & drv, std::string_view name, RepairFlag repair = NoRepair);
 
 /* Read a derivation from a file. */
-Derivation readDerivation(const Store & store, const Path & drvPath);
+Derivation readDerivation(const Store & store, PathView drvPath);
 
 // FIXME: remove
-bool isDerivation(const string & fileName);
+bool isDerivation(std::string_view fileName);
 
 Hash hashDerivationModulo(Store & store, const Derivation & drv, bool maskOutputs);
 
@@ -96,7 +96,7 @@ typedef std::map<StorePath, Hash> DrvHashes;
 
 extern DrvHashes drvHashes; // FIXME: global, not thread-safe
 
-bool wantOutput(const string & output, const std::set<string> & wanted);
+bool wantOutput(std::string_view output, const std::set<string> & wanted);
 
 struct Source;
 struct Sink;
@@ -104,6 +104,6 @@ struct Sink;
 Source & readDerivation(Source & in, const Store & store, BasicDerivation & drv);
 void writeDerivation(Sink & out, const Store & store, const BasicDerivation & drv);
 
-std::string hashPlaceholder(const std::string & outputName);
+std::string hashPlaceholder(std::string_view outputName);
 
 }

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -25,13 +25,13 @@ struct DerivationOutput
     void parseHashInfo(FileIngestionMethod & recursive, Hash & hash) const;
 };
 
-typedef std::map<string, DerivationOutput> DerivationOutputs;
+typedef std::map<string, DerivationOutput, std::less<>> DerivationOutputs;
 
 /* For inputs that are sub-derivations, we specify exactly which
    output IDs we are interested in. */
-typedef std::map<StorePath, StringSet> DerivationInputs;
+typedef std::map<StorePath, StringSet, std::less<>> DerivationInputs;
 
-typedef std::map<string, string> StringPairs;
+typedef std::map<string, string, std::less<>> StringPairs;
 
 struct BasicDerivation
 {
@@ -68,7 +68,7 @@ struct Derivation : BasicDerivation
 
     /* Print a derivation. */
     std::string unparse(const Store & store, bool maskOutputs,
-        std::map<std::string, StringSet> * actualInputs = nullptr) const;
+        std::map<std::string, StringSet, std::less<>> * actualInputs = nullptr) const;
 
     Derivation() { }
     Derivation(Derivation && other) = default;
@@ -92,11 +92,11 @@ bool isDerivation(std::string_view fileName);
 Hash hashDerivationModulo(Store & store, const Derivation & drv, bool maskOutputs);
 
 /* Memoisation of hashDerivationModulo(). */
-typedef std::map<StorePath, Hash> DrvHashes;
+typedef std::map<StorePath, Hash, std::less<>> DrvHashes;
 
 extern DrvHashes drvHashes; // FIXME: global, not thread-safe
 
-bool wantOutput(std::string_view output, const std::set<string> & wanted);
+bool wantOutput(std::string_view output, const std::set<string, std::less<>> & wanted);
 
 struct Source;
 struct Sink;

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -34,9 +34,9 @@ static GlobalConfig::Register r1(&fileTransferSettings);
 std::string resolveUri(std::string_view uri)
 {
     if (uri.compare(0, 8, "channel:") == 0)
-        return "https://nixos.org/channels/" + std::string(uri, 8) + "/nixexprs.tar.xz";
+        return "https://nixos.org/channels/" << uri.substr(8) << "/nixexprs.tar.xz";
     else
-        return uri;
+        return std::string { uri };
 }
 
 struct curlFileTransfer : public FileTransfer

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -31,7 +31,7 @@ FileTransferSettings fileTransferSettings;
 
 static GlobalConfig::Register r1(&fileTransferSettings);
 
-std::string resolveUri(const std::string & uri)
+std::string resolveUri(std::string_view uri)
 {
     if (uri.compare(0, 8, "channel:") == 0)
         return "https://nixos.org/channels/" + std::string(uri, 8) + "/nixexprs.tar.xz";
@@ -811,7 +811,7 @@ void FileTransfer::download(FileTransferRequest && request, Sink & sink)
     }
 }
 
-bool isUri(const string & s)
+bool isUri(std::string_view s)
 {
     if (s.compare(0, 8, "channel:") == 0) return true;
     size_t pos = s.find("://");

--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -47,7 +47,7 @@ struct FileTransferRequest
     std::string mimeType;
     std::function<void(char *, size_t)> dataCallback;
 
-    FileTransferRequest(const std::string & uri)
+    FileTransferRequest(std::string_view uri)
         : uri(uri), parentAct(getCurActivity()) { }
 
     std::string verb()
@@ -109,9 +109,9 @@ public:
     { }
 };
 
-bool isUri(const string & s);
+bool isUri(std::string_view s);
 
 /* Resolve deprecated 'channel:<foo>' URLs. */
-std::string resolveUri(const std::string & uri);
+std::string resolveUri(std::string_view uri);
 
 }

--- a/src/libstore/fs-accessor.hh
+++ b/src/libstore/fs-accessor.hh
@@ -21,13 +21,13 @@ public:
 
     virtual ~FSAccessor() { }
 
-    virtual Stat stat(const Path & path) = 0;
+    virtual Stat stat(PathView path) = 0;
 
-    virtual StringSet readDirectory(const Path & path) = 0;
+    virtual StringSet readDirectory(PathView path) = 0;
 
-    virtual std::string readFile(const Path & path) = 0;
+    virtual std::string readFile(PathView path) = 0;
 
-    virtual std::string readLink(const Path & path) = 0;
+    virtual std::string readLink(PathView path) = 0;
 };
 
 }

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -286,7 +286,7 @@ void LocalStore::findRoots(PathView path, unsigned char type, Roots & roots)
 
             /* Handle indirect roots. */
             else {
-                target = absPath(Path { target }, dirOf(path));
+                target = absPath(target, dirOf(path));
                 if (!pathExists(target)) {
                     if (isInDir(path, stateDir + "/" + gcRootsDir + "/auto")) {
                         printInfo(format("removing stale link from '%1%' to '%2%'") % path % target);

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -121,13 +121,13 @@ StringSet Settings::getDefaultSystemFeatures()
     return features;
 }
 
-bool Settings::isExperimentalFeatureEnabled(const std::string & name)
+bool Settings::isExperimentalFeatureEnabled(std::string_view name)
 {
     auto & f = experimentalFeatures.get();
     return std::find(f.begin(), f.end(), name) != f.end();
 }
 
-void Settings::requireExperimentalFeature(const std::string & name)
+void Settings::requireExperimentalFeature(std::string_view name)
 {
     if (!isExperimentalFeatureEnabled(name))
         throw Error("experimental Nix feature '%1%' is disabled; use '--experimental-features %1%' to override", name);
@@ -144,7 +144,7 @@ bool Settings::isWSL1()
 
 const string nixVersion = PACKAGE_VERSION;
 
-template<> void BaseSetting<SandboxMode>::set(const std::string & str)
+template<> void BaseSetting<SandboxMode>::set(std::string_view str)
 {
     if (str == "true") value = smEnabled;
     else if (str == "relaxed") value = smRelaxed;
@@ -165,7 +165,7 @@ template<> void BaseSetting<SandboxMode>::toJSON(JSONPlaceholder & out)
     AbstractSetting::toJSON(out);
 }
 
-template<> void BaseSetting<SandboxMode>::convertToArg(Args & args, const std::string & category)
+template<> void BaseSetting<SandboxMode>::convertToArg(Args & args, std::string_view category)
 {
     args.addFlag({
         .longName = name,
@@ -187,7 +187,7 @@ template<> void BaseSetting<SandboxMode>::convertToArg(Args & args, const std::s
     });
 }
 
-void MaxBuildJobsSetting::set(const std::string & str)
+void MaxBuildJobsSetting::set(std::string_view str)
 {
     if (str == "auto") value = std::max(1U, std::thread::hardware_concurrency());
     else if (!string2Int(str, value))

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -170,19 +170,19 @@ template<> void BaseSetting<SandboxMode>::convertToArg(Args & args, std::string_
     args.addFlag({
         .longName = name,
         .description = "Enable sandboxing.",
-        .category = category,
+        .category = std::string { category },
         .handler = {[=]() { override(smEnabled); }}
     });
     args.addFlag({
         .longName = "no-" + name,
         .description = "Disable sandboxing.",
-        .category = category,
+        .category = std::string { category },
         .handler = {[=]() { override(smDisabled); }}
     });
     args.addFlag({
         .longName = "relaxed-" + name,
         .description = "Enable sandboxing, but allow builds to disable it.",
-        .category = category,
+        .category = std::string { category },
         .handler = {[=]() { override(smRelaxed); }}
     });
 }

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -17,15 +17,15 @@ struct MaxBuildJobsSetting : public BaseSetting<unsigned int>
 {
     MaxBuildJobsSetting(Config * options,
         unsigned int def,
-        const std::string & name,
-        const std::string & description,
+        std::string_view name,
+        std::string_view description,
         const std::set<std::string> & aliases = {})
         : BaseSetting<unsigned int>(def, name, description, aliases)
     {
         options->addSetting(this);
     }
 
-    void set(const std::string & str) override;
+    void set(std::string_view str) override;
 };
 
 class Settings : public Config {
@@ -360,9 +360,9 @@ public:
     Setting<Strings> experimentalFeatures{this, {}, "experimental-features",
         "Experimental Nix features to enable."};
 
-    bool isExperimentalFeatureEnabled(const std::string & name);
+    bool isExperimentalFeatureEnabled(std::string_view name);
 
-    void requireExperimentalFeature(const std::string & name);
+    void requireExperimentalFeature(std::string_view name);
 
     Setting<bool> allowDirty{this, true, "allow-dirty",
         "Whether to allow dirty Git/Mercurial trees."};

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -24,7 +24,7 @@ private:
 public:
 
     HttpBinaryCacheStore(
-        const Params & params, const Path & _cacheUri)
+        const Params & params, PathView _cacheUri)
         : BinaryCacheStore(params)
         , cacheUri(_cacheUri)
     {
@@ -80,7 +80,7 @@ protected:
         throw SubstituterDisabled("substituter '%s' is disabled", getUri());
     }
 
-    bool fileExists(const std::string & path) override
+    bool fileExists(std::string_view path) override
     {
         checkEnabled();
 
@@ -99,9 +99,9 @@ protected:
         }
     }
 
-    void upsertFile(const std::string & path,
-        const std::string & data,
-        const std::string & mimeType) override
+    void upsertFile(std::string_view path,
+        std::string_view data,
+        std::string_view mimeType) override
     {
         auto req = FileTransferRequest(cacheUri + "/" + path);
         req.data = std::make_shared<string>(data); // FIXME: inefficient
@@ -113,13 +113,13 @@ protected:
         }
     }
 
-    FileTransferRequest makeRequest(const std::string & path)
+    FileTransferRequest makeRequest(std::string_view path)
     {
         FileTransferRequest request(cacheUri + "/" + path);
         return request;
     }
 
-    void getFile(const std::string & path, Sink & sink) override
+    void getFile(std::string_view path, Sink & sink) override
     {
         checkEnabled();
         auto request(makeRequest(path));
@@ -133,7 +133,7 @@ protected:
         }
     }
 
-    void getFile(const std::string & path,
+    void getFile(std::string_view path,
         Callback<std::shared_ptr<std::string>> callback) noexcept override
     {
         checkEnabled();
@@ -160,7 +160,7 @@ protected:
 };
 
 static RegisterStoreImplementation regStore([](
-    const std::string & uri, const Store::Params & params)
+    std::string_view uri, const Store::Params & params)
     -> std::shared_ptr<Store>
 {
     static bool forceHttp = getEnv("_NIX_FORCE_HTTP") == "1";

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -85,7 +85,7 @@ protected:
         checkEnabled();
 
         try {
-            FileTransferRequest request(cacheUri + "/" + path);
+            FileTransferRequest request(std::string { cacheUri } << "/" << path);
             request.head = true;
             getFileTransfer()->download(request);
             return true;
@@ -103,7 +103,7 @@ protected:
         std::string_view data,
         std::string_view mimeType) override
     {
-        auto req = FileTransferRequest(cacheUri + "/" + path);
+        auto req = FileTransferRequest(Path { cacheUri } << "/" << path);
         req.data = std::make_shared<string>(data); // FIXME: inefficient
         req.mimeType = mimeType;
         try {
@@ -115,7 +115,7 @@ protected:
 
     FileTransferRequest makeRequest(std::string_view path)
     {
-        FileTransferRequest request(cacheUri + "/" + path);
+        FileTransferRequest request(std::string { cacheUri } << "/" << path);
         return request;
     }
 

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -291,7 +291,7 @@ static RegisterStoreImplementation regStore([](
     -> std::shared_ptr<Store>
 {
     if (std::string(uri, 0, uriScheme.size()) != uriScheme) return 0;
-    return std::make_shared<LegacySSHStore>(std::string(uri, uriScheme.size()), params);
+    return std::make_shared<LegacySSHStore>(uri.substr(uriScheme.size()), params);
 });
 
 }

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -37,7 +37,7 @@ struct LegacySSHStore : public Store
 
     SSHMaster master;
 
-    LegacySSHStore(const string & host, const Params & params)
+    LegacySSHStore(std::string_view host, const Params & params)
         : Store(params)
         , host(host)
         , connections(make_ref<Pool<Connection>>(
@@ -191,15 +191,15 @@ struct LegacySSHStore : public Store
         copyNAR(conn->from, sink);
     }
 
-    std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override
+    std::optional<StorePath> queryPathFromHashPart(std::string_view hashPart) override
     { unsupported("queryPathFromHashPart"); }
 
-    StorePath addToStore(const string & name, const Path & srcPath,
+    StorePath addToStore(std::string_view name, PathView srcPath,
         FileIngestionMethod method, HashType hashAlgo,
         PathFilter & filter, RepairFlag repair) override
     { unsupported("addToStore"); }
 
-    StorePath addTextToStore(const string & name, const string & s,
+    StorePath addTextToStore(std::string_view name, std::string_view s,
         const StorePathSet & references, RepairFlag repair) override
     { unsupported("addTextToStore"); }
 
@@ -287,7 +287,7 @@ struct LegacySSHStore : public Store
 };
 
 static RegisterStoreImplementation regStore([](
-    const std::string & uri, const Store::Params & params)
+    std::string_view uri, const Store::Params & params)
     -> std::shared_ptr<Store>
 {
     if (std::string(uri, 0, uriScheme.size()) != uriScheme) return 0;

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -13,7 +13,7 @@ private:
 public:
 
     LocalBinaryCacheStore(
-        const Params & params, const Path & binaryCacheDir)
+        const Params & params, PathView binaryCacheDir)
         : BinaryCacheStore(params)
         , binaryCacheDir(binaryCacheDir)
     {
@@ -28,13 +28,13 @@ public:
 
 protected:
 
-    bool fileExists(const std::string & path) override;
+    bool fileExists(std::string_view path) override;
 
-    void upsertFile(const std::string & path,
-        const std::string & data,
-        const std::string & mimeType) override;
+    void upsertFile(std::string_view path,
+        std::string_view data,
+        std::string_view mimeType) override;
 
-    void getFile(const std::string & path, Sink & sink) override
+    void getFile(std::string_view path, Sink & sink) override
     {
         try {
             readFile(binaryCacheDir + "/" + path, sink);
@@ -68,7 +68,7 @@ void LocalBinaryCacheStore::init()
     BinaryCacheStore::init();
 }
 
-static void atomicWrite(const Path & path, const std::string & s)
+static void atomicWrite(PathView path, std::string_view s)
 {
     Path tmp = path + ".tmp." + std::to_string(getpid());
     AutoDelete del(tmp, false);
@@ -78,20 +78,20 @@ static void atomicWrite(const Path & path, const std::string & s)
     del.cancel();
 }
 
-bool LocalBinaryCacheStore::fileExists(const std::string & path)
+bool LocalBinaryCacheStore::fileExists(std::string_view path)
 {
     return pathExists(binaryCacheDir + "/" + path);
 }
 
-void LocalBinaryCacheStore::upsertFile(const std::string & path,
-    const std::string & data,
-    const std::string & mimeType)
+void LocalBinaryCacheStore::upsertFile(std::string_view path,
+    std::string_view data,
+    std::string_view mimeType)
 {
     atomicWrite(binaryCacheDir + "/" + path, data);
 }
 
 static RegisterStoreImplementation regStore([](
-    const std::string & uri, const Store::Params & params)
+    std::string_view uri, const Store::Params & params)
     -> std::shared_ptr<Store>
 {
     if (getEnv("_NIX_FORCE_HTTP_BINARY_CACHE_STORE") == "1" ||

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -23,7 +23,7 @@ struct LocalStoreAccessor : public FSAccessor
         Path storePath = store->toStorePath(path);
         if (!store->isValidPath(store->parseStorePath(storePath)))
             throw InvalidPath("path '%1%' is not a valid store path", storePath);
-        return store->getRealStoreDir() + std::string(path, store->storeDir.size());
+        return Path { store->getRealStoreDir() } << path.substr(store->storeDir.size());
     }
 
     FSAccessor::Stat stat(PathView path) override

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -18,7 +18,7 @@ struct LocalStoreAccessor : public FSAccessor
 
     LocalStoreAccessor(ref<LocalFSStore> store) : store(store) { }
 
-    Path toRealPath(const Path & path)
+    Path toRealPath(PathView path)
     {
         Path storePath = store->toStorePath(path);
         if (!store->isValidPath(store->parseStorePath(storePath)))
@@ -26,7 +26,7 @@ struct LocalStoreAccessor : public FSAccessor
         return store->getRealStoreDir() + std::string(path, store->storeDir.size());
     }
 
-    FSAccessor::Stat stat(const Path & path) override
+    FSAccessor::Stat stat(PathView path) override
     {
         auto realPath = toRealPath(path);
 
@@ -47,7 +47,7 @@ struct LocalStoreAccessor : public FSAccessor
             S_ISREG(st.st_mode) && st.st_mode & S_IXUSR};
     }
 
-    StringSet readDirectory(const Path & path) override
+    StringSet readDirectory(PathView path) override
     {
         auto realPath = toRealPath(path);
 
@@ -60,12 +60,12 @@ struct LocalStoreAccessor : public FSAccessor
         return res;
     }
 
-    std::string readFile(const Path & path) override
+    std::string readFile(PathView path) override
     {
         return nix::readFile(toRealPath(path));
     }
 
-    std::string readLink(const Path & path) override
+    std::string readLink(PathView path) override
     {
         return nix::readLink(toRealPath(path));
     }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -380,7 +380,7 @@ void LocalStore::makeStoreWritable()
 const time_t mtimeStore = 1; /* 1 second into the epoch */
 
 
-static void canonicaliseTimestampAndPermissions(const Path & path, const struct stat & st)
+static void canonicaliseTimestampAndPermissions(PathView path, const struct stat & st)
 {
     if (!S_ISLNK(st.st_mode)) {
 
@@ -415,7 +415,7 @@ static void canonicaliseTimestampAndPermissions(const Path & path, const struct 
 }
 
 
-void canonicaliseTimestampAndPermissions(const Path & path)
+void canonicaliseTimestampAndPermissions(PathView path)
 {
     struct stat st;
     if (lstat(path.c_str(), &st))
@@ -424,7 +424,7 @@ void canonicaliseTimestampAndPermissions(const Path & path)
 }
 
 
-static void canonicalisePathMetaData_(const Path & path, uid_t fromUid, InodesSeen & inodesSeen)
+static void canonicalisePathMetaData_(PathView path, uid_t fromUid, InodesSeen & inodesSeen)
 {
     checkInterrupt();
 
@@ -514,7 +514,7 @@ static void canonicalisePathMetaData_(const Path & path, uid_t fromUid, InodesSe
 }
 
 
-void canonicalisePathMetaData(const Path & path, uid_t fromUid, InodesSeen & inodesSeen)
+void canonicalisePathMetaData(PathView path, uid_t fromUid, InodesSeen & inodesSeen)
 {
     canonicalisePathMetaData_(path, fromUid, inodesSeen);
 
@@ -531,7 +531,7 @@ void canonicalisePathMetaData(const Path & path, uid_t fromUid, InodesSeen & ino
 }
 
 
-void canonicalisePathMetaData(const Path & path, uid_t fromUid)
+void canonicalisePathMetaData(PathView path, uid_t fromUid)
 {
     InodesSeen inodesSeen;
     canonicalisePathMetaData(path, fromUid, inodesSeen);
@@ -544,7 +544,7 @@ void LocalStore::checkDerivationOutputs(const StorePath & drvPath, const Derivat
     std::string drvName(drvPath.name());
     drvName = string(drvName, 0, drvName.size() - drvExtension.size());
 
-    auto check = [&](const StorePath & expected, const StorePath & actual, const std::string & varName)
+    auto check = [&](const StorePath & expected, const StorePath & actual, std::string_view varName)
     {
         if (actual != expected)
             throw Error("derivation '%s' has incorrect output '%s', should be '%s'",
@@ -789,7 +789,7 @@ StorePathSet LocalStore::queryDerivationOutputs(const StorePath & path)
 }
 
 
-std::optional<StorePath> LocalStore::queryPathFromHashPart(const std::string & hashPart)
+std::optional<StorePath> LocalStore::queryPathFromHashPart(std::string_view hashPart)
 {
     if (hashPart.size() != storePathHashLen) throw Error("invalid hash part");
 
@@ -1028,7 +1028,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
 }
 
 
-StorePath LocalStore::addToStoreFromDump(const string & dump, const string & name,
+StorePath LocalStore::addToStoreFromDump(std::string_view dump, std::string_view name,
     FileIngestionMethod method, HashType hashAlgo, RepairFlag repair)
 {
     Hash h = hashString(hashAlgo, dump);
@@ -1088,7 +1088,7 @@ StorePath LocalStore::addToStoreFromDump(const string & dump, const string & nam
 }
 
 
-StorePath LocalStore::addToStore(const string & name, const Path & _srcPath,
+StorePath LocalStore::addToStore(std::string_view name, PathView _srcPath,
     FileIngestionMethod method, HashType hashAlgo, PathFilter & filter, RepairFlag repair)
 {
     Path srcPath(absPath(_srcPath));
@@ -1106,7 +1106,7 @@ StorePath LocalStore::addToStore(const string & name, const Path & _srcPath,
 }
 
 
-StorePath LocalStore::addTextToStore(const string & name, const string & s,
+StorePath LocalStore::addTextToStore(std::string_view name, std::string_view s,
     const StorePathSet & references, RepairFlag repair)
 {
     auto hash = hashString(htSHA256, s);
@@ -1308,7 +1308,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
 }
 
 
-void LocalStore::verifyPath(const Path & pathS, const StringSet & store,
+void LocalStore::verifyPath(PathView pathS, const StringSet & store,
     PathSet & done, StorePathSet & validPaths, RepairFlag repair, bool & errors)
 {
     checkInterrupt();
@@ -1371,7 +1371,7 @@ unsigned int LocalStore::getProtocol()
 
 #if defined(FS_IOC_SETFLAGS) && defined(FS_IOC_GETFLAGS) && defined(FS_IMMUTABLE_FL)
 
-static void makeMutable(const Path & path)
+static void makeMutable(PathView path)
 {
     checkInterrupt();
 
@@ -1459,7 +1459,7 @@ void LocalStore::signPathInfo(ValidPathInfo & info)
 }
 
 
-void LocalStore::createUser(const std::string & userName, uid_t userId)
+void LocalStore::createUser(std::string_view userName, uid_t userId)
 {
     for (auto & dir : {
         fmt("%s/profiles/per-user/%s", stateDir, userName),

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -382,7 +382,7 @@ const time_t mtimeStore = 1; /* 1 second into the epoch */
 
 static void canonicaliseTimestampAndPermissions(PathView path, const struct stat & st)
 {
-	Path freshPath { path };
+    Path freshPath { path };
     if (!S_ISLNK(st.st_mode)) {
 
         /* Mask out all type related bits. */

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1093,7 +1093,7 @@ StorePath LocalStore::addToStoreFromDump(std::string_view dump, std::string_view
 StorePath LocalStore::addToStore(std::string_view name, PathView _srcPath,
     FileIngestionMethod method, HashType hashAlgo, PathFilter & filter, RepairFlag repair)
 {
-    Path srcPath = absPath(Path { _srcPath });
+    Path srcPath = absPath(_srcPath);
 
     /* Read the whole path into memory. This is not a very scalable
        method for very large paths, but `copyPath' is mainly used for

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -135,7 +135,7 @@ public:
 
     StorePathSet queryDerivationOutputs(const StorePath & path) override;
 
-    std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override;
+    std::optional<StorePath> queryPathFromHashPart(std::string_view hashPart) override;
 
     StorePathSet querySubstitutablePaths(const StorePathSet & paths) override;
 
@@ -146,7 +146,7 @@ public:
         RepairFlag repair, CheckSigsFlag checkSigs,
         std::shared_ptr<FSAccessor> accessor) override;
 
-    StorePath addToStore(const string & name, const Path & srcPath,
+    StorePath addToStore(std::string_view name, PathView srcPath,
         FileIngestionMethod method, HashType hashAlgo,
         PathFilter & filter, RepairFlag repair) override;
 
@@ -154,10 +154,10 @@ public:
        in `dump', which is either a NAR serialisation (if recursive ==
        true) or simply the contents of a regular file (if recursive ==
        false). */
-    StorePath addToStoreFromDump(const string & dump, const string & name,
+    StorePath addToStoreFromDump(std::string_view dump, std::string_view name,
         FileIngestionMethod method = FileIngestionMethod::Recursive, HashType hashAlgo = htSHA256, RepairFlag repair = NoRepair) override;
 
-    StorePath addTextToStore(const string & name, const string & s,
+    StorePath addTextToStore(std::string_view name, std::string_view s,
         const StorePathSet & references, RepairFlag repair) override;
 
     void buildPaths(
@@ -171,7 +171,7 @@ public:
 
     void addTempRoot(const StorePath & path) override;
 
-    void addIndirectRoot(const Path & path) override;
+    void addIndirectRoot(PathView path) override;
 
     void syncWithGC() override;
 
@@ -195,7 +195,7 @@ public:
     void optimiseStore() override;
 
     /* Optimise a single store path. */
-    void optimisePath(const Path & path);
+    void optimisePath(PathView path);
 
     bool verifyStore(bool checkContents, RepairFlag repair) override;
 
@@ -240,7 +240,7 @@ private:
     /* Delete a path from the Nix store. */
     void invalidatePathChecked(const StorePath & path);
 
-    void verifyPath(const Path & path, const StringSet & store,
+    void verifyPath(PathView path, const StringSet & store,
         PathSet & done, StorePathSet & validPaths, RepairFlag repair, bool & errors);
 
     void updatePathInfo(State & state, const ValidPathInfo & info);
@@ -248,24 +248,24 @@ private:
     void upgradeStore6();
     void upgradeStore7();
     PathSet queryValidPathsOld();
-    ValidPathInfo queryPathInfoOld(const Path & path);
+    ValidPathInfo queryPathInfoOld(PathView path);
 
     struct GCState;
 
-    void deleteGarbage(GCState & state, const Path & path);
+    void deleteGarbage(GCState & state, PathView path);
 
-    void tryToDelete(GCState & state, const Path & path);
+    void tryToDelete(GCState & state, PathView path);
 
     bool canReachRoot(GCState & state, StorePathSet & visited, const StorePath & path);
 
-    void deletePathRecursive(GCState & state, const Path & path);
+    void deletePathRecursive(GCState & state, PathView path);
 
     bool isActiveTempFile(const GCState & state,
-        const Path & path, const string & suffix);
+        PathView path, std::string_view suffix);
 
     AutoCloseFD openGCLock(LockType lockType);
 
-    void findRoots(const Path & path, unsigned char type, Roots & roots);
+    void findRoots(PathView path, unsigned char type, Roots & roots);
 
     void findRootsNoTemp(Roots & roots, bool censor);
 
@@ -280,8 +280,8 @@ private:
     typedef std::unordered_set<ino_t> InodeHash;
 
     InodeHash loadInodeHash();
-    Strings readDirectoryIgnoringInodes(const Path & path, const InodeHash & inodeHash);
-    void optimisePath_(Activity * act, OptimiseStats & stats, const Path & path, InodeHash & inodeHash);
+    Strings readDirectoryIgnoringInodes(PathView path, const InodeHash & inodeHash);
+    void optimisePath_(Activity * act, OptimiseStats & stats, PathView path, InodeHash & inodeHash);
 
     // Internal versions that are not wrapped in retry_sqlite.
     bool isValidPath_(State & state, const StorePath & path);
@@ -293,7 +293,7 @@ private:
 
     Path getRealStoreDir() override { return realStoreDir; }
 
-    void createUser(const std::string & userName, uid_t userId) override;
+    void createUser(std::string_view userName, uid_t userId) override;
 
     friend class DerivationGoal;
     friend class SubstitutionGoal;
@@ -312,10 +312,10 @@ typedef set<Inode> InodesSeen;
      without execute permission; setuid bits etc. are cleared)
    - the owner and group are set to the Nix user and group, if we're
      running as root. */
-void canonicalisePathMetaData(const Path & path, uid_t fromUid, InodesSeen & inodesSeen);
-void canonicalisePathMetaData(const Path & path, uid_t fromUid);
+void canonicalisePathMetaData(PathView path, uid_t fromUid, InodesSeen & inodesSeen);
+void canonicalisePathMetaData(PathView path, uid_t fromUid);
 
-void canonicaliseTimestampAndPermissions(const Path & path);
+void canonicaliseTimestampAndPermissions(PathView path);
 
 MakeError(PathInUse, Error);
 

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -33,7 +33,7 @@ Machine::Machine(decltype(storeUri) storeUri,
     sshPublicHostKey(sshPublicHostKey)
 {}
 
-bool Machine::allSupported(const std::set<string> & features) const {
+bool Machine::allSupported(const std::set<string, std::less<>> & features) const {
     return std::all_of(features.begin(), features.end(),
         [&](std::string_view feature) {
             return supportedFeatures.count(feature) ||
@@ -41,7 +41,7 @@ bool Machine::allSupported(const std::set<string> & features) const {
         });
 }
 
-bool Machine::mandatoryMet(const std::set<string> & features) const {
+bool Machine::mandatoryMet(const std::set<string, std::less<>> & features) const {
     return std::all_of(mandatoryFeatures.begin(), mandatoryFeatures.end(),
         [&](std::string_view feature) {
             return features.count(feature);
@@ -81,8 +81,8 @@ void parseMachines(std::string_view s, Machines & machines)
             isSet(2) ? tokens[2] : "",
             isSet(3) ? std::stoull(tokens[3]) : 1LL,
             isSet(4) ? std::stoull(tokens[4]) : 1LL,
-            isSet(5) ? tokenizeString<std::set<string>>(tokens[5], ",") : std::set<string>{},
-            isSet(6) ? tokenizeString<std::set<string>>(tokens[6], ",") : std::set<string>{},
+            isSet(5) ? tokenizeString<std::set<string, std::less<>>>(tokens[5], ",") : std::set<string, std::less<>>{},
+            isSet(6) ? tokenizeString<std::set<string, std::less<>>>(tokens[6], ",") : std::set<string, std::less<>>{},
             isSet(7) ? tokens[7] : "");
     }
 }

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -35,7 +35,7 @@ Machine::Machine(decltype(storeUri) storeUri,
 
 bool Machine::allSupported(const std::set<string> & features) const {
     return std::all_of(features.begin(), features.end(),
-        [&](const string & feature) {
+        [&](std::string_view feature) {
             return supportedFeatures.count(feature) ||
                 mandatoryFeatures.count(feature);
         });
@@ -43,12 +43,12 @@ bool Machine::allSupported(const std::set<string> & features) const {
 
 bool Machine::mandatoryMet(const std::set<string> & features) const {
     return std::all_of(mandatoryFeatures.begin(), mandatoryFeatures.end(),
-        [&](const string & feature) {
+        [&](std::string_view feature) {
             return features.count(feature);
         });
 }
 
-void parseMachines(const std::string & s, Machines & machines)
+void parseMachines(std::string_view s, Machines & machines)
 {
     for (auto line : tokenizeString<std::vector<string>>(s, "\n;")) {
         trim(line);

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -11,14 +11,14 @@ struct Machine {
     const string sshKey;
     const unsigned int maxJobs;
     const unsigned int speedFactor;
-    const std::set<string> supportedFeatures;
-    const std::set<string> mandatoryFeatures;
+    const std::set<string, std::less<>> supportedFeatures;
+    const std::set<string, std::less<>> mandatoryFeatures;
     const std::string sshPublicHostKey;
     bool enabled = true;
 
-    bool allSupported(const std::set<string> & features) const;
+    bool allSupported(const std::set<string, std::less<>> & features) const;
 
-    bool mandatoryMet(const std::set<string> & features) const;
+    bool mandatoryMet(const std::set<string, std::less<>> & features) const;
 
     Machine(decltype(storeUri) storeUri,
         decltype(systemTypes) systemTypes,

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -32,7 +32,7 @@ struct Machine {
 
 typedef std::vector<Machine> Machines;
 
-void parseMachines(const std::string & s, Machines & machines);
+void parseMachines(std::string_view s, Machines & machines);
 
 Machines getMachines();
 

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -21,11 +21,11 @@ void Store::computeFSClosure(const StorePathSet & startPaths,
 
     Sync<State> state_(State{0, paths_, 0});
 
-    std::function<void(const Path &)> enqueue;
+    std::function<void(PathView)> enqueue;
 
     std::condition_variable done;
 
-    enqueue = [&](const Path & path) -> void {
+    enqueue = [&](PathView path) -> void {
         {
             auto state(state_.lock());
             if (state->exc) return;
@@ -149,7 +149,7 @@ void Store::queryMissing(const std::vector<StorePathWithOutputs> & targets,
     };
 
     auto checkOutput = [&](
-        const Path & drvPathS, ref<Derivation> drv, const Path & outPathS, ref<Sync<DrvState>> drvState_)
+        PathView drvPathS, ref<Derivation> drv, PathView outPathS, ref<Sync<DrvState>> drvState_)
     {
         if (drvState_->lock()->done) return;
 

--- a/src/libstore/names.cc
+++ b/src/libstore/names.cc
@@ -41,8 +41,8 @@ bool DrvName::matches(DrvName & n)
 }
 
 
-string nextComponent(string::const_iterator & p,
-    const string::const_iterator end)
+string nextComponent(std::string_view::const_iterator & p,
+    const std::string_view::const_iterator end)
 {
     /* Skip any dots and dashes (component separators). */
     while (p != end && (*p == '.' || *p == '-')) ++p;
@@ -81,8 +81,9 @@ static bool componentsLT(std::string_view c1, std::string_view c2)
 
 int compareVersions(std::string_view v1, std::string_view v2)
 {
-    string::const_iterator p1 = v1.begin();
-    string::const_iterator p2 = v2.begin();
+    std::string_view::const_iterator
+        p1 = v1.begin(),
+        p2 = v2.begin();
 
     while (p1 != v1.end() || p2 != v2.end()) {
         string c1 = nextComponent(p1, v1.end());

--- a/src/libstore/names.cc
+++ b/src/libstore/names.cc
@@ -63,7 +63,7 @@ string nextComponent(string::const_iterator & p,
 }
 
 
-static bool componentsLT(const string & c1, const string & c2)
+static bool componentsLT(std::string_view c1, std::string_view c2)
 {
     int n1, n2;
     bool c1Num = string2Int(c1, n1), c2Num = string2Int(c2, n2);
@@ -79,7 +79,7 @@ static bool componentsLT(const string & c1, const string & c2)
 }
 
 
-int compareVersions(const string & v1, const string & v2)
+int compareVersions(std::string_view v1, std::string_view v2)
 {
     string::const_iterator p1 = v1.begin();
     string::const_iterator p2 = v2.begin();

--- a/src/libstore/names.hh
+++ b/src/libstore/names.hh
@@ -24,8 +24,8 @@ private:
 
 typedef list<DrvName> DrvNames;
 
-string nextComponent(string::const_iterator & p,
-    const string::const_iterator end);
+string nextComponent(std::string_view::const_iterator & p,
+    const std::string_view::const_iterator end);
 int compareVersions(std::string_view v1, std::string_view v2);
 DrvNames drvNamesFromArgs(const Strings & opArgs);
 

--- a/src/libstore/names.hh
+++ b/src/libstore/names.hh
@@ -26,7 +26,7 @@ typedef list<DrvName> DrvNames;
 
 string nextComponent(string::const_iterator & p,
     const string::const_iterator end);
-int compareVersions(const string & v1, const string & v2);
+int compareVersions(std::string_view v1, std::string_view v2);
 DrvNames drvNamesFromArgs(const Strings & opArgs);
 
 }

--- a/src/libstore/nar-accessor.cc
+++ b/src/libstore/nar-accessor.cc
@@ -97,7 +97,7 @@ struct NarAccessor : public FSAccessor
         void createSymlink(PathView path, std::string_view target) override
         {
             createMember(path,
-                NarMember{FSAccessor::Type::tSymlink, false, 0, 0, target});
+                NarMember{FSAccessor::Type::tSymlink, false, 0, 0, std::string { target }});
         }
     };
 
@@ -248,7 +248,7 @@ void listNar(JSONPlaceholder & res, ref<FSAccessor> accessor,
             for (auto & name : accessor->readDirectory(path)) {
                 if (recurse) {
                     auto res3 = res2.placeholder(name);
-                    listNar(res3, accessor, path + "/" + name, true);
+                    listNar(res3, accessor, Path { path } << "/" << name, true);
                 } else
                     res2.object(name);
             }
@@ -256,7 +256,7 @@ void listNar(JSONPlaceholder & res, ref<FSAccessor> accessor,
         break;
     case FSAccessor::Type::tSymlink:
         obj.attr("type", "symlink");
-        obj.attr("target", accessor->readLink(path));
+        obj.attr("target", std::string_view { accessor->readLink(path) });
         break;
     default:
         throw Error("path '%s' does not exist in NAR", path);

--- a/src/libstore/nar-accessor.hh
+++ b/src/libstore/nar-accessor.hh
@@ -17,7 +17,7 @@ ref<FSAccessor> makeNarAccessor(ref<const std::string> nar);
 typedef std::function<std::string(uint64_t, uint64_t)> GetNarBytes;
 
 ref<FSAccessor> makeLazyNarAccessor(
-    const std::string & listing,
+    std::string_view listing,
     GetNarBytes getNarBytes);
 
 class JSONPlaceholder;
@@ -25,6 +25,6 @@ class JSONPlaceholder;
 /* Write a JSON representation of the contents of a NAR (except file
    contents). */
 void listNar(JSONPlaceholder & res, ref<FSAccessor> accessor,
-    const Path & path, bool recurse);
+    PathView path, bool recurse);
 
 }

--- a/src/libstore/nar-info-disk-cache.cc
+++ b/src/libstore/nar-info-disk-cache.cc
@@ -122,14 +122,14 @@ public:
         });
     }
 
-    Cache & getCache(State & state, const std::string & uri)
+    Cache & getCache(State & state, std::string_view uri)
     {
         auto i = state.caches.find(uri);
         if (i == state.caches.end()) abort();
         return i->second;
     }
 
-    void createCache(const std::string & uri, const Path & storeDir, bool wantMassQuery, int priority) override
+    void createCache(std::string_view uri, PathView storeDir, bool wantMassQuery, int priority) override
     {
         retrySQLite<void>([&]() {
             auto state(_state.lock());
@@ -142,7 +142,7 @@ public:
         });
     }
 
-    std::optional<CacheInfo> cacheExists(const std::string & uri) override
+    std::optional<CacheInfo> cacheExists(std::string_view uri) override
     {
         return retrySQLite<std::optional<CacheInfo>>([&]() -> std::optional<CacheInfo> {
             auto state(_state.lock());
@@ -166,7 +166,7 @@ public:
     }
 
     std::pair<Outcome, std::shared_ptr<NarInfo>> lookupNarInfo(
-        const std::string & uri, const std::string & hashPart) override
+        std::string_view uri, std::string_view hashPart) override
     {
         return retrySQLite<std::pair<Outcome, std::shared_ptr<NarInfo>>>(
             [&]() -> std::pair<Outcome, std::shared_ptr<NarInfo>> {
@@ -210,7 +210,7 @@ public:
     }
 
     void upsertNarInfo(
-        const std::string & uri, const std::string & hashPart,
+        std::string_view uri, std::string_view hashPart,
         std::shared_ptr<const ValidPathInfo> info) override
     {
         retrySQLite<void>([&]() {

--- a/src/libstore/nar-info-disk-cache.hh
+++ b/src/libstore/nar-info-disk-cache.hh
@@ -12,7 +12,7 @@ public:
 
     virtual ~NarInfoDiskCache() { }
 
-    virtual void createCache(const std::string & uri, const Path & storeDir,
+    virtual void createCache(std::string_view uri, PathView storeDir,
         bool wantMassQuery, int priority) = 0;
 
     struct CacheInfo
@@ -21,13 +21,13 @@ public:
         int priority;
     };
 
-    virtual std::optional<CacheInfo> cacheExists(const std::string & uri) = 0;
+    virtual std::optional<CacheInfo> cacheExists(std::string_view uri) = 0;
 
     virtual std::pair<Outcome, std::shared_ptr<NarInfo>> lookupNarInfo(
-        const std::string & uri, const std::string & hashPart) = 0;
+        std::string_view uri, std::string_view hashPart) = 0;
 
     virtual void upsertNarInfo(
-        const std::string & uri, const std::string & hashPart,
+        std::string_view uri, std::string_view hashPart,
         std::shared_ptr<const ValidPathInfo> info) = 0;
 };
 

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -3,14 +3,14 @@
 
 namespace nix {
 
-NarInfo::NarInfo(const Store & store, const std::string & s, const std::string & whence)
+NarInfo::NarInfo(const Store & store, std::string_view s, std::string_view whence)
     : ValidPathInfo(StorePath::dummy.clone()) // FIXME: hack
 {
     auto corrupt = [&]() {
         throw Error("NAR info file '%1%' is corrupt", whence);
     };
 
-    auto parseHashField = [&](const string & s) {
+    auto parseHashField = [&](std::string_view s) {
         try {
             return Hash(s);
         } catch (BadHash &) {

--- a/src/libstore/nar-info.hh
+++ b/src/libstore/nar-info.hh
@@ -17,7 +17,7 @@ struct NarInfo : ValidPathInfo
     NarInfo() = delete;
     NarInfo(StorePath && path) : ValidPathInfo(std::move(path)) { }
     NarInfo(const ValidPathInfo & info) : ValidPathInfo(info) { }
-    NarInfo(const Store & store, const std::string & s, const std::string & whence);
+    NarInfo(const Store & store, std::string_view s, std::string_view whence);
 
     std::string to_string(const Store & store) const;
 };

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -15,7 +15,7 @@
 namespace nix {
 
 
-static void makeWritable(const Path & path)
+static void makeWritable(PathView path)
 {
     struct stat st;
     if (lstat(path.c_str(), &st))
@@ -28,7 +28,7 @@ static void makeWritable(const Path & path)
 struct MakeReadOnly
 {
     Path path;
-    MakeReadOnly(const Path & path) : path(path) { }
+    MakeReadOnly(PathView path) : path(path) { }
     ~MakeReadOnly()
     {
         try {
@@ -63,7 +63,7 @@ LocalStore::InodeHash LocalStore::loadInodeHash()
 }
 
 
-Strings LocalStore::readDirectoryIgnoringInodes(const Path & path, const InodeHash & inodeHash)
+Strings LocalStore::readDirectoryIgnoringInodes(PathView path, const InodeHash & inodeHash)
 {
     Strings names;
 
@@ -90,7 +90,7 @@ Strings LocalStore::readDirectoryIgnoringInodes(const Path & path, const InodeHa
 
 
 void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
-    const Path & path, InodeHash & inodeHash)
+    PathView path, InodeHash & inodeHash)
 {
     checkInterrupt();
 
@@ -299,7 +299,7 @@ void LocalStore::optimiseStore()
         % stats.filesLinked);
 }
 
-void LocalStore::optimisePath(const Path & path)
+void LocalStore::optimisePath(PathView path)
 {
     OptimiseStats stats;
     InodeHash inodeHash;

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -20,7 +20,7 @@ ParsedDerivation::ParsedDerivation(StorePath && drvPath, BasicDerivation & drv)
 
 ParsedDerivation::~ParsedDerivation() { }
 
-std::optional<std::string> ParsedDerivation::getStringAttr(const std::string & name) const
+std::optional<std::string> ParsedDerivation::getStringAttr(std::string_view name) const
 {
     if (structuredAttrs) {
         auto i = structuredAttrs->find(name);
@@ -40,7 +40,7 @@ std::optional<std::string> ParsedDerivation::getStringAttr(const std::string & n
     }
 }
 
-bool ParsedDerivation::getBoolAttr(const std::string & name, bool def) const
+bool ParsedDerivation::getBoolAttr(std::string_view name, bool def) const
 {
     if (structuredAttrs) {
         auto i = structuredAttrs->find(name);
@@ -60,7 +60,7 @@ bool ParsedDerivation::getBoolAttr(const std::string & name, bool def) const
     }
 }
 
-std::optional<Strings> ParsedDerivation::getStringsAttr(const std::string & name) const
+std::optional<Strings> ParsedDerivation::getStringsAttr(std::string_view name) const
 {
     if (structuredAttrs) {
         auto i = structuredAttrs->find(name);

--- a/src/libstore/parsed-derivations.hh
+++ b/src/libstore/parsed-derivations.hh
@@ -21,11 +21,11 @@ public:
         return structuredAttrs.get();
     }
 
-    std::optional<std::string> getStringAttr(const std::string & name) const;
+    std::optional<std::string> getStringAttr(std::string_view name) const;
 
-    bool getBoolAttr(const std::string & name, bool def = false) const;
+    bool getBoolAttr(std::string_view name, bool def = false) const;
 
-    std::optional<Strings> getStringsAttr(const std::string & name) const;
+    std::optional<Strings> getStringsAttr(std::string_view name) const;
 
     StringSet getRequiredSystemFeatures() const;
 

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -122,7 +122,7 @@ std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s)
             tokenizeString<std::set<string>>(((std::string_view) s).substr(n + 1), ","));
 }
 
-StorePathWithOutputs Store::parsePathWithOutputs(const std::string & s)
+StorePathWithOutputs Store::parsePathWithOutputs(std::string_view s)
 {
     auto [path, outputs] = nix::parsePathWithOutputs(s);
     return {parseStorePath(path), std::move(outputs)};

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -117,9 +117,10 @@ std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s)
 {
     size_t n = s.find("!");
     return n == s.npos
-        ? std::make_pair(s, std::set<string>())
-        : std::make_pair(((std::string_view) s).substr(0, n),
-            tokenizeString<std::set<string>>(((std::string_view) s).substr(n + 1), ","));
+        ? std::make_pair(s, std::set<string, std::less<>>())
+        : std::make_pair(
+            s.substr(0, n),
+            tokenizeString<std::set<string, std::less<>>>(s.substr(n + 1), ","));
 }
 
 StorePathWithOutputs Store::parsePathWithOutputs(std::string_view s)

--- a/src/libstore/path.hh
+++ b/src/libstore/path.hh
@@ -59,7 +59,7 @@ struct StorePath : rust::Value<3 * sizeof(void *) + 24, ffi_StorePath_drop>
     static StorePath dummy;
 };
 
-typedef std::set<StorePath> StorePathSet;
+typedef std::set<StorePath, std::less<>> StorePathSet;
 typedef std::vector<StorePath> StorePaths;
 
 StorePathSet cloneStorePathSet(const StorePathSet & paths);
@@ -81,13 +81,13 @@ enum struct FileIngestionMethod : uint8_t {
 struct StorePathWithOutputs
 {
     StorePath path;
-    std::set<std::string> outputs;
+    std::set<std::string, std::less<>> outputs;
 
-    StorePathWithOutputs(const StorePath & path, const std::set<std::string> & outputs = {})
+    StorePathWithOutputs(const StorePath & path, const std::set<std::string, std::less<>> & outputs = {})
         : path(path.clone()), outputs(outputs)
     { }
 
-    StorePathWithOutputs(StorePath && path, std::set<std::string> && outputs)
+    StorePathWithOutputs(StorePath && path, std::set<std::string, std::less<>> && outputs)
         : path(std::move(path)), outputs(std::move(outputs))
     { }
 

--- a/src/libstore/pathlocks.cc
+++ b/src/libstore/pathlocks.cc
@@ -14,7 +14,7 @@
 namespace nix {
 
 
-AutoCloseFD openLockFile(const Path & path, bool create)
+AutoCloseFD openLockFile(PathView path, bool create)
 {
     AutoCloseFD fd;
 
@@ -26,7 +26,7 @@ AutoCloseFD openLockFile(const Path & path, bool create)
 }
 
 
-void deleteLockFile(const Path & path, int fd)
+void deleteLockFile(PathView path, int fd)
 {
     /* Get rid of the lock file.  Have to be careful not to introduce
        races.  Write a (meaningless) token to the file to indicate to
@@ -74,7 +74,7 @@ PathLocks::PathLocks()
 }
 
 
-PathLocks::PathLocks(const PathSet & paths, const string & waitMsg)
+PathLocks::PathLocks(const PathSet & paths, std::string_view waitMsg)
     : deletePaths(false)
 {
     lockPaths(paths, waitMsg);
@@ -82,7 +82,7 @@ PathLocks::PathLocks(const PathSet & paths, const string & waitMsg)
 
 
 bool PathLocks::lockPaths(const PathSet & paths,
-    const string & waitMsg, bool wait)
+    std::string_view waitMsg, bool wait)
 {
     assert(fds.empty());
 

--- a/src/libstore/pathlocks.cc
+++ b/src/libstore/pathlocks.cc
@@ -18,7 +18,7 @@ AutoCloseFD openLockFile(PathView path, bool create)
 {
     AutoCloseFD fd;
 
-    fd = open(path.c_str(), O_CLOEXEC | O_RDWR | (create ? O_CREAT : 0), 0600);
+    fd = open(Path { path }.c_str(), O_CLOEXEC | O_RDWR | (create ? O_CREAT : 0), 0600);
     if (!fd && (create || errno != ENOENT))
         throw SysError("opening lock file '%1%'", path);
 
@@ -32,7 +32,7 @@ void deleteLockFile(PathView path, int fd)
        races.  Write a (meaningless) token to the file to indicate to
        other processes waiting on this lock that the lock is stale
        (deleted). */
-    unlink(path.c_str());
+    unlink(Path { path }.c_str());
     writeFull(fd, "d");
     /* Note that the result of unlink() is ignored; removing the lock
        file is an optimisation, not a necessity. */

--- a/src/libstore/pathlocks.hh
+++ b/src/libstore/pathlocks.hh
@@ -7,10 +7,10 @@ namespace nix {
 /* Open (possibly create) a lock file and return the file descriptor.
    -1 is returned if create is false and the lock could not be opened
    because it doesn't exist.  Any other error throws an exception. */
-AutoCloseFD openLockFile(const Path & path, bool create);
+AutoCloseFD openLockFile(PathView path, bool create);
 
 /* Delete an open lock file. */
-void deleteLockFile(const Path & path, int fd);
+void deleteLockFile(PathView path, int fd);
 
 enum LockType { ltRead, ltWrite, ltNone };
 
@@ -26,9 +26,9 @@ private:
 public:
     PathLocks();
     PathLocks(const PathSet & paths,
-        const string & waitMsg = "");
+        std::string_view waitMsg = "");
     bool lockPaths(const PathSet & _paths,
-        const string & waitMsg = "",
+        std::string_view waitMsg = "",
         bool wait = true);
     ~PathLocks();
     void unlock();

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -68,14 +68,14 @@ Generations findGenerations(PathView profile, int & curGen)
 
 
 static void makeName(PathView profile, unsigned int num,
-    Path & outLink)
+    PathView outLink)
 {
     Path prefix = (format("%1%-%2%") % profile % num).str();
     outLink = prefix + "-link";
 }
 
 
-Path createGeneration(ref<LocalFSStore> store, Path profile, Path outPath)
+Path createGeneration(ref<LocalFSStore> store, PathView profile, PathView outPath)
 {
     /* The new generation number should be higher than old the
        previous ones. */
@@ -235,7 +235,7 @@ void deleteGenerationsOlderThan(PathView profile, std::string_view timeSpec, boo
 }
 
 
-void switchLink(Path link, Path target)
+void switchLink(PathView link, PathView target)
 {
     /* Hacky. */
     if (dirOf(target) == dirOf(link)) target = baseNameOf(target);

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -24,8 +24,8 @@ static int parseName(std::string_view profileName, std::string_view name)
 {
     if (name.substr(0, profileName.size()) != profileName) return -1;
     if (name[profileName.size()] != '-') return -1;
-	std::string_view s = name.substr(profileName.size() + 1);
-	std::string_view::size_type p = s.find("-link");
+    std::string_view s = name.substr(profileName.size() + 1);
+    std::string_view::size_type p = s.find("-link");
     if (p == std::string_view::npos) return -1;
     int n;
     if (string2Int(s.substr(0, p), n) && n >= 0)

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -22,12 +22,13 @@ static bool cmpGensByNumber(const Generation & a, const Generation & b)
    `<profilename>-<number>-link'. */
 static int parseName(std::string_view profileName, std::string_view name)
 {
-    if (string(name, 0, profileName.size() + 1) != profileName + "-") return -1;
-    string s = string(name, profileName.size() + 1);
-    string::size_type p = s.find("-link");
-    if (p == string::npos) return -1;
+    if (name.substr(0, profileName.size()) != profileName) return -1;
+    if (name[profileName.size()] != '-') return -1;
+	std::string_view s = name.substr(profileName.size() + 1);
+	std::string_view::size_type p = s.find("-link");
+    if (p == std::string_view::npos) return -1;
     int n;
-    if (string2Int(string(s, 0, p), n) && n >= 0)
+    if (string2Int(s.substr(0, p), n) && n >= 0)
         return n;
     else
         return -1;
@@ -35,7 +36,7 @@ static int parseName(std::string_view profileName, std::string_view name)
 
 
 
-Generations findGenerations(Path profile, int & curGen)
+Generations findGenerations(PathView profile, int & curGen)
 {
     Generations gens;
 
@@ -116,7 +117,7 @@ Path createGeneration(ref<LocalFSStore> store, Path profile, Path outPath)
 
 static void removeFile(PathView path)
 {
-    if (remove(path.c_str()) == -1)
+    if (remove(Path { path }.c_str()) == -1)
         throw SysError("cannot unlink '%1%'", path);
 }
 
@@ -245,7 +246,7 @@ void switchLink(Path link, Path target)
 
 void lockProfile(PathLocks & lock, PathView profile)
 {
-    lock.lockPaths({profile}, (format("waiting for lock on profile '%1%'") % profile).str());
+    lock.lockPaths({ Path { profile } }, (format("waiting for lock on profile '%1%'") % profile).str());
     lock.setDeletion(true);
 }
 

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -20,7 +20,7 @@ static bool cmpGensByNumber(const Generation & a, const Generation & b)
 
 /* Parse a generation name of the format
    `<profilename>-<number>-link'. */
-static int parseName(const string & profileName, const string & name)
+static int parseName(std::string_view profileName, std::string_view name)
 {
     if (string(name, 0, profileName.size() + 1) != profileName + "-") return -1;
     string s = string(name, profileName.size() + 1);
@@ -66,7 +66,7 @@ Generations findGenerations(Path profile, int & curGen)
 }
 
 
-static void makeName(const Path & profile, unsigned int num,
+static void makeName(PathView profile, unsigned int num,
     Path & outLink)
 {
     Path prefix = (format("%1%-%2%") % profile % num).str();
@@ -114,14 +114,14 @@ Path createGeneration(ref<LocalFSStore> store, Path profile, Path outPath)
 }
 
 
-static void removeFile(const Path & path)
+static void removeFile(PathView path)
 {
     if (remove(path.c_str()) == -1)
         throw SysError("cannot unlink '%1%'", path);
 }
 
 
-void deleteGeneration(const Path & profile, unsigned int gen)
+void deleteGeneration(PathView profile, unsigned int gen)
 {
     Path generation;
     makeName(profile, gen, generation);
@@ -129,7 +129,7 @@ void deleteGeneration(const Path & profile, unsigned int gen)
 }
 
 
-static void deleteGeneration2(const Path & profile, unsigned int gen, bool dryRun)
+static void deleteGeneration2(PathView profile, unsigned int gen, bool dryRun)
 {
     if (dryRun)
         printInfo(format("would remove generation %1%") % gen);
@@ -140,7 +140,7 @@ static void deleteGeneration2(const Path & profile, unsigned int gen, bool dryRu
 }
 
 
-void deleteGenerations(const Path & profile, const std::set<unsigned int> & gensToDelete, bool dryRun)
+void deleteGenerations(PathView profile, const std::set<unsigned int> & gensToDelete, bool dryRun)
 {
     PathLocks lock;
     lockProfile(lock, profile);
@@ -157,7 +157,7 @@ void deleteGenerations(const Path & profile, const std::set<unsigned int> & gens
     }
 }
 
-void deleteGenerationsGreaterThan(const Path & profile, int max, bool dryRun)
+void deleteGenerationsGreaterThan(PathView profile, int max, bool dryRun)
 {
     PathLocks lock;
     lockProfile(lock, profile);
@@ -181,7 +181,7 @@ void deleteGenerationsGreaterThan(const Path & profile, int max, bool dryRun)
     }
 }
 
-void deleteOldGenerations(const Path & profile, bool dryRun)
+void deleteOldGenerations(PathView profile, bool dryRun)
 {
     PathLocks lock;
     lockProfile(lock, profile);
@@ -195,7 +195,7 @@ void deleteOldGenerations(const Path & profile, bool dryRun)
 }
 
 
-void deleteGenerationsOlderThan(const Path & profile, time_t t, bool dryRun)
+void deleteGenerationsOlderThan(PathView profile, time_t t, bool dryRun)
 {
     PathLocks lock;
     lockProfile(lock, profile);
@@ -219,7 +219,7 @@ void deleteGenerationsOlderThan(const Path & profile, time_t t, bool dryRun)
 }
 
 
-void deleteGenerationsOlderThan(const Path & profile, const string & timeSpec, bool dryRun)
+void deleteGenerationsOlderThan(PathView profile, std::string_view timeSpec, bool dryRun)
 {
     time_t curTime = time(0);
     string strDays = string(timeSpec, 0, timeSpec.size() - 1);
@@ -243,14 +243,14 @@ void switchLink(Path link, Path target)
 }
 
 
-void lockProfile(PathLocks & lock, const Path & profile)
+void lockProfile(PathLocks & lock, PathView profile)
 {
     lock.lockPaths({profile}, (format("waiting for lock on profile '%1%'") % profile).str());
     lock.setDeletion(true);
 }
 
 
-string optimisticLockProfile(const Path & profile)
+string optimisticLockProfile(PathView profile)
 {
     return pathExists(profile) ? readLink(profile) : "";
 }

--- a/src/libstore/profiles.hh
+++ b/src/libstore/profiles.hh
@@ -33,7 +33,7 @@ Generations findGenerations(PathView profile, int & curGen);
 
 class LocalFSStore;
 
-Path createGeneration(ref<LocalFSStore> store, Path profile, Path outPath);
+Path createGeneration(ref<LocalFSStore> store, PathView profile, PathView outPath);
 
 void deleteGeneration(PathView profile, unsigned int gen);
 
@@ -47,7 +47,7 @@ void deleteGenerationsOlderThan(PathView profile, time_t t, bool dryRun);
 
 void deleteGenerationsOlderThan(PathView profile, std::string_view timeSpec, bool dryRun);
 
-void switchLink(Path link, Path target);
+void switchLink(PathView link, PathView target);
 
 /* Ensure exclusive access to a profile.  Any command that modifies
    the profile first acquires this lock. */

--- a/src/libstore/profiles.hh
+++ b/src/libstore/profiles.hh
@@ -29,7 +29,7 @@ typedef list<Generation> Generations;
 
 /* Returns the list of currently present generations for the specified
    profile, sorted by generation number. */
-Generations findGenerations(Path profile, int & curGen);
+Generations findGenerations(PathView profile, int & curGen);
 
 class LocalFSStore;
 

--- a/src/libstore/profiles.hh
+++ b/src/libstore/profiles.hh
@@ -35,23 +35,23 @@ class LocalFSStore;
 
 Path createGeneration(ref<LocalFSStore> store, Path profile, Path outPath);
 
-void deleteGeneration(const Path & profile, unsigned int gen);
+void deleteGeneration(PathView profile, unsigned int gen);
 
-void deleteGenerations(const Path & profile, const std::set<unsigned int> & gensToDelete, bool dryRun);
+void deleteGenerations(PathView profile, const std::set<unsigned int> & gensToDelete, bool dryRun);
 
-void deleteGenerationsGreaterThan(const Path & profile, const int max, bool dryRun);
+void deleteGenerationsGreaterThan(PathView profile, const int max, bool dryRun);
 
-void deleteOldGenerations(const Path & profile, bool dryRun);
+void deleteOldGenerations(PathView profile, bool dryRun);
 
-void deleteGenerationsOlderThan(const Path & profile, time_t t, bool dryRun);
+void deleteGenerationsOlderThan(PathView profile, time_t t, bool dryRun);
 
-void deleteGenerationsOlderThan(const Path & profile, const string & timeSpec, bool dryRun);
+void deleteGenerationsOlderThan(PathView profile, std::string_view timeSpec, bool dryRun);
 
 void switchLink(Path link, Path target);
 
 /* Ensure exclusive access to a profile.  Any command that modifies
    the profile first acquires this lock. */
-void lockProfile(PathLocks & lock, const Path & profile);
+void lockProfile(PathLocks & lock, PathView profile);
 
 /* Optimistic locking is used by long-running operations like `nix-env
    -i'.  Instead of acquiring the exclusive lock for the entire
@@ -62,7 +62,7 @@ void lockProfile(PathLocks & lock, const Path & profile);
    generally cheap, since the build results are still in the Nix
    store.  Most of the time, only the user environment has to be
    rebuilt. */
-string optimisticLockProfile(const Path & profile);
+string optimisticLockProfile(PathView profile);
 
 /* Resolve ~/.nix-profile. If ~/.nix-profile doesn't exist yet, create
    it. */

--- a/src/libstore/references.cc
+++ b/src/libstore/references.cc
@@ -79,7 +79,7 @@ void RefScanSink::operator () (const unsigned char * data, size_t len)
 }
 
 
-PathSet scanForReferences(const string & path,
+PathSet scanForReferences(std::string_view path,
     const PathSet & refs, HashResult & hash)
 {
     RefScanSink sink;
@@ -118,7 +118,7 @@ PathSet scanForReferences(const string & path,
 }
 
 
-RewritingSink::RewritingSink(const std::string & from, const std::string & to, Sink & nextSink)
+RewritingSink::RewritingSink(std::string_view from, std::string_view to, Sink & nextSink)
     : from(from), to(to), nextSink(nextSink)
 {
     assert(from.size() == to.size());
@@ -152,7 +152,7 @@ void RewritingSink::flush()
     prev.clear();
 }
 
-HashModuloSink::HashModuloSink(HashType ht, const std::string & modulus)
+HashModuloSink::HashModuloSink(HashType ht, std::string_view modulus)
     : hashSink(ht)
     , rewritingSink(modulus, std::string(modulus.size(), 0), hashSink)
 {

--- a/src/libstore/references.hh
+++ b/src/libstore/references.hh
@@ -5,7 +5,7 @@
 
 namespace nix {
 
-PathSet scanForReferences(const Path & path, const PathSet & refs,
+PathSet scanForReferences(PathView path, const PathSet & refs,
     HashResult & hash);
 
 struct RewritingSink : Sink
@@ -16,7 +16,7 @@ struct RewritingSink : Sink
 
     std::vector<uint64_t> matches;
 
-    RewritingSink(const std::string & from, const std::string & to, Sink & nextSink);
+    RewritingSink(std::string_view from, std::string_view to, Sink & nextSink);
 
     void operator () (const unsigned char * data, size_t len) override;
 
@@ -28,7 +28,7 @@ struct HashModuloSink : AbstractHashSink
     HashSink hashSink;
     RewritingSink rewritingSink;
 
-    HashModuloSink(HashType ht, const std::string & modulus);
+    HashModuloSink(HashType ht, std::string_view modulus);
 
     void operator () (const unsigned char * data, size_t len) override;
 

--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -8,7 +8,7 @@
 
 namespace nix {
 
-RemoteFSAccessor::RemoteFSAccessor(ref<Store> store, const Path & cacheDir)
+RemoteFSAccessor::RemoteFSAccessor(ref<Store> store, PathView cacheDir)
     : store(store)
     , cacheDir(cacheDir)
 {
@@ -16,13 +16,13 @@ RemoteFSAccessor::RemoteFSAccessor(ref<Store> store, const Path & cacheDir)
         createDirs(cacheDir);
 }
 
-Path RemoteFSAccessor::makeCacheFile(const Path & storePath, const std::string & ext)
+Path RemoteFSAccessor::makeCacheFile(PathView storePath, std::string_view ext)
 {
     assert(cacheDir != "");
     return fmt("%s/%s.%s", cacheDir, storePathToHash(storePath), ext);
 }
 
-void RemoteFSAccessor::addToCache(const Path & storePath, const std::string & nar,
+void RemoteFSAccessor::addToCache(PathView storePath, std::string_view nar,
     ref<FSAccessor> narAccessor)
 {
     nars.emplace(storePath, narAccessor);
@@ -43,7 +43,7 @@ void RemoteFSAccessor::addToCache(const Path & storePath, const std::string & na
     }
 }
 
-std::pair<ref<FSAccessor>, Path> RemoteFSAccessor::fetch(const Path & path_)
+std::pair<ref<FSAccessor>, Path> RemoteFSAccessor::fetch(PathView path_)
 {
     auto path = canonPath(path_);
 
@@ -102,25 +102,25 @@ std::pair<ref<FSAccessor>, Path> RemoteFSAccessor::fetch(const Path & path_)
     return {narAccessor, restPath};
 }
 
-FSAccessor::Stat RemoteFSAccessor::stat(const Path & path)
+FSAccessor::Stat RemoteFSAccessor::stat(PathView path)
 {
     auto res = fetch(path);
     return res.first->stat(res.second);
 }
 
-StringSet RemoteFSAccessor::readDirectory(const Path & path)
+StringSet RemoteFSAccessor::readDirectory(PathView path)
 {
     auto res = fetch(path);
     return res.first->readDirectory(res.second);
 }
 
-std::string RemoteFSAccessor::readFile(const Path & path)
+std::string RemoteFSAccessor::readFile(PathView path)
 {
     auto res = fetch(path);
     return res.first->readFile(res.second);
 }
 
-std::string RemoteFSAccessor::readLink(const Path & path)
+std::string RemoteFSAccessor::readLink(PathView path)
 {
     auto res = fetch(path);
     return res.first->readLink(res.second);

--- a/src/libstore/remote-fs-accessor.hh
+++ b/src/libstore/remote-fs-accessor.hh
@@ -26,7 +26,7 @@ class RemoteFSAccessor : public FSAccessor
 public:
 
     RemoteFSAccessor(ref<Store> store,
-        const /* FIXME: use std::optional */ Path & cacheDir = "");
+        /* FIXME: use std::optional */ PathView cacheDir = "");
 
     Stat stat(PathView path) override;
 

--- a/src/libstore/remote-fs-accessor.hh
+++ b/src/libstore/remote-fs-accessor.hh
@@ -14,13 +14,13 @@ class RemoteFSAccessor : public FSAccessor
 
     Path cacheDir;
 
-    std::pair<ref<FSAccessor>, Path> fetch(const Path & path_);
+    std::pair<ref<FSAccessor>, Path> fetch(PathView path_);
 
     friend class BinaryCacheStore;
 
-    Path makeCacheFile(const Path & storePath, const std::string & ext);
+    Path makeCacheFile(PathView storePath, std::string_view ext);
 
-    void addToCache(const Path & storePath, const std::string & nar,
+    void addToCache(PathView storePath, std::string_view nar,
         ref<FSAccessor> narAccessor);
 
 public:
@@ -28,13 +28,13 @@ public:
     RemoteFSAccessor(ref<Store> store,
         const /* FIXME: use std::optional */ Path & cacheDir = "");
 
-    Stat stat(const Path & path) override;
+    Stat stat(PathView path) override;
 
-    StringSet readDirectory(const Path & path) override;
+    StringSet readDirectory(PathView path) override;
 
-    std::string readFile(const Path & path) override;
+    std::string readFile(PathView path) override;
 
-    std::string readLink(const Path & path) override;
+    std::string readLink(PathView path) override;
 };
 
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -78,11 +78,11 @@ UDSRemoteStore::UDSRemoteStore(const Params & params)
 }
 
 
-UDSRemoteStore::UDSRemoteStore(std::string socket_path, const Params & params)
+UDSRemoteStore::UDSRemoteStore(Path socket_path, const Params & params)
     : Store(params)
     , LocalFSStore(params)
     , RemoteStore(params)
-    , path(socket_path)
+    , path(std::move(socket_path))
 {
 }
 
@@ -481,7 +481,7 @@ StorePath RemoteStore::addToStore(std::string_view name, PathView _srcPath,
 
     auto conn(getConnection());
 
-    Path srcPath(absPath(_srcPath));
+    Path srcPath(absPath(Path { _srcPath }));
 
     conn->to
         << wopAddToStore
@@ -814,7 +814,7 @@ static RegisterStoreImplementation regStore([](
     -> std::shared_ptr<Store>
 {
     if (std::string(uri, 0, uriScheme.size()) != uriScheme) return 0;
-    return std::make_shared<UDSRemoteStore>(std::string(uri, uriScheme.size()), params);
+    return std::make_shared<UDSRemoteStore>(Path { uri.substr(uriScheme.size()) }, params);
 });
 
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -418,7 +418,7 @@ StorePathSet RemoteStore::queryDerivationOutputs(const StorePath & path)
 }
 
 
-std::optional<StorePath> RemoteStore::queryPathFromHashPart(const std::string & hashPart)
+std::optional<StorePath> RemoteStore::queryPathFromHashPart(std::string_view hashPart)
 {
     auto conn(getConnection());
     conn->to << wopQueryPathFromHashPart << hashPart;
@@ -474,7 +474,7 @@ void RemoteStore::addToStore(const ValidPathInfo & info, Source & source,
 }
 
 
-StorePath RemoteStore::addToStore(const string & name, const Path & _srcPath,
+StorePath RemoteStore::addToStore(std::string_view name, PathView _srcPath,
     FileIngestionMethod method, HashType hashAlgo, PathFilter & filter, RepairFlag repair)
 {
     if (repair) throw Error("repairing is not supported when building through the Nix daemon");
@@ -514,7 +514,7 @@ StorePath RemoteStore::addToStore(const string & name, const Path & _srcPath,
 }
 
 
-StorePath RemoteStore::addTextToStore(const string & name, const string & s,
+StorePath RemoteStore::addTextToStore(std::string_view name, std::string_view s,
     const StorePathSet & references, RepairFlag repair)
 {
     if (repair) throw Error("repairing is not supported when building through the Nix daemon");
@@ -583,7 +583,7 @@ void RemoteStore::addTempRoot(const StorePath & path)
 }
 
 
-void RemoteStore::addIndirectRoot(const Path & path)
+void RemoteStore::addIndirectRoot(PathView path)
 {
     auto conn(getConnection());
     conn->to << wopAddIndirectRoot << path;
@@ -810,7 +810,7 @@ std::exception_ptr RemoteStore::Connection::processStderr(Sink * sink, Source * 
 static std::string uriScheme = "unix://";
 
 static RegisterStoreImplementation regStore([](
-    const std::string & uri, const Store::Params & params)
+    std::string_view uri, const Store::Params & params)
     -> std::shared_ptr<Store>
 {
     if (std::string(uri, 0, uriScheme.size()) != uriScheme) return 0;

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -481,7 +481,7 @@ StorePath RemoteStore::addToStore(std::string_view name, PathView _srcPath,
 
     auto conn(getConnection());
 
-    Path srcPath(absPath(Path { _srcPath }));
+    Path srcPath(absPath(_srcPath));
 
     conn->to
         << wopAddToStore

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -51,7 +51,7 @@ public:
 
     StorePathSet queryDerivationOutputs(const StorePath & path) override;
 
-    std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override;
+    std::optional<StorePath> queryPathFromHashPart(std::string_view hashPart) override;
 
     StorePathSet querySubstitutablePaths(const StorePathSet & paths) override;
 
@@ -62,11 +62,11 @@ public:
         RepairFlag repair, CheckSigsFlag checkSigs,
         std::shared_ptr<FSAccessor> accessor) override;
 
-    StorePath addToStore(const string & name, const Path & srcPath,
+    StorePath addToStore(std::string_view name, PathView srcPath,
         FileIngestionMethod method = FileIngestionMethod::Recursive, HashType hashAlgo = htSHA256,
         PathFilter & filter = defaultPathFilter, RepairFlag repair = NoRepair) override;
 
-    StorePath addTextToStore(const string & name, const string & s,
+    StorePath addTextToStore(std::string_view name, std::string_view s,
         const StorePathSet & references, RepairFlag repair) override;
 
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
@@ -78,7 +78,7 @@ public:
 
     void addTempRoot(const StorePath & path) override;
 
-    void addIndirectRoot(const Path & path) override;
+    void addIndirectRoot(PathView path) override;
 
     void syncWithGC() override;
 

--- a/src/libstore/s3.hh
+++ b/src/libstore/s3.hh
@@ -14,9 +14,9 @@ struct S3Helper
     ref<Aws::Client::ClientConfiguration> config;
     ref<Aws::S3::S3Client> client;
 
-    S3Helper(const std::string & profile, const std::string & region, const std::string & scheme, const std::string & endpoint);
+    S3Helper(std::string_view profile, std::string_view region, std::string_view scheme, std::string_view endpoint);
 
-    ref<Aws::Client::ClientConfiguration> makeConfig(const std::string & region, const std::string & scheme, const std::string & endpoint);
+    ref<Aws::Client::ClientConfiguration> makeConfig(std::string_view region, std::string_view scheme, std::string_view endpoint);
 
     struct FileTransferResult
     {
@@ -25,7 +25,7 @@ struct S3Helper
     };
 
     FileTransferResult getObject(
-        const std::string & bucketName, const std::string & key);
+        std::string_view bucketName, std::string_view key);
 };
 
 }

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -25,7 +25,7 @@ namespace nix {
         throw SQLiteError("%s: %s (in '%s')", fs.s, sqlite3_errstr(exterr), path);
 }
 
-SQLite::SQLite(const Path & path, bool create)
+SQLite::SQLite(PathView path, bool create)
 {
     if (sqlite3_open_v2(path.c_str(), &db,
             SQLITE_OPEN_READWRITE | (create ? SQLITE_OPEN_CREATE : 0), 0) != SQLITE_OK)
@@ -53,7 +53,7 @@ void SQLite::isCache()
     exec("pragma main.journal_mode = truncate");
 }
 
-void SQLite::exec(const std::string & stmt)
+void SQLite::exec(std::string_view stmt)
 {
     retrySQLite<void>([&]() {
         if (sqlite3_exec(db, stmt.c_str(), 0, 0, 0) != SQLITE_OK)
@@ -61,7 +61,7 @@ void SQLite::exec(const std::string & stmt)
     });
 }
 
-void SQLiteStmt::create(sqlite3 * db, const string & sql)
+void SQLiteStmt::create(sqlite3 * db, std::string_view sql)
 {
     checkInterrupt();
     assert(!stmt);
@@ -95,7 +95,7 @@ SQLiteStmt::Use::~Use()
     sqlite3_reset(stmt);
 }
 
-SQLiteStmt::Use & SQLiteStmt::Use::operator () (const std::string & value, bool notNull)
+SQLiteStmt::Use & SQLiteStmt::Use::operator () (std::string_view value, bool notNull)
 {
     if (notNull) {
         if (sqlite3_bind_text(stmt, curArg++, value.c_str(), -1, SQLITE_TRANSIENT) != SQLITE_OK)

--- a/src/libstore/sqlite.hh
+++ b/src/libstore/sqlite.hh
@@ -15,7 +15,7 @@ struct SQLite
 {
     sqlite3 * db = 0;
     SQLite() { }
-    SQLite(const Path & path, bool create = true);
+    SQLite(PathView path, bool create = true);
     SQLite(const SQLite & from) = delete;
     SQLite& operator = (const SQLite & from) = delete;
     SQLite& operator = (SQLite && from) { db = from.db; from.db = 0; return *this; }
@@ -25,7 +25,7 @@ struct SQLite
     /* Disable synchronous mode, set truncate journal mode. */
     void isCache();
 
-    void exec(const std::string & stmt);
+    void exec(std::string_view stmt);
 };
 
 /* RAII wrapper to create and destroy SQLite prepared statements. */
@@ -35,8 +35,8 @@ struct SQLiteStmt
     sqlite3_stmt * stmt = 0;
     std::string sql;
     SQLiteStmt() { }
-    SQLiteStmt(sqlite3 * db, const std::string & sql) { create(db, sql); }
-    void create(sqlite3 * db, const std::string & s);
+    SQLiteStmt(sqlite3 * db, std::string_view sql) { create(db, sql); }
+    void create(sqlite3 * db, std::string_view s);
     ~SQLiteStmt();
     operator sqlite3_stmt * () { return stmt; }
 
@@ -54,7 +54,7 @@ struct SQLiteStmt
         ~Use();
 
         /* Bind the next parameter. */
-        Use & operator () (const std::string & value, bool notNull = true);
+        Use & operator () (std::string_view value, bool notNull = true);
         Use & operator () (const unsigned char * data, size_t len, bool notNull = true);
         Use & operator () (int64_t value, bool notNull = true);
         Use & bind(); // null

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -98,7 +98,7 @@ static RegisterStoreImplementation regStore([](
     -> std::shared_ptr<Store>
 {
     if (std::string(uri, 0, uriScheme.size()) != uriScheme) return 0;
-    return std::make_shared<SSHStore>(std::string(uri, uriScheme.size()), params);
+    return std::make_shared<SSHStore>(uri.substr(uriScheme.size()), params);
 });
 
 }

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -19,7 +19,7 @@ public:
     const Setting<Path> remoteProgram{(Store*) this, "nix-daemon", "remote-program", "path to the nix-daemon executable on the remote system"};
     const Setting<std::string> remoteStore{(Store*) this, "", "remote-store", "URI of the store on the remote system"};
 
-    SSHStore(const std::string & host, const Params & params)
+    SSHStore(std::string_view host, const Params & params)
         : Store(params)
         , RemoteStore(params)
         , host(host)
@@ -94,7 +94,7 @@ ref<RemoteStore::Connection> SSHStore::openConnection()
 }
 
 static RegisterStoreImplementation regStore([](
-    const std::string & uri, const Store::Params & params)
+    std::string_view uri, const Store::Params & params)
     -> std::shared_ptr<Store>
 {
     if (std::string(uri, 0, uriScheme.size()) != uriScheme) return 0;

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -62,7 +62,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(std::string_view 
                 args.push_back("-v");
         }
 
-        args.push_back(command);
+        args.push_back(std::string { command });
         execvp(args.begin()->c_str(), stringsToCharPtrs(args).data());
 
         // could not exec ssh/bash

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -2,7 +2,7 @@
 
 namespace nix {
 
-SSHMaster::SSHMaster(const std::string & host, const std::string & keyFile, bool useMaster, bool compress, int logFD)
+SSHMaster::SSHMaster(std::string_view host, std::string_view keyFile, bool useMaster, bool compress, int logFD)
     : host(host)
     , fakeSSH(host == "localhost")
     , keyFile(keyFile)
@@ -24,7 +24,7 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
         args.push_back("-C");
 }
 
-std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string & command)
+std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(std::string_view command)
 {
     Path socketPath = startMaster();
 

--- a/src/libstore/ssh.hh
+++ b/src/libstore/ssh.hh
@@ -29,7 +29,7 @@ private:
 
 public:
 
-    SSHMaster(const std::string & host, const std::string & keyFile, bool useMaster, bool compress, int logFD = -1);
+    SSHMaster(std::string_view host, std::string_view keyFile, bool useMaster, bool compress, int logFD = -1);
 
     struct Connection
     {
@@ -37,7 +37,7 @@ public:
         AutoCloseFD out, in;
     };
 
-    std::unique_ptr<Connection> startCommand(const std::string & command);
+    std::unique_ptr<Connection> startCommand(std::string_view command);
 
     Path startMaster();
 };

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -38,7 +38,7 @@ Path Store::followLinksToStore(std::string_view _path) const
     while (!isInStore(path)) {
         if (!isLink(path)) break;
         string target = readLink(path);
-        path = absPath(Path { target }, dirOf(path));
+        path = absPath(target, dirOf(path));
     }
     if (!isInStore(path))
         throw NotInStore("path '%1%' is not in the Nix store", path);

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -109,7 +109,7 @@ struct SubstitutablePathInfo
     unsigned long long narSize; /* 0 = unknown */
 };
 
-typedef std::map<StorePath, SubstitutablePathInfo> SubstitutablePathInfos;
+typedef std::map<StorePath, SubstitutablePathInfo, std::less<>> SubstitutablePathInfos;
 
 
 struct ValidPathInfo
@@ -246,7 +246,7 @@ class Store : public std::enable_shared_from_this<Store>, public Config
 {
 public:
 
-    typedef std::map<std::string, std::string> Params;
+    typedef std::map<std::string, std::string, std::less<>> Params;
 
     const PathSetting storeDir_{this, false, settings.nixStore,
         "store", "path to the Nix store"};

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -304,14 +304,14 @@ struct RestoreSink : ParseSink
 
     void createDirectory(PathView path)
     {
-    	Path p = Path { dstPath } << path;
+        Path p = Path { dstPath } << path;
         if (mkdir(p.c_str(), 0777) == -1)
             throw SysError("creating directory '%1%'", p);
     };
 
     void createRegularFile(PathView path)
     {
-    	Path p = Path { dstPath } << path;
+        Path p = Path { dstPath } << path;
         fd = open(p.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0666);
         if (!fd) throw SysError("creating file '%1%'", p);
     }

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -45,22 +45,22 @@ namespace nix {
      `+' denotes string concatenation. */
 
 
-void dumpPath(const Path & path, Sink & sink,
+void dumpPath(PathView path, Sink & sink,
     PathFilter & filter = defaultPathFilter);
 
-void dumpString(const std::string & s, Sink & sink);
+void dumpString(std::string_view s, Sink & sink);
 
 /* FIXME: fix this API, it sucks. */
 struct ParseSink
 {
-    virtual void createDirectory(const Path & path) { };
+    virtual void createDirectory(PathView path) { };
 
-    virtual void createRegularFile(const Path & path) { };
+    virtual void createRegularFile(PathView path) { };
     virtual void isExecutable() { };
     virtual void preallocateContents(unsigned long long size) { };
     virtual void receiveContents(unsigned char * data, unsigned int len) { };
 
-    virtual void createSymlink(const Path & path, const string & target) { };
+    virtual void createSymlink(PathView path, std::string_view target) { };
 };
 
 struct TeeSink : ParseSink
@@ -72,12 +72,12 @@ struct TeeSink : ParseSink
 
 void parseDump(ParseSink & sink, Source & source);
 
-void restorePath(const Path & path, Source & source);
+void restorePath(PathView path, Source & source);
 
 /* Read a NAR from 'source' and write it to 'sink'. */
 void copyNAR(Source & source, Sink & sink);
 
-void copyPath(const Path & from, const Path & to);
+void copyPath(PathView from, PathView to);
 
 
 extern const std::string narVersionMagic1;

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -57,7 +57,7 @@ void Args::parseCmdline(const Strings & _cmdline)
     processArgs(pendingArgs, true);
 }
 
-void Args::printHelp(const string & programName, std::ostream & out)
+void Args::printHelp(std::string_view programName, std::ostream & out)
 {
     std::cout << fmt(ANSI_BOLD "Usage:" ANSI_NORMAL " %s " ANSI_ITALIC "FLAGS..." ANSI_NORMAL, programName);
     for (auto & exp : expectedArgs) {
@@ -96,7 +96,7 @@ bool Args::processFlag(Strings::iterator & pos, Strings::iterator end)
 {
     assert(pos != end);
 
-    auto process = [&](const std::string & name, const Flag & flag) -> bool {
+    auto process = [&](std::string_view name, const Flag & flag) -> bool {
         ++pos;
         std::vector<std::string> args;
         for (size_t n = 0 ; n < flag.handler.arity; ++n) {
@@ -198,7 +198,7 @@ void printTable(std::ostream & out, const Table2 & table)
     }
 }
 
-void Command::printHelp(const string & programName, std::ostream & out)
+void Command::printHelp(std::string_view programName, std::ostream & out)
 {
     Args::printHelp(programName, out);
 
@@ -231,10 +231,10 @@ MultiCommand::MultiCommand(const Commands & commands)
     categories[Command::catDefault] = "Available commands";
 }
 
-void MultiCommand::printHelp(const string & programName, std::ostream & out)
+void MultiCommand::printHelp(std::string_view programName, std::ostream & out)
 {
     if (command) {
-        command->second->printHelp(programName + " " + command->first, out);
+        command->second->printHelp(std::string { programName } + " " + command->first, out);
         return;
     }
 

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -164,7 +164,7 @@ public:
     {
         addFlag({
             .longName = std::string { longName },
-            .shortName = std::string { shortName },
+            .shortName = shortName,
             .description = std::string { description },
             .labels = {"N"},
             .handler = {[=](std::string s) {

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -225,7 +225,7 @@ struct Command : virtual Args
     void printHelp(std::string_view programName, std::ostream & out) override;
 };
 
-typedef std::map<std::string, std::function<ref<Command>()>> Commands;
+typedef std::map<std::string, std::function<ref<Command>()>, std::less<>> Commands;
 
 /* An argument parser that supports multiple subcommands,
    i.e. ‘<command> <subcommand>’. */

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -20,7 +20,7 @@ public:
        wrong. */
     void parseCmdline(const Strings & cmdline);
 
-    virtual void printHelp(const string & programName, std::ostream & out);
+    virtual void printHelp(std::string_view programName, std::ostream & out);
 
     virtual std::string description() { return ""; }
 
@@ -116,40 +116,42 @@ public:
     /* Helper functions for constructing flags / positional
        arguments. */
 
-    void mkFlag1(char shortName, const std::string & longName,
-        const std::string & label, const std::string & description,
+    // TODO move strings, not copy string views
+    void mkFlag1(char shortName, std::string_view longName,
+        std::string_view label, std::string_view description,
         std::function<void(std::string)> fun)
     {
         addFlag({
-            .longName = longName,
+            .longName = std::string { longName },
             .shortName = shortName,
-            .description = description,
-            .labels = {label},
+            .description = std::string { description },
+            .labels = { std::string { label } },
             .handler = {[=](std::string s) { fun(s); }}
         });
     }
 
-    void mkFlag(char shortName, const std::string & name,
-        const std::string & description, bool * dest)
+    void mkFlag(char shortName, std::string_view name,
+        std::string_view description, bool * dest)
     {
         mkFlag(shortName, name, description, dest, true);
     }
 
+    // TODO move strings, not copy string views, also move value
     template<class T>
-    void mkFlag(char shortName, const std::string & longName, const std::string & description,
+    void mkFlag(char shortName, std::string_view longName, std::string_view description,
         T * dest, const T & value)
     {
         addFlag({
-            .longName = longName,
+            .longName = std::string { longName },
             .shortName = shortName,
-            .description = description,
+            .description = std::string { description },
             .handler = {[=]() { *dest = value; }}
         });
     }
 
     template<class I>
-    void mkIntFlag(char shortName, const std::string & longName,
-        const std::string & description, I * dest)
+    void mkIntFlag(char shortName, std::string_view longName,
+        std::string_view description, I * dest)
     {
         mkFlag<I>(shortName, longName, description, [=](I n) {
             *dest = n;
@@ -157,13 +159,13 @@ public:
     }
 
     template<class I>
-    void mkFlag(char shortName, const std::string & longName,
-        const std::string & description, std::function<void(I)> fun)
+    void mkFlag(char shortName, std::string_view longName,
+        std::string_view description, std::function<void(I)> fun)
     {
         addFlag({
-            .longName = longName,
-            .shortName = shortName,
-            .description = description,
+            .longName = std::string { longName },
+            .shortName = std::string { shortName },
+            .description = std::string { description },
             .labels = {"N"},
             .handler = {[=](std::string s) {
                 I n;
@@ -175,17 +177,17 @@ public:
     }
 
     /* Expect a string argument. */
-    void expectArg(const std::string & label, string * dest, bool optional = false)
+    void expectArg(std::string_view label, string * dest, bool optional = false)
     {
-        expectedArgs.push_back(ExpectedArg{label, 1, optional, [=](std::vector<std::string> ss) {
+        expectedArgs.push_back(ExpectedArg{std::string { label }, 1, optional, [=](std::vector<std::string> ss) {
             *dest = ss[0];
         }});
     }
 
     /* Expect 0 or more arguments. */
-    void expectArgs(const std::string & label, std::vector<std::string> * dest)
+    void expectArgs(std::string_view label, std::vector<std::string> * dest)
     {
-        expectedArgs.push_back(ExpectedArg{label, 0, false, [=](std::vector<std::string> ss) {
+        expectedArgs.push_back(ExpectedArg{std::string { label }, 0, false, [=](std::vector<std::string> ss) {
             *dest = std::move(ss);
         }});
     }
@@ -220,7 +222,7 @@ struct Command : virtual Args
 
     virtual Category category() { return catDefault; }
 
-    void printHelp(const string & programName, std::ostream & out) override;
+    void printHelp(std::string_view programName, std::ostream & out) override;
 };
 
 typedef std::map<std::string, std::function<ref<Command>()>> Commands;
@@ -241,7 +243,7 @@ public:
 
     MultiCommand(const Commands & commands);
 
-    void printHelp(const string & programName, std::ostream & out) override;
+    void printHelp(std::string_view programName, std::ostream & out) override;
 
     bool processFlag(Strings::iterator & pos, Strings::iterator end) override;
 

--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -260,7 +260,7 @@ struct BrotliDecompressionSink : ChunkedCompressionSink
     }
 };
 
-ref<std::string> decompress(const std::string & method, const std::string & in)
+ref<std::string> decompress(std::string_view method, std::string_view in)
 {
     StringSink ssink;
     auto sink = makeDecompressionSink(method, ssink);
@@ -269,7 +269,7 @@ ref<std::string> decompress(const std::string & method, const std::string & in)
     return ssink.s;
 }
 
-ref<CompressionSink> makeDecompressionSink(const std::string & method, Sink & nextSink)
+ref<CompressionSink> makeDecompressionSink(std::string_view method, Sink & nextSink)
 {
     if (method == "none" || method == "")
         return make_ref<NoneSink>(nextSink);
@@ -470,7 +470,7 @@ struct BrotliCompressionSink : ChunkedCompressionSink
     }
 };
 
-ref<CompressionSink> makeCompressionSink(const std::string & method, Sink & nextSink, const bool parallel)
+ref<CompressionSink> makeCompressionSink(std::string_view method, Sink & nextSink, const bool parallel)
 {
     if (method == "none")
         return make_ref<NoneSink>(nextSink);
@@ -484,7 +484,7 @@ ref<CompressionSink> makeCompressionSink(const std::string & method, Sink & next
         throw UnknownCompressionMethod("unknown compression method '%s'", method);
 }
 
-ref<std::string> compress(const std::string & method, const std::string & in, const bool parallel)
+ref<std::string> compress(std::string_view method, std::string_view in, const bool parallel)
 {
     StringSink ssink;
     auto sink = makeCompressionSink(method, ssink, parallel);

--- a/src/libutil/compression.hh
+++ b/src/libutil/compression.hh
@@ -13,13 +13,13 @@ struct CompressionSink : BufferedSink
     virtual void finish() = 0;
 };
 
-ref<std::string> decompress(const std::string & method, const std::string & in);
+ref<std::string> decompress(std::string_view method, std::string_view in);
 
-ref<CompressionSink> makeDecompressionSink(const std::string & method, Sink & nextSink);
+ref<CompressionSink> makeDecompressionSink(std::string_view method, Sink & nextSink);
 
-ref<std::string> compress(const std::string & method, const std::string & in, const bool parallel = false);
+ref<std::string> compress(std::string_view method, std::string_view in, const bool parallel = false);
 
-ref<CompressionSink> makeCompressionSink(const std::string & method, Sink & nextSink, const bool parallel = false);
+ref<CompressionSink> makeCompressionSink(std::string_view method, Sink & nextSink, const bool parallel = false);
 
 MakeError(UnknownCompressionMethod, Error);
 

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -96,7 +96,7 @@ void AbstractConfig::applyConfig(std::string_view contents, std::string_view pat
         if (include) {
             if (tokens.size() != 2)
                 throw UsageError("illegal configuration line '%1%' in '%2%'", line, path);
-            auto p = absPath(tokens[1], dirOf(path));
+            auto p = absPath(Path { tokens[1] }, dirOf(path));
             if (pathExists(p)) {
                 applyConfigFile(p);
             } else if (!ignoreMissing) {

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -96,7 +96,7 @@ void AbstractConfig::applyConfig(std::string_view contents, std::string_view pat
         if (include) {
             if (tokens.size() != 2)
                 throw UsageError("illegal configuration line '%1%' in '%2%'", line, path);
-            auto p = absPath(Path { tokens[1] }, dirOf(path));
+            auto p = absPath(tokens[1], dirOf(path));
             if (pathExists(p)) {
                 applyConfigFile(p);
             } else if (!ignoreMissing) {

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -57,7 +57,7 @@ string showErrPos(const ErrPos &errPos)
 }
 
 // if nixCode contains lines of code, print them to the ostream, indicating the error column.
-void printCodeLines(std::ostream &out, const string &prefix, const NixCode &nixCode)
+void printCodeLines(std::ostream &out, std::string_view prefix, const NixCode &nixCode)
 {
     // previous line of code.
     if (nixCode.prevLineOfCode.has_value()) {

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -119,7 +119,7 @@ public:
     { }
 
     template<typename... Args>
-    BaseError(const std::string & fs, const Args & ... args)
+    BaseError(std::string_view fs, const Args & ... args)
         : err { .level = lvlError,
                 .hint = hintfmt(fs, args...)
               }
@@ -148,8 +148,8 @@ public:
     const char * what() const noexcept override { return calcWhat().c_str(); }
 #endif
 
-    const string & msg() const { return calcWhat(); }
-    const string & prefix() const { return prefix_; }
+    std::string_view msg() const { return calcWhat(); }
+    std::string_view prefix() const { return prefix_; }
     BaseError & addPrefix(const FormatOrString & fs);
 
     const ErrorInfo & info() { calcWhat(); return err; }

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -253,7 +253,7 @@ static void finish(HashType ht, Ctx & ctx, unsigned char * hash)
 }
 
 
-Hash hashString(HashType ht, const string & s)
+Hash hashString(HashType ht, std::string_view s)
 {
     Ctx ctx;
     Hash hash(ht);
@@ -264,7 +264,7 @@ Hash hashString(HashType ht, const string & s)
 }
 
 
-Hash hashFile(HashType ht, const Path & path)
+Hash hashFile(HashType ht, PathView path)
 {
     HashSink sink(ht);
     readFile(path, sink);
@@ -310,7 +310,7 @@ HashResult HashSink::currentHash()
 
 
 HashResult hashPath(
-    HashType ht, const Path & path, PathFilter & filter)
+    HashType ht, PathView path, PathFilter & filter)
 {
     HashSink sink(ht);
     dumpPath(path, sink, filter);
@@ -328,7 +328,7 @@ Hash compressHash(const Hash & hash, unsigned int newSize)
 }
 
 
-HashType parseHashType(const string & s)
+HashType parseHashType(std::string_view s)
 {
     if (s == "md5") return htMD5;
     else if (s == "sha1") return htSHA1;

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -101,15 +101,15 @@ Hash newHashAllowEmpty(std::string hashStr, HashType ht);
 string printHash16or32(const Hash & hash);
 
 /* Compute the hash of the given string. */
-Hash hashString(HashType ht, const string & s);
+Hash hashString(HashType ht, std::string_view s);
 
 /* Compute the hash of the given file. */
-Hash hashFile(HashType ht, const Path & path);
+Hash hashFile(HashType ht, PathView path);
 
 /* Compute the hash of the given path.  The hash is defined as
    (essentially) hashString(ht, dumpPath(path)). */
 typedef std::pair<Hash, unsigned long long> HashResult;
-HashResult hashPath(HashType ht, const Path & path,
+HashResult hashPath(HashType ht, PathView path,
     PathFilter & filter = defaultPathFilter);
 
 /* Compress a hash to the specified number of bytes by cyclically
@@ -117,7 +117,7 @@ HashResult hashPath(HashType ht, const Path & path,
 Hash compressHash(const Hash & hash, unsigned int newSize);
 
 /* Parse a string representing a hash type. */
-HashType parseHashType(const string & s);
+HashType parseHashType(std::string_view s);
 
 /* And the reverse. */
 string printHashType(HashType ht);

--- a/src/libutil/istringstream_nocopy.hh
+++ b/src/libutil/istringstream_nocopy.hh
@@ -8,11 +8,11 @@
 #include <string>
 #include <iostream>
 
-template <class CharT, class Traits = std::char_traits<CharT>, class Allocator = std::allocator<CharT>>
+template <class CharT, class Traits = std::char_traits<CharT>>
 class basic_istringbuf_nocopy : public std::basic_streambuf<CharT, Traits>
 {
 public:
-    typedef std::basic_string<CharT, Traits, Allocator> string_type;
+    typedef std::basic_string_view<CharT, Traits> string_type;
 
     typedef typename std::basic_streambuf<CharT, Traits>::off_type off_type;
 
@@ -23,12 +23,12 @@ public:
     typedef typename std::basic_streambuf<CharT, Traits>::traits_type traits_type;
 
 private:
-    const string_type & s;
+    const string_type s;
 
     off_type off;
 
 public:
-    basic_istringbuf_nocopy(const string_type & s) : s{s}, off{0}
+    basic_istringbuf_nocopy(const string_type s) : s { std::move(s) }, off{0}
     {
     }
 
@@ -79,10 +79,10 @@ private:
 
 };
 
-template <class CharT, class Traits = std::char_traits<CharT>, class Allocator = std::allocator<CharT>>
+template <class CharT, class Traits = std::char_traits<CharT>>
 class basic_istringstream_nocopy : public std::basic_iostream<CharT, Traits>
 {
-    typedef basic_istringbuf_nocopy<CharT, Traits, Allocator> buf_type;
+    typedef basic_istringbuf_nocopy<CharT, Traits> buf_type;
     buf_type buf;
 public:
     basic_istringstream_nocopy(const typename buf_type::string_type & s) :

--- a/src/libutil/json.cc
+++ b/src/libutil/json.cc
@@ -24,26 +24,26 @@ void toJSON(std::ostream & str, const char * s)
     if (!s) str << "null"; else toJSON(str, s, s + strlen(s));
 }
 
-template<> void toJSON<int>(std::ostream & str, const int & n) { str << n; }
-template<> void toJSON<unsigned int>(std::ostream & str, const unsigned int & n) { str << n; }
-template<> void toJSON<long>(std::ostream & str, const long & n) { str << n; }
-template<> void toJSON<unsigned long>(std::ostream & str, const unsigned long & n) { str << n; }
-template<> void toJSON<long long>(std::ostream & str, const long long & n) { str << n; }
-template<> void toJSON<unsigned long long>(std::ostream & str, const unsigned long long & n) { str << n; }
-template<> void toJSON<float>(std::ostream & str, const float & n) { str << n; }
-template<> void toJSON<double>(std::ostream & str, const double & n) { str << n; }
+template<> void toJSON<int>(std::ostream & str, int n) { str << n; }
+template<> void toJSON<unsigned int>(std::ostream & str, unsigned int n) { str << n; }
+template<> void toJSON<long>(std::ostream & str, long n) { str << n; }
+template<> void toJSON<unsigned long>(std::ostream & str, unsigned long n) { str << n; }
+template<> void toJSON<long long>(std::ostream & str, long long n) { str << n; }
+template<> void toJSON<unsigned long long>(std::ostream & str, unsigned long long n) { str << n; }
+template<> void toJSON<float>(std::ostream & str, float n) { str << n; }
+template<> void toJSON<double>(std::ostream & str, double n) { str << n; }
 
-template<> void toJSON<std::string>(std::ostream & str, const std::string & s)
+template<> void toJSON<std::string_view>(std::ostream & str, std::string_view s)
 {
-    toJSON(str, s.c_str(), s.c_str() + s.size());
+    toJSON(str, s.data(), s.data() + s.size());
 }
 
-template<> void toJSON<bool>(std::ostream & str, const bool & b)
+template<> void toJSON<bool>(std::ostream & str, bool b)
 {
     str << (b ? "true" : "false");
 }
 
-template<> void toJSON<std::nullptr_t>(std::ostream & str, const std::nullptr_t & b)
+template<> void toJSON<std::nullptr_t>(std::ostream & str, const std::nullptr_t b)
 {
     str << "null";
 }
@@ -131,7 +131,7 @@ JSONObject::~JSONObject()
     }
 }
 
-void JSONObject::attr(const std::string & s)
+void JSONObject::attr(std::string_view s)
 {
     comma();
     toJSON(state->str, s);
@@ -139,19 +139,19 @@ void JSONObject::attr(const std::string & s)
     if (state->indent) state->str << ' ';
 }
 
-JSONList JSONObject::list(const std::string & name)
+JSONList JSONObject::list(std::string_view name)
 {
     attr(name);
     return JSONList(state);
 }
 
-JSONObject JSONObject::object(const std::string & name)
+JSONObject JSONObject::object(std::string_view name)
 {
     attr(name);
     return JSONObject(state);
 }
 
-JSONPlaceholder JSONObject::placeholder(const std::string & name)
+JSONPlaceholder JSONObject::placeholder(std::string_view name)
 {
     attr(name);
     return JSONPlaceholder(state);

--- a/src/libutil/json.hh
+++ b/src/libutil/json.hh
@@ -88,6 +88,8 @@ public:
         return *this;
     }
 
+    JSONList & elem(const std::string v) = delete;
+
     JSONList list();
 
     JSONObject object();
@@ -137,6 +139,12 @@ public:
         toJSON(state->str, v);
         return *this;
     }
+
+    JSONObject & attr(std::string_view name, std::string v) = delete;
+
+    JSONObject & attr(std::string_view name, const std::string & v) {
+        return attr(name, std::string_view { v });
+    };
 
     JSONList list(std::string_view name);
 

--- a/src/libutil/json.hh
+++ b/src/libutil/json.hh
@@ -10,7 +10,10 @@ void toJSON(std::ostream & str, const char * start, const char * end);
 void toJSON(std::ostream & str, const char * s);
 
 template<typename T>
-void toJSON(std::ostream & str, const T & n);
+void toJSON(std::ostream & str, T n);
+
+// Avoid unintentinoal copying
+template<> void toJSON<std::string>(std::ostream & str, std::string s) = delete;
 
 class JSONWriter
 {
@@ -78,7 +81,7 @@ public:
     ~JSONList();
 
     template<typename T>
-    JSONList & elem(const T & v)
+    JSONList & elem(const T v)
     {
         comma();
         toJSON(state->str, v);
@@ -107,7 +110,7 @@ private:
         open();
     }
 
-    void attr(const std::string & s);
+    void attr(std::string_view s);
 
 public:
 
@@ -128,18 +131,18 @@ public:
     ~JSONObject();
 
     template<typename T>
-    JSONObject & attr(const std::string & name, const T & v)
+    JSONObject & attr(std::string_view name, const T v)
     {
         attr(name);
         toJSON(state->str, v);
         return *this;
     }
 
-    JSONList list(const std::string & name);
+    JSONList list(std::string_view name);
 
-    JSONObject object(const std::string & name);
+    JSONObject object(std::string_view name);
 
-    JSONPlaceholder placeholder(const std::string & name);
+    JSONPlaceholder placeholder(std::string_view name);
 };
 
 class JSONPlaceholder : JSONWriter
@@ -171,7 +174,7 @@ public:
     ~JSONPlaceholder();
 
     template<typename T>
-    void write(const T & v)
+    void write(const T v)
     {
         assertValid();
         first = false;

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -46,6 +46,7 @@ public:
         enum { tInt = 0, tString = 1 } type;
         uint64_t i = 0;
         std::string s;
+        Field(std::string_view s) : type(tString), s(s) { }
         Field(const std::string & s) : type(tString), s(s) { }
         Field(const char * s) : type(tString), s(s) { }
         Field(const uint64_t & i) : type(tInt), i(i) { }
@@ -75,10 +76,10 @@ public:
         logEI(ei);
     }
 
-    virtual void warn(const std::string & msg);
+    virtual void warn(std::string_view msg);
 
     virtual void startActivity(ActivityId act, Verbosity lvl, ActivityType type,
-        const std::string & s, const Fields & fields, ActivityId parent) { };
+        std::string_view s, const Fields & fields, ActivityId parent) { };
 
     virtual void stopActivity(ActivityId act) { };
 
@@ -87,7 +88,7 @@ public:
     virtual void writeToStdout(std::string_view s);
 
     template<typename... Args>
-    inline void stdout(const std::string & fs, const Args & ... args)
+    inline void stdout(std::string_view fs, const Args & ... args)
     {
         boost::format f(fs);
         formatHelper(f, args...);
@@ -104,7 +105,7 @@ struct Activity
 
     const ActivityId id;
 
-    Activity(Logger & logger, Verbosity lvl, ActivityType type, const std::string & s = "",
+    Activity(Logger & logger, Verbosity lvl, ActivityType type, std::string_view s = "",
         const Logger::Fields & fields = {}, ActivityId parent = getCurActivity());
 
     Activity(Logger & logger, ActivityType type,
@@ -150,7 +151,7 @@ Logger * makeSimpleLogger(bool printBuildLogs = true);
 
 Logger * makeJSONLogger(Logger & prevLogger);
 
-bool handleJSONLogMessage(const std::string & msg,
+bool handleJSONLogMessage(std::string_view msg,
     const Activity & act, std::map<ActivityId, Activity> & activities,
     bool trusted);
 
@@ -188,15 +189,16 @@ extern Verbosity verbosity; /* suppress msgs > this */
 
 /* if verbosity >= lvlWarn, print a message with a yellow 'warning:' prefix. */
 template<typename... Args>
-inline void warn(const std::string & fs, const Args & ... args)
+inline void warn(std::string_view fs, const Args & ... args)
 {
-    boost::format f(fs);
+	// TODO Boost should work with string_view
+    boost::format f(std::string { fs });
     formatHelper(f, args...);
     logger->warn(f.str());
 }
 
 void warnOnce(bool & haveWarned, const FormatOrString & fs);
 
-void writeToStderr(const string & s);
+void writeToStderr(std::string_view s);
 
 }

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -191,7 +191,7 @@ extern Verbosity verbosity; /* suppress msgs > this */
 template<typename... Args>
 inline void warn(std::string_view fs, const Args & ... args)
 {
-	// TODO Boost should work with string_view
+    // TODO Boost should work with string_view
     boost::format f(std::string { fs });
     formatHelper(f, args...);
     logger->warn(f.str());

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -90,7 +90,7 @@ public:
     template<typename... Args>
     inline void stdout(std::string_view fs, const Args & ... args)
     {
-        boost::format f(fs);
+        boost::format f(std::string { fs }); // c'mon, Boost
         formatHelper(f, args...);
         writeToStdout(f.str());
     }

--- a/src/libutil/rust-ffi.hh
+++ b/src/libutil/rust-ffi.hh
@@ -93,8 +93,7 @@ struct Slice
 
 struct StringSlice : Slice<char>
 {
-    StringSlice(const std::string & s): Slice(s.data(), s.size()) {}
-    explicit StringSlice(std::string_view s): Slice(s.data(), s.size()) {}
+    StringSlice(std::string_view s): Slice(s.data(), s.size()) {}
     StringSlice(const char * s): Slice(s, strlen(s)) {}
 
     operator std::string_view() const

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -233,7 +233,7 @@ void writeString(const unsigned char * buf, size_t len, Sink & sink)
 }
 
 
-Sink & operator << (Sink & sink, const string & s)
+Sink & operator << (Sink & sink, std::string_view s)
 {
     writeString((const unsigned char *) s.data(), s.size(), sink);
     return sink;

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -16,7 +16,7 @@ struct Sink
     virtual void operator () (const unsigned char * data, size_t len) = 0;
     virtual bool good() { return true; }
 
-    void operator () (const std::string & s)
+    void operator () (std::string_view s)
     {
         (*this)((const unsigned char *) s.data(), s.size());
     }
@@ -34,7 +34,7 @@ struct BufferedSink : virtual Sink
 
     void operator () (const unsigned char * data, size_t len) override;
 
-    void operator () (const std::string & s)
+    void operator () (std::string_view s)
     {
         Sink::operator()(s);
     }
@@ -159,9 +159,9 @@ struct StringSink : Sink
 /* A source that reads data from a string. */
 struct StringSource : Source
 {
-    const string & s;
+    std::string_view s;
     size_t pos;
-    StringSource(const string & _s) : s(_s), pos(0) { }
+    StringSource(std::string_view _s) : s(_s), pos(0) { }
     size_t read(unsigned char * data, size_t len) override;
 };
 
@@ -271,7 +271,7 @@ inline Sink & operator << (Sink & sink, uint64_t n)
     return sink;
 }
 
-Sink & operator << (Sink & sink, const string & s);
+Sink & operator << (Sink & sink, std::string_view s);
 Sink & operator << (Sink & sink, const Strings & s);
 Sink & operator << (Sink & sink, const StringSet & s);
 

--- a/src/libutil/tarfile.hh
+++ b/src/libutil/tarfile.hh
@@ -2,8 +2,8 @@
 
 namespace nix {
 
-void unpackTarfile(Source & source, const Path & destDir);
+void unpackTarfile(Source & source, PathView destDir);
 
-void unpackTarfile(const Path & tarFile, const Path & destDir);
+void unpackTarfile(PathView tarFile, PathView destDir);
 
 }

--- a/src/libutil/tests/config.cc
+++ b/src/libutil/tests/config.cc
@@ -80,7 +80,7 @@ namespace nix {
         class TestSetting : public AbstractSetting {
             public:
             TestSetting() : AbstractSetting("test", "test", {}) {}
-            void set(const std::string & value) {}
+            void set(std::string_view value) {}
             std::string to_string() const { return {}; }
         };
 

--- a/src/libutil/tests/json.cc
+++ b/src/libutil/tests/json.cc
@@ -19,7 +19,7 @@ namespace nix {
     TEST(toJSON, quotesStdString) {
         std::string input = "test";
         std::stringstream out;
-        toJSON(out, input);
+        toJSON(out, std::string_view { input });
 
         ASSERT_EQ(out.str(), "\"test\"");
     }

--- a/src/libutil/tests/tests.cc
+++ b/src/libutil/tests/tests.cc
@@ -12,7 +12,7 @@ namespace nix {
      * --------------------------------------------------------------------------*/
 
     TEST(absPath, doesntChangeRoot) {
-        auto p = absPath("/");
+        auto p = absPath(Path { "/" });
 
         ASSERT_EQ(p, "/");
     }
@@ -22,7 +22,7 @@ namespace nix {
 
     TEST(absPath, turnsEmptyPathIntoCWD) {
         char cwd[PATH_MAX+1];
-        auto p = absPath("");
+        auto p = absPath(Path { "" });
 
         ASSERT_EQ(p, getcwd((char*)&cwd, PATH_MAX));
     }
@@ -31,7 +31,7 @@ namespace nix {
         char _cwd[PATH_MAX+1];
         char* cwd = getcwd((char*)&_cwd, PATH_MAX);
 
-        auto p = absPath("", cwd);
+        auto p = absPath(Path { "" }, cwd);
 
         ASSERT_EQ(p, cwd);
     }
@@ -39,7 +39,7 @@ namespace nix {
     TEST(absPath, isIdempotent) {
         char _cwd[PATH_MAX+1];
         char* cwd = getcwd((char*)&_cwd, PATH_MAX);
-        auto p1 = absPath(cwd);
+        auto p1 = absPath(Path { cwd });
         auto p2 = absPath(p1);
 
         ASSERT_EQ(p1, p2);
@@ -48,7 +48,7 @@ namespace nix {
 
     TEST(absPath, pathIsCanonicalised) {
         auto path = "/some/path/with/trailing/dot/.";
-        auto p1 = absPath(path);
+        auto p1 = absPath(Path { path });
         auto p2 = absPath(p1);
 
         ASSERT_EQ(p1, "/some/path/with/trailing/dot");

--- a/src/libutil/tests/url.cc
+++ b/src/libutil/tests/url.cc
@@ -5,7 +5,7 @@ namespace nix {
 
 /* ----------- tests for url.hh --------------------------------------------------*/
 
-    string print_map(std::map<string, string> m) {
+    string print_map(std::map<string, string, std::less<>> m) {
         std::map<string, string>::iterator it;
         string s = "{ ";
         for (it = m.begin(); it != m.end(); ++it) {

--- a/src/libutil/thread-pool.hh
+++ b/src/libutil/thread-pool.hh
@@ -68,13 +68,13 @@ private:
 template<typename T>
 void processGraph(
     ThreadPool & pool,
-    const std::set<T> & nodes,
-    std::function<std::set<T>(const T &)> getEdges,
+    const std::set<T, std::less<>> & nodes,
+    std::function<std::set<T, std::less<>>(const T &)> getEdges,
     std::function<void(const T &)> processNode)
 {
     struct Graph {
-        std::set<T> left;
-        std::map<T, std::set<T>> refs, rrefs;
+        std::set<T, std::less<>> left;
+        std::map<T, std::set<T, std::less<>>> refs, rrefs;
     };
 
     Sync<Graph> graph_(Graph{nodes, {}, {}});

--- a/src/libutil/types.hh
+++ b/src/libutil/types.hh
@@ -15,15 +15,15 @@ using std::vector;
 using std::string;
 
 typedef list<string> Strings;
-typedef set<string> StringSet;
-typedef std::map<string, string> StringMap;
+typedef set<string, std::less<>> StringSet;
+typedef std::map<string, string, std::less<>> StringMap;
 
 /* Paths are just strings. */
 
 typedef string Path;
 typedef std::string_view PathView;
 typedef list<Path> Paths;
-typedef set<Path> PathSet;
+typedef set<Path, std::less<>> PathSet;
 
 /* Helper class to run code at startup. */
 template<typename T>

--- a/src/libutil/types.hh
+++ b/src/libutil/types.hh
@@ -21,6 +21,7 @@ typedef std::map<string, string> StringMap;
 /* Paths are just strings. */
 
 typedef string Path;
+typedef std::string_view PathView;
 typedef list<Path> Paths;
 typedef set<Path> PathSet;
 

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -19,9 +19,9 @@ ParsedURL parseURL(std::string_view url)
 
     std::smatch match;
 
-	// Inferior until
-	// https://lists.isocpp.org/std-proposals/att-0008/Dxxxx_string_view_support_for_regex.pdf
-	std::string freshUrl { url };
+    // Inferior until
+    // https://lists.isocpp.org/std-proposals/att-0008/Dxxxx_string_view_support_for_regex.pdf
+    std::string freshUrl { url };
 
     if (std::regex_match(freshUrl, match, uriRegex)) {
         auto & base = match[1];

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -75,9 +75,9 @@ std::string percentDecode(std::string_view in)
     return decoded;
 }
 
-std::map<std::string, std::string> decodeQuery(std::string_view query)
+UrlQuery decodeQuery(std::string_view query)
 {
-    std::map<std::string, std::string> result;
+    UrlQuery result;
 
     for (auto s : tokenizeString<Strings>(query, "&")) {
         auto e = s.find('=');
@@ -104,7 +104,7 @@ std::string percentEncode(std::string_view s)
     return res;
 }
 
-std::string encodeQuery(const std::map<std::string, std::string> & ss)
+std::string encodeQuery(const UrlQuery & ss)
 {
     std::string res;
     bool first = true;

--- a/src/libutil/url.hh
+++ b/src/libutil/url.hh
@@ -25,9 +25,9 @@ MakeError(BadURL, Error);
 
 std::string percentDecode(std::string_view in);
 
-std::map<std::string, std::string> decodeQuery(const std::string & query);
+std::map<std::string, std::string> decodeQuery(std::string_view query);
 
-ParsedURL parseURL(const std::string & url);
+ParsedURL parseURL(std::string_view url);
 
 // URI stuff.
 const static std::string pctEncoded = "(?:%[0-9a-fA-F][0-9a-fA-F])";

--- a/src/libutil/url.hh
+++ b/src/libutil/url.hh
@@ -6,6 +6,8 @@
 
 namespace nix {
 
+typedef std::map<std::string, std::string, std::less<>> UrlQuery;
+
 struct ParsedURL
 {
     std::string url;
@@ -13,7 +15,7 @@ struct ParsedURL
     std::string scheme;
     std::optional<std::string> authority;
     std::string path;
-    std::map<std::string, std::string> query;
+    UrlQuery query;
     std::string fragment;
 
     std::string to_string() const;
@@ -25,7 +27,7 @@ MakeError(BadURL, Error);
 
 std::string percentDecode(std::string_view in);
 
-std::map<std::string, std::string> decodeQuery(std::string_view query);
+UrlQuery decodeQuery(std::string_view query);
 
 ParsedURL parseURL(std::string_view url);
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -79,7 +79,7 @@ void replaceEnv(std::map<std::string, std::string> newEnv)
 }
 
 
-Path absPath(Path path, std::optional<Path> dir)
+Path absPath(Path && path, std::optional<Path> dir)
 {
     if (path[0] != '/') {
         if (!dir) {
@@ -108,7 +108,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
 {
     assert(path != "");
 
-    string s;
+    Path s;
 
     if (path[0] != '/')
         throw Error("not an absolute path: '%1%'", path);

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -104,7 +104,7 @@ Path absPath(Path && path, std::optional<Path> dir)
 }
 
 Path absCWD() {
-	return absPath(Path { "." });
+    return absPath(Path { "." });
 }
 
 
@@ -117,7 +117,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
     if (path[0] != '/')
         throw Error("not an absolute path: '%1%'", path);
 
-	std::string_view::const_iterator i = path.begin(), end = path.end();
+    std::string_view::const_iterator i = path.begin(), end = path.end();
     string temp;
 
     /* Count the number of times we follow a symlink and stop at some
@@ -1265,7 +1265,7 @@ string replaceStrings(std::string_view s,
 
 std::string rewriteStrings(std::string_view _s, const StringMap & rewrites)
 {
-	std::string s{ _s };
+    std::string s{ _s };
     for (auto & i : rewrites) {
         if (i.first == i.second) continue;
         size_t j = 0;

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -103,6 +103,10 @@ Path absPath(Path && path, std::optional<Path> dir)
     return canonPath(path);
 }
 
+Path absCWD() {
+	return absPath(Path { "." });
+}
+
 
 Path canonPath(PathView path, bool resolveSymlinks)
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -50,7 +50,7 @@ void clearEnv();
 /* Return an absolutized path, resolving paths relative to the
    specified directory, or the current directory otherwise.  The path
    is also canonicalised. */
-Path absPath(Path path, std::optional<Path> dir = {});
+Path absPath(Path && path, std::optional<Path> dir = {});
 
 /* Canonicalise a path by removing all `.' or `..' components and
    double or trailing slashes.  Optionally resolves all symlink

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -51,6 +51,10 @@ void clearEnv();
    specified directory, or the current directory otherwise.  The path
    is also canonicalised. */
 Path absPath(Path && path, std::optional<Path> dir = {});
+static inline Path absPath(PathView path, std::optional<Path> dir = {}) {
+    return absPath(Path { path }, dir);
+}
+Path absCWD();
 
 /* Canonicalise a path by removing all `.' or `..' components and
    double or trailing slashes.  Optionally resolves all symlink
@@ -184,6 +188,7 @@ public:
     void cancel();
     void reset(PathView p, bool recursive = true);
     operator Path() const { return path; }
+    operator PathView() const { return path; }
 };
 
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -405,8 +405,8 @@ bool statusOk(int status);
 /* Parse a string into an integer. */
 template<class N> bool string2Int(std::string_view s, N & n)
 {
-	// TODO find a way to not allocate, problem is atoi/strtol relies on null
-	// termination, maybe non-standard srtntol or Boost.
+    // TODO find a way to not allocate, problem is atoi/strtol relies on null
+    // termination, maybe non-standard srtntol or Boost.
     if (s.substr(0, 1) == "-" && !std::numeric_limits<N>::is_signed)
         return false;
     istringstream_nocopy str(s);
@@ -444,12 +444,12 @@ std::string shellEscape(std::string_view s);
 // might be fixed in future C++ standard.
 inline std::string& operator<<(std::string& a, std::string_view b)
 {
-	return a += b;
+    return a += b;
 }
 inline std::string && operator<<(std::string && a, std::string_view b)
 {
-	a += b;
-	return std::move(a);
+    a += b;
+    return std::move(a);
 }
 
 /* Exception handling in destructors: print an error message, then

--- a/src/libutil/xml-writer.cc
+++ b/src/libutil/xml-writer.cc
@@ -35,7 +35,7 @@ void XMLWriter::indent_(size_t depth)
 }
 
 
-void XMLWriter::openElement(const string & name,
+void XMLWriter::openElement(std::string_view name,
     const XMLAttrs & attrs)
 {
     assert(!closed);
@@ -44,7 +44,7 @@ void XMLWriter::openElement(const string & name,
     writeAttrs(attrs);
     output << ">";
     if (indent) output << std::endl;
-    pendingElems.push_back(name);
+    pendingElems.push_back(std::string { name });
 }
 
 
@@ -59,7 +59,7 @@ void XMLWriter::closeElement()
 }
 
 
-void XMLWriter::writeEmptyElement(const string & name,
+void XMLWriter::writeEmptyElement(std::string_view name,
     const XMLAttrs & attrs)
 {
     assert(!closed);

--- a/src/libutil/xml-writer.hh
+++ b/src/libutil/xml-writer.hh
@@ -34,11 +34,11 @@ public:
 
     void close();
 
-    void openElement(const string & name,
+    void openElement(std::string_view name,
         const XMLAttrs & attrs = XMLAttrs());
     void closeElement();
 
-    void writeEmptyElement(const string & name,
+    void writeEmptyElement(std::string_view name,
         const XMLAttrs & attrs = XMLAttrs());
 
 private:
@@ -53,7 +53,7 @@ class XMLOpenElement
 private:
     XMLWriter & writer;
 public:
-    XMLOpenElement(XMLWriter & writer, const string & name,
+    XMLOpenElement(XMLWriter & writer, std::string_view name,
         const XMLAttrs & attrs = XMLAttrs())
         : writer(writer)
     {

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -290,7 +290,7 @@ static void _main(int argc, char * * argv)
     else
         for (auto i : left) {
             if (fromArgs)
-                exprs.push_back(state->parseExprFromString(i, absPath(".")));
+                exprs.push_back(state->parseExprFromString(i, absCWD()));
             else {
                 auto absolute = i;
                 try {
@@ -355,7 +355,7 @@ static void _main(int argc, char * * argv)
         if (!shell) {
 
             try {
-                auto expr = state->parseExprFromString("(import <nixpkgs> {}).bashInteractive", absPath("."));
+                auto expr = state->parseExprFromString("(import <nixpkgs> {}).bashInteractive", absCWD());
 
                 Value v;
                 state->eval(expr, v);
@@ -381,7 +381,9 @@ static void _main(int argc, char * * argv)
         // Build or fetch all dependencies of the derivation.
         for (const auto & input : drv.inputDrvs)
             if (std::all_of(envExclude.cbegin(), envExclude.cend(),
-                    [&](std::string_view exclude) { return !std::regex_search(store->printStorePath(input.first), std::regex(exclude)); }))
+                    [&](std::string_view exclude) {
+                        return !std::regex_search(store->printStorePath(input.first), std::regex(std::string { exclude }));
+                    }))
                 pathsToBuild.emplace_back(input.first, input.second);
         for (const auto & src : drv.inputSrcs)
             pathsToBuild.emplace_back(src);

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -26,9 +26,10 @@ extern char * * environ;
 /* Recreate the effect of the perl shellwords function, breaking up a
  * string into arguments like a shell word, including escapes
  */
-std::vector<string> shellwords(std::string_view s)
+std::vector<string> shellwords(std::string_view _s)
 {
     std::regex whitespace("^(\\s+).*");
+	std::string s { _s }; // until std::regex understand string_view
     auto begin = s.cbegin();
     std::vector<string> res;
     std::string cur;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -29,7 +29,7 @@ extern char * * environ;
 std::vector<string> shellwords(std::string_view _s)
 {
     std::regex whitespace("^(\\s+).*");
-	std::string s { _s }; // until std::regex understand string_view
+    std::string s { _s }; // until std::regex understand string_view
     auto begin = s.cbegin();
     std::vector<string> res;
     std::string cur;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -26,7 +26,7 @@ extern char * * environ;
 /* Recreate the effect of the perl shellwords function, breaking up a
  * string into arguments like a shell word, including escapes
  */
-std::vector<string> shellwords(const string & s)
+std::vector<string> shellwords(std::string_view s)
 {
     std::regex whitespace("^(\\s+).*");
     auto begin = s.cbegin();
@@ -380,7 +380,7 @@ static void _main(int argc, char * * argv)
         // Build or fetch all dependencies of the derivation.
         for (const auto & input : drv.inputDrvs)
             if (std::all_of(envExclude.cbegin(), envExclude.cend(),
-                    [&](const string & exclude) { return !std::regex_search(store->printStorePath(input.first), std::regex(exclude)); }))
+                    [&](std::string_view exclude) { return !std::regex_search(store->printStorePath(input.first), std::regex(exclude)); }))
                 pathsToBuild.emplace_back(input.first, input.second);
         for (const auto & src : drv.inputSrcs)
             pathsToBuild.emplace_back(src);

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -11,7 +11,7 @@
 
 using namespace nix;
 
-typedef std::map<string,string> Channels;
+typedef std::map<string, string, std::less<>> Channels;
 
 static Channels channels;
 static Path channelsList;

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -46,12 +46,12 @@ static void writeChannels()
 // Adds a channel.
 static void addChannel(std::string_view url, std::string_view name)
 {
-    if (!regex_search(url, std::regex("^(file|http|https)://")))
+    if (!regex_search(std::string { url }, std::regex("^(file|http|https)://")))
         throw Error("invalid channel URL '%1%'", url);
-    if (!regex_search(name, std::regex("^[a-zA-Z0-9_][a-zA-Z0-9_\\.-]*$")))
+    if (!regex_search(std::string { name }, std::regex("^[a-zA-Z0-9_][a-zA-Z0-9_\\.-]*$")))
         throw Error("invalid channel identifier '%1%'", name);
     readChannels();
-    channels[name] = url;
+    channels[std::string { name }] = url;
     writeChannels();
 }
 
@@ -61,10 +61,11 @@ static Path profile;
 static void removeChannel(std::string_view name)
 {
     readChannels();
-    channels.erase(name);
+    // Erase unfortunately needs original key type.
+    channels.erase(std::string { name });
     writeChannels();
 
-    runProgram(settings.nixBinDir + "/nix-env", true, { "--profile", profile, "--uninstall", name });
+    runProgram(settings.nixBinDir + "/nix-env", true, { "--profile", profile, "--uninstall", std::string { name } });
 }
 
 static Path nixDefExpr;

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -44,7 +44,7 @@ static void writeChannels()
 }
 
 // Adds a channel.
-static void addChannel(const string & url, const string & name)
+static void addChannel(std::string_view url, std::string_view name)
 {
     if (!regex_search(url, std::regex("^(file|http|https)://")))
         throw Error("invalid channel URL '%1%'", url);
@@ -58,7 +58,7 @@ static void addChannel(const string & url, const string & name)
 static Path profile;
 
 // Remove a channel.
-static void removeChannel(const string & name)
+static void removeChannel(std::string_view name)
 {
     readChannels();
     channels.erase(name);

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -74,7 +74,7 @@ static void setSigChldAction(bool autoReap)
 }
 
 
-bool matchUser(const string & user, const string & group, const Strings & users)
+bool matchUser(std::string_view user, std::string_view group, const Strings & users)
 {
     if (find(users.begin(), users.end(), "*") != users.end())
         return true;

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -67,7 +67,7 @@ typedef void (* Operation) (Globals & globals,
 
 
 static string needArg(Strings::iterator & i,
-    Strings & args, const string & arg)
+    Strings & args, std::string_view arg)
 {
     if (i == args.end()) throw UsageError("'%1%' requires an argument", arg);
     return *i++;
@@ -75,7 +75,7 @@ static string needArg(Strings::iterator & i,
 
 
 static bool parseInstallSourceOptions(Globals & globals,
-    Strings::iterator & i, Strings & args, const string & arg)
+    Strings::iterator & i, Strings & args, std::string_view arg)
 {
     if (arg == "--from-expression" || arg == "-E")
         globals.instSource.type = srcNixExprs;
@@ -90,14 +90,14 @@ static bool parseInstallSourceOptions(Globals & globals,
 }
 
 
-static bool isNixExpr(const Path & path, struct stat & st)
+static bool isNixExpr(PathView path, struct stat & st)
 {
     return S_ISREG(st.st_mode) || (S_ISDIR(st.st_mode) && pathExists(path + "/default.nix"));
 }
 
 
 static void getAllExprs(EvalState & state,
-    const Path & path, StringSet & attrs, Value & v)
+    PathView path, StringSet & attrs, Value & v)
 {
     StringSet namesSorted;
     for (auto & i : readDirectory(path)) namesSorted.insert(i.name);
@@ -146,7 +146,7 @@ static void getAllExprs(EvalState & state,
 
 
 
-static void loadSourceExpr(EvalState & state, const Path & path, Value & v)
+static void loadSourceExpr(EvalState & state, PathView path, Value & v)
 {
     struct stat st;
     if (stat(path.c_str(), &st) == -1)
@@ -175,7 +175,7 @@ static void loadSourceExpr(EvalState & state, const Path & path, Value & v)
 
 static void loadDerivations(EvalState & state, Path nixExprPath,
     string systemFilter, Bindings & autoArgs,
-    const string & pathPrefix, DrvInfos & elems)
+    std::string_view pathPrefix, DrvInfos & elems)
 {
     Value vRoot;
     loadSourceExpr(state, nixExprPath, vRoot);
@@ -313,7 +313,7 @@ static DrvInfos filterBySelector(EvalState & state, const DrvInfos & allElems,
 }
 
 
-static bool isPath(const string & s)
+static bool isPath(std::string_view s)
 {
     return s.find('/') != string::npos;
 }
@@ -441,7 +441,7 @@ static bool keep(DrvInfo & drv)
 
 
 static void installDerivations(Globals & globals,
-    const Strings & args, const Path & profile)
+    const Strings & args, PathView profile)
 {
     debug(format("installing derivations"));
 
@@ -628,7 +628,7 @@ static void opUpgrade(Globals & globals, Strings opFlags, Strings opArgs)
 
 
 static void setMetaFlag(EvalState & state, DrvInfo & drv,
-    const string & name, const string & value)
+    std::string_view name, std::string_view value)
 {
     Value * v = state.allocValue();
     mkString(*v, value.c_str());

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -12,7 +12,7 @@
 namespace nix {
 
 
-DrvInfos queryInstalled(EvalState & state, const Path & userEnv)
+DrvInfos queryInstalled(EvalState & state, PathView userEnv)
 {
     DrvInfos elems;
     if (pathExists(userEnv + "/manifest.json"))
@@ -29,8 +29,8 @@ DrvInfos queryInstalled(EvalState & state, const Path & userEnv)
 
 
 bool createUserEnv(EvalState & state, DrvInfos & elems,
-    const Path & profile, bool keepDerivations,
-    const string & lockToken)
+    PathView profile, bool keepDerivations,
+    std::string_view lockToken)
 {
     /* Build the components in the user environment, if they don't
        exist already. */

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -15,9 +15,9 @@ namespace nix {
 DrvInfos queryInstalled(EvalState & state, PathView userEnv)
 {
     DrvInfos elems;
-    if (pathExists(userEnv + "/manifest.json"))
+    if (pathExists(Path { userEnv } << "/manifest.json"))
         throw Error("profile '%s' is incompatible with 'nix-env'; please use 'nix profile' instead", userEnv);
-    Path manifestFile = userEnv + "/manifest.nix";
+    Path manifestFile = Path { userEnv } << "/manifest.nix";
     if (pathExists(manifestFile)) {
         Value v;
         state.evalFile(manifestFile, v);

--- a/src/nix-env/user-env.hh
+++ b/src/nix-env/user-env.hh
@@ -4,10 +4,10 @@
 
 namespace nix {
 
-DrvInfos queryInstalled(EvalState & state, const Path & userEnv);
+DrvInfos queryInstalled(EvalState & state, PathView userEnv);
 
 bool createUserEnv(EvalState & state, DrvInfos & elems,
-    const Path & profile, bool keepDerivations,
-    const string & lockToken);
+    PathView profile, bool keepDerivations,
+    std::string_view lockToken);
 
 }

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -181,7 +181,7 @@ static int _main(int argc, char * * argv)
 
         for (auto & i : files) {
             Expr * e = fromArgs
-                ? state->parseExprFromString(i, absPath("."))
+                ? state->parseExprFromString(i, absCWD())
                 : state->parseExprFromFile(resolveExprPath(state->checkSourcePath(lookupFileArg(*state, i))));
             processExpr(*state, attrPaths, parseOnly, strict, autoArgs,
                 evalOnly, outputKind, xmlOutputSourceLocation, e);

--- a/src/nix-store/dotgraph.cc
+++ b/src/nix-store/dotgraph.cc
@@ -26,7 +26,7 @@ static string nextColour()
 }
 
 
-static string makeEdge(const string & src, const string & dst)
+static string makeEdge(std::string_view src, std::string_view dst)
 {
     format f = format("%1% -> %2% [color = %3%];\n")
         % dotQuote(src) % dotQuote(dst) % dotQuote(nextColour());
@@ -34,8 +34,8 @@ static string makeEdge(const string & src, const string & dst)
 }
 
 
-static string makeNode(const string & id, std::string_view label,
-    const string & colour)
+static string makeNode(std::string_view id, std::string_view label,
+    std::string_view colour)
 {
     format f = format("%1% [label = %2%, shape = box, "
         "style = filled, fillcolor = %3%];\n")

--- a/src/nix-store/graphml.cc
+++ b/src/nix-store/graphml.cc
@@ -19,7 +19,7 @@ static inline std::string_view xmlQuote(std::string_view s)
 }
 
 
-static string symbolicName(const std::string & p)
+static string symbolicName(std::string_view p)
 {
     return string(p, p.find('-') + 1);
 }

--- a/src/nix-store/graphml.cc
+++ b/src/nix-store/graphml.cc
@@ -19,9 +19,9 @@ static inline std::string_view xmlQuote(std::string_view s)
 }
 
 
-static string symbolicName(std::string_view p)
+static std::string_view symbolicName(std::string_view p)
 {
-    return string(p, p.find('-') + 1);
+    return p.substr(p.find('-') + 1);
 }
 
 

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -230,7 +230,7 @@ static StorePathSet maybeUseOutputs(const StorePath & storePath, bool useOutput,
    graph.  Topological sorting is used to keep the tree relatively
    flat. */
 static void printTree(const StorePath & path,
-    const string & firstPad, const string & tailPad, StorePathSet & done)
+    std::string_view firstPad, std::string_view tailPad, StorePathSet & done)
 {
     if (!done.insert(path.clone()).second) {
         cout << fmt("%s%s [...]\n", firstPad, store->printStorePath(path));

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -251,8 +251,8 @@ static void printTree(const StorePath & path,
     for (const auto &[n, i] : enumerate(sorted)) {
         bool last = n + 1 == sorted.size();
         printTree(i,
-            tailPad + (last ? treeLast : treeConn),
-            tailPad + (last ? treeNull : treeLine),
+            std::string { tailPad } + (last ? treeLast : treeConn),
+            std::string { tailPad } + (last ? treeNull : treeLine),
             done);
     }
 }

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -127,7 +127,7 @@ struct RegisterCommand
 {
     static Commands * commands;
 
-    RegisterCommand(const std::string & name,
+    RegisterCommand(std::string_view name,
         std::function<ref<Command>()> command)
     {
         if (!commands) commands = new Commands;
@@ -136,13 +136,13 @@ struct RegisterCommand
 };
 
 template<class T>
-static RegisterCommand registerCommand(const std::string & name)
+static RegisterCommand registerCommand(std::string_view name)
 {
     return RegisterCommand(name, [](){ return make_ref<T>(); });
 }
 
 std::shared_ptr<Installable> parseInstallable(
-    SourceExprCommand & cmd, ref<Store> store, const std::string & installable,
+    SourceExprCommand & cmd, ref<Store> store, std::string_view installable,
     bool useDefaultInstallables);
 
 Buildables build(ref<Store> store, RealiseMode mode,

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -148,13 +148,13 @@ std::shared_ptr<Installable> parseInstallable(
 Buildables build(ref<Store> store, RealiseMode mode,
     std::vector<std::shared_ptr<Installable>> installables);
 
-std::set<StorePath> toStorePaths(ref<Store> store, RealiseMode mode,
+std::set<StorePath, std::less<>> toStorePaths(ref<Store> store, RealiseMode mode,
     std::vector<std::shared_ptr<Installable>> installables);
 
 StorePath toStorePath(ref<Store> store, RealiseMode mode,
     std::shared_ptr<Installable> installable);
 
-std::set<StorePath> toDerivations(ref<Store> store,
+std::set<StorePath, std::less<>> toDerivations(ref<Store> store,
     std::vector<std::shared_ptr<Installable>> installables,
     bool useDeriver = false);
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -24,7 +24,7 @@ struct BuildEnvironment
     std::string bashFunctions;
 };
 
-BuildEnvironment readEnvironment(const Path & path)
+BuildEnvironment readEnvironment(PathView path)
 {
     BuildEnvironment res;
 

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -22,12 +22,12 @@ std::string formatProtocol(unsigned int proto)
     return "unknown";
 }
 
-bool checkPass(const std::string & msg) {
+bool checkPass(std::string_view msg) {
     logger->log(ANSI_GREEN "[PASS] " ANSI_NORMAL + msg);
     return true;
 }
 
-bool checkFail(const std::string & msg) {
+bool checkFail(std::string_view msg) {
     logger->log(ANSI_RED "[FAIL] " ANSI_NORMAL + msg);
     return false;
 }

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -23,12 +23,12 @@ std::string formatProtocol(unsigned int proto)
 }
 
 bool checkPass(std::string_view msg) {
-    logger->log(ANSI_GREEN "[PASS] " ANSI_NORMAL + msg);
+    logger->log(Path { ANSI_GREEN } << "[PASS] " << ANSI_NORMAL << msg);
     return true;
 }
 
 bool checkFail(std::string_view msg) {
-    logger->log(ANSI_RED "[FAIL] " ANSI_NORMAL + msg);
+    logger->log(Path { ANSI_RED } << "[FAIL] " << ANSI_NORMAL << msg);
     return false;
 }
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -47,7 +47,7 @@ Value * SourceExprCommand::getSourceExpr(EvalState & state)
 
         std::unordered_set<std::string> seen;
 
-        auto addEntry = [&](const std::string & name) {
+        auto addEntry = [&](std::string_view name) {
             if (name == "") return;
             if (!seen.insert(name).second) return;
             Value * v1 = state.allocValue();
@@ -94,7 +94,7 @@ struct InstallableStorePath : Installable
     ref<Store> store;
     StorePath storePath;
 
-    InstallableStorePath(ref<Store> store, const Path & storePath)
+    InstallableStorePath(ref<Store> store, PathView storePath)
         : store(store), storePath(store->parseStorePath(storePath)) { }
 
     std::string what() override { return store->printStorePath(storePath); }
@@ -171,7 +171,7 @@ struct InstallableExpr : InstallableValue
 {
     std::string text;
 
-    InstallableExpr(SourceExprCommand & cmd, const std::string & text)
+    InstallableExpr(SourceExprCommand & cmd, std::string_view text)
          : InstallableValue(cmd), text(text) { }
 
     std::string what() override { return text; }
@@ -188,7 +188,7 @@ struct InstallableAttrPath : InstallableValue
 {
     std::string attrPath;
 
-    InstallableAttrPath(SourceExprCommand & cmd, const std::string & attrPath)
+    InstallableAttrPath(SourceExprCommand & cmd, std::string_view attrPath)
         : InstallableValue(cmd), attrPath(attrPath)
     { }
 
@@ -246,7 +246,7 @@ static std::vector<std::shared_ptr<Installable>> parseInstallables(
 }
 
 std::shared_ptr<Installable> parseInstallable(
-    SourceExprCommand & cmd, ref<Store> store, const std::string & installable,
+    SourceExprCommand & cmd, ref<Store> store, std::string_view installable,
     bool useDefaultInstallables)
 {
     auto installables = parseInstallables(cmd, store, {installable}, false);

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -49,7 +49,7 @@ Value * SourceExprCommand::getSourceExpr(EvalState & state)
 
         auto addEntry = [&](std::string_view name) {
             if (name == "") return;
-            if (!seen.insert(name).second) return;
+            if (!seen.insert(std::string { name }).second) return;
             Value * v1 = state.allocValue();
             mkPrimOpApp(*v1, state.getBuiltin("findFile"), state.getBuiltin("nixPath"));
             Value * v2 = state.allocValue();
@@ -179,7 +179,7 @@ struct InstallableExpr : InstallableValue
     std::pair<Value *, Pos> toValue(EvalState & state) override
     {
         auto v = state.allocValue();
-        state.eval(state.parseExprFromString(text, absPath(".")), *v);
+        state.eval(state.parseExprFromString(text, absCWD()), *v);
         return {v, noPos};
     }
 };
@@ -249,7 +249,7 @@ std::shared_ptr<Installable> parseInstallable(
     SourceExprCommand & cmd, ref<Store> store, std::string_view installable,
     bool useDefaultInstallables)
 {
-    auto installables = parseInstallables(cmd, store, {installable}, false);
+    auto installables = parseInstallables(cmd, store, { std::string { installable } }, false);
     assert(installables.size() == 1);
     return installables.front();
 }

--- a/src/nix/legacy.hh
+++ b/src/nix/legacy.hh
@@ -10,7 +10,7 @@ typedef std::function<void(int, char * *)> MainFunction;
 
 struct RegisterLegacyCommand
 {
-    typedef std::map<std::string, MainFunction> Commands;
+    typedef std::map<std::string, MainFunction, std::less<>> Commands;
     static Commands * commands;
 
     RegisterLegacyCommand(std::string_view name, MainFunction fun)

--- a/src/nix/legacy.hh
+++ b/src/nix/legacy.hh
@@ -16,7 +16,7 @@ struct RegisterLegacyCommand
     RegisterLegacyCommand(std::string_view name, MainFunction fun)
     {
         if (!commands) commands = new Commands;
-        (*commands)[name] = fun;
+        (*commands)[std::string { name }] = fun;
     }
 };
 

--- a/src/nix/legacy.hh
+++ b/src/nix/legacy.hh
@@ -13,7 +13,7 @@ struct RegisterLegacyCommand
     typedef std::map<std::string, MainFunction> Commands;
     static Commands * commands;
 
-    RegisterLegacyCommand(const std::string & name, MainFunction fun)
+    RegisterLegacyCommand(std::string_view name, MainFunction fun)
     {
         if (!commands) commands = new Commands;
         (*commands)[name] = fun;

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -57,7 +57,7 @@ struct MixLs : virtual Args, MixJSON
                 auto names = accessor->readDirectory(curPath);
                 for (auto & name : names)
                     showFile(Path { curPath } << "/" << name,
-                    		Path { relPath } << "/" << name);
+                            Path { relPath } << "/" << name);
             } else
                 showFile(curPath, relPath);
         };

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -56,7 +56,8 @@ struct MixLs : virtual Args, MixJSON
             if (st.type == FSAccessor::Type::tDirectory && !showDirectory) {
                 auto names = accessor->readDirectory(curPath);
                 for (auto & name : names)
-                    showFile(curPath + "/" + name, relPath + "/" + name);
+                    showFile(Path { curPath } << "/" << name,
+                    		Path { relPath } << "/" << name);
             } else
                 showFile(curPath, relPath);
         };

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -24,9 +24,9 @@ struct MixLs : virtual Args, MixJSON
 
     void listText(ref<FSAccessor> accessor)
     {
-        std::function<void(const FSAccessor::Stat &, const Path &, const std::string &, bool)> doPath;
+        std::function<void(const FSAccessor::Stat &, PathView, std::string_view, bool)> doPath;
 
-        auto showFile = [&](const Path & curPath, const std::string & relPath) {
+        auto showFile = [&](PathView curPath, std::string_view relPath) {
             if (verbose) {
                 auto st = accessor->stat(curPath);
                 std::string tp =
@@ -50,8 +50,8 @@ struct MixLs : virtual Args, MixJSON
             }
         };
 
-        doPath = [&](const FSAccessor::Stat & st, const Path & curPath,
-            const std::string & relPath, bool showDirectory)
+        doPath = [&](const FSAccessor::Stat & st, PathView curPath,
+            std::string_view relPath, bool showDirectory)
         {
             if (st.type == FSAccessor::Type::tDirectory && !showDirectory) {
                 auto names = accessor->readDirectory(curPath);

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -125,7 +125,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
             "--help-config' for a list of configuration settings.\n";
     }
 
-    void printHelp(const string & programName, std::ostream & out) override
+    void printHelp(std::string_view programName, std::ostream & out) override
     {
         MultiCommand::printHelp(programName, out);
 

--- a/src/nix/make-content-addressable.cc
+++ b/src/nix/make-content-addressable.cc
@@ -96,7 +96,7 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
             store->addToStore(info, *source);
 
             if (json)
-                jsonRewrites->attr(store->printStorePath(path), store->printStorePath(info.path));
+                jsonRewrites->attr(store->printStorePath(path), std::string_view { store->printStorePath(info.path) });
 
             remappings.insert_or_assign(std::move(path), std::move(info.path));
         }

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -65,10 +65,10 @@ struct NixRepl : gc
     ~NixRepl();
     void mainLoop(const std::vector<std::string> & files);
     StringSet completePrefix(string prefix);
-    bool getLine(string & input, const std::string &prompt);
+    bool getLine(string & input, std::string_viewprompt);
     Path getDerivationPath(Value & v);
     bool processLine(string line);
-    void loadFile(const Path & path);
+    void loadFile(PathView path);
     void initEnv();
     void reloadFiles();
     void addAttrsToScope(Value & attrs);
@@ -234,7 +234,7 @@ void NixRepl::mainLoop(const std::vector<std::string> & files)
 }
 
 
-bool NixRepl::getLine(string & input, const std::string &prompt)
+bool NixRepl::getLine(string & input, std::string_viewprompt)
 {
     struct sigaction act, old;
     sigset_t savedSignalMask, set;
@@ -344,7 +344,7 @@ StringSet NixRepl::completePrefix(string prefix)
 }
 
 
-static int runProgram(const string & program, const Strings & args)
+static int runProgram(std::string_view program, const Strings & args)
 {
     Strings args2(args);
     args2.push_front(program);
@@ -362,7 +362,7 @@ static int runProgram(const string & program, const Strings & args)
 }
 
 
-bool isVarName(const string & s)
+bool isVarName(std::string_view s)
 {
     if (s.size() == 0) return false;
     char c = s[0];
@@ -539,7 +539,7 @@ bool NixRepl::processLine(string line)
 }
 
 
-void NixRepl::loadFile(const Path & path)
+void NixRepl::loadFile(PathView path)
 {
     loadedFiles.remove(path);
     loadedFiles.push_back(path);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -682,7 +682,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         else if (maxDepth > 0) {
             str << "{ ";
 
-            typedef std::map<string, Value *> Sorted;
+            typedef std::map<string, Value *, std::less<>> Sorted;
             Sorted sorted;
             for (auto & i : *v.attrs)
                 sorted[i.name] = i.value;

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -43,7 +43,7 @@ struct RunCommon : virtual Command
         auto store2 = store.dynamic_pointer_cast<LocalStore>();
 
         if (store2 && store->storeDir != store2->realStoreDir) {
-            Strings helperArgs = { chrootHelperName, store->storeDir, store2->realStoreDir, program };
+            Strings helperArgs = { chrootHelperName, store->storeDir, store2->realStoreDir, std::string { program } };
             for (auto & arg : args) helperArgs.push_back(arg);
 
             execv(readLink("/proc/self/exe").c_str(), stringsToCharPtrs(helperArgs).data());
@@ -51,7 +51,7 @@ struct RunCommon : virtual Command
             throw SysError("could not execute chroot helper");
         }
 
-        execvp(program.c_str(), stringsToCharPtrs(args).data());
+        execvp(std::string { program }.c_str(), stringsToCharPtrs(args).data());
 
         throw SysError("unable to execute '%s'", program);
     }

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -23,7 +23,7 @@ std::string chrootHelperName = "__run_in_chroot";
 struct RunCommon : virtual Command
 {
     void runProgram(ref<Store> store,
-        const std::string & program,
+        std::string_view program,
         const Strings & args)
     {
         stopProgressBar();

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -23,7 +23,7 @@ std::string hilite(std::string_view s, const std::smatch & m, std::string postfi
 {
     return
         m.empty()
-        ? s
+        ? std::string { s }
         : std::string(m.prefix())
           + ANSI_RED + std::string(m.str()) + postfix
           + std::string(m.suffix());
@@ -161,9 +161,9 @@ struct CmdSearch : SourceExprCommand, MixJSON
 
                             auto jsonElem = jsonOut->object(attrPath);
 
-                            jsonElem.attr("pkgName", parsed.name);
-                            jsonElem.attr("version", parsed.version);
-                            jsonElem.attr("description", description);
+                            jsonElem.attr("pkgName", std::string_view { parsed.name });
+                            jsonElem.attr("version", std::string_view { parsed.version });
+                            jsonElem.attr("description", std::string_view { description });
 
                         } else {
                             auto name = hilite(parsed.name, nameMatch, "\e[0;2m")
@@ -178,11 +178,11 @@ struct CmdSearch : SourceExprCommand, MixJSON
 
                     if (cache) {
                         cache->attr("type", "derivation");
-                        cache->attr("name", drv.queryName());
-                        cache->attr("system", drv.querySystem());
+                        cache->attr("name", std::string_view { drv.queryName() });
+                        cache->attr("system", std::string_view { drv.querySystem() });
                         if (description != "") {
                             auto meta(cache->object("meta"));
-                            meta.attr("description", description);
+                            meta.attr("description", std::string_view { description });
                         }
                     }
                 }

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -19,7 +19,7 @@ std::string wrap(std::string prefix, std::string s)
     return prefix + s + ANSI_NORMAL;
 }
 
-std::string hilite(const std::string & s, const std::smatch & m, std::string postfix)
+std::string hilite(std::string_view s, const std::smatch & m, std::string postfix)
 {
     return
         m.empty()

--- a/src/nix/show-derivation.cc
+++ b/src/nix/show-derivation.cc
@@ -69,10 +69,10 @@ struct CmdShowDerivation : InstallablesCommand
                 auto outputsObj(drvObj.object("outputs"));
                 for (auto & output : drv.outputs) {
                     auto outputObj(outputsObj.object(output.first));
-                    outputObj.attr("path", store->printStorePath(output.second.path));
+                    outputObj.attr("path", std::string_view { store->printStorePath(output.second.path) });
                     if (output.second.hash != "") {
-                        outputObj.attr("hashAlgo", output.second.hashAlgo);
-                        outputObj.attr("hash", output.second.hash);
+                        outputObj.attr("hashAlgo", std::string_view { output.second.hashAlgo });
+                        outputObj.attr("hash", std::string_view { output.second.hash });
                     }
                 }
             }
@@ -80,7 +80,7 @@ struct CmdShowDerivation : InstallablesCommand
             {
                 auto inputsList(drvObj.list("inputSrcs"));
                 for (auto & input : drv.inputSrcs)
-                    inputsList.elem(store->printStorePath(input));
+                    inputsList.elem(std::string_view { store->printStorePath(input) });
             }
 
             {
@@ -88,23 +88,23 @@ struct CmdShowDerivation : InstallablesCommand
                 for (auto & input : drv.inputDrvs) {
                     auto inputList(inputDrvsObj.list(store->printStorePath(input.first)));
                     for (auto & outputId : input.second)
-                        inputList.elem(outputId);
+                        inputList.elem(std::string_view { outputId });
                 }
             }
 
-            drvObj.attr("platform", drv.platform);
-            drvObj.attr("builder", drv.builder);
+            drvObj.attr("platform", std::string_view { drv.platform });
+            drvObj.attr("builder", std::string_view { drv.builder });
 
             {
                 auto argsList(drvObj.list("args"));
                 for (auto & arg : drv.args)
-                    argsList.elem(arg);
+                    argsList.elem(std::string_view { arg });
             }
 
             {
                 auto envObj(drvObj.object("env"));
                 for (auto & var : drv.env)
-                    envObj.attr(var.first, var.second);
+                    envObj.attr(var.first, std::string_view { var.second });
             }
         }
 

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -46,7 +46,7 @@ struct CmdCopySigs : StorePathsCommand
 
         //logger->setExpected(doneLabel, storePaths.size());
 
-        auto doPath = [&](const Path & storePathS) {
+        auto doPath = [&](PathView storePathS) {
             //Activity act(*logger, lvlInfo, format("getting signatures for '%s'") % storePath);
 
             checkInterrupt();

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -73,7 +73,7 @@ struct CmdVerify : StorePathsCommand
 
         ThreadPool pool;
 
-        auto doPath = [&](const Path & storePath) {
+        auto doPath = [&](PathView storePath) {
             try {
                 checkInterrupt();
 

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -12,11 +12,11 @@ static std::string hilite(std::string_view s, size_t pos, size_t len,
     std::string_view colour = ANSI_RED)
 {
     return
-        std::string(s, 0, pos)
-        + colour
-        + std::string(s, pos, len)
-        + ANSI_NORMAL
-        + std::string(s, pos + len);
+        std::string { s.substr(0, pos) }
+        << colour
+        << s.substr(pos, len)
+        << ANSI_NORMAL
+        << s.substr(pos + len);
 }
 
 static std::string filterPrintable(std::string_view s)
@@ -187,7 +187,7 @@ struct CmdWhyDepends : SourceExprCommand
             visitPath = [&](PathView p) {
                 auto st = accessor->stat(p);
 
-                auto p2 = p == pathS ? "/" : std::string(p, pathS.size() + 1);
+                auto p2 = p == pathS ? "/" : p.substr(pathS.size() + 1);
 
                 auto getColour = [&](std::string_view hash) {
                     return hash == dependencyPathHash ? ANSI_GREEN : ANSI_BLUE;
@@ -196,7 +196,7 @@ struct CmdWhyDepends : SourceExprCommand
                 if (st.type == FSAccessor::Type::tDirectory) {
                     auto names = accessor->readDirectory(p);
                     for (auto & name : names)
-                        visitPath(p + "/" + name);
+                        visitPath(Path { p } << "/" + name);
                 }
 
                 else if (st.type == FSAccessor::Type::tRegular) {
@@ -248,8 +248,8 @@ struct CmdWhyDepends : SourceExprCommand
                 }
 
                 printNode(*ref.second,
-                    tailPad + (last ? treeNull : treeLine),
-                    tailPad + (last ? treeNull : treeLine));
+                    std::string { tailPad } + (last ? treeNull : treeLine),
+                    std::string { tailPad } + (last ? treeNull : treeLine));
             }
         };
 

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -8,8 +8,8 @@
 
 using namespace nix;
 
-static std::string hilite(const std::string & s, size_t pos, size_t len,
-    const std::string & colour = ANSI_RED)
+static std::string hilite(std::string_view s, size_t pos, size_t len,
+    std::string_view colour = ANSI_RED)
 {
     return
         std::string(s, 0, pos)
@@ -19,7 +19,7 @@ static std::string hilite(const std::string & s, size_t pos, size_t len,
         + std::string(s, pos + len);
 }
 
-static std::string filterPrintable(const std::string & s)
+static std::string filterPrintable(std::string_view s)
 {
     std::string res;
     for (char c : s)
@@ -144,11 +144,11 @@ struct CmdWhyDepends : SourceExprCommand
            closure (i.e., that have a non-infinite distance to
            'dependency'). Print every edge on a path between `package`
            and `dependency`. */
-        std::function<void(Node &, const string &, const string &)> printNode;
+        std::function<void(Node &, std::string_view, std::string_view)> printNode;
 
         struct BailOut { };
 
-        printNode = [&](Node & node, const string & firstPad, const string & tailPad) {
+        printNode = [&](Node & node, std::string_view firstPad, std::string_view tailPad) {
             auto pathS = store->printStorePath(node.path);
 
             assert(node.dist != inf);
@@ -182,14 +182,14 @@ struct CmdWhyDepends : SourceExprCommand
                contain the reference. */
             std::map<std::string, Strings> hits;
 
-            std::function<void(const Path &)> visitPath;
+            std::function<void(PathView)> visitPath;
 
-            visitPath = [&](const Path & p) {
+            visitPath = [&](PathView p) {
                 auto st = accessor->stat(p);
 
                 auto p2 = p == pathS ? "/" : std::string(p, pathS.size() + 1);
 
-                auto getColour = [&](const std::string & hash) {
+                auto getColour = [&](std::string_view hash) {
                     return hash == dependencyPathHash ? ANSI_GREEN : ANSI_BLUE;
                 };
 

--- a/src/resolve-system-dependencies/resolve-system-dependencies.cc
+++ b/src/resolve-system-dependencies/resolve-system-dependencies.cc
@@ -23,12 +23,12 @@ Path resolveCacheFile(Path lib)
     return cacheDir + "/" + lib;
 }
 
-std::set<string> readCacheFile(const Path & file)
+std::set<string> readCacheFile(PathView file)
 {
     return tokenizeString<set<string>>(readFile(file), "\n");
 }
 
-std::set<std::string> runResolver(const Path & filename)
+std::set<std::string> runResolver(PathView filename)
 {
     AutoCloseFD fd = open(filename.c_str(), O_RDONLY);
     if (!fd)
@@ -109,7 +109,7 @@ std::set<std::string> runResolver(const Path & filename)
     return libs;
 }
 
-bool isSymlink(const Path & path)
+bool isSymlink(PathView path)
 {
     struct stat st;
     if (lstat(path.c_str(), &st) == -1)
@@ -118,7 +118,7 @@ bool isSymlink(const Path & path)
     return S_ISLNK(st.st_mode);
 }
 
-Path resolveSymlink(const Path & path)
+Path resolveSymlink(PathView path)
 {
     auto target = readLink(path);
     return hasPrefix(target, "/")
@@ -126,7 +126,7 @@ Path resolveSymlink(const Path & path)
         : dirOf(path) + "/" + target;
 }
 
-std::set<string> resolveTree(const Path & path, PathSet & deps)
+std::set<string> resolveTree(PathView path, PathSet & deps)
 {
     std::set<string> results;
     if (!deps.insert(path).second) return {};
@@ -139,7 +139,7 @@ std::set<string> resolveTree(const Path & path, PathSet & deps)
     return results;
 }
 
-std::set<string> getPath(const Path & path)
+std::set<string> getPath(PathView path)
 {
     if (hasPrefix(path, "/dev")) return {};
 


### PR DESCRIPTION
As an optimization I couldn't care less about `const std::string &` vs `std:string_view`. However, `std:string_view` matches Rust's `&str`, which is used far more than `&String`, so I figure this is good for FFI, which is more likely to be worth it.

Still, this is a real slog so I'll not keep working on it unless told this is wanted.