### PR TITLE
In checkOverlay, accept underscored names for final/prev args.

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -346,10 +346,14 @@ struct CmdFlakeCheck : FlakeCommand
         auto checkOverlay = [&](const std::string & attrPath, Value & v, const Pos & pos) {
             try {
                 state->forceValue(v, pos);
-                if (!v.isLambda() || v.lambda.fun->hasFormals() || std::string(v.lambda.fun->arg) != "final")
+                if (!v.isLambda() || v.lambda.fun->hasFormals() ||
+                    (std::string(v.lambda.fun->arg) != "final" &&
+                        std::string(v.lambda.fun->arg) != "_final"))
                     throw Error("overlay does not take an argument named 'final'");
                 auto body = dynamic_cast<ExprLambda *>(v.lambda.fun->body);
-                if (!body || body->hasFormals() || std::string(body->arg) != "prev")
+                if (!body || body->hasFormals() ||
+                    (std::string(body->arg) != "prev" &&
+                        std::string(body->arg) != "_prev"))
                     throw Error("overlay does not take an argument named 'prev'");
                 // FIXME: if we have a 'nixpkgs' input, use it to
                 // evaluate the overlay.


### PR DESCRIPTION
I wonder if this would be an acceptable quick fix for a pain point I and some others have with `flake check`. I'd like to be able to run `nix-linter` within `checks`, via `pre-commit-hooks`. But `nix-linter` and `flake check` disagree with each other: the linter forbids unused arguments unless they are ‘unnamed’ (`_`) or prefixed with `_`, but check requires exactly the names `final` and `prev` for overlay arguments, even if they are unused.

This just adds the capability to use `_final`/`_prev` in addition to `final`/`prev`, respectively.

Resolves #4416, see also #5146.