### PR TITLE
Change builder argv[0] to full path, instead of only basename

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -2804,13 +2804,13 @@ void DerivationGoal::runChild()
                 args.push_back(drv->builder);
             } else {
                 builder = drv->builder.c_str();
-                args.push_back(std::string(baseNameOf(drv->builder)));
+                args.push_back(std::string(drv->builder));
             }
         }
 #else
         else {
             builder = drv->builder.c_str();
-            args.push_back(std::string(baseNameOf(drv->builder)));
+            args.push_back(std::string(drv->builder));
         }
 #endif
 

--- a/src/libstore/build/hook-instance.cc
+++ b/src/libstore/build/hook-instance.cc
@@ -37,7 +37,7 @@ HookInstance::HookInstance()
             throw SysError("dupping builder's stdout/stderr");
 
         Strings args = {
-            std::string(baseNameOf(settings.buildHook.get())),
+            std::string(settings.buildHook.get()),
             std::to_string(verbosity),
         };
 


### PR DESCRIPTION
See commit message.
I have a few projects that use Nix, but cannot resolve their own location without knowing the full path they were called with (e.g. GCC). It seems, either way, that this decision was arbitrarily made (see 822794001cb4260b8c04a7bd2d50d890edae709a), and calling the builder by its full path (so `/nix/store/...-foo/bar` instead of `bar`) follows expected behavior more closely.

Running a similar patch, but against 2.3.5, locally. 