### PR TITLE
command-ref/nix-shell: fix --pure, --keep

### DIFF
--- a/doc/manual/src/command-ref/nix-shell.md
+++ b/doc/manual/src/command-ref/nix-shell.md
@@ -11,8 +11,8 @@
   [`--command` *cmd*]
   [`--run` *cmd*]
   [`--exclude` *regexp*]
-  [--pure]
-  [--keep *name*]
+  [`--pure`]
+  [`--keep` *name*]
   {{`--packages` | `-p`} {*packages* | *expressions*} … | [*path*]}
 
 # Description


### PR DESCRIPTION
Currently `man nix-shell` outputs (`–pure` instead of `--pure`):

```
Synopsis
       nix-shell [--arg name value] [--argstr name value] [{--attr | -A} attrPath] [--command cmd] [--run
       cmd] [--exclude regexp] [–pure] [–keep name] {{--packages | -p} {packages | expressions} … | [path]}
```