### PR TITLE
Reserve the `__contentAddressed` derivation parameter

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -809,9 +809,6 @@ private:
     /* Whether this is a fixed-output derivation. */
     bool fixedOutput;
 
-    /* Whether this is a content adressed derivation */
-    bool contentAddressed = false;
-
     /* Whether to run the build in a private network namespace. */
     bool privateNetwork = false;
 
@@ -1198,9 +1195,7 @@ void DerivationGoal::haveDerivation()
 
     parsedDrv = std::make_unique<ParsedDerivation>(drvPath, *drv);
 
-    contentAddressed = parsedDrv->contentAddressed();
-
-    if (this->contentAddressed) {
+    if (parsedDrv->contentAddressed()) {
         settings.requireExperimentalFeature("content-addressed-paths");
         throw Error("content-addressed-paths isn't implemented yet");
     }

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -809,6 +809,9 @@ private:
     /* Whether this is a fixed-output derivation. */
     bool fixedOutput;
 
+    /* Whether this is a content adressed derivation */
+    bool contentAddressed = false;
+
     /* Whether to run the build in a private network namespace. */
     bool privateNetwork = false;
 
@@ -1194,6 +1197,14 @@ void DerivationGoal::haveDerivation()
     }
 
     parsedDrv = std::make_unique<ParsedDerivation>(drvPath, *drv);
+
+    contentAddressed = parsedDrv->contentAddressed();
+
+    if (this->contentAddressed) {
+        settings.requireExperimentalFeature("content-addressed-paths");
+        throw Error("content-addressed-paths isn't implemented yet");
+    }
+
 
     /* We are first going to try to create the invalid output paths
        through substitutes.  If that doesn't work, we'll build

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -117,4 +117,9 @@ bool ParsedDerivation::substitutesAllowed() const
     return getBoolAttr("allowSubstitutes", true);
 }
 
+bool ParsedDerivation::contentAddressed() const
+{
+    return getBoolAttr("__contentAddressed", false);
+}
+
 }

--- a/src/libstore/parsed-derivations.hh
+++ b/src/libstore/parsed-derivations.hh
@@ -34,6 +34,8 @@ public:
     bool willBuildLocally() const;
 
     bool substitutesAllowed() const;
+
+    bool contentAddressed() const;
 };
 
 }


### PR DESCRIPTION
Not implementing anything here, just throwing an error if a derivation sets `__contentAddressed = true` without `--experimental-features content-addressed-paths` (and also with it as there's nothing implemented yet)