### PR TITLE
A different take on git submodule support for flakes

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -727,9 +727,10 @@ Fingerprint LockedFlake::getFingerprint() const
     // and we haven't changed it, then it's sufficient to use
     // flake.sourceInfo.storePath for the fingerprint.
     return hashString(htSHA256,
-        fmt("%s;%s;%d;%d;%s",
+        fmt("%s;%s;%s;%d;%d;%s",
             flake.sourceInfo->storePath.to_string(),
             flake.lockedRef.subdir,
+            flake.lockedRef.input.getModules().value_or(""),
             flake.lockedRef.input.getRevCount().value_or(0),
             flake.lockedRef.input.getLastModified().value_or(0),
             lockFile));

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -9,6 +9,8 @@
 #include <iomanip>
 #include <regex>
 
+#include <nlohmann/json.hpp>
+
 namespace nix {
 
 void emitTreeAttrs(
@@ -20,7 +22,6 @@ void emitTreeAttrs(
     bool forceDirty)
 {
     assert(input.isImmutable());
-
     state.mkAttrs(v, 9);
 
     auto storePath = state.store->printStorePath(tree.storePath);
@@ -36,8 +37,12 @@ void emitTreeAttrs(
 
     if (input.getType() == "git") {
         Value *modules = state.allocAttr(v, state.symbols.create("modules"));
-        state.mkAttrs(*modules, input.modules.size());
-        for (auto & [path, url] : input.modules) {
+
+        auto modulesJson = fetchers::getStrAttr(input.attrs, "modules");
+        auto modulesInfo = fetchers::jsonToAttrs(nlohmann::json::parse(modulesJson));
+
+        state.mkAttrs(*modules, modulesInfo.size());
+        for (auto & [path, url] : modulesInfo) {
             Value *vUrl = state.allocValue();
             mkString(*vUrl, std::get<string>(url).c_str());
             modules->attrs->push_back(Attr(state.symbols.create(path), vUrl));

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -257,6 +257,13 @@ std::optional<time_t> Input::getLastModified() const
     return {};
 }
 
+std::optional<std::string> Input::getModules() const
+{
+    if (auto s = maybeGetStrAttr(attrs, "modules"))
+        return *s;
+    return {};
+}
+
 ParsedURL InputScheme::toURL(const Input & input)
 {
     throw Error("don't know how to convert input '%s' to a URL", attrsToJSON(input.attrs));

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -95,6 +95,7 @@ public:
     std::optional<Hash> getRev() const;
     std::optional<uint64_t> getRevCount() const;
     std::optional<time_t> getLastModified() const;
+    std::optional<std::string> getModules() const;
 };
 
 

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -35,6 +35,7 @@ struct Input
 
     std::shared_ptr<InputScheme> scheme; // note: can be null
     Attrs attrs;
+    Attrs modules;
     bool immutable = false;
     bool direct = true;
 

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -35,7 +35,6 @@ struct Input
 
     std::shared_ptr<InputScheme> scheme; // note: can be null
     Attrs attrs;
-    Attrs modules;
     bool immutable = false;
     bool direct = true;
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -113,12 +113,12 @@ static Attrs readSubmodules(const Path & path, const string & gitrev)
     printTalkative("submodule file %s", submodules);
 
     auto parsedModules = parseSubmodules(submodules);
-    for (auto & [path, url] : parsedModules) {
-      printTalkative("submodule %s fetched from %s", path, url);
-      auto commitHash = findCommitHash(path, entries, path);
+    for (auto & [subPath, url] : parsedModules) {
+      printTalkative("submodule %s fetched from %s", subPath, url);
+      auto commitHash = findCommitHash(path, entries, subPath);
       printTalkative("found %s", commitHash);
 
-      attrs.emplace(path, url + "?rev=" + commitHash);
+      attrs.emplace(subPath, url + "?rev=" + commitHash);
     }
 
     return attrs;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -61,7 +61,7 @@ std::pair<bool, std::string> getActualUrl(const Input &input) {
 std::string getGitDir(const std::string & actualUrl) {
   auto gitDir = actualUrl + "/.git";
   auto commonGitDir = chomp(runProgram(
-      "git", true, {"-C", actualUrl, "rev-parse", "--git-common-dir"}));
+      "git", true, {"-C", actualUrl, "rev-parse", "--path-format=absolute", "--git-common-dir"}));
   if (commonGitDir != ".git")
     gitDir = commonGitDir;
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -118,7 +118,13 @@ static Attrs readSubmodules(const Path & path, const string & gitrev)
       auto commitHash = findCommitHash(path, entries, subPath);
       printTalkative("found %s", commitHash);
 
-      attrs.emplace(subPath, url + "?rev=" + commitHash);
+      static const std::regex barePathRegex("^/.*$");
+      std::string prefix = "git+";
+      if (std::regex_match(url, barePathRegex))
+          prefix = prefix + "file://";
+
+
+      attrs.emplace(subPath, prefix + url + "?allRefs=1&rev=" + commitHash);
     }
 
     return attrs;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -167,7 +167,7 @@ struct GitInputScheme : InputScheme
         if (maybeGetStrAttr(attrs, "type") != "git") return {};
 
         for (auto & [name, value] : attrs)
-            if (name != "type" && name != "url" && name != "ref" && name != "rev" && name != "shallow" && name != "submodules" && name != "lastModified" && name != "revCount" && name != "narHash" && name != "allRefs" && name != "name")
+            if (name != "type" && name != "url" && name != "ref" && name != "rev" && name != "shallow" && name != "submodules" && name != "lastModified" && name != "revCount" && name != "narHash" && name != "allRefs" && name != "name" && name != "modules")
                 throw Error("unsupported Git input attribute '%s'", name);
 
         parseURL(getStrAttr(attrs, "url"));

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -329,11 +329,14 @@ struct GitInputScheme : InputScheme
 
             /* Check whether this repo has any commits. There are
                probably better ways to do this. */
-            auto gitDir = chomp(runProgram(
+            auto gitDir = actualUrl + "/.git";
+            auto commonGitDir = chomp(runProgram(
                 "git",
                 true,
                 { "-C", actualUrl, "rev-parse", "--git-common-dir" }
             ));
+            if (commonGitDir != ".git")
+                    gitDir = commonGitDir;
 
             bool haveCommits = !readDirectory(gitDir + "/refs/heads").empty();
 
@@ -574,7 +577,7 @@ struct GitInputScheme : InputScheme
 
         auto lastModified = std::stoull(runProgram("git", true, { "-C", repoDir, "log", "-1", "--format=%ct", "--no-show-signature", input.getRev()->gitRev() }));
         auto rev = input.getRev()->gitRev();
-        auto modulesInfo = readSubmodules(actualUrl, rev);
+        auto modulesInfo = readSubmodules(repoDir, rev);
 
         Attrs infoAttrs({
             {"rev", rev},

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -389,7 +389,10 @@ struct GitInputScheme : InputScheme
                     "lastModified",
                     haveCommits ? std::stoull(runProgram("git", true, { "-C", actualUrl, "log", "-1", "--format=%ct", "--no-show-signature", "HEAD" })) : 0);
 
-                input.attrs.insert_or_assign("modules", "{}");
+                input.attrs.insert_or_assign(
+                    "modules",
+                    haveCommits ?
+                    attrsToJSON(readSubmodules(actualUrl, "HEAD")).dump() : "{}");
 
                 return {
                     Tree(store->toRealPath(storePath), std::move(storePath)),

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -73,6 +73,7 @@ std::string getGitDir(const std::string & actualUrl) {
 bool hasCommits(const std::string & actualUrl) {
   auto gitDir = getGitDir(actualUrl);
 
+  printTalkative("in hasCommits\nactualUrl %s\ngitDir %s", actualUrl, gitDir);
   return !readDirectory(gitDir + "/refs/heads").empty();
 }
 
@@ -141,6 +142,7 @@ std::map<string,string> parseSubmodules(const string & contents) {
       results.insert(std::pair{path, url});
     }
   }
+  printTalkative("Saving %s\t%s\t%s\n", *path, *url, branch.value_or("master"));
   return results;
 }
 
@@ -190,7 +192,7 @@ static Attrs readSubmodules(const Path & path, const string & gitrev)
 
     auto submodules = getBlob(path, gitrev, i->second.second);
 
-    printTalkative("submodule file %s", submodules);
+    printTalkative("submodule file\n %s", submodules);
 
     auto parsedModules = parseSubmodules(submodules);
     for (auto & [subPath, url] : parsedModules) {
@@ -216,6 +218,7 @@ static Attrs readSubmodules(const Path & path, const string & gitrev)
 
         auto narHash = hashString(htSHA256, *sink.s);
         attrs.emplace(subPath, "path://" + fullPath + "?narHash=" + narHash.to_string(SRI, false));
+        printTalkative("DIRTY\nsubPath: %s\nurl: %s\ndirtyUrl: %s\n", subPath, url, "path://" + fullPath + "?narHash=" + narHash.to_string(SRI, false));
       }
     }
 

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -37,6 +37,8 @@ path0_=$(nix eval --impure --raw --expr "(builtins.fetchTree { type = \"git\"; u
 export _NIX_FORCE_HTTP=1
 [[ $(tail -n 1 $path0/hello) = "hello" ]]
 
+ls -l $repo
+nix eval --debug --impure --raw --expr "(builtins.fetchGit file://$repo).outPath"
 # Fetch the default branch.
 path=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
 [[ $(cat $path/hello) = world ]]

--- a/tests/fetchGitSubmodules.sh
+++ b/tests/fetchGitSubmodules.sh
@@ -30,6 +30,7 @@ initGitRepo $subRepo
 addGitContent $subRepo
 
 initGitRepo $rootRepo
+addGitContent $rootRepo
 
 git -C $rootRepo submodule init
 git -C $rootRepo submodule add $subRepo sub
@@ -98,4 +99,12 @@ noSubmoduleRepo=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$subR
 
 subUrl=$(nix eval --raw --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; }).modules.sub")
 
+[[ $subUrl =~ rev=$subRev$ ]]
+
+# Beschmutzigen...
+echo etwa dreck > $rootRepo/content
+
+subUrl=$(nix eval --impure --raw --expr "(builtins.fetchGit $rootRepo).modules.sub")
+
+# Submodule is still clean so should be the same as above
 [[ $subUrl =~ rev=$subRev$ ]]

--- a/tests/fetchGitSubmodules.sh
+++ b/tests/fetchGitSubmodules.sh
@@ -38,6 +38,10 @@ git -C $rootRepo commit -m "Add submodule"
 
 rev=$(git -C $rootRepo rev-parse HEAD)
 
+nix eval --json --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; }).modules"
+
+false
+
 r1=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; }).outPath")
 r2=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = false; }).outPath")
 r3=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = true; }).outPath")

--- a/tests/fetchGitSubmodules.sh
+++ b/tests/fetchGitSubmodules.sh
@@ -38,10 +38,6 @@ git -C $rootRepo commit -m "Add submodule"
 
 rev=$(git -C $rootRepo rev-parse HEAD)
 
-nix eval --json --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; }).modules"
-
-false
-
 r1=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; }).outPath")
 r2=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = false; }).outPath")
 r3=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$rootRepo; rev = \"$rev\"; submodules = true; }).outPath")
