### PR TITLE
Draft: add support for lfs for fetchGit

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -145,6 +145,10 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
                     if (pathExists(flakeRoot + "/.git/shallow"))
                         parsedURL.query.insert_or_assign("shallow", "1");
 
+                    if (pathExists(flakeRoot + "/.git/lfs")) {
+                        parsedURL.query.insert_or_assign("largeFileSystem", "1");
+                    }
+
                     return std::make_pair(
                         FlakeRef(Input::fromURL(parsedURL), get(parsedURL.query, "dir").value_or("")),
                         fragment);

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1034,6 +1034,19 @@ std::vector<char *> stringsToCharPtrs(const Strings & ss)
     return res;
 }
 
+// return true if the programmed returned ok, false otherwise
+bool getProgramStatus(Path program, bool searchPath, const Strings & args,
+    const std::optional<std::string> & input)
+{
+    RunOptions opts(program, args);
+    opts.searchPath = searchPath;
+    opts.input = input;
+
+    auto res = runProgram(opts);
+
+    return statusOk(res.first);
+}
+
 // Output = "standard out" output stream
 string runProgram(Path program, bool searchPath, const Strings & args,
     const std::optional<std::string> & input)

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -267,6 +267,11 @@ struct ProcessOptions
 
 pid_t startProcess(std::function<void()> fun, const ProcessOptions & options = ProcessOptions());
 
+/* Run a program and return true if the exit code doesn't expresse an error,
+    false otherwise */
+bool getProgramStatus(Path program, bool searchPath = false,
+    const Strings & args = Strings(),
+    const std::optional<std::string> & input = {});
 
 /* Run a program and return its stdout in a string (i.e., like the
    shell backtick operator). */


### PR DESCRIPTION
I wanted to add veloren, an open-source video game that have a flake expression, using crate2nix.

It use git lfs, so I needed to support it to the flake. Right now, hydra is able to fetch the game repo, at least as a flake (and check fail, but that's for another, unrelated reason I should fix). I'm unsure a few things, so I'll add comment to my code.

Also, I'm unsure of the name of the parameter. I named it largeFileSystem, but it could be renamed to another thing.

Also, this need git lfs to be present in the path (just like fetchGit require git).

additionally, is there any specific procedure when wanting to change how flake url work ? I hope I don't need an RFC.