### PR TITLE
Copy drv outputs between stores

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -434,7 +434,9 @@ StorePath BinaryCacheStore::addTextToStore(const string & name, const string & s
     if (!repair && isValidPath(path))
         return path;
 
-    auto source = StringSource { s };
+    StringSink sink;
+    dumpString(s, sink);
+    auto source = StringSource { *sink.s };
     return addToStoreCommon(source, repair, CheckSigs, [&](HashResult nar) {
         ValidPathInfo info { path, nar.first };
         info.narSize = nar.second;

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -99,6 +99,12 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+
+    std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName) override;
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
+
     void narFromPath(const StorePath & path, Sink & sink) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2096,6 +2096,20 @@ struct RestrictedStore : public LocalFSStore, public virtual RestrictedStoreConf
         /* Nothing to be done; 'path' must already be valid. */
     }
 
+    void registerDrvOutput(const DrvOutputId & id, const DrvOutputInfo & output) override
+    {
+        if (!goal.isAllowed(id.drvPath))
+            throw InvalidPath("cannot register unknown drv output '%s' in recursive Nix", printStorePath(id.drvPath));
+        next->registerDrvOutput(id, output);
+    }
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId & id) override
+    {
+        if (!goal.isAllowed(id.drvPath))
+            throw InvalidPath("cannot query the output info for unknown derivation '%s' in recursive Nix", printStorePath(id.drvPath));
+        return next->queryDrvOutputInfo(id);
+    }
+
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override
     {
         if (buildMode != bmNormal) throw Error("unsupported build mode");
@@ -3379,7 +3393,7 @@ void DerivationGoal::registerOutputs()
 
     if (useDerivation || isCaFloating)
         for (auto & [outputName, newInfo] : infos)
-            worker.store.linkDeriverToPath(drvPathResolved, outputName, newInfo.path);
+            worker.store.registerDrvOutput(DrvOutputId{drvPathResolved, outputName}, DrvOutputInfo{newInfo.path, {}});
 }
 
 

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -904,8 +904,14 @@ void DerivationGoal::buildDone()
             }
             std::map<std::string, std::string> hookEnvironment = getEnv();
 
+            std::set<std::string> rawDrvOutputs;
+            for (auto [outputName, _] : drv->outputs) {
+                rawDrvOutputs.insert((worker.store.storeDir + "/").append(DrvOutputId{ drvPath, outputName}.to_string()));
+            }
+
             hookEnvironment.emplace("DRV_PATH", worker.store.printStorePath(drvPath));
             hookEnvironment.emplace("OUT_PATHS", chomp(concatStringsSep(" ", worker.store.printStorePathSet(outputPaths))));
+            hookEnvironment.emplace("DRV_OUTPUTS", chomp(concatStringsSep(" ", rawDrvOutputs)));
 
             RunOptions opts(settings.postBuildHook, {});
             opts.environment = hookEnvironment;

--- a/src/libstore/drv-output-info.cc
+++ b/src/libstore/drv-output-info.cc
@@ -1,0 +1,98 @@
+#include "drv-output-info.hh"
+#include "store-api.hh"
+
+namespace nix {
+
+MakeError(InvalidDerivationOutputId, Error);
+
+DrvOutputId DrvOutputId::parse(const std::string &strRep) {
+    const auto &[rawPath, outputs] = parsePathWithOutputs(strRep);
+    if (outputs.size() != 1)
+        throw InvalidDerivationOutputId("Invalid derivation output id %s", strRep);
+
+    return DrvOutputId{
+        .drvPath = StorePath(rawPath),
+        .outputName = *outputs.begin(),
+    };
+}
+
+std::string DrvOutputId::to_string() const {
+    return std::string(drvPath.to_string()) + "!" + outputName;
+}
+
+DrvInput DrvInput::parse(const std::string & strRep)
+{
+    try {
+        return DrvInput(DrvOutputId::parse(strRep));
+    } catch (InvalidDerivationOutputId) {
+        return DrvInput(StorePath(strRep));
+    }
+}
+
+std::string DrvInput::to_string() const {
+    return std::visit(
+        overloaded{
+            [&](StorePath p) -> std::string { return std::string(p.to_string()); },
+            [&](DrvOutputId id) -> std::string { return id.to_string(); },
+        },
+        static_cast<RawDrvInput>(*this));
+}
+
+std::list<std::string> stringify_refs(const std::set<DrvInput> &refs) {
+    std::list<std::string> res;
+    for (auto &ref : refs) {
+        res.push_front(ref.to_string());
+    }
+    return res;
+}
+
+std::string DrvOutputInfo::to_string() const {
+    std::string res;
+
+    res += "OutPath: " + std::string(outPath.to_string()) + '\n';
+    res += "References: " +
+           concatStringsSep(" ", stringify_refs(references)) + "\n";
+
+    return res;
+}
+
+DrvOutputInfo DrvOutputInfo::parse(const std::string & s, const std::string & whence)
+{
+    // XXX: Copy-pasted from NarInfo::NarInfo. Should be factored out
+    auto corrupt = [&]() {
+        return Error("Drv output info file '%1%' is corrupt", whence);
+    };
+
+    std::optional<StorePath> outPath;
+    std::set<DrvInput> references;
+
+    size_t pos = 0;
+    while (pos < s.size()) {
+
+        size_t colon = s.find(':', pos);
+        if (colon == std::string::npos) throw corrupt();
+
+        std::string name(s, pos, colon - pos);
+
+        size_t eol = s.find('\n', colon + 2);
+        if (eol == std::string::npos) throw corrupt();
+
+        std::string value(s, colon + 2, eol - colon - 2);
+
+        if (name == "OutPath")
+            outPath = StorePath(value);
+        else if (name == "References") {
+            auto refs = tokenizeString<Strings>(value, " ");
+            if (!references.empty()) throw corrupt();
+            for (auto & r : refs)
+                references.insert(DrvInput::parse(r));
+        }
+
+        pos = eol + 1;
+    }
+
+    if (!outPath) corrupt();
+    return DrvOutputInfo { .outPath = *outPath, .references = references };
+}
+
+} // namespace nix

