### PR TITLE
nix-shell --pure: Let it work for any derivation

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -489,6 +489,9 @@ static void main_nix_build(int argc, char * * argv)
                     "_nix_shell_clean_tmpdir; ") +
                 (pure ? "" : "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;") +
                 "%2%"
+                // always clear PATH.
+                // when nix-shell is run impure, we rehydrate it with the `p=$PATH` above
+                "unset PATH;"
                 "dontAddDisableDepTrack=1;\n"
                 + structuredAttrsRC +
                 "\n[ -e $stdenv/setup ] && source $stdenv/setup; "


### PR DESCRIPTION
`nix-shell --pure` when applied to a non stdenv derivation doesn't seem
to clear the PATH. It expects the stdenv/setup file to do so.

This adds an explicit `unset PATH` by nix-build.cc (nix-shell) itself so
that it's not reliant on stdenv/setup anymore.

This does not break impure nix-shell since the PATH is persisted as the
variable `p` prior in the bash rcfile

This was tested with the following derivation
```nix
let
  nixpkgs = import (builtins.fetchTarball {
    name = "nixos-unstable-2020-09-24";
    url =
      "https://github.com/nixos/nixpkgs/archive/5aba0fe9766a7201a336249fd6cb76e0d7ba2faf.tar.gz";
    sha256 = "05gawlhizp85agdpw3kpjn41vggdiywbabsbmk76r2dr513188jz";
  }) { };
in
with nixpkgs;
derivation {
    name = "test-purity-path";
    system = builtins.currentSystem;
    builder = writeScript "builder.sh" ''
        export > $out
    '';
    FOO = "bar";
    passAsFile = ["FOO"];
}
```

```bash
❯  /home/fmzakari/code/github.com/NixOS/nix/result/bin/nix-shell purity-derivation.nix --pur
[nix-shell:~/code/nix/playground]$ echo $PATH
/nix/store/fgbzvd4c6nly9m4dpczrxybdpkm8mnk3-bash-interactive-4.4-p23/bin:

[nix-shell:~/code/nix/playground]$ exit
exit
bash: rm: command not found

❯ /home/fmzakari/code/github.com/NixOS/nix/result/bin/nix-shell purity-derivation.nix

[nix-shell:~/code/nix/playground]$ echo $PATH
/nix/store/fgbzvd4c6nly9m4dpczrxybdpkm8mnk3-bash-interactive-4.4-p23/bin::/home/fmzakari/.nix-profile/bin:/home/fmzakari/.nix-profile/bin:/home/fmzakari/.local/bin:/home/fmzakari/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/fmzakari/.zsh/plugins/zsh-syntax-highlighting:/home/fmzakari/.zsh/plugins/powerlevel10k
```

Interestingly it looks like the rcfile has a dependency on **rm** during a trap if we do _passAsFile_
I'd love if we could remove this dependency as well.
https://github.com/NixOS/nix/blob/94ec9e47030c2a7280503d338f0dca7ad92811f5/src/nix-build/nix-build.cc#L484

fixes #5092