### PR TITLE
Traverse symlinked path components in import

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -605,23 +605,13 @@ Path resolveExprPath(Path path)
 {
     assert(path[0] == '/');
 
-    unsigned int followCount = 0, maxFollow = 1024;
-
-    /* If `path' is a symlink, follow it.  This is so that relative
+    /* Expand all symlinks in `path`. This is so that relative
        path references work. */
-    struct stat st;
-    while (true) {
-        // Basic cycle/depth limit to avoid infinite loops.
-        if (++followCount >= maxFollow)
-            throw Error("too many symbolic links encountered while traversing the path '%s'", path);
-        st = lstat(path);
-        if (!S_ISLNK(st.st_mode)) break;
-        path = absPath(readLink(path), dirOf(path));
-    }
+    path = absPath(path, {}, true);
 
     /* If `path' refers to a directory, append `/default.nix'. */
-    if (S_ISDIR(st.st_mode))
-        path = canonPath(path + "/default.nix");
+    if (getFileType(path) == DT_DIR)
+        path = canonPath(path + "/default.nix", true);
 
     return path;
 }

--- a/tests/check-imports.sh
+++ b/tests/check-imports.sh
@@ -47,10 +47,10 @@ testImportFile $TEST_ROOT/example/dir/subdir/alt-good.nix
 testImportFile $TEST_ROOT/example/dir/subdir
 
 # two-level relative import from path with symlink dir
-# FIXME: testImportFile $TEST_ROOT/example/dir/subdir/import-good.nix
+testImportFile $TEST_ROOT/example/dir/subdir/import-good.nix
 
 # relative traverse of symlink dir
 # FIXME: testImportFile $TEST_ROOT/example/dir/subdir/../good.nix
 
 # dir import with symlinked default.nix
-# FIXME: testImportFile $TEST_ROOT/example/alt-dir
+testImportFile $TEST_ROOT/example/alt-dir

--- a/tests/check-imports.sh
+++ b/tests/check-imports.sh
@@ -1,0 +1,56 @@
+source common.sh
+
+rm -rf $TEST_ROOT/example
+mkdir -p $TEST_ROOT/example/{,alt-}dir
+echo '"good"' > $TEST_ROOT/example/good.nix
+echo '"good"' > $TEST_ROOT/example/dir/alt-good.nix
+echo 'import ../good.nix' > $TEST_ROOT/example/dir/import-good.nix
+echo 'import ./alt-good.nix' > $TEST_ROOT/example/dir/default.nix
+ln -s dir/import-good.nix $TEST_ROOT/example/
+ln -s . $TEST_ROOT/example/dir/subdir
+ln -s good.nix $TEST_ROOT/example/good-link.nix
+ln -s good-link.nix $TEST_ROOT/example/good-link-link.nix
+ln -s ../good.nix $TEST_ROOT/example/dir/good-link.nix
+ln -s ../dir/default.nix $TEST_ROOT/example/alt-dir/
+
+testGoodEval() {
+    test "`nix eval --impure --raw "$@"`" = "good"
+}
+
+testImportFile() {
+    testGoodEval -f "$1"
+    testGoodEval --expr "(import $1)"
+}
+
+# direct import
+testImportFile $TEST_ROOT/example/good.nix
+
+# dir import
+testImportFile $TEST_ROOT/example/dir
+
+# two-level relative import
+testImportFile $TEST_ROOT/example/dir/import-good.nix
+
+# symlink
+testImportFile $TEST_ROOT/example/good-link.nix
+
+# relative symlink
+testImportFile $TEST_ROOT/example/dir/good-link.nix
+
+# two-level symlink
+testImportFile $TEST_ROOT/example/good-link-link.nix
+
+# symlink dir
+testImportFile $TEST_ROOT/example/dir/subdir/alt-good.nix
+
+# symlink dir import
+testImportFile $TEST_ROOT/example/dir/subdir
+
+# two-level relative import from path with symlink dir
+# FIXME: testImportFile $TEST_ROOT/example/dir/subdir/import-good.nix
+
+# relative traverse of symlink dir
+# FIXME: testImportFile $TEST_ROOT/example/dir/subdir/../good.nix
+
+# dir import with symlinked default.nix
+# FIXME: testImportFile $TEST_ROOT/example/alt-dir

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -42,6 +42,7 @@ nix_tests = \
   flakes.sh \
   build.sh \
   compute-levels.sh \
+  check-imports.sh \
   ca/build.sh \
   ca/substitute.sh \
   ca/signatures.sh \


### PR DESCRIPTION
Fix for #2109 

*Note that this will not fix case where symlink is followed by `..` (traverse level up).*