### PR TITLE
Revert #4595: libfetchers/tarball: Lock on effectiveUrl

### DIFF
--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -145,13 +145,7 @@ DownloadFileResult downloadFile(
     bool immutable,
     const Headers & headers = {});
 
-struct DownloadTarballMeta
-{
-    time_t lastModified;
-    std::string effectiveUrl;
-};
-
-std::pair<Tree, DownloadTarballMeta> downloadTarball(
+std::pair<Tree, time_t> downloadTarball(
     ref<Store> store,
     const std::string & url,
     const std::string & name,

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -207,16 +207,16 @@ struct GitArchiveInputScheme : InputScheme
 
         auto url = getDownloadUrl(input);
 
-        auto [tree, meta] = downloadTarball(store, url.url, "source", true, url.headers);
+        auto [tree, lastModified] = downloadTarball(store, url.url, "source", true, url.headers);
 
-        input.attrs.insert_or_assign("lastModified", uint64_t(meta.lastModified));
+        input.attrs.insert_or_assign("lastModified", uint64_t(lastModified));
 
         getCache()->add(
             store,
             immutableAttrs,
             {
                 {"rev", rev->gitRev()},
-                {"lastModified", uint64_t(meta.lastModified)}
+                {"lastModified", uint64_t(lastModified)}
             },
             tree.storePath,
             true);

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -109,7 +109,7 @@ DownloadFileResult downloadFile(
     };
 }
 
-std::pair<Tree, DownloadTarballMeta> downloadTarball(
+std::pair<Tree, time_t> downloadTarball(
     ref<Store> store,
     const std::string & url,
     const std::string & name,
@@ -127,10 +127,7 @@ std::pair<Tree, DownloadTarballMeta> downloadTarball(
     if (cached && !cached->expired)
         return {
             Tree(store->toRealPath(cached->storePath), std::move(cached->storePath)),
-            {
-                .lastModified = time_t(getIntAttr(cached->infoAttrs, "lastModified")),
-                .effectiveUrl = maybeGetStrAttr(cached->infoAttrs, "effectiveUrl").value_or(url),
-            },
+            getIntAttr(cached->infoAttrs, "lastModified")
         };
 
     auto res = downloadFile(store, url, name, immutable, headers);
@@ -155,7 +152,6 @@ std::pair<Tree, DownloadTarballMeta> downloadTarball(
 
     Attrs infoAttrs({
         {"lastModified", uint64_t(lastModified)},
-        {"effectiveUrl", res.effectiveUrl},
         {"etag", res.etag},
     });
 
@@ -168,10 +164,7 @@ std::pair<Tree, DownloadTarballMeta> downloadTarball(
 
     return {
         Tree(store->toRealPath(*unpackedStorePath), std::move(*unpackedStorePath)),
-        {
-            .lastModified = lastModified,
-            .effectiveUrl = res.effectiveUrl,
-        },
+        lastModified,
     };
 }
 
@@ -230,11 +223,9 @@ struct TarballInputScheme : InputScheme
         return true;
     }
 
-    std::pair<Tree, Input> fetch(ref<Store> store, const Input & _input) override
+    std::pair<Tree, Input> fetch(ref<Store> store, const Input & input) override
     {
-        Input input(_input);
-        auto [tree, meta] = downloadTarball(store, getStrAttr(input.attrs, "url"), "source", false);
-        input.attrs.insert_or_assign("url", meta.effectiveUrl);
+        auto tree = downloadTarball(store, getStrAttr(input.attrs, "url"), "source", false).first;
         return {std::move(tree), input};
     }
 };


### PR DESCRIPTION
This reverts #4595.

Locking on the redirect destination proved to be problematic for some
URLs. For example, GitHub releases downloads redirect to URLs that
expire after some time, which would be broken by this behavior.

Fixes #4672.

We might be able to make a new scheme e.g. `channel` just for the use case mentioned in #4595, but I feel like given the relative minor use case, it would not be worth it.