### PR TITLE
nix-shell: set MANPATH when --packages is used

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -262,10 +262,12 @@ static void main_nix_build(int argc, char * * argv)
 
     if (packages) {
         std::ostringstream joined;
-        joined << "with import <nixpkgs> { }; (pkgs.runCommandCC or pkgs.runCommand) \"shell\" { buildInputs = [ ";
+        joined << "with import <nixpkgs> { }; let packages = [ ";
         for (const auto & i : left)
             joined << '(' << i << ") ";
-        joined << "]; } \"\"";
+        joined << "]; in (pkgs.runCommandCC or pkgs.runCommand) \"shell\" { buildInputs = packages; ";
+        joined << "MANPATH = lib.makeSearchPath \"share/man\" (lib.flatten (builtins.map (p: [ (lib.getMan p) (lib.getOutput \"devman\" p) ]) packages)); ";
+        joined << "} \"\"";
         fromArgs = true;
         left = {joined.str()};
     } else if (!fromArgs) {
@@ -448,13 +450,15 @@ static void main_nix_build(int argc, char * * argv)
                 "shopt -u nullglob; "
                 "unset TZ; %6%"
                 "shopt -s execfail;"
-                "%7%",
+                "MANPATH=$MANPATH%7%; "
+                "%8%",
                 shellEscape(tmpDir),
                 (pure ? "" : "p=$PATH; "),
                 (pure ? "" : "PATH=$PATH:$p; unset p; "),
                 shellEscape(dirOf(*shell)),
                 shellEscape(*shell),
                 (getenv("TZ") ? (string("export TZ=") + shellEscape(getenv("TZ")) + "; ") : ""),
+                ((pure || !getenv("MANPATH")) ? "" : (string(":") + getenv("MANPATH"))),
                 envCommand));
 
         Strings envStrs;

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -42,7 +42,7 @@ nix_tests = \
   build.sh \
   compute-levels.sh \
   ca/build.sh \
-  ca/substitute.sh
+  ca/substitute.sh \
   ca/signatures.sh \
   ca/nix-copy.sh
   # parallel.sh


### PR DESCRIPTION
Setting MANPATH allows man viewers to reliably find man pages which are
contained in the store paths of the packages passed to nix-shell -p.
Running nix-shell -p package --run "man package" is something that
one generally would assume should work which this change allows for.

Currently nix-shell -p package --run "man somepage" only works
occasionally and only due to a behavior of GNU's man-db that is not
documented: It tries to guess the man directory corresponding to every
entry in PATH which only works if the packages added to nix-shell have a
`bin` directory that gets added to PATH and is not supported by other
man page viewers like mandoc.

The simplest way to achieve this is setting MANPATH in the derivation
and utilizing lib.makeSearchPath and lib.getOutput to construct the
actual MANPATH. For outputs, we consider the `man` and `devman` outputs
and fall back to `out` if they are missing (the current code results in
a duplicate entries for many packages in MANPATH for the sake of
simplicity).

---

I'm also interested in implementing this for `nix shell`, however since `Installables` are always just the default output (i. e. `drv."${drv.outputName}"`) this is trickier since we'd also need the `man` or even `devman` output to implement this correctly.