### PR TITLE
nix develop: Add --redirect flag to redirect dependencies

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -248,9 +248,9 @@ struct Common : InstallableCommand, MixProfile
         }
 
         /* Substitute redirects. */
-        for (auto & [installableS, dir] : redirects) {
-            dir = absPath(dir);
-            auto installable = parseInstallable(store, installableS);
+        for (auto & [installable_, dir_] : redirects) {
+            auto dir = absPath(dir_);
+            auto installable = parseInstallable(store, installable_);
             auto buildable = installable->toBuildable();
             auto doRedirect = [&](const StorePath & path)
             {


### PR DESCRIPTION
This is primarily useful if you're hacking simultaneously on a package and one of its dependencies. E.g. if you're hacking on Hydra and Nix, you would start a dev shell for Nix (which installs in e.g. `~/Dev/nix/outputs`), and then a dev shell for Hydra as follows:

```
$ nix develop \
  --redirect .#hydraJobs.build.x86_64-linux.nix ~/Dev/nix/outputs/out \
  --redirect .#hydraJobs.build.x86_64-linux.nix.dev ~/Dev/nix/outputs/dev
```

(This assumes `hydraJobs.build.x86_64-linux` has a `passthru.nix` attribute. You can also use a store path.)

This causes all references in the environment to those store paths to be rewritten to `~/Dev/nix/outputs/{out,dev}`. Note: don't forget to run `fixupPhase` in the first shell, otherwise pkgconfig files are not in the correct location. Note 2: unfortunately, you may need to set `LD_LIBRARY_PATH=~/Dev/nix/outputs/out/lib` because Nixpkgs' ld-wrapper only adds `-rpath` entries for `-L` flags that point to the Nix store.

@viric 