### PR TITLE
Use "?dir=..." portion of "registry add" local path specification.

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -157,7 +157,8 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
         } else {
             if (!hasPrefix(path, "/"))
                 throw BadURL("flake reference '%s' is not an absolute path", url);
-            path = canonPath(path);
+            auto query = decodeQuery(match[2]);
+            path = canonPath(path + "/" + get(query, "dir").value_or(""));
         }
 
         fetchers::Attrs attrs;


### PR DESCRIPTION
The registry targets generally follow a URL formatting schema with
support for a query parameter of "?dir=subpath" to specify a sub-path
location below the URL root.

Alternatively to a URL specification, an absolute path can be specified.  This specification
mode _accepts_ the query parameter but ignores/drops that query parameter.  It would
probably be better to either:

-  disallow the query parameter for the path form, or
-  recognize the query parameter and add to the path

This patch implements the second for consistency, and to make it easier for
tooling that might switch between a remote git reference and a local
path reference.

See also issue #4050.