### PR TITLE
Make nix-store --delete explain why a path is alive

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -558,7 +558,7 @@ bool LocalStore::canReachRoot(GCState & state, StorePathSet & visited, const Sto
     if (state.dead.count(path)) return false;
 
     if (state.roots.count(path)) {
-        debug("cannot delete '%1%' because it's a root", printStorePath(path));
+        printInfo("need '%1%' because it's a root", printStorePath(path));
         state.alive.insert(path);
         return true;
     }
@@ -594,6 +594,7 @@ bool LocalStore::canReachRoot(GCState & state, StorePathSet & visited, const Sto
     for (auto & i : incoming)
         if (i != path)
             if (canReachRoot(state, visited, i)) {
+                printInfo("need '%1%' for '%2%'", printStorePath(path), printStorePath(i));
                 state.alive.insert(path);
                 return true;
             }
@@ -760,9 +761,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
             tryToDelete(state, printStorePath(i));
             if (state.dead.find(i) == state.dead.end())
                 throw Error(
-                    "cannot delete path '%1%' since it is still alive. "
-                    "To find out why use: "
-                    "nix-store --query --roots",
+                    "cannot delete path '%1%' since it is still alive",
                     printStorePath(i));
         }
 


### PR DESCRIPTION
Fixes #1810

The output looks like this:
```
$ nix-store --delete /nix/store/85i1173dllq1s23k5wnyiw9a33k808bp-perl-5.32.1-man
finding garbage collector roots...
need '/nix/store/clp069h9m0hmdhi6v86gf90n1p2gqhr1-nixos-system-orivej-21.05.git.b26b54f0563' because it's a root
need '/nix/store/0ywlmj5i7gsjm0vx9nzmkmr0zrws0lac-perl-5.32.1-env' for '/nix/store/clp069h9m0hmdhi6v86gf90n1p2gqhr1-nixos-system-orivej-21.05.git.b26b54f0563'
need '/nix/store/85i1173dllq1s23k5wnyiw9a33k808bp-perl-5.32.1-man' for '/nix/store/0ywlmj5i7gsjm0vx9nzmkmr0zrws0lac-perl-5.32.1-env'
0 store paths deleted, 0.00 MiB freed
error: cannot delete path '/nix/store/85i1173dllq1s23k5wnyiw9a33k808bp-perl-5.32.1-man' since it is still alive
```

```
$ nix-store --delete /nix/store/amfzfi6gfxnjndmmff3kz9vmkq9lzh35-perl-5.32.0-devdoc
finding garbage collector roots...
need '/nix/store/clp069h9m0hmdhi6v86gf90n1p2gqhr1-nixos-system-orivej-21.05.git.b26b54f0563' because it's a root
need '/nix/store/4xixizlfkjp0z8z9xbg76zvgqpjb7rvq-nixos-system-orivej-21.05.git.b26b54f0563.drv' for '/nix/store/clp069h9m0hmdhi6v86gf90n1p2gqhr1-nixos-system-orivej-21.05.git.b26b54f0563'
need '/nix/store/22srqan5h3vk09r0vzqkbnbv4dvb3lx2-system-path.drv' for '/nix/store/4xixizlfkjp0z8z9xbg76zvgqpjb7rvq-nixos-system-orivej-21.05.git.b26b54f0563.drv'
need '/nix/store/68iqmqk0qp6vwwwwgclgkwyr4hbfjq3v-lilypond-2.22.1.drv' for '/nix/store/22srqan5h3vk09r0vzqkbnbv4dvb3lx2-system-path.drv'
need '/nix/store/vyxhlf79jibd4pq0fxfr14fxiq49ri7a-texlive-combined-2021.drv' for '/nix/store/68iqmqk0qp6vwwwwgclgkwyr4hbfjq3v-lilypond-2.22.1.drv'
need '/nix/store/3xnyaqjgd9izsc7a5s5qfc97pi2fxlnd-texlive-combined-2021' for '/nix/store/vyxhlf79jibd4pq0fxfr14fxiq49ri7a-texlive-combined-2021.drv'
need '/nix/store/7d7s9ln9scd20v41r3ihhs7xskyx9cqy-texlive-lualibs-2.73' for '/nix/store/3xnyaqjgd9izsc7a5s5qfc97pi2fxlnd-texlive-combined-2021'
need '/nix/store/li12jji15fz0i71ia90cnnf5i8l9r1zz-texlive-lualibs-2.73.drv' for '/nix/store/7d7s9ln9scd20v41r3ihhs7xskyx9cqy-texlive-lualibs-2.73'
need '/nix/store/2fl1ypicql8gfkzx31c0nfgkps2i939a-lualibs.r57277.tar.xz.drv' for '/nix/store/li12jji15fz0i71ia90cnnf5i8l9r1zz-texlive-lualibs-2.73.drv'
need '/nix/store/cb21wchxnmjkkxlj22qv7782b2is6141-curl-7.74.0.drv' for '/nix/store/2fl1ypicql8gfkzx31c0nfgkps2i939a-lualibs.r57277.tar.xz.drv'
need '/nix/store/0fyhz66ybzb0gnyrnjbl9jma09s220yp-nghttp2-1.41.0.drv' for '/nix/store/cb21wchxnmjkkxlj22qv7782b2is6141-curl-7.74.0.drv'
need '/nix/store/1zf9plakb12amj6f6b2i29b7ssbs95ly-openssl-1.1.1i.drv' for '/nix/store/0fyhz66ybzb0gnyrnjbl9jma09s220yp-nghttp2-1.41.0.drv'
need '/nix/store/jpj7rxchjh6ql0gf2y6s01ii1rdzwlmp-perl-5.32.0.drv' for '/nix/store/1zf9plakb12amj6f6b2i29b7ssbs95ly-openssl-1.1.1i.drv'
need '/nix/store/amfzfi6gfxnjndmmff3kz9vmkq9lzh35-perl-5.32.0-devdoc' for '/nix/store/jpj7rxchjh6ql0gf2y6s01ii1rdzwlmp-perl-5.32.0.drv'
0 store paths deleted, 0.00 MiB freed
error: cannot delete path '/nix/store/amfzfi6gfxnjndmmff3kz9vmkq9lzh35-perl-5.32.0-devdoc' since it is still alive
```