### PR TITLE
Allow -h in addition to --help

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -74,6 +74,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
 
         addFlag({
             .longName = "help",
+            .shortName = 'h',
             .description = "Show usage information.",
             .handler = {[&]() { throw HelpRequested(); }},
         });

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -34,7 +34,7 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
 
         addFlag({
             .longName = "human-readable",
-            .shortName = 'h',
+            .shortName = 'H',
             .description = "With `-s` and `-S`, print sizes in a human-friendly format such as `5.67G`.",
             .handler = {&humanReadable, true},
         });


### PR DESCRIPTION
I'm currently trying to figure out flakes and the shiny new `nix` command.
So far I really like it, but I'm somewhat missing the very common `-h` option for help.
I swear I did run `nix flake -h` or `nix run -h` at least ten times today despite knowing better.
I guess this is just muscle-memory.