### PR TITLE
gitignore the `libstore-tests` executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ perl/Makefile.config
 
 # /src/libstore/
 *.gen.*
+/src/libstore/tests/libstore-tests
 
 # /src/libutil/
 /src/libutil/tests/libutil-tests


### PR DESCRIPTION
So that running `make` still leaves a clean tree
