### PR TITLE
Fix docker command

### DIFF
--- a/doc/manual/src/installation/installing-docker.md
+++ b/doc/manual/src/installation/installing-docker.md
@@ -3,7 +3,7 @@
 To run the latest stable release of Nix with Docker run the following command:
 
 ```console
-$ docker -ti run nixos/nix
+$ docker run -ti nixos/nix
 Unable to find image 'nixos/nix:latest' locally
 latest: Pulling from nixos/nix
 5843afab3874: Pull complete


### PR DESCRIPTION
`docker -ti run nixos` does not run on docker version 20.10.7 (my machine).  This fixes it to read `docker run -ti nixos`.