### PR TITLE
Allow to compile after `./configure --enable-gc=no`

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -64,7 +64,11 @@ static char * dupStringWithLen(const char * s, size_t size)
 
 RootValue allocRootValue(Value * v)
 {
+#if HAVE_BOEHMGC
     return std::allocate_shared<Value *>(traceable_allocator<Value *>(), v);
+#else
+    return std::make_shared<Value *>(v);
+#endif
 }
 
 


### PR DESCRIPTION
As of now, configuring with `--enable-gc=no`, and trying to compile triggers a
```
  CXX    src/libexpr/eval.o
src/libexpr/eval.cc:67:42: error: use of undeclared identifier 'traceable_allocator'
    return std::allocate_shared<Value *>(traceable_allocator<Value *>(), v);
```

This PR seems to fix it, but I have very low confidence in my C++.

cc @regnat 

Signed-off-by: Pamplemousse <xav.maso@gmail.com>