### PR TITLE
Create parent for trusted list path before writing

### DIFF
--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -22,7 +22,9 @@ static TrustedList readTrustedList()
 
 static void writeTrustedList(const TrustedList & trustedList)
 {
-    writeFile(trustedListPath(), nlohmann::json(trustedList).dump());
+    auto path = trustedListPath();
+    createDirs(dirOf(path));
+    writeFile(path, nlohmann::json(trustedList).dump());
 }
 
 void ConfigFile::apply()


### PR DESCRIPTION
This makes sure that $HOME/.local/share/nix exists before we try to
write to it.