### PR TITLE
nix-shell -p: pass `--arg`s as nixpkgs parameters

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -269,7 +269,7 @@ static void main_nix_build(int argc, char * * argv)
 
     if (packages) {
         std::ostringstream joined;
-        joined << "with import <nixpkgs> { }; (pkgs.runCommandCC or pkgs.runCommand) \"shell\" { buildInputs = [ ";
+        joined << "{...}@args: with import <nixpkgs> args; (pkgs.runCommandCC or pkgs.runCommand) \"shell\" { buildInputs = [ ";
         for (const auto & i : left)
             joined << '(' << i << ") ";
         joined << "]; } \"\"";

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -54,6 +54,10 @@ nix-instantiate shell.nix -A shellDrv --add-root $TEST_ROOT/shell
 output=$(NIX_PATH=nixpkgs=shell.nix nix-shell --pure -p foo bar --run 'echo "$(foo) $(bar)"')
 [ "$output" = "foo bar" ]
 
+# Test nix-shell -p --arg x y
+output=$(NIX_PATH=nixpkgs=shell.nix nix-shell --pure -p foo --argstr fooContents baz --run 'echo "$(foo)"')
+[ "$output" = "baz" ]
+
 # Test nix-shell shebang mode
 sed -e "s|@ENV_PROG@|$(type -P env)|" shell.shebang.sh > $TEST_ROOT/shell.shebang.sh
 chmod a+rx $TEST_ROOT/shell.shebang.sh

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,4 +1,4 @@
-{ inNixShell ? false, contentAddressed ? false }:
+{ inNixShell ? false, contentAddressed ? false, fooContents ? "foo" }:
 
 let cfg = import ./config.nix; in
 with cfg;
@@ -62,7 +62,7 @@ let pkgs = rec {
 
   foo = runCommand "foo" {} ''
     mkdir -p $out/bin
-    echo 'echo foo' > $out/bin/foo
+    echo 'echo ${fooContents}' > $out/bin/foo
     chmod a+rx $out/bin/foo
     ln -s ${shell} $out/bin/bash
   '';


### PR DESCRIPTION
I've simply applied @regnat's suggestion, credits to them :) 

Closes #1323

```
[ldesgoui@soldier:~/nix]$ ./result/bin/nix-shell -p hello file --argstr system i686-linux --run 'file $(type -P hello)' --pure
/nix/store/hqp0fq9nvbazwkjhjbrfhlxn433wyxfg-hello-2.10/bin/hello: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /nix/store/vcdbwr6kjbny8khx3h9fvagkwdpc87ky-glibc-2.32-46/lib/ld-linux.so.2, for GNU/Linux 2.6.32, not stripped

[ldesgoui@soldier:~/nix]$ ./result/bin/nix-shell -p hello file --run 'file $(type -P hello)' --pure
/nix/store/vf8fb2avrxnnhc6n70dkqdlk25f61rwm-hello-2.10/bin/hello: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /nix/store/ikl21vjfq900ccbqg1xasp83kadw6q8y-glibc-2.32-46/lib/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, not stripped
```