### PR TITLE
Add cacert to /etc/ssl/certs in the docker image

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -180,6 +180,9 @@ let
       set -x
       mkdir -p $out/etc
 
+      mkdir -p $out/etc/ssl/certs
+      ln -s /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt $out/etc/ssl/certs
+
       cat $passwdContentsPath > $out/etc/passwd
       echo "" >> $out/etc/passwd
 


### PR DESCRIPTION
Fixes #5797