### PR TITLE
If we can't write a lock file, pretend the top-level flake is dirty

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -635,8 +635,10 @@ LockedFlake lockFlake(
                     }
                 } else
                     throw Error("cannot write modified lock file of flake '%s' (use '--no-write-lock-file' to ignore)", topRef);
-            } else
+            } else {
                 warn("not writing modified lock file of flake '%s':\n%s", topRef, chomp(diff));
+                flake.forceDirty = true;
+            }
         }
 
         return LockedFlake { .flake = std::move(flake), .lockFile = std::move(newLockFile) };
@@ -659,7 +661,13 @@ void callFlake(EvalState & state,
 
     mkString(*vLocks, lockedFlake.lockFile.to_string());
 
-    emitTreeAttrs(state, *lockedFlake.flake.sourceInfo, lockedFlake.flake.lockedRef.input, *vRootSrc);
+    emitTreeAttrs(
+        state,
+        *lockedFlake.flake.sourceInfo,
+        lockedFlake.flake.lockedRef.input,
+        *vRootSrc,
+        false,
+        lockedFlake.flake.forceDirty);
 
     mkString(*vRootSubdir, lockedFlake.flake.lockedRef.subdir);
 

--- a/src/libexpr/flake/flake.hh
+++ b/src/libexpr/flake/flake.hh
@@ -58,9 +58,10 @@ struct ConfigFile
 /* The contents of a flake.nix file. */
 struct Flake
 {
-    FlakeRef originalRef;   // the original flake specification (by the user)
-    FlakeRef resolvedRef;   // registry references and caching resolved to the specific underlying flake
-    FlakeRef lockedRef;     // the specific local store result of invoking the fetcher
+    FlakeRef originalRef; // the original flake specification (by the user)
+    FlakeRef resolvedRef; // registry references and caching resolved to the specific underlying flake
+    FlakeRef lockedRef; // the specific local store result of invoking the fetcher
+    bool forceDirty = false; // pretend that 'lockedRef' is dirty
     std::optional<std::string> description;
     std::shared_ptr<const fetchers::Tree> sourceInfo;
     FlakeInputs inputs;
@@ -140,6 +141,8 @@ void emitTreeAttrs(
     EvalState & state,
     const fetchers::Tree & tree,
     const fetchers::Input & input,
-    Value & v, bool emptyRevFallback = false);
+    Value & v,
+    bool emptyRevFallback = false,
+    bool forceDirty = false);
 
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1412,11 +1412,6 @@ static void prim_readFile(EvalState & state, const Pos & pos, Value * * args, Va
 {
     PathSet context;
     Path path = state.coerceToPath(pos, *args[0], context);
-    if (baseNameOf(path) == "flake.lock")
-        throw Error({
-            .msg = hintfmt("cannot read '%s' because flake lock files can be out of sync", path),
-            .errPos = pos
-        });
     try {
         state.realiseContext(context);
     } catch (InvalidPathError & e) {


### PR DESCRIPTION
If we can't write a lock file, pretend the top-level flake is dirty. This is alternative to #4639. You can still read flake.lock, but at least in
reproducible workflows like NixOS configurations where you require a  non-dirty tree, evaluation will fail because there is no rev.
