### PR TITLE
Print build logs when not connected to a TTY

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -270,11 +270,15 @@ void mainWrapped(int argc, char * * argv)
         if (legacy) return legacy(argc, argv);
     }
 
-    verbosity = lvlNotice;
-    settings.verboseBuild = false;
     evalSettings.pureEval = true;
 
     setLogFormat("bar");
+    settings.verboseBuild = false;
+    if (isatty(STDERR_FILENO)) {
+        verbosity = lvlNotice;
+    } else {
+        verbosity = lvlInfo;
+    }
 
     Finally f([] { logger->stop(); });
 


### PR DESCRIPTION
When stderr is not connected to a tty, print out the build logs
instead of showing a bar.

Closes https://github.com/NixOS/nix/issues/4402
