### PR TITLE
doc/nix-shell: Remove outdated bashrc information

### DIFF
--- a/doc/manual/src/command-ref/nix-shell.md
+++ b/doc/manual/src/command-ref/nix-shell.md
@@ -78,9 +78,7 @@ All options not listed here are passed to `nix-store
     cleared before the interactive shell is started, so you get an
     environment that more closely corresponds to the “real” Nix build. A
     few variables, in particular `HOME`, `USER` and `DISPLAY`, are
-    retained. Note that (depending on your Bash
-    installation) `/etc/bashrc` is still sourced, so any variables set
-    there will affect the interactive shell.
+    retained.
 
   - `--packages` / `-p` *packages*…\
     Set up an environment in which the specified packages are present.


### PR DESCRIPTION
This behaviour was removed in 65f6d5db6f5ef2724a3dc03e1773c510123287f1.