### PR TITLE
Allow PRECOMPILE_HEADERS in cross-compilation

### DIFF
--- a/mk/precompiled-headers.mk
+++ b/mk/precompiled-headers.mk
@@ -21,13 +21,13 @@ clean-files += $(GCH) $(PCH)
 
 ifeq ($(PRECOMPILE_HEADERS), 1)
 
-  ifeq ($(CXX), g++)
+  ifeq ($(findstring g++,$(CXX)), g++)
 
     GLOBAL_CXXFLAGS_PCH += -include $(buildprefix)precompiled-headers.h -Winvalid-pch
 
     GLOBAL_ORDER_AFTER += $(GCH)
 
-  else ifeq ($(CXX), clang++)
+  else ifeq ($(findstring clang++,$(CXX)), clang++)
 
     GLOBAL_CXXFLAGS_PCH += -include-pch $(PCH) -Winvalid-pch
 


### PR DESCRIPTION
In cross, CXX will look like aarch64-unknown-linux-gnu-g++. We could
run some command to check what kind of compiler it is, but for now we
can just check if g++ is anywhere in the string. I couldn’t find any
"ends with" for makefile, so it can be anywhere in CXX.