### PR TITLE
[2.3]: Use the real path when checking imported CA paths

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1038,7 +1038,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
                         auto actualFoHash = hashCAPath(
                                 recursive,
                                 expectedHash.type,
-                                info.path
+                                realPath
                                 );
                         if (ca != actualFoHash) {
                             throw Error("ca hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",


### PR DESCRIPTION
Otherwise chrooted store (used in particular for the NixOS installation) will fail because Nix will try to read the virtual path instead of the physical one

Should fix https://github.com/NixOS/nixpkgs/issues/126141