### PR TITLE
[2.3] backport: Make `functionArgs` primitive accept primops

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1350,6 +1350,10 @@ static void prim_catAttrs(EvalState & state, const Pos & pos, Value * * args, Va
 static void prim_functionArgs(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     state.forceValue(*args[0]);
+    if (args[0]->type == tPrimOpApp || args[0]->type == tPrimOp) {
+        state.mkAttrs(v, 0);
+        return;
+    }
     if (args[0]->type != tLambda)
         throw TypeError(format("'functionArgs' requires a function, at %1%") % pos);
 


### PR DESCRIPTION
(cherry picked from commit b2748c6e99239ff6803ba0da76c362790c8be192)

This fixes user observable evaluation errors which shouldn't happen when using `lib.generators.toPretty`, so it seems sensible to fix this in 2.3 as well.