### PR TITLE
flake: Use the real nixUnstable from nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -259,10 +259,10 @@
       # 'nix.perl-bindings' packages.
       overlay = final: prev: {
 
-        # An older version of Nix to test against when using the daemon.
-        # Currently using `nixUnstable` as the stable one doesn't respect
-        # `NIX_DAEMON_SOCKET_PATH` which is needed for the tests.
         nixStable = prev.nix;
+
+        # Forward from the previous stage as we don’t want it to pick the lowdown override
+        nixUnstable = prev.nixUnstable;
 
         nix = with final; with commonDeps pkgs; stdenv.mkDerivation {
           name = "nix-${version}";


### PR DESCRIPTION
Don’t let it pick our overridden lowdown as that would cause it not to be cached in cache.nixos.org.

This reduces the build times in the CI from 30mins to 20mins (so still not awesome, but already much better for a 1line change)