### PR TITLE
Fix conversion from JSON to fetch attributes

### DIFF
--- a/src/libfetchers/attrs.cc
+++ b/src/libfetchers/attrs.cc
@@ -15,7 +15,7 @@ Attrs jsonToAttrs(const nlohmann::json & json)
         else if (i.value().is_string())
             attrs.emplace(i.key(), i.value().get<std::string>());
         else if (i.value().is_boolean())
-            attrs.emplace(i.key(), i.value().get<bool>());
+            attrs.emplace(i.key(), Explicit<bool> { i.value().get<bool>() });
         else
             throw Error("unsupported input attribute type in lock file");
     }


### PR DESCRIPTION
It appears as through the fetch attribute, which is simply a variant with 3 elements, implicitly converts boolean arguments to integers. One must use Explicit<bool> to correctly populate it with a boolean. This was missing from the implementation, and resulted in clearly boolean JSON fields being treated as numbers.