### PR TITLE
Allow the copy of ca derivation outputs

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -449,7 +449,7 @@ StorePath BinaryCacheStore::addTextToStore(const string & name, const string & s
 std::optional<const DrvOutputInfo> BinaryCacheStore::queryDrvOutputInfo(const DrvOutputId & id)
 {
     auto outputInfoFilePath =
-        "/drvOutputs/" + std::string(id.drvPath.hashPart()) + "!" + id.outputName;
+        "drvOutputs/" + std::string(id.drvPath.hashPart()) + "!" + id.outputName + ".doi";
     auto rawOutputInfo = getFile(outputInfoFilePath);
 
     if (rawOutputInfo) {
@@ -469,7 +469,7 @@ std::optional<StorePath> BinaryCacheStore::queryOutputPathOf(
 
 void BinaryCacheStore::registerDrvOutput(const DrvOutputId & id, const DrvOutputInfo & info)
 {
-    auto filePath = "/drvOutputs/" + std::string(id.drvPath.hashPart()) + "!" + id.outputName + ".doi";
+    auto filePath = "drvOutputs/" + std::string(id.drvPath.hashPart()) + "!" + id.outputName + ".doi";
     upsertFile(filePath, info.to_string(), "text/x-nix-derivertopath");
 }
 

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -444,10 +444,19 @@ StorePath BinaryCacheStore::addTextToStore(const string & name, const string & s
     })->path;
 }
 
+std::optional<StorePath> BinaryCacheStore::queryOutputPathOf(const StorePath & drvPath, const std::string & outputName)
+{
+    auto rawPath = getFile("/ac/" + std::string(drvPath.hashPart()) + "!" + outputName);
+    if (rawPath)
+        return {parseStorePath(*rawPath)};
+    else
+        return std::nullopt;
+}
+
 void BinaryCacheStore::linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output)
 {
     auto filePath = "/ac/" + std::string(deriver.hashPart()) + "!" + outputName;
-    upsertFile(filePath, std::string(output.hashPart()), "text/x-nix-derivertopath");
+    upsertFile(filePath, printStorePath(output), "text/x-nix-derivertopath");
 }
 
 ref<FSAccessor> BinaryCacheStore::getFSAccessor()

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -434,7 +434,9 @@ StorePath BinaryCacheStore::addTextToStore(const string & name, const string & s
     if (!repair && isValidPath(path))
         return path;
 
-    auto source = StringSource { s };
+    StringSink sink;
+    dumpString(s, sink);
+    auto source = StringSource { *sink.s };
     return addToStoreCommon(source, repair, CheckSigs, [&](HashResult nar) {
         ValidPathInfo info { path, nar.first };
         info.narSize = nar.second;

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -444,6 +444,12 @@ StorePath BinaryCacheStore::addTextToStore(const string & name, const string & s
     })->path;
 }
 
+void BinaryCacheStore::linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output)
+{
+    auto filePath = "/ac/" + std::string(deriver.hashPart()) + "!" + outputName;
+    upsertFile(filePath, std::string(output.hashPart()), "text/x-nix-derivertopath");
+}
+
 ref<FSAccessor> BinaryCacheStore::getFSAccessor()
 {
     return make_ref<RemoteFSAccessor>(ref<Store>(shared_from_this()), localNarCache);

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -101,6 +101,8 @@ public:
 
     void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output) override;
 
+    std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName) override;
+
     void narFromPath(const StorePath & path, Sink & sink) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -103,7 +103,7 @@ public:
 
     std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName) override;
 
-    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
 
     void narFromPath(const StorePath & path, Sink & sink) override;
 

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -99,9 +99,11 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
-    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output) override;
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
 
     std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName) override;
+
+    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
 
     void narFromPath(const StorePath & path, Sink & sink) override;
 

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -99,6 +99,8 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
+    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output) override;
+
     void narFromPath(const StorePath & path, Sink & sink) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -901,9 +901,15 @@ void DerivationGoal::buildDone()
             for (auto i : drv->outputs) {
                 outputPaths.insert(finalOutputs.at(i.first));
             }
+            std::set<string> rawOutputs;
+            for (auto i: drv->outputs) {
+                // rawOutputs.insert(DrvOutputId{drvPath, i.first}.to_string());
+                rawOutputs.insert(StorePathWithOutputs{drvPath, {i.first}}.to_string(worker.store));
+            }
             std::map<std::string, std::string> hookEnvironment = getEnv();
 
             hookEnvironment.emplace("DRV_PATH", worker.store.printStorePath(drvPath));
+            hookEnvironment.emplace("OUTPUTS", chomp(concatStringsSep(" ", rawOutputs)));
             hookEnvironment.emplace("OUT_PATHS", chomp(concatStringsSep(" ", worker.store.printStorePathSet(outputPaths))));
 
             RunOptions opts(settings.postBuildHook, {});

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2098,9 +2098,10 @@ struct RestrictedStore : public LocalFSStore, public virtual RestrictedStoreConf
         next->registerDrvOutput(id, output);
     }
 
-    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId & id) override {
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId & id) override
+    {
         if (!goal.isAllowed(id.drvPath))
-            throw InvalidPath("cannot query for unknown drv output '%s' in recursive Nix", printStorePath(id.drvPath));
+            throw InvalidPath("cannot query the output info for unknown derivation '%s' in recursive Nix", printStorePath(id.drvPath));
         return next->queryDrvOutputInfo(id);
     }
 

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2091,6 +2091,19 @@ struct RestrictedStore : public LocalFSStore, public virtual RestrictedStoreConf
         /* Nothing to be done; 'path' must already be valid. */
     }
 
+    void registerDrvOutput(const DrvOutputId & id, const DrvOutputInfo & output) override
+    {
+        if (!goal.isAllowed(id.drvPath))
+            throw InvalidPath("cannot register unknown drv output '%s' in recursive Nix", printStorePath(id.drvPath));
+        next->registerDrvOutput(id, output);
+    }
+
+    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId & id) override {
+        if (!goal.isAllowed(id.drvPath))
+            throw InvalidPath("cannot query for unknown drv output '%s' in recursive Nix", printStorePath(id.drvPath));
+        return next->queryDrvOutputInfo(id);
+    }
+
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override
     {
         if (buildMode != bmNormal) throw Error("unsupported build mode");
@@ -3365,7 +3378,7 @@ void DerivationGoal::registerOutputs()
 
     if (useDerivation || isCaFloating)
         for (auto & [outputName, newInfo] : infos)
-            worker.store.linkDeriverToPath(drvPathResolved, outputName, newInfo.path);
+            worker.store.registerDrvOutput(DrvOutputId{drvPathResolved, outputName}, DrvOutputInfo{newInfo.path, {}});
 }
 
 

