### PR TITLE
Move the default profiles to the user’s home

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1517,7 +1517,7 @@ void LocalDerivationGoal::startDaemon()
                 try {
                     daemon::processConnection(store, from, to,
                         daemon::NotTrusted, daemon::Recursive,
-                        [&](Store & store) { store.createUser("nobody", 65535); });
+                        [&](Store & store) {});
                     debug("terminated daemon connection");
                 } catch (SysError &) {
                     ignoreException();

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -201,8 +201,6 @@ LocalStore::LocalStore(const Params & params)
             throw SysError("could not set permissions on '%s' to 755", perUserDir);
     }
 
-    createUser(getUserName(), getuid());
-
     /* Optionally, create directories and set permissions for a
        multi-user install. */
     if (getuid() == 0 && settings.buildUsersGroup != "") {
@@ -1823,20 +1821,6 @@ void LocalStore::signPathInfo(ValidPathInfo & info)
     }
 }
 
-
-void LocalStore::createUser(const std::string & userName, uid_t userId)
-{
-    for (auto & dir : {
-        fmt("%s/profiles/per-user/%s", stateDir, userName),
-        fmt("%s/gcroots/per-user/%s", stateDir, userName)
-    }) {
-        createDirs(dir);
-        if (chmod(dir.c_str(), 0755) == -1)
-            throw SysError("changing permissions of directory '%s'", dir);
-        if (chown(dir.c_str(), userId, getgid()) == -1)
-            throw SysError("changing owner of directory '%s'", dir);
-    }
-}
 
 std::optional<std::pair<int64_t, Realisation>> LocalStore::queryRealisationCore_(
         LocalStore::State & state,

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -281,8 +281,6 @@ private:
     void signPathInfo(ValidPathInfo & info);
     void signRealisation(Realisation &);
 
-    void createUser(const std::string & userName, uid_t userId) override;
-
     // XXX: Make a generic `Store` method
     FixedOutputHash hashCAPath(
         const FileIngestionMethod & method,

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -292,7 +292,10 @@ Path getDefaultProfile()
 {
     Path profileLink = getHome() + "/.nix-profile";
     try {
-        auto profile = profilesDir() + "/profile";
+        auto profile =
+            getuid() == 0
+            ? settings.nixStateDir + "/profiles/default"
+            : profilesDir() + "/profile";
         if (!pathExists(profileLink)) {
             replaceSymlink(profile, profileLink);
         }

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -293,17 +293,29 @@ Path getDefaultProfile()
     Path profileLink = getHome() + "/.nix-profile";
     try {
         // Migrate from the “old-style” profiles stored under `/nix/var`:
-        // If the link exists and points to the old location, rewrite it to the
-        // new one (otherwise keep-it as-it-is as it might have been
-        // intentionnally changed, in which case we shouldn’t touch it)
+        // If the link exists and points to the old location, then:
+        // - Rewrite it to point to the new location
+        // - For every generation of the old default profile, create a symlink
+        //   from the new directory to it (so that all the previous profiles
+        //   and generations are still available).
         auto legacyProfile = getuid() == 0
             ? settings.nixStateDir + "/profiles/default"
             : fmt("%s/profiles/per-user/%s/profile", settings.nixStateDir, getUserName());
-        if (!pathExists(profileLink) ||
-            (isLink(profileLink) &&
-            readLink(profileLink) == legacyProfile)
-            ) {
-            replaceSymlink(profilesDir() + "/profile", profileLink);
+        auto newProfile = profilesDir() + "/profile";
+        if (!pathExists(profileLink)
+            || (isLink(profileLink)
+                && readLink(profileLink) == legacyProfile)) {
+            warn("Migrating the default profile");
+            replaceSymlink(newProfile, profileLink);
+            replaceSymlink(legacyProfile, newProfile);
+            if (pathExists(legacyProfile)) {
+                for (auto & oldGen : findGenerations(legacyProfile).first) {
+                    replaceSymlink(
+                        oldGen.path,
+                        dirOf(newProfile) + "/"
+                            + std::string(baseNameOf(oldGen.path)));
+                }
+            }
         }
         return absPath(readLink(profileLink), dirOf(profileLink));
     } catch (Error &) {

--- a/src/libstore/profiles.hh
+++ b/src/libstore/profiles.hh
@@ -68,6 +68,10 @@ void lockProfile(PathLocks & lock, const Path & profile);
    rebuilt. */
 std::string optimisticLockProfile(const Path & profile);
 
+/* Creates and returns the path to a directory suitable for storing the user’s
+   profiles. */
+Path profilesDir();
+
 /* Resolve ~/.nix-profile. If ~/.nix-profile doesn't exist yet, create
    it. */
 Path getDefaultProfile();

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -657,9 +657,6 @@ public:
         return toRealPath(printStorePath(storePath));
     }
 
-    virtual void createUser(const std::string & userName, uid_t userId)
-    { }
-
     /*
      * Synchronises the options of the client with those of the daemon
      * (a no-op when there’s no daemon)

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -137,6 +137,9 @@ void deletePath(const Path & path, uint64_t & bytesFreed);
 
 std::string getUserName();
 
+/* Return the given user's home directory from /etc/passwd. */
+Path getHomeOf(uid_t userId);
+
 /* Return $HOME or the user's home directory from /etc/passwd. */
 Path getHome();
 

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -1,9 +1,11 @@
+#include "profiles.hh"
 #include "shared.hh"
 #include "globals.hh"
 #include "filetransfer.hh"
 #include "store-api.hh"
 #include "legacy.hh"
 #include "fetchers.hh"
+#include "util.hh"
 
 #include <fcntl.h>
 #include <regex>
@@ -166,7 +168,7 @@ static int main_nix_channel(int argc, char ** argv)
         nixDefExpr = home + "/.nix-defexpr";
 
         // Figure out the name of the channels profile.
-        profile = fmt("%s/profiles/per-user/%s/channels", settings.nixStateDir, getUserName());
+        profile = profilesDir() + "/channels";
 
         enum {
             cNone,

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -248,7 +248,6 @@ static void daemonLoop()
                         querySetting("build-users-group", "") == "")
                         throw Error("if you run 'nix-daemon' as root, then you MUST set 'build-users-group'!");
 #endif
-                    store.createUser(user, peer.uid);
                 });
 
                 exit(0);

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -62,7 +62,7 @@ readLink() {
 }
 
 clearProfiles() {
-    profiles="$NIX_STATE_DIR"/profiles
+    profiles="$HOME"/.local/share/nix/profiles
     rm -rf $profiles
 }
 

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -17,6 +17,7 @@ nix_tests = \
   fetchMercurial.sh \
   gc-auto.sh \
   user-envs.sh \
+  user-envs-migration.sh \
   binary-cache.sh \
   multiple-outputs.sh \
   ca/build.sh \

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -30,7 +30,3 @@ NIX_REMOTE= nix-store --dump-db > $TEST_ROOT/d2
 cmp $TEST_ROOT/d1 $TEST_ROOT/d2
 
 killDaemon
-
-user=$(whoami)
-[ -e $NIX_STATE_DIR/gcroots/per-user/$user ]
-[ -e $NIX_STATE_DIR/profiles/per-user/$user ]

--- a/tests/user-envs-migration.sh
+++ b/tests/user-envs-migration.sh
@@ -1,0 +1,35 @@
+# Test that the migration of user environments
+# (https://github.com/NixOS/nix/pull/5226) does preserve everything
+
+source common.sh
+
+if isDaemonNewer "2.4pre20211005"; then
+    exit 99
+fi
+
+
+killDaemon
+unset NIX_REMOTE
+
+clearStore
+clearProfiles
+rm -rf ~/.nix-profile
+
+# Fill the environment using the older Nix
+PATH_WITH_NEW_NIX="$PATH"
+export PATH="$NIX_DAEMON_PACKAGE/bin:$PATH"
+
+nix-env -f user-envs.nix -i foo-1.0
+nix-env -f user-envs.nix -i bar-0.1
+
+# Migrate to the new profile dir, and ensure that everything’s there
+export PATH="$PATH_WITH_NEW_NIX"
+nix-env -q # Trigger the migration
+( [[ -L ~/.nix-profile ]] && \
+    [[ $(readlink ~/.nix-profile) == ~/.local/share/nix/profiles/profile ]] ) || \
+    fail "The nix profile should point to the new location"
+
+(nix-env -q | grep foo && nix-env -q | grep bar && \
+    [[ -e ~/.nix-profile/bin/foo ]] && \
+    [[ $(nix-env --list-generations | wc -l) == 2 ]]) ||
+    fail "The nix profile should have the same content as before the migration"


### PR DESCRIPTION
Rather than using `/nix/var/nix/{profiles,gcroots}/per-user/`, put the user
profiles and gcroots under `$XDG_DATA_DIR/nix/{profiles,gcroots}`.

This means that the daemon no longer needs to manage these paths itself
(they are fully handled client-side). In particular, it doesn’t have to
`chown` them anymore (removing one need for root).

This does change the layout of the gc-roots created by nix-env, and is
likely to break some stuff, so I’m not sure how to properly handle that.

First step towards #5208
