### PR TITLE
Fix IFD with chroot store

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -82,7 +82,7 @@ StringMap EvalState::realiseContext(const PathSet & context)
        paths. */
     if (allowedPaths) {
         for (auto & [_placeholder, outputPath] : res) {
-            allowPath(outputPath);
+            allowPath(store->toRealPath(outputPath));
         }
     }
 


### PR DESCRIPTION
This was apparently broken in https://github.com/NixOS/nix/commit/d90f9d4b9994dc1f15b9d664ae313f06261d6058#diff-0f59bb6f197822ef9f19ceae9624989499d170c84dfdc1f486a8959bb4588cafR85 where the selected overload silently switched from the `StorePath` one to that taking `Path`.

I would have added a test, but I didn't see any other chroot build tests that I could have used as a template.