### PR TITLE
docker: also create var/tmp as some tools rely on it

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -201,7 +201,7 @@ let
 
       mkdir $out/tmp
 
-      mkdir $out/var/tmp
+      mkdir -p $out/var/tmp
 
       mkdir -p $out/etc/nix
       cat $nixConfContentsPath > $out/etc/nix/nix.conf

--- a/docker.nix
+++ b/docker.nix
@@ -201,6 +201,8 @@ let
 
       mkdir $out/tmp
 
+      mkdir $out/var/tmp
+
       mkdir -p $out/etc/nix
       cat $nixConfContentsPath > $out/etc/nix/nix.conf
 
@@ -236,6 +238,7 @@ pkgs.dockerTools.buildLayeredImageWithNixDb {
   '';
   fakeRootCommands = ''
     chmod 1777 tmp
+    chmod 1777 var/tmp
   '';
 
   config = {


### PR DESCRIPTION
Some tools rely on var/tmp being present. This PR creates that directory.