### PR TITLE
Document libcpuid dependency and make it optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -195,10 +195,17 @@ PKG_CHECK_MODULES([SODIUM], [libsodium], [CXXFLAGS="$SODIUM_CFLAGS $CXXFLAGS"])
 PKG_CHECK_MODULES([LIBBROTLI], [libbrotlienc libbrotlidec], [CXXFLAGS="$LIBBROTLI_CFLAGS $CXXFLAGS"])
 
 # Look for libcpuid.
+have_libcpuid=
 if test "$machine_name" = "x86_64"; then
-  PKG_CHECK_MODULES([LIBCPUID], [libcpuid], [CXXFLAGS="$LIBCPUID_CFLAGS $CXXFLAGS"])
-  have_libcpuid=1
-  AC_DEFINE([HAVE_LIBCPUID], [1], [Use libcpuid])
+    AC_ARG_ENABLE([cpuid],
+                  AS_HELP_STRING([--disable-cpuid], [Do not determine microarchitecture levels with libcpuid (relevant to x86_64 only)]))
+    if test "x$enable_cpuid" != "xno"; then
+      PKG_CHECK_MODULES([LIBCPUID], [libcpuid],
+        [CXXFLAGS="$LIBCPUID_CFLAGS $CXXFLAGS"
+         have_libcpuid=1
+         AC_DEFINE([HAVE_LIBCPUID], [1], [Use libcpuid])]
+      )
+    fi
 fi
 AC_SUBST(HAVE_LIBCPUID, [$have_libcpuid])
 

--- a/doc/manual/src/installation/prerequisites-source.md
+++ b/doc/manual/src/installation/prerequisites-source.md
@@ -58,3 +58,9 @@
     `--disable-seccomp-sandboxing` option to the `configure` script (Not
     recommended unless your system doesn't support `libseccomp`). To get
     the library, visit <https://github.com/seccomp/libseccomp>.
+
+  - On 64-bit x86 machines only, `libcpuid` library
+    is used to determine which microarchitecture levels are supported
+    (e.g., as whether to have `x86_64-v2-linux` among additional system types).
+    The library is available from its homepage
+    <http://libcpuid.sourceforge.net>.

--- a/doc/manual/src/installation/prerequisites-source.md
+++ b/doc/manual/src/installation/prerequisites-source.md
@@ -64,3 +64,5 @@
     (e.g., as whether to have `x86_64-v2-linux` among additional system types).
     The library is available from its homepage
     <http://libcpuid.sourceforge.net>.
+    This is an optional dependency and can be disabled
+    by providing a `--disable-cpuid` to the `configure` script.

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -48,7 +48,6 @@ nix_tests = \
   flakes.sh \
   flake-local-settings.sh \
   build.sh \
-  compute-levels.sh \
   repl.sh ca/repl.sh \
   ca/build.sh \
   ca/build-with-garbage-path.sh \
@@ -62,6 +61,10 @@ nix_tests = \
   ca/nix-copy.sh \
   eval-store.sh
   # parallel.sh
+
+ifeq ($(HAVE_LIBCPUID), 1)
+	nix_tests += compute-levels.sh
+endif
 
 install-tests += $(foreach x, $(nix_tests), tests/$(x))
 


### PR DESCRIPTION
`libcpuid` dependency:

1. was not documented
2. had nearly all plumbing in order to have it optional, yet no way to actually build without it on x86_64

I've tried building without it (test failed, made test conditional) and with it (test does get executed), so the change seems to work as expected.