### PR TITLE
Remove unused "<let-body>" symbol

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -33,11 +33,9 @@ namespace nix {
         Symbol file;
         FileOrigin origin;
         std::optional<ErrorInfo> error;
-        Symbol sLetBody;
         ParseData(EvalState & state)
             : state(state)
             , symbols(state.symbols)
-            , sLetBody(symbols.create("<let-body>"))
             { };
     };
 


### PR DESCRIPTION
The requirement for the symbol has been removed since at least 7d47498.