### PR TITLE
Skip Reference Check on bundler

### DIFF
--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -11,7 +11,6 @@ struct CmdBundle : InstallableCommand
 {
     std::string bundler = "github:matthewbauer/nix-bundle";
     std::optional<Path> outLink;
-    bool skipReferenceCheck = false;
 
     CmdBundle()
     {
@@ -34,11 +33,6 @@ struct CmdBundle : InstallableCommand
             .completer = completePath
         });
 
-        addFlag({
-            .longName = "skip-refcheck",
-            .description = "Skip checking of references in bundle.",
-            .handler = {&skipReferenceCheck, true},
-            });
     }
 
     std::string description() override
@@ -122,10 +116,6 @@ struct CmdBundle : InstallableCommand
         store->buildPaths({{drvPath}});
 
         auto outPathS = store->printStorePath(outPath);
-
-        auto info = store->queryPathInfo(outPath);
-        if (!info->references.empty() && !skipReferenceCheck)
-            throw Error("'%s' has references; a bundler must not leave any references", outPathS);
 
         if (!outLink)
             outLink = baseNameOf(app.program);

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -11,6 +11,7 @@ struct CmdBundle : InstallableCommand
 {
     std::string bundler = "github:matthewbauer/nix-bundle";
     std::optional<Path> outLink;
+    bool skipReferenceCheck = false;
 
     CmdBundle()
     {
@@ -32,6 +33,12 @@ struct CmdBundle : InstallableCommand
             .handler = {&outLink},
             .completer = completePath
         });
+
+        addFlag({
+            .longName = "skip-refcheck",
+            .description = "Skip checking of references in bundle.",
+            .handler = {&skipReferenceCheck, true},
+            });
     }
 
     std::string description() override
@@ -117,7 +124,7 @@ struct CmdBundle : InstallableCommand
         auto outPathS = store->printStorePath(outPath);
 
         auto info = store->queryPathInfo(outPath);
-        if (!info->references.empty())
+        if (!info->references.empty() && !skipReferenceCheck)
             throw Error("'%s' has references; a bundler must not leave any references", outPathS);
 
         if (!outLink)


### PR DESCRIPTION
The main reason for this change is a lot of bundlers are going to copy paths from the nix store into a bundle and this check will cause them to fail.

My specific use case is to create a .nix folder inside the derivation that can be used with nix-user-chroot from an app image.