### PR TITLE
nix-shell: Add strictDeps-proof --tools, --inputs

### DIFF
--- a/doc/manual/src/quick-start.md
+++ b/doc/manual/src/quick-start.md
@@ -55,7 +55,7 @@ to subsequent chapters.
 1. You can also test a package without installing it:
 
    ```console
-   $ nix-shell -p hello
+   $ nix-shell --tools hello
    ```
 
    This builds or downloads GNU Hello and its dependencies, then drops

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -260,7 +260,7 @@ them and open them again. Other than that, you should be ready to go.
 
 Try it! Open a new terminal, and type:
 $(poly_extra_try_me_commands)
-  $ nix-shell -p nix-info --run "nix-info -m"
+  $ nix-shell -t nix-info --run "nix-info -m"
 $(poly_extra_setup_instructions)
 Thank you for using this installer. If you have any feedback, don't
 hesitate:

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -5,10 +5,12 @@ with import ./config.nix;
 let pkgs = rec {
   setupSh = builtins.toFile "setup" ''
     export VAR_FROM_STDENV_SETUP=foo
-    for pkg in $buildInputs; do
+    for pkg in $nativeBuildInputs ${if isStrictDeps then "" else "$buildInputs"}; do
       export PATH=$PATH:$pkg/bin
     done
   '';
+
+  isStrictDeps = (builtins.tryEval <strictDeps>).success;
 
   stdenv = mkDerivation {
     name = "stdenv";
@@ -43,6 +45,16 @@ let pkgs = rec {
     mkdir -p $out/bin
     echo 'echo bar' > $out/bin/bar
     chmod a+rx $out/bin/bar
+  '';
+
+  flibble = runCommand "flibble" {} ''
+    mkdir -p $out
+    echo 'flibble' > $out/data
+  '';
+
+  flobble = runCommand "flobble" {} ''
+    mkdir -p $out
+    echo 'flobble' > $out/data
   '';
 
   bash = shell;


### PR DESCRIPTION
Unlike `-p`, which will be phased out, these are future proof with `strictDeps` in mind.

A more immediate benefit is that `--tools` is capable of providing shell autocompletions.

Closes #2504, closes #4254 

@Ericson2314  perhaps we could duplicate `-p` arguments in `buildInputs` and `nativeBuildInputs`, emulating non-strictDeps. Seems rather crude though. What do you think?

Preserves the odd `packages -p` behavior also mentioned in #4230 and assumes intent of `-p` aka `--inputs` for those packages.