### PR TITLE
doc/manual/local.mk: use local src/nix/nix instead of /usr/bin/nix

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -18,7 +18,7 @@ dummy-env = env -i \
 	NIX_SSL_CERT_FILE=/dummy/no-ca-bundle.crt \
 	NIX_STATE_DIR=/dummy
 
-nix-eval = $(dummy-env) $(bindir)/nix eval --experimental-features nix-command -I nix/corepkgs=corepkgs --store dummy:// --impure --raw
+nix-eval = $(dummy-env) src/nix/nix eval --experimental-features nix-command -I nix/corepkgs=corepkgs --store dummy:// --impure --raw
 
 $(d)/%.1: $(d)/src/command-ref/%.md
 	@printf "Title: %s\n\n" "$$(basename $@ .1)" > $^.tmp
@@ -42,31 +42,31 @@ $(d)/src/SUMMARY.md: $(d)/src/SUMMARY.md.in $(d)/src/command-ref/new-cli
 	$(trace-gen) cat doc/manual/src/SUMMARY.md.in | while IFS= read line; do if [[ $$line = @manpages@ ]]; then cat doc/manual/src/command-ref/new-cli/SUMMARY.md; else echo "$$line"; fi; done > $@.tmp
 	@mv $@.tmp $@
 
-$(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/generate-manpage.nix $(bindir)/nix
+$(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/generate-manpage.nix src/nix/nix
 	@rm -rf $@
 	$(trace-gen) $(nix-eval) --write-to $@ --expr 'import doc/manual/generate-manpage.nix (builtins.fromJSON (builtins.readFile $<))'
 
-$(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/generate-options.nix $(d)/src/command-ref/conf-file-prefix.md $(bindir)/nix
+$(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/generate-options.nix $(d)/src/command-ref/conf-file-prefix.md src/nix/nix
 	@cat doc/manual/src/command-ref/conf-file-prefix.md > $@.tmp
 	$(trace-gen) $(nix-eval) --expr 'import doc/manual/generate-options.nix (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp
 	@mv $@.tmp $@
 
-$(d)/nix.json: $(bindir)/nix
-	$(trace-gen) $(dummy-env) $(bindir)/nix __dump-args > $@.tmp
+$(d)/nix.json: src/nix/nix
+	$(trace-gen) $(dummy-env) src/nix/nix __dump-args > $@.tmp
 	@mv $@.tmp $@
 
-$(d)/conf-file.json: $(bindir)/nix
-	$(trace-gen) $(dummy-env) $(bindir)/nix show-config --json --experimental-features nix-command > $@.tmp
+$(d)/conf-file.json: src/nix/nix
+	$(trace-gen) $(dummy-env) src/nix/nix show-config --json --experimental-features nix-command > $@.tmp
 	@mv $@.tmp $@
 
-$(d)/src/expressions/builtins.md: $(d)/builtins.json $(d)/generate-builtins.nix $(d)/src/expressions/builtins-prefix.md $(bindir)/nix
+$(d)/src/expressions/builtins.md: $(d)/builtins.json $(d)/generate-builtins.nix $(d)/src/expressions/builtins-prefix.md src/nix/nix
 	@cat doc/manual/src/expressions/builtins-prefix.md > $@.tmp
 	$(trace-gen) $(nix-eval) --expr 'import doc/manual/generate-builtins.nix (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp
 	@cat doc/manual/src/expressions/builtins-suffix.md >> $@.tmp
 	@mv $@.tmp $@
 
-$(d)/builtins.json: $(bindir)/nix
-	$(trace-gen) $(dummy-env) NIX_PATH=nix/corepkgs=corepkgs $(bindir)/nix __dump-builtins > $@.tmp
+$(d)/builtins.json: src/nix/nix
+	$(trace-gen) $(dummy-env) NIX_PATH=nix/corepkgs=corepkgs src/nix/nix __dump-builtins > $@.tmp
 	@mv $@.tmp $@
 
 # Generate the HTML manual.


### PR DESCRIPTION
Build failure happens when one tries to build `nix` on a linux
system as user with later plan to install as root (typical package
building separation):

```
$ cd /tmp
$ git clone https://github.com/NixOS/nix.git
$ cd nix
$ ./bootstrap.sh
$ ./configure --prefix=/usr ac_cv_header_aws_s3_S3Client_h=no
$ make
...
$ LANG=C make
  LD     /usr/lib/libnixutil.so
/usr/lib/gcc/x86_64-pc-linux-gnu/12.0.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot open output file /usr/lib/libnixutil.so: Permission denied
collect2: error: ld returned 1 exit status
make: *** [mk/lib.mk:117: /usr/lib/libnixutil.so] Error 1
```

Build failure happens because `doc/manual/nix.json` depends
on installed `$(bindir)` path instead of local inplace path:

```
$ make -r -d doc/manual/nix.json
...
Considering target file 'doc/manual/nix.json'.
 File 'doc/manual/nix.json' does not exist.
  Considering target file '/usr/bin/nix'.
    Considering target file 'src/build-remote/build-remote.o'.
     Looking for an implicit rule for 'src/build-remote/build-remote.o'.
...
doc/manual/local.mk:$(d)/nix.json: $(bindir)/nix
```

The fix is to always use inplace built `src/nix/nix` binary.

Closes: https://github.com/NixOS/nix/issues/5184