### PR TITLE
flake: Do not use aliases

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
             libarchive
             boost
             lowdown-nix
-            gmock
+            gtest
           ]
           ++ lib.optionals stdenv.isLinux [libseccomp]
           ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium


### PR DESCRIPTION
gmock is not available with `nixpkgs.config.allowAliases = false`.