### PR TITLE
Fix functionArgs for primops

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2236,6 +2236,11 @@ static RegisterPrimOp primop_catAttrs({
 static void prim_functionArgs(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
+    if (args[0]->type == tPrimOp || args[0]->type == tPrimOpApp) {
+        state.mkAttrs(v, 0);
+        return;
+    }
+
     if (args[0]->type != tLambda)
         throw TypeError({
             .hint = hintfmt("'functionArgs' requires a function"),


### PR DESCRIPTION
Both functions and primops have `builtins.typeOf v == "lambda"`, and they also both return true for `builtins.isFunction`, yet `builtins.functionArgs` fails for primops without this change:

    $ nix-instantiate --eval -E 'builtins.isFunction builtins.add'
    true

    $ nix-instantiate --eval -E 'builtins.functionArgs builtins.add'
    error: 'functionArgs' requires a function, at (string):1:1

For simplicity, primops aren't assumed to have named function arguments, which is correct for most of them, so `builtins.functionArgs` now just returns `{}` for all of them