### PR TITLE
Make the tests depend on the nix executable

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1,13 +1,11 @@
 # Run program $1 as part of ‘make installcheck’.
 
-test-deps =
-
 define run-install-test
 
   installcheck: $1.test
 
   .PHONY: $1.test
-  $1.test: $1 $(test-deps)
+  $1.test: $1 test-deps
 	@env TEST_NAME=$(notdir $(basename $1)) TESTS_ENVIRONMENT="$(tests-environment)" mk/run_test.sh $1 < /dev/null
 
 endef

--- a/src/nix/local.mk
+++ b/src/nix/local.mk
@@ -20,10 +20,15 @@ nix_LIBS = libexpr libmain libfetchers libstore libutil libcmd
 
 nix_LDFLAGS = -pthread $(SODIUM_LIBS) $(EDITLINE_LIBS) $(BOOST_LDFLAGS) -llowdown
 
-$(foreach name, \
-  nix-build nix-channel nix-collect-garbage nix-copy-closure nix-daemon nix-env nix-hash nix-instantiate nix-prefetch-url nix-shell nix-store, \
-  $(eval $(call install-symlink, nix, $(bindir)/$(name))))
+INSTALLED_PROGRAMS = \
+	$(foreach name, \
+	nix-build nix-channel nix-collect-garbage nix-copy-closure nix-daemon nix-env nix-hash nix-instantiate nix-prefetch-url nix-shell nix-store, \
+	$(bindir)/$(name))
+
+$(foreach prog, $(INSTALLED_PROGRAMS), $(eval $(call install-symlink, nix, $(prog))))
 $(eval $(call install-symlink, $(bindir)/nix, $(libexecdir)/nix/build-remote))
+
+test-deps: $(INSTALLED_PROGRAMS) $(bindir)/nix $(libexecdir)/nix/build-remote
 
 src/nix-env/user-env.cc: src/nix-env/buildenv.nix.gen.hh
 

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -48,4 +48,4 @@ tests-environment = NIX_REMOTE= $(bash) -e
 
 clean-files += $(d)/common.sh $(d)/config.nix
 
-test-deps += tests/common.sh tests/config.nix tests/plugins/libplugintest.$(SO_EXT)
+test-deps += tests/common.sh tests/config.nix tests/plugins/libplugintest.$(SO_EXT) $(bindir)/nix

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -48,4 +48,4 @@ tests-environment = NIX_REMOTE= $(bash) -e
 
 clean-files += $(d)/common.sh $(d)/config.nix
 
-test-deps += tests/common.sh tests/config.nix tests/plugins/libplugintest.$(SO_EXT) $(bindir)/nix
+test-deps: tests/common.sh tests/config.nix tests/plugins/libplugintest.$(SO_EXT) $(bindir)/nix


### PR DESCRIPTION
That way just running `make installcheck` is enough to run them against the actual nix code in the repo.

(I don't know whether that's actually desirable for everyone. It seems to make sense to me to have this, so opening the PR anyways but feel free to close it if that breaks anything)