### PR TITLE
Add missing 'nix profile' subcommands

### DIFF
--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -126,9 +126,9 @@ void deleteGeneration(const Path & profile, GenerationNumber gen)
 static void deleteGeneration2(const Path & profile, GenerationNumber gen, bool dryRun)
 {
     if (dryRun)
-        printInfo(format("would remove profile version %1%") % gen);
+        notice("would remove profile version %1%", gen);
     else {
-        printInfo(format("removing profile version %1%") % gen);
+        notice("removing profile version %1%", gen);
         deleteGeneration(profile, gen);
     }
 }

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -126,9 +126,9 @@ void deleteGeneration(const Path & profile, GenerationNumber gen)
 static void deleteGeneration2(const Path & profile, GenerationNumber gen, bool dryRun)
 {
     if (dryRun)
-        printInfo(format("would remove generation %1%") % gen);
+        printInfo(format("would remove profile version %1%") % gen);
     else {
-        printInfo(format("removing generation %1%") % gen);
+        printInfo(format("removing profile version %1%") % gen);
         deleteGeneration(profile, gen);
     }
 }
@@ -142,7 +142,7 @@ void deleteGenerations(const Path & profile, const std::set<GenerationNumber> & 
     auto [gens, curGen] = findGenerations(profile);
 
     if (gensToDelete.count(*curGen))
-        throw Error("cannot delete current generation of profile %1%'", profile);
+        throw Error("cannot delete current version of profile %1%'", profile);
 
     for (auto & i : gens) {
         if (!gensToDelete.count(i.number)) continue;
@@ -254,12 +254,12 @@ void switchGeneration(
 
     if (!dst) {
         if (dstGen)
-            throw Error("generation %1% does not exist", *dstGen);
+            throw Error("profile version %1% does not exist", *dstGen);
         else
-            throw Error("no generation older than the current (%1%) exists", curGen.value_or(0));
+            throw Error("no profile version older than the current (%1%) exists", curGen.value_or(0));
     }
 
-    notice("switching from generation %d to %d", curGen.value_or(0), dst->number);
+    notice("switching profile from version %d to %d", curGen.value_or(0), dst->number);
 
     if (dryRun) return;
 

--- a/src/libstore/profiles.hh
+++ b/src/libstore/profiles.hh
@@ -11,7 +11,7 @@ namespace nix {
 class StorePath;
 
 
-typedef unsigned int GenerationNumber;
+typedef uint64_t GenerationNumber;
 
 struct Generation
 {
@@ -45,6 +45,13 @@ void deleteGenerationsOlderThan(const Path & profile, time_t t, bool dryRun);
 void deleteGenerationsOlderThan(const Path & profile, const string & timeSpec, bool dryRun);
 
 void switchLink(Path link, Path target);
+
+/* Roll back a profile to the specified generation, or to the most
+   recent one older than the current. */
+void switchGeneration(
+    const Path & profile,
+    std::optional<GenerationNumber> dstGen,
+    bool dryRun);
 
 /* Ensure exclusive access to a profile.  Any command that modifies
    the profile first acquires this lock. */

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -91,6 +91,14 @@ protected:
               })
             , arity(1)
         { }
+
+        template<class I>
+        Handler(std::optional<I> * dest)
+            : fun([=](std::vector<std::string> ss) {
+                *dest = string2IntWithUnitPrefix<I>(ss[0]);
+            })
+            , arity(1)
+        { }
     };
 
     /* Options. */

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1265,12 +1265,12 @@ static void opDeleteGenerations(Globals & globals, Strings opFlags, Strings opAr
     } else if (opArgs.size() == 1 && opArgs.front().find('d') != string::npos) {
         deleteGenerationsOlderThan(globals.profile, opArgs.front(), globals.dryRun);
     } else if (opArgs.size() == 1 && opArgs.front().find('+') != string::npos) {
-        if(opArgs.front().size() < 2)
-            throw Error("invalid number of generations ‘%1%’", opArgs.front());
+        if (opArgs.front().size() < 2)
+            throw Error("invalid number of generations '%1%'", opArgs.front());
         string str_max = string(opArgs.front(), 1, opArgs.front().size());
         auto max = string2Int<GenerationNumber>(str_max);
         if (!max || *max == 0)
-            throw Error("invalid number of generations to keep ‘%1%’", opArgs.front());
+            throw Error("invalid number of generations to keep '%1%'", opArgs.front());
         deleteGenerationsGreaterThan(globals.profile, *max, globals.dryRun);
     } else {
         std::set<GenerationNumber> gens;

--- a/src/nix/profile-history.md
+++ b/src/nix/profile-history.md
@@ -6,10 +6,10 @@ R""(
 
   ```console
   # nix profile history
-  Version 508 -> 509:
+  Version 508 (2020-04-10):
     flake:nixpkgs#legacyPackages.x86_64-linux.awscli: ∅ -> 1.17.13
 
-  Version 509 -> 510:
+  Version 509 (2020-05-16) <- 508:
     flake:nixpkgs#legacyPackages.x86_64-linux.awscli: 1.17.13 -> 1.18.211
   ```
 

--- a/src/nix/profile-rollback.md
+++ b/src/nix/profile-rollback.md
@@ -1,0 +1,26 @@
+R""(
+
+# Examples
+
+* Roll back your default profile to the previous version:
+
+  ```console
+  # nix profile rollback
+  switching from generation 519 to 518
+  ```
+
+* Switch your default profile to version 510:
+
+  ```console
+  # nix profile rollback --to 510
+  switching from generation 518 to 510
+  ```
+
+# Description
+
+This command switches a profile to the most recent version older
+than the currently active version, or if `--to` *N* is given, to
+version *N* of the profile. To see the available versions of a
+profile, use `nix profile history`.
+
+)""

--- a/src/nix/profile-rollback.md
+++ b/src/nix/profile-rollback.md
@@ -6,14 +6,14 @@ R""(
 
   ```console
   # nix profile rollback
-  switching from generation 519 to 518
+  switching profile from version 519 to 518
   ```
 
 * Switch your default profile to version 510:
 
   ```console
   # nix profile rollback --to 510
-  switching from generation 518 to 510
+  switching profile from version 518 to 510
   ```
 
 # Description

--- a/src/nix/profile-wipe-history.md
+++ b/src/nix/profile-wipe-history.md
@@ -1,0 +1,20 @@
+R""(
+
+# Examples
+
+* Delete all versions of the default profile older than 100 days:
+
+  ```console
+  # nix profile wipe-history --profile /tmp/profile --older-than 100d
+  removing profile version 515
+  removing profile version 514
+  ```
+
+# Description
+
+This command deletes non-current versions of a profile, making it
+impossible to roll back to these versions. By default, all non-current
+versions are deleted. With `--older-than` *N*`d`, all non-current
+versions older than *N* days are deleted.
+
+)""

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -12,6 +12,7 @@
 
 #include <nlohmann/json.hpp>
 #include <regex>
+#include <iomanip>
 
 using namespace nix;
 
@@ -528,10 +529,11 @@ struct CmdProfileHistory : virtual StoreCommand, EvalCommand, MixDefaultProfile
             if (!first) std::cout << "\n";
             first = false;
 
-            if (prevGen)
-                std::cout << fmt("Version %d -> %d:\n", prevGen->first.number, gen.number);
-            else
-                std::cout << fmt("Version %d:\n", gen.number);
+            std::cout << fmt("Version %s%d" ANSI_NORMAL " (%s)%s:\n",
+                gen.number == curGen ? ANSI_GREEN : ANSI_BOLD,
+                gen.number,
+                std::put_time(std::gmtime(&gen.creationTime), "%Y-%m-%d"),
+                prevGen ? fmt(" <- %d", prevGen->first.number) : "");
 
             ProfileManifest::printDiff(
                 prevGen ? prevGen->second : ProfileManifest(),

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -543,6 +543,38 @@ struct CmdProfileHistory : virtual StoreCommand, EvalCommand, MixDefaultProfile
     }
 };
 
+struct CmdProfileRollback : virtual StoreCommand, MixDefaultProfile, MixDryRun
+{
+    std::optional<GenerationNumber> version;
+
+    CmdProfileRollback()
+    {
+        addFlag({
+            .longName = "to",
+            .description = "The profile version to roll back to.",
+            .labels = {"version"},
+            .handler = {&version},
+        });
+    }
+
+    std::string description() override
+    {
+        return "roll back to the previous version or a specified version of this profile";
+    }
+
+    std::string doc() override
+    {
+        return
+          #include "profile-rollback.md"
+          ;
+    }
+
+    void run(ref<Store> store) override
+    {
+        switchGeneration(*profile, version, dryRun);
+    }
+};
+
 struct CmdProfile : NixMultiCommand
 {
     CmdProfile()
@@ -553,6 +585,7 @@ struct CmdProfile : NixMultiCommand
               {"list", []() { return make_ref<CmdProfileList>(); }},
               {"diff-closures", []() { return make_ref<CmdProfileDiffClosures>(); }},
               {"history", []() { return make_ref<CmdProfileHistory>(); }},
+              {"rollback", []() { return make_ref<CmdProfileRollback>(); }},
           })
     { }
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -559,7 +559,7 @@ struct CmdProfileRollback : virtual StoreCommand, MixDefaultProfile, MixDryRun
 
     std::string description() override
     {
-        return "roll back to the previous version or a specified version of this profile";
+        return "roll back to the previous version or a specified version of a profile";
     }
 
     std::string doc() override


### PR DESCRIPTION
This adds `nix profile rollback` and `nix profile wipe-history` subcommands. It also makes `nix profile history` show profile dates.

Fixes #3951.