### PR TITLE
Unshare mount namespace in main()

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -103,17 +103,19 @@ public:
     ~ProgressBar()
     {
         stop();
-        updateThread.join();
     }
 
     void stop() override
     {
-        auto state(state_.lock());
-        if (!state->active) return;
-        state->active = false;
-        writeToStderr("\r\e[K");
-        updateCV.notify_one();
-        quitCV.notify_one();
+        {
+            auto state(state_.lock());
+            if (!state->active) return;
+            state->active = false;
+            writeToStderr("\r\e[K");
+            updateCV.notify_one();
+            quitCV.notify_one();
+        }
+        updateThread.join();
     }
 
     bool isVerbose() override {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -504,10 +504,6 @@ void LocalStore::makeStoreWritable()
         throw SysError("getting info about the Nix store mount point");
 
     if (stat.f_flag & ST_RDONLY) {
-        saveMountNamespace();
-        if (unshare(CLONE_NEWNS) == -1)
-            throw SysError("setting up a private mount namespace");
-
         if (mount(0, realStoreDir.get().c_str(), "none", MS_REMOUNT | MS_BIND, 0) == -1)
             throw SysError("remounting %1% writable", realStoreDir);
     }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -255,6 +255,14 @@ void mainWrapped(int argc, char * * argv)
     initNix();
     initGC();
 
+    #if __linux__
+    if (getuid() == 0) {
+        saveMountNamespace();
+        if (unshare(CLONE_NEWNS) == -1)
+            throw SysError("setting up a private mount namespace");
+    }
+    #endif
+
     programPath = argv[0];
     auto programName = std::string(baseNameOf(programPath));
 


### PR DESCRIPTION
Doing it as a side-effect of calling `LocalStore::makeStoreWritable()` s very ugly.

Also, make sure that stopping the progress bar joins the update thread, otherwise that thread should be unshared as well.