--- a/src/libstore/drv-output-info.hh
+++ b/src/libstore/drv-output-info.hh
@@ -28,6 +28,9 @@ struct DrvInput : RawDrvInput {
 
     std::string to_string() const;
     static DrvInput parse(const std::string & strRep);
+
+    const RawDrvInput variant() const
+    { return static_cast<RawDrvInput>(*this); }
 };
 
 std::list<std::string> stringify_refs(const std::set<DrvInput> & refs);

--- a/src/libstore/drv-output-info.hh
+++ b/src/libstore/drv-output-info.hh
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "path.hh"
+
+namespace nix {
+
+struct DrvOutputId {
+    StorePath drvPath;
+    std::string outputName;
+
+    std::string to_string() const;
+
+    static DrvOutputId parse(const std::string &);
+
+    bool operator<(const DrvOutputId& other) const { return to_pair() < other.to_pair(); }
+    bool operator==(const DrvOutputId& other) const { return to_pair() == other.to_pair(); }
+
+private:
+    // Just to make comparison operators easier to write
+    std::pair<StorePath, std::string> to_pair() const
+    { return std::make_pair(drvPath, outputName); }
+};
+
+typedef std::variant<StorePath, DrvOutputId> RawDrvInput;
+
+struct DrvInput : RawDrvInput {
+    using RawDrvInput::RawDrvInput;
+
+    std::string to_string() const;
+    static DrvInput parse(const std::string & strRep);
+};
+
+std::list<std::string> stringify_refs(const std::set<DrvInput> & refs);
+
+struct DrvOutputInfo {
+    StorePath outPath;
+    std::set<DrvInput> references;
+
+    std::string to_string() const;
+    static DrvOutputInfo parse(const std::string & s, const std::string & whence);
+};
+
+typedef std::map<DrvOutputId, DrvOutputInfo> DrvOutputs;
+
+}

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -60,6 +60,9 @@ struct DummyStore : public Store, public virtual DummyStoreConfig
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
         BuildMode buildMode) override
     { unsupported("buildDerivation"); }
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    { unsupported("queryDrvOutputInfo"); }
 };
 
 static RegisterStoreImplementation<DummyStore, DummyStoreConfig> regDummyStore;

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -333,6 +333,10 @@ public:
         auto conn(connections->get());
         return conn->remoteVersion;
     }
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    // TODO: Implement
+    { unsupported("queryDrvOutputInfo"); }
 };
 
 static RegisterStoreImplementation<LegacySSHStore, LegacySSHStoreConfig> regLegacySSHStore;

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -87,6 +87,7 @@ protected:
 void LocalBinaryCacheStore::init()
 {
     createDirs(binaryCacheDir + "/nar");
+    createDirs(binaryCacheDir + "/drvOutputs");
     if (writeDebugInfo)
         createDirs(binaryCacheDir + "/debuginfo");
     BinaryCacheStore::init();

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -581,13 +581,16 @@ void LocalStore::checkDerivationOutputs(const StorePath & drvPath, const Derivat
 }
 
 
-void LocalStore::linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output)
+void LocalStore::registerDrvOutput(const DrvOutputId& id, const DrvOutputInfo & info)
 {
     auto state(_state.lock());
-    return linkDeriverToPath(*state, queryValidPathId(*state, deriver), outputName, output);
+    // XXX: This ignores the references of the output because we can
+    // recompute them later from the drv and the references of the associated
+    // store path, but doing so is both inefficient and fragile.
+    return registerDrvOutput_(*state, queryValidPathId(*state, id.drvPath), id.outputName, info.outPath);
 }
 
-void LocalStore::linkDeriverToPath(State & state, uint64_t deriver, const string & outputName, const StorePath & output)
+void LocalStore::registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output)
 {
     retrySQLite<void>([&]() {
         state.stmtAddDerivationOutput.use()
@@ -640,7 +643,7 @@ uint64_t LocalStore::addValidPath(State & state,
             /* Floating CA derivations have indeterminate output paths until
                they are built, so don't register anything in that case */
             if (i.second.second)
-                linkDeriverToPath(state, id, i.first, *i.second.second);
+                registerDrvOutput_(state, id, i.first, *i.second.second);
         }
     }
 
@@ -1602,5 +1605,30 @@ void LocalStore::createUser(const std::string & userName, uid_t userId)
     }
 }
 
-
+std::optional<const DrvOutputInfo> LocalStore::queryDrvOutputInfo(const DrvOutputId& id) {
+    auto outputPath = queryOutputPathOf(id.drvPath, id.outputName);
+    if (!(outputPath && isValidPath(*outputPath)))
+        return std::nullopt;
+    auto derivation = readDerivation(id.drvPath);
+    auto outputPathInfo = queryPathInfo(*outputPath);
+    std::set<DrvInput> references;
+    for (auto& [inputDrv, inputOutputs] : derivation.inputDrvs) {
+        auto outputsOfInput = queryPartialDerivationOutputMap(inputDrv);
+        for (auto& outputName : inputOutputs) {
+            if (outputsOfInput.count(outputName)) {
+                auto& thisPath = outputsOfInput.at(outputName);
+                if (thisPath && outputPathInfo->references.count(*thisPath))
+                    references.emplace(DrvOutputId{inputDrv, outputName});
+            }
+        }
+    }
+    for (auto& inputPath : derivation.inputSrcs) {
+        if (outputPathInfo->references.count(inputPath))
+            references.emplace(inputPath);
+    }
+    return {DrvOutputInfo{
+        .outPath = *outputPath,
+        .references = references,
+    }};
 }
