### PR TITLE
1184 large path error [WIP]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,5 @@ endif
 include mk/lib.mk
 
 GLOBAL_CXXFLAGS += -g -Wall -include config.h -std=c++17
+
+LDFLAGS += -ldl

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -165,7 +165,6 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     TeeSource teeSource { narSource, teeSinkUncompressed };
     narAccessor = makeNarAccessor(teeSource);
     compressionSink->finish();
-    // fileSink.flush();
     fileSink.flush(narSource.source_identifier);
     }
 

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -165,7 +165,8 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     TeeSource teeSource { narSource, teeSinkUncompressed };
     narAccessor = makeNarAccessor(teeSource);
     compressionSink->finish();
-    fileSink.flush();
+    // fileSink.flush();
+    fileSink.flush(narSource.source_identifier);
     }
 
     auto now2 = std::chrono::steady_clock::now();

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -86,7 +86,7 @@ void BinaryCacheStore::getFile(const std::string & path, Sink & sink)
                 promise.set_exception(std::current_exception());
             }
         }});
-    sink(*promise.get_future().get());
+    sink(*promise.get_future().get(), path);
 }
 
 std::shared_ptr<std::string> BinaryCacheStore::getFile(const std::string & path)

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -933,7 +933,7 @@ void DerivationGoal::buildDone()
 
                 LogSink(Activity & act) : act(act) { }
 
-                void operator() (std::string_view data) override {
+                void operator() (std::string_view data, std::string_view source_identifier) override {
                     for (auto c : data) {
                         if (c == '\n') {
                             flushLine();
@@ -3201,7 +3201,7 @@ void DerivationGoal::registerOutputs()
                     StringSink sink;
                     dumpPath(actualPath, sink);
                     RewritingSink rsink2(oldHashPart, std::string(newInfo0.path.hashPart()), nextSink);
-                    rsink2(*sink.s);
+                    rsink2(*sink.s, actualPath);
                     rsink2.flush();
                 });
                 Path tmpPath = actualPath + ".tmp";
@@ -3723,7 +3723,7 @@ void DerivationGoal::handleChildOutput(int fd, const string & data)
                 currentLogLine[currentLogLinePos++] = c;
             }
 
-        if (logSink) (*logSink)(data);
+        if (logSink) (*logSink)(data, "derivation output");  // TODO actual information?
     }
 
     if (hook && fd == hook->fromHook.readSide.get()) {

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -51,7 +51,7 @@ struct TunnelLogger : public Logger
         if (state->canSendStderr) {
             assert(state->pendingMsgs.empty());
             try {
-                to(s);
+                to(s, "TunnelLogger");  // TODO better, or ""?
                 to.flush();
             } catch (...) {
                 /* Write failed; that means that the other side is
@@ -92,7 +92,7 @@ struct TunnelLogger : public Logger
         state->canSendStderr = true;
 
         for (auto & msg : state->pendingMsgs)
-            to(msg);
+            to(msg, "TunnelLogger::startWork");  // TODO not sure function names the best here.
 
         state->pendingMsgs.clear();
 
@@ -153,7 +153,7 @@ struct TunnelSink : Sink
 {
     Sink & to;
     TunnelSink(Sink & to) : to(to) { }
-    void operator () (std::string_view data)
+    void operator () (std::string_view data, std::string_view source_identifier)
     {
         to << STDERR_WRITE;
         writeString(data, to);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -52,7 +52,7 @@ struct TunnelLogger : public Logger
             assert(state->pendingMsgs.empty());
             try {
                 to(s, "TunnelLogger");  // TODO better, or ""?
-                to.flush();
+                to.flush("TunnelLogger");
             } catch (...) {
                 /* Write failed; that means that the other side is
                    gone. */
@@ -96,7 +96,7 @@ struct TunnelLogger : public Logger
 
         state->pendingMsgs.clear();
 
-        to.flush();
+        to.flush("TunnelLogger::startWork");
     }
 
     /* stopWork() means that we're done; stop sending stderr to the
@@ -168,7 +168,7 @@ struct TunnelSource : BufferedSource
     size_t readUnbuffered(char * data, size_t len) override
     {
         to << STDERR_READ << len;
-        to.flush();
+        // to.flush(from.source_identifier);
         size_t n = readString(data, len, from);
         if (n == 0) throw EndOfFile("unexpected end-of-file");
         return n;
@@ -909,6 +909,7 @@ void processConnection(
     unsigned int magic = readInt(from);
     if (magic != WORKER_MAGIC_1) throw Error("protocol mismatch");
     to << WORKER_MAGIC_2 << PROTOCOL_VERSION;
+    // to.flush(from.source_identifier);
     to.flush();
     unsigned int clientVersion = readInt(from);
 
@@ -945,6 +946,7 @@ void processConnection(
         authHook(*store);
 
         tunnelLogger->stopWork();
+        // to.flush(from.source_identifier);
         to.flush();
 
         /* Process client requests. */

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -171,8 +171,8 @@ struct curlFileTransfer : public FileTransfer
                 }
 
                 if (errorSink)
-                    (*errorSink)({(char *) contents, realSize});
-                (*decompressionSink)({(char *) contents, realSize});
+                    (*errorSink)({(char *) contents, realSize}, request.uri);
+                (*decompressionSink)({(char *) contents, realSize}, request.uri);
 
                 return realSize;
             } catch (...) {
@@ -843,7 +843,7 @@ void FileTransfer::download(FileTransferRequest && request, Sink & sink)
            if it's blocked on a full buffer. We don't hold the state
            lock while doing this to prevent blocking the download
            thread if sink() takes a long time. */
-        sink(chunk);
+        sink(chunk, request.uri);
     }
 }
 

