### PR TITLE
never use /var/folders for TMPDIR on darwin (2.3 backport)

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -155,7 +155,7 @@ void initNix()
        sshd). This breaks build users because they don't have access
        to the TMPDIR, in particular in ‘nix-store --serve’. */
 #if __APPLE__
-    if (getuid() == 0 && hasPrefix(getEnv("TMPDIR"), "/var/folders/"))
+    if (hasPrefix(getEnv("TMPDIR"), "/var/folders/"))
         unsetenv("TMPDIR");
 #endif
 }


### PR DESCRIPTION
This fix has been in master since April (#3488) and it's still causing some build failures for users with a single-user installation.

---

This doesn't just cause problems for nix-store --serve but also results
in certain build failures. Builds that use unix domain sockets in their
tests often fail because the /var/folders prefix already consumes more
than half of the maximum length of socket paths.

    struct sockaddr_un {
       sa_family_t sun_family;               /* AF_UNIX */
       char        sun_path[108];            /* Pathname */
    };

(cherry picked from commit 4d9db420ffc9bd48da107a61c093b0d65d9d8db1)