### PR TITLE
Add a github cron to check the hydra status

### DIFF
--- a/.github/workflows/hydra_status.yml
+++ b/.github/workflows/hydra_status.yml
@@ -1,0 +1,16 @@
+name: Hydra status
+on:
+  schedule:
+    - cron: "12,42 * * * *"
+  workflow_dispatch:
+jobs:
+  check_hydra_status:
+    name: Check Hydra status
+    if: github.repository_owner == 'NixOS'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+    - run: bash scripts/check-hydra-status.sh
+

--- a/scripts/check-hydra-status.sh
+++ b/scripts/check-hydra-status.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+# set -x
+
+
+# mapfile BUILDS_FOR_LATEST_EVAL < <(
+# curl -H 'Accept: application/json' https://hydra.nixos.org/jobset/nix/master/evals | \
+#   jq -r '.evals[0].builds[] | @sh')
+BUILDS_FOR_LATEST_EVAL=$(
+curl -sS -H 'Accept: application/json' https://hydra.nixos.org/jobset/nix/master/evals | \
+  jq -r '.evals[0].builds[]')
+
+someBuildFailed=0
+
+for buildId in $BUILDS_FOR_LATEST_EVAL; do
+  buildInfo=$(curl -sS -H 'Accept: application/json' "https://hydra.nixos.org/build/$buildId")
+
+  buildStatus=$(echo "$buildInfo" | \
+    jq -r '.buildstatus')
+
+  if [[ "$buildStatus" -ne 0 ]]; then
+    someBuildFailed=1
+    echo "Job “$(echo "$buildInfo" | jq -r '.job')” failed on hydra"
+  fi
+done
+
+exit "$someBuildFailed"


### PR DESCRIPTION
Add a regular github action that will check the status of the latest hydra evaluation.

Things aren’t ideal right now because this job will only notify “the user who last modified the cron syntax in the workflow file” (so myself atm). But at least that’ll give a notification for failing hydra jobs
