### PR TITLE
Don't let 'preferLocalBuild' override 'max-jobs=0'

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -679,13 +679,9 @@ void DerivationGoal::tryToBuild()
 }
 
 void DerivationGoal::tryLocalBuild() {
-    bool buildLocally = buildMode != bmNormal || parsedDrv->willBuildLocally(worker.store);
-
-    /* Make sure that we are allowed to start a build.  If this
-       derivation prefers to be done locally, do it even if
-       maxBuildJobs is 0. */
+    /* Make sure that we are allowed to start a build. */
     unsigned int curBuilds = worker.getNrLocalBuilds();
-    if (curBuilds >= settings.maxBuildJobs && !(buildLocally && curBuilds == 0)) {
+    if (curBuilds >= settings.maxBuildJobs) {
         worker.waitForBuildSlot(shared_from_this());
         outputLocks.unlock();
         return;

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -101,6 +101,10 @@ bool ParsedDerivation::canBuildLocally(Store & localStore) const
         && !drv.isBuiltin())
         return false;
 
+    if (settings.maxBuildJobs.get() == 0
+        && !drv.isBuiltin())
+        return false;
+
     for (auto & feature : getRequiredSystemFeatures())
         if (!localStore.systemFeatures.get().count(feature)) return false;
 


### PR DESCRIPTION
This resolves #3810 by changing the behavior of `max-jobs = 0`, so
that specifying the option also avoids local building of derivations
with the attribute `preferLocalBuild = true`.

A more complicated resolution was suggested by @grahamc in #3810, that also made it possible to retain the original behavior of `max-jobs=0`. However, it has been suggested ([here](https://github.com/NixOS/nix/issues/3810#issuecomment-658257637) and [here](https://github.com/NixOS/nix/issues/4442#issuecomment-758003203)) that just letting `preferLocalbuild` respect `max-jobs=0` is an acceptable solution too.