### PR TITLE
Be more helpful when a flake eval is missing some files

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -528,26 +528,45 @@ std::tuple<std::string, FlakeRef, InstallableValue::DerivationInfo> InstallableF
     auto cache = openEvalCache(*state, lockedFlake);
     auto root = cache->getRoot();
 
-    for (auto & attrPath : getActualAttrPaths()) {
-        auto attr = root->findAlongAttrPath(
-            parseAttrPath(*state, attrPath),
-            true
-        );
+    try {
+        for (auto & attrPath : getActualAttrPaths()) {
+            auto attr = root->findAlongAttrPath(
+                parseAttrPath(*state, attrPath),
+                true
+            );
 
-        if (!attr) continue;
+            if (!attr) continue;
 
-        if (!attr->isDerivation())
-            throw Error("flake output attribute '%s' is not a derivation", attrPath);
+            if (!attr->isDerivation())
+                throw Error("flake output attribute '%s' is not a derivation", attrPath);
 
-        auto drvPath = attr->forceDerivation();
+            auto drvPath = attr->forceDerivation();
 
-        auto drvInfo = DerivationInfo{
-            std::move(drvPath),
-            state->store->maybeParseStorePath(attr->getAttr(state->sOutPath)->getString()),
-            attr->getAttr(state->sOutputName)->getString()
-        };
+            auto drvInfo = DerivationInfo{
+                std::move(drvPath),
+                    state->store->maybeParseStorePath(attr->getAttr(state->sOutPath)->getString()),
+                    attr->getAttr(state->sOutputName)->getString()
+            };
 
-        return {attrPath, lockedFlake->flake.lockedRef, std::move(drvInfo)};
+            return {attrPath, lockedFlake->flake.lockedRef, std::move(drvInfo)};
+        }
+    } catch (FileError & e) {
+        if (e.errNo != ENOENT) throw;
+        if (!state->store->isInStore(e.path)) throw;
+        auto resolvedInput = lockedFlake->flake.resolvedRef.input;
+        auto [sourceStorePath, relPath] = state->store->toStorePath(e.path);
+        if (sourceStorePath != lockedFlake->flake.lockedRef.input.computeStorePath(*state->store)) throw;
+        if (fetchers::maybeGetStrAttr(resolvedInput.attrs, "type").value_or("") != "git") throw;
+        if (auto repositoryPath = resolvedInput.getSourcePath()) {
+            auto sourcePath = *repositoryPath + "/" + relPath;
+            if (pathExists(sourcePath))
+                e.addTrace(
+                    noPos,
+                    "The file is present in '%s'. "
+                    "Did you forget to track it in Git?",
+                    *repositoryPath);
+        }
+        throw;
     }
 
     throw Error("flake '%s' does not provide attribute %s",

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -205,4 +205,17 @@ public:
     virtual const char* sname() const override { return "SysError"; }
 };
 
+class FileError : public SysError
+{
+public:
+    const Path path;
+
+    template<typename... Args>
+    FileError(const std::string & fs, const Path & path, const Args & ... args)
+        :SysError(fs, path, args...)
+        , path(path)
+        {
+        }
+};
+
 }

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -216,7 +216,7 @@ struct stat lstat(const Path & path)
 {
     struct stat st;
     if (lstat(path.c_str(), &st))
-        throw SysError("getting status of '%1%'", path);
+        throw FileError("getting status of '%1%'", path);
     return st;
 }
 
@@ -228,7 +228,7 @@ bool pathExists(const Path & path)
     res = lstat(path.c_str(), &st);
     if (!res) return true;
     if (errno != ENOENT && errno != ENOTDIR)
-        throw SysError("getting status of %1%", path);
+        throw FileError("getting status of %1%", path);
     return false;
 }
 
@@ -244,7 +244,7 @@ Path readLink(const Path & path)
             if (errno == EINVAL)
                 throw Error("'%1%' is not a symlink", path);
             else
-                throw SysError("reading symbolic link '%1%'", path);
+                throw FileError("reading symbolic link '%1%'", path);
         else if (rlSize < bufSize)
             return string(buf.data(), rlSize);
     }
@@ -276,7 +276,7 @@ DirEntries readDirectory(DIR *dir, const Path & path)
 #endif
         );
     }
-    if (errno) throw SysError("reading directory '%1%'", path);
+    if (errno) throw FileError("reading directory '%1%'", path);
 
     return entries;
 }
@@ -284,7 +284,7 @@ DirEntries readDirectory(DIR *dir, const Path & path)
 DirEntries readDirectory(const Path & path)
 {
     AutoCloseDir dir(opendir(path.c_str()));
-    if (!dir) throw SysError("opening directory '%1%'", path);
+    if (!dir) throw FileError("opening directory '%1%'", path);
 
     return readDirectory(dir.get(), path);
 }
@@ -314,7 +314,7 @@ string readFile(const Path & path)
 {
     AutoCloseFD fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
     if (!fd)
-        throw SysError("opening file '%1%'", path);
+        throw FileError("opening file '%1%'", path);
     return readFile(fd.get());
 }
 
@@ -323,7 +323,7 @@ void readFile(const Path & path, Sink & sink)
 {
     AutoCloseFD fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
     if (!fd)
-        throw SysError("opening file '%s'", path);
+        throw FileError("opening file '%s'", path);
     drainFD(fd.get(), sink);
 }
 
@@ -332,7 +332,7 @@ void writeFile(const Path & path, std::string_view s, mode_t mode)
 {
     AutoCloseFD fd = open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, mode);
     if (!fd)
