### PR TITLE
Add try/catch to queryJSON for assertion and errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ GTAGS
 compile_commands.json
 
 nix-rust/target
+
+result
+
+.vscode/

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -911,36 +911,44 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems, bool printOutP
 {
     JSONObject topObj(cout, true);
     for (auto & i : elems) {
-        JSONObject pkgObj = topObj.object(i.attrPath);
+        try {
+            if (i.hasFailed()) continue;
 
-        auto drvName = DrvName(i.queryName());
-        pkgObj.attr("name", drvName.fullName);
-        pkgObj.attr("pname", drvName.name);
-        pkgObj.attr("version", drvName.version);
-        pkgObj.attr("system", i.querySystem());
+            JSONObject pkgObj = topObj.object(i.attrPath);
 
-        if (printOutPath) {
-            DrvInfo::Outputs outputs = i.queryOutputs();
-            JSONObject outputObj = pkgObj.object("outputs");
-            for (auto & j : outputs) {
-                outputObj.attr(j.first, j.second);
-            }
-        }
+            auto drvName = DrvName(i.queryName());
+            pkgObj.attr("name", drvName.fullName);
+            pkgObj.attr("pname", drvName.name);
+            pkgObj.attr("version", drvName.version);
+            pkgObj.attr("system", i.querySystem());
 
-        if (printMeta) {
-            JSONObject metaObj = pkgObj.object("meta");
-            StringSet metaNames = i.queryMetaNames();
-            for (auto & j : metaNames) {
-                auto placeholder = metaObj.placeholder(j);
-                Value * v = i.queryMeta(j);
-                if (!v) {
-                    printError("derivation '%s' has invalid meta attribute '%s'", i.queryName(), j);
-                    placeholder.write(nullptr);
-                } else {
-                    PathSet context;
-                    printValueAsJSON(*globals.state, true, *v, noPos, placeholder, context);
+            if (printOutPath) {
+                DrvInfo::Outputs outputs = i.queryOutputs();
+                JSONObject outputObj = pkgObj.object("outputs");
+                for (auto & j : outputs) {
+                    outputObj.attr(j.first, j.second);
                 }
             }
+
+            if (printMeta) {
+                JSONObject metaObj = pkgObj.object("meta");
+                StringSet metaNames = i.queryMetaNames();
+                for (auto & j : metaNames) {
+                    auto placeholder = metaObj.placeholder(j);
+                    Value * v = i.queryMeta(j);
+                    if (!v) {
+                        printError("derivation '%s' has invalid meta attribute '%s'", i.queryName(), j);
+                        placeholder.write(nullptr);
+                    } else {
+                        PathSet context;
+                        printValueAsJSON(*globals.state, true, *v, noPos, placeholder, context);
+                    }
+                }
+            }
+        } catch (AssertionError & e) {
+            printMsg(lvlTalkative, "skipping derivation named '%1%' which gives an assertion failure", i.queryName());
+        } catch (Error & e) {
+            printMsg(lvlError, "skipping derivation named '%1%' which gives an error '%2%'", i.queryName(), e.msg());
         }
     }
 }

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -948,7 +948,8 @@ static void queryJSON(Globals & globals, vector<DrvInfo> & elems, bool printOutP
         } catch (AssertionError & e) {
             printMsg(lvlTalkative, "skipping derivation named '%1%' which gives an assertion failure", i.queryName());
         } catch (Error & e) {
-            printMsg(lvlError, "skipping derivation named '%1%' which gives an error '%2%'", i.queryName(), e.msg());
+            e.addTrace(std::nullopt, "while querying the derivation named '%1%'", i.queryName());
+            throw;
         }
     }
 }


### PR DESCRIPTION
The table output for `nix-env -qaP` has a _try/catch_ for assertion & errors when parsing each individual derivation.
This functionality is missing for `queryJSON`.

I've added a similar `try/catch`.
**Note:** Perhaps ideally this should be a flag to control how "strict" `nix-env` should be.

I am finding that maintaing parity between the different output formats (_JSON_, _XML_ & _Tabular_) is very difficult.
I think a good issue and contribution would be the creation of a single struct that is then serialized to all 3 agnostically.

fixes #5921