### PR TITLE
nix develop: Preserve stdin with `-c`

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -474,9 +474,9 @@ struct CmdDevelop : Common, MixEnvironment
             ignoreException();
         }
 
-        // If running a phase, don't want an interactive shell running after
+        // If running a phase or single command, don't want an interactive shell running after
         // Ctrl-C, so don't pass --rcfile
-        auto args = phase ? Strings{std::string(baseNameOf(shell)), rcFilePath}
+        auto args = phase || !command.empty() ? Strings{std::string(baseNameOf(shell)), rcFilePath}
             : Strings{std::string(baseNameOf(shell)), "--rcfile", rcFilePath};
 
         restoreAffinity();

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -58,8 +58,12 @@ output=$($TEST_ROOT/shell.shebang.rb abc ruby)
 
 # Test 'nix develop'.
 nix develop -f shell.nix shellDrv -c bash -c '[[ -n $stdenv ]]'
-# Preserve stdin with `-c`
+
+# Ensure `nix develop -c` preserves stdin
 echo foo | nix develop -f shell.nix shellDrv -c cat | grep -q foo
+
+# Ensure `nix develop -c` actually executes the command if stdout isn't a terminal
+nix develop -f shell.nix shellDrv -c echo foo |& grep -q foo
 
 # Test 'nix print-dev-env'.
 source <(nix print-dev-env -f shell.nix shellDrv)

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -58,7 +58,8 @@ output=$($TEST_ROOT/shell.shebang.rb abc ruby)
 
 # Test 'nix develop'.
 nix develop -f shell.nix shellDrv -c bash -c '[[ -n $stdenv ]]'
-echo foo | nix develop -f shell.nix shellDrv -c cat  # preserve stdin with `-c`
+# Preserve stdin with `-c`
+echo foo | nix develop -f shell.nix shellDrv -c cat | grep -q foo
 
 # Test 'nix print-dev-env'.
 source <(nix print-dev-env -f shell.nix shellDrv)

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -58,6 +58,7 @@ output=$($TEST_ROOT/shell.shebang.rb abc ruby)
 
 # Test 'nix develop'.
 nix develop -f shell.nix shellDrv -c bash -c '[[ -n $stdenv ]]'
+echo foo | nix develop -f shell.nix shellDrv -c cat  # preserve stdin with `-c`
 
 # Test 'nix print-dev-env'.
 source <(nix print-dev-env -f shell.nix shellDrv)


### PR DESCRIPTION
For use in editor integration, I would like to run a derivation taking input from stdin instead of $src, basically
```
echo "print('hi')" | nix develop .#foo -c python -
```
However, this currently breaks because of `nix develop`'s use of `--rcfile`: the stdin is executed by the shell instead of being passed to the `-c` command. Not using `--rcfile` with `-c`, just like it's already being done with `--phase`, fixes this.