### PR TITLE
Fix substitution loop #3964, #3534

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -330,8 +330,13 @@ void DerivationGoal::outputsSubstitutionTried()
 
     /*  If the substitutes form an incomplete closure, then we should
         build the dependencies of this derivation, but after that, we
-        can still use the substitutes for this derivation itself. */
-    if (nrIncompleteClosure > 0) retrySubstitution = true;
+        can still use the substitutes for this derivation itself.
+
+        If the nrIncompleteClosure != nrFailed, we have another issue as well.
+        In particular, it may be the case that the hole in the closure is
+        an output of the current derivation, which causes a loop if retried.
+     */
+    if (nrIncompleteClosure > 0 && nrIncompleteClosure == nrFailed) retrySubstitution = true;
 
     nrFailed = nrNoSubstituters = nrIncompleteClosure = 0;
 

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -46,7 +46,7 @@ struct Goal : public std::enable_shared_from_this<Goal>
     unsigned int nrNoSubstituters;
 
     /* Number of substitution goals we are/were waiting for that
-       failed because othey had unsubstitutable references. */
+       failed because they had unsubstitutable references. */
     unsigned int nrIncompleteClosure;
 
     /* Name of this goal for debugging purposes. */


### PR DESCRIPTION
Closes #3964, #3534 

It did not require refactoring or extra parameters to terminate the loop.
