### PR TITLE
nix repl: Update :edit doc to remove inaccurate use of "derivation"

### DIFF
--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -100,7 +100,7 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attr
 }
 
 
-Pos findDerivationFilename(EvalState & state, Value & v, std::string what)
+Pos findPackageFilename(EvalState & state, Value & v, std::string what)
 {
     Value * v2;
     try {

--- a/src/libexpr/attr-path.hh
+++ b/src/libexpr/attr-path.hh
@@ -14,7 +14,7 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attr
     Bindings & autoArgs, Value & vIn);
 
 /* Heuristic to find the filename and lineno or a nix value. */
-Pos findDerivationFilename(EvalState & state, Value & v, std::string what);
+Pos findPackageFilename(EvalState & state, Value & v, std::string what);
 
 std::vector<Symbol> parseAttrPath(EvalState & state, std::string_view s);
 

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -31,7 +31,7 @@ struct CmdEdit : InstallableCommand
         auto [v, pos] = installable->toValue(*state);
 
         try {
-            pos = findDerivationFilename(*state, *v, installable->what());
+            pos = findPackageFilename(*state, *v, installable->what());
         } catch (NoPositionInfo &) {
         }
 

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -412,7 +412,7 @@ bool NixRepl::processLine(string line)
              << "  <x> = <expr>  Bind expression to variable\n"
              << "  :a <expr>     Add attributes from resulting set to scope\n"
              << "  :b <expr>     Build derivation\n"
-             << "  :e <expr>     Open the derivation in $EDITOR\n"
+             << "  :e <expr>     Open package or function in $EDITOR\n"
              << "  :i <expr>     Build derivation, then install result into current profile\n"
              << "  :l <path>     Load Nix expression and add it to scope\n"
              << "  :p <expr>     Evaluate and print expression recursively\n"

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -454,7 +454,7 @@ bool NixRepl::processLine(string line)
             pos = v.lambda.fun->pos;
         } else {
             // assume it's a derivation
-            pos = findDerivationFilename(*state, v, arg);
+            pos = findPackageFilename(*state, v, arg);
         }
 
         // Open in EDITOR


### PR DESCRIPTION
"Derivation" is an inaccurate term for what `:e` and its backing method operate on.

For a detailed argumentation, expand the commit messages.