### PR TITLE
Minimal implementation of a drv outputs copy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,11 @@
       # 'nix.perl-bindings' packages.
       overlay = final: prev: {
 
+        # An older version of Nix to test against when using the daemon.
+        # Currently using `nixUnstable` as the stable one doesn't respect
+        # `NIX_DAEMON_SOCKET_PATH` which is needed for the tests.
+        mainstream-nix = prev.nixUnstable;
+
         nix = with final; with commonDeps pkgs; (stdenv.mkDerivation {
           name = "nix-${version}";
           inherit version;
@@ -122,6 +127,8 @@
           src = self;
 
           VERSION_SUFFIX = versionSuffix;
+
+          OUTER_NIX = mainstream-nix;
 
           outputs = [ "out" "dev" "doc" ];
 
@@ -483,6 +490,8 @@
 
         stdenv.mkDerivation {
           name = "nix";
+
+          OUTER_NIX = mainstream-nix;
 
           outputs = [ "out" "dev" "doc" ];
 

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -434,7 +434,9 @@ StorePath BinaryCacheStore::addTextToStore(const string & name, const string & s
     if (!repair && isValidPath(path))
         return path;
 
-    auto source = StringSource { s };
+    StringSink sink;
+    dumpString(s, sink);
+    auto source = StringSource { *sink.s };
     return addToStoreCommon(source, repair, CheckSigs, [&](HashResult nar) {
         ValidPathInfo info { path, nar.first };
         info.narSize = nar.second;

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -99,6 +99,12 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+
+    std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName) override;
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
+
     void narFromPath(const StorePath & path, Sink & sink) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -493,8 +493,8 @@ void DerivationGoal::inputsRealised()
     if (useDerivation) {
         auto & fullDrv = *dynamic_cast<Derivation *>(drv.get());
 
-        if ((!fullDrv.inputDrvs.empty() &&
-             fullDrv.type() == DerivationType::CAFloating) || fullDrv.type() == DerivationType::DeferredInputAddressed) {
+        if ((!fullDrv.inputDrvs.empty() && derivationIsCA(fullDrv.type()))
+            || fullDrv.type() == DerivationType::DeferredInputAddressed) {
             /* We are be able to resolve this derivation based on the
                now-known results of dependencies. If so, we become a stub goal
                aliasing that resolved derivation goal */

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -904,8 +904,14 @@ void DerivationGoal::buildDone()
             }
             std::map<std::string, std::string> hookEnvironment = getEnv();
 
+            std::set<std::string> rawDrvOutputs;
+            for (auto [outputName, _] : drv->outputs) {
+                rawDrvOutputs.insert((worker.store.storeDir + "/").append(DrvOutputId{ drvPath, outputName}.to_string()));
+            }
+
             hookEnvironment.emplace("DRV_PATH", worker.store.printStorePath(drvPath));
             hookEnvironment.emplace("OUT_PATHS", chomp(concatStringsSep(" ", worker.store.printStorePathSet(outputPaths))));
+            hookEnvironment.emplace("DRV_OUTPUTS", chomp(concatStringsSep(" ", rawDrvOutputs)));
 
             RunOptions opts(settings.postBuildHook, {});
             opts.environment = hookEnvironment;

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -493,8 +493,9 @@ void DerivationGoal::inputsRealised()
     if (useDerivation) {
         auto & fullDrv = *dynamic_cast<Derivation *>(drv.get());
 
-        if ((!fullDrv.inputDrvs.empty() && derivationIsCA(fullDrv.type()))
-            || fullDrv.type() == DerivationType::DeferredInputAddressed) {
+        if (settings.isExperimentalFeatureEnabled("ca-derivations") &&
+            ((!fullDrv.inputDrvs.empty() && derivationIsCA(fullDrv.type()))
+            || fullDrv.type() == DerivationType::DeferredInputAddressed)) {
             /* We are be able to resolve this derivation based on the
                now-known results of dependencies. If so, we become a stub goal
                aliasing that resolved derivation goal */
@@ -3420,7 +3421,8 @@ void DerivationGoal::registerOutputs()
         drvPathResolved = writeDerivation(worker.store, drv2);
     }
 
-    if (useDerivation || isCaFloating)
+    if (settings.isExperimentalFeatureEnabled("ca-derivations") &&
+        (useDerivation || isCaFloating))
         for (auto & [outputName, newInfo] : infos)
             worker.store.registerDrvOutput(DrvOutputId{drvPathResolved, outputName}, DrvOutputInfo{newInfo.path});
 }

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2096,6 +2096,20 @@ struct RestrictedStore : public LocalFSStore, public virtual RestrictedStoreConf
         /* Nothing to be done; 'path' must already be valid. */
     }
 
+    void registerDrvOutput(const DrvOutputId & id, const DrvOutputInfo & output) override
+    {
+        if (!goal.isAllowed(id.drvPath))
+            throw InvalidPath("cannot register unknown drv output '%s' in recursive Nix", printStorePath(id.drvPath));
+        next->registerDrvOutput(id, output);
+    }
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId & id) override
+    {
+        if (!goal.isAllowed(id.drvPath))
+            throw InvalidPath("cannot query the output info for unknown derivation '%s' in recursive Nix", printStorePath(id.drvPath));
+        return next->queryDrvOutputInfo(id);
+    }
+
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override
     {
         if (buildMode != bmNormal) throw Error("unsupported build mode");
@@ -3393,7 +3407,7 @@ void DerivationGoal::registerOutputs()
 
     if (useDerivation || isCaFloating)
         for (auto & [outputName, newInfo] : infos)
-            worker.store.linkDeriverToPath(drvPathResolved, outputName, newInfo.path);
+            worker.store.registerDrvOutput(DrvOutputId{drvPathResolved, outputName}, DrvOutputInfo{newInfo.path});
 }
 
 

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -64,6 +64,11 @@ struct DerivationGoal : public Goal
 
     std::unique_ptr<ParsedDerivation> parsedDrv;
 
+    /* Path to the corresponding resolved derivation,
+     *  if we're not already resolved
+     */
+    std::optional<StorePath> resolvedDrvPath;
+
     /* The remainder is state held during the build. */
 
     /* Locks on (fixed) output paths. */

--- a/src/libstore/ca-specific-schema.sql
+++ b/src/libstore/ca-specific-schema.sql
@@ -1,0 +1,13 @@
+-- Extension of the sql schema for content-addressed derivations.
+-- Won't be loaded unless the experimental feature `ca-derivations`
+-- is enabled
+
+create table if not exists OutputMappings (
+    id integer primary key autoincrement not null,
+    drvPath text not null,
+    outputName text not null, -- symbolic output id, usually "out"
+    outputPath integer not null,
+    foreign key (outputPath) references ValidPaths(id) on delete cascade
+);
+
+create index if not exists IndexOutputMappings on OutputMappings(outputPath);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -866,6 +866,29 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case wopRegisterDrvOutput: {
+        logger->startWork();
+        auto outputId = DrvOutputId::parse(readString(from));
+        auto outputPath = StorePath(readString(from));
+        store->registerDrvOutput(outputId, DrvOutputInfo{outputPath});
+        logger->stopWork();
+        break;
+    }
+
+    case wopQueryDrvOutputInfo: {
+        logger->startWork();
+        auto outputId = DrvOutputId::parse(readString(from));
+        auto info = store->queryDrvOutputInfo(outputId);
+        logger->stopWork();
+        if (info) {
+            to << std::string(info->outPath.to_string());
+        }
+        else {
+            to << "";
+        }
+        break;
+    }
+
     default:
         throw Error("invalid operation %1%", op);
     }

--- a/src/libstore/drv-output-info.cc
+++ b/src/libstore/drv-output-info.cc
@@ -1,0 +1,82 @@
+#include "drv-output-info.hh"
+#include "store-api.hh"
+
+namespace nix {
+
+MakeError(InvalidDerivationOutputId, Error);
+
+DrvOutputId DrvOutputId::parse(const std::string &strRep) {
+    const auto &[rawPath, outputs] = parsePathWithOutputs(strRep);
+    if (outputs.size() != 1)
+        throw InvalidDerivationOutputId("Invalid derivation output id %s", strRep);
+
+    return DrvOutputId{
+        .drvPath = StorePath(rawPath),
+        .outputName = *outputs.begin(),
+    };
+}
+
+std::string DrvOutputId::to_string() const {
+    return std::string(drvPath.to_string()) + "!" + outputName;
+}
+
+DrvInput DrvInput::parse(const std::string & strRep)
+{
+    try {
+        return DrvInput(DrvOutputId::parse(strRep));
+    } catch (InvalidDerivationOutputId) {
+        return DrvInput(StorePath(strRep));
+    }
+}
+
+std::string DrvInput::to_string() const {
+    return std::visit(
+        overloaded{
+            [&](StorePath p) -> std::string { return std::string(p.to_string()); },
+            [&](DrvOutputId id) -> std::string { return id.to_string(); },
+        },
+        static_cast<RawDrvInput>(*this));
+}
+
+std::string DrvOutputInfo::to_string() const {
+    std::string res;
+
+    res += "OutPath: " + std::string(outPath.to_string()) + '\n';
+
+    return res;
+}
+
+DrvOutputInfo DrvOutputInfo::parse(const std::string & s, const std::string & whence)
+{
+    // XXX: Copy-pasted from NarInfo::NarInfo. Should be factored out
+    auto corrupt = [&]() {
+        return Error("Drv output info file '%1%' is corrupt", whence);
+    };
+
+    std::optional<StorePath> outPath;
+    std::set<DrvInput> references;
+
+    size_t pos = 0;
+    while (pos < s.size()) {
+
+        size_t colon = s.find(':', pos);
+        if (colon == std::string::npos) throw corrupt();
+
+        std::string name(s, pos, colon - pos);
+
+        size_t eol = s.find('\n', colon + 2);
+        if (eol == std::string::npos) throw corrupt();
+
+        std::string value(s, colon + 2, eol - colon - 2);
+
+        if (name == "OutPath")
+            outPath = StorePath(value);
+
+        pos = eol + 1;
+    }
+
+    if (!outPath) corrupt();
+    return DrvOutputInfo { .outPath = *outPath };
+}
+
+} // namespace nix

--- a/src/libstore/drv-output-info.hh
+++ b/src/libstore/drv-output-info.hh
@@ -28,6 +28,9 @@ struct DrvInput : RawDrvInput {
 
     std::string to_string() const;
     static DrvInput parse(const std::string & strRep);
+
+    const RawDrvInput variant() const
+    { return static_cast<RawDrvInput>(*this); }
 };
 
 struct DrvOutputInfo {

--- a/src/libstore/drv-output-info.hh
+++ b/src/libstore/drv-output-info.hh
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "path.hh"
+
+namespace nix {
+
+struct DrvOutputId {
+    StorePath drvPath;
+    std::string outputName;
+
+    std::string to_string() const;
+
+    static DrvOutputId parse(const std::string &);
+
+    bool operator<(const DrvOutputId& other) const { return to_pair() < other.to_pair(); }
+    bool operator==(const DrvOutputId& other) const { return to_pair() == other.to_pair(); }
+
+private:
+    // Just to make comparison operators easier to write
+    std::pair<StorePath, std::string> to_pair() const
+    { return std::make_pair(drvPath, outputName); }
+};
+
+typedef std::variant<StorePath, DrvOutputId> RawDrvInput;
+
+struct DrvInput : RawDrvInput {
+    using RawDrvInput::RawDrvInput;
+
+    std::string to_string() const;
+    static DrvInput parse(const std::string & strRep);
+};
+
+struct DrvOutputInfo {
+    StorePath outPath;
+
+    std::string to_string() const;
+    static DrvOutputInfo parse(const std::string & s, const std::string & whence);
+};
+
+typedef std::map<DrvOutputId, DrvOutputInfo> DrvOutputs;
+
+}

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -60,6 +60,9 @@ struct DummyStore : public Store, public virtual DummyStoreConfig
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
         BuildMode buildMode) override
     { unsupported("buildDerivation"); }
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    { unsupported("queryDrvOutputInfo"); }
 };
 
 static RegisterStoreImplementation<DummyStore, DummyStoreConfig> regDummyStore;

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -333,6 +333,10 @@ public:
         auto conn(connections->get());
         return conn->remoteVersion;
     }
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override
+    // TODO: Implement
+    { unsupported("queryDrvOutputInfo"); }
 };
 
 static RegisterStoreImplementation<LegacySSHStore, LegacySSHStoreConfig> regLegacySSHStore;

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -87,6 +87,7 @@ protected:
 void LocalBinaryCacheStore::init()
 {
     createDirs(binaryCacheDir + "/nar");
+    createDirs(binaryCacheDir + "/drvOutputs");
     if (writeDebugInfo)
         createDirs(binaryCacheDir + "/debuginfo");
     BinaryCacheStore::init();

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -21,7 +21,7 @@ namespace nix {
    0.7.  Version 2 was Nix 0.8 and 0.9.  Version 3 is Nix 0.10.
    Version 4 is Nix 0.11.  Version 5 is Nix 0.12-0.16.  Version 6 is
    Nix 1.0.  Version 7 is Nix 1.3. Version 10 is 2.0. */
-const int nixSchemaVersion = 10;
+const int nixSchemaVersion = 11;
 
 
 struct OptimiseStats
@@ -64,8 +64,10 @@ private:
         SQLiteStmt stmtQueryReferrers;
         SQLiteStmt stmtInvalidatePath;
         SQLiteStmt stmtAddDerivationOutput;
+        SQLiteStmt stmtRegisterRealisedOutput;
         SQLiteStmt stmtQueryValidDerivers;
         SQLiteStmt stmtQueryDerivationOutputs;
+        SQLiteStmt stmtQueryRealisedOutput;
         SQLiteStmt stmtQueryPathFromHashPart;
         SQLiteStmt stmtQueryValidPaths;
 
@@ -222,7 +224,7 @@ public:
     /* Register the store path 'output' as the output named 'outputName' of
        derivation 'deriver'. */
     void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
-    void registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
+    void cacheDrvOutputMapping(State & state, const uint64_t deriver, const string & outputName, const StorePath & output);
 
     std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -219,6 +219,13 @@ public:
        garbage until it exceeds maxFree. */
     void autoGC(bool sync = true);
 
+    /* Register the store path 'output' as the output named 'outputName' of
+       derivation 'deriver'. */
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+    void registerDrvOutput_(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId&) override;
+
 private:
 
     int getSchema();
@@ -286,11 +293,6 @@ private:
     /* Add signatures to a ValidPathInfo using the secret keys
        specified by the ‘secret-key-files’ option. */
     void signPathInfo(ValidPathInfo & info);
-
-    /* Register the store path 'output' as the output named 'outputName' of
-       derivation 'deriver'. */
-    void linkDeriverToPath(const StorePath & deriver, const string & outputName, const StorePath & output);
-    void linkDeriverToPath(State & state, uint64_t deriver, const string & outputName, const StorePath & output);
 
     Path getRealStoreDir() override { return realStoreDir; }
 

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -48,7 +48,7 @@ ifneq ($(sandbox_shell),)
 libstore_CXXFLAGS += -DSANDBOX_SHELL="\"$(sandbox_shell)\""
 endif
 
-$(d)/local-store.cc: $(d)/schema.sql.gen.hh
+$(d)/local-store.cc: $(d)/schema.sql.gen.hh $(d)/ca-specific-schema.sql.gen.hh
 
 $(d)/build.cc:
 
@@ -58,7 +58,7 @@ $(d)/build.cc:
 	@echo ')foo"' >> $@.tmp
 	@mv $@.tmp $@
 
-clean-files += $(d)/schema.sql.gen.hh
+clean-files += $(d)/schema.sql.gen.hh $(d)/ca-specific-schema.sql.gen.hh
 
 $(eval $(call install-file-in, $(d)/nix-store.pc, $(prefix)/lib/pkgconfig, 0644))
 

--- a/src/libstore/path.hh
+++ b/src/libstore/path.hh
@@ -75,7 +75,14 @@ struct StorePathWithOutputs
     std::set<std::string> outputs;
 
     std::string to_string(const Store & store) const;
+
+    bool operator<(const StorePathWithOutputs & other) const
+    {
+        return path < other.path || outputs < other.outputs;
+    }
 };
+
+typedef std::variant<StorePath, StorePathWithOutputs> PathOrOutputs;
 
 std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s);
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -81,6 +81,10 @@ public:
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
+    void registerDrvOutput(const DrvOutputId & outputId, const DrvOutputInfo & info) override;
+
+    std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) override;
+
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/schema.sql
+++ b/src/libstore/schema.sql
@@ -40,3 +40,13 @@ create table if not exists DerivationOutputs (
 );
 
 create index if not exists IndexDerivationOutputs on DerivationOutputs(path);
+
+create table if not exists OutputMappings (
+    id integer primary key autoincrement not null,
+    drvPath text not null,
+    outputName text not null, -- symbolic output id, usually "out"
+    outputPath integer not null,
+    foreign key (outputPath) references ValidPaths(id) on delete cascade
+);
+
+create index if not exists IndexOutputMappings on OutputMappings(outputPath);

--- a/src/libstore/schema.sql
+++ b/src/libstore/schema.sql
@@ -40,13 +40,3 @@ create table if not exists DerivationOutputs (
 );
 
 create index if not exists IndexDerivationOutputs on DerivationOutputs(path);
-
-create table if not exists OutputMappings (
-    id integer primary key autoincrement not null,
-    drvPath text not null,
-    outputName text not null, -- symbolic output id, usually "out"
-    outputPath integer not null,
-    foreign key (outputPath) references ValidPaths(id) on delete cascade
-);
-
-create index if not exists IndexOutputMappings on OutputMappings(outputPath);

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -364,6 +364,17 @@ bool Store::PathInfoCacheValue::isKnownNow()
     return std::chrono::steady_clock::now() < time_point + ttl;
 }
 
+std::optional<StorePath> Store::queryOutputPathOf(const StorePath & drvPath, const std::string & outputName)
+{
+    auto resp = queryPartialDerivationOutputMap(drvPath);
+    if (auto maybePathPtr = resp.find(outputName); maybePathPtr != resp.end()) {
+                return maybePathPtr->second;
+    } else {
+                return std::nullopt;
+    }
+}
+
+
 OutputPathMap Store::queryDerivationOutputMap(const StorePath & path) {
     auto resp = queryPartialDerivationOutputMap(path);
     OutputPathMap result;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -738,9 +738,13 @@ void Store::buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMod
     StorePathSet paths2;
 
     for (auto & path : paths) {
-        if (path.path.isDerivation())
-            unsupported("buildPaths");
-        paths2.insert(path.path);
+        if (path.path.isDerivation()) {
+            for (auto & outputName : path.outputs) {
+                if (!queryDrvOutputInfo({path.path, outputName}))
+                    unsupported("buildPaths");
+            }
+        } else
+            paths2.insert(path.path);
     }
 
     if (queryValidPaths(paths2).size() != paths2.size())

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -653,6 +653,8 @@ public:
         StorePathSet & out, bool flipDirection = false,
         bool includeOutputs = false, bool includeDerivers = false);
 
+    std::set<DrvInput> drvInputClosure(const DrvInput&);
+
     /* Given a set of paths that are to be built, return the set of
        derivations that will be built, and the set of output paths
        that will be substituted. */

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drv-output-info.hh"
 #include "path.hh"
 #include "hash.hh"
 #include "content-address.hh"
@@ -396,6 +397,10 @@ protected:
 
 public:
 
+    virtual std::optional<const DrvOutputInfo> queryDrvOutputInfo(const DrvOutputId &) = 0;
+
+    virtual std::optional<StorePath> queryOutputPathOf(const StorePath & drvPath, const std::string & outputName);
+
     /* Queries the set of incoming FS references for a store path.
        The result is not cleared. */
     virtual void queryReferrers(const StorePath & path, StorePathSet & referrers)
@@ -467,6 +472,20 @@ public:
        a regular file containing the given string. */
     virtual StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair = NoRepair) = 0;
