### PR TITLE
repl.cc: Check for HAVE_BOEHMGC

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -31,8 +31,10 @@ extern "C" {
 #include "command.hh"
 #include "finally.hh"
 
+#if HAVE_BOEHMGC
 #define GC_INCLUDE_NEW
 #include <gc/gc_cpp.h>
+#endif
 
 namespace nix {
 
@@ -44,7 +46,10 @@ namespace nix {
 #define ESC_CYA "\033[36m"
 #define ESC_END "\033[0m"
 
-struct NixRepl : gc
+struct NixRepl
+    #if HAVE_BOEHMGC
+    : gc
+    #endif
 {
     string curDir;
     EvalState state;


### PR DESCRIPTION
`2.3-maintenance` backport of fix for #3906.

(cherry picked from commit 59067f0f587f75908c4f990bcbab29340c7f7652)