### PR TITLE
Fix stack buffer overflow in references.cc

### DIFF
--- a/src/libstore/references.cc
+++ b/src/libstore/references.cc
@@ -54,7 +54,7 @@ void RefScanSink::operator () (std::string_view data)
        fragment, so search in the concatenation of the tail of the
        previous fragment and the start of the current fragment. */
     auto s = tail;
-    s.append(data.data(), refLength);
+    s.append(data.data(), std::min(data.size(), refLength));
     search(s, hashes, seen);
 
     search(data, hashes, seen);


### PR DESCRIPTION
Build nix with AddressSanitizer (ASan) and it reported a **stack buffer overflow** when executing _nix-build_


```bash
[nix-shell:~/code/github.com/NixOS/nix]$ ./outputs/out/bin/nix-build /tmp/concurrent.nix 
==349601==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7ffe6f7c9000; bottom 0x7f082ec76000; size: 0x00f640b53000 (1057647570944)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
these 5 derivations will be built:
  /nix/store/9vvwqn7jjgqn0fn4msr04adyl36cwbcf-builder.sh.drv
  /nix/store/wacxnkpcl88r7zszspigcpas7a8gs06z-a.drv
  /nix/store/ys0wy01m6x8dwgp04b24l194x4mlmf7v-b.drv
  /nix/store/flm2m5yasrdjhnyariybg0lx5n98c6rm-builder.sh.drv
  /nix/store/8br3bkjslbd9qnkxha2h8m40qwbi8zxv-test.drv
building '/nix/store/9vvwqn7jjgqn0fn4msr04adyl36cwbcf-builder.sh.drv'...
=================================================================
==349601==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffe6f7bb4e8 at pc 0x0000006783ee bp 0x7ffe6f7bb250 sp 0x7ffe6f7baa00
READ of size 32 at 0x7ffe6f7bb4e8 thread T0
    #0 0x6783ed in __interceptor_memcpy.part.0 (/home/fmzakari/code/github.com/NixOS/nix/outputs/out/bin/nix+0x6783ed)
    #1 0x7f085457928f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) (/home/fmzakari/code/github.com/NixOS/nix/outputs/out/lib/libnixutil.so+0x4db28f)
    #2 0x7f085457a86a in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_append(char const*, unsigned long) (/home/fmzakari/code/github.com/NixOS/nix/outputs/out/lib/libnixutil.so+0x4dc86a)
    #3 0x7f08550951d1 in nix::RefScanSink::operator()(std::basic_string_view<char, std::char_traits<char> >) /home/fmzakari/code/github.com/NixOS/nix/src/libstore/references.cc:57:7
    #4 0x7f0854d147e6 in nix::TeeSink::operator()(std::basic_string_view<char, std::char_traits<char> >) /home/fmzakari/code/github.com/NixOS/nix/src/libutil/serialise.hh:184:9
    #5 0x85bd19 in nix::operator<<(nix::Sink&, unsigned long) /home/fmzakari/code/github.com/NixOS/nix/src/libutil/serialise.hh:316:5
    #6 0x7f085446cef6 in nix::writeString(std::basic_string_view<char, std::char_traits<char> >, nix::Sink&) /home/fmzakari/code/github.com/NixOS/nix/src/libutil/serialise.cc:322:10
    #7 0x7f085446d01e in nix::operator<<(nix::Sink&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/fmzakari/code/github.com/NixOS/nix/src/libutil/serialise.cc:330:5
    #8 0x7f085437ffa1 in nix::dumpPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, nix::Sink&, std::function<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>&) /home/fmzakari/code/github.com/NixOS/nix/src/libutil/archive.cc:123:10
    #9 0x7f085509637e in nix::scanForReferences(nix::Sink&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::set<nix::StorePath, std::less<nix::StorePath>, std::allocator<nix::StorePath> > const&) /home/fmzakari/code/github.com/NixOS/nix/src/libstore/references.cc:98:5
    #10 0x7f0854e31979 in nix::LocalDerivationGoal::registerOutputs() /home/fmzakari/code/github.com/NixOS/nix/src/libstore/build/local-derivation-goal.cc:2143:27
    #11 0x7f0854dc53a0 in nix::DerivationGoal::buildDone() /home/fmzakari/code/github.com/NixOS/nix/src/libstore/build/derivation-goal.cc:879:9
    #12 0x7f0854db95c2 in nix::DerivationGoal::work() /home/fmzakari/code/github.com/NixOS/nix/src/libstore/build/derivation-goal.cc:143:5
    #13 0x7f0854e9f83c in nix::Worker::run(std::set<std::shared_ptr<nix::Goal>, nix::CompareGoalPtrs, std::allocator<std::shared_ptr<nix::Goal> > > const&) /home/fmzakari/code/github.com/NixOS/nix/src/libstore/build/worker.cc:268:23
    #14 0x7f0854e012fe in nix::Store::buildPaths(std::vector<nix::DerivedPath, std::allocator<nix::DerivedPath> > const&, nix::BuildMode, std::shared_ptr<nix::Store>) /home/fmzakari/code/github.com/NixOS/nix/src/libstore/build/entry-points.cc:24:12
    #15 0x753e0b in main_nix_build(int, char**)::$_2::operator()(std::vector<nix::StorePathWithOutputs, std::allocator<nix::StorePathWithOutputs> > const&) const /home/fmzakari/code/github.com/NixOS/nix/src/nix-build/nix-build.cc:344:20
    #16 0x74d0db in main_nix_build(int, char**) /home/fmzakari/code/github.com/NixOS/nix/src/nix-build/nix-build.cc:568:9
    #17 0x7e72b2 in void std::__invoke_impl<void, void (*&)(int, char**), int, char**>(std::__invoke_other, void (*&)(int, char**), int&&, char**&&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60:14
    #18 0x7e7218 in std::enable_if<is_invocable_r_v<void, void (*&)(int, char**), int, char**>, void>::type std::__invoke_r<void, void (*&)(int, char**), int, char**>(void (*&)(int, char**), int&&, char**&&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110:2
    #19 0x7e70e8 in std::_Function_handler<void (int, char**), void (*)(int, char**)>::_M_invoke(std::_Any_data const&, int&&, char**&&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291:9
    #20 0x97f6cf in std::function<void (int, char**)>::operator()(int, char**) const /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622:14
    #21 0x979ef4 in nix::mainWrapped(int, char**) /home/fmzakari/code/github.com/NixOS/nix/src/nix/main.cc:273:28
    #22 0x97ed9a in main::$_2::operator()() const /home/fmzakari/code/github.com/NixOS/nix/src/nix/main.cc:388:9
    #23 0x97ed20 in void std::__invoke_impl<void, main::$_2&>(std::__invoke_other, main::$_2&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60:14
    #24 0x97ece0 in std::enable_if<is_invocable_r_v<void, main::$_2&>, void>::type std::__invoke_r<void, main::$_2&>(main::$_2&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110:2
    #25 0x97ec10 in std::_Function_handler<void (), main::$_2>::_M_invoke(std::_Any_data const&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291:9
    #26 0x98c1ab in std::function<void ()>::operator()() const /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622:14
    #27 0x7f085597822a in nix::handleExceptions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()>) /home/fmzakari/code/github.com/NixOS/nix/src/libmain/shared.cc:359:13
    #28 0x97d895 in main /home/fmzakari/code/github.com/NixOS/nix/src/nix/main.cc:387:12
    #29 0x7f0853b37dec in __libc_start_main (/nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc.so.6+0x27dec)
    #30 0x6022b9 in _start /build/glibc-2.32/csu/../sysdeps/x86_64/start.S:120

Address 0x7ffe6f7bb4e8 is located in stack of thread T0 at offset 40 in frame
    #0 0x85baef in nix::operator<<(nix::Sink&, unsigned long) /home/fmzakari/code/github.com/NixOS/nix/src/libutil/serialise.hh:306

  This frame has 2 object(s):
    [32, 40) 'buf' (line 307)
    [64, 80) 'agg.tmp' <== Memory access at offset 40 partially underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow (/home/fmzakari/code/github.com/NixOS/nix/outputs/out/bin/nix+0x6783ed) in __interceptor_memcpy.part.0
Shadow bytes around the buggy address:
  0x10004deef640: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004deef650: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x10004deef660: 00 00 f2 f2 00 00 00 00 f2 f2 f2 f2 f8 f2 f2 f2
  0x10004deef670: f8 f8 f8 f8 f3 f3 f3 f3 00 00 00 00 00 00 00 00
  0x10004deef680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10004deef690: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00[f2]f2 f2
  0x10004deef6a0: 00 00 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004deef6b0: 00 00 00 00 f1 f1 f1 f1 00 00 f3 f3 00 00 00 00
  0x10004deef6c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004deef6d0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x10004deef6e0: 00 00 00 00 00 00 f2 f2 f2 f2 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==349601==ABORTING
```

Here is the Nix derivation I ran
```nix
let nixpkgs = import <nixpkgs> {};
in
with nixpkgs;
with stdenv;
with lib;
let make-large-derivation = name: derivation {
        inherit name;
        system = builtins.currentSystem;
        builder = writeScript "builder.sh" ''
            #!/bin/sh
            ${coreutils}/bin/dd if=/dev/urandom of=$out bs=64M count=16
        '';
    };
    a = (make-large-derivation "a");
    b = (make-large-derivation "b");
in
derivation {
    name = "test";
    system = builtins.currentSystem;
    builder = writeScript "builder.sh" ''
        #!/bin/sh
        echo ${a} >> $out
        echo ${b} >> $out
    '';
}
```

With this fix the derivation builds successfully with no memory sanitizer errors reported.