### PR TITLE
Fix a minor data race with _isInterrupted

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1205,7 +1205,7 @@ void closeOnExec(int fd)
 //////////////////////////////////////////////////////////////////////
 
 
-bool _isInterrupted = false;
+std::atomic<bool> _isInterrupted = false;
 
 static thread_local bool interruptThrown = false;
 thread_local std::function<bool()> interruptCheck;

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -337,7 +337,7 @@ void closeOnExec(int fd);
 
 /* User interruption. */
 
-extern bool _isInterrupted;
+extern std::atomic<bool> _isInterrupted;
 
 extern thread_local std::function<bool()> interruptCheck;
 


### PR DESCRIPTION
```
    WARNING: ThreadSanitizer: data race (pid=8220)
      Write of size 1 at 0x7efbfea73e68 by thread T1:
        #0 nix::triggerInterrupt() src/libutil/util.cc:1577 (libnixutil.so+0x15bc7a)
        #1 signalHandlerThread src/libutil/util.cc:1567 (libnixutil.so+0x15be14)
        #2 void std::__invoke_impl<void, void (*)(__sigset_t), __sigset_t>(std::__invoke_other, void (*&&)(__sigset_t), __sigset_t&&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60 (libnixutil.so+0x167f19)
        #3 std::__invoke_result<void (*)(__sigset_t), __sigset_t>::type std::__invoke<void (*)(__sigset_t), __sigset_t>(void (*&&)(__sigset_t), __sigset_t&&) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:95 (libnixutil.so+0x167f19)
        #4 void std::thread::_Invoker<std::tuple<void (*)(__sigset_t), __sigset_t> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/thread:264 (libnixutil.so+0x167f19)
        #5 std::thread::_Invoker<std::tuple<void (*)(__sigset_t), __sigset_t> >::operator()() /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/thread:271 (libnixutil.so+0x167f19)
        #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(__sigset_t), __sigset_t> > >::_M_run() /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/thread:215 (libnixutil.so+0x167f19)
        #7 <null> <null> (libstdc++.so.6+0xd6c9f)
    
      Previous read of size 1 at 0x7efbfea73e68 by main thread:
        #0 nix::checkInterrupt() src/libutil/util.hh:350 (nix+0x5aa914)
        #1 daemonLoop src/nix/daemon.cc:189 (nix+0x5aa914)
        #2 runDaemon src/nix/daemon.cc:308 (nix+0x5aa914)
        #3 CmdDaemon::run(nix::ref<nix::Store>) src/nix/daemon.cc:355 (nix+0x5b0521)
        #4 nix::StoreCommand::run() src/libcmd/command.cc:54 (libnixcmd.so+0x439df)
        #5 nix::mainWrapped(int, char**) src/nix/main.cc:376 (nix+0x667c78)
        #6 operator() src/nix/main.cc:388 (nix+0x668ef8)
        #7 __invoke_impl<void, main(int, char**)::<lambda()>&> /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60 (nix+0x668ef8)
        #8 __invoke_r<void, main(int, char**)::<lambda()>&> /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110 (nix+0x668ef8)
        #9 _M_invoke /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291 (nix+0x668ef8)
        #10 std::function<void ()>::operator()() const /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622 (libnixmain.so+0x512a2)
        #11 nix::handleExceptions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()>) src/libmain/shared.cc:359 (libnixmain.so+0x512a2)
        #12 main src/nix/main.cc:387 (nix+0x47ab01)
    
      Location is global 'nix::_isInterrupted' of size 1 at 0x7efbfea73e68 (libnixutil.so+0x0000001bde68)
    
      Thread T1 (tid=8950, running) created by main thread at:
        #0 pthread_create <null> (libtsan.so.0+0x5cb82)
        #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xd6f14)
        #2 nix::initNix() src/libmain/shared.cc:164 (libnixmain.so+0x54755)
        #3 nix::mainWrapped(int, char**) src/nix/main.cc:255 (nix+0x66723a)
        #4 operator() src/nix/main.cc:388 (nix+0x668ef8)
        #5 __invoke_impl<void, main(int, char**)::<lambda()>&> /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:60 (nix+0x668ef8)
        #6 __invoke_r<void, main(int, char**)::<lambda()>&> /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/invoke.h:110 (nix+0x668ef8)
        #7 _M_invoke /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:291 (nix+0x668ef8)
        #8 std::function<void ()>::operator()() const /nix/store/sjhz1j2d1ssn59f66kqp92xj9mpsww2d-gcc-10.3.0/include/c++/10.3.0/bits/std_function.h:622 (libnixmain.so+0x512a2)
        #9 nix::handleExceptions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()>) src/libmain/shared.cc:359 (libnixmain.so+0x512a2)
        #10 main src/nix/main.cc:387 (nix+0x47ab01)

```