### PR TITLE
More support for `NO_COLOR` environment variable

### DIFF
--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -57,7 +57,7 @@ void ConfigFile::apply()
                 trusted = *saved;
             } else {
                 // FIXME: filter ANSI escapes, newlines, \r, etc.
-                if (std::tolower(logger->ask(fmt("do you want to allow configuration setting '%s' to be set to '" ANSI_RED "%s" ANSI_NORMAL "' (y/N)?", name, valueS)).value_or('n')) != 'y') {
+                if (std::tolower(logger->ask(fmt("do you want to allow configuration setting '%s' to be set to '" + ANSI_RED + "%s" ANSI_NORMAL  "' (y/N)?", name, valueS)).value_or('n')) != 'y') {
                     if (std::tolower(logger->ask("do you want to permanently mark this value as untrusted (y/N)?").value_or('n')) == 'y') {
                         trustedList[name][valueS] = false;
                         writeTrustedList(trustedList);

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -389,10 +389,10 @@ public:
             if (running || done || expected || failed) {
                 if (running)
                     if (expected != 0)
-                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" ANSI_GREEN + numberFmt + ANSI_NORMAL "/" + numberFmt,
+                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" + ANSI_GREEN + numberFmt + ANSI_NORMAL "/" + numberFmt,
                             running / unit, done / unit, expected / unit);
                     else
-                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" ANSI_GREEN + numberFmt + ANSI_NORMAL,
+                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" + ANSI_GREEN + numberFmt + ANSI_NORMAL,
                             running / unit, done / unit);
                 else if (expected != done)
                     if (expected != 0)
@@ -405,7 +405,7 @@ public:
                 s = fmt(itemFmt, s);
 
                 if (failed)
-                    s += fmt(" (" ANSI_RED "%d failed" ANSI_NORMAL ")", failed / unit);
+                    s += fmt(" (" + ANSI_RED + "%d failed" ANSI_NORMAL ")", failed / unit);
             }
 
             return s;
@@ -445,12 +445,12 @@ public:
 
         if (state.corruptedPaths) {
             if (!res.empty()) res += ", ";
-            res += fmt(ANSI_RED "%d corrupted" ANSI_NORMAL, state.corruptedPaths);
+            res += fmt(ANSI_RED + "%d corrupted" ANSI_NORMAL, state.corruptedPaths);
         }
 
         if (state.untrustedPaths) {
             if (!res.empty()) res += ", ";
-            res += fmt(ANSI_RED "%d untrusted" ANSI_NORMAL, state.untrustedPaths);
+            res += fmt(ANSI_RED + "%d untrusted" ANSI_NORMAL, state.untrustedPaths);
         }
 
         return res;

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -323,7 +323,7 @@ int handleExceptions(const string & programName, std::function<void()> fun)
 
     ErrorInfo::programName = baseNameOf(programName);
 
-    string error = ANSI_RED "error:" ANSI_NORMAL " ";
+    string error = ANSI_RED + "error:" ANSI_NORMAL " ";
     try {
         try {
             fun();

--- a/src/libutil/ansicolor.hh
+++ b/src/libutil/ansicolor.hh
@@ -2,16 +2,19 @@
 
 namespace nix {
 
+// A forward declaration from `util.hh`
+bool shouldANSI();
+
 /* Some ANSI escape sequences. */
-#define ANSI_NORMAL "\e[0m"
-#define ANSI_BOLD "\e[1m"
-#define ANSI_FAINT "\e[2m"
-#define ANSI_ITALIC "\e[3m"
-#define ANSI_RED "\e[31;1m"
-#define ANSI_GREEN "\e[32;1m"
-#define ANSI_YELLOW "\e[33;1m"
-#define ANSI_BLUE "\e[34;1m"
-#define ANSI_MAGENTA "\e[35;1m"
-#define ANSI_CYAN "\e[36;1m"
+#define ANSI_NORMAL  "\e[0m"
+#define ANSI_BOLD    "\e[1m"
+#define ANSI_FAINT   "\e[2m"
+#define ANSI_ITALIC  "\e[3m"
+#define ANSI_RED     (::std::string( ::nix::shouldANSI() ? "\e[31;1m" : ""))
+#define ANSI_GREEN   (::std::string( ::nix::shouldANSI() ? "\e[32;1m" : ""))
+#define ANSI_YELLOW  (::std::string( ::nix::shouldANSI() ? "\e[33;1m" : ""))
+#define ANSI_BLUE    (::std::string( ::nix::shouldANSI() ? "\e[34;1m" : ""))
+#define ANSI_MAGENTA (::std::string( ::nix::shouldANSI() ? "\e[35;1m" : ""))
+#define ANSI_CYAN    (::std::string( ::nix::shouldANSI() ? "\e[36;1m" : ""))
 
 }

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -163,7 +163,7 @@ void printCodeLines(std::ostream & out,
             std::string arrows("^");
 
             out << std::endl
-                << fmt("%1%      |%2%" ANSI_RED "%3%" ANSI_NORMAL,
+                << fmt("%1%      |%2%" + ANSI_RED + "%3%" ANSI_NORMAL,
                 prefix,
                 spaces,
                 arrows);
@@ -185,15 +185,15 @@ void printAtPos(const ErrPos & pos, std::ostream & out)
     if (pos) {
         switch (pos.origin) {
             case foFile: {
-                out << fmt(ANSI_BLUE "at " ANSI_YELLOW "%s:%s" ANSI_NORMAL ":", pos.file, showErrPos(pos));
+                out << fmt(ANSI_BLUE + "at " + ANSI_YELLOW + "%s:%s" ANSI_NORMAL ":", pos.file, showErrPos(pos));
                 break;
             }
             case foString: {
-                out << fmt(ANSI_BLUE "at " ANSI_YELLOW "«string»:%s" ANSI_NORMAL ":", showErrPos(pos));
+                out << fmt(ANSI_BLUE + "at " + ANSI_YELLOW + "«string»:%s" ANSI_NORMAL ":", showErrPos(pos));
                 break;
             }
             case foStdin: {
-                out << fmt(ANSI_BLUE "at " ANSI_YELLOW "«stdin»:%s" ANSI_NORMAL ":", showErrPos(pos));
+                out << fmt(ANSI_BLUE + "at " + ANSI_YELLOW + "«stdin»:%s" ANSI_NORMAL ":", showErrPos(pos));
                 break;
             }
             default:
@@ -224,35 +224,35 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
     std::string prefix;
     switch (einfo.level) {
         case Verbosity::lvlError: {
-            prefix = ANSI_RED "error";
+            prefix = ANSI_RED + "error";
             break;
         }
         case Verbosity::lvlNotice: {
-            prefix = ANSI_RED "note";
+            prefix = ANSI_RED + "note";
             break;
         }
         case Verbosity::lvlWarn: {
-            prefix = ANSI_YELLOW "warning";
+            prefix = ANSI_YELLOW + "warning";
             break;
         }
         case Verbosity::lvlInfo: {
-            prefix = ANSI_GREEN "info";
+            prefix = ANSI_GREEN + "info";
             break;
         }
         case Verbosity::lvlTalkative: {
-            prefix = ANSI_GREEN "talk";
+            prefix = ANSI_GREEN + "talk";
             break;
         }
         case Verbosity::lvlChatty: {
-            prefix = ANSI_GREEN "chat";
+            prefix = ANSI_GREEN + "chat";
             break;
         }
         case Verbosity::lvlVomit: {
-            prefix = ANSI_GREEN "vomit";
+            prefix = ANSI_GREEN + "vomit";
             break;
         }
         case Verbosity::lvlDebug: {
-            prefix = ANSI_YELLOW "debug";
+            prefix = ANSI_YELLOW + "debug";
             break;
         }
         default:

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -27,7 +27,7 @@ Logger * logger = makeSimpleLogger(true);
 
 void Logger::warn(const std::string & msg)
 {
-    log(lvlWarn, ANSI_YELLOW "warning:" ANSI_NORMAL " " + msg);
+    log(lvlWarn, ANSI_YELLOW + "warning:" ANSI_NORMAL " " + msg);
 }
 
 void Logger::writeToStdout(std::string_view s)

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -24,12 +24,12 @@ std::string formatProtocol(unsigned int proto)
 }
 
 bool checkPass(const std::string & msg) {
-    logger->log(ANSI_GREEN "[PASS] " ANSI_NORMAL + msg);
+    logger->log(ANSI_GREEN + "[PASS] " ANSI_NORMAL + msg);
     return true;
 }
 
 bool checkFail(const std::string & msg) {
-    logger->log(ANSI_RED "[FAIL] " ANSI_NORMAL + msg);
+    logger->log(ANSI_RED + "[FAIL] " ANSI_NORMAL + msg);
     return false;
 }
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -893,7 +893,7 @@ struct CmdFlakeShow : FlakeCommand
                         auto attrPath2(attrPath);
                         attrPath2.push_back(attr);
                         visit(*visitor2, attrPath2,
-                            fmt(ANSI_GREEN "%s%s" ANSI_NORMAL ANSI_BOLD "%s" ANSI_NORMAL, nextPrefix, last ? treeLast : treeConn, attr),
+                            fmt(ANSI_GREEN + "%s%s" ANSI_NORMAL ANSI_BOLD "%s" ANSI_NORMAL, nextPrefix, last ? treeLast : treeConn, attr),
                             nextPrefix + (last ? treeNull : treeLine));
                     }
                 };
@@ -962,7 +962,7 @@ struct CmdFlakeShow : FlakeCommand
                     if (attrPath.size() == 1)
                         recurse();
                     else if (!showLegacy)
-                        logger->cout("%s: " ANSI_YELLOW "omitted" ANSI_NORMAL " (use '--legacy' to show)", headerPrefix);
+                        logger->cout("%s: " + ANSI_YELLOW + "omitted" ANSI_NORMAL " (use '--legacy' to show)", headerPrefix);
                     else {
                         if (visitor.isDerivation())
                             showDerivation();
@@ -997,7 +997,7 @@ struct CmdFlakeShow : FlakeCommand
                         || (attrPath.size() == 2 && attrPath[0] == "overlays") ? "Nixpkgs overlay" :
                         attrPath.size() == 2 && attrPath[0] == "nixosConfigurations" ? "NixOS configuration" :
                         attrPath.size() == 2 && attrPath[0] == "nixosModules" ? "NixOS module" :
-                        ANSI_YELLOW "unknown" ANSI_NORMAL);
+                        ANSI_YELLOW + "unknown" ANSI_NORMAL);
                 }
             } catch (EvalError & e) {
                 if (!(attrPath.size() > 0 && attrPath[0] == "legacyPackages"))

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -197,7 +197,7 @@ namespace {
 
 void NixRepl::mainLoop(const std::vector<std::string> & files)
 {
-    string error = ANSI_RED "error:" ANSI_NORMAL " ";
+    string error = ANSI_RED + "error:" ANSI_NORMAL " ";
     std::cout << "Welcome to Nix version " << nixVersion << ". Type :? for help." << std::endl << std::endl;
 
     for (auto & i : files)
@@ -715,7 +715,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         break;
 
     case nNull:
-        str << ANSI_CYAN "null" ANSI_NORMAL;
+        str << ANSI_CYAN + "null" ANSI_NORMAL;
         break;
 
     case nAttrs: {
@@ -751,7 +751,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
                     try {
                         printValue(str, *i.second, maxDepth - 1, seen);
                     } catch (AssertionError & e) {
-                        str << ANSI_RED "«error: " << e.msg() << "»" ANSI_NORMAL;
+                        str << ANSI_RED << "«error: " << e.msg() << "»" ANSI_NORMAL;
                     }
                 str << "; ";
             }
@@ -775,7 +775,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
                     try {
                         printValue(str, *v.listElems()[n], maxDepth - 1, seen);
                     } catch (AssertionError & e) {
-                        str << ANSI_RED "«error: " << e.msg() << "»" ANSI_NORMAL;
+                        str << ANSI_RED << "«error: " << e.msg() << "»" ANSI_NORMAL;
                     }
                 str << " ";
             }
@@ -788,11 +788,11 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         if (v.isLambda()) {
             std::ostringstream s;
             s << v.lambda.fun->pos;
-            str << ANSI_BLUE "«lambda @ " << filterANSIEscapes(s.str()) << "»" ANSI_NORMAL;
+            str << ANSI_BLUE << "«lambda @ " << filterANSIEscapes(s.str()) << "»" ANSI_NORMAL;
         } else if (v.isPrimOp()) {
-            str << ANSI_MAGENTA "«primop»" ANSI_NORMAL;
+            str << ANSI_MAGENTA << "«primop»" ANSI_NORMAL;
         } else if (v.isPrimOpApp()) {
-            str << ANSI_BLUE "«primop-app»" ANSI_NORMAL;
+            str << ANSI_BLUE << "«primop-app»" ANSI_NORMAL;
         } else {
             abort();
         }
@@ -803,7 +803,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         break;
 
     default:
-        str << ANSI_RED "«unknown»" ANSI_NORMAL;
+        str << ANSI_RED << "«unknown»" ANSI_NORMAL;
         break;
     }
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -87,7 +87,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
                 {"--profile", profileDir, "-i", store->printStorePath(storePath), "--no-sandbox"});
         }
 
-        printInfo(ANSI_GREEN "upgrade to version %s done" ANSI_NORMAL, version);
+        printInfo(ANSI_GREEN + "upgrade to version %s done" ANSI_NORMAL, version);
     }
 
     /* Return the profile in which Nix is installed. */


### PR DESCRIPTION
This builds on top of #4971. Without this, color is still shown in the
REPL.

See https://no-color.org/ for more information about the variable.