### PR TITLE
Add traceContext primop

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -342,6 +342,10 @@ private:
     friend struct ExprSelect;
     friend void prim_getAttr(EvalState & state, const Pos & pos, Value * * args, Value & v);
     friend void prim_match(EvalState & state, const Pos & pos, Value * * args, Value & v);
+
+    bool trackRealisedPaths;
+    std::vector<StorePath> realisedPaths;
+    friend void prim_traceContext(EvalState & state, const Pos & pos, Value * * args, Value & v);
 };
 
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3510,7 +3510,7 @@ void prim_traceContext(EvalState & state, const Pos & pos, Value * * args, Value
 
     state.mkAttrs(v, 2);
 
-    state.forceValueDeep(*args[0]);
+    state.forceValue(*args[0]);
     v.attrs->push_back(Attr(state.sValue, args[0]));
 
     Value * paths = state.allocAttr(v, state.symbols.create("paths"));


### PR DESCRIPTION
This primop lets you get information on paths realised (pathExists,
import, readFile) by Nix. It tracks paths realised in Nix & puts the
results under the "paths" attr. For instance:

```
$ nix eval --impure --expr '(builtins.traceContext (import ./.).outPath)'
{ paths = [ "/nix/store/2mpgi4bvn8py4liv9w3mjxd2c5r7bvv8-source" "/nix/store/3k7i1rdqcgyzjxvqm37hapdidy4ls4s3-source" "/nix/store/kqxic0j6wpsaw2bb51hr1yc1nb1z2xw8-source" ]; value = "/nix/store/3k7i1rdqcgyzjxvqm37hapdidy4ls4s3-source"; }
```

This is an alternative to the --include-eval-refs from
https://github.com/NixOS/nix/pull/3523 & --include-ifd from
https://github.com/NixOS/nix/pull/3506.