### PR TITLE
Add a flag to start the REPL on evaluation errors

### DIFF
--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -34,7 +34,7 @@ void StoreCommand::run()
 EvalCommand::EvalCommand()
 {
     addFlag({
-        .longName = "start-repl-on-eval-errors",
+        .longName = "debugger",
         .description = "start an interactive environment if evaluation fails",
         .handler = {&startReplOnEvalErrors, true},
     });

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -36,7 +36,11 @@ private:
 
 struct EvalCommand : virtual StoreCommand, MixEvalArgs
 {
+    bool startReplOnEvalErrors = false;
+
     ref<EvalState> getEvalState();
+
+    EvalCommand();
 
     std::shared_ptr<EvalState> evalState;
 };
@@ -250,5 +254,9 @@ void printClosureDiff(
     const StorePath & beforePath,
     const StorePath & afterPath,
     std::string_view indent);
+
+void runRepl(
+    ref<EvalState> evalState,
+    const std::map<std::string, Value *> & extraEnv);
 
 }

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -234,13 +234,6 @@ void completeFlakeRefWithFragment(
     completeFlakeRef(evalState->store, prefix);
 }
 
-ref<EvalState> EvalCommand::getEvalState()
-{
-    if (!evalState)
-        evalState = std::make_shared<EvalState>(searchPath, getStore());
-    return ref<EvalState>(evalState);
-}
-
 void completeFlakeRef(ref<Store> store, std::string_view prefix)
 {
     if (prefix == "")


### PR DESCRIPTION
This allows interactively inspecting the state of the evaluator at the point of failure.

Example:

```
$ nix eval path:///home/eelco/Dev/nix/flake2#modules.hello-closure._final --start-repl-on-eval-errors
error: --- TypeError -------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix
at: (20:53) in file: /nix/store/4264z41dxfdiqr95svmpnxxxwhfplhy0-source/flake.nix

    19|
    20|           _final = builtins.foldl' (xs: mod: xs // (mod._module.config { config = _final; })) _defaults _allModules;
      |                                                     ^
    21|         };

attempt to call something which is not a function but a set

Starting REPL to allow you to inspect the current state of the evaluator.

The following extra variables are in scope: arg, fun

Welcome to Nix version 2.4. Type :? for help.

nix-repl> fun
error: --- EvalError -------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix
at: (150:28) in file: /nix/store/4264z41dxfdiqr95svmpnxxxwhfplhy0-source/flake.nix

   149|
   150|           tarballClosure = (module {
      |                            ^
   151|             extends = [ self.modules.derivation ];

attribute 'derivation' missing

nix-repl> :t fun
a set

nix-repl> builtins.attrNames fun
[ "tarballClosure" ]

nix-repl>
```

TODO: 
* Add the lexical environment at the failure site to the scope of the repl.
* Add many more places where the repl can be invoked.
* Add a breakpoint builtin?