### PR TITLE
Add plugin command support for `nix repl`

### DIFF
--- a/doc/manual/command-ref/conf-file.xml
+++ b/doc/manual/command-ref/conf-file.xml
@@ -611,8 +611,8 @@ password <replaceable>my-password</replaceable>
         plugins may construct static instances of RegisterPrimOp to
         add new primops or constants to the expression language,
         RegisterStoreImplementation to add new store implementations,
-        RegisterCommand to add new subcommands to the
-        <literal>nix</literal> command, and RegisterSetting to add new
+        RegisterReplCmd to add new commands to the
+        <literal>nix</literal> REPL, and RegisterSetting to add new
         nix config settings. See the constructors for those types for
         more details.
       </para>

--- a/src/libexpr/repl.cc
+++ b/src/libexpr/repl.cc
@@ -368,7 +368,7 @@ bool NixRepl::processLine(string line)
             if (std::any_of(cmd.names.begin(), cmd.names.end(),
                 [&](auto name){ return name == command.substr(1); })) {
                 // chop off the `:`
-                cmd.cmd(command.substr(1), arg);
+                cmd.cmd(*this, command.substr(1), arg);
                 return true;
             }
         }

--- a/src/libexpr/repl.cc
+++ b/src/libexpr/repl.cc
@@ -1,0 +1,625 @@
+#include <iostream>
+#include <iomanip>
+#include <cstdlib>
+#include <cstring>
+#include <climits>
+
+#include <setjmp.h>
+
+#include "repl.hh"
+#include "ansicolor.hh"
+#include "shared.hh"
+#include "eval.hh"
+#include "eval-inline.hh"
+#include "attr-path.hh"
+#include "store-api.hh"
+#include "common-eval-args.hh"
+#include "get-drvs.hh"
+#include "derivations.hh"
+#include "affinity.hh"
+#include "globals.hh"
+#include "finally.hh"
+
+namespace nix {
+
+RegisterReplCmd::ReplCmds * RegisterReplCmd::replCmds;
+
+RegisterReplCmd::RegisterReplCmd(vector<string> names, string help, ReplCmdFun cmd,
+                                 string argPlaceholder)
+{
+    if (!replCmds) replCmds = new ReplCmds;
+    replCmds->push_back({names, argPlaceholder, help, cmd});
+}
+
+string NixRepl::removeWhitespace(string s)
+{
+    s = chomp(s);
+    size_t n = s.find_first_not_of(" \n\r\t");
+    if (n != string::npos) s = string(s, n);
+    return s;
+}
+
+
+NixRepl::NixRepl(const Strings & searchPath, nix::ref<Store> store,
+                 NixRepl::CompletionFunctions completionFunctions)
+    : state(std::make_unique<EvalState>(searchPath, store))
+    , staticEnv(false, &state->staticBaseEnv)
+    , historyFile(getDataDir() + "/nix/repl-history")
+    , completionFunctions(completionFunctions)
+{
+    curDir = absPath(".");
+}
+
+
+NixRepl::~NixRepl()
+{
+    completionFunctions.writeHistory(historyFile.c_str());
+}
+
+
+namespace {
+    // Used to communicate to NixRepl::getLine whether a signal occurred in ::readline.
+    volatile sig_atomic_t g_signal_received = 0;
+
+    void sigintHandler(int signo) {
+        g_signal_received = signo;
+    }
+}
+
+bool NixRepl::getLine(string & input, const std::string &prompt)
+{
+    struct sigaction act, old;
+    sigset_t savedSignalMask, set;
+
+    auto setupSignals = [&]() {
+        act.sa_handler = sigintHandler;
+        sigfillset(&act.sa_mask);
+        act.sa_flags = 0;
+        if (sigaction(SIGINT, &act, &old))
+            throw SysError("installing handler for SIGINT");
+
+        sigemptyset(&set);
+        sigaddset(&set, SIGINT);
+        if (sigprocmask(SIG_UNBLOCK, &set, &savedSignalMask))
+            throw SysError("unblocking SIGINT");
+    };
+    auto restoreSignals = [&]() {
+        if (sigprocmask(SIG_SETMASK, &savedSignalMask, nullptr))
+            throw SysError("restoring signals");
+
+        if (sigaction(SIGINT, &old, 0))
+            throw SysError("restoring handler for SIGINT");
+    };
+
+    setupSignals();
+    char * s = completionFunctions.readline(prompt.c_str());
+    Finally doFree([&]() { free(s); });
+    restoreSignals();
+
+    if (g_signal_received) {
+        g_signal_received = 0;
+        input.clear();
+        return true;
+    }
+
+    if (!s)
+      return false;
+    input += s;
+    input += '\n';
+    return true;
+}
+
+
+StringSet NixRepl::completePrefix(string prefix)
+{
+    StringSet completions;
+
+    size_t start = prefix.find_last_of(" \n\r\t(){}[]");
+    std::string prev, cur;
+    if (start == std::string::npos) {
+        prev = "";
+        cur = prefix;
+    } else {
+        prev = std::string(prefix, 0, start + 1);
+        cur = std::string(prefix, start + 1);
+    }
+
+    size_t slash, dot;
+
+    if ((slash = cur.rfind('/')) != string::npos) {
+        try {
+            auto dir = std::string(cur, 0, slash);
+            auto prefix2 = std::string(cur, slash + 1);
+            for (auto & entry : readDirectory(dir == "" ? "/" : dir)) {
+                if (entry.name[0] != '.' && hasPrefix(entry.name, prefix2))
+                    completions.insert(prev + dir + "/" + entry.name);
+            }
+        } catch (Error &) {
+        }
+    } else if ((dot = cur.rfind('.')) == string::npos) {
+        /* This is a variable name; look it up in the current scope. */
+        StringSet::iterator i = varNames.lower_bound(cur);
+        while (i != varNames.end()) {
+            if (string(*i, 0, cur.size()) != cur) break;
+            completions.insert(prev + *i);
+            i++;
+        }
+    } else {
+        try {
+            /* This is an expression that should evaluate to an
+               attribute set.  Evaluate it to get the names of the
+               attributes. */
+            string expr(cur, 0, dot);
+            string cur2 = string(cur, dot + 1);
+
+            Expr * e = parseString(expr);
+            Value v;
+            e->eval(*state, *env, v);
+            state->forceAttrs(v);
+
+            for (auto & i : *v.attrs) {
+                string name = i.name;
+                if (string(name, 0, cur2.size()) != cur2) continue;
+                completions.insert(prev + expr + "." + name);
+            }
+
+        } catch (ParseError & e) {
+            // Quietly ignore parse errors.
+        } catch (EvalError & e) {
+            // Quietly ignore evaluation errors.
+        } catch (UndefinedVarError & e) {
+            // Quietly ignore undefined variable errors.
+        }
+    }
+
+    return completions;
+}
+
+
+static int runProgram(const string & program, const Strings & args)
+{
+    Strings args2(args);
+    args2.push_front(program);
+
+    Pid pid;
+    pid = fork();
+    if (pid == -1) throw SysError("forking");
+    if (pid == 0) {
+        restoreAffinity();
+        execvp(program.c_str(), stringsToCharPtrs(args2).data());
+        _exit(1);
+    }
+
+    return pid.wait();
+}
+
+
+bool isVarName(const string & s)
+{
+    if (s.size() == 0) return false;
+    char c = s[0];
+    if ((c >= '0' && c <= '9') || c == '-' || c == '\'') return false;
+    for (auto & i : s)
+        if (!((i >= 'a' && i <= 'z') ||
+              (i >= 'A' && i <= 'Z') ||
+              (i >= '0' && i <= '9') ||
+              i == '_' || i == '-' || i == '\''))
+            return false;
+    return true;
+}
+
+
+Path NixRepl::getDerivationPath(Value & v) {
+    auto drvInfo = getDerivation(*state, v, false);
+    if (!drvInfo)
+        throw Error("expression does not evaluate to a derivation, so I can't build it");
+    Path drvPath = drvInfo->queryDrvPath();
+    if (drvPath == "" || !state->store->isValidPath(state->store->parseStorePath(drvPath)))
+        throw Error("expression did not evaluate to a valid derivation");
+    return drvPath;
+}
+
+
+bool NixRepl::processLine(string line)
+{
+    if (line == "") return true;
+
+    string command, arg;
+
+    if (line[0] == ':') {
+        size_t p = line.find_first_of(" \n\r\t");
+        command = string(line, 0, p);
+        if (p != string::npos) arg = removeWhitespace(string(line, p));
+    } else {
+        arg = line;
+    }
+
+    if (command == ":?" || command == ":help") {
+        std::cout
+             << "The following commands are available:\n"
+             << "\n"
+             << "  <expr>        Evaluate and print expression\n"
+             << "  <x> = <expr>  Bind expression to variable\n"
+             << "  :a <expr>     Add attributes from resulting set to scope\n"
+             << "  :b <expr>     Build derivation\n"
+             << "  :e <expr>     Open the derivation in $EDITOR\n"
+             << "  :i <expr>     Build derivation, then install result into current profile\n"
+             << "  :l <path>     Load Nix expression and add it to scope\n"
+             << "  :p <expr>     Evaluate and print expression recursively\n"
+             << "  :q            Exit nix-repl\n"
+             << "  :r            Reload all files\n"
+             << "  :s <expr>     Build dependencies of derivation, then start nix-shell\n"
+             << "  :t <expr>     Describe result of evaluation\n"
+             << "  :u <expr>     Build derivation, then start nix-shell\n";
+        if (RegisterReplCmd::replCmds) {
+            for (auto &&cmd : *RegisterReplCmd::replCmds) {
+                std::ostringstream nameHelp {};
+                nameHelp
+                    << ":"
+                    << cmd.names[0]
+                    << " "
+                    << cmd.argPlaceholder;
+                string formattedNameHelp = nameHelp.str();
+                std::cout
+                    << "  "
+                    << std::left
+                    << std::setw(14)
+                    << formattedNameHelp
+                    << std::setw(0)
+                    << cmd.help
+                    << "\n";
+            }
+        }
+    }
+
+    else if (command == ":a" || command == ":add") {
+        Value v;
+        evalString(arg, v);
+        addAttrsToScope(v);
+    }
+
+    else if (command == ":l" || command == ":load") {
+        state->resetFileCache();
+        loadFile(arg);
+    }
+
+    else if (command == ":r" || command == ":reload") {
+        state->resetFileCache();
+        reloadFiles();
+    }
+
+    else if (command == ":e" || command == ":edit") {
+        Value v;
+        evalString(arg, v);
+
+        Pos pos;
+
+        if (v.type == tPath || v.type == tString) {
+            PathSet context;
+            auto filename = state->coerceToString(noPos, v, context);
+            pos.file = state->symbols.create(filename);
+        } else if (v.type == tLambda) {
+            pos = v.lambda.fun->pos;
+        } else {
+            // assume it's a derivation
+            pos = findDerivationFilename(*state, v, arg);
+        }
+
+        // Open in EDITOR
+        auto args = editorFor(pos.file, pos.line);
+        auto editor = args.front();
+        args.pop_front();
+        runProgram(editor, args);
+
+        // Reload right after exiting the editor
+        state->resetFileCache();
+        reloadFiles();
+    }
+
+    else if (command == ":t") {
+        Value v;
+        evalString(arg, v);
+        std::cout << showType(v) << std::endl;
+
+    } else if (command == ":u") {
+        Value v, f, result;
+        evalString(arg, v);
+        evalString("drv: (import <nixpkgs> {}).runCommand \"shell\" { buildInputs = [ drv ]; } \"\"", f);
+        state->callFunction(f, v, result, Pos());
+
+        Path drvPath = getDerivationPath(result);
+        runProgram(settings.nixBinDir + "/nix-shell", Strings{drvPath});
+    }
+
+    else if (command == ":b" || command == ":i" || command == ":s") {
+        Value v;
+        evalString(arg, v);
+        Path drvPath = getDerivationPath(v);
+
+        if (command == ":b") {
+            /* We could do the build in this process using buildPaths(),
+               but doing it in a child makes it easier to recover from
+               problems / SIGINT. */
+            if (runProgram(settings.nixBinDir + "/nix", Strings{"build", "--no-link", drvPath}) == 0) {
+                auto drv = readDerivation(*state->store, drvPath, Derivation::nameFromPath(state->store->parseStorePath(drvPath)));
+                std::cout << std::endl << "this derivation produced the following outputs:" << std::endl;
+                for (auto & i : drv.outputsAndPaths(*state->store))
+                    std::cout << fmt("  %s -> %s\n", i.first, state->store->printStorePath(i.second.second));
+            }
+        } else if (command == ":i") {
+            runProgram(settings.nixBinDir + "/nix-env", Strings{"-i", drvPath});
+        } else {
+            runProgram(settings.nixBinDir + "/nix-shell", Strings{drvPath});
+        }
+    }
+
+    else if (command == ":p" || command == ":print") {
+        Value v;
+        evalString(arg, v);
+        printValue(std::cout, v, 1000000000) << std::endl;
+    }
+
+    else if (command == ":q" || command == ":quit")
+        return false;
+
+    else if (command != "") {
+        // find a custom command
+        for (auto&& cmd : *RegisterReplCmd::replCmds) {
+            if (std::any_of(cmd.names.begin(), cmd.names.end(),
+                [&](auto name){ return name == command.substr(1); })) {
+                // chop off the `:`
+                cmd.cmd(command.substr(1), arg);
+                return true;
+            }
+        }
+        // failed, it must not exist
+        throw Error("unknown command '%1%'", command);
+    }
+
+    else {
+        size_t p = line.find('=');
+        string name;
+        if (p != string::npos &&
+            p < line.size() &&
+            line[p + 1] != '=' &&
+            isVarName(name = removeWhitespace(string(line, 0, p))))
+        {
+            Expr * e = parseString(string(line, p + 1));
+            Value & v(*state->allocValue());
+            v.type = tThunk;
+            v.thunk.env = env;
+            v.thunk.expr = e;
+            addVarToScope(state->symbols.create(name), v);
+        } else {
+            Value v;
+            evalString(line, v);
+            printValue(std::cout, v, 1) << std::endl;
+        }
+    }
+
+    return true;
+}
+
+
+void NixRepl::loadFile(const Path & path)
+{
+    loadedFiles.remove(path);
+    loadedFiles.push_back(path);
+    Value v, v2;
+    state->evalFile(lookupFileArg(*state, path), v);
+    state->autoCallFunction(*autoArgs, v, v2);
+    addAttrsToScope(v2);
+}
+
+
+void NixRepl::initEnv()
+{
+    env = &state->allocEnv(envSize);
+    env->up = &state->baseEnv;
+    displ = 0;
+    staticEnv.vars.clear();
+
+    varNames.clear();
+    for (auto & i : state->staticBaseEnv.vars)
+        varNames.insert(i.first);
+}
+
+
+void NixRepl::reloadFiles()
+{
+    initEnv();
+
+    Strings old = loadedFiles;
+    loadedFiles.clear();
+
+    bool first = true;
+    for (auto & i : old) {
+        if (!first) std::cout << std::endl;
+        first = false;
+        std::cout << format("Loading '%1%'...") % i << std::endl;
+        loadFile(i);
+    }
+}
+
+
+void NixRepl::addAttrsToScope(Value & attrs)
+{
+    state->forceAttrs(attrs);
+    for (auto & i : *attrs.attrs)
+        addVarToScope(i.name, *i.value);
+    std::cout << format("Added %1% variables.") % attrs.attrs->size() << std::endl;
+}
+
+
+void NixRepl::addVarToScope(const Symbol & name, Value & v)
+{
+    if (displ >= envSize)
+        throw Error("environment full; cannot add more variables");
+    staticEnv.vars[name] = displ;
+    env->values[displ++] = &v;
+    varNames.insert((string) name);
+}
+
+
+Expr * NixRepl::parseString(string s)
+{
+    Expr * e = state->parseExprFromString(s, curDir, staticEnv);
+    return e;
+}
+
+
+void NixRepl::evalString(string s, Value & v)
+{
+    Expr * e = parseString(s);
+    e->eval(*state, *env, v);
+    state->forceValue(v);
+}
+
+
+std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int maxDepth)
+{
+    ValuesSeen seen;
+    return printValue(str, v, maxDepth, seen);
+}
+
+
+std::ostream & printStringValue(std::ostream & str, const char * string) {
+    str << "\"";
+    for (const char * i = string; *i; i++)
+        if (*i == '\"' || *i == '\\') str << "\\" << *i;
+        else if (*i == '\n') str << "\\n";
+        else if (*i == '\r') str << "\\r";
+        else if (*i == '\t') str << "\\t";
+        else str << *i;
+    str << "\"";
+    return str;
+}
+
+
+// FIXME: lot of cut&paste from Nix's eval.cc.
+std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int maxDepth, ValuesSeen & seen)
+{
+    str.flush();
+    checkInterrupt();
+
+    state->forceValue(v);
+
+    switch (v.type) {
+
+    case tInt:
+        str << ANSI_CYAN << v.integer << ANSI_NORMAL;
+        break;
+
+    case tBool:
+        str << ANSI_CYAN << (v.boolean ? "true" : "false") << ANSI_NORMAL;
+        break;
+
+    case tString:
+        str << ANSI_YELLOW;
+        printStringValue(str, v.string.s);
+        str << ANSI_NORMAL;
+        break;
+
+    case tPath:
+        str << ANSI_GREEN << v.path << ANSI_NORMAL; // !!! escaping?
+        break;
+
+    case tNull:
+        str << ANSI_CYAN "null" ANSI_NORMAL;
+        break;
+
+    case tAttrs: {
+        seen.insert(&v);
+
+        bool isDrv = state->isDerivation(v);
+
+        if (isDrv) {
+            str << "«derivation ";
+            Bindings::iterator i = v.attrs->find(state->sDrvPath);
+            PathSet context;
+            Path drvPath = i != v.attrs->end() ? state->coerceToPath(*i->pos, *i->value, context) : "???";
+            str << drvPath << "»";
+        }
+
+        else if (maxDepth > 0) {
+            str << "{ ";
+
+            typedef std::map<string, Value *> Sorted;
+            Sorted sorted;
+            for (auto & i : *v.attrs)
+                sorted[i.name] = i.value;
+
+            for (auto & i : sorted) {
+                if (isVarName(i.first))
+                    str << i.first;
+                else
+                    printStringValue(str, i.first.c_str());
+                str << " = ";
+                if (seen.find(i.second) != seen.end())
+                    str << "«repeated»";
+                else
+                    try {
+                        printValue(str, *i.second, maxDepth - 1, seen);
+                    } catch (AssertionError & e) {
+                        str << ANSI_RED "«error: " << e.msg() << "»" ANSI_NORMAL;
+                    }
+                str << "; ";
+            }
+
+            str << "}";
+        } else
+            str << "{ ... }";
+
+        break;
+    }
+
+    case tList1:
+    case tList2:
+    case tListN:
+        seen.insert(&v);
+
+        str << "[ ";
+        if (maxDepth > 0)
+            for (unsigned int n = 0; n < v.listSize(); ++n) {
+                if (seen.find(v.listElems()[n]) != seen.end())
+                    str << "«repeated»";
+                else
+                    try {
+                        printValue(str, *v.listElems()[n], maxDepth - 1, seen);
+                    } catch (AssertionError & e) {
+                        str << ANSI_RED "«error: " << e.msg() << "»" ANSI_NORMAL;
+                    }
+                str << " ";
+            }
+        else
+            str << "... ";
+        str << "]";
+        break;
+
+    case tLambda: {
+        std::ostringstream s;
+        s << v.lambda.fun->pos;
+        str << ANSI_BLUE "«lambda @ " << filterANSIEscapes(s.str()) << "»" ANSI_NORMAL;
+        break;
+    }
+
+    case tPrimOp:
+        str << ANSI_MAGENTA "«primop»" ANSI_NORMAL;
+        break;
+
+    case tPrimOpApp:
+        str << ANSI_BLUE "«primop-app»" ANSI_NORMAL;
+        break;
+
+    case tFloat:
+        str << v.fpoint;
+        break;
+
+    default:
+        str << ANSI_RED "«unknown»" ANSI_NORMAL;
+        break;
+    }
+
+    return str;
+}
+}

