### PR TITLE
Unsmudge fetchGit for reproducibility and security

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -306,6 +306,23 @@ static RegisterPrimOp primop_fetchGit({
         - url\
           The URL of the repo.
 
+          The URL can be a path value, in order to fetch from a local
+          repository. When `ref` and `rev` unset, the default behavior is to
+          produce an output that includes the uncommitted changes to files known
+          to git. This is similar to `HEAD` after running `git add -u` and
+          `git commit`. Files that have not been added to the index or `HEAD`
+          will be ignored.
+
+          This will not run the git smudge filters, but changed files will be
+          processed with the git clean filter, in order to be consistent with
+          remote repositories. This way, decrypted git-crypt secrets are not
+          added to the store. Warning: the current implementation does not
+          apply this logic to submodules.
+
+          Tip: if you prefer to keep your index clean, you can use `git add -N`
+          to add files to the index without adding their contents. You can add
+          the contents later with `git add -p` or `git add`.
+
         - name\
           The name of the directory the repo should be exported to in the
           store. Defaults to the basename of the URL.
@@ -315,11 +332,13 @@ static RegisterPrimOp primop_fetchGit({
 
         - ref\
           The git ref to look for the requested revision under. This is
-          often a branch or tag name. Defaults to `HEAD`.
+          often a branch or tag name. For remote repositories, this defaults
+          to `HEAD`. If the `url` is a path value, some local changes are
+          included; see `url`.
 
           By default, the `ref` value is prefixed with `refs/heads/`. As
           of Nix 2.3.0 Nix will not prefix `refs/heads/` if `ref` starts
-          with `refs/`.
+          with `refs/`. `HEAD` is also not prefixed.
 
         - submodules\
           A Boolean parameter that specifies whether submodules should be


### PR DESCRIPTION
Motivation
========

This PR makes `builtins.fetchGit` more secure and reproducible by using the clean version of the files.

Previously, only remotely fetched files would be in their clean state. With this change, files from local repositories will also be clean instead of smudged.

This also fixes the documentation which was wrong about the default behavior for `ref` (not HEAD when local).

Background
==========

Git filters allow the user to change how files are represented
in the worktree.
On checkout, the configured smudge converts blobs to files in the worktree.
On checkin, the configured clean command converts files back into blobs.

Notable uses include
 - allow the user to work with a platform-specific representation, conveniently
 - git-crypt: only allow some users to see file contents, transparently
 - git-lfs: work with large files without inflating the repository

See also https://git-scm.com/docs/gitattributes#_filter

Why ignore filters
==================

To quote the git docs

> the intent is that if someone unsets the filter driver definition, or
> does not have the appropriate filter program, the project should still
> be usable.

So the feature was designed to be optional. This confirms that we have a
choice. Let's look at the individual use cases.

Allow the user to work with a platform-specific representation
--------------------------------------------------------------

While this might seem convenient, any such processing can also be done in
`postUnpack`, so it isn't necessary here.
Tarballs from GitHub and such don't apply the smudge filter either, so if
the project is going to be packaged in Nixpkgs, it will have to process its
files like this anyway.
The real kicker here is that running the smudge filter creates an
unreproducible dependency, because the filter does not come from a pinned
immutable source and it could inject information from arbitrary sources.

Git-crypt
---------

The nix store can be read by any process on the system, or in some cases,
when using a cache, literally world-readable.
Running the filters in fetchGit would essentially make impossible the use of
git-crypt and Nix flakes in the same repository.
Even without flakes (or with changes to the flakes feature for that matter),
the software you want to build generally does not depend on credentials, so
not decrypting is not only a secure default, but a good one.
In a rare case where a build does not to decrypt a git-crypted file, one could
still pass the decrypted file or the git-crypt key explicitly (at the cost of
exposing it in the store, which is inevitable for nix-built paths).

Git LFS
-------

Git LFS was designed to prevent excessive bloat in a repository, so the
"smudged" versions of these files will be huge.

If we were to include these directly in the `fetchGit` output, this creates
copies of all the large files for each commit we check out, or even for
each uncommitted but built local change (with fetchGit ./.).

In many cases, those files may not even be used in the build process. If
they are required, it seems feasible to fetch them explicitly with a
fetcher that fetches from LFS based on the sha256 in the unsmudged files.
It is more fine grained than downloading all LFS files and it does not even
require IFD because it happens after fetchGit, which runs at evaluation time.

If for some reason LFS support can not be achieved in Nix expressions, we
should add support for LFS itself, without running any other filters.

Conclusion
==========

Not running the filters is more reproducible, secure and potentially more
efficient than running them.