### PR TITLE
launchd: Use exec to avoid leaving the extra shell wrapper running

### DIFF
--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -19,7 +19,7 @@
     <array>
       <string>/bin/sh</string>
       <string>-c</string>
-      <string>/bin/wait4path /nix/var/nix/profiles/default/bin/nix-daemon &amp;&amp; /nix/var/nix/profiles/default/bin/nix-daemon</string>
+      <string>/bin/wait4path /nix/var/nix/profiles/default/bin/nix-daemon &amp;&amp; exec /nix/var/nix/profiles/default/bin/nix-daemon</string>
     </array>
     <key>StandardErrorPath</key>
     <string>/var/log/nix-daemon.log</string>


### PR DESCRIPTION
Before:

```
  UID   PID  PPID   C STIME   TTY           TIME CMD
    0  1737     1   0  2:28PM ??         0:00.00 /bin/sh -c /bin/wait4path /nix/var/nix/profiles/default/bin/nix-daemon && /nix/var/nix/profiles/default/bin/nix-daemon
    0  1739  1737   0  2:28PM ??         0:00.05 /nix/var/nix/profiles/default/bin/nix-daemon
```

After:

```
  UID   PID  PPID   C STIME   TTY           TIME CMD
    0  1763     1   0  2:29PM ??         0:00.05 /nix/var/nix/profiles/default/bin/nix-daemon
```
