### PR TITLE
Store the realisations of unresolved derivations

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -506,6 +506,7 @@ void DerivationGoal::inputsRealised()
             Derivation drvResolved { *std::move(attempt) };
 
             auto pathResolved = writeDerivation(worker.store, drvResolved);
+            resolvedDrv = drvResolved;
 
             auto msg = fmt("Resolved derivation: '%s' -> '%s'",
                 worker.store.printStorePath(drvPath),
@@ -1019,7 +1020,45 @@ void DerivationGoal::buildDone()
 }
 
 void DerivationGoal::resolvedFinished() {
-    done(BuildResult::Built);
+    assert(resolvedDrv);
+
+    // If the derivation was originally a full `Derivation` (and not just
+    // a `BasicDerivation`, we must retrieve it because the `staticOutputHashes`
+    // will be wrong otherwise
+    Derivation fullDrv = *drv;
+    if (auto upcasted = dynamic_cast<Derivation *>(drv.get()))
+        fullDrv = *upcasted;
+
+    auto originalHashes = staticOutputHashes(worker.store, fullDrv);
+    auto resolvedHashes = staticOutputHashes(worker.store, *resolvedDrv);
+
+    // `wantedOutputs` might be empty, which means “all the outputs”
+    auto realWantedOutputs = wantedOutputs;
+    if (realWantedOutputs.empty())
+        realWantedOutputs = resolvedDrv->outputNames();
+
+    for (auto & wantedOutput : realWantedOutputs) {
+        assert(originalHashes.count(wantedOutput) != 0);
+        assert(resolvedHashes.count(wantedOutput) != 0);
+        auto realisation = worker.store.queryRealisation(
+                DrvOutput{resolvedHashes.at(wantedOutput), wantedOutput}
+        );
+        // We've just built it, but maybe the build failed, in which case the
+        // realisation won't be there
+        if (realisation) {
+            auto newRealisation = *realisation;
+            newRealisation.id = DrvOutput{originalHashes.at(wantedOutput), wantedOutput};
+            worker.store.registerDrvOutput(newRealisation);
+        } else {
+            // If we don't have a realisation, then it must mean that something
+            // failed when building the resolved drv
+            assert(!result.success());
+        }
+    }
+
+    // This is potentially a bit fishy in terms of error reporting. Not sure
+    // how to do it in a cleaner way
+    amDone(nrFailed == 0 ? ecSuccess : ecFailed, ex);
 }
 
 HookReply DerivationGoal::tryBuildHook()
@@ -3803,6 +3842,19 @@ void DerivationGoal::checkPathValidity()
                     ? PathStatus::Valid
                     : PathStatus::Corrupt,
             };
+        }
+        if (settings.isExperimentalFeatureEnabled("ca-derivations")) {
+            Derivation fullDrv = *drv;
+            if (auto upcasted = dynamic_cast<Derivation *>(drv.get()))
+                fullDrv = *upcasted;
+            auto outputHashes = staticOutputHashes(worker.store, fullDrv);
+            if (auto real = worker.store.queryRealisation(
+                    DrvOutput{outputHashes.at(i.first), i.first})) {
+                info.known = {
+                    .path = real->outPath,
+                    .status = PathStatus::Valid,
+                };
+            }
         }
         initialOutputs.insert_or_assign(i.first, info);
     }

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -48,6 +48,9 @@ struct DerivationGoal : public Goal
     /* The path of the derivation. */
     StorePath drvPath;
 
