### PR TITLE
Add ignore-git option

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -932,6 +932,9 @@ public:
 
     void requireExperimentalFeature(const std::string & name);
 
+    Setting<bool> ignoreGit{this, false, "ignore-git",
+        "Whether to ignore the existence of .git subdirectories in local directories"};
+
     Setting<bool> allowDirty{this, true, "allow-dirty",
         "Whether to allow dirty Git/Mercurial trees."};
 

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -26,6 +26,7 @@ nonFlakeDir=$TEST_ROOT/nonFlake
 flakeA=$TEST_ROOT/flakeA
 flakeB=$TEST_ROOT/flakeB
 flakeGitBare=$TEST_ROOT/flakeGitBare
+flakeGitBroken=$TEST_ROOT/flakeGitBroken
 
 for repo in $flake1Dir $flake2Dir $flake3Dir $flake7Dir $templatesDir $nonFlakeDir $flakeA $flakeB; do
     rm -rf $repo $repo.tmp
@@ -737,3 +738,16 @@ git -C $flakeB commit -a -m 'Foo'
 
 # Test list-inputs with circular dependencies
 nix flake metadata $flakeA
+
+# Test ignore-git config setting
+
+rm -rf $flakeGitBroken
+mkdir -p $flakeGitBroken
+git -C $flakeGitBroken init
+cp $flake1Dir/flake.nix $flakeGitBroken
+
+## Check that it fails without ignore-git
+! nix flake metadata $flakeGitBroken
+
+## Check that it works with ignore-git
+nix flake metadata --ignore-git $flakeGitBroken


### PR DESCRIPTION
Allows to ignore .git directories when interpreting local flake references,
thus interpreting all local flakes as path:// and not git+file://. This
has multiple effects, notably:

- (pro) Allows to use flakes without adding flake.nix to the index (useful for
  repositories where flake.nix cannot be commited for one reason or another,
  see https://discourse.nixos.org/t/my-painpoints-with-flakes/9750 for example);
- (con) Disables the gitignore behavior;
- (con) Puts the entire .git into nix store.
