### PR TITLE
Make `nix build --json` return output paths in floating CA case

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -716,10 +716,40 @@ Buildables build(ref<Store> store, Realise mode,
         }
     }
 
+    std::map<StorePath, BuildResult> buildRes;
+
     if (mode == Realise::Nothing)
         printMissing(store, pathsToBuild, lvlError);
     else if (mode == Realise::Outputs)
-        store->buildPaths(pathsToBuild, bMode);
+        buildRes = store->buildPaths(pathsToBuild, bMode);
+
+    if (settings.isExperimentalFeatureEnabled("ca-derivations"))
+        for (auto & b0 : buildables) {
+            auto *bp = std::get_if<BuildableFromDrv>(&b0);
+            if (!bp)  continue;
+            auto & b = *bp;
+
+            auto i = buildRes.find(b.drvPath);
+            // shouldn't happen except for with remote store + older protocols
+            if (i == buildRes.end()) continue;
+            auto & [_, result] = *i;
+
+            // Don't necessarily have derivation, so we get hash modulo a different way.
+            // TODO: It would be better if the map keys were just output names,
+            // and stored the drv hash modulo once.
+            auto firstOutput = result.builtOutputs.begin();
+            // Can happen for input-addressed or old daemon protocol
+            if (firstOutput == result.builtOutputs.end()) continue;
+            auto & drvHashModulo = firstOutput->first.drvHash;
+
+            for (auto & [outputName, outputPath] : b.outputs) {
+                if (outputPath) continue;
+
+                auto i = result.builtOutputs.find(DrvOutput { drvHashModulo, outputName});
+                assert(i != result.builtOutputs.end());
+                outputPath = i->second.outPath;
+            }
+        }
 
     return buildables;
 }

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -6,7 +6,31 @@
 
 namespace nix {
 
-void Store::buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, BuildMode buildMode)
+static void setResultRealizations(Store & store, const Derivation & drv, BuildResult & result) {
+    // XXX: Should use `goal->queryPartialDerivationOutputMap()` once it's
+    // extended to return the full realisation for each output
+    auto staticDrvOutputs = drv.outputsAndOptPaths(store);
+    auto outputHashes = staticOutputHashes(store, drv);
+    for (auto & [outputName, staticOutput] : staticDrvOutputs) {
+        auto outputId = DrvOutput{outputHashes.at(outputName), outputName};
+        if (staticOutput.second)
+            result.builtOutputs.insert_or_assign(
+                    outputId,
+                    Realisation{ outputId, *staticOutput.second}
+                    );
+        if (settings.isExperimentalFeatureEnabled("ca-derivations") && !derivationHasKnownOutputPaths(drv.type())) {
+            auto realisation = store.queryRealisation(outputId);
+            if (realisation)
+                result.builtOutputs.insert_or_assign(
+                        outputId,
+                        *realisation
+                        );
+        }
+    }
+}
+
+
+std::map<StorePath, BuildResult> Store::buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, BuildMode buildMode)
 {
     Worker worker(*this);
 
@@ -42,7 +66,17 @@ void Store::buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, Build
         if (ex) logError(ex->info());
         throw Error(worker.exitStatus(), "build of %s failed", showPaths(failed));
     }
+
+    std::map<StorePath, BuildResult> results;
+    for (auto & i0 : goals) {
+        auto i = dynamic_cast<DerivationGoal *>(i0.get());
+        if (!i) continue;
+        auto & result = results.insert_or_assign(i->drvPath, i->getResult()).first->second;
+        setResultRealizations(*this, *i->drv, result);
+    }
+    return results;
 }
+
 
 BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
     BuildMode buildMode)
@@ -59,26 +93,7 @@ BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivat
         result.status = BuildResult::MiscFailure;
         result.errorMsg = e.msg();
     }
-    // XXX: Should use `goal->queryPartialDerivationOutputMap()` once it's
-    // extended to return the full realisation for each output
-    auto staticDrvOutputs = drv.outputsAndOptPaths(*this);
-    auto outputHashes = staticOutputHashes(*this, drv);
-    for (auto & [outputName, staticOutput] : staticDrvOutputs) {
-        auto outputId = DrvOutput{outputHashes.at(outputName), outputName};
-        if (staticOutput.second)
-            result.builtOutputs.insert_or_assign(
-                    outputId,
-                    Realisation{ outputId, *staticOutput.second}
-                    );
-        if (settings.isExperimentalFeatureEnabled("ca-derivations") && !derivationHasKnownOutputPaths(drv.type())) {
-            auto realisation = this->queryRealisation(outputId);
-            if (realisation)
-                result.builtOutputs.insert_or_assign(
-                        outputId,
-                        *realisation
-                        );
-        }
-    }
+    setResultRealizations(*this, drv, result);
 
     return result;
 }

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1312,7 +1312,7 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
     // an allowed derivation
     { throw Error("queryRealisation"); }
 
