### PR TITLE
Add a pointer from "realising" to `nix log`.

### DIFF
--- a/doc/manual/src/command-ref/nix-store.md
+++ b/doc/manual/src/command-ref/nix-store.md
@@ -156,13 +156,11 @@ To test whether a previously-built derivation is deterministic:
 $ nix-build '<nixpkgs>' -A hello --check -K
 ```
 
-To see the stderr/stdout of a build:
+Use [`--read-log`](#operation---read-log) to show the stderr and stdout of a build:
 
 ```console
 $ nix-store --read-log $(nix-instantiate ./test.nix)
 ```
-
-Use `nix log` to see the logs of a build.
 
 # Operation `--serve`
 

--- a/doc/manual/src/command-ref/nix-store.md
+++ b/doc/manual/src/command-ref/nix-store.md
@@ -156,6 +156,14 @@ To test whether a previously-built derivation is deterministic:
 $ nix-build '<nixpkgs>' -A hello --check -K
 ```
 
+To see the stderr/stdout of a build:
+
+```console
+$ nix-store --read-log $(nix-instantiate ./test.nix)
+```
+
+Use `nix log` to see the logs of a build.
+
 # Operation `--serve`
 
 ## Synopsis


### PR DESCRIPTION
While working my way through the nix-pills, I was surprised to not see
the stdout of a build when realising a derivation. I eventually
discovered `nix log` and https://github.com/NixOS/nix-pills/pull/146,
but the *first* place I looked was this man page expecting to see a
note about stdout/stderr getting suppressed during builds.
Unfortunately, I didn't find anything. I think this addition to the man
page would help future learners like myself.