### PR TITLE
sandbox: allow SystemVersionCompat.plist on Darwin

### DIFF
--- a/src/libstore/sandbox-defaults.sb
+++ b/src/libstore/sandbox-defaults.sb
@@ -32,7 +32,9 @@
        (literal "/tmp") (subpath TMPDIR))
 
 ; Some packages like to read the system version.
-(allow file-read* (literal "/System/Library/CoreServices/SystemVersion.plist"))
+(allow file-read*
+       (literal "/System/Library/CoreServices/SystemVersion.plist")
+       (literal "/System/Library/CoreServices/SystemVersionCompat.plist"))
 
 ; Without this line clang cannot write to /dev/null, breaking some configure tests.
 (allow file-read-metadata (literal "/dev"))


### PR DESCRIPTION
For whatever reason, many programs trying to access SystemVersion.plist also open SystemVersionCompat.plist; this includes Python code and coreutils’ `cat(1)` (but not the native macOS `/bin/cat`). Illustratory `dtruss(1m)` output:

    open("/System/Library/CoreServices/SystemVersion.plist\0", 0x0, 0x0)		 = 3 0
    open("/System/Library/CoreServices/SystemVersionCompat.plist\0", 0x0, 0x0)		 = 4 0

I assume this is a Big Sur change relating to the 10.16.x/11.x version compatibility divide and that it’s something along the lines of a hook inside libSystem.

Fixes a lot of sandboxed package builds under Big Sur.

I started by trying to just patch things to not impurely require the system version but it’d be a big `staging` PR and a lot of patching, so this restores the previous status quo for now.