### PR TITLE
Fix the drv output map for non ca derivations

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -914,7 +914,7 @@ LocalStore::queryDerivationOutputMapNoResolve(const StorePath& path_)
         if (realisation)
             outputs.insert_or_assign(outputName, realisation->outPath);
         else
-            outputs.insert_or_assign(outputName, std::nullopt);
+            outputs.insert({outputName, std::nullopt});
     }
 
     return outputs;


### PR DESCRIPTION
With the `ca-derivation` experimental features, non-ca derivations used
to have their output paths returned as unknown as long as they weren't
built (because of a mistake in the code that systematically erased the
previous value)
