### PR TITLE
Capitalize JSON for consistency

### DIFF
--- a/src/libexpr/flake/lockfile.cc
+++ b/src/libexpr/flake/lockfile.cc
@@ -35,7 +35,7 @@ LockedNode::LockedNode(const nlohmann::json & json)
 {
     if (!lockedRef.input.isImmutable())
         throw Error("lockfile contains mutable lock '%s'",
-            fetchers::attrsToJson(lockedRef.input.toAttrs()));
+            fetchers::attrsToJSON(lockedRef.input.toAttrs()));
 }
 
 StorePath LockedNode::computeStorePath(Store & store) const
@@ -111,7 +111,7 @@ LockFile::LockFile(const nlohmann::json & json, const Path & path)
     // a bit since we don't need to worry about cycles.
 }
 
-nlohmann::json LockFile::toJson() const
+nlohmann::json LockFile::toJSON() const
 {
     nlohmann::json nodes;
     std::unordered_map<std::shared_ptr<const Node>, std::string> nodeKeys;
@@ -155,8 +155,8 @@ nlohmann::json LockFile::toJson() const
         }
 
         if (auto lockedNode = std::dynamic_pointer_cast<const LockedNode>(node)) {
-            n["original"] = fetchers::attrsToJson(lockedNode->originalRef.toAttrs());
-            n["locked"] = fetchers::attrsToJson(lockedNode->lockedRef.toAttrs());
+            n["original"] = fetchers::attrsToJSON(lockedNode->originalRef.toAttrs());
+            n["locked"] = fetchers::attrsToJSON(lockedNode->lockedRef.toAttrs());
             if (!lockedNode->isFlake) n["flake"] = false;
         }
 
@@ -175,7 +175,7 @@ nlohmann::json LockFile::toJson() const
 
 std::string LockFile::to_string() const
 {
-    return toJson().dump(2);
+    return toJSON().dump(2);
 }
 
 LockFile LockFile::read(const Path & path)
@@ -186,7 +186,7 @@ LockFile LockFile::read(const Path & path)
 
 std::ostream & operator <<(std::ostream & stream, const LockFile & lockFile)
 {
-    stream << lockFile.toJson().dump(2);
+    stream << lockFile.toJSON().dump(2);
     return stream;
 }
 
@@ -224,7 +224,7 @@ bool LockFile::isImmutable() const
 bool LockFile::operator ==(const LockFile & other) const
 {
     // FIXME: slow
-    return toJson() == other.toJson();
+    return toJSON() == other.toJSON();
 }
 
 InputPath parseInputPath(std::string_view s)

--- a/src/libexpr/flake/lockfile.hh
+++ b/src/libexpr/flake/lockfile.hh
@@ -52,7 +52,7 @@ struct LockFile
     LockFile() {};
     LockFile(const nlohmann::json & json, const Path & path);
 
-    nlohmann::json toJson() const;
+    nlohmann::json toJSON() const;
 
     std::string to_string() const;
 

--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -23,7 +23,7 @@ Attrs jsonToAttrs(const nlohmann::json & json)
     return attrs;
 }
 
-nlohmann::json attrsToJson(const Attrs & attrs)
+nlohmann::json attrsToJSON(const Attrs & attrs)
 {
     nlohmann::json json;
     for (auto & attr : attrs) {
@@ -44,7 +44,7 @@ std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::strin
     if (i == attrs.end()) return {};
     if (auto v = std::get_if<std::string>(&i->second))
         return *v;
-    throw Error("input attribute '%s' is not a string %s", name, attrsToJson(attrs).dump());
+    throw Error("input attribute '%s' is not a string %s", name, attrsToJSON(attrs).dump());
 }
 
 std::string getStrAttr(const Attrs & attrs, const std::string & name)

--- a/src/libfetchers/attrs.hh
+++ b/src/libfetchers/attrs.hh
@@ -13,7 +13,7 @@ typedef std::map<std::string, Attr> Attrs;
 
 Attrs jsonToAttrs(const nlohmann::json & json);
 
-nlohmann::json attrsToJson(const Attrs & attrs);
+nlohmann::json attrsToJSON(const Attrs & attrs);
 
 std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::string & name);
 

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -65,7 +65,7 @@ Input Input::fromAttrs(Attrs && attrs)
 ParsedURL Input::toURL() const
 {
     if (!scheme)
-        throw Error("cannot show unsupported input '%s'", attrsToJson(attrs));
+        throw Error("cannot show unsupported input '%s'", attrsToJSON(attrs));
     return scheme->toURL(*this);
 }
 
