### PR TITLE
nix-gc: ignore non-existing links

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -664,7 +664,11 @@ void LocalStore::removeUnusedLinks(const GCState & state)
         if (name == "." || name == "..") continue;
         Path path = linksDir + "/" + name;
 
-        auto st = lstat(path);
+        struct stat st;
+        if (lstat(path.c_str(), &st)) {
+            if (errno == ENOENT) continue;
+            throw SysError("getting status of %1%", path);
+        }
 
         if (st.st_nlink != 1) {
             actualSize += st.st_size;


### PR DESCRIPTION
Before I would get:

finding garbage collector roots...
deleting garbage...
deleting '/nix/store/trash'
deleting unused links...
0 store paths deleted, 0.00 MiB freed
error: getting status of '/nix/store/.links/1gwb16smc3b53iaa5nzfxjypys4pl32liw59aw01zvfjpaz53wg': No such file or directory