### PR TITLE
[backport 2.3] Separate auth and logic for the daemon

### DIFF
--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -2,6 +2,9 @@ source common.sh
 
 clearStore
 
+# Ensure "fake ssh" remote store works just as legacy fake ssh would.
+nix --store ssh-ng://localhost?remote-store=$TEST_ROOT/other-store doctor
+
 startDaemon
 
 storeCleared=1 NIX_REMOTE_=$NIX_REMOTE $SHELL ./user-envs.sh


### PR DESCRIPTION
Before, `processConnection` wanted to know a user name and user id, and `nix-daemon --stdio`, when it isn't proxying to an underlying daemon, would just assume "root" and 0. But `nix-daemon --stdio` (no proxying) shouldn't make guesses about who holds the other end of its standard streams.

Now `processConnection` takes an "auth hook", so `nix-daemon` can provide the appropriate policy and daemon.cc doesn't need to know or care what it is.

(cherry picked from commit 8d4162ff9e940ea9e2f97b07f3030a722695901a)

Depends on https://github.com/NixOS/nix/pull/5650
(not actually, but yes in terms of it wouldn't be useful until then.)