### PR TITLE
Make number of parallel substituter queries configurable

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -250,6 +250,17 @@ public:
         )",
         {"build-use-substitutes"}};
 
+    Setting<unsigned int> maxQuerySubstitutersJobs{
+        this, 25, "max-query-substituters-jobs",
+        R"(
+          This option defines the maximum number of parallel queries Nix will
+          use to ask substituters for the presence of substitutes (which is a
+          separate step from actually downloading substitutes). For builds of
+          many derivations backed by substituters supporting HTTP/2,
+          significant speedups of this step have been observed by increasing
+          this option thanks to request multiplexing.
+        )"};
+
     Setting<std::string> buildUsersGroup{
         this, "", "build-users-group",
         R"(

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -100,7 +100,7 @@ void Store::queryMissing(const std::vector<DerivedPath> & targets,
 
     downloadSize_ = narSize_ = 0;
 
-    ThreadPool pool;
+    ThreadPool pool(settings.maxQuerySubstitutersJobs);
 
     struct State
     {


### PR DESCRIPTION
This is the minimal fix for #5118. The default is taken from `http-connections`, though as stated, multiplexing can mean that a far higher number is even more effective. Still, the new default should be a sizeable improvement over the old one of `nproc` for most machines while still low enough that time and memory overhead from the additional threads should be insignificant.