### PR TITLE
Fix multi-user installation with a symlinked store

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -209,7 +209,7 @@ __sudo() {
 
     echo "I am executing:"
     echo ""
-    printf "    $ sudo %s\\n" "$cmd"
+    printf "    $ sudo --preserve-env=NIX_IGNORE_SYMLINK_STORE %s\\n" "$cmd"
     echo ""
     echo "$expl"
     echo ""
@@ -223,7 +223,7 @@ _sudo() {
     if ! headless; then
         __sudo "$expl" "$*"
     fi
-    sudo "$@"
+    sudo --preserve-env=NIX_IGNORE_SYMLINK_STORE "$@"
 }
 
 


### PR DESCRIPTION
Installing Nix with a symlinked store is not recommended, but is nevertheless
supported according to the documentation.

However, even when setting `NIX_IGNORE_SYMLINK_STORE=1`, installation still fails
with the following error:

```
I am executing:

    $ sudo /nix/store/aizhr07dljmlbf17wfrj40x3s0b5iv3d-nix-2.3.4/bin/nix-store --load-db

to load data for the first time in to the Nix Database

error: the path '/nix' is a symlink; this is not allowed for the Nix store and its parent directories
```

This is because sudo does not preserve environment variables and so the environment variable
`NIX_IGNORE_SYMLINK_STORE` will always be undefined when evaluated by `nix-store`.

This change makes sudo preserve the relevant environment variable in order to make installation
work again.