### PR TITLE
Add "bundle" command to Nix

### DIFF
--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -107,10 +107,7 @@ struct CmdBundle : InstallableCommand
 
         store->buildPaths({{drvPath}});
 
-        auto accessor = store->getFSAccessor();
         auto outPathS = store->printStorePath(outPath);
-        if (accessor->stat(outPathS).type != FSAccessor::tRegular)
-            throw Error("'%s' is not a file; a bundler must only create a single file", outPathS);
 
         auto info = store->queryPathInfo(outPath);
         if (!info->references.empty())

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -75,17 +75,21 @@ struct CmdBundle : InstallableCommand
         const flake::LockFlags lockFlags{ .writeLockFile = false };
         auto bundler = InstallableFlake(
             evalState, std::move(bundlerFlakeRef),
-            Strings{bundlerName == "" ? ("defaultBundler." + settings.thisSystem.get()) : bundlerName},
-            Strings({"bundlers." + settings.thisSystem.get() + "."}), lockFlags);
+            Strings{bundlerName == "" ? "defaultBundler" : bundlerName},
+            Strings({"bundlers."}), lockFlags);
 
         Value * arg = evalState->allocValue();
-        evalState->mkAttrs(*arg, 1);
+        evalState->mkAttrs(*arg, 2);
 
         PathSet context;
         for (auto & i : app.context)
             context.insert("=" + store->printStorePath(i.path));
         mkString(*evalState->allocAttr(*arg, evalState->symbols.create("program")), app.program, context);
 
+        mkString(*evalState->allocAttr(*arg, evalState->symbols.create("system")), settings.thisSystem.get());
+
+        arg->attrs->sort();
+ 
         auto vRes = evalState->allocValue();
         evalState->callFunction(*bundler.toValue(*evalState).first, *arg, *vRes, noPos);
 

--- a/src/nix/export.cc
+++ b/src/nix/export.cc
@@ -1,0 +1,126 @@
+#include "command.hh"
+#include "common-args.hh"
+#include "shared.hh"
+#include "store-api.hh"
+#include "fs-accessor.hh"
+
+using namespace nix;
+
+struct CmdExport : InstallableCommand
+{
+    std::string exporter = "github:matthewbauer/nix-bundle";
+    Path outLink;
+
+    CmdExport()
+    {
+        addFlag({
+            .longName = "exporter",
+            .description = "use custom exporter",
+            .labels = {"flake-url"},
+            .handler = {&exporter},
+            .completer = {[&](size_t, std::string_view prefix) {
+                completeFlakeRef(getStore(), prefix);
+            }}
+        });
+
+        addFlag({
+            .longName = "out-link",
+            .shortName = 'o',
+            .description = "path of the symlink to the build result",
+            .labels = {"path"},
+            .handler = {&outLink},
+            .completer = completePath
+        });
+    }
+
+    std::string description() override
+    {
+        return "export an application out of the Nix store";
+    }
+
+    Examples examples() override
+    {
+        return {
+            Example{
+                "To export Hello:",
+                "nix export hello"
+            },
+        };
+    }
+
+    Strings getDefaultFlakeAttrPaths() override
+    {
+        Strings res{"defaultApp." + settings.thisSystem.get()};
+        for (auto & s : SourceExprCommand::getDefaultFlakeAttrPaths())
+            res.push_back(s);
+        return res;
+    }
+
+    Strings getDefaultFlakeAttrPathPrefixes() override
+    {
+        Strings res{"apps." + settings.thisSystem.get() + ".", "packages"};
+        for (auto & s : SourceExprCommand::getDefaultFlakeAttrPathPrefixes())
+            res.push_back(s);
+        return res;
+    }
+
+    void run(ref<Store> store) override
+    {
+        auto evalState = getEvalState();
+
+        auto app = installable->toApp(*evalState);
+        store->buildPaths(app.context);
+
+        auto [exporterFlakeRef, exporterName] = parseFlakeRefWithFragment(exporter, absPath("."));
+        const flake::LockFlags lockFlags{ .writeLockFile = false };
+        auto exporter = InstallableFlake(
+            evalState, std::move(exporterFlakeRef),
+            Strings{exporterName == "" ? ("defaultExporter." + settings.thisSystem.get()) : exporterName},
+            Strings({"exporters." + settings.thisSystem.get() + "."}), lockFlags);
+
+        Value * arg = evalState->allocValue();
+        evalState->mkAttrs(*arg, 1);
+
+        PathSet context;
+        for (auto & i : app.context)
+            context.insert("=" + store->printStorePath(i.path));
+        mkString(*evalState->allocAttr(*arg, evalState->symbols.create("program")), app.program, context);
+
+        auto vRes = evalState->allocValue();
+        evalState->callFunction(*exporter.toValue(*evalState).first, *arg, *vRes, noPos);
+
+        if (!evalState->isDerivation(*vRes))
+            throw Error("the exporter '%s' does not produce a derivation", exporter.what());
+
+        Bindings::iterator i = vRes->attrs->find(evalState->sDrvPath);
+        if (i == vRes->attrs->end())
+            throw Error("the exporter '%s' does not produce a derivation", exporter.what());
+
+        PathSet context2;
+        StorePath drvPath = store->parseStorePath(evalState->coerceToPath(*i->pos, *i->value, context2));
+
+        i = vRes->attrs->find(evalState->sOutPath);
+        if (i == vRes->attrs->end())
+            throw Error("the exporter '%s' does not produce a derivation", exporter.what());
+
+        StorePath outPath = store->parseStorePath(evalState->coerceToPath(*i->pos, *i->value, context2));
+
+        store->buildPaths({{drvPath}});
+
+        auto accessor = store->getFSAccessor();
+        auto outPathS = store->printStorePath(outPath);
+        if (accessor->stat(outPathS).type != FSAccessor::tRegular)
+            throw Error("'%s' is not a file; an exporter must only create a single file", outPathS);
+
+        auto info = store->queryPathInfo(outPath);
+        if (!info->references.empty())
+            throw Error("'%s' has references; an exporter must not leave any references", outPathS);
+
+        if (outLink == "")
+            outLink = baseNameOf(app.program);
+
+        store.dynamic_pointer_cast<LocalFSStore>()->addPermRoot(outPath, absPath(outLink), true);
+    }
+};
+
+static auto r2 = registerCommand<CmdExport>("export");

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -368,14 +368,14 @@ struct CmdFlakeCheck : FlakeCommand
             }
         };
 
