### PR TITLE
Make `nix flake show` less strict wrt what apps can be

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1024,13 +1024,17 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                     (attrPath.size() == 2 && attrPath[0] == "defaultApp") ||
                     (attrPath.size() == 3 && attrPath[0] == "apps"))
                 {
-                    auto aType = visitor.maybeGetAttr("type");
-                    if (!aType || aType->getString() != "app")
-                        throw EvalError("not an app definition");
-                    if (json) {
-                        j.emplace("type", "app");
-                    } else {
-                        logger->cout("%s: app", headerPrefix);
+                    if (visitor.isDerivation())
+                        showDerivation();
+                    else {
+                        auto aType = visitor.maybeGetAttr("type");
+                        if (!aType || aType->getString() != "app")
+                            throw EvalError("not an app definition");
+                        if (json) {
+                            j.emplace("type", "app");
+                        } else {
+                            logger->cout("%s: app", headerPrefix);
+                        }
                     }
                 }
 

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -380,6 +380,11 @@ cat > $templatesDir/trivial/flake.nix <<EOF
   outputs = { self, nixpkgs }: {
     packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
     defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
+    apps.x86_64-linux.helloWorld = {
+        type = "app";
+        program = "\${nixpkgs.legacyPackages.x86_64-linux.hello}/bin/hello";
+    };
+    apps.x86_64-linux.helloWorld2 = nixpkgs.legacyPackages.x86_64-linux.hello;
   };
 }
 EOF


### PR DESCRIPTION
Allow `apps.foo` and `defaultApp` to be a plain derivation like `nix run` does.

Fix #5560

cc @kamadorueda 
