### PR TITLE
Add missing Nix::Store import to fix nix-serve StoreDir.

### DIFF
--- a/perl/lib/Nix/Config.pm.in
+++ b/perl/lib/Nix/Config.pm.in
@@ -1,6 +1,7 @@
 package Nix::Config;
 
 use MIME::Base64;
+use Nix::Store;
 
 $version = "@PACKAGE_VERSION@";
 


### PR DESCRIPTION
This fixes an issue I'm seeing where the `/nix-cache-info` endpoint of `nix-serve` returns the name of the perl binding rather than the store path itself.

**Steps to reproduce**
1.  In one terminal run:
        `nix-shell --packages nix-serve --run 'nix-serve --listen localhost:8080'`
2. With nix-serve still running, in another terminal run:
        `curl -s http://localhost:8080/nix-cache-info | grep 'StoreDir:'`

Actual output: `StoreDir: Nix::Store::getStoreDir`
Expected output: `StoreDir: /nix/store`

It looks like this was introduced by [c9f51e870](https://github.com/NixOS/nix/commit/c9f51e870#diff-8552ecdc52d99c776063d0257ebd01ad651722d7d5855cf5c4e16d290f6066df).