### PR TITLE
nix develop: add --unpack

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -393,6 +393,12 @@ struct CmdDevelop : Common, MixEnvironment
         });
 
         addFlag({
+            .longName = "unpack",
+            .description = "Run the `unpack` phase.",
+            .handler = {&phase, {"unpack"}},
+        });
+
+        addFlag({
             .longName = "configure",
             .description = "Run the `configure` phase.",
             .handler = {&phase, {"configure"}},

--- a/src/nix/develop.md
+++ b/src/nix/develop.md
@@ -29,6 +29,7 @@ R""(
 * Run a particular build phase directly:
 
   ```console
+  # nix develop --unpack
   # nix develop --configure
   # nix develop --build
   # nix develop --check


### PR DESCRIPTION
this is the phase i use the most with `nix develop` and it'd be nicer to type `--unpack` instead of `--phase unpack`