### PR TITLE
Support statically built Nix on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -476,7 +476,7 @@
         # Binary package for various platforms.
         build = forAllSystems (system: self.packages.${system}.nix);
 
-        buildStatic = lib.genAttrs linux64BitSystems (system: self.packages.${system}.nix-static);
+        buildStatic = lib.genAttrs (linux64BitSystems ++ ["x86_64-darwin"]) (system: self.packages.${system}.nix-static);
 
         buildCross = forAllCrossSystems (crossSystem:
           lib.genAttrs ["x86_64-linux"] (system: self.packages.${system}."nix-${crossSystem}"));
@@ -646,7 +646,7 @@
       packages = forAllSystems (system: rec {
         inherit (nixpkgsFor.${system}.native) nix;
         default = nix;
-      } // (lib.optionalAttrs (builtins.elem system linux64BitSystems) {
+      } // (lib.optionalAttrs (builtins.elem system (linux64BitSystems ++ ["x86_64-darwin"])) {
         nix-static = nixpkgsFor.${system}.static.nix;
         dockerImage =
           let

--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -126,8 +126,12 @@ define build-library
     $(1)_PATH := $$(_d)/$$($(1)_NAME).a
 
     $$($(1)_PATH): $$($(1)_OBJS) | $$(_d)/
-	+$$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$^
-	$$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
+    ifeq ($(OS), Linux)
+	+$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$^
+	$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
+    else
+	$(trace-ar) $(AR) crs $$@ $$^
+    endif
 
     $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS) $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LDFLAGS_USE))
 


### PR DESCRIPTION
This adds support for static Darwin Nix via https://github.com/NixOS/nixpkgs/pull/106115.

- Need to skip the `-Ur` flag for darwin cctools
- Update nixpkgs to my branch (should probably wait until merged into Nixpkgs & maybe released)
- Enable x86_64-darwin builds.