### PR TITLE
Make the flake options work when using the daemon

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -307,7 +307,7 @@ LockedFlake lockFlake(
 
     if (lockFlags.applyNixConfig) {
         flake.config.apply();
-        // FIXME: send new config to the daemon.
+        state.store->setOptions();
     }
 
     try {

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -290,6 +290,10 @@ ConnectionHandle RemoteStore::getConnection()
     return ConnectionHandle(connections->get());
 }
 
+void RemoteStore::setOptions()
+{
+    setOptions(*(getConnection().handle));
+}
 
 bool RemoteStore::isValidPathUncached(const StorePath & path)
 {

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -147,6 +147,8 @@ protected:
 
     virtual void setOptions(Connection & conn);
 
+    void setOptions() override;
+
     ConnectionHandle getConnection();
 
     friend struct ConnectionHandle;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -724,6 +724,11 @@ public:
     virtual void createUser(const std::string & userName, uid_t userId)
     { }
 
+    /*
+     * Synchronises the options of the client with those of the daemon
+     * (a no-op when there’s no daemon)
+     */
+    virtual void setOptions() { }
 protected:
 
     Stats stats;

--- a/tests/flake-local-settings.sh
+++ b/tests/flake-local-settings.sh
@@ -1,0 +1,35 @@
+source common.sh
+
+clearStore
+rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
+
+cp ./simple.nix ./simple.builder.sh ./config.nix $TEST_HOME
+
+cd $TEST_HOME
+
+rm -f post-hook-ran
+cat <<EOF > echoing-post-hook.sh
+#!/bin/sh
+
+echo "ThePostHookRan" > $PWD/post-hook-ran
+EOF
+chmod +x echoing-post-hook.sh
+
+cat <<EOF > flake.nix
+{
+    nixConfig.post-build-hook = "$PWD/echoing-post-hook.sh";
+
+    outputs = a: {
+       defaultPackage.$system = import ./simple.nix;
+    };
+}
+EOF
+
+# Ugly hack for testing
+mkdir -p .local/share/nix
+cat <<EOF > .local/share/nix/trusted-settings.json
+{"post-build-hook":{"$PWD/echoing-post-hook.sh":true}}
+EOF
+
+nix build
+test -f post-hook-ran || fail "The post hook should have ran"

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -46,6 +46,7 @@ nix_tests = \
   recursive.sh \
   describe-stores.sh \
   flakes.sh \
+  flake-local-settings.sh \
   build.sh \
   compute-levels.sh \
   repl.sh \


### PR DESCRIPTION
When setting flake-local options (with the `nixConfig` field), forward these options to the daemon in case we’re using one.

This is necessary in particular for options like `binary-caches` or `post-build-hook` to make sense.

Fix <https://github.com/NixOS/nix/commit/343239fc8a1993f707a990c2cd54a41f1fa3de99#r44356843>
