### PR TITLE
SSHStore / LegacySSHStore: Show better error if the remote's stdout is polluted

### DIFF
--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -89,6 +89,8 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
                 if (magic != SERVE_MAGIC_2)
                     throw Error("'nix-store --serve' protocol mismatch from '%s'", host);
             } catch (SerialisationError & e) {
+                /* In case the other side is waiting for our input,
+                   close it. */
                 conn->sshConn->in.close();
                 auto msg = conn->from.drain();
                 throw Error("'nix-store --serve' protocol mismatch from '%s', got '%s'",

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -82,9 +82,18 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
             conn->to << SERVE_MAGIC_1 << SERVE_PROTOCOL_VERSION;
             conn->to.flush();
 
-            unsigned int magic = readInt(conn->from);
-            if (magic != SERVE_MAGIC_2)
-                throw Error("protocol mismatch with 'nix-store --serve' on '%s'", host);
+            StringSink saved;
+            try {
+                TeeSource tee(conn->from, saved);
+                unsigned int magic = readInt(tee);
+                if (magic != SERVE_MAGIC_2)
+                    throw Error("'nix-store --serve' protocol mismatch from '%s'", host);
+            } catch (SerialisationError & e) {
+                conn->sshConn->in.close();
+                auto msg = conn->from.drain();
+                throw Error("'nix-store --serve' protocol mismatch from '%s', got '%s'",
+                    host, chomp(*saved.s + msg));
+            }
             conn->remoteVersion = readInt(conn->from);
             if (GET_PROTOCOL_MAJOR(conn->remoteVersion) != 0x200)
                 throw Error("unsupported 'nix-store --serve' protocol version on '%s'", host);

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -169,6 +169,9 @@ void RemoteStore::initConnection(Connection & conn)
             if (magic != WORKER_MAGIC_2)
                 throw Error("protocol mismatch");
         } catch (SerialisationError & e) {
+            /* In case the other side is waiting for our input, close
+               it. */
+            conn.closeWrite();
             auto msg = conn.from.drain();
             throw Error("protocol mismatch, got '%s'", chomp(*saved.s + msg));
         }

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -125,13 +125,14 @@ public:
 
     struct Connection
     {
-        AutoCloseFD fd;
         FdSink to;
         FdSource from;
         unsigned int daemonVersion;
         std::chrono::time_point<std::chrono::steady_clock> startTime;
 
         virtual ~Connection();
+
+        virtual void closeWrite() = 0;
 
         std::exception_ptr processStderr(Sink * sink = 0, Source * source = 0, bool flush = true);
     };

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -57,6 +57,11 @@ private:
     struct Connection : RemoteStore::Connection
     {
         std::unique_ptr<SSHMaster::Connection> sshConn;
+
+        void closeWrite() override
+        {
+            sshConn->in.close();
+        }
     };
 
     ref<RemoteStore::Connection> openConnection() override;

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -45,6 +45,12 @@ std::string UDSRemoteStore::getUri()
 }
 
 
+void UDSRemoteStore::Connection::closeWrite()
+{
+    shutdown(fd.get(), SHUT_WR);
+}
+
+
 ref<RemoteStore::Connection> UDSRemoteStore::openConnection()
 {
     auto conn = make_ref<Connection>();

--- a/src/libstore/uds-remote-store.hh
+++ b/src/libstore/uds-remote-store.hh
@@ -40,6 +40,12 @@ public:
 
 private:
 
+    struct Connection : RemoteStore::Connection
+    {
+        AutoCloseFD fd;
+        void closeWrite() override;
+    };
+
     ref<RemoteStore::Connection> openConnection() override;
     std::optional<std::string> path;
 };


### PR DESCRIPTION
Instead of

```
error: serialised integer 7161674624452356180 is too large for type 'j'
```

we now get e.g.

```
error: 'nix-store --serve' protocol mismatch from 'sshtest@localhost', got 'This account is currently not available.'
```

Fixes https://github.com/NixOS/nixpkgs/issues/37287.