### PR TITLE
Fix gcc10 build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1602702596,
-        "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
+        "lastModified": 1610556192,
+        "narHash": "sha256-oFM1MwWrrUbPcgs8rwfjLy73SgorMCg4Uxfkpwt5ypE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad0d20345219790533ebe06571f82ed6b034db31",
+        "rev": "79150e05734300699740157d6c31a991a590910c",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-20.09-small",
+        "ref": "nixos-unstable-small",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "The purely functional package manager";
 
-  inputs.nixpkgs.url = "nixpkgs/nixos-20.09-small";
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable-small";
   inputs.lowdown-src = { url = "github:kristapsdz/lowdown"; flake = false; };
 
   outputs = { self, nixpkgs, lowdown-src }:
@@ -90,7 +90,7 @@
             lowdown
             gmock
           ]
-          ++ lib.optionals stdenv.isLinux [libseccomp utillinuxMinimal]
+          ++ lib.optionals stdenv.isLinux [libseccomp util-linuxMinimal]
           ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium;
 
         awsDeps = lib.optional (stdenv.isLinux || stdenv.isDarwin)

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -128,7 +128,7 @@ static FlakeInput parseFlakeInput(EvalState & state,
                         attrs.emplace(attr.name, Explicit<bool> { attr.value->boolean });
                         break;
                     case nInt:
-                        attrs.emplace(attr.name, attr.value->integer);
+                        attrs.emplace(attr.name, (long unsigned int)attr.value->integer);
                         break;
                     default:
                         throw TypeError("flake input attribute '%s' is %s while a string, Boolean, or integer is expected",


### PR DESCRIPTION
Wasn't able to update to the latest nixUnstable in https://github.com/NixOS/nixpkgs/pull/109309 because it failed to build with gcc10.

Updated the flake so that it tracks unstable which has gcc10 now.

Also fixed a compiler error for gcc where there was an implicit cast from `int64_t` to `long unsigned int`