### PR TITLE
Add another path where a Rosetta 2 daemon plist file is possibly located

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -148,7 +148,8 @@ StringSet Settings::getDefaultExtraPlatforms()
     // machines. Note that we can’t force processes from executing
     // x86_64 in aarch64 environments or vice versa since they can
     // always exec with their own binary preferences.
-    if (pathExists("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist")) {
+    if (pathExists("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist") ||
+        pathExists("/System/Library/LaunchDaemons/com.apple.oahd.plist")) {
         if (std::string{SYSTEM} == "x86_64-darwin")
             extraPlatforms.insert("aarch64-darwin");
         else if (std::string{SYSTEM} == "aarch64-darwin")


### PR DESCRIPTION
This PR fixes Rosetta 2 detection on macOS 11.5.0 and later.

<https://github.com/NixOS/nix/pull/4310> updated `Settings::getDefaultExtraPlatforms` to detect the presence of Rosetta 2 and include `x86_64-darwin` automatically when eligible. It does so by checking the existence of a file at `/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist`. However, [as of macOS 11.5.0](https://github.com/rtrouton/rtrouton_scripts/issues/87), this detection method stopped working because the file is now located in a different path `/System/Library/LaunchDaemons/com.apple.oahd.plist`. This PR introduces a check for this new path to fix this issue.