--- a/src/libstore/build/drvOutput-substitution-goal.cc
+++ b/src/libstore/build/drvOutput-substitution-goal.cc
@@ -1,0 +1,98 @@
+#include "substitution-goal.hh"
+#include "drv-output-info.hh"
+
+namespace nix {
+class DrvOutputSubstitutionGoal : public SubstitutionGoal
+{
+private:
+    DrvOutputId id;
+
+    /* DrvOutput info returned by the substituter */
+    std::optional<DrvOutputInfo> drvOutputInfo;
+
+    std::optional<GoalState> tryCurrent() override;
+    void referencesValid() override;
+    void tryToRun() override;
+
+    DrvInput getTarget() const override { return id; }
+
+public:
+    DrvOutputSubstitutionGoal(const DrvOutputId&, Worker&, RepairFlag);
+};
+
+DrvOutputSubstitutionGoal::DrvOutputSubstitutionGoal(const DrvOutputId& id, Worker& worker, RepairFlag repair)
+    : SubstitutionGoal(worker, repair)
+    , id(id)
+{
+    name = fmt("substitution of '%s'", id.to_string());
+    trace("created");
+}
+
+
+std::optional<DrvOutputSubstitutionGoal::GoalState> DrvOutputSubstitutionGoal::tryCurrent()
+{
+    // XXX Should be done in a separate thread
+    drvOutputInfo = sub->queryDrvOutputInfo(id);
+    if (!drvOutputInfo) {
+        return std::nullopt;
+    }
+    remotelyKnownPath = drvOutputInfo->outPath;
+    // XXX: Handle the case of a different storeDir between local and remote
+    if (sub->storeDir == worker.store.storeDir)
+        assert(!locallyKnownPath || remotelyKnownPath == *locallyKnownPath);
+    else {
+        return std::nullopt;
+    }
+    // XXX: Query for signatures
+
+    /* To maintain the closure invariant, we first have to realise the
+       drv outputs referenced by this one. */
+    for (auto & i : drvOutputInfo->references)
+        addWaitee(worker.makeSubstitutionGoal(i));
+
+    return {&SubstitutionGoal::referencesValid};
+}
+
+void DrvOutputSubstitutionGoal::referencesValid()
+{
+    if (nrFailed > 0) {
+        debug("some references of the drv output '%s' could not be realised", id.to_string());
+        amDone(nrNoSubstituters > 0 || nrIncompleteClosure > 0 ? ecIncompleteClosure : ecFailed);
+        return;
+    }
+    addWaitee(worker.makeSubstitutionGoal(drvOutputInfo->outPath, repair));
+    state = &SubstitutionGoal::tryToRun;
+}
+
+void DrvOutputSubstitutionGoal::tryToRun()
+{
+    if (nrFailed > 0) {
+        if (nrNoSubstituters != nrFailed) {
+            substituterFailed = 1;
+        }
+        tryNext();
+        return;
+    }
+
+    assert(worker.store.isValidPath(drvOutputInfo->outPath));
+    promise = std::promise<void>();
+
+    outPipe.create();
+
+    worker.store.registerDrvOutput(id, *drvOutputInfo);
+    promise.set_value();
+    // thr = std::thread([&]() {
+    //     worker.store.registerDrvOutput(id, *drvOutputInfo);
+    //     promise.set_value();
+    // });
+    // worker.childStarted(shared_from_this(), {outPipe.readSide.get()}, true, false);
+    // state = &SubstitutionGoal::finished;
+    amDone(ecSuccess);
+}
+
+std::shared_ptr<SubstitutionGoal> makeSubstitutionGoal(const DrvOutputId& id, Worker & worker, RepairFlag repair, [[maybe_unused]] std::optional<ContentAddress> ca)
+{
+    return std::make_shared<DrvOutputSubstitutionGoal>(id, worker, repair);
+}
+
+}

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -60,7 +60,7 @@ void Goal::waiteeDone(GoalPtr waitee, ExitCode result)
 
 void Goal::amDone(ExitCode result, std::optional<Error> ex)
 {
-    trace("done");
+    debug("%1%: done with exit code %2%", name, result);
     assert(exitCode == ecBusy);
     assert(result == ecSuccess || result == ecFailed || result == ecNoSubstituters || result == ecIncompleteClosure);
     exitCode = result;

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -7,7 +7,7 @@ namespace nix {
 
 /* Forward definition. */
 struct Goal;
-struct Worker;
+class Worker;
 
 /* A pointer to a goal. */
 typedef std::shared_ptr<Goal> GoalPtr;

--- a/src/libstore/build/path-substitution-goal.cc
+++ b/src/libstore/build/path-substitution-goal.cc
@@ -1,0 +1,225 @@
+#include "substitution-goal.hh"
+#include "nar-info.hh"
+#include "finally.hh"
+
+namespace nix {
+
+class PathSubstitutionGoal : public SubstitutionGoal
+{
+private:
+    friend class Worker;
+
+    /* The store path that should be realised through a substitute. */
+    StorePath storePath;
+
+    /* Location where we're downloading the substitute.  Differs from
+       storePath when doing a repair. */
+    Path destPath;
+
+    /* Content address for recomputing store path */
+    std::optional<ContentAddress> ca;
+
+public:
+    PathSubstitutionGoal(const StorePath & storePath, Worker & worker, RepairFlag repair = NoRepair, std::optional<ContentAddress> ca = std::nullopt);
+
+    void timedOut(Error && ex) override { abort(); };
+
+    string key() override
+    {
+        /* "a$" ensures substitution goals happen before derivation
+           goals. */
+        return "a$" + std::string(storePath.name()) + "$" + worker.store.printStorePath(storePath);
+    }
+
+    /* The states. */
+    void tryNext() override;
+    void referencesValid() override;
+    void tryToRun() override;
+
+    DrvInput getTarget() const override { return storePath; }
+};
+
+PathSubstitutionGoal::PathSubstitutionGoal(const StorePath & storePath, Worker & worker, RepairFlag repair, std::optional<ContentAddress> ca)
+    : SubstitutionGoal(worker, repair)
+    , storePath(storePath)
+    , ca(ca)
+{
+    name = fmt("substitution of '%s'", worker.store.printStorePath(this->storePath));
+    locallyKnownPath = storePath;
+    trace("created");
+}
+
+void PathSubstitutionGoal::tryNext()
+{
+    trace("trying next substituter");
+
+    if (subs.size() == 0) {
+        /* None left.  Terminate this goal and let someone else deal
+           with it. */
+        debug("path '%s' is required, but there is no substituter that can build it", worker.store.printStorePath(storePath));
+
+        /* Hack: don't indicate failure if there were no substituters.
+           In that case the calling derivation should just do a
+           build. */
+        amDone(substituterFailed ? ecFailed : ecNoSubstituters);
+
+        if (substituterFailed) {
+            worker.failedSubstitutions++;
+            worker.updateProgress();
+        }
+
+        return;
+    }
+
+    sub = subs.front();
+    subs.pop_front();
+
+    if (ca) {
+        remotelyKnownPath = sub->makeFixedOutputPathFromCA(storePath.name(), *ca);
+        if (sub->storeDir == worker.store.storeDir)
+            assert(remotelyKnownPath == storePath);
+    } else if (sub->storeDir != worker.store.storeDir) {
+        tryNext();
+        return;
+    }
+
+    try {
+        // FIXME: make async
+        info = sub->queryPathInfo(remotelyKnownPath ? *remotelyKnownPath : storePath);
+    } catch (InvalidPath &) {
+        tryNext();
+        return;
+    } catch (SubstituterDisabled &) {
+        if (settings.tryFallback) {
+            tryNext();
+            return;
+        }
+        throw;
+    } catch (Error & e) {
+        if (settings.tryFallback) {
+            logError(e.info());
+            tryNext();
+            return;
+        }
+        throw;
+    }
+
+    if (info->path != storePath) {
+        if (info->isContentAddressed(*sub) && info->references.empty()) {
+            auto info2 = std::make_shared<ValidPathInfo>(*info);
+            info2->path = storePath;
+            info = info2;
+        } else {
+            printError("asked '%s' for '%s' but got '%s'",
+                sub->getUri(), worker.store.printStorePath(storePath), sub->printStorePath(info->path));
+            tryNext();
+            return;
+        }
+    }
+
+    /* Update the total expected download size. */
+    auto narInfo = std::dynamic_pointer_cast<const NarInfo>(info);
+
+    maintainExpectedNar = std::make_unique<MaintainCount<uint64_t>>(worker.expectedNarSize, info->narSize);
+
+    maintainExpectedDownload =
+        narInfo && narInfo->fileSize
+        ? std::make_unique<MaintainCount<uint64_t>>(worker.expectedDownloadSize, narInfo->fileSize)
+        : nullptr;
+
+    worker.updateProgress();
+
+    /* Bail out early if this substituter lacks a valid
+       signature. LocalStore::addToStore() also checks for this, but
+       only after we've downloaded the path. */
+    if (worker.store.requireSigs
+        && !sub->isTrusted
+        && !info->checkSignatures(worker.store, worker.store.getPublicKeys()))
+    {
+        logWarning({
+            .name = "Invalid path signature",
+            .hint = hintfmt("substituter '%s' does not have a valid signature for path '%s'",
+                sub->getUri(), worker.store.printStorePath(storePath))
+        });
+        tryNext();
+        return;
+    }
+
+    /* To maintain the closure invariant, we first have to realise the
+       paths referenced by this one. */
+    for (auto & i : info->references)
+        if (i != storePath) /* ignore self-references */
+            addWaitee(worker.makeSubstitutionGoal(i));
+
+    if (waitees.empty()) /* to prevent hang (no wake-up event) */
+        referencesValid();
+    else
+        state = &SubstitutionGoal::referencesValid;
+}
+
+void PathSubstitutionGoal::referencesValid()
+{
+    trace("all references realised");
+
+    if (nrFailed > 0) {
+        debug("some references of path '%s' could not be realised", worker.store.printStorePath(storePath));
+        amDone(nrNoSubstituters > 0 || nrIncompleteClosure > 0 ? ecIncompleteClosure : ecFailed);
+        return;
+    }
+
+    for (auto & i : info->references)
+        if (i != storePath) /* ignore self-references */
+            assert(worker.store.isValidPath(i));
+
+    state = &SubstitutionGoal::tryToRun;
+    worker.wakeUp(shared_from_this());
+}
+
+
+void PathSubstitutionGoal::tryToRun()
+{
+    trace("trying to run");
+
+    /* Make sure that we are allowed to start a build.  Note that even
+       if maxBuildJobs == 0 (no local builds allowed), we still allow
+       a substituter to run.  This is because substitutions cannot be
+       distributed to another machine via the build hook. */
+    if (worker.getNrLocalBuilds() >= std::max(1U, (unsigned int) settings.maxBuildJobs)) {
+        worker.waitForBuildSlot(shared_from_this());
+        return;
+    }
+
+    maintainRunningSubstitutions = std::make_unique<MaintainCount<uint64_t>>(worker.runningSubstitutions);
+    worker.updateProgress();
+
+    outPipe.create();
+
+    promise = std::promise<void>();
+
+    thr = std::thread([this]() {
+        try {
+            /* Wake up the worker loop when we're done. */
+            Finally updateStats([this]() { outPipe.writeSide = -1; });
+
+            Activity act(*logger, actSubstitute, Logger::Fields{worker.store.printStorePath(storePath), sub->getUri()});
+            PushActivity pact(act.id);
+
+            copyStorePath(ref<Store>(sub), ref<Store>(worker.store.shared_from_this()),
+                remotelyKnownPath ? *remotelyKnownPath : storePath, repair, sub->isTrusted ? NoCheckSigs : CheckSigs);
+
+            promise.set_value();
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    });
+
+    worker.childStarted(shared_from_this(), {outPipe.readSide.get()}, true, false);
+
+    state = &SubstitutionGoal::finished;
+}
+
+std::shared_ptr<SubstitutionGoal> makeSubstitutionGoal(const StorePath & storePath, Worker & worker, RepairFlag repair, std::optional<ContentAddress> ca)
+{
+    return std::make_shared<PathSubstitutionGoal>(storePath, worker, repair, ca);
+}
+}

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -5,18 +5,13 @@
 
 namespace nix {
 
-SubstitutionGoal::SubstitutionGoal(const StorePath & storePath, Worker & worker, RepairFlag repair, std::optional<ContentAddress> ca)
+SubstitutionGoal::SubstitutionGoal(Worker& worker, RepairFlag repair)
     : Goal(worker)
-    , storePath(storePath)
     , repair(repair)
-    , ca(ca)
 {
     state = &SubstitutionGoal::init;
-    name = fmt("substitution of '%s'", worker.store.printStorePath(this->storePath));
-    trace("created");
     maintainExpectedSubstitutions = std::make_unique<MaintainCount<uint64_t>>(worker.expectedSubstitutions);
 }
-
 
 SubstitutionGoal::~SubstitutionGoal()
 {
@@ -37,21 +32,22 @@ void SubstitutionGoal::work()
     (this->*state)();
 }
 
-
 void SubstitutionGoal::init()
 {
     trace("init");
 
-    worker.store.addTempRoot(storePath);
+    if (locallyKnownPath) {
+        worker.store.addTempRoot(*locallyKnownPath);
 
-    /* If the path already exists we're done. */
-    if (!repair && worker.store.isValidPath(storePath)) {
-        amDone(ecSuccess);
-        return;
+        /* If the path already exists we're done. */
+        if (!repair && worker.store.isValidPath(*locallyKnownPath)) {
+            amDone(ecSuccess);
+            return;
+        }
     }
 
     if (settings.readOnlyMode)
-        throw Error("cannot substitute path '%s' - no write access to the Nix store", worker.store.printStorePath(storePath));
+        throw Error("cannot substitute path '%s' - no write access to the Nix store", getTarget().to_string());
 
     subs = settings.useSubstitutes ? getDefaultSubstituters() : std::list<ref<Store>>();
 
@@ -59,179 +55,12 @@ void SubstitutionGoal::init()
 }
 
 
-void SubstitutionGoal::tryNext()
-{
-    trace("trying next substituter");
 
-    if (subs.size() == 0) {
-        /* None left.  Terminate this goal and let someone else deal
-           with it. */
-        debug("path '%s' is required, but there is no substituter that can build it", worker.store.printStorePath(storePath));
-
-        /* Hack: don't indicate failure if there were no substituters.
-           In that case the calling derivation should just do a
-           build. */
-        amDone(substituterFailed ? ecFailed : ecNoSubstituters);
-
-        if (substituterFailed) {
-            worker.failedSubstitutions++;
-            worker.updateProgress();
-        }
-
-        return;
-    }
-
-    sub = subs.front();
-    subs.pop_front();
-
-    if (ca) {
-        subPath = sub->makeFixedOutputPathFromCA(storePath.name(), *ca);
-        if (sub->storeDir == worker.store.storeDir)
-            assert(subPath == storePath);
-    } else if (sub->storeDir != worker.store.storeDir) {
-        tryNext();
-        return;
-    }
-
-    try {
-        // FIXME: make async
-        info = sub->queryPathInfo(subPath ? *subPath : storePath);
-    } catch (InvalidPath &) {
-        tryNext();
-        return;
-    } catch (SubstituterDisabled &) {
-        if (settings.tryFallback) {
-            tryNext();
-            return;
-        }
-        throw;
-    } catch (Error & e) {
-        if (settings.tryFallback) {
-            logError(e.info());
-            tryNext();
-            return;
-        }
-        throw;
-    }
-
-    if (info->path != storePath) {
-        if (info->isContentAddressed(*sub) && info->references.empty()) {
-            auto info2 = std::make_shared<ValidPathInfo>(*info);
-            info2->path = storePath;
-            info = info2;
-        } else {
-            printError("asked '%s' for '%s' but got '%s'",
-                sub->getUri(), worker.store.printStorePath(storePath), sub->printStorePath(info->path));
-            tryNext();
-            return;
-        }
-    }
-
-    /* Update the total expected download size. */
-    auto narInfo = std::dynamic_pointer_cast<const NarInfo>(info);
-
-    maintainExpectedNar = std::make_unique<MaintainCount<uint64_t>>(worker.expectedNarSize, info->narSize);
-
-    maintainExpectedDownload =
-        narInfo && narInfo->fileSize
-        ? std::make_unique<MaintainCount<uint64_t>>(worker.expectedDownloadSize, narInfo->fileSize)
-        : nullptr;
-
-    worker.updateProgress();
-
-    /* Bail out early if this substituter lacks a valid
-       signature. LocalStore::addToStore() also checks for this, but
-       only after we've downloaded the path. */
-    if (worker.store.requireSigs
-        && !sub->isTrusted
-        && !info->checkSignatures(worker.store, worker.store.getPublicKeys()))
-    {
-        logWarning({
-            .name = "Invalid path signature",
-            .hint = hintfmt("substituter '%s' does not have a valid signature for path '%s'",
-                sub->getUri(), worker.store.printStorePath(storePath))
-        });
-        tryNext();
-        return;
-    }
-
-    /* To maintain the closure invariant, we first have to realise the
-       paths referenced by this one. */
-    for (auto & i : info->references)
-        if (i != storePath) /* ignore self-references */
-            addWaitee(worker.makeSubstitutionGoal(i));
-
-    if (waitees.empty()) /* to prevent hang (no wake-up event) */
-        referencesValid();
-    else
-        state = &SubstitutionGoal::referencesValid;
-}
-
-
-void SubstitutionGoal::referencesValid()
-{
-    trace("all references realised");
-
-    if (nrFailed > 0) {
-        debug("some references of path '%s' could not be realised", worker.store.printStorePath(storePath));
-        amDone(nrNoSubstituters > 0 || nrIncompleteClosure > 0 ? ecIncompleteClosure : ecFailed);
-        return;
-    }
-
-    for (auto & i : info->references)
-        if (i != storePath) /* ignore self-references */
-            assert(worker.store.isValidPath(i));
-
-    state = &SubstitutionGoal::tryToRun;
-    worker.wakeUp(shared_from_this());
-}
-
-
-void SubstitutionGoal::tryToRun()
-{
-    trace("trying to run");
-
-    /* Make sure that we are allowed to start a build.  Note that even
-       if maxBuildJobs == 0 (no local builds allowed), we still allow
-       a substituter to run.  This is because substitutions cannot be
-       distributed to another machine via the build hook. */
-    if (worker.getNrLocalBuilds() >= std::max(1U, (unsigned int) settings.maxBuildJobs)) {
-        worker.waitForBuildSlot(shared_from_this());
-        return;
-    }
-
-    maintainRunningSubstitutions = std::make_unique<MaintainCount<uint64_t>>(worker.runningSubstitutions);
-    worker.updateProgress();
-
-    outPipe.create();
-
-    promise = std::promise<void>();
-
-    thr = std::thread([this]() {
-        try {
-            /* Wake up the worker loop when we're done. */
-            Finally updateStats([this]() { outPipe.writeSide = -1; });
-
-            Activity act(*logger, actSubstitute, Logger::Fields{worker.store.printStorePath(storePath), sub->getUri()});
-            PushActivity pact(act.id);
-
-            copyStorePath(ref<Store>(sub), ref<Store>(worker.store.shared_from_this()),
-                subPath ? *subPath : storePath, repair, sub->isTrusted ? NoCheckSigs : CheckSigs);
-
-            promise.set_value();
-        } catch (...) {
-            promise.set_exception(std::current_exception());
-        }
-    });
-
-    worker.childStarted(shared_from_this(), {outPipe.readSide.get()}, true, false);
-
-    state = &SubstitutionGoal::finished;
-}
 
 
 void SubstitutionGoal::finished()
 {
+    assert(locallyKnownPath);
     trace("substitute finished");
 
     thr.join();
@@ -259,9 +88,9 @@ void SubstitutionGoal::finished()
         return;
     }
 
-    worker.markContentsGood(storePath);
+    worker.markContentsGood(*locallyKnownPath);
 
-    printMsg(lvlChatty, "substitution of path '%s' succeeded", worker.store.printStorePath(storePath));
+    printMsg(lvlChatty, "substitution of path '%s' succeeded", worker.store.printStorePath(*locallyKnownPath));
 
     maintainRunningSubstitutions.reset();
 

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -79,7 +79,7 @@ std::shared_ptr<SubstitutionGoal> Worker::makeSubstitutionGoal(const StorePath &
     std::weak_ptr<SubstitutionGoal> & goal_weak = substitutionGoals[path];
     auto goal = goal_weak.lock(); // FIXME
     if (!goal) {
-        goal = std::make_shared<SubstitutionGoal>(path, *this, repair, ca);
+        goal = nix::makeSubstitutionGoal(path, *this, repair, ca);
         goal_weak = goal;
         wakeUp(goal);
     }

--- a/src/libstore/build/worker.hh
+++ b/src/libstore/build/worker.hh
@@ -68,8 +68,8 @@ private:
 
     /* Maps used to prevent multiple instantiations of a goal for the
        same derivation / path. */
-    std::map<StorePath, std::weak_ptr<DerivationGoal>> derivationGoals;
-    std::map<StorePath, std::weak_ptr<SubstitutionGoal>> substitutionGoals;
+    std::map<DrvInput, std::weak_ptr<DerivationGoal>> derivationGoals;
+    std::map<DrvInput, std::weak_ptr<SubstitutionGoal>> substitutionGoals;
 
     /* Goals waiting for busy paths to be unlocked. */
     WeakGoals waitingForAnyGoal;
@@ -143,7 +143,7 @@ public:
         const StringSet & wantedOutputs, BuildMode buildMode = bmNormal);
 
     /* substitution goal */
-    std::shared_ptr<SubstitutionGoal> makeSubstitutionGoal(const StorePath & storePath, RepairFlag repair = NoRepair, std::optional<ContentAddress> ca = std::nullopt);
+    std::shared_ptr<SubstitutionGoal> makeSubstitutionGoal(const DrvInput & target, RepairFlag repair = NoRepair, std::optional<ContentAddress> ca = std::nullopt);
 
     /* Remove a dead goal. */
     void removeGoal(GoalPtr goal);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -859,6 +859,16 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case wopLinkDeriverToPath: {
+        logger->startWork();
+        auto drvPath = store->parseStorePath(readString(from));
+        auto outputName = readString(from);
+        auto outputPath = store->parseStorePath(readString(from));
+        store->linkDeriverToPath(drvPath, outputName, outputPath);
+        logger->stopWork();
+        break;
+    }
+
     default:
         throw Error("invalid operation %1%", op);
     }

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -876,8 +876,13 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         logger->startWork();
         auto outputId = DrvOutputId::parse(readString(from));
         auto info = store->queryDrvOutputInfo(outputId);
-        to << std::string(info->outPath.to_string());
-        to << stringify_refs(info->references);
+        if (info) {
+            to << std::string(info->outPath.to_string());
+            to << stringify_refs(info->references);
+        }
+        else {
+            to << "";
+        }
     }
 
     default:

--- a/src/libstore/drv-output-info.cc
+++ b/src/libstore/drv-output-info.cc
@@ -7,7 +7,7 @@ MakeError(InvalidDerivationOutputId, Error);
 
 DrvOutputId DrvOutputId::parse(const std::string &strRep) {
     const auto &[rawPath, outputs] = parsePathWithOutputs(strRep);
-    if (outputs.size() == 1)
+    if (outputs.size() != 1)
         throw InvalidDerivationOutputId("Invalid derivation output id %s", strRep);
 
     return DrvOutputId{

--- a/src/libstore/drv-output-info.cc
+++ b/src/libstore/drv-output-info.cc
@@ -1,0 +1,98 @@
+#include "drv-output-info.hh"
+#include "store-api.hh"
+
+namespace nix {
+
+MakeError(InvalidDerivationOutputId, Error);
+
+DrvOutputId DrvOutputId::parse(const std::string &strRep) {
+    const auto &[rawPath, outputs] = parsePathWithOutputs(strRep);
+    if (outputs.size() == 1)
+        throw InvalidDerivationOutputId("Invalid derivation output id %s", strRep);
+
+    return DrvOutputId{
+        .drvPath = StorePath(rawPath),
+        .outputName = *outputs.begin(),
+    };
+}
+
+std::string DrvOutputId::to_string() const {
+    return std::string(drvPath.to_string()) + "!" + outputName;
+}
+
+DrvInput DrvInput::parse(const std::string & strRep)
+{
+    try {
+        return DrvInput(DrvOutputId::parse(strRep));
+    } catch (InvalidDerivationOutputId) {
+        return DrvInput(StorePath(strRep));
+    }
+}
+
+std::string DrvInput::to_string() const {
+    return std::visit(
+        overloaded{
+            [&](StorePath p) -> std::string { return std::string(p.to_string()); },
+            [&](DrvOutputId id) -> std::string { return id.to_string(); },
+        },
+        static_cast<RawDrvInput>(*this));
+}
+
+std::list<std::string> stringify_refs(const std::set<DrvInput> &refs) {
+    std::list<std::string> res;
+    for (auto &ref : refs) {
+        res.push_front(ref.to_string());
+    }
+    return res;
+}
+
+std::string DrvOutputInfo::to_string() const {
+    std::string res;
+
+    res += "OutPath: " + std::string(outPath.to_string()) + '\n';
+    res += "References: " +
+           concatStringsSep(" ", stringify_refs(references)) + "\n";
+
+    return res;
+}
+
+DrvOutputInfo DrvOutputInfo::parse(const std::string & s, const std::string & whence)
+{
+    // XXX: Copy-pasted from NarInfo::NarInfo. Should be factored out
+    auto corrupt = [&]() {
+        return Error("Drv output info file '%1%' is corrupt", whence);
+    };
+
+    std::optional<StorePath> outPath;
+    std::set<DrvInput> references;
+
+    size_t pos = 0;
+    while (pos < s.size()) {
+
+        size_t colon = s.find(':', pos);
+        if (colon == std::string::npos) throw corrupt();
+
+        std::string name(s, pos, colon - pos);
+
+        size_t eol = s.find('\n', colon + 2);
+        if (eol == std::string::npos) throw corrupt();
+
+        std::string value(s, colon + 2, eol - colon - 2);
+
+        if (name == "OutPath")
+            outPath = StorePath(value);
+        else if (name == "References") {
+            auto refs = tokenizeString<Strings>(value, " ");
+            if (!references.empty()) throw corrupt();
+            for (auto & r : refs)
+                references.insert(DrvInput::parse(r));
+        }
+
+        pos = eol + 1;
+    }
+
+    if (!outPath) corrupt();
+    return DrvOutputInfo { .outPath = *outPath, .references = references };
+}
+
+} // namespace nix

--- a/src/libstore/drv-output-info.hh
+++ b/src/libstore/drv-output-info.hh
@@ -28,6 +28,8 @@ struct DrvInput : RawDrvInput {
 
     std::string to_string() const;
     static DrvInput parse(const std::string & strRep);
+
+    std::optional<StorePath> getPath(const Store& store) const;
 };
 
 std::list<std::string> stringify_refs(const std::set<DrvInput> & refs);

--- a/src/libstore/drv-output-info.hh
+++ b/src/libstore/drv-output-info.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "path.hh"
+
+namespace nix {
+
+struct DrvOutputId {
+    StorePath drvPath;
+    std::string outputName;
+
+    std::string to_string() const;
+
+    static DrvOutputId parse(const std::string &);
+
+    bool operator<(const DrvOutputId& other) const { return to_pair() < other.to_pair(); }
+    bool operator==(const DrvOutputId& other) const { return to_pair() == other.to_pair(); }
+
+private:
+    // Just to make comparison operators easier to write
+    std::pair<StorePath, std::string> to_pair() const
+    { return std::make_pair(drvPath, outputName); }
+};
+
+typedef std::variant<StorePath, DrvOutputId> RawDrvInput;
+
+struct DrvInput : RawDrvInput {
+    using RawDrvInput::RawDrvInput;
+
+    std::string to_string() const;
+    static DrvInput parse(const std::string & strRep);
+};
+
+std::list<std::string> stringify_refs(const std::set<DrvInput> & refs);
+
+struct DrvOutputInfo {
+    StorePath outPath;
+    std::set<DrvInput> references;
+
+    std::string to_string() const;
+    static DrvOutputInfo parse(const std::string & s, const std::string & whence);
+};
+
+typedef std::map<DrvOutputId, DrvOutputInfo> DrvOutputs;
+
+}

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -61,7 +61,7 @@ struct DummyStore : public Store, public virtual DummyStoreConfig
         BuildMode buildMode) override
     { unsupported("buildDerivation"); }
 
-    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
     { unsupported("queryDrvOutputInfo"); }
 };
 

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -60,6 +60,9 @@ struct DummyStore : public Store, public virtual DummyStoreConfig
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
         BuildMode buildMode) override
     { unsupported("buildDerivation"); }
+
+    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    { unsupported("queryDrvOutputInfo"); }
 };
 
 static RegisterStoreImplementation<DummyStore, DummyStoreConfig> regDummyStore;

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -333,6 +333,10 @@ public:
         auto conn(connections->get());
         return conn->remoteVersion;
     }
