### PR TITLE
nix-env: Use pname and version attrs in -q

### DIFF
--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -57,6 +57,36 @@ std::string DrvInfo::queryName() const
 }
 
 
+std::optional<std::string> DrvInfo::queryPname() const
+{
+    if (!attrs) {
+        pname = std::optional<std::string>{std::nullopt};
+    } else if (!pname.has_value()) {
+        auto i = attrs->find(state->symbols.create("pname"));
+        if (i != attrs->end() && i->value->type() == nString)
+            pname = state->forceStringNoCtx(*i->value);
+        else
+            pname = std::optional<std::string>{std::nullopt};
+    }
+    return *pname;
+}
+
+
+std::optional<std::string> DrvInfo::queryVersion() const
+{
+    if (!attrs) {
+        version = std::optional<std::string>{std::nullopt};
+    } else if (!version.has_value()) {
+        auto i = attrs->find(state->symbols.create("version"));
+        if (i != attrs->end() && i->value->type() == nString)
+            version = state->forceStringNoCtx(*i->value);
+        else
+            version = std::optional<std::string>{std::nullopt};
+    }
+    return *version;
+}
+
+
 std::string DrvInfo::querySystem() const
 {
     if (system == "" && attrs) {

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -19,6 +19,8 @@ private:
     EvalState * state;
 
     mutable std::string name;
+    mutable std::optional<std::optional<std::string>> pname;
+    mutable std::optional<std::optional<std::string>> version;
     mutable std::string system;
     mutable std::optional<std::optional<StorePath>> drvPath;
     mutable std::optional<StorePath> outPath;
@@ -41,6 +43,8 @@ public:
     DrvInfo(EvalState & state, ref<Store> store, const std::string & drvPathWithOutputs);
 
     std::string queryName() const;
+    std::optional<std::string> queryPname() const;
+    std::optional<std::string> queryVersion() const;
     std::string querySystem() const;
     std::optional<StorePath> queryDrvPath() const;
     StorePath requireDrvPath() const;

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -920,8 +920,8 @@ static void queryJSON(Globals & globals, std::vector<DrvInfo> & elems, bool prin
 
             auto drvName = DrvName(i.queryName());
             pkgObj.attr("name", drvName.fullName);
-            pkgObj.attr("pname", drvName.name);
-            pkgObj.attr("version", drvName.version);
+            pkgObj.attr("pname", i.queryPname() ? *i.queryPname() : drvName.name);
+            pkgObj.attr("version", i.queryVersion() ? *i.queryVersion() : drvName.version);
             pkgObj.attr("system", i.querySystem());
             pkgObj.attr("outputName", i.queryOutputName());
 
@@ -1115,8 +1115,8 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
             if (xmlOutput) {
                 auto drvName = DrvName(i.queryName());
                 attrs["name"] = drvName.fullName;
-                attrs["pname"] = drvName.name;
-                attrs["version"] = drvName.version;
+                attrs["pname"] = i.queryPname() ? *i.queryPname() : drvName.name;
+                attrs["version"] = i.queryVersion() ? *i.queryVersion() : drvName.version;
             } else if (printName) {
                 columns.push_back(i.queryName());
             }


### PR DESCRIPTION
Previously[1], we started including `pname` and `version` keys in `nix-env -qa --json` output (and thus in packages.json).

But those values were obtained using parseDrvName, which does not work in many cases, for example when a project does not follow Nix’s arbitrary requirement that version names have to start with a digit.

The keys are also misleading as many modern Nixpkgs packages pass identically named attributes to mkDerivation but these keys do not use those values.

Let’s fix this discrepancy by officially recognizing `pname` and `version` attributes as special and using them in the JSON output.

This will be useful for Repology as well.

[1]: https://github.com/NixOS/nix/commit/cd933b22d2041b7efc348dcc09ff255967ffc663
