### PR TITLE
Don’t require experimental features for nix show-config

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -295,7 +295,8 @@ void mainWrapped(int argc, char * * argv)
 
     if (args.command->first != "repl"
         && args.command->first != "doctor"
-        && args.command->first != "upgrade-nix")
+        && args.command->first != "upgrade-nix"
+        && args.command->first != "show-config")
         settings.requireExperimentalFeature("nix-command");
 
     if (args.useNet && !haveInternet()) {


### PR DESCRIPTION
This command is available in nix stable (2.3), so we should allow it
in nix 2.4 too.