### PR TITLE
--eval-store and faster closure copying

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -270,7 +270,7 @@ connected:
 
         {
             Activity act(*logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
-            copyPaths(store, ref<Store>(sshStore), store->parseStorePathSet(inputs), NoRepair, NoCheckSigs, substitute);
+            copyPaths(*store, *sshStore, store->parseStorePathSet(inputs), NoRepair, NoCheckSigs, substitute);
         }
 
         uploadLock = -1;
@@ -321,7 +321,7 @@ connected:
             if (auto localStore = store.dynamic_pointer_cast<LocalStore>())
                 for (auto & path : missingPaths)
                     localStore->locksHeld.insert(store->printStorePath(path)); /* FIXME: ugly */
-            copyPaths(ref<Store>(sshStore), store, missingPaths, NoRepair, NoCheckSigs, NoSubstitute);
+            copyPaths(*sshStore, *store, missingPaths, NoRepair, NoCheckSigs, NoSubstitute);
         }
         // XXX: Should be done as part of `copyPaths`
         for (auto & realisation : missingRealisations) {

--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -54,6 +54,38 @@ void StoreCommand::run()
     run(getStore());
 }
 
+EvalCommand::EvalCommand()
+{
+    // FIXME: move to MixEvalArgs?
+    addFlag({
+        .longName = "eval-store",
+        .description = "The Nix store to use for evaluations.",
+        .labels = {"store-url"},
+        //.category = ...,
+        .handler = {&evalStoreUrl},
+    });
+}
+
+EvalCommand::~EvalCommand()
+{
+    if (evalState)
+        evalState->printStats();
+}
+
+ref<Store> EvalCommand::getEvalStore()
+{
+    if (!evalStore)
+        evalStore = evalStoreUrl ? openStore(*evalStoreUrl) : getStore();
+    return ref<Store>(evalStore);
+}
+
+ref<EvalState> EvalCommand::getEvalState()
+{
+    if (!evalState)
+        evalState = std::make_shared<EvalState>(searchPath, getEvalStore(), getStore());
+    return ref<EvalState>(evalState);
+}
+
 BuiltPathsCommand::BuiltPathsCommand(bool recursive)
     : recursive(recursive)
 {

--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -56,14 +56,6 @@ void StoreCommand::run()
 
 EvalCommand::EvalCommand()
 {
-    // FIXME: move to MixEvalArgs?
-    addFlag({
-        .longName = "eval-store",
-        .description = "The Nix store to use for evaluations.",
-        .labels = {"store-url"},
-        //.category = ...,
-        .handler = {&evalStoreUrl},
-    });
 }
 
 EvalCommand::~EvalCommand()

--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -115,7 +115,7 @@ void BuiltPathsCommand::run(ref<Store> store)
         for (auto & p : store->queryAllValidPaths())
             paths.push_back(BuiltPath::Opaque{p});
     } else {
-        paths = toBuiltPaths(store, realiseMode, operateOn, installables);
+        paths = toBuiltPaths(getEvalStore(), store, realiseMode, operateOn, installables);
         if (recursive) {
             // XXX: This only computes the store path closure, ignoring
             // intermediate realisations

--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -54,8 +54,6 @@ struct EvalCommand : virtual StoreCommand, MixEvalArgs
     ref<EvalState> getEvalState();
 
 private:
-    std::optional<std::string> evalStoreUrl;
-
     std::shared_ptr<Store> evalStore;
 
     std::shared_ptr<EvalState> evalState;

--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -45,11 +45,20 @@ private:
 
 struct EvalCommand : virtual StoreCommand, MixEvalArgs
 {
-    ref<EvalState> getEvalState();
-
-    std::shared_ptr<EvalState> evalState;
+    EvalCommand();
 
     ~EvalCommand();
+
+    ref<Store> getEvalStore();
+
+    ref<EvalState> getEvalState();
+
+private:
+    std::optional<std::string> evalStoreUrl;
+
+    std::shared_ptr<Store> evalStore;
+
+    std::shared_ptr<EvalState> evalState;
 };
 
 struct MixFlakeOptions : virtual Args, EvalCommand

--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -223,15 +223,21 @@ static RegisterCommand registerCommand2(std::vector<std::string> && name)
     return RegisterCommand(std::move(name), [](){ return make_ref<T>(); });
 }
 
-BuiltPaths build(ref<Store> store, Realise mode,
+BuiltPaths build(ref<Store> evalStore, ref<Store> store, Realise mode,
     std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode = bmNormal);
 
-std::set<StorePath> toStorePaths(ref<Store> store,
-    Realise mode, OperateOn operateOn,
+std::set<StorePath> toStorePaths(
+    ref<Store> evalStore,
+    ref<Store> store,
+    Realise mode,
+    OperateOn operateOn,
     std::vector<std::shared_ptr<Installable>> installables);
 
-StorePath toStorePath(ref<Store> store,
-    Realise mode, OperateOn operateOn,
+StorePath toStorePath(
+    ref<Store> evalStore,
+    ref<Store> store,
+    Realise mode,
+    OperateOn operateOn,
     std::shared_ptr<Installable> installable);
 
 std::set<StorePath> toDerivations(ref<Store> store,
@@ -239,6 +245,7 @@ std::set<StorePath> toDerivations(ref<Store> store,
     bool useDeriver = false);
 
 BuiltPaths toBuiltPaths(
+    ref<Store> evalStore,
     ref<Store> store,
     Realise mode,
     OperateOn operateOn,

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -766,7 +766,7 @@ BuiltPaths build(ref<Store> evalStore, ref<Store> store, Realise mode,
     if (mode == Realise::Nothing)
         printMissing(store, pathsToBuild, lvlError);
     else if (mode == Realise::Outputs)
-        store->buildPaths(pathsToBuild, bMode);
+        store->buildPaths(pathsToBuild, bMode, evalStore);
 
     return getBuiltPaths(evalStore, store, pathsToBuild);
 }

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -392,8 +392,6 @@ DerivedPaths InstallableValue::toDerivedPaths()
     for (auto & i : drvsToOutputs)
         res.push_back(DerivedPath::Built { i.first, i.second });
 
-    copyClosure(state->store, state->buildStore, drvsToCopy);
-
     return res;
 }
 
@@ -703,10 +701,10 @@ std::shared_ptr<Installable> SourceExprCommand::parseInstallable(
     return installables.front();
 }
 
-BuiltPaths getBuiltPaths(ref<Store> store, DerivedPaths hopefullyBuiltPaths)
+BuiltPaths getBuiltPaths(ref<Store> evalStore, ref<Store> store, const DerivedPaths & hopefullyBuiltPaths)
 {
     BuiltPaths res;
-    for (auto& b : hopefullyBuiltPaths)
+    for (auto & b : hopefullyBuiltPaths)
         std::visit(
             overloaded{
                 [&](DerivedPath::Opaque bo) {
@@ -714,14 +712,13 @@ BuiltPaths getBuiltPaths(ref<Store> store, DerivedPaths hopefullyBuiltPaths)
                 },
                 [&](DerivedPath::Built bfd) {
                     OutputPathMap outputs;
-                    auto drv = store->readDerivation(bfd.drvPath);
-                    auto outputHashes = staticOutputHashes(*store, drv);
+                    auto drv = evalStore->readDerivation(bfd.drvPath);
+                    auto outputHashes = staticOutputHashes(*evalStore, drv); // FIXME: expensive
                     auto drvOutputs = drv.outputsAndOptPaths(*store);
-                    for (auto& output : bfd.outputs) {
+                    for (auto & output : bfd.outputs) {
                         if (!outputHashes.count(output))
                             throw Error(
-                                "the derivation '%s' doesn't have an output "
-                                "named '%s'",
+                                "the derivation '%s' doesn't have an output named '%s'",
                                 store->printStorePath(bfd.drvPath), output);
                         if (settings.isExperimentalFeatureEnabled(
                                 "ca-derivations")) {
@@ -753,7 +750,7 @@ BuiltPaths getBuiltPaths(ref<Store> store, DerivedPaths hopefullyBuiltPaths)
     return res;
 }
 
-BuiltPaths build(ref<Store> store, Realise mode,
+BuiltPaths build(ref<Store> evalStore, ref<Store> store, Realise mode,
     std::vector<std::shared_ptr<Installable>> installables, BuildMode bMode)
 {
     if (mode == Realise::Nothing)
@@ -771,18 +768,19 @@ BuiltPaths build(ref<Store> store, Realise mode,
     else if (mode == Realise::Outputs)
         store->buildPaths(pathsToBuild, bMode);
 
-    return getBuiltPaths(store, pathsToBuild);
+    return getBuiltPaths(evalStore, store, pathsToBuild);
 }
 
 BuiltPaths toBuiltPaths(
+    ref<Store> evalStore,
     ref<Store> store,
     Realise mode,
     OperateOn operateOn,
     std::vector<std::shared_ptr<Installable>> installables)
 {
-    if (operateOn == OperateOn::Output) {
-        return build(store, mode, installables);
-    } else {
+    if (operateOn == OperateOn::Output)
+        return build(evalStore, store, mode, installables);
+    else {
         if (mode == Realise::Nothing)
             settings.readOnlyMode = true;
 
@@ -793,23 +791,27 @@ BuiltPaths toBuiltPaths(
     }
 }
 
-StorePathSet toStorePaths(ref<Store> store,
+StorePathSet toStorePaths(
+    ref<Store> evalStore,
+    ref<Store> store,
     Realise mode, OperateOn operateOn,
     std::vector<std::shared_ptr<Installable>> installables)
 {
     StorePathSet outPaths;
-    for (auto & path : toBuiltPaths(store, mode, operateOn, installables)) {
+    for (auto & path : toBuiltPaths(evalStore, store, mode, operateOn, installables)) {
         auto thisOutPaths = path.outPaths();
         outPaths.insert(thisOutPaths.begin(), thisOutPaths.end());
     }
     return outPaths;
 }
 
-StorePath toStorePath(ref<Store> store,
+StorePath toStorePath(
+    ref<Store> evalStore,
+    ref<Store> store,
     Realise mode, OperateOn operateOn,
     std::shared_ptr<Installable> installable)
 {
-    auto paths = toStorePaths(store, mode, operateOn, {installable});
+    auto paths = toStorePaths(evalStore, store, mode, operateOn, {installable});
 
     if (paths.size() != 1)
         throw Error("argument '%s' should evaluate to one store path", installable->what());

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -289,19 +289,6 @@ void completeFlakeRefWithFragment(
     completeFlakeRef(evalState->store, prefix);
 }
 
-ref<EvalState> EvalCommand::getEvalState()
-{
-    if (!evalState)
-        evalState = std::make_shared<EvalState>(searchPath, getStore());
-    return ref<EvalState>(evalState);
-}
-
-EvalCommand::~EvalCommand()
-{
-    if (evalState)
-        evalState->printStats();
-}
-
 void completeFlakeRef(ref<Store> store, std::string_view prefix)
 {
     if (prefix == "")

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -26,7 +26,7 @@ struct App
 struct UnresolvedApp
 {
     App unresolved;
-    App resolve(ref<Store>);
+    App resolve(ref<Store> evalStore, ref<Store> store);
 };
 
 struct Installable

--- a/src/libexpr/common-eval-args.cc
+++ b/src/libexpr/common-eval-args.cc
@@ -61,6 +61,14 @@ MixEvalArgs::MixEvalArgs()
             fetchers::overrideRegistry(from.input, to.input, extraAttrs);
         }}
     });
+
+    addFlag({
+        .longName = "eval-store",
+        .description = "The Nix store to use for evaluations.",
+        .category = category,
+        .labels = {"store-url"},
+        .handler = {&evalStoreUrl},
+    });
 }
 
 Bindings * MixEvalArgs::getAutoArgs(EvalState & state)

--- a/src/libexpr/common-eval-args.hh
+++ b/src/libexpr/common-eval-args.hh
@@ -16,8 +16,9 @@ struct MixEvalArgs : virtual Args
 
     Strings searchPath;
 
-private:
+    std::optional<std::string> evalStoreUrl;
 
+private:
     std::map<std::string, std::string> autoArgs;
 };
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -378,7 +378,10 @@ static Strings parseNixPath(const string & s)
 }
 
 
-EvalState::EvalState(const Strings & _searchPath, ref<Store> store)
+EvalState::EvalState(
+    const Strings & _searchPath,
+    ref<Store> store,
+    std::shared_ptr<Store> buildStore)
     : sWith(symbols.create("<with>"))
     , sOutPath(symbols.create("outPath"))
     , sDrvPath(symbols.create("drvPath"))
@@ -411,6 +414,7 @@ EvalState::EvalState(const Strings & _searchPath, ref<Store> store)
     , sEpsilon(symbols.create(""))
     , repair(NoRepair)
     , store(store)
+    , buildStore(buildStore ? buildStore : store)
     , regexCache(makeRegexCache())
     , baseEnv(allocEnv(128))
     , staticBaseEnv(false, 0)

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -94,7 +94,11 @@ public:
 
     Value vEmptySet;
 
+    /* Store used to materialise .drv files. */
     const ref<Store> store;
+
+    /* Store used to build stuff. */
+    const ref<Store> buildStore;
 
 
 private:
@@ -128,7 +132,10 @@ private:
 
 public:
 
-    EvalState(const Strings & _searchPath, ref<Store> store);
+    EvalState(
+        const Strings & _searchPath,
+        ref<Store> store,
+        std::shared_ptr<Store> buildStore = nullptr);
     ~EvalState();
 
     void addToSearchPath(const string & s);

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -340,11 +340,10 @@ void DerivationGoal::gaveUpOnSubstitution()
     /* Copy the input sources from the eval store to the build
        store. */
     if (&worker.evalStore != &worker.store) {
-        RealisedPath::Set inputSrcs, inputClosure;
+        RealisedPath::Set inputSrcs;
         for (auto & i : drv->inputSrcs)
             inputSrcs.insert(i);
-        RealisedPath::closure(worker.evalStore, inputSrcs, inputClosure);
-        copyClosure(worker.evalStore, worker.store, inputClosure);
+        copyClosure(worker.evalStore, worker.store, inputSrcs);
     }
 
     for (auto & i : drv->inputSrcs) {

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -6,9 +6,9 @@
 
 namespace nix {
 
-void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode)
+void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMode, std::shared_ptr<Store> evalStore)
 {
-    Worker worker(*this);
+    Worker worker(*this, evalStore ? *evalStore : *this);
 
     Goals goals;
     for (auto & br : reqs) {
@@ -51,7 +51,7 @@ void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMod
 BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
     BuildMode buildMode)
 {
-    Worker worker(*this);
+    Worker worker(*this, *this);
     auto goal = worker.makeBasicDerivationGoal(drvPath, drv, {}, buildMode);
 
     BuildResult result;
@@ -93,7 +93,7 @@ void Store::ensurePath(const StorePath & path)
     /* If the path is already valid, we're done. */
     if (isValidPath(path)) return;
 
-    Worker worker(*this);
+    Worker worker(*this, *this);
     GoalPtr goal = worker.makePathSubstitutionGoal(path);
     Goals goals = {goal};
 
@@ -111,7 +111,7 @@ void Store::ensurePath(const StorePath & path)
 
 void LocalStore::repairPath(const StorePath & path)
 {
-    Worker worker(*this);
+    Worker worker(*this, *this);
     GoalPtr goal = worker.makePathSubstitutionGoal(path, Repair);
     Goals goals = {goal};
 

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1254,8 +1254,10 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
         return next->queryRealisation(id);
     }
 
-    void buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode) override
+    void buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override
     {
+        assert(!evalStore);
+
         if (buildMode != bmNormal) throw Error("unsupported build mode");
 
         StorePathSet newPaths;

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -204,7 +204,7 @@ void PathSubstitutionGoal::tryToRun()
             Activity act(*logger, actSubstitute, Logger::Fields{worker.store.printStorePath(storePath), sub->getUri()});
             PushActivity pact(act.id);
 
-            copyStorePath(ref<Store>(sub), ref<Store>(worker.store.shared_from_this()),
+            copyStorePath(*sub, worker.store,
                 subPath ? *subPath : storePath, repair, sub->isTrusted ? NoCheckSigs : CheckSigs);
 
             promise.set_value();

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -9,11 +9,12 @@
 
 namespace nix {
 
-Worker::Worker(Store & store)
+Worker::Worker(Store & store, Store & evalStore)
     : act(*logger, actRealise)
     , actDerivations(*logger, actBuilds)
     , actSubstitutions(*logger, actCopyPaths)
     , store(store)
+    , evalStore(evalStore)
 {
     /* Debugging: prevent recursive workers. */
     nrLocalBuilds = 0;

--- a/src/libstore/build/worker.hh
+++ b/src/libstore/build/worker.hh
@@ -110,6 +110,7 @@ public:
     bool checkMismatch;
 
     Store & store;
+    Store & evalStore;
 
     std::unique_ptr<HookInstance> hook;
 
@@ -131,7 +132,7 @@ public:
        it answers with "decline-permanently", we don't try again. */
     bool tryBuildHook = true;
 
-    Worker(Store & store);
+    Worker(Store & store, Store & evalStore);
     ~Worker();
 
     /* Make a goal (with caching). */

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -505,6 +505,17 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case wopImportPaths2: {
+        logger->startWork();
+        auto paths = store->importPaths(from,
+            trusted ? NoCheckSigs : CheckSigs);
+        logger->stopWork();
+        Strings paths2;
+        for (auto & i : paths) paths2.push_back(store->printStorePath(i));
+        to << paths2;
+        break;
+    }
+
     case wopBuildPaths: {
         auto drvs = readDerivedPaths(*store, clientVersion, from);
         BuildMode mode = bmNormal;

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -568,7 +568,7 @@ DrvHashModulo hashDerivationModulo(Store & store, const Derivation & drv, bool m
 }
 
 
-std::map<std::string, Hash> staticOutputHashes(Store& store, const Derivation& drv)
+std::map<std::string, Hash> staticOutputHashes(Store & store, const Derivation & drv)
 {
     std::map<std::string, Hash> res;
     std::visit(overloaded {

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -43,11 +43,6 @@ struct DummyStore : public virtual DummyStoreConfig, public virtual Store
         RepairFlag repair, CheckSigsFlag checkSigs) override
     { unsupported("addToStore"); }
 
-    StorePath addToStore(const string & name, const Path & srcPath,
-        FileIngestionMethod method, HashType hashAlgo,
-        PathFilter & filter, RepairFlag repair) override
-    { unsupported("addToStore"); }
-
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override
     { unsupported("addTextToStore"); }

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -267,8 +267,11 @@ public:
         return status;
     }
 
-    void buildPaths(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode) override
+    void buildPaths(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override
     {
+        if (evalStore && evalStore.get() != this)
+            throw Error("building on an SSH store is incompatible with '--eval-store'");
+
         auto conn(connections->get());
 
         conn->to << cmdBuildPaths;

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -1,0 +1,46 @@
+#include "path-info.hh"
+#include "worker-protocol.hh"
+
+namespace nix {
+
+ValidPathInfo ValidPathInfo::read(Source & source, const Store & store, unsigned int format)
+{
+    return read(source, store, format, store.parseStorePath(readString(source)));
+}
+
+ValidPathInfo ValidPathInfo::read(Source & source, const Store & store, unsigned int format, StorePath && path)
+{
+    auto deriver = readString(source);
+    auto narHash = Hash::parseAny(readString(source), htSHA256);
+    ValidPathInfo info(path, narHash);
+    if (deriver != "") info.deriver = store.parseStorePath(deriver);
+    info.references = worker_proto::read(store, source, Phantom<StorePathSet> {});
+    source >> info.registrationTime >> info.narSize;
+    if (format >= 16) {
+        source >> info.ultimate;
+        info.sigs = readStrings<StringSet>(source);
+        info.ca = parseContentAddressOpt(readString(source));
+    }
+    return info;
+}
+
+void ValidPathInfo::write(
+    Sink & sink,
+    const Store & store,
+    unsigned int format,
+    bool includePath) const
+{
+    if (includePath)
+        sink << store.printStorePath(path);
+    sink << (deriver ? store.printStorePath(*deriver) : "")
+         << narHash.to_string(Base16, false);
+    worker_proto::write(store, sink, references);
+    sink << registrationTime << narSize;
+    if (format >= 16) {
+        sink << ultimate
+             << sigs
+             << renderContentAddress(ca);
+    }
+}
+
+}

--- a/src/libstore/path-info.hh
+++ b/src/libstore/path-info.hh
@@ -105,6 +105,11 @@ struct ValidPathInfo
     ValidPathInfo(const StorePath & path, Hash narHash) : path(path), narHash(narHash) { };
 
     virtual ~ValidPathInfo() { }
+
+    static ValidPathInfo read(Source & source, const Store & store, unsigned int format);
+    static ValidPathInfo read(Source & source, const Store & store, unsigned int format, StorePath && path);
+
+    void write(Sink & sink, const Store & store, unsigned int format, bool includePath = true) const;
 };
 
 typedef std::map<StorePath, ValidPathInfo> ValidPathInfos;

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -45,7 +45,7 @@ struct Realisation {
     size_t checkSignatures(const PublicKeys & publicKeys) const;
 
     static std::set<Realisation> closure(Store &, const std::set<Realisation> &);
-    static void closure(Store &, const std::set<Realisation> &, std::set<Realisation>& res);
+    static void closure(Store &, const std::set<Realisation> &, std::set<Realisation> & res);
 
     bool isCompatibleWith(const Realisation & other) const;
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -705,8 +705,11 @@ static void writeDerivedPaths(RemoteStore & store, ConnectionHandle & conn, cons
     }
 }
 
-void RemoteStore::buildPaths(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode)
+void RemoteStore::buildPaths(const std::vector<DerivedPath> & drvPaths, BuildMode buildMode, std::shared_ptr<Store> evalStore)
 {
+    if (evalStore && evalStore.get() != this)
+        throw Error("building on a remote store is incompatible with '--eval-store'");
+
     auto conn(getConnection());
     conn->to << wopBuildPaths;
     assert(GET_PROTOCOL_MINOR(conn->daemonVersion) >= 13);

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -875,6 +875,16 @@ void RemoteStore::queryMissing(const std::vector<DerivedPath> & targets,
 }
 
 
+StorePaths RemoteStore::importPaths(Source & source, CheckSigsFlag checkSigs)
+{
+    auto conn(getConnection());
+    conn->to << wopImportPaths2;
+    source.drainInto(conn->to);
+    conn.processStderr();
+    return worker_proto::read(*this, conn->from, Phantom<StorePaths> {});
+}
+
+
 void RemoteStore::connect()
 {
     auto conn(getConnection());

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -112,6 +112,8 @@ public:
         StorePathSet & willBuild, StorePathSet & willSubstitute, StorePathSet & unknown,
         uint64_t & downloadSize, uint64_t & narSize) override;
 
+    StorePaths importPaths(Source & source, CheckSigsFlag checkSigs) override;
+
     void connect() override;
 
     unsigned int getProtocol() override;

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -78,6 +78,11 @@ public:
     void addToStore(const ValidPathInfo & info, Source & nar,
         RepairFlag repair, CheckSigsFlag checkSigs) override;
 
+    void addMultipleToStore(
+        Source & source,
+        RepairFlag repair,
+        CheckSigsFlag checkSigs) override;
+
     StorePath addTextToStore(const string & name, const string & s,
         const StorePathSet & references, RepairFlag repair) override;
 
@@ -111,8 +116,6 @@ public:
     void queryMissing(const std::vector<DerivedPath> & targets,
         StorePathSet & willBuild, StorePathSet & willSubstitute, StorePathSet & unknown,
         uint64_t & downloadSize, uint64_t & narSize) override;
-
-    StorePaths importPaths(Source & source, CheckSigsFlag checkSigs) override;
 
     void connect() override;
 
@@ -152,8 +155,6 @@ protected:
     virtual ref<FSAccessor> getFSAccessor() override;
 
     virtual void narFromPath(const StorePath & path, Sink & sink) override;
-
-    ref<const ValidPathInfo> readValidPathInfo(ConnectionHandle & conn, const StorePath & path);
 
 private:
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -85,7 +85,7 @@ public:
 
     std::optional<const Realisation> queryRealisation(const DrvOutput &) override;
 
-    void buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode) override;
+    void buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override;
 
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
         BuildMode buildMode) override;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -773,6 +773,12 @@ std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStor
     CheckSigsFlag checkSigs = CheckSigs,
     SubstituteFlag substitute = NoSubstitute);
 
+/* Copy the closure of `paths` from `srcStore` to `dstStore`. */
+void copyClosure(ref<Store> srcStore, ref<Store> dstStore,
+    const RealisedPath::Set & paths,
+    RepairFlag repair = NoRepair,
+    CheckSigsFlag checkSigs = CheckSigs,
+    SubstituteFlag substitute = NoSubstitute);
 
 /* Remove the temporary roots file for this process.  Any temporary
    root becomes garbage after this point unless it has been registered

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -683,7 +683,7 @@ public:
        the Nix store. Optionally, the contents of the NARs are
        preloaded into the specified FS accessor to speed up subsequent
        access. */
-    virtual StorePaths importPaths(Source & source, CheckSigsFlag checkSigs = CheckSigs);
+    StorePaths importPaths(Source & source, CheckSigsFlag checkSigs = CheckSigs);
 
     struct Stats
     {

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -676,7 +676,7 @@ public:
        the Nix store. Optionally, the contents of the NARs are
        preloaded into the specified FS accessor to speed up subsequent
        access. */
-    StorePaths importPaths(Source & source, CheckSigsFlag checkSigs = CheckSigs);
+    virtual StorePaths importPaths(Source & source, CheckSigsFlag checkSigs = CheckSigs);
 
     struct Stats
     {
@@ -766,6 +766,7 @@ std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStor
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,
     SubstituteFlag substitute = NoSubstitute);
+
 std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
     const StorePathSet & paths,
     RepairFlag repair = NoRepair,

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -440,6 +440,12 @@ public:
     virtual void addToStore(const ValidPathInfo & info, Source & narSource,
         RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs) = 0;
 
+    /* Import multiple paths into the store. */
+    virtual void addMultipleToStore(
+        Source & source,
+        RepairFlag repair = NoRepair,
+        CheckSigsFlag checkSigs = CheckSigs);
+
     /* Copy the contents of a path to the store and register the
        validity the resulting path.  The resulting path is returned.
        The function object `filter' can be used to exclude files (see

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -497,7 +497,8 @@ public:
        not derivations, substitute them. */
     virtual void buildPaths(
         const std::vector<DerivedPath> & paths,
-        BuildMode buildMode = bmNormal);
+        BuildMode buildMode = bmNormal,
+        std::shared_ptr<Store> evalStore = nullptr);
 
     /* Build a single non-materialized derivation (i.e. not from an
        on-disk .drv file).

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -751,8 +751,12 @@ protected:
 
 
 /* Copy a path from one store to another. */
-void copyStorePath(ref<Store> srcStore, ref<Store> dstStore,
-    const StorePath & storePath, RepairFlag repair = NoRepair, CheckSigsFlag checkSigs = CheckSigs);
+void copyStorePath(
+    Store & srcStore,
+    Store & dstStore,
+    const StorePath & storePath,
+    RepairFlag repair = NoRepair,
+    CheckSigsFlag checkSigs = CheckSigs);
 
 
 /* Copy store paths from one store to another. The paths may be copied
@@ -761,20 +765,23 @@ void copyStorePath(ref<Store> srcStore, ref<Store> dstStore,
    of store paths is not automatically closed; use copyClosure() for
    that. Returns a map of what each path was copied to the dstStore
    as. */
-std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
+std::map<StorePath, StorePath> copyPaths(
+    Store & srcStore, Store & dstStore,
     const RealisedPath::Set &,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,
     SubstituteFlag substitute = NoSubstitute);
 
-std::map<StorePath, StorePath> copyPaths(ref<Store> srcStore, ref<Store> dstStore,
+std::map<StorePath, StorePath> copyPaths(
+    Store & srcStore, Store & dstStore,
     const StorePathSet & paths,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,
     SubstituteFlag substitute = NoSubstitute);
 
 /* Copy the closure of `paths` from `srcStore` to `dstStore`. */
-void copyClosure(ref<Store> srcStore, ref<Store> dstStore,
+void copyClosure(
+    Store & srcStore, Store & dstStore,
     const RealisedPath::Set & paths,
     RepairFlag repair = NoRepair,
     CheckSigsFlag checkSigs = CheckSigs,

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 31)
+#define PROTOCOL_VERSION (1 << 8 | 32)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -55,7 +55,7 @@ typedef enum {
     wopQueryDerivationOutputMap = 41,
     wopRegisterDrvOutput = 42,
     wopQueryRealisation = 43,
-    wopImportPaths2 = 44, // hack
+    wopAddMultipleToStore = 44,
 } WorkerOp;
 
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -55,6 +55,7 @@ typedef enum {
     wopQueryDerivationOutputMap = 41,
     wopRegisterDrvOutput = 42,
     wopQueryRealisation = 43,
+    wopImportPaths2 = 44, // hack
 } WorkerOp;
 
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -341,7 +341,7 @@ static void main_nix_build(int argc, char * * argv)
             printMissing(ref<Store>(store), willBuild, willSubstitute, unknown, downloadSize, narSize);
 
         if (!dryRun)
-            store->buildPaths(paths, buildMode);
+            store->buildPaths(paths, buildMode, evalStore);
     };
 
     if (runEnv) {
@@ -397,8 +397,6 @@ static void main_nix_build(int argc, char * * argv)
             pathsToCopy.insert(src);
         }
 
-        copyClosure(*evalStore, *store, pathsToCopy);
-
         buildPaths(pathsToBuild);
 
         if (dryRun) return;
@@ -449,7 +447,7 @@ static void main_nix_build(int argc, char * * argv)
         if (env.count("__json")) {
             StorePathSet inputs;
             for (auto & [depDrvPath, wantedDepOutputs] : drv.inputDrvs) {
-                auto outputs = store->queryPartialDerivationOutputMap(depDrvPath);
+                auto outputs = evalStore->queryPartialDerivationOutputMap(depDrvPath);
                 for (auto & i : wantedDepOutputs) {
                     auto o = outputs.at(i);
                     store->computeFSClosure(*o, inputs);
@@ -564,8 +562,6 @@ static void main_nix_build(int argc, char * * argv)
                 drvMap[drvPath] = {drvMap.size(), {outputName}};
         }
 
-        copyClosure(*evalStore, *store, drvsToCopy);
-
         buildPaths(pathsToBuild);
 
         if (dryRun) return;
@@ -578,7 +574,7 @@ static void main_nix_build(int argc, char * * argv)
             if (counter)
                 drvPrefix += fmt("-%d", counter + 1);
 
-            auto builtOutputs = store->queryPartialDerivationOutputMap(drvPath);
+            auto builtOutputs = evalStore->queryPartialDerivationOutputMap(drvPath);
 
             auto maybeOutputPath = builtOutputs.at(outputName);
             assert(maybeOutputPath);

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -397,7 +397,7 @@ static void main_nix_build(int argc, char * * argv)
             pathsToCopy.insert(src);
         }
 
-        copyClosure(evalStore, store, pathsToCopy);
+        copyClosure(*evalStore, *store, pathsToCopy);
 
         buildPaths(pathsToBuild);
 
@@ -564,7 +564,7 @@ static void main_nix_build(int argc, char * * argv)
                 drvMap[drvPath] = {drvMap.size(), {outputName}};
         }
 
-        copyClosure(evalStore, store, drvsToCopy);
+        copyClosure(*evalStore, *store, drvsToCopy);
 
         buildPaths(pathsToBuild);
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -250,8 +250,9 @@ static void main_nix_build(int argc, char * * argv)
         throw UsageError("'-p' and '-E' are mutually exclusive");
 
     auto store = openStore();
+    auto evalStore = myArgs.evalStoreUrl ? openStore(*myArgs.evalStoreUrl) : store;
 
-    auto state = std::make_unique<EvalState>(myArgs.searchPath, store);
+    auto state = std::make_unique<EvalState>(myArgs.searchPath, evalStore, store);
     state->repair = repair;
 
     auto autoArgs = myArgs.getAutoArgs(*state);

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -532,6 +532,7 @@ static void main_nix_build(int argc, char * * argv)
 
         std::vector<StorePathWithOutputs> pathsToBuild;
         std::vector<std::pair<StorePath, std::string>> pathsToBuildOrdered;
+        RealisedPath::Set drvsToCopy;
 
         std::map<StorePath, std::pair<size_t, StringSet>> drvMap;
 
@@ -544,14 +545,16 @@ static void main_nix_build(int argc, char * * argv)
 
             pathsToBuild.push_back({drvPath, {outputName}});
             pathsToBuildOrdered.push_back({drvPath, {outputName}});
+            drvsToCopy.insert(drvPath);
 
             auto i = drvMap.find(drvPath);
             if (i != drvMap.end())
                 i->second.second.insert(outputName);
-            else {
+            else
                 drvMap[drvPath] = {drvMap.size(), {outputName}};
-            }
         }
+
+        copyClosure(state->store, state->buildStore, drvsToCopy);
 
         buildPaths(pathsToBuild);
 

--- a/src/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix-copy-closure/nix-copy-closure.cc
@@ -54,10 +54,7 @@ static int main_nix_copy_closure(int argc, char ** argv)
         for (auto & path : storePaths)
             storePaths2.insert(from->followLinksToStorePath(path));
 
-        RealisedPath::Set closure;
-        RealisedPath::closure(*from, storePaths2, closure);
-
-        copyPaths(from, to, closure, NoRepair, NoCheckSigs, useSubstitutes);
+        copyClosure(from, to, storePaths2, NoRepair, NoCheckSigs, useSubstitutes);
 
         return 0;
     }

--- a/src/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix-copy-closure/nix-copy-closure.cc
@@ -54,7 +54,7 @@ static int main_nix_copy_closure(int argc, char ** argv)
         for (auto & path : storePaths)
             storePaths2.insert(from->followLinksToStorePath(path));
 
-        copyClosure(from, to, storePaths2, NoRepair, NoCheckSigs, useSubstitutes);
+        copyClosure(*from, *to, storePaths2, NoRepair, NoCheckSigs, useSubstitutes);
 
         return 0;
     }

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -155,7 +155,7 @@ static int main_nix_instantiate(int argc, char * * argv)
         auto store = openStore();
         auto evalStore = myArgs.evalStoreUrl ? openStore(*myArgs.evalStoreUrl) : store;
 
-        auto state = std::make_unique<EvalState>(myArgs.searchPath, store);
+        auto state = std::make_unique<EvalState>(myArgs.searchPath, evalStore, store);
         state->repair = repair;
 
         Bindings & autoArgs = *myArgs.getAutoArgs(*state);

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -153,6 +153,7 @@ static int main_nix_instantiate(int argc, char * * argv)
             settings.readOnlyMode = true;
 
         auto store = openStore();
+        auto evalStore = myArgs.evalStoreUrl ? openStore(*myArgs.evalStoreUrl) : store;
 
         auto state = std::make_unique<EvalState>(myArgs.searchPath, store);
         state->repair = repair;

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -100,7 +100,8 @@ UnresolvedApp Installable::toApp(EvalState & state)
         throw Error("attribute '%s' has unsupported type '%s'", attrPath, type);
 }
 
-App UnresolvedApp::resolve(ref<Store> store)
+// FIXME: move to libcmd
+App UnresolvedApp::resolve(ref<Store> evalStore, ref<Store> store)
 {
     auto res = unresolved;
 
@@ -110,7 +111,7 @@ App UnresolvedApp::resolve(ref<Store> store)
         installableContext.push_back(
             std::make_shared<InstallableDerivedPath>(store, ctxElt.toDerivedPath()));
 
-    auto builtContext = build(store, Realise::Outputs, installableContext);
+    auto builtContext = build(evalStore, store, Realise::Outputs, installableContext);
     res.program = resolveString(*store, unresolved.program, builtContext);
     if (!store->isInStore(res.program))
         throw Error("app program '%s' is not in the Nix store", res.program);

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -52,7 +52,10 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
 
     void run(ref<Store> store) override
     {
-        auto buildables = build(store, dryRun ? Realise::Nothing : Realise::Outputs, installables, buildMode);
+        auto buildables = build(
+            getEvalStore(), store,
+            dryRun ? Realise::Nothing : Realise::Outputs,
+            installables, buildMode);
 
         if (json) logger->cout("%s", derivedPathsWithHintsToJSON(buildables, store).dump());
 

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -69,7 +69,7 @@ struct CmdBundle : InstallableCommand
     {
         auto evalState = getEvalState();
 
-        auto app = installable->toApp(*evalState).resolve(store);
+        auto app = installable->toApp(*evalState).resolve(getEvalStore(), store);
 
         auto [bundlerFlakeRef, bundlerName] = parseFlakeRefWithFragment(bundler, absPath("."));
         const flake::LockFlags lockFlags{ .writeLockFile = false };

--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -90,7 +90,7 @@ struct CmdCopy : BuiltPathsCommand
         }
 
         copyPaths(
-            srcStore, dstStore, stuffToCopy, NoRepair, checkSigs, substitute);
+            *srcStore, *dstStore, stuffToCopy, NoRepair, checkSigs, substitute);
     }
 };
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -307,7 +307,7 @@ struct Common : InstallableCommand, MixProfile
             auto dir = absPath(dir_);
             auto installable = parseInstallable(store, installable_);
             auto builtPaths = toStorePaths(
-                store, Realise::Nothing, OperateOn::Output, {installable});
+                getEvalStore(), store, Realise::Nothing, OperateOn::Output, {installable});
             for (auto & path: builtPaths) {
                 auto from = store->printStorePath(path);
                 if (script.find(from) == std::string::npos)
@@ -495,8 +495,8 @@ struct CmdDevelop : Common, MixEnvironment
                 Strings{"legacyPackages." + settings.thisSystem.get() + "."},
                 nixpkgsLockFlags);
 
-            shell = state->store->printStorePath(
-                toStorePath(state->store, Realise::Outputs, OperateOn::Output, bashInstallable)) + "/bin/bash";
+            shell = store->printStorePath(
+                toStorePath(getEvalStore(), store, Realise::Outputs, OperateOn::Output, bashInstallable)) + "/bin/bash";
         } catch (Error &) {
             ignoreException();
         }

--- a/src/nix/diff-closures.cc
+++ b/src/nix/diff-closures.cc
@@ -131,9 +131,9 @@ struct CmdDiffClosures : SourceExprCommand
     void run(ref<Store> store) override
     {
         auto before = parseInstallable(store, _before);
-        auto beforePath = toStorePath(store, Realise::Outputs, operateOn, before);
+        auto beforePath = toStorePath(getEvalStore(), store, Realise::Outputs, operateOn, before);
         auto after = parseInstallable(store, _after);
-        auto afterPath = toStorePath(store, Realise::Outputs, operateOn, after);
+        auto afterPath = toStorePath(getEvalStore(), store, Realise::Outputs, operateOn, after);
         printClosureDiff(store, beforePath, afterPath, "");
     }
 };

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -841,7 +841,7 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun
 
         if (!dryRun && !dstUri.empty()) {
             ref<Store> dstStore = dstUri.empty() ? openStore() : openStore(dstUri);
-            copyPaths(store, dstStore, sources);
+            copyPaths(*store, *dstStore, sources);
         }
     }
 };

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -253,7 +253,7 @@ struct CmdProfileInstall : InstallablesCommand, MixDefaultProfile
 
                 manifest.elements.emplace_back(std::move(element));
             } else {
-                auto buildables = build(store, Realise::Outputs, {installable}, bmNormal);
+                auto buildables = build(getEvalStore(), store, Realise::Outputs, {installable}, bmNormal);
 
                 for (auto & buildable : buildables) {
                     ProfileElement element;

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -93,7 +93,7 @@ struct CmdShell : InstallablesCommand, RunCommon, MixEnvironment
 
     void run(ref<Store> store) override
     {
-        auto outPaths = toStorePaths(store, Realise::Outputs, OperateOn::Output, installables);
+        auto outPaths = toStorePaths(getEvalStore(), store, Realise::Outputs, OperateOn::Output, installables);
 
         auto accessor = store->getFSAccessor();
 
@@ -178,7 +178,7 @@ struct CmdRun : InstallableCommand, RunCommon
     {
         auto state = getEvalState();
 
-        auto app = installable->toApp(*state).resolve(store);
+        auto app = installable->toApp(*state).resolve(getEvalStore(), store);
 
         Strings allArgs{app.program};
         for (auto & i : args) allArgs.push_back(i);

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -62,9 +62,9 @@ struct CmdWhyDepends : SourceExprCommand
     void run(ref<Store> store) override
     {
         auto package = parseInstallable(store, _package);
-        auto packagePath = toStorePath(store, Realise::Outputs, operateOn, package);
+        auto packagePath = toStorePath(getEvalStore(), store, Realise::Outputs, operateOn, package);
         auto dependency = parseInstallable(store, _dependency);
-        auto dependencyPath = toStorePath(store, Realise::Derivation, operateOn, dependency);
+        auto dependencyPath = toStorePath(getEvalStore(), store, Realise::Derivation, operateOn, dependency);
         auto dependencyPathHash = dependencyPath.hashPart();
 
         StorePathSet closure;

--- a/tests/eval-store.sh
+++ b/tests/eval-store.sh
@@ -1,0 +1,26 @@
+source common.sh
+
+eval_store=$TEST_ROOT/eval-store
+
+clearStore
+rm -rf "$eval_store"
+
+nix build -f dependencies.nix --eval-store "$eval_store" -o "$TEST_ROOT/result"
+[[ -e $TEST_ROOT/result/foobar ]]
+(! ls $NIX_STORE_DIR/*.drv)
+ls $eval_store/nix/store/*.drv
+
+clearStore
+rm -rf "$eval_store"
+
+nix-instantiate dependencies.nix --eval-store "$eval_store"
+(! ls $NIX_STORE_DIR/*.drv)
+ls $eval_store/nix/store/*.drv
+
+clearStore
+rm -rf "$eval_store"
+
+nix-build dependencies.nix --eval-store "$eval_store" -o "$TEST_ROOT/result"
+[[ -e $TEST_ROOT/result/foobar ]]
+(! ls $NIX_STORE_DIR/*.drv)
+ls $eval_store/nix/store/*.drv

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -56,7 +56,8 @@ nix_tests = \
   ca/nix-run.sh \
   ca/recursive.sh \
   ca/concurrent-builds.sh \
-  ca/nix-copy.sh
+  ca/nix-copy.sh \
+  eval-store.sh
   # parallel.sh
 
 install-tests += $(foreach x, $(nix_tests), tests/$(x))


### PR DESCRIPTION
When the Nix daemon is running remotely and is accessed via a high-latency connection, an operation like `nix build nixpkgs#hello` can be very slow because the client first needs to send a lot of .drv files one-by-one to the remote, each requiring a round trip. To make this faster, this PR does the following:

* It adds an option `--eval-store` that allows the evaluation to be done in a local Nix store. This is also useful for store that can't build, like binary caches. For instance, you can now do: 
    ```
    # nix path-info --json --store https://cache.nixos.org --eval-store auto nixpkgs#hello
    ```

* It adds a new worker protocol interface to add multiple store paths in the same call. On a link with a 50 ms delay, this speeds up the copying of the `hello` .drv closure from 57.8s to 0.7s. Note that this disables parallel copying (the use of `processGraph()` with a thread pool in `copyPaths()` is commented out).

Fixes #5026.
Partially fixes #5025.