+
+    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    // TODO: Implement
+    { unsupported("queryDrvOutputInfo"); }
 };
 
 static RegisterStoreImplementation<LegacySSHStore, LegacySSHStoreConfig> regLegacySSHStore;

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -334,7 +334,7 @@ public:
         return conn->remoteVersion;
     }
 
-    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
     // TODO: Implement
     { unsupported("queryDrvOutputInfo"); }
 };

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -87,6 +87,7 @@ protected:
 void LocalBinaryCacheStore::init()
 {
     createDirs(binaryCacheDir + "/nar");
+    createDirs(binaryCacheDir + "/ac");
     if (writeDebugInfo)
         createDirs(binaryCacheDir + "/debuginfo");
     BinaryCacheStore::init();

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -87,7 +87,7 @@ protected:
 void LocalBinaryCacheStore::init()
 {
     createDirs(binaryCacheDir + "/nar");
-    createDirs(binaryCacheDir + "/ac");
+    createDirs(binaryCacheDir + "/drvOutputs");
     if (writeDebugInfo)
         createDirs(binaryCacheDir + "/debuginfo");
     BinaryCacheStore::init();

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -578,13 +578,16 @@ void LocalStore::checkDerivationOutputs(const StorePath & drvPath, const Derivat
 }
 
 
-void LocalStore::linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output)
+void LocalStore::registerDrvOutput(const DrvOutputId& id, const DrvOutputInfo & info)
 {
     auto state(_state.lock());
-    return linkDeriverToPath(*state, queryValidPathId(*state, deriver), outputName, output);
+    // XXX: This ignores the references of the output because we can
+    // recompute them later from the drv and the references of the associated
+    // store path, but doing so is both inefficient and fragile.
+    return registerDrvOutput_(*state, queryValidPathId(*state, id.drvPath), id.outputName, info.outPath);
 }
 
-void LocalStore::linkDeriverToPath(State & state, uint64_t deriver, const string & outputName, const StorePath & output)
+void LocalStore::registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output)
 {
     retrySQLite<void>([&]() {
         state.stmtAddDerivationOutput.use()
@@ -634,7 +637,7 @@ uint64_t LocalStore::addValidPath(State & state,
             /* Floating CA derivations have indeterminate output paths until
                they are built, so don't register anything in that case */
             if (i.second.second)
-                linkDeriverToPath(state, id, i.first, *i.second.second);
+                registerDrvOutput_(state, id, i.first, *i.second.second);
         }
     }
 
@@ -1584,5 +1587,31 @@ void LocalStore::createUser(const std::string & userName, uid_t userId)
     }
 }
 
