### PR TITLE
Cherry-pick "Use fragment size for autoGC capacity calculation" on 2.3

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -876,7 +876,7 @@ void LocalStore::autoGC(bool sync)
         if (statvfs(realStoreDir.c_str(), &st))
             throw SysError("getting filesystem info about '%s'", realStoreDir);
 
-        return (uint64_t) st.f_bavail * st.f_bsize;
+        return (uint64_t) st.f_bavail * st.f_frsize;
     };
 
     std::shared_future<void> future;


### PR DESCRIPTION
This cherry-picks https://github.com/NixOS/nix/pull/3562 on top of the `2.3-maintaince` branch to get this important GC fix in a minor release.