### PR TITLE
allow paths in flake local options

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -251,6 +251,10 @@ static Flake getFlake(
             forceTrivialValue(state, *setting.value, *setting.pos);
             if (setting.value->type() == nString)
                 flake.config.settings.insert({setting.name, state.forceStringNoCtx(*setting.value, *setting.pos)});
+            else if (setting.value->type() == nPath) {
+                PathSet emptyContext = {};
+                flake.config.settings.insert({setting.name, state.coerceToString(*setting.pos, *setting.value, emptyContext, false, true, true)});
+            }
             else if (setting.value->type() == nInt)
                 flake.config.settings.insert({setting.name, state.forceInt(*setting.value, *setting.pos)});
             else if (setting.value->type() == nBool)

--- a/tests/flake-local-settings.sh
+++ b/tests/flake-local-settings.sh
@@ -11,13 +11,13 @@ rm -f post-hook-ran
 cat <<EOF > echoing-post-hook.sh
 #!/bin/sh
 
-echo "ThePostHookRan" > $PWD/post-hook-ran
+echo "ThePostHookRan as \$0" > $PWD/post-hook-ran
 EOF
 chmod +x echoing-post-hook.sh
 
 cat <<EOF > flake.nix
 {
-    nixConfig.post-build-hook = "$PWD/echoing-post-hook.sh";
+    nixConfig.post-build-hook = ./echoing-post-hook.sh;
     nixConfig.allow-dirty = false; # See #5621
 
     outputs = a: {
@@ -33,3 +33,13 @@ clearStore
 
 nix build --accept-flake-config
 test -f post-hook-ran || fail "The post hook should have ran"
+
+# Make sure that the path to the post hook doesn’t change if we change
+# something in the flake.
+# Otherwise the user would have to re-validate the setting each time.
+mv post-hook-ran previous-post-hook-run
+echo "# Dummy comment" >> flake.nix
+clearStore
+nix build --accept-flake-config
+diff -q post-hook-ran previous-post-hook-run || \
+    fail "Both post hook runs should report the same filename"


### PR DESCRIPTION
Fix #5505

Depends on #5544 because they both touch the same test, and #5544 made the testing easier
