### PR TITLE
launchd: Set NumberOfFiles to 4096

### DIFF
--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -25,5 +25,10 @@
     <string>/var/log/nix-daemon.log</string>
     <key>StandardOutPath</key>
     <string>/dev/null</string>
+    <key>SoftResourceLimits</key>
+    <dict>
+      <key>NumberOfFiles</key>
+      <integer>4096</integer>
+    </dict>
   </dict>
 </plist>


### PR DESCRIPTION
The default maxfiles on macOS 11 and macOS 12 is 256, which is too low
for nix to work:

```
$ launchctl limit maxfiles
	maxfiles    256            unlimited
```

Set NumberOfFiles of nix-daemon to 4096 to avoid `Too many open files`
error.