### PR TITLE
nix/build: add `--rebuild` option

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -9,6 +9,7 @@ using namespace nix;
 struct CmdBuild : InstallablesCommand, MixDryRun, MixProfile
 {
     Path outLink = "result";
+    BuildMode buildMode = bmNormal;
 
     CmdBuild()
     {
@@ -25,6 +26,12 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixProfile
             .longName = "no-link",
             .description = "do not create a symlink to the build result",
             .handler = {&outLink, Path("")},
+        });
+
+        addFlag({
+            .longName = "rebuild",
+            .description = "Rebuild an already built package locally and compare the result to the existing store-paths.",
+            .handler = {&buildMode, bmCheck},
         });
     }
 
@@ -53,7 +60,7 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixProfile
 
     void run(ref<Store> store) override
     {
-        auto buildables = build(store, dryRun ? Realise::Nothing : Realise::Outputs, installables);
+        auto buildables = build(store, dryRun ? Realise::Nothing : Realise::Outputs, installables, buildMode);
 
         if (dryRun) return;
 

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -5,6 +5,7 @@
 #include "common-eval-args.hh"
 #include "path.hh"
 #include "flake/lockfile.hh"
+#include "store-api.hh"
 
 #include <optional>
 
@@ -185,7 +186,7 @@ static RegisterCommand registerCommand(const std::string & name)
 }
 
 Buildables build(ref<Store> store, Realise mode,
-    std::vector<std::shared_ptr<Installable>> installables);
+    std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode = bmNormal);
 
 std::set<StorePath> toStorePaths(ref<Store> store,
     Realise mode, OperateOn operateOn,

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -642,7 +642,7 @@ std::shared_ptr<Installable> SourceExprCommand::parseInstallable(
 }
 
 Buildables build(ref<Store> store, Realise mode,
-    std::vector<std::shared_ptr<Installable>> installables)
+    std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode)
 {
     if (mode == Realise::Nothing)
         settings.readOnlyMode = true;
@@ -668,7 +668,7 @@ Buildables build(ref<Store> store, Realise mode,
     if (mode == Realise::Nothing)
         printMissing(store, pathsToBuild, lvlError);
     else if (mode == Realise::Outputs)
-        store->buildPaths(pathsToBuild);
+        store->buildPaths(pathsToBuild, bMode);
 
     return buildables;
 }


### PR DESCRIPTION
Occasionally, `nix-build --check` is fairly helpful and I'd like to be
able to use this feature for flakes that need to be built with `nix
build` as well.

cc @edolstra