### PR TITLE
Remove curl deps in install script

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -76,14 +76,21 @@ fi
 
 tarball=$tmpDir/nix-@nixVersion@-$system.tar.xz
 
-require_util curl "download the binary tarball"
 require_util tar "unpack the binary tarball"
 if [ "$(uname -s)" != "Darwin" ]; then
     require_util xz "unpack the binary tarball"
 fi
 
+if command -v wget > /dev/null 2>&1; then
+    fetch() { wget "$1" -O "$2"; }
+elif command -v curl > /dev/null 2>&1; then
+    fetch() { curl -L "$1" -o "$2"; }
+else
+    oops "you don't have wget or curl installed, which I need to download the binary tarball"
+fi
+
 echo "downloading Nix @nixVersion@ binary tarball for $system from '$url' to '$tmpDir'..."
-curl -L "$url" -o "$tarball" || oops "failed to download '$url'"
+fetch "$url" "$tarball" || oops "failed to download '$url'"
 
 if command -v sha256sum > /dev/null 2>&1; then
     hash2="$(sha256sum -b "$tarball" | cut -c1-64)"


### PR DESCRIPTION
Hi 👋 

I believe wget is installed by default on pretty much every linux distros, while curl isn't (e.g. Ubuntu 20.x). The less dependencies the better 🙂 

If this pr is accepted, I believe the installation command on https://nixos.org/download.html#nix-quick-install might also be changed to something like `wget https://nixos.org/nix/install -O - | sh`.
