### PR TITLE
Bump version number for `DerivedPath` changes

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -263,7 +263,7 @@ static void writeValidPathInfo(
 static std::vector<DerivedPath> readDerivedPaths(Store & store, unsigned int clientVersion, Source & from)
 {
     std::vector<DerivedPath> reqs;
-    if (GET_PROTOCOL_MINOR(clientVersion) >= 29) {
+    if (GET_PROTOCOL_MINOR(clientVersion) >= 30) {
         reqs = worker_proto::read(store, from, Phantom<std::vector<DerivedPath>> {});
     } else {
         for (auto & s : readStrings<Strings>(from))

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -672,7 +672,7 @@ std::optional<const Realisation> RemoteStore::queryRealisation(const DrvOutput &
 
 static void writeDerivedPaths(RemoteStore & store, ConnectionHandle & conn, const std::vector<DerivedPath> & reqs)
 {
-    if (GET_PROTOCOL_MINOR(conn->daemonVersion) >= 29) {
+    if (GET_PROTOCOL_MINOR(conn->daemonVersion) >= 30) {
         worker_proto::write(store, conn->to, reqs);
     } else {
         Strings ss;

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 29)
+#define PROTOCOL_VERSION (1 << 8 | 30)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 


### PR DESCRIPTION
I guess I misunderstood John's initial explanation about why wildcards
for outputs are sent to older stores[1]. My `nix-daemon` from 2021-03-26
also has version 1.29, but misses the wildcard[2]. So bumping seems to
be the right call.

However this now properly (I guess?) fixes errors like this:

```
$ nix-shell -A hello
error: derivation '/nix/store/zipc1j00q8i30xaylg0fz64lf2ypx752-bash-interactive-4.4-p23.drv' does not have wanted outputs '*'
```

[1] https://github.com/NixOS/nix/pull/4759#issuecomment-830812464
[2] 255d145ba7ac907d1cba8d088da556b591627756

cc @Ericson2314 @edolstra 