### PR TITLE
Add link to explanation when introducing a new operator

### DIFF
--- a/doc/manual/src/expressions/language-constructs.md
+++ b/doc/manual/src/expressions/language-constructs.md
@@ -276,6 +276,7 @@ stdenv.mkDerivation {
   ...
 }
 ```
+("->" is a boolean operation known as [logical implication](https://en.wikipedia.org/wiki/Truth_table#Logical_implication))
 
 The points of interest are:
 


### PR DESCRIPTION
The logical implication operator is included in this section but never explained. It might stump new readers with a pretty uncommon operator, and it's never referenced explicitly.

It might be a bit pedantic, but it stumped me when I first read through the documentation page by page. Open to suggestions.

First referenced in #5845