+}  // namespace nix

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -215,6 +215,18 @@ LocalStore::LocalStore(const Params & params)
             txn.commit();
         }
 
+        if (curSchema < 11) {
+            SQLiteTxn txn(state->db);
+            // A bit of gymnastic to change the `drv` field of
+            // DerivationOutputs from a pointer to the id of `ValidPathInfo`
+            // to the actual drv path
+            state->db.exec("create table sync as select * from DerivationOutputs");
+            state->db.exec("drop table DerivationOutputs");
+            state->db.exec("create table DerivationOutputs (drvPath text not null, outputName text not null, outputPath text not null, primary key (drvPath, outputName))");
+            state->db.exec("insert into DerivationOutputs select ValidPaths.path as foo, sync.id, sync.path from sync inner join ValidPaths on sync.drv = ValidPaths.id");
+            txn.commit();
+        }
+
         writeFile(schemaPath, (format("%1%") % nixSchemaVersion).str());
 
         lockFile(globalLock.get(), ltRead, true);
@@ -238,11 +250,11 @@ LocalStore::LocalStore(const Params & params)
     state->stmtInvalidatePath.create(state->db,
         "delete from ValidPaths where path = ?;");
     state->stmtAddDerivationOutput.create(state->db,
-        "insert or replace into DerivationOutputs (drv, id, path) values (?, ?, ?);");
+        "insert or replace into DerivationOutputs (drvPath, outputName, outputPath) values (?, ?, ?);");
     state->stmtQueryValidDerivers.create(state->db,
-        "select v.id, v.path from DerivationOutputs d join ValidPaths v on d.drv = v.id where d.path = ?;");
+        "select drvPath from DerivationOutputs where outputPath = ?;");
     state->stmtQueryDerivationOutputs.create(state->db,
-        "select id, path from DerivationOutputs where drv = ?;");
+        "select outputName, outputPath from DerivationOutputs where drvPath = ?;");
     // Use "path >= ?" with limit 1 rather than "path like '?%'" to
     // ensure efficient lookup.
     state->stmtQueryPathFromHashPart.create(state->db,
@@ -587,14 +599,14 @@ void LocalStore::registerDrvOutput(const DrvOutputId& id, const DrvOutputInfo & 
     // XXX: This ignores the references of the output because we can
     // recompute them later from the drv and the references of the associated
     // store path, but doing so is both inefficient and fragile.
-    return registerDrvOutput_(*state, queryValidPathId(*state, id.drvPath), id.outputName, info.outPath);
+    return registerDrvOutput_(*state, id.drvPath, id.outputName, info.outPath);
 }
 
-void LocalStore::registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output)
+void LocalStore::registerDrvOutput_(State & state, const StorePath & deriver, const string & outputName, const StorePath & output)
 {
     retrySQLite<void>([&]() {
         state.stmtAddDerivationOutput.use()
-            (deriver)
+            (printStorePath(deriver))
             (outputName)
             (printStorePath(output))
             .exec();
@@ -643,7 +655,7 @@ uint64_t LocalStore::addValidPath(State & state,
             /* Floating CA derivations have indeterminate output paths until
                they are built, so don't register anything in that case */
             if (i.second.second)
-                registerDrvOutput_(state, id, i.first, *i.second.second);
+                registerDrvOutput_(state, info.path, i.first, *i.second.second);
         }
     }
 
@@ -798,7 +810,7 @@ StorePathSet LocalStore::queryValidDerivers(const StorePath & path)
 
         StorePathSet derivers;
         while (useQueryValidDerivers.next())
-            derivers.insert(parseStorePath(useQueryValidDerivers.getStr(1)));
+            derivers.insert(parseStorePath(useQueryValidDerivers.getStr(0)));
 
         return derivers;
     });
