### PR TITLE
Use int64_t and NixFloat in fromTOML types

### DIFF
--- a/src/libexpr/primops/fromTOML.cc
+++ b/src/libexpr/primops/fromTOML.cc
@@ -47,10 +47,10 @@ static void prim_fromTOML(EvalState & state, const Pos & pos, Value * * args, Va
                 mkBool(v, toml::get<bool>(t));
                 break;;
             case toml::value_t::integer:
-                mkInt(v, toml::get<long>(t));
+                mkInt(v, toml::get<int64_t>(t));
                 break;;
             case toml::value_t::floating:
-                mkFloat(v, toml::get<double>(t));
+                mkFloat(v, toml::get<NixFloat>(t));
                 break;;
             case toml::value_t::string:
                 mkString(v, toml::get<std::string>(t));


### PR DESCRIPTION
This makes sure that values parsed from TOML have a proper size. Using
e.g. `double` caused issues on i686 where the size of `double` (32bit)
was too small to accommodate some values.