### PR TITLE
Fix gc crash

### DIFF
--- a/boehmgc-coroutine-sp-fallback.diff
+++ b/boehmgc-coroutine-sp-fallback.diff
@@ -1,5 +1,5 @@
 diff --git a/pthread_stop_world.c b/pthread_stop_world.c
-index 1cee6a0b..8977b0dd 100644
+index 1cee6a0b..46c3acd9 100644
 --- a/pthread_stop_world.c
 +++ b/pthread_stop_world.c
 @@ -674,6 +674,8 @@ GC_INNER void GC_push_all_stacks(void)
@@ -11,7 +11,7 @@ index 1cee6a0b..8977b0dd 100644
  
      if (!EXPECT(GC_thr_initialized, TRUE))
        GC_thr_init();
-@@ -723,6 +725,30 @@ GC_INNER void GC_push_all_stacks(void)
+@@ -723,6 +725,28 @@ GC_INNER void GC_push_all_stacks(void)
            hi = p->altstack + p->altstack_size;
            /* FIXME: Need to scan the normal stack too, but how ? */
            /* FIXME: Assume stack grows down */
@@ -35,9 +35,7 @@ index 1cee6a0b..8977b0dd 100644
 +              lo = hi - stack_limit;
 +            }
 +          #else
-+            if (lo < hi || lo >= hi + stack_limit) { // sp outside stack
-+              lo = hi + stack_limit;
-+            }
++          #error "STACK_GROWS_UP not supported in boost_coroutine2 (as of june 2021), so we don't support it in Nix."
 +          #endif
          }
          GC_push_all_stack_sections(lo, hi, traced_stack_sect);

--- a/boehmgc-coroutine-sp-fallback.diff
+++ b/boehmgc-coroutine-sp-fallback.diff
@@ -1,0 +1,44 @@
+diff --git a/pthread_stop_world.c b/pthread_stop_world.c
+index 1cee6a0b..8977b0dd 100644
+--- a/pthread_stop_world.c
++++ b/pthread_stop_world.c
+@@ -674,6 +674,8 @@ GC_INNER void GC_push_all_stacks(void)
+     struct GC_traced_stack_sect_s *traced_stack_sect;
+     pthread_t self = pthread_self();
+     word total_size = 0;
++    size_t stack_limit;
++    pthread_attr_t pattr;
+ 
+     if (!EXPECT(GC_thr_initialized, TRUE))
+       GC_thr_init();
+@@ -723,6 +725,30 @@ GC_INNER void GC_push_all_stacks(void)
+           hi = p->altstack + p->altstack_size;
+           /* FIXME: Need to scan the normal stack too, but how ? */
+           /* FIXME: Assume stack grows down */
++        } else {
++          if (pthread_getattr_np(p->id, &pattr)) {
++            ABORT("GC_push_all_stacks: pthread_getattr_np failed!");
++          }
++          if (pthread_attr_getstacksize(&pattr, &stack_limit)) {
++            ABORT("GC_push_all_stacks: pthread_attr_getstacksize failed!");
++          }
++          // When a thread goes into a coroutine, we lose its original sp until
++          // control flow returns to the thread.
++          // While in the coroutine, the sp points outside the thread stack,
++          // so we can detect this and push the entire thread stack instead,
++          // as an approximation.
++          // We assume that the coroutine has similarly added its entire stack.
++          // This could be made accurate by cooperating with the application
++          // via new functions and/or callbacks.
++          #ifndef STACK_GROWS_UP
++            if (lo >= hi || lo < hi - stack_limit) { // sp outside stack
++              lo = hi - stack_limit;
++            }
++          #else
++            if (lo < hi || lo >= hi + stack_limit) { // sp outside stack
++              lo = hi + stack_limit;
++            }
++          #endif
+         }
+         GC_push_all_stack_sections(lo, hi, traced_stack_sect);
+ #       ifdef STACK_GROWS_UP

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,13 @@
           });
 
         propagatedDeps =
-          [ (boehmgc.override { enableLargeConfig = true; })
+          [ ((boehmgc.override {
+              enableLargeConfig = true;
+            }).overrideAttrs(o: {
+              patches = (o.patches or []) ++ [
+                ./boehmgc-coroutine-sp-fallback.diff
+              ];
+            }))
           ];
 
         perlDeps =


### PR DESCRIPTION
I've figured out another cause of gc crashes, related to coroutines.

This now solves
 - a crash that occurs whenever a gc-registered thread is in a coroutine (the boehmgc patch)
 - an inappropriate "stack overflow" when gc runs while a coroutine exists (the BoehmGCStackAllocator commit)

I'll run `nixUnstable` with this PR and #4895 to see if any other crashes occur.
