### PR TITLE
nix/copy: Add `--build` option

### DIFF
--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -13,7 +13,6 @@ struct CmdCopy : StorePathsCommand
     std::string srcUri, dstUri;
 
     CheckSigsFlag checkSigs = CheckSigs;
-
     SubstituteFlag substitute = NoSubstitute;
 
     CmdCopy()
@@ -46,7 +45,11 @@ struct CmdCopy : StorePathsCommand
             .handler = {&substitute, Substitute},
         });
 
-        realiseMode = Build;
+        addFlag({
+            .longName = "build",
+            .description = "Whether to build derivations",
+            .handler = {&realiseMode, Build},
+        });
     }
 
     std::string description() override


### PR DESCRIPTION
In 9570036146b9bdbd66ce0b9f71479d0f56f3bf35 `nix copy` was changed to
actually build derivations that are supposed to be copied.

This is not desirable though if you want to copy derivations for a
different platform architecture to a remote store.

This patch only builds drvs if `nix copy --build` is specified,
otherwise it falls back to the previous behavior where drvs were only
copied.

cc @edolstra