### PR TITLE
Revert "doc: Change install syntax to be fish compatible"

### DIFF
--- a/doc/manual/installation/installing-binary.xml
+++ b/doc/manual/installation/installing-binary.xml
@@ -12,7 +12,7 @@
 </para>
 
 <screen>
-  $ curl -L https://nixos.org/nix/install | sh -s
+  $ sh &lt;(curl -L https://nixos.org/nix/install)
 </screen>
 
 <para>
@@ -39,7 +39,7 @@
     To explicitly select a single-user installation on your system:
 
     <screen>
-  curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+  sh &lt;(curl -L https://nixos.org/nix/install) --no-daemon
 </screen>
   </para>
 
@@ -97,7 +97,7 @@ $ rm -rf /nix
     installation on your system:
   </para>
 
-  <screen>curl -L https://nixos.org/nix/install | sh -s -- --daemon</screen>
+  <screen>sh &lt;(curl -L https://nixos.org/nix/install) --daemon</screen>
 
   <para>
     The multi-user installation of Nix will create build users between
@@ -178,7 +178,7 @@ sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
     is a bit of a misnomer). To use this approach, just install Nix with:
   </para>
 
-  <screen>$ curl -L https://nixos.org/nix/install | sh -s -- --darwin-use-unencrypted-nix-store-volume</screen>
+  <screen>$ sh &lt;(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume</screen>
 
   <para>
     If you don't like the sound of this, you'll want to weigh the
@@ -429,7 +429,7 @@ LABEL=Nix\040Store /nix apfs rw,nobrowse
   NixOS.org installation script:
 
   <screen>
-  curl -L https://nixos.org/nix/install | sh -s
+  sh &lt;(curl -L https://nixos.org/nix/install)
 </screen>
   </para>
 


### PR DESCRIPTION
This reverts commit ea962a84c35cb260e5feee5c5ba114f0db171055, due to #5238. In my opinion, this is the best solution until a cross shell one-liner is found that doesn't make `sh` headless.