### PR TITLE
Support documentation on functors

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -666,6 +666,21 @@ std::optional<EvalState::Doc> EvalState::getDoc(Value & v)
                 .args = v2->primOp->args,
                 .doc = v2->primOp->doc,
             };
+    } else if (auto functor = isFunctor(v)) {
+        if (auto doc = v.attrs->get(symbols.create("__doc"))) {
+            std::vector<std::string> args;
+            if (auto vArgs = v.attrs->get(symbols.create("__args"))) {
+                forceList(*vArgs->value, *vArgs->pos);
+                for (unsigned int n = 0; n < vArgs->value->listSize(); ++n)
+                    args.push_back(forceString(*vArgs->value->listElems()[n], noPos));
+            }
+            return Doc {
+                .pos = *functor->pos,
+                .arity = args.size(),
+                .args = std::move(args),
+                .doc = forceString(*doc->value, *doc->pos),
+            };
+        }
     }
     return {};
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1448,14 +1448,11 @@ void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
 {
     forceValue(fun);
 
-    if (fun.type() == nAttrs) {
-        auto found = fun.attrs->find(sFunctor);
-        if (found != fun.attrs->end()) {
-            Value * v = allocValue();
-            callFunction(*found->value, fun, *v, noPos);
-            forceValue(*v);
-            return autoCallFunction(args, *v, res);
-        }
+    if (auto functor = isFunctor(fun)) {
+        Value * v = allocValue();
+        callFunction(*functor->value, fun, *v, *functor->pos);
+        forceValue(*v);
+        return autoCallFunction(args, *v, res);
     }
 
     if (!fun.isLambda() || !fun.lambda.fun->hasFormals()) {
@@ -1768,9 +1765,9 @@ bool EvalState::forceBool(Value & v, const Pos & pos)
 }
 
 
-bool EvalState::isFunctor(Value & fun)
+Attr * EvalState::isFunctor(Value & fun)
 {
-    return fun.type() == nAttrs && fun.attrs->find(sFunctor) != fun.attrs->end();
+    return fun.type() == nAttrs ? fun.attrs->get(sFunctor) : nullptr;
 }
 
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -316,7 +316,9 @@ public:
        elements and attributes are compared recursively. */
     bool eqValues(Value & v1, Value & v2);
 
-    bool isFunctor(Value & fun);
+    /* Return the __functor attribute of 'fun' if it exists, otherwise
+       return null. */
+    Attr * isFunctor(Value & fun);
 
     // FIXME: use std::span
     void callFunction(Value & fun, size_t nrArgs, Value * * args, Value & vRes, const Pos & pos);

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -294,7 +294,7 @@ public:
         std::optional<Symbol> name;
         size_t arity;
         std::vector<std::string> args;
-        std::string doc;
+        std::optional<std::string> doc;
     };
 
     std::optional<Doc> getDoc(Value & v);

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -291,9 +291,15 @@ public:
     struct Doc
     {
         Pos pos;
-        std::optional<Symbol> name;
+        Symbol name;
         size_t arity;
-        std::vector<std::string> args;
+        struct Arg
+        {
+            std::string name;
+            std::optional<std::set<std::string>> attrs;
+            bool ellipsis = false;
+        };
+        std::vector<Arg> args;
         std::optional<std::string> doc;
     };
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -294,7 +294,7 @@ public:
         std::optional<Symbol> name;
         size_t arity;
         std::vector<std::string> args;
-        const char * doc;
+        std::string doc;
     };
 
     std::optional<Doc> getDoc(Value & v);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -528,6 +528,9 @@ bool NixRepl::processLine(string line)
         if (auto doc = state->getDoc(v)) {
             std::string markdown;
 
+            if (doc->pos)
+                markdown += filterANSIEscapes(fmt("**Source**: %s\n\n", doc->pos), true);
+
             if (!doc->args.empty()) {
                 std::vector<std::string> args;
                 for (auto & arg : doc->args) {
@@ -556,7 +559,7 @@ bool NixRepl::processLine(string line)
             if (doc->doc)
                 markdown += stripIndentation(*doc->doc);
 
-            logger->cout(trim(renderMarkdownToTerminal(markdown)));
+            logger->cout(chomp(renderMarkdownToTerminal(markdown)));
         } else
             throw Error("value does not have documentation");
     }

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -537,12 +537,15 @@ bool NixRepl::processLine(string line)
                     "**Synopsis:** `"
                     + (v.isPrimOp()
                         ? "builtins." + (std::string) (*doc->name)
+                        : doc->name
+                        ? (std::string) (*doc->name)
                         : arg)
                     + "` "
                     + concatStringsSep(" ", args) + "\n\n";
             }
 
-            markdown += stripIndentation(doc->doc);
+            if (doc->doc)
+                markdown += stripIndentation(*doc->doc);
 
             logger->cout(trim(renderMarkdownToTerminal(markdown)));
         } else

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -528,13 +528,17 @@ bool NixRepl::processLine(string line)
         if (auto doc = state->getDoc(v)) {
             std::string markdown;
 
-            if (!doc->args.empty() && doc->name) {
+            if (!doc->args.empty()) {
                 auto args = doc->args;
                 for (auto & arg : args)
                     arg = "*" + arg + "*";
 
                 markdown +=
-                    "**Synopsis:** `builtins." + (std::string) (*doc->name) + "` "
+                    "**Synopsis:** `"
+                    + (v.isPrimOp()
+                        ? "builtins." + (std::string) (*doc->name)
+                        : arg)
+                    + "` "
                     + concatStringsSep(" ", args) + "\n\n";
             }
 

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -529,16 +529,25 @@ bool NixRepl::processLine(string line)
             std::string markdown;
 
             if (!doc->args.empty()) {
-                auto args = doc->args;
-                for (auto & arg : args)
-                    arg = "*" + arg + "*";
+                std::vector<std::string> args;
+                for (auto & arg : doc->args) {
+                    if (arg.attrs) {
+                        std::vector<std::string> attrs;
+                        for (auto & attr : *arg.attrs)
+                            attrs.push_back("`" + attr + "`");
+                        if (arg.ellipsis)
+                            attrs.push_back("...");
+                        args.push_back("{ " + concatStringsSep(", ", attrs) + " }");
+                    } else
+                        args.push_back("*" + arg.name + "*");
+                }
 
                 markdown +=
                     "**Synopsis:** `"
                     + (v.isPrimOp()
-                        ? "builtins." + (std::string) (*doc->name)
-                        : doc->name
-                        ? (std::string) (*doc->name)
+                        ? "builtins." + (std::string) doc->name
+                        : doc->name.set()
+                        ? (std::string) doc->name
                         : arg)
                     + "` "
                     + concatStringsSep(" ", args) + "\n\n";


### PR DESCRIPTION
For example, given a functor like

```
id = {
  __args = [ "x" ];
  __doc = ''The identity function. It takes a single argument *x* and returns it.'';
  __functor = _: x: x;
};
```

the repl can now print documentation about it:

```
nix-repl> :doc lib.id
Synopsis: lib.id x

    The identity function. It takes a single argument x and returns it.
```