### PR TITLE
rust: small patches

### DIFF
--- a/nix-rust/src/lib.rs
+++ b/nix-rust/src/lib.rs
@@ -1,3 +1,4 @@
+#[allow(improper_ctypes_definitions)]
 #[cfg(not(test))]
 mod c;
 mod error;

--- a/nix-rust/src/util/base32.rs
+++ b/nix-rust/src/util/base32.rs
@@ -13,7 +13,7 @@ pub fn decoded_len(input_len: usize) -> usize {
     input_len * 5 / 8
 }
 
-static BASE32_CHARS: &'static [u8; 32] = &b"0123456789abcdfghijklmnpqrsvwxyz";
+static BASE32_CHARS: &[u8; 32] = &b"0123456789abcdfghijklmnpqrsvwxyz";
 
 lazy_static! {
     static ref BASE32_CHARS_REVERSE: Box<[u8; 256]> = {


### PR DESCRIPTION
Small linter fixes for rust:
- redundant static lifetimes
-  '-' as u8: changed to b'-'; byte literal
- len() == 0; into is_empty()
- needles lifetimes
- etc..