### PR TITLE
Fix missing includes causing build failure

### DIFF
--- a/src/libexpr/symbol-table.hh
+++ b/src/libexpr/symbol-table.hh
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <map>
+#include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include "types.hh"

--- a/src/libstore/crypto.hh
+++ b/src/libstore/crypto.hh
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "types.hh"
-
 #include <map>
+#include <string>
+
+#include "types.hh"
 
 namespace nix {
 

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "types.hh"
 
 namespace nix {

--- a/src/libstore/names.hh
+++ b/src/libstore/names.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "types.hh"
 

--- a/src/nix/markdown.hh
+++ b/src/nix/markdown.hh
@@ -1,3 +1,5 @@
+#include <string_view>
+
 #include "types.hh"
 
 namespace nix {


### PR DESCRIPTION
I was trying to get Nix master (57b935a) to build on Darwin using `nix-shell`, but ran into missing string & string_view includes in several places. Curiously, it does build with `nix build --rebuild`, but I don't understand the difference.