### PR TITLE
Fix error: 'optional' in namespace 'std' does not name a template type

### DIFF
--- a/src/libfetchers/attrs.hh
+++ b/src/libfetchers/attrs.hh
@@ -6,6 +6,8 @@
 
 #include <nlohmann/json_fwd.hpp>
 
+#include <optional>
+
 namespace nix::fetchers {
 
 typedef std::variant<std::string, uint64_t, Explicit<bool>> Attr;


### PR DESCRIPTION
log:
```
In file included from src/libfetchers/attrs.cc:1:
src/libfetchers/attrs.hh:18:6: error: 'optional' in namespace 'std' does not name a template type
   18 | std::optional<std::string> maybeGetStrAttr(const Attrs & attrs, const std::string & name);
      |      ^~~~~~~~
src/libfetchers/attrs.hh:8:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
    7 | #include <nlohmann/json_fwd.hpp>
  +++ |+#include <optional>
    8 | 
src/libfetchers/attrs.hh:22:6: error: 'optional' in namespace 'std' does not name a template type
   22 | std::optional<uint64_t> maybeGetIntAttr(const Attrs & attrs, const std::string & name);
      |      ^~~~~~~~
src/libfetchers/attrs.hh:22:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
   22 | std::optional<uint64_t> maybeGetIntAttr(const Attrs & attrs, const std::string & name);
      | ^~~
src/libfetchers/attrs.hh:26:6: error: 'optional' in namespace 'std' does not name a template type
   26 | std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, const std::string & name);
      |      ^~~~~~~~
src/libfetchers/attrs.hh:26:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
   26 | std::optional<bool> maybeGetBoolAttr(const Attrs & attrs, const std::string & name);
      | ^~~
```