+
+    /**
+     * Add a mapping indicating that `deriver!outputName` maps to the output path
+     * `output`.
+     *
+     * This is redundant for known-input-addressed and fixed-output derivations
+     * as this information is already present in the drv file, but necessary for
+     * floating-ca derivations and their dependencies as there's no way to
+     * retrieve this information otherwise.
+     */
+    virtual void registerDrvOutput(const StorePath & deriver, const string & outputName, const DrvOutputInfo & output)
+    { registerDrvOutput(DrvOutputId{ deriver, outputName }, output); }
+    virtual void registerDrvOutput(const DrvOutputId &, const DrvOutputInfo & output)
+    { unsupported("registerDrvOutput"); }
 
     /* Write a NAR dump of a store path. */
     virtual void narFromPath(const StorePath & path, Sink & sink) = 0;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -755,6 +755,11 @@ void copyStorePath(ref<Store> srcStore, ref<Store> dstStore,
    that. Returns a map of what each path was copied to the dstStore
    as. */
 std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
+    const std::set<PathOrOutputs> &storePaths,
+    RepairFlag repair = NoRepair,
+    CheckSigsFlag checkSigs = CheckSigs,
+    SubstituteFlag substitute = NoSubstitute);
+std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
     const StorePathSet & storePaths,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "store-api.hh"
