### PR TITLE
[configure]: Detect the JSON Library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -311,6 +311,20 @@ fi
 AC_SUBST(tarFlags)
 
 
+# Do we have the JSON library?
+AC_ARG_VAR([nlohmann_json_include], [Path to the JSON includes])
+AC_LANG_PUSH(C++)
+    [if test -n "$nlohmann_json_include" ; then
+	CXXFLAGS="-I$nlohmann_json_include $CXXFLAGS" ;
+    fi]
+    AC_CHECK_HEADERS([nlohmann/json_fwd.hpp],[
+	AC_SUBST([CXXFLAGS],[$CXXFLAGS])
+    ],[
+	AC_MSG_ERROR([We need the JSON library from https://github.com/nlohmann/json!])
+    ])
+AC_LANG_POP(C++)
+
+
 AC_ARG_WITH(sandbox-shell, AC_HELP_STRING([--with-sandbox-shell=PATH],
   [path of a statically-linked shell to use as /bin/sh in sandboxes]),
   sandbox_shell=$withval)


### PR DESCRIPTION
This extends the `configure.ac` to check for the presence of the [JSON library](https://github.com/nlohmann/json), and inject an optional extra path into `CXXFGLAGS`.

Follow up to #4684 .

**Note**
This is a draft because it's my first try at _autoconf_ scripting, so I'm eager to get feedback about it. There might be a more idiomatic way to achieve the same outcome, in particular `AC_ARG_VAR` actually creates an output variable, which we are not using.