### PR TITLE
Allow testing `ssh://` and `ssh-ng://` across versions too

### DIFF
--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -17,7 +17,10 @@ struct LegacySSHStoreConfig : virtual CommonSSHStoreConfig
 {
     using CommonSSHStoreConfig::CommonSSHStoreConfig;
 
-    const Setting<Path> remoteProgram{(StoreConfig*) this, "nix-store", "remote-program",
+    const Setting<Path> remoteProgram{
+        (StoreConfig*) this,
+        getEnv("_NIX_TEST_LEGACY_SSH_REMOTE_PROGRAM").value_or("nix-store"),
+        "remote-program",
         "Path to the `nix-store` executable on the remote machine."};
 
     const Setting<int> maxConnections{(StoreConfig*) this, 1, "max-connections",

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -16,7 +16,10 @@ struct SSHStoreConfig : virtual RemoteStoreConfig, virtual CommonSSHStoreConfig
     using RemoteStoreConfig::RemoteStoreConfig;
     using CommonSSHStoreConfig::CommonSSHStoreConfig;
 
-    const Setting<Path> remoteProgram{(StoreConfig*) this, "nix-daemon", "remote-program",
+    const Setting<Path> remoteProgram{
+        (StoreConfig*) this,
+        getEnv("_NIX_TEST_SSH_REMOTE_PROGRAM").value_or("nix-daemon"),
+        "remote-program",
         "Path to the `nix-daemon` executable on the remote machine."};
 
     const std::string name() override { return "Experimental SSH Store"; }


### PR DESCRIPTION
We want to make sure both protocols don't break. Also recall `ssh-ng://` will be slightly different than `unix://` because the former transfers files over the protocol too.

I am not sure what the status of adding new configuration env vars is. I hope if `NIX_DAEMON_SOCKET` path was OK, these too are too, but if not I suppose we could try to sneak and shove some `?remote-command=...` into the tests.

~~depends on #5598~~

The dependency is mainly to avoid merge conflicts.