### PR TITLE
fix install on macOS monterey

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -13,11 +13,22 @@ NIX_BUILD_USER_NAME_TEMPLATE="_nixbld%d"
 read_only_root() {
     # this touch command ~should~ always produce an error
     # as of this change I confirmed /usr/bin/touch emits:
+    # "touch: /: Operation not permitted" Monterey
     # "touch: /: Read-only file system" Catalina+ and Big Sur
     # "touch: /: Permission denied" Mojave
     # (not matching prefix for compat w/ coreutils touch in case using
     # an explicit path causes problems; its prefix differs)
-    [[ "$(/usr/bin/touch / 2>&1)" = *"Read-only file system" ]]
+    case "$(/usr/bin/touch / 2>&1)" in
+        *"Read-only file system") # Catalina, Big Sur
+            return 0
+            ;;
+        *"Operation not permitted") # Monterey
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 
     # Avoiding the slow semantic way to get this information (~330ms vs ~8ms)
     # unless using touch causes problems. Just in case, that approach is:


### PR DESCRIPTION
I installed Monterey today and tried to install Nix from a very recent master commit and it failed. (I am not sure how the current release installer fares).

The error message from touch, which we're using as a cheap way to detect the read-only root, appears to have shifted. The change here just accepts both forms. I guess this is fine if we don't find some additional conditions that can cause this error message. (In that case we may have to fall back on a slower method of testing this.)

I've used the installer from [my own CI build of this](https://github.com/abathur/nix/runs/3668153655?check_suite_focus=true) to verify that the install works on Monterey.