### PR TITLE
[prerequisites]: add JSON lib dependency

### DIFF
--- a/doc/manual/src/installation/prerequisites-source.md
+++ b/doc/manual/src/installation/prerequisites-source.md
@@ -69,3 +69,6 @@
     `--disable-seccomp-sandboxing` option to the `configure` script (Not
     recommended unless your system doesn't support `libseccomp`). To get
     the library, visit <https://github.com/seccomp/libseccomp>.
+ 
+  - Niels Lohmann's [JSON library](https://github.com/nlohmann/json).
+  


### PR DESCRIPTION
The JSON library is apparently needed for configuration parsing (e.g.,in `src/libutil/config.hh`).