### PR TITLE
Fix XDG_CONFIG_DIRS fallback

### DIFF
--- a/doc/manual/src/command-ref/conf-file-prefix.md
+++ b/doc/manual/src/command-ref/conf-file-prefix.md
@@ -16,8 +16,9 @@ By default Nix reads settings from the following places:
     will be loaded in reverse order.
 
     Otherwise it will look for `nix/nix.conf` files in `XDG_CONFIG_DIRS`
-    and `XDG_CONFIG_HOME`. If these are unset, it will look in
-    `$HOME/.config/nix/nix.conf`.
+    and `XDG_CONFIG_HOME`. If unset, `XDG_CONFIG_DIRS` defaults to
+    `/etc/xdg`, and `XDG_CONFIG_HOME` defaults to `$HOME/.config`
+    as per [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
   - If `NIX_CONFIG` is set, its contents is treated as the contents of
     a configuration file.

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -562,7 +562,7 @@ Path getConfigDir()
 std::vector<Path> getConfigDirs()
 {
     Path configHome = getConfigDir();
-    string configDirs = getEnv("XDG_CONFIG_DIRS").value_or("");
+    string configDirs = getEnv("XDG_CONFIG_DIRS").value_or("/etc/xdg");
     std::vector<Path> result = tokenizeString<std::vector<string>>(configDirs, ":");
     result.insert(result.begin(), configHome);
     return result;


### PR DESCRIPTION
According to XDG Base Directory Specification, it should fall back to /etc/xdg when the env var is not present.
