### PR TITLE
darwin: encrypt nix volume if filevault is enabled

### DIFF
--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -100,14 +100,12 @@ prepare_darwin_volume_password(){
     # can tell, the file with this password (/var/db/SystemKey) is
     # inside the FileVault envelope. If that isn't true, it may make
     # sense to store the password inside the envelope?
-    sudo /usr/bin/security add-generic-password -a "$1" -s "$2" -l "$1 encryption password" -D "Encrypted volume password" -j "Added automatically by the Nix installer for use by /Library/LaunchDaemons/org.nixos.darwin-store.plist" -T /System/Library/CoreServices/APFSUserAgent -T /System/Library/CoreServices/CSUserAgent "/Library/Keychains/System.keychain" &>/dev/null
-    # TODO: decide if we should add `-T /System/Library/CoreServices/APFSUserAgent`
-    # This should let the system seamlessly supply the password for this volume
-    # which in turn means the fstab entry is enough for the system to (eventually)
-    # decrypt and mount the volume we're adding, but I hesitate because I'm not
-    # certain the system _should_ transparently failover if the LaunchDaemon is
-    # broken for some reason? Without supplying this flag, the system will instead
-    # start prompting them to allow APFSUserAgent to access this credential.
+    sudo /usr/bin/security add-generic-password -a "$1" -s "$2" -l "$1 encryption password" -D "Encrypted volume password" -j "Added automatically by the Nix installer for use by /Library/LaunchDaemons/org.nixos.darwin-store.plist" -T /System/Library/CoreServices/APFSUserAgent -T /System/Library/CoreServices/CSUserAgent -T /usr/bin/security "/Library/Keychains/System.keychain" &>/dev/null
+    # TODO: /usr/bin/security could be replaced with our own binary at some point?
+    # *UserAgent exemptions should let the system seamlessly supply the password
+    # if noauto is removed from the fstab entry. This is intentional, so that
+    # the user will hopefully look for help if the volume stops mounting,
+    # rather than failing over into subtle race-condition problems.
 
     # 2. add a password with the -U (update) flag and -w (prompt if last)
     #    flags, but specify no keychain; security will use the first it finds

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# make it easy to play w/ 'Case-sensitive APFS'
+readonly NIX_VOLUME_FS="${NIX_VOLUME_FS:-APFS}"
+
 # i.e., "disk1"
 root_disk_identifier() {
     diskutil info -plist / | xmllint --xpath "/plist/dict/key[text()='ParentWholeDisk']/following-sibling::string[1]/text()" -
@@ -187,7 +190,7 @@ main() {
     if [ -n "$create_volume" ]; then
         echo "Creating a Nix volume..." >&2
 
-        sudo diskutil apfs addVolume "$disk" APFS "$volume" -mountpoint /nix
+        sudo diskutil apfs addVolume "$disk" "$NIX_VOLUME_FS" "$volume" -mountpoint /nix
         new_uuid="$(volume_uuid "$volume")"
 
         if [ "$INSTALL_MODE" = "no-daemon" ]; then # exported by caller

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -120,9 +120,10 @@ main() {
         echo "     ------------------------------------------------------------------ "
         echo ""
         echo "  1. Remove the entry from fstab using 'sudo vifs'"
-        echo "  2. Remove /Library/LaunchDaemons/org.nixos.darwin-store.plist"
-        echo "  3. Destroy the data volume using 'diskutil apfs deleteVolume'"
-        echo "  4. Remove the 'nix' line from /etc/synthetic.conf (or the file)"
+        echo "  2. Run `sudo launchctl bootout system/org.nixos.darwin-store`
+        echo "  3. Remove /Library/LaunchDaemons/org.nixos.darwin-store.plist"
+        echo "  4. Destroy the data volume using 'diskutil apfs deleteVolume'"
+        echo "  5. Remove the 'nix' line from /etc/synthetic.conf (or the file)"
         echo ""
     ) >&2
 

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -120,7 +120,7 @@ main() {
         echo "     ------------------------------------------------------------------ "
         echo ""
         echo "  1. Remove the entry from fstab using 'sudo vifs'"
-        echo "  2. Run `sudo launchctl bootout system/org.nixos.darwin-store`
+        echo "  2. Run `sudo launchctl bootout system/org.nixos.darwin-store`"
         echo "  3. Remove /Library/LaunchDaemons/org.nixos.darwin-store.plist"
         echo "  4. Destroy the data volume using 'diskutil apfs deleteVolume'"
         echo "  5. Remove the 'nix' line from /etc/synthetic.conf (or the file)"

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -62,7 +62,7 @@ generate_mount_command(){
     if test_filevault_in_use; then
         printf "    <string>%s</string>\n" /bin/sh -c '/usr/bin/security find-generic-password -l "Nix Volume" -a "Nix Volume" -s "Nix Volume" -w | /usr/sbin/diskutil apfs unlockVolume "Nix Volume" -mountpoint /nix -stdinpassphrase'
     else
-        printf "    <string>%s</string>\n" /usr/sbin/diskutil mount nobrowse -mountPoint /nix "Nix Volume"
+        printf "    <string>%s</string>\n" /usr/sbin/diskutil mount -mountPoint /nix "Nix Volume"
     fi
 }
 

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -97,7 +97,7 @@ set PASSPHRASE [exec /usr/bin/xxd -l 32 -p -c 256 /dev/random]
 
 # Cargo culting: people recommend this; not sure how necessary
 set send_slow {1 .1}
-spawn /usr/bin/sudo /usr/bin/security add-generic-password -a "$VOLUME" -l "$volume encryption password" -s "$UUID" -D "Encrypted volume password" -U -w
+spawn /usr/bin/sudo /usr/bin/security add-generic-password -a "$VOLUME" -l "$VOLUME encryption password" -s "$UUID" -D "Encrypted volume password" -U -w
 expect {
     "password data for new item: " {
         send -s -- "$PASSPHRASE\r"

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -201,7 +201,7 @@ main() {
             # can tell, the file with this password (/var/db/SystemKey) is
             # inside the FileVault envelope. If that isn't true, it may make
             # sense to store the password inside the envelope?
-            sudo /usr/bin/security add-generic-password -a "$volume" -s "$new_uuid" -D "$volume encryption password" -j "Added automatically by the Nix installer for use by /Library/LaunchDaemons/org.nixos.darwin-store.plist" "/Library/Keychains/System.keychain"
+            sudo /usr/bin/security add-generic-password -a "$volume" -s "$new_uuid" -l "$volume encryption password" -D "Encrypted volume password" -j "Added automatically by the Nix installer for use by /Library/LaunchDaemons/org.nixos.darwin-store.plist" "/Library/Keychains/System.keychain"
             # TODO: decide if we should add `-T /System/Library/CoreServices/APFSUserAgent`
             # This should let the system seamlessly supply the password for this volume
             # which in turn means the fstab entry is enough for the system to (eventually)

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -204,6 +204,11 @@ main() {
         else
             sudo diskutil apfs addVolume "$disk" APFS 'Nix Volume' -mountpoint /nix
         fi
+
+        if [ "$INSTALL_MODE" = "no-daemon" ]; then
+            # TODO: is there a better way to do this?
+            sudo chown $USER:admin /nix
+        fi
     else
         echo "Using existing '$volume' volume" >&2
     fi

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -86,7 +86,7 @@ generate_mount_daemon(){
   <string>org.nixos.darwin-store</string>
   <key>ProgramArguments</key>
   <array>
-    $(generate_mount_command)
+$(generate_mount_command)
   </array>
 </dict>
 </plist>

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -1,34 +1,128 @@
-#!/bin/sh
-set -e
+#!/usr/bin/env bash
+set -eu
+
+# support import-only `. create-darwin-volume.sh no-main[ ...]`
+if [ "${1-}" = "no-main" ]; then
+    shift
+    readonly _CREATE_VOLUME_NO_MAIN=1
+else
+    readonly _CREATE_VOLUME_NO_MAIN=0
+    # declare some things we expect to inherit from install-multi-user
+    # I don't love this (because it's a bit of a kludge)
+    readonly NIX_ROOT="${NIX_ROOT:-/nix}"
+    readonly ESC='\033[0m'
+    readonly GREEN='\033[32m'
+    readonly RED='\033[31m'
+    _sudo() {
+        shift # throw away the 'explanation'
+        /usr/bin/sudo "$@"
+    }
+    failure() {
+        if [ "$*" = "" ]; then
+            cat
+        else
+            echo "$@"
+        fi
+        exit 1
+    }
+    task() {
+        echo "$@"
+    }
+fi
 
 # make it easy to play w/ 'Case-sensitive APFS'
 readonly NIX_VOLUME_FS="${NIX_VOLUME_FS:-APFS}"
-
-readonly NIX_VOLUME_MOUNTD="${NIX_VOLUME_MOUNTD:-/Library/LaunchDaemons/org.nixos.darwin-store.plist}"
+readonly NIX_VOLUME_LABEL="${NIX_VOLUME_LABEL:-Nix}"
+# shellcheck disable=SC1003,SC2026
+readonly NIX_VOLUME_FOR_FSTAB="${NIX_VOLUME_LABEL/ /'\\\'040}"
+readonly NIX_VOLUME_MOUNTD_DEST="${NIX_VOLUME_MOUNTD_DEST:-/Library/LaunchDaemons/org.nixos.darwin-store.plist}"
 
 # i.e., "disk1"
 root_disk_identifier() {
     /usr/sbin/diskutil info -plist / | xmllint --xpath "/plist/dict/key[text()='ParentWholeDisk']/following-sibling::string[1]/text()" -
 }
 
-volume_uuid(){
-    /usr/sbin/diskutil info -plist "$1" | xmllint --xpath "(/plist/dict/key[text()='VolumeUUID']/following-sibling::string/text())" -
+readonly ROOT_SPECIAL_DEVICE="$(root_disk_identifier)" # usually 'disk1'
+# Strongly assuming we'll make a volume on the device root is on
+# But you can override NIX_VOLUME_USE_DISK to create it on some other device
+readonly NIX_VOLUME_USE_DISK="${NIX_VOLUME_USE_DISK:-$ROOT_SPECIAL_DEVICE}"
+
+substep(){
+    # shellcheck disable=SC2068
+    printf "   %s\n" "" "- $1" "" ${@:2}
 }
 
+printf -v _UNCHANGED_GRP_FMT "%b" $'\033[2m%='"$ESC" # "dim"
+# bold+invert+red and bold+invert+green just for the +/- below
+# red/green foreground for rest of the line
+printf -v _OLD_LINE_FMT "%b" $'\033[1;7;31m-'"$ESC ${RED}%L${ESC}"
+printf -v _NEW_LINE_FMT "%b" $'\033[1;7;32m+'"$ESC ${GREEN}%L${ESC}"
+_diff() {
+    # shellcheck disable=SC2068
+    /usr/bin/diff --unchanged-group-format="$_UNCHANGED_GRP_FMT" --old-line-format="$_OLD_LINE_FMT" --new-line-format="$_NEW_LINE_FMT" --unchanged-line-format="  %L" $@
+}
+
+confirm_rm() {
+    if ui_confirm "Can I remove $1?"; then
+        # ok "Yay! Thanks! Let's get going!"
+        _sudo "to remove $1" rm "$1"
+    fi
+}
+confirm_edit() {
+    cat <<EOF
+It looks like Nix isn't the only thing here, but I think I know how to edit it
+out. Here's the diff:
+EOF
+
+    # could technically test the diff, but caller should do it
+    _diff "$1" "$2"
+    if ui_confirm "Does the change above look right?"; then
+        # ok "Yay! Thanks! Let's get going!"
+        _sudo "remove nix from $1" cp "$2" "$1"
+    fi
+}
+
+volume_uuid(){
+    /usr/sbin/diskutil info -plist "$1" | xmllint --xpath "(/plist/dict/key[text()='VolumeUUID']/following-sibling::string[1]/text())" - 2>/dev/null
+}
+
+volume_special_device(){
+    /usr/sbin/diskutil info -plist "$1" | xmllint --xpath "(/plist/dict/key[text()='DeviceIdentifier']/following-sibling::string[1]/text())" - 2>/dev/null
+}
 find_nix_volume() {
+    /usr/sbin/diskutil apfs list -plist "$1" | xmllint --xpath "(/plist/dict/array/dict/key[text()='Volumes']/following-sibling::array/dict/key[text()='Name']/following-sibling::string[text()='$NIX_VOLUME_LABEL'])[1]" - &>/dev/null
+}
+find_nix_volume_label() {
     /usr/sbin/diskutil apfs list -plist "$1" | xmllint --xpath "(/plist/dict/array/dict/key[text()='Volumes']/following-sibling::array/dict/key[text()='Name']/following-sibling::string[starts-with(translate(text(),'N','n'),'nix')]/text())[1]" - 2>/dev/null || true
 }
 
 test_fstab() {
-    /usr/bin/grep -q "/nix apfs rw" /etc/fstab 2>/dev/null
+    /usr/bin/grep -q "$NIX_ROOT apfs rw" /etc/fstab 2>/dev/null
 }
 
 test_nix_symlink() {
-    [ -L "/nix" ] || /usr/bin/grep -q "^nix." /etc/synthetic.conf 2>/dev/null
+    [ -L "$NIX_ROOT" ] || /usr/bin/grep -q "^nix." /etc/synthetic.conf 2>/dev/null
+}
+test_synthetic_conf_mountable() {
+    /usr/bin/grep -q "^${NIX_ROOT:1}$" /etc/synthetic.conf 2>/dev/null
+}
+test_synthetic_conf_symlinked() {
+    /usr/bin/grep -qE "^${NIX_ROOT:1}\s+\S{3,}" /etc/synthetic.conf 2>/dev/null
 }
 
-test_synthetic_conf() {
-    /usr/bin/grep -q "^nix$" /etc/synthetic.conf 2>/dev/null
+test_nix_volume_mountd_installed() {
+    test -e "$NIX_VOLUME_MOUNTD_DEST"
+}
+
+# true here is a cruft smell when ! test_keychain_by_uuid
+test_keychain_by_label() {
+    # Note: doesn't need sudo just to check; doesn't output pw
+    security find-generic-password -a "$NIX_VOLUME_LABEL" &>/dev/null
+}
+# current volume password
+test_keychain_by_uuid() {
+    # Note: doesn't need sudo just to check; doesn't output pw
+    security find-generic-password -s "$(volume_uuid "$NIX_VOLUME_LABEL")" &>/dev/null
 }
 
 # Create the paths defined in synthetic.conf, saving us a reboot.
@@ -46,33 +140,27 @@ create_synthetic_objects(){
 }
 
 test_nix() {
-    test -d "/nix"
+    test -d "$NIX_ROOT"
 }
 
 test_voldaemon() {
-    test -f "$NIX_VOLUME_MOUNTD"
+    test -f "$NIX_VOLUME_MOUNTD_DEST"
 }
 
 test_filevault_in_use() {
     /usr/bin/fdesetup isactive >/dev/null
 }
 
-# use after error msg for conditions we don't understand
-suggest_report_error(){
-    # ex "error: something sad happened :(" >&2
-    echo "       please report this @ https://github.com/nixos/nix/issues" >&2
-}
-
 generate_mount_command(){
-    if test_filevault_in_use; then
-        printf "    <string>%s</string>\n" /bin/sh -c '/usr/bin/security find-generic-password -a "Nix" -w | /usr/sbin/diskutil apfs unlockVolume "Nix" -mountpoint /nix -stdinpassphrase'
+    if [ "${1-}" = "" ]; then
+        printf "    <string>%s</string>\n" /bin/sh -c "/usr/bin/security find-generic-password -s '$1' -w | /usr/sbin/diskutil apfs unlockVolume '$NIX_VOLUME_LABEL' -mountpoint $NIX_ROOT -stdinpassphrase"
     else
-        printf "    <string>%s</string>\n" /usr/sbin/diskutil mount -mountPoint /nix "Nix"
+        printf "    <string>%s</string>\n" /usr/sbin/diskutil mount -mountPoint "$NIX_ROOT" "$NIX_VOLUME_LABEL"
     fi
 }
 
 generate_mount_daemon(){
-    cat << EOF
+    cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -83,19 +171,406 @@ generate_mount_daemon(){
   <string>org.nixos.darwin-store</string>
   <key>ProgramArguments</key>
   <array>
-$(generate_mount_command)
+$(generate_mount_command "$1")
   </array>
 </dict>
 </plist>
 EOF
 }
 
-# $1=<volume name> $2=<volume uuid>
-prepare_darwin_volume_password(){
-    password="$(/usr/bin/xxd -l 32 -p -c 256 /dev/random)"
-    sudo /usr/bin/security -i <<EOF
-add-generic-password -a "$1" -s "$2" -l "$1 encryption password" -D "Encrypted volume password" -j "Added automatically by the Nix installer for use by $NIX_VOLUME_MOUNTD" -w "$password" -T /System/Library/CoreServices/APFSUserAgent -T /System/Library/CoreServices/CSUserAgent -T /usr/bin/security "/Library/Keychains/System.keychain"
+# TODO: this is a succinct example of an annoyance I have: I'd like to
+# dedup "direction" and "prompt" cases into a goal/command/explanation...
+#
+# uninstall_launch_daemon_abstract() {
+#     goal "uninstall LaunchDaemon $1"
+#     to "terminate the daemon" \
+#         run sudo launchctl bootout "system/$1"
+#     to "remove the daemon definition" \
+#         run sudo rm "$2"
+# }
+#
+# One way to make something like this work would be passing in ~closures
+# uninstall_launch_daemon_abstract "substep" "print_action"
+# uninstall_launch_daemon_abstract "ui_confirm" "run_action"
+#
+# But in some cases the approach a human and our script need to take diverge
+# by enough to challenge this paradigm, as in
+# synthetic_conf_uninstall_directions|prompt
+uninstall_launch_daemon_directions() {
+    substep "Uninstall LaunchDaemon $1" \
+      "  sudo launchctl bootout system/$1" \
+      "  sudo rm $2"
+}
+
+_eat_bootout_err(){
+    grep -v "Boot-out failed: 36: Operation now in progress" 1>&2
+}
+
+uninstall_launch_daemon_prompt() {
+    cat <<EOF
+The installer added $1 (a LaunchDaemon
+to $3).
 EOF
+    if ui_confirm "Can I remove it?"; then
+        if ! _sudo "to terminate the daemon" \
+            launchctl bootout "system/$1" 2> >(_eat_bootout_err); then
+            # this can "fail" with a message like:
+            # Boot-out failed: 36: Operation now in progress
+            # I gather it still works, but let's test
+            ! _sudo "to confirm its removal" launchctl blame "system/$1" 2>/dev/null
+            # if already removed, this returned 113 and emitted roughly:
+            # Could not find service "$1" in domain for system
+        fi
+        _sudo "to remove the daemon definition" rm "$2"
+    fi
+}
+nix_volume_mountd_uninstall_directions() {
+    uninstall_launch_daemon_directions "org.nixos.darwin-store" \
+        "$NIX_VOLUME_MOUNTD_DEST"
+}
+nix_volume_mountd_uninstall_prompt() {
+    uninstall_launch_daemon_prompt "org.nixos.darwin-store" \
+        "$NIX_VOLUME_MOUNTD_DEST" \
+        "mount your Nix volume"
+}
+nix_daemon_uninstall_directions() {
+    uninstall_launch_daemon_directions "org.nixos.nix-daemon" \
+        "$NIX_DAEMON_DEST"
+}
+nix_daemon_uninstall_prompt() {
+    uninstall_launch_daemon_prompt "org.nixos.nix-daemon" \
+        "$NIX_DAEMON_DEST" \
+        "run the nix-daemon"
+}
+
+synthetic_conf_uninstall_directions() {
+    # :1 to strip leading slash
+    # shellcheck disable=SC2086
+    substep "Remove ${NIX_ROOT:1} from /etc/synthetic.conf" \
+        "  If nix is the only entry: sudo rm /etc/synthetic.conf" \
+        "  Otherwise: grep -v "^${NIX_ROOT:1}$" /etc/synthetic.conf | sudo dd of=/etc/synthetic.conf"
+}
+
+synthetic_conf_uninstall_prompt() {
+    cat <<EOF
+During install, I add '${NIX_ROOT:1}' to /etc/synthetic.conf, which
+instructs macOS to create an empty root directory where I can mount
+the Nix volume.
+EOF
+    # there are a few things we can do here
+    # 1. if grep -v didn't match anything (also, if there's no diff), we know this is moot
+    # 2. if grep -v was empty (but did match?) I think we know that we can just remove the file
+    # 3. if the edit doesn't ~empty the file, show them the diff and ask
+    # shellcheck disable=SC2086
+    if ! grep -v "^${NIX_ROOT:1}$" /etc/synthetic.conf > $SCRATCH/synthetic.conf.edit; then
+        if confirm_rm "/etc/synthetic.conf"; then
+            return 0
+        fi
+    else
+        if cmp <<<"" "$SCRATCH/synthetic.conf.edit"; then
+            # this edit would leave it empty; propose deleting it
+            if confirm_rm "/etc/synthetic.conf"; then
+                return 0
+            fi
+        else
+            if confirm_edit "$SCRATCH/synthetic.conf.edit" "/etc/synthetic.conf"; then
+                return 0
+            fi
+        fi
+    fi
+    # fallback instructions
+    echo "Manually remove nix from /etc/synthetic.conf"
+    return 1
+}
+
+add_nix_vol_fstab_line() {
+    # shellcheck disable=SC2068
+    EDITOR="ex" _sudo "to add nix to fstab" "$@" <<EOF
+:a
+LABEL=$NIX_VOLUME_FOR_FSTAB $NIX_ROOT apfs rw,noauto,nobrowse
+.
+:x
+EOF
+}
+
+delete_nix_vol_fstab_line() {
+    # TODO: I'm scaffolding this to handle the new nix volumes
+    # but it might be nice to generalize a smidge further to
+    # go ahead and set up a pattern for curing "old" things
+    # we no longer do?
+    # shellcheck disable=SC2068
+    EDITOR="patch" _sudo "to cut nix from fstab" "$@" < <(diff /etc/fstab <(grep -v "LABEL=$NIX_VOLUME_FOR_FSTAB $NIX_ROOT apfs rw" /etc/fstab))
+    # left ",noauto,nobrowse" out of the grep; people might fiddle this a little
+}
+fstab_uninstall_directions() {
+    substep "Remove ${NIX_ROOT} from /etc/fstab" \
+      "  If nix is the only entry: sudo rm /etc/fstab" \
+      "  Otherwise, run 'sudo vifs' to remove the nix line"
+}
+fstab_uninstall_prompt() {
+    cat <<EOF
+During install, I add '${NIX_ROOT}' to /etc/fstab so that macOS knows what
+mount options to use for the Nix volume.
+EOF
+    cp /etc/fstab "$SCRATCH/fstab.edit"
+    # technically doesn't need the _sudo path, but throwing away the
+    # output is probably better than mostly-duplicating the code...
+    delete_nix_vol_fstab_line patch "$SCRATCH/fstab.edit" &>/dev/null
+
+    # if the patch test test, minus comment lines, is equal to empty (:)
+    if diff -q <(:) <(grep -v "^#" "$SCRATCH/fstab.edit") &>/dev/null; then
+        # this edit would leave it empty; propose deleting it
+        if confirm_rm "/etc/fstab"; then
+            return 0
+        else
+            # TODO: fallback instructions
+            echo "Manually remove nix from /etc/fstab"
+        fi
+    else
+        echo "I might be able to help you make this edit. Here's the diff:"
+        if ! _diff "/etc/fstab" "$SCRATCH/fstab.edit" && ui_confirm "Does the change above look right?"; then
+            delete_nix_vol_fstab_line vifs
+        else
+            # TODO: fallback instructions
+            echo "Manually remove nix from /etc/fstab"
+        fi
+    fi
+}
+volume_uninstall_directions() {
+    if test_keychain_by_uuid; then
+        keychain_uuid_uninstall_directions
+    fi
+    substep "Destroy the nix data volume" \
+      "  sudo diskutil apfs deleteVolume $(volume_special_device "$NIX_VOLUME_LABEL")"
+}
+darwin_volume_uninstall_directions() {
+    if test_synthetic_conf_mountable; then
+        synthetic_conf_uninstall_directions
+    fi
+    if test_fstab; then
+        fstab_uninstall_directions
+    fi
+    if find_nix_volume "$NIX_VOLUME_USE_DISK"; then
+        volume_uninstall_directions
+        # also handles a keychain entry for this volume
+    fi
+    # Not certain. Target case is an orphaned credential...
+    if ! test_keychain_by_uuid && test_keychain_by_label; then
+        keychain_label_uninstall_directions
+    fi
+    if test_nix_volume_mountd_installed; then
+        nix_volume_mountd_uninstall_directions
+    fi
+}
+darwin_volume_uninstall_prompts() {
+    if test_synthetic_conf_mountable; then
+        if synthetic_conf_uninstall_prompt; then
+            reminder "macOS will clean up the empty mount-point directory at $NIX_ROOT on reboot."
+        fi
+    fi
+    if test_fstab; then
+        fstab_uninstall_prompt
+    fi
+    if find_nix_volume "$NIX_VOLUME_USE_DISK"; then
+        volume_uninstall_prompt
+    fi
+    # Not certain. Target case is an orphaned credential...
+    if ! test_keychain_by_uuid && test_keychain_by_label; then
+        keychain_label_uninstall_prompt
+    fi
+    if test_nix_volume_mountd_installed; then
+        nix_volume_mountd_uninstall_prompt
+    fi
+}
+# only a function for keychain_label; the keychain_uuid
+# case is handled in volume_uninstall_prompt.
+keychain_label_uninstall_prompt() {
+    cat <<EOF
+It looks like your keychain has at least 1 orphaned volume password.
+I can help delete these if you like, or you can clean them up later.
+EOF
+    if ui_confirm "Do you want to review them now?"; then
+        cat <<EOF
+
+I'll show one raw keychain entries (without the password) at a time.
+
+EOF
+        while test_keychain_by_label; do
+            security find-generic-password -a "$NIX_VOLUME_LABEL"
+            if ui_confirm "Can I delete this entry?"; then
+                _sudo "to remove an old volume password from keychain" \
+                security delete-generic-password -a "$NIX_VOLUME_LABEL"
+            fi
+        done
+    else
+        keychain_label_uninstall_directions
+    fi
+}
+volume_uninstall_prompt() {
+    and_keychain=""
+    if test_keychain_by_uuid; then
+        and_keychain=" (and its encryption key)"
+    fi
+    cat <<EOF
+I can delete the Nix volume if you're certain you don't need it.
+
+Here are the details of the Nix volume:
+$(diskutil info "$NIX_VOLUME_LABEL")
+EOF
+    if ui_confirm "Can I delete this volume$and_keychain?"; then
+        if [ -n "$and_keychain" ]; then
+            _sudo "to remove the volume password from keychain" \
+                security delete-generic-password -s "$(volume_uuid "$NIX_VOLUME_LABEL")"
+        fi
+        diskID="$(volume_special_device "$NIX_VOLUME_LABEL")"
+        _sudo "to unmount the Nix volume" \
+            diskutil unmount force "$diskID"
+        _sudo "to delete the Nix volume" \
+            diskutil apfs deleteVolume "$diskID"
+    else
+        if [ -n "$and_keychain" ]; then
+            keychain_uuid_uninstall_directions
+        fi
+        volume_uninstall_directions
+    fi
+}
+keychain_uuid_uninstall_directions() {
+    substep "Remove the volume password from keychain" \
+      "  sudo security delete-generic-password -s '$(volume_uuid "$NIX_VOLUME_LABEL")'"
+}
+keychain_label_uninstall_directions() {
+    substep "Remove the volume password from keychain" \
+      "  sudo security delete-generic-password -a '$NIX_VOLUME_LABEL'"
+}
+
+# TODO:
+# - some of these are obsoleted by better uninstall directions elsewhere
+# - if the "curing" approach wins out, several of these can be cut, or only
+#   be errors if curing fails, or... something?
+darwin_volume_validate_assumptions() {
+    if test -e "$NIX_ROOT"; then
+        if test_nix_symlink; then
+            if test_synthetic_conf_symlinked; then
+                failure <<EOF
+$NIX_ROOT is a symlink (maybe because it is included in /etc/synthetic.conf?)
+Remove it from synthetic.conf, reboot, and confirm it is not linked.
+  $NIX_ROOT -> $(readlink "$NIX_ROOT")
+EOF
+            else
+                failure <<EOF
+$NIX_ROOT is a symlink (to $(readlink "$NIX_ROOT")) for some reason.
+You'll have to remove this symlink before I can create the Nix volume.
+EOF
+            fi
+        elif test_synthetic_conf_symlinked; then
+            failure "Please remove the nix line from /etc/synthetic.conf and reboot before continuing."
+        elif test_synthetic_conf_mountable; then
+            # TODO: consider whether this is an error or a warning.
+            # It would be more ideal to just collect this as a bit of known cruft
+            # but only tell the user to go clean everything up if we hit something
+            # that is absolutely a dealbreaker later...
+            failure <<EOF
+nix is already in /etc/synthetic.conf, probably from a previous install.
+Please remove it and reboot before continuing.
+EOF
+        else
+            failure "$NIX_ROOT already exists."
+        fi
+    fi
+    if test_synthetic_conf_symlinked; then
+        failure "Please remove the nix line from /etc/synthetic.conf before continuing."
+    fi
+    if test_synthetic_conf_mountable; then
+        # TODO: consider whether this is an error or a warning.
+        # It would be more ideal to just collect this as a bit of known cruft
+        # but only tell the user to go clean everything up if we hit something
+        # that is absolutely a dealbreaker later...
+        failure <<EOF
+nix is already in /etc/synthetic.conf, probably from a previous install.
+Please remove it before continuing.
+EOF
+    fi
+    if find_nix_volume "$NIX_VOLUME_USE_DISK"; then
+        failure <<EOF
+$NIX_VOLUME_USE_DISK already has a '$NIX_VOLUME_LABEL' volume, but the
+installer is configured to create a new one. Set NIX_VOLUME_CREATE=0
+to tell the installer to use your volume instead of creating one.
+
+Volume information:
+$(diskutil info "$NIX_VOLUME_LABEL")
+EOF
+    fi
+    if test_fstab; then
+        # TODO: re-use uninstall instrs?
+        failure <<EOF
+$NIX_ROOT is already in /etc/fstab, probably from a previous install.
+Please remove it before continuing.
+EOF
+    fi
+    if test_nix_volume_mountd_installed; then
+        # TODO: better message, less haste
+        failure "Nix volume mounter already installed."
+    fi
+    if test_keychain_by_label; then
+        # TODO: better message, less haste
+        failure "Keychain already has a credential for Nix volume mounter."
+    fi
+}
+
+setup_synthetic_conf() {
+    if ! test_synthetic_conf_mountable; then
+        task "Configuring /etc/synthetic.conf to make a mount-point at $NIX_ROOT" >&2
+        # TODO: technically /etc/synthetic.d/nix is supported in Big Sur+
+        # but handling both takes even more code...
+        _sudo "to add Nix to /etc/synthetic.conf" \
+            ex /etc/synthetic.conf <<EOF
+:a
+${NIX_ROOT:1}
+.
+:x
+EOF
+        if ! test_synthetic_conf_mountable; then
+            failure "error: failed to configure synthetic.conf" >&2
+        fi
+        create_synthetic_objects
+        if ! test_nix; then
+            failure "error: failed to bootstrap $NIX_ROOT" >&2
+        fi
+    fi
+}
+
+# fstab used to be responsible for mounting the volume. Now the last
+# step adds a LaunchDaemon responsible for mounting. This is technically
+# redundant for mounting, but diskutil appears to pick up mount options
+# from fstab (and diskutil's support for specifying them directly is not
+# consistent across versions/subcommands), enabling us to specify mount
+# options by *label*.
+#
+# Being able to do all of this by label is helpful because it's a stable
+# identifier that we can know at code-time, letting us skirt some logistic
+# complexity that comes with doing this by UUID (which is stable, but not
+# known ahead of time) or special device name/path (which is not stable).
+setup_fstab() {
+    if ! test_fstab; then
+        task "Configuring /etc/fstab to specify volume mount options" >&2
+        add_nix_vol_fstab_line vifs
+        # printf "\$a\nLABEL=%s %s apfs rw,noauto,nobrowse\n.\nwq\n" "${NIX_VOLUME_FOR_FSTAB}" "$NIX_ROOT"| EDITOR=/bin/ed /usr/bin/sudo /usr/sbin/vifs
+    fi
+}
+setup_volume() {
+    task "Creating a Nix volume" >&2
+    _sudo "to create the Nix volume" \
+        /usr/sbin/diskutil apfs addVolume "$NIX_VOLUME_USE_DISK" "$NIX_VOLUME_FS" "$NIX_VOLUME_LABEL" -mountpoint "$NIX_ROOT"
+
+    # if [ "$INSTALL_MODE" = "no-daemon" ]; then # exported by caller
+    #     # TODO:
+    #     # - is there a better way to do this?
+    #     # - technically not needed since daemon is default, but I'm trying
+    #     # to minimize unnecessary breaks for now
+    #     /usr/bin/sudo /usr/sbin/chown "$USER:admin" /nix
+    # fi
+    #
+    #
     # Notes:
     # 1) system is in some sense less secure than user keychain... (it's
     # possible to read the password for decrypting the keychain) but
@@ -112,104 +587,70 @@ EOF
     # the user will hopefully look for help if the volume stops mounting,
     # rather than failing over into subtle race-condition problems.
 
-    builtin printf "$password"
-}
-
-main() {
-    (
-        echo ""
-        echo "     ------------------------------------------------------------------ "
-        echo "    | This installer will create a volume for the nix store and        |"
-        echo "    | configure it to mount at /nix.  Follow these steps to uninstall. |"
-        echo "     ------------------------------------------------------------------ "
-        echo ""
-        echo "  1. Remove the entry from fstab using 'sudo vifs'"
-        echo "  2. Run 'sudo launchctl bootout system/org.nixos.darwin-store'"
-        echo "  3. Remove $NIX_VOLUME_MOUNTD"
-        echo "  4. Destroy the data volume using 'diskutil apfs deleteVolume'"
-        echo "  5. Remove the 'nix' line from /etc/synthetic.conf (or the file)"
-        echo ""
-    ) >&2
-
-    if test_nix_symlink; then
-        echo "error: /nix is a symlink, please remove it and make sure it's not in synthetic.conf (in which case a reboot is required)" >&2
-        echo "  /nix -> $(readlink "/nix")" >&2
-        exit 2
-    fi
-
-    if ! test_synthetic_conf; then
-        echo "Configuring /etc/synthetic.conf..." >&2
-        # TODO: technically /etc/synthetic.d/nix is supported in Big Sur+
-        # but handling both takes even more code...
-        echo nix | /usr/bin/sudo /usr/bin/tee -a /etc/synthetic.conf
-        if ! test_synthetic_conf; then
-            echo "error: failed to configure synthetic.conf;" >&2
-            suggest_report_error
-            exit 1
-        fi
-    fi
-
-    if ! test_nix; then
-        echo "Creating mountpoint for /nix..." >&2
-        create_synthetic_objects # the ones we defined in synthetic.conf
-        if ! test_nix; then
-            /usr/bin/sudo /bin/mkdir -p /nix 2>/dev/null || true
-        fi
-        if ! test_nix; then
-            echo "error: failed to bootstrap /nix; if a reboot doesn't help," >&2
-            suggest_report_error
-            exit 1
-        fi
-    fi
-
-    disk="$(root_disk_identifier)"
-    volume=$(find_nix_volume "$disk") # existing volname starting w/ "nix"?
-    if [ -z "$volume" ]; then
-        volume="Nix"    # otherwise use default
-        create_volume=1
-    fi
-    # fstab used to be responsible for mounting the volume. Now the last
-    # step adds a LaunchDaemon responsible for mounting. This is technically
-    # redundant for mounting, but diskutil appears to pick up mount options
-    # from fstab (and diskutil's support for specifying them directly is not
-    # consistent across versions/subcommands), enabling us to specify mount
-    # options by *label*.
-    #
-    # Being able to do all of this by label is helpful because it's a stable
-    # identifier that we can know at code-time, letting us skirt some logistic
-    # complexity that comes with doing this by UUID (which is stable, but not
-    # known ahead of time) or special device name/path (which is not stable).
-    if ! test_fstab; then
-        echo "Configuring /etc/fstab..." >&2
-        label=$(echo "$volume" | sed 's/ /\\040/g')
-        # shellcheck disable=SC2209
-        printf "\$a\nLABEL=%s /nix apfs rw,noauto,nobrowse\n.\nwq\n" "$label" | EDITOR=/bin/ed /usr/bin/sudo /usr/sbin/vifs
-    fi
-
-    if [ -n "$create_volume" ]; then
-        echo "Creating a Nix volume..." >&2
-
-        /usr/bin/sudo /usr/sbin/diskutil apfs addVolume "$disk" "$NIX_VOLUME_FS" "$volume" -mountpoint /nix
-        new_uuid="$(volume_uuid "$volume")"
-
-        if [ "$INSTALL_MODE" = "no-daemon" ]; then # exported by caller
-            # TODO: is there a better way to do this?
-            /usr/bin/sudo /usr/sbin/chown "$USER:admin" /nix
-        fi
-
-        if test_filevault_in_use; then
-            prepare_darwin_volume_password "$volume" "$new_uuid" | /usr/bin/sudo /usr/sbin/diskutil apfs encryptVolume "$volume" -user disk -stdinpassphrase
-        fi
+    if test_filevault_in_use; then
+        new_uuid="$(volume_uuid "$NIX_VOLUME_LABEL")"
+        password="$(/usr/bin/xxd -l 32 -p -c 256 /dev/random)"
+        _sudo "to add your Nix volume's password to Keychain" \
+        /usr/bin/security -i <<EOF
+add-generic-password -a "$NIX_VOLUME_LABEL" -s "$new_uuid" -l "$NIX_VOLUME_LABEL encryption password" -D "Encrypted volume password" -j "Added automatically by the Nix installer for use by $NIX_VOLUME_MOUNTD_DEST" -w "$password" -T /System/Library/CoreServices/APFSUserAgent -T /System/Library/CoreServices/CSUserAgent -T /usr/bin/security "/Library/Keychains/System.keychain"
+EOF
+        builtin printf "%s" "$password" | _sudo "to encrypt your Nix volume" \
+            /usr/sbin/diskutil apfs encryptVolume "$NIX_VOLUME_LABEL" -user disk -stdinpassphrase
+        setup_volume_daemon "$new_uuid"
     else
-        echo "Using existing '$volume' volume" >&2
-    fi
-
-    if ! test_voldaemon; then
-        echo "Configuring LaunchDaemon to mount '$volume'..." >&2
-        generate_mount_daemon | /usr/bin/sudo /usr/bin/tee "$NIX_VOLUME_MOUNTD" >/dev/null
-
-        /usr/bin/sudo /bin/launchctl bootstrap system "$NIX_VOLUME_MOUNTD"
+        setup_volume_daemon "" # using UUID to discriminate FDE
     fi
 }
 
-main "$@"
+setup_volume_daemon() {
+    if ! test_voldaemon; then
+        task "Configuring LaunchDaemon to mount '$NIX_VOLUME_LABEL'" >&2
+        generate_mount_daemon "$1" | _sudo "to install the Nix volume mounter" \
+            dd of="$NIX_VOLUME_MOUNTD_DEST" 2>/dev/null
+
+        _sudo "to launch the Nix volume mounter" \
+            /bin/launchctl bootstrap system "$NIX_VOLUME_MOUNTD_DEST"
+    fi
+}
+
+setup_darwin_volume() {
+    setup_synthetic_conf
+    setup_fstab
+    setup_volume
+}
+
+if [ "$_CREATE_VOLUME_NO_MAIN" = 1 ]; then
+    # shellcheck disable=SC2198
+    if [ -n "$@" ]; then
+        "$@" # expose functions in case we want multiple routines?
+    fi
+else
+    # no reason to pay for bash to process this
+    main() {
+        {
+            echo ""
+            echo "     ------------------------------------------------------------------ "
+            echo "    | This installer will create a volume for the nix store and        |"
+            echo "    | configure it to mount at $NIX_ROOT.  Follow these steps to uninstall. |"
+            echo "     ------------------------------------------------------------------ "
+            echo ""
+            echo "  1. Remove the entry from fstab using 'sudo vifs'"
+            echo "  2. Run 'sudo launchctl bootout system/org.nixos.darwin-store'"
+            echo "  3. Remove $NIX_VOLUME_MOUNTD_DEST"
+            echo "  4. Destroy the data volume using 'diskutil apfs deleteVolume'"
+            echo "  5. Remove the 'nix' line from /etc/synthetic.conf (or the file)"
+            echo ""
+        } >&2
+
+        if test_nix_symlink; then
+            failure >&2 <<EOF
+error: $NIX_ROOT is a symlink (-> $(readlink "$NIX_ROOT")).
+Please remove it. If nix is in /etc/synthetic.conf, remove it and reboot.
+EOF
+        fi
+
+        setup_darwin_volume
+    }
+
+    main "$@"
+fi

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -93,7 +93,7 @@ prepare_darwin_volume_password(){
 log_user 0
 set VOLUME [lindex $argv 0];
 set UUID [lindex $argv 1];
-set PASSPHRASE [exec /usr/bin/ruby -rsecurerandom -e "puts SecureRandom.hex(32)"]
+set PASSPHRASE [exec /usr/bin/xxd -l 32 -p -c 256 /dev/random]
 
 # Cargo culting: people recommend this; not sure how necessary
 set send_slow {1 .1}

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -63,9 +63,9 @@ suggest_report_error(){
 
 generate_mount_command(){
     if test_filevault_in_use; then
-        printf "    <string>%s</string>\n" /bin/sh -c '/usr/bin/security find-generic-password -a "Nix Volume" -w | /usr/sbin/diskutil apfs unlockVolume "Nix Volume" -mountpoint /nix -stdinpassphrase'
+        printf "    <string>%s</string>\n" /bin/sh -c '/usr/bin/security find-generic-password -a "Nix" -w | /usr/sbin/diskutil apfs unlockVolume "Nix" -mountpoint /nix -stdinpassphrase'
     else
-        printf "    <string>%s</string>\n" /usr/sbin/diskutil mount -mountPoint /nix "Nix Volume"
+        printf "    <string>%s</string>\n" /usr/sbin/diskutil mount -mountPoint /nix "Nix"
     fi
 }
 
@@ -158,7 +158,7 @@ main() {
     disk="$(root_disk_identifier)"
     volume=$(find_nix_volume "$disk") # existing volname starting w/ "nix"?
     if [ -z "$volume" ]; then
-        volume="Nix Volume"    # otherwise use default
+        volume="Nix"    # otherwise use default
         create_volume=1
     fi
     # fstab used to be responsible for mounting the volume. Now the last

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -222,9 +222,9 @@ main() {
         echo "Configuring LaunchDaemon to mount '$volume'..." >&2
         generate_mount_daemon | sudo tee /Library/LaunchDaemons/org.nixos.darwin-store.plist >/dev/null
 
-        sudo launchctl load /Library/LaunchDaemons/org.nixos.darwin-store.plist
+        sudo launchctl bootstrap system /Library/LaunchDaemons/org.nixos.darwin-store.plist
 
-        sudo launchctl start org.nixos.darwin-store
+        # sudo launchctl start org.nixos.darwin-store
     fi
 }
 

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -94,7 +94,7 @@ EOF
 }
 
 prepare_darwin_volume_password(){
-    sudo /usr/bin/expect << 'EOF'
+    sudo /usr/bin/expect -f - "$1" << 'EOF'
 log_user 0
 set VOLUME [lindex $argv 0];
 set PASSPHRASE [exec /usr/bin/ruby -rsecurerandom -e "puts SecureRandom.hex(32)"]

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -77,14 +77,6 @@ generate_mount_daemon(){
 <dict>
   <key>RunAtLoad</key>
   <true/>
-  <key>KeepAlive</key>
-  <dict>
-    <key>PathState</key>
-    <dict>
-      <key>/nix/var/nix</key>
-      <false/>
-    </dict>
-  </dict>
   <key>Label</key>
   <string>org.nixos.darwin-store</string>
   <key>ProgramArguments</key>

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -177,7 +177,7 @@ main() {
         echo "Configuring /etc/fstab..." >&2
         label=$(echo "$volume" | sed 's/ /\\040/g')
         # shellcheck disable=SC2209
-        printf "\$a\nLABEL=%s /nix apfs rw,nobrowse\n.\nwq\n" "$label" | EDITOR=ed sudo vifs
+        printf "\$a\nLABEL=%s /nix apfs rw,noauto,nobrowse\n.\nwq\n" "$label" | EDITOR=ed sudo vifs
     fi
 
     if [ -n "$create_volume" ]; then

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -184,7 +184,7 @@ main() {
 
     if ! test_voldaemon; then
         echo "Configuring LaunchDaemon to mount '$volume'..." >&2
-        generate_mount_daemon | sudo tee /Library/LaunchDaemons/org.nixos.darwin-store.plist
+        generate_mount_daemon | sudo tee /Library/LaunchDaemons/org.nixos.darwin-store.plist >/dev/null
 
         sudo launchctl load /Library/LaunchDaemons/org.nixos.darwin-store.plist
 

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -120,7 +120,7 @@ main() {
         echo "     ------------------------------------------------------------------ "
         echo ""
         echo "  1. Remove the entry from fstab using 'sudo vifs'"
-        echo "  2. Run `sudo launchctl bootout system/org.nixos.darwin-store`"
+        echo "  2. Run 'sudo launchctl bootout system/org.nixos.darwin-store'"
         echo "  3. Remove /Library/LaunchDaemons/org.nixos.darwin-store.plist"
         echo "  4. Destroy the data volume using 'diskutil apfs deleteVolume'"
         echo "  5. Remove the 'nix' line from /etc/synthetic.conf (or the file)"

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -159,8 +159,10 @@ main() {
 
     disk="$(root_disk_identifier)"
     volume=$(find_nix_volume "$disk") # existing volname starting w/ "nix"?
-    volume="${volume:-Nix Volume}"    # otherwise use default
-
+    if [ -z "$volume" ]; then
+        volume="Nix Volume"    # otherwise use default
+        create_volume=1
+    fi
     # fstab used to be responsible for mounting the volume. Now the last
     # step adds a LaunchDaemon responsible for mounting. This is technically
     # redundant for mounting, but diskutil appears to pick up mount options
@@ -179,7 +181,7 @@ main() {
         printf "\$a\nLABEL=%s /nix apfs rw,nobrowse\n.\nwq\n" "$label" | EDITOR=ed sudo vifs
     fi
 
-    if [ -z "$volume" ]; then
+    if [ -n "$create_volume" ]; then
         echo "Creating a Nix volume..." >&2
 
         if test_filevault_in_use; then

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -94,14 +94,15 @@ EOF
 }
 
 prepare_darwin_volume_password(){
-    sudo /usr/bin/expect -f - "$1" << 'EOF'
+    sudo /usr/bin/expect -f - "$1" "$2" << 'EOF'
 log_user 0
 set VOLUME [lindex $argv 0];
+set UUID [lindex $argv 1];
 set PASSPHRASE [exec /usr/bin/ruby -rsecurerandom -e "puts SecureRandom.hex(32)"]
 
 # Cargo culting: people recommend this; not sure how necessary
 set send_slow {1 .1}
-spawn /usr/bin/sudo /usr/bin/security add-generic-password -a "$VOLUME" -D "$VOLUME encryption password" -U -w
+spawn /usr/bin/sudo /usr/bin/security add-generic-password -a "$VOLUME" -s "$UUID" -D "$VOLUME encryption password" -U -w
 expect {
     "password data for new item: " {
         send -s -- "$PASSPHRASE\r"
@@ -186,6 +187,7 @@ main() {
         echo "Creating a Nix volume..." >&2
 
         sudo diskutil apfs addVolume "$disk" APFS "$volume" -mountpoint /nix
+        new_uuid="$(volume_uuid "$volume")"
 
         if [ "$INSTALL_MODE" = "no-daemon" ]; then # exported by caller
             # TODO: is there a better way to do this?
@@ -203,7 +205,7 @@ main() {
             # can tell, the file with this password (/var/db/SystemKey) is
             # inside the FileVault envelope. If that isn't true, it may make
             # sense to store the password inside the envelope?
-            sudo /usr/bin/security add-generic-password -a "$volume" -s "$(volume_uuid "$volume")" -D "$volume encryption password" -j "Added automatically by the Nix installer for use by /Library/LaunchDaemons/org.nixos.darwin-store.plist" "/Library/Keychains/System.keychain"
+            sudo /usr/bin/security add-generic-password -a "$volume" -s "$new_uuid" -D "$volume encryption password" -j "Added automatically by the Nix installer for use by /Library/LaunchDaemons/org.nixos.darwin-store.plist" "/Library/Keychains/System.keychain"
             # TODO: decide if we should add `-T /System/Library/CoreServices/APFSUserAgent`
             # This should let the system seamlessly supply the password for this volume
             # which in turn means the fstab entry is enough for the system to (eventually)
@@ -214,7 +216,7 @@ main() {
 
             # 2. add a password with the -U (update) flag and -w (prompt if last)
             #    flags, but specify no keychain; security will use the first it finds
-            prepare_darwin_volume_password "$volume" | sudo diskutil apfs encryptVolume "$volume" -user disk -stdinpassphrase
+            prepare_darwin_volume_password "$volume" "$new_uuid" | sudo diskutil apfs encryptVolume "$volume" -user disk -stdinpassphrase
         fi
     else
         echo "Using existing '$volume' volume" >&2

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -e
 
-root_disk() {
-    diskutil info -plist /
-}
-
 # i.e., "disk1"
 root_disk_identifier() {
     diskutil info -plist / | xmllint --xpath "/plist/dict/key[text()='ParentWholeDisk']/following-sibling::string[1]/text()" -

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -187,10 +187,15 @@ main() {
             # and be prompted for a pw to add; two step workaround:
             # 1. add a blank pw to a keychain
             #    - system if daemon
-            sudo /usr/bin/security add-generic-password -a "Nix Volume" -s "Nix Volume" -D "Nix Volume password" "/Library/Keychains/System.keychain"
-            #    - login if single-user
-            # TODO: pass something in to discriminate this case?
-            # sudo /usr/bin/security add-generic-password -a "Nix Volume" -s "Nix Volume" -D "Nix Volume password"
+            if [ "$INSTALL_MODE" = "daemon" ]; then # exported by caller
+                # system is technically less secure than user... in theory we
+                # could install the password in each user keychain, but we'd
+                # need some ergonomic way to add users after install...
+                sudo /usr/bin/security add-generic-password -a "Nix Volume" -s "Nix Volume" -D "Nix Volume password" "/Library/Keychains/System.keychain"
+            #    - login (default) if single-user
+            else
+                sudo /usr/bin/security add-generic-password -a "Nix Volume" -s "Nix Volume" -D "Nix Volume password"
+            fi
             # 2. add a password with the -U (update) flag and -w (prompt if last)
             #    flags, but specify no keychain; security will use the first it finds
             prepare_darwin_volume_password | sudo diskutil apfs addVolume "$disk" APFS 'Nix Volume' -mountpoint /nix -stdinpassphrase

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -97,7 +97,7 @@ set PASSPHRASE [exec /usr/bin/xxd -l 32 -p -c 256 /dev/random]
 
 # Cargo culting: people recommend this; not sure how necessary
 set send_slow {1 .1}
-spawn /usr/bin/sudo /usr/bin/security add-generic-password -a "$VOLUME" -s "$UUID" -D "$VOLUME encryption password" -U -w
+spawn /usr/bin/sudo /usr/bin/security add-generic-password -a "$VOLUME" -l "$volume encryption password" -s "$UUID" -D "Encrypted volume password" -U -w
 expect {
     "password data for new item: " {
         send -s -- "$PASSPHRASE\r"

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -124,9 +124,10 @@ main() {
         echo "    | configure it to mount at /nix.  Follow these steps to uninstall. |"
         echo "     ------------------------------------------------------------------ "
         echo ""
-        echo "  1. Remove /Library/LaunchDaemons/org.nixos.darwin-store.plist"
-        echo "  2. Destroy the data volume using 'diskutil apfs deleteVolume'"
-        echo "  3. Remove the 'nix' line from /etc/synthetic.conf or the file"
+        echo "  1. Remove the entry from fstab using 'sudo vifs'"
+        echo "  2. Remove /Library/LaunchDaemons/org.nixos.darwin-store.plist"
+        echo "  3. Destroy the data volume using 'diskutil apfs deleteVolume'"
+        echo "  4. Remove the 'nix' line from /etc/synthetic.conf (or the file)"
         echo ""
     ) >&2
 

--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -195,7 +195,7 @@ main() {
 
         if [ "$INSTALL_MODE" = "no-daemon" ]; then # exported by caller
             # TODO: is there a better way to do this?
-            sudo chown $USER:admin /nix
+            sudo chown "$USER:admin" /nix
         fi
 
         if test_filevault_in_use; then

--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -3,36 +3,62 @@
 set -eu
 set -o pipefail
 
-readonly PLIST_DEST=/Library/LaunchDaemons/org.nixos.nix-daemon.plist
+readonly NIX_DAEMON_DEST=/Library/LaunchDaemons/org.nixos.nix-daemon.plist
+# create by default; set 0 to DIY, use a symlink, etc.
+readonly NIX_VOLUME_CREATE=${NIX_VOLUME_CREATE:-1} # now default
+
+# TODO: I'm trying to decide between how well-contained the darwin-volume
+# stuff should stay here. Current goal is to source create-darwin-volume.sh
+# and leave most of the code there, which accomplishes my main goals:
+# 1. take advantage of the UI/X affordances here
+# 2. retain some degree of invokability (a kindness to anyone who has a script
+#    set up to download and run it)?
+. "$EXTRACTED_NIX_PATH/create-darwin-volume.sh" "no-main"
 
 dsclattr() {
     /usr/bin/dscl . -read "$1" \
         | awk "/$2/ { print \$2 }"
 }
 
+test_nix_daemon_installed() {
+  test -e "$NIX_DAEMON_DEST"
+}
+
 poly_validate_assumptions() {
     if [ "$(uname -s)" != "Darwin" ]; then
         failure "This script is for use with macOS!"
     fi
+    writable="$(diskutil info -plist / | xmllint --xpath "name(/plist/dict/key[text()='Writable']/following-sibling::*[1])" -)"
+
+    if ! [ -e $NIX_ROOT ] && [ "$writable" = "false" ] && [ "$NIX_VOLUME_CREATE" = 1 ]; then
+        # we need to create a Nix volume
+        darwin_volume_validate_assumptions
+    fi
 }
 
 poly_service_installed_check() {
-    [ -e "$PLIST_DEST" ]
+    test_nix_daemon_installed || test_nix_volume_mountd_installed
 }
 
 poly_service_uninstall_directions() {
-        cat <<EOF
-$1. Delete $PLIST_DEST
+    echo "$1. Remove macOS-specific components:"
+    darwin_volume_uninstall_directions
+    if test_nix_daemon_installed; then
+        nix_daemon_uninstall_directions
+    fi
+}
 
-  sudo launchctl unload $PLIST_DEST
-  sudo rm $PLIST_DEST
-
-EOF
+poly_service_uninstall_prompts() {
+    echo "$1. Remove macOS-specific components:"
+    darwin_volume_uninstall_prompts
+    if test_nix_daemon_installed; then
+        nix_daemon_uninstall_prompt
+    fi
 }
 
 poly_service_setup_note() {
     cat <<EOF
- - load and start a LaunchDaemon (at $PLIST_DEST) for nix-daemon
+ - load and start a LaunchDaemon (at $NIX_DAEMON_DEST) for nix-daemon
 
 EOF
 }
@@ -46,7 +72,7 @@ poly_extra_setup_instructions(){
 
 poly_configure_nix_daemon_service() {
     _sudo "to set up the nix-daemon as a LaunchDaemon" \
-          cp -f "/nix/var/nix/profiles/default$PLIST_DEST" "$PLIST_DEST"
+          cp -f "/nix/var/nix/profiles/default$NIX_DAEMON_DEST" "$NIX_DAEMON_DEST"
 
     _sudo "to load the LaunchDaemon plist for nix-daemon" \
           launchctl load /Library/LaunchDaemons/org.nixos.nix-daemon.plist
@@ -148,4 +174,8 @@ poly_create_build_user() {
     _sudo "Creating the Nix build user (#$builder_num), $username" \
           /usr/bin/dscl . create "/Users/$username" \
           UniqueID "${uid}"
+}
+
+poly_prepare_to_install() {
+    setup_darwin_volume
 }

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -684,6 +684,8 @@ main() {
         exit 1
     fi
 
+    poly_prepare_to_install
+
     create_build_group
     create_build_users
     create_directories

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -103,7 +103,7 @@ done
 if [ "$(uname -s)" = "Darwin" ]; then
     writable="$(diskutil info -plist / | xmllint --xpath "name(/plist/dict/key[text()='Writable']/following-sibling::*[1])" -)"
     if ! [ -e $dest ] && [ "$writable" = "false" ] && [ "$CREATE_DARWIN_VOLUME" = 1 ]; then
-        printf '\e[1;31mCreating volume and mountpoint /nix if needed.\e[0m\n'
+        printf "\e[1;31mCreating volume and mountpoint $dest if needed.\e[0m\n"
         "$self/create-darwin-volume.sh"
     fi
 fi

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -37,12 +37,9 @@ EOF
 fi
 
 # Determine if we could use the multi-user installer or not
-if [ "$(uname -s)" = "Darwin" ]; then
-    echo "Note: a multi-user installation is possible. See https://nixos.org/nix/manual/#sect-multi-user-installation" >&2
-elif [ "$(uname -s)" = "Linux" ]; then
+if [ "$(uname -s)" = "Linux" ]; then
     echo "Note: a multi-user installation is possible. See https://nixos.org/nix/manual/#sect-multi-user-installation" >&2
 fi
-
 
 case "$(uname -s)" in
     "Darwin")
@@ -50,6 +47,7 @@ case "$(uname -s)" in
     *)
         INSTALL_MODE=no-daemon;;
 esac
+ACTION="install"
 # CREATE_DARWIN_VOLUME=${CREATE_DARWIN_VOLUME:-1} # now default
 # handle the command line flags
 while [ $# -gt 0 ]; do
@@ -75,6 +73,8 @@ while [ $# -gt 0 ]; do
                 echo "         is no longer needed and will be removed in the future."
                 echo ""
             } >&2;;
+        --uninstall)
+            ACTION="uninstall";;
         --nix-extra-conf-file)
             export NIX_EXTRA_CONF="$(cat $2)"
             shift;;
@@ -112,7 +112,7 @@ done
 
 if [ "$INSTALL_MODE" = "daemon" ]; then
     printf '\e[1;31mSwitching to the Multi-user Installer\e[0m\n'
-    exec "$self/install-multi-user"
+    exec "$self/install-multi-user" "$ACTION"
     exit 0
 fi
 

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -60,16 +60,16 @@ while [ $# -gt 0 ]; do
         --no-modify-profile)
             NIX_INSTALLER_NO_MODIFY_PROFILE=1;;
         --darwin-use-unencrypted-nix-store-volume)
-            (
+            {
                 echo "Warning: the flag --darwin-use-unencrypted-nix-store-volume"
                 echo "         is no longer needed and will be removed in the future."
                 echo ""
-            ) >&2;;
+            } >&2;;
         --nix-extra-conf-file)
             export NIX_EXTRA_CONF="$(cat $2)"
             shift;;
         *)
-            (
+            {
                 echo "Nix Installer [--daemon|--no-daemon] [--daemon-user-count INT] [--no-channel-add] [--no-modify-profile] [--nix-extra-conf-file FILE]"
 
                 echo "Choose installation method."
@@ -93,7 +93,7 @@ while [ $# -gt 0 ]; do
                 echo ""
                 echo " --nix-extra-conf-file: Path to nix.conf to prepend when installing /etc/nix.conf"
                 echo ""
-            ) >&2
+            } >&2
 
             exit;;
     esac

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -43,7 +43,7 @@ elif [ "$(uname -s)" = "Linux" ]; then
     echo "Note: a multi-user installation is possible. See https://nixos.org/nix/manual/#sect-multi-user-installation" >&2
 fi
 
-INSTALL_MODE=no-daemon
+export INSTALL_MODE=no-daemon
 CREATE_DARWIN_VOLUME=${CREATE_DARWIN_VOLUME:-1} # now default
 # handle the command line flags
 while [ $# -gt 0 ]; do

--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -207,3 +207,7 @@ poly_create_build_user() {
           --password "!" \
           "$username"
 }
+
+poly_prepare_to_install() {
+    :
+}

--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -81,19 +81,10 @@ poly_extra_try_me_commands(){
 EOF
     fi
 }
-poly_extra_setup_instructions(){
-    if [ -e /run/systemd/system ]; then
-        :
-    else
-        cat <<EOF
-Additionally, you may want to add nix-daemon to your init-system.
-
-EOF
-    fi
-}
 
 poly_configure_nix_daemon_service() {
     if [ -e /run/systemd/system ]; then
+        task "Setting up the nix-daemon systemd service"
         _sudo "to set up the nix-daemon service" \
               systemctl link "/nix/var/nix/profiles/default$SERVICE_SRC"
 
@@ -110,6 +101,8 @@ poly_configure_nix_daemon_service() {
 
         _sudo "to start the nix-daemon.service" \
               systemctl restart nix-daemon.service
+    else
+        reminder "I don't support your init system yet; you may want to add nix-daemon manually."
     fi
 }
 


### PR DESCRIPTION
# Motive/Goal 
Get single-invocation `curl -L https://nixos.org/nix/install | sh` installs working on macOS Catalina+

---
Recap in case it helps anyone:
- To support read-only / in Catalina, we updated the installer to move /nix to its own volume. 
- We wanted to encrypt this volume when FileVault FDE was enabled on the system to meet the user's expectation that their data was encrypted, but didn't find an approach we could confidently recommend.
- To sate the Nix-starved mob, we sliced off all of the cases we felt like we could handle, hid them behind the `--darwin-use-unencrypted-nix-store-volume` scare-flag to make sure people with Opinions and/or compliance concerns would pay attention, and left the remainder (non-T2 devices with FileVault enabled) to manually prepare their volumes.
---
We've recently confirmed that we can skirt the race condition by using a RunAtLoad LaunchDaemon to unlock and mount the volume. (I've tested straightforward cases like restoring editors with open files on the /nix volume, and restoring .apps managed by Nix. It may still be possible to force race conditions with multiple RunAtLoad daemons, but I think it's OK to work around those as-needed with `wait4path`.)

## Status
- PR currently works
    - tested locally with FileVault enabled on Big Sur beta using both single & multi-user installs
    - install [working in CI](https://github.com/abathur/syspolicyd_assessments/actions/runs/326476454) on matrix of FileVault yes/no, Catalina/Big Sur, --daemon ~--no-daemon~
- ~To finish the code out, we need to haggle over how this should affect single-user mode and "default" macOS installs. (see upcoming 2nd post for more on this):~ blocked single-user macOS installs
- To finish the code out, we need to haggle over the curing/uninstall concept?
- Need doc edits once code is baked.

## Try it out?
I have a temporary installer up at https://files.t-ravis.com/install-volume, so `curl https://files.t-ravis.com/install-volume | sh` should work. If you can't try it out, you can see output from the [CI run (same one listed earlier)](https://github.com/abathur/syspolicyd_assessments/actions/runs/326476454). I refresh it to test larger functionality changes, but it may be a few commits behind if they don't merit the chore of regenerating. Here's a history of the versions it has pointed at, with the current at the bottom:
- ~4e3a355~ 
- ~1668c39 (broken)~ 
- ~b9657d5~ 
- ~c95ce48~ 
- ~366cb2b (install OK but service broken)~ 
- ~eab5cb2 (install OK but service broken)~
- ~97d946a (install OK but service broken)~
- ~0c565a2~
- ~6541c0d~
- ~385994d~
- 0f73713

@LnL7 @lilyball @matthewbauer @dhess @mroi @domenkozar (others I'm forgetting are inevitably also interested; feel free to add people)