### PR TITLE
Apply a 60-minute timeout to the 'tests' workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,18 @@
 name: "Test"
+
 on:
   pull_request:
   push:
+
 jobs:
+
   tests:
     needs: [check_cachix]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2.3.5
       with:
@@ -23,6 +26,7 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
+
   check_cachix:
     name: Cachix secret present for installer tests
     runs-on: ubuntu-latest
@@ -34,6 +38,7 @@ jobs:
         env:
           _CACHIX_SECRETS: ${{ secrets.CACHIX_SIGNING_KEY }}${{ secrets.CACHIX_AUTH_TOKEN }}
         run: echo "::set-output name=secret::${{ env._CACHIX_SECRETS != '' }}"
+
   installer:
     needs: [tests, check_cachix]
     if: github.event_name == 'push' && needs.check_cachix.outputs.secret == 'true'
@@ -53,6 +58,7 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - id: prepare-installer
       run: scripts/prepare-installer-for-github-actions
+
   installer_test:
     needs: [installer, check_cachix]
     if: github.event_name == 'push' && needs.check_cachix.outputs.secret == 'true'


### PR DESCRIPTION
The default is 6 hours which is a lot if the job hangs.