### PR TITLE
remove doc for obsolete --no-build-hook flag

### DIFF
--- a/doc/manual/src/command-ref/opt-common.md
+++ b/doc/manual/src/command-ref/opt-common.md
@@ -134,15 +134,6 @@ Most Nix commands accept the following command-line options:
     failure in obtaining the substitutes to lead to a full build from
     source (with the related consumption of resources).
 
-  - `--no-build-hook`  
-    Disables the build hook mechanism. This allows to ignore remote
-    builders if they are setup on the machine.
-    
-    It's useful in cases where the bandwidth between the client and the
-    remote builder is too low. In that case it can take more time to
-    upload the sources to the remote builder and fetch back the result
-    than to do the computation locally.
-
   - `--readonly-mode`  
     When this option is used, no attempt is made to open the Nix
     database. Most Nix operations do need database access, so those


### PR DESCRIPTION
NieDzejkob reported in #nixos that the documented `--no-build-hook` flag wasn't working. It appears to have been removed in 25f3262.

Not sure if this means any other documentation should have been added but wasn't.