### PR TITLE
Check for rosetta 2 support before installing x86_64-darwin Nix

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -45,7 +45,7 @@ case "$(uname -s).$(uname -m)" in
         path=@tarballPath_x86_64-darwin@
         system=x86_64-darwin
         ;;
-    Darwin.arm64)
+    Darwin.arm64|Darwin.aarch64)
         # check for Rosetta 2 support
         if ! [ -d /Library/Apple/usr/libexec/oah ]; then
           oops "Rosetta 2 is not installed on this ARM64 macOS machine. Run softwareupdate --install-rosetta then restart installation"
@@ -53,7 +53,7 @@ case "$(uname -s).$(uname -m)" in
 
         hash=@binaryTarball_x86_64-darwin@
         path=@tarballPath_x86_64-darwin@
-        # eventually maybe: arm64-darwin
+        # eventually maybe: aarch64-darwin
         system=x86_64-darwin
         ;;
     *) oops "sorry, there is no binary distribution of Nix for your platform";;

--- a/scripts/install.in
+++ b/scripts/install.in
@@ -46,6 +46,11 @@ case "$(uname -s).$(uname -m)" in
         system=x86_64-darwin
         ;;
     Darwin.arm64)
+        # check for Rosetta 2 support
+        if ! [ -d /Library/Apple/usr/libexec/oah ]; then
+          oops "Rosetta 2 is not installed on this ARM64 macOS machine. Run softwareupdate --install-rosetta then restart installation"
+        fi
+
         hash=@binaryTarball_x86_64-darwin@
         path=@tarballPath_x86_64-darwin@
         # eventually maybe: arm64-darwin

--- a/scripts/install.in
+++ b/scripts/install.in
@@ -47,7 +47,7 @@ case "$(uname -s).$(uname -m)" in
         ;;
     Darwin.arm64|Darwin.aarch64)
         # check for Rosetta 2 support
-        if ! [ -d /Library/Apple/usr/libexec/oah ]; then
+        if ! [ -f /Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist ]; then
           oops "Rosetta 2 is not installed on this ARM64 macOS machine. Run softwareupdate --install-rosetta then restart installation"
         fi
 


### PR DESCRIPTION
Check for "rosetta 2" on ARM64 macOS first. Otherwise, installation will fail with:

  Bad CPU type in executable

when running nix-store during later installation. This should be a safe check, but will need someone without rosetta 2 to verify this works as expected first (I've now installed it after setting up my new system).
