### PR TITLE
Fix tar invocation on FreeBSD

### DIFF
--- a/tests/tarball.sh
+++ b/tests/tarball.sh
@@ -17,7 +17,7 @@ test_tarball() {
     local compressor="$2"
 
     tarball=$TEST_ROOT/tarball.tar$ext
-    (cd $TEST_ROOT && tar c tarball) | $compressor > $tarball
+    (cd $TEST_ROOT && tar cf - tarball) | $compressor > $tarball
 
     nix-env -f file://$tarball -qa --out-path | grep -q dependencies
 


### PR DESCRIPTION
tar(1) on FreeBSD does not use standard output or input when the -f flag
is not provided. Instead, it defaults to /dev/sa0 on FreeBSD.

Make this tar invocation a bit more robust and explicitly tell tar(1) to
use standard output.

This is one of the issues discovered while porting Nix to FreeBSD. It has
been tested and committed locally to FreeBSD ports:
https://svnweb.freebsd.org/ports/head/sysutils/nix/Makefile?revision=550026&view=markup#l108