### PR TITLE
Fix host OS detection for darwin-specific linker flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,9 +274,11 @@ AC_CHECK_FUNCS([strsignal posix_fallocate sysconf])
 
 # This is needed if bzip2 is a static library, and the Nix libraries
 # are dynamic.
-if test "$(uname)" = "Darwin"; then
+case "${host_os}" in
+  darwin*)
     LDFLAGS="-all_load $LDFLAGS"
-fi
+    ;;
+esac
 
 
 AC_ARG_WITH(sandbox-shell, AS_HELP_STRING([--with-sandbox-shell=PATH],[path of a statically-linked shell to use as /bin/sh in sandboxes]),


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/5114

Followup to https://github.com/NixOS/nix/pull/4935, and can similarly be backported to 2.3