### PR TITLE
Add builtins.unsafeGetLambdaPos

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -444,6 +444,17 @@ static void prim_genericClosure(EvalState & state, const Pos & pos, Value * * ar
         v.listElems()[n++] = i;
 }
 
+/* Return position information of the given lambda. */
+void prim_unsafeGetLambdaPos(EvalState & state, const Pos & pos, Value * * args, Value & v)
+{
+    /* ensure the argument is a function */
+    state.forceValue(*args[0], pos);
+    if (args[0]->type != tLambda) {
+        throwTypeError(pos, "value is %1% while a lambda was expected", *args[0]);
+    }
+
+    state.mkPos(v, &args[0]->lambda.fun->pos);
+}
 
 static void prim_abort(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
@@ -2314,6 +2325,7 @@ void EvalState::createBaseEnv()
     addPrimOp("__isBool", 1, prim_isBool);
     addPrimOp("__isPath", 1, prim_isPath);
     addPrimOp("__genericClosure", 1, prim_genericClosure);
+    addPrimOp("__unsafeGetLambdaPos", 1, prim_unsafeGetLambdaPos);
     addPrimOp("abort", 1, prim_abort);
     addPrimOp("__addErrorContext", 2, prim_addErrorContext);
     addPrimOp("__tryEval", 1, prim_tryEval);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -450,7 +450,7 @@ void prim_unsafeGetLambdaPos(EvalState & state, const Pos & pos, Value * * args,
     /* ensure the argument is a function */
     state.forceValue(*args[0], pos);
     if (args[0]->type != tLambda) {
-        throwTypeError(pos, "value is %1% while a lambda was expected", *args[0]);
+        throwTypeError(pos, "%2%: value is %1% while a lambda was expected", *args[0]);
     }
 
     state.mkPos(v, &args[0]->lambda.fun->pos);

--- a/tests/lang/eval-okay-getlambdapos.exp
+++ b/tests/lang/eval-okay-getlambdapos.exp
@@ -1,0 +1,1 @@
+{ column = 9; file = "eval-okay-getlambdapos.nix"; line = 2; }

--- a/tests/lang/eval-okay-getlambdapos.nix
+++ b/tests/lang/eval-okay-getlambdapos.nix
@@ -1,0 +1,4 @@
+let
+  fun = { foo }: {};
+  pos = builtins.unsafeGetLambdaPos fun;
+in { inherit (pos) column line; file = baseNameOf pos.file; }


### PR DESCRIPTION
This is useful for a potential pure-Nix implementation of #3904 as `unsafeGetAttrPos` does not appear to be usable for finding lambdas that are defined by import, for example.

One thing I noticed while implementing this is that the way that Nix exposes Pos for things in the REPL as a set is surprising:

```
nix-repl> s = {a = 2;}                             

nix-repl> builtins.unsafeGetAttrPos "a" s          
{ column = 3; file = " {a = 2;}\n"; line = 1; }

nix-repl> f = a: "2"

nix-repl> builtins.unsafeGetLambdaPos f             
{ column = 2; file = " a: \"2\"\n"; line = 1; }
```

in that it doesn't report whether the `file` attribute is actually a file or arbitrary Nix source. It is unclear whether it's possible to rely on there being a leading space to determine whether a given `file` is actually Nix code.