### PR TITLE
nix/flake: validate `builders` from `flake` output

### DIFF
--- a/src/nix/flake-check.md
+++ b/src/nix/flake-check.md
@@ -54,6 +54,11 @@ The following flake output attributes must be *Nixpkgs overlays*:
 * `overlay`
 * `overlays`.`*name*
 
+The following flake output attributes must be functions for building
+derivations:
+
+* `builders`.`*name*
+
 The following flake output attributes must be *NixOS modules*:
 
 * `nixosModule`


### PR DESCRIPTION
While implementing a flake exposing `builders` — such as it's done in
`import-cargo`[1] — I realized that `nix flake check` doesn't seem to
allow such an output:

    $ nix flake check
    warning: unknown flake output 'builders'

I actually think that this is a valid field and added an actual validator
which expects lambdas being exposed inside.

Also fixed a minor typo in the `bundler`-check.

[1] https://github.com/edolstra/import-cargo

cc @edolstra 