### PR TITLE
Make ProgressBar print build logs when TTY is not detected

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -85,7 +85,7 @@ private:
 public:
 
     ProgressBar(bool printBuildLogs, bool isTTY)
-        : printBuildLogs(printBuildLogs)
+        : printBuildLogs(printBuildLogs || !isTTY)
         , isTTY(isTTY)
     {
         state_.lock()->active = isTTY;


### PR DESCRIPTION
Resolves #4402 until #4296 is finished. Nix will now behave as if `--log-format bar-with-logs` has been passed when `shouldANSI()` is false (i.e. stderr is not a TTY, `TERM` is `dumb` or unset, or `NO_COLOR` is set).
