### PR TITLE
Allow Flake inputs to accept boolean and integer attributes

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -120,15 +120,19 @@ static FlakeInput parseFlakeInput(EvalState & state,
                 expectType(state, nString, *attr.value, *attr.pos);
                 input.follows = parseInputPath(attr.value->string.s);
             } else {
-                if (attr.value->type() == nString) {
-                    attrs.emplace(attr.name, attr.value->string.s);
-                } else if (attr.value->type() == nBool) {
-                    attrs.emplace(attr.name, Explicit<bool>{ attr.value->boolean });
-                } else if (attr.value->type() == nInt) {
-                    attrs.emplace(attr.name, attr.value->integer);
-                } else {
-                    throw TypeError("flake input attribute '%s' is %s while a string, boolean, or integer is expected",
-                        attr.name, showType(*attr.value));
+                switch (attr.value->type()) {
+                    case nString:
+                        attrs.emplace(attr.name, attr.value->string.s);
+                        break;
+                    case nBool:
+                        attrs.emplace(attr.name, Explicit<bool> { attr.value->boolean });
+                        break;
+                    case nInt:
+                        attrs.emplace(attr.name, attr.value->integer);
+                        break;
+                    default:
+                        throw TypeError("flake input attribute '%s' is %s while a string, boolean, or integer is expected",
+                            attr.name, showType(*attr.value));
                 }
             }
         } catch (Error & e) {

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -131,7 +131,7 @@ static FlakeInput parseFlakeInput(EvalState & state,
                         attrs.emplace(attr.name, attr.value->integer);
                         break;
                     default:
-                        throw TypeError("flake input attribute '%s' is %s while a string, boolean, or integer is expected",
+                        throw TypeError("flake input attribute '%s' is %s while a string, Boolean, or integer is expected",
                             attr.name, showType(*attr.value));
                 }
             }

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -120,11 +120,16 @@ static FlakeInput parseFlakeInput(EvalState & state,
                 expectType(state, nString, *attr.value, *attr.pos);
                 input.follows = parseInputPath(attr.value->string.s);
             } else {
-                if (attr.value->type() == nString)
+                if (attr.value->type() == nString) {
                     attrs.emplace(attr.name, attr.value->string.s);
-                else
-                    throw TypeError("flake input attribute '%s' is %s while a string is expected",
+                } else if (attr.value->type() == nBool) {
+                    attrs.emplace(attr.name, Explicit<bool>{ attr.value->boolean });
+                } else if (attr.value->type() == nInt) {
+                    attrs.emplace(attr.name, attr.value->integer);
+                } else {
+                    throw TypeError("flake input attribute '%s' is %s while a string, boolean, or integer is expected",
                         attr.name, showType(*attr.value));
+                }
             }
         } catch (Error & e) {
             e.addTrace(*attr.pos, hintfmt("in flake attribute '%s'", attr.name));


### PR DESCRIPTION
Looking through the code base for Nix, I found that it creates `fetchers::Input` from the attributes given to Flakes' input refs (see also lines 108 through 133 in `flake.cc`): 

https://github.com/NixOS/nix/blob/920e6a6920fa0ae82150bb2b0c210a03ccf5919b/src/libexpr/flake/flakeref.cc#L191-L198

The attributes accepted by the fetches can be strings, integers, or booleans. However, currently, the code in `flake.cc` rejects all attributes that are not strings. It does, however, forward all extra string arguments, no matter what they are, to the `fetchers::Input`. This seems inconsistent, and prevents input types like Git from accepting certain arguments, including `submodules`.

This PR expands the code in `flake.cc` to accept non-string arguments. Combined with this, I was able to make non-flake inputs with recursive git modules work as follows:

```Nix
inputs = {
    blog-source = {
      flake = false;
      url = "https://my.example.com/repo.git";
      type = "git";
      submodules = true;
    }
};
```

Note that `type = "git"` is already supported by Nix; this PR allows the `submodules = true` argument to be passed in alongside `type`. I believe this would close #4357 (and its duplicate, #4423).

So far, the only non-integer attributes are  `submodules` (bool), `revCount` (int), and `lastModified` (int). While the latter two are not particularly useful, I think the benefits for git submodules and consistency make this a worthwhile change. 