### PR TITLE
Save changes made by "nix registry pin" to user registry

### DIFF
--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -111,6 +111,7 @@ struct CmdRegistryPin : virtual Args, EvalCommand
         fetchers::Attrs extraAttrs;
         if (ref.subdir != "") extraAttrs["dir"] = ref.subdir;
         userRegistry->add(ref.input, resolved, extraAttrs);
+        userRegistry->write(fetchers::getUserRegistryPath());
     }
 };
 


### PR DESCRIPTION
Changes made by `nix registry pin` are currently not written to the user registry and therefore lost when nix exits.