### PR TITLE
extract_archive: fix "Hard-link target '...'" error

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -93,7 +93,7 @@ static void extract_archive(TarArchive & archive, const Path & destDir)
         else
             archive.check(r);
 
-        archive_entry_set_pathname(entry,
+        archive_entry_copy_pathname(entry,
             (destDir + "/" + name).c_str());
 
         archive.check(archive_read_extract(archive.archive, entry, flags));

--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -96,6 +96,13 @@ static void extract_archive(TarArchive & archive, const Path & destDir)
         archive_entry_copy_pathname(entry,
             (destDir + "/" + name).c_str());
 
+        // Patch hardlink path
+        const char *original_hardlink = archive_entry_hardlink(entry);
+        if (original_hardlink) {
+            archive_entry_copy_hardlink(entry,
+                (destDir + "/" + original_hardlink).c_str());
+        }
+
         archive.check(archive_read_extract(archive.archive, entry, flags));
     }
 


### PR DESCRIPTION
Same issue as https://github.com/clearlinux/swupd-client/pull/384

Fixes #5741 

Also corrects a technicality on the previous line (libarchive secretly copies it anyways).