### PR TITLE
Fix builtins.path

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1199,7 +1199,7 @@ static void prim_path(EvalState & state, const Pos & pos, Value * * args, Value 
     string name;
     Value * filterFun = nullptr;
     auto method = FileIngestionMethod::Recursive;
-    Hash expectedHash(htSHA256);
+    std::optional<Hash> expectedHash;
 
     for (auto & attr : *args[0]->attrs) {
         const string & n(attr.name);

--- a/tests/filter-source.sh
+++ b/tests/filter-source.sh
@@ -10,10 +10,16 @@ touch $TEST_ROOT/filterin/bak
 touch $TEST_ROOT/filterin/bla.c.bak
 ln -s xyzzy $TEST_ROOT/filterin/link
 
-nix-build ./filter-source.nix -o $TEST_ROOT/filterout
+checkFilter() {
+    test ! -e $1/foo/bar
+    test -e $1/xyzzy
+    test -e $1/bak
+    test ! -e $1/bla.c.bak
+    test ! -L $1/link
+}
 
-test ! -e $TEST_ROOT/filterout/foo/bar
-test -e $TEST_ROOT/filterout/xyzzy
-test -e $TEST_ROOT/filterout/bak
-test ! -e $TEST_ROOT/filterout/bla.c.bak
-test ! -L $TEST_ROOT/filterout/link
+nix-build ./filter-source.nix -o $TEST_ROOT/filterout1
+checkFilter $TEST_ROOT/filterout1
+
+nix-build ./path.nix -o $TEST_ROOT/filterout2
+checkFilter $TEST_ROOT/filterout2

--- a/tests/path.nix
+++ b/tests/path.nix
@@ -1,0 +1,14 @@
+with import ./config.nix;
+
+mkDerivation {
+  name = "filter";
+  builder = builtins.toFile "builder" "ln -s $input $out";
+  input =
+    builtins.path {
+      path = ((builtins.getEnv "TEST_ROOT") + "/filterin");
+      filter = path: type:
+           type != "symlink"
+        && baseNameOf path != "foo"
+        && !((import ./lang/lib.nix).hasSuffix ".bak" (baseNameOf path));
+    };
+}


### PR DESCRIPTION
This fixes an error found in builtins.path that looks like:

> store path mismatch in (possibly filtered) path added from '/private/tmp/nix-shell.CyXViH/nix-test/filter-source/filterin'

when no hash is specified.
