### PR TITLE
Try parse installables as store paths first

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -647,41 +647,22 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
     } else {
 
         for (auto & s : ss) {
-            std::exception_ptr ex;
-
-            try {
-                auto [flakeRef, fragment] = parseFlakeRefWithFragment(s, absPath("."));
-                result.push_back(std::make_shared<InstallableFlake>(
-                        this,
-                        getEvalState(),
-                        std::move(flakeRef),
-                        fragment == "" ? getDefaultFlakeAttrPaths() : Strings{fragment},
-                        getDefaultFlakeAttrPathPrefixes(),
-                        lockFlags));
-                continue;
-            } catch (...) {
-                ex = std::current_exception();
-            }
-
             if (s.find('/') != std::string::npos) {
                 try {
                     result.push_back(std::make_shared<InstallableStorePath>(store, store->followLinksToStorePath(s)));
                     continue;
-                } catch (BadStorePath &) {
                 } catch (...) {
-                    if (!ex)
-                        ex = std::current_exception();
                 }
             }
 
-            std::rethrow_exception(ex);
-
-            /*
-            throw Error(
-                pathExists(s)
-                ? "path '%s' is not a flake or a store path"
-                : "don't know how to handle argument '%s'", s);
-            */
+            auto [flakeRef, fragment] = parseFlakeRefWithFragment(s, absPath("."));
+            result.push_back(std::make_shared<InstallableFlake>(
+                    this,
+                    getEvalState(),
+                    std::move(flakeRef),
+                    fragment == "" ? getDefaultFlakeAttrPaths() : Strings{fragment},
+                    getDefaultFlakeAttrPathPrefixes(),
+                    lockFlags));
         }
     }
 

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -23,6 +23,7 @@ flake6Dir=$TEST_ROOT/flake6
 flake7Dir=$TEST_ROOT/flake7
 templatesDir=$TEST_ROOT/templates
 nonFlakeDir=$TEST_ROOT/nonFlake
+badFlakeDir=$TEST_ROOT/badFlake
 flakeA=$TEST_ROOT/flakeA
 flakeB=$TEST_ROOT/flakeB
 flakeGitBare=$TEST_ROOT/flakeGitBare
@@ -722,3 +723,8 @@ git -C $flakeB commit -a -m 'Foo'
 
 # Test list-inputs with circular dependencies
 nix flake metadata $flakeA
+
+# Test flake in store does not evaluate
+mkdir $badFlakeDir
+echo INVALID > $badFlakeDir/flake.nix
+nix store delete $(nix store add-path $badFlakeDir)


### PR DESCRIPTION
Potential fix for #4568.

This simply flips the order of tests for flake / store path in `SourceExprCommand::parseInstallables`. There was some extra logic to prioritise the parseFlake exception, but I don't believe we need it anymore.

I was a little surprised this passed all tests. I'm not sure how much confidence that gives us, but figured I'd open a PR to discuss. Please consider I'm not very familiar with this code or the impact of this change.