### PR TITLE
Minor docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Information on additional installation methods is available on the [Nix download
 
 ## Building And Developing
 
-See our [Hacking guide](https://hydra.nixos.org/job/nix/master/build.x86_64-linux/latest/download-by-type/doc/manual#chap-hacking) in our manual for instruction on how to
+See our [Hacking guide](https://hydra.nixos.org/job/nix/master/build.x86_64-linux/latest/download-by-type/doc/manual/hacking.html) in our manual for instruction on how to
 build nix from source with nix-build or how to get a development environment.
 
 ## Additional Resources

--- a/doc/manual/src/hacking.md
+++ b/doc/manual/src/hacking.md
@@ -39,7 +39,7 @@ To build Nix itself in this shell:
 
 ```console
 [nix-shell]$ ./bootstrap.sh
-[nix-shell]$ ./configure $configureFlags
+[nix-shell]$ ./configure $configureFlags --prefix=$(pwd)/inst
 [nix-shell]$ make -j $NIX_BUILD_CORES
 ```
 


### PR DESCRIPTION
After the new markdown docs were merged, the `Hacking` link broke.

Additionally, when I was trying to hack on Nix yesterday, I was confused as to why `make install` was trying to access `/usr`, whereas the Hacking page noted Nix would be installed to `./inst`. I had to look at https://hydra.nixos.org/build/126292991/download/1/manual/installation/building-source.html to realize I needed to pass `--prefix=$(pwd)/inst` when configuring for the Hacking page to be accurate. Thus, I've added the flag to the page.