### PR TITLE
Fix segfault or stack overflow caused by large derivation fields

### DIFF
--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -272,7 +272,15 @@ Derivation parseDerivation(const Store & store, std::string && s, std::string_vi
 
 static void printString(string & res, std::string_view s)
 {
-    char buf[s.size() * 2 + 2];
+    char * buf;
+    size_t bufSize = s.size() * 2 + 2;
+    std::unique_ptr<char[]> dynBuf;
+    if (bufSize < 0x10000) {
+        buf = (char *)alloca(bufSize);
+    } else {
+        dynBuf = decltype(dynBuf)(new char[bufSize]);
+        buf = dynBuf.get();
+    }
     char * p = buf;
     *p++ = '"';
     for (auto c : s)

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -273,7 +273,7 @@ Derivation parseDerivation(const Store & store, std::string && s, std::string_vi
 static void printString(string & res, std::string_view s)
 {
     size_t bufSize = s.size() * 2 + 2;
-    withBuffer<void, char>(bufSize, [&](char buf[]) {
+    withBuffer(bufSize, [&](char *buf) {
         char * p = buf;
         *p++ = '"';
         for (auto c : s)

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -273,15 +273,7 @@ Derivation parseDerivation(const Store & store, std::string && s, std::string_vi
 
 static void printString(string & res, std::string_view s)
 {
-    // Large stack allocations can skip past the stack protection page.
-    const size_t stack_protection_size = 4096;
-    // We reduce the max stack allocated buffer by an extra amount to increase
-    // the chance of hitting it, even when `fun`'s first access is some distance
-    // into its *further* stack frame, particularly if the call was inlined and
-    // therefore not writing a frame pointer.
-    const size_t play = 64 * sizeof(char *); // 512B on 64b archs
-
-    boost::container::small_vector<char, stack_protection_size - play> buffer;
+    boost::container::small_vector<char, 64 * 1024> buffer;
     buffer.reserve(s.size() * 2 + 2);
     char * buf = buffer.data();
     char * p = buf;

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -272,25 +272,19 @@ Derivation parseDerivation(const Store & store, std::string && s, std::string_vi
 
 static void printString(string & res, std::string_view s)
 {
-    char * buf;
     size_t bufSize = s.size() * 2 + 2;
-    std::unique_ptr<char[]> dynBuf;
-    if (bufSize < 0x10000) {
-        buf = (char *)alloca(bufSize);
-    } else {
-        dynBuf = decltype(dynBuf)(new char[bufSize]);
-        buf = dynBuf.get();
-    }
-    char * p = buf;
-    *p++ = '"';
-    for (auto c : s)
-        if (c == '\"' || c == '\\') { *p++ = '\\'; *p++ = c; }
-        else if (c == '\n') { *p++ = '\\'; *p++ = 'n'; }
-        else if (c == '\r') { *p++ = '\\'; *p++ = 'r'; }
-        else if (c == '\t') { *p++ = '\\'; *p++ = 't'; }
-        else *p++ = c;
-    *p++ = '"';
-    res.append(buf, p - buf);
+    withBuffer<void, char>(bufSize, [&](char buf[]) {
+        char * p = buf;
+        *p++ = '"';
+        for (auto c : s)
+            if (c == '\"' || c == '\\') { *p++ = '\\'; *p++ = c; }
+            else if (c == '\n') { *p++ = '\\'; *p++ = 'n'; }
+            else if (c == '\r') { *p++ = '\\'; *p++ = 'r'; }
+            else if (c == '\t') { *p++ = '\\'; *p++ = 't'; }
+            else *p++ = c;
+        *p++ = '"';
+        res.append(buf, p - buf);
+    });
 }
 
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -671,5 +671,14 @@ template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 std::string showBytes(uint64_t bytes);
 
+template<typename R = void, typename T = char> inline R withBuffer(size_t size, std::function<R (T[])> fun) {
+    if (size < 0x10000) {
+        T buf[size];
+        return fun(buf);
+    } else {
+        auto buf = std::unique_ptr<T[]>(new T[size]);
+        return fun(buf.get());
+    }
+}
 
 }

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -671,7 +671,10 @@ template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 std::string showBytes(uint64_t bytes);
 
-template<typename R = void, typename T = char> inline R withBuffer(size_t size, std::function<R (T[])> fun) {
+template<typename T = char, typename Fn>
+inline auto withBuffer(size_t size, Fn fun)
+  -> std::invoke_result_t<Fn, T *>
+{
     if (size < 0x10000) {
         T buf[size];
         return fun(buf);

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -671,30 +671,5 @@ template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 std::string showBytes(uint64_t bytes);
 
-/**
-  `withBuffer(size, fun)` applies `fun` to a temporary `char` array of size `size`.
-  The array will be allocated either on the stack or on the heap depending on its size
-*/
-template<typename T = char, typename Fn>
-inline auto withBuffer(size_t n, Fn fun)
-  -> std::invoke_result_t<Fn, T *>
-{
-    // Large stack allocations can skip past the stack protection page.
-    const size_t stack_protection_size = 4096;
-    // We reduce the max stack allocated buffer by an extra amount to increase
-    // the chance of hitting it, even when `fun`'s first access is some distance
-    // into its *further* stack frame, particularly if the call was inlined and
-    // therefore not writing a frame pointer.
-    const size_t play = 64 * sizeof(char *); // 512B on 64b archs
-    size_t size_bytes = n * sizeof(T);
-
-    if (size_bytes < stack_protection_size - play) {
-        T buf[n];
-        return fun(buf);
-    } else {
-        auto buf = std::unique_ptr<T[]>(new T[n]);
-        return fun(buf.get());
-    }
-}
 
 }

--- a/tests/big-derivation-attr.nix
+++ b/tests/big-derivation-attr.nix
@@ -1,0 +1,13 @@
+let
+  sixteenBytes = "0123456789abcdef";
+  times16 = s: builtins.concatStringsSep "" [s s s s s s s s s s s s s s s s];
+  exp = n: x: if n == 1 then x else times16 (exp (n - 1) x);
+  sixteenMegabyte = exp 6 sixteenBytes;
+in
+assert builtins.stringLength sixteenMegabyte == 16777216;
+derivation {
+  name = "big-derivation-attr";
+  builder = "/x";
+  system = "y";
+  bigAttr = sixteenMegabyte;
+}

--- a/tests/simple.sh
+++ b/tests/simple.sh
@@ -25,3 +25,9 @@ if test "$outPath" != "/foo/lfy1s6ca46rm5r6w4gg9hc0axiakjcnm-dependencies.drv"; 
     echo "hashDerivationModulo appears broken, got $outPath"
     exit 1
 fi
+
+outPath="$(NIX_REMOTE=local?store=/foo\&real=$TEST_ROOT/real-store nix-instantiate --readonly-mode big-derivation-attr.nix)"
+if test "$outPath" != "/foo/xxiwa5zlaajv6xdjynf9yym9g319d6mn-big-derivation-attr.drv"; then
+    echo "big-derivation-attr.nix hash appears broken, got $outPath. Memory corruption in large drv attr?"
+    exit 1
+fi


### PR DESCRIPTION
This removes a dynamic stack allocation, making the derivation
unparsing logic robust against overflows when large strings are
added to a derivation.
Overflow behavior depends on the platform and stack configuration.

For instance, x86_64-linux/glibc behaves as (somewhat) expected:

$ (ulimit -s 20000; nix-instantiate tests/lang/eval-okay-big-derivation-attr.nix)
error: stack overflow (possible infinite recursion)

$ (ulimit -s 40000; nix-instantiate tests/lang/eval-okay-big-derivation-attr.nix)
error: expression does not evaluate to a derivation (or a set or list of those)

However, on aarch64-darwin:

$ nix-instantiate big-attr.nix                                                                                                                                                                                                                                                       ~
zsh: segmentation fault  nix-instantiate big-attr.nix

This indicates a slight flaw in the single stack protection page
approach that is not encountered with normal stack frames.
With this change, we avoid both types of failure.