### PR TITLE
Collect eval memory before building with nix-build

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -579,6 +579,19 @@ static void main_nix_build(int argc, char * * argv)
             else
                 drvMap[drvPath] = {drvMap.size(), {outputName}};
         }
+        // Can only free the eval state after all the DrvInfo's have been freed
+        // as they carry a reference to the eval state instance (which isn't
+        // managed in any way).
+        drvs = {};
+        exprs = {};
+        state = nullptr;
+
+        // Collect garbage a couple of times as per Boehm GC docs that suggest
+        // to run it more than just once.
+        // Running it 10 times seems reasonable and doesn't appear to take too
+        // much time.
+        for (int i = 0; i < 10; i++)
+            GC_gcollect();
 
         buildPaths(store, evalStore, buildMode, pathsToBuild, dryRun);
 


### PR DESCRIPTION
```
nix-build: free eval memory before building paths

This ensures that we free some of the memory that was allocated during
the eval of the build target. In particular this will free the Boehm GC
managed memory allocations.

On my sample system I was able to reduce the memory consumption from
550MiB to about 200MiB when building the NixOS GNOME test.

The memory did initially climb to 550MiB and then shrink down to 200MiB
once the builds were kicked off.

This means I can now run more build processes (without having to resort
to swap) on resource constrained systems.

Fixes #5200 (for me)
```