### PR TITLE
Fix profile update in nix command

### DIFF
--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -152,7 +152,7 @@ void MixProfile::updateProfile(const Buildables & buildables)
                 for (auto & output : bfd.outputs) {
                     /* Output path should be known because we just tried to
                        build it. */
-                    assert(!output.second);
+                    assert(output.second);
                     result.push_back(*output.second);
                 }
             },


### PR DESCRIPTION
This fixes a wrong assertion when using `nix --profile ...` to update a profile:

```
$ nix build --profile my-profile -v nix
nix: src/nix/command.cc:155: nix::MixProfile::updateProfile(const Buildables&)::<lambda(nix::BuildableFromDrv)>: Assertion `!output.second' failed.
[1]    9634 abort (core dumped)  nix build --profile my-profile -v nix
```

This typo was intorduced by e9fad3006b0b6f3a6430fdbfc61392cac6834502.

CC @Ericson2314 