### PR TITLE
Shebang support with flakes

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,2 +1,46 @@
 # Release X.Y (202?-??-??)
 
+* The experimental nix command is now a `#!-interpreter` by appending the
+  contents of any `#! nix` lines and the script's location to a single call.
+  Some examples:
+  ```
+  #!/usr/bin/env nix
+  #! nix shell --file "<nixpkgs>" hello --command bash
+
+  hello | cowsay
+  ```
+  or with flakes:
+  ```
+  #!/usr/bin/env nix
+  #! nix shell nixpkgs#bash nixpkgs#hello nixpkgs#cowsay --command bash
+
+  hello | cowsay
+  ```
+  or
+  ```bash
+  #! /usr/bin/env nix
+  #! nix shell --impure --expr
+  #! nix "with (import (builtins.getFlake ''nixpkgs'') {}); terraform.withPlugins (plugins: [ plugins.openstack ])"
+  #! nix --command bash
+
+  terraform "$@"
+  ```
+  or
+  ```
+  #!/usr/bin/env nix
+  //! ```cargo
+  //! [dependencies]
+  //! time = "0.1.25"
+  //! ```
+  /*
+  #!nix shell nixpkgs#rustc nixpkgs#rust-script nixpkgs#cargo --command rust-script
+  */
+  fn main() {
+      for argument in std::env::args().skip(1) {
+          println!("{}", argument);
+      };
+      println!("{}", std::env::var("HOME").expect(""));
+      println!("{}", time::now().rfc822z());
+  }
+  // vim: ft=rust
+  ```

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -105,7 +105,8 @@ void Args::parseCmdline(const std::string & programName, const Strings & _cmdlin
 
                 std::string line;
                 std::getline(stream,line);
-                while (std::getline(stream,line) && !line.empty()){
+                std::string commentChars("#/\\%@*-");
+                while (std::getline(stream,line) && !line.empty() && commentChars.find(line[0]) != std::string::npos){
                     line = chomp(line);
 
                     std::smatch match;

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -1,6 +1,8 @@
 #include "args.hh"
 #include "hash.hh"
 
+#include <fstream>
+#include <string>
 #include <regex>
 #include <glob.h>
 
@@ -93,14 +95,17 @@ void Args::parseCmdline(const std::string & programName, const Strings & _cmdlin
     if (isNixCommand && cmdline.size() > 0) {
         auto script = *cmdline.begin();
         try {
-            auto lines = tokenizeString<Strings>(readFile(script), "\n");
-            if (std::regex_search(lines.front(), std::regex("^#!"))) {
-                lines.pop_front();
+            std::ifstream stream(script);
+            char shebang[3]={0,0,0};
+            stream.get(shebang,3);
+            if (strncmp(shebang,"#!",2) == 0){
                 for (auto pos = std::next(cmdline.begin()); pos != cmdline.end();pos++)
                     savedArgs.push_back(*pos);
                 cmdline.clear();
 
-                for (auto line : lines) {
+                std::string line;
+                std::getline(stream,line);
+                while (std::getline(stream,line) && !line.empty()){
                     line = chomp(line);
 
                     std::smatch match;

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -67,10 +67,10 @@ static std::optional<std::string> needsCompletion(std::string_view s)
 void Args::parseCmdline(const Strings & _cmdline)
 {
     // Default via 5.1.2.2.1 in C standard
-    Args::parseCmdline("", _cmdline);
+    Args::parseCmdline(_cmdline, false);
 }
 
-void Args::parseCmdline(const std::string & programName, const Strings & _cmdline)
+void Args::parseCmdline(const Strings & _cmdline, bool allowShebang)
 {
     Strings pendingArgs;
     bool dashDash = false;
@@ -91,8 +91,7 @@ void Args::parseCmdline(const std::string & programName, const Strings & _cmdlin
     // if we have at least one argument, it's the name of an
     // executable file, and it starts with "#!".
     Strings savedArgs;
-    auto isNixCommand = std::regex_search(programName, std::regex("nix$"));
-    if (isNixCommand && cmdline.size() > 0) {
+    if (allowShebang){
         auto script = *cmdline.begin();
         try {
             std::ifstream stream(script);
@@ -105,7 +104,7 @@ void Args::parseCmdline(const std::string & programName, const Strings & _cmdlin
 
                 std::string line;
                 std::getline(stream,line);
-                std::string commentChars("#/\\%@*-");
+                static const std::string commentChars("#/\\%@*-");
                 while (std::getline(stream,line) && !line.empty() && commentChars.find(line[0]) != std::string::npos){
                     line = chomp(line);
 

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -27,7 +27,7 @@ public:
 
     /* Parse the command line with argv0, throwing a UsageError if something
        goes wrong. */
-    void parseCmdline(const std::string & argv0, const Strings & cmdline);
+    void parseCmdline(const Strings & _cmdline, bool allowShebang);
 
     /* Return a short one-line description of the command. */
     virtual std::string description() { return ""; }

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -25,9 +25,11 @@ public:
      */
     void parseCmdline(const Strings & cmdline);
 
-    /**
-     * Return a short one-line description of the command.
-     */
+    /* Parse the command line with argv0, throwing a UsageError if something
+       goes wrong. */
+    void parseCmdline(const std::string & argv0, const Strings & cmdline);
+
+    /* Return a short one-line description of the command. */
     virtual std::string description() { return ""; }
 
     virtual bool forceImpureByDefault() { return false; }

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -695,7 +695,7 @@ std::string shellEscape(const std::string_view s);
 
 
 /* Recreate the effect of the perl shellwords function, breaking up a
- * string into arguments like a shell word, including escapes */
+   string into arguments like a shell word, including escapes. */
 std::vector<std::string> shellwords(const std::string & s);
 
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -694,10 +694,13 @@ std::string toLower(const std::string & s);
 std::string shellEscape(const std::string_view s);
 
 
-/**
- * Exception handling in destructors: print an error message, then
- * ignore the exception.
- */
+/* Recreate the effect of the perl shellwords function, breaking up a
+ * string into arguments like a shell word, including escapes */
+std::vector<std::string> shellwords(const std::string & s);
+
+
+/* Exception handling in destructors: print an error message, then
+   ignore the exception. */
 void ignoreException(Verbosity lvl = lvlError);
 
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -29,50 +29,6 @@ using namespace std::string_literals;
 
 extern char * * environ __attribute__((weak));
 
-/* Recreate the effect of the perl shellwords function, breaking up a
- * string into arguments like a shell word, including escapes
- */
-static std::vector<std::string> shellwords(const std::string & s)
-{
-    std::regex whitespace("^(\\s+).*");
-    auto begin = s.cbegin();
-    std::vector<std::string> res;
-    std::string cur;
-    enum state {
-        sBegin,
-        sQuote
-    };
-    state st = sBegin;
-    auto it = begin;
-    for (; it != s.cend(); ++it) {
-        if (st == sBegin) {
-            std::smatch match;
-            if (regex_search(it, s.cend(), match, whitespace)) {
-                cur.append(begin, it);
-                res.push_back(cur);
-                cur.clear();
-                it = match[1].second;
-                begin = it;
-            }
-        }
-        switch (*it) {
-            case '"':
-                cur.append(begin, it);
-                begin = it + 1;
-                st = st == sBegin ? sQuote : sBegin;
-                break;
-            case '\\':
-                /* perl shellwords mostly just treats the next char as part of the string with no special processing */
-                cur.append(begin, it);
-                begin = ++it;
-                break;
-        }
-    }
-    cur.append(begin, it);
-    if (!cur.empty()) res.push_back(cur);
-    return res;
-}
-
 static void main_nix_build(int argc, char * * argv)
 {
     auto dryRun = false;

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -397,7 +397,7 @@ void mainWrapped(int argc, char * * argv)
     });
 
     try {
-        args.parseCmdline(argvToStrings(argc, argv));
+        args.parseCmdline(programName, argvToStrings(argc, argv));
     } catch (UsageError &) {
         if (!args.helpRequested && !completions) throw;
     }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -17,6 +17,7 @@
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <regex>
 
 #include <nlohmann/json.hpp>
 
@@ -397,7 +398,9 @@ void mainWrapped(int argc, char * * argv)
     });
 
     try {
-        args.parseCmdline(programName, argvToStrings(argc, argv));
+        auto isNixCommand = std::regex_search(programName, std::regex("nix$"));
+        auto allowShebang = isNixCommand && argc > 1;
+        args.parseCmdline(argvToStrings(argc, argv),allowShebang);
     } catch (UsageError &) {
         if (!args.helpRequested && !completions) throw;
     }

--- a/src/nix/shell.md
+++ b/src/nix/shell.md
@@ -51,4 +51,121 @@ R""(
 provides the specified [*installables*](./nix.md#installable). If no command is specified, it starts the
 default shell of your user account specified by `$SHELL`.
 
+# Use as a `#!`-interpreter
+
+You can use `nix` as a script interpreter to allow scripts written
+in arbitrary languages to obtain their own dependencies via Nix. This is
+done by starting the script with the following lines:
+
+```bash
+#! /usr/bin/env nix
+#! nix shell installables --command real-interpreter
+```
+
+where *real-interpreter* is the “real” script interpreter that will be
+invoked by `nix shell` after it has obtained the dependencies and
+initialised the environment, and *installables* are the attribute names of
+the dependencies in Nixpkgs.
+
+The lines starting with `#! nix` specify options (see above). Note that you
+cannot write `#! /usr/bin/env nix shell -i ...` because many operating systems
+only allow one argument in `#!` lines.
+
+For example, here is a Python script that depends on Python and the
+`prettytable` package:
+
+```python
+#! /usr/bin/env nix
+#! nix shell github:tomberek/-#python3With.prettytable --command python
+
+import prettytable
+
+# Print a simple table.
+t = prettytable.PrettyTable(["N", "N^2"])
+for n in range(1, 10): t.add_row([n, n * n])
+print t
+```
+
+Similarly, the following is a Perl script that specifies that it
+requires Perl and the `HTML::TokeParser::Simple` and `LWP` packages:
+
+```perl
+#! /usr/bin/env nix
+#! nix shell github:tomberek/-#perlWith.HTMLTokeParserSimple.LWP --command perl -x
+
+use HTML::TokeParser::Simple;
+
+# Fetch nixos.org and print all hrefs.
+my $p = HTML::TokeParser::Simple->new(url => 'http://nixos.org/');
+
+while (my $token = $p->get_tag("a")) {
+    my $href = $token->get_attr("href");
+    print "$href\n" if $href;
+}
+```
+
+Sometimes you need to pass a simple Nix expression to customize a
+package like Terraform:
+
+```bash
+#! /usr/bin/env nix
+#! nix shell --impure --expr
+#! nix "with (import (builtins.getFlake ''nixpkgs'') {}); terraform.withPlugins (plugins: [ plugins.openstack ])"
+#! nix --command bash
+
+terraform "$@"
+```
+
+> **Note**
+>
+> You must use double quotes (`"`) when passing a simple Nix expression
+> in a nix shell shebang.
+
+Finally, using the merging of multiple nix shell shebangs the following
+Haskell script uses a specific branch of Nixpkgs/NixOS (the 21.11 stable
+branch):
+
+```haskell
+#!/usr/bin/env nix
+#!nix shell --override-input nixpkgs github:NixOS/nixpkgs/nixos-21.11
+#!nix github:tomberek/-#haskellWith.download-curl.tagsoup --command runghc
+
+import Network.Curl.Download
+import Text.HTML.TagSoup
+import Data.Either
+import Data.ByteString.Char8 (unpack)
+
+-- Fetch nixos.org and print all hrefs.
+main = do
+  resp <- openURI "https://nixos.org/"
+  let tags = filter (isTagOpenName "a") $ parseTags $ unpack $ fromRight undefined resp
+  let tags' = map (fromAttrib "href") tags
+  mapM_ putStrLn $ filter (/= "") tags'
+```
+
+If you want to be even more precise, you can specify a specific revision
+of Nixpkgs:
+
+    #!nix shell --override-input nixpkgs github:NixOS/nixpkgs/eabc38219184cc3e04a974fe31857d8e0eac098d
+
+The examples above all used `-p` to get dependencies from Nixpkgs. You
+can also use a Nix expression to build your own dependencies. For
+example, the Python example could have been written as:
+
+```python
+#! /usr/bin/env nix
+#! nix shell --impure --file deps.nix -i python
+```
+
+where the file `deps.nix` in the same directory as the `#!`-script
+contains:
+
+```nix
+with import <nixpkgs> {};
+python3.withPackages (ps: with ps; [ prettytable ])
+```
+
+
+
+
 )""

