### PR TITLE
Fix the error when accessing a forbidden path in pure eval

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -519,8 +519,12 @@ Path EvalState::checkSourcePath(const Path & path_)
         }
     }
 
-    if (!found)
-        throw RestrictedPathError("access to absolute path '%1%' is forbidden in restricted mode", abspath);
+    if (!found) {
+        auto modeInformation = evalSettings.pureEval
+            ? "in pure eval mode (use '--impure' to override)"
+            : "in restricted mode";
+        throw RestrictedPathError("access to absolute path '%1%' is forbidden %2%", abspath, modeInformation);
+    }
 
     /* Resolve symlinks. */
     debug(format("checking access to '%s'") % abspath);

--- a/tests/pure-eval.sh
+++ b/tests/pure-eval.sh
@@ -6,7 +6,10 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 
 [[ $(nix eval --impure --expr 'builtins.readFile ./pure-eval.sh') =~ clearStore ]]
 
-(! nix eval --expr 'builtins.readFile ./pure-eval.sh')
+missingImpureErrorMsg=$(! nix eval --expr 'builtins.readFile ./pure-eval.sh' 2>&1)
+
+echo "$missingImpureErrorMsg" | grep -q -- --impure || \
+    fail "The error message should mention the “--impure” flag to unblock users"
 
 (! nix eval --expr builtins.currentTime)
 (! nix eval --expr builtins.currentSystem)


### PR DESCRIPTION
If we’re in pure eval mode, then tell that in the error message rather than (wrongly) speaking about restricted mode.

Fix https://github.com/NixOS/nix/issues/5611

cc @CrystalGamma 