### PR TITLE
Track the dependencies of CA realisations

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -927,6 +927,7 @@ void DerivationGoal::resolvedFinished() {
             auto newRealisation = *realisation;
             newRealisation.id = DrvOutput{initialOutputs.at(wantedOutput).outputHash, wantedOutput};
             newRealisation.signatures.clear();
+            newRealisation.drvOutputDeps = drvOutputReferences(worker.store, *drv, realisation->outPath);
             signRealisation(newRealisation);
             worker.store.registerDrvOutput(newRealisation);
         } else {

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -927,7 +927,7 @@ void DerivationGoal::resolvedFinished() {
             auto newRealisation = *realisation;
             newRealisation.id = DrvOutput{initialOutputs.at(wantedOutput).outputHash, wantedOutput};
             newRealisation.signatures.clear();
-            newRealisation.drvOutputDeps = drvOutputReferences(worker.store, *drv, realisation->outPath);
+            newRealisation.dependentRealisations = drvOutputReferences(worker.store, *drv, realisation->outPath);
             signRealisation(newRealisation);
             worker.store.registerDrvOutput(newRealisation);
         } else {

--- a/src/libstore/ca-specific-schema.sql
+++ b/src/libstore/ca-specific-schema.sql
@@ -3,10 +3,19 @@
 -- is enabled
 
 create table if not exists Realisations (
+    id integer primary key autoincrement not null,
     drvPath text not null,
     outputName text not null, -- symbolic output id, usually "out"
     outputPath integer not null,
     signatures text, -- space-separated list
-    primary key (drvPath, outputName),
     foreign key (outputPath) references ValidPaths(id) on delete cascade
+);
+
+create index if not exists IndexRealisations on Realisations(drvPath, outputName);
+
+create table if not exists RealisationsRefs (
+    referrer integer not null,
+    realisationReference integer,
+    foreign key (referrer) references Realisations(id) on delete cascade,
+    foreign key (realisationReference) references Realisations(id) on delete restrict
 );

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -714,10 +714,10 @@ void LocalStore::registerDrvOutput(const Realisation & info)
     retrySQLite<void>([&]() {
         auto state(_state.lock());
         state->stmts->RegisterRealisedOutput.use()
-                (info.id.strHash())
-                (info.id.outputName)
-                (printStorePath(info.outPath))
-                (concatStringsSep(" ", info.signatures))
+            (info.id.strHash())
+            (info.id.outputName)
+            (printStorePath(info.outPath))
+            (concatStringsSep(" ", info.signatures))
             .exec();
         uint64_t myId = state->db.getLastInsertedRowId();
         for (auto & [outputId, _] : info.dependentRealisations) {

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -255,8 +255,8 @@ StorePaths Store::topoSortPaths(const StorePathSet & paths)
 }
 
 std::map<DrvOutput, StorePath> drvOutputReferences(
-    const std::set<Realisation> inputRealisations,
-    const StorePathSet pathReferences)
+    const std::set<Realisation> & inputRealisations,
+    const StorePathSet & pathReferences)
 {
     std::map<DrvOutput, StorePath> res;
 

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -254,25 +254,22 @@ StorePaths Store::topoSortPaths(const StorePathSet & paths)
         }});
 }
 
