### PR TITLE
Allow nix.conf options to be set in flake.nix

### DIFF
--- a/src/libexpr/flake/flake.hh
+++ b/src/libexpr/flake/flake.hh
@@ -47,8 +47,16 @@ struct FlakeInput
     FlakeInputs overrides;
 };
 
-// The Flake structure is the main internal representation of a flake.nix file.
+struct ConfigFile
+{
+    using ConfigValue = std::variant<std::string, int64_t, Explicit<bool>, std::vector<std::string>>;
 
+    std::map<std::string, ConfigValue> options;
+
+    void apply();
+};
+
+/* The contents of a flake.nix file. */
 struct Flake
 {
     FlakeRef originalRef;   // the original flake specification (by the user)
@@ -57,6 +65,7 @@ struct Flake
     std::optional<std::string> description;
     std::shared_ptr<const fetchers::Tree> sourceInfo;
     FlakeInputs inputs;
+    ConfigFile config; // 'nixConfig' attribute
     ~Flake();
 };
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -533,8 +533,11 @@ InstallableFlake::getCursors(EvalState & state)
 
 std::shared_ptr<flake::LockedFlake> InstallableFlake::getLockedFlake() const
 {
-    if (!_lockedFlake)
+    if (!_lockedFlake) {
         _lockedFlake = std::make_shared<flake::LockedFlake>(lockFlake(*state, flakeRef, lockFlags));
+        _lockedFlake->flake.config.apply();
+        // FIXME: send new config to the daemon.
+    }
     return _lockedFlake;
 }
 


### PR DESCRIPTION
This makes it possible to have per-project configuration in `flake.nix`, e.g. binary caches and other stuff:

```
nixConfig.bash-prompt-suffix = "[1;35mngi# [0m";
nixConfig.substituters = [ "https://cache.ngi0.nixos.org/" ];
```

@garbas 