### PR TITLE
Make the Nar hash non modulo

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1436,14 +1436,10 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
                 /* Check the content hash (optionally - slow). */
                 printMsg(lvlTalkative, "checking contents of '%s'", printStorePath(i));
 
-                std::unique_ptr<AbstractHashSink> hashSink;
-                if (!info->ca || !info->references.count(info->path))
-                    hashSink = std::make_unique<HashSink>(info->narHash.type);
-                else
-                    hashSink = std::make_unique<HashModuloSink>(info->narHash.type, std::string(info->path.hashPart()));
+                auto hashSink = HashSink(info->narHash.type);
 
-                dumpPath(Store::toRealPath(i), *hashSink);
-                auto current = hashSink->finish();
+                dumpPath(Store::toRealPath(i), hashSink);
+                auto current = hashSink.finish();
 
                 if (info->narHash != nullHash && info->narHash != current.first) {
                     printError("path '%s' was modified! expected hash '%s', got '%s'",

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1152,17 +1152,13 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
 
             /* While restoring the path from the NAR, compute the hash
                of the NAR. */
-            std::unique_ptr<AbstractHashSink> hashSink;
-            if (!info.ca.has_value() || !info.references.count(info.path))
-                hashSink = std::make_unique<HashSink>(htSHA256);
-            else
-                hashSink = std::make_unique<HashModuloSink>(htSHA256, std::string(info.path.hashPart()));
+            HashSink hashSink(htSHA256);
 
-            TeeSource wrapperSource { source, *hashSink };
+            TeeSource wrapperSource { source, hashSink };
 
             restorePath(realPath, wrapperSource);
 
-            auto hashResult = hashSink->finish();
+            auto hashResult = hashSink.finish();
 
             if (hashResult.first != info.narHash)
                 throw Error("hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -97,15 +97,11 @@ struct CmdVerify : StorePathsCommand
 
                 if (!noContents) {
 
-                    std::unique_ptr<AbstractHashSink> hashSink;
-                    if (!info->ca)
-                        hashSink = std::make_unique<HashSink>(info->narHash.type);
-                    else
-                        hashSink = std::make_unique<HashModuloSink>(info->narHash.type, std::string(info->path.hashPart()));
+                    auto hashSink = HashSink(info->narHash.type);
 
-                    store->narFromPath(info->path, *hashSink);
+                    store->narFromPath(info->path, hashSink);
 
-                    auto hash = hashSink->finish();
+                    auto hash = hashSink.finish();
 
                     if (hash.first != info->narHash) {
                         corrupted++;


### PR DESCRIPTION
It makes much more sense to have the Nar hash be a plain straight hash rather than a hash modulo

Fix #4792 