### PR TITLE
libstore/filetransfer: set CURLOPT_ACCEPT_ENCODING

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -288,6 +288,7 @@ struct curlFileTransfer : public FileTransfer
             curl_easy_setopt(req, CURLOPT_USERAGENT,
                 ("curl/" LIBCURL_VERSION " Nix/" + nixVersion +
                     (fileTransferSettings.userAgentSuffix != "" ? " " + fileTransferSettings.userAgentSuffix.get() : "")).c_str());
+            curl_easy_setopt(req, CURLOPT_ACCEPT_ENCODING, "");
             #if LIBCURL_VERSION_NUM >= 0x072b00
             curl_easy_setopt(req, CURLOPT_PIPEWAIT, 1);
             #endif


### PR DESCRIPTION
This allows Nix to use transport-level compression, where supported.

As documented on https://curl.haxx.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html, setting an empty string will use libcurl's default.

Also, no tests ran, because `nix-build` failed:

```
ran test tests/gc.sh... [FAIL]
    ++ nix-instantiate dependencies.nix
    gc.sh: line 3: nix-instantiate: command not found
    + drvPath=
```