### PR TITLE
Don't explicitely pattern-match on the various outputs

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1131,12 +1131,11 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
     /* Optimisation, but required in read-only mode! because in that
        case we don't actually write store derivations, so we can't
        read them later.
-
-       However, we don't bother doing this for floating CA derivations because
-       their "hash modulo" is indeterminate until built. */
-    if (drv.type() != DerivationType::CAFloating)
-        drvHashes.insert_or_assign(drvPath,
-            hashDerivationModulo(*state.store, Derivation(drv), false));
+    */
+    drvHashes.insert_or_assign(
+        drvPath,
+        hashDerivationModulo(*state.store, Derivation(drv), false)
+    );
 
     state.mkAttrs(v, 1 + drv.outputs.size());
     mkString(*state.allocAttr(v, state.sDrvPath), drvPathS, {"=" + drvPathS});

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1063,8 +1063,10 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
             drv.env[i] = hashPlaceholder(i);
             drv.outputs.insert_or_assign(i, DerivationOutput {
                 .output = DerivationOutputCAFloating {
-                    .method = ingestionMethod,
-                    .hashType = std::move(ht),
+                    .hashMethod = CAPathHashMethod {
+                        .fileIngestionMethod = ingestionMethod,
+                        .hashType = std::move(ht),
+                    },
                 },
             });
         }

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -493,8 +493,7 @@ void DerivationGoal::inputsRealised()
     if (useDerivation) {
         auto & fullDrv = *dynamic_cast<Derivation *>(drv.get());
 
-        if ((!fullDrv.inputDrvs.empty() &&
-             fullDrv.type() == DerivationType::CAFloating) || fullDrv.type() == DerivationType::DeferredInputAddressed) {
+        if (fullDrv.needsRewriting()) {
             /* We are be able to resolve this derivation based on the
                now-known results of dependencies. If so, we become a stub goal
                aliasing that resolved derivation goal */

--- a/src/libstore/content-address.hh
+++ b/src/libstore/content-address.hh
@@ -10,6 +10,17 @@ enum struct FileIngestionMethod : uint8_t {
     Recursive = true
 };
 
+/*
+  We only have one way to hash text with references, so this is single-value
+  type is only useful in std::variant.
+*/
+struct TextHashMethod { };
+struct CAPathHashMethod {
+  FileIngestionMethod fileIngestionMethod;
+  HashType hashType;
+  std::string print() const;
+};
+
 struct TextHash {
     Hash hash;
 };
@@ -19,6 +30,7 @@ struct FixedOutputHash {
     FileIngestionMethod method;
     Hash hash;
     std::string printMethodAlgo() const;
+    CAPathHashMethod hashMethod() const;
 };
 
 /*
@@ -55,19 +67,9 @@ std::optional<ContentAddress> parseContentAddressOpt(std::string_view rawCaOpt);
 
 Hash getContentAddressHash(const ContentAddress & ca);
 
-/*
-  We only have one way to hash text with references, so this is single-value
-  type is only useful in std::variant.
-*/
-struct TextHashMethod { };
-struct FixedOutputHashMethod {
-  FileIngestionMethod fileIngestionMethod;
-  HashType hashType;
-};
-
 typedef std::variant<
     TextHashMethod,
-    FixedOutputHashMethod
+    CAPathHashMethod
   > ContentAddressMethod;
 
 ContentAddressMethod parseContentAddressMethod(std::string_view rawCaMethod);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -388,7 +388,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                         auto path = store->addTextToStore(name, contents, refs, repair);
                         return store->queryPathInfo(path);
                     },
-                    [&](FixedOutputHashMethod &fohm) {
+                    [&](CAPathHashMethod &fohm) {
                         if (!refs.empty())
                             throw UnimplementedError("cannot yet have refs with flat or nar-hashed data");
                         auto path = store->addToStoreFromDump(source, name, fohm.fileIngestionMethod, fohm.hashType, repair);

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -9,76 +9,36 @@ namespace nix {
 
 std::optional<StorePath> DerivationOutput::path(const Store & store, std::string_view drvName, std::string_view outputName) const
 {
-    return std::visit(overloaded {
-        [](DerivationOutputInputAddressed doi) -> std::optional<StorePath> {
-            return { doi.path };
-        },
-        [&](DerivationOutputCAFixed dof) -> std::optional<StorePath> {
-            return {
-                dof.path(store, drvName, outputName)
-            };
-        },
-        [](DerivationOutputCAFloating dof) -> std::optional<StorePath> {
-            return std::nullopt;
-        },
-        [](DerivationOutputDeferred) -> std::optional<StorePath> {
-            return std::nullopt;
-        },
-    }, output);
+    if (auto dof = std::get_if<DerivationOutputCAFixed>(&output))
+        return { dof->path(store, drvName, outputName) };
+    if (auto doi = std::get_if<DerivationOutputInputAddressed>(&output))
+        return { doi->path };
+    return std::nullopt;
 }
 
 std::optional<FileIngestionMethod> DerivationOutput::fileIngestionMethod() const
 {
-    return std::visit(overloaded {
-        [](DerivationOutputInputAddressed doi) -> std::optional<FileIngestionMethod> {
-            return { std::nullopt };
-        },
-        [](DerivationOutputCAFixed dof) -> std::optional<FileIngestionMethod> {
-            return { dof.hash.method };
-        },
-        [](DerivationOutputCAFloating dof) -> std::optional<FileIngestionMethod> {
-            return { dof.method };
-        },
-        [](DerivationOutputDeferred) -> std::optional<FileIngestionMethod> {
-            return std::nullopt;
-        },
-    }, output);
+    if (auto dof = std::get_if<DerivationOutputCAFixed>(&output))
+        return { dof->hash.method };
+    if (auto dof = std::get_if<DerivationOutputCAFloating>(&output))
+        return { dof->method };
+    return std::nullopt;
 }
 
 std::optional<HashType> DerivationOutput::hashType() const
 {
-    return std::visit(overloaded {
-        [](DerivationOutputInputAddressed doi) -> std::optional<HashType> {
-            return { std::nullopt };
-        },
-        [](DerivationOutputCAFixed dof) -> std::optional<HashType> {
-            return { dof.hash.hash.type };
-        },
-        [](DerivationOutputCAFloating dof) -> std::optional<HashType> {
-            return { dof.hashType };
-        },
-        [](DerivationOutputDeferred) -> std::optional<HashType> {
-            return std::nullopt;
-        },
-    }, output);
+    if (auto dof = std::get_if<DerivationOutputCAFixed>(&output))
+        return { dof->hash.hash.type };
+    if (auto dof = std::get_if<DerivationOutputCAFloating>(&output))
+        return { dof->hashType };
+    return std::nullopt;
 }
 
 std::optional<Hash> DerivationOutput::hash() const
 {
-    return std::visit(overloaded {
-        [](DerivationOutputInputAddressed doi) -> std::optional<Hash> {
-            return { std::nullopt };
-        },
-        [](DerivationOutputCAFixed dof) -> std::optional<Hash> {
-            return { dof.hash.hash };
-        },
-        [](DerivationOutputCAFloating dof) -> std::optional<Hash> {
-            return std::nullopt;
-        },
-        [](DerivationOutputDeferred) -> std::optional<Hash> {
-            return std::nullopt;
-        },
-    }, output);
+    if (auto dof = std::get_if<DerivationOutputCAFixed>(&output))
+        return { dof->hash.hash };
+    return std::nullopt;
 }
 
 std::optional<std::string> DerivationOutput::hashMetaData() const

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -453,7 +453,6 @@ DerivationType BasicDerivation::type() const
     }
 }
 
-
 DrvHashes drvHashes;
 
 /* pathDerivationModulo and hashDerivationModulo are mutually recursive
@@ -497,7 +496,6 @@ static const DrvHashModulo & pathDerivationModulo(Store & store, const StorePath
  */
 DrvHashModulo hashDerivationModulo(Store & store, const Derivation & drv, bool maskOutputs)
 {
-    /* Return a fixed hash for fixed-output derivations. */
     switch (drv.type()) {
     case DerivationType::CAFloating:
         return UnknownHashes {};
@@ -710,6 +708,16 @@ static void rewriteDerivation(Store & store, BasicDerivation & drv, const String
 
 
 Sync<DrvPathResolutions> drvPathResolutions;
+
+bool Derivation::needsRewriting() const
+{
+    auto myType = type();
+    if (myType == DerivationType::CAFloating && !inputDrvs.empty())
+        return true;
+    if (myType == DerivationType::DeferredInputAddressed)
+        return true;
+    return false;
+}
 
 std::optional<BasicDerivation> Derivation::tryResolve(Store & store) {
     BasicDerivation resolved { *this };

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -58,6 +58,23 @@ struct DerivationOutput
        the right derivation name. When in doubt, you should use the safer
        interface provided by BasicDerivation::outputsAndOptPaths */
     std::optional<StorePath> path(const Store & store, std::string_view drvName, std::string_view outputName) const;
+
+    /*
+     * The following invariants should hold:
+     * - fileIngestionMethod()!=null <=> hashType()!=null
+     * - hash()!=null=>(fileIngestionMethod()!=null && hashType()!=null)
+     *
+     * (Possibly this should be encoded in the types themselves)
+     */
+    std::optional<FileIngestionMethod> fileIngestionMethod() const;
+    std::optional<HashType> hashType() const;
+    std::optional<Hash> hash() const;
+
+    /**
+     * Utility function to directly print the metadata of the hash as expected
+     * by the drv format.
+     */
+    std::optional<std::string> hashMetaData() const;
 };
 
 typedef std::map<string, DerivationOutput> DerivationOutputs;

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -37,8 +37,7 @@ struct DerivationOutputCAFixed
 struct DerivationOutputCAFloating
 {
     /* information used for expected hash computation */
-    FileIngestionMethod method;
-    HashType hashType;
+    CAPathHashMethod hashMethod;
 };
 
 /* Input-addressed output which depends on a (CA) derivation whose hash isn't
@@ -61,13 +60,12 @@ struct DerivationOutput
 
     /*
      * The following invariants should hold:
-     * - fileIngestionMethod()!=null <=> hashType()!=null
-     * - hash()!=null=>(fileIngestionMethod()!=null && hashType()!=null)
+     * - hash()!=null=>caHashMethod()!=null
+     * - hash()!=null=>path()!=null
      *
      * (Possibly this should be encoded in the types themselves)
      */
-    std::optional<FileIngestionMethod> fileIngestionMethod() const;
-    std::optional<HashType> hashType() const;
+    std::optional<CAPathHashMethod> caHashMethod() const;
     std::optional<Hash> hash() const;
 
     /**

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -54,7 +54,6 @@ struct DerivationOutput
         DerivationOutputCAFloating,
         DerivationOutputDeferred
     > output;
-    std::optional<HashType> hashAlgoOpt(const Store & store) const;
     /* Note, when you use this function you should make sure that you're passing
        the right derivation name. When in doubt, you should use the safer
        interface provided by BasicDerivation::outputsAndOptPaths */

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -125,7 +125,6 @@ struct BasicDerivation
 
     bool isBuiltin() const;
 
-    /* Return true iff this is a fixed-output derivation. */
     DerivationType type() const;
 
     /* Return the output names of a derivation. */
@@ -146,6 +145,8 @@ struct Derivation : BasicDerivation
     /* Print a derivation. */
     std::string unparse(const Store & store, bool maskOutputs,
         std::map<std::string, StringSet> * actualInputs = nullptr) const;
+
+    bool needsRewriting() const;
 
     /* Return the underlying basic derivation but with these changes:
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -809,7 +809,7 @@ std::map<std::string, std::optional<StorePath>> LocalStore::queryPartialDerivati
     }
     /* can't just use else-if instead of `!haveCached` because we need to unlock
        `drvPathResolutions` before it is locked in `Derivation::resolve`. */
-    if (!haveCached && (drv.type() == DerivationType::CAFloating || drv.type() == DerivationType::DeferredInputAddressed)) {
+    if (drv.needsRewriting()) {
         /* Try resolve drv and use that path instead. */
         auto attempt = drv.tryResolve(*this);
         if (!attempt)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -495,7 +495,7 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
                 worker_proto::write(*this, conn->to, references);
                 conn.processStderr();
             },
-            [&](FixedOutputHashMethod fohm) -> void {
+            [&](CAPathHashMethod fohm) -> void {
                 conn->to
                     << wopAddToStore
                     << name
@@ -542,7 +542,7 @@ StorePath RemoteStore::addToStoreFromDump(Source & dump, const string & name,
         FileIngestionMethod method, HashType hashType, RepairFlag repair)
 {
     StorePathSet references;
-    return addCAToStore(dump, name, FixedOutputHashMethod{ .fileIngestionMethod = method, .hashType = hashType }, references, repair)->path;
+    return addCAToStore(dump, name, CAPathHashMethod{ .fileIngestionMethod = method, .hashType = hashType }, references, repair)->path;
 }
 
 


### PR DESCRIPTION
This is a refactoring on top of #4056 to remove as much as possible the pattern-matchings on the different kind of outputs that a derivation has. The idea behind that is that we generally don't care about the exact type of output that we have, we're only interested in the answer to one of the two questions: "is this a CA output?" and "Do we know the path of this output?". So I've added a few methods to `DerivationOutput` to query this directly without having to introspect the underlying output type and used that as much as possible.

(I've also mixed in a few unrelated minor changes, I can remove them if needed)