### PR TITLE
add real path to allowedPaths

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -520,7 +520,7 @@ Path EvalState::checkSourcePath(const Path & path_)
     }
 
     if (!found)
-        throw RestrictedPathError("access to path '%1%' is forbidden in restricted mode", abspath);
+        throw RestrictedPathError("access to absolute path '%1%' is forbidden in restricted mode", abspath);
 
     /* Resolve symlinks. */
     debug(format("checking access to '%s'") % abspath);
@@ -533,7 +533,7 @@ Path EvalState::checkSourcePath(const Path & path_)
         }
     }
 
-    throw RestrictedPathError("access to path '%1%' is forbidden in restricted mode", path);
+    throw RestrictedPathError("access to canonical path '%1%' is forbidden in restricted mode", path);
 }
 
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -70,7 +70,7 @@ void EvalState::realiseContext(const PathSet & context)
                 if (outputPaths.count(outputName) == 0)
                     throw Error("derivation '%s' does not have an output named '%s'",
                             store->printStorePath(drvPath), outputName);
-                allowedPaths->insert(store->printStorePath(outputPaths.at(outputName)));
+                allowPath(outputPaths.at(outputName));
             }
         }
     }


### PR DESCRIPTION
Use established method and use toRealPath instead of printStorePath.

Modify errors to be able to distinguish them.

Fixes #4277 