### PR TITLE
Custom commit messages when commiting the lockfile

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -9,3 +9,7 @@
   as `lib.zipAttrsWith` from nixpkgs, but much more efficient.
 * New command `nix store copy-log` to copy build logs from one store
   to another.
+* The `commit-lockfile-summary` option can be set to a non-empty string
+  to override the commit summary used when commiting an updated lockfile.
+  This may be used in conjunction with the nixConfig attribute in
+  `flake.nix` to better conform to repository conventions.

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -966,6 +966,13 @@ public:
 
     Setting<bool> acceptFlakeConfig{this, false, "accept-flake-config",
         "Whether to accept nix configuration from a flake without prompting."};
+
+    Setting<std::string> commitLockFileSummary{
+        this, "", "commit-lockfile-summary",
+        R"(
+          The commit summary to use when commiting changed flake lock files. If
+          empty, the summary is generated based on the action performed.
+        )"};
 };
 
 


### PR DESCRIPTION
This allows, for instance, the following command:

```bash
$ nix flake update --commit-lock-file --commit-summary "chore: update nixpkgs"
```

This would lead to a commit message like the following (taken from running the above on nixos/nix):
```
chore: update nixpkgs

Flake lock file updates:

• Updated input 'lowdown-src':
   'github:kristapsdz/lowdown/d2c2b44ff6c27b936ec27358a2653caaef8f73b8' (2021-10-06)
  → 'github:kristapsdz/lowdown/1de10c1d71bfb4348ae0beaec8b1547d5e114969' (2021-11-19)
• Updated input 'nixpkgs':
   'github:NixOS/nixpkgs/82891b5e2c2359d7e58d08849e4c89511ab94234' (2021-09-28)
  → 'github:NixOS/nixpkgs/c68e3678f42352cc4f0ff42f48944c292eef1297' (2022-01-09)

```

If a user wanted a custom commit message, they'd previously have to do something like this (untested, might be wrong):

```bash
$ nix flake update --commit-lock-file
$ git commit --ammend -m "$msg" # also gets rid of the extended commit message
```

There are a variety of reasons one may want to write their own commit message for a dep update, but the biggest one is to conform to the conventions used by a given repository (for instance, in the example, the use of the prefix `chore:` to convey that the commit is routine).

This PR contains two commits; one to update the file and one to document the changes in the changelog. I'm not too familiar with the code here, so (large amounts of) feedback is welcome and probably necessary - thanks!