### PR TITLE
curl usage in install script in sync with instructions

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -81,10 +81,10 @@ if [ "$(uname -s)" != "Darwin" ]; then
     require_util xz "unpack the binary tarball"
 fi
 
-if command -v wget > /dev/null 2>&1; then
-    fetch() { wget "$1" -O "$2"; }
-elif command -v curl > /dev/null 2>&1; then
+if command -v curl > /dev/null 2>&1; then
     fetch() { curl -L "$1" -o "$2"; }
+elif command -v wget > /dev/null 2>&1; then
+    fetch() { wget "$1" -O "$2"; }
 else
     oops "you don't have wget or curl installed, which I need to download the binary tarball"
 fi


### PR DESCRIPTION
Hi!

This change makes the install script consistent with the installation instructions while keeping `wget` as an alternative.

Based on the current installation instructions, one starts with invoking `curl` but the install script gives precedence to `wget`. It can happen, that `curl` works on a system, but `wget` does not. [^1] It is very confusing when the install process starts by downloading the script but then the installer script indicates a network error.

In pull request [#5096](https://github.com/NixOS/nix/pull/5096) @AnatoleLucet and @Mic92 introduced support for `wget` during the installation. In it Anatole suggested changing the installation instructions from the current `curl -L https://nixos.org/nix/install | sh` to one that's using `wget`, but this didn't happen. I simply switched the order of the availability checks to ensure that curl comes first.

[^1]: For example, if the user is behind a proxy and the the environmental variable used is HTTPS_PROXY then `curl` will work, but `wget` won't. This is just one example, but as long as `curl` can work and `wget`can fail these errors can appear and will be confusing. 

