### PR TITLE
add more examples to --help of `nix run`

### DIFF
--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -167,6 +167,14 @@ struct CmdRun : InstallableCommand, RunCommon
                 "To run Blender:",
                 "nix run blender-bin"
             },
+            Example{
+                "To run vim from nixpkgs:",
+                "nix run nixpkgs#vim"
+            },
+            Example{
+                "To run vim from nixpkgs with arguments:",
+                "nix run nixpkgs#vim -- --help"
+            },
         };
     }
 


### PR DESCRIPTION
#### Added documentation on how to run a program with arguments via `nix run`

It was not clear to me how to pass arguments to a program executed via `nix-run`.
Some IRC folks consulted me to use the `--` argument.
I assume this is a wide spread use case and should be documented