### PR TITLE
Generate a warning on an implicit input specification.

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -218,11 +218,14 @@ static Flake getFlake(
 
         if (outputs->value->lambda.fun->matchAttrs) {
             for (auto & formal : outputs->value->lambda.fun->formals->formals) {
-                if (formal.name != state.sSelf)
+                if (formal.name != state.sSelf) {
+                    if (!flake.inputs.count(formal.name))
+                        warn("implicit flake:%s input via output function argument in %s", formal.name, lockedRef);
                     flake.inputs.emplace(formal.name, FlakeInput {
                         .ref = parseFlakeRef(formal.name)
                     });
-            }
+                };
+            };
         }
 
     } else

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -245,6 +245,53 @@ nix build -o $TEST_ROOT/result --no-registries git+file://$flake2Dir#bar --refre
 nix build -o $TEST_ROOT/result $flake3Dir#xyzzy
 git -C $flake3Dir add flake.lock
 
+# Check how non-existent implicit input references are handled with
+# body eval errors
+rm $flake3Dir/flake.nix
+
+cat > $flake3Dir/flake.nix <<EOF
+{
+  description = "Fnord";
+
+  outputs = { self, noflake }: rec {
+    packages.$system.xyzzy = nofluke.packages.$system.foo;
+  };
+}
+EOF
+
+git -C $flake3Dir add flake.nix
+git -C $flake3Dir commit -m 'Update flake.nix with fluke'
+
+err=$flake3Dir/impl.errout
+! nix build -o $TEST_ROOT/result $flake3Dir#xyzzy 2>$err
+cat $err
+grep -q UndefinedVarError $err
+grep -q nofluke $err
+
+# Check how non-existent implicit input references are handled
+rm $flake3Dir/flake.nix
+
+cat > $flake3Dir/flake.nix <<EOF
+{
+  description = "Fnord";
+
+  outputs = { self, noflake }: rec {
+    packages.$system.xyzzy = noflake.packages.$system.foo;
+  };
+}
+EOF
+
+git -C $flake3Dir add flake.nix
+git -C $flake3Dir commit -m 'Update flake.nix with fluke'
+
+err=$flake3Dir/impl.errout
+! nix build -o $TEST_ROOT/result $flake3Dir#xyzzy
+! nix build -o $TEST_ROOT/result $flake3Dir#xyzzy 2>$err
+cat $err
+grep "warning: implicit flake:noflake input via output function argument in git+file:///build/nix-test/flakes/flake3" $err
+grep error $err
+grep "cannot find flake 'flake:noflake' in the flake registries" $err
+
 # Add dependency to flake3.
 rm $flake3Dir/flake.nix
 

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -282,13 +282,13 @@ cat > $flake3Dir/flake.nix <<EOF
 EOF
 
 git -C $flake3Dir add flake.nix
-git -C $flake3Dir commit -m 'Update flake.nix with fluke'
+git -C $flake3Dir commit -m 'Update flake.nix with noflake'
 
 err=$flake3Dir/impl.errout
 ! nix build -o $TEST_ROOT/result $flake3Dir#xyzzy
 ! nix build -o $TEST_ROOT/result $flake3Dir#xyzzy 2>$err
 cat $err
-grep "warning: implicit flake:noflake input via output function argument in git+file:///build/nix-test/flakes/flake3" $err
+grep "warning: implicit flake:noflake input via output function argument in git+file:///" $err
 grep error $err
 grep "cannot find flake 'flake:noflake' in the flake registries" $err
 


### PR DESCRIPTION
The ability to implicitly specify inputs as referencing flakes of the
same name is not specifically identified by the documentation (and
it's not clear if this behavior is intended to remain in the future).

If there is a typographical mismatch between an explicit input name
and the argument used for the `output`, this will result in a more
obscure error "cannot find flake 'flake:foo' in the flake registries",
which leads the user in the direction of managing the registries
instead of noticing the mis-spelling.

By adding a warning when an implicit input is created, it can make it
easier for the user to identify whether this was intended or whether
they have made an erroneous typo resulting in mismatched names.