### PR TITLE
preloadNSS / dns timeout

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -125,7 +125,9 @@ static void preloadNSS() {
        load its lookup libraries in the parent before any child gets a chance to. */
     std::call_once(dns_resolve_flag, []() {
 #ifdef __GLIBC__
-        dlopen (LIBNSS_DNS_SO, RTLD_NOW);
+        if (dlopen (LIBNSS_DNS_SO, RTLD_NOW) == NULL) {
+            printMsg(Verbosity::lvlWarn, fmt("Unable to load nss_dns backend"));
+        }
         __nss_configure_lookup ("hosts", "dns");
 #endif
     });

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -15,7 +15,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <signal.h>
+#ifdef __linux__
 #include <features.h>
+#endif
 #ifdef __GLIBC__
 #include <gnu/lib-names.h>
 #include <nss.h>

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -15,9 +15,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <signal.h>
+#include <features.h>
+#ifdef __GLIBC__
 #include <gnu/lib-names.h>
 #include <nss.h>
 #include <dlfcn.h>
+#endif
 
 #include <openssl/crypto.h>
 
@@ -121,8 +124,10 @@ static void preloadNSS() {
        been loaded in the parent. So we force a lookup of an invalid domain to force the NSS machinery to
        load its lookup libraries in the parent before any child gets a chance to. */
     std::call_once(dns_resolve_flag, []() {
+#ifdef __GLIBC__
         dlopen (LIBNSS_DNS_SO, RTLD_NOW);
         __nss_configure_lookup ("hosts", "dns");
+#endif
     });
 }
 


### PR DESCRIPTION
@tomberek was reporting dns timeout when running commands like `nix --version`.

Reading glibc again, I stumbled upon `__nss_configure_lookup` which is actually exactly what we're trying to achieve.

I think this simplifies the workaround a lot as it does not rely on a side-effect anymore, and is pretty straight-forward to understand.