### PR TITLE
Add shell completion for why-depends

### DIFF
--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -34,8 +34,21 @@ struct CmdWhyDepends : SourceExprCommand
 
     CmdWhyDepends()
     {
-        expectArg("package", &_package);
-        expectArg("dependency", &_dependency);
+        expectArgs({
+            .label = "package",
+            .handler = {&_package},
+            .completer = {[&](size_t, std::string_view prefix) {
+                completeInstallable(prefix);
+            }}
+        });
+
+        expectArgs({
+            .label = "dependency",
+            .handler = {&_dependency},
+            .completer = {[&](size_t, std::string_view prefix) {
+                completeInstallable(prefix);
+            }}
+        });
 
         addFlag({
             .longName = "all",


### PR DESCRIPTION
Closes #5806.

I tried adding a `size_t` argument to `completeInstallable` and doing `.completer = completeInstallable` but I got scary errors about no known conversion from initialiser list to `nix::Args::ExpectedArg&&`. Not sure why it works with `completePath` but not `completeInstallable`.