### PR TITLE
Throw on unexpected input for --delete-older-than

### DIFF
--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -211,6 +211,9 @@ void deleteGenerationsOlderThan(const Path & profile, time_t t, bool dryRun)
 
 void deleteGenerationsOlderThan(const Path & profile, const string & timeSpec, bool dryRun)
 {
+    if (timeSpec.empty() || timeSpec[timeSpec.size() - 1] != 'd')
+        throw Error("invalid number of days specifier '%1%', expected something like '14d'", timeSpec);
+
     time_t curTime = time(0);
     string strDays = string(timeSpec, 0, timeSpec.size() - 1);
     auto days = string2Int<int>(strDays);


### PR DESCRIPTION
'--delete-older-than 10' deletes the generations older than a single day, and '--delete-older-than 12m' deletes all generations older than 12 days.

This changes makes it throw on those invalid inputs, and gives an example of a valid input.

This commit fixes #2557