-        auto checkExporter = [&](const std::string & attrPath, Value & v, const Pos & pos) {
+        auto checkBundler = [&](const std::string & attrPath, Value & v, const Pos & pos) {
             try {
                 state->forceValue(v, pos);
                 if (v.type != tLambda)
-                    throw Error("exporter must be a function");
+                    throw Error("bundler must be a function");
                 if (!v.lambda.fun->formals ||
                     v.lambda.fun->formals->argNames.find(state->symbols.create("program")) == v.lambda.fun->formals->argNames.end())
-                    throw Error("exporter must take formal argument 'program'");
+                    throw Error("bundler must take formal argument 'program'");
             } catch (Error & e) {
                 e.addTrace(pos, hintfmt("while checking the template '%s'", attrPath));
                 throw;
@@ -504,19 +504,19 @@ struct CmdFlakeCheck : FlakeCommand
                                     *attr.value, *attr.pos);
                         }
 
-                        else if (name == "defaultExporter")
+                        else if (name == "defaultBundler")
                             for (auto & attr : *vOutput.attrs) {
                                 checkSystemName(attr.name, *attr.pos);
-                                checkExporter(fmt("%s.%s", name, attr.name), *attr.value, *attr.pos);
+                                checkBundler(fmt("%s.%s", name, attr.name), *attr.value, *attr.pos);
                             }
 
-                        else if (name == "exporters") {
+                        else if (name == "bundlers") {
                             state->forceAttrs(vOutput, pos);
                             for (auto & attr : *vOutput.attrs) {
                                 checkSystemName(attr.name, *attr.pos);
                                 state->forceAttrs(*attr.value, *attr.pos);
                                 for (auto & attr2 : *attr.value->attrs)
-                                    checkExporter(
+                                    checkBundler(
                                         fmt("%s.%s.%s", name, attr.name, attr2.name),
                                         *attr2.value, *attr2.pos);
                             }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -374,8 +374,9 @@ struct CmdFlakeCheck : FlakeCommand
                 if (v.type != tLambda)
                     throw Error("bundler must be a function");
                 if (!v.lambda.fun->formals ||
-                    v.lambda.fun->formals->argNames.find(state->symbols.create("program")) == v.lambda.fun->formals->argNames.end())
-                    throw Error("bundler must take formal argument 'program'");
+                    v.lambda.fun->formals->argNames.find(state->symbols.create("program")) == v.lambda.fun->formals->argNames.end() ||
+                    v.lambda.fun->formals->argNames.find(state->symbols.create("system")) == v.lambda.fun->formals->argNames.end())
+                    throw Error("bundler must take formal arguments 'program' and 'system'");
             } catch (Error & e) {
                 e.addTrace(pos, hintfmt("while checking the template '%s'", attrPath));
                 throw;
@@ -505,21 +506,13 @@ struct CmdFlakeCheck : FlakeCommand
                         }
 
                         else if (name == "defaultBundler")
-                            for (auto & attr : *vOutput.attrs) {
-                                checkSystemName(attr.name, *attr.pos);
-                                checkBundler(fmt("%s.%s", name, attr.name), *attr.value, *attr.pos);
-                            }
+                            checkBundler(name, vOutput, pos);
 
                         else if (name == "bundlers") {
                             state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                checkSystemName(attr.name, *attr.pos);
-                                state->forceAttrs(*attr.value, *attr.pos);
-                                for (auto & attr2 : *attr.value->attrs)
-                                    checkBundler(
-                                        fmt("%s.%s.%s", name, attr.name, attr2.name),
-                                        *attr2.value, *attr2.pos);
-                            }
+                            for (auto & attr : *vOutput.attrs)
+                                checkBundler(fmt("%s.%s", name, attr.name),
+                                    *attr.value, *attr.pos);
                         }
 
                         else


### PR DESCRIPTION
This adds a ‘nix bundle’ command which hooks into [nix-bundle](https://github.com/matthewbauer/nix-bundle). It can
be used in a similar way as nix-bundle, with the benefit of hooking
into the new “app” functionality. For instance,

```
$ nix bundle nixpkgs#jq
$ ./jq --help
jq - commandline JSON processor [version 1.6]
...
$ scp jq machine-without-nix:
$ ssh machine-without-nix ./jq
jq - commandline JSON processor [version 1.6]
...
```

Note that nix-bundle currently requires Linux to run. Other bundlers
might not have that requirement.

“bundlers” are meant to be reusable, so that, other repos can
implement their own bundling.

Fixes #3705