### PR TITLE
nix build: make dry-run to print a json output if --json is enabled

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -54,6 +54,8 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
     {
         auto buildables = build(store, dryRun ? Realise::Nothing : Realise::Outputs, installables, buildMode);
 
+        if (json) logger->cout("%s", derivedPathsWithHintsToJSON(buildables, store).dump());
+
         if (dryRun) return;
 
         if (outLink != "")
@@ -79,8 +81,6 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
                 }
 
         updateProfile(buildables);
-
-        if (json) logger->cout("%s", derivedPathsWithHintsToJSON(buildables, store).dump());
     }
 };
 


### PR DESCRIPTION
Fixes #4747

Before:

```
./outputs/out/bin/nix build --dry-run --experimental-features nix-command --json -f default.nix don't know how to build these paths (may be caused by read-only store access):
  /nix/store/cm7abdds6mr136s5x59d20z5h4c28adw-nix-2.4pre20210423_fe2bf46.drv
```

After:

```
[nix-shell:~/code-root/github.com/NixOS/nix]$ ./outputs/out/bin/nix build --dry-run --experimental-features nix-command --json -f default.nix don't know how to build these paths (may be caused by read-only store access):
  /nix/store/5llx7yykal9jsrj0fkwk3x4fzwy2wahg-nix-2.4pre20210427_7dca9c2.drv
[{"drvPath":"/nix/store/5llx7yykal9jsrj0fkwk3x4fzwy2wahg-nix-2.4pre20210427_7dca9c2.drv","outputs":{"out":"/nix/store/plnsw4ygkgi22rkjxh68ylvyhawwrprs-nix-2.4pre20210427_7dca9c2"}}]
```