### PR TITLE
Fix accidental O(n^2 * log n) performance in NixRepl::addAttrsToScope

### DIFF
--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -368,6 +368,13 @@ struct StaticEnv
             [](const Vars::value_type & a, const Vars::value_type & b) { return a.first < b.first; });
     }
 
+    void deduplicate()
+    {
+        const auto last = std::unique(vars.begin(), vars.end(),
+            [] (const Vars::value_type & a, const Vars::value_type & b) { return a.first == b.first; });
+        vars.erase(last, vars.end());
+    }
+
     Vars::const_iterator find(const Symbol & name) const
     {
         Vars::value_type key(name, 0);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -661,8 +661,16 @@ void NixRepl::reloadFiles()
 void NixRepl::addAttrsToScope(Value & attrs)
 {
     state->forceAttrs(attrs);
-    for (auto & i : *attrs.attrs)
-        addVarToScope(i.name, *i.value);
+    if (displ + attrs.attrs->size() >= envSize)
+        throw Error("environment full; cannot add more variables");
+
+    for (auto & i : *attrs.attrs) {
+        staticEnv.vars.emplace_back(i.name, displ);
+        env->values[displ++] = i.value;
+        varNames.insert((string) i.name);
+    }
+    staticEnv.sort();
+    staticEnv.deduplicate();
     notice("Added %1% variables.", attrs.attrs->size());
 }
 


### PR DESCRIPTION
Only sort once, after adding all of the attrs first. This reduces my
`nix repl '<nixpkgs>'` loading time from 1.07s to 103ms.

Fixes #5823

```
nix (Nix) 2.4
Benchmark 1: nix repl \<nixpkgs\>
  Time (mean ± σ):     121.7 ms ±  11.8 ms    [User: 87.0 ms, System: 18.0 ms]
  Range (min … max):   110.7 ms … 154.3 ms    26 runs

# nix (Nix) 2.5.1
Benchmark 1: /nix/store/2lhhix0vgwp6fd8pg0z1q49hmgbymynq-nix-2.5.1/bin/nix repl \<nixpkgs\>
  Time (mean ± σ):      1.073 s ±  0.004 s    [User: 1.052 s, System: 0.019 s]
  Range (min … max):    1.069 s …  1.080 s    10 runs

# nix (Nix) 2.6.0 (patched)
Benchmark 1: ./outputs/out/bin/nix repl \<nixpkgs\>
  Time (mean ± σ):     103.0 ms ±   2.3 ms    [User: 83.8 ms, System: 16.8 ms]
  Range (min … max):   100.8 ms … 110.7 ms    29 runs
```
