### PR TITLE
Release Notes 2.4: add `--indirect` no-op change

### DIFF
--- a/doc/manual/src/release-notes/rl-2.4.md
+++ b/doc/manual/src/release-notes/rl-2.4.md
@@ -276,6 +276,9 @@ more than 2800 commits from 195 contributors since release 2.3.
 
 * Plugins can now register `nix` subcommands.
 
+* The `--indirect` flag to `nix-store --add-root` has become a no-op.
+  `--add-root` will always generate indirect GC roots from now on.
+
 ## Incompatible changes
 
 * The `nix` command is now marked as an experimental feature. This


### PR DESCRIPTION
Since
https://github.com/NixOS/nix/commit/00d25e84577659ccf0bc360c61c47b6cd25d1c26
which was first included in nix 2.4.

It is a backwards-compatible change since the flag will just be
ignored.

cc @edolstra 