### PR TITLE
Disable cache when a flake --update-input is explicitly specified.

### DIFF
--- a/src/libfetchers/cache.hh
+++ b/src/libfetchers/cache.hh
@@ -29,8 +29,13 @@ struct Cache
     virtual std::optional<Result> lookupExpired(
         ref<Store> store,
         const Attrs & inAttrs) = 0;
+
+    virtual void cacheLookupsEnabled(const bool & enabled) = 0;
 };
 
 ref<Cache> getCache();
+
+struct disabler;
+struct std::shared_ptr<disabler> disableCacheLookups(void);
 
 }


### PR DESCRIPTION
If the user has supplied the explicit --update-input flag, then the
input should be fetched from the remote regardless of whether it was
previously fetched and cached (usually within the last hour).  The
caching can lead to user confusion and frustration when updates don't
appear to be getting performed properly.