### PR TITLE
Fix pure build of 2.3

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -57,7 +57,7 @@ rec {
       git
       mercurial
     ]
-    ++ lib.optionals stdenv.isLinux [libseccomp utillinuxMinimal]
+    ++ lib.optionals stdenv.isLinux [libseccomp util-linuxMinimal]
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
     ++ lib.optional (stdenv.isLinux || stdenv.isDarwin)
       ((aws-sdk-cpp.override {


### PR DESCRIPTION
`utillinuxMinimal` is now an alias on 21.05.