### PR TITLE
tests/local.mk: fix missing newline escape

### DIFF
--- a/tests/local.mk
+++ b/tests/local.mk
@@ -42,7 +42,7 @@ nix_tests = \
   build.sh \
   compute-levels.sh \
   ca/build.sh \
-  ca/substitute.sh
+  ca/substitute.sh \
   ca/signatures.sh \
   ca/nix-copy.sh
   # parallel.sh


### PR DESCRIPTION
Fixes syntax error introduced in 54ced9072b94515a756e1e8e76c92a42f0ccf366.

Thanks to @sternenseemann for spotting this
