### PR TITLE
Mitigate a segmentation fault when a derivation has no name attribute

### DIFF
--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -41,7 +41,7 @@ private:
     size_t size_, capacity_;
     Attr attrs[0];
 
-    Bindings(size_t capacity) : size_(0), capacity_(capacity) { }
+    Bindings(size_t capacity) : pos(&noPos), size_(0), capacity_(capacity) { }
     Bindings(const Bindings & bindings) = delete;
 
 public:


### PR DESCRIPTION
Fixes #5113, but does not fix the underlying issue that the location data is not propagated early enough (it might fix the segmentation fault, tho).