### PR TITLE
libfetchers/git: fetch submodules by default

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -44,7 +44,7 @@ void emitTreeAttrs(
 
     if (input.getType() == "git")
         mkBool(*state.allocAttr(v, state.symbols.create("submodules")),
-            fetchers::maybeGetBoolAttr(input.attrs, "submodules").value_or(false));
+            fetchers::maybeGetBoolAttr(input.attrs, "submodules").value_or(true));
 
     if (auto revCount = input.getRevCount())
         mkInt(*state.allocAttr(v, state.symbols.create("revCount")), *revCount);

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -172,7 +172,7 @@ struct GitInputScheme : InputScheme
         Input input(_input);
 
         bool shallow = maybeGetBoolAttr(input.attrs, "shallow").value_or(false);
-        bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
+        bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(true);
         bool allRefs = maybeGetBoolAttr(input.attrs, "allRefs").value_or(false);
 
         std::string cacheType = "git";

--- a/tests/fetchGitSubmodules.sh
+++ b/tests/fetchGitSubmodules.sh
@@ -42,8 +42,8 @@ r1=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \
 r2=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = false; }).outPath")
 r3=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = true; }).outPath")
 
-[[ $r1 == $r2 ]]
-[[ $r2 != $r3 ]]
+[[ $r1 == $r3 ]]
+[[ $r2 != $r1 ]]
 
 r4=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; ref = \"master\"; rev = \"$rev\"; }).outPath")
 r5=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; ref = \"master\"; rev = \"$rev\"; submodules = false; }).outPath")
@@ -52,13 +52,13 @@ r7=$(nix eval --raw --expr "(builtins.fetchGit { url = $rootRepo; ref = \"master
 r8=$(nix eval --raw --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; submodules = true; }).outPath")
 
 [[ $r1 == $r4 ]]
-[[ $r4 == $r5 ]]
+[[ $r4 == $r6 ]]
 [[ $r3 == $r6 ]]
 [[ $r6 == $r7 ]]
 [[ $r7 == $r8 ]]
 
 have_submodules=$(nix eval --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; }).submodules")
-[[ $have_submodules == false ]]
+[[ $have_submodules == true ]]
 
 have_submodules=$(nix eval --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; submodules = false; }).submodules")
 [[ $have_submodules == false ]]
@@ -66,8 +66,8 @@ have_submodules=$(nix eval --expr "(builtins.fetchGit { url = $rootRepo; rev = \
 have_submodules=$(nix eval --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; submodules = true; }).submodules")
 [[ $have_submodules == true ]]
 
-pathWithoutSubmodules=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; }).outPath")
-pathWithSubmodules=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = true; }).outPath")
+pathWithoutSubmodules=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = false; }).outPath")
+pathWithSubmodules=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; }).outPath")
 pathWithSubmodulesAgain=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = true; }).outPath")
 pathWithSubmodulesAgainWithRef=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; ref = \"master\"; rev = \"$rev\"; submodules = true; }).outPath")
 


### PR DESCRIPTION
This is the desired behavior according to @edolstra's comment: https://github.com/NixOS/nix/issues/4423#issuecomment-799270569

In addition to making submodules opt-out instead of opt-in, this allows submodules to be pulled for a top-level flake's `self` attribute automatically, which was previously impossible.

#### Note:
This doesn't work with the "github:owner/repo" syntax, but neither do submodules in general. I can open a separate ticket for that if desired

Resolves #4423