### PR TITLE
nix: add (failing) selfreference test for multiple realizations

### DIFF
--- a/tests/ca/selfref-gc.sh
+++ b/tests/ca/selfref-gc.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+requireDaemonNewerThan "2.4pre20210626"
+
+sed -i 's/experimental-features .*/& ca-derivations ca-references nix-command flakes/' "$NIX_CONF_DIR"/nix.conf
+
+export NIX_TESTS_CA_BY_DEFAULT=1
+cd ..
+source ./selfref-gc.sh

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -37,6 +37,7 @@ nix_tests = \
   check.sh \
   plugins.sh \
   search.sh \
+  selfref-gc.sh ca/selfref-gc.sh \
   nix-copy-ssh.sh \
   post-hook.sh \
   ca/post-hook.sh \

--- a/tests/selfref-gc.sh
+++ b/tests/selfref-gc.sh
@@ -1,0 +1,28 @@
+source common.sh
+
+clearStore
+
+nix-build --no-out-link -E '
+  with import ./config.nix;
+
+  let d1 = mkDerivation {
+    name = "selfref-gc";
+    outputs = [ "out" ];
+    buildCommand = "
+      echo SELF_REF: $out > $out
+    ";
+  }; in
+
+  # the only change from d1 is d1 as an (unused) build input
+  # to get identical store path in CA.
+  mkDerivation {
+    name = "selfref-gc";
+    outputs = [ "out" ];
+    buildCommand = "
+      echo UNUSED: ${d1}
+      echo SELF_REF: $out > $out
+    ";
+  }
+'
+
+nix-collect-garbage


### PR DESCRIPTION
The test illustrates failure in issue #5320. Here derivation and
it's built input have identical CA sotre path. As a result we generate
extraneout reference to build input.