### PR TITLE
Add x86_64-darwin and aarch64 to "extra-platforms" automatically when Rosetta2 is detected

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -50,6 +50,10 @@
 #define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
 #endif
 
+#if __APPLE__
+#include <spawn.h>
+#endif
+
 #include <pwd.h>
 #include <grp.h>
 
@@ -2844,7 +2848,27 @@ void DerivationGoal::runChild()
             }
         }
 
+#if __APPLE__
+        posix_spawnattr_t attrp;
+
+        if (posix_spawnattr_init(&attrp))
+            throw SysError("failed to initialize builder");
+
+        if (posix_spawnattr_setflags(&attrp, POSIX_SPAWN_SETEXEC))
+            throw SysError("failed to initialize builder");
+
+        if (drv->platform == "aarch64-darwin") {
+            cpu_type_t cpu = CPU_TYPE_ARM64;
+            posix_spawnattr_setbinpref_np(&attrp, 1, &cpu, NULL);
+        } else if (drv->platform == "x86_64-darwin") {
+            cpu_type_t cpu = CPU_TYPE_X86_64;
+            posix_spawnattr_setbinpref_np(&attrp, 1, &cpu, NULL);
+        }
+
+        posix_spawn(NULL, builder, NULL, &attrp, stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
+#else
         execve(builder, stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
+#endif
 
         throw SysError("executing '%1%'", drv->builder);
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -140,7 +140,7 @@ StringSet Settings::getDefaultExtraPlatforms()
     // machines. Note that we can’t force processes from executing
     // x86_64 in aarch64 environments or vice versa since they can
     // always exec with their own binary preferences.
-    else if (pathExists("/Library/Apple/usr/libexec/oah")) {
+    else if (pathExists("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist")) {
         if (std::string{SYSTEM} == "x86_64-darwin")
             return StringSet{"aarch64-darwin"};
         else if (std::string{SYSTEM} == "aarch64-darwin")

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -131,6 +131,28 @@ StringSet Settings::getDefaultSystemFeatures()
     return features;
 }
 
+StringSet Settings::getDefaultExtraPlatforms()
+{
+    if (std::string{SYSTEM} == "x86_64-linux" && !isWSL1())
+        return StringSet{"i686-linux"};
+#if __APPLE__
+    // Rosetta 2 emulation layer can run x86_64 binaries on aarch64
+    // machines. Note that we can’t force processes from executing
+    // x86_64 in aarch64 environments or vice versa since they can
+    // always exec with their own binary preferences.
+    else if (pathExists("/Library/Apple/usr/libexec/oah")) {
+        if (std::string{SYSTEM} == "x86_64-darwin")
+            return StringSet{"aarch64-darwin"};
+        else if (std::string{SYSTEM} == "aarch64-darwin")
+            return StringSet{"x86_64-darwin"};
+        else
+            return StringSet{};
+    }
+#endif
+    else
+        return StringSet{};
+}
+
 bool Settings::isExperimentalFeatureEnabled(const std::string & name)
 {
     auto & f = experimentalFeatures.get();

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -34,6 +34,8 @@ class Settings : public Config {
 
     StringSet getDefaultSystemFeatures();
 
+    StringSet getDefaultExtraPlatforms();
+
     bool isWSL1();
 
 public:
@@ -545,7 +547,7 @@ public:
 
     Setting<StringSet> extraPlatforms{
         this,
-        std::string{SYSTEM} == "x86_64-linux" && !isWSL1() ? StringSet{"i686-linux"} : StringSet{},
+        getDefaultExtraPlatforms(),
         "extra-platforms",
         R"(
           Platforms other than the native one which this machine is capable of


### PR DESCRIPTION
First:

**Add extraPlatforms for Rosetta 2 macOS**

macOS systems with ARM64 can utilize a translation layer at /Library/Apple/usr/libexec/oah to run x86_64 binaries. This change makes Nix recognize that and it to "extra-platforms". Note that there are two cases here since Nix could be built for either x86_64 or aarch64. In either case, we can switch to the other architecture. Unfortunately there is not a good way to prevent aarch64 binaries from being run in x86_64 contexts or vice versa - programs can always execute programs for the other architecture.

~Question: Can someone confirm that /Library/Apple/usr/libexec/oah **does not** exist when Rosetta 2 is not installed? There could be some stubs there even if Rosetta 2 is not setup yet.~

Second:

**Use posix_spawn_setbinpref_np to advise which architecture to run**

When running universal binaries like /bin/bash, Darwin XNU will choose which architecture of the binary to use based on "binary preferences". This change sets that to the current platform for aarch64 and x86_64 builds. In addition it now uses posix_spawn instead of the usual execve. Note, that this does not prevent the other architecture from being run, just advises which to use.

/cc @abathur @thefloweringash @edolstra