### PR TITLE
Properly lock the builds of CA derivations

### DIFF
--- a/tests/ca/concurrent-builds.sh
+++ b/tests/ca/concurrent-builds.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Ensure that we can’t build twice the same derivation concurrently.
+# Regression test for https://github.com/NixOS/nix/issues/5029
+
+source common.sh
+
+sed -i 's/experimental-features .*/& ca-derivations ca-references/' "$NIX_CONF_DIR"/nix.conf
+
+export NIX_TESTS_CA_BY_DEFAULT=1
+
+clearStore
+
+for i in {0..5}; do
+    nix build --no-link --file ./racy.nix &
+done
+
+wait

--- a/tests/ca/racy.nix
+++ b/tests/ca/racy.nix
@@ -1,0 +1,15 @@
+# A derivation that would certainly fail if several builders tried to
+# build it at once.
+
+
+with import ./config.nix;
+
+mkDerivation {
+  name = "simple";
+  buildCommand = ''
+    mkdir $out
+    echo bar >> $out/foo
+    sleep 3
+    [[ "$(cat $out/foo)" == bar ]]
+  '';
+}

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -55,6 +55,7 @@ nix_tests = \
   ca/nix-shell.sh \
   ca/nix-run.sh \
   ca/recursive.sh \
+  ca/concurrent-builds.sh \
   ca/nix-copy.sh
   # parallel.sh
 


### PR DESCRIPTION
Make sure that we can’t build the same derivation twice at the same
time.

Fix https://github.com/NixOS/nix/issues/5029
