### PR TITLE
Restore an accidentally suppressed negation

### DIFF
--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -112,7 +112,7 @@ App UnresolvedApp::resolve(ref<Store> store)
 
     auto builtContext = build(store, Realise::Outputs, installableContext);
     res.program = resolveString(*store, unresolved.program, builtContext);
-    if (store->isInStore(res.program))
+    if (!store->isInStore(res.program))
         throw Error("app program '%s' is not in the Nix store", res.program);
 
     return res;


### PR DESCRIPTION
Accidentally removed in ca96f5219489c1002499bfe2c580fdd458219144. This caused `nix run` to systematically fail with

```
error: app program '/nix/store/…' is not in the Nix store
```
