### PR TITLE
Sort attrs from tables in fromTOML

### DIFF
--- a/src/libexpr/primops/fromTOML.cc
+++ b/src/libexpr/primops/fromTOML.cc
@@ -31,6 +31,8 @@ static void prim_fromTOML(EvalState & state, const Pos & pos, Value * * args, Va
                         auto & v2 = *state.allocAttr(v, state.symbols.create(elem.first));
                         visit(v2, elem.second);
                     }
+
+                    v.attrs->sort();
                 }
                 break;;
             case toml::value_t::array:


### PR DESCRIPTION
The `v->attrs.sort()` call when parsing TOML tables was dropped in #5795 for the migration from cpptoml to toml11, but it seems to be necessary for the attrsets to work correctly

Fixes #5833