### PR TITLE
Refactoring for private Value type

### DIFF
--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -67,7 +67,7 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attr
 
         if (apType == apAttr) {
 
-            if (v->type != tAttrs)
+            if (v->normalType() != nAttrs)
                 throw TypeError(
                     "the expression selected by the selection path '%1%' should be a set but is %2%",
                     attrPath,

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -67,7 +67,7 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attr
 
         if (apType == apAttr) {
 
-            if (v->normalType() != nAttrs)
+            if (v->type() != nAttrs)
                 throw TypeError(
                     "the expression selected by the selection path '%1%' should be a set but is %2%",
                     attrPath,

--- a/src/libexpr/attr-set.cc
+++ b/src/libexpr/attr-set.cc
@@ -25,7 +25,7 @@ void EvalState::mkAttrs(Value & v, size_t capacity)
         return;
     }
     clearValue(v);
-    v.type = tAttrs;
+    v.setAttrs();
     v.attrs = allocBindings(capacity);
     nrAttrsets++;
     nrAttrsInAttrsets += capacity;

--- a/src/libexpr/attr-set.cc
+++ b/src/libexpr/attr-set.cc
@@ -24,9 +24,7 @@ void EvalState::mkAttrs(Value & v, size_t capacity)
         v = vEmptySet;
         return;
     }
-    clearValue(v);
-    v.setAttrs();
-    v.attrs = allocBindings(capacity);
+    v.mkAttrs(allocBindings(capacity));
     nrAttrsets++;
     nrAttrsInAttrsets += capacity;
 }

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -513,7 +513,7 @@ std::string AttrCursor::getString()
     auto & v = forceValue();
 
     if (v.type != tString && v.type != tPath)
-        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.type));
+        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.normalType()));
 
     return v.type == tString ? v.string.s : v.path;
 }
@@ -548,7 +548,7 @@ string_t AttrCursor::getStringWithContext()
     else if (v.type == tPath)
         return {v.path, {}};
     else
-        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.type));
+        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.normalType()));
 }
 
 bool AttrCursor::getBool()

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -390,14 +390,14 @@ Value & AttrCursor::forceValue()
     }
 
     if (root->db && (!cachedValue || std::get_if<placeholder_t>(&cachedValue->second))) {
-        if (v.normalType() == nString)
+        if (v.type() == nString)
             cachedValue = {root->db->setString(getKey(), v.string.s, v.string.context),
                            string_t{v.string.s, {}}};
-        else if (v.normalType() == nPath)
+        else if (v.type() == nPath)
             cachedValue = {root->db->setString(getKey(), v.path), v.path};
-        else if (v.normalType() == nBool)
+        else if (v.type() == nBool)
             cachedValue = {root->db->setBool(getKey(), v.boolean), v.boolean};
-        else if (v.normalType() == nAttrs)
+        else if (v.type() == nAttrs)
             ; // FIXME: do something?
         else
             cachedValue = {root->db->setMisc(getKey()), misc_t()};
@@ -442,7 +442,7 @@ std::shared_ptr<AttrCursor> AttrCursor::maybeGetAttr(Symbol name, bool forceErro
 
     auto & v = forceValue();
 
-    if (v.normalType() != nAttrs)
+    if (v.type() != nAttrs)
         return nullptr;
         //throw TypeError("'%s' is not an attribute set", getAttrPathStr());
 
@@ -512,10 +512,10 @@ std::string AttrCursor::getString()
 
     auto & v = forceValue();
 
-    if (v.normalType() != nString && v.normalType() != nPath)
-        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.normalType()));
+    if (v.type() != nString && v.type() != nPath)
+        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.type()));
 
-    return v.normalType() == nString ? v.string.s : v.path;
+    return v.type() == nString ? v.string.s : v.path;
 }
 
 string_t AttrCursor::getStringWithContext()
@@ -543,12 +543,12 @@ string_t AttrCursor::getStringWithContext()
 
     auto & v = forceValue();
 
-    if (v.normalType() == nString)
+    if (v.type() == nString)
         return {v.string.s, v.getContext()};
-    else if (v.normalType() == nPath)
+    else if (v.type() == nPath)
         return {v.path, {}};
     else
-        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.normalType()));
+        throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.type()));
 }
 
 bool AttrCursor::getBool()
@@ -567,7 +567,7 @@ bool AttrCursor::getBool()
 
     auto & v = forceValue();
 
-    if (v.normalType() != nBool)
+    if (v.type() != nBool)
         throw TypeError("'%s' is not a Boolean", getAttrPathStr());
 
     return v.boolean;
@@ -589,7 +589,7 @@ std::vector<Symbol> AttrCursor::getAttrs()
 
     auto & v = forceValue();
 
-    if (v.normalType() != nAttrs)
+    if (v.type() != nAttrs)
         throw TypeError("'%s' is not an attribute set", getAttrPathStr());
 
     std::vector<Symbol> attrs;

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -390,14 +390,14 @@ Value & AttrCursor::forceValue()
     }
 
     if (root->db && (!cachedValue || std::get_if<placeholder_t>(&cachedValue->second))) {
-        if (v.type == tString)
+        if (v.normalType() == nString)
             cachedValue = {root->db->setString(getKey(), v.string.s, v.string.context),
                            string_t{v.string.s, {}}};
-        else if (v.type == tPath)
+        else if (v.normalType() == nPath)
             cachedValue = {root->db->setString(getKey(), v.path), v.path};
-        else if (v.type == tBool)
+        else if (v.normalType() == nBool)
             cachedValue = {root->db->setBool(getKey(), v.boolean), v.boolean};
-        else if (v.type == tAttrs)
+        else if (v.normalType() == nAttrs)
             ; // FIXME: do something?
         else
             cachedValue = {root->db->setMisc(getKey()), misc_t()};
@@ -442,7 +442,7 @@ std::shared_ptr<AttrCursor> AttrCursor::maybeGetAttr(Symbol name, bool forceErro
 
     auto & v = forceValue();
 
-    if (v.type != tAttrs)
+    if (v.normalType() != nAttrs)
         return nullptr;
         //throw TypeError("'%s' is not an attribute set", getAttrPathStr());
 
@@ -512,10 +512,10 @@ std::string AttrCursor::getString()
 
     auto & v = forceValue();
 
-    if (v.type != tString && v.type != tPath)
+    if (v.normalType() != nString && v.normalType() != nPath)
         throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.normalType()));
 
-    return v.type == tString ? v.string.s : v.path;
+    return v.normalType() == nString ? v.string.s : v.path;
 }
 
 string_t AttrCursor::getStringWithContext()
@@ -543,9 +543,9 @@ string_t AttrCursor::getStringWithContext()
 
     auto & v = forceValue();
 
-    if (v.type == tString)
+    if (v.normalType() == nString)
         return {v.string.s, v.getContext()};
-    else if (v.type == tPath)
+    else if (v.normalType() == nPath)
         return {v.path, {}};
     else
         throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.normalType()));
@@ -567,7 +567,7 @@ bool AttrCursor::getBool()
 
     auto & v = forceValue();
 
-    if (v.type != tBool)
+    if (v.normalType() != nBool)
         throw TypeError("'%s' is not a Boolean", getAttrPathStr());
 
     return v.boolean;
@@ -589,7 +589,7 @@ std::vector<Symbol> AttrCursor::getAttrs()
 
     auto & v = forceValue();
 
-    if (v.type != tAttrs)
+    if (v.normalType() != nAttrs)
         throw TypeError("'%s' is not an attribute set", getAttrPathStr());
 
     std::vector<Symbol> attrs;

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -36,13 +36,11 @@ void EvalState::forceValue(Value & v, const Pos & pos)
         Env * env = v.thunk.env;
         Expr * expr = v.thunk.expr;
         try {
-            v.setBlackhole();
+            v.mkBlackhole();
             //checkInterrupt();
             expr->eval(*this, *env, v);
         } catch (...) {
-            v.setThunk();
-            v.thunk.env = env;
-            v.thunk.expr = expr;
+            v.mkThunk(env, expr);
             throw;
         }
     }

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -56,7 +56,7 @@ void EvalState::forceValue(Value & v, const Pos & pos)
 inline void EvalState::forceAttrs(Value & v)
 {
     forceValue(v);
-    if (v.normalType() != nAttrs)
+    if (v.type() != nAttrs)
         throwTypeError("value is %1% while a set was expected", v);
 }
 
@@ -64,7 +64,7 @@ inline void EvalState::forceAttrs(Value & v)
 inline void EvalState::forceAttrs(Value & v, const Pos & pos)
 {
     forceValue(v, pos);
-    if (v.normalType() != nAttrs)
+    if (v.type() != nAttrs)
         throwTypeError(pos, "value is %1% while a set was expected", v);
 }
 

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -56,7 +56,7 @@ void EvalState::forceValue(Value & v, const Pos & pos)
 inline void EvalState::forceAttrs(Value & v)
 {
     forceValue(v);
-    if (v.type != tAttrs)
+    if (v.normalType() != nAttrs)
         throwTypeError("value is %1% while a set was expected", v);
 }
 
