### PR TITLE
libstore: fix buffer resize in `addToStoreFromDump`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -181,7 +181,14 @@
           mkdir -p $out
         '';
 
-        installCheckPhase = "make installcheck -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES";
+        installCheckPhase = ''
+          export PATH=${runCommand "nix-2.3-prefetch" { } ''
+            mkdir -p $out/bin
+            cp ${nixStable}/bin/nix-prefetch-url $out/bin/nix-prefetch-url-2.3
+            $out/bin/nix-prefetch-url-2.3 --version | grep -q 2.3
+          ''}/bin:$PATH
+          make installcheck -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES
+        '';
       };
 
       binaryTarball = buildPackages: nix: pkgs: let
@@ -310,6 +317,13 @@
             echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
           '';
 
+          preInstallCheck = ''
+            export PATH=${runCommand "nix-2.3-prefetch" { } ''
+              mkdir -p $out/bin
+              cp ${nixStable}/bin/nix-prefetch-url $out/bin/nix-prefetch-url-2.3
+              $out/bin/nix-prefetch-url-2.3 --version | grep -q 2.3
+            ''}/bin:$PATH
+          '';
           doInstallCheck = true;
           installCheckFlags = "sysconfdir=$(out)/etc";
 
@@ -627,6 +641,12 @@
               PATH=$prefix/bin:$PATH
               unset PYTHONPATH
               export MANPATH=$out/share/man:$MANPATH
+
+              export PATH=${runCommand "nix-2.3-prefetch" { } ''
+                mkdir -p $out/bin
+                cp ${nixStable}/bin/nix-prefetch-url $out/bin/nix-prefetch-url-2.3
+                $out/bin/nix-prefetch-url-2.3 --version | grep -q 2.3
+              ''}/bin:$PATH
             '';
         });
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1337,6 +1337,7 @@ StorePath LocalStore::addToStoreFromDump(Source & source0, const string & name,
             got = source.read(dump.data() + oldSize, want);
         } catch (EndOfFile &) {
             inMemory = true;
+            dump.resize(oldSize);
             break;
         }
         dump.resize(oldSize + got);

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -1,5 +1,6 @@
 nix_tests = \
   hash.sh lang.sh add.sh simple.sh dependencies.sh \
+  nix-prefetch-url-2.3.sh \
   config.sh \
   gc.sh \
   ca/gc.sh \

--- a/tests/nix-prefetch-url-2.3.sh
+++ b/tests/nix-prefetch-url-2.3.sh
@@ -1,0 +1,15 @@
+source common.sh
+
+export NIX_DAEMON_SOCKET_PATH=$NIX_STATE_DIR/daemon-socket/socket
+startDaemon
+
+tmpFile="$(mktemp)"
+echo fnord > "$tmpFile"
+
+prefetch() {
+    bash -c "exec -a nix-prefetch-url nix-prefetch-url-2.3 $@"
+}
+
+p="$(prefetch file://"$tmpFile" 2>&1 | tail -n2 | head -n1 | awk '{ print $3 }' | sed -e "s/'//g")"
+
+test 6 = "$(stat -c '%s' "$p")"


### PR DESCRIPTION
The original issue I'm aiming to solve were hash-mismatches on
remote-builds like this:

    this derivation will be built:
      /nix/store/2nwv1fm5bs0a2sgb2a014gv7hgfaj3f7-ruby2.7.4-vagrant_cloud-3.0.5.drv
    building '/nix/store/2nwv1fm5bs0a2sgb2a014gv7hgfaj3f7-ruby2.7.4-vagrant_cloud-3.0.5.drv' on 'ssh-ng://builder-ng'...
    copying 1 paths...
    copying path '/nix/store/j3wsx0in5hgnl3sr91i8h19b74w5hcz5-vagrant_cloud-3.0.5.gem' to 'ssh-ng://builder-ng'...
    error: ca hash mismatch importing path '/nix/store/j3wsx0in5hgnl3sr91i8h19b74w5hcz5-vagrant_cloud-3.0.5.gem';
             specified: sha256:0np0d8rjca130si5iaxasbqmfbbx4l3kd9mxdsa3p5mqiia7za3b
             got:       sha256:14iwaq2d9ai4x36w2vd4gv0zwpa9yj5nv8l6rxqfs5njd69jv90h
    error: builder for '/nix/store/2nwv1fm5bs0a2sgb2a014gv7hgfaj3f7-ruby2.7.4-vagrant_cloud-3.0.5.drv' failed with exit code 1

In contrast to my initial assumption this isn't related to hashing
changes in the CAS-implementation, but actually a problem when using
`nix-prefetch-url(1)` from Nix 2.3 with a daemon from Nix 2.4.

Basically the following happens:

* `nix-prefetch-url` from 2.3 transmits the file to the daemon using
  `wopAddToStore`.
* The daemon (`LocalStore::addToStoreFromDump` to be precise) checks
  whether the entire file can be kept in memory before writing it to the
  disk.

  This happens by writing into a buffer in chunks of 2^16 bytes. If an
  EOF is reached before the buffer exceeds `settings.narBufferSize`, the
  file can be kept in memory entirely.
* When the source is entirely read in, a last iteration will happen
  which results in the EOF. However, in this round the buffer is
  increased by 2^16 bytes again without downsizing it on the EOF (this
  only happens in the rounds without an EOF).
* The result is that the files in the store now have the size
  `(original_size + 2^16)` where the excess bytes are null-bytes at the
  end of the file.
* Because the file has different contents now than computed via the hash
  sink, a hash-mismatch occurs as soon as the file is copied to a remote
  system where the hash is apparently re-validated (in fact I could work
  around the issue from above by declaring `--builders ''`).

Resizing the buffer back to the original size in case of an EOF solves
the problem for me. I also added a regression-test that fails without
the change in `LocalStore::addToStoreFromDump` (in this case the size of
the imported file would be `65542` rather than `6`).

The issue is only observable with a 2.3 `nix-prefetch-url(1)` because
the 2.4 implementation uses `wopAddToStoreNar` which imports paths
slightly different.

cc @Ericson2314 @edolstra 