### PR TITLE
nix key: Fix error message and don't require flakes

### DIFF
--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -218,8 +218,7 @@ struct CmdKey : NixMultiCommand
     void run() override
     {
         if (!command)
-            throw UsageError("'nix flake' requires a sub-command.");
-        settings.requireExperimentalFeature(Xp::Flakes);
+            throw UsageError("'nix key' requires a sub-command.");
         command->second->prepare();
         command->second->run();
     }


### PR DESCRIPTION
The equivalent change is required to be backported to the 2.4 branch I suppose?

```diff
diff --git a/src/nix/sigs.cc b/src/nix/sigs.cc
index 43e0d9148..3d659d6d2 100644
--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -218,8 +218,7 @@ struct CmdKey : NixMultiCommand
     void run() override
     {
         if (!command)
-            throw UsageError("'nix flake' requires a sub-command.");
-        settings.requireExperimentalFeature("flakes");
+            throw UsageError("'nix key' requires a sub-command.");
         command->second->prepare();
         command->second->run();
     }
```

* * *

This was found off the back of trying to "anti-dogfood" `nix-command` and `flakes` out of the feature tests infra. This is the first obvious and trivial issue I've hit. I'll try making a draft PR of what I'm talking about soon, but it's back-breaking work trying to untangle the experimental features from our testing infra. I'll probably end-up needing some help.

Though this does show that our lack of testing without experimental features might be causing us harm.