### PR TITLE
Add a CI check to ensure compatibility with an old daemon

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,11 @@
       # 'nix.perl-bindings' packages.
       overlay = final: prev: {
 
+        # An older version of Nix to test against when using the daemon.
+        # Currently using `nixUnstable` as the stable one doesn't respect
+        # `NIX_DAEMON_SOCKET_PATH` which is needed for the tests.
+        mainstream-nix = prev.nixUnstable;
+
         nix = with final; with commonDeps pkgs; stdenv.mkDerivation {
           name = "nix-${version}";
           inherit version;
@@ -157,6 +162,8 @@
           src = self;
 
           VERSION_SUFFIX = versionSuffix;
+
+          OUTER_NIX = mainstream-nix;
 
           outputs = [ "out" "dev" "doc" ];
 
@@ -485,6 +492,8 @@
 
         stdenv.mkDerivation {
           name = "nix";
+
+          OUTER_NIX = mainstream-nix;
 
           outputs = [ "out" "dev" "doc" ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,32 @@
             echo "file installer $out/install" >> $out/nix-support/hydra-build-products
           '';
 
+      testNixVersions = pkgs: client: daemon: with commonDeps pkgs; pkgs.stdenv.mkDerivation {
+        NIX_DAEMON_PACKAGE = daemon;
+        NIX_CLIENT_PACKAGE = client;
+        name = "nix-tests-${client.version}-against-${daemon.version}";
+        inherit version;
+
+        src = self;
+
+        VERSION_SUFFIX = versionSuffix;
+
+        nativeBuildInputs = nativeBuildDeps;
+        buildInputs = buildDeps ++ awsDeps;
+        propagatedBuildInputs = propagatedDeps;
+
+        enableParallelBuilding = true;
+
+        dontBuild = true;
+        doInstallCheck = true;
+
+        installPhase = ''
+          mkdir -p $out
+        '';
+        installCheckPhase = "make installcheck";
+
+      };
+
     in {
 
       # A Nixpkgs overlay that overrides the 'nix' and
@@ -153,7 +179,7 @@
         # An older version of Nix to test against when using the daemon.
         # Currently using `nixUnstable` as the stable one doesn't respect
         # `NIX_DAEMON_SOCKET_PATH` which is needed for the tests.
-        mainstream-nix = prev.nixUnstable;
+        nixStable = prev.nix;
 
         nix = with final; with commonDeps pkgs; stdenv.mkDerivation {
           name = "nix-${version}";
@@ -162,8 +188,6 @@
           src = self;
 
           VERSION_SUFFIX = versionSuffix;
-
-          OUTER_NIX = mainstream-nix;
 
           outputs = [ "out" "dev" "doc" ];
 
@@ -441,6 +465,15 @@
       checks = forAllSystems (system: {
         binaryTarball = self.hydraJobs.binaryTarball.${system};
         perlBindings = self.hydraJobs.perlBindings.${system};
+        installTests =
+          let pkgs = nixpkgsFor.${system}; in
+          pkgs.runCommand "install-tests" {
+            againstSelf = testNixVersions pkgs pkgs.nix pkgs.pkgs.nix;
+            againstCurrentUnstable = testNixVersions pkgs pkgs.nix pkgs.nixUnstable;
+            # Disabled because the latest stable version doesn't handle
+            # `NIX_DAEMON_SOCKET_PATH` which is required for the tests to work
+            # againstLatestStable = testNixVersions pkgs pkgs.nix pkgs.nixStable;
+          } "touch $out";
       });
 
       packages = forAllSystems (system: {
@@ -492,8 +525,6 @@
 
         stdenv.mkDerivation {
           name = "nix";
-
-          OUTER_NIX = mainstream-nix;
 
           outputs = [ "out" "dev" "doc" ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,10 @@
       testNixVersions = pkgs: client: daemon: with commonDeps pkgs; pkgs.stdenv.mkDerivation {
         NIX_DAEMON_PACKAGE = daemon;
         NIX_CLIENT_PACKAGE = client;
-        name = "nix-tests-${client.version}-against-${daemon.version}";
+        # Must keep this name short as OSX has a rather strict limit on the
+        # socket path length, and this name appears in the path of the
+        # nix-daemon socket used in the tests
+        name = "nix-tests";
         inherit version;
 
         src = self;

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -29,6 +29,12 @@ unset XDG_CACHE_HOME
 mkdir -p $TEST_HOME
 
 export PATH=@bindir@:$PATH
+if [[ -n "${NIX_CLIENT_PACKAGE:-}" ]]; then
+  export PATH="$NIX_CLIENT_PACKAGE/bin":$PATH
+fi
+if [[ -n "${NIX_DAEMON_PACKAGE:-}" ]]; then
+  export NIX_DAEMON_COMMAND="$NIX_DAEMON_PACKAGE/bin/nix-daemon"
+fi
 coreutils=@coreutils@
 
 export dot=@dot@

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -57,7 +57,6 @@ clearStore() {
     mkdir "$NIX_STORE_DIR"
     rm -rf "$NIX_STATE_DIR"
     mkdir "$NIX_STATE_DIR"
-    nix-store --init
     clearProfiles
 }
 
@@ -73,7 +72,7 @@ startDaemon() {
     # Start the daemon, wait for the socket to appear.  !!!
     # ‘nix-daemon’ should have an option to fork into the background.
     rm -f $NIX_STATE_DIR/daemon-socket/socket
-    nix daemon &
+    ${NIX_DAEMON_COMMAND:-nix daemon} &
     for ((i = 0; i < 30; i++)); do
         if [ -e $NIX_DAEMON_SOCKET_PATH ]; then break; fi
         sleep 1

--- a/tests/db-migration.sh
+++ b/tests/db-migration.sh
@@ -1,0 +1,25 @@
+# Test that we can successfully migrate from an older db schema
+
+# Only run this if we have an older Nix available
+if [[ -z "$OUTER_NIX" ]]; then
+    exit 0
+fi
+
+source common.sh
+
+# Fill the db using the older Nix
+PATH_WITH_NEW_NIX="$PATH"
+export PATH="$OUTER_NIX/bin:$PATH"
+clearStore
+nix-build simple.nix --no-out-link
+nix-store --generate-binary-cache-key cache1.example.org $TEST_ROOT/sk1 $TEST_ROOT/pk1
+dependenciesOutPath=$(nix-build dependencies.nix --no-out-link --secret-key-files "$TEST_ROOT/sk1")
+fixedOutPath=$(IMPURE_VAR1=foo IMPURE_VAR2=bar nix-build fixed.nix -A good.0 --no-out-link)
+
+# Migrate to the new schema and ensure that everything's there
+export PATH="$PATH_WITH_NEW_NIX"
+info=$(nix path-info --json $dependenciesOutPath)
+[[ $info =~ '"ultimate":true' ]]
+[[ $info =~ 'cache1.example.org' ]]
+nix verify -r "$fixedOutPath"
+nix verify -r "$dependenciesOutPath" --sigs-needed 1 --trusted-public-keys $(cat $TEST_ROOT/pk1)

--- a/tests/db-migration.sh
+++ b/tests/db-migration.sh
@@ -1,7 +1,8 @@
 # Test that we can successfully migrate from an older db schema
 
 # Only run this if we have an older Nix available
-if [[ -z "$OUTER_NIX" ]]; then
+# XXX: This assumes that the `daemon` package is older than the `client` one
+if [[ -z "$NIX_DAEMON_PACKAGE" ]]; then
     exit 0
 fi
 
@@ -9,7 +10,7 @@ source common.sh
 
 # Fill the db using the older Nix
 PATH_WITH_NEW_NIX="$PATH"
-export PATH="$OUTER_NIX/bin:$PATH"
+export PATH="$NIX_DAEMON_PACKAGE/bin:$PATH"
 clearStore
 nix-build simple.nix --no-out-link
 nix-store --generate-binary-cache-key cache1.example.org $TEST_ROOT/sk1 $TEST_ROOT/pk1

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -7,6 +7,7 @@ nix_tests = \
   referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \
   gc-runtime.sh check-refs.sh filter-source.sh \
   local-store.sh remote-store.sh remote-store-old-daemon.sh export.sh export-graph.sh \
+  db-migration.sh \
   timeout.sh secure-drv-outputs.sh nix-channel.sh \
   multiple-outputs.sh import-derivation.sh fetchurl.sh optimise-store.sh \
   binary-cache.sh \

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -6,7 +6,7 @@ nix_tests = \
   gc-auto.sh \
   referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \
   gc-runtime.sh check-refs.sh filter-source.sh \
-  local-store.sh remote-store.sh remote-store-old-daemon.sh export.sh export-graph.sh \
+  local-store.sh remote-store.sh export.sh export-graph.sh \
   db-migration.sh \
   timeout.sh secure-drv-outputs.sh nix-channel.sh \
   multiple-outputs.sh import-derivation.sh fetchurl.sh optimise-store.sh \

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -6,7 +6,7 @@ nix_tests = \
   gc-auto.sh \
   referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \
   gc-runtime.sh check-refs.sh filter-source.sh \
-  local-store.sh remote-store.sh export.sh export-graph.sh \
+  local-store.sh remote-store.sh remote-store-old-daemon.sh export.sh export-graph.sh \
   timeout.sh secure-drv-outputs.sh nix-channel.sh \
   multiple-outputs.sh import-derivation.sh fetchurl.sh optimise-store.sh \
   binary-cache.sh \

--- a/tests/remote-store-old-daemon.sh
+++ b/tests/remote-store-old-daemon.sh
@@ -1,0 +1,7 @@
+# Test that the new Nix can properly talk to an old daemon.
+# If `$OUTER_NIX` isn't set (e.g. when bootsraping), just skip this test
+
+if [[ -n "$OUTER_NIX" ]]; then
+    export NIX_DAEMON_COMMAND=$OUTER_NIX/bin/nix-daemon
+    source remote-store.sh
+fi

--- a/tests/remote-store-old-daemon.sh
+++ b/tests/remote-store-old-daemon.sh
@@ -1,7 +1,0 @@
-# Test that the new Nix can properly talk to an old daemon.
-# If `$OUTER_NIX` isn't set (e.g. when bootsraping), just skip this test
-
-if [[ -n "$OUTER_NIX" ]]; then
-    export NIX_DAEMON_COMMAND=$OUTER_NIX/bin/nix-daemon
-    source remote-store.sh
-fi

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -23,11 +23,11 @@ startDaemon
 
 storeCleared=1 NIX_REMOTE_=$NIX_REMOTE $SHELL ./user-envs.sh
 
+nix-store --gc --max-freed 1K
+
 nix-store --dump-db > $TEST_ROOT/d1
 NIX_REMOTE= nix-store --dump-db > $TEST_ROOT/d2
 cmp $TEST_ROOT/d1 $TEST_ROOT/d2
-
-nix-store --gc --max-freed 1K
 
 killDaemon
 


### PR DESCRIPTION
Run the `remote-store` test on the CI where `nix-daemon` is replaced by the nix provided in the global environment (assumed to be the latest stable release)

Fix #4226 