### PR TITLE
Allow to disable global flake-registry with ""

### DIFF
--- a/src/libfetchers/fetch-settings.hh
+++ b/src/libfetchers/fetch-settings.hh
@@ -71,7 +71,12 @@ struct FetchSettings : public Config
         "Whether to warn about dirty Git/Mercurial trees."};
 
     Setting<std::string> flakeRegistry{this, "https://channels.nixos.org/flake-registry.json", "flake-registry",
-        "Path or URI of the global flake registry."};
+        R"(
+          Path or URI of the global flake registry.
+
+          When empty, disables the global flake registry.
+        )"};
+
 
     Setting<bool> useRegistries{this, true, "use-registries",
         "Whether to use flake registries to resolve flake references."};

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -153,6 +153,9 @@ static std::shared_ptr<Registry> getGlobalRegistry(ref<Store> store)
 {
     static auto reg = [&]() {
         auto path = fetchSettings.flakeRegistry.get();
+        if (path == "") {
+            return std::make_shared<Registry>(Registry::Global); // empty registry
+        }
 
         if (!hasPrefix(path, "/")) {
             auto storePath = downloadFile(store, path, "flake-registry.json", false).storePath;

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -74,8 +74,10 @@ nix registry add --registry $registry flake3 git+file://$flake3Dir
 nix registry add --registry $registry flake4 flake3
 nix registry add --registry $registry nixpkgs flake1
 
-# Test 'nix flake list'.
+# Test 'nix registry list'.
 [[ $(nix registry list | wc -l) == 5 ]]
+nix registry list | grep -q    '^global'
+nix registry list | grep -q -v '^user' # nothing in user registry
 
 # Test 'nix flake metadata'.
 nix flake metadata flake1
@@ -338,6 +340,16 @@ nix registry pin flake1
 nix registry pin flake1 flake3
 [[ $(nix registry list | wc -l) == 6 ]]
 nix registry remove flake1
+[[ $(nix registry list | wc -l) == 5 ]]
+
+# Test 'nix registry list' with a disabled global registry.
+nix registry add user-flake1 git+file://$flake1Dir
+nix registry add user-flake2 git+file://$flake2Dir
+[[ $(nix --flake-registry "" registry list | wc -l) == 2 ]]
+nix --flake-registry "" registry list | grep -q -v '^global' # nothing in global registry
+nix --flake-registry "" registry list | grep -q    '^user'
+nix registry remove user-flake1
+nix registry remove user-flake2
 [[ $(nix registry list | wc -l) == 5 ]]
 
 # Test 'nix flake clone'.


### PR DESCRIPTION
Closes #4874

I'm not sure why the implementation of `getGlobalRegistry` was wrapped in a lambda, but returning nullptr from it made the compiler not able to find a type for both nullptr and Registry for the lambda..
So I simply removed the lambda, problem solved AFAI can see.