### PR TITLE
perlBindings: fix build on aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -256,7 +256,8 @@
                 boost
                 nlohmann_json
               ]
-              ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium;
+              ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
+              ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
             configureFlags = ''
               --with-dbi=${perlPackages.DBI}/${pkgs.perl.libPrefix}


### PR DESCRIPTION
I haven't tested this.

@Kloenk help :)

```
nix-build -A checks.aarch64-darwin.perlBindings
```

Needs to be backported to 2.3-maintenance