### PR TITLE
Add a fish completion script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ makefiles = \
   src/resolve-system-dependencies/local.mk \
   scripts/local.mk \
   misc/bash/local.mk \
+  misc/fish/local.mk \
   misc/zsh/local.mk \
   misc/systemd/local.mk \
   misc/launchd/local.mk \

--- a/misc/fish/completion.fish
+++ b/misc/fish/completion.fish
@@ -1,0 +1,37 @@
+function _nix_complete
+  # Get the current command up to a cursor.
+  # - Behaves correctly even with pipes and nested in commands like env.
+  # - TODO: Returns the command verbatim (does not interpolate variables).
+  #   That might not be optimal for arguments like -f.
+  set -l nix_args (commandline --current-process --tokenize --cut-at-cursor)
+  # --cut-at-cursor with --tokenize removes the current token so we need to add it separately.
+  # https://github.com/fish-shell/fish-shell/issues/7375
+  # Can be an empty string.
+  set -l current_token (commandline --current-token --cut-at-cursor)
+
+  # Nix wants the index of the argv item to complete but the $nix_args variable
+  # also contains the program name (argv[0]) so we would need to subtract 1.
+  # But the variable also misses the current token so it cancels out.
+  set -l nix_arg_to_complete (count $nix_args)
+
+  env NIX_GET_COMPLETIONS=$nix_arg_to_complete $nix_args $current_token
+end
+
+function _nix_accepts_files
+  set -l response (_nix_complete)
+  # First line is either filenames or no-filenames.
+  test $response[1] = 'filenames'
+end
+
+function _nix
+  set -l response (_nix_complete)
+  # Skip the first line since it handled by _nix_accepts_files.
+  # Tail lines each contain a command followed by a tab character and, optionally, a description.
+  # This is also the format fish expects.
+  string collect -- $response[2..-1]
+end
+
+# Disable file path completion if paths do not belong in the current context.
+complete --command nix --condition 'not _nix_accepts_files' --no-files
+
+complete --command nix --arguments '(_nix)'

--- a/misc/fish/local.mk
+++ b/misc/fish/local.mk
@@ -1,0 +1,1 @@
+$(eval $(call install-file-as, $(d)/completion.fish, $(datarootdir)/fish/vendor_completions.d/nix.fish, 0644))


### PR DESCRIPTION
This is only rudimentary support as allowed by `NIX_GET_COMPLETIONS`.

In the future, we could use complete’s `--wraps` argument to autocomplete arguments for programs after `nix shell -c`.

Demo: https://asciinema.org/a/9MKYgMwkhEdmqCPGPc3zgK6eY

It even supports completing `env NIX_PATH=nixpkgs=channel:nixos-unstable nix s`. Though here, files are suggested, even though `no-filenames` is returned. Possibly a fish bug.

Test using:

```fish
mkdir -p ~/.config/fish/completions
ln -s $PWD/misc/fish/completion.fish ~/.config/fish/completions/nix.fish

complete -C 'nix '
complete -C 'nix b'
complete -C 'nix     build '
complete -C 'nix build'
complete -C 'nix build -'
complete -C 'nix build .#'
complete -C 'env NIX_PATH=nixpkgs=channel:nixos-unstable nix s'
complete -C 'nix build $PWD#' # this one does not work since commandline returns the command verbatim
```

cc @lilyball 