### PR TITLE
Fix compatibility with newer AWS SDKs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,7 @@ if test -n "$enable_s3"; then
   declare -a aws_version_tokens=($(printf '#include <aws/core/VersionConfig.h>\nAWS_SDK_VERSION_STRING' | $CPP $CPPFLAGS - | grep -v '^#.*' | sed 's/"//g' | tr '.' ' '))
   AC_DEFINE_UNQUOTED([AWS_VERSION_MAJOR], ${aws_version_tokens@<:@0@:>@}, [Major version of aws-sdk-cpp.])
   AC_DEFINE_UNQUOTED([AWS_VERSION_MINOR], ${aws_version_tokens@<:@1@:>@}, [Minor version of aws-sdk-cpp.])
+  AC_DEFINE_UNQUOTED([AWS_VERSION_PATCH], ${aws_version_tokens@<:@2@:>@}, [Patch version of aws-sdk-cpp.])
 fi
 
 

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -57,6 +57,10 @@ class AwsLogger : public Aws::Utils::Logging::FormattedLogSystem
     {
         debug("AWS: %s", chomp(statement));
     }
+
+#if !(AWS_VERSION_MAJOR <= 1 && AWS_VERSION_MINOR <= 7 && AWS_VERSION_PATCH <= 115)
+    void Flush() override {}
+#endif
 };
 
 static void initAWS()


### PR DESCRIPTION
Fixes #3201.

The incompatibility appears to have been introduced in AWS SDK 1.7.115 through: https://github.com/aws/aws-sdk-cpp/commit/4d92ec7ab6daa0cb15efee04ba40800a0d9e9a65

I ran tests locally on macOS against AWS SDK 1.8.99 with the following overlay:

```patch
--- a/flake.nix
+++ b/flake.nix
@@ -223,6 +223,20 @@
             '';
         };
 
+        aws-sdk-cpp = prev.aws-sdk-cpp.overrideAttrs (oldAttrs: rec {
+          version = "1.8.99";
+          src = final.fetchFromGitHub {
+            owner = "awslabs";
+            repo = "aws-sdk-cpp";
+            rev = version;
+            hash = "sha256-CqiVCA8Ugc4TnXuatLfh2D8qrFaYod40W1gmWJyqlns=";
+          };
+          patches = [ ];
+          cmakeFlags = oldAttrs.cmakeFlags ++ [
+            "-DENABLE_TESTING=OFF" # Relies on network
+          ];
+        });
+
       };
 
       hydraJobs = {
```