-
+ref<const DrvOutputInfo> LocalStore::queryDrvOutputInfo(const DrvOutputId& id) {
+    auto outputPath = queryOutputPathOf(id.drvPath, id.outputName);
+    if (!outputPath)
+        throw Error("Querying for informations for the non-built output %s",
+                    id.to_string());
+    auto derivation = readDerivation(id.drvPath);
+    auto outputPathInfo = queryPathInfo(*outputPath);
+    std::set<DrvInput> references;
+    for (auto& [inputDrv, inputOutputs] : derivation.inputDrvs) {
+        auto outputsOfInput = queryPartialDerivationOutputMap(inputDrv);
+        for (auto& outputName : inputOutputs) {
+            if (outputsOfInput.count(outputName)) {
+                auto& thisPath = outputsOfInput.at(outputName);
+                if (thisPath && outputPathInfo->references.count(*thisPath))
+                    references.emplace(DrvOutputId{inputDrv, outputName});
+            }
+        }
+    }
+    for (auto& inputPath : derivation.inputSrcs) {
+        if (outputPathInfo->references.count(inputPath))
+            references.emplace(inputPath);
+    }
+    return make_ref<const DrvOutputInfo>(DrvOutputInfo{
+        .outPath = *outputPath,
+        .references = references,
+    });
 }
+}  // namespace nix

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1587,11 +1587,10 @@ void LocalStore::createUser(const std::string & userName, uid_t userId)
     }
 }
 
-ref<const DrvOutputInfo> LocalStore::queryDrvOutputInfo(const DrvOutputId& id) {
+std::optional<const DrvOutputInfo> LocalStore::queryDrvOutputInfo(const DrvOutputId& id) {
     auto outputPath = queryOutputPathOf(id.drvPath, id.outputName);
-    if (!outputPath)
-        throw Error("Querying for informations for the non-built output %s",
-                    id.to_string());
+    if (!(outputPath && isValidPath(*outputPath)))
+        return std::nullopt;
     auto derivation = readDerivation(id.drvPath);
     auto outputPathInfo = queryPathInfo(*outputPath);
     std::set<DrvInput> references;
@@ -1609,9 +1608,9 @@ ref<const DrvOutputInfo> LocalStore::queryDrvOutputInfo(const DrvOutputId& id) {
         if (outputPathInfo->references.count(inputPath))
             references.emplace(inputPath);
     }
-    return make_ref<const DrvOutputInfo>(DrvOutputInfo{
+    return {DrvOutputInfo{
         .outPath = *outputPath,
         .references = references,
-    });
+    }};
 }
 }  // namespace nix

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -289,7 +289,7 @@ private:
 
     /* Register the store path 'output' as the output named 'outputName' of
        derivation 'deriver'. */