--- a/src/libstore/references.hh
+++ b/src/libstore/references.hh
@@ -19,7 +19,7 @@ struct RewritingSink : Sink
 
     RewritingSink(const std::string & from, const std::string & to, Sink & nextSink);
 
-    void operator () (std::string_view data) override;
+    void operator () (std::string_view data, std::string_view source_identifier) override;
 
     void flush();
 };
@@ -31,7 +31,7 @@ struct HashModuloSink : AbstractHashSink
 
     HashModuloSink(HashType ht, const std::string & modulus);
 
-    void operator () (std::string_view data) override;
+    void operator () (std::string_view data, std::string_view source_identifier) override;
 
     HashResult finish() override;
 };

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -12,6 +12,7 @@
 #include "logging.hh"
 #include "callback.hh"
 #include "filetransfer.hh"
+#include <iostream>
 
 namespace nix {
 
@@ -464,7 +465,7 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
     const StorePathSet & references,
     RepairFlag repair)
 {
-    dump.source_identifier = name;
+    // dump.source_identifier = name;
     std::optional<ConnectionHandle> conn_(getConnection());
     auto & conn = *conn_;
 
@@ -546,6 +547,7 @@ StorePath RemoteStore::addToStoreFromDump(Source & dump, const string & name,
         FileIngestionMethod method, HashType hashType, RepairFlag repair)
 {
     StorePathSet references;
+    // std::cout << "RemoteStore::addToStoreFromDump" << dump.source_identifier << std::endl;
     return addCAToStore(dump, name, FixedOutputHashMethod{ .fileIngestionMethod = method, .hashType = hashType }, references, repair)->path;
 }
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -871,7 +871,7 @@ std::exception_ptr RemoteStore::Connection::processStderr(Sink * sink, Source * 
         if (msg == STDERR_WRITE) {
             string s = readString(from);
             if (!sink) throw Error("no sink");
-            (*sink)(s);
+            (*sink)(s, from.source_identifier);
         }
 
         else if (msg == STDERR_READ) {

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -412,7 +412,7 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStoreConfig, public virtual
             printTalkative("downloaded 's3://%s/%s' (%d bytes) in %d ms",
                 bucketName, path, res.data->size(), res.durationMs);
 
-            sink(*res.data);
+            sink(*res.data, path);
         } else
             throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache '%s'", path, getUri());
     }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -252,6 +252,7 @@ StorePath Store::addToStore(const string & name, const Path & _srcPath,
         else
             readFile(srcPath, sink);
     });
+    // std::cout << "Store::addToStore" << _srcPath << std::endl;
     source->source_identifier = _srcPath;
     return addToStoreFromDump(*source, name, method, hashAlgo, repair);
 }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -252,6 +252,7 @@ StorePath Store::addToStore(const string & name, const Path & _srcPath,
         else
             readFile(srcPath, sink);
     });
+    source->source_identifier = _srcPath;
     return addToStoreFromDump(*source, name, method, hashAlgo, repair);
 }
 

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -57,7 +57,7 @@ static void dumpContents(const Path & path, size_t size,
         auto n = std::min(left, buf.size());
         readFull(fd.get(), buf.data(), n);
         left -= n;
-        sink({buf.data(), n});
+        sink({buf.data(), n}, "Path: " + path);
     }
 
     writePadding(size, sink);

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -79,7 +79,7 @@ struct RetrieveRegularNARSink : ParseSink
 
     void receiveContents(std::string_view data) override
     {
-        sink(data);
+        sink(data, "");
     }
 
     void createSymlink(const Path & path, const string & target) override

--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -39,7 +39,7 @@ struct NoneSink : CompressionSink
 {
     Sink & nextSink;
     NoneSink(Sink & nextSink) : nextSink(nextSink) { }
-    void finish() override { flush(); }
+    void finish() override { flush(""); }
     void write(std::string_view data, std::string_view source_identifier) override { nextSink(data, source_identifier); }
 };
 
@@ -73,7 +73,7 @@ struct GzipDecompressionSink : CompressionSink
 
     void finish() override
     {
-        CompressionSink::flush();
+        CompressionSink::flush("GzipDecompressionSink");
         write({}, "GzipDecompressionSink");
     }
 
@@ -128,7 +128,7 @@ struct XzDecompressionSink : CompressionSink
 
     void finish() override
     {
-        CompressionSink::flush();
+        CompressionSink::flush("XzDecompressionSink");
         write({}, "XzDecompressionSink");
     }
 
@@ -179,7 +179,7 @@ struct BzipDecompressionSink : ChunkedCompressionSink
 
     void finish() override
     {
-        flush();
+        flush("BzipDecompressionSink");
         write({}, "BzipDecompressionSink");
     }
 
@@ -228,7 +228,7 @@ struct BrotliDecompressionSink : ChunkedCompressionSink
 
     void finish() override
     {
-        flush();
+        flush("BrotliDecompressionSink");
         writeInternal({}, "BrotliDecompressionSink" );
     }
 
@@ -336,7 +336,7 @@ struct XzCompressionSink : CompressionSink
 
     void finish() override
     {
-        CompressionSink::flush();
+        CompressionSink::flush("XzCompressionSink");
         write({}, "XzCompressionSink");
     }
 
@@ -387,7 +387,7 @@ struct BzipCompressionSink : ChunkedCompressionSink
 
     void finish() override
     {
-        flush();
+        flush("BzipCompressionSink");
         writeInternal({}, "BzipCompressionSink");
     }
 