+#include "serialise.hh"
+
 namespace nix {
 
 
@@ -50,6 +53,8 @@ typedef enum {
     wopAddToStoreNar = 39,
     wopQueryMissing = 40,
     wopQueryDerivationOutputMap = 41,
+    wopRegisterDrvOutput = 42,
+    wopQueryDrvOutputInfo = 43,
 } WorkerOp;
 
 

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -330,10 +330,14 @@ struct InstallableStorePath : Installable
     {
         if (storePath.path.isDerivation()) {
             std::map<std::string, std::optional<StorePath>> outputs;
-            auto drv = store->readDerivation(storePath.path);
-            for (auto & [name, output] : drv.outputsAndOptPaths(*store))
-                if (storePath.outputs.empty() || storePath.outputs.count(name))
+            if (storePath.outputs.empty()) {
+                auto drv = store->readDerivation(storePath.path);
+                for (auto & [name, output] : drv.outputsAndOptPaths(*store))
                     outputs.emplace(name, output.second);
+            } else {
+                for (auto & outputName : storePath.outputs)
+                    outputs.emplace(outputName, std::nullopt);
+            }
             return {
                 BuildableFromDrv {
                     .drvPath = storePath.path,

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -319,30 +319,31 @@ Installable::getCursor(EvalState & state)
 struct InstallableStorePath : Installable
 {
     ref<Store> store;
-    StorePath storePath;
+    StorePathWithOutputs storePath;
 
-    InstallableStorePath(ref<Store> store, StorePath && storePath)
+    InstallableStorePath(ref<Store> store, StorePathWithOutputs && storePath)
         : store(store), storePath(std::move(storePath)) { }
 
-    std::string what() override { return store->printStorePath(storePath); }
+    std::string what() override { return storePath.to_string(*store); }
 
     Buildables toBuildables() override
     {
-        if (storePath.isDerivation()) {
+        if (storePath.path.isDerivation()) {
             std::map<std::string, std::optional<StorePath>> outputs;
-            auto drv = store->readDerivation(storePath);
+            auto drv = store->readDerivation(storePath.path);
             for (auto & [name, output] : drv.outputsAndOptPaths(*store))
-                outputs.emplace(name, output.second);
+                if (storePath.outputs.empty() || storePath.outputs.count(name))
+                    outputs.emplace(name, output.second);
             return {
                 BuildableFromDrv {
-                    .drvPath = storePath,
+                    .drvPath = storePath.path,
                     .outputs = std::move(outputs)
                 }
             };
         } else {
             return {
                 BuildableOpaque {
-                    .path = storePath,
+                    .path = storePath.path,
                 }
             };
         }
@@ -350,7 +351,7 @@ struct InstallableStorePath : Installable
 
     std::optional<StorePath> getStorePath() override
     {
-        return storePath;
+        return storePath.path;
     }
 };
 
@@ -625,7 +626,7 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
 
             if (s.find('/') != std::string::npos) {
                 try {
-                    result.push_back(std::make_shared<InstallableStorePath>(store, store->followLinksToStorePath(s)));
+                    result.push_back(std::make_shared<InstallableStorePath>(store, store->followLinksToStorePathWithOutputs(s)));
                     continue;
                 } catch (BadStorePath &) {
                 } catch (...) {

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -408,9 +408,14 @@ std::vector<InstallableValue::DerivationInfo> InstallableAttrPath::toDerivations
 
     std::vector<DerivationInfo> res;
     for (auto & drvInfo : drvInfos) {
+        std::optional<StorePath> outPath;
+        try {
+            outPath = state->store->parseStorePath(drvInfo.queryOutPath());
+        }
+        catch (BadStorePath &) { }
         res.push_back({
             state->store->parseStorePath(drvInfo.queryDrvPath()),
-            state->store->parseStorePath(drvInfo.queryOutPath()),
+            outPath,
             drvInfo.queryOutputName()
         });
     }
@@ -657,49 +662,114 @@ std::shared_ptr<Installable> SourceExprCommand::parseInstallable(
     return installables.front();
 }
 
-Buildables build(ref<Store> store, Realise mode,
-    std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode)
+Buildables toBuildables(std::vector<std::shared_ptr<Installable>> installables)
+{
+    Buildables buildables;
+    for (auto & i : installables) {
+        for (auto & b : i->toBuildables()) {
+            buildables.push_back(b);
+        }
+    }
+    return buildables;
+}
+
+std::set<Buildable> buildableClosure(ref<Store> store, Buildable root)
+{
+    // XXX: Calling this on a `BuildableFromDrv` forgets all about the builders
+    // of the dependencies, which is probably not what we want
+    StorePathSet closure;
+    StorePathSet rawRoots = std::visit(
+        overloaded{
+            [&](BuildableOpaque bo) -> StorePathSet { return {bo.path}; },
+            [&](BuildableFromDrv bfd) {
+                auto outputs = store->queryDerivationOutputMap(bfd.drvPath);
+                // XXX: This assumes that the output name is valid and realised
+                StorePathSet outputPaths;
+                for (auto &output : bfd.outputs)
+                    outputPaths.insert(outputs.at(output.first));
+                return outputPaths;
+            },
+        },
+      root);
+    store->computeFSClosure(rawRoots, closure, false, false);
+    std::set<Buildable> res;
+    res.insert(root);
+    for (auto & path : closure) {
+        res.insert(BuildableOpaque{path});
+    }
+    return res;
+}
+
+std::set<Buildable> buildableClosure(ref<Store> store, Buildables roots, OperateOn operateOn, Realise mode, BuildMode bMode)
+{
+    std::set<Buildable> res;
+    if (operateOn == OperateOn::Output) {
+        build(store, mode, roots, bMode);
+        for (auto & root : roots) {
+            auto partialRes = buildableClosure(store, root);
+            res.insert(partialRes.begin(), partialRes.end());
+        }
+    } else {
+        for (auto & root : roots) {
+            if (auto bfd = std::get_if<BuildableFromDrv>(&root))
+                res.insert(BuildableOpaque{bfd->drvPath});
+            if (auto bo = std::get_if<BuildableOpaque>(&root))
+                if (bo->path.isDerivation())
+                    res.insert(*bo);
+        }
+    }
+    return res;
+}
+
+void build(ref<Store> store, Realise mode, Buildables buildables, BuildMode bMode)
 {
     if (mode == Realise::Nothing)
         settings.readOnlyMode = true;
 
-    Buildables buildables;
-
     std::vector<StorePathWithOutputs> pathsToBuild;
 
-    for (auto & i : installables) {
-        for (auto & b : i->toBuildables()) {
-            std::visit(overloaded {
-                [&](BuildableOpaque bo) {
-                    pathsToBuild.push_back({bo.path});
-                },
-                [&](BuildableFromDrv bfd) {
-                    StringSet outputNames;
-                    for (auto & output : bfd.outputs)
+    for (auto & b : buildables) {
+        std::visit(overloaded {
+            [&](BuildableOpaque bo) {
+                pathsToBuild.push_back({bo.path});
+            },
+            [&](BuildableFromDrv bfd) {
+                StringSet outputNames;
+                for (auto & output : bfd.outputs) {
+                    auto maybeOutputPath = store->queryOutputPathOf(bfd.drvPath, output.first);
+                    if (!(maybeOutputPath.has_value() && store->isValidPath(*maybeOutputPath)))
                         outputNames.insert(output.first);
+                }
+                if (!outputNames.empty())
                     pathsToBuild.push_back({bfd.drvPath, outputNames});
-                },
-            }, b);
-            buildables.push_back(std::move(b));
-        }
+            },
+        }, b);
     }
 
     if (mode == Realise::Nothing)
         printMissing(store, pathsToBuild, lvlError);
     else if (mode == Realise::Outputs)
         store->buildPaths(pathsToBuild, bMode);
+}
 
+
+Buildables build(ref<Store> store, Realise mode,
+    std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode)
+{
+    Buildables buildables = toBuildables(installables);
+    build(store, mode, buildables, bMode);
     return buildables;
 }
 
 StorePathSet toStorePaths(ref<Store> store,
     Realise mode, OperateOn operateOn,
-    std::vector<std::shared_ptr<Installable>> installables)
+    Buildables buildables)
 {
     StorePathSet outPaths;
 
     if (operateOn == OperateOn::Output) {
-        for (auto & b : build(store, mode, installables))
+        build(store, mode, buildables);
+        for (auto & b : buildables)
             std::visit(overloaded {
                 [&](BuildableOpaque bo) {
                     outPaths.insert(bo.path);
@@ -716,13 +786,19 @@ StorePathSet toStorePaths(ref<Store> store,
         if (mode == Realise::Nothing)
             settings.readOnlyMode = true;
 
-        for (auto & i : installables)
-            for (auto & b : i->toBuildables())
-                if (auto bfd = std::get_if<BuildableFromDrv>(&b))
-                    outPaths.insert(bfd->drvPath);
+        for (auto & b : buildables)
+            if (auto bfd = std::get_if<BuildableFromDrv>(&b))
+                outPaths.insert(bfd->drvPath);
     }
 
     return outPaths;
+}
+
+StorePathSet toStorePaths(ref<Store> store,
+    Realise mode, OperateOn operateOn,
+    std::vector<std::shared_ptr<Installable>> installables)
+{
+    return toStorePaths(store, mode, operateOn, toBuildables(installables));
 }
 
 StorePath toStorePath(ref<Store> store,

--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -673,56 +673,41 @@ Buildables toBuildables(std::vector<std::shared_ptr<Installable>> installables)
     return buildables;
 }
 
+std::set<DrvInput> buildableToDrvInputs(const Buildable& b) {
+    return std::visit(
+        overloaded{
+            [](BuildableOpaque bo) -> std::set<DrvInput> { return {bo.path}; },
+            [](BuildableFromDrv bfd) -> std::set<DrvInput> {
+                std::set<DrvInput> res;
+                for (auto& wantedOutput : bfd.outputs)
+                    res.emplace(DrvOutputId{bfd.drvPath, wantedOutput.first});
+                return res;
+            },
+        },
+        b);
+}
+
+Buildable drvInputToBuildable(const DrvInput& input) {
+    return std::visit(
+        overloaded{
+            [](StorePath path) -> Buildable { return BuildableOpaque{path}; },
+            [](DrvOutputId id) -> Buildable {
+                return BuildableFromDrv{id.drvPath, {{id.outputName, std::nullopt}}};
+            },
+        },
+        static_cast<RawDrvInput>(input));
+}
+
 std::set<Buildable> buildableClosure(ref<Store> store, Buildable root)
 {
-    // XXX: Calling this on a `BuildableFromDrv` forgets all about the builders
-    // of the dependencies, which is probably not what we want
+    auto rootDrvInputs = buildableToDrvInputs(root);
     std::set<Buildable> closure;
-    std::visit(overloaded{
-        [&](BuildableOpaque bo) {
-            StorePathSet storePathsClosure;
-            store->computeFSClosure({bo.path}, storePathsClosure, false, false);
-            for (auto & path : storePathsClosure) {
-                closure.insert(BuildableOpaque{path});
-            }
-        },
-        [&](BuildableFromDrv bfd) {
-            std::set<StorePath> drvClosure;
-            store->computeFSClosure({bfd.drvPath}, drvClosure, false, false);
 
-            StorePathSet runtimeClosure;
-            StorePathSet outputPaths;
-            for (auto & output : bfd.outputs)
-                outputPaths.insert(*output.second);
-            store->computeFSClosure(outputPaths, runtimeClosure, false, false);
-
-            for (auto & input : drvClosure) {
-                if (input.isDerivation()) {
-                    // Take all the outputs of the derivation that are in the
-                    // runtime closure, and add them as `BuildableFromDrv` to
-                    // the closure
-                    auto drvOutputs = store->queryPartialDerivationOutputMap(input);
-                    std::map<std::string, std::optional<StorePath>> neededOutputs;
-                    for (auto & [outputName, output] : drvOutputs) {
-                        if (output && runtimeClosure.count(*output)) {
-                            neededOutputs.emplace(outputName, output);
-                        }
-                    }
-                    if (!neededOutputs.empty())
-                        closure.insert(
-                                BuildableFromDrv{
-                                    .drvPath = input,
-                                    .outputs = neededOutputs,
-                                }
-                        );
-                } else {
-                    if (runtimeClosure.count(input))
-                        closure.insert(BuildableOpaque{input});
-                }
-            }
-        },
-        },
-        root);
+    for (auto & partialRoot : rootDrvInputs) {
+        for (auto & transitiveInput : store->drvInputClosure(partialRoot)) {
+            closure.emplace(drvInputToBuildable(transitiveInput));
+        }
+    }
     return closure;
 }
 

--- a/src/nix/installables.hh
+++ b/src/nix/installables.hh
@@ -19,12 +19,21 @@ namespace eval_cache { class EvalCache; class AttrCursor; }
 struct BuildableOpaque {
     StorePath path;
     nlohmann::json toJSON(ref<Store> store) const;
+
+    bool operator<(const BuildableOpaque & other) const
+    { return path < other.path; }
 };
 
 struct BuildableFromDrv {
     StorePath drvPath;
     std::map<std::string, std::optional<StorePath>> outputs;
     nlohmann::json toJSON(ref<Store> store) const;
+
+    bool operator<(const BuildableFromDrv & other) const
+    {
+        return drvPath < other.drvPath ||
+            (drvPath == other.drvPath && outputs < other.outputs);
+    }
 };
 
 typedef std::variant<

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -58,7 +58,6 @@ clearStore() {
     mkdir "$NIX_STORE_DIR"
     rm -rf "$NIX_STATE_DIR"
     mkdir "$NIX_STATE_DIR"
-    nix-store --init
     clearProfiles
 }
 
@@ -74,7 +73,7 @@ startDaemon() {
     # Start the daemon, wait for the socket to appear.  !!!
     # ‘nix-daemon’ should have an option to fork into the background.
     rm -f $NIX_STATE_DIR/daemon-socket/socket
-    nix-daemon &
+    ${NIX_DAEMON_BIN:-nix-daemon} &
     for ((i = 0; i < 30; i++)); do
         if [ -e $NIX_DAEMON_SOCKET_PATH ]; then break; fi
         sleep 1

--- a/tests/content-addressed.nix
+++ b/tests/content-addressed.nix
@@ -16,14 +16,16 @@ rec {
   };
   rootCA = mkDerivation {
     name = "rootCA";
-    outputs = [ "out" "dev" ];
+    outputs = [ "out" "dev" "foo"];
     buildCommand = ''
       echo "building a CA derivation"
       echo "The seed is ${toString seed}"
       mkdir -p $out
       echo ${rootLegacy}/hello > $out/dep
-      # test symlink at root
+      ln -s $out $out/self
+      # test symlinks at root
       ln -s $out $dev
+      ln -s $out $foo
     '';
     __contentAddressed = true;
     outputHashMode = "recursive";
@@ -34,7 +36,8 @@ rec {
     buildCommand = ''
       echo "building a dependent derivation"
       mkdir -p $out
-      echo ${rootCA}/hello > $out/dep
+      cat ${rootCA}/self/dep
+      echo ${rootCA}/self/dep > $out/dep
     '';
     __contentAddressed = true;
     outputHashMode = "recursive";

--- a/tests/content-addressed.nix
+++ b/tests/content-addressed.nix
@@ -63,4 +63,15 @@ rec {
       echo ${rootCA}/non-ca-hello > $out/dep
     '';
   };
+  dependentFixedOutput = mkDerivation {
+    name = "dependent-fixed-output";
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-QvtAMbUl/uvi+LCObmqOhvNOapHdA2raiI4xG5zI5pA=";
+    buildCommand = ''
+      cat ${dependentCA}/dep
+      echo foo > $out
+    '';
+
+  };
 }

--- a/tests/db-migration.sh
+++ b/tests/db-migration.sh
@@ -1,0 +1,25 @@
+# Test that we can successfully migrate from an older db schema
+
+# Only run this if we have an older Nix available
+if [[ -z "$OUTER_NIX" ]]; then
+    exit 0
+fi
+
+source common.sh
+
+# Fill the db using the older Nix
+PATH_WITH_NEW_NIX="$PATH"
+export PATH="$OUTER_NIX/bin:$PATH"
+clearStore
+nix-build simple.nix --no-out-link
+nix-store --generate-binary-cache-key cache1.example.org $TEST_ROOT/sk1 $TEST_ROOT/pk1
+dependenciesOutPath=$(nix-build dependencies.nix --no-out-link --secret-key-files "$TEST_ROOT/sk1")
+fixedOutPath=$(IMPURE_VAR1=foo IMPURE_VAR2=bar nix-build fixed.nix -A good.0 --no-out-link)
+
+# Migrate to the new schema and ensure that everything's there
+export PATH="$PATH_WITH_NEW_NIX"
+info=$(nix path-info --json $dependenciesOutPath)
+[[ $info =~ '"ultimate":true' ]]
+[[ $info =~ 'cache1.example.org' ]]
+nix verify -r "$fixedOutPath"
+nix verify -r "$dependenciesOutPath" --sigs-needed 1 --trusted-public-keys $(cat $TEST_ROOT/pk1)

--- a/tests/init.sh
+++ b/tests/init.sh
@@ -17,7 +17,7 @@ cat > "$NIX_CONF_DIR"/nix.conf <<EOF
 build-users-group =
 keep-derivations = false
 sandbox = false
-experimental-features = nix-command flakes
+experimental-features = nix-command flakes ca-references ca-derivations
 gc-reserved-space = 0
 flake-registry = $TEST_ROOT/registry.json
 include nix.conf.extra

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -36,8 +36,9 @@ nix_tests = \
   recursive.sh \
   describe-stores.sh \
   flakes.sh \
+  build.sh \
   content-addressed.sh \
-  build.sh
+  nix-copy-content-addressed.sh
   # parallel.sh
   # build-remote-content-addressed-fixed.sh \
 

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -6,7 +6,7 @@ nix_tests = \
   gc-auto.sh \
   referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \
   gc-runtime.sh check-refs.sh filter-source.sh \
-  local-store.sh remote-store.sh export.sh export-graph.sh \
+  local-store.sh remote-store.sh remote-store-old-daemon.sh export.sh export-graph.sh \
   timeout.sh secure-drv-outputs.sh nix-channel.sh \
   multiple-outputs.sh import-derivation.sh fetchurl.sh optimise-store.sh \
   binary-cache.sh nix-profile.sh repair.sh dump-db.sh case-hack.sh \

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -7,6 +7,7 @@ nix_tests = \
   referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \
   gc-runtime.sh check-refs.sh filter-source.sh \
   local-store.sh remote-store.sh remote-store-old-daemon.sh export.sh export-graph.sh \
+  db-migration.sh \
   timeout.sh secure-drv-outputs.sh nix-channel.sh \
   multiple-outputs.sh import-derivation.sh fetchurl.sh optimise-store.sh \
   binary-cache.sh nix-profile.sh repair.sh dump-db.sh case-hack.sh \

--- a/tests/nix-copy-content-addressed.sh
+++ b/tests/nix-copy-content-addressed.sh
@@ -1,0 +1,24 @@
+source common.sh
+
+clearStore
+clearCache
+
+commonArgs=( \
+    --experimental-features 'nix-command flakes ca-derivations ca-references' \
+    --file ./content-addressed.nix \
+    -v
+)
+
+remoteRoot=$TEST_ROOT/store2
+chmod -R u+w "$remoteRoot" || true
+rm -rf "$remoteRoot"
+
+# Fill the remote cache
+nix copy --to $remoteRoot --no-require-sigs "${commonArgs[@]}"
+clearStore
+
+# Fetch the otput from the cache
+nix copy --from $remoteRoot --no-require-sigs "${commonArgs[@]}"
+
+# Ensure that everything is locally present
+nix build "${commonArgs[@]}" -j0 --no-link

--- a/tests/push-to-store.sh
+++ b/tests/push-to-store.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+set -x
+
 echo Pushing "$@" to "$REMOTE_STORE"
-printf "%s" "$OUT_PATHS" | xargs -d: nix copy --to "$REMOTE_STORE" --no-require-sigs
+printf "%s" "$DRV_OUTPUTS" | xargs nix copy --to "$REMOTE_STORE" --no-require-sigs

--- a/tests/remote-store-old-daemon.sh
+++ b/tests/remote-store-old-daemon.sh
@@ -1,0 +1,7 @@
+# Test that the new Nix can properly talk to an old daemon.
+# If `$OUTER_NIX` isn't set (e.g. when bootsraping), just skip this test
+
+if [[ -n "$OUTER_NIX" ]]; then
+    export NIX_DAEMON_BIN=$OUTER_NIX/bin/nix-daemon
+    source remote-store.sh
+fi

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -23,11 +23,11 @@ startDaemon
 
 storeCleared=1 NIX_REMOTE_=$NIX_REMOTE $SHELL ./user-envs.sh
 
+nix-store --gc --max-freed 1K
+
 nix-store --dump-db > $TEST_ROOT/d1
 NIX_REMOTE= nix-store --dump-db > $TEST_ROOT/d2
 cmp $TEST_ROOT/d1 $TEST_ROOT/d2
-
-nix-store --gc --max-freed 1K
 
 killDaemon
 


### PR DESCRIPTION
Depends on #4227 #4282 #4284 

This PR tries to provide the simplest possible way of copying drv outputs.
In particular it doesn't try to tackle the issue of copying the drv output closure at all, all it does is allow to do `nix copy /nix/store/...-foo.drv!out` which will copy the corresponding outpath and register the out path mapping for `...-foo.drv!out`.

For coherence (and also because it's at least as simple to do things that way), `nix copy nixpgs#foo` has the same semantics, meaning that it will both copy the output path(s) and register the derivation output(s).