### PR TITLE
Add a new Cmd type working on RealisedPaths

### DIFF
--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -141,7 +141,7 @@ private:
 };
 
 /* A command that operates on zero or more store paths. */
-struct StorePathsCommand : public InstallablesCommand
+struct RealisedPathsCommand : public InstallablesCommand
 {
 private:
 
@@ -154,15 +154,26 @@ protected:
 
 public:
 
-    StorePathsCommand(bool recursive = false);
+    RealisedPathsCommand(bool recursive = false);
 
     using StoreCommand::run;
 
-    virtual void run(ref<Store> store, std::vector<StorePath> storePaths) = 0;
+    virtual void run(ref<Store> store, std::vector<RealisedPath> paths) = 0;
 
     void run(ref<Store> store) override;
 
     bool useDefaultInstallables() override { return !all; }
+};
+
+struct StorePathsCommand : public RealisedPathsCommand
+{
+    StorePathsCommand(bool recursive = false);
+
+    using RealisedPathsCommand::run;
+
+    virtual void run(ref<Store> store, std::vector<StorePath> storePaths) = 0;
+
+    void run(ref<Store> store, std::vector<RealisedPath> paths) override;
 };
 
 /* A command that operates on exactly one store path. */
@@ -217,6 +228,12 @@ StorePath toStorePath(ref<Store> store,
 std::set<StorePath> toDerivations(ref<Store> store,
     std::vector<std::shared_ptr<Installable>> installables,
     bool useDeriver = false);
+
+std::set<RealisedPath> toRealisedPaths(
+    ref<Store> store,
+    Realise mode,
+    OperateOn operateOn,
+    std::vector<std::shared_ptr<Installable>> installables);
 
 /* Helper function to generate args that invoke $EDITOR on
    filename:lineno. */

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -704,23 +704,43 @@ Buildables build(ref<Store> store, Realise mode,
     return buildables;
 }
 
-StorePathSet toStorePaths(ref<Store> store,
-    Realise mode, OperateOn operateOn,
+std::set<RealisedPath> toRealisedPaths(
+    ref<Store> store,
+    Realise mode,
+    OperateOn operateOn,
     std::vector<std::shared_ptr<Installable>> installables)
 {
-    StorePathSet outPaths;
-
+    std::set<RealisedPath> res;
     if (operateOn == OperateOn::Output) {
         for (auto & b : build(store, mode, installables))
             std::visit(overloaded {
                 [&](BuildableOpaque bo) {
-                    outPaths.insert(bo.path);
+                    res.insert(bo.path);
                 },
                 [&](BuildableFromDrv bfd) {
+                    auto drv = store->readDerivation(bfd.drvPath);
+                    auto outputHashes = staticOutputHashes(*store, drv);
                     for (auto & output : bfd.outputs) {
-                        if (!output.second)
-                            throw Error("Cannot operate on output of unbuilt CA drv");
-                        outPaths.insert(*output.second);
+                        if (settings.isExperimentalFeatureEnabled("ca-derivations")) {
+                            if (!outputHashes.count(output.first))
+                                throw Error(
+                                    "The derivation %s doesn't have an output "
+                                    "named %s",
+                                    store->printStorePath(bfd.drvPath),
+                                    output.first);
+                            auto outputId = DrvOutput{outputHashes.at(output.first), output.first};
+                            auto realisation = store->queryRealisation(outputId);
+                            if (!realisation)
+                                throw Error("Cannot operate on output of unbuilt CA drv %s", outputId.to_string());
+                            res.insert(RealisedPath{*realisation});
+                        }
+                        else {
+                            // If ca-derivations isn't enabled, behave as if
+                            // all the paths are opaque to keep the default
+                            // behavior
+                            assert(output.second);
+                            res.insert(*output.second);
+                        }
                     }
                 },
             }, b);
@@ -731,9 +751,19 @@ StorePathSet toStorePaths(ref<Store> store,
         for (auto & i : installables)
             for (auto & b : i->toBuildables())
                 if (auto bfd = std::get_if<BuildableFromDrv>(&b))
-                    outPaths.insert(bfd->drvPath);
+                    res.insert(bfd->drvPath);
     }
 
+    return res;
+}
+
+StorePathSet toStorePaths(ref<Store> store,
+    Realise mode, OperateOn operateOn,
+    std::vector<std::shared_ptr<Installable>> installables)
+{
+    StorePathSet outPaths;
+    for (auto & path : toRealisedPaths(store, mode, operateOn, installables))
+            outPaths.insert(path.path());
     return outPaths;
 }
 

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -724,14 +724,13 @@ std::set<RealisedPath> toRealisedPaths(
                         if (settings.isExperimentalFeatureEnabled("ca-derivations")) {
                             if (!outputHashes.count(output.first))
                                 throw Error(
-                                    "The derivation %s doesn't have an output "
-                                    "named %s",
+                                    "the derivation '%s' doesn't have an output named '%s'",
                                     store->printStorePath(bfd.drvPath),
                                     output.first);
                             auto outputId = DrvOutput{outputHashes.at(output.first), output.first};
                             auto realisation = store->queryRealisation(outputId);
                             if (!realisation)
-                                throw Error("Cannot operate on output of unbuilt CA drv %s", outputId.to_string());
+                                throw Error("cannot operate on an output of unbuilt content-addresed derivation '%s'", outputId.to_string());
                             res.insert(RealisedPath{*realisation});
                         }
                         else {

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -46,4 +46,35 @@ Realisation Realisation::fromJSON(
     };
 }
 
+StorePath RealisedPath::path() const {
+    return visit([](auto && arg) { return arg.getPath(); });
+}
+
+void RealisedPath::closure(
+    Store& store,
+    const RealisedPath::Set& startPaths,
+    RealisedPath::Set& ret)
+{
+    // FIXME: This only builds the store-path closure, not the real realisation
+    // closure
+    StorePathSet initialStorePaths, pathsClosure;
+    for (auto& path : startPaths)
+        initialStorePaths.insert(path.path());
+    store.computeFSClosure(initialStorePaths, pathsClosure);
+    ret.insert(startPaths.begin(), startPaths.end());
+    ret.insert(pathsClosure.begin(), pathsClosure.end());
+}
+
+void RealisedPath::closure(Store& store, RealisedPath::Set& ret) const
+{
+    RealisedPath::closure(store, {*this}, ret);
+}
+
+RealisedPath::Set RealisedPath::closure(Store& store) const
+{
+    RealisedPath::Set ret;
+    closure(store, ret);
+    return ret;
+}
+
 } // namespace nix

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -65,7 +65,7 @@ void RealisedPath::closure(
     ret.insert(pathsClosure.begin(), pathsClosure.end());
 }
 
-void RealisedPath::closure(Store& store, RealisedPath::Set& ret) const
+void RealisedPath::closure(Store& store, RealisedPath::Set & ret) const
 {
     RealisedPath::closure(store, {*this}, ret);
 }

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -47,7 +47,7 @@ Realisation Realisation::fromJSON(
 }
 
 StorePath RealisedPath::path() const {
-    return visit([](auto && arg) { return arg.getPath(); });
+    return std::visit([](auto && arg) { return arg.getPath(); }, raw);
 }
 
 void RealisedPath::closure(

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -2,34 +2,7 @@
 
 #include "path.hh"
 #include <nlohmann/json_fwd.hpp>
-
-
-/* Awfull hacky generation of the comparison operators by doing a lexicographic
- * comparison between the choosen fields
- * ```
- * GENERATE_CMP(ClassName, my->field1, my->field2, ...)
- * ```
- *
- * will generate comparison operators semantically equivalent to:
- * ```
- * bool operator<(const ClassName& other) {
- *   return field1 < other.field1 && field2 < other.field2 && ...;
- * }
- * ```
- */
-#define GENERATE_ONE_CMP(COMPARATOR, MY_TYPE, FIELDS...) \
-    bool operator COMPARATOR(const MY_TYPE& other) const { \
-      const MY_TYPE* me = this; \
-      auto fields1 = std::make_tuple( FIELDS ); \
-      me = &other; \
-      auto fields2 = std::make_tuple( FIELDS ); \
-      return fields1 COMPARATOR fields2; \
-    }
-#define GENERATE_EQUAL(args...) GENERATE_ONE_CMP(==, args)
-#define GENERATE_LEQ(args...) GENERATE_ONE_CMP(<, args)
-#define GENERATE_CMP(args...) \
-    GENERATE_EQUAL(args) \
-    GENERATE_LEQ(args)
+#include "comparator.hh"
 
 namespace nix {
 

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -59,19 +59,6 @@ struct RealisedPath {
     RealisedPath(Realisation r) : raw(r) {}
 
     /**
-     * Syntactic sugar to run `std::visit` on the raw value:
-     * path.visit(blah) == std::visit(blah, path.raw)
-     */
-    template <class Visitor>
-    constexpr decltype(auto) visit(Visitor && vis) {
-        return std::visit(vis, raw);
-    }
-    template <class Visitor>
-    constexpr decltype(auto) visit(Visitor && vis) const {
-        return std::visit(vis, raw);
-    }
-
-    /**
      * Get the raw store path associated to this
      */
     StorePath path() const;

--- a/src/libutil/comparator.hh
+++ b/src/libutil/comparator.hh
@@ -1,0 +1,30 @@
+#pragma once
+
+/* Awfull hacky generation of the comparison operators by doing a lexicographic
+ * comparison between the choosen fields.
+ *
+ * ```
+ * GENERATE_CMP(ClassName, me->field1, me->field2, ...)
+ * ```
+ *
+ * will generate comparison operators semantically equivalent to:
+ *
+ * ```
+ * bool operator<(const ClassName& other) {
+ *   return field1 < other.field1 && field2 < other.field2 && ...;
+ * }
+ * ```
+ */
+#define GENERATE_ONE_CMP(COMPARATOR, MY_TYPE, FIELDS...) \
+    bool operator COMPARATOR(const MY_TYPE& other) const { \
+      const MY_TYPE* me = this; \
+      auto fields1 = std::make_tuple( FIELDS ); \
+      me = &other; \
+      auto fields2 = std::make_tuple( FIELDS ); \
+      return fields1 COMPARATOR fields2; \
+    }
+#define GENERATE_EQUAL(args...) GENERATE_ONE_CMP(==, args)
+#define GENERATE_LEQ(args...) GENERATE_ONE_CMP(<, args)
+#define GENERATE_CMP(args...) \
+    GENERATE_EQUAL(args) \
+    GENERATE_LEQ(args)

--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -16,6 +16,8 @@ struct CmdCopy : StorePathsCommand
 
     SubstituteFlag substitute = NoSubstitute;
 
+    using StorePathsCommand::run;
+
     CmdCopy()
         : StorePathsCommand(true)
     {


### PR DESCRIPTION
Where a `RealisedPath` is a store path with its history, meaning either
an opaque path for stuff that has been directly added to the store, or a
`Realisation` for stuff that has been built by a derivation

This is a low-level refactoring that doesn't bring anything by itself
(except a few dozen extra lines of code :/ ), but raising the
abstraction level a bit is important on a number of levels:

- Commands like `nix build` have to query for the realisations after the
  build is finished which is fragile (see
  27905f12e4a7207450abe37c9ed78e31603b67e1 for example). Having them
  oprate directly at the realisation level would avoid that
- Others like `nix copy` currently operate directly on (built) store
  paths, but need a bit more information as they will need to register
  the realisations on the remote side
