### PR TITLE
Add a nix.conf option for allowing a symlinked store

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -41,7 +41,7 @@ Settings::Settings()
 {
     buildUsersGroup = getuid() == 0 ? "nixbld" : "";
     lockCPU = getEnv("NIX_AFFINITY_HACK") == "1";
-    ignoreSymlinkStore = getEnv("NIX_IGNORE_SYMLINK_STORE") == "1";
+    allowSymlinkedStore = getEnv("NIX_IGNORE_SYMLINK_STORE") == "1";
 
     caFile = getEnv("NIX_SSL_CERT_FILE").value_or(getEnv("SSL_CERT_FILE").value_or(""));
     if (caFile == "") {

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -41,6 +41,7 @@ Settings::Settings()
 {
     buildUsersGroup = getuid() == 0 ? "nixbld" : "";
     lockCPU = getEnv("NIX_AFFINITY_HACK") == "1";
+    ignoreSymlinkStore = getEnv("NIX_IGNORE_SYMLINK_STORE") == "1";
 
     caFile = getEnv("NIX_SSL_CERT_FILE").value_or(getEnv("SSL_CERT_FILE").value_or(""));
     if (caFile == "") {

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -883,7 +883,7 @@ public:
         "Path or URI of the global flake registry."};
 
     Setting<bool> ignoreSymlinkStore{
-        this, false, "ignore-symlink-store",
+        this, false, "allow-symlinked-store",
         R"(
           If set to `true`, Nix will stop complaining if the store directory
           (typically /nix/store) contains symlink components.

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -882,7 +882,7 @@ public:
     Setting<std::string> flakeRegistry{this, "https://github.com/NixOS/flake-registry/raw/master/flake-registry.json", "flake-registry",
         "Path or URI of the global flake registry."};
 
-    Setting<bool> ignoreSymlinkStore{
+    Setting<bool> allowSymlinkedStore{
         this, false, "allow-symlinked-store",
         R"(
           If set to `true`, Nix will stop complaining if the store directory

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -881,6 +881,19 @@ public:
 
     Setting<std::string> flakeRegistry{this, "https://github.com/NixOS/flake-registry/raw/master/flake-registry.json", "flake-registry",
         "Path or URI of the global flake registry."};
+
+    Setting<bool> ignoreSymlinkStore{
+        this, false, "ignore-symlink-store",
+        R"(
+	  If set to `true`, Nix will stop complaining if the store directory
+	  (typically /nix/store) contains symlink components.
+
+	  This risks making some builds "impure" because builders sometimes
+	  "canonicalise" paths by resolving all symlink components. Problems
+          occur if those builds are then deployed to machines where /nix/store
+          resolves to a different location from that of the build machine. You
+          can enable this setting if you are sure you're not going to do that.
+        )"};
 };
 
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -885,11 +885,11 @@ public:
     Setting<bool> ignoreSymlinkStore{
         this, false, "ignore-symlink-store",
         R"(
-	  If set to `true`, Nix will stop complaining if the store directory
-	  (typically /nix/store) contains symlink components.
+          If set to `true`, Nix will stop complaining if the store directory
+          (typically /nix/store) contains symlink components.
 
-	  This risks making some builds "impure" because builders sometimes
-	  "canonicalise" paths by resolving all symlink components. Problems
+          This risks making some builds "impure" because builders sometimes
+          "canonicalise" paths by resolving all symlink components. Problems
           occur if those builds are then deployed to machines where /nix/store
           resolves to a different location from that of the build machine. You
           can enable this setting if you are sure you're not going to do that.

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -109,7 +109,7 @@ LocalStore::LocalStore(const Params & params)
     }
 
     /* Ensure that the store and its parents are not symlinks. */
-    if (getEnv("NIX_IGNORE_SYMLINK_STORE") != "1") {
+    if (!settings.ignoreSymlinkStore) {
         Path path = realStoreDir;
         struct stat st;
         while (path != "/") {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -109,7 +109,7 @@ LocalStore::LocalStore(const Params & params)
     }
 
     /* Ensure that the store and its parents are not symlinks. */
-    if (!settings.ignoreSymlinkStore) {
+    if (!settings.allowSymlinkedStore) {
         Path path = realStoreDir;
         struct stat st;
         while (path != "/") {


### PR DESCRIPTION
Using an environment variable for allowing a symlinked store is currently broken, and is extremely brittle (See #4022). This is because nix invocations that happen in a different environment than the user's will still return errors complaining about the symlink (ex. through `sudo` or the `nix-daemon`).

Fixes #2926.