--- a/src/libexpr/repl.hh
+++ b/src/libexpr/repl.hh
@@ -57,7 +57,7 @@ struct NixRepl
     std::ostream &  printValue(std::ostream & str, Value & v, unsigned int maxDepth, ValuesSeen & seen);
 };
 
-using ReplCmdFun = std::function<void (string name, string arg)>;
+using ReplCmdFun = std::function<void (NixRepl & repl, string name, string arg)>;
 
 /**
  * A registry for extending the REPL commands list.

--- a/src/libexpr/repl.hh
+++ b/src/libexpr/repl.hh
@@ -1,0 +1,99 @@
+#include "eval.hh"
+#include <vector>
+#include <functional>
+
+#if HAVE_BOEHMGC
+#define GC_INCLUDE_NEW
+#include <gc/gc_cpp.h>
+#endif
+
+namespace nix {
+
+struct NixRepl
+    #if HAVE_BOEHMGC
+    : gc
+    #endif
+{
+    struct CompletionFunctions {
+        std::function<int (const char * filename)> writeHistory;
+        std::function<char * (const char * prompt)> readline;
+    };
+
+    string curDir;
+    std::unique_ptr<EvalState> state;
+    Bindings * autoArgs;
+
+    Strings loadedFiles;
+
+    const static int envSize = 32768;
+    StaticEnv staticEnv;
+    Env * env;
+    int displ;
+    StringSet varNames;
+
+    const Path historyFile;
+    CompletionFunctions completionFunctions;
+
+    NixRepl(const Strings & searchPath, nix::ref<Store> store,
+            CompletionFunctions completionFunctions);
+    ~NixRepl();
+    void mainLoop(const std::vector<std::string> & files);
+    StringSet completePrefix(string prefix);
+    bool getLine(string & input, const std::string &prompt);
+    Path getDerivationPath(Value & v);
+    bool processLine(string line);
+    void loadFile(const Path & path);
+    void initEnv();
+    void reloadFiles();
+    void addAttrsToScope(Value & attrs);
+    void addVarToScope(const Symbol & name, Value & v);
+    Expr * parseString(string s);
+    void evalString(string s, Value & v);
+
+    static string removeWhitespace(string s);
+
+    typedef set<Value *> ValuesSeen;
+    std::ostream &  printValue(std::ostream & str, Value & v, unsigned int maxDepth);
+    std::ostream &  printValue(std::ostream & str, Value & v, unsigned int maxDepth, ValuesSeen & seen);
+};
+
+using ReplCmdFun = std::function<void (string name, string arg)>;
+
+/**
+ * A registry for extending the REPL commands list.
+ */
+struct RegisterReplCmd
+{
+    struct ReplCmd
+    {
+        /**
+         * Names of the commands this matches, not prefixed by :. The first one
+         * is displayed in help.
+         */
+        vector<string> names;
+        /**
+         * Argument placeholder, for example, "<expr>".
+         */
+        string argPlaceholder;
+        /**
+         * Help message displayed in :?.
+         */
+        string help;
+        /**
+         * Callback.
+         */
+        ReplCmdFun cmd;
+    };
+
+    using ReplCmds = vector<ReplCmd>;
+
+    static ReplCmds * replCmds;
+
+    RegisterReplCmd(
+        vector<string> names,
+        string help,
+        ReplCmdFun cmd,
+        string argPlaceholder = ""
+    );
+};
+}

