### PR TITLE
Properly normalize the content-addressed paths

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2300,10 +2300,6 @@ void LocalDerivationGoal::registerOutputs()
                 sink.s = make_ref<std::string>(rewriteStrings(*sink.s, outputRewrites));
                 StringSource source(*sink.s);
                 restorePath(actualPath, source);
-
-                /* FIXME: set proper permissions in restorePath() so
-                   we don't have to do another traversal. */
-                canonicalisePathMetaData(actualPath, -1, inodesSeen);
             }
         };
 
@@ -2451,6 +2447,10 @@ void LocalDerivationGoal::registerOutputs()
                 return *(ValidPathInfo*)0;
             },
         }, output.output);
+
+        /* FIXME: set proper permissions in restorePath() so
+            we don't have to do another traversal. */
+        canonicalisePathMetaData(actualPath, -1, inodesSeen);
 
         /* Calculate where we'll move the output files. In the checking case we
            will leave leave them where they are, for now, rather than move to

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -10,3 +10,10 @@ nix build -f multiple-outputs.nix --json a.all b.all | jq --exit-status '
     (.drvPath | match(".*multiple-outputs-b.drv")) and
     (.outputs.out | match(".*multiple-outputs-b")))
 '
+
+testNormalization () {
+    clearStore
+    outPath=$(nix-build ./simple.nix)
+    test "$(stat -c %Y $outPath)" -eq 1
+}
+testNormalization

--- a/tests/ca/build.sh
+++ b/tests/ca/build.sh
@@ -59,9 +59,17 @@ testNixCommand () {
     nix build --experimental-features 'nix-command ca-derivations' --file ./content-addressed.nix --no-link
 }
 
+# Regression test for https://github.com/NixOS/nix/issues/4775
+testNormalization () {
+    clearStore
+    outPath=$(buildAttr rootCA 1)
+    test "$(stat -c %Y $outPath)" -eq 1
+}
+
 # Disabled until we have it properly working
 # testRemoteCache
 clearStore
+testNormalization
 testDeterministicCA
 clearStore
 testCutoff


### PR DESCRIPTION
Make sure that their timestamp are always normalized.  Otherwise, strange − and non-deterministic − things might happen, like https://github.com/NixOS/nixpkgs/issues/121813

Fix #4775
