### PR TITLE
Use the hash modulo in the derivation outputs

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1107,7 +1107,7 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
                 // Shouldn't happen as the toplevel derivation is not CA.
                 assert(false);
             },
-            [&](UnknownHashes) {
+            [&](DeferredHash _) {
                 for (auto & i : outputs) {
                     drv.outputs.insert_or_assign(i,
                         DerivationOutput {

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -504,9 +504,6 @@ void DerivationGoal::inputsRealised()
             Derivation drvResolved { *std::move(attempt) };
 
             auto pathResolved = writeDerivation(worker.store, drvResolved);
-            /* Add to memotable to speed up downstream goal's queries with the
-               original derivation. */
-            drvPathResolutions.lock()->insert_or_assign(drvPath, pathResolved);
 
             auto msg = fmt("Resolved derivation: '%s' -> '%s'",
                 worker.store.printStorePath(drvPath),
@@ -2097,15 +2094,15 @@ struct RestrictedStore : public LocalFSStore, public virtual RestrictedStoreConf
 
     void registerDrvOutput(const Realisation & info) override
     {
-        if (!goal.isAllowed(info.id.drvPath))
-            throw InvalidPath("cannot register unknown drv output '%s' in recursive Nix", printStorePath(info.id.drvPath));
+        // XXX: Should we check for something here? Probably, but I'm not sure
+        // how
         next->registerDrvOutput(info);
     }
 
     std::optional<const Realisation> queryRealisation(const DrvOutput & id) override
     {
-        if (!goal.isAllowed(id.drvPath))
-            throw InvalidPath("cannot query the output info for unknown derivation '%s' in recursive Nix", printStorePath(id.drvPath));
+        // XXX: Should we check for something here? Probably, but I'm not sure
+        // how
         return next->queryRealisation(id);
     }
 
@@ -3394,23 +3391,14 @@ void DerivationGoal::registerOutputs()
        means it's safe to link the derivation to the output hash. We must do
        that for floating CA derivations, which otherwise couldn't be cached,
        but it's fine to do in all cases. */
-    bool isCaFloating = drv->type() == DerivationType::CAFloating;
 
-    auto drvPathResolved = drvPath;
-    if (!useDerivation && isCaFloating) {
-        /* Once a floating CA derivations reaches this point, it
-           must already be resolved, so we don't bother trying to
-           downcast drv to get would would just be an empty
-           inputDrvs field. */
-        Derivation drv2 { *drv };
-        drvPathResolved = writeDerivation(worker.store, drv2);
-    }
-
-    if (settings.isExperimentalFeatureEnabled("ca-derivations"))
+    if (settings.isExperimentalFeatureEnabled("ca-derivations")) {
+        auto outputHashes = staticOutputHashes(worker.store, *drv);
         for (auto& [outputName, newInfo] : infos)
             worker.store.registerDrvOutput(Realisation{
-                .id = DrvOutput{drvPathResolved, outputName},
+                .id = DrvOutput{outputHashes.at(outputName), outputName},
                 .outPath = newInfo.path});
+    }
 }
 
 

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2093,18 +2093,14 @@ struct RestrictedStore : public LocalFSStore, public virtual RestrictedStoreConf
     }
 
     void registerDrvOutput(const Realisation & info) override
-    {
-        // XXX: Should we check for something here? Probably, but I'm not sure
-        // how
-        next->registerDrvOutput(info);
-    }
+    // XXX: This should probably be allowed as a no-op if the realisation
+    // corresponds to an allowed derivation
+    { throw Error("registerDrvOutput"); }
 
     std::optional<const Realisation> queryRealisation(const DrvOutput & id) override
-    {
-        // XXX: Should we check for something here? Probably, but I'm not sure
-        // how
-        return next->queryRealisation(id);
-    }
+    // XXX: This should probably be allowed if the realisation corresponds to
+    // an allowed derivation
+    { throw Error("queryRealisation"); }
 
     void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override
     {

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -7,18 +7,18 @@ namespace nix {
 MakeError(InvalidDerivationOutputId, Error);
 
 DrvOutput DrvOutput::parse(const std::string &strRep) {
-    const auto &[rawPath, outputs] = parsePathWithOutputs(strRep);
-    if (outputs.size() != 1)
+    size_t n = strRep.find("!");
+    if (n == strRep.npos)
         throw InvalidDerivationOutputId("Invalid derivation output id %s", strRep);
 
     return DrvOutput{
-        .drvPath = StorePath(rawPath),
-        .outputName = *outputs.begin(),
+        .drvHash = Hash::parseAnyPrefixed(strRep.substr(0, n)),
+        .outputName = strRep.substr(n+1),
     };
 }
 
 std::string DrvOutput::to_string() const {
-    return std::string(drvPath.to_string()) + "!" + outputName;
+    return strHash() + "!" + outputName;
 }
 
 nlohmann::json Realisation::toJSON() const {

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -6,10 +6,14 @@
 namespace nix {
 
 struct DrvOutput {
-    StorePath drvPath;
+    // The hash modulo of the derivation
+    Hash drvHash;
     std::string outputName;
 
     std::string to_string() const;
+
+    std::string strHash() const
+    { return drvHash.to_string(Base16, true); }
 
     static DrvOutput parse(const std::string &);
 
@@ -18,8 +22,8 @@ struct DrvOutput {
 
 private:
     // Just to make comparison operators easier to write
-    std::pair<StorePath, std::string> to_pair() const
-    { return std::make_pair(drvPath, outputName); }
+    std::pair<Hash, std::string> to_pair() const
+    { return std::make_pair(drvHash, outputName); }
 };
 
 struct Realisation {


### PR DESCRIPTION
Rather than storing the derivation outputs as `drvPath!outputName` internally,
store them as `drvHashModulo!outputName` (or `outputHash!outputName` for
fixed-output derivations).

This makes the storage slightly more opaque, but enables an earlier
cutoff in cases where a fixed-output dependency changes (but keeps the
same output hash) − same as what we already do for input-addressed
derivations.

Depends on: #4330
Fix: #4347
