### PR TITLE
Use no substituers by default in the tests

### DIFF
--- a/tests/init.sh
+++ b/tests/init.sh
@@ -19,6 +19,7 @@ keep-derivations = false
 sandbox = false
 experimental-features = nix-command flakes
 gc-reserved-space = 0
+substituters =
 flake-registry = $TEST_ROOT/registry.json
 include nix.conf.extra
 EOF


### PR DESCRIPTION
Otherwise https://cache.nixos.org is chosen by default, causing the OSX testsuite to hang inside the sandbox.

(In a way, this is probably rugging an actual bug under the carpet as Nix should be able to gracefully timeout in such a case, but that's beyond mac OSX-fu)

Fix #4339 