### PR TITLE
Don’t create lockfiles with an invalid path name

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -566,7 +566,7 @@ void DerivationGoal::tryToBuild()
                 lockFiles.insert(worker.store.Store::toRealPath(*i.second.second));
             else
                 lockFiles.insert(
-                    worker.store.Store::toRealPath(drvPath) + "!" + i.first
+                    worker.store.Store::toRealPath(drvPath) + "." + i.first
                 );
         }
     }


### PR DESCRIPTION
Store paths are only allowed to contain a limited subset of the
alphabet, which doesn’t include `!`. So don’t create lockfiles that
contain this `!` character as that would otherwise confuse (and break)
the gc.

Fix #5176
