### PR TITLE
nix registry: Mark experimental

### DIFF
--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -226,6 +226,7 @@ struct CmdRegistry : virtual NixMultiCommand
 
     void run() override
     {
+        settings.requireExperimentalFeature(Xp::Flakes);
         if (!command)
             throw UsageError("'nix registry' requires a sub-command.");
         command->second->prepare();


### PR DESCRIPTION
This is part of the flakes feature. Mark it as such.

* * *

This will require this trivial-enough backport to 2.4:

```diff
diff --git a/src/nix/registry.cc b/src/nix/registry.cc
index 6a92576c7..e3667b6bc 100644
--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -226,6 +226,7 @@ struct CmdRegistry : virtual NixMultiCommand
 
     void run() override
     {
+        settings.requireExperimentalFeature("flakes");
         if (!command)
             throw UsageError("'nix registry' requires a sub-command.");
         command->second->prepare();
```