### PR TITLE
Add builtins.debug

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -646,6 +646,9 @@ struct EvalSettings : Config
 
     Setting<bool> useEvalCache{this, true, "eval-cache",
         "Whether to use the flake evaluation cache."};
+
+    Setting<bool> traceVerbose{this, false, "trace-verbose",
+        "Whether `builtins.traceVerbose` should trace its first argument when evaluated."};
 };
 
 extern EvalSettings evalSettings;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -973,7 +973,7 @@ static RegisterPrimOp primop_trace({
 /* Takes two arguments and evaluates to the second one. Used as the
  * builtins.traceVerbose implementation when --trace-verbose is not enabled
  */
-static void prim_second(EvalState & state, const Pos & pos, Value * * args, Value & v)
+static void prim_second(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
     state.forceValue(*args[1], pos);
     v = *args[1];
@@ -3938,7 +3938,7 @@ void EvalState::createBaseEnv()
     addPrimOp({
         .fun = evalSettings.traceVerbose ? prim_trace : prim_second,
         .arity = 2,
-        .name = symbols.create("__traceVerbose"),
+        .name = "__traceVerbose",
         .args = { "e1", "e2" },
         .doc = R"(
           Evaluate *e1* and print its abstract syntax representation on standard

--- a/tests/lang.sh
+++ b/tests/lang.sh
@@ -5,6 +5,8 @@ export NIX_REMOTE=dummy://
 
 nix-instantiate --eval -E 'builtins.trace "Hello" 123' 2>&1 | grep -q Hello
 nix-instantiate --eval -E 'builtins.addErrorContext "Hello" 123' 2>&1
+nix-instantiate --trace-verbose --eval -E 'builtins.traceVerbose "Hello" 123' 2>&1 | grep -q Hello
+(! nix-instantiate --eval -E 'builtins.traceVerbose "Hello" 123' 2>&1 | grep -q Hello)
 (! nix-instantiate --show-trace --eval -E 'builtins.addErrorContext "Hello" 123' 2>&1 | grep -q Hello)
 nix-instantiate --show-trace --eval -E 'builtins.addErrorContext "Hello" (throw "Foo")' 2>&1 | grep -q Hello
 


### PR DESCRIPTION
When working on tests I thought that it would be useful to have some sort of logger which would be enabled by increasing verbosity level. This PR adds `builtins.debug` which evaluates the first argument when `-vv` is specified.

Exact use case:
I and @blaggacao started working on these check utils https://github.com/numtide/flake-utils/blob/master/check-utils.nix and plan is to add this kind of logging to simplify the debugging process for the end-users

PS: Please be gentle, I don't do CPP :D