### PR TITLE
Remove `unknown pragma` gcc warning

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -12,7 +12,9 @@
 
 
 %{
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wunneeded-internal-declaration"
+#endif
 
 #include <boost/lexical_cast.hpp>
 

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -82,7 +82,7 @@ struct RetrieveRegularNARSink : ParseSink
         sink(data);
     }
 
-    void createSymlink(const Path & path, const string & target)
+    void createSymlink(const Path & path, const string & target) override
     {
         regular = false;
     }


### PR DESCRIPTION
Remove a clang-specific pragma when building with GCC to avoid a spurious warning.

(Also adds a missing `override` on the way because it was causing a new series of clang warnings)
