### PR TITLE
Minimal CA support

### DIFF
--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -49,6 +49,8 @@ void Store::exportPath(const StorePath & path, Sink & sink)
 
     HashAndWriteSink hashAndWriteSink(sink);
 
+    if (!isValidPath(path))
+        throw Error("path '%s' is not valid", printStorePath(path));
     narFromPath(path, hashAndWriteSink);
 
     /* Refuse to export paths that have changed.  This prevents

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -79,8 +79,6 @@ ref<FSAccessor> LocalFSStore::getFSAccessor()
 
 void LocalFSStore::narFromPath(const StorePath & path, Sink & sink)
 {
-    if (!isValidPath(path))
-        throw Error("path '%s' is not valid", printStorePath(path));
     dumpPath(getRealStoreDir() + std::string(printStorePath(path), storeDir.size()), sink);
 }
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -576,6 +576,18 @@ void LocalStore::checkDerivationOutputs(const StorePath & drvPath, const Derivat
     }
 }
 
+void LocalStore::linkDeriverToPath(State & state, const ValidPathInfo & info) {
+    if (info.deriver && info.outputname) {
+        debug("Updating the output path of the deriver");
+        /* debug(queryValidPathId(state, info.deriver.value())); */
+        state.stmtAddDerivationOutput.use()
+            (queryValidPathId(state, info.deriver.value()))
+            (info.outputname.value())
+            (printStorePath(info.path))
+            .exec();
+    }
+
+}
 
 uint64_t LocalStore::addValidPath(State & state,
     const ValidPathInfo & info, bool checkOutputs)
@@ -618,6 +630,8 @@ uint64_t LocalStore::addValidPath(State & state,
                 .exec();
         }
     }
+
+    linkDeriverToPath(state, info);
 
     {
         auto state_(Store::state.lock());
@@ -692,6 +706,8 @@ void LocalStore::updatePathInfo(State & state, const ValidPathInfo & info)
         (renderContentAddress(info.ca), (bool) info.ca)
         (printStorePath(info.path))
         .exec();
+
+    linkDeriverToPath(state, info);
 }
 
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -577,9 +577,20 @@ void LocalStore::checkDerivationOutputs(const StorePath & drvPath, const Derivat
 }
 
 void LocalStore::linkDeriverToPath(State & state, const ValidPathInfo & info) {
-    if (info.deriver && info.outputname) {
-        debug("Updating the output path of the deriver");
-        /* debug(queryValidPathId(state, info.deriver.value())); */
+    /*
+     * If the path doesn't have a specified deriver/outputName or the deriver
+     * isn't in store (as it happens for example with remote builds), don't
+     * do anything
+     */
+    if (info.deriver && info.outputname && isValidPath(info.deriver.value())) {
+        debug(
+            "Setting the output path of %s to %s",
+            StorePathWithOutputs{
+                .path = *info.deriver,
+                .outputs = {info.outputname.value()},
+            }.to_string(*this),
+            printStorePath(info.path)
+        );
         state.stmtAddDerivationOutput.use()
             (queryValidPathId(state, info.deriver.value()))
             (info.outputname.value())

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -291,6 +291,11 @@ private:
        specified by the ‘secret-key-files’ option. */
     void signPathInfo(ValidPathInfo & info);
 
+    /* Add a mapping from the deriver of the path info (if specified) to its
+     * out path
+     */
+    void linkDeriverToPath(State & state, const ValidPathInfo & info);
+
     Path getRealStoreDir() override { return realStoreDir; }
 
     void createUser(const std::string & userName, uid_t userId) override;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -115,6 +115,7 @@ struct ValidPathInfo
 {
     StorePath path;
     std::optional<StorePath> deriver;
+    std::optional<string> outputname;
     Hash narHash;
     StorePathSet references;
     time_t registrationTime = 0;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -673,6 +673,14 @@ public:
     virtual void createUser(const std::string & userName, uid_t userId)
     { }
 
+    /* Create a new path similar to the one referred to by `info`, but that's
+     * content-addressed.
+     *
+     * This doesn't alter the original path
+     */
+    ValidPathInfo makeContentAddressed(const ValidPathInfo & info, const StringMap & extraRewrites = {});
+
+
 protected:
 
     Stats stats;

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -128,6 +128,7 @@ StorePath getDerivationEnvironment(ref<Store> store, const StorePath & drvPath)
     assert(hasSuffix(drvName, ".drv"));
     drvName.resize(drvName.size() - 4);
     drvName += "-env";
+    drv.env["name"] = drvName;
     for (auto & output : drv.outputs)
         drv.env.erase(output.first);
     drv.env["out"] = "";

--- a/src/nix/make-content-addressable.cc
+++ b/src/nix/make-content-addressable.cc
@@ -49,9 +49,6 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
             auto pathS = store->printStorePath(path);
             auto oldInfo = store->queryPathInfo(path);
 
-            StringSink sink;
-            store->narFromPath(path, sink);
-
             StringMap rewrites;
 
             StorePathSet references;

--- a/tests/content-addressed.nix
+++ b/tests/content-addressed.nix
@@ -1,0 +1,17 @@
+with import ./config.nix;
+
+{ seed ? 0 }:
+# A simple content-addressed derivation.
+# The derivation can be arbitrarily modified by passing a different `seed`,
+# but the output will always be the same
+mkDerivation {
+  name = "simple-content-addressed";
+  buildCommand = ''
+    set -x
+    echo "Building a CA derivation"
+    echo "The seed is ${toString seed}"
+    mkdir -p $out
+    echo "Hello World" > $out/hello
+  '';
+  __contentAddressed = true;
+}

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+clearStore
+clearCache
+
+export REMOTE_STORE=file://$cacheDir
+
+out1=$(nix-build ./content-addressed.nix --arg seed 1)
+out2=$(nix-build ./content-addressed.nix --arg seed 2)
+
+test $out1 == $out2

--- a/tests/init.sh
+++ b/tests/init.sh
@@ -17,7 +17,7 @@ cat > "$NIX_CONF_DIR"/nix.conf <<EOF
 build-users-group =
 keep-derivations = false
 sandbox = false
-experimental-features = nix-command flakes
+experimental-features = nix-command flakes ca-derivations
 gc-reserved-space = 0
 include nix.conf.extra
 EOF


### PR DESCRIPTION
First very limited support:

- Only `nix-build` works properly with CA derivations (`nix-store`, `nix build`, etc.. will print and create a symlink to a non-existent output path)
- It isn't possible to depend on a content-addressed derivation

Mostly taken out of #3528 with some changes to reuse the logic already in `nix/make-content-addressable.cc`.
Builds on top of #3678 

/cc @edolstra @Ericson2314 