### PR TITLE
Fix content-addressed flake outputs

### DIFF
--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -501,7 +501,7 @@ std::tuple<std::string, FlakeRef, InstallableValue::DerivationInfo> InstallableF
 
         auto drvInfo = DerivationInfo{
             std::move(drvPath),
-            state->store->parseStorePath(attr->getAttr(state->sOutPath)->getString()),
+            state->store->maybeParseStorePath(attr->getAttr(state->sOutPath)->getString()),
             attr->getAttr(state->sOutputName)->getString()
         };
 


### PR DESCRIPTION
Prevent some `nix flake` commands to crash by trying to parse a
placeholder output as a store path
