### PR TITLE
shut up clang warnings

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -12,6 +12,8 @@
 
 
 %{
+#pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+
 #include <boost/lexical_cast.hpp>
 
 #include "nixexpr.hh"

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -7,7 +7,7 @@ namespace nix {
 
 /* Forward definition. */
 struct Goal;
-struct Worker;
+class Worker;
 
 /* A pointer to a goal. */
 typedef std::shared_ptr<Goal> GoalPtr;

--- a/src/libstore/build/worker.hh
+++ b/src/libstore/build/worker.hh
@@ -8,8 +8,8 @@
 namespace nix {
 
 /* Forward definition. */
-class DerivationGoal;
-class SubstitutionGoal;
+struct DerivationGoal;
+struct SubstitutionGoal;
 
 /* Workaround for not being able to declare a something like
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -296,8 +296,8 @@ private:
 
     void createUser(const std::string & userName, uid_t userId) override;
 
-    friend class DerivationGoal;
-    friend class SubstitutionGoal;
+    friend struct DerivationGoal;
+    friend struct SubstitutionGoal;
 };
 
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -22,6 +22,9 @@ std::string chrootHelperName = "__run_in_chroot";
 
 struct RunCommon : virtual Command
 {
+
+    using Command::run;
+
     void runProgram(ref<Store> store,
         const std::string & program,
         const Strings & args)
@@ -59,6 +62,9 @@ struct RunCommon : virtual Command
 
 struct CmdShell : InstallablesCommand, RunCommon, MixEnvironment
 {
+
+    using InstallablesCommand::run;
+
     std::vector<std::string> command = { getEnv("SHELL").value_or("bash") };
 
     CmdShell()
@@ -144,6 +150,8 @@ static auto rCmdShell = registerCommand<CmdShell>("shell");
 
 struct CmdRun : InstallableCommand, RunCommon
 {
+    using InstallableCommand::run;
+
     std::vector<std::string> args;
 
     CmdRun()


### PR DESCRIPTION
- Fix some class/struct discrepancies
- Explicit the overloading of `run` in the `Cmd*` classes
- Ignore a warning in the generated lexer