### PR TITLE
buildenv: Create dangling symlinks in environments

### DIFF
--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -41,10 +41,15 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
                 throw SysError("getting status of '%1%'", srcFile);
         } catch (SysError & e) {
             if (e.errNo == ENOENT || e.errNo == ENOTDIR) {
-                warn("skipping dangling symlink '%s'", dstFile);
-                continue;
+                /* Use lstat() to populate srcSt for use with S_ISDIR() below. */
+                if (lstat(srcFile.c_str(), &srcSt) == -1) {
+                    warn("skipping dangling symlink '%s'", dstFile);
+                    continue;
+                }
+                warn("creating dangling symlink '%s'", dstFile);
+            } else {
+                throw;
             }
-            throw;
         }
 
         /* The files below are special-cased to that they don't show up

--- a/tests/user-envs-link.builder.sh
+++ b/tests/user-envs-link.builder.sh
@@ -1,0 +1,2 @@
+mkdir $out
+ln -s $target $out/link

--- a/tests/user-envs.nix
+++ b/tests/user-envs.nix
@@ -17,6 +17,12 @@ let
     };
   });
 
+  danglingLink = mkDerivation {
+    name = "dangling-link";
+    target = builtins.getEnv "TEST_ROOT" + "/somefile";
+    builder = ./user-envs-link.builder.sh;
+  };
+
 in
 
   [
@@ -26,4 +32,5 @@ in
     (makeDrv "foo-2.0" "foo")
     (makeDrv "bar-0.1.1" "bar")
     (makeDrv "foo-0.1" "foo" // { meta.priority = 10; })
+    danglingLink
   ]


### PR DESCRIPTION
Previously the buildenv builder skipped symlinks completely if they couldn't be resolved. And since the builder is running in the Nix sandbox, it can't resolve any links that aren't accessible in the sandbox, even if they would be resolveable outside the sandbox.

This commit changes this behavior: If symlinks can't be resolved, they are still created in the environment, on the assumption that they are resolveable for the end user. A warning during the build is still issued.

- [x] Added a test ensuring that this new behavior can be used
- [x] Tested it manually with
  ```bash
  $ sudo outputs/out/bin/nix-env -p $PWD/profile/main -ri -E \
    '_: (import <nixpkgs> {}).runCommand "l" {} "mkdir $out && ln -s ${toString builtins.currentTime} $out/foo"'
  this derivation will be built:
    /nix/store/gy0rbk15n187irrpfvc4mqrnnbiy2rdh-l.drv
  building '/nix/store/gy0rbk15n187irrpfvc4mqrnnbiy2rdh-l.drv'...
  building '/nix/store/a9cm6361zlz0hd3zlhbrm6n7vsxz705k-user-environment.drv'...
  warning: creating dangling symlink '/nix/store/4avrk1xyp0bk57347pg3sc8qyzi7f9l5-user-environment/foo'
  $ realpath profile/main/foo/
  /nix/store/q3kvm0gk4w8z8mah9vgh2myf61abmak9-l/1620672396
  ```
  (`sudo` so that not my older nix-daemon version is used)