### PR TITLE
Make `nix search` highlight all regexes and matches

### DIFF
--- a/src/libutil/fmt.cc
+++ b/src/libutil/fmt.cc
@@ -1,0 +1,38 @@
+#include <regex>
+
+namespace nix {
+
+std::string hiliteMatches(const std::string &s, std::vector<std::smatch> matches, std::string prefix, std::string postfix) {
+    // Avoid copy on zero matches
+    if (matches.size() == 0)
+        return s;
+
+    std::sort(matches.begin(), matches.end(), [](const auto &a, const auto &b) {
+        return a.position() < b.position();
+    });
+
+    std::string out;
+    ssize_t last_end = 0;
+
+    for (auto it = matches.begin(); it != matches.end();) {
+        auto m = *it;
+        size_t start = m.position();
+        out.append(s.substr(last_end, m.position() - last_end));
+        // Merge continous matches
+        ssize_t end = start + m.length();
+        while(++it != matches.end() && (*it).position() <= end) {
+            auto n = *it;
+            ssize_t nend = start + (n.position() - start + n.length());
+            if(nend > end)
+                end = nend;
+        }
+        out.append(prefix);
+        out.append(s.substr(start, end - start));
+        out.append(postfix);
+        last_end = end;
+    }
+    out.append(s.substr(last_end));
+    return out;
+}
+
+}

--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -2,6 +2,7 @@
 
 #include <boost/format.hpp>
 #include <string>
+#include <regex>
 #include "ansicolor.hh"
 
 
@@ -154,4 +155,6 @@ inline hintformat hintfmt(std::string plain_string)
     // we won't be receiving any args in this case, so just print the original string
     return hintfmt("%s", normaltxt(plain_string));
 }
+
+std::string hiliteMatches(const std::string &s, std::vector<std::smatch> matches, std::string prefix, std::string postfix);
 }

--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -156,5 +156,12 @@ inline hintformat hintfmt(std::string plain_string)
     return hintfmt("%s", normaltxt(plain_string));
 }
 
+/**
+ * Highlight all the given matches in the given string `s` by wrapping them
+ * between `prefix` and `postfix`.
+ *
+ * If some matches overlap, then their union will be wrapped rather than the
+ * individual matches.
+ */
 std::string hiliteMatches(const std::string &s, std::vector<std::smatch> matches, std::string prefix, std::string postfix);
 }

--- a/src/libutil/tests/fmt.cc
+++ b/src/libutil/tests/fmt.cc
@@ -1,0 +1,68 @@
+#include "fmt.hh"
+
+#include <gtest/gtest.h>
+
+#include <regex>
+
+namespace nix {
+/* ----------- tests for fmt.hh -------------------------------------------------*/
+
+    TEST(hiliteMatches, noHighlight) {
+        ASSERT_STREQ(hiliteMatches("Hello, world!", std::vector<std::smatch>(), "(", ")").c_str(), "Hello, world!");
+    }
+
+    TEST(hiliteMatches, simpleHighlight) {
+        std::string str = "Hello, world!";
+        std::regex re = std::regex("world");
+        auto matches = std::vector(std::sregex_iterator(str.begin(), str.end(), re), std::sregex_iterator());
+        ASSERT_STREQ(
+                    hiliteMatches(str, matches, "(", ")").c_str(),
+                    "Hello, (world)!"
+        );
+    }
+
+    TEST(hiliteMatches, multipleMatches) {
+        std::string str = "Hello, world, world, world, world, world, world, Hello!";
+        std::regex re = std::regex("world");
+        auto matches = std::vector(std::sregex_iterator(str.begin(), str.end(), re), std::sregex_iterator());
+        ASSERT_STREQ(
+                    hiliteMatches(str, matches, "(", ")").c_str(),
+                    "Hello, (world), (world), (world), (world), (world), (world), Hello!"
+        );
+    }
+
+    TEST(hiliteMatches, overlappingMatches) {
+        std::string str = "world, Hello, world, Hello, world, Hello, world, Hello, world!";
+        std::regex re = std::regex("Hello, world");
+        std::regex re2 = std::regex("world, Hello");
+        auto v = std::vector(std::sregex_iterator(str.begin(), str.end(), re), std::sregex_iterator());
+        for(auto it = std::sregex_iterator(str.begin(), str.end(), re2); it != std::sregex_iterator(); ++it) {
+            v.push_back(*it);
+        }
+        ASSERT_STREQ(
+                    hiliteMatches(str, v, "(", ")").c_str(),
+                    "(world, Hello, world, Hello, world, Hello, world, Hello, world)!"
+        );
+    }
+
+    TEST(hiliteMatches, complexOverlappingMatches) {
+        std::string str = "legacyPackages.x86_64-linux.git-crypt";
+        std::vector regexes = {
+            std::regex("t-cry"),
+            std::regex("ux\\.git-cry"),
+            std::regex("git-c"),
+            std::regex("pt"),
+        };
+        std::vector<std::smatch> matches;
+        for(auto regex : regexes)
+        {
+            for(auto it = std::sregex_iterator(str.begin(), str.end(), regex); it != std::sregex_iterator(); ++it) {
+                matches.push_back(*it);
+            }
+        }
+        ASSERT_STREQ(
+                    hiliteMatches(str, matches, "(", ")").c_str(),
+                    "legacyPackages.x86_64-lin(ux.git-crypt)"
+        );
+    }
+}

--- a/tests/search.sh
+++ b/tests/search.sh
@@ -23,3 +23,16 @@ clearCache
 nix search -f search.nix '' |grep -q foo
 nix search -f search.nix '' |grep -q bar
 nix search -f search.nix '' |grep -q hello
+
+## Tests for multiple regex/match highlighting
+
+e=$'\x1b' # grep doesn't support \e, \033 or even \x1b
+# Multiple overlapping regexes
+(( $(nix search -f search.nix '' 'oo' 'foo' 'oo' | grep "$e\[32;1mfoo$e\\[0;1m" | wc -l) == 1 ))
+(( $(nix search -f search.nix '' 'broken b' 'en bar' | grep "$e\[32;1mbroken bar$e\\[0m" | wc -l) == 1 ))
+
+# Multiple matches
+# Searching for 'o' should yield the 'o' in 'broken bar', the 'oo' in foo and 'o' in hello
+(( $(nix search -f search.nix '' 'o' | grep -Eo "$e\[32;1mo{1,2}$e\[(0|0;1)m" | wc -l) == 3 ))
+# Searching for 'b' should yield the 'b' in bar and the two 'b's in 'broken bar'
+(( $(nix search -f search.nix '' 'b' | grep -Eo "$e\[32;1mb$e\[(0|0;1)m" | wc -l) == 3 ))


### PR DESCRIPTION
This PR makes the `nix search` command highlight all matches of all regexes provided on the command line, previously only the first match of the last regex would be highlighted.
Fixes issue #4560.

This is my first pull request so feedback would be appreciated!