### PR TITLE
libstore/derivation-goal: don't raise an error if the only remaining output is a wildcard

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -1292,10 +1292,13 @@ void DerivationGoal::checkPathValidity()
     // If we requested all the outputs via the empty set, we are always fine.
     // If we requested specific elements, the loop above removes all the valid
     // ones, so any that are left must be invalid.
-    if (!wantedOutputsLeft.empty())
-        throw Error("derivation '%s' does not have wanted outputs %s",
-            worker.store.printStorePath(drvPath),
-            concatStringsSep(", ", quoteStrings(wantedOutputsLeft)));
+    if (!wantedOutputsLeft.empty()) {
+        if (!(wantedOutputsLeft.size() == 1 && wantedOutputs.find("*") != wantedOutputs.end())) {
+            throw Error("derivation '%s' does not have wanted outputs %s",
+                worker.store.printStorePath(drvPath),
+                concatStringsSep(", ", quoteStrings(wantedOutputsLeft)));
+        }
+    }
 }
 
 


### PR DESCRIPTION
Since 255d145ba7ac907d1cba8d088da556b591627756, Nix can use wildcards to
query a derivation's output internally, for instance

    /nix/store/zipc1j00q8i30xaylg0fz64lf2ypx752-bash-interactive-4.4-p23.drv!*

This however seems to break the check in `derivation-goal.cc` which
errors if requested outputs aren't present. This can be reproduced on
Nix without this patch by opening a `nix-shell` like this:

    $ nix-shell -A hello
    error: derivation '/nix/store/zipc1j00q8i30xaylg0fz64lf2ypx752-bash-interactive-4.4-p23.drv' does not have wanted outputs '*'

As `*` as a wildcard accepts anything, the error won't be thrown if the
wildcard is the only remainig, "unmatched" output.

cc @Ericson2314 @regnat @edolstra @grahamc 