### PR TITLE
[2.4] installer: Do not use echo -e in #!/bin/sh script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
       with:
         fetch-depth: 0
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@v14.1
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v10
       if: needs.check_cachix.outputs.secret == 'true'
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 0
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@v14.1
     - uses: cachix/cachix-action@v10
       with:
         name: '${{ env.CACHIX_NAME }}'
@@ -63,7 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@v14.1
       with:
         install_url: '${{needs.installer.outputs.installerURL}}'
         install_options: "--tarball-url-prefix https://${{ env.CACHIX_NAME }}.cachix.org/serve"

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -215,7 +215,7 @@ if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
         if [ -w "$fn" ]; then
             if ! grep -q "$p" "$fn"; then
                 echo "modifying $fn..." >&2
-                echo -e "\nif [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
+                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p" "$p" >> "$fn"
             fi
             added=1
             break
@@ -226,7 +226,7 @@ if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
         if [ -w "$fn" ]; then
             if ! grep -q "$p" "$fn"; then
                 echo "modifying $fn..." >&2
-                echo -e "\nif [ -e $p ]; then . $p; fi # added by Nix installer" >> "$fn"
+                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p" "$p" >> "$fn"
             fi
             added=1
             break

--- a/tests/eval-store.sh
+++ b/tests/eval-store.sh
@@ -1,6 +1,8 @@
 source common.sh
 
-requireDaemonNewerThan "2.4pre20210727"
+# Using `--eval-store` with the daemon will eventually copy everything
+# to the build store, invalidating most of the tests here
+needLocalStore
 
 eval_store=$TEST_ROOT/eval-store
 


### PR DESCRIPTION
Cherry-pick to 2.4-maintenance:

* 0b55c8767dfa15540f47579442350ffad51fc047 “Disable the eval-store test when using the daemon” from #5390
  * for passing CI
* 8a3746de0a3a78abdab09fb7e194c58b9bd16172 “install-nix-actionv@v14.1”
  * for passing CI
* #5459
  * fixes #5458