### PR TITLE
Make `nix shell` fallback to static outputs when needed

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -736,9 +736,18 @@ std::set<RealisedPath> toRealisedPaths(
                                     output.first);
                             auto outputId = DrvOutput{outputHashes.at(output.first), output.first};
                             auto realisation = store->queryRealisation(outputId);
-                            if (!realisation)
-                                throw Error("cannot operate on an output of unbuilt content-addresed derivation '%s'", outputId.to_string());
-                            res.insert(RealisedPath{*realisation});
+                            if (!realisation) {
+                                // TODO: remove this check once #4725 is fixed
+                                // as we’ll have the guaranty that if
+                                // `output.second` exists, then the realisation
+                                // will be there too
+                                if (output.second)
+                                    res.insert(*output.second);
+                                else
+                                    throw Error("cannot operate on an output of unbuilt content-addresed derivation '%s'", outputId.to_string());
+                            } else {
+                                res.insert(RealisedPath{*realisation});
+                            }
                         }
                         else {
                             // If ca-derivations isn't enabled, behave as if


### PR DESCRIPTION
In case of pure input-addressed derivations, the build loop doesn't guaranty that the realisations are stored in the db (if the output paths are already there or can be substituted, the realisations won't be registered). This caused `nix shell` to fail in some cases because it was assuming that the realisations were always existing.

A better (but more involved) fix would probably to ensure that we always register the realisations, but in the meantime this patches the surface issue.

Fix #4721
