### PR TITLE
Fix registerDrvOutput with the daemon

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -887,7 +887,6 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         logger->startWork();
         auto outputId = DrvOutput::parse(readString(from));
         auto outputPath = StorePath(readString(from));
-        auto resolvedDrv = StorePath(readString(from));
         store->registerDrvOutput(Realisation{
             .id = outputId, .outPath = outputPath});
         logger->stopWork();


### PR DESCRIPTION
Resolve a protocol issue that caused the daemon to endlessly wait for some information that the client doesn't ever send
