### PR TITLE
Miscellaneous improvements for positioning in eval-errors

### DIFF
--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -35,6 +35,7 @@ class Bindings
 {
 public:
     typedef uint32_t size_t;
+    Pos *pos;
 
 private:
     size_t size_, capacity_;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -201,6 +201,15 @@ string showType(const Value & v)
     }
 }
 
+Pos Value::determinePos(const Pos &pos) const
+{
+    switch (internalType) {
+        case tAttrs: return *attrs->pos;
+        case tLambda: return lambda.fun->pos;
+        case tApp: return app.left->determinePos(pos);
+        default: return pos;
+    }
+}
 
 bool Value::isTrivial() const
 {
@@ -1060,6 +1069,8 @@ void ExprAttrs::eval(EvalState & state, Env & env, Value & v)
         v.attrs->push_back(Attr(nameSym, i.valueExpr->maybeThunk(state, *dynamicEnv), &i.pos));
         v.attrs->sort(); // FIXME: inefficient
     }
+
+    v.attrs->pos = &pos;
 }
 
 

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -180,6 +180,7 @@ struct ExprOpHasAttr : Expr
 struct ExprAttrs : Expr
 {
     bool recursive;
+    Pos pos;
     struct AttrDef {
         bool inherited;
         Expr * e;
@@ -199,7 +200,8 @@ struct ExprAttrs : Expr
     };
     typedef std::vector<DynamicAttrDef> DynamicAttrDefs;
     DynamicAttrDefs dynamicAttrs;
-    ExprAttrs() : recursive(false) { };
+    ExprAttrs(const Pos &pos) : recursive(false), pos(pos) { };
+    ExprAttrs() : recursive(false), pos(noPos) { };
     COMMON_METHODS
 };
 

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -478,7 +478,7 @@ binds
           $$->attrs[i.symbol] = ExprAttrs::AttrDef(new ExprSelect(CUR_POS, $4, i.symbol), makeCurPos(@6, data));
       }
     }
