### PR TITLE
Don't try to parse signature check as commit timestamp

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -269,7 +269,7 @@ struct GitInputScheme : InputScheme
                 // modified dirty file?
                 input.attrs.insert_or_assign(
                     "lastModified",
-                    haveCommits ? std::stoull(runProgram("git", true, { "-C", actualUrl, "log", "-1", "--format=%ct", "HEAD" })) : 0);
+                    haveCommits ? std::stoull(runProgram("git", true, { "-C", actualUrl, "log", "-1", "--format=%ct", "--no-show-signature", "HEAD" })) : 0);
 
                 return {
                     Tree(store->printStorePath(storePath), std::move(storePath)),
@@ -421,7 +421,7 @@ struct GitInputScheme : InputScheme
 
         auto storePath = store->addToStore(name, tmpDir, FileIngestionMethod::Recursive, htSHA256, filter);
 
-        auto lastModified = std::stoull(runProgram("git", true, { "-C", repoDir, "log", "-1", "--format=%ct", input.getRev()->gitRev() }));
+        auto lastModified = std::stoull(runProgram("git", true, { "-C", repoDir, "log", "-1", "--format=%ct", "--no-show-signature", input.getRev()->gitRev() }));
 
         Attrs infoAttrs({
             {"rev", input.getRev()->gitRev()},


### PR DESCRIPTION
Fixes #3933

When the `log.showSignature` git setting is enabled, the output of
`git log` contains signature verification information in addition to the
timestamp `GitInputScheme::fetch` wants:

    $ git log -1 --format=%ct
    gpg: Signature made Sat 07 Sep 2019 02:02:03 PM PDT
    gpg:                using RSA key 0123456789ABCDEF0123456789ABCDEF01234567
    gpg:                issuer "user@example.com"
    gpg: Good signature from "User <user@example.com>" [ultimate] 1567890123
    1567890123

For folks that had `log.showSignature` set, this caused all nix operations
on flakes to fail:

    $ nix build
    error: stoull