### PR TITLE
Re-allow reading flake.lock in nix-build

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1412,9 +1412,9 @@ static void prim_readFile(EvalState & state, const Pos & pos, Value * * args, Va
 {
     PathSet context;
     Path path = state.coerceToPath(pos, *args[0], context);
-    if (baseNameOf(path) == "flake.lock")
+    if (evalSettings.pureEval && baseNameOf(path) == "flake.lock" && state.store->isInStore(path))
         throw Error({
-            .msg = hintfmt("cannot read '%s' because flake lock files can be out of sync", path),
+            .msg = hintfmt("reading '%s' is not allowed because flake lock files can be out of sync", path),
             .errPos = pos
         });
     try {


### PR DESCRIPTION
As suggested in https://github.com/NixOS/nix/pull/5250#issuecomment-919780898