### PR TITLE
Fix compatibility with nlohmann-json 3.9.1

### DIFF
--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -115,6 +115,14 @@ public:
     {
         return handle_value<void(Value&, const char*)>(mkString, val.c_str());
     }
+#if NLOHMANN_JSON_VERSION_MAJOR >= 3 && NLOHMANN_JSON_VERSION_MINOR >= 8
+    bool binary(binary_t&)
+    {
+        // This function ought to be unreachable
+        assert(false);
+        return true;
+    }
+#endif
 
     bool start_object(std::size_t len)
     {


### PR DESCRIPTION
This is intended to fix https://github.com/NixOS/nixpkgs/pull/97266 and https://github.com/NixOS/nix/issues/4019

However, this is my first time submitting a PR to this repo, and in this manner, so please be patient with me.  I'm willing to work at it until it becomes right.  The upside is it is a very small PR.

Because this issue is between an incompatibility between nixpkgs and nix, I overrode the json version here to demonstrate functionality.  However, simply having the `binary` function ought not cause any issues for json version 3.7.3.  Once this PR becomes ready to accept I can and expect to remove them.