### PR TITLE
Fix the `nix` command with CA derivations

### DIFF
--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -409,7 +409,7 @@ std::vector<InstallableValue::DerivationInfo> InstallableAttrPath::toDerivations
     for (auto & drvInfo : drvInfos) {
         res.push_back({
             state->store->parseStorePath(drvInfo.queryDrvPath()),
-            state->store->parseStorePath(drvInfo.queryOutPath()),
+            state->store->maybeParseStorePath(drvInfo.queryOutPath()),
             drvInfo.queryOutputName()
         });
     }

--- a/tests/content-addressed.sh
+++ b/tests/content-addressed.sh
@@ -50,7 +50,13 @@ testGC () {
     nix-collect-garbage --experimental-features ca-derivations --option keep-derivations true
 }
 
+testNixCommand () {
+    clearStore
+    nix build --experimental-features 'nix-command ca-derivations' --file ./content-addressed.nix --no-link
+}
+
 testRemoteCache
 testDeterministicCA
 testCutoff
 testGC
+testNixCommand


### PR DESCRIPTION
Prevents a crash because most `nix` subcommands assumed that derivations know their output path, which isn't the case for CA derivations.
