### PR TITLE
Fix default nix-path

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2104,10 +2104,19 @@ EvalSettings::EvalSettings()
 Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;
-    auto add = [&](const Path & p) { if (pathExists(p)) { res.push_back(p); } };
+    auto add = [&](const Path & p, const std::string & s = std::string()) {
+        if (pathExists(p)) {
+            if (s.empty()) {
+                res.push_back(p);
+            } else {
+                res.push_back(s + "=" + p);
+            }
+        }
+    };
+
     add(getHome() + "/.nix-defexpr/channels");
-    add("nixpkgs=" + settings.nixStateDir + "/nix/profiles/per-user/root/channels/nixpkgs");
-    add(settings.nixStateDir + "/nix/profiles/per-user/root/channels");
+    add(settings.nixStateDir + "/profiles/per-user/root/channels/nixpkgs", "nixpkgs");
+    add(settings.nixStateDir + "/profiles/per-user/root/channels");
     return res;
 }
 


### PR DESCRIPTION
The default nix-path values for nixpkgs and root channels were incorrect, and so were not actually being added to `NIX_PATH` since the erroneous paths don't exist.

The test case is being able to import `<nixpkgs>` without an explicit `NIX_PATH`:

```
$ unset NIX_PATH

$ result/bin/nix show-config | grep nix-path
nix-path = /home/chris/.nix-defexpr/channels nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixpkgs /nix/var/nix/profiles/per-user/root/channels

$ result/bin/nix-build -E 'with import <nixpkgs> { };  hello'
this path will be fetched (0.04 MiB download, 0.20 MiB unpacked):
  /nix/store/a190zzakd2a5d91vly0d9yv85lcicwvq-hello-2.10
copying path '/nix/store/a190zzakd2a5d91vly0d9yv85lcicwvq-hello-2.10' from 'https://cache.nixos.org'...
/nix/store/a190zzakd2a5d91vly0d9yv85lcicwvq-hello-2.10
```

Is there anywhere I could plug in a test case for this?