--- a/src/libutil/callable.hh
+++ b/src/libutil/callable.hh
@@ -1,0 +1,30 @@
+#pragma once
+// from https://stackoverflow.com/a/48368508
+
+#include <type_traits>
+#include <functional>
+
+template <class F>
+struct lambda_traits : lambda_traits<decltype(&F::operator())>
+{ };
+
+template <typename F, typename R, typename... Args>
+struct lambda_traits<R(F::*)(Args...)> : lambda_traits<R(F::*)(Args...) const>
+{ };
+
+template <class F, class R, class... Args>
+struct lambda_traits<R(F::*)(Args...) const> {
+    using pointer = typename std::add_pointer<R(Args...)>::type;
+
+    static pointer cify(F&& f) {
+        static F fn = std::forward<F>(f);
+        return [](Args... args) {
+            return fn(std::forward<Args>(args)...);
+        };
+    }
+};
+
+template <class F>
+inline typename lambda_traits<F>::pointer cify(F&& f) {
+    return lambda_traits<F>::cify(std::forward<F>(f));
+}

--- a/src/libutil/ref.hh
+++ b/src/libutil/ref.hh
@@ -7,7 +7,7 @@
 namespace nix {
 
 /* A simple non-nullable reference-counted pointer. Actually a wrapper
-   around std::shared_ptr that prevents non-null constructions. */
+   around std::shared_ptr that prevents null constructions. */
 template<typename T>
 class ref
 {

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -558,6 +558,18 @@ Path getDataDir()
     return dataDir ? *dataDir : getHome() + "/.local/share";
 }
 
+Strings editorFor(const Path & file, unsigned int line)
+{
+    auto editor = getEnv("EDITOR").value_or("cat");
+    auto args = tokenizeString<Strings>(editor);
+    if (line > 0 && (
+        editor.find("emacs") != std::string::npos ||
+        editor.find("nano") != std::string::npos ||
+        editor.find("vim") != std::string::npos))
+        args.push_back(fmt("+%d", line));
+    args.push_back(file);
+    return args;
+}
 
 Paths createDirs(const Path & path)
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -144,6 +144,10 @@ std::vector<Path> getConfigDirs();
 /* Return $XDG_DATA_HOME or $HOME/.local/share. */
 Path getDataDir();
 
+/* Helper function to generate args that invoke $EDITOR on
+   filename:lineno. */
+Strings editorFor(const Path & file, unsigned int line);
+
 /* Create a directory and all its parents, if necessary.  Returns the
    list of created directories, in order of creation. */
 Paths createDirs(const Path & path);

--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -88,19 +88,6 @@ void StorePathCommand::run(ref<Store> store)
     run(store, *storePaths.begin());
 }
 
