### PR TITLE
libexpr: printValue improvements

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -157,6 +157,9 @@ void printValue(std::ostream & str, std::set<const Value *> & active, const Valu
     case tFloat:
         str << v.fpoint;
         break;
+    case tBlackhole:
+        str << "<BLACKHOLE>";
+        break;
     default:
         debug(format("invalid value %1%, aborting") % showType(v));
         abort();

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -158,6 +158,7 @@ void printValue(std::ostream & str, std::set<const Value *> & active, const Valu
         str << v.fpoint;
         break;
     default:
+        debug(format("invalid value %1%, aborting") % showType(v));
         abort();
     }
 
@@ -197,6 +198,7 @@ string showType(ValueType type)
         case nFloat: return "a float";
         case nThunk: return "a thunk";
     }
+    debug(format("invalid type id %1%, aborting") % type);
     abort();
 }
 


### PR DESCRIPTION
I was trying to trace an attrset of evaluated `evalConfig`s (NixOS) and Nix threw me the bad error produced by this function. Tidied it up a bit.

I've just been testing this by overriding my `nixUnstable` adding paths to the `patches` attribute and this codepath is pretty hard to hit so I guess that'll have to do.

(Oh also, this is my first Nix PR! Hi!)