### PR TITLE
Don't insert spaces when completing attribute paths

### DIFF
--- a/misc/bash/completion.sh
+++ b/misc/bash/completion.sh
@@ -7,8 +7,10 @@ function _complete_nix {
         local completion=${line%%	*}
         if [[ -z $have_type ]]; then
             have_type=1
-            if [[ $completion = filenames ]]; then
+            if [[ $completion == filenames ]]; then
                 compopt -o filenames
+            elif [[ $completion == attrs ]]; then
+                compopt -o nospace
             fi
         else
             COMPREPLY+=("$completion")

--- a/misc/fish/completion.fish
+++ b/misc/fish/completion.fish
@@ -19,7 +19,6 @@ end
 
 function _nix_accepts_files
   set -l response (_nix_complete)
-  # First line is either filenames or no-filenames.
   test $response[1] = 'filenames'
 end
 

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -203,6 +203,8 @@ void SourceExprCommand::completeInstallable(std::string_view prefix)
         Value v2;
         state->autoCallFunction(*autoArgs, v1, v2);
 
+        completionType = ctAttrs;
+
         if (v2.type() == nAttrs) {
             for (auto & i : *v2.attrs) {
                 std::string name = i.name;
@@ -232,7 +234,9 @@ void completeFlakeRefWithFragment(
        prefix. */
     try {
         auto hash = prefix.find('#');
-        if (hash != std::string::npos) {
+        if (hash == std::string::npos) {
+            completeFlakeRef(evalState->store, prefix);
+        } else {
             auto fragment = prefix.substr(hash + 1);
             auto flakeRefS = std::string(prefix.substr(0, hash));
             // FIXME: do tilde expansion.
@@ -247,6 +251,8 @@ void completeFlakeRefWithFragment(
                attrpath prefixes as well as the root of the
                flake. */
             attrPathPrefixes.push_back("");
+
+            completionType = ctAttrs;
 
             for (auto & attrPathPrefixS : attrPathPrefixes) {
                 auto attrPathPrefix = parseAttrPath(*evalState, attrPathPrefixS);
@@ -285,8 +291,6 @@ void completeFlakeRefWithFragment(
     } catch (Error & e) {
         warn(e.msg());
     }
-
-    completeFlakeRef(evalState->store, prefix);
 }
 
 void completeFlakeRef(ref<Store> store, std::string_view prefix)

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -191,7 +191,7 @@ void SourceExprCommand::completeInstallable(std::string_view prefix)
         auto sep = prefix_.rfind('.');
         std::string searchWord;
         if (sep != std::string::npos) {
-            searchWord = prefix_.substr(sep, std::string::npos);
+            searchWord = prefix_.substr(sep + 1, std::string::npos);
             prefix_ = prefix_.substr(0, sep);
         } else {
             searchWord = prefix_;

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -39,7 +39,7 @@ void Completions::add(std::string completion, std::string description)
 bool Completion::operator<(const Completion & other) const
 { return completion < other.completion || (completion == other.completion && description < other.description); }
 
-bool pathCompletions = false;
+CompletionType completionType = ctNormal;
 std::shared_ptr<Completions> completions;
 
 std::string completionMarker = "___COMPLETE___";
@@ -277,7 +277,7 @@ Args::Flag Args::Flag::mkHashTypeOptFlag(std::string && longName, std::optional<
 
 static void _completePath(std::string_view prefix, bool onlyDirs)
 {
-    pathCompletions = true;
+    completionType = ctFilenames;
     glob_t globbuf;
     int flags = GLOB_NOESCAPE | GLOB_TILDE;
     #ifdef GLOB_ONLYDIR

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -237,7 +237,13 @@ public:
     void add(std::string completion, std::string description = "");
 };
 extern std::shared_ptr<Completions> completions;
-extern bool pathCompletions;
+
+enum CompletionType {
+    ctNormal,
+    ctFilenames,
+    ctAttrs
+};
+extern CompletionType completionType;
 
 std::optional<std::string> needsCompletion(std::string_view s);
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -310,7 +310,14 @@ void mainWrapped(int argc, char * * argv)
     Finally printCompletions([&]()
     {
         if (completions) {
-            std::cout << (pathCompletions ? "filenames\n" : "no-filenames\n");
+            switch (completionType) {
+            case ctNormal:
+                std::cout << "normal\n"; break;
+            case ctFilenames:
+                std::cout << "filenames\n"; break;
+            case ctAttrs:
+                std::cout << "attrs\n"; break;
+            }
             for (auto & s : *completions)
                 std::cout << s.completion << "\t" << s.description << "\n";
         }


### PR DESCRIPTION
Adds a new completion mode `attrs` (and renames `no-filenames` to `normal`) for completing attribute paths, so that the shell doesn't add spaces.

Unfortunately I was only able to implement this for bash, even after reading the documentations for the zsh and fish completion systems. For zsh, there has to be a way since https://github.com/spwhitt/nix-zsh-completions does this (cc @hedning @matthewbauer). For fish, I have no idea (cc @haslersn @jtojnar).