### PR TITLE
Improve machine store URI parsing

### DIFF
--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -16,13 +16,18 @@ Machine::Machine(decltype(storeUri) storeUri,
     decltype(mandatoryFeatures) mandatoryFeatures,
     decltype(sshPublicHostKey) sshPublicHostKey) :
     storeUri(
-        // Backwards compatibility: if the URI is a hostname,
-        // prepend ssh://.
+        // Backwards compatibility: if the URI is schemeless, is not a path,
+        // and is not one of the special store connection words, prepend
+        // ssh://.
         storeUri.find("://") != std::string::npos
-        || hasPrefix(storeUri, "local")
-        || hasPrefix(storeUri, "remote")
-        || hasPrefix(storeUri, "auto")
-        || hasPrefix(storeUri, "/")
+        || storeUri.find("/") != std::string::npos
+        || storeUri == "auto"
+        || storeUri == "daemon"
+        || storeUri == "local"
+        || hasPrefix(storeUri, "auto?")
+        || hasPrefix(storeUri, "daemon?")
+        || hasPrefix(storeUri, "local?")
+        || hasPrefix(storeUri, "?")
         ? storeUri
         : "ssh://" + storeUri),
     systemTypes(systemTypes),


### PR DESCRIPTION
Currently, the store URI for machines is parsed such that `remote-builder@example.com` is not handled as an SSH store. This is because any URI starting with `auto`, `local` or `remote` is special-cased. All other schemeless non-path URIs get `ssh://` prepended to be handled as a `LegacySSHStore`.

With this PR, more URIs fall back to `LegacySSHStore`, based on how "non-URIs" are handled in: https://github.com/NixOS/nix/blob/323e5450a1a6e4eb97ba1c9aeba195187cfaff37/src/libstore/store-api.cc#L1102-L1123

I removed `remote` (I didn't see it coming back in store-api.cc) and added `daemon` (it's a "non-URI" store in store-api.cc). It also seems any URI including `/` is handled as a local path (see `isNonUriPath`). This might miss the mark somewhat: I don't fully understand the store mechanism.

This fixes #1874.

See also https://github.com/NixOS/nixpkgs/pull/127949.