### PR TITLE
forceValue: make pos mandatory

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -522,7 +522,7 @@ ref<eval_cache::EvalCache> openEvalCache(
             auto vFlake = state.allocValue();
             flake::callFlake(state, *lockedFlake, *vFlake);
 
-            state.forceAttrs(*vFlake);
+            state.forceAttrs(*vFlake, noPos);
 
             auto aOutputs = vFlake->attrs->get(state.symbols.create("outputs"));
             assert(aOutputs);

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -58,7 +58,7 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attr
         Value * vNew = state.allocValue();
         state.autoCallFunction(autoArgs, *v, *vNew);
         v = vNew;
-        state.forceValue(*v, v->determinePos(vIn.determinePos(noPos)));
+        state.forceValue(*v, noPos);
 
         /* It should evaluate to either a set or an expression,
            according to what is specified in the attrPath. */

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -58,7 +58,7 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const string & attr
         Value * vNew = state.allocValue();
         state.autoCallFunction(autoArgs, *v, *vNew);
         v = vNew;
-        state.forceValue(*v);
+        state.forceValue(*v, v->determinePos(vIn.determinePos(noPos)));
 
         /* It should evaluate to either a set or an expression,
            according to what is specified in the attrPath. */

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -336,7 +336,7 @@ Value & AttrCursor::getValue()
     if (!_value) {
         if (parent) {
             auto & vParent = parent->first->getValue();
-            root->state.forceAttrs(vParent, vParent.determinePos(noPos));
+            root->state.forceAttrs(vParent, noPos);
             auto attr = vParent.attrs->get(parent->second);
             if (!attr)
                 throw Error("attribute '%s' is unexpectedly missing", getAttrPathStr());
@@ -381,7 +381,7 @@ Value & AttrCursor::forceValue()
     auto & v = getValue();
 
     try {
-        root->state.forceValue(v, v.determinePos(noPos));
+        root->state.forceValue(v, noPos);
     } catch (EvalError &) {
         debug("setting '%s' to failed", getAttrPathStr());
         if (root->db)

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -381,7 +381,7 @@ Value & AttrCursor::forceValue()
     auto & v = getValue();
 
     try {
-        root->state.forceValue(v);
+        root->state.forceValue(v, v.determinePos(noPos));
     } catch (EvalError &) {
         debug("setting '%s' to failed", getAttrPathStr());
         if (root->db)

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -336,7 +336,7 @@ Value & AttrCursor::getValue()
     if (!_value) {
         if (parent) {
             auto & vParent = parent->first->getValue();
-            root->state.forceAttrs(vParent);
+            root->state.forceAttrs(vParent, vParent.determinePos(noPos));
             auto attr = vParent.attrs->get(parent->second);
             if (!attr)
                 throw Error("attribute '%s' is unexpectedly missing", getAttrPathStr());

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -51,27 +51,11 @@ void EvalState::forceValue(Value & v, const Pos & pos)
 }
 
 
-inline void EvalState::forceAttrs(Value & v)
-{
-    forceValue(v, v.determinePos(noPos));
-    if (v.type() != nAttrs)
-        throwTypeError("value is %1% while a set was expected", v);
-}
-
-
 inline void EvalState::forceAttrs(Value & v, const Pos & pos)
 {
     forceValue(v, pos);
     if (v.type() != nAttrs)
         throwTypeError(pos, "value is %1% while a set was expected", v);
-}
-
-
-inline void EvalState::forceList(Value & v)
-{
-    forceValue(v, v.determinePos(noPos));
-    if (!v.isList())
-        throwTypeError("value is %1% while a list was expected", v);
 }
 
 

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -53,7 +53,7 @@ void EvalState::forceValue(Value & v, const Pos & pos)
 
 inline void EvalState::forceAttrs(Value & v)
 {
-    forceValue(v);
+    forceValue(v, v.determinePos(noPos));
     if (v.type() != nAttrs)
         throwTypeError("value is %1% while a set was expected", v);
 }
@@ -69,7 +69,7 @@ inline void EvalState::forceAttrs(Value & v, const Pos & pos)
 
 inline void EvalState::forceList(Value & v)
 {
-    forceValue(v);
+    forceValue(v, v.determinePos(noPos));
     if (!v.isList())
         throwTypeError("value is %1% while a list was expected", v);
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1280,7 +1280,7 @@ void ExprOpHasAttr::eval(EvalState & state, Env & env, Value & v)
     e->eval(state, env, vTmp);
 
     for (auto & i : attrPath) {
-        state.forceValue(*vAttrs, vAttrs->determinePos(noPos));
+        state.forceValue(*vAttrs, noPos);
         Bindings::iterator j;
         Symbol name = getName(i, state, env);
         if (vAttrs->type() != nAttrs ||
@@ -2037,8 +2037,8 @@ Path EvalState::coerceToPath(const Pos & pos, Value & v, PathSet & context)
 
 bool EvalState::eqValues(Value & v1, Value & v2)
 {
-    forceValue(v1, v1.determinePos(noPos));
-    forceValue(v2, v2.determinePos(noPos));
+    forceValue(v1, noPos);
+    forceValue(v2, noPos);
 
     /* !!! Hack to support some old broken code that relies on pointer
        equality tests between sets.  (Specifically, builderDefs calls

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1132,7 +1132,7 @@ void ExprAttrs::eval(EvalState & state, Env & env, Value & v)
            Hence we need __overrides.) */
         if (hasOverrides) {
             Value * vOverrides = (*v.attrs)[overrides->second.displ].value;
-            state.forceAttrs(*vOverrides);
+            state.forceAttrs(*vOverrides, vOverrides->determinePos(noPos));
             Bindings * newBnds = state.allocBindings(v.attrs->capacity() + vOverrides->attrs->size());
             for (auto & i : *v.attrs)
                 newBnds->push_back(i);

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -221,7 +221,7 @@ public:
        of the evaluation of the thunk.  If `v' is a delayed function
        application, call the function and overwrite `v' with the
        result.  Otherwise, this is a no-op. */
-    inline void forceValue(Value & v, const Pos & pos = noPos);
+    inline void forceValue(Value & v, const Pos & pos);
 
     /* Force a value, then recursively force list elements and
        attributes. */

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -231,9 +231,7 @@ public:
     NixInt forceInt(Value & v, const Pos & pos);
     NixFloat forceFloat(Value & v, const Pos & pos);
     bool forceBool(Value & v, const Pos & pos);
-    inline void forceAttrs(Value & v);
     inline void forceAttrs(Value & v, const Pos & pos);
-    inline void forceList(Value & v);
     inline void forceList(Value & v, const Pos & pos);
     void forceFunction(Value & v, const Pos & pos); // either lambda or primop
     string forceString(Value & v, const Pos & pos = noPos);

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -107,7 +107,7 @@ DrvInfo::Outputs DrvInfo::queryOutputs(bool onlyOutputsToInstall)
                 string name = state->forceStringNoCtx(*elem, *i->pos);
                 Bindings::iterator out = attrs->find(state->symbols.create(name));
                 if (out == attrs->end()) continue; // FIXME: throw error?
-                state->forceAttrs(*out->value);
+                state->forceAttrs(*out->value, *i->pos);
 
                 /* And evaluate its ‘outPath’ attribute. */
                 Bindings::iterator outPath = out->value->attrs->find(state->sOutPath);

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -172,7 +172,7 @@ StringSet DrvInfo::queryMetaNames()
 
 bool DrvInfo::checkMeta(Value & v)
 {
-    state->forceValue(v);
+    state->forceValue(v, v.determinePos(noPos));
     if (v.type() == nList) {
         for (auto elem : v.listItems())
             if (!checkMeta(*elem)) return false;
@@ -278,7 +278,7 @@ static bool getDerivation(EvalState & state, Value & v,
     bool ignoreAssertionFailures)
 {
     try {
-        state.forceValue(v);
+        state.forceValue(v, v.determinePos(noPos));
         if (!state.isDerivation(v)) return true;
 
         /* Remove spurious duplicates (e.g., a set like `rec { x =

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -214,7 +214,7 @@ static void import(EvalState & state, const Pos & pos, Value & vPath, Value * vS
         if (!vScope)
             state.evalFile(path, v);
         else {
-            state.forceAttrs(*vScope);
+            state.forceAttrs(*vScope, pos);
 
             Env * env = &state.allocEnv(vScope->attrs->size());
             env->up = &state.baseEnv;
@@ -2485,7 +2485,7 @@ static void prim_zipAttrsWith(EvalState & state, const Pos & pos, Value * * args
     for (unsigned int n = 0; n < listSize; ++n) {
         Value * vElem = listElems[n];
         try {
-            state.forceAttrs(*vElem);
+            state.forceAttrs(*vElem, noPos);
             for (auto & attr : *vElem->attrs)
                 attrsSeen[attr.name].first++;
         } catch (TypeError & e) {

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -318,7 +318,7 @@ static void main_nix_build(int argc, char * * argv)
 
         for (auto & i : attrPaths) {
             Value & v(*findAlongAttrPath(*state, i, *autoArgs, vRoot).first);
-            state->forceValue(v);
+            state->forceValue(v, v.determinePos(noPos));
             getDerivations(*state, v, "", *autoArgs, drvs, false);
         }
     }

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -129,7 +129,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
 
     /* Evaluate it. */
     debug("evaluating user environment builder");
-    state.forceValue(topLevel);
+    state.forceValue(topLevel, topLevel.determinePos(noPos));
     PathSet context;
     Attr & aDrvPath(*topLevel.attrs->find(state.sDrvPath));
     auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(*aDrvPath.pos, *aDrvPath.value, context));

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -40,7 +40,7 @@ void processExpr(EvalState & state, const Strings & attrPaths,
 
     for (auto & i : attrPaths) {
         Value & v(*findAlongAttrPath(state, i, autoArgs, vRoot).first);
-        state.forceValue(v);
+        state.forceValue(v, v.determinePos(noPos));
 
         PathSet context;
         if (evalOnly) {

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -81,7 +81,7 @@ struct CmdEval : MixJSON, InstallableCommand
 
             recurse = [&](Value & v, const Pos & pos, const Path & path)
             {
-                state->forceValue(v);
+                state->forceValue(v, pos);
                 if (v.type() == nString)
                     // FIXME: disallow strings with contexts?
                     writeFile(path, v.string.s);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -124,12 +124,13 @@ struct CmdFlakeLock : FlakeCommand
 static void enumerateOutputs(EvalState & state, Value & vFlake,
     std::function<void(const std::string & name, Value & vProvide, const Pos & pos)> callback)
 {
-    state.forceAttrs(vFlake);
+    auto pos = vFlake.determinePos(noPos);
+    state.forceAttrs(vFlake, pos);
 
     auto aOutputs = vFlake.attrs->get(state.symbols.create("outputs"));
     assert(aOutputs);
 
-    state.forceAttrs(*aOutputs->value);
+    state.forceAttrs(*aOutputs->value, pos);
 
     auto sHydraJobs = state.symbols.create("hydraJobs");
 

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -33,7 +33,7 @@ string resolveMirrorUrl(EvalState & state, string url)
     auto mirrorList = vMirrors.attrs->find(state.symbols.create(mirrorName));
     if (mirrorList == vMirrors.attrs->end())
         throw Error("unknown mirror name '%s'", mirrorName);
-    state.forceList(*mirrorList->value);
+    state.forceList(*mirrorList->value, noPos);
 
     if (mirrorList->value->listSize() < 1)
         throw Error("mirror URL '%s' did not expand to anything", url);
@@ -200,7 +200,7 @@ static int main_nix_prefetch_url(int argc, char * * argv)
 
             /* Extract the URL. */
             auto & attr = v.attrs->need(state->symbols.create("urls"));
-            state->forceList(*attr.value);
+            state->forceList(*attr.value, noPos);
             if (attr.value->listSize() < 1)
                 throw Error("'urls' list is empty");
             url = state->forceString(*attr.value->listElems()[0]);

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -28,7 +28,7 @@ string resolveMirrorUrl(EvalState & state, string url)
     Value vMirrors;
     // FIXME: use nixpkgs flake
     state.eval(state.parseExprFromString("import <nixpkgs/pkgs/build-support/fetchurl/mirrors.nix>", "."), vMirrors);
-    state.forceAttrs(vMirrors);
+    state.forceAttrs(vMirrors, noPos);
 
     auto mirrorList = vMirrors.attrs->find(state.symbols.create(mirrorName));
     if (mirrorList == vMirrors.attrs->end())
@@ -196,7 +196,7 @@ static int main_nix_prefetch_url(int argc, char * * argv)
             Value vRoot;
             state->evalFile(path, vRoot);
             Value & v(*findAlongAttrPath(*state, attrPath, autoArgs, vRoot).first);
-            state->forceAttrs(v);
+            state->forceAttrs(v, noPos);
 
             /* Extract the URL. */
             auto & attr = v.attrs->need(state->symbols.create("urls"));

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -712,7 +712,7 @@ void NixRepl::evalString(string s, Value & v)
 {
     Expr * e = parseString(s);
     e->eval(*state, *env, v);
-    state->forceValue(v);
+    state->forceValue(v, v.determinePos(noPos));
 }
 
 
@@ -742,7 +742,7 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
     str.flush();
     checkInterrupt();
 
-    state->forceValue(v);
+    state->forceValue(v, v.determinePos(noPos));
 
     switch (v.type()) {
 

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -342,7 +342,7 @@ StringSet NixRepl::completePrefix(string prefix)
             Expr * e = parseString(expr);
             Value v;
             e->eval(*state, *env, v);
-            state->forceAttrs(v);
+            state->forceAttrs(v, noPos);
 
             for (auto & i : *v.attrs) {
                 string name = i.name;
@@ -673,7 +673,7 @@ void NixRepl::reloadFiles()
 
 void NixRepl::addAttrsToScope(Value & attrs)
 {
-    state->forceAttrs(attrs);
+    state->forceAttrs(attrs, attrs.determinePos(noPos));
     if (displ + attrs.attrs->size() >= envSize)
         throw Error("environment full; cannot add more variables");
 


### PR DESCRIPTION
- Make passing the position to `forceValue` mandatory,
  this way we remember people that the position is
  important for better error messages
- Add pos to all `forceValue` calls

Mentions #3505