### PR TITLE
Make `nix why-depends` quieter by default

### DIFF
--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -31,6 +31,7 @@ struct CmdWhyDepends : SourceExprCommand
 {
     std::string _package, _dependency;
     bool all = false;
+    bool precise = false;
 
     CmdWhyDepends()
     {
@@ -55,6 +56,12 @@ struct CmdWhyDepends : SourceExprCommand
             .shortName = 'a',
             .description = "Show all edges in the dependency graph leading from *package* to *dependency*, rather than just a shortest path.",
             .handler = {&all, true},
+        });
+
+        addFlag({
+            .longName = "precise",
+            .description = "For each edge of the graph, inspect the parent node to display the exact location in the path that causes the dependency",
+            .handler = {&precise, true},
         });
     }
 
@@ -158,11 +165,19 @@ struct CmdWhyDepends : SourceExprCommand
             auto pathS = store->printStorePath(node.path);
 
             assert(node.dist != inf);
-            logger->cout("%s%s%s%s" ANSI_NORMAL,
-                firstPad,
-                node.visited ? "\e[38;5;244m" : "",
-                firstPad != "" ? "→ " : "",
-                pathS);
+            if (precise) {
+                logger->cout("%s%s%s%s" ANSI_NORMAL,
+                    firstPad,
+                    node.visited ? "\e[38;5;244m" : "",
+                    firstPad != "" ? "→ " : "",
+                    pathS);
+            } else {
+                logger->cout("%s%s%s%s" ANSI_NORMAL,
+                    firstPad,
+                    node.visited ? "\e[38;5;244m" : "",
+                    firstPad != "" ? treeLast : "",
+                    pathS);
+            }
 
             if (node.path == dependencyPath && !all
                 && packagePath != dependencyPath)
@@ -237,7 +252,7 @@ struct CmdWhyDepends : SourceExprCommand
 
             // FIXME: should use scanForReferences().
 
-            visitPath(pathS);
+            if (precise) visitPath(pathS);
 
             for (auto & ref : refs) {
                 std::string hash(ref.second->path.hashPart());

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -60,7 +60,7 @@ struct CmdWhyDepends : SourceExprCommand
 
         addFlag({
             .longName = "precise",
-            .description = "For each edge of the graph, inspect the parent node to display the exact location in the path that causes the dependency",
+            .description = "For each edge in the dependency graph, show the files in the parent that cause the dependency.",
             .handler = {&precise, true},
         });
     }

--- a/tests/dependencies.builder0.sh
+++ b/tests/dependencies.builder0.sh
@@ -4,7 +4,7 @@
 mkdir $out
 echo $(cat $input1/foo)$(cat $input2/bar) > $out/foobar
 
-ln -s $input2 $out/input-2
+ln -s $input2 $out/reference-to-input-2
 
 # Self-reference.
 ln -s $out $out/self

--- a/tests/dependencies.nix
+++ b/tests/dependencies.nix
@@ -27,6 +27,8 @@ let {
     input1 = input1 + "/.";
     input2 = "${input2}/.";
     input1_drv = input1;
+    input2_drv = input2;
+    input0_drv = input0;
     meta.description = "Random test package";
   };
 

--- a/tests/gc.sh
+++ b/tests/gc.sh
@@ -18,7 +18,7 @@ if nix-store --gc --print-dead | grep -E $outPath$; then false; fi
 
 nix-store --gc --print-dead
 
-inUse=$(readLink $outPath/input-2)
+inUse=$(readLink $outPath/reference-to-input-2)
 if nix-store --delete $inUse; then false; fi
 test -e $inUse
 
@@ -35,7 +35,7 @@ nix-collect-garbage
 
 # Check that the root and its dependencies haven't been deleted.
 cat $outPath/foobar
-cat $outPath/input-2/bar
+cat $outPath/reference-to-input-2/bar
 
 # Check that the derivation has been GC'd.
 if test -e $drvPath; then false; fi

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -61,7 +61,8 @@ nix_tests = \
   ca/concurrent-builds.sh \
   ca/nix-copy.sh \
   eval-store.sh \
-  readfile-context.sh
+  readfile-context.sh \
+  why-depends.sh
   # parallel.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)

--- a/tests/why-depends.sh
+++ b/tests/why-depends.sh
@@ -1,0 +1,13 @@
+source common.sh
+
+clearStore
+
+cp ./dependencies.nix ./dependencies.builder0.sh ./config.nix $TEST_HOME
+
+cd $TEST_HOME
+
+nix-build ./dependencies.nix -A input0_drv -o dep
+nix-build ./dependencies.nix -o toplevel
+
+nix why-depends ./toplevel ./dep |
+    grep input-2

--- a/tests/why-depends.sh
+++ b/tests/why-depends.sh
@@ -9,5 +9,13 @@ cd $TEST_HOME
 nix-build ./dependencies.nix -A input0_drv -o dep
 nix-build ./dependencies.nix -o toplevel
 
-nix why-depends ./toplevel ./dep |
-    grep input-2
+FAST_WHY_DEPENDS_OUTPUT=$(nix why-depends ./toplevel ./dep)
+PRECISE_WHY_DEPENDS_OUTPUT=$(nix why-depends ./toplevel ./dep --precise)
+
+# Both outputs should show that `input-2` is in the dependency chain
+echo "$FAST_WHY_DEPENDS_OUTPUT" | grep -q input-2
+echo "$PRECISE_WHY_DEPENDS_OUTPUT" | grep -q input-2
+
+# But only the “precise” one should refere to `reference-to-input-2`
+echo "$FAST_WHY_DEPENDS_OUTPUT" | (! grep -q reference-to-input-2)
+echo "$PRECISE_WHY_DEPENDS_OUTPUT" | grep -q reference-to-input-2


### PR DESCRIPTION
Unless `--precise` is passed, make `nix why-depends` only show the dependencies between the store paths, without introspecting them to find the actual references.

This also makes it ~3x faster

/cc @lilyball 

Fix https://github.com/NixOS/nix/issues/5912