### PR TITLE
Fix edge case with doas in multi-user install script

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -633,11 +633,11 @@ configure_shell_profile() {
 
 setup_default_profile() {
     _sudo "to installing a bootstrapping Nix in to the default Profile" \
-          HOME="$ROOT_HOME" "$NIX_INSTALLED_NIX/bin/nix-env" -i "$NIX_INSTALLED_NIX"
+          env HOME="$ROOT_HOME" "$NIX_INSTALLED_NIX/bin/nix-env" -i "$NIX_INSTALLED_NIX"
 
     if [ -z "${NIX_SSL_CERT_FILE:-}" ] || ! [ -f "${NIX_SSL_CERT_FILE:-}" ]; then
         _sudo "to installing a bootstrapping SSL certificate just for Nix in to the default Profile" \
-              HOME="$ROOT_HOME" "$NIX_INSTALLED_NIX/bin/nix-env" -i "$NIX_INSTALLED_CACERT"
+              env HOME="$ROOT_HOME" "$NIX_INSTALLED_NIX/bin/nix-env" -i "$NIX_INSTALLED_CACERT"
         export NIX_SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
     fi
 
@@ -646,7 +646,7 @@ setup_default_profile() {
         # otherwise it will be lost in environments where sudo doesn't pass
         # all the environment variables by default.
         _sudo "to update the default channel in the default profile" \
-            HOME="$ROOT_HOME" NIX_SSL_CERT_FILE="$NIX_SSL_CERT_FILE" "$NIX_INSTALLED_NIX/bin/nix-channel" --update nixpkgs \
+            env HOME="$ROOT_HOME" NIX_SSL_CERT_FILE="$NIX_SSL_CERT_FILE" "$NIX_INSTALLED_NIX/bin/nix-channel" --update nixpkgs \
             || channel_update_failed=1
     fi
 }


### PR DESCRIPTION
In the multi-user install script, it is assumed that `sudo` can parse environment variable declarations, when it infact cannot when `sudo` is provided by `doas`. This pull request fixes this by prepending `env` to the command.
