### PR TITLE
be more memory friendly

### DIFF
--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -24,6 +24,76 @@ LocalNoInlineNoReturn(void throwTypeError(const Pos & pos, const char * s, const
 }
 
 
+/* Note: Various places expect the allocated memory to be zeroed. */
+[[gnu::always_inline]]
+inline void * allocBytes(size_t n)
+{
+    void * p;
+#if HAVE_BOEHMGC
+    p = GC_MALLOC(n);
+#else
+    p = calloc(n, 1);
+#endif
+    if (!p) throw std::bad_alloc();
+    return p;
+}
+
+
+[[gnu::always_inline]]
+Value * EvalState::allocValue()
+{
+    /* We use the boehm batch allocator to speed up allocations of Values (of which there are many).
+       GC_malloc_many returns a linked list of objects of the given size, where the first word
+       of each object is also the pointer to the next object in the list. This also means that we
+       have to explicitly clear the first word of every object we take. */
+    if (!*valueAllocCache) {
+        *valueAllocCache = GC_malloc_many(sizeof(Value));
+        if (!*valueAllocCache) throw std::bad_alloc();
+    }
+
+    /* GC_NEXT is a convenience macro for accessing the first word of an object.
+       Take the first list item, advance the list to the next item, and clear the next pointer. */
+    void * p = *valueAllocCache;
+    *valueAllocCache = GC_NEXT(p);
+    GC_NEXT(p) = nullptr;
+
+    nrValues++;
+    return (Value *) p;
+}
+
+
+[[gnu::always_inline]]
+Env & EvalState::allocEnv(size_t size)
+{
+    nrEnvs++;
+    nrValuesInEnvs += size;
+
+    Env * env;
+
+    if (size != 1)
+        env = (Env *) allocBytes(sizeof(Env) + size * sizeof(Value *));
+    else {
+        /* see allocValue for explanations. */
+        if (!*env1AllocCache) {
+            *env1AllocCache = GC_malloc_many(sizeof(Env) + sizeof(Value *));
+            if (!*env1AllocCache) throw std::bad_alloc();
+        }
+
+        void * p = *env1AllocCache;
+        *env1AllocCache = GC_NEXT(p);
+        GC_NEXT(p) = nullptr;
+        env = (Env *) p;
+    }
+
+    env->type = Env::Plain;
+
+    /* We assume that env->values has been cleared by the allocator; maybeThunk() and lookupVar fromWith expect this. */
+
+    return *env;
+}
+
+
+[[gnu::always_inline]]
 void EvalState::forceValue(Value & v, const Pos & pos)
 {
     forceValue(v, [&]() { return pos; });
@@ -52,6 +122,7 @@ void EvalState::forceValue(Value & v, Callable getPos)
 }
 
 
+[[gnu::always_inline]]
 inline void EvalState::forceAttrs(Value & v, const Pos & pos)
 {
     forceAttrs(v, [&]() { return pos; });
@@ -59,6 +130,7 @@ inline void EvalState::forceAttrs(Value & v, const Pos & pos)
 
 
 template <typename Callable>
+[[gnu::always_inline]]
 inline void EvalState::forceAttrs(Value & v, Callable getPos)
 {
     forceValue(v, getPos);
@@ -67,24 +139,12 @@ inline void EvalState::forceAttrs(Value & v, Callable getPos)
 }
 
 
+[[gnu::always_inline]]
 inline void EvalState::forceList(Value & v, const Pos & pos)
 {
     forceValue(v, pos);
     if (!v.isList())
         throwTypeError(pos, "value is %1% while a list was expected", v);
-}
-
-/* Note: Various places expect the allocated memory to be zeroed. */
-inline void * allocBytes(size_t n)
-{
-    void * p;
-#if HAVE_BOEHMGC
-    p = GC_MALLOC(n);
-#else
-    p = calloc(n, 1);
-#endif
-    if (!p) throw std::bad_alloc();
-    return p;
 }
 
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -879,7 +879,7 @@ Value * EvalState::allocValue()
     /* GC_NEXT is a convenience macro for accessing the first word of an object.
        Take the first list item, advance the list to the next item, and clear the next pointer. */
     void * p = *valueAllocCache;
-    GC_PTR_STORE_AND_DIRTY(&*valueAllocCache, GC_NEXT(p));
+    *valueAllocCache = GC_NEXT(p);
     GC_NEXT(p) = nullptr;
 
     nrValues++;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -350,8 +350,8 @@ public:
     void autoCallFunction(Bindings & args, Value & fun, Value & res);
 
     /* Allocation primitives. */
-    Value * allocValue();
-    Env & allocEnv(size_t size);
+    inline Value * allocValue();
+    inline Env & allocEnv(size_t size);
 
     Value * allocAttr(Value & vAttrs, const Symbol & name);
     Value * allocAttr(Value & vAttrs, std::string_view name);
@@ -512,3 +512,5 @@ extern EvalSettings evalSettings;
 static const std::string corepkgsPrefix{"/__corepkgs__/"};
 
 }
+
+#include "eval-inline.hh"

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -136,6 +136,9 @@ private:
     /* Allocation cache for GC'd Value objects. */
     std::shared_ptr<void *> valueAllocCache;
 
+    /* Allocation cache for size-1 Env objects. */
+    std::shared_ptr<void *> env1AllocCache;
+
 public:
 
     EvalState(

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -133,11 +133,13 @@ private:
     /* Cache used by prim_match(). */
     std::shared_ptr<RegexCache> regexCache;
 
+#if HAVE_BOEHMGC
     /* Allocation cache for GC'd Value objects. */
     std::shared_ptr<void *> valueAllocCache;
 
     /* Allocation cache for size-1 Env objects. */
     std::shared_ptr<void *> env1AllocCache;
+#endif
 
 public:
 

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -23,14 +23,13 @@ MakeError(RestrictedPathError, Error);
 
 struct Pos
 {
-    FileOrigin origin;
     Symbol file;
-    unsigned int line, column;
-
-    Pos() : origin(foString), line(0), column(0) { }
-    Pos(FileOrigin origin, const Symbol & file, unsigned int line, unsigned int column)
-        : origin(origin), file(file), line(line), column(column) { }
-
+    uint32_t line;
+    FileOrigin origin:2;
+    uint32_t column:30;
+    Pos() : line(0), origin(foString), column(0) { };
+    Pos(FileOrigin origin, const Symbol & file, uint32_t line, uint32_t column)
+        : file(file), line(line), origin(origin), column(column) { };
     operator bool() const
     {
         return line != 0;

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -53,6 +53,7 @@ typedef enum {
     lvlVomit
 } Verbosity;
 
+/* adjust Pos::origin bit width when adding stuff here */
 typedef enum {
     foFile,
     foStdin,

--- a/src/libutil/finally.hh
+++ b/src/libutil/finally.hh
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <functional>
-
 /* A trivial class to run a function at the end of a scope. */
+template<typename Fn>
 class Finally
 {
 private:
-    std::function<void()> fun;
+    Fn fun;
 
 public:
-    Finally(std::function<void()> fun) : fun(fun) { }
+    Finally(Fn fun) : fun(std::move(fun)) { }
     ~Finally() { fun(); }
 };


### PR DESCRIPTION
we do a lot of single-object allocations that needn't be done at all, are could at least be batched like the Value allocations are as of recently. singleton Envs are a good candidate since they make up the vast majority of envs allocated. we can also inline some allocation and check functions to avoid stack churn, and with memory batching get about 1.5% improvement on eval.