+    /* The path of the corresponding resolved derivation */
+    std::optional<BasicDerivation> resolvedDrv;
+
     /* The specific outputs that we need to build.  Empty means all of
        them. */
     StringSet wantedOutputs;

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -37,6 +37,7 @@ struct InitialOutputStatus {
 
 struct InitialOutput {
     bool wanted;
+    Hash outputHash;
     std::optional<InitialOutputStatus> known;
 };
 

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -756,8 +756,13 @@ std::optional<BasicDerivation> Derivation::tryResolveUncached(Store & store) {
         StringSet newOutputNames;
         for (auto & outputName : input.second) {
             auto actualPathOpt = inputDrvOutputs.at(outputName);
-            if (!actualPathOpt)
+            if (!actualPathOpt) {
+                warn("Input %s!%s missing, aborting the resolving",
+                    store.printStorePath(input.first),
+                    outputName
+                );
                 return std::nullopt;
+            }
             auto actualPath = *actualPathOpt;
             inputRewrites.emplace(
                 downstreamPlaceholder(store, input.first, outputName),
@@ -781,6 +786,8 @@ std::optional<BasicDerivation> Derivation::tryResolve(Store& store, const StoreP
 {
     // This is quite dirty and leaky, but will disappear once #4340 is merged
     static Sync<std::map<StorePath, std::optional<Derivation>>> resolutionsCache;
+
+    debug("Trying to resolve %s", store.printStorePath(drvPath));
 
     {
         auto resolutions = resolutionsCache.lock();

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -787,7 +787,7 @@ std::optional<BasicDerivation> Derivation::tryResolve(Store& store, const StoreP
     // This is quite dirty and leaky, but will disappear once #4340 is merged
     static Sync<std::map<StorePath, std::optional<Derivation>>> resolutionsCache;
 
-    debug("Trying to resolve %s", store.printStorePath(drvPath));
+    debug("trying to resolve %s", store.printStorePath(drvPath));
 
     {
         auto resolutions = resolutionsCache.lock();

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -757,9 +757,9 @@ std::optional<BasicDerivation> Derivation::tryResolveUncached(Store & store) {
         for (auto & outputName : input.second) {
             auto actualPathOpt = inputDrvOutputs.at(outputName);
             if (!actualPathOpt) {
-                warn("Input %s!%s missing, aborting the resolving",
-                    store.printStorePath(input.first),
-                    outputName
+                warn("output %s of input %s missing, aborting the resolving",
+                    outputName,
+                    store.printStorePath(input.first)
                 );
                 return std::nullopt;
             }

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -745,7 +745,7 @@ static void rewriteDerivation(Store & store, BasicDerivation & drv, const String
 
 }
 
-std::optional<BasicDerivation> Derivation::tryResolveUncached(Store & store) {
+std::optional<BasicDerivation> Derivation::tryResolve(Store & store) {
     BasicDerivation resolved { *this };
 
     // Input paths that we'll want to rewrite in the derivation
@@ -774,38 +774,6 @@ std::optional<BasicDerivation> Derivation::tryResolveUncached(Store & store) {
     rewriteDerivation(store, resolved, inputRewrites);
 
     return resolved;
-}
-
-std::optional<BasicDerivation> Derivation::tryResolve(Store& store)
-{
-    auto drvPath = writeDerivation(store, *this, NoRepair, false);
-    return Derivation::tryResolve(store, drvPath);
-}
-
-std::optional<BasicDerivation> Derivation::tryResolve(Store& store, const StorePath& drvPath)
-{
-    // This is quite dirty and leaky, but will disappear once #4340 is merged
-    static Sync<std::map<StorePath, std::optional<Derivation>>> resolutionsCache;
-
-    debug("trying to resolve %s", store.printStorePath(drvPath));
-
-    {
-        auto resolutions = resolutionsCache.lock();
-        auto resolvedDrvIter = resolutions->find(drvPath);
-        if (resolvedDrvIter != resolutions->end()) {
-            auto & [_, resolvedDrv] = *resolvedDrvIter;
-                return *resolvedDrv;
-        }
-    }
-
-    /* Try resolve drv and use that path instead. */
-    auto drv = store.readDerivation(drvPath);
-    auto attempt = drv.tryResolveUncached(store);
-    if (!attempt)
-        return std::nullopt;
-    /* Store in memo table. */
-    resolutionsCache.lock()->insert_or_assign(drvPath, *attempt);
-    return *attempt;
 }
 
 }

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -138,14 +138,10 @@ struct Derivation : BasicDerivation
 
        2. Input placeholders are replaced with realized input store paths. */
     std::optional<BasicDerivation> tryResolve(Store & store);
-    static std::optional<BasicDerivation> tryResolve(Store & store, const StorePath & drvPath);
 
     Derivation() = default;
     Derivation(const BasicDerivation & bd) : BasicDerivation(bd) { }
     Derivation(BasicDerivation && bd) : BasicDerivation(std::move(bd)) { }
-
-private:
-    std::optional<BasicDerivation> tryResolveUncached(Store & store);
 };
 
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -883,7 +883,7 @@ StorePathSet LocalStore::queryValidDerivers(const StorePath & path)
 
 
 std::map<std::string, std::optional<StorePath>>
-LocalStore::queryDerivationOutputMapNoResolve(const StorePath& path_)
+LocalStore::queryPartialDerivationOutputMap(const StorePath& path_)
 {
     auto path = path_;
     auto outputs = retrySQLite<std::map<std::string, std::optional<StorePath>>>([&]() {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -883,7 +883,7 @@ StorePathSet LocalStore::queryValidDerivers(const StorePath & path)
 
 
 std::map<std::string, std::optional<StorePath>>
-LocalStore::queryPartialDerivationOutputMap(const StorePath& path_)
+LocalStore::queryPartialDerivationOutputMap(const StorePath & path_)
 {
     auto path = path_;
     auto outputs = retrySQLite<std::map<std::string, std::optional<StorePath>>>([&]() {

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -127,7 +127,7 @@ public:
 
     StorePathSet queryValidDerivers(const StorePath & path) override;
 
-    std::map<std::string, std::optional<StorePath>> queryDerivationOutputMapNoResolve(const StorePath & path) override;
+    std::map<std::string, std::optional<StorePath>> queryPartialDerivationOutputMap(const StorePath & path) override;
 
     std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override;
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -366,7 +366,7 @@ bool Store::PathInfoCacheValue::isKnownNow()
     return std::chrono::steady_clock::now() < time_point + ttl;
 }
 
-std::map<std::string, std::optional<StorePath>> Store::queryDerivationOutputMapNoResolve(const StorePath & path)
+std::map<std::string, std::optional<StorePath>> Store::queryPartialDerivationOutputMap(const StorePath & path)
 {
     std::map<std::string, std::optional<StorePath>> outputs;
     auto drv = readInvalidDerivation(path);
@@ -374,19 +374,6 @@ std::map<std::string, std::optional<StorePath>> Store::queryDerivationOutputMapN
         outputs.emplace(outputName, output.second);
     }
     return outputs;
-}
-
-std::map<std::string, std::optional<StorePath>> Store::queryPartialDerivationOutputMap(const StorePath & path)
-{
-    if (settings.isExperimentalFeatureEnabled("ca-derivations")) {
-        auto resolvedDrv = Derivation::tryResolve(*this, path);
-        if (resolvedDrv) {
-            auto resolvedDrvPath = writeDerivation(*this, *resolvedDrv, NoRepair, true);
-            if (isValidPath(resolvedDrvPath))
-                return queryDerivationOutputMapNoResolve(resolvedDrvPath);
-        }
-    }
-    return queryDerivationOutputMapNoResolve(path);
 }
 
 OutputPathMap Store::queryDerivationOutputMap(const StorePath & path) {

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -415,12 +415,6 @@ public:
        `std::nullopt`.  */
     virtual std::map<std::string, std::optional<StorePath>> queryPartialDerivationOutputMap(const StorePath & path);
 
-    /*
-     * Similar to `queryPartialDerivationOutputMap`, but doesn't try to resolve
-     * the derivation
-     */
-    virtual std::map<std::string, std::optional<StorePath>> queryDerivationOutputMapNoResolve(const StorePath & path);
-
     /* Query the mapping outputName=>outputPath for the given derivation.
        Assume every output has a mapping and throw an exception otherwise. */
     OutputPathMap queryDerivationOutputMap(const StorePath & path);

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -518,9 +518,11 @@ static void main_nix_build(int argc, char * * argv)
             if (counter)
                 drvPrefix += fmt("-%d", counter + 1);
 
-            auto builtOutputs = store->queryDerivationOutputMap(drvPath);
+            auto builtOutputs = store->queryPartialDerivationOutputMap(drvPath);
 
-            auto outputPath = builtOutputs.at(outputName);
+            auto maybeOutputPath = builtOutputs.at(outputName);
+            assert(maybeOutputPath);
+            auto outputPath = *maybeOutputPath;
 
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>()) {
                 std::string symlink = drvPrefix;

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -48,6 +48,10 @@ testCutoff () {
 testGC () {
     nix-instantiate --experimental-features ca-derivations ./content-addressed.nix -A rootCA --arg seed 5
     nix-collect-garbage --experimental-features ca-derivations --option keep-derivations true
+    clearStore
+    buildAttr rootCA 1 --out-link $TEST_ROOT/rootCA
+    nix-collect-garbage --experimental-features ca-derivations
+    buildAttr rootCA 1 -j0
 }
 
 testNixCommand () {


### PR DESCRIPTION
When building a (non fully-input-addressed) derivation, we first resolve it to a `BasicDerivation` that depends directly on the output paths of its dependencies (rather than on the derivation outputs) − this is what enables early cutoff.

Currently we register the realisation of the resolved derivation, so that subsequent calls to `nix-build` can directly reuse this without rebuilding the derivation.  However, we don't register the unresolved derivation, meaning that we have to re-do the resolution step each time.
This in turn means that we must either keep all the build inputs or keep the knowledge of their output path (without the content of the path itself).
The former is very costly in disk-space (it amounts to making every build-input a runtime dependency), and the latter comes with a big set of challenges in presence of non-determinism that makes this a too heavy-handed solution for the time being (though we might switch to it eventually if we can find a way to solve its issues as it's a rather tempting design).

To avoid these issues, we choose a third way which is to also register the realisation of the unresolved derivation − so we can completely sidestep the resolving phase, which makes these behave as classical input-addressed derivations.

Depends on #4330 
