### PR TITLE
Make the “dumping large path” warning include information on what path is being large

### DIFF
--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -183,7 +183,7 @@ void exportPaths(int fd, ...)
 void importPaths(int fd, int dontCheckSigs)
     PPCODE:
         try {
-            FdSource source(fd);
+            FdSource source(fd, "");
             store()->importPaths(source, dontCheckSigs ? NoCheckSigs : CheckSigs);
         } catch (Error & e) {
             croak("%s", e.what());

--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -61,7 +61,7 @@ static int main_build_remote(int argc, char * * argv)
 
         verbosity = (Verbosity) std::stoll(argv[1]);
 
-        FdSource source(STDIN_FILENO);
+        FdSource source(STDIN_FILENO, "<stdin>");
 
         /* Read the parent's settings. */
         while (readInt(source)) {

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -442,7 +442,7 @@ struct GitInputScheme : InputScheme
         } else {
             // FIXME: should pipe this, or find some better way to extract a
             // revision.
-            auto source = sinkToSource([&](Sink & sink) {
+            auto source = sinkToSource("git:" + repoDir, [&](Sink & sink) {
                 RunOptions gitOptions("git", { "-C", repoDir, "archive", input.getRev()->gitRev() });
                 gitOptions.standardOut = &sink;
                 runProgram2(gitOptions);

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -407,7 +407,7 @@ StorePath BinaryCacheStore::addToStore(const string & name, const Path & srcPath
     }
     auto h = sink.finish().first;
 
-    auto source = sinkToSource([&](Sink & sink) {
+    auto source = sinkToSource("path:" + srcPath, [&](Sink & sink) {
         dumpPath(srcPath, sink, filter);
     });
     return addToStoreCommon(*source, repair, CheckSigs, [&](HashResult nar) {

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -963,7 +963,7 @@ void LocalDerivationGoal::startBuilder()
         }();
         if (string(msg, 0, 1) == "\2") break;
         if (string(msg, 0, 1) == "\1") {
-            FdSource source(builderOut.readSide.get());
+            FdSource source(builderOut.readSide.get(), "");
             auto ex = readError(source);
             ex.addTrace({}, "while setting up the build environment");
             throw ex;
@@ -1425,7 +1425,7 @@ void LocalDerivationGoal::startDaemon()
             debug("received daemon connection");
 
             auto workerThread = std::thread([store, remote{std::move(remote)}]() {
-                FdSource from(remote.get());
+                FdSource from(remote.get(), "");
                 FdSink to(remote.get());
                 try {
                     daemon::processConnection(store, from, to,
@@ -2355,7 +2355,7 @@ void LocalDerivationGoal::registerOutputs()
                 newInfo0.references.insert(newInfo0.path);
             if (scratchPath != newInfo0.path) {
                 // Also rewrite the output path
-                auto source = sinkToSource([&](Sink & nextSink) {
+                auto source = sinkToSource("path:" + actualPath, [&](Sink & nextSink) {
                     StringSink sink;
                     dumpPath(actualPath, sink);
                     RewritingSink rsink2(oldHashPart, std::string(newInfo0.path.hashPart()), nextSink);

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -32,7 +32,7 @@ void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
 
     auto fetch = [&](const std::string & url) {
 
-        auto source = sinkToSource([&](Sink & sink) {
+        auto source = sinkToSource("url:" + url, [&](Sink & sink) {
 
             /* No need to do TLS verification, because we check the hash of
                the result anyway. */

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -173,6 +173,10 @@ struct TunnelSource : BufferedSource
         if (n == 0) throw EndOfFile("unexpected end-of-file");
         return n;
     }
+    std::string debugLabel() override
+    {
+        return from.debugLabel();
+    }
 };
 
 struct ClientSettings

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -126,7 +126,7 @@ protected:
         const std::string & mimeType) override
     {
         auto req = makeRequest(path);
-        req.data = std::make_shared<string>(StreamToSourceAdapter(istream).drain());
+        req.data = std::make_shared<string>(StreamToSourceAdapter(istream, path).drain());
         req.mimeType = mimeType;
         try {
             getFileTransfer()->upload(req);

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -75,7 +75,7 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
             fmt("%s --serve --write", remoteProgram)
             + (remoteStore.get() == "" ? "" : " --store " + shellEscape(remoteStore.get())));
         conn->to = FdSink(conn->sshConn->in.get());
-        conn->from = FdSource(conn->sshConn->out.get());
+        conn->from = FdSource(conn->sshConn->out.get(), "<ssh>");
 
         try {
             conn->to << SERVE_MAGIC_1 << SERVE_PROTOCOL_VERSION;

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -52,7 +52,7 @@ protected:
         auto path2 = binaryCacheDir + "/" + path;
         Path tmp = path2 + ".tmp." + std::to_string(getpid());
         AutoDelete del(tmp, false);
-        StreamToSourceAdapter source(istream);
+        StreamToSourceAdapter source(istream, path);
         writeFile(tmp, source);
         if (rename(tmp.c_str(), path2.c_str()))
             throw SysError("renaming '%1%' to '%2%'", tmp, path2);

--- a/src/libstore/nar-accessor.cc
+++ b/src/libstore/nar-accessor.cc
@@ -102,6 +102,11 @@ struct NarAccessor : public FSAccessor
             pos += n;
             return n;
         }
+
+        std::string debugLabel() override
+        {
+            return source.debugLabel();
+        }
     };
 
     NarAccessor(ref<const std::string> nar) : nar(nar)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -573,7 +573,7 @@ void RemoteStore::addToStore(const ValidPathInfo & info, Source & source,
     if (GET_PROTOCOL_MINOR(conn->daemonVersion) < 18) {
         conn->to << wopImportPaths;
 
-        auto source2 = sinkToSource([&](Sink & sink) {
+        auto source2 = sinkToSource("remote:" + std::string(info.path.to_string()), [&](Sink & sink) {
             sink << 1 // == path follows
                 ;
             copyNAR(source, sink);

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -384,7 +384,7 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStoreConfig, public virtual
     {
         auto compress = [&](std::string compression)
         {
-            auto compressed = nix::compress(compression, StreamToSourceAdapter(istream).drain());
+            auto compressed = nix::compress(compression, StreamToSourceAdapter(istream, path).drain());
             return std::make_shared<std::stringstream>(std::move(*compressed));
         };
 

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -83,7 +83,7 @@ ref<RemoteStore::Connection> SSHStore::openConnection()
         fmt("%s --stdio", remoteProgram)
         + (remoteStore.get() == "" ? "" : " --store " + shellEscape(remoteStore.get())));
     conn->to = FdSink(conn->sshConn->in.get());
-    conn->from = FdSource(conn->sshConn->out.get());
+    conn->from = FdSource(conn->sshConn->out.get(), "<ssh>");
     return conn;
 }
 

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -120,8 +120,14 @@ static void dump(const Path & path, Sink & sink, PathFilter & filter)
 
 void dumpPath(const Path & path, Sink & sink, PathFilter & filter)
 {
-    sink << narVersionMagic1;
-    dump(path, sink, filter);
+    sink.setDebugLabel("dumping path '" + path + "'");
+    try {
+        sink << narVersionMagic1;
+        dump(path, sink, filter);
+    } catch (...) {
+        sink.removeDebugLabel();
+        throw;
+    }
 }
 
 
@@ -377,7 +383,7 @@ void copyNAR(Source & source, Sink & sink)
 
 void copyPath(const Path & from, const Path & to)
 {
-    auto source = sinkToSource([&](Sink & sink) {
+    auto source = sinkToSource("path:" + from, [&](Sink & sink) {
         dumpPath(from, sink);
     });
     restorePath(to, *source);

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -646,7 +646,7 @@ static void opRestore(Strings opFlags, Strings opArgs)
     if (!opFlags.empty()) throw UsageError("unknown flag");
     if (opArgs.size() != 1) throw UsageError("only one argument allowed");
 
-    FdSource source(STDIN_FILENO);
+    FdSource source(STDIN_FILENO, "<stdin>");
     restorePath(*opArgs.begin(), source);
 }
 
@@ -674,7 +674,7 @@ static void opImport(Strings opFlags, Strings opArgs)
 
     if (!opArgs.empty()) throw UsageError("no arguments expected");
 
-    FdSource source(STDIN_FILENO);
+    FdSource source(STDIN_FILENO, "<stdin>");
     auto paths = store->importPaths(source, NoCheckSigs);
 
     for (auto & i : paths)
@@ -773,7 +773,7 @@ static void opServe(Strings opFlags, Strings opArgs)
 
     if (!opArgs.empty()) throw UsageError("no arguments expected");
 
-    FdSource in(STDIN_FILENO);
+    FdSource in(STDIN_FILENO, "<stdin>");
     FdSink out(STDOUT_FILENO);
 
     /* Exchange the greeting. */

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -239,7 +239,7 @@ static void daemonLoop()
                 }
 
                 //  Handle the connection.
-                FdSource from(remote.get());
+                FdSource from(remote.get(), "");
                 FdSink to(remote.get());
                 processConnection(openUncachedStore(), from, to, trusted, NotRecursive, [&](Store & store) {
 #if 0
@@ -297,7 +297,7 @@ static void runDaemon(bool stdio)
                 }
             }
         } else {
-            FdSource from(STDIN_FILENO);
+            FdSource from(STDIN_FILENO, "<stdin>");
             FdSink to(STDOUT_FILENO);
             /* Auth hook is empty because in this mode we blindly trust the
                standard streams. Limiting access to those is explicitly

--- a/src/nix/make-content-addressable.cc
+++ b/src/nix/make-content-addressable.cc
@@ -83,7 +83,7 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
             if (!json)
                 notice("rewrote '%s' to '%s'", pathS, store->printStorePath(info.path));
 
-            auto source = sinkToSource([&](Sink & nextSink) {
+            auto source = sinkToSource("path:" + std::string(info.path.to_string()), [&](Sink & nextSink) {
                 RewritingSink rsink2(oldHashPart, std::string(info.path.hashPart()), nextSink);
                 rsink2(*sink.s);
                 rsink2.flush();


### PR DESCRIPTION
Disclaimer: this is my first time seriously modifying nix's source code, so I'm far from sure I did everything right. However, I do think that the added debug information is an incremental improvement, and can then be refined as we go, eg. if it turns out some of the debug labels are not precise enough.

Example output with the change:
```
[nix-shell:~/prog/nix]$ outputs/out/bin/nix-instantiate -E '"${./.}"'
warning: dumping very large path (> 256 MiB); this may run out of memory
  while dumping from source 'path:/home/ekleog/prog/nix'
```

What do you think? :)