### PR TITLE
Allow fixed-output derivations to depend on (floating) content-addressed ones

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -493,8 +493,8 @@ void DerivationGoal::inputsRealised()
     if (useDerivation) {
         auto & fullDrv = *dynamic_cast<Derivation *>(drv.get());
 
-        if ((!fullDrv.inputDrvs.empty() &&
-             fullDrv.type() == DerivationType::CAFloating) || fullDrv.type() == DerivationType::DeferredInputAddressed) {
+        if ((!fullDrv.inputDrvs.empty() && derivationIsCA(fullDrv.type()))
+            || fullDrv.type() == DerivationType::DeferredInputAddressed) {
             /* We are be able to resolve this derivation based on the
                now-known results of dependencies. If so, we become a stub goal
                aliasing that resolved derivation goal */

--- a/tests/content-addressed.nix
+++ b/tests/content-addressed.nix
@@ -16,14 +16,16 @@ rec {
   };
   rootCA = mkDerivation {
     name = "rootCA";
-    outputs = [ "out" "dev" ];
+    outputs = [ "out" "dev" "foo"];
     buildCommand = ''
       echo "building a CA derivation"
       echo "The seed is ${toString seed}"
       mkdir -p $out
       echo ${rootLegacy}/hello > $out/dep
-      # test symlink at root
+      ln -s $out $out/self
+      # test symlinks at root
       ln -s $out $dev
+      ln -s $out $foo
     '';
     __contentAddressed = true;
     outputHashMode = "recursive";
@@ -34,7 +36,8 @@ rec {
     buildCommand = ''
       echo "building a dependent derivation"
       mkdir -p $out
-      echo ${rootCA}/hello > $out/dep
+      cat ${rootCA}/self/dep
+      echo ${rootCA}/self/dep > $out/dep
     '';
     __contentAddressed = true;
     outputHashMode = "recursive";

--- a/tests/content-addressed.nix
+++ b/tests/content-addressed.nix
@@ -63,4 +63,15 @@ rec {
       echo ${rootCA}/non-ca-hello > $out/dep
     '';
   };
+  dependentFixedOutput = mkDerivation {
+    name = "dependent-fixed-output";
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-QvtAMbUl/uvi+LCObmqOhvNOapHdA2raiI4xG5zI5pA=";
+    buildCommand = ''
+      cat ${dependentCA}/dep
+      echo foo > $out
+    '';
+
+  };
 }

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -40,6 +40,7 @@ testCutoff () {
     #testDerivation dependentCA
     testCutoffFor transitivelyDependentCA
     testCutoffFor dependentNonCA
+    testCutoffFor dependentFixedOutput
 }
 
 testGC () {


### PR DESCRIPTION
Fix an overlook of https://github.com/NixOS/nix/pull/4056
