### PR TITLE
Work around zsh 5.8 bug

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -24,9 +24,9 @@ else
       # and shwordsplit to force splitting words in $NIX_PROFILES below.
       setopt local_options shwordsplit
     fi
-    for i in $NIX_PROFILES; do
-      if [ -e "$i/etc/ssl/certs/ca-bundle.crt" ]; then
-        export NIX_SSL_CERT_FILE=$i/etc/ssl/certs/ca-bundle.crt
+    for p in $NIX_PROFILES; do
+      if [ -e "$p/etc/ssl/certs/ca-bundle.crt" ]; then
+        export NIX_SSL_CERT_FILE=$p/etc/ssl/certs/ca-bundle.crt
       fi
     done
   }


### PR DESCRIPTION
This is the most braindead PR of all time, but without it I'm getting `bad math expression` error messages on macOS when I open a terminal, and zsh tries to source ` ~/.nix-profile/etc/profile.d/nix-daemon.sh`.

The problem is that zsh 5.8 (default in both nixpkgs and macOS) seems to introduce a problem where by the variable `i` specifically forces an arithmetic expression context incorrectly. This bites when you have a `for i in` expression and an item starting with `/`.

This wasn't a problem with zsh version 5.7.1, but avoiding it is obviously easy, so just do that.

I don't think it affects the other uses of `for i in ...` in the repo since they are evaluated only by bash.

```sh
% zsh --version
zsh 5.8 (x86_64-pc-linux-gnu)
% for p in /; do echo $p; done
/
% for i in /; do echo $i; done
zsh: bad math expression: operand expected at `/nonexiste...'
```
(Edit: correct zsh bug description)