### PR TITLE
fix CI for users with no install-tests cachix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
 jobs:
   tests:
+    needs: [check_cachix]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -16,6 +17,7 @@ jobs:
     - uses: cachix/install-nix-action@v13
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v10
+      if: needs.check_cachix.outputs.secret == 'true'
       with:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
Closes #5173. As reported there, it looks like either #4549 or #4577 broke CI for anyone who has it enabled on their fork but does *not* have cachix set up for install tests. These CI failures look like: https://github.com/matthewbauer/nix/runs/3416896499?check_suite_focus=true#step:5:12:

This updates the main test job to depend on the result of the cachix credential check, so that the cachix-action step can be conditional on the presence of a cachix secret.

Here are two clean CI runs:
- with cachix set up: https://github.com/abathur/nix/actions/runs/1192138507
- without cachix set up: https://github.com/temporaryorganizationtown/nix/actions/runs/1192149639

cc @domenkozar 

