### PR TITLE
Forbid runtime references to boost

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -312,6 +312,13 @@
                 chmod u+w $out/lib/*.so.*
                 patchelf --set-rpath $out/lib:${currentStdenv.cc.cc.lib}/lib $out/lib/libboost_thread.so.*
               ''}
+              ${lib.optionalString currentStdenv.isDarwin ''
+                for LIB in $out/lib/*.dylib; do
+                  chmod u+w $LIB
+                  install_name_tool -id $LIB $LIB
+                done
+                install_name_tool -change ${boost}/lib/libboost_system.dylib $out/lib/libboost_system.dylib $out/lib/libboost_thread.dylib
+              ''}
             '';
 
           configureFlags = configureFlags ++
@@ -328,6 +335,12 @@
           postInstall = ''
             mkdir -p $doc/nix-support
             echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
+            ${lib.optionalString currentStdenv.isDarwin ''
+            install_name_tool \
+              -change ${boost}/lib/libboost_context.dylib \
+              $out/lib/libboost_context.dylib \
+              $out/lib/libnixutil.dylib
+            ''}
           '';
 
           doInstallCheck = true;

--- a/flake.nix
+++ b/flake.nix
@@ -299,6 +299,8 @@
 
           propagatedBuildInputs = propagatedDeps;
 
+          disallowedReferences = [ boost ];
+
           preConfigure =
             ''
               # Copy libboost_context so we don't get all of Boost in our closure.


### PR DESCRIPTION
We explicitly hack around to remove them, so might as well check that the hack is useful.

(Introduced because I feared that the changes of https://github.com/NixOS/nix/pull/5906#discussion_r784810238 would bring back some runtime references)
