### PR TITLE
toJSON: display errors position

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1011,7 +1011,7 @@ static void prim_derivationStrict(EvalState & state, const Pos & pos, Value * * 
                     if (i->name == state.sStructuredAttrs) continue;
 
                     auto placeholder(jsonObject->placeholder(key));
-                    printValueAsJSON(state, true, *i->value, placeholder, context);
+                    printValueAsJSON(state, true, *i->value, placeholder, context, *i->pos);
 
                     if (i->name == state.sBuilder)
                         drv.builder = state.forceString(*i->value, context, posDrvName);
@@ -1690,7 +1690,7 @@ static void prim_toJSON(EvalState & state, const Pos & pos, Value * * args, Valu
 {
     std::ostringstream out;
     PathSet context;
-    printValueAsJSON(state, true, *args[0], out, context);
+    printValueAsJSON(state, true, *args[0], out, context, pos);
     mkString(v, out.str(), context);
 }
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -10,11 +10,11 @@
 namespace nix {
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, JSONPlaceholder & out, PathSet & context)
+    Value & v, JSONPlaceholder & out, PathSet & context, const Pos & pos)
 {
     checkInterrupt();
 
-    if (strict) state.forceValue(v);
+    if (strict) state.forceValue(v, pos);
 
     switch (v.type()) {
 
@@ -54,10 +54,10 @@ void printValueAsJSON(EvalState & state, bool strict,
                 for (auto & j : names) {
                     Attr & a(*v.attrs->find(state.symbols.create(j)));
                     auto placeholder(obj.placeholder(j));
-                    printValueAsJSON(state, strict, *a.value, placeholder, context);
+                    printValueAsJSON(state, strict, *a.value, placeholder, context, *a.pos);
                 }
             } else
-                printValueAsJSON(state, strict, *i->value, out, context);
+                printValueAsJSON(state, strict, *i->value, out, context, *i->pos);
             break;
         }
 
@@ -65,13 +65,13 @@ void printValueAsJSON(EvalState & state, bool strict,
             auto list(out.list());
             for (unsigned int n = 0; n < v.listSize(); ++n) {
                 auto placeholder(list.placeholder());
-                printValueAsJSON(state, strict, *v.listElems()[n], placeholder, context);
+                printValueAsJSON(state, strict, *v.listElems()[n], placeholder, context, pos);
             }
             break;
         }
 
         case nExternal:
-            v.external->printValueAsJSON(state, strict, out, context);
+            v.external->printValueAsJSON(state, strict, out, context, pos);
             break;
 
         case nFloat:
@@ -87,14 +87,14 @@ void printValueAsJSON(EvalState & state, bool strict,
 }
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, std::ostream & str, PathSet & context)
+    Value & v, std::ostream & str, PathSet & context, const Pos & pos)
 {
     JSONPlaceholder out(str);
-    printValueAsJSON(state, strict, v, out, context);
+    printValueAsJSON(state, strict, v, out, context, pos);
 }
 
 void ExternalValueBase::printValueAsJSON(EvalState & state, bool strict,
-    JSONPlaceholder & out, PathSet & context) const
+    JSONPlaceholder & out, PathSet & context, const Pos & pos) const
 {
     throw TypeError("cannot convert %1% to JSON", showType());
 }

--- a/src/libexpr/value-to-json.hh
+++ b/src/libexpr/value-to-json.hh
@@ -11,9 +11,9 @@ namespace nix {
 class JSONPlaceholder;
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, JSONPlaceholder & out, PathSet & context);
+    Value & v, JSONPlaceholder & out, PathSet & context, const Pos & pos);
 
 void printValueAsJSON(EvalState & state, bool strict,
-    Value & v, std::ostream & str, PathSet & context);
+    Value & v, std::ostream & str, PathSet & context, const Pos & pos);
 
 }

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -90,7 +90,7 @@ class ExternalValueBase
 
     /* Print the value as JSON. Defaults to unconvertable, i.e. throws an error */
     virtual void printValueAsJSON(EvalState & state, bool strict,
-        JSONPlaceholder & out, PathSet & context) const;
+        JSONPlaceholder & out, PathSet & context, const Pos & pos) const;
 
     /* Print the value as XML. Defaults to unevaluated */
     virtual void printValueAsXML(EvalState & state, bool strict, bool location,

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -879,7 +879,7 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems)
                 placeholder.write(nullptr);
             } else {
                 PathSet context;
-                printValueAsJSON(*globals.state, true, *v, placeholder, context);
+                printValueAsJSON(*globals.state, true, *v, placeholder, context, noPos);
             }
         }
     }

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -52,7 +52,7 @@ void processExpr(EvalState & state, const Strings & attrPaths,
             if (output == okXML)
                 printValueAsXML(state, strict, location, vRes, std::cout, context);
             else if (output == okJSON)
-                printValueAsJSON(state, strict, vRes, std::cout, context);
+                printValueAsJSON(state, strict, vRes, std::cout, context, noPos);
             else {
                 if (strict) state.forceValueDeep(vRes);
                 std::cout << vRes << std::endl;

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -112,7 +112,7 @@ struct CmdEval : MixJSON, InstallableCommand
 
         else if (json) {
             JSONPlaceholder jsonOut(std::cout);
-            printValueAsJSON(*state, true, *v, jsonOut, context);
+            printValueAsJSON(*state, true, *v, jsonOut, context, pos);
         }
 
         else {


### PR DESCRIPTION
- This change applies to builtins.toJSON and inner workings
- Proof of concept:
  ```nix
  let e = builtins.toJSON e; in e
  ```
- Before:
  ```
  $ nix-instantiate --eval poc.nix
  error: infinite recursion encountered
  ```
- After:
  ```
  $ nix-instantiate --eval poc.nix
  error: infinite recursion encountered

       at /data/github/kamadorueda/nix/poc.nix:1:9:

            1| let e = builtins.toJSON e; in e
             |         ^
  ```