### PR TITLE
Mark `__impureHostDeps` paths as optional

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -581,7 +581,9 @@ void LocalDerivationGoal::startBuilder()
                 throw Error("derivation '%s' requested impure path '%s', but it was not in allowed-impure-host-deps",
                     worker.store.printStorePath(drvPath), i);
 
-            dirsInChroot[i] = i;
+            /* Allow files in __impureHostDeps to be missing; e.g.
+               macOS 11+ has no /usr/lib/libSystem*.dylib */
+            dirsInChroot[i] = {i, true};
         }
 
 #if __linux__


### PR DESCRIPTION
Starting in macOS 11, the on-disk dylib bundles are no longer available, but nixpkgs needs to be able to keep compatibility with older versions that require `/usr/lib/libSystem.B.dylib` in `__impureHostDeps`. Allow it to keep backwards compatibility with these versions by marking these dependencies as optional.

Fixes #4658.

If you’d like to test out this fix, the following settings should with with nix-darwin:

```nix
{ pkgs, ... }:

{
  nix.package = pkgs.nixFlakes.override (prev: {
    patches = prev.patches or [ ] ++ [
      (pkgs.fetchpatch {
        url = "https://github.com/NixOS/nix/pull/4761.patch";
        sha256 = "1z7s2dkbsd3fk5688s0870k942r8nsnmr140sn5vgjafywihbihb";
      })
    ];
  });

  # Then enable:
  #nix.useSandbox = "relaxed";
}
```