@@ -99,3 +95,7 @@ noSubmoduleRepoBaseline=$(nix eval --raw --expr "(builtins.fetchGit { url = file
 noSubmoduleRepo=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$subRepo; rev = \"$subRev\"; submodules = true; }).outPath")
 
 [[ $noSubmoduleRepoBaseline == $noSubmoduleRepo ]]
+
+subUrl=$(nix eval --raw --expr "(builtins.fetchGit { url = $rootRepo; rev = \"$rev\"; }).modules.sub")
+
+[[ $subUrl =~ rev=$subRev$ ]]

--- a/tests/flakes-with-submodules.sh
+++ b/tests/flakes-with-submodules.sh
@@ -1,0 +1,117 @@
+source common.sh
+
+if [[ -z $(type -p git) ]]; then
+    echo "Git not installed; skipping flake tests"
+    exit 99
+fi
+
+clearStore
+rm -rf $TEST_HOME/.{cache,config}
+
+registry=$TEST_ROOT/registry.json
+
+nonFlakeDir=$TEST_ROOT/nonFlake
+flakeDir=$TEST_ROOT/flake
+flakeWithSubmodules=$TEST_ROOT/flakeWithSubmodules
+
+for repo in $flakeDir $nonFlakeDir $flakeWithSubmodules; do
+    rm -rf $repo $repo.tmp
+    mkdir -p $repo
+    git -C $repo init
+    git -C $repo config user.email "foobar@example.com"
+    git -C $repo config user.name "Foobar"
+done
+
+for dir in $nonFlakeDir $flakeDir; do
+cat > $dir/README.md <<EOF
+FNORD
+EOF
+git -C $dir add README.md
+git -C $dir commit -m 'Initial'
+done
+
+cp config.nix $flakeDir
+
+cat > $flakeDir/flake.nix <<EOF
+{
+    description = "Flake whose defaultPackage prints out its README.md";
+
+    outputs = { self }: with import ./config.nix; let
+        inherit (self.modules) nonFlake;
+        writeShellScriptBin = name: script: mkDerivation {
+            inherit name;
+            buildCommand = ''
+                mkdir -p \$out/bin
+                bin=\$_/\${name}
+                echo '#!/bin/sh' > \$bin
+                echo '\${script}' >> \$bin
+                chmod +x \$bin
+            '';
+        };
+    in {
+        packages.$system = {
+            cat-own-readme = writeShellScriptBin "cat-own-readme" ''
+                cat \${self}/README.md
+            '';
+        };
+
+        defaultPackage.$system = self.packages.$system.cat-own-readme;
+    };
+}
+EOF
+
+git -C $flakeDir add .
+git -C $flakeDir commit -m'add flake.nix'
+
+[[ $(nix run $flakeDir#cat-own-readme) == "FNORD" ]]
+
+git -C $flakeWithSubmodules submodule add $nonFlakeDir
+git -C $flakeWithSubmodules submodule add $flakeDir
+git -C $flakeWithSubmodules add .
+git -C $flakeWithSubmodules commit -m'add submodules'
+
+cp config.nix $flakeWithSubmodules
+
+cat > $flakeWithSubmodules/flake.nix <<EOF
+{
+    description = "Flake with Submodules";
+
+    outputs = { self }: with import ./config.nix; let
+        traceVal = val: builtins.trace val val;
+        nonFlake = builtins.fetchTree (traceVal self.modules.nonFlake);
+        flake = builtins.getFlake (traceVal self.modules.flake);
+
+        writeShellScriptBin = name: script: mkDerivation {
+            inherit name;
+            buildCommand = ''
+                mkdir -p \$out/bin
+                bin=\$_/\${name}
+                echo '#!/bin/sh' > \$bin
+                echo '\${script}' >> \$bin
+                chmod +x \$bin
+            '';
+        };
+    in {
+        packages.$system = {
+            cat-submodule-readme = writeShellScriptBin "cat-submodule-readme" ''
+                cat \${nonFlake}/README.md
+            '';
+            use-submodule-as-flake = flake.packages.$system.cat-own-readme;
+        };
+
+        defaultPackage.$system = self.packages.$system.cat-submodule-readme;
+    };
+}
+EOF
+
+git -C $flakeWithSubmodules add .
+git -C $flakeWithSubmodules commit -m'add flake.nix'
+
+[[ $(nix run $flakeWithSubmodules#cat-submodule-readme) == "FNORD" ]]
+[[ $(nix run $flakeWithSubmodules#use-submodule-as-flake) == "FNORD" ]]
+
+# TODO make the dirty case do the Right Thing as well.
+#echo FSOUTH > $flakeWithSubmodules/nonFlake/README.md
+#[[ $(nix run $flakeWithSubmodules#cat-submodule-readme) == "FSOUTH" ]]
+# [[ $(nix run $flakeWithSubmodules#use-submodule-as-flake) == "FSOUTH" ]]
+# nix run -vv $flakeWithSubmodules#cat-submodule-readme

--- a/tests/flakes-with-submodules.sh
+++ b/tests/flakes-with-submodules.sh
@@ -110,8 +110,10 @@ git -C $flakeWithSubmodules commit -m'add flake.nix'
 [[ $(nix run $flakeWithSubmodules#cat-submodule-readme) == "FNORD" ]]
 [[ $(nix run $flakeWithSubmodules#use-submodule-as-flake) == "FNORD" ]]
 
-# TODO make the dirty case do the Right Thing as well.
-#echo FSOUTH > $flakeWithSubmodules/nonFlake/README.md
-#[[ $(nix run $flakeWithSubmodules#cat-submodule-readme) == "FSOUTH" ]]
-# [[ $(nix run $flakeWithSubmodules#use-submodule-as-flake) == "FSOUTH" ]]
-# nix run -vv $flakeWithSubmodules#cat-submodule-readme
+# apply dirt
+echo FSUD > $flakeWithSubmodules/nonFlake/README.md
+[[ $(nix run $flakeWithSubmodules#cat-submodule-readme) == "FSUD" ]]
+
+# should work for flake as well
+echo FSUD > $flakeWithSubmodules/flake/README.md
+[[ $(nix run $flakeWithSubmodules#use-submodule-as-flake) == "FSUD" ]]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -47,6 +47,7 @@ nix_tests = \
   describe-stores.sh \
   flakes.sh \
   flake-local-settings.sh \
+  flakes-with-submodules.sh \
   build.sh \
   repl.sh ca/repl.sh \
   ca/build.sh \


### PR DESCRIPTION
As the title implies, this is a whole 'nother take. Ça veut dire, it does not interact **AT ALL** with `submodules = true;`. It does involve more code though.

## Idea
If a tree has a `.gitmodules` in it, then we:
- Get the paths where submodules go
- Get the respective URLs that go with those paths
- Traverse the git tree to work out the `rev`s
- Construct flake-friendly URLs (`git+xxxx://host/who/what?rev=xxxx` etc)
- Build an attrset that maps paths to flake-friendly URLs
- Slap this into the attrset returned by `fetchTree`

That's it. It looks like this:

```console
❯ nix eval --impure --expr 'builtins.fetchTree git+https://github.com/runtimeverification/iele-semantics' | nixfmt
{
  lastModified = 1636045922;
  lastModifiedDate = "20211104171202";
  modules = {
    "deps/secp256k1" =
      "git+https://github.com/bitcoin-core/secp256k1?allRefs=1&rev=f532bdc9f77f7bbf7e93faabfbe9c483f0a9f75f";
    plugin =
      "git+https://github.com/runtimeverification/blockchain-k-plugin?allRefs=1&rev=cc7384e565e4c8df4d17a3330cd9951d32d4830f";
    "tests/ethereum-tests" =
      "git+https://github.com/ethereum/tests.git?allRefs=1&rev=7057d0e021f7dbee37a2ddb6acf34f4946bc157d";
    "web/k-web-theme" =
      "git+https://github.com/runtimeverification/k-web-theme?allRefs=1&rev=189fe6650488f8f04dc89d25a61cdfd888cd9dd8";
  };
  narHash = "sha256-9GDWDomnRyJ47mDbygoBHThq9Q+3JGZDYTIHB8SsMlc=";
  outPath = "/nix/store/6d1w3h7fygfwl1f42x1bx6xhsrsmh7qj-source";
  rev = "431a4a44dad39aedb1dff126475cdce3b8d91e83";
  revCount = 1399;
  shortRev = "431a4a4";
  submodules = false;
}
```

It's just plain contextless strings so unless I'm fundamentally misunderstanding things, no dragons lie therein.
From here the user is empowered to do as much or as little as she wants with it: use `builtins.getFlake` for a flake, `builtins.fetchTree` for a non-flake, or ignore it altogether.

See `tests/flakes-with-submodules.sh` for a (rudimentary) example of how this might be used within a flake.

This could potentially be used as a basis for a more "flakeful" UX, where submodules behave like `indirect` (registry) inputs and get populated with the Right Thing if and only if they get added to the `outputs` function args set... or not.

Since my C++ is rusty and my familiarity with the Nix codebase is flakey (both puns intended btw 🙃), I invite y'all to punch holes in my reasoning and point out any blind spots so that we can address them and hopefully reach a solution that everyone's happy with.

I trust that this would save the sanity of at least a handful of Nixers/Nixresses out there who are forced to interact with git submodules against their better judgement (or in accordance with their poor judgement. to each their own 🤷‍♀️), thereby empowering them to once again pursue their (title-cased) Hopes and Dreams!

kk 'nuff prose. known issues/caveats:
- this does add the submodule data to the cache, so a `rm -rf ~/.cache/nix` is required (otherwise you'd get `error: input attribute 'modules' is missing`)
- ~~dirty submodule scenario isn't handled yet~~ added, and fixed so that it also works without `__contentAddressed = true;` (thanks @shlevy!)
- does not solve the "I want `self` to have `submodules = true;`" use case (https://github.com/NixOS/nix/issues/5312)
- might segfault, murder your kittens or both

Shout out to @cleverca22 for essentially onboarding me to the codebase (... and writing most of the harder parts)

Cheers