### PR TITLE
Install zsh completion script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ makefiles = \
   src/resolve-system-dependencies/local.mk \
   scripts/local.mk \
   misc/bash/local.mk \
+  misc/zsh/local.mk \
   misc/systemd/local.mk \
   misc/launchd/local.mk \
   misc/upstart/local.mk \

--- a/misc/zsh/local.mk
+++ b/misc/zsh/local.mk
@@ -1,0 +1,1 @@
+$(eval $(call install-file-as, $(d)/completion.zsh, $(datarootdir)/zsh/site-functions/_nix, 0644))


### PR DESCRIPTION
 A zsh completion script that works with nixFlakes (unfortunately [nix-zsh-completions doesn't play nice with it](https://github.com/spwhitt/nix-zsh-completions/issues/32)) was merged in #4128, but as @matthewbauer [mentioned](https://github.com/NixOS/nix/pull/4128#issuecomment-706476008) it's not picked up by fpath. This pull request does the suggested fix of using a local.mk to install the script as zsh/site-functions/_nix, which does add it to the fpath.

I have verified that it gets picked up by [adding this commit as a patch to my configuration](https://github.com/chuahou/conf.nix/commit/5ac5efaa8fb2ed0f8bc55aff2af23922deb09e15).

Previously PR #4132 was opened to fix this but closed due to https://github.com/spwhitt/nix-zsh-completions/pull/34, however the latter PR has since been closed in favour of the completion.zsh here.