### PR TITLE
Allow use of path and filterSource in flakes

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1886,6 +1886,20 @@ static void addPath(EvalState & state, const Pos & pos, const string & name, con
         dstPath = state.store->printStorePath(*expectedStorePath);
 
     mkString(v, dstPath, {dstPath});
+    if (state.allowedPaths)
+        state.allowedPaths->insert(v.string.s);
+
+    try {
+        state.realiseContext({});
+    } catch (InvalidPathError & e) {
+        throw EvalError({
+            .msg = hintfmt("cannot import '%1%', since path '%2%' is not valid", path, e.path),
+            .errPos = pos
+        });
+    } catch (Error & e) {
+        e.addTrace(pos, "while importing '%s'", path);
+        throw e;
+    }
 }
 
 


### PR DESCRIPTION
Using `builtins.filterSource` and/or `builtins.path` inside of flakes doesn't quite work as expected at the moment. Is this fundamentally a bad idea? There are a few issues about this, but nothing conclusive. This patch allows it, but i have no idea if this is breaking some invariant.

This part seems odd, but seems to be needed:
```
state.realiseContext({});
```

[Discourse](https://discourse.nixos.org/t/flakes-and-filtersource/7787/3)
[Discourse2](https://discourse.nixos.org/t/builtins-filtersource-causes-rebuilds/12564/2)
Fixes #3732
Fixes #2538

