### PR TITLE
Add support for .tar.gz shorthand (.tgz) to TarballInputScheme

### DIFF
--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -176,6 +176,7 @@ struct TarballInputScheme : InputScheme
 
         if (!hasSuffix(url.path, ".zip")
             && !hasSuffix(url.path, ".tar")
+            && !hasSuffix(url.path, ".tgz")
             && !hasSuffix(url.path, ".tar.gz")
             && !hasSuffix(url.path, ".tar.xz")
             && !hasSuffix(url.path, ".tar.bz2")


### PR DESCRIPTION
Hello!

I've got a flake (<https://github.com/ConnorBaker/aws-glue-scala-etl-flake>) that I've been working on to easily make an environment to develop AWS Glue jobs locally. Flake's small number of supported archives has been a big blocker for me -- in particular, the lack of support for `.tgz` (shorthand for `.tar.gz`).

I went through the source code for `tarball.cc` and saw that supported archive file extensions are enumerated in a boolean expression. I added `.tgz`, built `nix`, and ran the tests ([following the guidance here](https://hydra.nixos.org/build/160760192/download/1/manual/contributing/hacking.html)) -- all of which passed (or were skipped). I was also able to get my flake working with this build.

For reference, I've got a MacBook Pro with an M1 Max running macOS 12.1 Beta (21C5039b).

In terms of future efforts, would you all be open to changing the mechanism `tarball.cc` uses to check if it was given a supported archive? I saw ya'll are using `libarchive` and wonder if they've done anything towards that end that we could reuse.

Looking forward to hearing your thoughts!