### PR TITLE
src/nlohmann: Add license and readme

### DIFF
--- a/src/nlohmann/LICENSE.MIT
+++ b/src/nlohmann/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License 
+
+Copyright (c) 2013-2021 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/nlohmann/README.md
+++ b/src/nlohmann/README.md
@@ -1,0 +1,5 @@
+
+# nlohmann/json
+
+These files were vendored from https://github.com/nlohmann/json
+and licensed under the terms of the MIT license. See [./LICENSE.MIT](LICENSE.MIT).


### PR DESCRIPTION
We're not relicensing it.