### PR TITLE
nix profile: add aliases

### DIFF
--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -549,8 +549,10 @@ struct CmdProfile : NixMultiCommand
         : MultiCommand({
               {"install", []() { return make_ref<CmdProfileInstall>(); }},
               {"remove", []() { return make_ref<CmdProfileRemove>(); }},
+              {"rm", []() { return make_ref<CmdProfileRemove>(); }},
               {"upgrade", []() { return make_ref<CmdProfileUpgrade>(); }},
               {"list", []() { return make_ref<CmdProfileList>(); }},
+              {"ls", []() { return make_ref<CmdProfileList>(); }},
               {"diff-closures", []() { return make_ref<CmdProfileDiffClosures>(); }},
               {"history", []() { return make_ref<CmdProfileHistory>(); }},
           })


### PR DESCRIPTION
This PR adds aliases to the `nix profile` subcommand, which I think are helpful and I was surprised aren't there already.

A case can be made for aliases for `install` or `upgrade`, but I think for right now only having them for `list` and `remove` is fine.