### PR TITLE
Add a use-registries config option (and deprecate `--no-registries` )

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -60,7 +60,10 @@ MixFlakeOptions::MixFlakeOptions()
         .longName = "no-registries",
         .description = "Don't allow lookups in the flake registries.",
         .category = category,
-        .handler = {&lockFlags.useRegistries, false}
+        .handler = {[&]() {
+            lockFlags.useRegistries = false;
+            warn("--no-registries is deprecated; use --no-use-registries (a.k.a --option use-registries false)");
+        }}
     });
 
     addFlag({

--- a/src/libexpr/flake/flake.hh
+++ b/src/libexpr/flake/flake.hh
@@ -102,7 +102,7 @@ struct LockFlags
 
     /* Whether to use the registries to lookup indirect flake
        references like 'nixpkgs'. */
-    bool useRegistries = true;
+    std::optional<bool> useRegistries = std::nullopt;
 
     /* Whether to apply flake's nixConfig attribute to the configuration */
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -956,6 +956,9 @@ public:
           resolves to a different location from that of the build machine. You
           can enable this setting if you are sure you're not going to do that.
         )"};
+
+    Setting<bool> useRegistries{this, true, "use-registries",
+        "Whether to use flake registries for reference resolution"};
 };
 
 

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -147,6 +147,7 @@ nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"git+file://$flake1Di
 
 # Building a flake with an unlocked dependency should fail in pure mode.
 (! nix build -o $TEST_ROOT/result flake2#bar --no-registries)
+(! nix build -o $TEST_ROOT/result flake2#bar --no-use-registries)
 (! nix eval --expr "builtins.getFlake \"$flake2Dir\"")
 
 # But should succeed in impure mode.
@@ -170,6 +171,7 @@ nix build -o $TEST_ROOT/result $flake2Dir#bar
 # Building with a lockfile should not require a fetch of the registry.
 nix build -o $TEST_ROOT/result --flake-registry file:///no-registry.json $flake2Dir#bar --refresh
 nix build -o $TEST_ROOT/result --no-registries $flake2Dir#bar --refresh
+nix build -o $TEST_ROOT/result --no-use-registries $flake2Dir#bar --refresh
 
 # Updating the flake should not change the lockfile.
 nix flake lock $flake2Dir
@@ -180,6 +182,7 @@ nix build -o $TEST_ROOT/result flake2#bar
 
 # Or without a registry.
 nix build -o $TEST_ROOT/result --no-registries git+file://$flake2Dir#bar --refresh
+nix build -o $TEST_ROOT/result --no-use-registries git+file://$flake2Dir#bar --refresh
 
 # Test whether indirect dependencies work.
 nix build -o $TEST_ROOT/result $flake3Dir#xyzzy
@@ -603,6 +606,7 @@ nix flake metadata --json hg+file://$flake5Dir
 [[ $(nix flake metadata --json hg+file://$flake5Dir | jq -e -r .revCount) = 1 ]]
 
 nix build -o $TEST_ROOT/result hg+file://$flake5Dir --no-registries --no-allow-dirty
+nix build -o $TEST_ROOT/result hg+file://$flake5Dir --no-use-registries --no-allow-dirty
 
 # Test tarball flakes
 tar cfz $TEST_ROOT/flake.tar.gz -C $TEST_ROOT --exclude .hg flake5


### PR DESCRIPTION
Some people want to avoid using registries at all on their system; Instead
of having to add --no-registries to every command, this commit allows to
set registries = false in the config. --no-registries is still allowed
everywhere it was allowed previously, but now as a shorthand to --option
registries false rather than a separate flag.
