### PR TITLE
[Backport] Make `nix-shell` work when nixpkgs is content-addressed

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -358,6 +358,7 @@ static void main_nix_build(int argc, char * * argv)
            is not set, then build bashInteractive from
            <nixpkgs>. */
         auto shell = getEnv("NIX_BUILD_SHELL");
+        std::optional<StorePath> shellDrv;
 
         if (!shell) {
 
@@ -374,8 +375,7 @@ static void main_nix_build(int argc, char * * argv)
                 auto bashDrv = store->parseStorePath(drv->queryDrvPath());
                 pathsToBuild.push_back({bashDrv});
                 pathsToCopy.insert(bashDrv);
-
-                shell = drv->queryOutPath() + "/bin/bash";
+                shellDrv = bashDrv;
 
             } catch (Error & e) {
                 logError(e.info());
@@ -400,6 +400,11 @@ static void main_nix_build(int argc, char * * argv)
         buildPaths(pathsToBuild);
 
         if (dryRun) return;
+
+        if (shellDrv) {
+            auto shellDrvOutputs = store->queryPartialDerivationOutputMap(shellDrv.value());
+            shell = store->printStorePath(shellDrvOutputs.at("out").value()) + "/bin/bash";
+        }
 
         if (settings.isExperimentalFeatureEnabled("ca-derivations")) {
             auto resolvedDrv = drv.tryResolve(*store);

--- a/tests/ca-shell.nix
+++ b/tests/ca-shell.nix
@@ -1,0 +1,1 @@
+{ ... }@args: import ./shell.nix (args // { contentAddressed = true; })

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -3,59 +3,53 @@ source common.sh
 clearStore
 
 if [[ -n ${CONTENT_ADDRESSED:-} ]]; then
-    nix-shell () {
-        command nix-shell --arg contentAddressed true "$@"
-    }
-
-    nix_develop() {
-        nix develop --arg contentAddressed true "$@"
-    }
+    shellDotNix="$PWD/ca-shell.nix"
 else
-    nix_develop() {
-        nix develop "$@"
-    }
+    shellDotNix="$PWD/shell.nix"
 fi
+
+export NIX_PATH=nixpkgs="$shellDotNix"
 
 # Test nix-shell -A
 export IMPURE_VAR=foo
 export SELECTED_IMPURE_VAR=baz
-export NIX_BUILD_SHELL=$SHELL
-output=$(nix-shell --pure shell.nix -A shellDrv --run \
+
+output=$(nix-shell --pure "$shellDotNix" -A shellDrv --run \
     'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX - $TEST_inNixShell"')
 
 [ "$output" = " - foo - bar - true" ]
 
 # Test --keep
-output=$(nix-shell --pure --keep SELECTED_IMPURE_VAR shell.nix -A shellDrv --run \
+output=$(nix-shell --pure --keep SELECTED_IMPURE_VAR "$shellDotNix" -A shellDrv --run \
     'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX - $SELECTED_IMPURE_VAR"')
 
 [ "$output" = " - foo - bar - baz" ]
 
 # Test nix-shell on a .drv
-[[ $(nix-shell --pure $(nix-instantiate shell.nix -A shellDrv) --run \
+[[ $(nix-shell --pure $(nix-instantiate "$shellDotNix" -A shellDrv) --run \
     'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX - $TEST_inNixShell"') = " - foo - bar - false" ]]
 
-[[ $(nix-shell --pure $(nix-instantiate shell.nix -A shellDrv) --run \
+[[ $(nix-shell --pure $(nix-instantiate "$shellDotNix" -A shellDrv) --run \
     'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX - $TEST_inNixShell"') = " - foo - bar - false" ]]
 
 # Test nix-shell on a .drv symlink
 
 # Legacy: absolute path and .drv extension required
-nix-instantiate shell.nix -A shellDrv --add-root $TEST_ROOT/shell.drv
+nix-instantiate "$shellDotNix" -A shellDrv --add-root $TEST_ROOT/shell.drv
 [[ $(nix-shell --pure $TEST_ROOT/shell.drv --run \
     'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX"') = " - foo - bar" ]]
 
 # New behaviour: just needs to resolve to a derivation in the store
-nix-instantiate shell.nix -A shellDrv --add-root $TEST_ROOT/shell
+nix-instantiate "$shellDotNix" -A shellDrv --add-root $TEST_ROOT/shell
 [[ $(nix-shell --pure $TEST_ROOT/shell --run \
     'echo "$IMPURE_VAR - $VAR_FROM_STDENV_SETUP - $VAR_FROM_NIX"') = " - foo - bar" ]]
 
 # Test nix-shell -p
-output=$(NIX_PATH=nixpkgs=shell.nix nix-shell --pure -p foo bar --run 'echo "$(foo) $(bar)"')
+output=$(NIX_PATH=nixpkgs="$shellDotNix" nix-shell --pure -p foo bar --run 'echo "$(foo) $(bar)"')
 [ "$output" = "foo bar" ]
 
 # Test nix-shell -p --arg x y
-output=$(NIX_PATH=nixpkgs=shell.nix nix-shell --pure -p foo --argstr fooContents baz --run 'echo "$(foo)"')
+output=$(NIX_PATH=nixpkgs="$shellDotNix" nix-shell --pure -p foo --argstr fooContents baz --run 'echo "$(foo)"')
 [ "$output" = "baz" ]
 
 # Test nix-shell shebang mode
@@ -91,18 +85,18 @@ output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)
 [ "$output" = '-e load(ARGV.shift) -- '"$TEST_ROOT"'/spaced \'\''"shell.shebang.rb abc ruby' ]
 
 # Test 'nix develop'.
-nix_develop -f shell.nix shellDrv -c bash -c '[[ -n $stdenv ]]'
+nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'
 
 # Ensure `nix develop -c` preserves stdin
-echo foo | nix develop -f shell.nix shellDrv -c cat | grep -q foo
+echo foo | nix develop -f "$shellDotNix" shellDrv -c cat | grep -q foo
 
 # Ensure `nix develop -c` actually executes the command if stdout isn't a terminal
-nix_develop -f shell.nix shellDrv -c echo foo |& grep -q foo
+nix develop -f "$shellDotNix" shellDrv -c echo foo |& grep -q foo
 
 # Test 'nix print-dev-env'.
-[[ $(nix print-dev-env -f shell.nix shellDrv --json | jq -r .variables.arr1.value[2]) = '3 4' ]]
+[[ $(nix print-dev-env -f "$shellDotNix" shellDrv --json | jq -r .variables.arr1.value[2]) = '3 4' ]]
 
-source <(nix print-dev-env -f shell.nix shellDrv)
+source <(nix print-dev-env -f "$shellDotNix" shellDrv)
 [[ -n $stdenv ]]
 [[ ${arr1[2]} = "3 4" ]]
 [[ ${arr2[1]} = $'\n' ]]

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -74,6 +74,10 @@ let pkgs = rec {
   '';
 
   bash = shell;
+  bashInteractive = runCommand "bash" {} ''
+    mkdir -p $out/bin
+    ln -s ${shell} $out/bin/bash
+  '';
 
   # ruby "interpreter" that outputs "$@"
   ruby = runCommand "ruby" {} ''


### PR DESCRIPTION
Backport of #5259