### PR TITLE
toJSON: report error position for fancier output

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1008,7 +1008,7 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
                     if (i->name == state.sStructuredAttrs) continue;
 
                     auto placeholder(jsonObject->placeholder(key));
-                    printValueAsJSON(state, true, *i->value, placeholder, context);
+                    printValueAsJSON(state, true, *i->value, pos, placeholder, context);
 
                     if (i->name == state.sBuilder)
                         drv.builder = state.forceString(*i->value, context, posDrvName);
@@ -1687,7 +1687,7 @@ static void prim_toJSON(EvalState & state, const Pos & pos, Value * * args, Valu
 {
     std::ostringstream out;
     PathSet context;
-    printValueAsJSON(state, true, *args[0], out, context);
+    printValueAsJSON(state, true, *args[0], pos, out, context);
     mkString(v, out.str(), context);
 }
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -40,7 +40,7 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
 
         case nAttrs: {
-            auto maybeString = state.tryAttrsToString(noPos, v, context, false, false);
+            auto maybeString = state.tryAttrsToString(pos, v, context, false, false);
             if (maybeString) {
                 out.write(*maybeString);
                 break;
@@ -79,16 +79,12 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
 
         case nThunk:
-            throw TypeError({
-                .msg = hintfmt("cannot convert %1% to JSON", showType(v)),
-                .errPos = pos
-            });
-
         case nFunction:
-            throw TypeError({
+            auto e = TypeError({
                 .msg = hintfmt("cannot convert %1% to JSON", showType(v)),
-                .errPos = pos
+                .errPos = v.determinePos(pos)
             });
+            throw e.addTrace(pos, hintfmt("message for the trace"));
     }
 }
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -10,11 +10,11 @@
 namespace nix {
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, JSONPlaceholder & out, PathSet & context)
+    Value & v, const Pos & pos, JSONPlaceholder & out, PathSet & context)
 {
     checkInterrupt();
 
-    if (strict) state.forceValue(v);
+    if (strict) state.forceValue(v, pos);
 
     switch (v.type()) {
 
@@ -54,10 +54,10 @@ void printValueAsJSON(EvalState & state, bool strict,
                 for (auto & j : names) {
                     Attr & a(*v.attrs->find(state.symbols.create(j)));
                     auto placeholder(obj.placeholder(j));
-                    printValueAsJSON(state, strict, *a.value, placeholder, context);
+                    printValueAsJSON(state, strict, *a.value, *a.pos, placeholder, context);
                 }
             } else
-                printValueAsJSON(state, strict, *i->value, out, context);
+                printValueAsJSON(state, strict, *i->value, *i->pos, out, context);
             break;
         }
 
@@ -65,7 +65,7 @@ void printValueAsJSON(EvalState & state, bool strict,
             auto list(out.list());
             for (unsigned int n = 0; n < v.listSize(); ++n) {
                 auto placeholder(list.placeholder());
-                printValueAsJSON(state, strict, *v.listElems()[n], placeholder, context);
+                printValueAsJSON(state, strict, *v.listElems()[n], noPos, placeholder, context);
             }
             break;
         }
@@ -79,18 +79,24 @@ void printValueAsJSON(EvalState & state, bool strict,
             break;
 
         case nThunk:
-            throw TypeError("cannot convert %1% to JSON", showType(v));
+            throw TypeError({
+                .msg = hintfmt("cannot convert %1% to JSON", showType(v)),
+                .errPos = pos
+            });
 
         case nFunction:
-            throw TypeError("cannot convert %1% to JSON", showType(v));
+            throw TypeError({
+                .msg = hintfmt("cannot convert %1% to JSON", showType(v)),
+                .errPos = pos
+            });
     }
 }
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, std::ostream & str, PathSet & context)
+    Value & v, const Pos & pos, std::ostream & str, PathSet & context)
 {
     JSONPlaceholder out(str);
-    printValueAsJSON(state, strict, v, out, context);
+    printValueAsJSON(state, strict, v, pos, out, context);
 }
 
 void ExternalValueBase::printValueAsJSON(EvalState & state, bool strict,

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -65,7 +65,7 @@ void printValueAsJSON(EvalState & state, bool strict,
             auto list(out.list());
             for (unsigned int n = 0; n < v.listSize(); ++n) {
                 auto placeholder(list.placeholder());
-                printValueAsJSON(state, strict, *v.listElems()[n], noPos, placeholder, context);
+                printValueAsJSON(state, strict, *v.listElems()[n], pos, placeholder, context);
             }
             break;
         }

--- a/src/libexpr/value-to-json.hh
+++ b/src/libexpr/value-to-json.hh
@@ -11,9 +11,9 @@ namespace nix {
 class JSONPlaceholder;
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, JSONPlaceholder & out, PathSet & context);
+    Value & v, const Pos & pos, JSONPlaceholder & out, PathSet & context);
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, std::ostream & str, PathSet & context);
+    Value & v, const Pos & pos, std::ostream & str, PathSet & context);
 
 }

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -879,7 +879,7 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems)
                 placeholder.write(nullptr);
             } else {
                 PathSet context;
-                printValueAsJSON(*globals.state, true, *v, placeholder, context);
+                printValueAsJSON(*globals.state, true, *v, noPos, placeholder, context);
             }
         }
     }

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -52,7 +52,7 @@ void processExpr(EvalState & state, const Strings & attrPaths,
             if (output == okXML)
                 printValueAsXML(state, strict, location, vRes, std::cout, context);
             else if (output == okJSON)
-                printValueAsJSON(state, strict, vRes, noPos, std::cout, context);
+                printValueAsJSON(state, strict, vRes, v.determinePos(noPos), std::cout, context);
             else {
                 if (strict) state.forceValueDeep(vRes);
                 std::cout << vRes << std::endl;

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -52,7 +52,7 @@ void processExpr(EvalState & state, const Strings & attrPaths,
             if (output == okXML)
                 printValueAsXML(state, strict, location, vRes, std::cout, context);
             else if (output == okJSON)
-                printValueAsJSON(state, strict, vRes, std::cout, context);
+                printValueAsJSON(state, strict, vRes, noPos, std::cout, context);
             else {
                 if (strict) state.forceValueDeep(vRes);
                 std::cout << vRes << std::endl;

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -112,7 +112,7 @@ struct CmdEval : MixJSON, InstallableCommand
 
         else if (json) {
             JSONPlaceholder jsonOut(std::cout);
-            printValueAsJSON(*state, true, *v, jsonOut, context);
+            printValueAsJSON(*state, true, *v, pos, jsonOut, context);
         }
 
         else {


### PR DESCRIPTION
Given flake:

```nix
{ description = "nix json error provenance";
  inputs = {};
  outputs = { self }: {
    jsonFunction = _: "function";
    json = builtins.toJSON (_: "function");
  };
}

```
- Before:

```console
❯ nix eval --json .#jsonFunction
error: cannot convert a function to JSON
```

- After:

```console
❯ nix eval --json .#jsonFunction
error: cannot convert a function to JSON

       at /nix/store/b7imf1c2j4jnkg3ys7fsfbj02s5j0i4f-source/testflake/flake.nix:4:5:

            3|   outputs = { self }: {
            4|     jsonFunction = _: "function";
             |     ^
            5|     json = builtins.toJSON (_: "function");
```
