### PR TITLE
Fix `configure` error in introduction doc

### DIFF
--- a/doc/manual/src/introduction.md
+++ b/doc/manual/src/introduction.md
@@ -165,10 +165,10 @@ You’re then dropped into a shell where you can edit, build and test
 the package:
 
 ```console
-[nix-shell]$ tar xf $src
+[nix-shell]$ unpackPhase
 [nix-shell]$ cd pan-*
-[nix-shell]$ ./configure
-[nix-shell]$ make
+[nix-shell]$ configurePhase
+[nix-shell]$ buildPhase
 [nix-shell]$ ./pan/gui/pan
 ```
 


### PR DESCRIPTION
Ran into an error when working through the introduction; `configure` script was failing due to missing `--with-gtk3` flag.

Dug around and found this issue https://github.com/NixOS/nix/issues/2922 which lead me to try `configurePhase`. Looks like https://github.com/NixOS/nix/blob/master/doc/manual/src/command-ref/nix-shell.md also has the same example so I've just updated the intro to be the same as that.

closes https://github.com/NixOS/nix/issues/2922