### PR TITLE
(partially) Revert "Don't copy in rethrow"

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -575,7 +575,7 @@ static Bindings::iterator getAttr(
             // Adding another trace for the function name to make it clear
             // which call received wrong arguments.
             e.addTrace(pos, hintfmt("while invoking '%s'", funcName));
-            throw;
+            throw e;
         }
     }
 

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -948,7 +948,7 @@ void LocalDerivationGoal::startBuilder()
             FdSource source(builderOut.readSide.get());
             auto ex = readError(source);
             ex.addTrace({}, "while setting up the build environment");
-            throw;
+            throw ex;
         }
         debug("sandbox setup: " + msg);
         msgs.push_back(std::move(msg));


### PR DESCRIPTION
This reverts some parts of commit
8430a8f0866e4463a891ccce62779ea9ac0f3b38 which was trying to rethrow
some exceptions while we weren’t in the context of a `catch` block,
causing some weird “terminate called without an active exception”
errors.

Fix #5368
