### PR TITLE
nix/store on btrfs compression: add workaround

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -27,6 +27,8 @@ struct ArchiveSettings : Config
         #endif
         "use-case-hack",
         "Whether to enable a Darwin-specific hack for dealing with file name collisions."};
+    Setting<bool> preallocateContents{this, true, "preallocate-contents",
+        "Whether to preallocate files when writing objects with known size."};
 };
 
 static ArchiveSettings archiveSettings;
@@ -325,6 +327,9 @@ struct RestoreSink : ParseSink
 
     void preallocateContents(uint64_t len)
     {
+        if (!archiveSettings.preallocateContents)
+            return;
+
 #if HAVE_POSIX_FALLOCATE
         if (len) {
             errno = posix_fallocate(fd.get(), 0, len);


### PR DESCRIPTION
See #3550.

As suggested for now I've added a "preallocate-contents" option, and tested by restarting `nix-daemon` with `/path/to/output/derivation/bin/nix-daemon --option preallocate-contents false`

This works as a local fix but I definitely want to make this automatic for btrfs.

It's easy to call `statfs(realStoreDir.c_str(), &statfsbuf)` and check if `statfsbuf.f_type == BTRFS_SUPER_MAGIC` ; the question is how to make the setting "auto" ?

I'm thinking of:
 - changing from a Bool to a tristate true/false/auto enum; but would that work with the command-line `--option` switch? (I'm not too comfortable about introducing such a new setting type...)
 - if option is set to auto, check in `localStore` next to `makeStoreWritable` (e.g. some new `checkFsQuirks` method?), and if btrfs force the option somehow.. `globalConfig.set`? not really good with code compartimentization :/

Needless to say I don't like what I just suggested very much, so suggestions or comments welcome.
This is at least a starting point and folks who care can set the option in their nix.conf until then (depending on timing on the 3.0 release I'd be greedy and ask if it'd be possible to backport in 2.3 maintenance branch, but let's discuss that after we agree on the auto part I guess!)

Thanks!