### PR TITLE
darwin-install: fix already-mounted store volumes

### DIFF
--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -742,6 +742,9 @@ setup_volume() {
 
     use_special="${NIX_VOLUME_USE_SPECIAL:-$(create_volume)}"
 
+    _sudo "to ensure the Nix volume is not mounted" \
+        /usr/sbin/diskutil unmount force "$use_special" || true # might not be mounted
+
     use_uuid=${NIX_VOLUME_USE_UUID:-$(volume_uuid_from_special "$use_special")}
 
     setup_fstab "$use_uuid"


### PR DESCRIPTION
Fixes #5478

This adds an explicit unmount of the store volume to avoid cases
where the installer can hang in await_volume when:
- the user already has a store volume
- that volume is already mounted somewhere other than /nix
- they do not take a path through the installer that results in an
  explicit unmount (as both removing and encrypting the volume
  would do)

I managed to reproduce the issue described by the user there and confirm that an updated installer (built from this commit in https://github.com/abathur/nix/actions/runs/1422862859) could cleanly install despite the precondition.

<details><summary>For posterity, to create the precondition to demonstrate the issue...</summary>
I just created a volume named Nix Store in diskutil (which automatically mounts the volume to `/Volumes/Nix Store`) and rejected the installer's prompt for consent to replace this volume.</details>