-  | { $$ = new ExprAttrs; }
+  | { $$ = new ExprAttrs(makeCurPos(@0, data)); }
   ;
 
 attrs

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -953,7 +953,7 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
                     }
 
                 } else {
-                    auto s = state.coerceToString(posDrvName, *i->value, context, true);
+                    auto s = state.coerceToString(*i->pos, *i->value, context, true);
                     drv.env.emplace(key, s);
                     if (i->name == state.sBuilder) drv.builder = s;
                     else if (i->name == state.sSystem) drv.platform = s;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -547,13 +547,13 @@ typedef list<Value *> ValueList;
 #endif
 
 
-static Bindings::iterator extractAttrNameFromPrimopCall(
-        EvalState &state,
-        string funcName,
-        string attrName,
-        Bindings *attrSet,
-        const Pos &pos
-) {
+static Bindings::iterator getAttr(
+    EvalState & state,
+    string funcName,
+    string attrName,
+    Bindings * attrSet,
+    const Pos & pos)
+{
     Bindings::iterator value = attrSet->find(state.symbols.create(attrName));
     if (value == attrSet->end()) {
         hintformat errorMsg = hintfmt(
@@ -589,7 +589,7 @@ static void prim_genericClosure(EvalState & state, const Pos & pos, Value * * ar
     state.forceAttrs(*args[0], pos);
 
     /* Get the start set. */
-    Bindings::iterator startSet = extractAttrNameFromPrimopCall(
+    Bindings::iterator startSet = getAttr(
         state,
         "genericClosure",
         "startSet",
@@ -604,7 +604,7 @@ static void prim_genericClosure(EvalState & state, const Pos & pos, Value * * ar
         workSet.push_back(startSet->value->listElems()[n]);
 
     /* Get the operator. */
-    Bindings::iterator op = extractAttrNameFromPrimopCall(
+    Bindings::iterator op = getAttr(
         state,
         "genericClosure",
         "operator",
@@ -855,7 +855,7 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
     state.forceAttrs(*args[0], pos);
 
     /* Figure out the name first (for stack backtraces). */
-    Bindings::iterator attr = extractAttrNameFromPrimopCall(
+    Bindings::iterator attr = getAttr(
         state,
         "derivationStrict",
         state.sName,
@@ -1410,7 +1410,7 @@ static void prim_findFile(EvalState & state, const Pos & pos, Value * * args, Va
         if (i != v2.attrs->end())
             prefix = state.forceStringNoCtx(*i->value, pos);
 
-        i = extractAttrNameFromPrimopCall(
+        i = getAttr(
             state,
             "findFile",
             "path",
@@ -2058,7 +2058,7 @@ void prim_getAttr(EvalState & state, const Pos & pos, Value * * args, Value & v)
     string attr = state.forceStringNoCtx(*args[0], pos);
     state.forceAttrs(*args[1], pos);
     // !!! Should we create a symbol here or just do a lookup?
-    Bindings::iterator i = extractAttrNameFromPrimopCall(
+    Bindings::iterator i = getAttr(
         state,
         "getAttr",
         attr,
@@ -2191,7 +2191,7 @@ static void prim_listToAttrs(EvalState & state, const Pos & pos, Value * * args,
         Value & v2(*args[0]->listElems()[i]);
         state.forceAttrs(v2, pos);
 
-        Bindings::iterator j = extractAttrNameFromPrimopCall(
+        Bindings::iterator j = getAttr(
             state,
             "listToAttrs",
             state.sName,
@@ -2203,7 +2203,7 @@ static void prim_listToAttrs(EvalState & state, const Pos & pos, Value * * args,
 
         Symbol sym = state.symbols.create(name);
         if (seen.insert(sym).second) {
-            Bindings::iterator j2 = extractAttrNameFromPrimopCall(
+            Bindings::iterator j2 = getAttr(
                 state,
                 "listToAttrs",
                 state.sValue,

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -341,6 +341,8 @@ public:
         return internalType == tList1 ? 1 : internalType == tList2 ? 2 : bigList.size;
     }
 
+    Pos determinePos(const Pos &pos) const;
+
     /* Check whether forcing this value requires a trivial amount of
        computation. In particular, function applications are
        non-trivial. */


### PR DESCRIPTION
This is still a work-in-progress PR to improve the position of errors showed by Nix. I'm happy to do more work on this to get this actually mergable, but first I'd like to gather some feedback (cc @domenkozar @edolstra @bburdette @Ericson2314 ).

To summarize, the following changes are on this branch:

* primops/derivation: use position of currently evaluated attribute

  * The position of the `name`-attribute appears in the trace.
  * If e.g. `meta` has no `outPath`-attribute, a `cannot coerce set to
    string` error will be thrown where `pos` points to `name =` which is
    highly misleading.

* libexpr: misc improvements for proper error position

  When working on some more complex Nix code, there are sometimes rather
  unhelpful or misleading error messages, especially if coerce-errors are
  thrown.

  This patch is a first steps towards improving that. I'm happy to file
  more changes after that, but I'd like to gather some feedback first.

  To summarize, this patch does the following things:

  * Attrsets (a.k.a. `Bindings` in `libexpr`) now have a `Pos`. This is
    helpful e.g. to identify which attribute-set in `listToAttrs` is
    invalid.

  * The `Value`-struct has a new method named `determinePos` which tries
    to guess the position of a value and falls back to a default if that's
    not possible.

    This can be used to provide better messages if a coercion fails.

  * The new `determinePos`-API is used by `builtins.concatMap` now. With
    that change, Nix shows the exact position in the error where a wrong
    value was returned by the lambda.

    To make sure it's still obvious that `concatMap` is the problem,
    another stack-frame was added.

  * The changes described above can be added to every other `primop`, but
    first I'd like to get some feedback about the overall approach.