### PR TITLE
nix develop: Make bash environment parsing more robust

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -72,7 +72,7 @@ struct BuildEnvironment
     void toBash(std::ostream & out, const std::set<std::string> & ignoreVars) const
     {
         for (auto & [name, value] : vars) {
-            if (!ignoreVars.count(name) && !hasPrefix(name, "BASH_")) {
+            if (!ignoreVars.count(name)) {
                 if (auto str = std::get_if<String>(&value)) {
                     out << fmt("%s=%s\n", name, shellEscape(str->value));
                     if (str->exported)
@@ -191,17 +191,13 @@ struct Common : InstallableCommand, MixProfile
 {
     std::set<std::string> ignoreVars{
         "BASHOPTS",
-        "EUID",
         "HOME", // FIXME: don't ignore in pure mode?
-        "HOSTNAME",
         "NIX_BUILD_TOP",
         "NIX_ENFORCE_PURITY",
         "NIX_LOG_FD",
         "NIX_REMOTE",
         "PPID",
-        "PWD",
         "SHELLOPTS",
-        "SHLVL",
         "SSL_CERT_FILE", // FIXME: only want to ignore /no-cert-file.crt
         "TEMP",
         "TEMPDIR",

--- a/src/nix/get-env.sh
+++ b/src/nix/get-env.sh
@@ -42,6 +42,20 @@ __dumpEnv() {
         local type="${BASH_REMATCH[1]}"
         local __var_name="${BASH_REMATCH[2]}"
 
+        if [[ $__var_name =~ ^BASH_ || \
+              $__var_name = _ || \
+              $__var_name = DIRSTACK || \
+              $__var_name = EUID || \
+              $__var_name = FUNCNAME || \
+              $__var_name = HISTCMD || \
+              $__var_name = HOSTNAME || \
+              $__var_name = PIPESTATUS || \
+              $__var_name = PWD || \
+              $__var_name = RANDOM || \
+              $__var_name = SHLVL || \
+              $__var_name = SECONDS \
+            ]]; then continue; fi
+
         if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
 
         printf "    "

--- a/src/nix/get-env.sh
+++ b/src/nix/get-env.sh
@@ -8,10 +8,98 @@ if [[ -n $stdenv ]]; then
     source $stdenv/setup
 fi
 
+# Better to use compgen, but stdenv bash doesn't have it.
+__vars="$(declare -p)"
+__functions="$(declare -F)"
+
+__dumpEnv() {
+    printf '{\n'
+
+    printf '  "bashFunctions": {\n'
+    local __first=1
+    while read __line; do
+        if ! [[ $__line =~ ^declare\ -f\ (.*) ]]; then continue; fi
+        __fun_name="${BASH_REMATCH[1]}"
+        __fun_body="$(type $__fun_name)"
+        if [[ $__fun_body =~ \{(.*)\} ]]; then
+            if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+            __fun_body="${BASH_REMATCH[1]}"
+            printf "    "
+            __escapeString "$__fun_name"
+            printf ':'
+            __escapeString "$__fun_body"
+        else
+            printf "Cannot parse definition of function '%s'.\n" "$__fun_name" >&2
+            return 1
+        fi
+    done < <(printf "%s\n" "$__functions")
+    printf '\n  },\n'
+
+    printf '  "variables": {\n'
+    local __first=1
+    while read __line; do
+        if ! [[ $__line =~ ^declare\ (-[^ ])\ ([^=]*) ]]; then continue; fi
+        local type="${BASH_REMATCH[1]}"
+        local __var_name="${BASH_REMATCH[2]}"
+
+        if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+
+        printf "    "
+        __escapeString "$__var_name"
+        printf ': {'
+
+        # FIXME: handle -i, -r, -n.
+        if [[ $type == -x ]]; then
+            printf '"type": "exported", "value": '
+            __escapeString "${!__var_name}"
+        elif [[ $type == -- ]]; then
+            printf '"type": "var", "value": '
+            __escapeString "${!__var_name}"
+        elif [[ $type == -a ]]; then
+            printf '"type": "array", "value": ['
+            local __first2=1
+            __var_name="$__var_name[@]"
+            for __i in "${!__var_name}"; do
+                if [[ -z $__first2 ]]; then printf ', '; else __first2=; fi
+                __escapeString "$__i"
+                printf ' '
+            done
+            printf ']'
+        elif [[ $type == -A ]]; then
+            printf '"type": "associative", "value": {\n'
+            local __first2=1
+            declare -n __var_name2="$__var_name"
+            for __i in "${!__var_name2[@]}"; do
+                if [[ -z $__first2 ]]; then printf ',\n'; else __first2=; fi
+                printf "      "
+                __escapeString "$__i"
+                printf ": "
+                __escapeString "${__var_name2[$__i]}"
+            done
+            printf '\n    }'
+        else
+            printf '"type": "unknown"'
+        fi
+
+        printf "}"
+    done < <(printf "%s\n" "$__vars")
+    printf '\n  }\n}'
+}
+
+__escapeString() {
+    local __s="$1"
+    __s="${__s//\\/\\\\}"
+    __s="${__s//\"/\\\"}"
+    __s="${__s//$'\n'/\\n}"
+    __s="${__s//$'\r'/\\r}"
+    __s="${__s//$'\t'/\\t}"
+    printf '"%s"' "$__s"
+}
+
+# Dump the bash environment as JSON.
 for __output in $outputs; do
     if [[ -z $__done ]]; then
-        export > ${!__output}
-        set >> ${!__output}
+        __dumpEnv > ${!__output}
         __done=1
     else
         echo -n >> ${!__output}

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -98,3 +98,4 @@ nix_develop -f shell.nix shellDrv -c echo foo |& grep -q foo
 # Test 'nix print-dev-env'.
 source <(nix print-dev-env -f shell.nix shellDrv)
 [[ -n $stdenv ]]
+[[ ${arr1[2]} = "3 4" ]]

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -99,3 +99,5 @@ nix_develop -f shell.nix shellDrv -c echo foo |& grep -q foo
 source <(nix print-dev-env -f shell.nix shellDrv)
 [[ -n $stdenv ]]
 [[ ${arr1[2]} = "3 4" ]]
+[[ ${arr2[1]} = $'\n' ]]
+[[ ${arr2[2]} = $'x\ny' ]]

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -101,3 +101,4 @@ source <(nix print-dev-env -f shell.nix shellDrv)
 [[ ${arr1[2]} = "3 4" ]]
 [[ ${arr2[1]} = $'\n' ]]
 [[ ${arr2[2]} = $'x\ny' ]]
+[[ $(fun) = blabla ]]

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -20,6 +20,7 @@ let pkgs = rec {
     for pkg in $buildInputs; do
       export PATH=$PATH:$pkg/bin
     done
+    declare -a arr1=(1 2 "3 4" 5)
   '';
 
   stdenv = mkDerivation {

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -21,6 +21,7 @@ let pkgs = rec {
       export PATH=$PATH:$pkg/bin
     done
     declare -a arr1=(1 2 "3 4" 5)
+    declare -a arr2=(x $'\n' $'x\ny')
   '';
 
   stdenv = mkDerivation {

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -22,6 +22,9 @@ let pkgs = rec {
     done
     declare -a arr1=(1 2 "3 4" 5)
     declare -a arr2=(x $'\n' $'x\ny')
+    fun() {
+      echo blabla
+    }
   '';
 
   stdenv = mkDerivation {


### PR DESCRIPTION
Instead of using some nasty regexes, let `get-env.sh` export the bash environment as JSON.

Fixes #4992.