### PR TITLE
"recursive-nix" system feature only with experimental feature

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -122,7 +122,7 @@ StringSet Settings::getDefaultSystemFeatures()
     /* For backwards compatibility, accept some "features" that are
        used in Nixpkgs to route builds to certain machines but don't
        actually require anything special on the machines. */
-    StringSet features{"nixos-test", "benchmark", "big-parallel", "recursive-nix"};
+    StringSet features{"nixos-test", "benchmark", "big-parallel"};
 
     #if __linux__
     if (access("/dev/kvm", R_OK | W_OK) == 0)

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -355,8 +355,13 @@ ValidPathInfo Store::addToStoreSlow(std::string_view name, const Path & srcPath,
 StringSet StoreConfig::getDefaultSystemFeatures()
 {
     auto res = settings.systemFeatures.get();
+
     if (settings.isExperimentalFeatureEnabled(Xp::CaDerivations))
         res.insert("ca-derivations");
+
+    if (settings.isExperimentalFeatureEnabled(Xp::RecursiveNix))
+        res.insert("recursive-nix");
+
     return res;
 }
 


### PR DESCRIPTION
I worry this patch won't work as written because the order of
initialization is not what we need, or even the same in all situations.