### PR TITLE
darwin-install: fix incorrect fn name

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -78,7 +78,7 @@ poly_service_installed_check() {
 poly_service_uninstall_directions() {
     echo "$1. Remove macOS-specific components:"
     if should_create_volume && test_nix_volume_mountd_installed; then
-        darwin_volume_uninstall_directions
+        nix_volume_mountd_uninstall_directions
     fi
     if test_nix_daemon_installed; then
         nix_daemon_uninstall_directions


### PR DESCRIPTION
@matthewbauer mentioned this incorrect function name in a [commit comment](https://github.com/NixOS/nix/commit/eab14a642cbcbc35f4473888d906f9de7deda07b#r57721161) and it doesn't look like it has been PRed yet. 

The installer tests don't cover already-installed scenarios, which is when this should print, so I don't expect they'll provide any useful information here.

It should also be backported to 2.4.