### PR TITLE
tests: Fix the recursive test with the daemon

### DIFF
--- a/tests/recursive.sh
+++ b/tests/recursive.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+sed -i 's/experimental-features .*/& recursive-nix/' "$NIX_CONF_DIR"/nix.conf
+restartDaemon
+
 # FIXME
 if [[ $(uname) != Linux ]]; then exit 99; fi
 


### PR DESCRIPTION
Add the `recursive-nix` experimental-feature to the daemon, as the test
will otherwise fail
