### PR TITLE
Evaluate nix-shell -i args relative to script

### DIFF
--- a/doc/manual/rl-next/shebang-relative.md
+++ b/doc/manual/rl-next/shebang-relative.md
@@ -1,0 +1,8 @@
+synopsis: ensure nix-shell shebang uses relative path
+prs: #5088
+description: {
+
+`nix-shell` shebangs use the script file's relative location to resolve relative paths to files passed as command line arguments, but expression arguments were still evaluated using the current working directory as a base path.
+The new behavior is that evalutations are performed relative to the script.
+
+}

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -298,7 +298,9 @@ static void main_nix_build(int argc, char * * argv)
     else
         for (auto i : left) {
             if (fromArgs)
-                exprs.push_back(state->parseExprFromString(std::move(i), state->rootPath(CanonPath::fromCwd())));
+                exprs.push_back(state->parseExprFromString(
+                    std::move(i),
+                    state->rootPath(CanonPath::fromCwd(inShebang ? dirOf(script) : "."))));
             else {
                 auto absolute = i;
                 try {
@@ -311,7 +313,7 @@ static void main_nix_build(int argc, char * * argv)
                     /* If we're in a #! script, interpret filenames
                        relative to the script. */
                     exprs.push_back(state->parseExprFromFile(resolveExprPath(state->checkSourcePath(lookupFileArg(*state,
-                                        inShebang && !packages ? absPath(i, absPath(dirOf(script))) : i)))));
+                                        inShebang ? absPath(i, absPath(dirOf(script))) : i)))));
             }
         }
 

--- a/tests/functional/nix-shell.sh
+++ b/tests/functional/nix-shell.sh
@@ -59,6 +59,16 @@ chmod a+rx $TEST_ROOT/shell.shebang.sh
 output=$($TEST_ROOT/shell.shebang.sh abc def)
 [ "$output" = "foo bar abc def" ]
 
+# Test nix-shell shebang mode with an alternate working directory
+sed -e "s|@ENV_PROG@|$(type -P env)|" shell.shebang.expr > $TEST_ROOT/shell.shebang.expr
+chmod a+rx $TEST_ROOT/shell.shebang.expr
+# Should fail due to expressions using relative path
+! $TEST_ROOT/shell.shebang.expr bar
+cp shell.nix config.nix $TEST_ROOT
+# Should succeed
+output=$($TEST_ROOT/shell.shebang.expr bar)
+[ "$output" = '-e load(ARGV.shift) -- '"$TEST_ROOT"'/shell.shebang.expr bar' ]
+
 # Test nix-shell shebang mode again with metacharacters in the filename.
 # First word of filename is chosen to not match any file in the test root.
 sed -e "s|@ENV_PROG@|$(type -P env)|" shell.shebang.sh > $TEST_ROOT/spaced\ \\\'\"shell.shebang.sh


### PR DESCRIPTION
When writing a shebang script, you expect your path to be relative to
the script, not the cwd. We previously handled this correctly for
relative file paths, but not for expressions.

This handles both -p & -E args. My understanding is this should be
what we want in any cases I can think of - people run scripts from
many different working directories. @edolstra is there any reason to
handle -p args differently in this case?

Fixes #4232