### PR TITLE
Remove rsync usage in the installer

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -701,7 +701,10 @@ install_from_extracted_nix() {
         cd "$EXTRACTED_NIX_PATH"
 
         _sudo "to copy the basic Nix files to the new store at $NIX_ROOT/store" \
-              rsync -rlpt --chmod=-w ./store/* "$NIX_ROOT/store/"
+              cp -RLp ./store/* "$NIX_ROOT/store/"
+
+        _sudo "to make the new store non-writable at $NIX_ROOT/store" \
+              chmod -R ugo-w "$NIX_ROOT/store/"
 
         if [ -d "$NIX_INSTALLED_NIX" ]; then
             echo "      Alright! We have our first nix at $NIX_INSTALLED_NIX"


### PR DESCRIPTION
It's not commonly installed on systems like debian,
so avoid the bootstrapping problem by using cp and
chmod.

Not tested yet.

Fixes https://github.com/NixOS/nix/issues/2437