### PR TITLE
Fix insufficent attribute capacity in user profile

### DIFF
--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -53,10 +53,12 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
            output paths, and optionally the derivation path, as well
            as the meta attributes. */
         Path drvPath = keepDerivations ? i.queryDrvPath() : "";
+        DrvInfo::Outputs outputs = i.queryOutputs(true);
+        StringSet metaNames = i.queryMetaNames();
 
         Value & v(*state.allocValue());
         manifest.listElems()[n++] = &v;
-        state.mkAttrs(v, 16);
+        state.mkAttrs(v, 7 + outputs.size());
 
         mkString(*state.allocAttr(v, state.sType), "derivation");
         mkString(*state.allocAttr(v, state.sName), i.queryName());
@@ -68,7 +70,6 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
             mkString(*state.allocAttr(v, state.sDrvPath), i.queryDrvPath());
 
         // Copy each output meant for installation.
-        DrvInfo::Outputs outputs = i.queryOutputs(true);
         Value & vOutputs = *state.allocAttr(v, state.sOutputs);
         state.mkList(vOutputs, outputs.size());
         unsigned int m = 0;
@@ -88,8 +89,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
 
         // Copy the meta attributes.
         Value & vMeta = *state.allocAttr(v, state.sMeta);
-        state.mkAttrs(vMeta, 16);
-        StringSet metaNames = i.queryMetaNames();
+        state.mkAttrs(vMeta, metaNames.size());
         for (auto & j : metaNames) {
             Value * v = i.queryMeta(j);
             if (!v) continue;


### PR DESCRIPTION
I recently started to get assert failures in nix-env for certain packages:

```
$ nix-env -i mercurial
warning: there are multiple derivations named 'mercurial-5.6'; using the first one
installing 'mercurial-5.6'
nix-env: src/libexpr/attr-set.hh:54: void nix::Bindings::push_back(const nix::Attr&): Assertion `size_ < capacity_' failed.
```

In this case, the package has 17 meta attributes:

```
src/nix-env/user-env.cc:93
93              for (auto & j : metaNames) {
1: metaNames = std::set with 17 elements = {[0] = "available", [1] = "broken", [2] = "description", [3] = "downloadPage", [4] = "homepage",
  [5] = "insecure", [6] = "isBuildPythonPackage", [7] = "license", [8] = "maintainers", [9] = "name", [10] = "outputsToInstall", [11] = "platforms",
  [12] = "position", [13] = "unfree", [14] = "unsupported", [15] = "updateWalker", [16] = "version"}
```

This is my attempt to fix it by calculating the capacities.