### PR TITLE
Add a `devShells` attribute to the flake schema

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -326,6 +326,12 @@ struct Common : InstallableCommand, MixProfile
     {
         return {"devShell." + settings.thisSystem.get(), "defaultPackage." + settings.thisSystem.get()};
     }
+    Strings getDefaultFlakeAttrPathPrefixes() override
+    {
+        auto res = SourceExprCommand::getDefaultFlakeAttrPathPrefixes();
+        res.emplace_front("devShells." + settings.thisSystem.get());
+        return res;
+    }
 
     StorePath getShellOutPath(ref<Store> store)
     {

--- a/src/nix/develop.md
+++ b/src/nix/develop.md
@@ -84,11 +84,20 @@ the flake's `nixConfig` attribute.
 
 # Flake output attributes
 
-If no flake output attribute is given, `nix run` tries the following
+If no flake output attribute is given, `nix develop` tries the following
 flake output attributes:
 
 * `devShell.<system>`
 
 * `defaultPackage.<system>`
+
+If a flake output *name* is given, `nix develop` tries the following flake
+output attributes:
+
+* `devShells.<system>.<name>`
+
+* `packages.<system>.<name>`
+
+* `legacyPackages.<system>.<name>`
 
 )""

--- a/src/nix/flake-check.md
+++ b/src/nix/flake-check.md
@@ -33,6 +33,7 @@ The following flake output attributes must be derivations:
 * `checks.`*system*`.`*name*
 * `defaultPackage.`*system*`
 * `devShell.`*system*`
+* `devShells.`*system*`.`*name*`
 * `nixosConfigurations.`*name*`.config.system.build.toplevel
 * `packages.`*system*`.`*name*
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -486,7 +486,7 @@ struct CmdFlakeCheck : FlakeCommand
                             }
                         }
 
-                        else if (name == "packages") {
+                        else if (name == "packages" || name == "devShells") {
                             state->forceAttrs(vOutput, pos);
                             for (auto & attr : *vOutput.attrs) {
                                 checkSystemName(attr.name, *attr.pos);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -914,6 +914,7 @@ struct CmdFlakeShow : FlakeCommand
                     logger->cout("%s: %s '%s'",
                         headerPrefix,
                         attrPath.size() == 2 && attrPath[0] == "devShell" ? "development environment" :
+                        attrPath.size() >= 2 && attrPath[0] == "devShells" ? "development environment" :
                         attrPath.size() == 3 && attrPath[0] == "checks" ? "derivation" :
                         attrPath.size() >= 1 && attrPath[0] == "hydraJobs" ? "derivation" :
                         "package",
@@ -932,6 +933,7 @@ struct CmdFlakeShow : FlakeCommand
                     || ((attrPath.size() == 1 || attrPath.size() == 2)
                         && (attrPath[0] == "checks"
                             || attrPath[0] == "packages"
+                            || attrPath[0] == "devShells"
                             || attrPath[0] == "apps"))
                     )
                 {
@@ -940,7 +942,7 @@ struct CmdFlakeShow : FlakeCommand
 
                 else if (
                     (attrPath.size() == 2 && (attrPath[0] == "defaultPackage" || attrPath[0] == "devShell"))
-                    || (attrPath.size() == 3 && (attrPath[0] == "checks" || attrPath[0] == "packages"))
+                    || (attrPath.size() == 3 && (attrPath[0] == "checks" || attrPath[0] == "packages" || attrPath[0] == "devShells"))
                     )
                 {
                     if (visitor.isDerivation())


### PR DESCRIPTION
Add a `devShells` attribute to the flake schema, so that `nix develop .#foo`
tries first to expand to `nix develop .#devShells.${system}.foo`.

Also makes `nix flake show` and `nix flake check` aware of this attribute

Fix https://github.com/NixOS/nix/issues/5005
