### PR TITLE
nix repl: fix --show-trace and add the ability to set trace display

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -2,3 +2,5 @@
 
 * The TOML parser used by `builtins.fromTOML` has been replaced by [a
   more compliant one](https://github.com/ToruNiina/toml11).
+* Added `:st`/`:show-trace` commands to nix repl, which are used to
+  set or toggle display of error traces.

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -25,7 +25,7 @@ const string & BaseError::calcWhat() const
         err.name = sname();
 
         std::ostringstream oss;
-        showErrorInfo(oss, err, false);
+        showErrorInfo(oss, err, loggerSettings.showTrace);
         what_ = oss.str();
 
         return *what_;

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -430,7 +430,8 @@ bool NixRepl::processLine(string line)
              << "  :t <expr>     Describe result of evaluation\n"
              << "  :u <expr>     Build derivation, then start nix-shell\n"
              << "  :doc <expr>   Show documentation of a builtin function\n"
-             << "  :log <expr>   Show logs for a derivation\n";
+             << "  :log <expr>   Show logs for a derivation\n"
+             << "  :st [bool]    Enable, disable or toggle showing traces for errors\n";
     }
 
     else if (command == ":a" || command == ":add") {
@@ -570,6 +571,18 @@ bool NixRepl::processLine(string line)
             logger->cout(trim(renderMarkdownToTerminal(markdown)));
         } else
             throw Error("value does not have documentation");
+    }
+
+    else if (command == ":st" || command == ":show-trace") {
+        if (arg == "false" || (arg == "" && loggerSettings.showTrace)) {
+            std::cout << "not showing error traces\n";
+            loggerSettings.showTrace = false;
+        } else if (arg == "true" || (arg == "" && !loggerSettings.showTrace)) {
+            std::cout << "showing error traces\n";
+            loggerSettings.showTrace = true;
+        } else {
+            throw Error("unexpected argument '%s' to %s", arg, command);
+        };
     }
 
     else if (command != "")

--- a/tests/undefined-variable.nix
+++ b/tests/undefined-variable.nix
@@ -1,0 +1,1 @@
+let f = builtins.toFile "test-file.nix" "asd"; in import f


### PR DESCRIPTION
- BaseError::calcWhat: take loggerSettings.showTrace into account
- Add a test that nix repl --show-trace actually shows the trace
- Add ability to toggle show-trace from within the repl

Closes https://github.com/NixOS/nix/issues/5736
