### PR TITLE
Fix stack overflow introduced in #4206

### DIFF
--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -195,7 +195,7 @@ class DefaultStackAllocator : public StackAllocator {
     }
 
     void deallocate(boost::context::stack_context sctx) {
-        deallocate(sctx);
+        stack.deallocate(sctx);
     }
 };
 


### PR DESCRIPTION
This fixes a stack overflow observed in `hydra-queue-runner` when `nixUnstable` (updated to the latest master commit) is compiled without optimizations. It becomes a 100% CPU usage bug / deadlock when compiled with optimizations.

I'm not entirely sure that the fix is correct because I don't know much about this code or even the Boost library, but it seems to work fine for me.

Comments https://github.com/NixOS/hydra/issues/816#issuecomment-724140905 and https://github.com/NixOS/hydra/issues/816#issuecomment-724185036 show example stack traces (you have to manually expand the comments because I've hidden them as off-topic, as it wasn't pertinent to that issue).

cc @roberth and @edolstra 