### PR TITLE
Fix segfault if a file from an invalid searchpath-entry is attempted to get built

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -688,12 +688,13 @@ Path EvalState::findFile(SearchPath & searchPath, const string & path, const Pos
         Path res = r.second + suffix;
         if (pathExists(res)) return canonPath(res);
     }
+    auto nixCode = pos ? std::optional<NixCode>{NixCode { .errPos = pos }} : std::nullopt;
     throw ThrownError({
         .hint = hintfmt(evalSettings.pureEval
             ? "cannot look up '<%s>' in pure evaluation mode (use '--impure' to override)"
             : "file '%s' was not found in the Nix search path (add it using $NIX_PATH or -I)",
             path),
-        .nixCode = NixCode { .errPos = pos }
+        .nixCode = nixCode
     });
 }
 

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -19,3 +19,7 @@ nix-env -q --foo 2>&1 | grep "unknown flag"
 eval_res=$(nix-instantiate --eval -E 'let a = {} // a; in a.foo' 2>&1 || true)
 echo $eval_res | grep "(string) (1:15)"
 echo $eval_res | grep "infinite recursion encountered"
+
+# Invalid search-paths don't segfault
+nix-build '<foo/bar>' -I foo=$(mktemp -d) 2>&1 || status=$?
+[[ "$status" = "1" ]]


### PR DESCRIPTION
When I try to build an expression from a searchpath that happens to be
wrong, `nix-build` segfaults:

```
λ ma27 [~] → nix-build '<foo/bar>' -I foo=$(mktemp -d)
[1]    16252 segmentation fault (core dumped)  nix-build '<foo/bar>' -I foo=$(mktemp -d)
```

This happens if the `file`-Symbol in the `Pos` struct doesn't have a
value (due to the missing searchpath-entry). This causes a segfault
when the `Error`-implementation tries to cast `Pos` to an `ErrPos`.

This was most likely caused by 55eb71714854b262b5e1079ff250a13cc0bbf644,
previously it was explicitly checked if `pos` has any value. This patch
basically switches back to this behavior by setting `nixCode` to
`std::nullopt` if `pos` is incomplete.

Also added a testcase to make sure that this doesn't appear again in the
future.