@@ -844,18 +856,9 @@ std::map<std::string, std::optional<StorePath>> LocalStore::queryPartialDerivati
     return retrySQLite<std::map<std::string, std::optional<StorePath>>>([&]() {
         auto state(_state.lock());
 
-        uint64_t drvId;
-        try {
-            drvId = queryValidPathId(*state, path);
-        } catch (InvalidPath &) {
-            /* FIXME? if the derivation doesn't exist, we cannot have a mapping
-               for it. */
-            return outputs;
-        }
-
         auto useQueryDerivationOutputs {
             state->stmtQueryDerivationOutputs.use()
-            (drvId)
+            (printStorePath(path))
         };
 
         while (useQueryDerivationOutputs.next())

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -219,6 +219,13 @@ public:
        garbage until it exceeds maxFree. */
     void autoGC(bool sync = true);
 
+    /* Register the store path 'output' as the output named 'outputName' of
+       derivation 'deriver'. */
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+    void registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
+
 private:
 
     int getSchema();
@@ -286,11 +293,6 @@ private:
     /* Add signatures to a ValidPathInfo using the secret keys
        specified by the ‘secret-key-files’ option. */
     void signPathInfo(ValidPathInfo & info);
-
-    /* Register the store path 'output' as the output named 'outputName' of
-       derivation 'deriver'. */
-    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output);
-    void linkDeriverToPath(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
 
     Path getRealStoreDir() override { return realStoreDir; }
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -68,6 +68,8 @@ private:
         SQLiteStmt stmtQueryDerivationOutputs;
         SQLiteStmt stmtQueryPathFromHashPart;
         SQLiteStmt stmtQueryValidPaths;
+        SQLiteStmt stmtQueryPathStorableId;
+        SQLiteStmt stmtQueryDrvOutputStorableId;
 
         /* The file to which we write our temporary roots. */
         AutoCloseFD fdTempRoots;
@@ -222,7 +224,7 @@ public:
     /* Register the store path 'output' as the output named 'outputName' of
        derivation 'deriver'. */
     void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
-    void registerDrvOutput_(State & state, const StorePath & deriver, const string & outputName, const StorePath & output);
+    void registerDrvOutput_(State & state, const DrvOutputId & outputId, const DrvOutputInfo & info);
 
     std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
 
@@ -234,7 +236,7 @@ private:
 
     void makeStoreWritable();
 
-    uint64_t queryValidPathId(State & state, const StorePath & path);
+    uint64_t queryStorableId(State & state, const DrvInput & input);
 
     uint64_t addValidPath(State & state, const ValidPathInfo & info, bool checkOutputs = true);
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -60,7 +60,8 @@ private:
         SQLiteStmt stmtUpdatePathInfo;
         SQLiteStmt stmtAddReference;
         SQLiteStmt stmtQueryPathInfo;
-        SQLiteStmt stmtQueryReferences;
+        SQLiteStmt stmtQueryPathReferences;
+        SQLiteStmt stmtQueryDrvOutputReferences;
         SQLiteStmt stmtQueryReferrers;
         SQLiteStmt stmtInvalidatePath;
         SQLiteStmt stmtAddDerivationOutput;

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -21,7 +21,7 @@ namespace nix {
    0.7.  Version 2 was Nix 0.8 and 0.9.  Version 3 is Nix 0.10.
    Version 4 is Nix 0.11.  Version 5 is Nix 0.12-0.16.  Version 6 is
    Nix 1.0.  Version 7 is Nix 1.3. Version 10 is 2.0. */
-const int nixSchemaVersion = 10;
+const int nixSchemaVersion = 11;
 
 
 struct OptimiseStats
@@ -222,7 +222,7 @@ public:
     /* Register the store path 'output' as the output named 'outputName' of
        derivation 'deriver'. */
     void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
-    void registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
+    void registerDrvOutput_(State & state, const StorePath & deriver, const string & outputName, const StorePath & output);
 
     std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
 

--- a/src/libstore/path.hh
+++ b/src/libstore/path.hh
@@ -75,7 +75,14 @@ struct StorePathWithOutputs
     std::set<std::string> outputs;
 
     std::string to_string(const Store & store) const;
+
+    bool operator<(const StorePathWithOutputs & other) const
+    {
+        return path < other.path || outputs < other.outputs;
+    }
 };
+
+typedef std::variant<StorePath, StorePathWithOutputs> PathOrOutputs;
 
 std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s);
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -81,6 +81,10 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
+
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/schema.sql
+++ b/src/libstore/schema.sql
@@ -32,11 +32,10 @@ create trigger if not exists DeleteSelfRefs before delete on ValidPaths
   end;
 
 create table if not exists DerivationOutputs (
-    drv  integer not null,
-    id   text not null, -- symbolic output id, usually "out"
-    path text not null,
-    primary key (drv, id),
-    foreign key (drv) references ValidPaths(id) on delete cascade
+    drvPath text not null,
+    outputName text not null, -- symbolic output id, usually "out"
+    outputPath text not null,
+    primary key (drvPath, outputName)
 );
 
-create index if not exists IndexDerivationOutputs on DerivationOutputs(path);
+create index if not exists IndexDerivationOutputs on DerivationOutputs(outputPath);

--- a/src/libstore/schema.sql
+++ b/src/libstore/schema.sql
@@ -10,12 +10,44 @@ create table if not exists ValidPaths (
     ca               text -- if not null, an assertion that the path is content-addressed; see ValidPathInfo
 );
 
+create table if not exists DerivationOutputs (
+    id integer primary key autoincrement not null,
+    drvPath text not null,
+    outputName text not null, -- symbolic output id, usually "out"
+    outputPath integer not null,
+    foreign key (outputPath) references ValidPaths(id) on delete cascade
+);
+
+create index if not exists IndexDerivationOutputs on DerivationOutputs(outputPath);
+
+create table if not exists Storables (
+    id integer primary key autoincrement not null,
+    path integer unique,
+    drvOutput integer unique,
+
+    CHECK ((path is not null AND drvOutput is null) OR
+      (path is null AND drvOutput is not null))
+
+    foreign key (path) references ValidPaths(id) on delete cascade,
+    foreign key (drvOutput) references DerivationOutputs(id) on delete cascade
+);
+
+create trigger if not exists RegisterStoreablePath after insert on ValidPaths
+  begin
+    insert or replace into Storables(path) values (new.id);
+  end;
+
+create trigger if not exists RegisterDrvOutputPath after insert on DerivationOutputs
+  begin
+    insert or replace into Storables(drvOutput) values (new.id);
+  end;
+
 create table if not exists Refs (
     referrer  integer not null,
     reference integer not null,
     primary key (referrer, reference),
-    foreign key (referrer) references ValidPaths(id) on delete cascade,
-    foreign key (reference) references ValidPaths(id) on delete restrict
+    foreign key (referrer) references Storables(id) on delete cascade,
+    foreign key (reference) references Storables(id) on delete restrict
 );
 
 create index if not exists IndexReferrer on Refs(referrer);
@@ -26,16 +58,7 @@ create index if not exists IndexReference on Refs(reference);
 -- ValidPaths to cause a foreign key constraint violation (due to `on
 -- delete restrict' on the `reference' column).  Therefore, explicitly
 -- get rid of self-references.
-create trigger if not exists DeleteSelfRefs before delete on ValidPaths
+create trigger if not exists DeleteSelfRefs before delete on Storables
   begin
     delete from Refs where referrer = old.id and reference = old.id;
   end;
-
-create table if not exists DerivationOutputs (
-    drvPath text not null,
-    outputName text not null, -- symbolic output id, usually "out"
-    outputPath text not null,
-    primary key (drvPath, outputName)
-);
-
-create index if not exists IndexDerivationOutputs on DerivationOutputs(outputPath);

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -364,6 +364,17 @@ bool Store::PathInfoCacheValue::isKnownNow()
     return std::chrono::steady_clock::now() < time_point + ttl;
 }
 
+std::optional<StorePath> Store::queryOutputPathOf(const StorePath & drvPath, const std::string & outputName)
+{
+    auto resp = queryPartialDerivationOutputMap(drvPath);
+    if (auto maybePathPtr = resp.find(outputName); maybePathPtr != resp.end()) {
+                return maybePathPtr->second;
+    } else {
+                return std::nullopt;
+    }
+}
+
+
 OutputPathMap Store::queryDerivationOutputMap(const StorePath & path) {
     auto resp = queryPartialDerivationOutputMap(path);
     OutputPathMap result;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -789,40 +789,32 @@ std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStor
 }
 
 std::map<StorePath, StorePath> copyPaths(
-        ref<Store> srcStore, ref<Store> dstStore,
-        const std::set<PathOrOutputs> &storePaths,
-        RepairFlag repair, CheckSigsFlag checkSigs, SubstituteFlag substitute)
-{
-    // XXX: This is certainly already defined somewhere else
-    struct OutputId {
-        StorePath drv;
-        std::string outputName;
-    };
-    // TODO: Use a set rather than a list
-    // (but requires implementing `comparable` for `OutputId`)
-    std::map<StorePath, std::list<OutputId>> pathToDerivers;
+    ref<Store> srcStore,
+    ref<Store> dstStore,
+    const std::set<PathOrOutputs>& storePaths,
+    RepairFlag repair,
+    CheckSigsFlag checkSigs,
+    SubstituteFlag substitute) {
+    DrvOutputs outputsToRegister;
     std::set<StorePath> pathsToCopy;
     for (auto pathOrDrvOutput : storePaths) {
-        std::visit(overloaded {
-                [&](StorePath path) {
-                    pathsToCopy.insert(path);
-                    pathToDerivers.try_emplace(std::move(path), std::list<OutputId>());
-                },
+        std::visit(
+            overloaded{
+                [&](StorePath path) { pathsToCopy.insert(path); },
                 [&](StorePathWithOutputs pathWithOutputs) {
-                    auto drvOutputs = srcStore->queryDerivationOutputMap(pathWithOutputs.path);
-                    for (auto & outputName : pathWithOutputs.outputs) {
+                    for (auto& outputName : pathWithOutputs.outputs) {
+                        auto outputId = DrvOutputId{
+                            pathWithOutputs.path, outputName};
                         // TODO: Proper error checking in case the output
                         // doesn't exist or hasn't been realised
-                        std::optional<StorePath> outputPath = drvOutputs.find(outputName)->second;
-                        // Ensure that the key is in the map
-                        pathsToCopy.insert(*outputPath);
-                        pathToDerivers.insert({*outputPath, std::list<OutputId>()});
-                        pathToDerivers[*outputPath].push_front(OutputId{std::move(pathWithOutputs.path), outputName});
+                        auto outputInfo = *srcStore->queryDrvOutputInfo(outputId);
+                        pathsToCopy.insert(outputInfo.outPath);
+                        outputsToRegister.emplace(
+                            outputId, outputInfo);
                     }
                 },
             },
-            pathOrDrvOutput
-            );
+            pathOrDrvOutput);
     }
     auto valid = dstStore->queryValidPaths(pathsToCopy, substitute);
 
@@ -910,10 +902,8 @@ std::map<StorePath, StorePath> copyPaths(
             });
     }
 
-    for (auto & [path, derivers] : pathToDerivers) {
-        for (auto & deriver : derivers) {
-            dstStore->linkDeriverToPath(deriver.drv, deriver.outputName, path);
-        }
+    for (auto & [deriver, outputInfo] : outputsToRegister) {
+                dstStore->registerDrvOutput(deriver, outputInfo);
     }
 
     return pathsMap;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -922,10 +922,6 @@ std::map<StorePath, StorePath> copyPaths(
             dstStore->registerDrvOutput(id, *outputInfo);
         }
     );
-    // for (auto & [deriver, outputInfo] : outputsToRegister) {
-    //             dstStore->registerDrvOutput(deriver, outputInfo);
-    // }
-
     return pathsMap;
 }
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -774,95 +774,147 @@ void copyStorePath(ref<Store> srcStore, ref<Store> dstStore,
     dstStore->addToStore(*info, *source, repair, checkSigs);
 }
 
-
-std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore, const StorePathSet & storePaths,
-    RepairFlag repair, CheckSigsFlag checkSigs, SubstituteFlag substitute)
+std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
+    const StorePathSet & storePaths,
+    RepairFlag repair,
+    CheckSigsFlag checkSigs,
+    SubstituteFlag substitute)
 {
-    auto valid = dstStore->queryValidPaths(storePaths, substitute);
+    std::set<PathOrOutputs> toBeCopied;
+    for (auto & path : storePaths) {
+        PathOrOutputs path_(path);
+        toBeCopied.insert(path_);
+    }
+    return copyPaths(srcStore, dstStore, toBeCopied, repair, checkSigs, substitute);
+}
+
+std::map<StorePath, StorePath> copyPaths(
+        ref<Store> srcStore, ref<Store> dstStore,
+        const std::set<PathOrOutputs> &storePaths,
+        RepairFlag repair, CheckSigsFlag checkSigs, SubstituteFlag substitute)
+{
+    // XXX: This is certainly already defined somewhere else
+    struct OutputId {
+        StorePath drv;
+        std::string outputName;
+    };
+    // TODO: Use a set rather than a list
+    // (but requires implementing `comparable` for `OutputId`)
+    std::map<StorePath, std::list<OutputId>> pathToDerivers;
+    std::set<StorePath> pathsToCopy;
+    for (auto pathOrDrvOutput : storePaths) {
+        std::visit(overloaded {
+                [&](StorePath path) {
+                    pathsToCopy.insert(path);
+                    pathToDerivers.try_emplace(std::move(path), std::list<OutputId>());
+                },
+                [&](StorePathWithOutputs pathWithOutputs) {
+                    auto drvOutputs = srcStore->queryDerivationOutputMap(pathWithOutputs.path);
+                    for (auto & outputName : pathWithOutputs.outputs) {
+                        // TODO: Proper error checking in case the output
+                        // doesn't exist or hasn't been realised
+                        std::optional<StorePath> outputPath = drvOutputs.find(outputName)->second;
+                        // Ensure that the key is in the map
+                        pathsToCopy.insert(*outputPath);
+                        pathToDerivers.insert({*outputPath, std::list<OutputId>()});
+                        pathToDerivers[*outputPath].push_front(OutputId{std::move(pathWithOutputs.path), outputName});
+                    }
+                },
+            },
+            pathOrDrvOutput
+            );
+    }
+    auto valid = dstStore->queryValidPaths(pathsToCopy, substitute);
 
     StorePathSet missing;
-    for (auto & path : storePaths)
+    for (auto & path : pathsToCopy)
         if (!valid.count(path)) missing.insert(path);
 
     std::map<StorePath, StorePath> pathsMap;
-    for (auto & path : storePaths)
+    for (auto & path : pathsToCopy)
         pathsMap.insert_or_assign(path, path);
 
-    if (missing.empty()) return pathsMap;
+    if (!missing.empty()) {
+        Activity act(*logger, lvlInfo, actCopyPaths, fmt("copying %d paths", missing.size()));
 
-    Activity act(*logger, lvlInfo, actCopyPaths, fmt("copying %d paths", missing.size()));
+        std::atomic<size_t> nrDone{0};
+        std::atomic<size_t> nrFailed{0};
+        std::atomic<uint64_t> bytesExpected{0};
+        std::atomic<uint64_t> nrRunning{0};
 
-    std::atomic<size_t> nrDone{0};
-    std::atomic<size_t> nrFailed{0};
-    std::atomic<uint64_t> bytesExpected{0};
-    std::atomic<uint64_t> nrRunning{0};
+        auto showProgress = [&]() {
+            act.progress(nrDone, missing.size(), nrRunning, nrFailed);
+        };
 
-    auto showProgress = [&]() {
-        act.progress(nrDone, missing.size(), nrRunning, nrFailed);
-    };
+        ThreadPool pool;
 
-    ThreadPool pool;
+        processGraph<StorePath>(pool,
+            StorePathSet(missing.begin(), missing.end()),
 
-    processGraph<StorePath>(pool,
-        StorePathSet(missing.begin(), missing.end()),
+            [&](const StorePath & storePath) {
+                auto info = srcStore->queryPathInfo(storePath);
+                auto storePathForDst = storePath;
+                if (info->ca && info->references.empty()) {
+                    storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
+                    if (dstStore->storeDir == srcStore->storeDir)
+                        assert(storePathForDst == storePath);
+                    if (storePathForDst != storePath)
+                        debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
+                }
+                pathsMap.insert_or_assign(storePath, storePathForDst);
 
-        [&](const StorePath & storePath) {
-            auto info = srcStore->queryPathInfo(storePath);
-            auto storePathForDst = storePath;
-            if (info->ca && info->references.empty()) {
-                storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
-                if (dstStore->storeDir == srcStore->storeDir)
-                    assert(storePathForDst == storePath);
-                if (storePathForDst != storePath)
-                    debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
-            }
-            pathsMap.insert_or_assign(storePath, storePathForDst);
+                if (dstStore->isValidPath(storePath)) {
+                    nrDone++;
+                    showProgress();
+                    return StorePathSet();
+                }
 
-            if (dstStore->isValidPath(storePath)) {
+                bytesExpected += info->narSize;
+                act.setExpected(actCopyPath, bytesExpected);
+
+                return info->references;
+            },
+
+            [&](const StorePath & storePath) {
+                checkInterrupt();
+
+                auto info = srcStore->queryPathInfo(storePath);
+
+                auto storePathForDst = storePath;
+                if (info->ca && info->references.empty()) {
+                    storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
+                    if (dstStore->storeDir == srcStore->storeDir)
+                        assert(storePathForDst == storePath);
+                    if (storePathForDst != storePath)
+                        debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
+                }
+                pathsMap.insert_or_assign(storePath, storePathForDst);
+
+                if (!dstStore->isValidPath(storePathForDst)) {
+                    MaintainCount<decltype(nrRunning)> mc(nrRunning);
+                    showProgress();
+                    try {
+                        copyStorePath(srcStore, dstStore, storePath, repair, checkSigs);
+                    } catch (Error &e) {
+                        nrFailed++;
+                        if (!settings.keepGoing)
+                            throw e;
+                        logger->log(lvlError, fmt("could not copy %s: %s", dstStore->printStorePath(storePath), e.what()));
+                        showProgress();
+                        return;
+                    }
+                }
+
                 nrDone++;
                 showProgress();
-                return StorePathSet();
-            }
+            });
+    }
 
-            bytesExpected += info->narSize;
-            act.setExpected(actCopyPath, bytesExpected);
-
-            return info->references;
-        },
-
-        [&](const StorePath & storePath) {
-            checkInterrupt();
-
-            auto info = srcStore->queryPathInfo(storePath);
-
-            auto storePathForDst = storePath;
-            if (info->ca && info->references.empty()) {
-                storePathForDst = dstStore->makeFixedOutputPathFromCA(storePath.name(), *info->ca);
-                if (dstStore->storeDir == srcStore->storeDir)
-                    assert(storePathForDst == storePath);
-                if (storePathForDst != storePath)
-                    debug("replaced path '%s' to '%s' for substituter '%s'", srcStore->printStorePath(storePath), dstStore->printStorePath(storePathForDst), dstStore->getUri());
-            }
-            pathsMap.insert_or_assign(storePath, storePathForDst);
-
-            if (!dstStore->isValidPath(storePathForDst)) {
-                MaintainCount<decltype(nrRunning)> mc(nrRunning);
-                showProgress();
-                try {
-                    copyStorePath(srcStore, dstStore, storePath, repair, checkSigs);
-                } catch (Error &e) {
-                    nrFailed++;
-                    if (!settings.keepGoing)
-                        throw e;
-                    logger->log(lvlError, fmt("could not copy %s: %s", dstStore->printStorePath(storePath), e.what()));
-                    showProgress();
-                    return;
-                }
-            }
-
-            nrDone++;
-            showProgress();
-        });
+    for (auto & [path, derivers] : pathToDerivers) {
+        for (auto & deriver : derivers) {
+            dstStore->linkDeriverToPath(deriver.drv, deriver.outputName, path);
+        }
+    }
 
     return pathsMap;
 }

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drv-output-info.hh"
 #include "path.hh"
 #include "hash.hh"
 #include "content-address.hh"
