### PR TITLE
flake.nix: Propagate nlohmann_json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ makefiles = \
   src/libexpr/local.mk \
   src/libcmd/local.mk \
   src/nix/local.mk \
+  src/nlohmann/local.mk \
   src/resolve-system-dependencies/local.mk \
   scripts/local.mk \
   misc/bash/local.mk \

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,6 @@
 
         propagatedDeps =
           [ (boehmgc.override { enableLargeConfig = true; })
-            nlohmann_json
           ];
 
         perlDeps =
@@ -408,7 +407,7 @@
 
             doInstallCheck = true;
 
-            lcovFilter = [ "*/boost/*" "*-tab.*" ];
+            lcovFilter = [ "*/boost/*" "*-tab.*" "*/nlohmann/*" ];
 
             # We call `dot', and even though we just use it to
             # syntax-check generated dot files, it still requires some

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,6 @@
             openssl sqlite
             libarchive
             boost
-            nlohmann_json
             lowdown
             gmock
           ]
@@ -103,6 +102,7 @@
 
         propagatedDeps =
           [ (boehmgc.override { enableLargeConfig = true; })
+            nlohmann_json
           ];
 
         perlDeps =
@@ -254,7 +254,6 @@
                 xz
                 pkgs.perl
                 boost
-                nlohmann_json
               ]
               ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium;
 

--- a/src/libexpr/flake/lockfile.hh
+++ b/src/libexpr/flake/lockfile.hh
@@ -2,7 +2,7 @@
 
 #include "flakeref.hh"
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 namespace nix {
 class Store;

--- a/src/libfetchers/attrs.hh
+++ b/src/libfetchers/attrs.hh
@@ -4,7 +4,7 @@
 
 #include <variant>
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 #include <optional>
 

--- a/src/libstore/derived-path.hh
+++ b/src/libstore/derived-path.hh
@@ -6,7 +6,7 @@
 
 #include <optional>
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 namespace nix {
 

--- a/src/libstore/parsed-derivations.hh
+++ b/src/libstore/parsed-derivations.hh
@@ -2,7 +2,7 @@
 
 #include "store-api.hh"
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 namespace nix {
 

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "path.hh"
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 #include "comparator.hh"
 #include "crypto.hh"
 

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -4,7 +4,7 @@
 #include <map>
 #include <memory>
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 #include "util.hh"
 

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -4,7 +4,7 @@
 
 #include "types.hh"
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 #pragma once
 

--- a/src/libutil/local.mk
+++ b/src/libutil/local.mk
@@ -11,3 +11,5 @@ libutil_LDFLAGS = -pthread $(OPENSSL_LIBS) $(LIBBROTLI_LIBS) $(LIBARCHIVE_LIBS) 
 ifeq ($(HAVE_LIBCPUID), 1)
 	libutil_LDFLAGS += -lcpuid
 endif
+
+libutil_LIBS = nlohmann

--- a/src/nlohmann/local.mk
+++ b/src/nlohmann/local.mk
@@ -1,0 +1,4 @@
+GLOBAL_CXXFLAGS += -I src
+
+$(foreach i, $(wildcard src/nlohmann/*.hpp), \
+  $(eval $(call install-file-in, $(i), $(includedir)/nlohmann, 0644)))


### PR DESCRIPTION
Without it, the nix headers are unusable.