### PR TITLE
Show skipped tests and strictDeps = true

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,8 @@
             buildPackages.git
             buildPackages.mercurial
             buildPackages.jq
-          ];
+          ]
+          ++ lib.optionals stdenv.isLinux [(pkgs.util-linuxMinimal or pkgs.utillinuxMinimal)];
 
         buildDeps =
           [ curl
@@ -90,7 +91,7 @@
             lowdown
             gmock
           ]
-          ++ lib.optionals stdenv.isLinux [libseccomp (pkgs.util-linuxMinimal or pkgs.utillinuxMinimal)]
+          ++ lib.optionals stdenv.isLinux [libseccomp]
           ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
           ++ lib.optional stdenv.isx86_64 libcpuid;
 

--- a/flake.nix
+++ b/flake.nix
@@ -233,6 +233,8 @@
 
           separateDebugInfo = true;
 
+          strictDeps = true;
+
           passthru.perl-bindings = with final; stdenv.mkDerivation {
             name = "nix-perl-${version}";
 
@@ -517,6 +519,8 @@
           installCheckFlags = "sysconfdir=$(out)/etc";
 
           stripAllList = ["bin"];
+
+          strictDeps = true;
         };
       });
 

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -1,5 +1,5 @@
-if ! canUseSandbox; then exit; fi
-if ! [[ $busybox =~ busybox ]]; then exit; fi
+if ! canUseSandbox; then exit 99; fi
+if ! [[ $busybox =~ busybox ]]; then exit 99; fi
 
 unset NIX_STORE_DIR
 unset NIX_STATE_DIR

--- a/tests/gc-runtime.sh
+++ b/tests/gc-runtime.sh
@@ -4,7 +4,7 @@ case $system in
     *linux*)
         ;;
     *)
-        exit 0;
+        exit 99;
 esac
 
 set -m # enable job control, needed for kill

--- a/tests/linux-sandbox.sh
+++ b/tests/linux-sandbox.sh
@@ -2,13 +2,13 @@ source common.sh
 
 clearStore
 
-if ! canUseSandbox; then exit; fi
+if ! canUseSandbox; then exit 99; fi
 
 # Note: we need to bind-mount $SHELL into the chroot. Currently we
 # only support the case where $SHELL is in the Nix store, because
 # otherwise things get complicated (e.g. if it's in /bin, do we need
 # /lib as well?).
-if [[ ! $SHELL =~ /nix/store ]]; then exit; fi
+if [[ ! $SHELL =~ /nix/store ]]; then exit 99; fi
 
 chmod -R u+w $TEST_ROOT/store0 || true
 rm -rf $TEST_ROOT/store0

--- a/tests/recursive.sh
+++ b/tests/recursive.sh
@@ -1,7 +1,7 @@
 source common.sh
 
 # FIXME
-if [[ $(uname) != Linux ]]; then exit; fi
+if [[ $(uname) != Linux ]]; then exit 99; fi
 
 clearStore
 

--- a/tests/shell.sh
+++ b/tests/shell.sh
@@ -6,7 +6,7 @@ clearCache
 nix shell -f shell-hello.nix hello -c hello | grep 'Hello World'
 nix shell -f shell-hello.nix hello -c hello NixOS | grep 'Hello NixOS'
 
-if ! canUseSandbox; then exit; fi
+if ! canUseSandbox; then exit 99; fi
 
 chmod -R u+w $TEST_ROOT/store0 || true
 rm -rf $TEST_ROOT/store0


### PR DESCRIPTION
I wanted to check the assumption that `utillinuxMinimal` is placed correctly in `buildInputs` rather than `nativeBuildInputs` because of https://github.com/NixOS/nixpkgs/pull/117295
To my surprise, Nix builds the same with `strictDeps`, despite the fact that it should be in `nativeBuildInputs` in order to run (`unshare` during tests), at least to my understanding. `utillinuxMinimal` outputs do not appear in the output closure either, which also seems to suggest that it should be in `nativeBuildInputs`.

@Ericson2314 should `utillinuxMinimal` move to `nativeBuildInputs`? Why doesn't this PR break the build?