### PR TITLE
Add named ellipsis

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1283,9 +1283,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
 
             ExprLambda & lambda(*vCur.lambda.fun);
 
-            auto size =
-                (lambda.arg.empty() ? 0 : 1) +
-                (lambda.hasFormals() ? lambda.formals->formals.size() : 0);
+            auto size = lambda.getEnvSize();
             Env & env2(allocEnv(size));
             env2.up = vCur.lambda.env;
 
@@ -1325,6 +1323,21 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                         if (lambda.formals->argNames.find(i.name) == lambda.formals->argNames.end())
                             throwTypeError(pos, "%1% called with unexpected argument '%2%'", lambda, i.name);
                     abort(); // can't happen
+                }
+
+                if (lambda.formals->ellipsis && lambda.formals->ellipsis->set()) {
+                    Value *otherAttrs = new Value();
+                    Bindings *bindings = new Bindings(args[0]->attrs->size());
+
+                    otherAttrs->mkAttrs(bindings);
+
+                    for (auto &i : *args[0]->attrs) {
+                        if (lambda.formals->argNames.find(i.name) ==
+                            lambda.formals->argNames.end()) {
+                        otherAttrs->attrs->push_back(i);
+                        }
+                    }
+                    env2.values[displ++] = otherAttrs;
                 }
             }
 

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -224,9 +224,10 @@ struct Formal
 struct Formals
 {
     typedef std::list<Formal> Formals_;
+    typedef std::optional<Symbol> Ellipsis;
     Formals_ formals;
     std::set<Symbol> argNames; // used during parsing
-    bool ellipsis;
+    Ellipsis ellipsis;
 };
 
 struct ExprLambda : Expr
@@ -247,6 +248,7 @@ struct ExprLambda : Expr
     };
     void setName(Symbol & name);
     string showNamePos() const;
+    size_t getEnvSize();
     inline bool hasFormals() const { return formals != nullptr; }
     COMMON_METHODS
 };

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -157,6 +157,23 @@ static void addFormal(const Pos & pos, Formals * formals, const Formal & formal)
     formals->formals.push_front(formal);
 }
 
+static void setEllipsis(const Pos &, Formals * formals, bool ellipsis)
+{
+    if (ellipsis) formals->ellipsis.emplace();
+    else formals->ellipsis.reset();
+}
+
+static void setEllipsis(const Pos & pos, Formals * formals, Symbol name) {
+    setEllipsis(pos, formals, true);
+    formals->ellipsis.emplace(name);
+    // Check that the symbol we use is not also a formal argument:
+    if (!formals->argNames.insert(name).second)
+        throw ParseError({
+            .msg = hintfmt("duplicate formal function argument '%1%'", name),
+            .errPos = pos
+        });
+}
+
 
 static Expr * stripIndentation(const Pos & pos, SymbolTable & symbols, vector<Expr *> & es)
 {
@@ -570,11 +587,13 @@ formals
   : formal ',' formals
     { $$ = $3; addFormal(CUR_POS, $$, *$1); }
   | formal
-    { $$ = new Formals; addFormal(CUR_POS, $$, *$1); $$->ellipsis = false; }
+    { $$ = new Formals; addFormal(CUR_POS, $$, *$1); setEllipsis(CUR_POS, $$, false); }
   |
-    { $$ = new Formals; $$->ellipsis = false; }
+    { $$ = new Formals; setEllipsis(CUR_POS, $$, false); }
+  | ELLIPSIS '@' ID
+    { $$ = new Formals; setEllipsis(CUR_POS, $$, data->symbols.create($3)); }
   | ELLIPSIS
-    { $$ = new Formals; $$->ellipsis = true; }
+    { $$ = new Formals; setEllipsis(CUR_POS, $$, true); }
   ;
 
 formal

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -167,6 +167,7 @@ static void setEllipsis(const Pos & pos, Formals * formals, Symbol name) {
     setEllipsis(pos, formals, true);
     formals->ellipsis.emplace(name);
     // Check that the symbol we use is not also a formal argument:
+    settings.requireExperimentalFeature(Xp::NamedEllipsis);
     if (!formals->argNames.insert(name).second)
         throw ParseError({
             .msg = hintfmt("duplicate formal function argument '%1%'", name),

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -11,6 +11,7 @@ std::map<ExperimentalFeature, std::string> stringifiedXpFeatures = {
     { Xp::NixCommand, "nix-command" },
     { Xp::RecursiveNix, "recursive-nix" },
     { Xp::NoUrlLiterals, "no-url-literals" },
+    { Xp::NamedEllipsis, "named-ellipsis" },
 };
 
 const std::optional<ExperimentalFeature> parseExperimentalFeature(const std::string_view & name)

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -19,7 +19,8 @@ enum struct ExperimentalFeature
     Flakes,
     NixCommand,
     RecursiveNix,
-    NoUrlLiterals
+    NoUrlLiterals,
+    NamedEllipsis,
 };
 
 /**


### PR DESCRIPTION
This PR adds a new language feature: named ellipsis.

```nix
nix-repl> ({ x, ... @ y } : y)  { x = 1; a = 1; }
{ a = 1; }
```

Often, we see the following pattern:

```nix
{ foo, bar, ... } @ args:
  let
    strippedArgs = builtins.removeAttrs args [ "foo" "bar" ];
  in
    ...
```

This is error-prone and repeats all the formal arguments. With this PR, this can be replaced with:

```nix
{ foo, bar, ... @ strippedArgs }:
  ...
```

# TODO

- [ ] Write an RFC to get this properly discussed in the community
- [x] Hide this behind a flag
- [ ] Write tests
- [ ] Write documentation