### PR TITLE
small perf improvements

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -133,6 +133,9 @@ private:
     /* Cache used by prim_match(). */
     std::shared_ptr<RegexCache> regexCache;
 
+    /* Allocation cache for GC'd Value objects. */
+    void * valueAllocCache = nullptr;
+
 public:
 
     EvalState(


### PR DESCRIPTION
nix allocates a *lot* of Values, and going through GC_malloc every time can be avoided by allocating a block of Values at once and using them one by one. it's not a world of change, but a nice improvement for a very small change. enabling LTO gives quite a good performance boost too.