### PR TITLE
reproducibility: determinstic man page output for cores

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -12,11 +12,13 @@ man-pages := $(foreach n, \
 clean-files += $(d)/*.1 $(d)/*.5 $(d)/*.8
 
 # Provide a dummy environment for nix, so that it will not access files outside the macOS sandbox.
+# Set cores to 0 because otherwise nix show-config resolves the cores based on the current machine
 dummy-env = env -i \
 	HOME=/dummy \
 	NIX_CONF_DIR=/dummy \
 	NIX_SSL_CERT_FILE=/dummy/no-ca-bundle.crt \
-	NIX_STATE_DIR=/dummy
+	NIX_STATE_DIR=/dummy \
+	NIX_CONFIG='cores = 0'
 
 nix-eval = $(dummy-env) $(bindir)/nix eval --experimental-features nix-command -I nix/corepkgs=corepkgs --store dummy:// --impure --raw
 


### PR DESCRIPTION
Man page output depends on the build machine.

Fixes: https://r13y.com/diff/bceec81ab96da678ea6855d55af19840fba8d158daa4e4da618bb7896789bdfa-000c650227704ff22fee3a885db90cd5ac3ba19f68da841cbfd85065051a90a7.html

![20211126_10h13m16s_grim](https://user-images.githubusercontent.com/178444/143606259-6653b333-2b61-4688-817b-f95093924a38.png)

Note: Created during NixUX Friday Extravaganza @regnat @balsoft @Radvendii 