### PR TITLE
Shorten `mktemp` flag for macOS

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -239,7 +239,7 @@ struct Common : InstallableCommand, MixProfile
 
         out << buildEnvironment.bashFunctions << "\n";
 
-        out << "export NIX_BUILD_TOP=\"$(mktemp -d --tmpdir nix-shell.XXXXXX)\"\n";
+        out << "export NIX_BUILD_TOP=\"$(mktemp -d -t nix-shell.XXXXXX)\"\n";
         for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})
             out << fmt("export %s=\"$NIX_BUILD_TOP\"\n", i);
 


### PR DESCRIPTION
I noticed (via numtide/devshell#10) that `nix develop` calls `mktemp` with a set of flags which don't run correctly on macOS.

```
❯ nix develop
warning: Git tree '/Users/jamesottaway/.dotfiles' is dirty
mktemp: illegal option -- -
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix

[.dotfiles]$
```

I was originally worried that it'd be a big change, but I found [other `mktemp` calls around this repo where the shorter `-t` flag is used](https://github.com/NixOS/nix/search?q=mktemp). I can confirm that the combination of `-d -t` flags works fine on macOS:

```
❯ uname -v
Darwin Kernel Version 19.6.0: Tue Nov 10 00:10:30 PST 2020; root:xnu-6153.141.10~1/RELEASE_X86_64

❯ mktemp -d --tmpdir nix-shell.XXXXXX
mktemp: illegal option -- -
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix

❯ mktemp -d -t nix-shell.XXXXXX
/var/folders/11/n6zrq3m97qx1_rjmgjx4n3pm0000gp/T/nix-shell.XXXXXX.ok7Llubr
```