-        throw SysError("opening file '%1%'", path);
+        throw FileError("opening file '%1%'", path);
     try {
         writeFull(fd.get(), s);
     } catch (Error & e) {
@@ -346,7 +346,7 @@ void writeFile(const Path & path, Source & source, mode_t mode)
 {
     AutoCloseFD fd = open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT | O_CLOEXEC, mode);
     if (!fd)
-        throw SysError("opening file '%1%'", path);
+        throw FileError("opening file '%1%'", path);
 
     std::vector<char> buf(64 * 1024);
 
@@ -400,7 +400,7 @@ static void _deletePath(int parentfd, const Path & path, uint64_t & bytesFreed)
     struct stat st;
     if (fstatat(parentfd, name.c_str(), &st, AT_SYMLINK_NOFOLLOW) == -1) {
         if (errno == ENOENT) return;
-        throw SysError("getting status of '%1%'", path);
+        throw FileError("getting status of '%1%'", path);
     }
 
     if (!S_ISDIR(st.st_mode) && st.st_nlink == 1)
@@ -411,7 +411,7 @@ static void _deletePath(int parentfd, const Path & path, uint64_t & bytesFreed)
         const auto PERM_MASK = S_IRUSR | S_IWUSR | S_IXUSR;
         if ((st.st_mode & PERM_MASK) != PERM_MASK) {
             if (fchmodat(parentfd, name.c_str(), st.st_mode | PERM_MASK, 0) == -1)
-                throw SysError("chmod '%1%'", path);
+                throw FileError("chmod '%1%'", path);
         }
 
         int fd = openat(parentfd, path.c_str(), O_RDONLY);
@@ -511,7 +511,7 @@ std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix)
     // FIXME: use O_TMPFILE.
     AutoCloseFD fd(mkstemp((char *) tmpl.c_str()));
     if (!fd)
-        throw SysError("creating temporary file '%s'", tmpl);
+        throw FileError("creating temporary file '%s'", tmpl);
     return {std::move(fd), tmpl};
 }
 
@@ -591,7 +591,7 @@ Paths createDirs(const Path & path)
     }
 
     if (S_ISLNK(st.st_mode) && stat(path.c_str(), &st) == -1)
-        throw SysError("statting symlink '%1%'", path);
+        throw FileError("statting symlink '%1%'", path);
 
     if (!S_ISDIR(st.st_mode)) throw Error("'%1%' is not a directory", path);
 
@@ -603,7 +603,7 @@ void createSymlink(const Path & target, const Path & link,
     std::optional<time_t> mtime)
 {
     if (symlink(target.c_str(), link.c_str()))
-        throw SysError("creating symlink from '%1%' to '%2%'", link, target);
+        throw FileError("creating symlink from '%1%' to '%2%'", link, target);
     if (mtime) {
         struct timeval times[2];
         times[0].tv_sec = *mtime;
@@ -611,7 +611,7 @@ void createSymlink(const Path & target, const Path & link,
         times[1].tv_sec = *mtime;
         times[1].tv_usec = 0;
         if (lutimes(link.c_str(), times))
-            throw SysError("setting time of symlink '%s'", link);
+            throw FileError("setting time of symlink '%s'", link);
     }
 }
 
@@ -727,7 +727,7 @@ AutoDelete::~AutoDelete()
                 deletePath(path);
             else {
                 if (remove(path.c_str()) == -1)
-                    throw SysError("cannot unlink '%1%'", path);
+                    throw FileError("cannot unlink '%1%'", path);
             }
         }
     } catch (...) {

--- a/tests/flake-missing-file.sh
+++ b/tests/flake-missing-file.sh
@@ -1,0 +1,39 @@
+source common.sh
+
+if [[ -z $(type -p git) ]]; then
+    echo "Git not installed; skipping flake tests"
+    exit 99
+fi
+
+clearStore
+rm -rf $TEST_HOME/.cache $TEST_HOME/.config
+
+repo=$TEST_ROOT/flake
+
+rm -rf $repo $repo.tmp
+mkdir $repo
+git -C $repo init
+git -C $repo config user.email "foobar@example.com"
+git -C $repo config user.name "Foobar"
+
+cat > $repo/flake.nix <<EOF
+{
+  description = "Bla bla";
+
+  outputs = inputs: rec {
+    packages.$system.foo = import ./simple.nix;
+    defaultPackage.$system = packages.$system.foo;
+  };
+}
+EOF
+
+git -C $repo add flake.nix
+git -C $repo commit -m 'Initial'
+
+cp ./simple.nix $repo/
+nix build $repo |& grep -q "Did you forget to track it in Git" || \
+    fail "Trying to access a non git-tracked file should suggest that it is probably the issue"
+
+rm $repo/simple.nix
+nix build $repo |& (! grep -q "Did you forget to track it in Git") || \
+    fail "Trying to use an absent file shouldn’t suggest to git add it"

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -47,6 +47,7 @@ nix_tests = \
   describe-stores.sh \
   flakes.sh \
   flake-local-settings.sh \
+  flake-missing-file.sh \
   build.sh \
   compute-levels.sh \
   repl.sh ca/repl.sh \


### PR DESCRIPTION
When building a local git flake, if a file a missing at eval-time but
present in the source directory, tell the user that he probably forgot
to check it out

Fix #4507

The current approach is far from complete as is only works for `nix build`, but having a more generic thing is actually quite complex or hacky, and I’d like to have some feedback on my plan before implementing it.

My idea is to

- Add a `void enhanceMessage(void(void))` method to `Installable` that’s semantically just calling its argument, but can also add some informations to the error message if one is thrown.
    (In practice, this will be a no-op, except for `InstallableFlake` when the flake input is a local git repo − or probably mercurial too)
- Override `run()` in `InstallableCommand` to run `installable.enhanceMessage(run(store))`

I think this would work, but it isn’t utterly pretty, so if you have any concern or better idea, feel free to chime in.

Depends on #3121 
We depends on above ticket because a ticket provides needed information without guessing it.
