### PR TITLE
stricter checks for content of string literals

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -121,7 +121,8 @@ static Expr * unescapeStr(SymbolTable & symbols, const char * s, size_t length, 
             else if (c == 'r') t += '\r';
             else if (c == 't') t += '\t';
             else if (c == '\\') t += '\\';
-            else if (c == '"') t += '\"';
+            else if (c == '"') t += '"';
+            else if (c == '$') t += '$';
             else {
                 if (!utf.update(c, data, yylloc))
                      throw ParseError("unicode char after \\ in single quoted string \"%s\" at %s", c, s0, CUR_POS);

--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -21,6 +21,13 @@ using namespace nix;
 
 namespace nix {
 
+static inline Pos makeCurPos(const YYLTYPE & loc, ParseData * data)
+{
+    return Pos(data->path, loc.first_line, loc.first_column);
+}
+
+#define CUR_POS makeCurPos(*yylloc, data)
+
 
 static void initLoc(YYLTYPE * loc)
 {
@@ -51,30 +58,116 @@ static void adjustLoc(YYLTYPE * loc, const char * s, size_t len)
 }
 
 
-static Expr * unescapeStr(SymbolTable & symbols, const char * s, size_t length)
+static bool isBadSpace(uint32_t rune) {
+    return (rune < 0x0020 && rune != 0x000A && rune != 0x001B) || rune == 0x0085 || rune == 0x00A0 || (0x2002 <= rune && rune <= 0x200F) || rune == 0x3000;
+}
+
+
+struct Utf8Collector {
+    int position;
+    uint32_t rune;
+    Utf8Collector(): position(0), rune(0) {}
+    bool update(uint8_t c, ParseData * data, YYLTYPE * yylloc) {
+        switch (position) {
+            case 0: rune = c;
+                    if (c < 0x80) return true;
+                    if (c < 0xC0) throw ParseError("invalid UTF-8 (%02x) at %s", int(c), CUR_POS);
+                    position ++;
+                    return false;
+            case 1: if (c < 0x80 || 0xC0 <= c) throw ParseError("invalid UTF-8 (%02x) at %s", rune, int(c), CUR_POS);
+                    rune = (rune << 6) + (c & 0x3F);  // 0011Xrrr rrcccccc
+                    if ((rune & 0x0800) == 0) { rune &= 0x0007FF; position = 0; return true; }
+                    position ++;
+                    return false;
+            case 2: if (c < 0x80 || 0xC0 <= c) throw ParseError("invalid UTF-8 (%02x %02x %02x) at %s", (rune>>6), 0x80+(rune&0x3F), int(c), CUR_POS);
+                    rune = (rune << 6) + (c & 0x3F);  // 0000111X rrrrssss sscccccc
+                    if ((rune & 0x10000) == 0) { rune &= 0x00FFFF; position = 0; return true; }
+                    position ++;
+                    return false;
+            case 3: if (c < 0x80 || 0xC0 <= c) throw ParseError("invalid UTF-8 (%02x %02x %02x %02x) at %s", (rune>>12), 0x80+((rune>>6)&0x3F), 0x80+(rune&0x3F), int(c), CUR_POS);
+                    rune = (rune << 6) + (c & 0x3F);  // 00000001 111Xrrrss sssstttt ttcccccc
+                    rune &= 0x1FFFFF;
+                    if (0x10FFFF < rune) throw ParseError("invalid UTF-8 (rune=\\u%04x) at %s", rune, CUR_POS);
+                    if (0xFFF0 <= rune && rune <= 0xFFFF) printError("invalid UTF-8 (rune=\\u%04x) at %s", rune, CUR_POS);
+                    position = 0;
+                    return true;
+        }
+        throw ParseError("unreachable");
+    }
+};
+
+
+static Expr * unescapeStr(SymbolTable & symbols, const char * s, size_t length, ParseData * data, YYLTYPE * yylloc)
 {
     string t;
     t.reserve(length);
     char c;
+    Utf8Collector utf;
+    const char * s0 = s;
     while ((c = *s++)) {
-        if (c == '\\') {
+        if (!utf.update(c, data, yylloc)) {
+            t += c;
+            continue;
+        }
+        if (utf.rune == 0x000A)
+            printError("multiline single quoted string \"%s\" at %s", s, CUR_POS);
+        if (isBadSpace(utf.rune))
+            printError("bad space character \\u%04x at %s", utf.rune, CUR_POS);
+
+        if (utf.rune == '\\') {
             assert(*s);
             c = *s++;
             if (c == 'n') t += '\n';
             else if (c == 'r') t += '\r';
             else if (c == 't') t += '\t';
-            else t += c;
+            else if (c == '\\') t += '\\';
+            else if (c == '"') t += '\"';
+            else {
+                if (!utf.update(c, data, yylloc))
+                     throw ParseError("unicode char after \\ in single quoted string \"%s\" at %s", c, s0, CUR_POS);
+
+                printError("bad escape \\%c in single quoted string \"%s\" at %s", c, s0, CUR_POS);
+                t += c;
+            }
         }
-        else if (c == '\r') {
+        else if (utf.rune == '\r') {
             /* Normalise CR and CR/LF into LF. */
             t += '\n';
             if (*s == '\n') s++; /* cr/lf */
         }
         else t += c;
     }
+    if (utf.position != 0)
+        throw ParseError("invalid UTF-8 (uneven sequence, position=%d) at %s", utf.position, CUR_POS);
+
     return new ExprString(symbols.create(t));
 }
 
+static Expr * unescapeIndStr(const char * s, size_t length, ParseData * data, YYLTYPE * yylloc)
+{
+    string t;
+    t.reserve(length);
+    char c;
+    Utf8Collector utf;
+    while ((c = *s++)) {
+        if (!utf.update(c, data, yylloc)) {
+            t += c;
+            continue;
+        }
+        if (isBadSpace(utf.rune))
+            printError("bad space character \\u%04X at %s", utf.rune, CUR_POS);
+
+        if (utf.rune == '\r') {
+            /* Normalise CR and CR/LF into LF. */
+            t += '\n';
+            if (*s == '\n') s++; /* cr/lf */
+        }
+        else t += c;
+    }
+    if (utf.position != 0)
+        throw ParseError("invalid UTF-8 (uneven sequence, position=%d) at %s", utf.position, CUR_POS);
+    return new ExprIndStr(t);
+}
 
 }
 
@@ -156,7 +249,7 @@ or          { return OR_KW; }
                 /* It is impossible to match strings ending with '$' with one
                    regex because trailing contexts are only valid at the end
                    of a rule. (A sane but undocumented limitation.) */
-                yylval->e = unescapeStr(data->symbols, yytext, yyleng);
+                yylval->e = unescapeStr(data->symbols, yytext, yyleng, data, yylloc);
                 return STR;
               }
 <STRING>\$\{  { PUSH_STATE(DEFAULT); return DOLLAR_CURLY; }
@@ -169,9 +262,17 @@ or          { return OR_KW; }
                 return STR;
               }
 
-\'\'(\ *\n)?     { PUSH_STATE(IND_STRING); return IND_STRING_OPEN; }
+\'\'\ +(\r\n|\r|\n) { /* eat spaces and \n and warn about space */
+                      printError("spaces between '' and the end of line at %s", CUR_POS);
+                      PUSH_STATE(IND_STRING); return IND_STRING_OPEN_NEWLINE; }
+
+\'\'(\r\n|\r|\n)    { /* eat \n */
+                      PUSH_STATE(IND_STRING); return IND_STRING_OPEN_NEWLINE; }
+
+\'\'                { PUSH_STATE(IND_STRING); return IND_STRING_OPEN; }
+
 <IND_STRING>([^\$\']|\$[^\{\']|\'[^\'\$])+ {
-                   yylval->e = new ExprIndStr(yytext);
+                   yylval->e = unescapeIndStr(yytext, yyleng, data, yylloc);
                    return IND_STR;
                  }
 <IND_STRING>\'\'\$ |
@@ -184,7 +285,7 @@ or          { return OR_KW; }
                    return IND_STR;
                  }
 <IND_STRING>\'\'\\{ANY} {
-                   yylval->e = unescapeStr(data->symbols, yytext + 2, yyleng - 2);
+                   yylval->e = unescapeStr(data->symbols, yytext + 2, yyleng - 2, data, yylloc);
                    return IND_STR;
                  }
 <IND_STRING>\$\{ { PUSH_STATE(DEFAULT); return DOLLAR_CURLY; }


### PR DESCRIPTION
stricter checks for content of string literals

+++: fatal error on invalid UTF-8 sequences

+++: warning on indentation just after opening quote: it is stripped but people get not what expect:
```
  x = '' un
         dos
      '';
  y = '' tres '';
```

+++: warning on invisible spaces before \n

+++: warning on invisible chars like tabulation and half-width, double-width and nonbreable spaces

+++: warning on futile escape sequences:
```
  x = "\z";
```