### PR TITLE
Don’t source bashrc in pure mode

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -412,7 +412,7 @@ static void _main(int argc, char * * argv)
         auto rcfile = (Path) tmpDir + "/rc";
         writeFile(rcfile, fmt(
                 (keepTmp ? "" : "rm -rf '%1%'; "s) +
-                "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc; "
+                (pure ? "" : "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;") +
                 "%2%"
                 "dontAddDisableDepTrack=1; "
                 "[ -e $stdenv/setup ] && source $stdenv/setup; "


### PR DESCRIPTION
Pure mode should not try to source the user’s bashrc file. These may
have many impurities that the user does not expect to get into their
shell.

Fixes #3090

(cherry picked from commit 65f6d5db6f5ef2724a3dc03e1773c510123287f1)

Rationale for backport: on $project we were kinda confused why a shell wasn't as pure as we expected it to be. Since `.bashrc` was used to introduce a lot of settings that interfered with the environment we needed, this is IMHO a bugfix and should be part of the next 2.3 release as well.

cc @edolstra @matthewbauer @lheckemann 