### PR TITLE
preallocateContents option: disable by default

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -27,7 +27,7 @@ struct ArchiveSettings : Config
         #endif
         "use-case-hack",
         "Whether to enable a Darwin-specific hack for dealing with file name collisions."};
-    Setting<bool> preallocateContents{this, true, "preallocate-contents",
+    Setting<bool> preallocateContents{this, false, "preallocate-contents",
         "Whether to preallocate files when writing objects with known size."};
 };
 


### PR DESCRIPTION
On btrfs, fallocate preallocate file space and basically make it no-cow,
thus disabling compression which is probably desirable for nix store.

Change the preallocateContents to tristate true/false/auto and if
auto disable preallocation on btrfs.

Fixes #3550.

-------------

set as draft because I'm not happy with this:
 - I think it'd make sense to have the tristate enum somewhere common, config.hh/config.cc ? would that make more sense? if not I'll keep it here and rename the enum to make it specific to that option like `SandboxMode` that @cole-h suggested.
 - @Ericson2314 I tried an `enum struct` (`enum class` appears elsewhere in the code so I used that, it's apparently the same) but it wouldn't let me reuse true/false/auto keywords -- I'm very sad, what's the point of namespacing then :P erm, sorry, I mean I'll rename that when I move the option off.

That aside I ended up going for a "check the first time it's used and update the option" -- it works well enough. The daemon forks when a request comes in so it basically checks with statfs everytime a new request comes in, but that's probably reasonable enough.