### PR TITLE
Add nix processes command

### DIFF
--- a/src/nix/processes.cc
+++ b/src/nix/processes.cc
@@ -59,7 +59,12 @@ struct CmdProcesses : StoreCommand
                 }
                 if (pathExists(fmt("/proc/%d/fd", pid))) {
                     for (auto & fd : readDirectory(fmt("/proc/%d/fd", pid))) {
-                        auto path2 = readLink(fmt("/proc/%d/fd/%s", pid, fd.name));
+                        Path path2;
+                        try {
+                            path2 = readLink(fmt("/proc/%d/fd/%s", pid, fd.name));;
+                        } catch (const Error & e) {
+                            continue;
+                        }
                         if (path == path2)
                             return pid;
                     }
@@ -194,7 +199,12 @@ struct CmdProcesses : StoreCommand
                 auto openFds = fmt("/proc/%d/fd", pid);
                 if (pathExists(openFds))
                     for (auto & entry : readDirectory(openFds)) {
-                        auto path = readLink(fmt("/proc/%d/fd/%s", pid, entry.name));
+                        Path path;
+                        try {
+                            path = readLink(fmt("/proc/%d/fd/%s", pid, entry.name));
+                        } catch (const Error & e) {
+                            continue;
+                        }
                         if (hasSuffix(path, ".lock"))
                             std::cout << fmt("File Lock: %s", path) << std::endl;
                     }

--- a/src/nix/processes.cc
+++ b/src/nix/processes.cc
@@ -155,7 +155,7 @@ struct CmdProcesses : StoreCommand
 
             struct stat st;
             stat(userPoolDir.c_str(), &st);
-            if (st.st_uid != geteuid())
+            if (st.st_uid != geteuid() && geteuid() != 0)
                 throw Error("you don't have permissions to see the userpool locks");
 
             auto dirs = readDirectory(userPoolDir);

--- a/src/nix/processes.cc
+++ b/src/nix/processes.cc
@@ -158,11 +158,11 @@ struct CmdProcesses : StoreCommand
             if (st.st_uid != geteuid() && geteuid() != 0)
                 throw Error("you don't have permissions to see the userpool locks");
 
-            auto dirs = readDirectory(userPoolDir);
-            for (auto i = dirs.begin(); i != dirs.end(); i++) {
+            bool isFirst = true;
+            for (auto & dir : readDirectory(userPoolDir)) {
                 int uid;
                 try {
-                    uid = std::stoi(i->name);
+                    uid = std::stoi(dir.name);
                 } catch (const std::invalid_argument& e) {
                     continue;
                 }
@@ -181,8 +181,10 @@ struct CmdProcesses : StoreCommand
                 if (pid == -1)
                     continue;
 
-                if (i != dirs.begin())
+                if (!isFirst)
                     std::cout << std::endl;
+                else
+                    isFirst = false;
 
                 struct passwd * pw = getpwuid(uid);
                 if (!pw)

--- a/src/nix/processes.cc
+++ b/src/nix/processes.cc
@@ -1,0 +1,131 @@
+#include "command.hh"
+#include "store-api.hh"
+#include "pathlocks.hh"
+
+#include <fcntl.h>
+
+using namespace nix;
+
+struct CmdProcesses : StoreCommand
+{
+    CmdProcesses()
+    {
+    }
+
+    std::string description() override
+    {
+        return "show processes";
+    }
+
+    Examples examples() override
+    {
+        return {
+            Example{
+                "To show what processes are currently building:",
+                "nix processes"
+            },
+        };
+    }
+
+    Category category() override { return catSecondary; }
+
+    static std::optional<std::string> getCmdline(int pid)
+    {
+        auto cmdlinePath = fmt("/proc/%d/cmdline", pid);
+        if (pathExists(cmdlinePath)) {
+            string cmdline = readFile(cmdlinePath);
+            string cmdline_;
+            for (auto & i : cmdline) {
+                if (i == 0) cmdline_ += ' ';
+                else cmdline_ += i;
+            }
+            return cmdline_;
+        }
+        return std::nullopt;
+    }
+
+    // fuser just checks /proc on Linux, so we could just do that instead of calling an external program
+    // TODO: do this in C++ on Linux
+    static int fuser(Path path)
+    {
+        int fds[2];
+        if (pipe(fds) == -1)
+            throw Error("failed to make fuser pipe");
+
+        pid_t pid = fork();
+        if (pid < 0)
+            throw Error("failed to fork for fuser");
+
+        if (pid == 0) {
+            dup2(fds[1], fileno(stdout));
+            dup2(open("/dev/null", 0), fileno(stderr));
+            close(fds[0]); close(fds[1]);
+            if (!execlp("fuser", "fuser", path.c_str(), NULL))
+                throw Error("failed to execute program fuser");
+        }
+
+        int status;
+        waitpid(pid, &status, 0);
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+            throw Error("failed to execute fuser with status '%d'", status);
+        char buffer[4096];
+        ssize_t size = read(fds[0], &buffer, sizeof(buffer));
+        return std::stoi(std::string(buffer, size));
+    }
+
+    void run(ref<Store> store) override
+    {
+        if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>()) {
+            auto userPoolDir = store2->stateDir + "/userpool";
+
+            struct stat st;
+            stat(userPoolDir.c_str(), &st);
+            if (st.st_uid != geteuid())
+                throw Error("you don't have permissions to see the userpool locks");
+
+            auto dirs = readDirectory(userPoolDir);
+            for (auto i = dirs.begin(); i != dirs.end(); i++) {
+                auto uid = i->name;
+                auto uidPath = userPoolDir + "/" + uid;
+
+                // try to lock it ourselves
+                int fd = open(uidPath.c_str(), O_CLOEXEC | O_RDWR, 0600);
+                if (lockFile(fd, ltWrite, false)) {
+                    close(fd);
+                    continue;
+                }
+                close(fd);
+
+                int pid = fuser(uidPath);
+
+                if (i != dirs.begin())
+                    std::cout << std::endl;
+
+                struct passwd * pw = getpwuid(std::stoi(uid));
+                if (!pw)
+                    throw Error("can't find uid for '%s'", uid);
+                std::cout << fmt("Build User: %s (%d)", pw->pw_name, uid) << std::endl;
+
+                if (auto cmdline = getCmdline(pid))
+                    std::cout << fmt("Build Process: %s (%d)", *cmdline, pid) << std::endl;
+                else
+                    std::cout << fmt("Build Process: %d", pid) << std::endl;
+
+                // TODO: print leaves of child process by searching for ppid in /proc
+                // if (pathExists(fmt("/proc/%d/task", pid)))
+                //     printLeafProcesses(pid);
+
+                auto openFds = fmt("/proc/%d/fd", pid);
+                if (pathExists(openFds))
+                    for (auto & entry : readDirectory(openFds)) {
+                        auto path = readLink(fmt("/proc/%d/fd/%s", pid, entry.name));
+                        if (hasSuffix(path, ".lock"))
+                            std::cout << fmt("File Lock: %s", path) << std::endl;
+                    }
+            }
+        } else
+            throw Error("must provide local store for nix process, found '%s'", store->getUri());
+    }
+};
+
+static auto r1 = registerCommand<CmdProcesses>("processes");

--- a/src/nix/processes.cc
+++ b/src/nix/processes.cc
@@ -132,8 +132,9 @@ struct CmdProcesses : StoreCommand
                 numChildren++;
                 bool hasChildren = printChildren(childPid) > 0;
                 if (!hasChildren) {
-                    if (auto cmdline = getCmdline(childPid))
-                        std::cout << fmt("Child Process: %s (%d)", *cmdline, childPid) << std::endl;
+                    auto cmdline = getCmdline(childPid);
+                    if (cmdline && !cmdline->empty())
+                        std::cout << fmt("Child Process: %s", *cmdline) << std::endl;
                     else
                         std::cout << fmt("Child Process: %d", childPid) << std::endl;
                 }
@@ -181,10 +182,10 @@ struct CmdProcesses : StoreCommand
                 struct passwd * pw = getpwuid(uid);
                 if (!pw)
                     throw Error("can't find uid for '%d'", uid);
-                std::cout << fmt("Build User: %s (%d)", pw->pw_name, uid) << std::endl;
+                std::cout << fmt("Build User: %s", pw->pw_name) << std::endl;
 
                 if (auto cmdline = getCmdline(pid))
-                    std::cout << fmt("Build Process: %s (%d)", *cmdline, pid) << std::endl;
+                    std::cout << fmt("Build Process: %s", *cmdline) << std::endl;
                 else
                     std::cout << fmt("Build Process: %d", pid) << std::endl;
 


### PR DESCRIPTION
adds a processes command for #3751

some thing still missing:

- mostly relies on procfs for cmdline info
- no phase reporting

output looks like:

```
Build User: nixbld1
Build Process: nix-daemon 3535     
Child Process: /nix/store/b3zsk4ihlpiimv3vff86bb5bxghgdzb9-gcc-9.2.0/libexec/gcc/x86_64-unknown-linux-gnu/9.2.0/cc1 -quiet -D _FORTIFY_SOURCE=2 -idirafter /nix/store/fwpn2f7a4iqszyydw7ag61zlnp6xk5d3-glibc-2.30-dev/include -idirafter /nix/store/b3zsk4ihlpiimv3vff86bb5bxghgdzb9-gcc-9.2.0/lib/gcc/x86_64-unknown-linux-gnu/9.2.0/include-fixed conftest.c -quiet -dumpbase conftest.c -mtune=generic -march=x86-64 -auxbase conftest -g -O2 -O2 -Wformat=1 -Wformat-security -Werror=format-security -fstack-protector-strong -fno-strict-overflow -fPIC --param ssp-buffer-size=4 -o /build/cceFfp2A.s 
File Lock: /nix/store/l285fr6qxcf0v0iaphs38lcghv206zar-hello-2.10.lock
```
