### PR TITLE
Don't allow IFD in flakes by default

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -92,7 +92,7 @@ doc/manual/generated/man1/nix3-manpages: $(d)/src/command-ref/new-cli
 	  lowdown -sT man -M section=1 $$tmpFile -o $(DESTDIR)$$(dirname $@)/$$name.1; \
 	  rm $$tmpFile; \
 	done
-	touch $@
+	@touch $@
 
 $(docdir)/manual/index.html: $(MANUAL_SRCS) $(d)/book.toml $(d)/custom.css $(d)/src/SUMMARY.md $(d)/src/command-ref/new-cli $(d)/src/command-ref/conf-file.md $(d)/src/expressions/builtins.md $(call rwildcard, $(d)/src, *.md)
 	$(trace-gen) RUST_LOG=warn mdbook build doc/manual -d $(DESTDIR)$(docdir)/manual

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -52,7 +52,8 @@ void EvalState::realiseContext(const PathSet & context)
     if (drvs.empty()) return;
 
     if (!evalSettings.enableImportFromDerivation)
-        throw EvalError("attempted to realize '%1%' during evaluation but 'allow-import-from-derivation' is false",
+        throw Error(
+            "cannot build '%1%' during evaluation because the option 'allow-import-from-derivation' is disabled",
             store->printStorePath(drvs.begin()->drvPath));
 
     /* For performance, prefetch all substitute info. */

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -52,9 +52,9 @@ void BinaryCacheStore::init()
                     throw Error("binary cache '%s' is for Nix stores with prefix '%s', not '%s'",
                         getUri(), value, storeDir);
             } else if (name == "WantMassQuery") {
-                wantMassQuery.setDefault(value == "1" ? "true" : "false");
+                wantMassQuery.setDefault(value == "1");
             } else if (name == "Priority") {
-                priority.setDefault(fmt("%d", std::stoi(value)));
+                priority.setDefault(std::stoi(value));
             }
         }
     }

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -57,8 +57,8 @@ public:
     {
         // FIXME: do this lazily?
         if (auto cacheInfo = diskCache->cacheExists(cacheUri)) {
-            wantMassQuery.setDefault(cacheInfo->wantMassQuery ? "true" : "false");
-            priority.setDefault(fmt("%d", cacheInfo->priority));
+            wantMassQuery.setDefault(cacheInfo->wantMassQuery);
+            priority.setDefault(cacheInfo->priority);
         } else {
             try {
                 BinaryCacheStore::init();

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -232,8 +232,8 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStoreConfig, public virtual
     void init() override
     {
         if (auto cacheInfo = diskCache->cacheExists(getUri())) {
-            wantMassQuery.setDefault(cacheInfo->wantMassQuery ? "true" : "false");
-            priority.setDefault(fmt("%d", cacheInfo->priority));
+            wantMassQuery.setDefault(cacheInfo->wantMassQuery);
+            priority.setDefault(cacheInfo->priority);
         } else {
             BinaryCacheStore::init();
             diskCache->createCache(getUri(), storeDir, wantMassQuery, priority);

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -177,11 +177,6 @@ AbstractSetting::AbstractSetting(
 {
 }
 
-void AbstractSetting::setDefault(const std::string & str)
-{
-    if (!overridden) set(str);
-}
-
 nlohmann::json AbstractSetting::toJSON()
 {
     return nlohmann::json(toJSONObject());

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -194,8 +194,6 @@ public:
 
     bool overridden = false;
 
-    void setDefault(const std::string & str);
-
 protected:
 
     AbstractSetting(
@@ -253,6 +251,7 @@ public:
     bool operator !=(const T & v2) const { return value != v2; }
     void operator =(const T & v) { assign(v); }
     virtual void assign(const T & v) { value = v; }
+    void setDefault(const T & v) { if (!overridden) value = v; }
 
     void set(const std::string & str, bool append = false) override;
 

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -62,6 +62,7 @@ struct CmdSearch : InstallableCommand, MixJSON
     void run(ref<Store> store) override
     {
         settings.readOnlyMode = true;
+        evalSettings.enableImportFromDerivation.setDefault(false);
 
         // Empty search string should match all packages
         // Use "^" here instead of ".*" due to differences in resulting highlighting


### PR DESCRIPTION
Import-from-derivation is a controversial feature because it can cause arbitrary amounts of building when running commands like `nix flake show`. It's better to disallow it now and re-enable it in a future version than the other way around.

This PR disables IFD for the folliowing operations:

* `nix search` (this was already implied by read-only mode)
* `nix flake show`
* `nix flake check`, but only on the hydraJobs output
