### PR TITLE
Fix macOS sandbox build

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -40,7 +40,7 @@ $(d)/nix.json: $(bindir)/nix
 	@mv $@.tmp $@
 
 $(d)/conf-file.json: $(bindir)/nix
-	$(trace-gen) env -i NIX_CONF_DIR=/dummy HOME=/dummy $(bindir)/nix show-config --json --experimental-features nix-command > $@.tmp
+	$(trace-gen) env -i NIX_CONF_DIR=/dummy HOME=/dummy NIX_SSL_CERT_FILE=/dummy/no-ca-bundle.crt $(bindir)/nix show-config --json --experimental-features nix-command > $@.tmp
 	@mv $@.tmp $@
 
 $(d)/src/expressions/builtins.md: $(d)/builtins.json $(d)/generate-builtins.nix $(d)/src/expressions/builtins-prefix.md $(bindir)/nix


### PR DESCRIPTION
Building `nix` on macOS with `sandbox = true` currently fails with a `Operation not permitted` error:

```
libc++abi.dylib: terminating with uncaught exception of type nix::SysError: error: --- SysError ---
getting status of /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt: Operation not permitted
/nix/store/vkrcf5jchyibdxwrgwcifxp2digqshdy-bash-4.4-p23/bin/bash: line 1:  6910 Abort trap: 6           env -i NIX_CONF_DIR=/dummy HOME=/dummy /nix/store/lqbpssp3j4ji31zsnk0fqww0hjr5mmva-nix-3.0pre20200930_924712e/bin/nix show-config --json --experimental-features nix-command > doc/manual/conf-file.json.tmp
make: *** [doc/manual/local.mk:43: doc/manual/conf-file.json] Error 134
make: *** Waiting for unfinished jobs....
builder for '/nix/store/rfac0c56m8p8lgafpv3xmk9ibqn94bws-nix-3.0pre20200930_924712e.drv' failed with exit code 2
```

When `nix` is executed in the sandbox, it tries to read the default `NIX_SSL_CERT_FILE` file, which is not in the allowed paths.

Since  the sandbox has no network access, `NIX_SSL_CERT_FILE` is not needed and can point to a non existent file.