### PR TITLE
Fix scheme query parameter for s3 cache

### DIFF
--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -209,7 +209,7 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStoreConfig, public virtual
     S3Helper s3Helper;
 
     S3BinaryCacheStoreImpl(
-        const std::string & scheme,
+        const std::string & uriScheme,
         const std::string & bucketName,
         const Params & params)
         : StoreConfig(params)


### PR DESCRIPTION
Fixes #4365

There seems to have been some variable shadowing such that the `scheme` argument passed to `makeConfig` was always `s3`.  
Through renaming the offending variable the correct `scheme` now get's passed.

---

Fix is tested to work (push & pull) with `…?scheme=http…` in our CI.