### PR TITLE
Fix max-jobs option

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1612,6 +1612,13 @@ void DerivationGoal::tryToBuild()
 
     actLock.reset();
 
+    state = &DerivationGoal::tryLocalBuild;
+    worker.wakeUp(shared_from_this());
+}
+
+void DerivationGoal::tryLocalBuild() {
+    bool buildLocally = buildMode != bmNormal || parsedDrv->willBuildLocally(worker.store);
+
     /* Make sure that we are allowed to start a build.  If this
        derivation prefers to be done locally, do it even if
        maxBuildJobs is 0. */
@@ -1621,12 +1628,6 @@ void DerivationGoal::tryToBuild()
         outputLocks.unlock();
         return;
     }
-
-    state = &DerivationGoal::tryLocalBuild;
-    worker.wakeUp(shared_from_this());
-}
-
-void DerivationGoal::tryLocalBuild() {
 
     /* If `build-users-group' is not empty, then we have to build as
        one of the members of that group. */


### PR DESCRIPTION
After 0ed946aa616bbf7ffe7f90d3309abdd27d875b10, max-jobs setting (`-j`/`--max-jobs`) stopped working.

The reason was that `nrLocalBuilds` (which compared to `maxBuildJobs` to figure out whether the limit is reached or not) is not incremented yet when `tryBuild` is started; So, the solution is to move the check to `tryLocalBuild`.

Closes https://github.com/nixos/nix/issues/3763

FIXME: Add a test