### PR TITLE
Escape filename given to nix-shell in shebang mode

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -217,9 +217,9 @@ static void main_nix_build(int argc, char * * argv)
                 // read the shebang to understand which packages to read from. Since
                 // this is handled via nix-shell -p, we wrap our ruby script execution
                 // in ruby -e 'load' which ignores the shebangs.
-                envCommand = (format("exec %1% %2% -e 'load(\"%3%\")' -- %4%") % execArgs % interpreter % script % joined.str()).str();
+                envCommand = (format("exec %1% %2% -e 'load(ARGV.shift)' -- %3% %4%") % execArgs % interpreter % shellEscape(script) % joined.str()).str();
             } else {
-                envCommand = (format("exec %1% %2% %3% %4%") % execArgs % interpreter % script % joined.str()).str();
+                envCommand = (format("exec %1% %2% %3% %4%") % execArgs % interpreter % shellEscape(script) % joined.str()).str();
             }
         }
 

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -50,7 +50,7 @@ let pkgs = rec {
   # ruby "interpreter" that outputs "$@"
   ruby = runCommand "ruby" {} ''
     mkdir -p $out/bin
-    echo 'printf -- "$*"' > $out/bin/ruby
+    echo 'printf %s "$*"' > $out/bin/ruby
     chmod a+rx $out/bin/ruby
   '';
 


### PR DESCRIPTION
This prevents spaces or other metacharacters from causing nix-shell to execute the wrong path.

Fixes #4229.
