### PR TITLE
Add a `nix realisation` command for working on realisations

### DIFF
--- a/src/nix/realisation.cc
+++ b/src/nix/realisation.cc
@@ -1,0 +1,78 @@
+#include "command.hh"
+#include "common-args.hh"
+
+#include <nlohmann/json.hpp>
+
+using namespace nix;
+
+struct CmdRealisation : virtual NixMultiCommand
+{
+    CmdRealisation() : MultiCommand(RegisterCommand::getCommandsFor({"realisation"}))
+    { }
+
+    std::string description() override
+    {
+        return "manipulate a Nix realisation";
+    }
+
+    Category category() override { return catUtility; }
+
+    void run() override
+    {
+        if (!command)
+            throw UsageError("'nix realisation' requires a sub-command.");
+        command->second->prepare();
+        command->second->run();
+    }
+};
+
+static auto rCmdRealisation = registerCommand<CmdRealisation>("realisation");
+
+struct CmdRealisationInfo : RealisedPathsCommand, MixJSON
+{
+    std::string description() override
+    {
+        return "query information about one or several realisations";
+    }
+
+    std::string doc() override
+    {
+        return
+            #include "realisation/info.md"
+            ;
+    }
+
+    Category category() override { return catSecondary; }
+
+    void run(ref<Store> store, std::vector<RealisedPath> paths) override
+    {
+        settings.requireExperimentalFeature("ca-derivations");
+        if (json) {
+            nlohmann::json res = nlohmann::json::array();
+            for (auto & path : paths) {
+                nlohmann::json currentPath;
+                if (auto realisation = std::get_if<Realisation>(&path.raw))
+                    currentPath = realisation->toJSON();
+                else
+                    currentPath["opaquePath"] = store->printStorePath(path.path());
+
+                res.push_back(currentPath);
+            }
+            std::cout << res.dump();
+        }
+        else {
+            for (auto & path : paths) {
+                if (auto realisation = std::get_if<Realisation>(&path.raw)) {
+                    std::cout <<
+                        realisation->id.to_string() << " " <<
+                        store->printStorePath(realisation->outPath);
+                } else
+                    std::cout << store->printStorePath(path.path());
+
+                std::cout << std::endl;
+            }
+        }
+    }
+};
+
+static auto rCmdRealisationInfo = registerCommand2<CmdRealisationInfo>({"realisation", "info"});

--- a/src/nix/realisation/info.md
+++ b/src/nix/realisation/info.md
@@ -1,0 +1,15 @@
+R"MdBoundary(
+# Description
+
+Display some informations about the given realisation
+
+# Examples
+
+Show some information about the realisation of the `hello` package:
+
+```console
+$ nix realisation info nixpkgs#hello --json
+[{"id":"sha256:3d382378a00588e064ee30be96dd0fa7e7df7cf3fbcace85a0e7b7dada1eef25!out","outPath":"fd3m7xawvrqcg98kgz5hc2vk3x9q0lh7-hello"}]
+```
+
+)MdBoundary"


### PR DESCRIPTION
Currently only has `nix realisation info`, more to come probably.

I'm not sure this is a very useful tool in the long run, but I wrote this to help me debug some issue, and I think it can be quite useful, at least for the time being.
