### PR TITLE
libstore/machines: catch `stoull`-error and provide a better error message

### DIFF
--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -83,6 +83,20 @@ ref<Store> Machine::openStore() const {
     return nix::openStore(storeUri, storeParams);
 }
 
+unsigned long long stoull_machine_arg(std::vector<std::string> & machine, int at, const std::string & type)
+{
+    try {
+        return std::stoull(machine[at]);
+    } catch (std::invalid_argument) {
+        throw FormatError(
+            "Cannot " ANSI_BOLD "stoull" ANSI_NORMAL " '%s'! Argument '%d' is supposed to be a '%s'!",
+            machine[at],
+            at + 1,
+            type
+        );
+    }
+}
+
 void parseMachines(const std::string & s, Machines & machines)
 {
     for (auto line : tokenizeString<std::vector<string>>(s, "\n;")) {
@@ -114,8 +128,8 @@ void parseMachines(const std::string & s, Machines & machines)
         machines.emplace_back(tokens[0],
             isSet(1) ? tokenizeString<std::vector<string>>(tokens[1], ",") : std::vector<string>{settings.thisSystem},
             isSet(2) ? tokens[2] : "",
-            isSet(3) ? std::stoull(tokens[3]) : 1LL,
-            isSet(4) ? std::stoull(tokens[4]) : 1LL,
+            isSet(3) ? stoull_machine_arg(tokens, 3, "max jobs") : 1LL,
+            isSet(4) ? stoull_machine_arg(tokens, 4, "speed factor") : 1LL,
             isSet(5) ? tokenizeString<std::set<string>>(tokens[5], ",") : std::set<string>{},
             isSet(6) ? tokenizeString<std::set<string>>(tokens[6], ",") : std::set<string>{},
             isSet(7) ? tokens[7] : "");

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -22,6 +22,13 @@ builders=(
 chmod -R +w $TEST_ROOT/machine* || true
 rm -rf $TEST_ROOT/machine* || true
 
+out="$(nix-build $file \
+  --builders "ssh://localhost?remote-store=$TEST_ROOT/machine3 x86_64-linux - foo bar" \
+  --store $TEST_ROOT/machine0 \
+  --arg busybox $busybox 2>&1)" || true
+
+[[ "$out" =~ .*"Cannot stoull 'bar'! Argument '5' is supposed to be a 'speed factor'!".* ]]
+
 # Note: ssh://localhost bypasses ssh, directly invoking nix-store as a
 # child process. This allows us to test LegacySSHStore::buildDerivation().
 # ssh-ng://... likewise allows us to test RemoteStore::buildDerivation().


### PR DESCRIPTION
Quite recently I got the order of arguments wrong while doing a
remote-build with `nix-build --builders` that resulted in the following,
rather unhelpful error:

    $ nix-build -A grafana -j0 \
        --option builders 'ssh://ma27@builder x86_64-linux 32 32 big-parallel'
    error: stoull
    error: unexpected EOF reading a line
    (use '--show-trace' to show detailed location information)

This is because I forgot that argument `3' is supposed to be the SSH key
and thus the speed-factor was `big-parallel`. I decided to wrap the
calls to `std::stoull` and provide a more meaningful error if this
happens:

    error: Cannot stoull 'big-parallel'! Argument '5' is supposed to be a 'speed factor'!
    error: unexpected EOF reading a line

cc @edolstra 