### PR TITLE
Get deriver when passing --derivation

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -754,10 +754,8 @@ std::set<RealisedPath> toRealisedPaths(
         if (mode == Realise::Nothing)
             settings.readOnlyMode = true;
 
-        for (auto & i : installables)
-            for (auto & b : i->toDerivedPathsWithHints())
-                if (auto bfd = std::get_if<DerivedPathWithHints::Built>(&b))
-                    res.insert(bfd->drvPath);
+        auto drvPaths = toDerivations(store, installables, true);
+        res.insert(drvPaths.begin(), drvPaths.end());
     }
 
     return res;


### PR DESCRIPTION
This makes Nix look up paths derivations when they are passed as a
store paths. So:

$ nix path-info --derivation /nix/store/0pisd259nldh8yfjvw663mspm60cn5v8-hello-2.10

now gives

/nix/store/qp724w90516n4bk5r9gfb37vzmqdh3z7-hello-2.10.drv

instead of "".

If no deriver is available, Nix now errors instead of silently
ignoring that argument.

/cc @edolstra