### PR TITLE
Get rid of `basicDerivation::findOutput`

### DIFF
--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -7,14 +7,6 @@
 
 namespace nix {
 
-const StorePath & BasicDerivation::findOutput(const string & id) const
-{
-    auto i = outputs.find(id);
-    if (i == outputs.end())
-        throw Error("derivation has no output '%s'", id);
-    return i->second.path;
-}
-
 
 bool BasicDerivation::isBuiltin() const
 {

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -39,10 +39,6 @@ struct BasicDerivation
     BasicDerivation() { }
     virtual ~BasicDerivation() { };
 
-    /* Return the path corresponding to the output identifier `id' in
-       the given derivation. */
-    const StorePath & findOutput(const std::string & id) const;
-
     bool isBuiltin() const;
 
     /* Return true iff this is a fixed-output derivation. */

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -381,7 +381,8 @@ static void queryInstSources(EvalState & state,
 
                 if (path.isDerivation()) {
                     elem.setDrvPath(state.store->printStorePath(path));
-                    elem.setOutPath(state.store->printStorePath(state.store->derivationFromPath(path).findOutput("out")));
+                    auto outputs = state.store->queryDerivationOutputMap(path);
+                    elem.setOutPath(state.store->printStorePath(outputs.at("out")));
                     if (name.size() >= drvExtension.size() &&
                         string(name, name.size() - drvExtension.size()) == drvExtension)
                         name = string(name, 0, name.size() - drvExtension.size());


### PR DESCRIPTION
It's a tiny function which is:

 - hardly worth abstrating over, and also only used once.

 - doesn't work once we get CA drvs

I rewrote the one callsite to be forwards compatable with CA
derivations, and also potentially more performant: instead of reading in
the derivation it can ust consult the SQLite DB in the common case.

CC @regnat 