### PR TITLE
treat s3 permission errors as file-not-found

### DIFF
--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -166,7 +166,8 @@ S3Helper::FileTransferResult S3Helper::getObject(
             dynamic_cast<std::stringstream &>(result.GetBody()).str());
 
     } catch (S3Error & e) {
-        if (e.err != Aws::S3::S3Errors::NO_SUCH_KEY) throw;
+        if ((e.err != Aws::S3::S3Errors::NO_SUCH_KEY) &&
+            (e.err != Aws::S3::S3Errors::ACCESS_DENIED)) throw;
     }
 
     auto now2 = std::chrono::steady_clock::now();


### PR DESCRIPTION
When using private s3 caches, a miss will return a 403, which causes nix to throw and die.

This prevents the crash by treating it as a miss.

Signed-off-by: Jonathan Ringer <jonringer117@gmail.com>