### PR TITLE
Be more lenient when realisations have a conflicting dependency set

### DIFF
--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -144,8 +144,16 @@ bool Realisation::isCompatibleWith(const Realisation & other) const
 {
     assert (id == other.id);
     if (outPath == other.outPath) {
-        assert(dependentRealisations == other.dependentRealisations);
-        return true;
+        if (dependentRealisations.empty() != other.dependentRealisations.empty()) {
+            warn(
+                "Encountered a realisation for '%s' with an empty set of "
+                "dependencies. This is likely an artifact from an older Nix. "
+                "I’ll try to fix the realisation if I can",
+                id.to_string());
+            return true;
+        } else if (dependentRealisations == other.dependentRealisations) {
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
- This can legitimately happen (for example because of a non-determinism
  causing a build-time dependency to be kept or not as a runtime
  reference)
- Because of older Nix versions, it can happen that we encounter a
  realisation with an (erroneously) empty set of dependencies, in which
  case we don’t want to fail, but just warn the user and try to fix it.
