### PR TITLE
support name attribute in fetchGit

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -58,8 +58,11 @@ struct GitInputScheme : InputScheme
     {
         if (maybeGetStrAttr(attrs, "type") != "git") return {};
 
-        for (auto & [name, value] : attrs)
-            if (name != "type" && name != "url" && name != "ref" && name != "rev" && name != "shallow" && name != "submodules" && name != "lastModified" && name != "revCount" && name != "narHash")
+        for (auto & [ name, value ] : attrs)
+            if (name != "type" && name != "url" && name != "ref" &&
+                name != "rev" && name != "shallow" && name != "submodules" &&
+                name != "lastModified" && name != "revCount" &&
+                name != "narHash" && name != "name")
                 throw Error("unsupported Git input attribute '%s'", name);
 
         parseURL(getStrAttr(attrs, "url"));


### PR DESCRIPTION
I think this was accidentally removed during the refactoring of
fetch{Tree,Git} which introduced issues such as:

```
unsupported Git input attribute 'name'
```