### PR TITLE
appended ' __attribute__((weak)); ' to 'extern char * * environ '

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -35,7 +35,7 @@
 #endif
 
 
-extern char * * environ;
+extern char * * environ __attribute__((weak));
 
 
 namespace nix {

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -21,7 +21,7 @@
 using namespace nix;
 using namespace std::string_literals;
 
-extern char * * environ;
+extern char * * environ __attribute__((weak));
 
 /* Recreate the effect of the perl shellwords function, breaking up a
  * string into arguments like a shell word, including escapes

--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -4,7 +4,7 @@
 #include "nixexpr.hh"
 #include "profiles.hh"
 
-extern char * * environ;
+extern char * * environ __attribute__((weak));
 
 namespace nix {
 


### PR DESCRIPTION
a simple modification to an external reference in `util.cc`, `nix-build.cc`, and `command.cc`. This fixes a compilation
errors on *BSD where environ is defined in a different way. 