### PR TITLE
convert more string copies into string_views

### DIFF
--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -121,7 +121,7 @@ Pos findPackageFilename(EvalState & state, Value & v, std::string what)
     std::string filename(pos, 0, colon);
     unsigned int lineno;
     try {
-        lineno = std::stoi(std::string(pos, colon + 1));
+        lineno = std::stoi(std::string(pos, colon + 1, string::npos));
     } catch (std::invalid_argument & e) {
         throw ParseError("cannot parse line number '%s'", pos);
     }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1857,7 +1857,7 @@ void EvalState::forceFunction(Value & v, const Pos & pos)
 }
 
 
-string EvalState::forceString(Value & v, const Pos & pos)
+std::string_view EvalState::forceString(Value & v, const Pos & pos)
 {
     forceValue(v, pos);
     if (v.type() != nString) {
@@ -1866,7 +1866,7 @@ string EvalState::forceString(Value & v, const Pos & pos)
         else
             throwTypeError("value is %1% while a string was expected", v);
     }
-    return string(v.string.s);
+    return v.string.s;
 }
 
 
@@ -1901,17 +1901,17 @@ std::vector<std::pair<Path, std::string>> Value::getContext()
 }
 
 
-string EvalState::forceString(Value & v, PathSet & context, const Pos & pos)
+std::string_view EvalState::forceString(Value & v, PathSet & context, const Pos & pos)
 {
-    string s = forceString(v, pos);
+    auto s = forceString(v, pos);
     copyContext(v, context);
     return s;
 }
 
 
