### PR TITLE
Forward the whole Nix config to the post-build-hook

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -757,6 +757,7 @@ void runPostBuildHook(
 
     hookEnvironment.emplace("DRV_PATH", store.printStorePath(drvPath));
     hookEnvironment.emplace("OUT_PATHS", chomp(concatStringsSep(" ", store.printStorePathSet(outputPaths))));
+    hookEnvironment.emplace("NIX_CONFIG", globalConfig.toKeyValue());
 
     RunOptions opts(settings.postBuildHook, {});
     opts.environment = hookEnvironment;

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -152,6 +152,16 @@ nlohmann::json Config::toJSON()
     return res;
 }
 
+std::string Config::toKeyValue()
+{
+    auto res = std::string();
+    for (auto & s : _settings)
+        if (!s.second.isAlias) {
+            res += fmt("%s = %s\n", s.first, s.second.setting->to_string());
+        }
+    return res;
+}
+
 void Config::convertToArgs(Args & args, const std::string & category)
 {
     for (auto & s : _settings)
@@ -382,6 +392,16 @@ nlohmann::json GlobalConfig::toJSON()
     auto res = nlohmann::json::object();
     for (auto & config : *configRegistrations)
         res.update(config->toJSON());
+    return res;
+}
+
+std::string GlobalConfig::toKeyValue()
+{
+    std::string res;
+    std::map<std::string, Config::SettingInfo> settings;
+    globalConfig.getSettings(settings);
+    for (auto & s : settings)
+        res += fmt("%s = %s\n", s.first, s.second.value);
     return res;
 }
 

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -100,6 +100,12 @@ public:
     virtual nlohmann::json toJSON() = 0;
 
     /**
+     * Outputs all settings in a key-value pair format suitable to be used as
+     * `nix.conf`
+     */
+    virtual std::string toKeyValue() = 0;
+
+    /**
      * Converts settings to `Args` to be used on the command line interface
      * - args: args to write to
      * - category: category of the settings
@@ -168,6 +174,8 @@ public:
     void resetOverridden() override;
 
     nlohmann::json toJSON() override;
+
+    std::string toKeyValue() override;
 
     void convertToArgs(Args & args, const std::string & category) override;
 };
@@ -329,6 +337,8 @@ struct GlobalConfig : public AbstractConfig
     void resetOverridden() override;
 
     nlohmann::json toJSON() override;
+
+    std::string toKeyValue() override;
 
     void convertToArgs(Args & args, const std::string & category) override;
 

--- a/src/nix/show-config.cc
+++ b/src/nix/show-config.cc
@@ -22,10 +22,7 @@ struct CmdShowConfig : Command, MixJSON
             // FIXME: use appropriate JSON types (bool, ints, etc).
             logger->cout("%s", globalConfig.toJSON().dump());
         } else {
-            std::map<std::string, Config::SettingInfo> settings;
-            globalConfig.getSettings(settings);
-            for (auto & s : settings)
-                logger->cout("%s = %s", s.first, s.second.value);
+            logger->cout("%s", globalConfig.toKeyValue());
         }
     }
 };


### PR DESCRIPTION
Fill `NIX_CONFIG` with the value of the current Nix configuration before
calling the post-build-hook.
That way the whole configuration (including the possible
`experimental-features`, a possibly `--store` option or whatever) will
be made available to the hook
