### PR TITLE
Forward the whole Nix config to the repl subprocesses

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -107,11 +107,8 @@ NixRepl::~NixRepl()
 string runNix(Path program, const Strings & args,
     const std::optional<std::string> & input = {})
 {
-    auto experimentalFeatures = concatStringsSep(" ", settings.experimentalFeatures.get());
-    auto nixConf = getEnv("NIX_CONFIG").value_or("");
-    nixConf.append("\nexperimental-features = " + experimentalFeatures);
     auto subprocessEnv = getEnv();
-    subprocessEnv["NIX_CONFIG"] = nixConf;
+    subprocessEnv["NIX_CONFIG"] = globalConfig.toKeyValue();
     RunOptions opts(settings.nixBinDir+ "/" + program, args);
     opts.input = input;
     opts.environment = subprocessEnv;

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -46,6 +46,7 @@ nix_tests = \
   flakes.sh \
   build.sh \
   compute-levels.sh \
+  repl.sh \
   ca/build.sh \
   ca/build-with-garbage-path.sh \
   ca/duplicate-realisation-in-closure.sh \

--- a/tests/repl.sh
+++ b/tests/repl.sh
@@ -1,0 +1,18 @@
+source common.sh
+
+replCmds="
+simple = import ./simple.nix
+:b simple
+"
+
+testRepl () {
+    local nixArgs=("$@")
+    local outPath=$(nix repl "${nixArgs[@]}" <<< "$replCmds" |&
+        grep -o -E "$NIX_STORE_DIR/\w*-simple")
+    nix path-info "${nixArgs[@]}" "$outPath"
+}
+
+# Simple test, try building a drv
+testRepl
+# Same thing (kind-of), but with a remote store.
+testRepl --store "$TEST_ROOT/store?real=$NIX_STORE_DIR"


### PR DESCRIPTION
Fill `NIX_CONFIG` with the value of the current Nix configuration before
calling the nix subprocesses in the repl
That way the whole configuration (including the possible
`experimental-features`, a possibly `--store` option or whatever) will
be made available.

This is required for example to make `nix repl` work with a custom
`--store`
