### PR TITLE
Fix --no-gc-warning

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -238,7 +238,7 @@ LegacyArgs::LegacyArgs(const std::string & programName,
     addFlag({
         .longName = "no-gc-warning",
         .description = "Disable warnings about not using `--add-root`.",
-        .handler = {&gcWarning, true},
+        .handler = {&gcWarning, false},
     });
 
     addFlag({


### PR DESCRIPTION
8e758d402ba1045c7b8273f8cb1d6d8d917ca52b took *ex falso quodlibet* too literally.