### PR TITLE
Fix typo in `nix shell --help` doc

### DIFF
--- a/src/nix/shell.md
+++ b/src/nix/shell.md
@@ -41,8 +41,8 @@ R""(
 
 # Description
 
-`nix shell` runs a command in an environment in which the `$PATH`
-variable provides the specified *installables*. If not command is
-specified, it starts the default shell of your user account.
+`nix shell` runs a command in an environment in which the `$PATH` variable
+provides the specified *installables*. If no command is specified, it starts the
+default shell of your user account specified by `$SHELL`.
 
 )""


### PR DESCRIPTION
Changed `If not command` to `If no command`, also specified that the
default shell launched with `nix shell` can be specified via `$SHELL`.

Sorry if this is a nitpick, noticed this when I was exploring the project 
with `nix shell --help`.