### PR TITLE
Re-query for the derivation outputs in the post-build-hook

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -899,8 +899,10 @@ void DerivationGoal::buildDone()
                 Logger::Fields{worker.store.printStorePath(drvPath)});
             PushActivity pact(act.id);
             StorePathSet outputPaths;
-            for (auto i : drv->outputs) {
-                outputPaths.insert(finalOutputs.at(i.first));
+            for (auto& [_, maybeOutPath] :
+                 worker.store.queryPartialDerivationOutputMap(drvPath)) {
+                if (maybeOutPath)
+                    outputPaths.insert(*maybeOutPath);
             }
             std::map<std::string, std::string> hookEnvironment = getEnv();
 


### PR DESCRIPTION
We can't assume that the runtime state knows about them as they might have been built remotely, in which case we must query the db again to get them.

Fix (hopefully) #4245 