### PR TITLE
install: Fix hash variable for Darwin.arm64

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -51,7 +51,7 @@ case "$(uname -s).$(uname -m)" in
           oops "Rosetta 2 is not installed on this ARM64 macOS machine. Run softwareupdate --install-rosetta then restart installation"
         fi
 
-        hash=@binaryTarball_x86_64-darwin@
+        hash=@tarballHash_x86_64-darwin@
         path=@tarballPath_x86_64-darwin@
         # eventually maybe: arm64-darwin
         system=x86_64-darwin


### PR DESCRIPTION
When commit 233b61d3d6482544c35b9d340240bf3260acff13 (#4224) renamed `@binaryTarball_${system}@` to `@tarballHash_${system}@`, it updated this reference for every platform except Darwin.arm64.

Cc @zimbatm.