### PR TITLE
Add ignored_acls setting

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -805,6 +805,15 @@ public:
           may be useful in certain scenarios (e.g. to spin up containers or
           set up userspace network interfaces in tests).
         )"};
+
+    Setting<StringSet> ignoredAcls{
+        this, {"security.selinux"}, "ignored-acls",
+        R"(
+          A list of ACLs that should be ignored, normally Nix attempts to
+          remove all ACLs from files and directories in the Nix store, but
+          some ACLs like `security.selinux` or `system.nfs4_acl` can't be
+          removed even by root. Therefore it's best to just ignore them.
+        )"};
 #endif
 
     Setting<Strings> hashedMirrors{

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -583,9 +583,7 @@ static void canonicalisePathMetaData_(const Path & path, uid_t fromUid, InodesSe
             throw SysError("querying extended attributes of '%s'", path);
 
         for (auto & eaName: tokenizeString<Strings>(std::string(eaBuf.data(), eaSize), std::string("\000", 1))) {
-            /* Ignore SELinux security labels since these cannot be
-               removed even by root. */
-            if (eaName == "security.selinux") continue;
+            if (settings.ignoredAcls.get().count(eaName)) continue;
             if (lremovexattr(path.c_str(), eaName.c_str()) == -1)
                 throw SysError("removing extended attribute '%s' from '%s'", eaName, path);
         }


### PR DESCRIPTION
This PR adds a `ignored-acls` setting to `nix.conf`, which makes it possible to ignore certain ACLs, like the ones added by selinux or nfs.

Fixes and closes https://github.com/NixOS/nixpkgs/issues/29778

Signed-off-by: Magic_RB <magic_rb@redalder.org>