### PR TITLE
Start the pager early-enough in `nix why-depends`

### DIFF
--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -239,7 +239,6 @@ struct CmdWhyDepends : SourceExprCommand
 
             visitPath(pathS);
 
-            RunPager pager;
             for (auto & ref : refs) {
                 std::string hash(ref.second->path.hashPart());
 
@@ -259,6 +258,7 @@ struct CmdWhyDepends : SourceExprCommand
             }
         };
 
+        RunPager pager;
         try {
             printNode(graph.at(packagePath), "", "");
         } catch (BailOut & ) { }


### PR DESCRIPTION
`nix why-depends` is piping its output into a pager by default.
However the pager was only started after the first path is printed,
causing it to be excluded from the pager output.

(Actually the pager was started *inside* the recursive function that was
printing the dependency chain, so a new instance was started at each
level. It’s a little miracle that it worked at all).

Fix #5911

cc @lilyball 