### PR TITLE
Remove unimplemented hashAlgoOpt

### DIFF
--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -52,7 +52,7 @@ struct DerivationOutput
         DerivationOutputCAFloating,
         DerivationOutputDeferred
     > output;
-    std::optional<HashType> hashAlgoOpt(const Store & store) const;
+
     /* Note, when you use this function you should make sure that you're passing
        the right derivation name. When in doubt, you should use the safer
        interface provided by BasicDerivation::outputsAndOptPaths */


### PR DESCRIPTION
It was in the header but never implemented.

Found this after trying to troubleshoot linking errors in Cabal :facepalm: 