### PR TITLE
include additional supported compression formats into binary-cache-store

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -183,6 +183,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
            compression == "lzip" ? ".lzip" :
            compression == "lz4" ? ".lz4" :
            compression == "br" ? ".br" :
+           compression == "gzip" ? ".gz" :
            "");
 
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now2 - now1).count();

--- a/tests/gz.sh
+++ b/tests/gz.sh
@@ -1,0 +1,28 @@
+source common.sh
+
+clearStore
+clearCache
+
+cacheURI="file://$cacheDir?compression=gzip"
+
+outPath=$(nix-build dependencies.nix --no-out-link)
+
+nix copy --to $cacheURI $outPath
+
+HASH=$(nix hash path $outPath)
+
+clearStore
+clearCacheCache
+
+nix copy --from $cacheURI $outPath --no-check-sigs
+
+if ls $cacheDir/nar/*.gz &> /dev/null; then
+    echo "files do exist"
+else
+    echo "nars do not exist"
+    exit 1
+fi
+
+HASH2=$(nix hash path $outPath)
+
+[[ $HASH = $HASH2 ]]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -31,6 +31,7 @@ nix_tests = \
   signing.sh \
   shell.sh \
   brotli.sh \
+  gz.sh \
   zstd.sh \
   pure-eval.sh \
   check.sh \


### PR DESCRIPTION
Append extensions for additional libarchive supported formats. This specifically came up when looking at utilizing gzip compression and expecting to see `.gz` or `.gzip` in the binary cache.