### PR TITLE
Backport 2.3: Set the NIX_PATH a bit more like master does it

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -34,5 +34,15 @@ else
   unset -f check_nix_profiles
 fi
 
-export NIX_PATH="nixpkgs=@localstatedir@/nix/profiles/per-user/root/channels/nixpkgs:@localstatedir@/nix/profiles/per-user/root/channels"
+# Default NIX_PATH if undefined so that <nixpkgs> paths work when the user
+# has fetched the Nixpkgs channel.
+if [ -z "${NIX_PATH+x}" ]; then
+  if [ -n "$HOME" ]; then
+    NIX_PATH="$HOME/.nix-defexpr/channels"
+  fi
+  NIX_PATH+=":nixpkgs=@localstatedir@/nix/profiles/per-user/root/channels/nixpkgs"
+  NIX_PATH+=":@localstatedir@/nix/profiles/per-user/root/channels"
+  export NIX_PATH
+fi
+
 export PATH="$HOME/.nix-profile/bin:@localstatedir@/nix/profiles/default/bin:$PATH"

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -6,9 +6,14 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     NIX_LINK=$HOME/.nix-profile
 
 
-    # Append ~/.nix-defexpr/channels to $NIX_PATH so that <nixpkgs>
-    # paths work when the user has fetched the Nixpkgs channel.
-    export NIX_PATH=${NIX_PATH:+$NIX_PATH:}$HOME/.nix-defexpr/channels
+    # Default NIX_PATH if undefined so that <nixpkgs> paths work when the user
+    # has fetched the Nixpkgs channel.
+    if [ -z "${NIX_PATH+x}" ]; then
+        NIX_PATH="$HOME/.nix-defexpr/channels"
+        NIX_PATH+=":nixpkgs=@localstatedir@/nix/profiles/per-user/root/channels/nixpkgs"
+        NIX_PATH+=":@localstatedir@/nix/profiles/per-user/root/channels"
+        export NIX_PATH
+    fi
 
     # Set up environment.
     # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix


### PR DESCRIPTION
1. Per-user profile before system-wide

2. Already-defined NIX_PATH (including empty) should not be modified.

However, I did *not* take master's change of only adding directories
which exist, because I think that would cause a regression where the
directories didn't yet exist, but then one ran a `nix-env` or
`nix-channel` command which creates them. Nix master would correctly
re-default the command each page load, but with Nix 2.3 the shell
profile / rc would not be automatically reloaded.

The commit on master we're imitating is
ec9dd9a5aeb9b7fca170d86b8906ffac7e5ef057.