### PR TITLE
Log ssh output for ssh-ng too

### DIFF
--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -53,10 +53,10 @@ ref<Store> Machine::openStore() const {
     Store::Params storeParams;
     if (hasPrefix(storeUri, "ssh://")) {
         storeParams["max-connections"] = "1";
-        storeParams["log-fd"] = "4";
     }
 
     if (hasPrefix(storeUri, "ssh://") || hasPrefix(storeUri, "ssh-ng://")) {
+        storeParams["log-fd"] = "4";
         if (sshKey != "")
             storeParams["ssh-key"] = sshKey;
         if (sshPublicHostKey != "")

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -24,6 +24,10 @@ struct SSHStoreConfig : virtual RemoteStoreConfig
 class SSHStore : public virtual SSHStoreConfig, public virtual RemoteStore
 {
 public:
+    // Hack for getting remote build log output.
+    // Intentionally not in `SSHStoreConfig` so that it doesn't appear in
+    // the documentation
+    const Setting<int> logFD{(StoreConfig*) this, -1, "log-fd", "file descriptor to which SSH's stderr is connected"};
 
     SSHStore(const std::string & scheme, const std::string & host, const Params & params)
         : StoreConfig(params)
@@ -38,7 +42,8 @@ public:
             sshPublicHostKey,
             // Use SSH master only if using more than 1 connection.
             connections->capacity() > 1,
-            compress)
+            compress,
+            logFD)
     {
     }
 


### PR DESCRIPTION
I think this was just an oversight. Right now, ssh:// gets ssh errors but not ssh-ng://.

/cc @edolstra