### PR TITLE
Fix wrong hash var for aarch64-darwin binary

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -56,7 +56,7 @@ case "$(uname -s).$(uname -m)" in
         system=x86_64-darwin
         ;;
     Darwin.arm64|Darwin.aarch64)
-        hash=@binaryTarball_aarch64-darwin@
+        hash=@tarballHash_aarch64-darwin@
         path=@tarballPath_aarch64-darwin@
         system=aarch64-darwin
         ;;


### PR DESCRIPTION
I noticed the nix:master build in hydra does not properly add the tarball hash for the aarch64-darwin build. From the build logs it appears the proper template var name is `@tarballHash_aarch64-darwin@`, not `@binaryTarball_aarch64-darwin@`.