### PR TITLE
Fix memory corruption caused by GC-invisible coroutine stacks

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -27,6 +27,10 @@
 #include <gc/gc.h>
 #include <gc/gc_cpp.h>
 
+#include <boost/coroutine2/coroutine.hpp>
+#include <boost/coroutine2/protected_fixedsize_stack.hpp>
+#include <boost/context/stack_context.hpp>
+
 #endif
 
 namespace nix {
@@ -220,6 +224,26 @@ static void * oomHandler(size_t requested)
     /* Convert this to a proper C++ exception. */
     throw std::bad_alloc();
 }
+
+class BoehmGCStackAllocator : public StackAllocator {
+  boost::coroutines2::protected_fixedsize_stack stack;
+
+  public:
+    boost::context::stack_context allocate() override {
+        auto sctx = stack.allocate();
+        GC_add_roots(static_cast<char *>(sctx.sp) - sctx.size, sctx.sp);
+        return sctx;
+    }
+
+    void deallocate(boost::context::stack_context sctx) override {
+        GC_remove_roots(static_cast<char *>(sctx.sp) - sctx.size, sctx.sp);
+        stack.deallocate(sctx);
+    }
+
+};
+
+static BoehmGCStackAllocator boehmGCStackAllocator;
+
 #endif
 
 
@@ -256,6 +280,8 @@ void initGC()
     GC_INIT();
 
     GC_set_oom_fn(oomHandler);
+
+    StackAllocator::defaultAllocator = &boehmGCStackAllocator;
 
     /* Set the initial heap size to something fairly big (25% of
        physical RAM, up to a maximum of 384 MiB) so that in most cases

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -226,7 +226,12 @@ static void * oomHandler(size_t requested)
 }
 
 class BoehmGCStackAllocator : public StackAllocator {
-  boost::coroutines2::protected_fixedsize_stack stack;
+  boost::coroutines2::protected_fixedsize_stack stack {
+    // We allocate 8 MB, the default max stack size on NixOS.
+    // A smaller stack might be quicker to allocate but reduces the stack
+    // depth available for source filter expressions etc.
+    std::max(boost::context::stack_traits::default_size(), static_cast<std::size_t>(8 * 1024 * 1024))
+    };
 
   public:
     boost::context::stack_context allocate() override {

--- a/src/libexpr/local.mk
+++ b/src/libexpr/local.mk
@@ -15,7 +15,7 @@ libexpr_CXXFLAGS += -I src/libutil -I src/libstore -I src/libfetchers -I src/lib
 
 libexpr_LIBS = libutil libstore libfetchers
 
-libexpr_LDFLAGS =
+libexpr_LDFLAGS = -lboost_context
 ifneq ($(OS), FreeBSD)
  libexpr_LDFLAGS += -ldl
 endif

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -5,6 +5,7 @@
 #include "types.hh"
 #include "util.hh"
 
+namespace boost::context { struct stack_context; }
 
 namespace nix {
 
@@ -497,5 +498,18 @@ struct FramedSink : nix::BufferedSink
     };
 };
 
+/* Stack allocation strategy for sinkToSource.
+   Mutable to avoid a boehm gc dependency in libutil.
+
+   boost::context doesn't provide a virtual class, so we define our own.
+ */
+struct StackAllocator {
+    virtual boost::context::stack_context allocate() = 0;
+    virtual void deallocate(boost::context::stack_context sctx) = 0;
+
+    /* The stack allocator to use in sinkToSource and potentially elsewhere.
+       It is reassigned by the initGC() method in libexpr. */
+    static StackAllocator *defaultAllocator;
+};
 
 }


### PR DESCRIPTION
Crucially this introduces BoehmGCStackAllocator, but it also
adds a bunch of wiring to avoid making libutil depend on bdw-gc.
The extra wiring, more than half of the PR, can be removed if it's ok to depend on bdw-gc.

Part of the solutions for #4178, #4200

Ping @edolstra 
