### PR TITLE
libexpr: Fix read out-of-bound on the heap

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -38,11 +38,13 @@ static void adjustLoc(YYLTYPE * loc, const char * s, size_t len)
     loc->first_line = loc->last_line;
     loc->first_column = loc->last_column;
 
-    while (len--) {
+    for (size_t i = 0; i < len; i++) {
        switch (*s++) {
        case '\r':
-           if (*s == '\n') /* cr/lf */
+           if (*s == '\n') { /* cr/lf */
+               i++;
                s++;
+           }
            /* fall through */
        case '\n':
            ++loc->last_line;


### PR DESCRIPTION
  * When `s` contains `\r\n`, `len` does not get decremented enough, and so more looping than necessary happens;
  * I replaced the `while` loop with a `for` because `len` is a `size_t`, thus decrementing it if its value is `0` would not stop the loop.
  
cc @regnat

Signed-off-by: Pamplemousse <xav.maso@gmail.com>