### PR TITLE
Fix unspecified behaviour in readStorePathCAMap

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -43,8 +43,11 @@ StorePathCAMap readStorePathCAMap(const Store & store, Source & from)
 {
     StorePathCAMap paths;
     auto count = readNum<size_t>(from);
-    while (count--)
-        paths.insert_or_assign(store.parseStorePath(readString(from)), parseContentAddressOpt(readString(from)));
+    while (count--) {
+        auto path = store.parseStorePath(readString(from));
+        auto ca = parseContentAddressOpt(readString(from));
+        paths.insert_or_assign(path, ca);
+    }
     return paths;
 }
 


### PR DESCRIPTION
When deploying a Hydra instance with current Nix master, most builds would not run because of errors like this:

```
queue monitor: error: --- Error --- hydra-queue-runner
error: --- UsageError --- nix-daemon
not a content address because it is not in the form '<prefix>:<rest>': /nix/store/...-somedrv
```

The last error message is from `parseContentAddress`, which expects a colon-separated string, however what we got here is a store path.

Looking at the worker protocol, the following message sent to the Nix daemon caused the error above:

| Value | Description |
|--------|------------------------|
| 0x1E | wopQuerySubstitutablePathInfos |
| 0x01 | Number of paths |
| 0x16 | Length of string  |
| `/nix/store/...-somedrv` | Store path |
| 0x00 | Length of string |
| ""      | Empty content address string |

Looking at `writeStorePathCAMap`, the store path is indeed the first field that's transmitted. However, `readStorePathCAMap` expects it to be the *second* field *on my machine*, since expression evaluation order is a classic form of [unspecified behaviour](https://en.wikipedia.org/wiki/Unspecified_behavior#Order_of_evaluation_of_subexpressions) in C++.

This has been introduced in https://github.com/NixOS/nix/pull/3689, specifically in commit 66a62b3189c8c9b0965850e6b3c9b0fda0b50fd8.