### PR TITLE
Disallow reading flake.lock

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1412,6 +1412,11 @@ static void prim_readFile(EvalState & state, const Pos & pos, Value * * args, Va
 {
     PathSet context;
     Path path = state.coerceToPath(pos, *args[0], context);
+    if (baseNameOf(path) == "flake.lock")
+        throw Error({
+            .msg = hintfmt("cannot read '%s' because flake lock files can be out of sync", path),
+            .errPos = pos
+        });
     try {
         state.realiseContext(context);
     } catch (InvalidPathError & e) {


### PR DESCRIPTION
With `--no-write-lock-file`, it's possible that flake.lock is out of sync with the actual inputs used by the evaluation. So doing `fromJSON (readFile ./flake.lock)` will give wrong results.

Fixes #4639.