### PR TITLE
Restore RestrictedStore.addToStoreFromDump implementation

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2074,6 +2074,14 @@ struct RestrictedStore : public LocalFSStore, public virtual RestrictedStoreConf
         return path;
     }
 
+    StorePath addToStoreFromDump(Source & dump, const string & name,
+        FileIngestionMethod method = FileIngestionMethod::Recursive, HashType hashAlgo = htSHA256, RepairFlag repair = NoRepair) override
+    {
+        auto path = next->addToStoreFromDump(dump, name, method, hashAlgo, repair);
+        goal.addDependency(path);
+        return path;
+    }
+
     void narFromPath(const StorePath & path, Sink & sink) override
     {
         if (!goal.isAllowed(path))


### PR DESCRIPTION
I accidentally removed it in commit ca30abb3fb36440e5a13161c39647189036fc18f

```
addToStoreFromDump() is not supported by this store
```

or similar message.

found by @grahamc 