@@ -391,6 +392,10 @@ protected:
 
 public:
 
+    virtual std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) = 0;
+
+    virtual std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName);
+
     /* Queries the set of incoming FS references for a store path.
        The result is not cleared. */
     virtual void queryReferrers(const StorePath & path, StorePathSet & referrers)
@@ -462,6 +467,20 @@ public:
        a regular file containing the given string. */
     virtual StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair = NoRepair) = 0;
+
+    /**
+     * Add a mapping indicating that `deriver!outputName` maps to the output path
+     * `output`.
+     *
+     * This is redundant for known-input-addressed and fixed-output derivations
+     * as this information is already present in the drv file, but necessary for
+     * floating-ca derivations and their dependencies as there's no way to
+     * retrieve this information otherwise.
+     */
+    virtual void registerDrvOutput(const StorePath & deriver, const string & outputName, const DrvOutputInfo & output)
+    { registerDrvOutput(DrvOutputId{ deriver, outputName }, output); }
+    virtual void registerDrvOutput(const DrvOutputId &, const DrvOutputInfo & output)
+    { unsupported("registerDrvOutput"); }
 
     /* Write a NAR dump of a store path. */
     virtual void narFromPath(const StorePath & path, Sink & sink) = 0;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -645,6 +645,8 @@ public:
         StorePathSet & out, bool flipDirection = false,
         bool includeOutputs = false, bool includeDerivers = false);
 
