### PR TITLE
Speed up 'nix flake check'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -178,8 +178,8 @@
         installPhase = ''
           mkdir -p $out
         '';
-        installCheckPhase = "make installcheck";
 
+        installCheckPhase = "make installcheck -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES";
       };
 
       binaryTarball = buildPackages: nix: pkgs: let

--- a/flake.nix
+++ b/flake.nix
@@ -502,10 +502,7 @@
             # `NIX_DAEMON_SOCKET_PATH` which is required for the tests to work
             # againstLatestStable = testNixVersions pkgs pkgs.nix pkgs.nixStable;
           } "touch $out";
-      } // (if system == "x86_64-linux" then (builtins.listToAttrs (map (crossSystem: {
-        name = "binaryTarball-${crossSystem}";
-        value = self.hydraJobs.binaryTarballCross.${system}.${crossSystem};
-      }) crossSystems)) else {}));
+      });
 
       packages = forAllSystems (system: {
         inherit (nixpkgsFor.${system}) nix;


### PR DESCRIPTION
Checks take about an hour which is too much. This PR does the following to reduce this:

* Run `make installcheck` in parallel.
* Don't do cross builds since we're already doing them in Hydra and they're not critical.