-    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output);
+    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output) override;
     void linkDeriverToPath(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
 
     Path getRealStoreDir() override { return realStoreDir; }

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -219,6 +219,13 @@ public:
        garbage until it exceeds maxFree. */
     void autoGC(bool sync = true);
 
+    /* Register the store path 'output' as the output named 'outputName' of
+       derivation 'deriver'. */
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+    void registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
+
+    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
+
 private:
 
     int getSchema();
@@ -286,11 +293,6 @@ private:
     /* Add signatures to a ValidPathInfo using the secret keys
        specified by the ‘secret-key-files’ option. */
     void signPathInfo(ValidPathInfo & info);
-
-    /* Register the store path 'output' as the output named 'outputName' of
-       derivation 'deriver'. */
-    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output) override;
-    void linkDeriverToPath(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
 
     Path getRealStoreDir() override { return realStoreDir; }
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -224,7 +224,7 @@ public:
     void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
     void registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
 
-    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
 
 private:
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -300,6 +300,7 @@ private:
 
     friend class DerivationGoal;
     friend class SubstitutionGoal;
+    friend class PathSubstitutionGoal;
 };
 
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -301,6 +301,7 @@ private:
     friend class DerivationGoal;
     friend class SubstitutionGoal;
     friend class PathSubstitutionGoal;
+    friend class DrvOutputSubstitutionGoal;
 };
 
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -21,7 +21,7 @@ namespace nix {
    0.7.  Version 2 was Nix 0.8 and 0.9.  Version 3 is Nix 0.10.
    Version 4 is Nix 0.11.  Version 5 is Nix 0.12-0.16.  Version 6 is
    Nix 1.0.  Version 7 is Nix 1.3. Version 10 is 2.0. */
-const int nixSchemaVersion = 10;
+const int nixSchemaVersion = 11;
 
 
 struct OptimiseStats
@@ -222,7 +222,7 @@ public:
     /* Register the store path 'output' as the output named 'outputName' of
        derivation 'deriver'. */
     void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
-    void registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
+    void registerDrvOutput_(State & state, const StorePath & deriver, const string & outputName, const StorePath & output);
 
     std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
 

--- a/src/libstore/path.hh
+++ b/src/libstore/path.hh
@@ -75,7 +75,14 @@ struct StorePathWithOutputs
     std::set<std::string> outputs;
 
     std::string to_string(const Store & store) const;
+
+    bool operator<(const StorePathWithOutputs & other) const
+    {
+        return path < other.path || outputs < other.outputs;
+    }
 };
+
+typedef std::variant<StorePath, StorePathWithOutputs> PathOrOutputs;
 
 std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s);
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -599,6 +599,16 @@ StorePath RemoteStore::addTextToStore(const string & name, const string & s,
     return addCAToStore(source, name, TextHashMethod{}, references, repair)->path;
 }
 
+void RemoteStore::linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output)
+{
+    auto conn(getConnection());
+    conn->to << wopLinkDeriverToPath;
+    conn->to << printStorePath(deriver);
+    conn->to << outputName;
+    conn->to << printStorePath(output);
+    conn.processStderr();
+}
+
 
 void RemoteStore::buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, BuildMode buildMode)
 {

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -81,6 +81,8 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
+    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output) override;
+
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -81,7 +81,9 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
-    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output) override;
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+
+    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
 
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -83,7 +83,7 @@ public:
 
     void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
 
-    ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
 
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
 

--- a/src/libstore/schema.sql
+++ b/src/libstore/schema.sql
@@ -32,11 +32,10 @@ create trigger if not exists DeleteSelfRefs before delete on ValidPaths
   end;
 
 create table if not exists DerivationOutputs (
-    drv  integer not null,
-    id   text not null, -- symbolic output id, usually "out"
-    path text not null,
-    primary key (drv, id),
-    foreign key (drv) references ValidPaths(id) on delete cascade
+    drvPath text not null,
+    outputName text not null, -- symbolic output id, usually "out"
+    outputPath text not null,
+    primary key (drvPath, outputName)
 );
 
-create index if not exists IndexDerivationOutputs on DerivationOutputs(path);
+create index if not exists IndexDerivationOutputs on DerivationOutputs(outputPath);

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -364,6 +364,16 @@ bool Store::PathInfoCacheValue::isKnownNow()
     return std::chrono::steady_clock::now() < time_point + ttl;
 }
 
+std::optional<StorePath> Store::queryOutputPathOf(const StorePath & drvPath, const std::string & outputName)
+{
+    auto resp = queryPartialDerivationOutputMap(drvPath);
+    if (auto maybePathPtr = resp.find(outputName); maybePathPtr != resp.end()) {
+        return maybePathPtr->second;
+    } else {
+        return std::nullopt;
+    }
+}
+
 OutputPathMap Store::queryDerivationOutputMap(const StorePath & path) {
     auto resp = queryPartialDerivationOutputMap(path);
     OutputPathMap result;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -763,95 +763,147 @@ void copyStorePath(ref<Store> srcStore, ref<Store> dstStore,
     dstStore->addToStore(*info, *source, repair, checkSigs);
 }
 
-
-std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore, const StorePathSet & storePaths,
-    RepairFlag repair, CheckSigsFlag checkSigs, SubstituteFlag substitute)
+std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
+    const StorePathSet & storePaths,
+    RepairFlag repair,
+    CheckSigsFlag checkSigs,
+    SubstituteFlag substitute)
 {
-    auto valid = dstStore->queryValidPaths(storePaths, substitute);
+    std::set<PathOrOutputs> toBeCopied;
+    for (auto & path : storePaths) {
+        PathOrOutputs path_(path);
+        toBeCopied.insert(path_);
+    }
+    return copyPaths(srcStore, dstStore, toBeCopied, repair, checkSigs, substitute);
+}
+
+std::map<StorePath, StorePath> copyPaths(
+        ref<Store> srcStore, ref<Store> dstStore,
+        const std::set<PathOrOutputs> &storePaths,
+        RepairFlag repair, CheckSigsFlag checkSigs, SubstituteFlag substitute)
+{
+    // XXX: This is certainly already defined somewhere else
+    struct OutputId {
+        StorePath drv;
+        std::string outputName;
+    };
+    // TODO: Use a set rather than a list
+    // (but requires implementing `comparable` for `OutputId`)
+    std::map<StorePath, std::list<OutputId>> pathToDerivers;
+    std::set<StorePath> pathsToCopy;
+    for (auto pathOrDrvOutput : storePaths) {
+        std::visit(overloaded {
+                [&](StorePath path) {
+                    pathsToCopy.insert(path);
+                    pathToDerivers.try_emplace(std::move(path), std::list<OutputId>());
+                },
+                [&](StorePathWithOutputs pathWithOutputs) {
+                    auto drvOutputs = srcStore->queryDerivationOutputMap(pathWithOutputs.path);
+                    for (auto & outputName : pathWithOutputs.outputs) {
+                        // TODO: Proper error checking in case the output
+                        // doesn't exist or hasn't been realised
+                        std::optional<StorePath> outputPath = drvOutputs.find(outputName)->second;
+                        // Ensure that the key is in the map
+                        pathsToCopy.insert(*outputPath);
+                        pathToDerivers.insert({*outputPath, std::list<OutputId>()});
+                        pathToDerivers[*outputPath].push_front(OutputId{std::move(pathWithOutputs.path), outputName});
+                    }
+                },
+            },
+            pathOrDrvOutput
+            );
+    }
+    auto valid = dstStore->queryValidPaths(pathsToCopy, substitute);
 
     StorePathSet missing;
-    for (auto & path : storePaths)
+    for (auto & path : pathsToCopy)
         if (!valid.count(path)) missing.insert(path);
 
     std::map<StorePath, StorePath> pathsMap;
-    for (auto & path : storePaths)
+    for (auto & path : pathsToCopy)
         pathsMap.insert_or_assign(path, path);
 
-    if (missing.empty()) return pathsMap;
+    if (!missing.empty()) {
+        Activity act(*logger, lvlInfo, actCopyPaths, fmt("copying %d paths", missing.size()));
 
-    Activity act(*logger, lvlInfo, actCopyPaths, fmt("copying %d paths", missing.size()));
+        std::atomic<size_t> nrDone{0};
+        std::atomic<size_t> nrFailed{0};
+        std::atomic<uint64_t> bytesExpected{0};
+        std::atomic<uint64_t> nrRunning{0};
 
-    std::atomic<size_t> nrDone{0};
-    std::atomic<size_t> nrFailed{0};
-    std::atomic<uint64_t> bytesExpected{0};
-    std::atomic<uint64_t> nrRunning{0};
+        auto showProgress = [&]() {
+            act.progress(nrDone, missing.size(), nrRunning, nrFailed);
+        };
 
-    auto showProgress = [&]() {
-        act.progress(nrDone, missing.size(), nrRunning, nrFailed);
-    };
+        ThreadPool pool;
 
-    ThreadPool pool;
+        processGraph<StorePath>(pool,
+            StorePathSet(missing.begin(), missing.end()),
 
-    processGraph<StorePath>(pool,
-        StorePathSet(missing.begin(), missing.end()),
+            [&](const StorePath & storePath) {
+                auto info = srcStore->queryPathInfo(storePath);
+                auto storePathForDst = storePath;
+                if (info->ca && info->references.empty()) {
+                    storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
+                    if (dstStore->storeDir == srcStore->storeDir)
+                        assert(storePathForDst == storePath);
+                    if (storePathForDst != storePath)
+                        debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
+                }
+                pathsMap.insert_or_assign(storePath, storePathForDst);
 
-        [&](const StorePath & storePath) {
-            auto info = srcStore->queryPathInfo(storePath);
-            auto storePathForDst = storePath;
-            if (info->ca && info->references.empty()) {
-                storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
-                if (dstStore->storeDir == srcStore->storeDir)
-                    assert(storePathForDst == storePath);
-                if (storePathForDst != storePath)
-                    debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
-            }
-            pathsMap.insert_or_assign(storePath, storePathForDst);
+                if (dstStore->isValidPath(storePath)) {
+                    nrDone++;
+                    showProgress();
+                    return StorePathSet();
+                }
 
-            if (dstStore->isValidPath(storePath)) {
+                bytesExpected += info->narSize;
+                act.setExpected(actCopyPath, bytesExpected);
+
+                return info->references;
+            },
+
+            [&](const StorePath & storePath) {
+                checkInterrupt();
+
+                auto info = srcStore->queryPathInfo(storePath);
+
+                auto storePathForDst = storePath;
+                if (info->ca && info->references.empty()) {
+                    storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
+                    if (dstStore->storeDir == srcStore->storeDir)
+                        assert(storePathForDst == storePath);
+                    if (storePathForDst != storePath)
+                        debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
+                }
+                pathsMap.insert_or_assign(storePath, storePathForDst);
+
+                if (!dstStore->isValidPath(storePathForDst)) {
+                    MaintainCount<decltype(nrRunning)> mc(nrRunning);
+                    showProgress();
+                    try {
+                        copyStorePath(srcStore, dstStore, storePath, repair, checkSigs);
+                    } catch (Error &e) {
+                        nrFailed++;
+                        if (!settings.keepGoing)
+                            throw e;
+                        logger->log(lvlError, fmt("could not copy %s: %s", dstStore->printStorePath(storePath), e.what()));
+                        showProgress();
+                        return;
+                    }
+                }
+
                 nrDone++;
                 showProgress();
-                return StorePathSet();
-            }
+            });
+    }
 
-            bytesExpected += info->narSize;
-            act.setExpected(actCopyPath, bytesExpected);
-
-            return info->references;
-        },
-
-        [&](const StorePath & storePath) {
-            checkInterrupt();
-
-            auto info = srcStore->queryPathInfo(storePath);
-
-            auto storePathForDst = storePath;
-            if (info->ca && info->references.empty()) {
-                storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
-                if (dstStore->storeDir == srcStore->storeDir)
-                    assert(storePathForDst == storePath);
-                if (storePathForDst != storePath)
-                    debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
-            }
-            pathsMap.insert_or_assign(storePath, storePathForDst);
-
-            if (!dstStore->isValidPath(storePathForDst)) {
-                MaintainCount<decltype(nrRunning)> mc(nrRunning);
-                showProgress();
-                try {
-                    copyStorePath(srcStore, dstStore, storePath, repair, checkSigs);
-                } catch (Error &e) {
-                    nrFailed++;
-                    if (!settings.keepGoing)
-                        throw e;
-                    logger->log(lvlError, fmt("could not copy %s: %s", dstStore->printStorePath(storePath), e.what()));
-                    showProgress();
-                    return;
-                }
-            }
-
-            nrDone++;
-            showProgress();
-        });
+    for (auto & [path, derivers] : pathToDerivers) {
+        for (auto & deriver : derivers) {
+            dstStore->linkDeriverToPath(deriver.drv, deriver.outputName, path);
+        }
+    }
 
     return pathsMap;
 }

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -463,6 +463,18 @@ public:
     virtual StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair = NoRepair) = 0;
 
