### PR TITLE
Print built derivations as json for build 

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -5,9 +5,11 @@
 #include "store-api.hh"
 #include "local-fs-store.hh"
 
+#include <nlohmann/json.hpp>
+
 using namespace nix;
 
-struct CmdBuild : InstallablesCommand, MixDryRun, MixProfile
+struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
 {
     Path outLink = "result";
     BuildMode buildMode = bmNormal;
@@ -86,6 +88,8 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixProfile
                     }, buildables[i]);
 
         updateProfile(buildables);
+
+        if (json) logger->cout("%s", buildablesToJSON(buildables, store).dump());
     }
 };
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -16,7 +16,34 @@
 #include <regex>
 #include <queue>
 
+#include <nlohmann/json.hpp>
+
 namespace nix {
+
+nlohmann::json BuildableOpaque::toJSON(ref<Store> store) const {
+    nlohmann::json res;
+    res["path"] = store->printStorePath(path);
+    return res;
+}
+
+nlohmann::json BuildableFromDrv::toJSON(ref<Store> store) const {
+    nlohmann::json res;
+    res["drvPath"] = store->printStorePath(drvPath);
+    for (const auto& [output, path] : outputs) {
+        res["outputs"][output] = path ? store->printStorePath(*path) : "";
+    }
+    return res;
+}
+
+nlohmann::json buildablesToJSON(const Buildables & buildables, ref<Store> store) {
+    auto res = nlohmann::json::array();
+    for (const Buildable & buildable : buildables) {
+        std::visit([&res, store](const auto & buildable) {
+            res.push_back(buildable.toJSON(store));
+        }, buildable);
+    }
+    return res;
+}
 
 void completeFlakeInputPath(
     ref<EvalState> evalState,

--- a/src/nix/installables.hh
+++ b/src/nix/installables.hh
@@ -7,6 +7,8 @@
 
 #include <optional>
 
+#include <nlohmann/json_fwd.hpp>
+
 namespace nix {
 
 struct DrvInfo;
@@ -16,11 +18,13 @@ namespace eval_cache { class EvalCache; class AttrCursor; }
 
 struct BuildableOpaque {
     StorePath path;
+    nlohmann::json toJSON(ref<Store> store) const;
 };
 
 struct BuildableFromDrv {
     StorePath drvPath;
     std::map<std::string, std::optional<StorePath>> outputs;
+    nlohmann::json toJSON(ref<Store> store) const;
 };
 
 typedef std::variant<
@@ -29,6 +33,7 @@ typedef std::variant<
 > Buildable;
 
 typedef std::vector<Buildable> Buildables;
+nlohmann::json buildablesToJSON(const Buildables & buildables, ref<Store> store);
 
 struct App
 {

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -1,0 +1,12 @@
+source common.sh
+
+expectedJSONRegex='\[\{"drvPath":".*multiple-outputs-a.drv","outputs":\{"first":".*multiple-outputs-a-first","second":".*multiple-outputs-a-second"}},\{"drvPath":".*multiple-outputs-b.drv","outputs":\{"out":".*multiple-outputs-b"}}]'
+nix build -f multiple-outputs.nix --json a.all b.all | jq --exit-status '
+  (.[0] |
+    (.drvPath | match(".*multiple-outputs-a.drv")) and
+    (.outputs.first | match(".*multiple-outputs-a-first")) and
+    (.outputs.second | match(".*multiple-outputs-a-second")))
+  and (.[1] |
+    (.drvPath | match(".*multiple-outputs-b.drv")) and
+    (.outputs.out | match(".*multiple-outputs-b")))
+'

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -35,7 +35,8 @@ nix_tests = \
   recursive.sh \
   describe-stores.sh \
   flakes.sh \
-  content-addressed.sh
+  content-addressed.sh \
+  build.sh
   # parallel.sh
   # build-remote-content-addressed-fixed.sh \
 


### PR DESCRIPTION
Add --json option to nix build to allow machine readable output on
stdout with all built derivations

Fixes #1930

I think closes #2423 and #1647

Wasn't quite sure is there a better place to put a test?