### PR TITLE
Provide defaults when no args are given to some subcommands

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -965,7 +965,7 @@ struct CmdFlake : virtual MultiCommand, virtual Command
     void run() override
     {
         if (!command)
-            throw UsageError("'nix flake' requires a sub-command.");
+            command = std::pair("info", make_ref<CmdFlakeInfo>());
         settings.requireExperimentalFeature("flakes");
         command->second->prepare();
         command->second->run();

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -333,7 +333,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
             auto & element(manifest.elements[i]);
             if (element.source
                 && !element.source->originalRef.input.isImmutable()
-                && matches(*store, element, i, matchers))
+                && (matches(*store, element, i, matchers) || matchers.empty()))
             {
                 Activity act(*logger, lvlChatty, actUnknown,
                     fmt("checking '%s' for updates", element.source->attrPath));

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -455,7 +455,7 @@ struct CmdProfile : virtual MultiCommand, virtual Command
     void run() override
     {
         if (!command)
-            throw UsageError("'nix profile' requires a sub-command.");
+            command = std::pair("info", make_ref<CmdProfileInfo>());
         command->second->prepare();
         command->second->run();
     }


### PR DESCRIPTION
Changes:

- nix profile now accepts no arguments, defaulting to nix profile info
- nix flake now accepts no arguments, defaulting to nix flake info
- nix profile upgrade now accepts no arguments, default to nix profile upgrade .*