### PR TITLE
Put native system in extra platforms if --system is used

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -136,6 +136,10 @@ StringSet Settings::getDefaultExtraPlatforms()
 {
     StringSet extraPlatforms;
 
+    // if custom --system is used, provide native system as extra platform always
+    if (std::string{SYSTEM} != settings.thisSystem.get())
+        extraPlatforms.insert(std::string{SYSTEM});
+
     if (std::string{SYSTEM} == "x86_64-linux" && !isWSL1())
         extraPlatforms.insert("i686-linux");
 


### PR DESCRIPTION
When we use a custom --system arg, we want Nix to also be able to utilize it’s native architecture for builds.

The best use case for this is M1 macOS users who want to prefer x86_64 for compatibility, but sometimes use
aarch64-darwin too. They can now add:

  system = x86_64-darwin

to $HOME/.config/nix/nix.conf without sacrificing ability to build aarch64-darwin.