### PR TITLE
[backport 2.3] ssh-store: add remote-store and remote-program query params

### DIFF
--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -17,6 +17,8 @@ public:
     const Setting<Path> sshKey{(Store*) this, "", "ssh-key", "path to an SSH private key"};
     const Setting<std::string> sshPublicHostKey{(Store*) this, "", "base64-ssh-public-host-key", "The public half of the host's SSH key"};
     const Setting<bool> compress{(Store*) this, false, "compress", "whether to compress the connection"};
+    const Setting<Path> remoteProgram{this, "nix-daemon", "remote-program", "path to the nix-daemon executable on the remote system"};
+    const Setting<std::string> remoteStore{this, "", "remote-store", "URI of the store on the remote system"};
 
     SSHStore(const std::string & host, const Params & params)
         : Store(params)
@@ -84,7 +86,9 @@ ref<FSAccessor> SSHStore::getFSAccessor()
 ref<RemoteStore::Connection> SSHStore::openConnection()
 {
     auto conn = make_ref<Connection>();
-    conn->sshConn = master.startCommand("nix-daemon --stdio");
+    conn->sshConn = master.startCommand(
+        fmt("%s --stdio", remoteProgram)
+        + (remoteStore.get() == "" ? "" : " --store " + shellEscape(remoteStore.get())));
     conn->to = FdSink(conn->sshConn->in.get());
     conn->from = FdSource(conn->sshConn->out.get());
     initConnection(*conn);

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -17,8 +17,8 @@ public:
     const Setting<Path> sshKey{(Store*) this, "", "ssh-key", "path to an SSH private key"};
     const Setting<std::string> sshPublicHostKey{(Store*) this, "", "base64-ssh-public-host-key", "The public half of the host's SSH key"};
     const Setting<bool> compress{(Store*) this, false, "compress", "whether to compress the connection"};
-    const Setting<Path> remoteProgram{this, "nix-daemon", "remote-program", "path to the nix-daemon executable on the remote system"};
-    const Setting<std::string> remoteStore{this, "", "remote-store", "URI of the store on the remote system"};
+    const Setting<Path> remoteProgram{(Store*) this, "nix-daemon", "remote-program", "path to the nix-daemon executable on the remote system"};
+    const Setting<std::string> remoteStore{(Store*) this, "", "remote-store", "URI of the store on the remote system"};
 
     SSHStore(const std::string & host, const Params & params)
         : Store(params)

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -680,7 +680,7 @@ class LocalFSStore : public virtual Store
 public:
 
     // FIXME: the (Store*) cast works around a bug in gcc that causes
-    // it to emit the call to the Option constructor. Clang works fine
+    // it to omit the call to the Setting constructor. Clang works fine
     // either way.
     const PathSetting rootDir{(Store*) this, true, "",
         "root", "directory prefixed to all other paths"};


### PR DESCRIPTION
Backport of https://github.com/NixOS/nix/pull/3344 + d82b78bf51b2d8f626264fa992a907dd1088389a (which was just pushed, not part of a PR)

Beyond just being a nice feature, it is useful for testing purposes.