### PR TITLE
Docs: Fix syntax error in json example in man page

### DIFF
--- a/src/nix/registry.md
+++ b/src/nix/registry.md
@@ -41,7 +41,7 @@ A registry is a JSON file with the following format:
 ```json
 {
   "version": 2,
-  [
+  "flakes": [
     {
       "from": {
         "type": "indirect",


### PR DESCRIPTION
I compared the example in the man page with my actual /etc/nix/registry.json file to find the right key.  

My regsitry.json file has 
```json
{
  "flakes": [
    {
      "exact": true,
      "from": {
        "id": "sys",
        "type": "indirect"
      },
      "to": {
        "lastModified": 1629705759,
        "narHash": "sha256-M5sHgjA1OZn/c21pk64qd5kjbkBpbZuYwgaDEl9kiP8=",
        "path": "/nix/store/9wwj3h66flmwfs0iq0rc88473xgfnag1-source",
        "rev": "5bc8b980b9178ef9a4bb622320cf34e59ea2ea10",
        "type": "path"
      }
    }
  ],
  "version": 2
}
```
but I don't know if the `exact: true` part is required so I did not include it in the example.