### PR TITLE
Not working, but an attempt at allowing null bytes in strings

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -391,8 +391,8 @@ Value & AttrCursor::forceValue()
 
     if (root->db && (!cachedValue || std::get_if<placeholder_t>(&cachedValue->second))) {
         if (v.type() == nString)
-            cachedValue = {root->db->setString(getKey(), v.string.s, v.string.context),
-                           string_t{v.string.s, {}}};
+            cachedValue = {root->db->setString(getKey(), *v.string.s, v.string.context),
+                           string_t{*v.string.s, {}}};
         else if (v.type() == nPath)
             cachedValue = {root->db->setString(getKey(), v.path), string_t{v.path, {}}};
         else if (v.type() == nBool)
@@ -515,7 +515,7 @@ std::string AttrCursor::getString()
     if (v.type() != nString && v.type() != nPath)
         throw TypeError("'%s' is not a string but %s", getAttrPathStr(), showType(v.type()));
 
-    return v.type() == nString ? v.string.s : v.path;
+    return v.type() == nString ? *v.string.s : v.path;
 }
 
 string_t AttrCursor::getStringWithContext()
@@ -544,7 +544,7 @@ string_t AttrCursor::getStringWithContext()
     auto & v = forceValue();
 
     if (v.type() == nString)
-        return {v.string.s, v.getContext()};
+        return {*v.string.s, v.getContext()};
     else if (v.type() == nPath)
         return {v.path, {}};
     else

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -109,7 +109,7 @@ static FlakeInput parseFlakeInput(EvalState & state,
         try {
             if (attr.name == sUrl) {
                 expectType(state, nString, *attr.value, *attr.pos);
-                url = attr.value->string.s;
+                url = *attr.value->string.s;
                 attrs.emplace("url", *url);
             } else if (attr.name == sFlake) {
                 expectType(state, nBool, *attr.value, *attr.pos);
@@ -118,11 +118,11 @@ static FlakeInput parseFlakeInput(EvalState & state,
                 input.overrides = parseFlakeInputs(state, attr.value, *attr.pos);
             } else if (attr.name == sFollows) {
                 expectType(state, nString, *attr.value, *attr.pos);
-                input.follows = parseInputPath(attr.value->string.s);
+                input.follows = parseInputPath(*attr.value->string.s);
             } else {
                 switch (attr.value->type()) {
                     case nString:
-                        attrs.emplace(attr.name, attr.value->string.s);
+                        attrs.emplace(attr.name, *attr.value->string.s);
                         break;
                     case nBool:
                         attrs.emplace(attr.name, Explicit<bool> { attr.value->boolean });
@@ -212,7 +212,7 @@ static Flake getFlake(
 
     if (auto description = vInfo.attrs->get(state.sDescription)) {
         expectType(state, nString, *description->value, *description->pos);
-        flake.description = description->value->string.s;
+        flake.description = *description->value->string.s;
     }
 
     auto sInputs = state.symbols.create("inputs");

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -130,7 +130,7 @@ DrvInfo::Outputs DrvInfo::queryOutputs(bool onlyOutputsToInstall)
     Outputs result;
     for (auto i = outTI->listElems(); i != outTI->listElems() + outTI->listSize(); ++i) {
         if ((*i)->type() != nString) throw errMsg;
-        auto out = outputs.find((*i)->string.s);
+        auto out = outputs.find(*(*i)->string.s);
         if (out == outputs.end()) throw errMsg;
         result.insert(*out);
     }
@@ -203,7 +203,7 @@ string DrvInfo::queryMetaString(const string & name)
 {
     Value * v = queryMeta(name);
     if (!v || v->type() != nString) return "";
-    return v->string.s;
+    return *v->string.s;
 }
 
 
@@ -215,7 +215,7 @@ NixInt DrvInfo::queryMetaInt(const string & name, NixInt def)
     if (v->type() == nString) {
         /* Backwards compatibility with before we had support for
            integer meta fields. */
-        if (auto n = string2Int<NixInt>(v->string.s))
+        if (auto n = string2Int<NixInt>(*v->string.s))
             return *n;
     }
     return def;
@@ -229,7 +229,7 @@ NixFloat DrvInfo::queryMetaFloat(const string & name, NixFloat def)
     if (v->type() == nString) {
         /* Backwards compatibility with before we had support for
            float meta fields. */
-        if (auto n = string2Float<NixFloat>(v->string.s))
+        if (auto n = string2Float<NixFloat>(*v->string.s))
             return *n;
     }
     return def;
@@ -244,8 +244,8 @@ bool DrvInfo::queryMetaBool(const string & name, bool def)
     if (v->type() == nString) {
         /* Backwards compatibility with before we had support for
            Boolean meta fields. */
-        if (strcmp(v->string.s, "true") == 0) return true;
-        if (strcmp(v->string.s, "false") == 0) return false;
+        if (*v->string.s == "true") return true;
+        if (*v->string.s == "false") return false;
     }
     return def;
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -414,7 +414,7 @@ static RegisterPrimOp primop_isNull({
       Return `true` if *e* evaluates to `null`, and `false` otherwise.
 
       > **Warning**
-      > 
+      >
       > This function is *deprecated*; just write `e == null` instead.
     )",
     .fun = prim_isNull,
@@ -532,7 +532,7 @@ struct CompareValues
             case nFloat:
                 return v1->fpoint < v2->fpoint;
             case nString:
-                return strcmp(v1->string.s, v2->string.s) < 0;
+                return (*v1->string.s).compare(*v2->string.s);
             case nPath:
                 return strcmp(v1->path, v2->path) < 0;
             default:
@@ -1422,8 +1422,8 @@ static void prim_readFile(EvalState & state, const Pos & pos, Value * * args, Va
         });
     }
     string s = readFile(state.checkSourcePath(state.toRealPath(path, context)));
-    if (s.find((char) 0) != string::npos)
-        throw Error("the contents of the file '%1%' cannot be represented as a Nix string", path);
+    //if (s.find((char) 0) != string::npos)
+    //    throw Error("the contents of the file '%1%' cannot be represented as a Nix string", path);
     mkString(v, s.c_str());
 }
 
@@ -2052,7 +2052,7 @@ static void prim_attrNames(EvalState & state, const Pos & pos, Value * * args, V
         mkString(*(v.listElems()[n++] = state.allocValue()), i.name);
 
     std::sort(v.listElems(), v.listElems() + n,
-              [](Value * v1, Value * v2) { return strcmp(v1->string.s, v2->string.s) < 0; });
+              [](Value * v1, Value * v2) { return (*v1->string.s).compare(*v2->string.s) < 0; });
 }
 
 static RegisterPrimOp primop_attrNames({
@@ -2188,7 +2188,7 @@ static void prim_removeAttrs(EvalState & state, const Pos & pos, Value * * args,
     std::set<Symbol> names;
     for (unsigned int i = 0; i < args[1]->listSize(); ++i) {
         state.forceStringNoCtx(*args[1]->listElems()[i], pos);
-        names.insert(state.symbols.create(args[1]->listElems()[i]->string.s));
+        names.insert(state.symbols.create(*args[1]->listElems()[i]->string.s));
     }
 
     /* Copy all attributes not in that set.  Note that we don't need
@@ -2515,7 +2515,7 @@ static RegisterPrimOp primop_tail({
       the argument isn’t a list or is an empty list.
 
       > **Warning**
-      > 
+      >
       > This function should generally be avoided since it's inefficient:
       > unlike Haskell's `tail`, it takes O(n) time, so recursing over a
       > list by repeatedly calling `tail` takes O(n^2) time.

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -100,7 +100,7 @@ static void fetchTree(
                     state.coerceToString(*attr.pos, *attr.value, context, false, false)
                 );
             else if (attr.value->type() == nString)
-                addURI(state, attrs, attr.name, attr.value->string.s);
+                addURI(state, attrs, attr.name, *attr.value->string.s);
             else if (attr.value->type() == nBool)
                 attrs.emplace(attr.name, Explicit<bool>{attr.value->boolean});
             else if (attr.value->type() == nInt)
@@ -265,7 +265,7 @@ static RegisterPrimOp primop_fetchTarball({
       The fetched tarball is cached for a certain amount of time (1 hour
       by default) in `~/.cache/nix/tarballs/`. You can change the cache
       timeout either on the command line with `--option tarball-ttl number
-      of seconds` or in the Nix configuration file with this option: ` 
+      of seconds` or in the Nix configuration file with this option: `
       number of seconds to cache `.
 
       Note that when obtaining the hash with ` nix-prefetch-url ` the
@@ -368,7 +368,7 @@ static RegisterPrimOp primop_fetchGit({
           ```
 
           > **Note**
-          > 
+          >
           > It is nice to always specify the branch which a revision
           > belongs to. Without the branch being specified, the fetcher
           > might fail if the default branch changes. Additionally, it can
@@ -405,12 +405,12 @@ static RegisterPrimOp primop_fetchGit({
           ```
 
           > **Note**
-          > 
+          >
           > Nix will refetch the branch in accordance with
           > the option `tarball-ttl`.
 
           > **Note**
-          > 
+          >
           > This behavior is disabled in *Pure evaluation mode*.
     )",
     .fun = prim_fetchGit,

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -71,7 +71,7 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
         case nString:
             /* !!! show the context? */
             copyContext(v, context);
-            doc.writeEmptyElement("string", singletonAttrs("value", v.string.s));
+            doc.writeEmptyElement("string", singletonAttrs("value", *v.string.s));
             break;
 
         case nPath:
@@ -93,14 +93,14 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
                 if (a != v.attrs->end()) {
                     if (strict) state.forceValue(*a->value);
                     if (a->value->type() == nString)
-                        xmlAttrs["drvPath"] = drvPath = a->value->string.s;
+                        xmlAttrs["drvPath"] = drvPath = *a->value->string.s;
                 }
 
                 a = v.attrs->find(state.sOutPath);
                 if (a != v.attrs->end()) {
                     if (strict) state.forceValue(*a->value);
                     if (a->value->type() == nString)
-                        xmlAttrs["outPath"] = a->value->string.s;
+                        xmlAttrs["outPath"] = *a->value->string.s;
                 }
 
                 XMLOpenElement _(doc, "derivation", xmlAttrs);

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -154,7 +154,7 @@ public:
 
            For canonicity, the store paths should be in sorted order. */
         struct {
-            const char * s;
+            const std::string * s;
             const char * * context; // must be in sorted order
         } string;
 
@@ -225,10 +225,10 @@ public:
         boolean = b;
     }
 
-    inline void mkString(const char * s, const char * * context = 0)
+    inline void mkString(const std::string & s, const char * * context = 0)
     {
         internalType = tString;
-        string.s = s;
+        string.s = &s;
         string.context = context;
     }
 
@@ -381,7 +381,7 @@ static inline void mkApp(Value & v, Value & left, Value & right)
 
 static inline void mkString(Value & v, const Symbol & s)
 {
-    v.mkString(((const string &) s).c_str());
+    v.mkString((const string &) s);
 }
 
 

--- a/src/libutil/json.cc
+++ b/src/libutil/json.cc
@@ -5,25 +5,6 @@
 
 namespace nix {
 
-void toJSON(std::ostream & str, const char * start, const char * end)
-{
-    str << '"';
-    for (auto i = start; i != end; i++)
-        if (*i == '\"' || *i == '\\') str << '\\' << *i;
-        else if (*i == '\n') str << "\\n";
-        else if (*i == '\r') str << "\\r";
-        else if (*i == '\t') str << "\\t";
-        else if (*i >= 0 && *i < 32)
-            str << "\\u" << std::setfill('0') << std::setw(4) << std::hex << (uint16_t) *i << std::dec;
-        else str << *i;
-    str << '"';
-}
-
-void toJSON(std::ostream & str, const char * s)
-{
-    if (!s) str << "null"; else toJSON(str, s, s + strlen(s));
-}
-
 template<> void toJSON<int>(std::ostream & str, const int & n) { str << n; }
 template<> void toJSON<unsigned int>(std::ostream & str, const unsigned int & n) { str << n; }
 template<> void toJSON<long>(std::ostream & str, const long & n) { str << n; }
@@ -35,7 +16,26 @@ template<> void toJSON<double>(std::ostream & str, const double & n) { str << n;
 
 template<> void toJSON<std::string>(std::ostream & str, const std::string & s)
 {
-    toJSON(str, s.c_str(), s.c_str() + s.size());
+    str << '"';
+    for (const char & i : s)
+        if (i == '\"' || i == '\\') str << '\\' << i;
+        else if (i == '\n') str << "\\n";
+        else if (i == '\r') str << "\\r";
+        else if (i == '\t') str << "\\t";
+        else if (i >= 0 && i < 32)
+            str << "\\u" << std::setfill('0') << std::setw(4) << std::hex << (uint16_t) i << std::dec;
+        else str << i;
+    str << '"';
+}
+
+void toJSON(std::ostream & str, const char * s)
+{
+    if (!s) str << "null"; else toJSON(str, std::string(s));
+}
+
+void toJSON(std::ostream & str, const std::string * s)
+{
+    if (!s) str << "null"; else toJSON<std::string>(str, *s);
 }
 
 template<> void toJSON<bool>(std::ostream & str, const bool & b)

--- a/src/libutil/json.hh
+++ b/src/libutil/json.hh
@@ -6,7 +6,7 @@
 
 namespace nix {
 
-void toJSON(std::ostream & str, const char * start, const char * end);
+void toJSON(std::ostream & str, const std::string * s);
 void toJSON(std::ostream & str, const char * s);
 
 template<typename T>

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1132,7 +1132,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                             else {
                                 if (v->type() == nString) {
                                     attrs2["type"] = "string";
-                                    attrs2["value"] = v->string.s;
+                                    attrs2["value"] = *v->string.s;
                                     xml.writeEmptyElement("meta", attrs2);
                                 } else if (v->type() == nInt) {
                                     attrs2["type"] = "int";
@@ -1152,7 +1152,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                                     for (unsigned int j = 0; j < v->listSize(); ++j) {
                                         if (v->listElems()[j]->type() != nString) continue;
                                         XMLAttrs attrs3;
-                                        attrs3["value"] = v->listElems()[j]->string.s;
+                                        attrs3["value"] = *v->listElems()[j]->string.s;
                                         xml.writeEmptyElement("string", attrs3);
                                     }
                               } else if (v->type() == nAttrs) {
@@ -1164,7 +1164,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                                       if(a.value->type() != nString) continue;
                                       XMLAttrs attrs3;
                                       attrs3["type"] = i.name;
-                                      attrs3["value"] = a.value->string.s;
+                                      attrs3["value"] = *a.value->string.s;
                                       xml.writeEmptyElement("string", attrs3);
                                 }
                               }

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -84,7 +84,7 @@ struct CmdEval : MixJSON, InstallableCommand
                 state->forceValue(v);
                 if (v.type() == nString)
                     // FIXME: disallow strings with contexts?
-                    writeFile(path, v.string.s);
+                    writeFile(path, *v.string.s);
                 else if (v.type() == nAttrs) {
                     if (mkdir(path.c_str(), 0777) == -1)
                         throw SysError("creating directory '%s'", path);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -631,14 +631,14 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
 }
 
 
-std::ostream & printStringValue(std::ostream & str, const char * string) {
+std::ostream & printStringValue(std::ostream & str, const std::string & string) {
     str << "\"";
-    for (const char * i = string; *i; i++)
-        if (*i == '\"' || *i == '\\') str << "\\" << *i;
-        else if (*i == '\n') str << "\\n";
-        else if (*i == '\r') str << "\\r";
-        else if (*i == '\t') str << "\\t";
-        else str << *i;
+    for (const auto & i : string)
+        if (i == '\"' || i == '\\') str << "\\" << i;
+        else if (i == '\n') str << "\\n";
+        else if (i == '\r') str << "\\r";
+        else if (i == '\t') str << "\\t";
+        else str << i;
     str << "\"";
     return str;
 }
@@ -664,7 +664,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
 
     case nString:
         str << ANSI_YELLOW;
-        printStringValue(str, v.string.s);
+        printStringValue(str, *v.string.s);
         str << ANSI_NORMAL;
         break;
 


### PR DESCRIPTION
In the hopes of potentially fixing #1307. Just very naively replaces the `char *` with `std::string *`. This most likely is a problem for garbage collection, but I'm not really sure how and why. The errors I currently get seem to hint at that.

Compilation often ends with
```
[nix-shell:~/src/nix]$ make install -j8
  CXX    src/nix/repl.o
  LD     /home/infinisil/src/nix/bin/nix
  GEN    doc/manual/nix.json
  GEN    doc/manual/conf-file.json
  GEN    doc/manual/builtins.json
  GEN    doc/manual/src/command-ref/conf-file.md
  GEN    doc/manual/src/expressions/builtins.md
  GEN    doc/manual/src/command-ref/new-cli
error: out of memory
error: out of memory
make: *** [doc/manual/local.mk:53: doc/manual/src/command-ref/conf-file.md] Error 1
make: *** Waiting for unfinished jobs....
make: *** [doc/manual/local.mk:66: doc/manual/src/expressions/builtins.md] Error 1
/nix/store/xmxgxig6zxrixicc7905ssgb4yc3lysa-bash-interactive-4.4-p23/bin/bash: line 1: 1749184 Segmentation fault      (core dumped) env -i HOME=/dummy NIX_CONF_DIR=/dummy NIX_SSL_CERT_FILE=/dummy/no-ca-bundle.crt NIX_STATE_DIR=/dummy /home/infinisil/src/nix/bin/nix eval --experimental-features nix-command -I nix/corepkgs=corepkgs --store dummy:// --impure --raw --write-to doc/manual/src/command-ref/new-cli --expr 'import doc/manual/generate-manpage.nix (builtins.fromJSON (builtins.readFile doc/manual/nix.json))'
make: *** [doc/manual/local.mk:49: doc/manual/src/command-ref/new-cli] Error 139
```

Segfault with gdb:
```
[nix-shell:~/src/nix]$ gdb --args bin/nix-instantiate --eval -E 'builtins.readFile doc/manual/nix.json'GNU gdb (GDB) 10.2
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-unknown-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from bin/nix-instantiate...
(gdb) run
Starting program: /home/infinisil/src/nix/bin/nix-instantiate --eval -E builtins.readFile\ doc/manual/nix.json
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/nix/store/ikl21vjfq900ccbqg1xasp83kadw6q8y-glibc-2.32-46/lib/libthread_db.so.1".
[New Thread 0x7ffff5d54640 (LWP 1792955)]
[New Thread 0x7ffff53d3640 (LWP 1792956)]
[New Thread 0x7ffff4bd2640 (LWP 1792957)]
[New Thread 0x7ffff43d1640 (LWP 1792958)]
[New Thread 0x7ffff3bd0640 (LWP 1792959)]
[New Thread 0x7ffff33cf640 (LWP 1792960)]
[New Thread 0x7ffff2bce640 (LWP 1792961)]
[New Thread 0x7ffff23cd640 (LWP 1792962)]

Thread 1 "nix-instantiate" received signal SIGSEGV, Segmentation fault.
nix::printValue (str=..., active=std::set with 1 element = {...}, v=...) at src/libexpr/eval.cc:90
90	           if (i == '\"' || i == '\\') str << "\\" << i;
(gdb) print i
$1 = (const char &) <error reading variable>
```

Suspecting that `i` points to a value that has been deallocated since, but I don't have time to try to figure that out. Anybody can feel free to use this PR as a starting point.