### PR TITLE
Add flakeDir attribute to flake self for flake.nix-relative paths.

### DIFF
--- a/src/libexpr/flake/call-flake.nix
+++ b/src/libexpr/flake/call-flake.nix
@@ -43,7 +43,9 @@ let
 
           outputs = flake.outputs (inputs // { self = result; });
 
-          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; };
+          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo;
+                                              flakeDir = sourceInfo  + (if subdir != "" then "/" else "") + subdir;
+                                            };
         in
           if node.flake or true then
             assert builtins.isFunction flake.outputs;


### PR DESCRIPTION
The `self` input passed to a flake is always set to the root of the
input tree (usually identified by the `.git` directory).

In repositories where the `flake.nix` is not at the top-level
directory (e.g. `github:owner/project?dir=sub/path`) the `self`
location relative to the flake.nix location is awkward to use and may
change over time.  However, it is appropriate to fetch and cache the
source from the top-level directory of that source.

This patch adds a `flakeDir` attribute to `self` to allow the flake to
specify source locations relative to the `flake.nix` file instead of
relative to the top-level of the source.

This is particularly useful for repositories that host multiple
projects, where each sub-project has its own separate flake.nix file
for building that sub-project.

```
github:owner/foo flake.nix:
{
  description = "Flakes for foo utility";

  inputs.foo-cli.url = github:owner/foo?dir=subproj/foo_cli;
  inputs.foo-gnome-gui.url = github:owner/foo?dir=subproj/gnome_gui;

  outputs = { self, foo-cli, foo-gnome-gui }:
  rec {
    defaultPackage.x86_64-linux = packages.x86_64-linux.foo-gnome-gui;
    packages.x86_64-linux = {
      foo-gnome-gui = foo-gnome-gui;
      foo-cli = foo-cli;
    };
  };
}

github:owner/foo subproj/foo_cli:
{
  description = "Flake for foo cli utility";
  outputs = { self, nixpkgs }:
  rec {
    defaultPackage.x86_64-linux = packages.x86_64-linux.foo-cli;
    packages.x86_64-linux =
      let pkgs = import nixpkgs { system="x86_64-linux"; }; in
      {
        foo-cli = mkDerivation {
          name = "foo-cli";
          src = self.flakeDir;
        };
      };
  };
}
```