### PR TITLE
Catch flake-related exception type in REPL

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -356,6 +356,8 @@ StringSet NixRepl::completePrefix(string prefix)
             // Quietly ignore evaluation errors.
         } catch (UndefinedVarError & e) {
             // Quietly ignore undefined variable errors.
+        } catch (BadURL & e) {
+            // Quietly ignore BadURL flake-related errors.
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/NixOS/nix/issues/5656