### PR TITLE
mk/libraries.mk: fix trace-ld and trace-ar expansions

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -125,8 +125,8 @@ define build-library
     $(1)_PATH := $$(_d)/$$($(1)_NAME).a
 
     $$($(1)_PATH): $$($(1)_OBJS) | $$(_d)/
-	$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$?
-	$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
+	$$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$?
+	$$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
 
     $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS)
 


### PR DESCRIPTION
Noticed this minor logging deficiency when debugged --disable-shared
build:

  LD
  AR
  LD
  CXX    src/libstore/local-store.o

After the change build is logged as expected:

  LD     src/libmain/libnixmain.a
  LD     src/libfetchers/libnixfetchers.a
  AR     src/libmain/libnixmain.a
  CXX    src/libstore/local-store.o