### PR TITLE
docs+test: fix remaining installer downloads without -L

### DIFF
--- a/doc/manual/src/release-notes/rl-1.7.md
+++ b/doc/manual/src/release-notes/rl-1.7.md
@@ -117,7 +117,7 @@ features:
   - The binary tarball installer has been improved. You can now install
     Nix by running:
     
-        $ bash <(curl https://nixos.org/nix/install)
+        $ bash <(curl -L https://nixos.org/nix/install)
 
   - More evaluation errors include position information. For instance,
     selecting a missing attribute will print something like

--- a/doc/manual/src/release-notes/rl-2.1.md
+++ b/doc/manual/src/release-notes/rl-2.1.md
@@ -10,7 +10,7 @@ in certain situations. In addition, it has the following new features:
   - The Nix installer now supports performing a Multi-User
     installation for Linux computers which are running systemd. You
     can select a Multi-User installation by passing the `--daemon`
-    flag to the installer: `sh <(curl https://nixos.org/nix/install)
+    flag to the installer: `sh <(curl -L https://nixos.org/nix/install)
     --daemon`.
 
     The multi-user installer cannot handle systems with SELinux. If

--- a/tests/install-darwin.sh
+++ b/tests/install-darwin.sh
@@ -53,7 +53,7 @@ trap finish EXIT
 
 # First setup Nix
 cleanup
-curl -o install https://nixos.org/nix/install
+curl -L -o install https://nixos.org/nix/install
 yes | bash ./install
 verify
 


### PR DESCRIPTION
There were a couple of instances in old release notes that still end up on the docs page, and in my view it would be useful to have only working commands on the page. I got confused by these when I first installed Nix.

Also, for some reason the Darwin test had the wrong command, so we should probably check if it is being run and checked regularly :)