### PR TITLE
Add outputs to JSON query

### DIFF
--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -907,7 +907,7 @@ static VersionDiff compareVersionAgainstSet(
 }
 
 
-static void queryJSON(Globals & globals, vector<DrvInfo> & elems)
+static void queryJSON(Globals & globals, vector<DrvInfo> & elems, bool printOutPath)
 {
     JSONObject topObj(cout, true);
     for (auto & i : elems) {
@@ -918,6 +918,14 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems)
         pkgObj.attr("pname", drvName.name);
         pkgObj.attr("version", drvName.version);
         pkgObj.attr("system", i.querySystem());
+
+        if (printOutPath) {
+            DrvInfo::Outputs outputs = i.queryOutputs();
+            JSONObject outputObj = pkgObj.object("outputs");
+            for (auto & j : outputs) {
+                outputObj.attr(j.first, j.second);
+            }
+        }
 
         JSONObject metaObj = pkgObj.object("meta");
         StringSet metaNames = i.queryMetaNames();
@@ -1035,7 +1043,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
 
     /* Print the desired columns, or XML output. */
     if (jsonOutput) {
-        queryJSON(globals, elems);
+        queryJSON(globals, elems, printOutPath);
         return;
     }
 


### PR DESCRIPTION
Emit output information when printing JSON information and `--out-paths` is requested.

```console
❯ ../nix/result/bin/nix-env -qaP --out-path --json -f default.nix 2>/dev/null | head -n 20
{
  "all-cabal-hashes": {
    "name": "01a23b49c333c95167338433cd375e24fc60d66d.tar.gz",
    "pname": "01a23b49c333c95167338433cd375e24fc60d66d.tar.gz",
    "version": "",
    "system": "x86_64-linux",
    "outputs": {
      "out": "/nix/store/k17xwfdzsdmbvjlj9yqfc6mhddhjkqga-01a23b49c333c95167338433cd375e24fc60d66d.tar.gz"
    },
    "meta": {
      "available": true,
      "broken": false,
      "insecure": false,
      "name": "01a23b49c333c95167338433cd375e24fc60d66d.tar.gz",
      "outputsToInstall": [
        "out"
      ],
      "position": "/home/fzakaria/code/github.com/NixOS/nixpkgs/pkgs/build-support/fetchurl/default.nix:124",
      "unfree": false,
      "unsupported": false
```

fixes #5877