### PR TITLE
Add 'auto' support to machines files

### DIFF
--- a/doc/manual/src/advanced-topics/distributed-builds.md
+++ b/doc/manual/src/advanced-topics/distributed-builds.md
@@ -81,7 +81,9 @@ default, set it to `-`.
 2.  A comma-separated list of Nix platform type identifiers, such as
     `x86_64-darwin`. It is possible for a machine to support multiple
     platform types, e.g., `i686-linux,x86_64-linux`. If omitted, this
-    defaults to the local platform type.
+    defaults to the local platform type. To allow the builder to specify
+    its supported platform types, you can set `auto` here (only
+    supported with the `ssh-ng://` protocol).
 
 3.  The SSH identity file to be used to log in to the remote machine. If
     omitted, SSH will use its regular identities.
@@ -105,7 +107,8 @@ default, set it to `-`.
     ```
 
     will cause the build to be performed on a machine that has the `kvm`
-    feature.
+    feature. To allow the builder to specify its supported features, you
+    can set `auto` here (only supported with the `ssh-ng://` protocol).
 
 7.  A comma-separated list of *mandatory features*. A machine will only
     be used to build a derivation if all of the machine’s mandatory

--- a/doc/manual/src/release-notes/rl-2.4.md
+++ b/doc/manual/src/release-notes/rl-2.4.md
@@ -6,3 +6,6 @@
     `nix-instantiate default.nix --plugin-files ""` must now become
     `nix-instantiate --plugin-files "" default.nix`.
   - Plugins that add new `nix` subcommands are now actually respected.
+  - System types and support features of builders can now be automatically configured by setting to `auto`.
+    This works by asking the remote builder what systems and features it supports. This feature only works
+    with the `ssh-ng://` protocol.

