### PR TITLE
improve man page for nix.conf (builders)

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -207,15 +207,8 @@ public:
     Setting<std::string> builders{
         this, "@" + nixConfDir + "/machines", "builders",
         R"(
-          A semicolon-separated list of build machines, where each machine follows this format:
-
-          {protocol}://{user}@{host} [{comma sep. systems} - {maxJobs} {speedFactor} {comma sep. features}]
-
-          Examples:
-          
-          ssh://root@builder1.com
-          
-          ssh://root@builder2.com x86_64-linux,aarch64-linux - 40 20 nixos-test,benchmark,big-parallel,kvm
+          A semicolon-separated list of build machines.
+          For the exact format and examples, see [the manual chapter on remote builds](../advanced-topics/distributed-builds.md)
         )"};
 
     Setting<bool> buildersUseSubstitutes{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -206,7 +206,17 @@ public:
 
     Setting<std::string> builders{
         this, "@" + nixConfDir + "/machines", "builders",
-        "A semicolon-separated list of build machines, in the format of `nix.machines`."};
+        R"(
+          A semicolon-separated list of build machines, where each machine follows this format:
+
+          {protocol}://{user}@{host} [{comma sep. systems} - {maxJobs} {speedFactor} {comma sep. features}]
+
+          Examples:
+          
+          ssh://root@builder1.com
+          
+          ssh://root@builder2.com x86_64-linux,aarch64-linux - 40 20 nixos-test,benchmark,big-parallel,kvm
+        )"};
 
     Setting<bool> buildersUseSubstitutes{
         this, false, "builders-use-substitutes",


### PR DESCRIPTION
#### Motivation
How to exactly specify builders in nix.conf was unclear to me. The existing docs mention the format of `nix.machines`, but there is no such option in nixos. Probably the `nix.buildMachines` option is meant here, but this option is an attribute set, vs. the nix.conf expects a string. How to map the attribute set to the string format is unclear as well.

#### Done
Improve the help text for the builders options. Specify the exact format and provide two examples, a minimal one and one that uses the full spec.