### PR TITLE
Allow running all the tests with the daemon 

### DIFF
--- a/tests/binary-cache.sh
+++ b/tests/binary-cache.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+needLocalStore "“--no-require-sigs” can’t be used with the daemon"
+
 # We can produce drvs directly into the binary cache
 clearStore
 clearCacheCache

--- a/tests/ca/build-with-garbage-path.sh
+++ b/tests/ca/build-with-garbage-path.sh
@@ -3,7 +3,8 @@
 # Regression test for https://github.com/NixOS/nix/issues/4858
 
 source common.sh
-sed -i 's/experimental-features .*/& ca-derivations ca-references/' "$NIX_CONF_DIR"/nix.conf
+
+requireDaemonNewerThan "2.4pre20210621"
 
 # Get the output path of `rootCA`, and put some garbage instead
 outPath="$(nix-build ./content-addressed.nix -A rootCA --no-out-link)"

--- a/tests/ca/common.sh
+++ b/tests/ca/common.sh
@@ -1,1 +1,5 @@
 source ../common.sh
+
+sed -i 's/experimental-features .*/& ca-derivations ca-references/' "$NIX_CONF_DIR"/nix.conf
+
+restartDaemon

--- a/tests/ca/concurrent-builds.sh
+++ b/tests/ca/concurrent-builds.sh
@@ -5,7 +5,7 @@
 
 source common.sh
 
-sed -i 's/experimental-features .*/& ca-derivations ca-references/' "$NIX_CONF_DIR"/nix.conf
+buggyNeedLocalStore "For some reason, this deadlocks with the daemon"
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 

--- a/tests/ca/duplicate-realisation-in-closure.sh
+++ b/tests/ca/duplicate-realisation-in-closure.sh
@@ -1,5 +1,7 @@
 source ./common.sh
 
+requireDaemonNewerThan "2.4pre20210625"
+
 sed -i 's/experimental-features .*/& ca-derivations ca-references/' "$NIX_CONF_DIR"/nix.conf
 
 export REMOTE_STORE_DIR="$TEST_ROOT/remote_store"

--- a/tests/ca/gc.sh
+++ b/tests/ca/gc.sh
@@ -4,8 +4,6 @@
 
 source common.sh
 
-sed -i 's/experimental-features .*/& ca-derivations ca-references/' "$NIX_CONF_DIR"/nix.conf
-
 export NIX_TESTS_CA_BY_DEFAULT=1
 
 cd ..

--- a/tests/ca/post-hook.sh
+++ b/tests/ca/post-hook.sh
@@ -2,6 +2,8 @@
 
 source common.sh
 
+requireDaemonNewerThan "2.4pre20210626"
+
 sed -i 's/experimental-features .*/& ca-derivations ca-references nix-command flakes/' "$NIX_CONF_DIR"/nix.conf
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/ca/recursive.sh
+++ b/tests/ca/recursive.sh
@@ -2,6 +2,8 @@
 
 source common.sh
 
+requireDaemonNewerThan "2.4pre20210623"
+
 sed -i 's/experimental-features .*/& ca-derivations ca-references nix-command flakes/' "$NIX_CONF_DIR"/nix.conf
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/ca/substitute.sh
+++ b/tests/ca/substitute.sh
@@ -4,7 +4,7 @@
 
 source common.sh
 