-Strings editorFor(const Pos & pos)
-{
-    auto editor = getEnv("EDITOR").value_or("cat");
-    auto args = tokenizeString<Strings>(editor);
-    if (pos.line > 0 && (
-        editor.find("emacs") != std::string::npos ||
-        editor.find("nano") != std::string::npos ||
-        editor.find("vim") != std::string::npos))
-        args.push_back(fmt("+%d", pos.line));
-    args.push_back(pos.file);
-    return args;
-}
-
 MixProfile::MixProfile()
 {
     addFlag({

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -200,10 +200,6 @@ std::set<StorePath> toDerivations(ref<Store> store,
     std::vector<std::shared_ptr<Installable>> installables,
     bool useDeriver = false);
 
-/* Helper function to generate args that invoke $EDITOR on
-   filename:lineno. */
-Strings editorFor(const Pos & pos);
-
 struct MixProfile : virtual StoreCommand
 {
     std::optional<Path> profile;

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -43,7 +43,7 @@ struct CmdEdit : InstallableCommand
 
         stopProgressBar();
 
-        auto args = editorFor(pos);
+        auto args = editorFor(pos.file, pos.line);
 
         restoreSignals();
         execvp(args.front().c_str(), stringsToCharPtrs(args).data());

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -13,7 +13,7 @@ extern "C" {
 
 namespace nix {
 
-static int replListPossibleCallback(NixRepl & repl, char *s, char ***avp) {
+static int listPossibleCallback(NixRepl & repl, char *s, char ***avp) {
   auto possible = repl.completePrefix(s);
 
   if (possible.size() > (INT_MAX / sizeof(char*)))
@@ -75,7 +75,7 @@ static char * completionCallback(NixRepl & repl, char * s, int *match) {
   return nullptr;
 }
 
-void replMainLoop(NixRepl & repl, const std::vector<std::string> & files)
+static void replMainLoop(NixRepl & repl, const std::vector<std::string> & files)
 {
     string error = ANSI_RED "error:" ANSI_NORMAL " ";
     std::cout << "Welcome to Nix version " << nixVersion << ". Type :? for help." << std::endl << std::endl;
@@ -96,7 +96,7 @@ void replMainLoop(NixRepl & repl, const std::vector<std::string> & files)
         return completionCallback(repl, s, match);
     }));
     rl_set_list_possib_func(cify([&repl](char *s, char ***avp) {
-            return replListPossibleCallback(repl, s, avp);
+            return listPossibleCallback(repl, s, avp);
         }));
 
     std::string input;

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -1,14 +1,7 @@
-#include <iostream>
-#include <cstdlib>
-#include <cstring>
-#include <climits>
+#include "command.hh"
+#include "repl.hh"
+#include "callable.hh"
 
-#include <setjmp.h>
-
-#ifdef READLINE
-#include <readline/history.h>
-#include <readline/readline.h>
-#else
 // editline < 1.15.2 don't wrap their API for C++ usage
 // (added in https://github.com/troglobit/editline/commit/91398ceb3427b730995357e9d120539fb9bb7461).
 // This results in linker errors due to to name-mangling of editline C symbols.
@@ -17,127 +10,11 @@
 extern "C" {
 #include <editline.h>
 }
-#endif
-
-#include "ansicolor.hh"
-#include "shared.hh"
-#include "eval.hh"
-#include "eval-inline.hh"
-#include "attr-path.hh"
-#include "store-api.hh"
-#include "common-eval-args.hh"
-#include "get-drvs.hh"
-#include "derivations.hh"
-#include "affinity.hh"
-#include "globals.hh"
-#include "command.hh"
-#include "finally.hh"
-
-#if HAVE_BOEHMGC
-#define GC_INCLUDE_NEW
-#include <gc/gc_cpp.h>
-#endif
 
 namespace nix {
 
-struct NixRepl
-    #if HAVE_BOEHMGC
-    : gc
-    #endif
-{
-    string curDir;
-    std::unique_ptr<EvalState> state;
-    Bindings * autoArgs;
-
-    Strings loadedFiles;
-
-    const static int envSize = 32768;
-    StaticEnv staticEnv;
-    Env * env;
-    int displ;
-    StringSet varNames;
-
-    const Path historyFile;
-
-    NixRepl(const Strings & searchPath, nix::ref<Store> store);
-    ~NixRepl();
-    void mainLoop(const std::vector<std::string> & files);
-    StringSet completePrefix(string prefix);
-    bool getLine(string & input, const std::string &prompt);
-    Path getDerivationPath(Value & v);
-    bool processLine(string line);
-    void loadFile(const Path & path);
-    void initEnv();
-    void reloadFiles();
-    void addAttrsToScope(Value & attrs);
-    void addVarToScope(const Symbol & name, Value & v);
-    Expr * parseString(string s);
-    void evalString(string s, Value & v);
-
-    typedef set<Value *> ValuesSeen;
-    std::ostream &  printValue(std::ostream & str, Value & v, unsigned int maxDepth);
-    std::ostream &  printValue(std::ostream & str, Value & v, unsigned int maxDepth, ValuesSeen & seen);
-};
-
-
-string removeWhitespace(string s)
-{
-    s = chomp(s);
-    size_t n = s.find_first_not_of(" \n\r\t");
-    if (n != string::npos) s = string(s, n);
-    return s;
-}
-
-
-NixRepl::NixRepl(const Strings & searchPath, nix::ref<Store> store)
-    : state(std::make_unique<EvalState>(searchPath, store))
-    , staticEnv(false, &state->staticBaseEnv)
-    , historyFile(getDataDir() + "/nix/repl-history")
-{
-    curDir = absPath(".");
-}
-
-
-NixRepl::~NixRepl()
-{
-    write_history(historyFile.c_str());
-}
-
-static NixRepl * curRepl; // ugly
-
-static char * completionCallback(char * s, int *match) {
-  auto possible = curRepl->completePrefix(s);
-  if (possible.size() == 1) {
-    *match = 1;
-    auto *res = strdup(possible.begin()->c_str() + strlen(s));
-    if (!res) throw Error("allocation failure");
-    return res;
-  } else if (possible.size() > 1) {
-    auto checkAllHaveSameAt = [&](size_t pos) {
-      auto &first = *possible.begin();
-      for (auto &p : possible) {
-        if (p.size() <= pos || p[pos] != first[pos])
-          return false;
-      }
-      return true;
-    };
-    size_t start = strlen(s);
-    size_t len = 0;
-    while (checkAllHaveSameAt(start + len)) ++len;
-    if (len > 0) {
-      *match = 1;
-      auto *res = strdup(std::string(*possible.begin(), start, len).c_str());
-      if (!res) throw Error("allocation failure");
-      return res;
-    }
-  }
-
-  *match = 0;
-  return nullptr;
-}
-
-static int listPossibleCallback(char *s, char ***avp) {
-  auto possible = curRepl->completePrefix(s);
+static int replListPossibleCallback(NixRepl & repl, char *s, char ***avp) {
+  auto possible = repl.completePrefix(s);
 
   if (possible.size() > (INT_MAX / sizeof(char*)))
     throw Error("too many completions");
@@ -167,49 +44,71 @@ static int listPossibleCallback(char *s, char ***avp) {
   return ac;
 }
 
-namespace {
-    // Used to communicate to NixRepl::getLine whether a signal occurred in ::readline.
-    volatile sig_atomic_t g_signal_received = 0;
-
-    void sigintHandler(int signo) {
-        g_signal_received = signo;
+static char * completionCallback(NixRepl & repl, char * s, int *match) {
+  auto possible = repl.completePrefix(s);
+  if (possible.size() == 1) {
+    *match = 1;
+    auto *res = strdup(possible.begin()->c_str() + strlen(s));
+    if (!res) throw Error("allocation failure");
+    return res;
+  } else if (possible.size() > 1) {
+    auto checkAllHaveSameAt = [&](size_t pos) {
+      auto &first = *possible.begin();
+      for (auto &p : possible) {
+        if (p.size() <= pos || p[pos] != first[pos])
+          return false;
+      }
+      return true;
+    };
+    size_t start = strlen(s);
+    size_t len = 0;
+    while (checkAllHaveSameAt(start + len)) ++len;
+    if (len > 0) {
+      *match = 1;
+      auto *res = strdup(std::string(*possible.begin(), start, len).c_str());
+      if (!res) throw Error("allocation failure");
+      return res;
     }
+  }
+
+  *match = 0;
+  return nullptr;
 }
 
-void NixRepl::mainLoop(const std::vector<std::string> & files)
+void replMainLoop(NixRepl & repl, const std::vector<std::string> & files)
 {
     string error = ANSI_RED "error:" ANSI_NORMAL " ";
     std::cout << "Welcome to Nix version " << nixVersion << ". Type :? for help." << std::endl << std::endl;
 
     for (auto & i : files)
-        loadedFiles.push_back(i);
+        repl.loadedFiles.push_back(i);
 
-    reloadFiles();
-    if (!loadedFiles.empty()) std::cout << std::endl;
+    repl.reloadFiles();
+    if (!repl.loadedFiles.empty()) std::cout << std::endl;
 
     // Allow nix-repl specific settings in .inputrc
     rl_readline_name = "nix-repl";
-    createDirs(dirOf(historyFile));
-#ifndef READLINE
+    createDirs(dirOf(repl.historyFile));
+
     el_hist_size = 1000;
-#endif
-    read_history(historyFile.c_str());
-    curRepl = this;
-#ifndef READLINE
-    rl_set_complete_func(completionCallback);
-    rl_set_list_possib_func(listPossibleCallback);
-#endif
+    read_history(repl.historyFile.c_str());
+    rl_set_complete_func(cify([&repl](char * s, int * match) {
+        return completionCallback(repl, s, match);
+    }));
+    rl_set_list_possib_func(cify([&repl](char *s, char ***avp) {
+            return replListPossibleCallback(repl, s, avp);
+        }));
 
     std::string input;
 
     while (true) {
         // When continuing input from previous lines, don't print a prompt, just align to the same
         // number of chars as the prompt.
-        if (!getLine(input, input.empty() ? "nix-repl> " : "          "))
+        if (!repl.getLine(input, input.empty() ? "nix-repl> " : "          "))
             break;
 
         try {
-            if (!removeWhitespace(input).empty() && !processLine(input)) return;
+            if (!repl.removeWhitespace(input).empty() && !repl.processLine(input)) return;
         } catch (ParseError & e) {
             if (e.msg().find("unexpected $end") != std::string::npos) {
                 // For parse errors on incomplete input, we continue waiting for the next line of
@@ -231,533 +130,6 @@ void NixRepl::mainLoop(const std::vector<std::string> & files)
     }
 }
 
-
-bool NixRepl::getLine(string & input, const std::string &prompt)
-{
-    struct sigaction act, old;
-    sigset_t savedSignalMask, set;
-
-    auto setupSignals = [&]() {
-        act.sa_handler = sigintHandler;
-        sigfillset(&act.sa_mask);
-        act.sa_flags = 0;
-        if (sigaction(SIGINT, &act, &old))
-            throw SysError("installing handler for SIGINT");
-
-        sigemptyset(&set);
-        sigaddset(&set, SIGINT);
-        if (sigprocmask(SIG_UNBLOCK, &set, &savedSignalMask))
-            throw SysError("unblocking SIGINT");
-    };
-    auto restoreSignals = [&]() {
-        if (sigprocmask(SIG_SETMASK, &savedSignalMask, nullptr))
-            throw SysError("restoring signals");
-
-        if (sigaction(SIGINT, &old, 0))
-            throw SysError("restoring handler for SIGINT");
-    };
-
-    setupSignals();
-    char * s = readline(prompt.c_str());
-    Finally doFree([&]() { free(s); });
-    restoreSignals();
-
-    if (g_signal_received) {
-        g_signal_received = 0;
-        input.clear();
-        return true;
-    }
-
-    if (!s)
-      return false;
-    input += s;
-    input += '\n';
-    return true;
-}
-
-
-StringSet NixRepl::completePrefix(string prefix)
-{
-    StringSet completions;
-
-    size_t start = prefix.find_last_of(" \n\r\t(){}[]");
-    std::string prev, cur;
-    if (start == std::string::npos) {
-        prev = "";
-        cur = prefix;
-    } else {
-        prev = std::string(prefix, 0, start + 1);
-        cur = std::string(prefix, start + 1);
-    }
-
-    size_t slash, dot;
-
-    if ((slash = cur.rfind('/')) != string::npos) {
-        try {
-            auto dir = std::string(cur, 0, slash);
-            auto prefix2 = std::string(cur, slash + 1);
-            for (auto & entry : readDirectory(dir == "" ? "/" : dir)) {
-                if (entry.name[0] != '.' && hasPrefix(entry.name, prefix2))
-                    completions.insert(prev + dir + "/" + entry.name);
-            }
-        } catch (Error &) {
-        }
-    } else if ((dot = cur.rfind('.')) == string::npos) {
-        /* This is a variable name; look it up in the current scope. */
-        StringSet::iterator i = varNames.lower_bound(cur);
-        while (i != varNames.end()) {
-            if (string(*i, 0, cur.size()) != cur) break;
-            completions.insert(prev + *i);
-            i++;
-        }
-    } else {
-        try {
-            /* This is an expression that should evaluate to an
-               attribute set.  Evaluate it to get the names of the
-               attributes. */
-            string expr(cur, 0, dot);
-            string cur2 = string(cur, dot + 1);
-
-            Expr * e = parseString(expr);
-            Value v;
-            e->eval(*state, *env, v);
-            state->forceAttrs(v);
-
-            for (auto & i : *v.attrs) {
-                string name = i.name;
-                if (string(name, 0, cur2.size()) != cur2) continue;
-                completions.insert(prev + expr + "." + name);
-            }
-
-        } catch (ParseError & e) {
-            // Quietly ignore parse errors.
-        } catch (EvalError & e) {
-            // Quietly ignore evaluation errors.
-        } catch (UndefinedVarError & e) {
-            // Quietly ignore undefined variable errors.
-        }
-    }
-
-    return completions;
-}
-
-
-static int runProgram(const string & program, const Strings & args)
-{
-    Strings args2(args);
-    args2.push_front(program);
-
-    Pid pid;
-    pid = fork();
-    if (pid == -1) throw SysError("forking");
-    if (pid == 0) {
-        restoreAffinity();
-        execvp(program.c_str(), stringsToCharPtrs(args2).data());
-        _exit(1);
-    }
-
-    return pid.wait();
-}
-
-
-bool isVarName(const string & s)
-{
-    if (s.size() == 0) return false;
-    char c = s[0];
-    if ((c >= '0' && c <= '9') || c == '-' || c == '\'') return false;
-    for (auto & i : s)
-        if (!((i >= 'a' && i <= 'z') ||
-              (i >= 'A' && i <= 'Z') ||
-              (i >= '0' && i <= '9') ||
-              i == '_' || i == '-' || i == '\''))
-            return false;
-    return true;
-}
-
-
-Path NixRepl::getDerivationPath(Value & v) {
-    auto drvInfo = getDerivation(*state, v, false);
-    if (!drvInfo)
-        throw Error("expression does not evaluate to a derivation, so I can't build it");
-    Path drvPath = drvInfo->queryDrvPath();
-    if (drvPath == "" || !state->store->isValidPath(state->store->parseStorePath(drvPath)))
-        throw Error("expression did not evaluate to a valid derivation");
-    return drvPath;
-}
-
-
-bool NixRepl::processLine(string line)
-{
-    if (line == "") return true;
-
-    string command, arg;
-
-    if (line[0] == ':') {
-        size_t p = line.find_first_of(" \n\r\t");
-        command = string(line, 0, p);
-        if (p != string::npos) arg = removeWhitespace(string(line, p));
-    } else {
-        arg = line;
-    }
-
-    if (command == ":?" || command == ":help") {
-        std::cout
-             << "The following commands are available:\n"
-             << "\n"
-             << "  <expr>        Evaluate and print expression\n"
-             << "  <x> = <expr>  Bind expression to variable\n"
-             << "  :a <expr>     Add attributes from resulting set to scope\n"
-             << "  :b <expr>     Build derivation\n"
-             << "  :e <expr>     Open the derivation in $EDITOR\n"
-             << "  :i <expr>     Build derivation, then install result into current profile\n"
-             << "  :l <path>     Load Nix expression and add it to scope\n"
-             << "  :p <expr>     Evaluate and print expression recursively\n"
-             << "  :q            Exit nix-repl\n"
-             << "  :r            Reload all files\n"
-             << "  :s <expr>     Build dependencies of derivation, then start nix-shell\n"
-             << "  :t <expr>     Describe result of evaluation\n"
-             << "  :u <expr>     Build derivation, then start nix-shell\n";
-    }
-
-    else if (command == ":a" || command == ":add") {
-        Value v;
-        evalString(arg, v);
-        addAttrsToScope(v);
-    }
-
-    else if (command == ":l" || command == ":load") {
-        state->resetFileCache();
-        loadFile(arg);
-    }
-
-    else if (command == ":r" || command == ":reload") {
-        state->resetFileCache();
-        reloadFiles();
-    }
-
-    else if (command == ":e" || command == ":edit") {
-        Value v;
-        evalString(arg, v);
-
-        Pos pos;
-
-        if (v.type == tPath || v.type == tString) {
-            PathSet context;
-            auto filename = state->coerceToString(noPos, v, context);
-            pos.file = state->symbols.create(filename);
-        } else if (v.type == tLambda) {
-            pos = v.lambda.fun->pos;
-        } else {
-            // assume it's a derivation
-            pos = findDerivationFilename(*state, v, arg);
-        }
-
-        // Open in EDITOR
-        auto args = editorFor(pos);
-        auto editor = args.front();
-        args.pop_front();
-        runProgram(editor, args);
-
-        // Reload right after exiting the editor
-        state->resetFileCache();
-        reloadFiles();
-    }
-
-    else if (command == ":t") {
-        Value v;
-        evalString(arg, v);
-        std::cout << showType(v) << std::endl;
-
-    } else if (command == ":u") {
-        Value v, f, result;
-        evalString(arg, v);
-        evalString("drv: (import <nixpkgs> {}).runCommand \"shell\" { buildInputs = [ drv ]; } \"\"", f);
-        state->callFunction(f, v, result, Pos());
-
-        Path drvPath = getDerivationPath(result);
-        runProgram(settings.nixBinDir + "/nix-shell", Strings{drvPath});
-    }
-
-    else if (command == ":b" || command == ":i" || command == ":s") {
-        Value v;
-        evalString(arg, v);
-        Path drvPath = getDerivationPath(v);
-
-        if (command == ":b") {
-            /* We could do the build in this process using buildPaths(),
-               but doing it in a child makes it easier to recover from
-               problems / SIGINT. */
-            if (runProgram(settings.nixBinDir + "/nix", Strings{"build", "--no-link", drvPath}) == 0) {
-                auto drv = readDerivation(*state->store, drvPath, Derivation::nameFromPath(state->store->parseStorePath(drvPath)));
-                std::cout << std::endl << "this derivation produced the following outputs:" << std::endl;
-                for (auto & i : drv.outputsAndPaths(*state->store))
-                    std::cout << fmt("  %s -> %s\n", i.first, state->store->printStorePath(i.second.second));
-            }
-        } else if (command == ":i") {
-            runProgram(settings.nixBinDir + "/nix-env", Strings{"-i", drvPath});
-        } else {
-            runProgram(settings.nixBinDir + "/nix-shell", Strings{drvPath});
-        }
-    }
-
-    else if (command == ":p" || command == ":print") {
-        Value v;
-        evalString(arg, v);
-        printValue(std::cout, v, 1000000000) << std::endl;
-    }
-
-    else if (command == ":q" || command == ":quit")
-        return false;
-
-    else if (command != "")
-        throw Error("unknown command '%1%'", command);
-
-    else {
-        size_t p = line.find('=');
-        string name;
-        if (p != string::npos &&
-            p < line.size() &&
-            line[p + 1] != '=' &&
-            isVarName(name = removeWhitespace(string(line, 0, p))))
-        {
-            Expr * e = parseString(string(line, p + 1));
-            Value & v(*state->allocValue());
-            v.type = tThunk;
-            v.thunk.env = env;
-            v.thunk.expr = e;
-            addVarToScope(state->symbols.create(name), v);
-        } else {
-            Value v;
-            evalString(line, v);
-            printValue(std::cout, v, 1) << std::endl;
-        }
-    }
-
-    return true;
-}
-
-
-void NixRepl::loadFile(const Path & path)
-{
-    loadedFiles.remove(path);
-    loadedFiles.push_back(path);
-    Value v, v2;
-    state->evalFile(lookupFileArg(*state, path), v);
-    state->autoCallFunction(*autoArgs, v, v2);
-    addAttrsToScope(v2);
-}
-
-
-void NixRepl::initEnv()
-{
-    env = &state->allocEnv(envSize);
-    env->up = &state->baseEnv;
-    displ = 0;
-    staticEnv.vars.clear();
-
-    varNames.clear();
-    for (auto & i : state->staticBaseEnv.vars)
-        varNames.insert(i.first);
-}
-
-
-void NixRepl::reloadFiles()
-{
-    initEnv();
-
-    Strings old = loadedFiles;
-    loadedFiles.clear();
-
-    bool first = true;
-    for (auto & i : old) {
-        if (!first) std::cout << std::endl;
-        first = false;
-        std::cout << format("Loading '%1%'...") % i << std::endl;
-        loadFile(i);
-    }
-}
-
-
-void NixRepl::addAttrsToScope(Value & attrs)
-{
-    state->forceAttrs(attrs);
-    for (auto & i : *attrs.attrs)
-        addVarToScope(i.name, *i.value);
-    std::cout << format("Added %1% variables.") % attrs.attrs->size() << std::endl;
-}
-
-
-void NixRepl::addVarToScope(const Symbol & name, Value & v)
-{
-    if (displ >= envSize)
-        throw Error("environment full; cannot add more variables");
-    staticEnv.vars[name] = displ;
-    env->values[displ++] = &v;
-    varNames.insert((string) name);
-}
-
-
-Expr * NixRepl::parseString(string s)
-{
-    Expr * e = state->parseExprFromString(s, curDir, staticEnv);
-    return e;
-}
-
-
-void NixRepl::evalString(string s, Value & v)
-{
-    Expr * e = parseString(s);
-    e->eval(*state, *env, v);
-    state->forceValue(v);
-}
-
-
-std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int maxDepth)
-{
-    ValuesSeen seen;
-    return printValue(str, v, maxDepth, seen);
-}
-
-
-std::ostream & printStringValue(std::ostream & str, const char * string) {
-    str << "\"";
-    for (const char * i = string; *i; i++)
-        if (*i == '\"' || *i == '\\') str << "\\" << *i;
-        else if (*i == '\n') str << "\\n";
-        else if (*i == '\r') str << "\\r";
-        else if (*i == '\t') str << "\\t";
-        else str << *i;
-    str << "\"";
-    return str;
-}
-
-
-// FIXME: lot of cut&paste from Nix's eval.cc.
-std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int maxDepth, ValuesSeen & seen)
-{
-    str.flush();
-    checkInterrupt();
-
-    state->forceValue(v);
-
-    switch (v.type) {
-
-    case tInt:
-        str << ANSI_CYAN << v.integer << ANSI_NORMAL;
-        break;
-
-    case tBool:
-        str << ANSI_CYAN << (v.boolean ? "true" : "false") << ANSI_NORMAL;
-        break;
-
-    case tString:
-        str << ANSI_YELLOW;
-        printStringValue(str, v.string.s);
-        str << ANSI_NORMAL;
-        break;
-
-    case tPath:
-        str << ANSI_GREEN << v.path << ANSI_NORMAL; // !!! escaping?
-        break;
-
-    case tNull:
-        str << ANSI_CYAN "null" ANSI_NORMAL;
-        break;
-
-    case tAttrs: {
-        seen.insert(&v);
-
-        bool isDrv = state->isDerivation(v);
-
-        if (isDrv) {
-            str << "«derivation ";
-            Bindings::iterator i = v.attrs->find(state->sDrvPath);
-            PathSet context;
-            Path drvPath = i != v.attrs->end() ? state->coerceToPath(*i->pos, *i->value, context) : "???";
-            str << drvPath << "»";
-        }
-
-        else if (maxDepth > 0) {
-            str << "{ ";
-
-            typedef std::map<string, Value *> Sorted;
-            Sorted sorted;
-            for (auto & i : *v.attrs)
-                sorted[i.name] = i.value;
-
-            for (auto & i : sorted) {
-                if (isVarName(i.first))
-                    str << i.first;
-                else
-                    printStringValue(str, i.first.c_str());
-                str << " = ";
-                if (seen.find(i.second) != seen.end())
-                    str << "«repeated»";
-                else
-                    try {
-                        printValue(str, *i.second, maxDepth - 1, seen);
-                    } catch (AssertionError & e) {
-                        str << ANSI_RED "«error: " << e.msg() << "»" ANSI_NORMAL;
-                    }
-                str << "; ";
-            }
-
-            str << "}";
-        } else
-            str << "{ ... }";
-
-        break;
-    }
-
-    case tList1:
-    case tList2:
-    case tListN:
-        seen.insert(&v);
-
-        str << "[ ";
-        if (maxDepth > 0)
-            for (unsigned int n = 0; n < v.listSize(); ++n) {
-                if (seen.find(v.listElems()[n]) != seen.end())
-                    str << "«repeated»";
-                else
-                    try {
-                        printValue(str, *v.listElems()[n], maxDepth - 1, seen);
-                    } catch (AssertionError & e) {
-                        str << ANSI_RED "«error: " << e.msg() << "»" ANSI_NORMAL;
-                    }
-                str << " ";
-            }
-        else
-            str << "... ";
-        str << "]";
-        break;
-
-    case tLambda: {
-        std::ostringstream s;
-        s << v.lambda.fun->pos;
-        str << ANSI_BLUE "«lambda @ " << filterANSIEscapes(s.str()) << "»" ANSI_NORMAL;
-        break;
-    }
-
-    case tPrimOp:
-        str << ANSI_MAGENTA "«primop»" ANSI_NORMAL;
-        break;
-
-    case tPrimOpApp:
-        str << ANSI_BLUE "«primop-app»" ANSI_NORMAL;
-        break;
-
-    case tFloat:
-        str << v.fpoint;
-        break;
-
-    default:
-        str << ANSI_RED "«unknown»" ANSI_NORMAL;
-        break;
-    }
-
-    return str;
-}
 
 struct CmdRepl : StoreCommand, MixEvalArgs
 {
@@ -790,9 +162,14 @@ struct CmdRepl : StoreCommand, MixEvalArgs
     void run(ref<Store> store) override
     {
         evalSettings.pureEval = false;
-        auto repl = std::make_unique<NixRepl>(searchPath, openStore());
+        auto repl = std::make_unique<NixRepl>(searchPath, openStore(),
+            NixRepl::CompletionFunctions {
+                .writeHistory = write_history,
+                .readline = readline
+            }
+        );
         repl->autoArgs = getAutoArgs(*repl->state);
-        repl->mainLoop(files);
+        replMainLoop(*repl, files);
     }
 };
 

--- a/tests/plugins.sh
+++ b/tests/plugins.sh
@@ -5,3 +5,16 @@ set -o pipefail
 res=$(nix eval --expr builtins.anotherNull --option setting-set true --option plugin-files $PWD/plugins/libplugintest*)
 
 [ "$res"x = "nullx" ]
+
+# test a custom command
+res=$(echo -e ':greet Hi\n:mySecondGreet Hello' | nix repl --option plugin-files $PWD/plugins/libplugintest* \
+      | grep -Ev '(^$)|(^Welcome to Nix.*$)')
+
+[ "$res"x = $'Hi greet!\nHello mySecondGreet!x' ]
+
+# test help
+res=$(echo ':?' | nix repl --option plugin-files $PWD/plugins/libplugintest* \
+      | grep 'aaaa')
+echo "$res" >&2
+
+[ "$res"x = '  :greet ph     aaaaax' ]

--- a/tests/plugins/plugintest.cc
+++ b/tests/plugins/plugintest.cc
@@ -1,5 +1,8 @@
 #include "config.hh"
 #include "primops.hh"
+#include "repl.hh"
+
+#include <iostream>
 
 using namespace nix;
 
@@ -22,3 +25,10 @@ static void prim_anotherNull (EvalState & state, const Pos & pos, Value ** args,
 }
 
 static RegisterPrimOp rp("anotherNull", 0, prim_anotherNull);
+
+static void myGreet (string name, string arg)
+{
+    std::cout << arg << " " << name << "!\n";
+}
+
+static RegisterReplCmd rc(vector<string>{"greet", "mySecondGreet"}, "aaaaa", myGreet, "ph");

--- a/tests/plugins/plugintest.cc
+++ b/tests/plugins/plugintest.cc
@@ -26,7 +26,7 @@ static void prim_anotherNull (EvalState & state, const Pos & pos, Value ** args,
 
 static RegisterPrimOp rp("anotherNull", 0, prim_anotherNull);
 
-static void myGreet (string name, string arg)
+static void myGreet (NixRepl & repl, string name, string arg)
 {
     std::cout << arg << " " << name << "!\n";
 }


### PR DESCRIPTION
Motivation: I want to make https://github.com/lf-/nix-doc a repl command, but it is useful to be able to extend the REPL otherwise.

Side note: In case my documentation changes look weird, there was an error in the documentation, which previously claimed that `RegisterCommand` was possible from a plugin, which it is not, because it is in `src/nix` and thus cannot be linked to by a library since that directory only links into an executable. I encountered this myself when initially implementing this feature and that is why I had to refactor the REPL logic out into libexpr.

- Refactor the repl core into libexpr
- Use dependency injection via std::function to provide the completion
  functions from editline so we don't introduce extra dependencies for
  libexpr
- Add a RegisterReplCmd analogous to RegisterPrimOp for repl commands
- Refactor: get rid of the "ugly" global curRepl and replace it with a
  trick with closures on the nix side (that are effectively globals
  [static vars in a templated function per-closure], but
  unique per repl user and thus not as ugly ;p)
- Rip out readline support since there appears to be no build system
  support for it according to `rg READLINE` and it is thus dead code
- Integration test this new plugin functionality
- Document it (see above)