### PR TITLE
Fix auto argument passing for more auto arguments than formals

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1348,7 +1348,7 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
     }
 
     Value * actualArgs = allocValue();
-    mkAttrs(*actualArgs, fun.lambda.fun->formals->formals.size());
+    mkAttrs(*actualArgs, std::max(static_cast<uint32_t>(fun.lambda.fun->formals->formals.size()), args.size()));
 
     if (fun.lambda.fun->formals->ellipsis) {
         // If the formals have an ellipsis (eg the function accepts extra args) pass


### PR DESCRIPTION
The change in #3965 didn't account for when the number of auto arguments is bigger than the number of formal arguments. This causes the following:

    $ nix-instantiate --eval -E '{ ... }@args: args.foo' --argstr foo foo
    nix-instantiate: src/libexpr/attr-set.hh:55: void nix::Bindings::push_back(const nix::Attr&): Assertion `size_ < capacity_' failed.
    Aborted (core dumped)

This fixes it

Ping @glittershark 