### PR TITLE
Add cache.nixos.org to trusted substituters by default

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -583,7 +583,7 @@ public:
 
     Setting<Strings> substituters{
         this,
-        nixStore == "/nix/store" ? Strings{"https://cache.nixos.org/"} : Strings(),
+        Strings{"https://cache.nixos.org/"},
         "substituters",
         R"(
           A list of URLs of substituters, separated by whitespace. The default
@@ -592,7 +592,7 @@ public:
         {"binary-caches"}};
 
     Setting<StringSet> trustedSubstituters{
-        this, nixStore == "/nix/store" ? StringSet{"https://cache.nixos.org/"} : {}, "trusted-substituters",
+        this, {"https://cache.nixos.org/"}, "trusted-substituters",
         R"(
           A list of URLs of substituters, separated by whitespace. These are
           not used by default, but can be enabled by users of the Nix daemon

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -592,7 +592,7 @@ public:
         {"binary-caches"}};
 
     Setting<StringSet> trustedSubstituters{
-        this, {}, "trusted-substituters",
+        this, nixStore == "/nix/store" ? StringSet{"https://cache.nixos.org/"} : {}, "trusted-substituters",
         R"(
           A list of URLs of substituters, separated by whitespace. These are
           not used by default, but can be enabled by users of the Nix daemon


### PR DESCRIPTION
When a user is untrusted, Nix will only trust substituters that are in
trusted-substituters. But users don’t always know if they are trusted
or not by the Nix daemon, especially when sharing configs accross
machines. So for example, a user has a nix.conf in $HOME/.config/nix/
that looks like this:

  substituters = https://cache.nixos.org https://my-custom-cache.cachix.org

Nix will override the default substituters, but skip both with:

  warning: ignoring untrusted substituter ‘https://cache.nixos.org’
  warning: ignoring untrusted substituter ‘https://my-custom-cache.cachix.org’

So the user now gets no substituters, and would have to remove the
substituters config setting to reenable cache.nixos.org. To fix this,
just include https://cache.nixos.org by default. This can still be
overridden by the user.