### PR TITLE
avoid null pointer dereference when attrSet->pos is null

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -564,22 +564,21 @@ static Bindings::iterator getAttr(
             funcName
         );
 
-        Pos aPos = *attrSet->pos;
-        if (aPos == noPos) {
-            throw TypeError({
-                .msg = errorMsg,
-                .errPos = pos,
-            });
-        } else {
+        if (attrSet->pos && *attrSet->pos != noPos) {
             auto e = TypeError({
                 .msg = errorMsg,
-                .errPos = aPos,
+                .errPos = *attrSet->pos,
             });
 
             // Adding another trace for the function name to make it clear
             // which call received wrong arguments.
             e.addTrace(pos, hintfmt("while invoking '%s'", funcName));
             throw e;
+        } else {
+            throw TypeError({
+                .msg = errorMsg,
+                .errPos = pos,
+            });
         }
     }
 

--- a/tests/lang.sh
+++ b/tests/lang.sh
@@ -32,7 +32,7 @@ done
 for i in lang/eval-fail-*.nix; do
     echo "evaluating $i (should fail)";
     i=$(basename $i .nix)
-    if nix-instantiate --eval lang/$i.nix; then
+    if ! expect 1 nix-instantiate --eval lang/$i.nix; then
         echo "FAIL: $i shouldn't evaluate"
         fail=1
     fi

--- a/tests/lang/eval-fail-list-to-attrs.nix
+++ b/tests/lang/eval-fail-list-to-attrs.nix
@@ -1,0 +1,4 @@
+# https://github.com/NixOS/nix/issues/4893
+builtins.getAttr "nope" (
+  builtins.listToAttrs [ { name = "foo"; value = "bar"; } ]
+)


### PR DESCRIPTION
This may be a fix for https://github.com/NixOS/nix/issues/4893

I added a small test that just checks for the segfault, given that `builtins.tryEval` cannot catch this kind of error.

To recap, here's the behavior before:

```
❯ nix eval --expr 'builtins.getAttr "bar" (builtins.listToAttrs [ { name = "foo"; value = "bar"; } ])'
[1]    1731608 segmentation fault (core dumped)  nix eval --expr 
```

And after the fix:

```
❯ ./result/bin/nix eval --expr 'builtins.getAttr "bar" (builtins.listToAttrs [ { name = "foo"; value = "bar"; } ])'
error: attribute 'bar' missing for call to 'getAttr'

       at «string»:1:1:

            1| builtins.getAttr "bar" (builtins.listToAttrs [ { name = "foo"; value = "bar"; } ])
             | ^
```