### PR TITLE
libcmd/markdown: handle allocation errors in lowdown_term_rndr

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -198,12 +198,12 @@
 
         };
 
-        lowdown = with final; stdenv.mkDerivation {
-          name = "lowdown-0.7.9";
+        lowdown = with final; stdenv.mkDerivation rec {
+          name = "lowdown-0.8.0";
 
           src = fetchurl {
-            url = https://kristaps.bsd.lv/lowdown/snapshots/lowdown-0.7.9.tar.gz;
-            hash = "sha512-7GQrKFICyTI5T4SinATfohiCq9TC0OgN8NmVfG3B3BZJM9J00DT8llAco8kNykLIKtl/AXuS4X8fETiCFEWEUQ==";
+            url = "https://kristaps.bsd.lv/lowdown/snapshots/${name}.tar.gz";
+            hash = "sha512-U9WeGoInT9vrawwa57t6u9dEdRge4/P+0wLxmQyOL9nhzOEUU2FRz2Be9H0dCjYE7p2v3vCXIYk40M+jjULATw==";
           };
 
           #src = lowdown-src;

--- a/src/libcmd/markdown.cc
+++ b/src/libcmd/markdown.cc
@@ -3,9 +3,7 @@
 #include "finally.hh"
 
 #include <sys/queue.h>
-extern "C" {
 #include <lowdown.h>
-}
 
 namespace nix {
 
@@ -42,7 +40,9 @@ std::string renderMarkdownToTerminal(std::string_view markdown)
         throw Error("cannot allocate Markdown output buffer");
     Finally freeBuffer([&]() { lowdown_buf_free(buf); });
 
-    lowdown_term_rndr(buf, nullptr, renderer, node);
+    int rndr_res = lowdown_term_rndr(buf, nullptr, renderer, node);
+    if (!rndr_res)
+        throw Error("allocation error while rendering Markdown");
 
     return std::string(buf->data, buf->size);
 }


### PR DESCRIPTION
We upgrade to lowdown 0.8.0 ([changelog](https://github.com/kristapsdz/lowdown/blob/6ca7c855a063d1c77ae0b89405047cc3913a74d8/versions.xml#L987-L1006) which contains a fix/improvement to a
behavior mentioned in [this issue thread](https://github.com/kristapsdz/lowdown/issues/45#issuecomment-756681153) where a big part of
lowdown's API would just call `exit(1)` on allocation errors since that
is a satisfying behavior for the lowdown binary.

Now `lowdown_term_rndr` returns 0 if an allocation error occurred which we
check for in libcmd/markdown.cc.

Also the `extern "C" { }` wrapper around lowdown.h has been removed as it
is not necessary.