### PR TITLE
toString also coerces a set with an outPath attribute to a string

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3109,7 +3109,7 @@ static RegisterPrimOp primop_toString({
 
         - A path (e.g., `toString /foo/bar` yields `"/foo/bar"`.
 
-        - A set containing `{ __toString = self: ...; }`.
+        - A set containing `{ __toString = self: ...; }` or `{ outPath = ...; }`.
 
         - An integer.
 


### PR DESCRIPTION
nix-repl> builtins.toString { outPath = "somestring"; }
"somestring"