-string EvalState::forceStringNoCtx(Value & v, const Pos & pos)
+std::string_view EvalState::forceStringNoCtx(Value & v, const Pos & pos)
 {
-    string s = forceString(v, pos);
+    auto s = forceString(v, pos);
     if (v.string.context) {
         if (pos)
             throwEvalError(pos, "the string '%1%' is not allowed to refer to a store path (such as '%2%')",

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1,5 +1,6 @@
 #include "eval.hh"
 #include "hash.hh"
+#include "types.hh"
 #include "util.hh"
 #include "store-api.hh"
 #include "derivations.hh"
@@ -1694,7 +1695,7 @@ void EvalState::concatLists(Value & v, size_t nrLists, Value * * lists, const Po
 void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
 {
     PathSet context;
-    std::vector<std::string> s;
+    std::vector<BackedStringView> s;
     size_t sSize = 0;
     NixInt n = 0;
     NixFloat nf = 0;
@@ -1705,7 +1706,7 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
     const auto str = [&] {
         std::string result;
         result.reserve(sSize);
-        for (const auto & part : s) result += part;
+        for (const auto & part : s) result += *part;
         return result;
     };
     /* c_str() is not str().c_str() because we want to create a string
@@ -1715,15 +1716,18 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
         char * result = allocString(sSize + 1);
         char * tmp = result;
         for (const auto & part : s) {
-            memcpy(tmp, part.c_str(), part.size());
-            tmp += part.size();
+            memcpy(tmp, part->data(), part->size());
+            tmp += part->size();
         }
         *tmp = 0;
         return result;
     };
 
+    Value values[es->size()];
+    Value * vTmpP = values;
+
     for (auto & [i_pos, i] : *es) {
-        Value vTmp;
+        Value & vTmp = *vTmpP++;
         i->eval(state, env, vTmp);
 
         /* If the first element is a path, then the result will also
@@ -1756,9 +1760,9 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
             /* skip canonization of first path, which would only be not
             canonized in the first place if it's coming from a ./${foo} type
             path */
-            s.emplace_back(
-                state.coerceToString(i_pos, vTmp, context, false, firstType == nString, !first));
-            sSize += s.back().size();
+            auto part = state.coerceToString(i_pos, vTmp, context, false, firstType == nString, !first);
+            sSize += part->size();
+            s.emplace_back(std::move(part));
         }
 
         first = false;
@@ -1942,34 +1946,35 @@ std::optional<string> EvalState::tryAttrsToString(const Pos & pos, Value & v,
     if (i != v.attrs->end()) {
         Value v1;
         callFunction(*i->value, v, v1, pos);
-        return coerceToString(pos, v1, context, coerceMore, copyToStore);
+        return coerceToString(pos, v1, context, coerceMore, copyToStore).toOwned();
     }
 
     return {};
 }
 
-string EvalState::coerceToString(const Pos & pos, Value & v, PathSet & context,
+BackedStringView EvalState::coerceToString(const Pos & pos, Value & v, PathSet & context,
     bool coerceMore, bool copyToStore, bool canonicalizePath)
 {
     forceValue(v, pos);
 
-    string s;
-
     if (v.type() == nString) {
         copyContext(v, context);
-        return v.string.s;
+        return std::string_view(v.string.s);
     }
 
     if (v.type() == nPath) {
-        Path path(canonicalizePath ? canonPath(v.path) : v.path);
-        return copyToStore ? copyPathToStore(context, path) : path;
+        BackedStringView path(PathView(v.path));
+        if (canonicalizePath)
+            path = canonPath(*path);
+        if (copyToStore)
+            path = copyPathToStore(context, std::move(path).toOwned());
+        return path;
     }
 
     if (v.type() == nAttrs) {
         auto maybeString = tryAttrsToString(pos, v, context, coerceMore, copyToStore);
-        if (maybeString) {
-            return *maybeString;
-        }
+        if (maybeString)
+            return std::move(*maybeString);
         auto i = v.attrs->find(sOutPath);
         if (i == v.attrs->end()) throwTypeError(pos, "cannot coerce a set to a string");
         return coerceToString(pos, *i->value, context, coerceMore, copyToStore);
@@ -1991,14 +1996,13 @@ string EvalState::coerceToString(const Pos & pos, Value & v, PathSet & context,
         if (v.isList()) {
             string result;
             for (auto [n, v2] : enumerate(v.listItems())) {
-                result += coerceToString(pos, *v2,
-                    context, coerceMore, copyToStore);
+                result += *coerceToString(pos, *v2, context, coerceMore, copyToStore);
                 if (n < v.listSize() - 1
                     /* !!! not quite correct */
                     && (!v2->isList() || v2->listSize() != 0))
                     result += " ";
             }
-            return result;
+            return std::move(result);
         }
     }
 
@@ -2032,7 +2036,7 @@ string EvalState::copyPathToStore(PathSet & context, const Path & path)
 
 Path EvalState::coerceToPath(const Pos & pos, Value & v, PathSet & context)
 {
-    string path = coerceToString(pos, v, context, false, false);
+    string path = coerceToString(pos, v, context, false, false).toOwned();
     if (path == "" || path[0] != '/')
         throwEvalError(pos, "string '%1%' doesn't represent an absolute path", path);
     return path;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "attr-set.hh"
+#include "types.hh"
 #include "value.hh"
 #include "nixexpr.hh"
 #include "symbol-table.hh"
@@ -251,7 +252,7 @@ public:
        string.  If `coerceMore' is set, also converts nulls, integers,
        booleans and lists to a string.  If `copyToStore' is set,
        referenced paths are copied to the Nix store as a side effect. */
-    string coerceToString(const Pos & pos, Value & v, PathSet & context,
+    BackedStringView coerceToString(const Pos & pos, Value & v, PathSet & context,
         bool coerceMore = false, bool copyToStore = true,
         bool canonicalizePath = true);
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -309,8 +309,8 @@ private:
     friend struct ExprAttrs;
     friend struct ExprLet;
 
-    Expr * parse(char * text, size_t length, FileOrigin origin, const Path & path,
-        const Path & basePath, StaticEnv & staticEnv);
+    Expr * parse(char * text, size_t length, FileOrigin origin, const PathView path,
+        const PathView basePath, StaticEnv & staticEnv);
 
 public:
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -201,8 +201,8 @@ public:
     void resetFileCache();
 
     /* Look up a file in the search path. */
-    Path findFile(const string & path);
-    Path findFile(SearchPath & searchPath, const string & path, const Pos & pos = noPos);
+    Path findFile(const std::string_view path);
+    Path findFile(SearchPath & searchPath, const std::string_view path, const Pos & pos = noPos);
 
     /* If the specified search path element is a URI, download it. */
     std::pair<bool, std::string> resolveSearchPathElem(const SearchPathElem & elem);
@@ -236,9 +236,9 @@ public:
     inline void forceList(Value & v);
     inline void forceList(Value & v, const Pos & pos);
     void forceFunction(Value & v, const Pos & pos); // either lambda or primop
-    string forceString(Value & v, const Pos & pos = noPos);
-    string forceString(Value & v, PathSet & context, const Pos & pos = noPos);
-    string forceStringNoCtx(Value & v, const Pos & pos = noPos);
+    std::string_view forceString(Value & v, const Pos & pos = noPos);
+    std::string_view forceString(Value & v, PathSet & context, const Pos & pos = noPos);
+    std::string_view forceStringNoCtx(Value & v, const Pos & pos = noPos);
 
     /* Return true iff the value `v' denotes a derivation (i.e. a
        set with attribute `type = "derivation"'). */

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -253,7 +253,9 @@ static Flake getFlake(
                 flake.config.settings.insert({setting.name, string(state.forceStringNoCtx(*setting.value, *setting.pos))});
             else if (setting.value->type() == nPath) {
                 PathSet emptyContext = {};
-                flake.config.settings.insert({setting.name, state.coerceToString(*setting.pos, *setting.value, emptyContext, false, true, true)});
+                flake.config.settings.emplace(
+                    setting.name,
+                    state.coerceToString(*setting.pos, *setting.value, emptyContext, false, true, true) .toOwned());
             }
             else if (setting.value->type() == nInt)
                 flake.config.settings.insert({setting.name, state.forceInt(*setting.value, *setting.pos)});

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -250,7 +250,7 @@ static Flake getFlake(
         for (auto & setting : *nixConfig->value->attrs) {
             forceTrivialValue(state, *setting.value, *setting.pos);
             if (setting.value->type() == nString)
-                flake.config.settings.insert({setting.name, state.forceStringNoCtx(*setting.value, *setting.pos)});
+                flake.config.settings.insert({setting.name, string(state.forceStringNoCtx(*setting.value, *setting.pos))});
             else if (setting.value->type() == nPath) {
                 PathSet emptyContext = {};
                 flake.config.settings.insert({setting.name, state.coerceToString(*setting.pos, *setting.value, emptyContext, false, true, true)});
@@ -265,7 +265,7 @@ static Flake getFlake(
                     if (elem->type() != nString)
                         throw TypeError("list element in flake configuration setting '%s' is %s while a string is expected",
                             setting.name, showType(*setting.value));
-                    ss.push_back(state.forceStringNoCtx(*elem, *setting.pos));
+                    ss.emplace_back(state.forceStringNoCtx(*elem, *setting.pos));
                 }
                 flake.config.settings.insert({setting.name, ss});
             }
@@ -726,7 +726,7 @@ static void prim_getFlake(EvalState & state, const Pos & pos, Value * * args, Va
 {
     state.requireExperimentalFeatureOnEvaluation(Xp::Flakes, "builtins.getFlake", pos);
 
-    auto flakeRefS = state.forceStringNoCtx(*args[0], pos);
+    string flakeRefS(state.forceStringNoCtx(*args[0], pos));
     auto flakeRef = parseFlakeRef(flakeRefS, {}, true);
     if (evalSettings.pureEval && !flakeRef.input.isImmutable())
         throw Error("cannot call 'getFlake' on mutable flake reference '%s', at %s (use --impure to override)", flakeRefS, pos);

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -104,7 +104,7 @@ DrvInfo::Outputs DrvInfo::queryOutputs(bool onlyOutputsToInstall)
             /* For each output... */
             for (auto elem : i->value->listItems()) {
                 /* Evaluate the corresponding set. */
-                string name = state->forceStringNoCtx(*elem, *i->pos);
+                string name(state->forceStringNoCtx(*elem, *i->pos));
                 Bindings::iterator out = attrs->find(state->symbols.create(name));
                 if (out == attrs->end()) continue; // FIXME: throw error?
                 state->forceAttrs(*out->value);

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -163,7 +163,7 @@ public:
     }
 };
 
-void parseJSON(EvalState & state, const string & s_, Value & v)
+void parseJSON(EvalState & state, const std::string_view & s_, Value & v)
 {
     JSONSax parser(state, v);
     bool res = json::sax_parse(s_, &parser);

--- a/src/libexpr/json-to-value.hh
+++ b/src/libexpr/json-to-value.hh
@@ -8,6 +8,6 @@ namespace nix {
 
 MakeError(JSONParseError, EvalError);
 
-void parseJSON(EvalState & state, const string & s, Value & v);
+void parseJSON(EvalState & state, const std::string_view & s, Value & v);
 
 }

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -709,24 +709,24 @@ void EvalState::addToSearchPath(const string & s)
 }
 
 
-Path EvalState::findFile(const string & path)
+Path EvalState::findFile(const std::string_view path)
 {
     return findFile(searchPath, path);
 }
 
 
-Path EvalState::findFile(SearchPath & searchPath, const string & path, const Pos & pos)
+Path EvalState::findFile(SearchPath & searchPath, const std::string_view path, const Pos & pos)
 {
     for (auto & i : searchPath) {
         std::string suffix;
         if (i.first.empty())
-            suffix = "/" + path;
+            suffix = concatStrings("/", path);
         else {
             auto s = i.first.size();
             if (path.compare(0, s, i.first) != 0 ||
                 (path.size() > s && path[s] != '/'))
                 continue;
-            suffix = path.size() == s ? "" : "/" + string(path, s);
+            suffix = path.size() == s ? "" : concatStrings("/", path.substr(s));
         }
         auto r = resolveSearchPathElem(i);
         if (!r.first) continue;
@@ -735,7 +735,7 @@ Path EvalState::findFile(SearchPath & searchPath, const string & path, const Pos
     }
 
     if (hasPrefix(path, "nix/"))
-        return corepkgsPrefix + path.substr(4);
+        return concatStrings(corepkgsPrefix, path.substr(4));
 
     throw ThrownError({
         .msg = hintfmt(evalSettings.pureEval

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -598,7 +598,7 @@ namespace nix {
 
 
 Expr * EvalState::parse(char * text, size_t length, FileOrigin origin,
-    const Path & path, const Path & basePath, StaticEnv & staticEnv)
+    const PathView path, const PathView basePath, StaticEnv & staticEnv)
 {
     yyscan_t scanner;
     ParseData data(*this);

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -180,7 +180,7 @@ static void prim_appendContext(EvalState & state, const Pos & pos, Value * * arg
             }
             for (auto elem : iter->value->listItems()) {
                 auto name = state.forceStringNoCtx(*elem, *iter->pos);
-                context.insert("!" + name + "!" + string(i.name));
+                context.insert(concatStrings("!", name, "!", i.name));
             }
         }
     }

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -7,7 +7,8 @@ namespace nix {
 static void prim_unsafeDiscardStringContext(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     PathSet context;
-    v.mkString(state.coerceToString(pos, *args[0], context));
+    auto s = state.coerceToString(pos, *args[0], context);
+    v.mkString(*s);
 }
 
 static RegisterPrimOp primop_unsafeDiscardStringContext("__unsafeDiscardStringContext", 1, prim_unsafeDiscardStringContext);
@@ -32,13 +33,13 @@ static RegisterPrimOp primop_hasContext("__hasContext", 1, prim_hasContext);
 static void prim_unsafeDiscardOutputDependency(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     PathSet context;
-    string s = state.coerceToString(pos, *args[0], context);
+    auto s = state.coerceToString(pos, *args[0], context);
 
     PathSet context2;
     for (auto & p : context)
         context2.insert(p.at(0) == '=' ? string(p, 1) : p);
 
-    v.mkString(s, context2);
+    v.mkString(*s, context2);
 }
 
 static RegisterPrimOp primop_unsafeDiscardOutputDependency("__unsafeDiscardOutputDependency", 1, prim_unsafeDiscardOutputDependency);

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -12,7 +12,7 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
     std::string url;
     std::optional<Hash> rev;
     std::optional<std::string> ref;
-    std::string name = "source";
+    std::string_view name = "source";
     PathSet context;
 
     state.forceValue(*args[0], pos);
@@ -22,14 +22,14 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
         state.forceAttrs(*args[0], pos);
 
         for (auto & attr : *args[0]->attrs) {
-            string n(attr.name);
+            std::string_view n(attr.name);
             if (n == "url")
                 url = state.coerceToString(*attr.pos, *attr.value, context, false, false);
             else if (n == "rev") {
                 // Ugly: unlike fetchGit, here the "rev" attribute can
                 // be both a revision or a branch/tag name.
                 auto value = state.forceStringNoCtx(*attr.value, *attr.pos);
-                if (std::regex_match(value, revRegex))
+                if (std::regex_match(value.begin(), value.end(), revRegex))
                     rev = Hash::parseAny(value, htSHA1);
                 else
                     ref = value;
@@ -62,7 +62,7 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
     fetchers::Attrs attrs;
     attrs.insert_or_assign("type", "hg");
     attrs.insert_or_assign("url", url.find("://") != std::string::npos ? url : "file://" + url);
-    attrs.insert_or_assign("name", name);
+    attrs.insert_or_assign("name", string(name));
     if (ref) attrs.insert_or_assign("ref", *ref);
     if (rev) attrs.insert_or_assign("rev", rev->gitRev());
     auto input = fetchers::Input::fromAttrs(std::move(attrs));

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -24,7 +24,7 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
         for (auto & attr : *args[0]->attrs) {
             std::string_view n(attr.name);
             if (n == "url")
-                url = state.coerceToString(*attr.pos, *attr.value, context, false, false);
+                url = state.coerceToString(*attr.pos, *attr.value, context, false, false).toOwned();
             else if (n == "rev") {
                 // Ugly: unlike fetchGit, here the "rev" attribute can
                 // be both a revision or a branch/tag name.
@@ -50,7 +50,7 @@ static void prim_fetchMercurial(EvalState & state, const Pos & pos, Value * * ar
             });
 
     } else
-        url = state.coerceToString(pos, *args[0], context, false, false);
+        url = state.coerceToString(pos, *args[0], context, false, false).toOwned();
 
     // FIXME: git externals probably can be used to bypass the URI
     // whitelist. Ah well.

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -125,7 +125,7 @@ static void fetchTree(
             if (attr.name == state.sType) continue;
             state.forceValue(*attr.value, *attr.pos);
             if (attr.value->type() == nPath || attr.value->type() == nString) {
-                auto s = state.coerceToString(*attr.pos, *attr.value, context, false, false);
+                auto s = state.coerceToString(*attr.pos, *attr.value, context, false, false).toOwned();
                 attrs.emplace(attr.name,
                     attr.name == "url"
                     ? type == "git"
@@ -151,7 +151,7 @@ static void fetchTree(
 
         input = fetchers::Input::fromAttrs(std::move(attrs));
     } else {
-        auto url = state.coerceToString(pos, *args[0], context, false, false);
+        auto url = state.coerceToString(pos, *args[0], context, false, false).toOwned();
 
         if (type == "git") {
             fetchers::Attrs attrs;

--- a/src/libexpr/primops/fromTOML.cc
+++ b/src/libexpr/primops/fromTOML.cc
@@ -9,7 +9,7 @@ static void prim_fromTOML(EvalState & state, const Pos & pos, Value * * args, Va
 {
     auto toml = state.forceStringNoCtx(*args[0], pos);
 
-    std::istringstream tomlStream(toml);
+    std::istringstream tomlStream(string{toml});
 
     std::function<void(Value &, toml::value)> visit;
 

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -699,10 +699,10 @@ void writeDerivation(Sink & out, const Store & store, const BasicDerivation & dr
 }
 
 
-std::string hashPlaceholder(const std::string & outputName)
+std::string hashPlaceholder(const std::string_view outputName)
 {
     // FIXME: memoize?
-    return "/" + hashString(htSHA256, "nix-output:" + outputName).to_string(Base32, false);
+    return "/" + hashString(htSHA256, concatStrings("nix-output:", outputName)).to_string(Base32, false);
 }
 
 std::string downstreamPlaceholder(const Store & store, const StorePath & drvPath, std::string_view outputName)

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -236,7 +236,7 @@ void writeDerivation(Sink & out, const Store & store, const BasicDerivation & dr
    It is used as a placeholder to allow derivations to refer to their
    own outputs without needing to use the hash of a derivation in
    itself, making the hash near-impossible to calculate. */
-std::string hashPlaceholder(const std::string & outputName);
+std::string hashPlaceholder(const std::string_view outputName);
 
 /* This creates an opaque and almost certainly unique string
    deterministically from a derivation path and output name.

--- a/src/libstore/names.cc
+++ b/src/libstore/names.cc
@@ -56,8 +56,8 @@ bool DrvName::matches(const DrvName & n)
 }
 
 
-string nextComponent(string::const_iterator & p,
-    const string::const_iterator end)
+std::string_view nextComponent(std::string_view::const_iterator & p,
+    const std::string_view::const_iterator end)
 {
     /* Skip any dots and dashes (component separators). */
     while (p != end && (*p == '.' || *p == '-')) ++p;
@@ -67,18 +67,18 @@ string nextComponent(string::const_iterator & p,
     /* If the first character is a digit, consume the longest sequence
        of digits.  Otherwise, consume the longest sequence of
        non-digit, non-separator characters. */
-    string s;
+    auto s = p;
     if (isdigit(*p))
-        while (p != end && isdigit(*p)) s += *p++;
+        while (p != end && isdigit(*p)) p++;
     else
         while (p != end && (!isdigit(*p) && *p != '.' && *p != '-'))
-            s += *p++;
+            p++;
 
-    return s;
+    return {s, size_t(p - s)};
 }
 
 
-static bool componentsLT(const string & c1, const string & c2)
+static bool componentsLT(const std::string_view c1, const std::string_view c2)
 {
     auto n1 = string2Int<int>(c1);
     auto n2 = string2Int<int>(c2);
@@ -94,14 +94,14 @@ static bool componentsLT(const string & c1, const string & c2)
 }
 
 
-int compareVersions(const string & v1, const string & v2)
+int compareVersions(const std::string_view v1, const std::string_view v2)
 {
-    string::const_iterator p1 = v1.begin();
-    string::const_iterator p2 = v2.begin();
+    auto p1 = v1.begin();
+    auto p2 = v2.begin();
 
     while (p1 != v1.end() || p2 != v2.end()) {
-        string c1 = nextComponent(p1, v1.end());
-        string c2 = nextComponent(p2, v2.end());
+        auto c1 = nextComponent(p1, v1.end());
+        auto c2 = nextComponent(p2, v2.end());
         if (componentsLT(c1, c2)) return -1;
         else if (componentsLT(c2, c1)) return 1;
     }

--- a/src/libstore/names.hh
+++ b/src/libstore/names.hh
@@ -27,9 +27,9 @@ private:
 
 typedef list<DrvName> DrvNames;
 
-string nextComponent(string::const_iterator & p,
-    const string::const_iterator end);
-int compareVersions(const string & v1, const string & v2);
+std::string_view nextComponent(std::string_view::const_iterator & p,
+    const std::string_view::const_iterator end);
+int compareVersions(const std::string_view v1, const std::string_view v2);
 DrvNames drvNamesFromArgs(const Strings & opArgs);
 
 }

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -26,7 +26,7 @@ static void makeWritable(const Path & path)
 struct MakeReadOnly
 {
     Path path;
-    MakeReadOnly(const Path & path) : path(path) { }
+    MakeReadOnly(const PathView path) : path(path) { }
     ~MakeReadOnly()
     {
         try {
@@ -205,12 +205,13 @@ void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
     /* Make the containing directory writable, but only if it's not
        the store itself (we don't want or need to mess with its
        permissions). */
-    bool mustToggle = dirOf(path) != realStoreDir.get();
-    if (mustToggle) makeWritable(dirOf(path));
+    const Path dirOfPath(dirOf(path));
+    bool mustToggle = dirOfPath != realStoreDir.get();
+    if (mustToggle) makeWritable(dirOfPath);
 
     /* When we're done, make the directory read-only again and reset
        its timestamp back to 0. */
-    MakeReadOnly makeReadOnly(mustToggle ? dirOf(path) : "");
+    MakeReadOnly makeReadOnly(mustToggle ? dirOfPath : "");
 
     Path tempLink = (format("%1%/.tmp-link-%2%-%3%")
         % realStoreDir % getpid() % random()).str();

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -170,7 +170,7 @@ std::string writeStructuredAttrsShell(const nlohmann::json & json)
 
     auto handleSimpleType = [](const nlohmann::json & value) -> std::optional<std::string> {
         if (value.is_string())
-            return shellEscape(value);
+            return shellEscape(value.get<std::string_view>());
 
         if (value.is_number()) {
             auto f = value.get<float>();

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -259,7 +259,7 @@ Hash::Hash(std::string_view rest, HashType type, bool isSRI)
         throw BadHash("hash '%s' has wrong length for hash type '%s'", rest, printHashType(this->type));
 }
 
-Hash newHashAllowEmpty(std::string hashStr, std::optional<HashType> ht)
+Hash newHashAllowEmpty(std::string_view hashStr, std::optional<HashType> ht)
 {
     if (hashStr.empty()) {
         if (!ht)

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -107,7 +107,7 @@ public:
 };
 
 /* Helper that defaults empty hashes to the 0 hash. */
-Hash newHashAllowEmpty(std::string hashStr, std::optional<HashType> ht);
+Hash newHashAllowEmpty(std::string_view hashStr, std::optional<HashType> ht);
 
 /* Print a hash in base-16 if it's MD5, or base-32 otherwise. */
 string printHash16or32(const Hash & hash);

--- a/src/libutil/types.hh
+++ b/src/libutil/types.hh
@@ -6,6 +6,7 @@
 #include <set>
 #include <string>
 #include <map>
+#include <variant>
 #include <vector>
 
 namespace nix {
@@ -45,6 +46,65 @@ struct Explicit {
     {
         return t == other.t;
     }
+};
+
+
+/* This wants to be a little bit like rust's Cow type.
+   Some parts of the evaluator benefit greatly from being able to reuse
+   existing allocations for strings, but have to be able to also use
+   newly allocated storage for values.
+
+   We do not define implicit conversions, even with ref qualifiers,
+   since those can easily become ambiguous to the reader and can degrade
+   into copying behaviour we want to avoid. */
+class BackedStringView {
+private:
+    std::variant<std::string, std::string_view> data;
+
+    /* Needed to introduce a temporary since operator-> must return
+       a pointer. Without this we'd need to store the view object
+       even when we already own a string. */
+    class Ptr {
+    private:
+        std::string_view view;
+    public:
+        Ptr(std::string_view view): view(view) {}
+        const std::string_view * operator->() const { return &view; }
+    };
+
+public:
+    BackedStringView(std::string && s): data(std::move(s)) {}
+    BackedStringView(std::string_view sv): data(sv) {}
+    template<size_t N>
+    BackedStringView(const char (& lit)[N]): data(std::string_view(lit)) {}
+
+    BackedStringView(const BackedStringView &) = delete;
+    BackedStringView & operator=(const BackedStringView &) = delete;
+
+    /* We only want move operations defined since the sole purpose of
+       this type is to avoid copies. */
+    BackedStringView(BackedStringView && other) = default;
+    BackedStringView & operator=(BackedStringView && other) = default;
+
+    bool isOwned() const
+    {
+        return std::holds_alternative<std::string>(data);
+    }
+
+    std::string toOwned() &&
+    {
+        return isOwned()
+            ? std::move(std::get<std::string>(data))
+            : std::string(std::get<std::string_view>(data));
+    }
+
+    std::string_view operator*() const
+    {
+        return isOwned()
+            ? std::get<std::string>(data)
+            : std::get<std::string_view>(data);
+    }
+    Ptr operator->() const { return Ptr(**this); }
 };
 
 }

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -81,7 +81,7 @@ void replaceEnv(std::map<std::string, std::string> newEnv)
 }
 
 
-Path absPath(Path path, std::optional<Path> dir, bool resolveSymlinks)
+Path absPath(Path path, std::optional<PathView> dir, bool resolveSymlinks)
 {
     if (path[0] != '/') {
         if (!dir) {
@@ -95,12 +95,12 @@ Path absPath(Path path, std::optional<Path> dir, bool resolveSymlinks)
             if (!getcwd(buf, sizeof(buf)))
 #endif
                 throw SysError("cannot get cwd");
-            dir = buf;
+            path = concatStrings(buf, "/", path);
 #ifdef __GNU__
             free(buf);
 #endif
-        }
-        path = *dir + "/" + path;
+        } else
+            path = concatStrings(*dir, "/", path);
     }
     return canonPath(path, resolveSymlinks);
 }
@@ -172,7 +172,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
 }
 
 
-Path dirOf(const Path & path)
+Path dirOf(const PathView path)
 {
     Path::size_type pos = path.rfind('/');
     if (pos == string::npos)
@@ -1344,9 +1344,11 @@ std::string toLower(const std::string & s)
 }
 
 
-std::string shellEscape(const std::string & s)
+std::string shellEscape(const std::string_view s)
 {
-    std::string r = "'";
+    std::string r;
+    r.reserve(s.size() + 2);
+    r += "'";
     for (auto & i : s)
         if (i == '\'') r += "'\\''"; else r += i;
     r += '\'';
@@ -1751,7 +1753,7 @@ void bind(int fd, const std::string & path)
 
     if (path.size() + 1 >= sizeof(addr.sun_path)) {
         Pid pid = startProcess([&]() {
-            auto dir = dirOf(path);
+            Path dir = dirOf(path);
             if (chdir(dir.c_str()) == -1)
                 throw SysError("chdir to '%s' failed", dir);
             std::string base(baseNameOf(path));
@@ -1780,7 +1782,7 @@ void connect(int fd, const std::string & path)
 
     if (path.size() + 1 >= sizeof(addr.sun_path)) {
         Pid pid = startProcess([&]() {
-            auto dir = dirOf(path);
+            Path dir = dirOf(path);
             if (chdir(dir.c_str()) == -1)
                 throw SysError("chdir to '%s' failed", dir);
             std::string base(baseNameOf(path));

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -49,7 +49,7 @@ void clearEnv();
    specified directory, or the current directory otherwise.  The path
    is also canonicalised. */
 Path absPath(Path path,
-    std::optional<Path> dir = {},
+    std::optional<PathView> dir = {},
     bool resolveSymlinks = false);
 
 /* Canonicalise a path by removing all `.' or `..' components and
@@ -62,7 +62,7 @@ Path canonPath(PathView path, bool resolveSymlinks = false);
    everything before the final `/'.  If the path is the root or an
    immediate child thereof (e.g., `/foo'), this means `/'
    is returned.*/
-Path dirOf(const Path & path);
+Path dirOf(const PathView path);
 
 /* Return the base name of the given canonical path, i.e., everything
    following the final `/' (trailing slashes are removed). */
@@ -148,6 +148,9 @@ Path getDataDir();
 /* Create a directory and all its parents, if necessary.  Returns the
    list of created directories, in order of creation. */
 Paths createDirs(const Path & path);
+inline Paths createDirs(PathView path) {
+    return createDirs(Path(path));
+}
 
 /* Create a symlink. */
 void createSymlink(const Path & target, const Path & link,
@@ -187,6 +190,7 @@ public:
     void cancel();
     void reset(const Path & p, bool recursive = true);
     operator Path() const { return path; }
+    operator PathView() const { return path; }
 };
 
 
@@ -491,7 +495,7 @@ std::string toLower(const std::string & s);
 
 
 /* Escape a string as a shell word. */
-std::string shellEscape(const std::string & s);
+std::string shellEscape(const std::string_view s);
 
 
 /* Exception handling in destructors: print an error message, then

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -472,9 +472,11 @@ struct CmdDevelop : Common, MixEnvironment
         else {
             script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\n" + script;
             if (developSettings.bashPrompt != "")
-                script += fmt("[ -n \"$PS1\" ] && PS1=%s;\n", shellEscape(developSettings.bashPrompt));
+                script += fmt("[ -n \"$PS1\" ] && PS1=%s;\n",
+                    shellEscape(developSettings.bashPrompt.get()));
             if (developSettings.bashPromptSuffix != "")
-                script += fmt("[ -n \"$PS1\" ] && PS1+=%s;\n", shellEscape(developSettings.bashPromptSuffix));
+                script += fmt("[ -n \"$PS1\" ] && PS1+=%s;\n",
+                    shellEscape(developSettings.bashPromptSuffix.get()));
         }
 
         writeFull(rcFileFd.get(), script);

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -107,7 +107,7 @@ struct CmdEval : MixJSON, InstallableCommand
 
         else if (raw) {
             stopProgressBar();
-            std::cout << state->coerceToString(noPos, *v, context);
+            std::cout << *state->coerceToString(noPos, *v, context);
         }
 
         else if (json) {

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -38,7 +38,7 @@ string resolveMirrorUrl(EvalState & state, string url)
     if (mirrorList->value->listSize() < 1)
         throw Error("mirror URL '%s' did not expand to anything", url);
 
-    auto mirror = state.forceString(*mirrorList->value->listElems()[0]);
+    string mirror(state.forceString(*mirrorList->value->listElems()[0]));
     return mirror + (hasSuffix(mirror, "/") ? "" : "/") + string(s, p + 1);
 }
 

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -463,7 +463,7 @@ bool NixRepl::processLine(string line)
         if (v.type() == nPath || v.type() == nString) {
             PathSet context;
             auto filename = state->coerceToString(noPos, v, context);
-            pos.file = state->symbols.create(filename);
+            pos.file = state->symbols.create(*filename);
         } else if (v.isLambda()) {
             pos = v.lambda.fun->pos;
         } else {

--- a/src/resolve-system-dependencies/resolve-system-dependencies.cc
+++ b/src/resolve-system-dependencies/resolve-system-dependencies.cc
@@ -107,7 +107,7 @@ Path resolveSymlink(const Path & path)
     auto target = readLink(path);
     return hasPrefix(target, "/")
         ? target
-        : dirOf(path) + "/" + target;
+        : concatStrings(dirOf(path), "/", target);
 }
 
 std::set<string> resolveTree(const Path & path, PathSet & deps)


### PR DESCRIPTION
most notably we don't have to copy strings that are already allocated in suitable memory (eg when pulling a string out of a tString or tPath Value). avoiding these copies gives us another ~1% on search and system eval, but improvements from copy avoidance look like they're starting to level out. time to go somewhere else :)


### current master

```
nix search --no-eval-cache --offline ../nixpkgs hello
  Time (mean ± σ):      8.907 s ±  0.053 s    [User: 6.814 s, System: 1.650 s]
  Range (min … max):    8.829 s …  9.049 s    20 runs
 
nix eval -f ../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  Time (mean ± σ):     376.8 ms ±   1.6 ms    [User: 341.9 ms, System: 34.9 ms]
  Range (min … max):   375.3 ms … 381.2 ms    20 runs
 
nix eval --raw --impure --file expr.nix
  Time (mean ± σ):      2.839 s ±  0.037 s    [User: 2.538 s, System: 0.230 s]
  Range (min … max):    2.758 s …  2.907 s    20 runs
```

### this patchset

```
nix search --no-eval-cache --offline ../nixpkgs hello
  Time (mean ± σ):      8.820 s ±  0.047 s    [User: 6.744 s, System: 1.667 s]
  Range (min … max):    8.720 s …  8.882 s    20 runs
 
nix eval -f ../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  Time (mean ± σ):     370.3 ms ±   2.5 ms    [User: 335.5 ms, System: 34.8 ms]
  Range (min … max):   368.0 ms … 379.8 ms    20 runs
 
nix eval --raw --impure --file expr.nix
  Time (mean ± σ):      2.806 s ±  0.028 s    [User: 2.503 s, System: 0.235 s]
  Range (min … max):    2.738 s …  2.847 s    20 runs
```