### PR TITLE
nix repl: properly deal with interruptions

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -396,6 +396,8 @@ bool NixRepl::processLine(string line)
 {
     if (line == "") return true;
 
+    _isInterrupted = false;
+
     string command, arg;
 
     if (line[0] == ':') {


### PR DESCRIPTION
When I stop a download with Ctrl-C in a `nix repl` of a flake, the REPL
refuses to do any other downloads:

    nix-repl> builtins.getFlake "nix-serve"
    [0.0 MiB DL] downloading 'https://api.github.com/repos/edolstra/nix-serve/tarball/e9828a9e01a14297d15ca41 error: download of 'https://api.github.com/repos/edolstra/nix-serve/tarball/e9828a9e01a14297d15ca416e5a9415d4972b0f0' was interrupted
    [0.0 MiB DL]
    nix-repl> builtins.getFlake "nix-serve"
    error: interrupted by the user
    [0.0 MiB DL]

To fix this issue, two changes were necessary:

* Reset the global `_isInterrupted` variable: only because a single
  operation was aborted, it should still be possible to continue the
  session.
* Recreate a `fileTransfer`-instance if the current one was shut down by
  an abort.

cc @edolstra 