### PR TITLE
Cleanup the generation of the nix3 manpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ perl/Makefile.config
 /libtool
 
 # /doc/manual/
-/doc/manual/*.1
+/doc/manual/**/*.1
 /doc/manual/*.5
 /doc/manual/*.8
 /doc/manual/nix.json


### PR DESCRIPTION
Use a dedicated make target for each man page rather than bundling the
generation as part of `install`.

This has two advantages:
- The generation is properly cached and we get rid of the mysterious `GEN
  install` when running `make install`
- Everything is properly parallel (not that the doc generation is the
  bottleneck in general, but it still takes a few hundred miliseconds
  that are nice to avoid for incremental builds)
