### PR TITLE
TCP support in the Nix daemon

### DIFF
--- a/src/libstore/tcp-store.cc
+++ b/src/libstore/tcp-store.cc
@@ -1,0 +1,107 @@
+#include "remote-store.hh"
+#include "finally.hh"
+
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+
+namespace nix {
+
+struct TCPStoreConfig : virtual RemoteStoreConfig
+{
+    using RemoteStoreConfig::RemoteStoreConfig;
+
+    const std::string name() override { return "TCP Store"; }
+};
+
+struct TCPStore : public virtual TCPStoreConfig, public virtual RemoteStore
+{
+    std::string host;
+    uint16_t port = 0;
+
+    TCPStore(const std::string scheme, std::string path, const Params & params)
+        : StoreConfig(params)
+        , RemoteStoreConfig(params)
+        , TCPStoreConfig(params)
+        , Store(params)
+        , RemoteStore(params)
+    {
+        // FIXME: use parsed URL.
+
+        auto p = path.find(':');
+        if (p == std::string::npos)
+            throw UsageError("tcp:// stores require a port number (e.g. 'tcp://example.org:1234'), in '%s'", path);
+
+        host = std::string(path, 0, p);
+        if (auto port2 = string2Int<uint16_t>(std::string(path, p + 1)))
+            port = *port2;
+        else
+            throw UsageError("invalid TCP port number, in '%s'", path);
+    }
+
+    std::string getUri() override
+    { return fmt("tcp://"); }
+
+    static std::set<std::string> uriSchemes()
+    { return {"tcp"}; }
+
+    bool sameMachine() override
+    { return false; }
+
+    ref<RemoteStore::Connection> openConnection() override
+    {
+        auto conn = make_ref<Connection>();
+
+        struct addrinfo hints;
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_flags = 0;
+        hints.ai_protocol = IPPROTO_TCP;
+
+        struct addrinfo * result;
+        if (auto s = getaddrinfo(host.c_str(), fmt("%d", port).c_str(), &hints, &result))
+            throw Error("DNS lookup of '%s' failed: %s", host, gai_strerror(s));
+
+        Finally cleanup([&]() { freeaddrinfo(result); });
+
+        std::string err;
+
+        for (auto rp = result; rp; rp = rp->ai_next) {
+            AutoCloseFD fd = socket(
+                rp->ai_family,
+                rp->ai_socktype
+                #ifdef SOCK_CLOEXEC
+                | SOCK_CLOEXEC
+                #endif
+                , rp->ai_protocol);
+            if (!fd) {
+                err = strerror(errno);
+                continue;
+            }
+            closeOnExec(fd.get());
+
+            if (::connect(fd.get(), rp->ai_addr, rp->ai_addrlen) == -1) {
+                err = strerror(errno);
+                continue;
+            }
+
+            conn->fd = std::move(fd);
+            conn->from.fd = conn->fd.get();
+            conn->to.fd = conn->fd.get();
+            conn->startTime = std::chrono::steady_clock::now();
+            return conn;
+        }
+
+        throw Error("could not connect to daemon at '%s': %s", host, err);
+    }
+};
+
+static RegisterStoreImplementation<TCPStore, TCPStoreConfig> regTCPStore;
+
+}

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -133,7 +133,7 @@ static PeerInfo getPeerInfo(int fd)
     xucred cred;
     socklen_t credLen = sizeof(cred);
     if (getsockopt(fd, SOL_LOCAL, LOCAL_PEERCRED, &cred, &credLen) == 0)
-        peer.uid = cred.uid;
+        peer.uid = cred.cr_uid;
 
 #endif
 

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -336,6 +336,17 @@ static RegisterLegacyCommand r_nix_daemon("nix-daemon", main_nix_daemon);
 
 struct CmdDaemon : StoreCommand
 {
+    bool stdio = false;
+
+    CmdDaemon()
+    {
+        addFlag({
+            .longName = "stdio",
+            .description = "Handle a single connection on stdin/stdout.",
+            .handler = {&stdio, true},
+        });
+    }
+
     std::string description() override
     {
         return "daemon to perform store operations on behalf of non-root clients";
@@ -352,7 +363,7 @@ struct CmdDaemon : StoreCommand
 
     void run(ref<Store> store) override
     {
-        runDaemon(false);
+        runDaemon(stdio);
     }
 };
 

--- a/src/nix/daemon.md
+++ b/src/nix/daemon.md
@@ -8,8 +8,8 @@ R""(
   # nix daemon
   ```
 
-* The daemon does not have native support for listening on a TCP
-  socket, but you can do this using `socat`:
+* The daemon does not have native support for opening a TCP socket to
+  listen to, but you can do this using `socat`:
 
   ```console
   # socat TCP-LISTEN:3456,reuseaddr,fork EXEC:'nix daemon --stdio',nofork

--- a/src/nix/daemon.md
+++ b/src/nix/daemon.md
@@ -31,4 +31,18 @@ management framework such as `systemd`.
 
 Note that this daemon does not fork into the background.
 
+# Systemd socket activation
+
+`nix daemon` supports systemd socket-based activation using the
+`nix-daemon.socket` unit in the Nix distribution. It supports
+listening on multiple addresses; for example, the following stanza in
+`nix-daemon.socket` makes the daemon listen both on a Unix domain
+socket and on port 1234:
+
+```
+[Socket]
+ListenStream=/nix/var/nix/daemon-socket/socket
+ListenStream=1234
+```
+
 )""

--- a/src/nix/daemon.md
+++ b/src/nix/daemon.md
@@ -8,6 +8,19 @@ R""(
   # nix daemon
   ```
 
+* The daemon does not have native support for listening on a TCP
+  socket, but you can do this using `socat`:
+
+  ```console
+  # socat TCP-LISTEN:3456,reuseaddr,fork EXEC:'nix daemon --stdio'
+  ```
+
+  You can then connect to this daemon using the `tcp` store type:
+
+  ```console
+  # nix store ping --store tcp://example.org:3456
+  ```
+
 # Description
 
 This command runs the Nix daemon, which is a required component in

--- a/src/nix/daemon.md
+++ b/src/nix/daemon.md
@@ -12,7 +12,7 @@ R""(
   socket, but you can do this using `socat`:
 
   ```console
-  # socat TCP-LISTEN:3456,reuseaddr,fork EXEC:'nix daemon --stdio'
+  # socat TCP-LISTEN:3456,reuseaddr,fork EXEC:'nix daemon --stdio',nofork
   ```
 
   You can then connect to this daemon using the `tcp` store type:


### PR DESCRIPTION
This PR makes it possible to connect to a remote Nix daemon via TCP, and for the Nix daemon to listen on multiple sockets (including TCP) via systemd.

Lacking encryption/authentication, this is primarily useful to testing, e.g. when locally simulating high-latency SSH store connections via qdisc/netem.

Example usage:
``` 
# nix path-info --store tcp://example.org:1234 ...
```