--- a/src/nix/shell.md
+++ b/src/nix/shell.md
@@ -148,9 +148,8 @@ of Nixpkgs:
 
     #!nix shell --override-input nixpkgs github:NixOS/nixpkgs/eabc38219184cc3e04a974fe31857d8e0eac098d
 
-The examples above all used `-p` to get dependencies from Nixpkgs. You
-can also use a Nix expression to build your own dependencies. For
-example, the Python example could have been written as:
+You can also use a Nix expression to build your own dependencies. For example,
+the Python example could have been written as:
 
 ```python
 #! /usr/bin/env nix
@@ -164,8 +163,6 @@ contains:
 with import <nixpkgs> {};
 python3.withPackages (ps: with ps; [ prettytable ])
 ```
-
-
 
 
 )""

--- a/tests/flakes/common.sh
+++ b/tests/flakes/common.sh
@@ -11,6 +11,7 @@ writeSimpleFlake() {
   outputs = inputs: rec {
     packages.$system = rec {
       foo = import ./simple.nix;
+      fooScript = (import ./shell.nix {}).foo;
       default = foo;
     };
     packages.someOtherSystem = rec {
@@ -24,13 +25,13 @@ writeSimpleFlake() {
 }
 EOF
 
-    cp ../simple.nix ../simple.builder.sh ../config.nix $flakeDir/
+    cp ../simple.nix ../shell.nix ../simple.builder.sh ../config.nix $flakeDir/
 }
 
 createSimpleGitFlake() {
     local flakeDir="$1"
     writeSimpleFlake $flakeDir
-    git -C $flakeDir add flake.nix simple.nix simple.builder.sh config.nix
+    git -C $flakeDir add flake.nix simple.nix shell.nix simple.builder.sh config.nix
     git -C $flakeDir commit -m 'Initial'
 }
 

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -69,8 +69,9 @@ cat > $nonFlakeDir/shebang.sh <<EOF
 #! nix --offline shell
 #! nix flake1#fooScript
 #! nix --no-write-lock-file --command bash
-set -e
+set -ex
 foo
+echo "\$@"
 EOF
 chmod +x $nonFlakeDir/shebang.sh
 
@@ -517,3 +518,4 @@ expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-f
 
 # Test shebang
 [[ $($nonFlakeDir/shebang.sh) = "foo" ]]
+[[ $($nonFlakeDir/shebang.sh "bar") = "foo"$'\n'"bar" ]]

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -78,6 +78,18 @@ chmod +x $nonFlakeDir/shebang.sh
 git -C $nonFlakeDir add README.md shebang.sh
 git -C $nonFlakeDir commit -m 'Initial'
 
+cat > $nonFlakeDir/shebang-perl.sh <<EOF
+#! $(type -P env) nix
+#! nix run nixpkgs#perl
+## Modules used
+use strict;
+use warnings;
+
+# Print function
+print("Hello World\n");
+EOF
+chmod +x $nonFlakeDir/shebang-perl.sh
+
 # Construct a custom registry, additionally test the --registry flag
 nix registry add --registry $registry flake1 git+file://$flake1Dir
 nix registry add --registry $registry flake2 git+file://$flake2Dir
@@ -519,3 +531,4 @@ expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-f
 # Test shebang
 [[ $($nonFlakeDir/shebang.sh) = "foo" ]]
 [[ $($nonFlakeDir/shebang.sh "bar") = "foo"$'\n'"bar" ]]
+[[ $($nonFlakeDir/shebang-perl.sh ) = "Hello World!" ]]

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -78,17 +78,17 @@ chmod +x $nonFlakeDir/shebang.sh
 git -C $nonFlakeDir add README.md shebang.sh
 git -C $nonFlakeDir commit -m 'Initial'
 
-cat > $nonFlakeDir/shebang-perl.sh <<EOF
+cat > $nonFlakeDir/shebang-comments.sh <<EOF
 #! $(type -P env) nix
-#! nix run nixpkgs#perl
-## Modules used
-use strict;
-use warnings;
-
-# Print function
-print("Hello World\n");
+# some comments
+# some comments
+# some comments
+#! nix --offline shell
+#! nix flake1#fooScript
+#! nix --no-write-lock-file --command bash
+foo
 EOF
-chmod +x $nonFlakeDir/shebang-perl.sh
+chmod +x $nonFlakeDir/shebang-comments.sh
 
 # Construct a custom registry, additionally test the --registry flag
 nix registry add --registry $registry flake1 git+file://$flake1Dir
@@ -531,4 +531,4 @@ expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-f
 # Test shebang
 [[ $($nonFlakeDir/shebang.sh) = "foo" ]]
 [[ $($nonFlakeDir/shebang.sh "bar") = "foo"$'\n'"bar" ]]
-[[ $($nonFlakeDir/shebang-perl.sh ) = "Hello World!" ]]
+[[ $($nonFlakeDir/shebang-comments.sh ) = "foo" ]]

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -64,7 +64,17 @@ cat > $nonFlakeDir/README.md <<EOF
 FNORD
 EOF
 
-git -C $nonFlakeDir add README.md
+cat > $nonFlakeDir/shebang.sh <<EOF
+#! $(type -P env) nix
+#! nix --offline shell
+#! nix flake1#fooScript
+#! nix --no-write-lock-file --command bash
+set -e
+foo
+EOF
+chmod +x $nonFlakeDir/shebang.sh
+
+git -C $nonFlakeDir add README.md shebang.sh
 git -C $nonFlakeDir commit -m 'Initial'
 
 # Construct a custom registry, additionally test the --registry flag
@@ -504,3 +514,6 @@ nix flake metadata $flake2Dir --reference-lock-file $TEST_ROOT/flake2-overridden
 
 # reference-lock-file can only be used if allow-dirty is set.
 expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-file $TEST_ROOT/flake2-overridden.lock
+
+# Test shebang
+[[ $($nonFlakeDir/shebang.sh) = "foo" ]]


### PR DESCRIPTION
Enables shebang usage of nix shell. All arguments with `#! nix` get
added to the nix invocation. This implementation does NOT set any
additional arguments other than placing the script path itself as the
first argument such that the interpreter can utilize it.

Example below:

```
    #!/usr/bin/env nix
    #! nix shell --quiet
    #! nix nixpkgs#bash
    #! nix nixpkgs#shellcheck
    #! nix nixpkgs#hello
    #! nix --ignore-environment --command bash
    # shellcheck shell=bash
    set -eu
    shellcheck "$0" || exit 1
    function main {
        hello
        echo 0:"$0" 1:"$1" 2:"$2"
    }
    "$@"
```

Overall it should make sense to any users of `nix-shell`.

- [x] add documentation
- [x] more tests
- [ ] decide on defaults
    - [ ] automatically inject "shell" argument? (edit: `nix run` would work if it added PATHs)
    - [ ] ~re-use the "-i interpreter" concept from nix-shell?~
    - [x] lock file options?
    - [ ] whitelist/blacklist certain options
- [x] remove duplication of heuristic logic/code with `nix-build`
- [ ] support a bootstrap mechanism detecting if nix is installed and fetching otherwise (eg nix —store or nix-portable)?
- [ ] merge



# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes

