### PR TITLE
2259 error message - "auto-call" error

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1375,7 +1375,7 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
             } else if (!i.def) {
                 throwMissingArgumentError(i.pos, R"(cannot evaluate a function that has an argument without a value ('%1%')
 
-Nix attempted to evaluate a function as a top level expression; in this case it must have all its 
+nix attempted to evaluate a function as a top level expression; in this case it must have its
 arguments supplied either by default values, or passed explicitly with --arg or --argstr.
 
 https://nixos.org/manual/nix/stable/#ss-functions)", i.name);

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1366,29 +1366,30 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
                 actualArgs->attrs->push_back(*j);
             } else if (!i.def) {
                 throwUndefinedVarError(i.pos, R"(cannot auto-call a function that has an argument without a default value ('%1%')
-  An 'auto-call' is when a nix expression is evaluated without any external arguments.
-  If that nix expression is a function, and that function's arguments all have default
-  values, then all is well.
 
-  But if the function arguments don't have default values, evaluation fails.
+An 'auto-call' is when a nix expression is evaluated without any external arguments.
+If that nix expression is a function, and that function's arguments all have default
+values, then all is well.
 
-  The classic case for this error is evaluating a nix file with nix-build that expects
-  to be evaluated by callPackage.
-    # in 'callPackage' format: expression is a function that takes an argument 'stdenv'.
-    # callPackage would implicitly pull 'stdenv' from nixpkgs, then call this function.
-    { stdenv }:
-    stdenv.mkDerivation  {
-    ...
+But if the function arguments don't have default values, evaluation fails.
 
-    # in 'auto-call' format: nixpkgs is imported explicitly, and used directly.
-    let
-      nixpkgs = import <nixpkgs> {};
-    in
-      nixpkgs.stdenv.mkDerivation {
-    ...
+The classic case for this error is evaluating a nix file with nix-build that expects
+to be evaluated by callPackage.
+  # in 'callPackage' format: expression is a function that takes an argument 'stdenv'.
+  # callPackage would implicitly pull 'stdenv' from nixpkgs, then call this function.
+  { stdenv }:
+  stdenv.mkDerivation  {
+  ...
 
-  See this nix pill for more information re callPackage format:
-  https://nixos.org/guides/nix-pills/callpackage-design-pattern.html)", i.name);
+  # in 'auto-call' format: nixpkgs is imported explicitly, and used directly.
+  let
+    nixpkgs = import <nixpkgs> {};
+  in
+    nixpkgs.stdenv.mkDerivation {
+  ...
+
+More about callPackage: 
+https://nixos.org/guides/nix-pills/callpackage-design-pattern.html)", i.name);
             }
         }
     }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -660,6 +660,14 @@ LocalNoInlineNoReturn(void throwUndefinedVarError(const Pos & pos, const char * 
     });
 }
 
+LocalNoInlineNoReturn(void throwMissingArgumentError(const Pos & pos, const char * s, const string & s1))
+{
+    throw MissingArgumentError({
+        .hint = hintfmt(s, s1),
+        .errPos = pos
+    });
+}
+
 LocalNoInline(void addErrorTrace(Error & e, const char * s, const string & s2))
 {
     e.addTrace(std::nullopt, s, s2);
@@ -1365,7 +1373,7 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
             if (j != args.end()) {
                 actualArgs->attrs->push_back(*j);
             } else if (!i.def) {
-                throwUndefinedVarError(i.pos, R"(cannot auto-call a function that has an argument without a default value ('%1%')
+                throwMissingArgumentError(i.pos, R"(cannot auto-call a function that has an argument without a default value ('%1%')
 
 An 'auto-call' is when a nix expression is evaluated without any external arguments.
 If that nix expression is a function, and that function's arguments all have default
@@ -1373,7 +1381,7 @@ values, then all is well.
 
 But if the function arguments don't have default values, evaluation fails.
 
-The classic case for this error is evaluating a nix file with nix-build that expects
+The classic case for this error is evaluating a nix file that expects
 to be evaluated by callPackage.
   # in 'callPackage' format: expression is a function that takes an argument 'stdenv'.
   # callPackage would implicitly pull 'stdenv' from nixpkgs, then call this function.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1373,31 +1373,13 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
             if (j != args.end()) {
                 actualArgs->attrs->push_back(*j);
             } else if (!i.def) {
-                throwMissingArgumentError(i.pos, R"(cannot auto-call a function that has an argument without a default value ('%1%')
+                throwMissingArgumentError(i.pos, R"(cannot evaluate a function that has an argument without a value ('%1%')
 
-An 'auto-call' is when a nix expression is evaluated without any external arguments.
-If that nix expression is a function, and that function's arguments all have default
-values, then all is well.
+Nix attempted to evaluate a function as a top level expression; in this case it must have all its 
+arguments supplied either by default values, or passed explicitly with --arg or --argstr.
 
-But if the function arguments don't have default values, evaluation fails.
+https://nixos.org/manual/nix/stable/#ss-functions)", i.name);
 
-The classic case for this error is evaluating a nix file that expects
-to be evaluated by callPackage.
-  # in 'callPackage' format: expression is a function that takes an argument 'stdenv'.
-  # callPackage would implicitly pull 'stdenv' from nixpkgs, then call this function.
-  { stdenv }:
-  stdenv.mkDerivation  {
-  ...
-
-  # in 'auto-call' format: nixpkgs is imported explicitly, and used directly.
-  let
-    nixpkgs = import <nixpkgs> {};
-  in
-    nixpkgs.stdenv.mkDerivation {
-  ...
-
-More about callPackage: 
-https://nixos.org/guides/nix-pills/callpackage-design-pattern.html)", i.name);
             }
         }
     }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1370,7 +1370,28 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
             if (j != args.end()) {
                 actualArgs->attrs->push_back(*j);
             } else if (!i.def) {
-                throwTypeError("cannot auto-call a function that has an argument without a default value ('%1%')", i.name);
+                throwUndefinedVarError(R"(cannot auto-call a function that has an argument without a default value ('%1%')
+  An 'auto-call' is when a nix expression is evaluated without any external arguments.  If that
+  nix expression is a function, and that function's arguments all have default values, then all is well.
+
+  But if the function arguments don't have default values, then evaluation fails.
+
+  The classic case for this error is evaluating a nix file with nix-build that expects to be evaluated by callPackage.
+    # in 'callPackage' format: expression is a function that takes an argument 'stdenv'.
+    # callPackage would implicitly pull 'stdenv' from nixpkgs, then call this function.
+    { stdenv }:
+    stdenv.mkDerivation  {
+    ...
+
+    # in 'auto-call' format: nixpkgs is imported explicitly, and used directly.
+    let
+      nixpkgs = import <nixpkgs> {};
+    in
+      nixpkgs.stdenv.mkDerivation {
+    ...
+
+  See this nix pill for more information re callPackage format:
+  https://nixos.org/guides/nix-pills/callpackage-design-pattern.html)", i.name);
             }
         }
     }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1370,11 +1370,11 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
             if (j != args.end()) {
                 actualArgs->attrs->push_back(*j);
             } else if (!i.def) {
-                throwUndefinedVarError(R"(cannot auto-call a function that has an argument without a default value ('%1%')
+                throwUndefinedVarError(i.pos, R"(cannot auto-call a function that has an argument without a default value ('%1%')
   An 'auto-call' is when a nix expression is evaluated without any external arguments.  If that
   nix expression is a function, and that function's arguments all have default values, then all is well.
 
-  But if the function arguments don't have default values, then evaluation fails.
+  But if the function arguments don't have default values, evaluation fails.
 
   The classic case for this error is evaluating a nix file with nix-build that expects to be evaluated by callPackage.
     # in 'callPackage' format: expression is a function that takes an argument 'stdenv'.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -636,11 +636,6 @@ LocalNoInlineNoReturn(void throwTypeError(const Pos & pos, const char * s))
     });
 }
 
-LocalNoInlineNoReturn(void throwTypeError(const char * s, const string & s1))
-{
-    throw TypeError(s, s1);
-}
-
 LocalNoInlineNoReturn(void throwTypeError(const Pos & pos, const char * s, const ExprLambda & fun, const Symbol & s2))
 {
     throw TypeError({
@@ -1371,12 +1366,14 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
                 actualArgs->attrs->push_back(*j);
             } else if (!i.def) {
                 throwUndefinedVarError(i.pos, R"(cannot auto-call a function that has an argument without a default value ('%1%')
-  An 'auto-call' is when a nix expression is evaluated without any external arguments.  If that
-  nix expression is a function, and that function's arguments all have default values, then all is well.
+  An 'auto-call' is when a nix expression is evaluated without any external arguments.
+  If that nix expression is a function, and that function's arguments all have default
+  values, then all is well.
 
   But if the function arguments don't have default values, evaluation fails.
 
-  The classic case for this error is evaluating a nix file with nix-build that expects to be evaluated by callPackage.
+  The classic case for this error is evaluating a nix file with nix-build that expects
+  to be evaluated by callPackage.
     # in 'callPackage' format: expression is a function that takes an argument 'stdenv'.
     # callPackage would implicitly pull 'stdenv' from nixpkgs, then call this function.
     { stdenv }:

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -17,6 +17,7 @@ MakeError(ThrownError, AssertionError);
 MakeError(Abort, EvalError);
 MakeError(TypeError, EvalError);
 MakeError(UndefinedVarError, Error);
+MakeError(MissingArgumentError, Error);
 MakeError(RestrictedPathError, Error);
 
 

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -38,7 +38,7 @@ namespace nix {
    ErrorInfo structs are sent to the logger as part of an exception, or directly with the
    logError or logWarning macros.
 
-   See the error-demo.cc program for usage examples.
+   See libutil/tests/logging.cc for usage examples.
 
  */
 


### PR DESCRIPTION
revised this "auto-call" error which I've found to be somewhat inscrutable in the past.  This is intended to address (in part) issue #2259.

- UndefinedVarError seemed more appropriate than TypeError
- added Pos
- big error message with examples.
- link to a nix pill for further explanation.

Current output is like this:

![image](https://user-images.githubusercontent.com/157330/98612034-7fe16b00-22b0-11eb-97d9-ba8a7b0db57a.png)

Revised error output is like so:
 
![image](https://user-images.githubusercontent.com/157330/98611815-f3cf4380-22af-11eb-9e4f-71a2ee44c721.png)

This reflect my perhaps imperfect understanding of autoCall, feedback on that is welcome.