@@ -64,7 +64,7 @@ inline void EvalState::forceAttrs(Value & v)
 inline void EvalState::forceAttrs(Value & v, const Pos & pos)
 {
     forceValue(v, pos);
-    if (v.type != tAttrs)
+    if (v.normalType() != nAttrs)
         throwTypeError(pos, "value is %1% while a set was expected", v);
 }
 

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -36,11 +36,11 @@ void EvalState::forceValue(Value & v, const Pos & pos)
         Env * env = v.thunk.env;
         Expr * expr = v.thunk.expr;
         try {
-            v.type = tBlackhole;
+            v.setBlackhole();
             //checkInterrupt();
             expr->eval(*this, *env, v);
         } catch (...) {
-            v.type = tThunk;
+            v.setThunk();
             v.thunk.env = env;
             v.thunk.expr = expr;
             throw;

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -32,7 +32,7 @@ LocalNoInlineNoReturn(void throwTypeError(const Pos & pos, const char * s, const
 
 void EvalState::forceValue(Value & v, const Pos & pos)
 {
-    if (v.type == tThunk) {
+    if (v.isThunk()) {
         Env * env = v.thunk.env;
         Expr * expr = v.thunk.expr;
         try {
@@ -46,9 +46,9 @@ void EvalState::forceValue(Value & v, const Pos & pos)
             throw;
         }
     }
-    else if (v.type == tApp)
+    else if (v.isApp())
         callFunction(*v.app.left, *v.app.right, v, noPos);
-    else if (v.type == tBlackhole)
+    else if (v.isBlackhole())
         throwEvalError(pos, "infinite recursion encountered");
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -68,7 +68,7 @@ RootValue allocRootValue(Value * v)
 }
 
 
-static void printValue(std::ostream & str, std::set<const Value *> & active, const Value & v)
+void printValue(std::ostream & str, std::set<const Value *> & active, const Value & v)
 {
     checkInterrupt();
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -77,7 +77,7 @@ void printValue(std::ostream & str, std::set<const Value *> & active, const Valu
         return;
     }
 
-    switch (v.type) {
+    switch (v.internalType) {
     case tInt:
         str << v.integer;
         break;
@@ -165,7 +165,7 @@ const Value *getPrimOp(const Value &v) {
     return primOp;
 }
 
-string showType(NormalType type)
+string showType(ValueType type)
 {
     switch (type) {
         case nInt: return "an integer";
@@ -186,7 +186,7 @@ string showType(NormalType type)
 
 string showType(const Value & v)
 {
-    switch (v.type) {
+    switch (v.internalType) {
         case tString: return v.string.context ? "a string with context" : "a string";
         case tPrimOp:
             return fmt("the built-in function '%s'", string(v.primOp->name));
@@ -205,9 +205,9 @@ string showType(const Value & v)
 bool Value::isTrivial() const
 {
     return
-        type != tApp
-        && type != tPrimOpApp
-        && (type != tThunk
+        internalType != tApp
+        && internalType != tPrimOpApp
+        && (internalType != tThunk
             || (dynamic_cast<ExprAttrs *>(thunk.expr)
                 && ((ExprAttrs *) thunk.expr)->dynamicAttrs.empty())
             || dynamic_cast<ExprLambda *>(thunk.expr)
@@ -1562,7 +1562,7 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
     NixFloat nf = 0;
 
     bool first = !forceString;
-    NormalType firstType = nString;
+    ValueType firstType = nString;
 
     for (auto & i : *es) {
         Value vTmp;
@@ -1728,7 +1728,7 @@ void copyContext(const Value & v, PathSet & context)
 std::vector<std::pair<Path, std::string>> Value::getContext()
 {
     std::vector<std::pair<Path, std::string>> res;
-    assert(type == tString);
+    assert(internalType == tString);
     if (string.context)
         for (const char * * p = string.context; *p; ++p)
             res.push_back(decodeContext(*p));

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -165,25 +165,20 @@ const Value *getPrimOp(const Value &v) {
     return primOp;
 }
 
-
-string showType(ValueType type)
+string showType(NormalType type)
 {
     switch (type) {
-        case tInt: return "an integer";
-        case tBool: return "a Boolean";
-        case tString: return "a string";
-        case tPath: return "a path";
-        case tNull: return "null";
-        case tAttrs: return "a set";
-        case tList1: case tList2: case tListN: return "a list";
-        case tThunk: return "a thunk";
-        case tApp: return "a function application";
-        case tLambda: return "a function";
-        case tBlackhole: return "a black hole";
-        case tPrimOp: return "a built-in function";
-        case tPrimOpApp: return "a partially applied built-in function";
-        case tExternal: return "an external value";
-        case tFloat: return "a float";
+        case nInt: return "an integer";
+        case nBool: return "a Boolean";
+        case nString: return "a string";
+        case nPath: return "a path";
+        case nNull: return "null";
+        case nAttrs: return "a set";
+        case nList: return "a list";
+        case nFunction: return "a function";
+        case nExternal: return "an external value";
+        case nFloat: return "a float";
+        case nThunk: return "a thunk";
     }
     abort();
 }
@@ -198,8 +193,11 @@ string showType(const Value & v)
         case tPrimOpApp:
             return fmt("the partially applied built-in function '%s'", string(getPrimOp(v)->primOp->name));
         case tExternal: return v.external->showType();
+        case tThunk: return "a thunk";
+        case tApp: return "a function application";
+        case tBlackhole: return "a black hole";
     default:
-        return showType(v.type);
+        return showType(v.normalType());
     }
 }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -346,7 +346,7 @@ private:
 
 
 /* Return a string representing the type of the value `v'. */
-string showType(NormalType type);
+string showType(ValueType type);
 string showType(const Value & v);
 
 /* Decode a context string ‘!<name>!<path>’ into a pair <path,

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -346,7 +346,7 @@ private:
 
 
 /* Return a string representing the type of the value `v'. */
-string showType(ValueType type);
+string showType(NormalType type);
 string showType(const Value & v);
 
 /* Decode a context string ‘!<name>!<path>’ into a pair <path,

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -82,9 +82,9 @@ static void expectType(EvalState & state, ValueType type,
     Value & value, const Pos & pos)
 {
     forceTrivialValue(state, value, pos);
-    if (value.normalType() != type)
+    if (value.type() != type)
         throw Error("expected %s but got %s at %s",
-            showType(type), showType(value.normalType()), pos);
+            showType(type), showType(value.type()), pos);
 }
 
 static std::map<FlakeId, FlakeInput> parseFlakeInputs(
@@ -120,7 +120,7 @@ static FlakeInput parseFlakeInput(EvalState & state,
                 expectType(state, nString, *attr.value, *attr.pos);
                 input.follows = parseInputPath(attr.value->string.s);
             } else {
-                if (attr.value->normalType() == nString)
+                if (attr.value->type() == nString)
                     attrs.emplace(attr.name, attr.value->string.s);
                 else
                     throw TypeError("flake input attribute '%s' is %s while a string is expected",
@@ -235,17 +235,17 @@ static Flake getFlake(
 
         for (auto & setting : *nixConfig->value->attrs) {
             forceTrivialValue(state, *setting.value, *setting.pos);
-            if (setting.value->normalType() == nString)
+            if (setting.value->type() == nString)
                 flake.config.settings.insert({setting.name, state.forceStringNoCtx(*setting.value, *setting.pos)});
-            else if (setting.value->normalType() == nInt)
+            else if (setting.value->type() == nInt)
                 flake.config.settings.insert({setting.name, state.forceInt(*setting.value, *setting.pos)});
-            else if (setting.value->normalType() == nBool)
+            else if (setting.value->type() == nBool)
                 flake.config.settings.insert({setting.name, state.forceBool(*setting.value, *setting.pos)});
-            else if (setting.value->normalType() == nList) {
+            else if (setting.value->type() == nList) {
                 std::vector<std::string> ss;
                 for (unsigned int n = 0; n < setting.value->listSize(); ++n) {
                     auto elem = setting.value->listElems()[n];
-                    if (elem->normalType() != nString)
+                    if (elem->type() != nString)
                         throw TypeError("list element in flake configuration setting '%s' is %s while a string is expected",
                             setting.name, showType(*setting.value));
                     ss.push_back(state.forceStringNoCtx(*elem, *setting.pos));

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -120,7 +120,7 @@ static FlakeInput parseFlakeInput(EvalState & state,
                 expectType(state, nString, *attr.value, *attr.pos);
                 input.follows = parseInputPath(attr.value->string.s);
             } else {
-                if (attr.value->type == tString)
+                if (attr.value->normalType() == nString)
                     attrs.emplace(attr.name, attr.value->string.s);
                 else
                     throw TypeError("flake input attribute '%s' is %s while a string is expected",
@@ -235,17 +235,17 @@ static Flake getFlake(
 
         for (auto & setting : *nixConfig->value->attrs) {
             forceTrivialValue(state, *setting.value, *setting.pos);
-            if (setting.value->type == tString)
+            if (setting.value->normalType() == nString)
                 flake.config.settings.insert({setting.name, state.forceStringNoCtx(*setting.value, *setting.pos)});
-            else if (setting.value->type == tInt)
+            else if (setting.value->normalType() == nInt)
                 flake.config.settings.insert({setting.name, state.forceInt(*setting.value, *setting.pos)});
-            else if (setting.value->type == tBool)
+            else if (setting.value->normalType() == nBool)
                 flake.config.settings.insert({setting.name, state.forceBool(*setting.value, *setting.pos)});
-            else if (setting.value->isList()) {
+            else if (setting.value->normalType() == nList) {
                 std::vector<std::string> ss;
                 for (unsigned int n = 0; n < setting.value->listSize(); ++n) {
                     auto elem = setting.value->listElems()[n];
-                    if (elem->type != tString)
+                    if (elem->normalType() != nString)
                         throw TypeError("list element in flake configuration setting '%s' is %s while a string is expected",
                             setting.name, showType(*setting.value));
                     ss.push_back(state.forceStringNoCtx(*elem, *setting.pos));

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -78,7 +78,7 @@ static void forceTrivialValue(EvalState & state, Value & value, const Pos & pos)
 }
 
 
-static void expectType(EvalState & state, NormalType type,
+static void expectType(EvalState & state, ValueType type,
     Value & value, const Pos & pos)
 {
     forceTrivialValue(state, value, pos);

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -73,7 +73,7 @@ static std::tuple<fetchers::Tree, FlakeRef, FlakeRef> fetchOrSubstituteTree(
 
 static void forceTrivialValue(EvalState & state, Value & value, const Pos & pos)
 {
-    if (value.type == tThunk && value.isTrivial())
+    if (value.isThunk() && value.isTrivial())
         state.forceValue(value, pos);
 }
 
@@ -216,7 +216,7 @@ static Flake getFlake(
     if (auto outputs = vInfo.attrs->get(sOutputs)) {
         expectType(state, nFunction, *outputs->value, *outputs->pos);
 
-        if (outputs->value->type == tLambda && outputs->value->lambda.fun->matchAttrs) {
+        if (outputs->value->isLambda() && outputs->value->lambda.fun->matchAttrs) {
             for (auto & formal : outputs->value->lambda.fun->formals->formals) {
                 if (formal.name != state.sSelf)
                     flake.inputs.emplace(formal.name, FlakeInput {

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -128,7 +128,7 @@ DrvInfo::Outputs DrvInfo::queryOutputs(bool onlyOutputsToInstall)
     if (!outTI->isList()) throw errMsg;
     Outputs result;
     for (auto i = outTI->listElems(); i != outTI->listElems() + outTI->listSize(); ++i) {
-        if ((*i)->type != tString) throw errMsg;
+        if ((*i)->normalType() != nString) throw errMsg;
         auto out = outputs.find((*i)->string.s);
         if (out == outputs.end()) throw errMsg;
         result.insert(*out);
@@ -172,20 +172,20 @@ StringSet DrvInfo::queryMetaNames()
 bool DrvInfo::checkMeta(Value & v)
 {
     state->forceValue(v);
-    if (v.isList()) {
+    if (v.normalType() == nList) {
         for (unsigned int n = 0; n < v.listSize(); ++n)
             if (!checkMeta(*v.listElems()[n])) return false;
         return true;
     }
-    else if (v.type == tAttrs) {
+    else if (v.normalType() == nAttrs) {
         Bindings::iterator i = v.attrs->find(state->sOutPath);
         if (i != v.attrs->end()) return false;
         for (auto & i : *v.attrs)
             if (!checkMeta(*i.value)) return false;
         return true;
     }
-    else return v.type == tInt || v.type == tBool || v.type == tString ||
-                v.type == tFloat;
+    else return v.normalType() == nInt || v.normalType() == nBool || v.normalType() == nString ||
+                v.normalType() == nFloat;
 }
 
 
@@ -201,7 +201,7 @@ Value * DrvInfo::queryMeta(const string & name)
 string DrvInfo::queryMetaString(const string & name)
 {
     Value * v = queryMeta(name);
-    if (!v || v->type != tString) return "";
+    if (!v || v->normalType() != nString) return "";
     return v->string.s;
 }
 
@@ -210,8 +210,8 @@ NixInt DrvInfo::queryMetaInt(const string & name, NixInt def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
-    if (v->type == tInt) return v->integer;
-    if (v->type == tString) {
+    if (v->normalType() == nInt) return v->integer;
+    if (v->normalType() == nString) {
         /* Backwards compatibility with before we had support for
            integer meta fields. */
         NixInt n;
@@ -224,8 +224,8 @@ NixFloat DrvInfo::queryMetaFloat(const string & name, NixFloat def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
-    if (v->type == tFloat) return v->fpoint;
-    if (v->type == tString) {
+    if (v->normalType() == nFloat) return v->fpoint;
+    if (v->normalType() == nString) {
         /* Backwards compatibility with before we had support for
            float meta fields. */
         NixFloat n;
@@ -239,8 +239,8 @@ bool DrvInfo::queryMetaBool(const string & name, bool def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
-    if (v->type == tBool) return v->boolean;
-    if (v->type == tString) {
+    if (v->normalType() == nBool) return v->boolean;
+    if (v->normalType() == nString) {
         /* Backwards compatibility with before we had support for
            Boolean meta fields. */
         if (strcmp(v->string.s, "true") == 0) return true;
@@ -331,7 +331,7 @@ static void getDerivations(EvalState & state, Value & vIn,
     /* Process the expression. */
     if (!getDerivation(state, v, pathPrefix, drvs, done, ignoreAssertionFailures)) ;
 
-    else if (v.type == tAttrs) {
+    else if (v.normalType() == nAttrs) {
 
         /* !!! undocumented hackery to support combining channels in
            nix-env.cc. */
@@ -353,7 +353,7 @@ static void getDerivations(EvalState & state, Value & vIn,
                 /* If the value of this attribute is itself a set,
                    should we recurse into it?  => Only if it has a
                    `recurseForDerivations = true' attribute. */
-                if (i->value->type == tAttrs) {
+                if (i->value->normalType() == nAttrs) {
                     Bindings::iterator j = i->value->attrs->find(state.sRecurseForDerivations);
                     if (j != i->value->attrs->end() && state.forceBool(*j->value, *j->pos))
                         getDerivations(state, *i->value, pathPrefix2, autoArgs, drvs, done, ignoreAssertionFailures);
@@ -362,7 +362,7 @@ static void getDerivations(EvalState & state, Value & vIn,
         }
     }
 
-    else if (v.isList()) {
+    else if (v.normalType() == nList) {
         for (unsigned int n = 0; n < v.listSize(); ++n) {
             string pathPrefix2 = addToPath(pathPrefix, (format("%1%") % n).str());
             if (getDerivation(state, *v.listElems()[n], pathPrefix2, drvs, done, ignoreAssertionFailures))

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -128,7 +128,7 @@ DrvInfo::Outputs DrvInfo::queryOutputs(bool onlyOutputsToInstall)
     if (!outTI->isList()) throw errMsg;
     Outputs result;
     for (auto i = outTI->listElems(); i != outTI->listElems() + outTI->listSize(); ++i) {
-        if ((*i)->normalType() != nString) throw errMsg;
+        if ((*i)->type() != nString) throw errMsg;
         auto out = outputs.find((*i)->string.s);
         if (out == outputs.end()) throw errMsg;
         result.insert(*out);
@@ -172,20 +172,20 @@ StringSet DrvInfo::queryMetaNames()
 bool DrvInfo::checkMeta(Value & v)
 {
     state->forceValue(v);
-    if (v.normalType() == nList) {
+    if (v.type() == nList) {
         for (unsigned int n = 0; n < v.listSize(); ++n)
             if (!checkMeta(*v.listElems()[n])) return false;
         return true;
     }
-    else if (v.normalType() == nAttrs) {
+    else if (v.type() == nAttrs) {
         Bindings::iterator i = v.attrs->find(state->sOutPath);
         if (i != v.attrs->end()) return false;
         for (auto & i : *v.attrs)
             if (!checkMeta(*i.value)) return false;
         return true;
     }
-    else return v.normalType() == nInt || v.normalType() == nBool || v.normalType() == nString ||
-                v.normalType() == nFloat;
+    else return v.type() == nInt || v.type() == nBool || v.type() == nString ||
+                v.type() == nFloat;
 }
 
 
@@ -201,7 +201,7 @@ Value * DrvInfo::queryMeta(const string & name)
 string DrvInfo::queryMetaString(const string & name)
 {
     Value * v = queryMeta(name);
-    if (!v || v->normalType() != nString) return "";
+    if (!v || v->type() != nString) return "";
     return v->string.s;
 }
 
@@ -210,8 +210,8 @@ NixInt DrvInfo::queryMetaInt(const string & name, NixInt def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
-    if (v->normalType() == nInt) return v->integer;
-    if (v->normalType() == nString) {
+    if (v->type() == nInt) return v->integer;
+    if (v->type() == nString) {
         /* Backwards compatibility with before we had support for
            integer meta fields. */
         NixInt n;
@@ -224,8 +224,8 @@ NixFloat DrvInfo::queryMetaFloat(const string & name, NixFloat def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
-    if (v->normalType() == nFloat) return v->fpoint;
-    if (v->normalType() == nString) {
+    if (v->type() == nFloat) return v->fpoint;
+    if (v->type() == nString) {
         /* Backwards compatibility with before we had support for
            float meta fields. */
         NixFloat n;
@@ -239,8 +239,8 @@ bool DrvInfo::queryMetaBool(const string & name, bool def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
-    if (v->normalType() == nBool) return v->boolean;
-    if (v->normalType() == nString) {
+    if (v->type() == nBool) return v->boolean;
+    if (v->type() == nString) {
         /* Backwards compatibility with before we had support for
            Boolean meta fields. */
         if (strcmp(v->string.s, "true") == 0) return true;
@@ -331,7 +331,7 @@ static void getDerivations(EvalState & state, Value & vIn,
     /* Process the expression. */
     if (!getDerivation(state, v, pathPrefix, drvs, done, ignoreAssertionFailures)) ;
 
-    else if (v.normalType() == nAttrs) {
+    else if (v.type() == nAttrs) {
 
         /* !!! undocumented hackery to support combining channels in
            nix-env.cc. */
@@ -353,7 +353,7 @@ static void getDerivations(EvalState & state, Value & vIn,
                 /* If the value of this attribute is itself a set,
                    should we recurse into it?  => Only if it has a
                    `recurseForDerivations = true' attribute. */
-                if (i->value->normalType() == nAttrs) {
+                if (i->value->type() == nAttrs) {
                     Bindings::iterator j = i->value->attrs->find(state.sRecurseForDerivations);
                     if (j != i->value->attrs->end() && state.forceBool(*j->value, *j->pos))
                         getDerivations(state, *i->value, pathPrefix2, autoArgs, drvs, done, ignoreAssertionFailures);
@@ -362,7 +362,7 @@ static void getDerivations(EvalState & state, Value & vIn,
         }
     }
 
-    else if (v.normalType() == nList) {
+    else if (v.type() == nList) {
         for (unsigned int n = 0; n < v.listSize(); ++n) {
             string pathPrefix2 = addToPath(pathPrefix, (format("%1%") % n).str());
             if (getDerivation(state, *v.listElems()[n], pathPrefix2, drvs, done, ignoreAssertionFailures))

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -129,7 +129,7 @@ struct ExprPath : Expr
 {
     string s;
     Value v;
-    ExprPath(const string & s) : s(s) { mkPathNoCopy(v, this->s.c_str()); };
+    ExprPath(const string & s) : s(s) { v.mkPath(this->s.c_str()); };
     COMMON_METHODS
     Value * maybeThunk(EvalState & state, Env & env);
 };

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1434,7 +1434,7 @@ static void prim_readDir(EvalState & state, const Pos & pos, Value * * args, Val
         Value * ent_val = state.allocAttr(v, state.symbols.create(ent.name));
         if (ent.type == DT_UNKNOWN)
             ent.type = getFileType(path + "/" + ent.name);
-        mkStringNoCopy(*ent_val,
+        ent_val->mkString(
             ent.type == DT_REG ? "regular" :
             ent.type == DT_DIR ? "directory" :
             ent.type == DT_LNK ? "symlink" :

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2239,11 +2239,11 @@ static RegisterPrimOp primop_catAttrs({
 static void prim_functionArgs(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    if (args[0]->type == tPrimOpApp || args[0]->type == tPrimOp) {
+    if (args[0]->isPrimOpApp() || args[0]->isPrimOp()) {
         state.mkAttrs(v, 0);
         return;
     }
-    if (args[0]->type != tLambda)
+    if (!args[0]->isLambda())
         throw TypeError({
             .hint = hintfmt("'functionArgs' requires a function"),
             .errPos = pos
@@ -2674,7 +2674,7 @@ static void prim_sort(EvalState & state, const Pos & pos, Value * * args, Value 
     auto comparator = [&](Value * a, Value * b) {
         /* Optimization: if the comparator is lessThan, bypass
            callFunction. */
-        if (args[0]->type == tPrimOp && args[0]->primOp->fun == prim_lessThan)
+        if (args[0]->isPrimOp() && args[0]->primOp->fun == prim_lessThan)
             return CompareValues()(a, b);
 
         Value vTmp1, vTmp2;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -356,7 +356,7 @@ static void prim_typeOf(EvalState & state, const Pos & pos, Value * * args, Valu
 {
     state.forceValue(*args[0], pos);
     string t;
-    switch (args[0]->normalType()) {
+    switch (args[0]->type()) {
         case nInt: t = "int"; break;
         case nBool: t = "bool"; break;
         case nString: t = "string"; break;
@@ -389,7 +389,7 @@ static RegisterPrimOp primop_typeOf({
 static void prim_isNull(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nNull);
+    mkBool(v, args[0]->type() == nNull);
 }
 
 static RegisterPrimOp primop_isNull({
@@ -409,7 +409,7 @@ static RegisterPrimOp primop_isNull({
 static void prim_isFunction(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nFunction);
+    mkBool(v, args[0]->type() == nFunction);
 }
 
 static RegisterPrimOp primop_isFunction({
@@ -425,7 +425,7 @@ static RegisterPrimOp primop_isFunction({
 static void prim_isInt(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nInt);
+    mkBool(v, args[0]->type() == nInt);
 }
 
 static RegisterPrimOp primop_isInt({
@@ -441,7 +441,7 @@ static RegisterPrimOp primop_isInt({
 static void prim_isFloat(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nFloat);
+    mkBool(v, args[0]->type() == nFloat);
 }
 
 static RegisterPrimOp primop_isFloat({
@@ -457,7 +457,7 @@ static RegisterPrimOp primop_isFloat({
 static void prim_isString(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nString);
+    mkBool(v, args[0]->type() == nString);
 }
 
 static RegisterPrimOp primop_isString({
@@ -473,7 +473,7 @@ static RegisterPrimOp primop_isString({
 static void prim_isBool(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nBool);
+    mkBool(v, args[0]->type() == nBool);
 }
 
 static RegisterPrimOp primop_isBool({
@@ -489,7 +489,7 @@ static RegisterPrimOp primop_isBool({
 static void prim_isPath(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nPath);
+    mkBool(v, args[0]->type() == nPath);
 }
 
 static RegisterPrimOp primop_isPath({
@@ -505,13 +505,13 @@ struct CompareValues
 {
     bool operator () (const Value * v1, const Value * v2) const
     {
-        if (v1->normalType() == nFloat && v2->normalType() == nInt)
+        if (v1->type() == nFloat && v2->type() == nInt)
             return v1->fpoint < v2->integer;
-        if (v1->normalType() == nInt && v2->normalType() == nFloat)
+        if (v1->type() == nInt && v2->type() == nFloat)
             return v1->integer < v2->fpoint;
-        if (v1->normalType() != v2->normalType())
+        if (v1->type() != v2->type())
             throw EvalError("cannot compare %1% with %2%", showType(*v1), showType(*v2));
-        switch (v1->normalType()) {
+        switch (v1->type()) {
             case nInt:
                 return v1->integer < v2->integer;
             case nFloat:
@@ -762,7 +762,7 @@ static RegisterPrimOp primop_deepSeq({
 static void prim_trace(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    if (args[0]->normalType() == nString)
+    if (args[0]->type() == nString)
         printError("trace: %1%", args[0]->string.s);
     else
         printError("trace: %1%", *args[0]);
@@ -887,7 +887,7 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
 
             if (ignoreNulls) {
                 state.forceValue(*i->value, pos);
-                if (i->value->normalType() == nNull) continue;
+                if (i->value->type() == nNull) continue;
             }
 
             if (i->name == state.sContentAddressed) {
@@ -1293,7 +1293,7 @@ static void prim_dirOf(EvalState & state, const Pos & pos, Value * * args, Value
 {
     PathSet context;
     Path dir = dirOf(state.coerceToString(pos, *args[0], context, false, false));
-    if (args[0]->normalType() == nPath) mkPath(v, dir.c_str()); else mkString(v, dir, context);
+    if (args[0]->type() == nPath) mkPath(v, dir.c_str()); else mkString(v, dir, context);
 }
 
 static RegisterPrimOp primop_dirOf({
@@ -1793,7 +1793,7 @@ static void prim_filterSource(EvalState & state, const Pos & pos, Value * * args
         });
 
     state.forceValue(*args[0], pos);
-    if (args[0]->normalType() != nFunction)
+    if (args[0]->type() != nFunction)
         throw TypeError({
             .hint = hintfmt(
                 "first argument in call to 'filterSource' is not a function but %1%",
@@ -2059,7 +2059,7 @@ static RegisterPrimOp primop_hasAttr({
 static void prim_isAttrs(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nAttrs);
+    mkBool(v, args[0]->type() == nAttrs);
 }
 
 static RegisterPrimOp primop_isAttrs({
@@ -2322,7 +2322,7 @@ static RegisterPrimOp primop_mapAttrs({
 static void prim_isList(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0], pos);
-    mkBool(v, args[0]->normalType() == nList);
+    mkBool(v, args[0]->type() == nList);
 }
 
 static RegisterPrimOp primop_isList({
@@ -2816,7 +2816,7 @@ static void prim_add(EvalState & state, const Pos & pos, Value * * args, Value &
 {
     state.forceValue(*args[0], pos);
     state.forceValue(*args[1], pos);
-    if (args[0]->normalType() == nFloat || args[1]->normalType() == nFloat)
+    if (args[0]->type() == nFloat || args[1]->type() == nFloat)
         mkFloat(v, state.forceFloat(*args[0], pos) + state.forceFloat(*args[1], pos));
     else
         mkInt(v, state.forceInt(*args[0], pos) + state.forceInt(*args[1], pos));
@@ -2835,7 +2835,7 @@ static void prim_sub(EvalState & state, const Pos & pos, Value * * args, Value &
 {
     state.forceValue(*args[0], pos);
     state.forceValue(*args[1], pos);
-    if (args[0]->normalType() == nFloat || args[1]->normalType() == nFloat)
+    if (args[0]->type() == nFloat || args[1]->type() == nFloat)
         mkFloat(v, state.forceFloat(*args[0], pos) - state.forceFloat(*args[1], pos));
     else
         mkInt(v, state.forceInt(*args[0], pos) - state.forceInt(*args[1], pos));
@@ -2854,7 +2854,7 @@ static void prim_mul(EvalState & state, const Pos & pos, Value * * args, Value &
 {
     state.forceValue(*args[0], pos);
     state.forceValue(*args[1], pos);
-    if (args[0]->normalType() == nFloat || args[1]->normalType() == nFloat)
+    if (args[0]->type() == nFloat || args[1]->type() == nFloat)
         mkFloat(v, state.forceFloat(*args[0], pos) * state.forceFloat(*args[1], pos));
     else
         mkInt(v, state.forceInt(*args[0], pos) * state.forceInt(*args[1], pos));
@@ -2881,7 +2881,7 @@ static void prim_div(EvalState & state, const Pos & pos, Value * * args, Value &
             .errPos = pos
         });
 
-    if (args[0]->normalType() == nFloat || args[1]->normalType() == nFloat) {
+    if (args[0]->type() == nFloat || args[1]->type() == nFloat) {
         mkFloat(v, state.forceFloat(*args[0], pos) / state.forceFloat(*args[1], pos));
     } else {
         NixInt i1 = state.forceInt(*args[0], pos);

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -17,7 +17,7 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
 
     state.forceValue(*args[0]);
 
-    if (args[0]->normalType() == nAttrs) {
+    if (args[0]->type() == nAttrs) {
 
         state.forceAttrs(*args[0], pos);
 

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -17,7 +17,7 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
 
     state.forceValue(*args[0]);
 
-    if (args[0]->type == tAttrs) {
+    if (args[0]->normalType() == nAttrs) {
 
         state.forceAttrs(*args[0], pos);
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -85,25 +85,25 @@ static void fetchTree(
 
     state.forceValue(*args[0]);
 
-    if (args[0]->type == tAttrs) {
+    if (args[0]->normalType() == nAttrs) {
         state.forceAttrs(*args[0], pos);
 
         fetchers::Attrs attrs;
 
         for (auto & attr : *args[0]->attrs) {
             state.forceValue(*attr.value);
-            if (attr.value->type == tPath || attr.value->type == tString)
+            if (attr.value->normalType() == nPath || attr.value->normalType() == nString)
                 addURI(
                     state,
                     attrs,
                     attr.name,
                     state.coerceToString(*attr.pos, *attr.value, context, false, false)
                 );
-            else if (attr.value->type == tString)
+            else if (attr.value->normalType() == nString)
                 addURI(state, attrs, attr.name, attr.value->string.s);
-            else if (attr.value->type == tBool)
+            else if (attr.value->normalType() == nBool)
                 attrs.emplace(attr.name, Explicit<bool>{attr.value->boolean});
-            else if (attr.value->type == tInt)
+            else if (attr.value->normalType() == nInt)
                 attrs.emplace(attr.name, attr.value->integer);
             else
                 throw TypeError("fetchTree argument '%s' is %s while a string, Boolean or integer is expected",
@@ -163,7 +163,7 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
 
     state.forceValue(*args[0]);
 
-    if (args[0]->type == tAttrs) {
+    if (args[0]->normalType() == nAttrs) {
 
         state.forceAttrs(*args[0], pos);
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -85,25 +85,25 @@ static void fetchTree(
 
     state.forceValue(*args[0]);
 
-    if (args[0]->normalType() == nAttrs) {
+    if (args[0]->type() == nAttrs) {
         state.forceAttrs(*args[0], pos);
 
         fetchers::Attrs attrs;
 
         for (auto & attr : *args[0]->attrs) {
             state.forceValue(*attr.value);
-            if (attr.value->normalType() == nPath || attr.value->normalType() == nString)
+            if (attr.value->type() == nPath || attr.value->type() == nString)
                 addURI(
                     state,
                     attrs,
                     attr.name,
                     state.coerceToString(*attr.pos, *attr.value, context, false, false)
                 );
-            else if (attr.value->normalType() == nString)
+            else if (attr.value->type() == nString)
                 addURI(state, attrs, attr.name, attr.value->string.s);
-            else if (attr.value->normalType() == nBool)
+            else if (attr.value->type() == nBool)
                 attrs.emplace(attr.name, Explicit<bool>{attr.value->boolean});
-            else if (attr.value->normalType() == nInt)
+            else if (attr.value->type() == nInt)
                 attrs.emplace(attr.name, attr.value->integer);
             else
                 throw TypeError("fetchTree argument '%s' is %s while a string, Boolean or integer is expected",
@@ -163,7 +163,7 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
 
     state.forceValue(*args[0]);
 
-    if (args[0]->normalType() == nAttrs) {
+    if (args[0]->type() == nAttrs) {
 
         state.forceAttrs(*args[0], pos);
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -16,7 +16,7 @@ void printValueAsJSON(EvalState & state, bool strict,
 
     if (strict) state.forceValue(v);
 
-    switch (v.normalType()) {
+    switch (v.type()) {
 
         case nInt:
             out.write(v.integer);

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -16,30 +16,30 @@ void printValueAsJSON(EvalState & state, bool strict,
 
     if (strict) state.forceValue(v);
 
-    switch (v.type) {
+    switch (v.normalType()) {
 
-        case tInt:
+        case nInt:
             out.write(v.integer);
             break;
 
-        case tBool:
+        case nBool:
             out.write(v.boolean);
             break;
 
-        case tString:
+        case nString:
             copyContext(v, context);
             out.write(v.string.s);
             break;
 
-        case tPath:
+        case nPath:
             out.write(state.copyPathToStore(context, v.path));
             break;
 
-        case tNull:
+        case nNull:
             out.write(nullptr);
             break;
 
-        case tAttrs: {
+        case nAttrs: {
             auto maybeString = state.tryAttrsToString(noPos, v, context, false, false);
             if (maybeString) {
                 out.write(*maybeString);
@@ -61,7 +61,7 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
         }
 
-        case tList1: case tList2: case tListN: {
+        case nList: {
             auto list(out.list());
             for (unsigned int n = 0; n < v.listSize(); ++n) {
                 auto placeholder(list.placeholder());
@@ -70,15 +70,18 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
         }
 
-        case tExternal:
+        case nExternal:
             v.external->printValueAsJSON(state, strict, out, context);
             break;
 
-        case tFloat:
+        case nFloat:
             out.write(v.fpoint);
             break;
 
-        default:
+        case nThunk:
+            throw TypeError("cannot convert %1% to JSON", showType(v));
+
+        case nFunction:
             throw TypeError("cannot convert %1% to JSON", showType(v));
     }
 }

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -58,31 +58,31 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
 
     if (strict) state.forceValue(v);
 
-    switch (v.type) {
+    switch (v.normalType()) {
 
-        case tInt:
+        case nInt:
             doc.writeEmptyElement("int", singletonAttrs("value", (format("%1%") % v.integer).str()));
             break;
 
-        case tBool:
+        case nBool:
             doc.writeEmptyElement("bool", singletonAttrs("value", v.boolean ? "true" : "false"));
             break;
 
-        case tString:
+        case nString:
             /* !!! show the context? */
             copyContext(v, context);
             doc.writeEmptyElement("string", singletonAttrs("value", v.string.s));
             break;
 
-        case tPath:
+        case nPath:
             doc.writeEmptyElement("path", singletonAttrs("value", v.path));
             break;
 
-        case tNull:
+        case nNull:
             doc.writeEmptyElement("null");
             break;
 
-        case tAttrs:
+        case nAttrs:
             if (state.isDerivation(v)) {
                 XMLAttrs xmlAttrs;
 
@@ -92,14 +92,14 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
                 a = v.attrs->find(state.sDrvPath);
                 if (a != v.attrs->end()) {
                     if (strict) state.forceValue(*a->value);
-                    if (a->value->type == tString)
+                    if (a->value->normalType() == nString)
                         xmlAttrs["drvPath"] = drvPath = a->value->string.s;
                 }
 
                 a = v.attrs->find(state.sOutPath);
                 if (a != v.attrs->end()) {
                     if (strict) state.forceValue(*a->value);
-                    if (a->value->type == tString)
+                    if (a->value->normalType() == nString)
                         xmlAttrs["outPath"] = a->value->string.s;
                 }
 
@@ -118,14 +118,19 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
 
             break;
 
-        case tList1: case tList2: case tListN: {
+        case nList: {
             XMLOpenElement _(doc, "list");
             for (unsigned int n = 0; n < v.listSize(); ++n)
                 printValueAsXML(state, strict, location, *v.listElems()[n], doc, context, drvsSeen);
             break;
         }
 
-        case tLambda: {
+        case nFunction: {
+            if (!v.isLambda()) {
+                // FIXME: Serialize primops and primopapps
+                doc.writeEmptyElement("unevaluated");
+                break;
+            }
             XMLAttrs xmlAttrs;
             if (location) posToXML(xmlAttrs, v.lambda.fun->pos);
             XMLOpenElement _(doc, "function", xmlAttrs);
@@ -143,15 +148,15 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
             break;
         }
 
-        case tExternal:
+        case nExternal:
             v.external->printValueAsXML(state, strict, location, doc, context, drvsSeen);
             break;
 
-        case tFloat:
+        case nFloat:
             doc.writeEmptyElement("float", singletonAttrs("value", (format("%1%") % v.fpoint).str()));
             break;
 
-        default:
+        case nThunk:
             doc.writeEmptyElement("unevaluated");
     }
 }

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -58,7 +58,7 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
 
     if (strict) state.forceValue(v);
 
-    switch (v.normalType()) {
+    switch (v.type()) {
 
         case nInt:
             doc.writeEmptyElement("int", singletonAttrs("value", (format("%1%") % v.integer).str()));
@@ -92,14 +92,14 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
                 a = v.attrs->find(state.sDrvPath);
                 if (a != v.attrs->end()) {
                     if (strict) state.forceValue(*a->value);
-                    if (a->value->normalType() == nString)
+                    if (a->value->type() == nString)
                         xmlAttrs["drvPath"] = drvPath = a->value->string.s;
                 }
 
                 a = v.attrs->find(state.sOutPath);
                 if (a != v.attrs->end()) {
                     if (strict) state.forceValue(*a->value);
-                    if (a->value->normalType() == nString)
+                    if (a->value->type() == nString)
                         xmlAttrs["outPath"] = a->value->string.s;
                 }
 

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -106,7 +106,13 @@ std::ostream & operator << (std::ostream & str, const ExternalValueBase & v);
 
 struct Value
 {
+private:
     ValueType type;
+
+friend std::string showType(const Value & v);
+friend void printValue(std::ostream & str, std::set<const Value *> & active, const Value & v);
+
+public:
 
     inline void setInt() { type = tInt; };
     inline void setBool() { type = tBool; };

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -136,12 +136,12 @@ public:
     // These should be removed eventually, by putting the functionality that's
     // needed by callers into methods of this type
 
-    // normalType() == nThunk
+    // type() == nThunk
     inline bool isThunk() const { return internalType == tThunk; };
     inline bool isApp() const { return internalType == tApp; };
     inline bool isBlackhole() const { return internalType == tBlackhole; };
 
-    // normalType() == nFunction
+    // type() == nFunction
     inline bool isLambda() const { return internalType == tLambda; };
     inline bool isPrimOp() const { return internalType == tPrimOp; };
     inline bool isPrimOpApp() const { return internalType == tPrimOpApp; };
@@ -204,7 +204,7 @@ public:
 
     // Returns the normal type of a Value. This only returns nThunk if the
     // Value hasn't been forceValue'd
-    inline ValueType normalType() const
+    inline ValueType type() const
     {
         switch (internalType) {
             case tInt: return nInt;

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -107,6 +107,25 @@ std::ostream & operator << (std::ostream & str, const ExternalValueBase & v);
 struct Value
 {
     ValueType type;
+
+    inline void setInt() { type = tInt; };
+    inline void setBool() { type = tBool; };
+    inline void setString() { type = tString; };
+    inline void setPath() { type = tPath; };
+    inline void setNull() { type = tNull; };
+    inline void setAttrs() { type = tAttrs; };
+    inline void setList1() { type = tList1; };
+    inline void setList2() { type = tList2; };
+    inline void setListN() { type = tListN; };
+    inline void setThunk() { type = tThunk; };
+    inline void setApp() { type = tApp; };
+    inline void setLambda() { type = tLambda; };
+    inline void setBlackhole() { type = tBlackhole; };
+    inline void setPrimOp() { type = tPrimOp; };
+    inline void setPrimOpApp() { type = tPrimOpApp; };
+    inline void setExternal() { type = tExternal; };
+    inline void setFloat() { type = tFloat; };
+
     union
     {
         NixInt integer;
@@ -223,7 +242,7 @@ static inline void clearValue(Value & v)
 static inline void mkInt(Value & v, NixInt n)
 {
     clearValue(v);
-    v.type = tInt;
+    v.setInt();
     v.integer = n;
 }
 
@@ -231,7 +250,7 @@ static inline void mkInt(Value & v, NixInt n)
 static inline void mkFloat(Value & v, NixFloat n)
 {
     clearValue(v);
-    v.type = tFloat;
+    v.setFloat();
     v.fpoint = n;
 }
 
@@ -239,7 +258,7 @@ static inline void mkFloat(Value & v, NixFloat n)
 static inline void mkBool(Value & v, bool b)
 {
     clearValue(v);
-    v.type = tBool;
+    v.setBool();
     v.boolean = b;
 }
 
@@ -247,13 +266,13 @@ static inline void mkBool(Value & v, bool b)
 static inline void mkNull(Value & v)
 {
     clearValue(v);
-    v.type = tNull;
+    v.setNull();
 }
 
 
 static inline void mkApp(Value & v, Value & left, Value & right)
 {
-    v.type = tApp;
+    v.setApp();
     v.app.left = &left;
     v.app.right = &right;
 }
@@ -261,7 +280,7 @@ static inline void mkApp(Value & v, Value & left, Value & right)
 
 static inline void mkPrimOpApp(Value & v, Value & left, Value & right)
 {
-    v.type = tPrimOpApp;
+    v.setPrimOpApp();
     v.app.left = &left;
     v.app.right = &right;
 }
@@ -269,7 +288,7 @@ static inline void mkPrimOpApp(Value & v, Value & left, Value & right)
 
 static inline void mkStringNoCopy(Value & v, const char * s)
 {
-    v.type = tString;
+    v.setString();
     v.string.s = s;
     v.string.context = 0;
 }
@@ -287,7 +306,7 @@ void mkString(Value & v, const char * s);
 static inline void mkPathNoCopy(Value & v, const char * s)
 {
     clearValue(v);
-    v.type = tPath;
+    v.setPath();
     v.path = s;
 }
 

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -29,6 +29,22 @@ typedef enum {
     tFloat
 } ValueType;
 
+// This type abstracts over all actual value types in the language,
+// grouping together implementation details like tList*, different function
+// types, and types in non-normal form (so thunks and co.)
+typedef enum {
+    nThunk,
+    nInt,
+    nFloat,
+    nBool,
+    nString,
+    nPath,
+    nNull,
+    nAttrs,
+    nList,
+    nFunction,
+    nExternal
+} NormalType;
 
 class Bindings;
 struct Env;
@@ -146,6 +162,26 @@ struct Value
         ExternalValueBase * external;
         NixFloat fpoint;
     };
+
+    // Returns the normal type of a Value. This only returns nThunk if the
+    // Value hasn't been forceValue'd
+    inline NormalType normalType() const
+    {
+        switch (type) {
+            case tInt: return nInt;
+            case tBool: return nBool;
+            case tString: return nString;
+            case tPath: return nPath;
+            case tNull: return nNull;
+            case tAttrs: return nAttrs;
+            case tList1: case tList2: case tListN: return nList;
+            case tLambda: case tPrimOp: case tPrimOpApp: return nFunction;
+            case tExternal: return nExternal;
+            case tFloat: return nFloat;
+            case tThunk: case tApp: case tBlackhole: return nThunk;
+        }
+        abort();
+    }
 
     bool isList() const
     {

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -126,6 +126,20 @@ struct Value
     inline void setExternal() { type = tExternal; };
     inline void setFloat() { type = tFloat; };
 
+    // Functions needed to distinguish the type
+    // These should be removed eventually, by putting the functionality that's
+    // needed by callers into methods of this type
+
+    // normalType() == nThunk
+    inline bool isThunk() const { return type == tThunk; };
+    inline bool isApp() const { return type == tApp; };
+    inline bool isBlackhole() const { return type == tBlackhole; };
+
+    // normalType() == nFunction
+    inline bool isLambda() const { return type == tLambda; };
+    inline bool isPrimOp() const { return type == tPrimOp; };
+    inline bool isPrimOpApp() const { return type == tPrimOpApp; };
+
     union
     {
         NixInt integer;

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -27,7 +27,7 @@ typedef enum {
     tPrimOpApp,
     tExternal,
     tFloat
-} ValueType;
+} InternalType;
 
 // This type abstracts over all actual value types in the language,
 // grouping together implementation details like tList*, different function
@@ -44,7 +44,7 @@ typedef enum {
     nList,
     nFunction,
     nExternal
-} NormalType;
+} ValueType;
 
 class Bindings;
 struct Env;
@@ -107,44 +107,44 @@ std::ostream & operator << (std::ostream & str, const ExternalValueBase & v);
 struct Value
 {
 private:
-    ValueType type;
+    InternalType internalType;
 
 friend std::string showType(const Value & v);
 friend void printValue(std::ostream & str, std::set<const Value *> & active, const Value & v);
 
 public:
 
-    inline void setInt() { type = tInt; };
-    inline void setBool() { type = tBool; };
-    inline void setString() { type = tString; };
-    inline void setPath() { type = tPath; };
-    inline void setNull() { type = tNull; };
-    inline void setAttrs() { type = tAttrs; };
-    inline void setList1() { type = tList1; };
-    inline void setList2() { type = tList2; };
-    inline void setListN() { type = tListN; };
-    inline void setThunk() { type = tThunk; };
-    inline void setApp() { type = tApp; };
-    inline void setLambda() { type = tLambda; };
-    inline void setBlackhole() { type = tBlackhole; };
-    inline void setPrimOp() { type = tPrimOp; };
-    inline void setPrimOpApp() { type = tPrimOpApp; };
-    inline void setExternal() { type = tExternal; };
-    inline void setFloat() { type = tFloat; };
+    inline void setInt() { internalType = tInt; };
+    inline void setBool() { internalType = tBool; };
+    inline void setString() { internalType = tString; };
+    inline void setPath() { internalType = tPath; };
+    inline void setNull() { internalType = tNull; };
+    inline void setAttrs() { internalType = tAttrs; };
+    inline void setList1() { internalType = tList1; };
+    inline void setList2() { internalType = tList2; };
+    inline void setListN() { internalType = tListN; };
+    inline void setThunk() { internalType = tThunk; };
+    inline void setApp() { internalType = tApp; };
+    inline void setLambda() { internalType = tLambda; };
+    inline void setBlackhole() { internalType = tBlackhole; };
+    inline void setPrimOp() { internalType = tPrimOp; };
+    inline void setPrimOpApp() { internalType = tPrimOpApp; };
+    inline void setExternal() { internalType = tExternal; };
+    inline void setFloat() { internalType = tFloat; };
 
     // Functions needed to distinguish the type
     // These should be removed eventually, by putting the functionality that's
     // needed by callers into methods of this type
 
     // normalType() == nThunk
-    inline bool isThunk() const { return type == tThunk; };
-    inline bool isApp() const { return type == tApp; };
-    inline bool isBlackhole() const { return type == tBlackhole; };
+    inline bool isThunk() const { return internalType == tThunk; };
+    inline bool isApp() const { return internalType == tApp; };
+    inline bool isBlackhole() const { return internalType == tBlackhole; };
 
     // normalType() == nFunction
-    inline bool isLambda() const { return type == tLambda; };
-    inline bool isPrimOp() const { return type == tPrimOp; };
-    inline bool isPrimOpApp() const { return type == tPrimOpApp; };
+    inline bool isLambda() const { return internalType == tLambda; };
+    inline bool isPrimOp() const { return internalType == tPrimOp; };
+    inline bool isPrimOpApp() const { return internalType == tPrimOpApp; };
 
     union
     {
@@ -204,9 +204,9 @@ public:
 
     // Returns the normal type of a Value. This only returns nThunk if the
     // Value hasn't been forceValue'd
-    inline NormalType normalType() const
+    inline ValueType normalType() const
     {
-        switch (type) {
+        switch (internalType) {
             case tInt: return nInt;
             case tBool: return nBool;
             case tString: return nString;
@@ -224,22 +224,22 @@ public:
 
     bool isList() const
     {
-        return type == tList1 || type == tList2 || type == tListN;
+        return internalType == tList1 || internalType == tList2 || internalType == tListN;
     }
 
     Value * * listElems()
     {
-        return type == tList1 || type == tList2 ? smallList : bigList.elems;
+        return internalType == tList1 || internalType == tList2 ? smallList : bigList.elems;
     }
 
     const Value * const * listElems() const
     {
-        return type == tList1 || type == tList2 ? smallList : bigList.elems;
+        return internalType == tList1 || internalType == tList2 ? smallList : bigList.elems;
     }
 
     size_t listSize() const
     {
-        return type == tList1 ? 1 : type == tList2 ? 2 : bigList.size;
+        return internalType == tList1 ? 1 : internalType == tList2 ? 2 : bigList.size;
     }
 
     /* Check whether forcing this value requires a trivial amount of

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1138,38 +1138,38 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                                         i.queryName(), j)
                                 });
                             else {
-                                if (v->normalType() == nString) {
+                                if (v->type() == nString) {
                                     attrs2["type"] = "string";
                                     attrs2["value"] = v->string.s;
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->normalType() == nInt) {
+                                } else if (v->type() == nInt) {
                                     attrs2["type"] = "int";
                                     attrs2["value"] = (format("%1%") % v->integer).str();
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->normalType() == nFloat) {
+                                } else if (v->type() == nFloat) {
                                     attrs2["type"] = "float";
                                     attrs2["value"] = (format("%1%") % v->fpoint).str();
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->normalType() == nBool) {
+                                } else if (v->type() == nBool) {
                                     attrs2["type"] = "bool";
                                     attrs2["value"] = v->boolean ? "true" : "false";
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->normalType() == nList) {
+                                } else if (v->type() == nList) {
                                     attrs2["type"] = "strings";
                                     XMLOpenElement m(xml, "meta", attrs2);
                                     for (unsigned int j = 0; j < v->listSize(); ++j) {
-                                        if (v->listElems()[j]->normalType() != nString) continue;
+                                        if (v->listElems()[j]->type() != nString) continue;
                                         XMLAttrs attrs3;
                                         attrs3["value"] = v->listElems()[j]->string.s;
                                         xml.writeEmptyElement("string", attrs3);
                                     }
-                              } else if (v->normalType() == nAttrs) {
+                              } else if (v->type() == nAttrs) {
                                   attrs2["type"] = "strings";
                                   XMLOpenElement m(xml, "meta", attrs2);
                                   Bindings & attrs = *v->attrs;
                                   for (auto &i : attrs) {
                                       Attr & a(*attrs.find(i.name));
-                                      if(a.value->normalType() != nString) continue;
+                                      if(a.value->type() != nString) continue;
                                       XMLAttrs attrs3;
                                       attrs3["type"] = i.name;
                                       attrs3["value"] = a.value->string.s;

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1138,38 +1138,38 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                                         i.queryName(), j)
                                 });
                             else {
-                                if (v->type == tString) {
+                                if (v->normalType() == nString) {
                                     attrs2["type"] = "string";
                                     attrs2["value"] = v->string.s;
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->type == tInt) {
+                                } else if (v->normalType() == nInt) {
                                     attrs2["type"] = "int";
                                     attrs2["value"] = (format("%1%") % v->integer).str();
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->type == tFloat) {
+                                } else if (v->normalType() == nFloat) {
                                     attrs2["type"] = "float";
                                     attrs2["value"] = (format("%1%") % v->fpoint).str();
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->type == tBool) {
+                                } else if (v->normalType() == nBool) {
                                     attrs2["type"] = "bool";
                                     attrs2["value"] = v->boolean ? "true" : "false";
                                     xml.writeEmptyElement("meta", attrs2);
-                                } else if (v->isList()) {
+                                } else if (v->normalType() == nList) {
                                     attrs2["type"] = "strings";
                                     XMLOpenElement m(xml, "meta", attrs2);
                                     for (unsigned int j = 0; j < v->listSize(); ++j) {
-                                        if (v->listElems()[j]->type != tString) continue;
+                                        if (v->listElems()[j]->normalType() != nString) continue;
                                         XMLAttrs attrs3;
                                         attrs3["value"] = v->listElems()[j]->string.s;
                                         xml.writeEmptyElement("string", attrs3);
                                     }
-                              } else if (v->type == tAttrs) {
+                              } else if (v->normalType() == nAttrs) {
                                   attrs2["type"] = "strings";
                                   XMLOpenElement m(xml, "meta", attrs2);
                                   Bindings & attrs = *v->attrs;
                                   for (auto &i : attrs) {
                                       Attr & a(*attrs.find(i.name));
-                                      if(a.value->type != tString) continue;
+                                      if(a.value->normalType() != nString) continue;
                                       XMLAttrs attrs3;
                                       attrs3["type"] = i.name;
                                       attrs3["value"] = a.value->string.s;

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -97,10 +97,10 @@ struct CmdEval : MixJSON, InstallableCommand
             recurse = [&](Value & v, const Pos & pos, const Path & path)
             {
                 state->forceValue(v);
-                if (v.type == tString)
+                if (v.normalType() == nString)
                     // FIXME: disallow strings with contexts?
                     writeFile(path, v.string.s);
-                else if (v.type == tAttrs) {
+                else if (v.normalType() == nAttrs) {
                     if (mkdir(path.c_str(), 0777) == -1)
                         throw SysError("creating directory '%s'", path);
                     for (auto & attr : *v.attrs)

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -97,10 +97,10 @@ struct CmdEval : MixJSON, InstallableCommand
             recurse = [&](Value & v, const Pos & pos, const Path & path)
             {
                 state->forceValue(v);
-                if (v.normalType() == nString)
+                if (v.type() == nString)
                     // FIXME: disallow strings with contexts?
                     writeFile(path, v.string.s);
-                else if (v.normalType() == nAttrs) {
+                else if (v.type() == nAttrs) {
                     if (mkdir(path.c_str(), 0777) == -1)
                         throw SysError("creating directory '%s'", path);
                     for (auto & attr : *v.attrs)

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -279,7 +279,7 @@ struct CmdFlakeCheck : FlakeCommand
                 if (v.isLambda()) {
                     if (!v.lambda.fun->matchAttrs || !v.lambda.fun->formals->ellipsis)
                         throw Error("module must match an open attribute set ('{ config, ... }')");
-                } else if (v.normalType() == nAttrs) {
+                } else if (v.type() == nAttrs) {
                     for (auto & attr : *v.attrs)
                         try {
                             state->forceValue(*attr.value, *attr.pos);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -279,7 +279,7 @@ struct CmdFlakeCheck : FlakeCommand
                 if (v.type == tLambda) {
                     if (!v.lambda.fun->matchAttrs || !v.lambda.fun->formals->ellipsis)
                         throw Error("module must match an open attribute set ('{ config, ... }')");
-                } else if (v.type == tAttrs) {
+                } else if (v.normalType() == nAttrs) {
                     for (auto & attr : *v.attrs)
                         try {
                             state->forceValue(*attr.value, *attr.pos);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -260,7 +260,7 @@ struct CmdFlakeCheck : FlakeCommand
         auto checkOverlay = [&](const std::string & attrPath, Value & v, const Pos & pos) {
             try {
                 state->forceValue(v, pos);
-                if (v.type != tLambda || v.lambda.fun->matchAttrs || std::string(v.lambda.fun->arg) != "final")
+                if (!v.isLambda() || v.lambda.fun->matchAttrs || std::string(v.lambda.fun->arg) != "final")
                     throw Error("overlay does not take an argument named 'final'");
                 auto body = dynamic_cast<ExprLambda *>(v.lambda.fun->body);
                 if (!body || body->matchAttrs || std::string(body->arg) != "prev")
@@ -276,7 +276,7 @@ struct CmdFlakeCheck : FlakeCommand
         auto checkModule = [&](const std::string & attrPath, Value & v, const Pos & pos) {
             try {
                 state->forceValue(v, pos);
-                if (v.type == tLambda) {
+                if (v.isLambda()) {
                     if (!v.lambda.fun->matchAttrs || !v.lambda.fun->formals->ellipsis)
                         throw Error("module must match an open attribute set ('{ config, ... }')");
                 } else if (v.normalType() == nAttrs) {
@@ -371,7 +371,7 @@ struct CmdFlakeCheck : FlakeCommand
         auto checkBundler = [&](const std::string & attrPath, Value & v, const Pos & pos) {
             try {
                 state->forceValue(v, pos);
-                if (v.type != tLambda)
+                if (!v.isLambda())
                     throw Error("bundler must be a function");
                 if (!v.lambda.fun->formals ||
                     v.lambda.fun->formals->argNames.find(state->symbols.create("program")) == v.lambda.fun->formals->argNames.end() ||

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -272,7 +272,7 @@ void mainWrapped(int argc, char * * argv)
         auto builtins = state.baseEnv.values[0]->attrs;
         for (auto & builtin : *builtins) {
             auto b = nlohmann::json::object();
-            if (builtin.value->type != tPrimOp) continue;
+            if (!builtin.value->isPrimOp()) continue;
             auto primOp = builtin.value->primOp;
             if (!primOp->doc) continue;
             b["arity"] = primOp->arity;

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -551,7 +551,7 @@ bool NixRepl::processLine(string line)
         {
             Expr * e = parseString(string(line, p + 1));
             Value & v(*state->allocValue());
-            v.type = tThunk;
+            v.setThunk();
             v.thunk.env = env;
             v.thunk.expr = e;
             addVarToScope(state->symbols.create(name), v);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -551,9 +551,7 @@ bool NixRepl::processLine(string line)
         {
             Expr * e = parseString(string(line, p + 1));
             Value & v(*state->allocValue());
-            v.setThunk();
-            v.thunk.env = env;
-            v.thunk.expr = e;
+            v.mkThunk(env, e);
             addVarToScope(state->symbols.create(name), v);
         } else {
             Value v;

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -446,7 +446,7 @@ bool NixRepl::processLine(string line)
 
         Pos pos;
 
-        if (v.normalType() == nPath || v.normalType() == nString) {
+        if (v.type() == nPath || v.type() == nString) {
             PathSet context;
             auto filename = state->coerceToString(noPos, v, context);
             pos.file = state->symbols.create(filename);
@@ -669,7 +669,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
 
     state->forceValue(v);
 
-    switch (v.normalType()) {
+    switch (v.type()) {
 
     case nInt:
         str << ANSI_CYAN << v.integer << ANSI_NORMAL;

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -450,7 +450,7 @@ bool NixRepl::processLine(string line)
             PathSet context;
             auto filename = state->coerceToString(noPos, v, context);
             pos.file = state->symbols.create(filename);
-        } else if (v.type == tLambda) {
+        } else if (v.isLambda()) {
             pos = v.lambda.fun->pos;
         } else {
             // assume it's a derivation
@@ -760,13 +760,13 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         break;
 
     case nFunction:
-        if (v.type == tLambda) {
+        if (v.isLambda()) {
             std::ostringstream s;
             s << v.lambda.fun->pos;
             str << ANSI_BLUE "«lambda @ " << filterANSIEscapes(s.str()) << "»" ANSI_NORMAL;
-        } else if (v.type == tPrimOp) {
+        } else if (v.isPrimOp()) {
             str << ANSI_MAGENTA "«primop»" ANSI_NORMAL;
-        } else if (v.type == tPrimOpApp) {
+        } else if (v.isPrimOpApp()) {
             str << ANSI_BLUE "«primop-app»" ANSI_NORMAL;
         } else {
             abort();


### PR DESCRIPTION
This is a relatively simple but large refactoring for making `Value::type` private. This is done because that field exposes implementation details such as:
- Different kinds of lists: `tList1`, `tList2`, `tListN`
- Different kinds of thunks: `tThunk`, `tApp` and `tBlackhole`
- Different kinds of functions: `tLambda`, `tPrimOp` and `tPrimOpApp`

While lists already have a generic interface (`Value::isList()`, `Value::listElems()` and `Value::listSize()`), the same isn't true for thunks and functions. So in order to minimize the necessary changes, new functions were introduced to be able to distinguish between kinds of thunks and functions:
- `Value::isThunk()`, `Value::isApp()` and `Value::isBlackhole()`
- `Value::isLambda()`, `Value::isPrimOp()` and `Value::isPrimOpApp()`

In addition, a new type for the normal form type of a value was introduced, `NormalType`, which can be determined using `Value::normalType()`. This returns the same types as `builtins.typeOf` does, plus `nThunk` for thunk values. With this refactoring, this type is the canonical way to check the result type of an evaluation (plus `nThunk` for when it hasn't been evaluated yet).

And finally, in order to set the underlying `type` of a `Value`, setters for all the `ValueType`'s are introduced. In the future this should probably be handled only by `Value::mk<Type>` functions, such that these setters can be removed.

This PR will be useful for #4090, as such a feature will introduce a new attribute set type and will need a generic interface for accessing them.

Best review commit-by-commit