### PR TITLE
Add a github action step to run the tests against current master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,10 @@ jobs:
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
     - run: |
         NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
-        $NIX_BUILD --option experimental-features 'flakes' --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.${builtins.currentSystem} (builtins.getFlake "github:nixos/nix/master").defaultPackage.${builtins.currentSystem}'
+        $NIX_BUILD \
+          --option experimental-features 'flakes' \
+          --option access-tokens github.com=${{ secrets.GITHUB_TOKEN }} \
+          --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.${builtins.currentSystem} (builtins.getFlake "github:nixos/nix/master").defaultPackage.${builtins.currentSystem}'
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - run: |
         cachix use nixos-nix-install-tests
         CURRENT_NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin
-        PATH=$CURRENT_NIX_BUILD:$PATH bash scripts/test-against-master.sh
+        PATH=$CURRENT_NIX_BUILD:$PATH GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} bash scripts/test-against-master.sh
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
     - run: |
-      NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
-      $NIX_BUILD --option experimental-features 'flakes' --impure --expr 'builtins.getFlake (builtins.toPath ./.).lib.testAgainst.x86_64-linux (builtins.getFlake (builtins.toPath ./.)).defaultPackage.x86_64-linux'
+        NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
+        $NIX_BUILD --option experimental-features 'flakes' --impure --expr 'builtins.getFlake (builtins.toPath ./.).lib.testAgainst.x86_64-linux (builtins.getFlake (builtins.toPath ./.)).defaultPackage.x86_64-linux'
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
     - run: |
         NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
-        $NIX_BUILD --option experimental-features 'flakes' --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.x86_64-linux (builtins.getFlake (builtins.toPath ./.)).defaultPackage.x86_64-linux'
+        $NIX_BUILD --option experimental-features 'flakes' --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.x86_64-linux (builtins.getFlake "github:nixos/nix/master").defaultPackage.x86_64-linux'
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
     - run: |
+        cachix use nixos-nix-install-tests
         NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
         $NIX_BUILD \
           --option experimental-features 'flakes' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,8 @@ jobs:
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
     - run: |
         cachix use nixos-nix-install-tests
-        NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
-        $NIX_BUILD \
-          --option experimental-features 'flakes' \
-          --option access-tokens github.com=${{ secrets.GITHUB_TOKEN }} \
-          --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.${builtins.currentSystem} (builtins.getFlake "github:nixos/nix/master").defaultPackage.${builtins.currentSystem}'
+        CURRENT_NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin
+        PATH=$CURRENT_NIX_BUILD:$PATH bash scripts/test-against-master.sh
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
     - run: |
         NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
-        $NIX_BUILD --option experimental-features 'flakes' --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.x86_64-linux (builtins.getFlake "github:nixos/nix/master").defaultPackage.x86_64-linux'
+        $NIX_BUILD --option experimental-features 'flakes' --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.${builtins.currentSystem} (builtins.getFlake "github:nixos/nix/master").defaultPackage.${builtins.currentSystem}'
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
     - run: |
         NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
-        $NIX_BUILD --option experimental-features 'flakes' --impure --expr 'builtins.getFlake (builtins.toPath ./.).lib.testAgainst.x86_64-linux (builtins.getFlake (builtins.toPath ./.)).defaultPackage.x86_64-linux'
+        $NIX_BUILD --option experimental-features 'flakes' --impure --expr '(builtins.getFlake (builtins.toPath ./.)).lib.testAgainst.x86_64-linux (builtins.getFlake (builtins.toPath ./.)).defaultPackage.x86_64-linux'
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
+    - run: |
+      NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin/nix-build
+      $NIX_BUILD --option experimental-features 'flakes' --impure --expr 'builtins.getFlake (builtins.toPath ./.).lib.testAgainst.x86_64-linux (builtins.getFlake (builtins.toPath ./.)).defaultPackage.x86_64-linux'
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,9 @@ jobs:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: cachix use nixos-nix-install-tests
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
-    - run: |
-        cachix use nixos-nix-install-tests
-        CURRENT_NIX_BUILD=$(nix-build -A defaultPackage.$(nix-instantiate --eval -E '(builtins.currentSystem)'))/bin
-        PATH=$CURRENT_NIX_BUILD:$PATH GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} bash scripts/test-against-master.sh
+    - run: bash scripts/test-against-master.sh
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -504,6 +504,12 @@
           } "touch $out";
       });
 
+      lib = {
+        testAgainst = forAllSystems (system:
+          testNixVersions nixpkgsFor.${system} nixpkgsFor.${system}.nix
+        );
+      };
+
       packages = forAllSystems (system: {
         inherit (nixpkgsFor.${system}) nix;
       } // (nixpkgs.lib.optionalAttrs (builtins.elem system linux64BitSystems) {

--- a/scripts/test-against-master.sh
+++ b/scripts/test-against-master.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x;
+
+CurrentNixDir=$(pwd)
+CurrentRev=${GITHUB_SHA:-$(git rev-parse HEAD)}
+WorkDir=$(mktemp -d)
+trap 'rm -r "$WorkDir"' EXIT
+
+pushd "$WorkDir"
+
+cat <<EOF > flake.nix
+{
+    inputs.currentNix.url = "git+file://$CurrentNixDir?rev=$CurrentRev";
+    inputs.nixMaster.url = "github:nixos/nix";
+
+    outputs = { self, currentNix, nixMaster }: {
+        checks = builtins.mapAttrs (systemName: _:
+        { againstMaster = currentNix.lib.testAgainst.\${systemName} nixMaster.defaultPackage.\${systemName}; }
+        ) currentNix.defaultPackage;
+    };
+}
+EOF
+nix --experimental-features 'nix-command flakes' flake check
+
+popd

--- a/scripts/test-against-master.sh
+++ b/scripts/test-against-master.sh
@@ -7,6 +7,10 @@ CurrentNixDir=$(pwd)
 CurrentRev=${GITHUB_SHA:-$(git rev-parse HEAD)}
 WorkDir=$(mktemp -d)
 trap 'rm -r "$WorkDir"' EXIT
+GITHUB_TOKEN_OPTION=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    GITHUB_TOKEN_OPTION=("--option" "access-tokens" "github.com=$GITHUB_TOKEN")
+fi
 
 pushd "$WorkDir"
 
@@ -22,6 +26,8 @@ cat <<EOF > flake.nix
     };
 }
 EOF
-nix --experimental-features 'nix-command flakes' flake check
+nix flake check\
+    --experimental-features 'nix-command flakes' \
+    "${GITHUB_TOKEN_OPTION[@]}"
 
 popd


### PR DESCRIPTION
Make github actions also run the testsuite using a `nix-daemon` executable that comes from the master branch.

This allows ensuring that every commit on master is backwards-compatible with the previous one.
