### PR TITLE
Expose a perl method to query a derivation

### DIFF
--- a/perl/lib/Nix/Store.pm
+++ b/perl/lib/Nix/Store.pm
@@ -22,6 +22,7 @@ our @EXPORT = qw(
     derivationFromPath
     addTempRoot
     getBinDir getStoreDir
+    queryRawRealisation
 );
 
 our $VERSION = '0.15';

--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -15,6 +15,7 @@
 #include "crypto.hh"
 
 #include <sodium.h>
+#include <nlohmann/json.hpp>
 
 
 using namespace nix;
@@ -119,6 +120,18 @@ SV * queryPathInfo(char * path, int base32)
         } catch (Error & e) {
             croak("%s", e.what());
         }
+
+SV * queryRawRealisation(char * outputId)
+    PPCODE:
+      try {
+        auto realisation = store()->queryRealisation(DrvOutput::parse(outputId));
+        if (realisation)
+            XPUSHs(sv_2mortal(newSVpv(realisation->toJSON().dump().c_str(), 0)));
+        else
+            XPUSHs(sv_2mortal(newSVpv("", 0)));
+      } catch (Error & e) {
+        croak("%s", e.what());
+      }
 
 
 SV * queryPathFromHashPart(char * hashPart)


### PR DESCRIPTION
Just doing a very stupid thing taking as argument a serialised drv
output and returning a serialised realisation.

This is needed for `nix-serve` to handle ca derivations
