### PR TITLE
Add back flake-compat shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = ./.;
+}).shellNix


### PR DESCRIPTION
This was removed in the merge commit adf2fbbdc2c94644b0d1023d844c7dc0e485a20f. I think this was a mistake that occurred when resolving a conflict.