### PR TITLE
Allow StorePathWithOutputs in the cli

### DIFF
--- a/src/nix/installables.cc
+++ b/src/nix/installables.cc
@@ -332,30 +332,30 @@ Installable::getCursor(EvalState & state)
 struct InstallableStorePath : Installable
 {
     ref<Store> store;
-    StorePath storePath;
+    StorePathWithOutputs storePath;
 
-    InstallableStorePath(ref<Store> store, StorePath && storePath)
+    InstallableStorePath(ref<Store> store, StorePathWithOutputs && storePath)
         : store(store), storePath(std::move(storePath)) { }
 
-    std::string what() override { return store->printStorePath(storePath); }
+    std::string what() override { return storePath.to_string(*store); }
 
     Buildables toBuildables() override
     {
-        if (storePath.isDerivation()) {
+        if (storePath.path.isDerivation()) {
             std::map<std::string, std::optional<StorePath>> outputs;
-            auto drv = store->readDerivation(storePath);
+            auto drv = store->readDerivation(storePath.path);
             for (auto & [name, output] : drv.outputsAndOptPaths(*store))
                 outputs.emplace(name, output.second);
             return {
                 BuildableFromDrv {
-                    .drvPath = storePath,
+                    .drvPath = storePath.path,
                     .outputs = std::move(outputs)
                 }
             };
         } else {
             return {
                 BuildableOpaque {
-                    .path = storePath,
+                    .path = storePath.path,
                 }
             };
         }
@@ -363,7 +363,7 @@ struct InstallableStorePath : Installable
 
     std::optional<StorePath> getStorePath() override
     {
-        return storePath;
+        return storePath.path;
     }
 };
 
@@ -638,7 +638,11 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
 
             if (s.find('/') != std::string::npos) {
                 try {
-                    result.push_back(std::make_shared<InstallableStorePath>(store, store->followLinksToStorePath(s)));
+                    auto [rawPath, outputs] = parsePathWithOutputs(s);
+                    result.push_back(std::make_shared<InstallableStorePath>(
+                        store,
+                        StorePathWithOutputs{store->followLinksToStorePath(s),
+                                             outputs}));
                     continue;
                 } catch (BadStorePath &) {
                 } catch (...) {


### PR DESCRIPTION
Allow things like `nix build /nix/store/...-foo.drv!dev`.

This is especially useful for ca derivations (because this is the
canonical way of refering to the outputs of ca derivations), but is also
generally useful for consitency − for example it means that
`nix build $(nix-instantiate ./foobar.nix)` will always work − barring
any GC interaction.

Depends on #4372
