### PR TITLE
Fix relative path input handling

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -172,8 +172,12 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
         auto parsedURL = parseURL(url);
         std::string fragment;
         std::swap(fragment, parsedURL.fragment);
+
+        auto input = Input::fromURL(parsedURL);
+        input.parent = baseDir;
+
         return std::make_pair(
-            FlakeRef(Input::fromURL(parsedURL), get(parsedURL.query, "dir").value_or("")),
+            FlakeRef(std::move(input), get(parsedURL.query, "dir").value_or("")),
             fragment);
     }
 }

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -95,8 +95,11 @@ struct PathInputScheme : InputScheme
             absPath = nix::absPath(path, parent);
 
             // for security, ensure that if the parent is a store path, it's inside it
-            if (store->isInStore(parent) && !isInDir(absPath, parent))
-                throw BadStorePath("relative path '%s' [%s] points outside of its parent's store path '%s'", path, absPath, parent);
+            if (store->isInStore(parent)) {
+                auto storePath = store->printStorePath(store->toStorePath(parent).first);
+                if (!isInDir(absPath, storePath))
+                    throw BadStorePath("relative path '%s' points outside of its parent's store path '%s'", path, storePath);
+            }
         } else
             absPath = path;
 

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -85,17 +85,22 @@ struct PathInputScheme : InputScheme
         std::string absPath;
         auto path = getStrAttr(input.attrs, "path");
 
-        if (path[0] != '/' && input.parent) {
+        if (path[0] != '/') {
+            if (!input.parent)
+                throw Error("cannot fetch input '%s' because it uses a relative path", input.to_string());
+
             auto parent = canonPath(*input.parent);
 
             // the path isn't relative, prefix it
-            absPath = canonPath(parent + "/" + path);
+            absPath = nix::absPath(path, parent);
 
             // for security, ensure that if the parent is a store path, it's inside it
-            if (!parent.rfind(store->storeDir, 0) && absPath.rfind(store->storeDir, 0))
-                throw BadStorePath("relative path '%s' points outside of its parent's store path %s, this is a security violation", path, parent);
+            if (store->isInStore(parent) && !isInDir(absPath, parent))
+                throw BadStorePath("relative path '%s' [%s] points outside of its parent's store path '%s'", path, absPath, parent);
         } else
             absPath = path;
+
+        Activity act(*logger, lvlTalkative, actUnknown, fmt("copying '%s'", absPath));
 
         // FIXME: check whether access to 'path' is allowed.
         auto storePath = store->maybeParseStorePath(absPath);

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -766,7 +766,7 @@ cat > $flakeFollowsA/flake.nix <<EOF
 {
     description = "Flake A";
     inputs = {
-        B.url = "path:./../../flakeB";
+        B.url = "path:../flakeB";
     };
     outputs = { ... }: {};
 }
@@ -774,7 +774,7 @@ EOF
 
 git -C $flakeFollowsA add flake.nix
 
-nix flake lock $flakeFollowsA 2>&1 | grep 'this is a security violation'
+nix flake lock $flakeFollowsA 2>&1 | grep 'points outside'
 
 # Test flake in store does not evaluate
 rm -rf $badFlakeDir


### PR DESCRIPTION
Previously inputs like `path:..` or `path:../foo` were accepted. In particular, `path:..` caused Nix to copy the entire Nix store.

Fixes #5168.