### PR TITLE
Fix the docs about the new NIX_CONFIG env var

### DIFF
--- a/doc/manual/src/command-ref/conf-file-prefix.md
+++ b/doc/manual/src/command-ref/conf-file-prefix.md
@@ -19,7 +19,7 @@ By default Nix reads settings from the following places:
     and `XDG_CONFIG_HOME`. If these are unset, it will look in
     `$HOME/.config/nix.conf`.
 
-  - If `NIX_OPTIONS` is set, its contents is treated as the contents of
+  - If `NIX_CONFIG` is set, its contents is treated as the contents of
     a configuration file.
 
 The configuration files consist of `name =

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -81,7 +81,7 @@ Most Nix commands interpret the following environment variables:
     Overrides the location of the system Nix configuration directory
     (default `prefix/etc/nix`).
 
-  - `NIX_OPTIONS`  
+  - `NIX_CONFIG`  
     Applies settings from Nix configuration from the environment.
     The content is treated as if it was read from a Nix configuration file.
     Settings are separated by the newline character.


### PR DESCRIPTION
This was accidentally documented as NIX_OPTIONS.