### PR TITLE
libutil: allow decompression with none/empty method

### DIFF
--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -186,7 +186,9 @@ struct BrotliDecompressionSink : ChunkedCompressionSink
 
 ref<std::string> decompress(const std::string & method, const std::string & in)
 {
-    if (method == "br") {
+    if (method == "none" || method == "")
+        return make_ref<std::string>(in);
+    else if (method == "br") {
         StringSink ssink;
         auto sink = makeDecompressionSink(method, ssink);
         (*sink)(in);

--- a/src/libutil/tests/compression.cc
+++ b/src/libutil/tests/compression.cc
@@ -17,6 +17,24 @@ namespace nix {
         ASSERT_EQ(*o, "this-is-a-test");
     }
 
+    TEST(decompress, decompressNoneCompressed) {
+        auto method = "none";
+        auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
+        ref<std::string> o = decompress(method, str);
+
+        ASSERT_EQ(*o, str);
+    }
+
+    TEST(decompress, decompressEmptyCompressed) {
+        // Empty-method decompression used e.g. by S3 store
+        // (Content-Encoding == "").
+        auto method = "";
+        auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
+        ref<std::string> o = decompress(method, str);
+
+        ASSERT_EQ(*o, str);
+    }
+
     TEST(decompress, decompressXzCompressed) {
         auto method = "xz";
         auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";


### PR DESCRIPTION
The S3 store relies on the ability to be able to decompress things with
an empty method, because it just passes the value of the Content-Encoding
directly to decompress.

If the file is not compressed, then this will cause the compression
routine to get confused.

This caused NixOS/nixpkgs#120120.