### PR TITLE
Don't use read-only mode for nix build --dry-run

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -716,7 +716,7 @@ Buildables build(ref<Store> store, Realise mode,
         }
     }
 
-    if (mode == Realise::Nothing)
+    if (mode == Realise::Nothing || mode == Realise::Derivation)
         printMissing(store, pathsToBuild, lvlError);
     else if (mode == Realise::Outputs)
         store->buildPaths(pathsToBuild, bMode);

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -52,7 +52,7 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
 
     void run(ref<Store> store) override
     {
-        auto buildables = build(store, dryRun ? Realise::Nothing : Realise::Outputs, installables, buildMode);
+        auto buildables = build(store, dryRun ? Realise::Derivation : Realise::Outputs, installables, buildMode);
 
         if (dryRun) return;
 


### PR DESCRIPTION
In dry run mode, new derivations can't be create, so running the command on anything that has not been evaluated before results in an error message of the form `don't know how to build these paths (may be caused by read-only store access)`.

For comparison, the classical `nix-build --dry-run` doesn't use read-only mode.

Closes #1795