### PR TITLE
man: fix formatting of nix3-profile-remove

### DIFF
--- a/src/nix/profile-remove.md
+++ b/src/nix/profile-remove.md
@@ -15,6 +15,7 @@ R""(
   ```
 
 * Remove all packages:
+
   ```console
   # nix profile remove '.*'
   ```


### PR DESCRIPTION
This is a mostly cosmetic fix of the formatting on the man page for `nix profile remove`.

![Broken formatting on man page](https://i.imgur.com/eYvGI1K.png "nix3-profile-remove")