### PR TITLE
flake.cc: computeLocks: Only verify overrides when they could change

### DIFF
--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -716,11 +716,10 @@ cat > $flakeFollowsA/flake.nix <<EOF
     inputs = {
         B = {
             url = "path:./flakeB";
-            inputs.foobar.follows = "D";
-            inputs.nonFlake.follows = "D";
+            inputs.foobar.follows = "foobar";
         };
 
-        D.url = "path:./flakeD";
+        foobar.url = "path:$flakeFollowsA/flakeE";
     };
     outputs = { ... }: {};
 }
@@ -731,8 +730,6 @@ cat > $flakeFollowsB/flake.nix <<EOF
     description = "Flake B";
     inputs = {
         foobar.url = "path:$flakeFollowsA/flakeE";
-        nonFlake.url = "path:$nonFlakeDir";
-        goodoo.follows = "C/goodoo";
         C = {
             url = "path:./flakeC";
             inputs.foobar.follows = "foobar";
@@ -747,7 +744,6 @@ cat > $flakeFollowsC/flake.nix <<EOF
     description = "Flake C";
     inputs = {
         foobar.url = "path:$flakeFollowsA/flakeE";
-        goodoo.follows = "foobar";
     };
     outputs = { ... }: {};
 }
@@ -785,7 +781,7 @@ newLock="$(cat "$flakeFollowsA/flake.lock")"
 diff <(echo "$newLock") <(echo "$oldLock")
 
 [[ $(jq -c .nodes.B.inputs.C $flakeFollowsA/flake.lock) = '"C"' ]]
-[[ $(jq -c .nodes.B.inputs.foobar $flakeFollowsA/flake.lock) = '["D"]' ]]
+[[ $(jq -c .nodes.B.inputs.foobar $flakeFollowsA/flake.lock) = '["foobar"]' ]]
 [[ $(jq -c .nodes.C.inputs.foobar $flakeFollowsA/flake.lock) = '["B","foobar"]' ]]
 
 # Ensure removing follows from flake.nix removes them from the lockfile


### PR DESCRIPTION
When we check for disappeared overrides, we can get "false positives"
for follows and overrides which are defined in the dependencies of the
flake we are locking, since they are not parsed by
parseFlakeInputs. However, at that point we already know that the
overrides couldn't have possible been changed if the input itself
hasn't changed (since we check that oldLock->originalRef == *input.ref
for the input's parent). So, to prevent this, only perform this check
when it was possible that the flake changed (e.g. the flake we're
locking, or a new input, or the input has changed and mustRefetch ==
true).

Closes #5728 