### PR TITLE
Fix heap use after free in progress-bar.cc

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -11,7 +11,7 @@
 
 namespace nix {
 
-static std::string getS(const std::vector<Logger::Field> & fields, size_t n)
+static std::string_view getS(const std::vector<Logger::Field> & fields, size_t n)
 {
     assert(n < fields.size());
     assert(fields[n].type == Logger::Field::tString);


### PR DESCRIPTION
Fix some heap-use-after-free in progress-bar.cc

These are somewhat tricky failures here due to temporary variable creation and _string_view_

I've included links to the fixes with more information to inform other developers to be wary.

Here was the failure:
```
[nix-shell:~/code/github.com/NixOS/nix]$ ./src/nix/nix build -f ~/code/playground/nix/concurrent.nix 
trace: Warning: `stdenv.lib` is deprecated and will be removed in the next release. Please use `lib` instead. For more information see https://github.com/NixOS/nixpkgs/issues/108938
==2023391==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7ffd7376c000; bottom 0x7ff604901000; size: 0x00076ee6b000 (31925383168)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
querying info about missing paths=================================================================
==2023391==ERROR: AddressSanitizer: heap-use-after-free on address 0x606000d3d4ad at pc 0x00000067893e bp 0x7ffd73767570 sp 0x7ffd73766d20
READ of size 6 at 0x606000d3d4ad thread T0
    #0 0x67893d in __interceptor_memcpy.part.0 (/home/fzakaria/code/github.com/NixOS/nix/src/nix/nix+0x67893d)
    #1 0x7ff62ab22057 in std::basic_streambuf<char, std::char_traits<char> >::xsputn(char const*, long) (/home/fzakaria/code/github.com/NixOS/nix/src/libutil/libnixutil.so+0x4da057)
    #2 0x7ff62ab133b3 in std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long) (/home/fzakaria/code/github.com/NixOS/nix/src/libutil/libnixutil.so+0x4cb3b3)
    #3 0x83bf37 in std::basic_ostream<char, std::char_traits<char> >& std::operator<<<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, std::basic_string_view<char, std::char_traits<char> >) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/string_view:621:14
    #4 0x83be22 in void boost::io::detail::put_last<char, std::char_traits<char>, std::basic_string_view<char, std::char_traits<char> > >(std::basic_ostream<char, std::char_traits<char> >&, std::basic_string_view<char, std::char_traits<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/feed_args.hpp:99:12
    #5 0x83bdd8 in void boost::io::detail::call_put_last<char, std::char_traits<char>, std::basic_string_view<char, std::char_traits<char> > const>(std::basic_ostream<char, std::char_traits<char> >&, void const*) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/feed_args.hpp:126:9
    #6 0x7253f0 in void boost::io::detail::put_last<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, boost::io::detail::put_holder<char, std::char_traits<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/feed_args.hpp:149:9
    #7 0x722e91 in void boost::io::detail::put<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::io::detail::put_holder<char, std::char_traits<char> > const&, boost::io::detail::format_item<char, std::char_traits<char>, std::allocator<char> > const&, boost::basic_format<char, std::char_traits<char>, std::allocator<char> >::string_type&, boost::basic_format<char, std::char_traits<char>, std::allocator<char> >::internal_streambuf_t&, std::locale*) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/feed_args.hpp:197:13
    #8 0x72235c in void boost::io::detail::distribute<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, boost::io::detail::put_holder<char, std::char_traits<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/feed_args.hpp:291:17
    #9 0x721a2f in boost::basic_format<char, std::char_traits<char>, std::allocator<char> >& boost::io::detail::feed_impl<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, boost::io::detail::put_holder<char, std::char_traits<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/feed_args.hpp:301:9
    #10 0x83bcd0 in boost::basic_format<char, std::char_traits<char>, std::allocator<char> >& boost::io::detail::feed<char, std::char_traits<char>, std::allocator<char>, std::basic_string_view<char, std::char_traits<char> > const&>(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, std::basic_string_view<char, std::char_traits<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/feed_args.hpp:313:16
    #11 0x83bbb8 in boost::basic_format<char, std::char_traits<char>, std::allocator<char> >& boost::basic_format<char, std::char_traits<char>, std::allocator<char> >::operator%<std::basic_string_view<char, std::char_traits<char> > >(std::basic_string_view<char, std::char_traits<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/include/boost/format/format_class.hpp:64:22
    #12 0x7ff62bf14a7d in void nix::formatHelper<boost::basic_format<char, std::char_traits<char>, std::allocator<char> >, std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, std::basic_string_view<char, std::char_traits<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/src/libutil/fmt.hh:44:20
    #13 0x7ff62bf1232f in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > nix::fmt<std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::basic_string_view<char, std::char_traits<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/fzakaria/code/github.com/NixOS/nix/src/libutil/fmt.hh:67:5
    #14 0x7ff62bf042d4 in nix::ProgressBar::startActivity(unsigned long, nix::Verbosity, nix::ActivityType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<nix::Logger::Field, std::allocator<nix::Logger::Field> > const&, unsigned long) /home/fzakaria/code/github.com/NixOS/nix/src/libmain/progress-bar.cc:188:20
    #15 0x7ff62b64cde9 in nix::RemoteStore::Connection::processStderr(nix::Sink*, nix::Source*, bool) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:1008:21
    #16 0x7ff62b660fed in nix::ConnectionHandle::processStderr(nix::Sink*, nix::Source*, bool) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:277:27
    #17 0x7ff62b6569fa in nix::RemoteStore::buildPaths(std::vector<nix::DerivedPath, std::allocator<nix::DerivedPath> > const&, nix::BuildMode, std::shared_ptr<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:759:10
    #18 0x7ff62b6572a5 in virtual thunk to nix::RemoteStore::buildPaths(std::vector<nix::DerivedPath, std::allocator<nix::DerivedPath> > const&, nix::BuildMode, std::shared_ptr<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc
    #19 0x7ff62a571d0f in nix::build(nix::ref<nix::Store>, nix::ref<nix::Store>, nix::Realise, std::vector<std::shared_ptr<nix::Installable>, std::allocator<std::shared_ptr<nix::Installable> > > const&, nix::BuildMode) /home/fzakaria/code/github.com/NixOS/nix/src/libcmd/installables.cc:766:16
    #20 0x87bc2c in CmdBuild::run(nix::ref<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/nix/build.cc:55:27
    #21 0x87c592 in virtual thunk to CmdBuild::run(nix::ref<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/nix/build.cc
    #22 0x7ff62a52f273 in nix::StoreCommand::run() /home/fzakaria/code/github.com/NixOS/nix/src/libcmd/command.cc:54:5
    #23 0x97b6c8 in nix::mainWrapped(int, char**) /home/fzakaria/code/github.com/NixOS/nix/src/nix/main.cc:376:27
    #24 0x97f2ea in main::$_2::operator()() const /home/fzakaria/code/github.com/NixOS/nix/src/nix/main.cc:388:9
    #25 0x97f270 in void std::__invoke_impl<void, main::$_2&>(std::__invoke_other, main::$_2&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60:14
    #26 0x97f230 in std::enable_if<is_invocable_r_v<void, main::$_2&>, void>::type std::__invoke_r<void, main::$_2&>(main::$_2&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110:2
    #27 0x97f160 in std::_Function_handler<void (), main::$_2>::_M_invoke(std::_Any_data const&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291:9
    #28 0x98c6fb in std::function<void ()>::operator()() const /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622:14
    #29 0x7ff62bf2224a in nix::handleExceptions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()>) /home/fzakaria/code/github.com/NixOS/nix/src/libmain/shared.cc:359:13
    #30 0x97dde5 in main /home/fzakaria/code/github.com/NixOS/nix/src/nix/main.cc:387:12
    #31 0x7ff62a0e1dec in __libc_start_main (/nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc.so.6+0x27dec)
    #32 0x602809 in _start /build/glibc-2.32/csu/../sysdeps/x86_64/start.S:120

0x606000d3d4ad is located 45 bytes inside of 52-byte region [0x606000d3d480,0x606000d3d4b4)
freed by thread T0 here:
    #0 0x715207 in operator delete(void*) (/home/fzakaria/code/github.com/NixOS/nix/src/nix/nix+0x715207)
    #1 0x7ff62bf041c6 in nix::ProgressBar::startActivity(unsigned long, nix::Verbosity, nix::ActivityType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<nix::Logger::Field, std::allocator<nix::Logger::Field> > const&, unsigned long) /home/fzakaria/code/github.com/NixOS/nix/src/libmain/progress-bar.cc:186:25
    #2 0x7ff62b64cde9 in nix::RemoteStore::Connection::processStderr(nix::Sink*, nix::Source*, bool) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:1008:21
    #3 0x7ff62b660fed in nix::ConnectionHandle::processStderr(nix::Sink*, nix::Source*, bool) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:277:27
    #4 0x7ff62b6569fa in nix::RemoteStore::buildPaths(std::vector<nix::DerivedPath, std::allocator<nix::DerivedPath> > const&, nix::BuildMode, std::shared_ptr<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:759:10
    #5 0x7ff62b6572a5 in virtual thunk to nix::RemoteStore::buildPaths(std::vector<nix::DerivedPath, std::allocator<nix::DerivedPath> > const&, nix::BuildMode, std::shared_ptr<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc
    #6 0x7ff62a571d0f in nix::build(nix::ref<nix::Store>, nix::ref<nix::Store>, nix::Realise, std::vector<std::shared_ptr<nix::Installable>, std::allocator<std::shared_ptr<nix::Installable> > > const&, nix::BuildMode) /home/fzakaria/code/github.com/NixOS/nix/src/libcmd/installables.cc:766:16
    #7 0x87bc2c in CmdBuild::run(nix::ref<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/nix/build.cc:55:27
    #8 0x87c592 in virtual thunk to CmdBuild::run(nix::ref<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/nix/build.cc
    #9 0x7ff62a52f273 in nix::StoreCommand::run() /home/fzakaria/code/github.com/NixOS/nix/src/libcmd/command.cc:54:5
    #10 0x97b6c8 in nix::mainWrapped(int, char**) /home/fzakaria/code/github.com/NixOS/nix/src/nix/main.cc:376:27
    #11 0x97f2ea in main::$_2::operator()() const /home/fzakaria/code/github.com/NixOS/nix/src/nix/main.cc:388:9
    #12 0x97f270 in void std::__invoke_impl<void, main::$_2&>(std::__invoke_other, main::$_2&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60:14
    #13 0x97f230 in std::enable_if<is_invocable_r_v<void, main::$_2&>, void>::type std::__invoke_r<void, main::$_2&>(main::$_2&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110:2
    #14 0x97f160 in std::_Function_handler<void (), main::$_2>::_M_invoke(std::_Any_data const&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291:9
    #15 0x98c6fb in std::function<void ()>::operator()() const /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622:14
    #16 0x7ff62bf2224a in nix::handleExceptions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()>) /home/fzakaria/code/github.com/NixOS/nix/src/libmain/shared.cc:359:13
    #17 0x97dde5 in main /home/fzakaria/code/github.com/NixOS/nix/src/nix/main.cc:387:12
    #18 0x7ff62a0e1dec in __libc_start_main (/nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc.so.6+0x27dec)

previously allocated by thread T0 here:
    #0 0x71440f in operator new(unsigned long) (/home/fzakaria/code/github.com/NixOS/nix/src/nix/nix+0x71440f)
    #1 0x72888f in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/basic_string.tcc:219:14
    #2 0x7ff62bf024e7 in nix::getS[abi:cxx11](std::vector<nix::Logger::Field, std::allocator<nix::Logger::Field> > const&, unsigned long) /home/fzakaria/code/github.com/NixOS/nix/src/libmain/progress-bar.cc:18:12
    #3 0x7ff62bf0415c in nix::ProgressBar::startActivity(unsigned long, nix::Verbosity, nix::ActivityType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<nix::Logger::Field, std::allocator<nix::Logger::Field> > const&, unsigned long) /home/fzakaria/code/github.com/NixOS/nix/src/libmain/progress-bar.cc:186:41
    #4 0x7ff62b64cde9 in nix::RemoteStore::Connection::processStderr(nix::Sink*, nix::Source*, bool) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:1008:21
    #5 0x7ff62b660fed in nix::ConnectionHandle::processStderr(nix::Sink*, nix::Source*, bool) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:277:27
    #6 0x7ff62b6569fa in nix::RemoteStore::buildPaths(std::vector<nix::DerivedPath, std::allocator<nix::DerivedPath> > const&, nix::BuildMode, std::shared_ptr<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc:759:10
    #7 0x7ff62b6572a5 in virtual thunk to nix::RemoteStore::buildPaths(std::vector<nix::DerivedPath, std::allocator<nix::DerivedPath> > const&, nix::BuildMode, std::shared_ptr<nix::Store>) /home/fzakaria/code/github.com/NixOS/nix/src/libstore/remote-store.cc
    #8 0x7ff62a571d0f in nix::build(nix::ref<nix::Store>, nix::ref<nix::Store>, nix::Realise, std::vecto
```
