### PR TITLE
Use ssh-ng by default

### DIFF
--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -24,7 +24,7 @@ Machine::Machine(decltype(storeUri) storeUri,
         || hasPrefix(storeUri, "auto")
         || hasPrefix(storeUri, "/")
         ? storeUri
-        : "ssh://" + storeUri),
+        : "ssh-ng://" + storeUri),
     systemTypes(systemTypes),
     sshKey(sshKey),
     maxJobs(maxJobs),


### PR DESCRIPTION
I think this is now safe to do. I haven’t had any issues using ssh-ng, but I suspect most users don’t know
about it.

Relates to #4665