### PR TITLE
Fix devShell build on non-NixOS with a different boost version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
 
         configureFlags =
           lib.optionals stdenv.isLinux [
+            "--with-boost=${boost}/lib"
             "--with-sandbox-shell=${sh}/bin/busybox"
             "LDFLAGS=-fuse-ld=gold"
           ];


### PR DESCRIPTION
On Archlinux, I have the `boost` and `boost-libs` arch packages installed, both at version 1.76.0.
When starting a `nix develop` (or `nix-shell`) and run the boostrap, configure and make step, make would fail when linking `nix` with:

```
% make
[...]
  LD     /path/to/my/repos/nix/outputs/out/bin/nix
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: warning: libboost_context.so.1.76.0, needed by /path/to/my/repos/nix/outputs/out/lib/libnixexpr.so, not found (try using -rpath or -rpath-link)
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_easy_getinfo@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_perform@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_cleanup@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_global_init@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_info_read@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_slist_free_all@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_easy_strerror@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_easy_setopt@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_easy_init@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixutil.so: undefined reference to `jump_fcontext'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_slist_append@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_add_handle@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_remove_handle@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_setopt@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixutil.so: undefined reference to `make_fcontext'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixexpr.so: undefined reference to `boost::context::stack_traits::default_size()'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixutil.so: undefined reference to `ontop_fcontext'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_easy_cleanup@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixexpr.so: undefined reference to `boost::context::stack_traits::page_size()'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_init@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_strerror@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_multi_wait@CURL_OPENSSL_4'
/nix/store/5ddb4j8z84p6sjphr0kh6cbq5jd12ncs-binutils-2.35.1/bin/ld: /path/to/my/repos/nix/outputs/out/lib/libnixstore.so: undefined reference to `curl_easy_reset@CURL_OPENSSL_4'
collect2: error: ld returned 1 exit status
make: *** [mk/lib.mk:118: /path/to/my/repos/nix/outputs/out/bin/nix] Error 1
```
After discussion on Matrix with @Enzime, it seems to be the configure step that uses the system boost instead of the one from Nix.