### PR TITLE
libstore: Use unix-dotfile vfs if useSQLiteWAL is false

### DIFF
--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -1,4 +1,5 @@
 #include "sqlite.hh"
+#include "globals.hh"
 #include "util.hh"
 
 #include <sqlite3.h>
@@ -27,8 +28,12 @@ namespace nix {
 
 SQLite::SQLite(const Path & path, bool create)
 {
+    // useSQLiteWAL also indicates what virtual file system we need.  Using
+    // `unix-dotfile` is needed on NFS file systems and on Windows' Subsystem
+    // for Linux (WSL) where useSQLiteWAL should be false by default.
+    const char *vfs = settings.useSQLiteWAL ? 0 : "unix-dotfile";
     if (sqlite3_open_v2(path.c_str(), &db,
-            SQLITE_OPEN_READWRITE | (create ? SQLITE_OPEN_CREATE : 0), 0) != SQLITE_OK)
+            SQLITE_OPEN_READWRITE | (create ? SQLITE_OPEN_CREATE : 0), vfs) != SQLITE_OK)
         throw Error("cannot open SQLite database '%s'", path);
 
     if (sqlite3_busy_timeout(db, 60 * 60 * 1000) != SQLITE_OK)


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/2357 . cc @wmertens @veprbl 

I don't know how to test this, since I don't know how to reproduce the sqlite db corruption issue mentioned in https://nixos.wiki/wiki/Nix_Installation_Guide#NFS . I also rarely write C code so this is probably wrong.

I also hope I got the logic correct.