### PR TITLE
Filter ANSI codes when piping nix commands

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -464,7 +464,10 @@ public:
             Logger::writeToStdout(s);
             draw(*state);
         } else {
-            Logger::writeToStdout(s);
+            if (isTTY)
+                Logger::writeToStdout(s);
+            else
+                Logger::writeToStdout(filterANSIEscapes(std::string(s), true));
         }
     }
 
@@ -484,7 +487,7 @@ Logger * makeProgressBar(bool printBuildLogs)
 {
     return new ProgressBar(
         printBuildLogs,
-        isatty(STDERR_FILENO) && getEnv("TERM").value_or("dumb") != "dumb"
+        isatty(STDERR_FILENO) && isatty(STDOUT_FILENO) && getEnv("TERM").value_or("dumb") != "dumb"
     );
 }
 

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -140,11 +140,11 @@ public:
     void log(State & state, Verbosity lvl, const std::string & s)
     {
         if (state.active) {
-            writeToStderr("\r\e[K" + filterANSIEscapes(s, !isTTY) + ANSI_NORMAL "\n");
+            writeToStderr("\r\e[K" + filterANSIEscapes(s, loggerSettings.filterStderrAnsi.get()) + ANSI_NORMAL "\n");
             draw(state);
         } else {
             auto s2 = s + ANSI_NORMAL "\n";
-            if (!isTTY) s2 = filterANSIEscapes(s2, true);
+            if (loggerSettings.filterStderrAnsi.get()) s2 = filterANSIEscapes(s2, true);
             writeToStderr(s2);
         }
     }
@@ -464,10 +464,10 @@ public:
             Logger::writeToStdout(s);
             draw(*state);
         } else {
-            if (isTTY)
-                Logger::writeToStdout(s);
-            else
+            if (loggerSettings.filterStdoutAnsi.get())
                 Logger::writeToStdout(filterANSIEscapes(std::string(s), true));
+            else
+                Logger::writeToStdout(s);
         }
     }
 
@@ -487,7 +487,7 @@ Logger * makeProgressBar(bool printBuildLogs)
 {
     return new ProgressBar(
         printBuildLogs,
-        isatty(STDERR_FILENO) && isatty(STDOUT_FILENO) && getEnv("TERM").value_or("dumb") != "dumb"
+        isatty(STDERR_FILENO) && getEnv("TERM").value_or("dumb") != "dumb"
     );
 }
 

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -39,15 +39,13 @@ class SimpleLogger : public Logger
 {
 public:
 
-    bool systemd, stderrTty, stdoutTty;
+    bool systemd;
     bool printBuildLogs;
 
     SimpleLogger(bool printBuildLogs)
         : printBuildLogs(printBuildLogs)
     {
         systemd = getEnv("IN_SYSTEMD") == "1";
-        stderrTty = isatty(STDERR_FILENO);
-        stdoutTty = isatty(STDOUT_FILENO);
     }
 
     bool isVerbose() override {
@@ -72,7 +70,7 @@ public:
             prefix = std::string("<") + c + ">";
         }
 
-        writeToStderr(prefix + filterANSIEscapes(fs.s, !stderrTty) + "\n");
+        writeToStderr(prefix + filterANSIEscapes(fs.s, loggerSettings.filterStderrAnsi.get()) + "\n");
     }
 
     void logEI(const ErrorInfo & ei) override
@@ -105,7 +103,10 @@ public:
 
     void writeToStdout(std::string_view s) override
     {
-        Logger::writeToStdout(stdoutTty ? s : filterANSIEscapes(std::string(s), true));
+        if (loggerSettings.filterStdoutAnsi.get())
+            Logger::writeToStdout(filterANSIEscapes(std::string(s), true));
+        else
+            Logger::writeToStdout(s);
     }
 
 };

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -43,6 +43,18 @@ struct LoggerSettings : Config
           Where Nix should print out a stack trace in case of Nix
           expression evaluation errors.
         )"};
+
+    Setting<bool> filterStdoutAnsi{
+        this, getEnv("CLICOLOR_FORCE").value_or("0") != "1" && (getEnv("CLICOLOR").value_or("1") == "0" || !isatty(STDOUT_FILENO)), "filter-stdout-ansi",
+        R"(
+          Whether color should be filtered in logger stdout output.
+        )"};
+
+    Setting<bool> filterStderrAnsi{
+        this, getEnv("CLICOLOR_FORCE").value_or("0") != "1" && (getEnv("CLICOLOR").value_or("1") == "0" || !isatty(STDERR_FILENO)), "filter-stderr-ansi",
+        R"(
+          Whether color should be filtered in logger stderr output.
+        )"};
 };
 
 extern LoggerSettings loggerSettings;


### PR DESCRIPTION
This removes \e[... codes from sequences so that commands like

  nix search > ~/out.list

Don’t retain the ANSI formating.