### PR TITLE
fix remote build hook

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2872,6 +2872,8 @@ void DerivationGoal::registerOutputs()
         for (auto & i : drv->outputsAndOptPaths(worker.store)) {
             if (!i.second.second || !worker.store.isValidPath(*i.second.second))
                 allValid = false;
+            else
+                finalOutputs.insert_or_assign(i.first, *i.second.second);
         }
         if (allValid) return;
     }

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -899,10 +899,8 @@ void DerivationGoal::buildDone()
                 Logger::Fields{worker.store.printStorePath(drvPath)});
             PushActivity pact(act.id);
             StorePathSet outputPaths;
-            for (auto& [_, maybeOutPath] :
-                 worker.store.queryPartialDerivationOutputMap(drvPath)) {
-                if (maybeOutPath)
-                    outputPaths.insert(*maybeOutPath);
+            for (auto i : drv->outputs) {
+                outputPaths.insert(finalOutputs.at(i.first));
             }
             std::map<std::string, std::string> hookEnvironment = getEnv();
 

--- a/tests/build-remote-input-addressed.sh
+++ b/tests/build-remote-input-addressed.sh
@@ -3,3 +3,31 @@ source common.sh
 file=build-hook.nix
 
 source build-remote.sh
+
+# Add a `post-build-hook` option to the nix conf.
+# This hook will be executed both for the local machine and the remote builders
+# (because they share the same config).
+registerBuildHook () {
+    # Dummy post-build-hook just to ensure that it's executed correctly.
+    # (we can't reuse the one from `$PWD/push-to-store.sh` because of
+    # https://github.com/NixOS/nix/issues/4341)
+    cat <<EOF > $TEST_ROOT/post-build-hook.sh
+#!/bin/sh
+
+echo "Post hook ran successfully"
+# Add an empty line to a counter file, just to check that this hook ran properly
+echo "" >> $TEST_ROOT/post-hook-counter
+EOF
+    chmod +x $TEST_ROOT/post-build-hook.sh
+    rm -f $TEST_ROOT/post-hook-counter
+
+    echo "post-build-hook = $TEST_ROOT/post-build-hook.sh" >> $NIX_CONF_DIR/nix.conf
+}
+
+registerBuildHook
+source build-remote.sh
+
+# `build-hook.nix` has four derivations to build, and the hook runs twice for
+# each derivation (once on the builder and once on the host), so the counter
+# should contain eight lines now
+[[ $(cat $TEST_ROOT/post-hook-counter | wc -l) -eq 8 ]]

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -14,6 +14,9 @@ builders=(
   "ssh-ng://localhost?remote-store=$TEST_ROOT/machine3?system-features=baz - - 1 1 baz"
 )
 
+chmod -R +w $TEST_ROOT/machine* || true
+rm -rf $TEST_ROOT/machine* || true
+
 # Note: ssh://localhost bypasses ssh, directly invoking nix-store as a
 # child process. This allows us to test LegacySSHStore::buildDerivation().
 # ssh-ng://... likewise allows us to test RemoteStore::buildDerivation().


### PR DESCRIPTION
Store the final drv outputs in memory when building remotely

The `DerivationGoal` has a variable storing the “final” derivation
output paths that is used (amongst other things) to fill the environment
for the post build hook. However this variable wasn't set when the
build-hook is used, causing a crash when both hooks are used together.

Fix this by setting this variable (from the informations in the db) after a run
of the post build hook.

Fix #4245 (with a proper test this time)
/cc @bjornfor