-    void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override
+    std::map<StorePath, BuildResult> buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override
     {
         if (buildMode != bmNormal) throw Error("unsupported build mode");
 
@@ -1323,7 +1323,7 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
                 throw InvalidPath("cannot build unknown path '%s' in recursive Nix", printStorePath(path.path));
         }
 
-        next->buildPaths(paths, buildMode);
+        auto res = next->buildPaths(paths, buildMode);
 
         for (auto & path : paths) {
             if (!path.path.isDerivation()) continue;
@@ -1337,6 +1337,8 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
         next->computeFSClosure(newPaths, closure);
         for (auto & path : closure)
             goal.addDependency(path);
+
+        return res;
     }
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -506,8 +506,10 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                 throw Error("repairing is not allowed because you are not in 'trusted-users'");
         }
         logger->startWork();
-        store->buildPaths(drvs, mode);
+        auto res = store->buildPaths(drvs, mode);
         logger->stopWork();
+        if (GET_PROTOCOL_MINOR(clientVersion) >= 30)
+            worker_proto::write(*store, to, res);
         to << 1;
         break;
     }

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -574,10 +574,13 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
 
         auto res = store->buildDerivation(drvPath, drv, buildMode);
         logger->stopWork();
-        to << res.status << res.errorMsg;
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 0xc) {
-            worker_proto::write(*store, to, res.builtOutputs);
-        }
+        if (GET_PROTOCOL_MINOR(clientVersion) < 29) {
+            to << res.status << res.errorMsg;
+            if (GET_PROTOCOL_MINOR(clientVersion) >= 28) {
+                worker_proto::write(*store, to, res.builtOutputs);
+            }
+        } else
+            worker_proto::write(*store, to, res);
         break;
     }
 

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -265,7 +265,7 @@ public:
         return status;
     }
 
-    void buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, BuildMode buildMode) override
+    std::map<StorePath, BuildResult> buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, BuildMode buildMode) override
     {
         auto conn(connections->get());
 
@@ -279,6 +279,10 @@ public:
 
         conn->to.flush();
 
+        std::map<StorePath, BuildResult> res;
+        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 7)
+            res = worker_proto::read(*this, conn->from, Phantom<std::map<StorePath, BuildResult>>{});
+
         BuildResult result;
         result.status = (BuildResult::Status) readInt(conn->from);
 
@@ -286,6 +290,8 @@ public:
             conn->from >> result.errorMsg;
             throw Error(result.status, result.errorMsg);
         }
+
+        return res;
     }
 
     void ensurePath(const StorePath & path) override

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -253,14 +253,15 @@ public:
         conn->to.flush();
 
         BuildResult status;
-        status.status = (BuildResult::Status) readInt(conn->from);
-        conn->from >> status.errorMsg;
 
-        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 3)
-            conn->from >> status.timesBuilt >> status.isNonDeterministic >> status.startTime >> status.stopTime;
-        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 6) {
-            status.builtOutputs = worker_proto::read(*this, conn->from, Phantom<DrvOutputs> {});
-        }
+        if (GET_PROTOCOL_MINOR(conn->remoteVersion) < 6) {
+            status.status = (BuildResult::Status) readInt(conn->from);
+            conn->from >> status.errorMsg;
+
+            if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 3)
+                conn->from >> status.timesBuilt >> status.isNonDeterministic >> status.startTime >> status.stopTime;
+        } else
+            status = worker_proto::read(*this, conn->from, Phantom<BuildResult> {});
         return status;
     }
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -679,7 +679,7 @@ std::optional<const Realisation> RemoteStore::queryRealisation(const DrvOutput &
 }
 
 
