### PR TITLE
[2.3] Fix host OS detection for darwin-specific linker flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,9 +294,11 @@ AC_CHECK_FUNCS([strsignal posix_fallocate sysconf])
 
 # This is needed if bzip2 is a static library, and the Nix libraries
 # are dynamic.
-if test "$(uname)" = "Darwin"; then
+case "${host_os}" in
+  darwin*)
     LDFLAGS="-all_load $LDFLAGS"
-fi
+    ;;
+esac
 
 
 # Do we have GNU tar?


### PR DESCRIPTION
Backport of #5115.

cc @domenkozar @r-burns