+    /**
+     * Add a mapping indicating that `deriver!outputName` maps to the output path
+     * `output`.
+     *
+     * This is redundant for known-input-addressed and fixed-output derivations
+     * as this information is already present in the drv file, but necessary for
+     * floating-ca derivations and their dependencies as there's no way to
+     * retrieve this information otherwise.
+     */
+    virtual void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output)
+    { unsupported("linkDeriverToPath"); }
+
     /* Write a NAR dump of a store path. */
     virtual void narFromPath(const StorePath & path, Sink & sink) = 0;
 

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -411,6 +411,8 @@ public:
     virtual std::map<std::string, std::optional<StorePath>> queryPartialDerivationOutputMap(const StorePath & path)
     { unsupported("queryPartialDerivationOutputMap"); }
 
+    virtual std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName);
+
     /* Query the mapping outputName=>outputPath for the given derivation.
        Assume every output has a mapping and throw an exception otherwise. */
     OutputPathMap queryDerivationOutputMap(const StorePath & path);

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -645,6 +645,8 @@ public:
         StorePathSet & out, bool flipDirection = false,
         bool includeOutputs = false, bool includeDerivers = false);
 
+    std::set<DrvInput> drvInputClosure(const DrvInput&);
+
     /* Given a set of paths that are to be built, return the set of
        derivations that will be built, and the set of output paths
        that will be substituted. */

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drv-output-info.hh"
 #include "path.hh"
 #include "hash.hh"
 #include "content-address.hh"
@@ -391,6 +392,8 @@ protected:
 
 public:
 
+    virtual ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) = 0;
+
     /* Queries the set of incoming FS references for a store path.
        The result is not cleared. */
     virtual void queryReferrers(const StorePath & path, StorePathSet & referrers)
@@ -474,8 +477,10 @@ public:
      * floating-ca derivations and their dependencies as there's no way to
      * retrieve this information otherwise.
      */
-    virtual void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output)
-    { unsupported("linkDeriverToPath"); }
+    virtual void registerDrvOutput(const StorePath & deriver, const string & outputName, const DrvOutputInfo & output)
+    { registerDrvOutput(DrvOutputId{ deriver, outputName }, output); }
+    virtual void registerDrvOutput(const DrvOutputId &, const DrvOutputInfo & output)
+    { unsupported("registerDrvOutput"); }
 
     /* Write a NAR dump of a store path. */
     virtual void narFromPath(const StorePath & path, Sink & sink) = 0;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -392,7 +392,7 @@ protected:
 
 public:
 
-    virtual ref<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) = 0;
+    virtual std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) = 0;
 
     /* Queries the set of incoming FS references for a store path.
        The result is not cleared. */

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -740,6 +740,11 @@ void copyStorePath(ref<Store> srcStore, ref<Store> dstStore,
    that. Returns a map of what each path was copied to the dstStore
    as. */
 std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
+    const std::set<PathOrOutputs> &storePaths,
+    RepairFlag repair = NoRepair,
+    CheckSigsFlag checkSigs = CheckSigs,
+    SubstituteFlag substitute = NoSubstitute);
+std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
     const StorePathSet & storePaths,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -53,7 +53,8 @@ typedef enum {
     wopAddToStoreNar = 39,
     wopQueryMissing = 40,
     wopQueryDerivationOutputMap = 41,
-    wopLinkDeriverToPath = 42,
+    wopRegisterDrvOutput = 42,
+    wopQueryDrvOutputInfo = 43,
 } WorkerOp;
 
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "store-api.hh"
+#include "serialise.hh"
+
 namespace nix {
 
 
@@ -50,6 +53,7 @@ typedef enum {
     wopAddToStoreNar = 39,
     wopQueryMissing = 40,
     wopQueryDerivationOutputMap = 41,
+    wopLinkDeriverToPath = 42,
 } WorkerOp;
 
 

--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -80,11 +80,13 @@ void BuildablesCommand::run(ref<Store> store)
         for (auto & installable : installables)
             for (auto & b : installable->toBuildables())
                 buildables.push_back(b);
+    }
 
-        if (recursive) {
-            std::set<Buildable> closure = buildableClosure(store, buildables);
-            buildables = Buildables(closure.begin(), closure.end());
-        }
+    if (recursive) {
+        std::set<Buildable> closure = buildableClosure(store, buildables, operateOn, realiseMode);
+        buildables = Buildables(closure.begin(), closure.end());
+    } else if (operateOn == OperateOn::Output) {
+        build(store, realiseMode, buildables);
     }
 
     run(store, std::move(buildables));

--- a/src/nix/command.cc
+++ b/src/nix/command.cc
@@ -45,7 +45,7 @@ void StoreCommand::run()
     run(getStore());
 }
 
-StorePathsCommand::StorePathsCommand(bool recursive)
+BuildablesCommand::BuildablesCommand(bool recursive)
     : recursive(recursive)
 {
     if (recursive)
@@ -65,31 +65,35 @@ StorePathsCommand::StorePathsCommand(bool recursive)
     mkFlag(0, "all", "apply operation to the entire store", &all);
 }
 
-void StorePathsCommand::run(ref<Store> store)
+void BuildablesCommand::run(ref<Store> store)
 {
-    StorePaths storePaths;
+    Buildables buildables;
 
     if (all) {
         if (installables.size())
             throw UsageError("'--all' does not expect arguments");
         for (auto & p : store->queryAllValidPaths())
-            storePaths.push_back(p);
+            buildables.push_back(BuildableOpaque{p});
     }
 
     else {
-        for (auto & p : toStorePaths(store, realiseMode, operateOn, installables))
-            storePaths.push_back(p);
+        for (auto & installable : installables)
+            for (auto & b : installable->toBuildables())
+                buildables.push_back(b);
 
         if (recursive) {
-            StorePathSet closure;
-            store->computeFSClosure(StorePathSet(storePaths.begin(), storePaths.end()), closure, false, false);
-            storePaths.clear();
-            for (auto & p : closure)
-                storePaths.push_back(p);
+            std::set<Buildable> closure = buildableClosure(store, buildables);
+            buildables = Buildables(closure.begin(), closure.end());
         }
     }
 
-    run(store, std::move(storePaths));
+    run(store, std::move(buildables));
+}
+
+void StorePathsCommand::run(ref<Store> store, Buildables buildables)
+{
+    auto storePathMap = toStorePaths(store, realiseMode, operateOn, buildables);
+    run(store, std::vector<StorePath>(storePathMap.begin(), storePathMap.end()));
 }
 
 void StorePathCommand::run(ref<Store> store)

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -138,29 +138,42 @@ private:
     std::string _installable{"."};
 };
 