-void RemoteStore::buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, BuildMode buildMode)
+std::map<StorePath, BuildResult> RemoteStore::buildPaths(const std::vector<StorePathWithOutputs> & drvPaths, BuildMode buildMode)
 {
     auto conn(getConnection());
     conn->to << wopBuildPaths;
@@ -696,7 +696,11 @@ void RemoteStore::buildPaths(const std::vector<StorePathWithOutputs> & drvPaths,
         if (buildMode != bmNormal)
             throw Error("repairing or checking is not supported when building through the Nix daemon");
     conn.processStderr();
+    std::map<StorePath, BuildResult> res;
+    if (GET_PROTOCOL_MINOR(conn->daemonVersion) >= 30)
+        res = worker_proto::read(*this, conn->from, Phantom<std::map<StorePath, BuildResult>>{});
     readInt(conn->from);
+    return res;
 }
 
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -62,9 +62,41 @@ void write(const Store & store, Sink & out, const Realisation & realisation)
 { out << realisation.toJSON().dump(); }
 
 DrvOutput read(const Store & store, Source & from, Phantom<DrvOutput> _)
-{ return DrvOutput::parse(readString(from)); }
+{
+    return DrvOutput::parse(readString(from));
+}
+
 void write(const Store & store, Sink & out, const DrvOutput & drvOutput)
-{ out << drvOutput.to_string(); }
+{
+    out << drvOutput.to_string();
+}
+
+
+// BuildResult marshalliig is valid for daemon protocol >= 29 && legacy ssh >= 6
+
+BuildResult read(const Store & store, Source & from, Phantom<BuildResult> _)
+{
+    BuildResult res;
+    // all versions
+    res.status = (BuildResult::Status) readInt(from);
+    from >> res.errorMsg;
+    // legacy ssh >= 3 only before
+    from >> res.timesBuilt >> res.isNonDeterministic >> res.startTime >> res.stopTime;
+    // daemon protocol >= 28 && legacy ssh >= 6 before
+    res.builtOutputs = worker_proto::read(store, from, Phantom<DrvOutputs> {});
+    return res;
+}
+
+void write(const Store & store, Sink & out, const BuildResult & res)
+{
+    // all versions
+    out << res.status << res.errorMsg;
+    // legacy ssh >= 3 only before
+    out << res.timesBuilt << res.isNonDeterministic << res.startTime << res.stopTime;
+    // daemon protocol >= 28 && legacy ssh >= 6 before
+    worker_proto::write(store, out, res.builtOutputs);
+}
+
 
 std::optional<StorePath> read(const Store & store, Source & from, Phantom<std::optional<StorePath>> _)
 {
@@ -676,15 +708,17 @@ BuildResult RemoteStore::buildDerivation(const StorePath & drvPath, const BasicD
     writeDerivation(conn->to, *this, drv);
     conn->to << buildMode;
     conn.processStderr();
-    BuildResult res;
-    unsigned int status;
-    conn->from >> status >> res.errorMsg;
-    res.status = (BuildResult::Status) status;
-    if (GET_PROTOCOL_MINOR(conn->daemonVersion) >= 0xc) {
-        auto builtOutputs = worker_proto::read(*this, conn->from, Phantom<DrvOutputs> {});
-        res.builtOutputs = builtOutputs;
-    }
-    return res;
+    if (GET_PROTOCOL_MINOR(conn->daemonVersion) < 29) {
+        BuildResult res;
+        res.status = (BuildResult::Status) readInt(conn->from);
+        conn->from >> res.errorMsg;
+        if (GET_PROTOCOL_MINOR(conn->daemonVersion) >= 28) {
+            auto builtOutputs = worker_proto::read(*this, conn->from, Phantom<DrvOutputs> {});
+            res.builtOutputs = builtOutputs;
+        }
+        return res;
+    } else
+        return worker_proto::read(*this, conn->from, Phantom<BuildResult>{});
 }
 
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -85,7 +85,7 @@ public:
 
     std::optional<const Realisation> queryRealisation(const DrvOutput &) override;
 
-    void buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
+    std::map<StorePath, BuildResult> buildPaths(const std::vector<StorePathWithOutputs> & paths, BuildMode buildMode) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
         BuildMode buildMode) override;

--- a/src/libstore/serve-protocol.hh
+++ b/src/libstore/serve-protocol.hh
@@ -5,7 +5,7 @@ namespace nix {
 #define SERVE_MAGIC_1 0x390c9deb
 #define SERVE_MAGIC_2 0x5452eecb
 
-#define SERVE_PROTOCOL_VERSION 0x206
+#define SERVE_PROTOCOL_VERSION (2 << 8 | 7)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -492,7 +492,7 @@ public:
        output paths can be created by running the builder, after
        recursively building any sub-derivations. For inputs that are
        not derivations, substitute them. */
-    virtual void buildPaths(
+    virtual std::map<StorePath, BuildResult> buildPaths(
         const std::vector<StorePathWithOutputs> & paths,
         BuildMode buildMode = bmNormal);
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION 0x11c
+#define PROTOCOL_VERSION 0x11d
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -88,6 +88,7 @@ MAKE_WORKER_PROTO(, StorePath);
 MAKE_WORKER_PROTO(, ContentAddress);
 MAKE_WORKER_PROTO(, Realisation);
 MAKE_WORKER_PROTO(, DrvOutput);
+MAKE_WORKER_PROTO(, BuildResult);
 
 MAKE_WORKER_PROTO(template<typename T>, std::set<T>);
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION 0x11d
+#define PROTOCOL_VERSION (1 << 8 | 30)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -901,14 +901,14 @@ static void opServe(Strings opFlags, Strings opArgs)
                 MonitorFdHup monitor(in.fd);
                 auto status = store->buildDerivation(drvPath, drv);
 
-                out << status.status << status.errorMsg;
+                if (GET_PROTOCOL_MINOR(clientVersion < 6)) {
+                    out << status.status << status.errorMsg;
 
-                if (GET_PROTOCOL_MINOR(clientVersion) >= 3)
-                    out << status.timesBuilt << status.isNonDeterministic << status.startTime << status.stopTime;
-                if (GET_PROTOCOL_MINOR(clientVersion >= 5)) {
-                    worker_proto::write(*store, out, status.builtOutputs);
+                    if (GET_PROTOCOL_MINOR(clientVersion) >= 3)
+                        out << status.timesBuilt << status.isNonDeterministic << status.startTime << status.stopTime;
+                } else {
+                    worker_proto::write(*store, out, status);
                 }
-
 
                 break;
             }

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -879,7 +879,9 @@ static void opServe(Strings opFlags, Strings opArgs)
 
                 try {
                     MonitorFdHup monitor(in.fd);
-                    store->buildPaths(paths);
+                    auto res = store->buildPaths(paths);
+                    if (GET_PROTOCOL_MINOR(clientVersion) >= 7)
+                        worker_proto::write(*store, out, res);
                     out << 0;
                 } catch (Error & e) {
                     assert(e.status);

--- a/tests/build-floating-ca-output.sh
+++ b/tests/build-floating-ca-output.sh
@@ -1,6 +1,10 @@
 source common.sh
 
-nix build -f multiple-outputs.nix --json a.all b.all | jq --exit-status '
+sed -i 's/experimental-features .*/& ca-derivations/' "$NIX_CONF_DIR"/nix.conf
+
+nix build -f multiple-outputs.nix --arg floatingCA true --json a.all b.all | jq
+
+nix build -f multiple-outputs.nix --arg floatingCA true --json a.all b.all | jq --exit-status '
   (.[0] |
     (.drvPath | match(".*multiple-outputs-a.drv")) and
     (.outputs |

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -41,6 +41,7 @@ nix_tests = \
   content-addressed.sh \
   nix-copy-content-addressed.sh \
   build.sh \
+  build-floating-ca-output.sh \
   compute-levels.sh
   # parallel.sh
 

--- a/tests/multiple-outputs.nix
+++ b/tests/multiple-outputs.nix
@@ -1,9 +1,17 @@
+{ floatingCA ? false }:
+
 with import ./config.nix;
 
 rec {
 
+  mkDerivation' = args: mkDerivation ((if floatingCA then {
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    __contentAddressed = true;
+  } else {}) // args);
+
   # Want to ensure that "out" doesn't get a suffix on it's path.
-  nameCheck = mkDerivation {
+  nameCheck = mkDerivation' {
     name = "multiple-outputs-a";
     outputs = [ "out" "dev" ];
     builder = builtins.toFile "builder.sh"
@@ -17,7 +25,7 @@ rec {
     helloString = "Hello, world!";
   };
 
-  a = mkDerivation {
+  a = mkDerivation' {
     name = "multiple-outputs-a";
     outputs = [ "first" "second" ];
     builder = builtins.toFile "builder.sh"
@@ -31,7 +39,7 @@ rec {
     helloString = "Hello, world!";
   };
 
-  b = mkDerivation {
+  b = mkDerivation' {
     defaultOutput = assert a.second.helloString == "Hello, world!"; a;
     firstOutput = assert a.outputName == "first"; a.first.first;
     secondOutput = assert a.second.outputName == "second"; a.second.first.first.second.second.first.second;
@@ -48,7 +56,7 @@ rec {
       '';
   };
 
-  c = mkDerivation {
+  c = mkDerivation' {
     name = "multiple-outputs-c";
     drv = b.drvPath;
     builder = builtins.toFile "builder.sh"
@@ -58,7 +66,7 @@ rec {
       '';
   };
 
-  d = mkDerivation {
+  d = mkDerivation' {
     name = "multiple-outputs-d";
     drv = builtins.unsafeDiscardOutputDependency b.drvPath;
     builder = builtins.toFile "builder.sh"
@@ -68,7 +76,7 @@ rec {
       '';
   };
 
-  cyclic = (mkDerivation {
+  cyclic = (mkDerivation' {
     name = "cyclic-outputs";
     outputs = [ "a" "b" "c" ];
     builder = builtins.toFile "builder.sh"


### PR DESCRIPTION
The libnixcmd build function now will fill in the missing output paths
in the buildables it works with. The JSON code, and possibly other code,
then just does the right thing.

depends on #4588