### PR TITLE
Return the store path instead of the real path in fetchTree.cc::fetch

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -229,20 +229,21 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
         ? fetchers::downloadTarball(state.store, *url, name, (bool) expectedHash).first.storePath
         : fetchers::downloadFile(state.store, *url, name, (bool) expectedHash).storePath;
 
-    auto path = state.store->toRealPath(storePath);
+    auto realPath = state.store->toRealPath(storePath);
 
     if (expectedHash) {
         auto hash = unpack
             ? state.store->queryPathInfo(storePath)->narHash
-            : hashFile(htSHA256, path);
+            : hashFile(htSHA256, realPath);
         if (hash != *expectedHash)
             throw Error((unsigned int) 102, "hash mismatch in file downloaded from '%s':\n  specified: %s\n  got:       %s",
                 *url, expectedHash->to_string(Base32, true), hash.to_string(Base32, true));
     }
 
     if (state.allowedPaths)
-        state.allowedPaths->insert(path);
+        state.allowedPaths->insert(realPath);
 
+    auto path = state.store->printStorePath(storePath);
     mkString(v, path, PathSet({path}));
 }
 

--- a/tests/local-store.sh
+++ b/tests/local-store.sh
@@ -15,6 +15,5 @@ PATH1=$(nix path-info --store ./x $CORRECT_PATH)
 PATH2=$(nix path-info --store "$PWD/x" $CORRECT_PATH)
 [ $CORRECT_PATH == $PATH2 ]
 
-# FIXME we could also test the query parameter version:
-# PATH3=$(nix path-info --store "local?store=$PWD/x" $CORRECT_PATH)
-# [ $CORRECT_PATH == $PATH3 ]
+PATH3=$(nix path-info --store "local?root=$PWD/x" $CORRECT_PATH)
+[ $CORRECT_PATH == $PATH3 ]


### PR DESCRIPTION
This resolves issue https://github.com/NixOS/nix/issues/5065

With this change the real path is added to `allowedPaths` in the evaluation state, but the result of the fetch operation is the store path. At first I tried just referencing the store path in the string context, but that just pushed the error further down into `realiseContext`.

I'm not confident that this is quite the correct fix but i managed to build a substantial derivation with it. In any case I should add a test before this is considered ready. Each primop that uses this fetch implementation should be exercised. 