-std::set<DrvOutput> drvOutputReferences(
+std::map<DrvOutput, StorePath> drvOutputReferences(
     const std::set<Realisation> inputRealisations,
     const StorePathSet pathReferences)
 {
-    std::set<DrvOutput> res;
+    std::map<DrvOutput, StorePath> res;
 
-    std::map<StorePath, std::set<DrvOutput>> inputsByOutputPath;
-    for (const auto & input : inputRealisations)
-        inputsByOutputPath[input.outPath].insert(input.id);
-
-    for (const auto & path : pathReferences) {
-        auto theseInputs = inputsByOutputPath[path];
-        res.insert(theseInputs.begin(), theseInputs.end());
+    for (const auto & input : inputRealisations) {
+        if (pathReferences.count(input.outPath)) {
+            res.insert({input.id, input.outPath});
+        }
     }
 
     return res;
 }
 
-std::set<DrvOutput> drvOutputReferences(
+std::map<DrvOutput, StorePath> drvOutputReferences(
     Store & store,
     const Derivation & drv,
     const StorePath & outputPath)

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -22,10 +22,14 @@ std::string DrvOutput::to_string() const {
 }
 
 nlohmann::json Realisation::toJSON() const {
+    nlohmann::json jsonDrvOutputDeps;
+    for (auto & dep : drvOutputDeps)
+        jsonDrvOutputDeps.push_back(dep.to_string());
     return nlohmann::json{
         {"id", id.to_string()},
         {"outPath", outPath.to_string()},
         {"signatures", signatures},
+        {"drvOutputDeps", jsonDrvOutputDeps},
     };
 }
 
@@ -51,10 +55,16 @@ Realisation Realisation::fromJSON(
     if (auto signaturesIterator = json.find("signatures"); signaturesIterator != json.end())
         signatures.insert(signaturesIterator->begin(), signaturesIterator->end());
 
+    std::set <DrvOutput> drvOutputDeps;
+    if (auto jsonDependencies = json.find("drvOutputDeps"); jsonDependencies != json.end())
+        for (auto & jsonDep : *jsonDependencies)
+            drvOutputDeps.insert(DrvOutput::parse(jsonDep.get<std::string>()));
+
     return Realisation{
         .id = DrvOutput::parse(getField("id")),
         .outPath = StorePath(getField("outPath")),
         .signatures = signatures,
+        .drvOutputDeps = drvOutputDeps,
     };
 }
 

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -22,14 +22,14 @@ std::string DrvOutput::to_string() const {
     return strHash() + "!" + outputName;
 }
 
-std::set<Realisation> Realisation::closure(Store & store, std::set<Realisation> startOutputs)
+std::set<Realisation> Realisation::closure(Store & store, const std::set<Realisation> & startOutputs)
 {
     std::set<Realisation> res;
     Realisation::closure(store, startOutputs, res);
     return res;
 }
 
-void Realisation::closure(Store & store, std::set<Realisation> startOutputs, std::set<Realisation> & res)
+void Realisation::closure(Store & store, const std::set<Realisation> & startOutputs, std::set<Realisation> & res)
 {
     auto getDeps = [&](const Realisation& current) -> std::set<Realisation> {
         std::set<Realisation> res;

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -28,7 +28,13 @@ struct Realisation {
 
     StringSet signatures;
 
-    std::set<DrvOutput> drvOutputDeps;
+    /**
+     * The realisations that are required for the current one to be valid.
+     *
+     * When importing this realisation, the store will first check that all its
+     * dependencies exist, and map to the correct output path
+     */
+    std::map<DrvOutput, StorePath> dependentRealisations;
 
     nlohmann::json toJSON() const;
     static Realisation fromJSON(const nlohmann::json& json, const std::string& whence);

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -28,6 +28,8 @@ struct Realisation {
 
     StringSet signatures;
 
+    std::set<DrvOutput> drvOutputDeps;
+
     nlohmann::json toJSON() const;
     static Realisation fromJSON(const nlohmann::json& json, const std::string& whence);
 

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -44,8 +44,8 @@ struct Realisation {
     bool checkSignature(const PublicKeys & publicKeys, const std::string & sig) const;
     size_t checkSignatures(const PublicKeys & publicKeys) const;
 
-    static std::set<Realisation> closure(Store &, std::set<Realisation>);
-    static void closure(Store &, std::set<Realisation>, std::set<Realisation>& res);
+    static std::set<Realisation> closure(Store &, const std::set<Realisation> &);
+    static void closure(Store &, const std::set<Realisation> &, std::set<Realisation>& res);
 
     StorePath getPath() const { return outPath; }
 

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -38,6 +38,9 @@ struct Realisation {
     bool checkSignature(const PublicKeys & publicKeys, const std::string & sig) const;
     size_t checkSignatures(const PublicKeys & publicKeys) const;
 
+    static std::set<Realisation> closure(Store &, std::set<Realisation>);
+    static void closure(Store &, std::set<Realisation>, std::set<Realisation>& res);
+
     StorePath getPath() const { return outPath; }
 
     GENERATE_CMP(Realisation, me->id, me->outPath);

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -803,8 +803,7 @@ std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStor
                     if (!currentChild)
                         throw Error(
                             "Incomplete realisation closure: '%s' is a "
-                            "dependency "
-                            "of '%s' but isn’t registered",
+                            "dependency of '%s' but isn’t registered",
                             drvOutput.to_string(), current.id.to_string());
                     children.insert(*currentChild);
                 }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -798,7 +798,7 @@ std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStor
             pool, Realisation::closure(*srcStore, toplevelRealisations),
             [&](const Realisation& current) -> std::set<Realisation> {
                 std::set<Realisation> children;
-                for (const auto& drvOutput : current.drvOutputDeps) {
+                for (const auto& [drvOutput, _] : current.dependentRealisations) {
                     auto currentChild = srcStore->queryRealisation(drvOutput);
                     if (!currentChild)
                         throw Error(

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -864,4 +864,9 @@ std::pair<std::string, Store::Params> splitUriAndParams(const std::string & uri)
 
 std::optional<ContentAddress> getDerivationCA(const BasicDerivation & drv);
 
+std::set<DrvOutput> drvOutputReferences(
+    Store & store,
+    const Derivation & drv,
+    const StorePath & outputPath);
+
 }

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -864,7 +864,7 @@ std::pair<std::string, Store::Params> splitUriAndParams(const std::string & uri)
 
 std::optional<ContentAddress> getDerivationCA(const BasicDerivation & drv);
 
-std::set<DrvOutput> drvOutputReferences(
+std::map<DrvOutput, StorePath> drvOutputReferences(
     Store & store,
     const Derivation & drv,
     const StorePath & outputPath);

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 30)
+#define PROTOCOL_VERSION (1 << 8 | 31)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 

--- a/src/nix/profile-upgrade.md
+++ b/src/nix/profile-upgrade.md
@@ -18,7 +18,7 @@ R""(
 * Upgrade a specific profile element by number:
 
   ```console
-  # nix profile info
+  # nix profile list
   0 flake:nixpkgs#legacyPackages.x86_64-linux.spotify …
 
   # nix profile upgrade 0


### PR DESCRIPTION
Fix https://github.com/NixOS/nix/issues/4249 , and more importantly is a required (though not sufficient) step towards fixing https://github.com/NixOS/nix/issues/4835 .

This changes the semantics of a `Realisation` to make it a closure: A realisation now depends on all the inputs of the derivation whose outputs end-up in the runtime closure.

This is important for #4835 because without this we don’t have a way to know whether substituting a realisation will lead to a duplicated dependency or not.

Depends on #4833  and #4834 
