### PR TITLE
Use passthru for perl-bindings, allows Nix patching for Hydra

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
       # 'nix.perl-bindings' packages.
       overlay = final: prev: {
 
-        nix = with final; with commonDeps pkgs; (stdenv.mkDerivation {
+        nix = with final; with commonDeps pkgs; stdenv.mkDerivation {
           name = "nix-${version}";
           inherit version;
 
@@ -163,9 +163,8 @@
           installCheckFlags = "sysconfdir=$(out)/etc";
 
           separateDebugInfo = true;
-        }) // {
 
-          perl-bindings = with final; stdenv.mkDerivation {
+          passthru.perl-bindings = with final; stdenv.mkDerivation {
             name = "nix-perl-${version}";
 
             src = self;


### PR DESCRIPTION
This allows patching Nix for Hydra with additional overlays, because `.overrideAttrs` and co. will persist the passthru's.