### PR TITLE
Add `allRefs = true` argument to `fetchGit` to explicitly perform a full checkout

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -324,6 +324,11 @@ static RegisterPrimOp primop_fetchGit({
           A Boolean parameter that specifies whether submodules should be
           checked out. Defaults to `false`.
 
+        - allRefs  
+          Whether to fetch all refs of the repository. With this argument being
+          true, it's possible to load a `rev` from *any* `ref` (by default only
+          `rev`s from the specified `ref` are supported).
+
       Here are some examples of how to use `fetchGit`.
 
         - To fetch a private repository over SSH:

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -59,12 +59,13 @@ struct GitInputScheme : InputScheme
         if (maybeGetStrAttr(attrs, "type") != "git") return {};
 
         for (auto & [name, value] : attrs)
-            if (name != "type" && name != "url" && name != "ref" && name != "rev" && name != "shallow" && name != "submodules" && name != "lastModified" && name != "revCount" && name != "narHash")
+            if (name != "type" && name != "url" && name != "ref" && name != "rev" && name != "shallow" && name != "submodules" && name != "lastModified" && name != "revCount" && name != "narHash" && name != "allRefs")
                 throw Error("unsupported Git input attribute '%s'", name);
 
         parseURL(getStrAttr(attrs, "url"));
         maybeGetBoolAttr(attrs, "shallow");
         maybeGetBoolAttr(attrs, "submodules");
+        maybeGetBoolAttr(attrs, "allRefs");
 
         if (auto ref = maybeGetStrAttr(attrs, "ref")) {
             if (std::regex_search(*ref, badGitRefRegex))
@@ -169,10 +170,12 @@ struct GitInputScheme : InputScheme
 
         bool shallow = maybeGetBoolAttr(input.attrs, "shallow").value_or(false);
         bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
+        bool allRefs = maybeGetBoolAttr(input.attrs, "allRefs").value_or(false);
 
         std::string cacheType = "git";
         if (shallow) cacheType += "-shallow";
         if (submodules) cacheType += "-submodules";
+        if (allRefs) cacheType += "-all-refs";
 
         auto getImmutableAttrs = [&]()
         {
@@ -338,11 +341,15 @@ struct GitInputScheme : InputScheme
                     }
                 }
             } else {
-                /* If the local ref is older than ‘tarball-ttl’ seconds, do a
-                   git fetch to update the local ref to the remote ref. */
-                struct stat st;
-                doFetch = stat(localRefFile.c_str(), &st) != 0 ||
-                    (uint64_t) st.st_mtime + settings.tarballTtl <= (uint64_t) now;
+                if (allRefs) {
+                    doFetch = true;
+                } else {
+                    /* If the local ref is older than ‘tarball-ttl’ seconds, do a
+                       git fetch to update the local ref to the remote ref. */
+                    struct stat st;
+                    doFetch = stat(localRefFile.c_str(), &st) != 0 ||
+                        (uint64_t) st.st_mtime + settings.tarballTtl <= (uint64_t) now;
+                }
             }
 
             if (doFetch) {
@@ -352,9 +359,11 @@ struct GitInputScheme : InputScheme
                 // we're using --quiet for now. Should process its stderr.
                 try {
                     auto ref = input.getRef();
-                    auto fetchRef = ref->compare(0, 5, "refs/") == 0
-                        ? *ref
-                        : "refs/heads/" + *ref;
+                    auto fetchRef = allRefs
+                        ? "refs/*"
+                        : ref->compare(0, 5, "refs/") == 0
+                            ? *ref
+                            : "refs/heads/" + *ref;
                     runProgram("git", true, { "-C", repoDir, "fetch", "--quiet", "--force", "--", actualUrl, fmt("%s:%s", fetchRef, fetchRef) });
                 } catch (Error & e) {
                     if (!pathExists(localRefFile)) throw;

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -41,6 +41,19 @@ export _NIX_FORCE_HTTP=1
 path=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
 [[ $(cat $path/hello) = world ]]
 
+# Fetch a rev from another branch
+git -C $repo checkout -b devtest
+echo "different file" >> $TEST_ROOT/git/differentbranch
+git -C $repo add differentbranch
+git -C $repo commit -m 'Test2'
+git -C $repo checkout master
+devrev=$(git -C $repo rev-parse devtest)
+out=$(nix eval --impure --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; }" 2>&1) || status=$?
+[[ $status == 1 ]]
+[[ $out =~ 'Cannot find Git revision' ]]
+
+[[ $(nix eval --raw --expr "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; allRefs = true; } + \"/differentbranch\")") = 'different file' ]]
+
 # In pure eval mode, fetchGit without a revision should fail.
 [[ $(nix eval --impure --raw --expr "builtins.readFile (fetchGit file://$repo + \"/hello\")") = world ]]
 (! nix eval --raw --expr "builtins.readFile (fetchGit file://$repo + \"/hello\")")


### PR DESCRIPTION
Sometimes it's needed to fetch the revision of a git repository without knowing the specific `ref`. In those cases it's needed to perform a full checkout which is now possible by declaring `builtins.fetchGit { allRefs = true;  /* url, rev, etc */ }`.

Refs #2431 #2409 

For further details, please read the descriptions of the two commits.

cc @edolstra 