### PR TITLE
[2.3-maintenance] Override socket path with `NIX_DAEMON_SOCKET_PATH` so we can test 2.4+ compat

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -34,7 +34,7 @@ Settings::Settings()
     , nixLibexecDir(canonPath(getEnv("NIX_LIBEXEC_DIR", NIX_LIBEXEC_DIR)))
     , nixBinDir(canonPath(getEnv("NIX_BIN_DIR", NIX_BIN_DIR)))
     , nixManDir(canonPath(NIX_MAN_DIR))
-    , nixDaemonSocketFile(canonPath(nixStateDir + DEFAULT_SOCKET_PATH))
+    , nixDaemonSocketFile(canonPath(getEnv("NIX_DAEMON_SOCKET_PATH", nixStateDir + DEFAULT_SOCKET_PATH)))
 {
     buildUsersGroup = getuid() == 0 ? "nixbld" : "";
     lockCPU = getEnv("NIX_AFFINITY_HACK", "1") == "1";


### PR DESCRIPTION
This is the first step to testing compatibility with 2.3 in 2.4 and
master.

(adapted from commit 223fbe644a4cde45269c01e971331d9414971d46)