### PR TITLE
Fix devShell handling of env values including @ and %

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -54,7 +54,7 @@ BuildEnvironment readEnvironment(const Path & path)
         R"re((?:[a-zA-Z_][a-zA-Z0-9_]*))re";
 
     static std::string simpleStringRegex =
-        R"re((?:[a-zA-Z0-9_/:\.\-\+=]*))re";
+        R"re((?:[a-zA-Z0-9_/:\.\-\+=@%]*))re";
 
     static std::string dquotedStringRegex =
         R"re((?:\$?"(?:[^"\\]|\\[$`"\\\n])*"))re";

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -34,6 +34,8 @@ let pkgs = rec {
     name = "shellDrv";
     builder = "/does/not/exist";
     VAR_FROM_NIX = "bar";
+    ASCII_PERCENT = "%";
+    ASCII_AT = "@";
     TEST_inNixShell = if inNixShell then "true" else "false";
     inherit stdenv;
     outputs = ["dev" "out"];


### PR DESCRIPTION
Given the following `devShell`, both `nix develop` and `nix print-dev-env` would fail parsing the environment file:

```shell
❮ nix --experimental-features 'nix-command flakes' -L print-dev-env
warning: Git tree '/home/manveru/tmp/quoting' is dirty
error: shell environment '/nix/store/xwc73vzp1lcsw1if8vs76r9z4xkgpfyl-test-env' has unexpected line 'BAR=@
       BASH=/noshell
       BASHOPTS=cmdhist:extquote:interactive_co'
```

here's the flake i used to test this:

```nix
{
  outputs = { nixpkgs, ... }: {
    devShell.x86_64-linux = derivation {
      name = "test";
      builder = "${nixpkgs.legacyPackages.x86_64-linux.bash}/bin/bash";
      args = [
        (builtins.toFile "builder" ''
          set -exuo pipefail
          echo hier
          echo $FOO > $out
        '')
      ];
      outputs = [ "out" ];
      system = "x86_64-linux";
      FOO = "%";
      BAR = "@";
    };
  };
}
```

I included a simple test that is now part of the normal `shell.nix` tests, and should prevent regressions.