### PR TITLE
WIP: fetchTree: substitute from binary caches before trying to fetch

### DIFF
--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -105,8 +105,6 @@ public:
     const Path tempRootsDir;
     const Path fnTempRoots;
 
-private:
-
     const PublicKeys & getPublicKeys();
 
 public:
@@ -297,7 +295,6 @@ private:
     void createUser(const std::string & userName, uid_t userId) override;
 
     friend class DerivationGoal;
-    friend class SubstitutionGoal;
 };
 
 


### PR DESCRIPTION
This allows fetching the referred sources from a binary cache in
addition to the original source Uri. In cases where accessing the
upstream is expensive, slow or unreliable and the soures are within on
of the trusted binary caches we can now subsitute them from there.

TODOs:
 - [ ] mostly a copy of what substitution-goal.cc does, this might mean we should refactor the entire substitution code to be useable for cases like this?
 - [ ] figure out which of the headers clangd pulled in on the fly are
       actually required for this
 - [ ] what are the downsides of having getPublicKeys public? It
       appears that at least one of the friend class cases only existed
       because it was not public.

Relates to #2114