### PR TITLE
Fix BinaryCacheStore::registerDrvOutput

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -460,7 +460,7 @@ std::optional<const Realisation> BinaryCacheStore::queryRealisation(const DrvOut
 
 void BinaryCacheStore::registerDrvOutput(const Realisation& info) {
     auto filePath = realisationsPrefix + "/" + info.id.to_string() + ".doi";
-    upsertFile(filePath, info.toJSON(), "application/json");
+    upsertFile(filePath, info.toJSON().dump(), "application/json");
 }
 
 ref<FSAccessor> BinaryCacheStore::getFSAccessor()


### PR DESCRIPTION
Was crashing because coercing a json document into a string is only
valid if the json is a string, otherwise we need to call `.dump()`
