### PR TITLE
Ignore EPERM when unsharing FS state

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -544,13 +544,7 @@ struct curlFileTransfer : public FileTransfer
             stopWorkerThread();
         });
 
-#ifdef __linux__
-        /* Cause this thread to not share any FS attributes with the main thread,
-           because this causes setns() in restoreMountNamespace() to fail.
-           Ideally, this would happen in the std::thread() constructor. */
-        if (unshare(CLONE_FS) != 0)
-            throw SysError("unsharing filesystem state in download thread");
-#endif
+        unshareFilesystem();
 
         std::map<CURL *, std::shared_ptr<TransferItem>> items;
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1660,6 +1660,14 @@ void restoreMountNamespace()
 #endif
 }
 
+void unshareFilesystem()
+{
+#ifdef __linux__
+    if (unshare(CLONE_FS) != 0 && errno != EPERM)
+        throw SysError("unsharing filesystem state in download thread");
+#endif
+}
+
 void restoreProcessContext(bool restoreMounts)
 {
     restoreSignals();

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -311,6 +311,11 @@ void saveMountNamespace();
    if saveMountNamespace() was never called. */
 void restoreMountNamespace();
 
+/* Cause this thread to not share any FS attributes with the main
+   thread, because this causes setns() in restoreMountNamespace() to
+   fail. */
+void unshareFilesystem();
+
 
 class ExecError : public Error
 {


### PR DESCRIPTION
On Docker (but not podman), `unshare(CLONE_FS)` fails with `EPERM`. So let's ignore it and hope nothing bad happens.

Fixes #5777.