### PR TITLE
sandbox: allow Rosetta 2 on Darwin

### DIFF
--- a/src/libstore/sandbox-defaults.sb
+++ b/src/libstore/sandbox-defaults.sb
@@ -97,3 +97,7 @@
 ; This is used by /bin/sh on macOS 10.15 and later.
 (allow file*
        (literal "/private/var/select/sh"))
+
+; Allow Rosetta 2 to run x86_64 binaries on aarch64-darwin.
+(allow file-read*
+       (subpath "/Library/Apple/usr/libexec/oah"))


### PR DESCRIPTION
This allows sandboxed x86_64-darwin builds on aarch64-darwin.