### PR TITLE
docs: Correct fallback user config path

### DIFF
--- a/doc/manual/src/command-ref/conf-file-prefix.md
+++ b/doc/manual/src/command-ref/conf-file-prefix.md
@@ -17,7 +17,7 @@ By default Nix reads settings from the following places:
 
     Otherwise it will look for `nix/nix.conf` files in `XDG_CONFIG_DIRS`
     and `XDG_CONFIG_HOME`. If these are unset, it will look in
-    `$HOME/.config/nix.conf`.
+    `$HOME/.config/nix/nix.conf`.
 
   - If `NIX_CONFIG` is set, its contents is treated as the contents of
     a configuration file.


### PR DESCRIPTION
This is in line with XDG Base Directory Specification, where ~/.config is supposed to be used when XDG_CONFIG_HOME is unset.

It also better matches the reality, where ~/.config/nix.conf does not seem to be used.

I tested it by unsetting `XDG_CONFIG_HOME` variable and adding `experimental-features = foo` to `~/.config/nix/nix.conf`. It did have the effect of overriding my global `experimental-features = nix-command`. Unlike `~/.config/nix.conf`.