### PR TITLE
Force all Pos* to be non-null

### DIFF
--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -17,8 +17,8 @@ struct Attr
 {
     Symbol name;
     Value * value;
-    Pos * pos;
-    Attr(Symbol name, Value * value, Pos * pos = &noPos)
+    ptr<Pos> pos;
+    Attr(Symbol name, Value * value, ptr<Pos> pos = ptr(&noPos))
         : name(name), value(value), pos(pos) { };
     Attr() : pos(&noPos) { };
     bool operator < (const Attr & a) const
@@ -35,13 +35,13 @@ class Bindings
 {
 public:
     typedef uint32_t size_t;
-    Pos *pos;
+    ptr<Pos> pos;
 
 private:
     size_t size_, capacity_;
     Attr attrs[0];
 
-    Bindings(size_t capacity) : size_(0), capacity_(capacity) { }
+    Bindings(size_t capacity) : pos(&noPos), size_(0), capacity_(capacity) { }
     Bindings(const Bindings & bindings) = delete;
 
 public:

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -308,7 +308,7 @@ public:
     void mkList(Value & v, size_t length);
     void mkAttrs(Value & v, size_t capacity);
     void mkThunk_(Value & v, Expr * expr);
-    void mkPos(Value & v, Pos * pos);
+    void mkPos(Value & v, ptr<Pos> pos);
 
     void concatLists(Value & v, size_t nrLists, Value * * lists, const Pos & pos);
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2109,7 +2109,7 @@ void prim_getAttr(EvalState & state, const Pos & pos, Value * * args, Value & v)
         pos
     );
     // !!! add to stack trace?
-    if (state.countCalls && i->pos) state.attrSelects[*i->pos]++;
+    if (state.countCalls && *i->pos != noPos) state.attrSelects[*i->pos]++;
     state.forceValue(*i->value, pos);
     v = *i->value;
 }
@@ -2369,7 +2369,7 @@ static void prim_functionArgs(EvalState & state, const Pos & pos, Value * * args
     for (auto & i : args[0]->lambda.fun->formals->formals) {
         // !!! should optimise booleans (allocate only once)
         Value * value = state.allocValue();
-        v.attrs->push_back(Attr(i.name, value, &i.pos));
+        v.attrs->push_back(Attr(i.name, value, ptr(&i.pos)));
         mkBool(*value, i.def);
     }
     v.attrs->sort();

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -42,7 +42,7 @@ static void showAttrs(EvalState & state, bool strict, bool location,
 
         XMLAttrs xmlAttrs;
         xmlAttrs["name"] = i;
-        if (location && a.pos != &noPos) posToXML(xmlAttrs, *a.pos);
+        if (location && a.pos != ptr(&noPos)) posToXML(xmlAttrs, *a.pos);
 
         XMLOpenElement _(doc, "attr", xmlAttrs);
         printValueAsXML(state, strict, location,

--- a/src/libutil/ref.hh
+++ b/src/libutil/ref.hh
@@ -99,4 +99,47 @@ make_ref(Args&&... args)
     return ref<T>(p);
 }
 
+
+/* A non-nullable pointer.
+   This is similar to a C++ "& reference", but mutable.
+   This is similar to ref<T> but backed by a regular pointer instead of a smart pointer.
+ */
+template<typename T>
+class ptr {
+private:
+    T * p;
+
+public:
+    ptr<T>(const ptr<T> & r)
+        : p(r.p)
+    { }
+
+    explicit ptr<T>(T * p)
+        : p(p)
+    {
+        if (!p)
+            throw std::invalid_argument("null pointer cast to ptr");
+    }
+
+    T* operator ->() const
+    {
+        return &*p;
+    }
+
+    T& operator *() const
+    {
+        return *p;
+    }
+
+    bool operator == (const ptr<T> & other) const
+    {
+        return p == other.p;
+    }
+
+    bool operator != (const ptr<T> & other) const
+    {
+        return p != other.p;
+    }
+};
+
 }

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -131,9 +131,9 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
     state.forceValue(topLevel);
     PathSet context;
     Attr & aDrvPath(*topLevel.attrs->find(state.sDrvPath));
-    auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(*aDrvPath.pos, *(aDrvPath.value), context));
+    auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(*aDrvPath.pos, *aDrvPath.value, context));
     Attr & aOutPath(*topLevel.attrs->find(state.sOutPath));
-    Path topLevelOut = state.coerceToPath(*aOutPath.pos, *(aOutPath.value), context);
+    Path topLevelOut = state.coerceToPath(*aOutPath.pos, *aOutPath.value, context);
 
     /* Realise the resulting store expression. */
     debug("building user environment");

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -131,9 +131,9 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
     state.forceValue(topLevel);
     PathSet context;
     Attr & aDrvPath(*topLevel.attrs->find(state.sDrvPath));
-    auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(aDrvPath.pos ? *(aDrvPath.pos) : noPos, *(aDrvPath.value), context));
+    auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(*aDrvPath.pos, *(aDrvPath.value), context));
     Attr & aOutPath(*topLevel.attrs->find(state.sOutPath));
-    Path topLevelOut = state.coerceToPath(aOutPath.pos ? *(aOutPath.pos) : noPos, *(aOutPath.value), context);
+    Path topLevelOut = state.coerceToPath(*aOutPath.pos, *(aOutPath.value), context);
 
     /* Realise the resulting store expression. */
     debug("building user environment");


### PR DESCRIPTION
This fixes a class of crashes and introduces `ptr<T>` to make the
code robust against this failure mode going forward.

Thanks regnat for the [idea](https://github.com/NixOS/nix/pull/4895#issuecomment-871184078) of a `ref<T>` without overhead! This became `ptr<T>`

Closes #4895
Closes #4893
Closes #5127
Closes #5113

Alternatives considered:
 - `&Pos`: not mutable, so doesn't fit the current usage pattern
 - `ref<Pos>`: undue overhead
 - Just #4895 and #5127: no simplification and no future guarantees. These do cover the most important changes, but it's sad because those could have been found automatically by the type system. At least it won't happen again for this issue.
 - Remove `noPos` and use `nullptr` instead. This is fragile. Same for `optional`, which doesn't prevent this problem at compile time.