@@ -437,7 +437,7 @@ struct BrotliCompressionSink : ChunkedCompressionSink
 
     void finish() override
     {
-        flush();
+        flush("BrotliCompressionSink");
         writeInternal({}, "BrotliCompressionSink");
     }
 

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -349,7 +349,7 @@ void HashSink::write(std::string_view data, std::string_view source_identifier)
 
 HashResult HashSink::finish()
 {
-    flush();
+    flush("");
     Hash hash(ht);
     nix::finish(ht, *ctx, hash.hash);
     return HashResult(hash, bytes);
@@ -357,7 +357,7 @@ HashResult HashSink::finish()
 
 HashResult HashSink::currentHash()
 {
-    flush();
+    flush("");
     Ctx ctx2 = *ctx;
     Hash hash(ht);
     nix::finish(ht, ctx2, hash.hash);

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -341,7 +341,7 @@ HashSink::~HashSink()
     delete ctx;
 }
 
-void HashSink::write(std::string_view data)
+void HashSink::write(std::string_view data, std::string_view source_identifier)
 {
     bytes += data.size();
     update(ht, *ctx, data);

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -156,7 +156,7 @@ public:
     HashSink(HashType ht);
     HashSink(const HashSink & h);
     ~HashSink();
-    void write(std::string_view data) override;
+    void write(std::string_view data, std::string_view source_identifier) override;
     HashResult finish() override;
     HashResult currentHash();
 };

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -19,6 +19,8 @@ void BufferedSink::operator () (std::string_view data, std::string_view source_i
 {
     if (!buffer) buffer = decltype(buffer)(new char[bufSize]);
 
+    // std::cout << "BufferedSink::operator" << source_identifier << std::endl;
+
     while (!data.empty()) {
         /* Optimisation: bypass the buffer if the data exceeds the
            buffer size. */
@@ -97,6 +99,8 @@ void Source::operator () (char * data, size_t len)
 
 void Source::drainInto(Sink & sink)
 {
+    // std::cout << "Source::drainInto " << source_identifier << std::endl;
+    
     std::string s;
     std::vector<char> buf(8192);
     while (true) {

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -19,8 +19,6 @@ void BufferedSink::operator () (std::string_view data, std::string_view source_i
 {
     if (!buffer) buffer = decltype(buffer)(new char[bufSize]);
 
-    // std::cout << "BufferedSink::operator" << source_identifier << std::endl;
-
     while (!data.empty()) {
         /* Optimisation: bypass the buffer if the data exceeds the
            buffer size. */
@@ -50,7 +48,7 @@ void BufferedSink::flush(std::string_view source_identifier)
 
 FdSink::~FdSink()
 {
-    try { flush(""); } catch (...) { ignoreException(); }
+    try { flush(); } catch (...) { ignoreException(); }
 }
 
 
@@ -99,8 +97,6 @@ void Source::operator () (char * data, size_t len)
 
 void Source::drainInto(Sink & sink)
 {
-    // std::cout << "Source::drainInto " << source_identifier << std::endl;
-    
     std::string s;
     std::vector<char> buf(8192);
     while (true) {

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -37,7 +37,7 @@ struct BufferedSink : virtual Sink
 
     void operator () (std::string_view data, std::string_view source_identifier) override;
 
-    void flush();
+    void flush(std::string_view source_identifier = "");
 
     virtual void write(std::string_view data, std::string_view source_identifier) = 0;
 };
@@ -101,7 +101,7 @@ struct FdSink : BufferedSink
 
     FdSink& operator=(FdSink && s)
     {
-        flush();
+        flush("");
         fd = s.fd;
         s.fd = -1;
         warn = s.warn;
@@ -472,7 +472,7 @@ struct FramedSink : nix::BufferedSink
     {
         try {
             to << 0;
-            to.flush();
+            to.flush("");
         } catch (...) {
             ignoreException();
         }

--- a/src/libutil/tests/compression.cc
+++ b/src/libutil/tests/compression.cc
@@ -56,7 +56,7 @@ namespace nix {
         StringSink strSink;
         auto inputString = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
         auto sink = makeCompressionSink("none", strSink);
-        (*sink)(inputString);
+        (*sink)(inputString, "compression test string");
         sink->finish();
 
         ASSERT_STREQ((*strSink.s).c_str(), inputString);
@@ -68,7 +68,7 @@ namespace nix {
         auto decompressionSink = makeDecompressionSink("bzip2", strSink);
         auto sink = makeCompressionSink("bzip2", *decompressionSink);
 
-        (*sink)(inputString);
+        (*sink)(inputString, "compression test string");
         sink->finish();
         decompressionSink->finish();
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -697,7 +697,7 @@ void drainFD(int fd, Sink & sink, bool block)
                 throw SysError("reading from file");
         }
         else if (rd == 0) break;
-        else sink({(char *) buf.data(), (size_t) rd});
+        else sink({(char *) buf.data(), (size_t) rd}, "file descriptor");  // TODO something useful here
     }
 }
 

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -636,7 +636,7 @@ static void opDump(Strings opFlags, Strings opArgs)
     FdSink sink(STDOUT_FILENO);
     string path = *opArgs.begin();
     dumpPath(path, sink);
-    sink.flush();
+    sink.flush(path);
 }
 
 
@@ -663,7 +663,7 @@ static void opExport(Strings opFlags, Strings opArgs)
 
     FdSink sink(STDOUT_FILENO);
     store->exportPaths(paths, sink);
-    sink.flush();
+    sink.flush("");  // TODO: build potentially giant path string?
 }
 
 
@@ -780,7 +780,7 @@ static void opServe(Strings opFlags, Strings opArgs)
     unsigned int magic = readInt(in);
     if (magic != SERVE_MAGIC_1) throw Error("protocol mismatch");
     out << SERVE_MAGIC_2 << SERVE_PROTOCOL_VERSION;
-    out.flush();
+    out.flush("stdin");
     unsigned int clientVersion = readInt(in);
 
     auto getBuildSettings = [&]() {
@@ -953,7 +953,7 @@ static void opServe(Strings opFlags, Strings opArgs)
                 throw Error("unknown serve command %1%", cmd);
         }
 
-        out.flush();
+        out.flush("stdin");
     }
 }
 

--- a/src/nix/dump-path.cc
+++ b/src/nix/dump-path.cc
@@ -22,7 +22,7 @@ struct CmdDumpPath : StorePathCommand
     {
         FdSink sink(STDOUT_FILENO);
         store->narFromPath(storePath, sink);
-        sink.flush();
+        sink.flush(storePath.to_string());
     }
 };
 
@@ -57,7 +57,7 @@ struct CmdDumpPath2 : Command
     {
         FdSink sink(STDOUT_FILENO);
         dumpPath(path, sink);
-        sink.flush();
+        sink.flush(path);
     }
 };
 

--- a/src/nix/make-content-addressable.cc
+++ b/src/nix/make-content-addressable.cc
@@ -64,7 +64,7 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
             *sink.s = rewriteStrings(*sink.s, rewrites);
 
             HashModuloSink hashModuloSink(htSHA256, oldHashPart);
-            hashModuloSink(*sink.s);
+            hashModuloSink(*sink.s, pathS);
 
             auto narHash = hashModuloSink.finish().first;
 
@@ -85,7 +85,7 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
 
             auto source = sinkToSource([&](Sink & nextSink) {
                 RewritingSink rsink2(oldHashPart, std::string(info.path.hashPart()), nextSink);
-                rsink2(*sink.s);
+                rsink2(*sink.s, pathS);
                 rsink2.flush();
             });
 


### PR DESCRIPTION
This is an exploratory PR which touches the Sink and Source objects and their descendants.  

The idea is to address issue #1184, the vague "large path" error.  The error we get now is this:

```
[nix-shell:~/code/nix-error-project/1184/test-case]$ ./build.sh 
warning: unknown setting 'experimental-features'
warning: dumping very large path (> 256 MiB); this may run out of memory
^Cerror: interrupted by the user
```

Whereas with these changes its this:

```
[nix-shell:~/code/nix-error-project/1184/test-case]$ ./newbuild.sh 
warning: dumping very large path (> 256 MiB); this may run out of memory
path: /home/bburdette/code/zknotes/zknotes/server
```

The main idea is pretty simple, add a `source_identifier` parameter to the Sink::operator(), and add a corresponding source_identifier string to Source:

```
struct Sink
{
    virtual ~Sink() { }                                 // NEW PARAMETER  ↓
    virtual void operator () (std::string_view data, std::string_view source_identifier) = 0;   
    virtual bool good() { return true; }
};
```

```
/* Abstract source of binary data. */
struct Source
{
    virtual ~Source() { }

    /* Store exactly ‘len’ bytes in the buffer pointed to by ‘data’.
       It blocks until all the requested data is available, or throws
       an error if it is not going to be available.   */
    void operator () (char * data, size_t len);

    /* Store up to ‘len’ in the buffer pointed to by ‘data’, and
       return the number of bytes stored.  It blocks until at least
       one byte is available. */
    virtual size_t read(char * data, size_t len) = 0;

    virtual bool good() { return true; }

    std::string source_identifier;                     // NEW STRING 

    void drainInto(Sink & sink);

    std::string drain();
};
```

With these elements in place, its possible to issue a more specific error message:

```
static void warnLargeDump(std::string_view source_identifier)
{
    warn("dumping very large path (> 256 MiB); this may run out of memory\npath: %s", source_identifier);
}

void FdSink::write(std::string_view data, std::string_view source_identifier)
{
    written += data.size();
    static bool warned = false;
    if (warn && !warned) {
        if (written > threshold) {
            warnLargeDump(source_identifier);
            warned = true;
        }
    }
    try {
        writeFull(fd, data);
    } catch (SysError & e) {
        _good = false;
        throw;
    }
}
```

So that's it.  But as you'd expect, there's a lot of code that gets disturbed as a result here.  And, there are are fair number of decisions to be made about whether to put something in these source_identifier strings, and if so what to put there.  

Furthermore, there's a certain reduction in api elegance, for instance with flush you might have something like this:

```
    // are we adding the string 'pathname' to the output here?   no, but looks kind of like we are
   outstream.flush(pathname);    
```

At any rate, before sinking a whole lot more hours into putting reasonable `source_identifier` strings everywhere, I'd gauge the acceptability of this idea in general.  Thanks for any feedback!

