### PR TITLE
Backport issue 3964 substitution loop

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -1222,8 +1222,13 @@ void DerivationGoal::outputsSubstituted()
 
     /*  If the substitutes form an incomplete closure, then we should
         build the dependencies of this derivation, but after that, we
-        can still use the substitutes for this derivation itself. */
-    if (nrIncompleteClosure > 0) retrySubstitution = true;
+        can still use the substitutes for this derivation itself.
+
+        If the nrIncompleteClosure != nrFailed, we have another issue as well.
+        In particular, it may be the case that the hole in the closure is
+        an output of the current derivation, which causes a loop if retried.
+     */
+    if (nrIncompleteClosure > 0 && nrIncompleteClosure == nrFailed) retrySubstitution = true;
 
     nrFailed = nrNoSubstituters = nrIncompleteClosure = 0;
 

--- a/tests/binary-cache.sh
+++ b/tests/binary-cache.sh
@@ -168,3 +168,34 @@ clearCacheCache
 nix-store -r $outPath --substituters "file://$cacheDir2 file://$cacheDir" --trusted-public-keys "$publicKey"
 
 fi # HAVE_LIBSODIUM
+
+# Test against issue https://github.com/NixOS/nix/issues/3964
+#
+expr='
+  with import ./config.nix;
+  mkDerivation {
+    name = "multi-output";
+    buildCommand = "mkdir -p $out; echo foo > $doc; echo $doc > $out/docref";
+    outputs = ["out" "doc"];
+  }
+'
+outPath=$(nix-build --no-out-link -E "$expr")
+docPath=$(nix-store -q --references $outPath)
+
+# $ nix-store -q --tree $outPath
+# ...-multi-output
+# +---...-multi-output-doc
+
+nix copy --to "file://$cacheDir" $outPath
+
+hashpart() {
+  basename "$1" | cut -c1-32
+}
+
+# break the closure of out by removing doc
+rm $cacheDir/$(hashpart $docPath).narinfo
+
+nix-store --delete $outPath $docPath
+# -vvv is the level that logs during the loop
+timeout 60 nix-build -E "$expr" --option substituters "file://$cacheDir" \
+  --option trusted-binary-caches "file://$cacheDir"  --no-require-sigs


### PR DESCRIPTION
Backport #4158

I had to revert the test, because it appears to rely on >2.3 functionality. See commit message.

@ajs124 could you try this?