### PR TITLE
Split the parsing of an `App` and its resolving

### DIFF
--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -23,6 +23,12 @@ struct App
     // FIXME: add args, sandbox settings, metadata, ...
 };
 
+struct UnresolvedApp
+{
+    App unresolved;
+    App resolve(ref<Store>);
+};
+
 struct Installable
 {
     virtual ~Installable() { }
@@ -33,7 +39,7 @@ struct Installable
 
     DerivedPath toDerivedPath();
 
-    App toApp(EvalState & state);
+    UnresolvedApp toApp(EvalState & state);
 
     virtual std::pair<Value *, Pos> toValue(EvalState & state)
     {

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -69,8 +69,7 @@ struct CmdBundle : InstallableCommand
     {
         auto evalState = getEvalState();
 
-        auto app = installable->toApp(*evalState);
-        store->buildPaths(toDerivedPaths(app.context));
+        auto app = installable->toApp(*evalState).resolve(store);
 
         auto [bundlerFlakeRef, bundlerName] = parseFlakeRefWithFragment(bundler, absPath("."));
         const flake::LockFlags lockFlags{ .writeLockFile = false };

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -178,9 +178,7 @@ struct CmdRun : InstallableCommand, RunCommon
     {
         auto state = getEvalState();
 
-        auto app = installable->toApp(*state);
-
-        state->store->buildPaths(toDerivedPaths(app.context));
+        auto app = installable->toApp(*state).resolve(store);
 
         Strings allArgs{app.program};
         for (auto & i : args) allArgs.push_back(i);


### PR DESCRIPTION
That way things (like `nix flake check`) can evaluate the `app` outputs without having to build anything

Follow-up of https://github.com/NixOS/nix/pull/4819
