### PR TITLE
Fix extra slash in canonPath output

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -155,6 +155,9 @@ Path canonPath(const Path & path, bool resolveSymlinks)
                     s.clear();  /* restart for symlinks pointing to absolute path */
                 } else {
                     s = dirOf(s);
+                    if (s == "/") {  // we don’t want trailing slashes here, which dirOf only produces if s = /
+                        s.clear();
+                    }
                 }
             }
         }


### PR DESCRIPTION
When you have a symlink like:

  /tmp -> ./private/tmp

you need to resolve ./private/tmp relative to /tmp’s dir: ‘/’. Unlike
any other path output by dirOf, / ends with a slash. We don’t want
trailing slashes here since we will append another slash in the next
comoponent, so clear s like we would if it was a symlink to an absoute
path.

This should fix at least part of the issue in
https://github.com/NixOS/nix/issues/4822, will need confirmation that
it actually fixes the problem to close though.

Introduced in f3f228700a52857fe6e8632df4e935551ea219ff.

/cc @ony @edolstra