### PR TITLE
narinfo: Change NAR URLs to be addressed on the NAR hash instead of the compressed hash

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -176,11 +176,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     auto [fileHash, fileSize] = fileHashSink.finish();
     narInfo->fileHash = fileHash;
     narInfo->fileSize = fileSize;
-    narInfo->url = "nar/" + narInfo->fileHash->to_string(Base32, false) + ".nar"
-        + (compression == "xz" ? ".xz" :
-           compression == "bzip2" ? ".bz2" :
-           compression == "br" ? ".br" :
-           "");
+    narInfo->url = "nar/" + info.narHash.to_string(Base32, false) + ".nar";
 
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now2 - now1).count();
     printMsg(lvlTalkative, "copying path '%1%' (%2% bytes, compressed %3$.1f%% in %4% ms) to binary cache",

--- a/tests/binary-cache.sh
+++ b/tests/binary-cache.sh
@@ -55,7 +55,7 @@ basicTests
 # Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
 clearStore
 
-nar=$(ls $cacheDir/nar/*.nar.xz | head -n1)
+nar=$(ls $cacheDir/nar/*.nar | head -n1)
 mv $nar $nar.good
 mkdir -p $TEST_ROOT/empty
 nix-store --dump $TEST_ROOT/empty | xz > $nar


### PR DESCRIPTION
This change is to simplify [Trustix](https://github.com/tweag/trustix) indexing and makes it possible to reconstruct this URL regardless of the compression used.

In particular this means that https://github.com/tweag/trustix/blob/7c2e9ca597de233846e0b265fb081626ca6c59d8/contrib/nix/nar/nar.go#L61-L71 can be removed and only the bits that are required to establish trust needs to be published in the Trustix build logs.

A notable change is that the compressed files no longer comes with a file extension indicating their compression. This should be fine as the associated narinfo file has the compression metadata.
For applications where this is not feasible (like Trustix) the application could check the compression by the magic numbers.

I have manually tested if my local version of Nix (2.3.10) can still substitute from a binary cache created after this change and everything still works.

### Related issues
- https://github.com/NixOS/nix/issues/4075

### Acknowledgements
This work is done within the context of [Trustix](https://nlnet.nl/project/Trustix/) and has been sponsored by a [NLNet Foundation NGI-0 PET](https://nlnet.nl/thema/NGIZeroPET.html) grant.

cc @Ericson2314 @domenkozar 