### PR TITLE
backport - docker: fix image so that nix profile works

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -137,11 +137,8 @@ let
         name = "root-profile-env";
         paths = defaultPkgs;
       };
-      profile = pkgs.buildPackages.runCommand "user-environment" { } ''
-        mkdir $out
-        cp -a ${rootEnv}/* $out/
-
-        cat > $out/manifest.nix <<EOF
+      manifest = pkgs.buildPackages.runCommand "manifest.nix" { } ''
+        cat > $out <<EOF
         [
         ${lib.concatStringsSep "\n" (builtins.map (drv: let
           outputs = drv.outputsToInstall or [ "out" ];
@@ -160,6 +157,11 @@ let
         '') defaultPkgs)}
         ]
         EOF
+      '';
+      profile = pkgs.buildPackages.runCommand "user-environment" { } ''
+        mkdir $out
+        cp -a ${rootEnv}/* $out/
+        ln -s ${manifest} $out/manifest.nix
       '';
     in
     pkgs.runCommand "base-system"


### PR DESCRIPTION
nix profile will otherwise throw this error:

error: path '/nix/var/nix/profiles/default/manifest.nix' is not in the Nix store

That's not entirely true since manifest.nix is within a directory in
the nix store but nix profile seems to require the manifest.nix itself
to be a store path.