### PR TITLE
Fix #4234, send build logs to Nix 2.3

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -142,6 +142,14 @@ struct TunnelLogger : public Logger
 
     void result(ActivityId act, ResultType type, const Fields & fields) override
     {
+        if (GET_PROTOCOL_MINOR(clientVersion) < 22 && type == resBuildLogLine && settings.verboseBuild) {
+            // Nix < 2.4 expects build logs to be logged as general logs at lvlError.
+            // We probably shouldn't do this for repeated builds, but that's not
+            // something we can know here without complicating the implementation
+            // unnecessarily.
+            auto lastLine = fields[0].s;
+            log(lvlError, lastLine);
+        }
         if (GET_PROTOCOL_MINOR(clientVersion) < 20) return;
         StringSink buf;
         buf << STDERR_RESULT << act << type << fields;


### PR DESCRIPTION
Fixes #4234 introduced in #3073

Sends build logs to clients in the extra way that Nix 2.3 clients expects to receive.

The conditional on clientVersion isn't accurate for a certain
range of master commits, but those are unsupported anyway.

It's not accurate for repeated builds either, because that
would complicate the code for too little gain.

~@ regnat this is one possible solution. If you have another solution that is perhaps more in line with #3073, we could go with that instead.~ It changed the way the build logs are treated internally, affecting the log messages on the socket. This PR supplements the log to be compatible with 2.3. I don't think there's much else to it.