-sed -i 's/experimental-features .*/& ca-derivations ca-references/' "$NIX_CONF_DIR"/nix.conf
+needLocalStore "“--no-require-sigs” can’t be used with the daemon"
 
 rm -rf $TEST_ROOT/binary_cache
 

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+# XXX: This shouldn’t be, but #4813 cause this test to fail
+buggyNeedLocalStore "see #4813"
+
 checkBuildTempDirRemoved ()
 {
     buildDir=$(sed -n 's/CHECK_TMPDIR=//p' $1 | head -1)

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -88,10 +88,10 @@ startDaemon() {
     fi
     # Start the daemon, wait for the socket to appear.  !!!
     # ‘nix-daemon’ should have an option to fork into the background.
-    rm -f $NIX_STATE_DIR/daemon-socket/socket
+    rm -f $NIX_DAEMON_SOCKET_PATH
     ${NIX_DAEMON_COMMAND:-nix daemon} &
     for ((i = 0; i < 30; i++)); do
-        if [ -e $NIX_DAEMON_SOCKET_PATH ]; then break; fi
+        if [[ -S $NIX_DAEMON_SOCKET_PATH ]]; then break; fi
         sleep 1
     done
     pidDaemon=$!

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -1,5 +1,9 @@
 set -e
 
+if [[ -z "$COMMON_SH_SOURCED" ]]; then
+
+COMMON_SH_SOURCED=1
+
 export TEST_ROOT=$(realpath ${TMPDIR:-/tmp}/nix-test)/${TEST_NAME:-default}
 export NIX_STORE_DIR
 if ! NIX_STORE_DIR=$(readlink -f $TEST_ROOT/store 2> /dev/null); then
@@ -45,6 +49,9 @@ export busybox="@sandbox_shell@"
 export version=@PACKAGE_VERSION@
 export system=@system@
 
+export IMPURE_VAR1=foo
+export IMPURE_VAR2=bar
+
 cacheDir=$TEST_ROOT/binary-cache
 
 readLink() {
@@ -75,6 +82,10 @@ clearCacheCache() {
 }
 
 startDaemon() {
+    # Don’t start the daemon twice, as this would just make it loop indefinitely
+    if [[ "$NIX_REMOTE" == daemon ]]; then
+      return
+    fi
     # Start the daemon, wait for the socket to appear.  !!!
     # ‘nix-daemon’ should have an option to fork into the background.
     rm -f $NIX_STATE_DIR/daemon-socket/socket
@@ -84,19 +95,43 @@ startDaemon() {
         sleep 1
     done
     pidDaemon=$!
-    trap "kill -9 $pidDaemon" EXIT
+    trap "killDaemon" EXIT
     export NIX_REMOTE=daemon
 }
 
 killDaemon() {
-    kill -9 $pidDaemon
+    kill $pidDaemon
+    for i in {0.10}; do
+        kill -0 $pidDaemon || break
+        sleep 1
+    done
+    kill -9 $pidDaemon || true
     wait $pidDaemon || true
     trap "" EXIT
+}
+
+restartDaemon() {
+  [[ -z "${pidDaemon:-}" ]] && return 0
+
+  killDaemon
+  unset NIX_REMOTE
+  startDaemon
 }
 
 if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user true; then
     _canUseSandbox=1
 fi
+
+isDaemonNewer () {
+  [[ -n "${NIX_DAEMON_PACKAGE:-}" ]] || return 0
+  local requiredVersion="$1"
+  local daemonVersion=$($NIX_DAEMON_PACKAGE/bin/nix-daemon --version | cut -d' ' -f3)
+  return [[ $(nix eval --expr "builtins.compareVersions ''$daemonVersion'' ''2.4''") -ge 0 ]]
+}
+
+requireDaemonNewerThan () {
+  isDaemonNewer "$1" || exit 99
+}
 
 canUseSandbox() {
     if [[ ! $_canUseSandbox ]]; then
@@ -123,4 +158,22 @@ expect() {
     [[ $res -eq $expected ]]
 }
 
+needLocalStore() {
+  if [[ "$NIX_REMOTE" == "daemon" ]]; then
+    echo "Can’t run through the daemon ($1), skipping this test..."
+    return 99
+  fi
+}
+
+# Just to make it easy to find which tests should be fixed
+buggyNeedLocalStore () {
+  needLocalStore
+}
+
 set -x
+
+if [[ -n "${NIX_DAEMON_PACKAGE:-}" ]]; then
+    startDaemon
+fi
+
+fi # COMMON_SH_SOURCED

--- a/tests/db-migration.sh
+++ b/tests/db-migration.sh
@@ -3,10 +3,13 @@
 # Only run this if we have an older Nix available
 # XXX: This assumes that the `daemon` package is older than the `client` one
 if [[ -z "$NIX_DAEMON_PACKAGE" ]]; then
-    exit 0
+    exit 99
 fi
 
 source common.sh
+
+killDaemon
+unset NIX_REMOTE
 
 # Fill the db using the older Nix
 PATH_WITH_NEW_NIX="$PATH"

--- a/tests/dump-db.sh
+++ b/tests/dump-db.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+needLocalStore "--dump-db requires a local store"
+
 clearStore
 
 path=$(nix-build dependencies.nix -o $TEST_ROOT/result)

--- a/tests/eval-store.sh
+++ b/tests/eval-store.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireDaemonNewerThan "2.4pre20210727"
+
 eval_store=$TEST_ROOT/eval-store
 
 clearStore

--- a/tests/fixed.sh
+++ b/tests/fixed.sh
@@ -2,9 +2,6 @@ source common.sh
 
 clearStore
 
-export IMPURE_VAR1=foo
-export IMPURE_VAR2=bar
-
 path=$(nix-store -q $(nix-instantiate fixed.nix -A good.0))
 
 echo 'testing bad...'

--- a/tests/gc-auto.sh
+++ b/tests/gc-auto.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+needLocalStore "“min-free” and “max-free” are daemon options"
+
 clearStore
 
 garbage1=$(nix store add-path --name garbage1 ./nar-access.sh)

--- a/tests/init.sh
+++ b/tests/init.sh
@@ -23,6 +23,7 @@ substituters =
 flake-registry = $TEST_ROOT/registry.json
 show-trace = true
 include nix.conf.extra
+trusted-users = $(whoami)
 EOF
 
 cat > "$NIX_CONF_DIR"/nix.conf.extra <<EOF

--- a/tests/linux-sandbox.sh
+++ b/tests/linux-sandbox.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+needLocalStore "the sandbox only runs on the builder side, so it makes no sense to test it with the daemon"
+
 clearStore
 
 if ! canUseSandbox; then exit 99; fi

--- a/tests/multiple-outputs.sh
+++ b/tests/multiple-outputs.sh
@@ -58,7 +58,7 @@ outPath2=$(nix-build $(nix-instantiate multiple-outputs.nix -A a.second) --no-ou
 
 # Delete one of the outputs and rebuild it.  This will cause a hash
 # rewrite.
-nix store delete $TEST_ROOT/result-second --ignore-liveness
+env -u NIX_REMOTE nix store delete $TEST_ROOT/result-second --ignore-liveness
 nix-build multiple-outputs.nix -A a.all -o $TEST_ROOT/result
 [ "$(cat $TEST_ROOT/result-second/file)" = "second" ]
 [ "$(cat $TEST_ROOT/result-second/link/file)" = "first" ]

--- a/tests/optimise-store.sh
+++ b/tests/optimise-store.sh
@@ -26,7 +26,8 @@ if [ "$inode1" = "$inode3" ]; then
     exit 1
 fi
 
-nix-store --optimise
+# XXX: This should work through the daemon too
+NIX_REMOTE="" nix-store --optimise
 
 inode1="$(stat --format=%i $outPath1/foo)"
 inode3="$(stat --format=%i $outPath3/foo)"

--- a/tests/post-hook.sh
+++ b/tests/post-hook.sh
@@ -5,6 +5,9 @@ clearStore
 rm -f $TEST_ROOT/result
 
 export REMOTE_STORE=file:$TEST_ROOT/remote_store
+echo 'require-sigs = false' >> $NIX_CONF_DIR/nix.conf
+
+restartDaemon
 
 # Build the dependencies and push them to the remote store
 nix-build -o $TEST_ROOT/result dependencies.nix --post-build-hook $PWD/push-to-store.sh

--- a/tests/referrers.sh
+++ b/tests/referrers.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+needLocalStore "uses some low-level store manipulations that aren’t available through the daemon"
+
 clearStore
 
 max=500

--- a/tests/repair.sh
+++ b/tests/repair.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+needLocalStore "--repair needs a local store"
+
 clearStore
 
 path=$(nix-build dependencies.nix -o $TEST_ROOT/result)

--- a/tests/structured-attrs.sh
+++ b/tests/structured-attrs.sh
@@ -1,5 +1,9 @@
 source common.sh
 
+# 27ce722638 required some incompatible changes to the nix file, so skip this
+# tests for the older versions
+requireDaemonNewerThan "2.4pre20210622"
+
 clearStore
 
 rm -f $TEST_ROOT/result

--- a/tests/timeout.sh
+++ b/tests/timeout.sh
@@ -2,6 +2,8 @@
 
 source common.sh
 
+# XXX: This shouldn’t be, but #4813 cause this test to fail
+needLocalStore "see #4813"
 
 set +e
 messages=$(nix-build -Q timeout.nix -A infiniteLoop --timeout 2 2>&1)


### PR DESCRIPTION
When `NIX_DAEMON_PACKAGE` is set, make all the tests use the Nix daemon.
That way we can test every piece of Nix functionality both with and without the daemon.

Tests for which using the daemon isn’t possible or doesn’t make sense can selectively be disabled with `needLocalStore`.
Similarely, tests can enforce a constraint on a new-enough daemon by using `requireDaemonNewerThan 2.4pre_20210714`

(There’s a few tests that break with the daemon for bad reasons. I didn’t fix these, but they are marked with `buggyNeedLocalStore`)

Fix #4824 