### PR TITLE
Allow control over early symlink cutoff in profiles

### DIFF
--- a/src/libstore/builtins/buildenv.hh
+++ b/src/libstore/builtins/buildenv.hh
@@ -14,7 +14,7 @@ struct Package {
 
 typedef std::vector<Package> Packages;
 
-void buildProfile(const Path & out, Packages && pkgs);
+void buildProfile(const Path & out, Packages && pkgs, uint64_t cutoff);
 
 void builtinBuildenv(const BasicDerivation & drv);
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -956,6 +956,17 @@ public:
           resolves to a different location from that of the build machine. You
           can enable this setting if you are sure you're not going to do that.
         )"};
+
+    Setting<uint64_t> minProfileSymlinkCutoff{
+        this, 0, "min-profile-symlink-cutoff",
+        R"(
+          When creating profiles, this is the minimum directory depth at which
+          early symlink cutoff can be done. A value of 0 (the default) means
+          that e.g. if only a single derivation provides a `/bin` directory,
+          `/bin` in the profile can be symlinked to that derivation's `/bin`
+          directly. A value of 1 means that such symlinks can't be created at
+          the toplevel, but only one level further down.
+        )"};
 };
 
 

--- a/src/nix-env/buildenv.nix
+++ b/src/nix-env/buildenv.nix
@@ -1,11 +1,11 @@
-{ derivations, manifest }:
+{ derivations, manifest, minProfileSymlinkCutoff }:
 
 derivation {
   name = "user-environment";
   system = "builtin";
   builder = "builtin:buildenv";
 
-  inherit manifest;
+  inherit manifest minProfileSymlinkCutoff;
 
   # !!! grmbl, need structured data for passing this in a clean way.
   derivations =

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -118,11 +118,13 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
 
     /* Construct a Nix expression that calls the user environment
        builder with the manifest as argument. */
-    Value args, topLevel;
+    Value args, topLevel, cutoff;
     state.mkAttrs(args, 3);
     mkString(*state.allocAttr(args, state.symbols.create("manifest")),
         state.store->printStorePath(manifestFile), {state.store->printStorePath(manifestFile)});
     args.attrs->push_back(Attr(state.symbols.create("derivations"), &manifest));
+    mkInt(cutoff, settings.minProfileSymlinkCutoff);
+    args.attrs->push_back(Attr(state.symbols.create("minProfileSymlinkCutoff"), &cutoff));
     args.attrs->sort();
     mkApp(topLevel, envBuilder, args);
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -150,7 +150,7 @@ struct ProfileManifest
             }
         }
 
-        buildProfile(tempDir, std::move(pkgs));
+        buildProfile(tempDir, std::move(pkgs), settings.minProfileSymlinkCutoff);
 
         writeFile(tempDir + "/manifest.json", toJSON(*store));
 


### PR DESCRIPTION
Introduces a new Nix option called `min-profiles-symlink-cutoff`, which allows control over how early symlink cutoff is done when creating profiles.

This new option allows ensuring that e.g. `/bin` itself can never be a symlink to a package by setting it to 1.

This is useful in situations where doing a directory listing in derivations is expensive (such as for network filesystems), as it allows e.g. knowing all binaries of a profile while being sure that no extra downloads are necessary.

The new strategy also allows making profiles easier to introspect, because a `tree` on the profile will additionally recurse as far as that options value, even if only a single package provides a certain path. Also notably the output of tree doesn't change considerably anymore just because another package is installed.

A test has been added to ensure this new functionality working. In addition I tested this manually for both `nix-env` (`sudo` needed for it to use the updated client instead of my older local Nix daemon):
```
$ tmp=$(mktemp -d) \
  && sudo nix-env --option min-profile-symlink-cutoff 0 -p "$tmp/test" -ir \
  -E '_: with import <nixpkgs> {}; [ tmatrix ]' \
  && tree "$tmp/test/"
/tmp/nix-shell.9dBVxs/tmp.QhHjjXWExn/test/
├── bin -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/bin
├── manifest.nix -> /nix/store/dixx8w6w5z0fbr6aczq4xwifmmva9p65-env-manifest.nix
└── share -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/share

2 directories, 1 file

$ tmp=$(mktemp -d) \
  && sudo nix-env --option min-profile-symlink-cutoff 1 -p "$tmp/test" -ir \
  -E '_: with import <nixpkgs> {}; [ tmatrix ]' \
  && tree "$tmp/test/"
/tmp/nix-shell.9dBVxs/tmp.fNt0wutwFf/test/
├── bin
│   └── tmatrix -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/bin/tmatrix
├── manifest.nix -> /nix/store/dixx8w6w5z0fbr6aczq4xwifmmva9p65-env-manifest.nix
└── share
    ├── bash-completion -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/share/bash-completion
    ├── man -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/share/man
    └── zsh -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/share/zsh

5 directories, 2 files

$ tmp=$(mktemp -d) \
  && sudo nix-env --option min-profile-symlink-cutoff 2 -p "$tmp/test" -ir \
  -E '_: with import <nixpkgs> {}; [ tmatrix ]' \
  && tree "$tmp/test/"
/tmp/nix-shell.9dBVxs/tmp.zFjfRNEdIE/test/
├── bin
│   └── tmatrix -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/bin/tmatrix
├── manifest.nix -> /nix/store/dixx8w6w5z0fbr6aczq4xwifmmva9p65-env-manifest.nix
└── share
    ├── bash-completion
    │   └── completions -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/share/bash-completion/completions
    ├── man
    │   └── man6 -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/share/man/man6
    └── zsh
        └── site-functions -> /nix/store/fc6i0q3hp3bb3g9l3azhvqcjby8n9lqf-tmatrix-1.3/share/zsh/site-functions

8 directories, 2 files
```

And `nix profile` (no `sudo` needed because it seems to assemble profiles on the client side):
```
$ tmp=$(mktemp -d) \
  && nix profile install --option experimental-features 'nix-command flakes ca-references' \
  --option min-profile-symlink-cutoff 0 --profile "$tmp/test" nixpkgs#tmatrix \
  && tree "$tmp/test/"
/tmp/nix-shell.9dBVxs/tmp.e0xF9d3WkC/test/
├── bin -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/bin
├── manifest.json
└── share -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/share

2 directories, 1 file

$ tmp=$(mktemp -d) \
  && nix profile install --option experimental-features 'nix-command flakes ca-references' \
  --option min-profile-symlink-cutoff 1 --profile "$tmp/test" nixpkgs#tmatrix \
  && tree "$tmp/test/"
/tmp/nix-shell.9dBVxs/tmp.WsxNLp5puA/test/
├── bin
│   └── tmatrix -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/bin/tmatrix
├── manifest.json
└── share
    ├── bash-completion -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/share/bash-completion
    ├── man -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/share/man
    └── zsh -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/share/zsh

5 directories, 2 files

$ tmp=$(mktemp -d) \
  && nix profile install --option experimental-features 'nix-command flakes ca-references' \
  --option min-profile-symlink-cutoff 2 --profile "$tmp/test" nixpkgs#tmatrix \
  && tree "$tmp/test/"
/tmp/nix-shell.9dBVxs/tmp.vzYUPDgQuG/test/
├── bin
│   └── tmatrix -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/bin/tmatrix
├── manifest.json
└── share
    ├── bash-completion
    │   └── completions -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/share/bash-completion/completions
    ├── man
    │   └── man6 -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/share/man/man6
    └── zsh
        └── site-functions -> /nix/store/f4c1fi37yq3xpvxz9gh02phxw8wadqg8-tmatrix-1.3/share/zsh/site-functions

8 directories, 2 files
```