### PR TITLE
Fix detection of scp-style URIs to support non-standard SSH ports

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -74,8 +74,11 @@ std::string fixURI(std::string uri, EvalState & state, const std::string & defau
 
 std::string fixURIForGit(std::string uri, EvalState & state)
 {
+    /* Detects scp-style uris (e.g. git@github.com:NixOS/nix) and fixes
+     * them by removing the `:` and assuming a scheme of `ssh://`
+     * */
     static std::regex scp_uri("([^/].*)@(.*):(.*)");
-    if (uri[0] != '/' && std::regex_match(uri, scp_uri))
+    if (uri[0] != '/' && std::regex_match(uri, scp_uri) && uri.find("://") == std::string::npos)
         return fixURI(std::regex_replace(uri, scp_uri, "$1@$2/$3"), state, "ssh");
     else
         return fixURI(uri, state);

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -77,8 +77,8 @@ std::string fixURIForGit(std::string uri, EvalState & state)
     /* Detects scp-style uris (e.g. git@github.com:NixOS/nix) and fixes
      * them by removing the `:` and assuming a scheme of `ssh://`
      * */
-    static std::regex scp_uri("([^/].*)@(.*):(.*)");
-    if (uri[0] != '/' && std::regex_match(uri, scp_uri) && uri.find("://") == std::string::npos)
+    static std::regex scp_uri("([^/]*)@(.*):(.*)");
+    if (uri[0] != '/' && std::regex_match(uri, scp_uri))
         return fixURI(std::regex_replace(uri, scp_uri, "$1@$2/$3"), state, "ssh");
     else
         return fixURI(uri, state);


### PR DESCRIPTION
This PR attempts to fix the broken detection of SCP style URIs (e.g. `git@github.com:NixOS/nix`). Currently the regex also matches URIs with a fixed port, e.g. `ssh://git@github.com:22/NixOS/nix`. This worked with Nix 2.3 but does not currently with Nix 2.4

Since scp URIs do not have a scheme this simply adds a test for the existence of a "://" substring