### PR TITLE
flake.cc: throw evalError when system missing from apps or defaultApps

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1021,6 +1021,16 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                 }
 
                 else if (
+                    ((attrPath.size() == 2 && attrPath[0] == "defaultApp" && attrPath[1] == "program") || attrPath[2] == "type"))
+                {
+                  throw EvalError("flake attribute 'defaultApp' should be defaultApp.<system>, where <system> is a valid architecture such as x86_64-linux");
+                }
+                else if (
+                    ((attrPath.size() == 3 && attrPath[0] == "apps" && attrPath[2] == "program") || attrPath[2] == "type"))
+                {
+                  throw EvalError("flake attribute 'apps' should be apps.<system>.name rather than apps.name, where <system> is a valid architecture such as x86_64-linux");
+                }
+                else if (
                     (attrPath.size() == 2 && attrPath[0] == "defaultApp") ||
                     (attrPath.size() == 3 && attrPath[0] == "apps"))
                 {


### PR DESCRIPTION
I am not sure if this is the best way to go about fixing the bug. I would appreciate discussion and suggestions of how the code to fix this could be better.

# What is the bug?

If `defaultApp` or `apps.name` are equal to a derivation, they will fail as an IFD like this:
```
user: matthew swordfish in nix on  mc/fix-apps-ifd-error [!] 
❯ cat ./tst/flake.nix 
{
  outputs = { self, nixpkgs, ... }: {
    # defaultApp.x86_64-linux = with nixpkgs.legacyPackages.x86_64-linux; {
    # defaultApp.random-attr-name = with nixpkgs.legacyPackages.x86_64-linux; {
    defaultApp = with nixpkgs.legacyPackages.x86_64-linux; {
        type = "app";
        program = let
            ifd = writeText "test.nix" "{a=1;}";
          in
            builtins.toString (writers.writeBash "test.sh" ''
              echo ${toString (import ifd).a}
            '');
      };
  };
}

user: matthew swordfish in nix on  mc/fix-apps-ifd-error [!] 
❯ nix flake show ./tst
warning: Git tree '/home/matthew/git/nix' is dirty
git+file:///home/matthew/git/nix?dir=tst
└───defaultApp
error: cannot build '/nix/store/cwnzkildf01bnsc8wgqadbk4330gl51w-test.nix.drv' during evaluation because the option 'allow-import-from-derivation' is disabled
(use '--show-trace' to show detailed location information)
```

If `defaultApp.x86_64-linux` or `apps.x86_64-linux.name` is defined instead, it will not fail with IFD:
```
user: matthew swordfish in nix on  mc/fix-apps-ifd-error [!] 
❯ cat ./tst/flake.nix 
{
  outputs = { self, nixpkgs, ... }: {
    # defaultApp.x86_64-linux = with nixpkgs.legacyPackages.x86_64-linux; {
    # defaultApp.random-attr-name = with nixpkgs.legacyPackages.x86_64-linux; {
    defaultApp.x86_64-linux = with nixpkgs.legacyPackages.x86_64-linux; {
        type = "app";
        program = let
            ifd = writeText "test.nix" "{a=1;}";
          in
            builtins.toString (writers.writeBash "test.sh" ''
              echo ${toString (import ifd).a}
            '');
      };
  };
}

user: matthew swordfish in nix on  mc/fix-apps-ifd-error [!] 
❯ nix flake show ./tst
warning: Git tree '/home/matthew/git/nix' is dirty
git+file:///home/matthew/git/nix?dir=tst
└───defaultApp
    └───x86_64-linux: app
```