### PR TITLE
Implement RemoteStore.addToStoreFromDump

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -393,6 +393,34 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case wopAddToStoreCANar: {
+        HashType hashAlgo;
+        std::string baseName;
+        FileIngestionMethod method;
+        {
+            uint8_t recursive;
+            std::string hashAlgoRaw;
+            from >> baseName >> recursive >> hashAlgoRaw;
+            if (recursive > (uint8_t) FileIngestionMethod::Recursive)
+                throw Error("unsupported FileIngestionMethod with value of %i; you may need to upgrade nix-daemon", recursive);
+            method = FileIngestionMethod { recursive };
+            hashAlgo = parseHashType(hashAlgoRaw);
+        }
+
+        logger->startWork();
+        std::optional<StorePath> path;
+        {
+            FramedSource narSource(from);
+            path = store->addToStoreFromDump(narSource, baseName, method, hashAlgo);
+        }
+        logger->stopWork();
+
+        if (path /* always */) {
+            to << store->printStorePath(*path);
+        }
+        break;
+    }
+
     case wopAddTextToStore: {
         string suffix = readString(from);
         string s = readString(from);
@@ -748,59 +776,12 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
             info.ultimate = false;
 
         if (GET_PROTOCOL_MINOR(clientVersion) >= 23) {
-
-            struct FramedSource : Source
-            {
-                Source & from;
-                bool eof = false;
-                std::vector<unsigned char> pending;
-                size_t pos = 0;
-
-                FramedSource(Source & from) : from(from)
-                { }
-
-                ~FramedSource()
-                {
-                    if (!eof) {
-                        while (true) {
-                            auto n = readInt(from);
-                            if (!n) break;
-                            std::vector<unsigned char> data(n);
-                            from(data.data(), n);
-                        }
-                    }
-                }
-
-                size_t read(unsigned char * data, size_t len) override
-                {
-                    if (eof) throw EndOfFile("reached end of FramedSource");
-
-                    if (pos >= pending.size()) {
-                        size_t len = readInt(from);
-                        if (!len) {
-                            eof = true;
-                            return 0;
-                        }
-                        pending = std::vector<unsigned char>(len);
-                        pos = 0;
-                        from(pending.data(), len);
-                    }
-
-                    auto n = std::min(len, pending.size() - pos);
-                    memcpy(data, pending.data() + pos, n);
-                    pos += n;
-                    return n;
-                }
-            };
-
             logger->startWork();
-
             {
                 FramedSource source(from);
                 store->addToStore(info, source, (RepairFlag) repair,
                     dontCheckSigs ? NoCheckSigs : CheckSigs);
             }
-
             logger->stopWork();
         }
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -408,16 +408,15 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         }
 
         logger->startWork();
-        std::optional<StorePath> path;
-        {
+        // Destructor of FramedSource must run before stopWork.
+        StorePath path = [&](){
             FramedSource narSource(from);
-            path = store->addToStoreFromDump(narSource, baseName, method, hashAlgo);
-        }
+            return store->addToStoreFromDump(narSource, baseName, method, hashAlgo);
+        }();
         logger->stopWork();
 
-        if (path /* always */) {
-            to << store->printStorePath(*path);
-        }
+        to << store->printStorePath(path);
+
         break;
     }
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -2,7 +2,6 @@
 #include "monitor-fd.hh"
 #include "worker-protocol.hh"
 #include "store-api.hh"
-#include "local-store.hh"
 #include "finally.hh"
 #include "affinity.hh"
 #include "archive.hh"

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -66,10 +66,6 @@ public:
     void addToStore(const ValidPathInfo & info, Source & nar,
         RepairFlag repair, CheckSigsFlag checkSigs) override;
 
-    StorePath addToStore(const string & name, const Path & srcPath,
-        FileIngestionMethod method = FileIngestionMethod::Recursive, HashType hashAlgo = htSHA256,
-        PathFilter & filter = defaultPathFilter, RepairFlag repair = NoRepair) override;
-
     StorePath addToStoreFromDump(Source & dump, const string & name,
         FileIngestionMethod method = FileIngestionMethod::Recursive, HashType hashAlgo = htSHA256,
         RepairFlag repair = NoRepair) override;

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -70,6 +70,10 @@ public:
         FileIngestionMethod method = FileIngestionMethod::Recursive, HashType hashAlgo = htSHA256,
         PathFilter & filter = defaultPathFilter, RepairFlag repair = NoRepair) override;
 
+    StorePath addToStoreFromDump(Source & dump, const string & name,
+        FileIngestionMethod method = FileIngestionMethod::Recursive, HashType hashAlgo = htSHA256,
+        RepairFlag repair = NoRepair) override;
+
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -6,7 +6,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION 0x118
+#define PROTOCOL_VERSION 0x119
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -17,7 +17,7 @@ typedef enum {
     wopQueryPathHash = 4, // obsolete
     wopQueryReferences = 5, // obsolete
     wopQueryReferrers = 6,
-    wopAddToStore = 7,
+    wopAddToStore = 7, // obsolete since Nix 3.0, use wopAddToStoreCANar
     wopAddTextToStore = 8,
     wopBuildPaths = 9,
     wopEnsurePath = 10,
@@ -50,6 +50,7 @@ typedef enum {
     wopAddToStoreNar = 39,
     wopQueryMissing = 40,
     wopQueryDerivationOutputMap = 41,
+    wopAddToStoreCANar = 42, // since Nix 3.0
 } WorkerOp;
 
 

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -93,7 +93,7 @@ void Source::operator () (unsigned char * data, size_t len)
 }
 
 
-std::string Source::drain()
+void Source::drainInto(Sink & sink)
 {
     std::string s;
     std::vector<unsigned char> buf(8192);
@@ -101,12 +101,19 @@ std::string Source::drain()
         size_t n;
         try {
             n = read(buf.data(), buf.size());
-            s.append((char *) buf.data(), n);
+            sink(buf.data(), n);
         } catch (EndOfFile &) {
             break;
         }
     }
-    return s;
+}
+
+
+std::string Source::drain()
+{
+    StringSink s;
+    drainInto(s);
+    return *s.s;
 }
 
 

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -69,6 +69,8 @@ struct Source
 
     virtual bool good() { return true; }
 
+    void drainInto(Sink & sink);
+
     std::string drain();
 };
 


### PR DESCRIPTION
This implements `RemoteStore.addToStoreFromDump`, allowing `nix-daemon` to serve as a proxy for another `nix-daemon`. A possible use case for this is distrusting a container that runs as an otherwise trusted uid. The implementation was fairly straightforward.
