### PR TITLE
Add missing include in util.cc

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -4,6 +4,7 @@
 #include "finally.hh"
 #include "serialise.hh"
 
+#include <array>
 #include <cctype>
 #include <cerrno>
 #include <climits>


### PR DESCRIPTION
The clang build error that #5197 was trying to fix seems to be caused by a missing `<array>` header in `util.cc` (cc @andir #5075).

This is completely untested but should be obvious enough.