### PR TITLE
enable Darwin.arm64 to install x86_64 binary

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -29,6 +29,8 @@ case "$(uname -s).$(uname -m)" in
     Linux.i?86) system=i686-linux; hash=@binaryTarball_i686-linux@;;
     Linux.aarch64) system=aarch64-linux; hash=@binaryTarball_aarch64-linux@;;
     Darwin.x86_64) system=x86_64-darwin; hash=@binaryTarball_x86_64-darwin@;;
+    # eventually maybe: system=arm64-darwin; hash=@binaryTarball_arm64-darwin@;;
+    Darwin.arm64) system=x86_64-darwin; hash=@binaryTarball_x86_64-darwin@;;
     *) oops "sorry, there is no binary distribution of Nix for your platform";;
 esac
 


### PR DESCRIPTION
Throwing @thefloweringash under the bus if this doesn't work 😁 but it
sounds like Apple Silicon devices can use the x86_64 binary for now.

Fixes #4058