### PR TITLE
Only show "available" packages in nix search in legacyPackages

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -109,6 +109,12 @@ struct CmdSearch : InstallableCommand, MixJSON
                     std::replace(description.begin(), description.end(), '\n', ' ');
                     auto attrPath2 = concatStringsSep(".", attrPath);
 
+                    auto available = true;
+                    if (attrPath[0] == "legacyPackages") {
+                        auto aAvailable = aMeta ? aMeta->maybeGetAttr("available") : nullptr;
+                        available = aAvailable ? aAvailable->getBool() : true;
+                    }
+
                     std::smatch attrPathMatch;
                     std::smatch descriptionMatch;
                     std::smatch nameMatch;
@@ -123,7 +129,7 @@ struct CmdSearch : InstallableCommand, MixJSON
                             found++;
                     }
 
-                    if (found == res.size()) {
+                    if (found == res.size() && available) {
                         results++;
                         if (json) {
                             auto jsonElem = jsonOut->object(attrPath2);


### PR DESCRIPTION
legacyPackages can export meta.available to show whether they are
available or not. If it’s unset, we assume it’s true. If available is
false, we don’t need to show it in nix search.

/cc @edolstra 