### PR TITLE
darwin-store: Ensure NIX_ROOT is mounted after reboot.

### DIFF
--- a/scripts/create-darwin-volume.sh
+++ b/scripts/create-darwin-volume.sh
@@ -305,6 +305,14 @@ generate_mount_daemon() {
 <dict>
   <key>RunAtLoad</key>
   <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>PathState</key>
+    <dict>
+      <key>$NIX_ROOT/store</key>
+      <false/>
+    </dict>
+  </dict>
   <key>Label</key>
   <string>org.nixos.darwin-store</string>
   <key>ProgramArguments</key>


### PR DESCRIPTION
When a darwin host is rebooted, /nix was not mounted.