### PR TITLE
Doc macos install

### DIFF
--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -378,7 +378,7 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
           of new entries without a reboot:
         </para>
 
-        <screen>alice$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B</screen>
+        <screen>alice$ /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t</screen>
       </listitem>
 
       <listitem>

--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -242,7 +242,7 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
 
       <!-- TODO: Yes, but how?! -->
 
-      It would also possible (and often requested) to just apply this
+      It would also be possible (and often requested) to just apply this
       change ecosystem-wide, but it's an intrusive process that has
       side effects we want to avoid for now.
       <!-- magnificent hand-wavy gesture -->


### PR DESCRIPTION
I went through the macOS installation docs recently and found out `apfs.util` no longer has a `-B` flag. I believe the `-t` flag accomplishes the same (more or less) behavior.