### PR TITLE
Properly test the early cutoff for CA derivations

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -223,11 +223,6 @@ void Worker::run(const Goals & _topGoals)
     uint64_t downloadSize, narSize;
     store.queryMissing(topPaths, willBuild, willSubstitute, unknown, downloadSize, narSize);
 
-    if (!willBuild.empty() && 0 == settings.maxBuildJobs && getMachines().empty())
-        throw Error(
-            "%d derivations need to be built, but neither local builds ('--max-jobs') "
-            "nor remote builds ('--builders') are enabled", willBuild.size());
-
     debug("entered goal loop");
 
     while (1) {


### PR DESCRIPTION
The current ca test suite doesn't really test early cutoff as it should because the tests that are supposed to do it don't change the `seed` argument, meaning that they build twice the exact same derivation rather than two derivations that resolve to the same thing. Fix that to make the test actually useful.

(I'm not sure what happened to this testsuite, but between this and #4282 it seems to have been mostly useless so far…).

Also removes the early check for `-j0` in the build loop as it's invalid with CA derivations (and would in particular make this test quite more painful to write)
