### PR TITLE
Document expected output of 'nix store ping'.

### DIFF
--- a/src/nix/ping-store.md
+++ b/src/nix/ping-store.md
@@ -27,4 +27,6 @@ argument `--store` *url*) can be accessed. What this means is
 dependent on the type of the store. For instance, for an SSH store it
 means that Nix can connect to the specified machine.
 
+When the command succeeds a zero exit code is returned with no output.
+
 )""


### PR DESCRIPTION
While interpreting the output is fairly intuitive it would be better to
explicitly specify what a good invocation looks like.

That this isn't completely obvious (or at least causes folks to
second-guess themselves) can be seen in a couple user threads:

- https://discourse.nixos.org/t/nixos-cache-fetching-issue/3575/11
- https://discourse.nixos.org/t/newbie-question-cant-get-trivial-example-of-nixops-to-work-on-my-mac/1125/8