-/* A command that operates on zero or more store paths. */
-struct StorePathsCommand : public InstallablesCommand
+/* A command that operates on a list of "buildables", which can be either
+ * store paths or a or derivation outputs */
+struct BuildablesCommand : public InstallablesCommand
 {
-private:
+
+protected:
 
     bool recursive = false;
     bool all = false;
-
-protected:
 
     Realise realiseMode = Realise::Derivation;
 
 public:
 
-    StorePathsCommand(bool recursive = false);
+    BuildablesCommand(bool recursive = false);
 
     using StoreCommand::run;
 
-    virtual void run(ref<Store> store, std::vector<StorePath> storePaths) = 0;
+    virtual void run(ref<Store> store, Buildables buildables) = 0;
 
     void run(ref<Store> store) override;
 
     bool useDefaultInstallables() override { return !all; }
+};
+
+/* A command that operates on zero or more store paths. */
+struct StorePathsCommand : public BuildablesCommand
+{
+public:
+    using BuildablesCommand::BuildablesCommand;
+
+    using BuildablesCommand::run;
+
+    virtual void run(ref<Store> store, std::vector<StorePath> storePaths) = 0;
+
+    void run(ref<Store> store, Buildables buildables) override;
 };
 
 /* A command that operates on exactly one store path. */
@@ -192,9 +205,16 @@ static RegisterCommand registerCommand(const std::string & name)
     return RegisterCommand(name, [](){ return make_ref<T>(); });
 }
 
+std::set<Buildable> buildableClosure(ref<Store> store, Buildables roots);
+
+void build(ref<Store> store, Realise mode,
+    Buildables buildables, BuildMode bMode = bmNormal);
 Buildables build(ref<Store> store, Realise mode,
     std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode = bmNormal);
 
+std::set<StorePath> toStorePaths(ref<Store> store,
+    Realise mode, OperateOn operateOn,
+    Buildables buildables);
 std::set<StorePath> toStorePaths(ref<Store> store,
     Realise mode, OperateOn operateOn,
     std::vector<std::shared_ptr<Installable>> installables);

--- a/src/nix/command.hh
+++ b/src/nix/command.hh
@@ -205,7 +205,7 @@ static RegisterCommand registerCommand(const std::string & name)
     return RegisterCommand(name, [](){ return make_ref<T>(); });
 }
 
-std::set<Buildable> buildableClosure(ref<Store> store, Buildables roots);
+std::set<Buildable> buildableClosure(ref<Store> store, Buildables roots, OperateOn operateOn, Realise mode, BuildMode bMode = bmNormal);
 
 void build(ref<Store> store, Realise mode,
     Buildables buildables, BuildMode bMode = bmNormal);

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -636,60 +636,41 @@ Buildables toBuildables(std::vector<std::shared_ptr<Installable>> installables)
     return buildables;
 }
 
+std::set<DrvInput> buildableToDrvInputs(const Buildable& b) {
+    return std::visit(
+        overloaded{
+            [](BuildableOpaque bo) -> std::set<DrvInput> { return {bo.path}; },
+            [](BuildableFromDrv bfd) -> std::set<DrvInput> {
+                std::set<DrvInput> res;
+                for (auto& wantedOutput : bfd.outputs)
+                    res.emplace(DrvOutputId{bfd.drvPath, wantedOutput.first});
+                return res;
+            },
+        },
+        b);
+}
+
+Buildable drvInputToBuildable(const DrvInput& input) {
+    return std::visit(
+        overloaded{
+            [](StorePath path) -> Buildable { return BuildableOpaque{path}; },
+            [](DrvOutputId id) -> Buildable {
+                return BuildableFromDrv{id.drvPath, {{id.outputName, std::nullopt}}};
+            },
+        },
+        static_cast<RawDrvInput>(input));
+}
+
 std::set<Buildable> buildableClosure(ref<Store> store, Buildable root)
 {
+    auto rootDrvInputs = buildableToDrvInputs(root);
     std::set<Buildable> closure;
-    std::visit(overloaded{
-        [&](BuildableOpaque bo) {
-            StorePathSet storePathsClosure;
-            store->computeFSClosure({bo.path}, storePathsClosure, false, false);
-            for (auto & path : storePathsClosure) {
-                closure.insert(BuildableOpaque{path});
-            }
-        },
-        [&](BuildableFromDrv bfd) {
-            std::set<StorePath> drvClosure;
-            store->computeFSClosure({bfd.drvPath}, drvClosure, false, false);
 
-            StorePathSet runtimeClosure;
-            StorePathSet outputPaths;
-            for (auto & output : bfd.outputs)
-                outputPaths.insert(*output.second);
-            store->computeFSClosure(outputPaths, runtimeClosure, false, false);
-
-            for (auto & input : drvClosure) {
-                // This shouldn't be needed, except that `registerDrvOutput`
-                // currently requires the drv to be present
-                closure.insert(BuildableOpaque { input });
-                if (input.isDerivation()) {
-                    // Take all the outputs of the derivation that are in the
-                    // runtime closure, and add them as `BuildableFromDrv` to
-                    // the closure
-                    auto derivation = store->readDerivation(input);
-                    /* auto drvOutputs = store->queryPartialDerivationOutputMap(input); */
-                    std::map<std::string, std::optional<StorePath>> neededOutputs;
-                    /* for (auto & [outputName, output] : drvOutputs) { */
-                    for (auto & [outputName, _] : derivation.outputs) {
-                        auto output = store->queryOutputPathOf(input, outputName);
-                        if (output && runtimeClosure.count(*output)) {
-                            neededOutputs.emplace(outputName, output);
-                        }
-                    }
-                    if (!neededOutputs.empty())
-                        closure.insert(
-                                BuildableFromDrv{
-                                    .drvPath = input,
-                                    .outputs = neededOutputs,
-                                }
-                        );
-                } else {
-                    if (runtimeClosure.count(input))
-                        closure.insert(BuildableOpaque{input});
-                }
-            }
-        },
-        },
-        root);
+    for (auto & partialRoot : rootDrvInputs) {
+        for (auto & transitiveInput : store->drvInputClosure(partialRoot)) {
+            closure.emplace(drvInputToBuildable(transitiveInput));
+        }
+    }
     return closure;
 }
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -627,49 +627,98 @@ std::shared_ptr<Installable> SourceExprCommand::parseInstallable(
     return installables.front();
 }
 
