### PR TITLE
fix build with gcc11

### DIFF
--- a/src/libutil/ref.hh
+++ b/src/libutil/ref.hh
@@ -17,7 +17,7 @@ private:
 
 public:
 
-    ref<T>(const ref<T> & r)
+    ref(const ref<T> & r)
         : p(r.p)
     { }
 


### PR DESCRIPTION
I cannot point to exact paragraph of C++ standard, but GCC 11 does not like this constructor and fails to compile Nix.

There is no problem with the similar constructor few lines below.

The PR does not break compilation by GCC9 and GCC10