### PR TITLE
Add NIX_CONFIG env var for applying nix.conf overrides

### DIFF
--- a/doc/manual/src/command-ref/conf-file-prefix.md
+++ b/doc/manual/src/command-ref/conf-file-prefix.md
@@ -19,6 +19,9 @@ By default Nix reads settings from the following places:
     and `XDG_CONFIG_HOME`. If these are unset, it will look in
     `$HOME/.config/nix.conf`.
 
+  - If `NIX_OPTIONS` is set, its contents is treated as the contents of
+    a configuration file.
+
 The configuration files consist of `name =
 value` pairs, one per line. Other files can be included with a line like
 `include

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -81,6 +81,11 @@ Most Nix commands interpret the following environment variables:
     Overrides the location of the system Nix configuration directory
     (default `prefix/etc/nix`).
 
+  - `NIX_OPTIONS`  
+    Applies settings from Nix configuration from the environment.
+    The content is treated as if it was read from a Nix configuration file.
+    Settings are separated by the newline character.
+
   - `NIX_USER_CONF_FILES`  
     Overrides the location of the user Nix configuration files to load
     from (defaults to the XDG spec locations). The variable is treated

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -86,6 +86,12 @@ void loadConfFile()
     for (auto file = files.rbegin(); file != files.rend(); file++) {
         globalConfig.applyConfigFile(*file);
     }
+
+    auto nixConfEnv = getEnv("NIX_CONFIG");
+    if (nixConfEnv.has_value()) {
+        globalConfig.applyConfig(nixConfEnv.value(), "NIX_CONFIG");
+    }
+
 }
 
 std::vector<Path> getUserConfigFiles()

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -16,3 +16,12 @@ here=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
 export NIX_USER_CONF_FILES=$here/config/nix-with-substituters.conf
 var=$(nix show-config | grep '^substituters =' | cut -d '=' -f 2 | xargs)
 [[ $var == https://example.com ]]
+
+# Test that it's possible to load config from the environment
+prev=$(nix show-config | grep '^cores' | cut -d '=' -f 2 | xargs)
+export NIX_CONFIG="cores = 4242"$'\n'"experimental-features = nix-command flakes"
+exp_cores=$(nix show-config | grep '^cores' | cut -d '=' -f 2 | xargs)
+exp_features=$(nix show-config | grep '^experimental-features' | cut -d '=' -f 2 | xargs)
+[[ $prev != $exp_cores ]]
+[[ $exp_cores == "4242" ]]
+[[ $exp_features == "nix-command flakes" ]]


### PR DESCRIPTION
This PR offers an alternative approach of providing nix config settings via environment variables as [propose by edolstra](https://github.com/NixOS/nix/pull/4163#issuecomment-711902262) in #4163 