### PR TITLE
Revert "narinfo: Change NAR URLs to be addressed on the NAR hash instead of the compressed hash"

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -176,7 +176,11 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     auto [fileHash, fileSize] = fileHashSink.finish();
     narInfo->fileHash = fileHash;
     narInfo->fileSize = fileSize;
-    narInfo->url = "nar/" + info.narHash.to_string(Base32, false) + ".nar";
+    narInfo->url = "nar/" + narInfo->fileHash->to_string(Base32, false) + ".nar"
+        + (compression == "xz" ? ".xz" :
+           compression == "bzip2" ? ".bz2" :
+           compression == "br" ? ".br" :
+           "");
 
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now2 - now1).count();
     printMsg(lvlTalkative, "copying path '%1%' (%2% bytes, compressed %3$.1f%% in %4% ms) to binary cache",

--- a/tests/binary-cache.sh
+++ b/tests/binary-cache.sh
@@ -60,7 +60,7 @@ basicDownloadTests
 # Test whether Nix notices if the NAR doesn't match the hash in the NAR info.
 clearStore
 
-nar=$(ls $cacheDir/nar/*.nar | head -n1)
+nar=$(ls $cacheDir/nar/*.nar.xz | head -n1)
 mv $nar $nar.good
 mkdir -p $TEST_ROOT/empty
 nix-store --dump $TEST_ROOT/empty | xz > $nar


### PR DESCRIPTION
Reverts NixOS/nix#4464
 
> Given that @grahamc and @domenkozar have both expressed (some of) their hesitations/problems with the change, would it be perhaps a good idea to revert this change for now and start an RFC for this?

-- https://github.com/NixOS/nix/pull/4464#issuecomment-776023704