### PR TITLE
installer: clarify starting assumption task

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -377,6 +377,11 @@ cure_artifacts() {
 }
 
 validate_starting_assumptions() {
+    task "Checking for artifacts of previous installs"
+    cat <<EOF
+Before I try to install, I'll check for signs Nix already is or has
+been installed on this system.
+EOF
     if type nix-env 2> /dev/null >&2; then
         warning <<EOF
 Nix already appears to be installed. This installer may run into issues.
@@ -385,6 +390,11 @@ If an error occurs, try manually uninstalling, then rerunning this script.
 $(uninstall_directions)
 EOF
     fi
+
+    # TODO: I think it would be good for this step to accumulate more
+    #       knowledge of older obsolete artifacts, if there are any.
+    #       We could issue a "reminder" here that the user might want
+    #       to clean them up?
 
     for profile_target in "${PROFILE_TARGETS[@]}"; do
         if [ -e "$profile_target$PROFILE_BACKUP_SUFFIX" ]; then


### PR DESCRIPTION
Just clarifies the "task" during `validate_starting_assumptions` so that it is obvious that errors here aren't part of whatever task executed last. Can also backport to 2.4-maintenance.

We had a macOS user present in Matrix with [some confusion](https://matrix.to/#/!lheuhImcToQZYTQTuI:nixos.org/$aVp31jcHUkGzwZb65SFnik9z-w5vDDQ94Jc256iMil0?via=nixos.org&via=matrix.org&via=nixos.dev) because the lack of a clear task statement here made them think the error meant that a problem had occurred during the preceding task in a macOS install: "Fixing any leftover Nix volume state"