-Buildables build(ref<Store> store, Realise mode,
-    std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode)
+Buildables toBuildables(std::vector<std::shared_ptr<Installable>> installables)
+{
+    Buildables buildables;
+    for (auto & i : installables) {
+        for (auto & b : i->toBuildables()) {
+            buildables.push_back(b);
+        }
+    }
+    return buildables;
+}
+
+std::set<Buildable> buildableClosure(ref<Store> store, Buildable root)
+{
+    // XXX: Calling this on a `BuildableFromDrv` forgets all about the builders
+    // of the dependencies, which is probably not what we want
+    StorePathSet closure;
+    StorePathSet rawRoots = std::visit(
+        overloaded{
+            [&](BuildableOpaque bo) -> StorePathSet { return {bo.path}; },
+            [&](BuildableFromDrv bfd) {
+                auto outputs = store->queryDerivationOutputMap(bfd.drvPath);
+                // XXX: This assumes that the output name is valid and realised
+                StorePathSet outputPaths;
+                for (auto &output : bfd.outputs)
+                    outputPaths.insert(outputs.at(output.first));
+                return outputPaths;
+            },
+        },
+      root);
+    store->computeFSClosure(rawRoots, closure, false, false);
+    std::set<Buildable> res;
+    res.insert(root);
+    for (auto & path : closure) {
+        res.insert(BuildableOpaque{path});
+    }
+    return res;
+}
+std::set<Buildable> buildableClosure(ref<Store> store, Buildables roots)
+{
+    std::set<Buildable> res;
+    for (auto & root : roots) {
+        auto partialRes = buildableClosure(store, root);
+        res.insert(partialRes.begin(), partialRes.end());
+    }
+    return res;
+}
+
+void build(ref<Store> store, Realise mode, Buildables buildables, BuildMode bMode)
 {
     if (mode == Realise::Nothing)
         settings.readOnlyMode = true;
 
-    Buildables buildables;
-
     std::vector<StorePathWithOutputs> pathsToBuild;
 
-    for (auto & i : installables) {
-        for (auto & b : i->toBuildables()) {
-            std::visit(overloaded {
-                [&](BuildableOpaque bo) {
-                    pathsToBuild.push_back({bo.path});
-                },
-                [&](BuildableFromDrv bfd) {
-                    StringSet outputNames;
-                    for (auto & output : bfd.outputs)
-                        outputNames.insert(output.first);
-                    pathsToBuild.push_back({bfd.drvPath, outputNames});
-                },
-            }, b);
-            buildables.push_back(std::move(b));
-        }
+    for (auto & b : buildables) {
+        std::visit(overloaded {
+            [&](BuildableOpaque bo) {
+                pathsToBuild.push_back({bo.path});
+            },
+            [&](BuildableFromDrv bfd) {
+                StringSet outputNames;
+                for (auto & output : bfd.outputs)
+                    outputNames.insert(output.first);
+                pathsToBuild.push_back({bfd.drvPath, outputNames});
+            },
+        }, b);
     }
 
     if (mode == Realise::Nothing)
         printMissing(store, pathsToBuild, lvlError);
     else if (mode == Realise::Outputs)
         store->buildPaths(pathsToBuild, bMode);
+}
 
+
+Buildables build(ref<Store> store, Realise mode,
+    std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode)
+{
+    Buildables buildables = toBuildables(installables);
+    build(store, mode, buildables, bMode);
     return buildables;
 }
 
 StorePathSet toStorePaths(ref<Store> store,
     Realise mode, OperateOn operateOn,
-    std::vector<std::shared_ptr<Installable>> installables)
+    Buildables buildables)
 {
     StorePathSet outPaths;
 
     if (operateOn == OperateOn::Output) {
-        for (auto & b : build(store, mode, installables))
+        build(store, mode, buildables);
+        for (auto & b : buildables)
             std::visit(overloaded {
                 [&](BuildableOpaque bo) {
                     outPaths.insert(bo.path);
@@ -686,13 +735,19 @@ StorePathSet toStorePaths(ref<Store> store,
         if (mode == Realise::Nothing)
             settings.readOnlyMode = true;
 
-        for (auto & i : installables)
-            for (auto & b : i->toBuildables())
-                if (auto bfd = std::get_if<BuildableFromDrv>(&b))
-                    outPaths.insert(bfd->drvPath);
+        for (auto & b : buildables)
+            if (auto bfd = std::get_if<BuildableFromDrv>(&b))
+                outPaths.insert(bfd->drvPath);
     }
 
     return outPaths;
+}
+
+StorePathSet toStorePaths(ref<Store> store,
+    Realise mode, OperateOn operateOn,
+    std::vector<std::shared_ptr<Installable>> installables)
+{
+    return toStorePaths(store, mode, operateOn, toBuildables(installables));
 }
 
 StorePath toStorePath(ref<Store> store,

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -642,28 +642,55 @@ std::set<Buildable> buildableClosure(ref<Store> store, Buildable root)
 {
     // XXX: Calling this on a `BuildableFromDrv` forgets all about the builders
     // of the dependencies, which is probably not what we want
-    StorePathSet closure;
-    StorePathSet rawRoots = std::visit(
-        overloaded{
-            [&](BuildableOpaque bo) -> StorePathSet { return {bo.path}; },
-            [&](BuildableFromDrv bfd) {
-                auto outputs = store->queryDerivationOutputMap(bfd.drvPath);
-                // XXX: This assumes that the output name is valid and realised
-                StorePathSet outputPaths;
-                for (auto &output : bfd.outputs)
-                    outputPaths.insert(outputs.at(output.first));
-                return outputPaths;
-            },
+    std::set<Buildable> closure;
+    std::visit(overloaded{
+        [&](BuildableOpaque bo) {
+            StorePathSet storePathsClosure;
+            store->computeFSClosure({bo.path}, storePathsClosure, false, false);
+            for (auto & path : storePathsClosure) {
+                closure.insert(BuildableOpaque{path});
+            }
         },
-      root);
-    store->computeFSClosure(rawRoots, closure, false, false);
-    std::set<Buildable> res;
-    res.insert(root);
-    for (auto & path : closure) {
-        res.insert(BuildableOpaque{path});
-    }
-    return res;
+        [&](BuildableFromDrv bfd) {
+            std::set<StorePath> drvClosure;
+            store->computeFSClosure({bfd.drvPath}, drvClosure, false, false);
+
+            StorePathSet runtimeClosure;
+            StorePathSet outputPaths;
+            for (auto & output : bfd.outputs)
+                outputPaths.insert(*output.second);
+            store->computeFSClosure(outputPaths, runtimeClosure, false, false);
+
+            for (auto & input : drvClosure) {
+                if (input.isDerivation()) {
+                    // Take all the outputs of the derivation that are in the
+                    // runtime closure, and add them as `BuildableFromDrv` to
+                    // the closure
+                    auto drvOutputs = store->queryPartialDerivationOutputMap(input);
+                    std::map<std::string, std::optional<StorePath>> neededOutputs;
+                    for (auto & [outputName, output] : drvOutputs) {
+                        if (output && runtimeClosure.count(*output)) {
+                            neededOutputs.emplace(outputName, output);
+                        }
+                    }
+                    if (!neededOutputs.empty())
+                        closure.insert(
+                                BuildableFromDrv{
+                                    .drvPath = input,
+                                    .outputs = neededOutputs,
+                                }
+                        );
+                } else {
+                    if (runtimeClosure.count(input))
+                        closure.insert(BuildableOpaque{input});
+                }
+            }
+        },
+        },
+        root);
+    return closure;
 }
+
 std::set<Buildable> buildableClosure(ref<Store> store, Buildables roots)
 {
     std::set<Buildable> res;

--- a/src/nix/installables.hh
+++ b/src/nix/installables.hh
@@ -16,11 +16,18 @@ namespace eval_cache { class EvalCache; class AttrCursor; }
 
 struct BuildableOpaque {
     StorePath path;
+    bool operator<(const BuildableOpaque & other) const
+    { return path < other.path; }
 };
 
 struct BuildableFromDrv {
     StorePath drvPath;
     std::map<std::string, std::optional<StorePath>> outputs;
+    bool operator<(const BuildableFromDrv & other) const
+    {
+        return drvPath < other.drvPath ||
+            (drvPath == other.drvPath && outputs < other.outputs);
+    }
 };
 
 typedef std::variant<

--- a/tests/binary-cache.sh
+++ b/tests/binary-cache.sh
@@ -5,8 +5,9 @@ clearCache
 
 # Create the binary cache.
 outPath=$(nix-build dependencies.nix --no-out-link)
+drvOutputId="$(nix-instantiate dependencies.nix)!out"
 
-nix copy --to file://$cacheDir $outPath
+nix copy --to file://$cacheDir $drvOutputId
 
 
 basicTests() {

--- a/tests/content-addressed-remote-cache.sh
+++ b/tests/content-addressed-remote-cache.sh
@@ -4,11 +4,23 @@ source common.sh
 
 clearStore
 clearCache
+clearCache
 
-commonFlags=(--experimental-features 'ca-derivations ca-references nix-command')
+export REMOTE_STORE=file://$cacheDir
 
-drvPath=$(nix-instantiate "${commonFlags[@]}" ./content-addressed.nix -A transitivelyDependentCA --arg seed 1)
-nix copy "${commonFlags[@]}" --to file://$cacheDir $drvPath\!out
+commonFlags=( \
+    ./content-addressed.nix -A transitivelyDependentCA \
+    --arg seed 1 \
+    --experimental-features 'ca-derivations ca-references nix-command' \
+    --no-out-link \
+)
+
+nix-build "${commonFlags[@]}" --post-build-hook $PWD/push-to-store.sh
 
 clearStore
-nix copy "${commonFlags[@]}" --from file://$cacheDir $drvPath\!out --no-require-sigs
+# XXX: The `grep` call is a work around the fact that `-j0` currently doesn't
+# take the possibility that drvs might be resolved into account, so would fail
+# because Nix can't know *a priori* that everything is already in the binary
+# cache
+nix-build "${commonFlags[@]}" --no-require-sigs --substituters file://$cacheDir |& \
+    (! grep -q 'Building a')

--- a/tests/content-addressed-remote-cache.sh
+++ b/tests/content-addressed-remote-cache.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+clearStore
+clearCache
+
+commonFlags=(--experimental-features 'ca-derivations ca-references nix-command')
+
+drvPath=$(nix-instantiate "${commonFlags[@]}" ./content-addressed.nix -A transitivelyDependentCA --arg seed 1)
+nix copy "${commonFlags[@]}" --to file://$cacheDir $drvPath\!out
+
+clearStore
+nix copy "${commonFlags[@]}" --from file://$cacheDir $drvPath\!out --no-require-sigs

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -35,6 +35,7 @@ nix_tests = \
   recursive.sh \
   describe-stores.sh \
   flakes.sh \
+  content-addressed-remote-cache.sh \
   content-addressed.sh
   # parallel.sh
   # build-remote-content-addressed-fixed.sh \

--- a/tests/push-to-store.sh
+++ b/tests/push-to-store.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -x
 
-echo Pushing "$@" to "$REMOTE_STORE"
-printf "%s" "$OUT_PATHS" | xargs -d: nix copy --to "$REMOTE_STORE" --no-require-sigs
+echo Pushing "$OUTPUTS" to "$REMOTE_STORE"
+printf "%s" "$OUTPUTS" | xargs -d: nix copy --to "$REMOTE_STORE" --no-require-sigs

--- a/tests/push-to-store.sh
+++ b/tests/push-to-store.sh
@@ -2,4 +2,4 @@
 set -x
 
 echo Pushing "$OUTPUTS" to "$REMOTE_STORE"
-printf "%s" "$OUTPUTS" | xargs -d: nix copy --to "$REMOTE_STORE" --no-require-sigs
+printf "%s" "$OUTPUTS" | xargs nix copy --experimental-features 'ca-derivations ca-references nix-command' --to "$REMOTE_STORE" --no-require-sigs


### PR DESCRIPTION
Big ugly PR adding support for moving CA derivation outputs around.
Not to be merged as-it-is, but can work as a POC.

It's obviously already possible to move the output paths around, but there's no way to copy the mapping `(drvPath, outputName) -> outputPath` which is essential for ca derivations. That's what this PR enables. More precisely, it

- Define (in code) the notions of:
  - **derivation output**: the triplet `(drvPath, outputName, outputPath)` along with some meta information (currently a set of dependencies, should probably be extended at least with a signature),
  - **derivation output id**: The tuple `drvPath!outputName` that uniquely (modulo non-determinism) identifies a derivation output,
  - **derivation input**: either a plain store path or a derivation output
    (this is very badly named because it's a general identifier for the elements of the store and not just the thing that's fed to derivations).
- Add a `Store::registerDrvOutput(DrvOutputId&, DrvOutputInfo)` method which generalizes `LocalStore::linkDeriverToPath`
  1. By making it a virtual method of the `Store` class (so that every store can implement it rather than just `LocalStore`)
  2. By allowing to not just register the `DrvOutputId->outPath` mapping, but also all the meta-information that might be needed
- Allow `copyPaths(...)` and the `nix copy` command to work on derivation outputs
  - `nix copy nixpkgs#hello` will now copy the derivation outputs of `nixpkgs#hello` rather than just the output paths.
  - It's now possible to run `nix copy /nix/store/....-hello.drv!out` to manually specify a derivation output
  - `nix copy /nix/store/....-hello` will just copy the output path like it used to do
- Fix https://github.com/NixOS/nix/issues/4138 (because otherwise copying drv outputs to a remote store would require copying the whole drv closure too which is painful).

Still to do:

- [ ] Allow signing drv outputs (which will be needed as it's the bit that has to be trusted now)
- [ ] Implement transparent substitution (needs hooking into the `SubstitutionGoal` which I haven't done yet
- [ ] Properly register the dependencies of a drv output in the database.
  To allow properly copying derivation outputs we need to compute their dependency closure (which is different from the closure of the output path).
  Currently there's a (fragile and probably not exact) logic to recompute it on-the-fly for the local store, but we should rather store all the dependencies of a drv output in a new table in the db


/cc @edolstra @Ericson2314 