### PR TITLE
Adds an accept-flake-config flag

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -951,6 +951,9 @@ public:
 
     Setting<bool> useRegistries{this, true, "use-registries",
         "Whether to use flake registries to resolve flake references."};
+
+    Setting<bool> acceptFlakeConfig{this, false, "accept-flake-config",
+        "Whether to accept nix configuration from a flake without prompting."};
 };
 
 

--- a/tests/flake-local-settings.sh
+++ b/tests/flake-local-settings.sh
@@ -25,11 +25,5 @@ cat <<EOF > flake.nix
 }
 EOF
 
-# Ugly hack for testing
-mkdir -p .local/share/nix
-cat <<EOF > .local/share/nix/trusted-settings.json
-{"post-build-hook":{"$PWD/echoing-post-hook.sh":true}}
-EOF
-
-nix build
+nix build --accept-flake-config
 test -f post-hook-ran || fail "The post hook should have ran"


### PR DESCRIPTION
Adds a warning when a saved setting is utilized.
Flattens the if logic structure
Corrects incorrect logic where if a setting was accepted, but not allowed to be written; in that case the setting would not be used for that instantiation.

## TODO
- [x] Test case
- [ ] triple-check the if logic


Note: Created during NixUX Hacking Fridays! @regnat @garbas @Radvendii 

Fixes: #5507 