### PR TITLE
Return derivation signatures in Perl bindings

### DIFF
--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -110,10 +110,14 @@ SV * queryPathInfo(char * path, int base32)
             XPUSHs(sv_2mortal(newSVpv(s.c_str(), 0)));
             mXPUSHi(info->registrationTime);
             mXPUSHi(info->narSize);
-            AV * arr = newAV();
+            AV * refs = newAV();
             for (auto & i : info->references)
-                av_push(arr, newSVpv(store()->printStorePath(i).c_str(), 0));
-            XPUSHs(sv_2mortal(newRV((SV *) arr)));
+                av_push(refs, newSVpv(store()->printStorePath(i).c_str(), 0));
+            XPUSHs(sv_2mortal(newRV((SV *) refs)));
+            AV * sigs = newAV();
+            for (auto & i : info->sigs)
+                av_push(sigs, newSVpv(i.c_str(), 0));
+            XPUSHs(sv_2mortal(newRV((SV *) sigs)));
         } catch (Error & e) {
             croak("%s", e.what());
         }


### PR DESCRIPTION
I propose to add derivation signatures to the array returned by `queryPathInfo`. I have a matching patch to nix-serve, to serve pre-signed packages instead of signing packages on demand.

I'm not a Perl expert, but as far as I can tell, adding values to the end of this array is backwards-compatible with usage like:

```
my ($deriver, $narHash, $time, $narSize, $refs) = queryPathInfo($storePath, 1)
```

but I can also create another function to get these signatures (`queryPathSigs` or similar) if that is a better approach.