### PR TITLE
nix store gc --dry-run: print paths

### DIFF
--- a/src/nix/store-gc.cc
+++ b/src/nix/store-gc.cc
@@ -37,6 +37,10 @@ struct CmdStoreGC : StoreCommand, MixDryRun
         GCResults results;
         PrintFreed freed(options.action == GCOptions::gcDeleteDead, results);
         store->collectGarbage(options, results);
+        if (dryRun)
+          for (auto & i : results.paths)
+            std::cout << i << std::endl;
+
     }
 };
 


### PR DESCRIPTION
Fixes #5704 .

Functionality is basic, and indeed code was copied from how it's already done here for non-experimental version: https://github.com/NixOS/nix/blob/f3f32f0c30f197af2fd5a90702f7002ae74b2dfb/src/nix-store/nix-store.cc#L605

---

Would add a test, but there appears no tests for `nix store gc` in-tree so wasn't sure where to put it (and adding new test/setup seems beyond scope here).  If there's a good place let me know :smile:.

I'm seeing many ways to print things, so mostly just did what we already do for this but maybe that's not right for new code-- LMK and happy to fix :+1:.

(seems sometimes with `fmt("%s\n", x)` and mix of newlines using `<< "\n"` and `<< std::endl`.  Each with trade-offs re:allocations, race against other prints (possibly separating path from newline, maybe), and flushing behavior, I think?)

Anyway short fix for issue I filed earlier, apologies if this is in wrong direction haven't been following development very closely but wanted to chip in :innocent:.

Thanks!