### PR TITLE
Fix gcc10 build again

### DIFF
--- a/src/libcmd/markdown.cc
+++ b/src/libcmd/markdown.cc
@@ -40,9 +40,7 @@ std::string renderMarkdownToTerminal(std::string_view markdown)
         throw Error("cannot allocate Markdown output buffer");
     Finally freeBuffer([&]() { lowdown_buf_free(buf); });
 
-    int rndr_res = lowdown_term_rndr(buf, nullptr, renderer, node);
-    if (!rndr_res)
-        throw Error("allocation error while rendering Markdown");
+    lowdown_term_rndr(buf, nullptr, renderer, node);
 
     return std::string(buf->data, buf->size);
 }


### PR DESCRIPTION
lowdown_term_rndr returns void, yet it was being assigned.
```
src/libcmd/markdown.cc: In function 'std::string nix::renderMarkdownToTerminal(std::string_view)':
src/libcmd/markdown.cc:43:37: error: void value not ignored as it ought to be
   43 |     int rndr_res = lowdown_term_rndr(buf, nullptr, renderer, node);
```