### PR TITLE
[backport] libstore-tests: add libutil dependency (fix static link failure)

### DIFF
--- a/src/libstore/tests/local.mk
+++ b/src/libstore/tests/local.mk
@@ -10,6 +10,6 @@ libstore-tests_SOURCES := $(wildcard $(d)/*.cc)
 
 libstore-tests_CXXFLAGS += -I src/libstore -I src/libutil
 
-libstore-tests_LIBS = libstore
+libstore-tests_LIBS = libstore libutil
 
 libstore-tests_LDFLAGS := $(GTEST_LIBS)


### PR DESCRIPTION
In https://github.com/NixOS/nix/pull/5350 we noticed link failures
pkgsStatic.nixUnstable. Adding explicit dependency on libutil fixes
libstore-tests linking.

Backport from https://github.com/NixOS/nix/pull/5354