### PR TITLE
fetchTree: add pos to EvalState::forceValue

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -121,7 +121,7 @@ static void fetchTree(
 
         for (auto & attr : *args[0]->attrs) {
             if (attr.name == state.sType) continue;
-            state.forceValue(*attr.value);
+            state.forceValue(*attr.value, *attr.pos);
             if (attr.value->type() == nPath || attr.value->type() == nString) {
                 auto s = state.coerceToString(*attr.pos, *attr.value, context, false, false);
                 attrs.emplace(attr.name,


### PR DESCRIPTION
- Improve error messages on infinite recursion by displaying the nearest position
- Demo:
  ```nix
  let x = builtins.fetchTree x;
  in x
  ```
  - Before:
    ```bash
    $ nix-instantiate --extra-experimental-features flakes --strict
    error: infinite recursion encountered
    ```
  - After:
    ```bash
    $ nix-instantiate --extra-experimental-features flakes --strict
    error: infinite recursion encountered
  
         at /data/github/kamadorueda/nix/test.nix:1:9:
  
              1| let x = builtins.fetchTree x;
               |         ^
              2| in x
- Demo:
  ```nix
  let x = builtins.fetchTree {
    type = "git";
    inherit x;
  };
  in x
  ```
  - Before:
    ```bash
    $ nix-instantiate --extra-experimental-features flakes --strict
    error: infinite recursion encountered
    ```
  - After:
    ```bash
    $ nix-instantiate --extra-experimental-features flakes --strict
    error: infinite recursion encountered
  
         at /data/github/kamadorueda/nix/test.nix:3:10:
  
              2|   type = "git";
              3|   inherit x;
               |          ^
              4| };
    ```

Mentions: #3505