### PR TITLE
reproducibility: hide non-reproducible settings from manual

### DIFF
--- a/doc/manual/generate-options.nix
+++ b/doc/manual/generate-options.nix
@@ -8,17 +8,19 @@ concatStrings (map
     let option = options.${name}; in
     "  - `${name}`  \n\n"
     + concatStrings (map (s: "    ${s}\n") (splitLines option.description)) + "\n\n"
-    + "    **Default:** " + (
-      if option.value == "" || option.value == []
-      then "*empty*"
-      else if isBool option.value
-      then (if option.value then "`true`" else "`false`")
-      else
-        # n.b. a StringMap value type is specified as a string, but
-        # this shows the value type.  The empty stringmap is "null" in
-        # JSON, but that converts to "{ }" here.
-        (if isAttrs option.value then "`\"\"`"
-         else "`" + toString option.value + "`")) + "\n\n"
+    + (if option.documentDefault
+       then "    **Default:** " + (
+       if option.value == "" || option.value == []
+       then "*empty*"
+       else if isBool option.value
+       then (if option.value then "`true`" else "`false`")
+       else
+         # n.b. a StringMap value type is specified as a string, but
+         # this shows the value type.  The empty stringmap is "null" in
+         # JSON, but that converts to "{ }" here.
+         (if isAttrs option.value then "`\"\"`"
+          else "`" + toString option.value + "`")) + "\n\n"
+       else "    **Default:** *machine-specific*")
     + (if option.aliases != []
        then "    **Deprecated alias:** " + (concatStringsSep ", " (map (s: "`${s}`") option.aliases)) + "\n\n"
        else "")

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -21,7 +21,7 @@ struct MaxBuildJobsSetting : public BaseSetting<unsigned int>
         const std::string & name,
         const std::string & description,
         const std::set<std::string> & aliases = {})
-        : BaseSetting<unsigned int>(def, name, description, aliases)
+        : BaseSetting<unsigned int>(def, true, name, description, aliases)
     {
         options->addSetting(this);
     }
@@ -38,7 +38,7 @@ struct PluginFilesSetting : public BaseSetting<Paths>
         const std::string & name,
         const std::string & description,
         const std::set<std::string> & aliases = {})
-        : BaseSetting<Paths>(def, name, description, aliases)
+        : BaseSetting<Paths>(def, true, name, description, aliases)
     {
         options->addSetting(this);
     }
@@ -130,7 +130,9 @@ public:
         {"build-max-jobs"}};
 
     Setting<unsigned int> buildCores{
-        this, getDefaultCores(), "cores",
+        this,
+        getDefaultCores(),
+        "cores",
         R"(
           Sets the value of the `NIX_BUILD_CORES` environment variable in the
           invocation of builders. Builders can use this variable at their
@@ -141,7 +143,7 @@ public:
           command line switch and defaults to `1`. The value `0` means that
           the builder should use all available CPU cores in the system.
         )",
-        {"build-cores"}};
+        {"build-cores"}, false};
 
     /* Read-only mode.  Don't copy stuff to the store, don't change
        the database. */
@@ -583,10 +585,11 @@ public:
           platform and generate incompatible code, so you may wish to
           cross-check the results of using this option against proper
           natively-built versions of your derivations.
-        )"};
+        )", {}, false};
 
     Setting<StringSet> systemFeatures{
-        this, getDefaultSystemFeatures(),
+        this,
+        getDefaultSystemFeatures(),
         "system-features",
         R"(
           A set of system “features” supported by this machine, e.g. `kvm`.
@@ -602,7 +605,7 @@ public:
           This setting by default includes `kvm` if `/dev/kvm` is accessible,
           and the pseudo-features `nixos-test`, `benchmark` and `big-parallel`
           that are used in Nixpkgs to route builds to specific machines.
-        )"};
+        )", {}, false};
 
     Setting<Strings> substituters{
         this,

--- a/src/libutil/abstract-setting-to-json.hh
+++ b/src/libutil/abstract-setting-to-json.hh
@@ -10,6 +10,7 @@ std::map<std::string, nlohmann::json> BaseSetting<T>::toJSONObject()
     auto obj = AbstractSetting::toJSONObject();
     obj.emplace("value", value);
     obj.emplace("defaultValue", defaultValue);
+    obj.emplace("documentDefault", documentDefault);
     return obj;
 }
 }

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -232,16 +232,19 @@ protected:
 
     T value;
     const T defaultValue;
+    const bool documentDefault;
 
 public:
 
     BaseSetting(const T & def,
+        const bool documentDefault,
         const std::string & name,
         const std::string & description,
         const std::set<std::string> & aliases = {})
         : AbstractSetting(name, description, aliases)
         , value(def)
         , defaultValue(def)
+        , documentDefault(documentDefault)
     { }
 
     operator const T &() const { return value; }
@@ -288,8 +291,9 @@ public:
         const T & def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {})
-        : BaseSetting<T>(def, name, description, aliases)
+        const std::set<std::string> & aliases = {},
+        const bool documentDefault = true)
+        : BaseSetting<T>(def, documentDefault, name, description, aliases)
     {
         options->addSetting(this);
     }
@@ -311,7 +315,7 @@ public:
         const std::string & name,
         const std::string & description,
         const std::set<std::string> & aliases = {})
-        : BaseSetting<Path>(def, name, description, aliases)
+        : BaseSetting<Path>(def, true, name, description, aliases)
         , allowEmpty(allowEmpty)
     {
         options->addSetting(this);

--- a/src/libutil/tests/config.cc
+++ b/src/libutil/tests/config.cc
@@ -161,7 +161,7 @@ namespace nix {
         Setting<std::string> setting{&config, "", "name-of-the-setting", "description"};
         setting.assign("value");
 
-        ASSERT_EQ(config.toJSON().dump(), R"#({"name-of-the-setting":{"aliases":[],"defaultValue":"","description":"description\n","value":"value"}})#");
+        ASSERT_EQ(config.toJSON().dump(), R"#({"name-of-the-setting":{"aliases":[],"defaultValue":"","description":"description\n","documentDefault":true,"value":"value"}})#");
     }
 
     TEST(Config, setSettingAlias) {


### PR DESCRIPTION
Because the manual is generated from default values which are themselves
generated from various sources (cpuid, bios settings (kvm), number of
cores). This commit hides non-reproducible settings from the manual
output.