### PR TITLE
installer: Do not use echo -e in #!/bin/sh script

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -215,7 +215,7 @@ if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
         if [ -w "$fn" ]; then
             if ! grep -q "$p" "$fn"; then
                 echo "modifying $fn..." >&2
-                echo -e "\nif [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
+                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p" "$p" >> "$fn"
             fi
             added=1
             break
@@ -226,7 +226,7 @@ if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
         if [ -w "$fn" ]; then
             if ! grep -q "$p" "$fn"; then
                 echo "modifying $fn..." >&2
-                echo -e "\nif [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
+                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p" "$p" >> "$fn"
             fi
             added=1
             break


### PR DESCRIPTION
ShellCheck correctly warns:

```
In scripts/install-nix-from-closure.sh line 218:
                echo -e "\nif [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
                     ^-- SC3037: In POSIX sh, echo flags are undefined.

In scripts/install-nix-from-closure.sh line 229:
                echo -e "\nif [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
                     ^-- SC3037: In POSIX sh, echo flags are undefined.
```

Indeed, this actually breaks on Ubuntu where `/bin/sh` is `dash`.

Fixes #5458.