### PR TITLE
Handle amount of disk space saved by hard linking being negative

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -683,7 +683,7 @@ void LocalStore::removeUnusedLinks(const GCState & state)
     struct stat st;
     if (stat(linksDir.c_str(), &st) == -1)
         throw SysError("statting '%1%'", linksDir);
-    auto overhead = st.st_blocks * 512ULL;
+    int64_t overhead = st.st_blocks * 512ULL;
 
     printInfo("note: currently hard linking saves %.2f MiB",
         ((unsharedSize - actualSize - overhead) / (1024.0 * 1024.0)));


### PR DESCRIPTION
https://github.com/NixOS/nix/commit/3f6e88a5527dcc4d58e3147f78388a88eb8896e0 brought back  the bug with `bogus messages like "currently hard linking saves 17592186044416.00 MiB" `which has been fixed 8 year ago in d025142
