### PR TITLE
Restore parent mount namespace in restoreProcessContext

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -544,6 +544,14 @@ struct curlFileTransfer : public FileTransfer
             stopWorkerThread();
         });
 
+#ifdef __linux__
+        /* Cause this thread to not share any FS attributes with the main thread,
+           because this causes setns() in restoreMountNamespace() to fail.
+           Ideally, this would happen in the std::thread() constructor. */
+        if (unshare(CLONE_FS) != 0)
+            throw SysError("unsharing filesystem state in download thread");
+#endif
+
         std::map<CURL *, std::shared_ptr<TransferItem>> items;
 
         bool quit = false;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -495,6 +495,7 @@ void LocalStore::makeStoreWritable()
         throw SysError("getting info about the Nix store mount point");
 
     if (stat.f_flag & ST_RDONLY) {
+        saveMountNamespace();
         if (unshare(CLONE_NEWNS) == -1)
             throw SysError("setting up a private mount namespace");
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -300,7 +300,15 @@ void setStackSize(size_t stackSize);
 
 /* Restore the original inherited Unix process context (such as signal
    masks, stack size, CPU affinity). */
-void restoreProcessContext();
+void restoreProcessContext(bool restoreMounts = true);
+
+/* Save the current mount namespace. Ignored if called more than
+   once. */
+void saveMountNamespace();
+
+/* Restore the mount namespace saved by saveMountNamespace(). Ignored
+   if saveMountNamespace() was never called. */
+void restoreMountNamespace();
 
 
 class ExecError : public Error


### PR DESCRIPTION
This ensures any started processes can't write to /nix/store (except
during builds). This partially reverts 01d07b1e, which happened because
of #2646.

The problem was only happening after nix downloads anything, causing
me to suspect the download thread. The problem turns out to be:
"A  process  can't  join a new mount namespace if it is sharing
filesystem-related attributes with another process", in this case this
process is the curl thread.

Ideally, we might kill it before spawning the shell process, but it's
inside a static variable in the getFileTransfer() function. So
instead, stop it from sharing FS state using unshare(). A strategy
such as the one from #5057 (single-threaded chroot helper binary) is
also very much on the table.

Fixes #4337.

Thanks @puckipedia for helping with debugging and ideas.