### PR TITLE
do not skip CR-ended lines emitted by builder

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -4601,16 +4601,18 @@ void DerivationGoal::handleChildOutput(int fd, const string & data)
             return;
         }
 
-        for (auto c : data)
-            if (c == '\r')
-                currentLogLinePos = 0;
-            else if (c == '\n')
-                flushLine();
-            else {
+        int lastc = -1;
+        for (auto c : data) {
+            if (c == '\r' || c == '\n') {
+                if (lastc != '\r')
+                    flushLine();
+            } else {
                 if (currentLogLinePos >= currentLogLine.size())
                     currentLogLine.resize(currentLogLinePos + 1);
                 currentLogLine[currentLogLinePos++] = c;
             }
+            lastc = c;
+        }
 
         if (logSink) (*logSink)(data);
     }


### PR DESCRIPTION
Some builders (`ninja` to name one) use CR at the end of lines, effectively printing

```
[1/990] compiling uno.cpp\r
[2/990] compiling dos.cpp\r
[3/990] compiling tres.cpp\r
```
supposing to update the last line without scrolling the lines upward

As this `ninja` output passes through `nix-build`, `nix-build` buffers it and there is no output at all for long time.
It would be nice to replace CR->LF to see the progress

Fixes: https://github.com/NixOS/nix/issues/4133