### PR TITLE
Fix the nix-daemon Mac OS SSL CA cert

### DIFF
--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -4,6 +4,8 @@
   <dict>
     <key>EnvironmentVariables</key>
     <dict>
+      <key>NIX_SSL_CERT_FILE</key>
+      <string>/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt</string>
       <key>OBJC_DISABLE_INITIALIZE_FORK_SAFETY</key>
       <string>YES</string>
     </dict>


### PR DESCRIPTION
Mac OS multi-user installations are currently broken because all requests
made by nix-daemon to the binary cache fail with:

```
unable to download ... Problem with the SSL CA cert (path? access rights?) (77).
```

This change ensures that the nix-daemon knows where to find the SSL CA cert file.

Fixes #2899 and #3261.