### PR TITLE
libstore: always use the socket if it exists

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1042,9 +1042,7 @@ std::shared_ptr<Store> openFromNonUri(const std::string & uri, const Store::Para
 {
     if (uri == "" || uri == "auto") {
         auto stateDir = get(params, "state").value_or(settings.nixStateDir);
-        if (access(stateDir.c_str(), R_OK | W_OK) == 0)
-            return std::make_shared<LocalStore>(params);
-        else if (pathExists(settings.nixDaemonSocketFile))
+        if (pathExists(settings.nixDaemonSocketFile))
             return std::make_shared<UDSRemoteStore>(params);
         else
             return std::make_shared<LocalStore>(params);


### PR DESCRIPTION
This change modifies the behaviour of Nix to always communicate with the
daemon, even if the store is writable to that user.

Bypassing the daemon had a number of issues. Mainly, the client
behaviour is not always consistent between users leading to confusion.
The max-jobs counter is not shared between various instances of the Nix
client. The clients fight between each-other to hold the lock on the
sqlite database.

By making the access consistent, it opens the road for the daemon to
permanently hold the lock on the sqlite database, and get rid of the
"sqlite is busy" type of errors.