### PR TITLE
nix shell: set MANPATH for installables that have a man dir

### DIFF
--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -104,16 +104,22 @@ struct CmdShell : InstallablesCommand, RunCommon, MixEnvironment
         setEnviron();
 
         auto unixPath = tokenizeString<Strings>(getEnv("PATH").value_or(""), ":");
+        auto manPath = tokenizeString<Strings>(getEnv("MANPATH").value_or(""), ":");
 
         while (!todo.empty()) {
             auto path = todo.front();
             todo.pop();
             if (!done.insert(path).second) continue;
 
-            if (true)
-                unixPath.push_front(store->printStorePath(path) + "/bin");
+            auto pathString = store->printStorePath(path);
 
-            auto propPath = store->printStorePath(path) + "/nix-support/propagated-user-env-packages";
+            if (accessor->stat(pathString + "/bin").type != FSAccessor::tMissing)
+                unixPath.push_front(pathString + "/bin");
+
+            if (accessor->stat(pathString + "/share/man").type != FSAccessor::tMissing)
+                manPath.push_front(pathString + "/share/man");
+
+            auto propPath = pathString + "/nix-support/propagated-user-env-packages";
             if (accessor->stat(propPath).type == FSAccessor::tRegular) {
                 for (auto & p : tokenizeString<Paths>(readFile(propPath)))
                     todo.push(store->parseStorePath(p));
@@ -121,6 +127,7 @@ struct CmdShell : InstallablesCommand, RunCommon, MixEnvironment
         }
 
         setenv("PATH", concatStringsSep(":", unixPath).c_str(), 1);
+        setenv("MANPATH", concatStringsSep(":", manPath).c_str(), 1);
 
         Strings args;
         for (auto & arg : command) args.push_back(arg);


### PR DESCRIPTION
The major change introduced in this commit is that nix shell will extend
`MANPATH` with the `/share/man` directory of all installables present in the
shell. This means that the support for man pages in nix shell becomes
more portable. Currently man pages are discovered by an undocumented
(at least not in its man page) feature of man-db's `man(1)` which also
checks `PATH` to heuristically find prefixes to search for man pages.
This is not supported by mandoc's `man(1)`, but `MANPATH` is supported by
both.

This allows us to partially revert the changes made in
c87f4b9324b87a059cf760a477177f322bb8dc26 as well: Since we don't need to
rely on man-db's `PATH` behavior for discovering man pages, we can only
add a `bin` directory to `PATH` if it exists.

Tested with both mandoc and man-db:

* `nix shell -f '<nixpkgs>' mblaze -c man mshow`
* `nix shell -f '<nixpkgs>' libunwind.devman -c man libunwind`