### PR TITLE
Set enableOwnership in macOS install

### DIFF
--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -759,6 +759,10 @@ setup_volume() {
 
     await_volume
 
+    if [ "$(/usr/sbin/diskutil info -plist "$NIX_ROOT" | xmllint --xpath "(/plist/dict/key[text()='GlobalPermissionsEnabled'])/following-sibling::*[1]" -)" = "<false/>" ]; then
+        sudo /usr/sbin/diskutil enableOwnership "$NIX_ROOT"
+    fi
+
     # TODO: below is a vague kludge for now; I just don't know
     # what if any safe action there is to take here. Also, the
     # reminder isn't very helpful.

--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -206,4 +206,8 @@ poly_prepare_to_install() {
 EOF
         setup_darwin_volume
     fi
+
+    if [ "$(diskutil info -plist /nix | xmllint --xpath "(/plist/dict/key[text()='GlobalPermissionsEnabled'])/following-sibling::*[1]" -)" = "<false/>" ]; then
+        failure "This script needs a /nix volume with global permissions! This may require running sudo diskutil enableOwnership /nix."
+    fi
 }


### PR DESCRIPTION
For external hard disks where ownership is not enabled by default.