--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -133,13 +133,14 @@ static int main_build_remote(int argc, char * * argv)
                     if (std::find(m.systemTypes.begin(), m.systemTypes.end(), "*") != m.systemTypes.end() ||
                         std::find(m.supportedFeatures.begin(), m.supportedFeatures.end(), "*") != m.supportedFeatures.end()) {
                         // wildcard is used, so we need to ask the machine what it supports
+
+                        if (hasPrefix(m.storeUri, "ssh://"))
+                            throw Error("Cannot use wildcards with legacy ssh store. Instead use the ssh-ng:// protocol.");
+
                         try {
                             Activity act(*logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", m.storeUri));
 
                             auto store = m.openStore();
-
-                            if (hasPrefix(m.storeUri, "ssh://"))
-                                throw Error("Cannot use wildcards with legacy ssh store. Instead use the ssh-ng:// protocol.");
 
                             store->connect();
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -916,9 +916,9 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     }
 
     case wopGetOptions: {
+        StringSet systemTypes = {settings.thisSystem.get()};
+        systemTypes.insert(settings.extraPlatforms.get().begin(), settings.extraPlatforms.get().end());
         logger->startWork();
-        auto systemTypes = StringSet(settings.extraPlatforms.get());
-        systemTypes.insert(settings.thisSystem.get());
         logger->stopWork();
         worker_proto::write(*store, to, systemTypes);
         worker_proto::write(*store, to, settings.systemFeatures.get());

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -915,6 +915,16 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case wopGetOptions: {
+        logger->startWork();
+        auto systemTypes = StringSet(settings.extraPlatforms.get());
+        systemTypes.insert(settings.thisSystem.get());
+        logger->stopWork();
+        worker_proto::write(*store, to, systemTypes);
+        worker_proto::write(*store, to, settings.systemFeatures.get());
+        break;
+    }
+
     default:
         throw Error("invalid operation %1%", op);
     }

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -11,6 +11,9 @@ namespace nix {
 LocalFSStore::LocalFSStore(const Params & params)
     : Store(params)
 {
+    StringSet systemTypes_ = {settings.thisSystem.get()};
+    systemTypes_.insert(settings.extraPlatforms.get().begin(), settings.extraPlatforms.get().end());
+    systemTypes = systemTypes_;
 }
 
 struct LocalStoreAccessor : public FSAccessor

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -107,7 +107,7 @@ void parseMachines(const std::string & s, Machines & machines)
         };
 
         machines.emplace_back(tokens[0],
-            isSet(1) ? tokenizeString<std::vector<string>>(tokens[1], ",") : std::vector<string>{settings.thisSystem},
+            isSet(1) ? tokenizeString<std::set<string>>(tokens[1], ",") : std::set<string>{settings.thisSystem},
             isSet(2) ? tokens[2] : "",
             isSet(3) ? std::stoull(tokens[3]) : 1LL,
             isSet(4) ? std::stoull(tokens[4]) : 1LL,

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -9,11 +9,11 @@ class Store;
 struct Machine {
 
     const string storeUri;
-    const std::vector<string> systemTypes;
+    std::vector<string> systemTypes;
     const string sshKey;
     const unsigned int maxJobs;
     const unsigned int speedFactor;
-    const std::set<string> supportedFeatures;
+    std::set<string> supportedFeatures;
     const std::set<string> mandatoryFeatures;
     const std::string sshPublicHostKey;
     bool enabled = true;

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -9,7 +9,7 @@ class Store;
 struct Machine {
 
     const string storeUri;
-    std::vector<string> systemTypes;
+    std::set<string> systemTypes;
     const string sshKey;
     const unsigned int maxJobs;
     const unsigned int speedFactor;

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -191,8 +191,21 @@ void RemoteStore::initConnection(Connection & conn)
     }
 
     setOptions(conn);
+
+    getOptions(conn);
 }
 
+
+void RemoteStore::getOptions(Connection & conn)
+{
+    if (GET_PROTOCOL_MINOR(conn.daemonVersion) >= 32) {
+        conn.to << wopGetOptions;
+        auto ex = conn.processStderr();
+        if (ex) std::rethrow_exception(ex);
+        systemTypes = worker_proto::read(*this, conn.from, Phantom<StringSet> {});
+        systemFeatures = worker_proto::read(*this, conn.from, Phantom<StringSet> {});
+    }
+}
 
 void RemoteStore::setOptions(Connection & conn)
 {

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -143,6 +143,8 @@ protected:
 
     virtual void setOptions(Connection & conn);
 
+    virtual void getOptions(Connection & conn);
+
     ConnectionHandle getConnection();
 
     friend struct ConnectionHandle;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -202,6 +202,10 @@ struct StoreConfig : public Config
         "system-features",
         "Optional features that the system this store builds on implements (like \"kvm\")."};
 
+    Setting<StringSet> systemTypes{this, {},
+        "system-types",
+        "Optional system types this store can build on."};
+
 };
 
 class Store : public std::enable_shared_from_this<Store>, public virtual StoreConfig

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 31)
+#define PROTOCOL_VERSION (1 << 8 | 32)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -55,6 +55,7 @@ typedef enum {
     wopQueryDerivationOutputMap = 41,
     wopRegisterDrvOutput = 42,
     wopQueryRealisation = 43,
+    wopGetOptions = 44,
 } WorkerOp;
 
 

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -16,7 +16,7 @@ builders=(
   # remote-store URL.
   "ssh://localhost?remote-store=$TEST_ROOT/machine1?system-features=$(join_by "%20" foo ${EXTRA_SYSTEM_FEATURES[@]}) - - 1 1 $(join_by "," foo ${EXTRA_SYSTEM_FEATURES[@]})"
   "$TEST_ROOT/machine2 - - 1 1 $(join_by "," bar ${EXTRA_SYSTEM_FEATURES[@]})"
-  "ssh-ng://localhost?remote-store=$TEST_ROOT/machine3?system-features=$(join_by "%20" baz ${EXTRA_SYSTEM_FEATURES[@]}) - - 1 1 $(join_by "," baz ${EXTRA_SYSTEM_FEATURES[@]})"
+  "ssh-ng://localhost?remote-store=$TEST_ROOT/machine3?system-features=$(join_by "%20" baz ${EXTRA_SYSTEM_FEATURES[@]}) auto - 1 1 $(join_by "," baz ${EXTRA_SYSTEM_FEATURES[@]})"
 )
 
 chmod -R +w $TEST_ROOT/machine* || true


### PR DESCRIPTION
This lets the remote machine fill in extra details for system types and supported feature. For instance, you
can do this:

```
ssh-ng://me@nixos1.local auto /home/me/.ssh/id_rsa 4 0 auto
ssh-ng://me@nixos2.local auto /home/me/.ssh/id_rsa 4 1 auto
ssh-ng://me@nixos3.local auto /home/me/.ssh/id_rsa 8 2 auto
```

and each machine can determine what it supports.
