### PR TITLE
Nix 2.3 Backport: PathSubstitutionGoal: Clean up pipe

### DIFF
--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -190,7 +190,6 @@ public:
 class AutoCloseFD
 {
     int fd;
-    void close();
 public:
     AutoCloseFD();
     AutoCloseFD(int fd);
@@ -202,6 +201,7 @@ public:
     int get() const;
     explicit operator bool() const;
     int release();
+    void close();
 };
 
 
@@ -210,6 +210,7 @@ class Pipe
 public:
     AutoCloseFD readSide, writeSide;
     void create();
+    void close();
 };
 
 


### PR DESCRIPTION
If there were many top-level goals (which are not destroyed until the
very end), commands like

```
  $ nix copy --to 'ssh://localhost?remote-store=/tmp/nix' \
    /run/current-system --no-check-sigs --substitute-on-destination
```
could fail with "Too many open files". So now we do some explicit
cleanup from amDone(). It would be cleaner to separate goals from
their temporary internal state, but that would be a bigger refactor.

Backport 8a29052cb2f52ef2c82c36fb3818fd0f66349729