### PR TITLE
Always default to cache.nixos.org even when different nix store dir

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -583,7 +583,7 @@ public:
 
     Setting<Strings> substituters{
         this,
-        nixStore == "/nix/store" ? Strings{"https://cache.nixos.org/"} : Strings(),
+        Strings{"https://cache.nixos.org/"},
         "substituters",
         R"(
           A list of URLs of substituters, separated by whitespace. The default


### PR DESCRIPTION
Since 0744f7f, it is now useful to have cache.nixos.org in substituers
even if /nix/store is not the Nix Store Dir. This can always be
overridden via configuration, though.