### PR TITLE
docker: fix image so that nix profile works

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -137,11 +137,8 @@ let
         name = "root-profile-env";
         paths = defaultPkgs;
       };
-      profile = pkgs.buildPackages.runCommand "user-environment" { } ''
-        mkdir $out
-        cp -a ${rootEnv}/* $out/
-
-        cat > $out/manifest.nix <<EOF
+      manifest = pkgs.buildPackages.runCommand "manifest.nix" { } ''
+        cat > $out <<EOF
         [
         ${lib.concatStringsSep "\n" (builtins.map (drv: let
           outputs = drv.outputsToInstall or [ "out" ];
@@ -160,6 +157,11 @@ let
         '') defaultPkgs)}
         ]
         EOF
+      '';
+      profile = pkgs.buildPackages.runCommand "user-environment" { } ''
+        mkdir $out
+        cp -a ${rootEnv}/* $out/
+        ln -s ${manifest} $out/manifest.nix
       '';
     in
     pkgs.runCommand "base-system"


### PR DESCRIPTION
`nix profile` will otherwise throw this error:

error: path '/nix/var/nix/profiles/default/manifest.nix' is not in the Nix store

That's not entirely true since manifest.nix is within a directory in the nix store but `nix profile` seems to require the manifest.nix itself to be a store path.

Not sure if the fix should really be somewhere else but this solves the problem for the docker image (if you want to try out `nix-command` and `flakes` in there for example).

I've also noted that installing any package through the old `nix-env` command "fixes" nix profile because `nix-env` seems to not care so much about the current state of the profile and just proceeds to set up a profile where manifest.nix is actually a direct store path.