### PR TITLE
bugfix: add a fish shell file to correctly source vars (#3980)

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -247,3 +247,42 @@ variables are set, either log in again, or type
 in your shell.
 EOF
 fi
+
+added=
+p=$HOME/.nix-profile/etc/profile.d/nix.fish
+if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ] && [ -f "$HOME/.config/fish/fish.config"]; then
+    # Make the fish shell source nix.fish during login.
+    for i in fish.config; do
+        fn="$HOME/.config/fish/$i"
+        if [ -w "$fn" ]; then
+            if ! grep -q "$p" "$fn"; then
+                echo "modifying $fn..." >&2
+                echo -e "\n[ -e $p ] && . $p # added by Nix installer" >> "$fn"
+            fi
+            added=1
+            break
+        fi
+    done
+fi
+
+if [ -z "$added" ]; then
+    cat >&2 <<EOF
+
+Installation finished!  To ensure that the necessary environment
+variables are set, please add the line
+
+  . $p
+
+to your shell configuration file (~/.config/fish/fish.config).
+EOF
+else
+    cat >&2 <<EOF
+
+Installation finished!  To ensure that the necessary environment
+variables are set, either log in again, or type
+
+  . $p
+
+in your shell.
+EOF
+fi

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,0 +1,33 @@
+if [ -n "$HOME" ] && [ -n "$USER" ]
+
+    # Set up the per-user profile.
+    # This part should be kept in sync with nixpkgs:nixos/modules/programs/shell.nix
+
+    set -l NIX_LINK $HOME/.nix-profile
+
+    # Set up environment.
+    # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
+    set -gx NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+
+    # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
+    if [ -e /etc/ssl/certs/ca-certificates.crt ] # NixOS, Ubuntu, Debian, Gentoo, Arch
+        set -gx NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+    else if [ -e /etc/ssl/ca-bundle.pem ] # openSUSE Tumbleweed
+        set -gx NIX_SSL_CERT_FILE /etc/ssl/ca-bundle.pem
+    else if [ -e /etc/ssl/certs/ca-bundle.crt ] # Old NixOS
+        set -gx NIX_SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
+    else if [ -e /etc/pki/tls/certs/ca-bundle.crt ] # Fedora, CentOS
+        set -gx NIX_SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
+    else if [ -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" ] # fall back to cacert in Nix profile
+        set -gx NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+    else if [ -e "$NIX_LINK/etc/ca-bundle.crt" ] # old cacert in Nix profile
+        set -gx NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
+    end
+
+    if [ -n "$MANPATH" ]; then
+        set -gx --prepend MANPATH "$NIX_LINK/share/man"
+    end
+
+    set -gx --prepend PATH "$NIX_LINK/bin"
+    set -e NIX_LINK
+end


### PR DESCRIPTION
I don't understand how nix-profile.sh.in gets turned into nix-profile.sh, so this PR might be missing something.