### PR TITLE
add path to 'very large path' error

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1842,7 +1842,7 @@ string EvalState::copyPathToStore(PathSet & context, const Path & path)
               // show paths we're copying, unless they're already in the store.
               std::unique_ptr<PushActivity> pact;
               auto path_to_add = checkSourcePath(path);
-              if (!store->isInStore(path)) {
+              if (!store->isInStore(path) || repair) {
                 Activity act(*logger, lvlInfo, actCopyPath, fmt("copying path '%s'", path_to_add));
                 pact = std::unique_ptr<PushActivity>(new PushActivity(act.id));
               }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1840,14 +1840,13 @@ string EvalState::copyPathToStore(PathSet & context, const Path & path)
             ? store->computeStorePathForPath(std::string(baseNameOf(path)), checkSourcePath(path)).first
             : [&] {
               // show paths we're copying, unless they're already in the store.
+              std::unique_ptr<PushActivity> pact;
+              auto path_to_add = checkSourcePath(path);
               if (!store->isInStore(path)) {
-                auto path_to_add = checkSourcePath(path);
                 Activity act(*logger, lvlInfo, actCopyPath, fmt("copying path '%s'", path_to_add));
-                PushActivity pact(act.id);
-                return store->addToStore(std::string(baseNameOf(path)), path_to_add, FileIngestionMethod::Recursive, htSHA256, defaultPathFilter, repair);
+                pact = std::unique_ptr<PushActivity>(new PushActivity(act.id));
               }
-              else
-                return store->addToStore(std::string(baseNameOf(path)), checkSourcePath(path), FileIngestionMethod::Recursive, htSHA256, defaultPathFilter, repair);
+              return store->addToStore(std::string(baseNameOf(path)), path_to_add, FileIngestionMethod::Recursive, htSHA256, defaultPathFilter, repair);
             } ();
 
         dstPath = store->printStorePath(p);


### PR DESCRIPTION
This is to address issue #1184, the vague 'dumping very large path' warning.  Rather than changing the warning message itself, we're creating an Activity when we copy a path, similar to what happens in [store-api.cc](https://github.com/NixOS/nix/blob/52b6e0f83746997f7223a69482ee0eda4ebbc2ff/src/libstore/store-api.cc#L743).

Here's the output with my test case:

```
[nix-shell:~/code/nix-error-project/1184/test-case]$ ./newbuild.sh 
copying path '/home/bburdette/code/zknotes/zknotes/server'...
warning: dumping very large path (> 256 MiB); this may run out of memory
^Cerror: interrupted by the user
```

I put in an `isInStore` check before adding the Activity, otherwise there's quite a bit of extra output:

```
[nix-shell:~/code/nix-error-project/1184/test-case]$ ./newbuild.sh 
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/stdenv/generic/default-builder.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/stdenv/linux/bootstrap-tools/scripts/unpack-bootstrap-tools.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/stdenv/generic/builder.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/build-support/setup-hooks/move-docs.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/build-support/setup-hooks/make-symlinks-relative.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/build-support/setup-hooks/compress-man-pages.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/build-support/setup-hooks/strip.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/build-support/setup-hooks/patch-shebangs.sh'...

                      <a few hundred more lines of these>

copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/build-support/setup-d
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/development/compilers/rust/setup-hook.sh'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/build-support/rust/patch-registry-deps'...
copying path '/nix/store/rrhid0i04x3v4majkx9sjzg6jrpxl3hz-nixos-20.09.2787.6e7f25001fe/nixos/pkgs/development/compilers/llvm/10/llvm-outputs.patch'...
copying path '/home/bburdette/code/zknotes/zknotes/server'...
warning: dumping very large path (> 256 MiB); this may run out of memory
```