### PR TITLE
demote remote build message to Info

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -201,7 +201,7 @@ static int _main(int argc, char * * argv)
                             % concatStringsSep<StringSet>(", ", m.mandatoryFeatures);
                         }
 
-                        logError({
+                        logErrorInfo(lvlInfo, {
                               .name = "Remote build",
                               .description = "Failed to find a machine for remote build!",
                               .hint = hint


### PR DESCRIPTION
Since this message can be a normal part of the build, it might be better off as an Info level message.  

So now we get the same message, but Info level:
![Selection_055](https://user-images.githubusercontent.com/157330/89923847-6bf97080-dbbe-11ea-9c18-d81fb4249d69.png)

And with --quiet they are filtered out:
![Selection_053](https://user-images.githubusercontent.com/157330/89923927-7ddb1380-dbbe-11ea-87a5-1860a0c5777b.png)
