### PR TITLE
Make `warn` method respect logging verbosity

### DIFF
--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -208,6 +208,8 @@ extern Verbosity verbosity; /* suppress msgs > this */
 template<typename... Args>
 inline void warn(const std::string & fs, const Args & ... args)
 {
+    if (nix::verbosity < lvlWarn) return;
+
     boost::format f(fs);
     formatHelper(f, args...);
     logger->warn(f.str());


### PR DESCRIPTION
Currently, the `warn` method does not respect the logging verbosity as set by the `--verbose` and `--quiet` parameters. This pull request fixes this.