### PR TITLE
Make install documentation fish-friendly

### DIFF
--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -12,7 +12,7 @@
 </para>
 
 <screen>
-  $ sh &lt;(curl -L https://nixos.org/nix/install)
+  $ curl -L https://nixos.org/nix/install | sh -s
 </screen>
 
 <para>
@@ -39,7 +39,7 @@
     To explicitly select a single-user installation on your system:
 
     <screen>
-  sh &lt;(curl -L https://nixos.org/nix/install) --no-daemon
+  curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
 </screen>
   </para>
 
@@ -97,7 +97,7 @@ $ rm -rf /nix
     installation on your system:
   </para>
 
-  <screen>sh &lt;(curl -L https://nixos.org/nix/install) --daemon</screen>
+  <screen>curl -L https://nixos.org/nix/install | sh -s -- --daemon</screen>
 
   <para>
     The multi-user installation of Nix will create build users between
@@ -178,7 +178,7 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
     is a bit of a misnomer). To use this approach, just install Nix with:
   </para>
 
-  <screen>$ sh &lt;(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume</screen>
+  <screen>$ curl -L https://nixos.org/nix/install | sh -s -- --darwin-use-unencrypted-nix-store-volume</screen>
 
   <para>
     If you don't like the sound of this, you'll want to weigh the
@@ -429,7 +429,7 @@ LABEL=Nix\040Store /nix apfs rw,nobrowse
   NixOS.org installation script:
 
   <screen>
-  sh &lt;(curl -L https://nixos.org/nix/install)
+  curl -L https://nixos.org/nix/install | sh -s
 </screen>
   </para>
 


### PR DESCRIPTION
# Compatibility suggestion

Fish shell is fairly popular and doesn't support the `<(subshell)` redirection syntax.

To get the equivalent behavior in Fish shell you need to explicitly use process substitution with `psub` but due to fish's incompatible subshell syntax, `()` v. `$()`, this isn't an option:

```sh (curl -L https://nixos.org/nix/install | psub)```

We can support both (all?) shells using a simple pipe instead:

```curl -L https://nixos.org/nix/install | sh -s [-- --daemon --other-options]```