### PR TITLE
Remove overly-strict ref check

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -546,6 +546,8 @@ struct GitInputScheme : InputScheme
                 // we're using --quiet for now. Should process its stderr.
                 try {
                     auto ref = input.getRef();
+                    if (std::regex_match(*ref, badGitRefRegex))
+                        throw BadURL("in input '%s', '%s' is not a branch/tag name", input.to_string(), *ref);
                     auto fetchRef = allRefs
                         ? "refs/*"
                         : ref->compare(0, 5, "refs/") == 0

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -44,7 +44,7 @@ struct GitArchiveInputScheme : InputScheme
         if (size == 3) {
             if (std::regex_match(path[2], revRegex))
                 rev = Hash::parseAny(path[2], htSHA1);
-            else if (std::regex_match(path[2], refRegex))
+            else if (!std::regex_match(path[2], badGitRefRegex))
                 ref = path[2];
             else
                 throw BadURL("in URL '%s', '%s' is not a commit hash or branch/tag name", url.url, path[2]);
@@ -56,8 +56,7 @@ struct GitArchiveInputScheme : InputScheme
                     rs += "/";
                 }
             }
-
-            if (std::regex_match(rs, refRegex)) {
+            if (!std::regex_match(rs, badGitRefRegex)) {
                 ref = rs;
             } else {
                 throw BadURL("in URL '%s', '%s' is not a branch/tag name", url.url, rs);
@@ -72,8 +71,8 @@ struct GitArchiveInputScheme : InputScheme
                 rev = Hash::parseAny(value, htSHA1);
             }
             else if (name == "ref") {
-                if (!std::regex_match(value, refRegex))
-                    throw BadURL("URL '%s' contains an invalid branch/tag name", url.url);
+                if (std::regex_match(value, badGitRefRegex))
+                    throw BadURL("in URL '%s', '%s' is not a branch/tag name", url.url, value);
                 if (ref)
                     throw BadURL("URL '%s' contains multiple branch/tag names", url.url);
                 ref = value;

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -20,13 +20,9 @@ struct IndirectInputScheme : InputScheme
         } else if (path.size() == 2) {
             if (std::regex_match(path[1], revRegex))
                 rev = Hash::parseAny(path[1], htSHA1);
-            else if (std::regex_match(path[1], refRegex))
-                ref = path[1];
             else
-                throw BadURL("in flake URL '%s', '%s' is not a commit hash or branch/tag name", url.url, path[1]);
+                ref = path[1];
         } else if (path.size() == 3) {
-            if (!std::regex_match(path[1], refRegex))
-                throw BadURL("in flake URL '%s', '%s' is not a branch/tag name", url.url, path[1]);
             ref = path[1];
             if (!std::regex_match(path[2], revRegex))
                 throw BadURL("in flake URL '%s', '%s' is not a commit hash", url.url, path[2]);

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -80,7 +80,7 @@ struct MercurialInputScheme : InputScheme
         parseURL(getStrAttr(attrs, "url"));
 
         if (auto ref = maybeGetStrAttr(attrs, "ref")) {
-            if (!std::regex_match(*ref, refRegex))
+            if (!std::regex_match(*ref, mercurialRefRegex))
                 throw BadURL("invalid Mercurial branch/tag name '%s'", *ref);
         }
 

--- a/src/libutil/url-parts.hh
+++ b/src/libutil/url-parts.hh
@@ -22,9 +22,8 @@ const static std::string segmentRegex = "(?:" + pcharRegex + "*)";
 const static std::string absPathRegex = "(?:(?:/" + segmentRegex + ")*/?)";
 const static std::string pathRegex = "(?:" + segmentRegex + "(?:/" + segmentRegex + ")*/?)";
 
-// A Git ref (i.e. branch or tag name).
-const static std::string refRegexS = "[a-zA-Z0-9][a-zA-Z0-9_.\\/-]*"; // FIXME: check
-extern std::regex refRegex;
+static const std::string mercurialRefRegexS = "[a-zA-Z0-9][a-zA-Z0-9_.\\/-]*"; // FIXME: check
+extern std::regex mercurialRefRegex;
 
 // Instead of defining what a good Git Ref is, we define what a bad Git Ref is
 // This is because of the definition of a ref in refs.c in https://github.com/git/git
@@ -36,8 +35,9 @@ extern std::regex badGitRefRegex;
 const static std::string revRegexS = "[0-9a-fA-F]{40}";
 extern std::regex revRegex;
 
-// A ref or revision, or a ref followed by a revision.
-const static std::string refAndOrRevRegex = "(?:(" + revRegexS + ")|(?:(" + refRegexS + ")(?:/(" + revRegexS + "))?))";
+// A ref or revision, or a ref followed by a revision. Ref is thus a bare
+// minimum and it is up to fetchers to do more-specific checks.
+const static std::string refAndOrRevRegex = "(?:(" + revRegexS + ")|(?:([^ #]*)(?:/(" + revRegexS + "))?))";
 
 const static std::string flakeIdRegexS = "[a-zA-Z][a-zA-Z0-9_-]*";
 extern std::regex flakeIdRegex;

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -5,8 +5,8 @@
 
 namespace nix {
 
-std::regex refRegex(refRegexS, std::regex::ECMAScript);
 std::regex badGitRefRegex(badGitRefRegexS, std::regex::ECMAScript);
+std::regex mercurialRefRegex(mercurialRefRegexS, std::regex::ECMAScript);
 std::regex revRegex(revRegexS, std::regex::ECMAScript);
 std::regex flakeIdRegex(flakeIdRegexS, std::regex::ECMAScript);
 

--- a/tests/fetchGitRefs.sh
+++ b/tests/fetchGitRefs.sh
@@ -70,6 +70,7 @@ valid_ref "$(printf 'heads/fu\303\237')"
 valid_ref 'foo-bar-baz'
 valid_ref '$1'
 valid_ref 'foo.locke'
+valid_ref '`!@#$%&()-=_+{}/|;"<>.,áÁπ𐌀𠀡 😃⅜'
 
 invalid_ref 'refs///heads/foo'
 invalid_ref 'heads/foo/'
@@ -109,3 +110,4 @@ invalid_ref 'foo/*/*'
 invalid_ref '*/foo/*'
 invalid_ref '/foo'
 invalid_ref ''
+invalid_ref 'foo bar'


### PR DESCRIPTION
- This claims to be a regex for a Git ref, but it is applied also to
  Mercurial. I was unable to find any docs for the syntax of a Mercurial
  ref, so seems better to just allow anything rather than disallow a
  valid one, blocking a valid use case.
- Again, this claims to be a regex for a Git ref, but it is extremely
  over-restrictive and disallows a variety of valid refs. Instead,
  remove the check entirely and allow either checks for badGitRefRegex
  or Git itself to say it is invalid instead.
- Tests added for some additional valid refs that previously failed.

I think that the badGitRefRegex check should also be removed, but want
feedback on just this first and that can be a follow-up.