### PR TITLE
reset yylloc when yyless(0) is called

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -28,6 +28,8 @@ using namespace nix;
 
 namespace nix {
 
+// backup to recover from yyless(0)
+YYLTYPE prev_yylloc;
 
 static void initLoc(YYLTYPE * loc)
 {
@@ -38,6 +40,8 @@ static void initLoc(YYLTYPE * loc)
 
 static void adjustLoc(YYLTYPE * loc, const char * s, size_t len)
 {
+    prev_yylloc = *loc;
+
     loc->first_line = loc->last_line;
     loc->first_column = loc->last_column;
 
@@ -210,6 +214,7 @@ or          { return OR_KW; }
 {HPATH_START}\$\{ {
   PUSH_STATE(PATH_START);
   yyless(0);
+  *yylloc = prev_yylloc;
 }
 
 <PATH_START>{PATH_SEG} {
@@ -265,6 +270,7 @@ or          { return OR_KW; }
      context (it may be ')', ';', or something of that sort) */
   POP_STATE();
   yyless(0);
+  *yylloc = prev_yylloc;
   return PATH_END;
 }
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/5300

See also [this stackoverflow answer](https://stackoverflow.com/questions/59754253/yyllocp-first-line-returns-uninitialized-value-in-second-iteration-of-a-reentra) for another solution to the same problem. This seemed like a simpler / more minimal change though.