### PR TITLE
run: use pname a fallback for main program

### DIFF
--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -83,11 +83,14 @@ UnresolvedApp Installable::toApp(EvalState & state)
         auto outPath = cursor->getAttr(state.sOutPath)->getString();
         auto outputName = cursor->getAttr(state.sOutputName)->getString();
         auto name = cursor->getAttr(state.sName)->getString();
+        auto aPname = cursor->maybeGetAttr("pname");
         auto aMeta = cursor->maybeGetAttr("meta");
         auto aMainProgram = aMeta ? aMeta->maybeGetAttr("mainProgram") : nullptr;
         auto mainProgram =
             aMainProgram
             ? aMainProgram->getString()
+            : aPname
+            ? aPname->getString()
             : DrvName(name).name;
         auto program = outPath + "/bin/" + mainProgram;
         return UnresolvedApp { App {

--- a/src/nix/run.md
+++ b/src/nix/run.md
@@ -44,9 +44,10 @@ program specified by the app definition.
 If *installable* evaluates to a derivation, it will try to execute the
 program `<out>/bin/<name>`, where *out* is the primary output store
 path of the derivation and *name* is the `meta.mainProgram` attribute
-of the derivation if it exists, and otherwise the name part of the
-value of the `name` attribute of the derivation (e.g. if `name` is set
-to `hello-1.10`, it will run `$out/bin/hello`).
+of the derivation if it exists, and otherwise the `pname` attribute of
+the derivation or the name part of the value of the `name` attribute of
+the derivation (e.g. if `name` is set to `hello-1.10`, it will run
+`$out/bin/hello`).
 
 # Flake output attributes
 


### PR DESCRIPTION
fallback: meta.mainProgram -> pname -> drvName(name)

see https://github.com/NixOS/nixpkgs/pull/142474