### PR TITLE
Check for `--meta` before emitting it for `--json`

### DIFF
--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -907,7 +907,7 @@ static VersionDiff compareVersionAgainstSet(
 }
 
 
-static void queryJSON(Globals & globals, vector<DrvInfo> & elems, bool printOutPath)
+static void queryJSON(Globals & globals, vector<DrvInfo> & elems, bool printOutPath, bool printMeta)
 {
     JSONObject topObj(cout, true);
     for (auto & i : elems) {
@@ -927,17 +927,19 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems, bool printOutP
             }
         }
 
-        JSONObject metaObj = pkgObj.object("meta");
-        StringSet metaNames = i.queryMetaNames();
-        for (auto & j : metaNames) {
-            auto placeholder = metaObj.placeholder(j);
-            Value * v = i.queryMeta(j);
-            if (!v) {
-                printError("derivation '%s' has invalid meta attribute '%s'", i.queryName(), j);
-                placeholder.write(nullptr);
-            } else {
-                PathSet context;
-                printValueAsJSON(*globals.state, true, *v, noPos, placeholder, context);
+        if (printMeta) {
+            JSONObject metaObj = pkgObj.object("meta");
+            StringSet metaNames = i.queryMetaNames();
+            for (auto & j : metaNames) {
+                auto placeholder = metaObj.placeholder(j);
+                Value * v = i.queryMeta(j);
+                if (!v) {
+                    printError("derivation '%s' has invalid meta attribute '%s'", i.queryName(), j);
+                    placeholder.write(nullptr);
+                } else {
+                    PathSet context;
+                    printValueAsJSON(*globals.state, true, *v, noPos, placeholder, context);
+                }
             }
         }
     }
@@ -1043,7 +1045,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
 
     /* Print the desired columns, or XML output. */
     if (jsonOutput) {
-        queryJSON(globals, elems, printOutPath);
+        queryJSON(globals, elems, printOutPath, printMeta);
         return;
     }
 


### PR DESCRIPTION
Check that the meta flag is present when emitting JSON query information for `nix-env`.

fixes #5882

CC @edolstra from discussion #5878

## Without `--meta`
``console
❯ ../nix/result/bin/nix-env -qaP --json | head
warning: name collision in input Nix expressions, skipping '/home/fzakaria/.nix-defexpr/channels_root/nixpkgs'
{
  "nixpkgs.zeroadPackages.zeroad-unwrapped": {
    "name": "0ad-0.0.25b",
    "pname": "0ad",
    "version": "0.0.25b",
    "system": "x86_64-linux"
  },
```
## With `--meta`
```
❯ ../nix/result/bin/nix-env -qaP --json --meta | head
warning: name collision in input Nix expressions, skipping '/home/fzakaria/.nix-defexpr/channels_root/nixpkgs'
{
  "nixpkgs.zeroadPackages.zeroad-unwrapped": {
    "name": "0ad-0.0.25b",
    "pname": "0ad",
    "version": "0.0.25b",
    "system": "x86_64-linux",
    "meta": {
      "available": true,
      "broken": false,
```