### PR TITLE
Try to substitute builtins.fetch*

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -134,6 +134,19 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
     if (evalSettings.pureEval && !expectedHash)
         throw Error("in pure evaluation mode, '%s' requires a 'sha256' argument", who);
 
+    // try to substitute if we can
+    if (settings.useSubstitutes && expectedHash) {
+        auto substitutableStorePath = fetchers::trySubstitute(state.store, unpack, *expectedHash, name);
+        if (substitutableStorePath) {
+            auto substitutablePath = state.store->toRealPath(*substitutableStorePath);
+            if (state.allowedPaths)
+                state.allowedPaths->insert(substitutablePath);
+
+            mkString(v, substitutablePath, PathSet({substitutablePath}));
+            return;
+        }
+    }
+
     auto storePath =
         unpack
         ? fetchers::downloadTarball(state.store, *url, name, (bool) expectedHash).storePath

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -100,4 +100,6 @@ Tree downloadTarball(
     const std::string & name,
     bool immutable);
 
+std::optional<StorePath> trySubstitute(ref<Store> store, bool unpack, Hash hash, std::string_view name);
+
 }


### PR DESCRIPTION
builtins.fetch* aren’t technically derivations, so they never got
substituted. To work around this, we can try to substitute this store
path during evaluation. This can happen any time a hash is provided.