### PR TITLE
fix nixbld user name/uid for macOS/darwin

### DIFF
--- a/scripts/bigsur-nixbld-user-migration.sh
+++ b/scripts/bigsur-nixbld-user-migration.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+((NEW_NIX_FIRST_BUILD_UID=301))
+
+id_available(){
+	dscl . list /Users UniqueID | grep -E '\b'$1'\b' >/dev/null
+}
+
+change_nixbld_names_and_ids(){
+	local name uid next_id
+	((next_id=NEW_NIX_FIRST_BUILD_UID))
+	echo "Attempting to migrate nixbld users."
+	echo "Each user should change from nixbld# to _nixbld#"
+	echo "and their IDs relocated to $next_id+"
+	while read -r name uid; do
+		echo "   Checking $name (uid: $uid)"
+		# iterate for a clean ID
+		while id_available "$next_id"; do
+			((next_id++))
+			if ((next_id >= 400)); then
+				echo "We've hit UID 400 without placing all of your users :("
+				echo "You should use the commands in this script as a starting"
+				echo "point to review your UID-space and manually move the"
+				echo "remaining users (or delete them, if you don't need them)."
+				exit 1
+			fi
+		done
+
+		if [[ $name == _* ]]; then
+			echo "      It looks like $name has already been renamed--skipping."
+		else
+			# first 3 are cleanup, it's OK if they aren't here
+			sudo dscl . delete /Users/$name dsAttrTypeNative:_writers_passwd &>/dev/null || true
+			sudo dscl . change /Users/$name NFSHomeDirectory "/private/var/empty 1" "/var/empty" &>/dev/null || true
+			# remove existing user from group
+			sudo dseditgroup -o edit -t user -d $name nixbld || true
+			sudo dscl . change /Users/$name UniqueID $uid $next_id
+			sudo dscl . change /Users/$name RecordName $name _$name
+			# add renamed user to group
+			sudo dseditgroup -o edit -t user -a _$name nixbld
+			echo "      $name migrated to _$name (uid: $next_id)"
+		fi
+	done < <(dscl . list /Users UniqueID | grep nixbld | sort -n -k2)
+}
+
+change_nixbld_names_and_ids

--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -4,6 +4,8 @@ set -eu
 set -o pipefail
 
 readonly PLIST_DEST=/Library/LaunchDaemons/org.nixos.nix-daemon.plist
+NIX_FIRST_BUILD_UID="301"
+NIX_BUILD_USER_NAME_TEMPLATE="_nixbld%d"
 
 dsclattr() {
     /usr/bin/dscl . -read "$1" \

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -25,7 +25,9 @@ readonly RED='\033[31m'
 readonly NIX_USER_COUNT=${NIX_USER_COUNT:-32}
 readonly NIX_BUILD_GROUP_ID="30000"
 readonly NIX_BUILD_GROUP_NAME="nixbld"
-readonly NIX_FIRST_BUILD_UID="30001"
+# darwin installer needs to override these
+NIX_FIRST_BUILD_UID="30001"
+NIX_BUILD_USER_NAME_TEMPLATE="nixbld%d"
 # Please don't change this. We don't support it, because the
 # default shell profile that comes with Nix doesn't support it.
 readonly NIX_ROOT="/nix"
@@ -104,7 +106,7 @@ EOF
 }
 
 nix_user_for_core() {
-    printf "nixbld%d" "$1"
+    printf "$NIX_BUILD_USER_NAME_TEMPLATE" "$1"
 }
 
 nix_uid_for_core() {


### PR DESCRIPTION
I've been able to confirm the update problem reported in #4531 on a spare system. This PR will:
1. Add a migration script people can run before taking the update to avoid the problem. (We probably don't need to carry this in the source for long, but it seems good to have a canonical source to link.)
2. Update the installer to adopt the same values (just for macOS--a hedge against this being an ongoing problem with every update).

## Background
I'm enough of a masochist to run clean-install + upgrade cycles until I have a vague sense of the problem:

1. It looks like the upgrade is doing some sort of user/account migration, and faceplants over something about our nixbld users (i.e., it runs clean if you remove them first).
2. ~I get the impression, because of the report timing, that this is something new after Big Sur 11.0 and probably new in 11.2.~ 
    - Reports in this thread have clarified that this has been an ongoing pain point on Big Sur. 
    - I've since confirmed that I see this with the update to 11.3 beta--it definitely seems like this will be an ongoing problem.
4. It doesn't seem to be a critical problem, as long as you ignore the error message that tells you to reinstall (i.e., users who jump the turnstile haven't reported ongoing trouble.)
5. I eventually found a sane way around when I stumbled on some new `sysadminctl -addUser` flags (`[-GID <group ID>]`, `[-roleAccount]`) and this usage note `*Role accounts require name starting with _ and UID in 200-400 range`. 
    - I confirmed that the update runs clean if we change `nixbld#` usernames to `_nixbld#` and use UIDs in the 200-400 range. 
    - The GID doesn't appear to matter, here.

## Open questions
1. I chose 301 as the new starting UID, but it's just a guess. Objections?
    - There are many macOS system role accounts in the 200-300 range (but none from 300-400), and at least on Catalina the only free contiguous block is from 271-299. I read this as 200-300 being Apple's territory, but if they go make a few dozen new role users I assume they'll just keep rolling into the 300s? 
    - I don't know if these are hard-set or dynamically allocated at update/install? In the latter case it'd be fine if they keep rolling into the 300s; in the former it might cause trouble.
2. Taking up 32 UIDs from 301-332 by default feels a bit greedy (but it may be wasted energy to sweat this?) Is it feasible to make a more-judicious choice (at least on macOS, perhaps based on `sysctl -n hw.ncpu` or `sysctl -n hw.physicalcpu`?)