### PR TITLE
Minor correction to macOS installation guide

### DIFF
--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -234,8 +234,9 @@ as a helpful reference if you run into trouble.
     without a reboot:
     
     ```console
-    $ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B
+    $ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t
     ```
+    (note: use `-B` instead of `-t` on Catalina)
 
 3.  Create the new APFS volume with diskutil:
     


### PR DESCRIPTION
The apfs -B option was renamed -t from Catalina to Big Sur.
Update to reflect for the latest OS.

Related: https://github.com/NixOS/nix/issues/3957
Related: https://github.com/NixOS/nix/commit/fe807904e5e6e56b551f34f3586e69ea6498287c