### PR TITLE
Short-circuit querying substituters on success

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1076,6 +1076,10 @@ void LocalStore::querySubstitutablePathInfos(const StorePathCAMap & paths, Subst
     if (!settings.useSubstitutes) return;
     for (auto & sub : getDefaultSubstituters()) {
         for (auto & path : paths) {
+            if (infos.find(path.first) != infos.end())
+                // choose first succeeding substituter
+                continue;
+
             auto subPath(path.first);
 
             // recompute store path so that we can use a different store root

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -430,9 +430,10 @@ public:
     virtual StorePathSet querySubstitutablePaths(const StorePathSet & paths) { return {}; };
 
     /* Query substitute info (i.e. references, derivers and download
-       sizes) of a map of paths to their optional ca values. If a path
-       does not have substitute info, it's omitted from the resulting
-       ‘infos’ map. */
+       sizes) of a map of paths to their optional ca values. The info
+       of the first succeeding substituter for each path will be
+       returned. If a path does not have substitute info, it's omitted
+       from the resulting ‘infos’ map. */
     virtual void querySubstitutablePathInfos(const StorePathCAMap & paths,
         SubstitutablePathInfos & infos) { return; };
 


### PR DESCRIPTION
This PR ensures that `querySubstitutablePathInfos` returns the `SubstitutablePathInfo`s of the *first* succeeding substituter, i.e. the one that will eventually be used for the actual substitution. Semantically this doesn't matter since no caller of this function checks for anything other than success or failure anyway, but it does mean that we can skip querying the other substituters.

On a project that makes heavy use of small derivations with configured substituters (in order)
* a file:// binary cache restored from a GitHub Actions cache,
* Cachix,
* and cache.nixos.org

this change speeds up the delay between evaluation and substitution (that is, the "querying info about missing paths" part) from 25s to 2.5s if all 842 derivations can be fetched from the local binary cache.