### PR TITLE
Add NIX_EXPERIMENTAL_FEATURES environment option

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -908,7 +908,7 @@ public:
           value.
           )"};
 
-    Setting<Strings> experimentalFeatures{this, {}, "experimental-features",
+    Setting<Strings> experimentalFeatures{this, tokenizeString<Strings>(getEnv("NIX_EXPERIMENTAL_FEATURES").value_or("")), "experimental-features",
         "Experimental Nix features to enable."};
 
     bool isExperimentalFeatureEnabled(const std::string & name);


### PR DESCRIPTION
This allows for a more portable nix-shell for projects that want to use experimental nix features and versions in their nix-shell without users having to fiddle with their local nix configuration.