### PR TITLE
src/libutil/util.hh: fix build on gcc-11

### DIFF
--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <signal.h>
 
+#include <atomic>
 #include <functional>
 #include <map>
 #include <sstream>


### PR DESCRIPTION
Due to missing <atomic> declaration the build fails as:

    src/libutil/util.hh:350:24: error: no match for 'operator||' (operand types are 'std::atomic<bool>' and 'bool')
      350 |     if (_isInterrupted || (interruptCheck && interruptCheck()))
          |         ~~~~~~~~~~~~~~ ^~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          |         |                                 |
          |         std::atomic<bool>                 bool