### PR TITLE
flakes: fix boolean and int nixConfig values

### DIFF
--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -38,11 +38,11 @@ void ConfigFile::apply()
 
         // FIXME: Move into libutil/config.cc.
         std::string valueS;
-        if (auto s = std::get_if<std::string>(&value))
+        if (auto* s = std::get_if<std::string>(&value))
             valueS = *s;
-        else if (auto n = std::get_if<int64_t>(&value))
-            valueS = fmt("%d", n);
-        else if (auto b = std::get_if<Explicit<bool>>(&value))
+        else if (auto* n = std::get_if<int64_t>(&value))
+            valueS = fmt("%d", *n);
+        else if (auto* b = std::get_if<Explicit<bool>>(&value))
             valueS = b->t ? "true" : "false";
         else if (auto ss = std::get_if<std::vector<std::string>>(&value))
             valueS = concatStringsSep(" ", *ss); // FIXME: evil

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -254,7 +254,7 @@ static Flake getFlake(
             else if (setting.value->type() == nInt)
                 flake.config.settings.insert({setting.name, state.forceInt(*setting.value, *setting.pos)});
             else if (setting.value->type() == nBool)
-                flake.config.settings.insert({setting.name, state.forceBool(*setting.value, *setting.pos)});
+                flake.config.settings.insert({setting.name, Explicit<bool> { state.forceBool(*setting.value, *setting.pos) }});
             else if (setting.value->type() == nList) {
                 std::vector<std::string> ss;
                 for (unsigned int n = 0; n < setting.value->listSize(); ++n) {

--- a/tests/flake-local-settings.sh
+++ b/tests/flake-local-settings.sh
@@ -18,6 +18,7 @@ chmod +x echoing-post-hook.sh
 cat <<EOF > flake.nix
 {
     nixConfig.post-build-hook = "$PWD/echoing-post-hook.sh";
+    nixConfig.allow-dirty = false; # See #5621
 
     outputs = a: {
        defaultPackage.$system = import ./simple.nix;


### PR DESCRIPTION
Some type confusion was causing ints to be pointers, and bools to be ints. Fixes #5621