### PR TITLE
Respect TERM=dumb more consistently

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -484,7 +484,7 @@ Logger * makeProgressBar(bool printBuildLogs)
 {
     return new ProgressBar(
         printBuildLogs,
-        isatty(STDERR_FILENO) && getEnv("TERM").value_or("dumb") != "dumb"
+        shouldANSI()
     );
 }
 

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -46,7 +46,7 @@ public:
         : printBuildLogs(printBuildLogs)
     {
         systemd = getEnv("IN_SYSTEMD") == "1";
-        tty = isatty(STDERR_FILENO);
+        tty = shouldANSI();
     }
 
     bool isVerbose() override {

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1372,6 +1372,10 @@ void ignoreException()
     }
 }
 
+bool shouldANSI()
+{
+	return isatty(STDERR_FILENO) && getEnv("TERM").value_or("dumb") != "dumb";
+}
 
 std::string filterANSIEscapes(const std::string & s, bool filterAll, unsigned int width)
 {

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1374,7 +1374,9 @@ void ignoreException()
 
 bool shouldANSI()
 {
-	return isatty(STDERR_FILENO) && getEnv("TERM").value_or("dumb") != "dumb";
+    return isatty(STDERR_FILENO)
+        && getEnv("TERM").value_or("dumb") != "dumb"
+        && !getEnv("NO_COLOR").has_value();
 }
 
 std::string filterANSIEscapes(const std::string & s, bool filterAll, unsigned int width)

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -482,6 +482,9 @@ constexpr char treeLast[] = "└───";
 constexpr char treeLine[] = "│   ";
 constexpr char treeNull[] = "    ";
 
+/* Determine whether ANSI escape sequences are appropriate for the
+   present output. */
+bool shouldANSI();
 
 /* Truncate a string to 'width' printable characters. If 'filterAll'
    is true, all ANSI escape sequences are filtered out. Otherwise,


### PR DESCRIPTION
This is a huge quality-of-life improvement for my niche use case:
<img width="437" alt="current" src="https://user-images.githubusercontent.com/9125590/124204151-ad776080-da9b-11eb-9ff6-55cc2e5b763d.png">
<img width="433" alt="patched" src="https://user-images.githubusercontent.com/9125590/124204156-b10ae780-da9b-11eb-960c-f11ccc9fc5f4.png">
