### PR TITLE
set the PER_LINUX32 personality flag, when building for armv6l-linux or armv7l-linux

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1778,6 +1778,10 @@ void LocalDerivationGoal::runChild()
             if (personality(PER_LINUX32) == -1)
                 throw SysError("cannot set i686-linux personality");
         }
+        if (drv->platform == "armv7l-linux" || drv->platform == "armv6l-linux") {
+          if (personality(PER_LINUX32) == -1)
+            throw SysError("cannot set 32bit linux personality");
+        }
 
         /* Impersonate a Linux 2.6 machine to get some determinism in
            builds that depend on the kernel version. */


### PR DESCRIPTION
this prevents 32bit builds from detecting a 64bit kernel and picking the wrong target