### PR TITLE
Install nlohmann_json headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ makefiles = \
   src/libexpr/local.mk \
   src/libcmd/local.mk \
   src/nix/local.mk \
+  src/nlohmann/local.mk \
   src/resolve-system-dependencies/local.mk \
   scripts/local.mk \
   misc/bash/local.mk \

--- a/src/nlohmann/local.mk
+++ b/src/nlohmann/local.mk
@@ -1,0 +1,2 @@
+$(foreach i, $(wildcard src/nlohmann/*.hpp), \
+  $(eval $(call install-file-in, $(i), $(includedir)/nlohmann, 0644)))


### PR DESCRIPTION
These headers are included by the libexpr, libfetchers, libstore
and libutil headers.
Considering that these are vendored sources, Nix should expose them,
as it is not a good idea for reverse dependencies to rely on a
potentially different source that can go out of sync.

<!-- 
As suggested here https://github.com/NixOS/nix/pull/4904#issuecomment-858510744 (which I didn't follow through at the time because of time pressure and uncertainty around the presence of nlohmann_json as a dependency in the flake expression back then) -->