### PR TITLE
Properly take the last assignment in the REPL

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -672,6 +672,8 @@ void NixRepl::addVarToScope(const Symbol & name, Value & v)
 {
     if (displ >= envSize)
         throw Error("environment full; cannot add more variables");
+    if (auto oldVar = staticEnv.find(name); oldVar != staticEnv.vars.end())
+        staticEnv.vars.erase(oldVar);
     staticEnv.vars.emplace_back(name, displ);
     staticEnv.sort();
     env->values[displ++] = &v;

--- a/tests/repl.sh
+++ b/tests/repl.sh
@@ -1,6 +1,7 @@
 source common.sh
 
 replCmds="
+simple = 1
 simple = import ./simple.nix
 :b simple
 :log simple


### PR DESCRIPTION
When a variable is assigned in the REPL, make sure to remove any possible reference to the old one so that we correctly pick the new one afterwards

Fix #5706

/cc @tfc @vlaci 