### PR TITLE
simplify changing cachix cache for install tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,52 +8,62 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      CACHIX_NAME: nix-ci
+
     steps:
     - uses: actions/checkout@v2.3.4
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v12
+    - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v8
       with:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     #- run: nix flake check
     - run: nix-build -A checks.$(if [[ `uname` = Linux ]]; then echo x86_64-linux; else echo x86_64-darwin; fi)
-  installer:
-    if: github.event_name == 'push'
-    needs: tests
+  check_cachix:
+    name: Cachix secret present for installer tests
     runs-on: ubuntu-latest
-    env:
-      CACHIX_NAME: nix-ci
+    outputs:
+      secret: ${{ steps.secret.outputs.secret }}
+    steps:
+      - name: Check for Cachix secret
+        id: secret
+        env:
+          _CACHIX_SECRETS: ${{ secrets.CACHIX_SIGNING_KEY }}${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: echo "::set-output name=secret::${{ env._CACHIX_SECRETS != '' }}"
+  installer:
+    needs: [tests, check_cachix]
+    if: github.event_name == 'push' && needs.check_cachix.outputs.secret == 'true'
+    runs-on: ubuntu-latest
     outputs:
       installerURL: ${{ steps.prepare-installer.outputs.installerURL }}
     steps:
     - uses: actions/checkout@v2.3.4
       with:
         fetch-depth: 0
+    - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/install-nix-action@v12
     - uses: cachix/cachix-action@v8
       with:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - id: prepare-installer
       run: scripts/prepare-installer-for-github-actions
   installer_test:
-    if: github.event_name == 'push'
-    needs: installer
+    needs: [installer, check_cachix]
+    if: github.event_name == 'push' && needs.check_cachix.outputs.secret == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      CACHIX_NAME: nix-ci
     steps:
     - uses: actions/checkout@v2.3.4
+    - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/install-nix-action@master
       with:
         install_url: '${{needs.installer.outputs.installerURL}}'
-        install_options: '--tarball-url-prefix https://${{ env.CACHIX_NAME }}.cachix.org/serve'
+        install_options: "--tarball-url-prefix https://${{ env.CACHIX_NAME }}.cachix.org/serve"
     - run: nix-instantiate -E 'builtins.currentTime' --eval
-    


### PR DESCRIPTION
@domenkozar  In the process of getting set up to [try out](https://github.com/abathur/nix/runs/1982035429) the new installer tests that landed in #4549 I noticed a couple of small workflow improvements:

- Make cachix cache name deterministic to avoid workflow friction (having to re-make this change every time, remember to take it back out before merge or test it on a separate branch, etc.)
    - I wanted to make this a secret to make it easily configurable, but GA apparently won't allow an output (i.e., the installerURL) to have a secret in it.
    - Instead I'm using lowercase`<username>-<repo>-install-tests` (i.e., `abathur-nix-install-tests`)
- Set CACHIX_AUTH_TOKEN in addition to CACHIX_SIGNING_KEY so that both methods are supported. It looks like cachix will try signing key first, then auth token.

Test runs in my fork for this change: 
- [successful install tests](https://github.com/abathur/nix/runs/1991061752?check_suite_focus=true)
- [skip install tests if neither secret is declared](https://github.com/abathur/nix/runs/1991311247?check_suite_focus=true) (implying the user isn't working on the installer?)

If adopted, Nix would need a new `nixos-nix-install-tests` cache.