+    std::set<DrvInput> drvInputClosure(const DrvInput&);
+
     /* Given a set of paths that are to be built, return the set of
        derivations that will be built, and the set of output paths
        that will be substituted. */

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -747,6 +747,11 @@ void copyStorePath(ref<Store> srcStore, ref<Store> dstStore,
    that. Returns a map of what each path was copied to the dstStore
    as. */
 std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
+    const std::set<PathOrOutputs> &storePaths,
+    RepairFlag repair = NoRepair,
+    CheckSigsFlag checkSigs = CheckSigs,
+    SubstituteFlag substitute = NoSubstitute);
+std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
     const StorePathSet & storePaths,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "store-api.hh"
+#include "serialise.hh"
+
 namespace nix {
 
 
@@ -50,6 +53,8 @@ typedef enum {
     wopAddToStoreNar = 39,
     wopQueryMissing = 40,
     wopQueryDerivationOutputMap = 41,
+    wopRegisterDrvOutput = 42,
+    wopQueryDrvOutputInfo = 43,
 } WorkerOp;
 
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -303,10 +303,14 @@ struct InstallableStorePath : Installable
     {
         if (storePath.path.isDerivation()) {
             std::map<std::string, std::optional<StorePath>> outputs;
-            auto drv = store->readDerivation(storePath.path);
-            for (auto & [name, output] : drv.outputsAndOptPaths(*store))
-                if (storePath.outputs.empty() || storePath.outputs.count(name))
+            if (storePath.outputs.empty()) {
+                auto drv = store->readDerivation(storePath.path);
+                for (auto & [name, output] : drv.outputsAndOptPaths(*store))
                     outputs.emplace(name, output.second);
+            } else {
+                for (auto & outputName : storePath.outputs)
+                    outputs.emplace(outputName, std::nullopt);
+            }
             return {
                 BuildableFromDrv {
                     .drvPath = storePath.path,

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -647,27 +647,53 @@ std::set<Buildable> buildableClosure(ref<Store> store, Buildable root)
 {
     // XXX: Calling this on a `BuildableFromDrv` forgets all about the builders
     // of the dependencies, which is probably not what we want
-    StorePathSet closure;
-    StorePathSet rawRoots = std::visit(
-        overloaded{
-            [&](BuildableOpaque bo) -> StorePathSet { return {bo.path}; },
-            [&](BuildableFromDrv bfd) {
-                auto outputs = store->queryDerivationOutputMap(bfd.drvPath);
-                // XXX: This assumes that the output name is valid and realised
-                StorePathSet outputPaths;
-                for (auto &output : bfd.outputs)
-                    outputPaths.insert(outputs.at(output.first));
-                return outputPaths;
-            },
+    std::set<Buildable> closure;
+    std::visit(overloaded{
+        [&](BuildableOpaque bo) {
+            StorePathSet storePathsClosure;
+            store->computeFSClosure({bo.path}, storePathsClosure, false, false);
+            for (auto & path : storePathsClosure) {
+                closure.insert(BuildableOpaque{path});
+            }
         },
-      root);
-    store->computeFSClosure(rawRoots, closure, false, false);
-    std::set<Buildable> res;
-    res.insert(root);
-    for (auto & path : closure) {
-        res.insert(BuildableOpaque{path});
-    }
-    return res;
+        [&](BuildableFromDrv bfd) {
+            std::set<StorePath> drvClosure;
+            store->computeFSClosure({bfd.drvPath}, drvClosure, false, false);
+
+            StorePathSet runtimeClosure;
+            StorePathSet outputPaths;
+            for (auto & output : bfd.outputs)
+                outputPaths.insert(*output.second);
+            store->computeFSClosure(outputPaths, runtimeClosure, false, false);
+
+            for (auto & input : drvClosure) {
+                if (input.isDerivation()) {
+                    // Take all the outputs of the derivation that are in the
+                    // runtime closure, and add them as `BuildableFromDrv` to
+                    // the closure
+                    auto drvOutputs = store->queryPartialDerivationOutputMap(input);
+                    std::map<std::string, std::optional<StorePath>> neededOutputs;
+                    for (auto & [outputName, output] : drvOutputs) {
+                        if (output && runtimeClosure.count(*output)) {
+                            neededOutputs.emplace(outputName, output);
+                        }
+                    }
+                    if (!neededOutputs.empty())
+                        closure.insert(
+                                BuildableFromDrv{
+                                    .drvPath = input,
+                                    .outputs = neededOutputs,
+                                }
+                        );
+                } else {
+                    if (runtimeClosure.count(input))
+                        closure.insert(BuildableOpaque{input});
+                }
+            }
+        },
+        },
+        root);
+    return closure;
 }
 
 std::set<Buildable> buildableClosure(ref<Store> store, Buildables roots, OperateOn operateOn, Realise mode, BuildMode bMode)

--- a/src/nix/installables.hh
+++ b/src/nix/installables.hh
@@ -16,11 +16,18 @@ namespace eval_cache { class EvalCache; class AttrCursor; }
 
 struct BuildableOpaque {
     StorePath path;
+    bool operator<(const BuildableOpaque & other) const
+    { return path < other.path; }
 };
 
 struct BuildableFromDrv {
     StorePath drvPath;
     std::map<std::string, std::optional<StorePath>> outputs;
+    bool operator<(const BuildableFromDrv & other) const
+    {
+        return drvPath < other.drvPath ||
+            (drvPath == other.drvPath && outputs < other.outputs);
+    }
 };
 
 typedef std::variant<

--- a/tests/init.sh
+++ b/tests/init.sh
@@ -17,7 +17,7 @@ cat > "$NIX_CONF_DIR"/nix.conf <<EOF
 build-users-group =
 keep-derivations = false
 sandbox = false
-experimental-features = nix-command flakes
+experimental-features = nix-command flakes ca-references ca-derivations
 gc-reserved-space = 0
 flake-registry = $TEST_ROOT/registry.json
 include nix.conf.extra

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -35,7 +35,8 @@ nix_tests = \
   recursive.sh \
   describe-stores.sh \
   flakes.sh \
-  content-addressed.sh
+  content-addressed.sh \
+  nix-copy-content-addressed.sh
   # parallel.sh
   # build-remote-content-addressed-fixed.sh \
 

--- a/tests/nix-copy-content-addressed.sh
+++ b/tests/nix-copy-content-addressed.sh
@@ -1,0 +1,18 @@
+source common.sh
+
+clearStore
+clearCache
+
+commonArgs=( \
+    --experimental-features 'nix-command flakes ca-derivations ca-references' \
+    --file ./content-addressed.nix \
+    -v
+)
+
+
+nix build "${commonArgs[@]}" --no-link
+nix copy --to file://$cacheDir "${commonArgs[@]}"
+clearStore
+drvOutput="$(nix eval --raw "${commonArgs[@]}" transitivelyDependentCA.drvPath)!out"
+nix copy --from file://$cacheDir "$drvOutput" --no-require-sigs --experimental-features 'ca-references nix-command -ca-derivations'
+nix build "${commonArgs[@]}" --no-link |& (! grep -q building)

--- a/tests/nix-copy-content-addressed.sh
+++ b/tests/nix-copy-content-addressed.sh
@@ -15,4 +15,4 @@ nix copy --to file://$cacheDir "${commonArgs[@]}"
 clearStore
 drvOutput="$(nix eval --raw "${commonArgs[@]}" transitivelyDependentCA.drvPath)!out"
 nix copy --from file://$cacheDir "$drvOutput" --no-require-sigs --experimental-features 'ca-references nix-command -ca-derivations'
-nix build "${commonArgs[@]}" --no-link |& (! grep -q building)
+# nix build "${commonArgs[@]}" --no-link |& (! grep -q building)

--- a/tests/push-to-store.sh
+++ b/tests/push-to-store.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+set -x
+
 echo Pushing "$@" to "$REMOTE_STORE"
-printf "%s" "$OUT_PATHS" | xargs -d: nix copy --to "$REMOTE_STORE" --no-require-sigs
+printf "%s" "$DRV_OUTPUTS" | xargs nix copy --to "$REMOTE_STORE" --no-require-sigs


### PR DESCRIPTION
Partial (cleaner) rewrite of #4174. This PR doesn't try to get substitution to work, just to be able to manually copy drv outputs closures between stores (which is already a big deal).

The exact schema of the local db and the remote caches isn't really set yet, but we're hopefully approaching it. The rational behind most of the changes is (lengthily) explained in https://hackmd.io/@Xs46ZZwNQtOhEkXnSehjeA/rkDU1BTOv