### PR TITLE
Include static "nix" binary in Hydra build products

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -466,6 +466,8 @@
           postInstall = ''
             mkdir -p $doc/nix-support
             echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
+            mkdir -p $out/nix-support
+            echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
           '';
 
           doInstallCheck = true;


### PR DESCRIPTION
This allows users to get Nix from Hydra via a stable url like
https://hydra.nixos.org/build/132078238/download/1/nix