### PR TITLE
Better detect when `buildPaths` would be a no-op

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -729,9 +729,17 @@ void Store::buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMod
     StorePathSet paths2;
 
     for (auto & path : paths) {
-        if (path.path.isDerivation())
-            unsupported("buildPaths");
-        paths2.insert(path.path);
+        if (path.path.isDerivation()) {
+            if (settings.isExperimentalFeatureEnabled("ca-derivations")) {
+                for (auto & outputName : path.outputs) {
+                    if (!queryRealisation({path.path, outputName}))
+                        unsupported("buildPaths");
+                }
+            } else
+                unsupported("buildPaths");
+
+        } else
+            paths2.insert(path.path);
     }
 
     if (queryValidPaths(paths2).size() != paths2.size())


### PR DESCRIPTION
`buildPaths` can be called even for stores where it's not defined in case it's
bound to be a no-op.
The “no-op detection” mechanism was only detecting the case wher `buildPaths`
was called on a set of (non-drv) paths that were already present on the store.

This commit extends this mechanism to also detect the case where `buildPaths`
is called on a set of derivation outputs which are already built on the store.

This only works with the ca-derivations flag. It could be possible to
extend this to also work without it, but it would add quite a bit of
complexity, and it's not used without it anyways.
