### PR TITLE
Fix `nix repl`’s building of CA derivations

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -504,8 +504,8 @@ bool NixRepl::processLine(string line)
             state->store->buildPaths({DerivedPath::Built{drvPath}});
             auto drv = state->store->readDerivation(drvPath);
             logger->cout("\nThis derivation produced the following outputs:");
-            for (auto & i : drv.outputsAndOptPaths(*state->store))
-                logger->cout("  %s -> %s", i.first, state->store->printStorePath(*i.second.second));
+            for (auto & [outputName, outputPath] : state->store->queryDerivationOutputMap(drvPath))
+                logger->cout("  %s -> %s", outputName, state->store->printStorePath(outputPath));
         } else if (command == ":i") {
             runNix("nix-env", {"-i", drvPathRaw});
         } else {

--- a/tests/ca/repl.sh
+++ b/tests/ca/repl.sh
@@ -1,0 +1,5 @@
+source common.sh
+
+export NIX_TESTS_CA_BY_DEFAULT=1
+
+cd .. && source repl.sh

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -48,7 +48,7 @@ nix_tests = \
   flakes.sh \
   build.sh \
   compute-levels.sh \
-  repl.sh \
+  repl.sh ca/repl.sh \
   ca/build.sh \
   ca/build-with-garbage-path.sh \
   ca/duplicate-realisation-in-closure.sh \

--- a/tests/repl.sh
+++ b/tests/repl.sh
@@ -7,7 +7,9 @@ simple = import ./simple.nix
 
 testRepl () {
     local nixArgs=("$@")
-    local outPath=$(nix repl "${nixArgs[@]}" <<< "$replCmds" |&
+    local replOutput="$(nix repl "${nixArgs[@]}" <<< "$replCmds")"
+    echo "$replOutput"
+    local outPath=$(echo "$replOutput" |&
         grep -o -E "$NIX_STORE_DIR/\w*-simple")
     nix path-info "${nixArgs[@]}" "$outPath"
 }


### PR DESCRIPTION
When running a `:b` command in the repl, after building the derivations query the store for its outputs rather than just assuming that they are known in the derivation itself (which isn’t true for CA derivations).

Fix #5328

/cc @trofi 