### PR TITLE
Better diagnostics if no valid signature found

### DIFF
--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -138,10 +138,8 @@ void PathSubstitutionGoal::tryNext()
        only after we've downloaded the path. */
     if (!sub->isTrusted && worker.store.pathInfoIsUntrusted(*info))
     {
-        warn("substituter '%s' does not have a valid signature for path '%s'",
-            sub->getUri(), worker.store.printStorePath(storePath));
-        warn("verify that your nix.conf contains a correct signature in 'trusted-public-keys' for %s",
-            sub->getUri());
+        warn("the substitute for '%s' from '%s' is not signed by any of the keys in 'trusted-public-keys'",
+            worker.store.printStorePath(storePath), sub->getUri());
         tryNext();
         return;
     }

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -140,6 +140,8 @@ void PathSubstitutionGoal::tryNext()
     {
         warn("substituter '%s' does not have a valid signature for path '%s'",
             sub->getUri(), worker.store.printStorePath(storePath));
+        warn("verify that your nix.conf contains a correct signature in 'trusted-public-keys' for %s",
+            sub->getUri());
         tryNext();
         return;
     }


### PR DESCRIPTION
I downloaded Nix tonight, and immediately broke it by accidentally removing the default binary caching.
After figuring this out, I also failed to fix it properly, due to using the wrong key for Nix's default binary cache

If the diagnostic message would have been clearer about what/where a "signature" for a "substituter" is + comes from, it probably would have saved me a few hours.

Maybe we can save other noobs the same pain?

---

If you're wondering how on earth someone could be this dumb, the process was roughly:

- "I want to try Nix, and I have to write something in Haskell. Nix works great with Haskell right?"
- "Online, people say to use this `stack` thing, and it has Nix integration docs."
- Proceed to see this in the docs
    - ![image](https://user-images.githubusercontent.com/26604994/145315230-7fffb5ca-c859-404f-b717-eb4581dd6b0e.png)
- Neither `/etc/nix/nix.conf` exists, or `~/.config/nix/nix.conf`
- So I create `~/.config/nix/nix.conf` with the following content:

```conf
experimental-features = nix-command flakes
trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
substituters = https://hydra.iohk.io
```

- Now I will install `stack` with Nix:
```
user@MSI:~$ nix-env -f "<nixpkgs>" -iA stack
installing 'stack-2.7.3'

these 698 derivations will be built:
  /nix/store/dhvmh2hb7900z4ki92cfiwap7rhhnqfv-bootstrap-stage0-stdenv-linux.drv
  ...
these 587 paths will be fetched (1125.72 MiB download, 2348.57 MiB unpacked):
  /nix/store/02z0ga1d6p21zkvcwiz8s42qwdzdzl72-cmake-3.21.2.tar.gz
```
- Wait a minute, this doesn't seem right?! That, or Nix sucks.
- Bug someone on Matrix
- They tell me I've disabled the default cache by creating `nix.conf` without `https://cache.nixos.org`
- I try to put it back, but manage to screw up the signature on one of the keys
- Now I just get a bunch of this:

![image](https://user-images.githubusercontent.com/26604994/145315584-12498cae-e431-441e-a36b-c5a6a50c7064.png)

- "Wtf does this mean?!"
- Google more, eventually fix the signature
- Why didn't the warning just tell me what was wrong?!
- Proceed to file this PR
