### PR TITLE
Warn when experimental features are used

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -2,6 +2,7 @@
 #include "util.hh"
 #include "archive.hh"
 #include "args.hh"
+#include "sync.hh"
 
 #include <algorithm>
 #include <map>
@@ -129,8 +130,14 @@ bool Settings::isExperimentalFeatureEnabled(const std::string & name)
 
 void Settings::requireExperimentalFeature(const std::string & name)
 {
-    if (!isExperimentalFeatureEnabled(name))
-        throw Error("experimental Nix feature '%1%' is disabled; use '--experimental-features %1%' to override", name);
+    if (!isExperimentalFeatureEnabled(name)) {
+        if (allowExperimentalFeatures) {
+            static Sync<std::unordered_set<std::string>> warned;
+            if (warned.lock()->insert(name).second)
+                warn("feature '%s' is experimental", name);
+        } else
+            throw Error("experimental Nix feature '%1%' is disabled; use '--experimental-features %1%' to override", name);
+    }
 }
 
 bool Settings::isWSL1()

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -357,6 +357,10 @@ public:
     Setting<std::string> githubAccessToken{this, "", "github-access-token",
         "GitHub access token to get access to GitHub data through the GitHub API for github:<..> flakes."};
 
+    Setting<bool> allowExperimentalFeatures{this, true, "allow-experimental-features",
+        "Whether the use of experimental features other than those listed in "
+        "the option 'experimental-features' gives a warning rather than fatal error."};
+
     Setting<Strings> experimentalFeatures{this, {}, "experimental-features",
         "Experimental Nix features to enable."};
 


### PR DESCRIPTION
If you use an experimental feature not listed in the `experimental-features` setting, you now get a warning rather than a fatal error. This makes things like the 'nix' command a bit less obnoxious.

However, if you set `allow-experimental-features = false`, it's still a fatal error. This is primarily for CI systems where use of experimental features in the daemon could go unnoticed.