### PR TITLE
[2.3] Backport libatomic fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,11 +157,18 @@ AX_BOOST_BASE([1.66], [CXXFLAGS="$BOOST_CPPFLAGS $CXXFLAGS"], [AC_MSG_ERROR([Nix
 # ends up with LDFLAGS being empty, so we set it afterwards.
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
-# Boost atomic needs GCC libatomic on 32-bit ARM
-case "$host_cpu" in
-  armv5*|armv6*|armv7*) LIBS="-latomic $LIBS"
-esac
-
+# On some platforms, new-style atomics need a helper library
+AC_MSG_CHECKING(whether -latomic is needed)
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
+#include <stdint.h>
+uint64_t v;
+int main() {
+    return (int)__atomic_load_n(&v, __ATOMIC_ACQUIRE);
+}]])], GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC=no, GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC=yes)
+AC_MSG_RESULT($GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC)
+if test "x$GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC" = xyes; then
+    LIBS="-latomic $LIBS"
+fi
 
 PKG_PROG_PKG_CONFIG
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_SYS_LARGEFILE
 AC_STRUCT_DIRENT_D_TYPE
 if test "$sys_name" = sunos; then
     # Solaris requires -lsocket -lnsl for network functions
-    LIBS="-lsocket -lnsl $LIBS"
+    LDFLAGS="-lsocket -lnsl $LDFLAGS"
 fi
 
 
@@ -167,7 +167,7 @@ int main() {
 }]])], GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC=no, GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC=yes)
 AC_MSG_RESULT($GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC)
 if test "x$GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC" = xyes; then
-    LIBS="-latomic $LIBS"
+    LDFLAGS="-latomic $LDFLAGS"
 fi
 
 PKG_PROG_PKG_CONFIG

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,11 @@ AX_BOOST_BASE([1.66], [CXXFLAGS="$BOOST_CPPFLAGS $CXXFLAGS"], [AC_MSG_ERROR([Nix
 # ends up with LDFLAGS being empty, so we set it afterwards.
 LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
 
+# Boost atomic needs GCC libatomic on 32-bit ARM
+case "$host_cpu" in
+  armv5*|armv6*|armv7*) LIBS="-latomic $LIBS"
+esac
+
 
 PKG_PROG_PKG_CONFIG
 


### PR DESCRIPTION
This backport will allow us to drop another [hack](https://github.com/NixOS/nixpkgs/blob/4efbeba8924ce7905237cdb90c841b549266a9fa/pkgs/tools/package-management/nix/default.nix#L79) from Nixpkgs, and presumably also fix the issue for anybody trying to build Nix outside Nixpkgs.
