### PR TITLE
Source bashrc first in nix develop

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -395,7 +395,7 @@ struct CmdDevelop : Common, MixEnvironment
         if (verbosity >= lvlDebug)
             script += "set -x\n";
 
-        script += fmt("rm -f '%s'\n", rcFilePath);
+        script += fmt("command rm -f '%s'\n", rcFilePath);
 
         if (phase) {
             if (!command.empty())
@@ -414,7 +414,7 @@ struct CmdDevelop : Common, MixEnvironment
         }
 
         else {
-            script += "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\n";
+            script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\n" + script;
             if (developSettings.bashPrompt != "")
                 script += fmt("[ -n \"$PS1\" ] && PS1=%s;\n", shellEscape(developSettings.bashPrompt));
             if (developSettings.bashPromptSuffix != "")


### PR DESCRIPTION
~/.bashrc should be sourced first in the rc script so that PATH &
other env vars give precedence over the bashrc PATH.

Also, in my bashrc I alias rm as:

  alias rm='rm -Iv'

To avoid running this alias (which shows ‘removed '/tmp/nix-shell.*'),
we can just prefix rm with command.