@@ -110,7 +110,7 @@ bool Input::contains(const Input & other) const
 std::pair<Tree, Input> Input::fetch(ref<Store> store) const
 {
     if (!scheme)
-        throw Error("cannot fetch unsupported input '%s'", attrsToJson(toAttrs()));
+        throw Error("cannot fetch unsupported input '%s'", attrsToJSON(toAttrs()));
 
     /* The tree may already be in the Nix store, or it could be
        substituted (which is often faster than fetching from the
@@ -247,7 +247,7 @@ std::optional<time_t> Input::getLastModified() const
 
 ParsedURL InputScheme::toURL(const Input & input)
 {
-    throw Error("don't know how to convert input '%s' to a URL", attrsToJson(input.attrs));
+    throw Error("don't know how to convert input '%s' to a URL", attrsToJSON(input.attrs));
 }
 
 Input InputScheme::applyOverrides(

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -60,10 +60,10 @@ void Registry::write(const Path & path)
     nlohmann::json arr;
     for (auto & entry : entries) {
         nlohmann::json obj;
-        obj["from"] = attrsToJson(entry.from.toAttrs());
-        obj["to"] = attrsToJson(entry.to.toAttrs());
+        obj["from"] = attrsToJSON(entry.from.toAttrs());
+        obj["to"] = attrsToJSON(entry.to.toAttrs());
         if (!entry.extraAttrs.empty())
-            obj["to"].update(attrsToJson(entry.extraAttrs));
+            obj["to"].update(attrsToJSON(entry.extraAttrs));
         if (entry.exact)
             obj["exact"] = true;
         arr.emplace_back(std::move(obj));

--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -12,7 +12,7 @@ LogFormat parseLogFormat(const std::string & logFormatStr) {
     else if (logFormatStr == "raw-with-logs")
         return LogFormat::rawWithLogs;
     else if (logFormatStr == "internal-json")
-        return LogFormat::internalJson;
+        return LogFormat::internalJSON;
     else if (logFormatStr == "bar")
         return LogFormat::bar;
     else if (logFormatStr == "bar-with-logs")
@@ -26,7 +26,7 @@ Logger * makeDefaultLogger() {
         return makeSimpleLogger(false);
     case LogFormat::rawWithLogs:
         return makeSimpleLogger(true);
-    case LogFormat::internalJson:
+    case LogFormat::internalJSON:
         return makeJSONLogger(*makeSimpleLogger(true));
     case LogFormat::bar:
         return makeProgressBar();

--- a/src/libmain/loggers.hh
+++ b/src/libmain/loggers.hh
@@ -7,7 +7,7 @@ namespace nix {
 enum class LogFormat {
   raw,
   rawWithLogs,
-  internalJson,
+  internalJSON,
   bar,
   barWithLogs,
 };

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -306,7 +306,7 @@ bool handleJSONLogMessage(const std::string & msg,
 
     } catch (std::exception & e) {
         logError({
-            .name = "Json log message",
+            .name = "JSON log message",
             .hint = hintfmt("bad log message from builder: %s", e.what())
         });
     }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -76,17 +76,17 @@ static void printFlakeInfo(const Store & store, const Flake & flake)
             std::put_time(std::localtime(&*lastModified), "%F %T"));
 }
 
-static nlohmann::json flakeToJson(const Store & store, const Flake & flake)
+static nlohmann::json flakeToJSON(const Store & store, const Flake & flake)
 {
     nlohmann::json j;
     if (flake.description)
         j["description"] = *flake.description;
     j["originalUrl"] = flake.originalRef.to_string();
-    j["original"] = fetchers::attrsToJson(flake.originalRef.toAttrs());
+    j["original"] = fetchers::attrsToJSON(flake.originalRef.toAttrs());
     j["resolvedUrl"] = flake.resolvedRef.to_string();
-    j["resolved"] = fetchers::attrsToJson(flake.resolvedRef.toAttrs());
+    j["resolved"] = fetchers::attrsToJSON(flake.resolvedRef.toAttrs());
     j["url"] = flake.lockedRef.to_string(); // FIXME: rename to lockedUrl
-    j["locked"] = fetchers::attrsToJson(flake.lockedRef.toAttrs());
+    j["locked"] = fetchers::attrsToJSON(flake.lockedRef.toAttrs());
     if (auto rev = flake.lockedRef.input.getRev())
         j["revision"] = rev->to_string(Base16, false);
     if (auto revCount = flake.lockedRef.input.getRevCount())
@@ -139,7 +139,7 @@ struct CmdFlakeInfo : FlakeCommand, MixJSON
         auto flake = getFlake();
 
         if (json) {
-            auto json = flakeToJson(*store, flake);
+            auto json = flakeToJSON(*store, flake);
             logger->cout("%s", json.dump());
         } else
             printFlakeInfo(*store, flake);
@@ -158,7 +158,7 @@ struct CmdFlakeListInputs : FlakeCommand, MixJSON
         auto flake = lockFlake();
 
         if (json)
-            logger->cout("%s", flake.lockFile.toJson());
+            logger->cout("%s", flake.lockFile.toJSON());
         else {
             logger->cout("%s", flake.flake.lockedRef);
 


### PR DESCRIPTION
Noticed while writing #4182 that toJSON isn't consistently capitalized, thought I'd just make JSON consistent everywhere.

Is something kinda nitpicky like this helpful or just needless churn?