### PR TITLE
Add nix search --all

### DIFF
--- a/src/nix/search.md
+++ b/src/nix/search.md
@@ -5,7 +5,7 @@ R""(
 * Show all packages in the `nixpkgs` flake:
 
   ```console
-  # nix search nixpkgs
+  # nix search -a nixpkgs
   * legacyPackages.x86_64-linux.AMB-plugins (0.8.1)
     A set of ambisonics ladspa plugins
 
@@ -34,7 +34,7 @@ R""(
 * Show all packages in the flake in the current directory:
 
   ```console
-  # nix search
+  # nix search -a
   ```
 
 * Search for Firefox or Chromium:
@@ -56,8 +56,7 @@ flake) for packages whose name or description matches all of the
 regular expressions *regex*.  For each matching package, It prints the
 full attribute name (from the root of the installable), the version
 and the `meta.description` field, highlighting the substrings that
-were matched by the regular expressions. If no regular expressions are
-specified, all packages are shown.
+were matched by the regular expressions.
 
 # Flake output attributes
 

--- a/tests/search.sh
+++ b/tests/search.sh
@@ -19,10 +19,10 @@ clearCache
 
 ## Search expressions
 
-# Check that empty search string matches all
-nix search -f search.nix '' |grep -q foo
-nix search -f search.nix '' |grep -q bar
-nix search -f search.nix '' |grep -q hello
+# Check that '--all' flag matches all
+nix search -af search.nix |grep -q foo
+nix search --all -f search.nix |grep -q bar
+nix search -af search.nix |grep -q hello
 
 ## Tests for multiple regex/match highlighting
 


### PR DESCRIPTION
Since calling nix search without a search string is likely to occur by mistake it should not try to match for all packages.
Given how long particular full searches can take a full match should occur from the '--all' flag.
Instead, empty searches now throw an error to the user.

Closes issues #4739 and #3553

(Note: for #3553 I opted to make nix-search throw an error on an empty search instead of show the help message due to it being an InstallableCommand, which meant that it would only show the help message if there was a flake in the current directory and throw an error otherwise. )