### PR TITLE
Backport to 2.4: fix oahd path

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -148,7 +148,8 @@ StringSet Settings::getDefaultExtraPlatforms()
     // machines. Note that we can’t force processes from executing
     // x86_64 in aarch64 environments or vice versa since they can
     // always exec with their own binary preferences.
-    if (pathExists("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist")) {
+    if (pathExists("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist") ||
+        pathExists("/System/Library/LaunchDaemons/com.apple.oahd.plist")) {
         if (std::string{SYSTEM} == "x86_64-darwin")
             extraPlatforms.insert("aarch64-darwin");
         else if (std::string{SYSTEM} == "aarch64-darwin")

--- a/src/libstore/sandbox-defaults.sb
+++ b/src/libstore/sandbox-defaults.sb
@@ -100,4 +100,5 @@
 
 ; Allow Rosetta 2 to run x86_64 binaries on aarch64-darwin.
 (allow file-read*
-       (subpath "/Library/Apple/usr/libexec/oah"))
+       (subpath "/Library/Apple/usr/libexec/oah")
+       (subpath "/System/Library/Apple/usr/libexec/oah"))


### PR DESCRIPTION
based on:

https://github.com/NixOS/nix/pull/5628

and

https://github.com/NixOS/nix/pull/5388