### PR TITLE
Fix parent path check boundary

### DIFF
--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -97,7 +97,7 @@ struct PathInputScheme : InputScheme
             // for security, ensure that if the parent is a store path, it's inside it
             if (store->isInStore(parent)) {
                 auto storePath = store->printStorePath(store->toStorePath(parent).first);
-                if (!isInDir(absPath, storePath))
+                if (!isDirOrInDir(absPath, storePath))
                     throw BadStorePath("relative path '%s' points outside of its parent's store path '%s'", path, storePath);
             }
         } else


### PR DESCRIPTION
posting on behalf of @blaggacao

# Issue

- when subflakes reference the top level flake eg via `path:../.`, they hit the check boundary and the evaluation errors out at the code path subject of this PR

# Expected

- the check boundary should be inclusive of the top level flake, no evaluation error should occur
- errors should still be thrown if we violate the (now) correct check boundary

# Implementation

- this PR rectifies the check boundary and makes it inclusive of the top level flake

//cc with some help from @balsoft