### PR TITLE
fix doc: nix profile info -> nix profile list

### DIFF
--- a/src/nix/profile-upgrade.md
+++ b/src/nix/profile-upgrade.md
@@ -18,7 +18,7 @@ R""(
 * Upgrade a specific profile element by number:
 
   ```console
-  # nix profile info
+  # nix profile list
   0 flake:nixpkgs#legacyPackages.x86_64-linux.spotify …
 
   # nix profile upgrade 0


### PR DESCRIPTION
Just noticed this "typo" while reading the man page. (If these kind of contributions are not welcome at the current development stage, just let me know and I'll stop.)