### PR TITLE
nix/*: Add `-h`-shortcut for `--help` to display helptext

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -68,6 +68,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
 
         addFlag({
             .longName = "help",
+            .shortName = 'h',
             .description = "show usage information",
             .handler = {[&]() { if (!completions) showHelpAndExit(); }},
         });


### PR DESCRIPTION
I'm used to pass `-h` to a command to read a helptext and always having
to type `--help` is slightly annoying.