### PR TITLE
Correct `NIX_BUILD_PATH` default description

### DIFF
--- a/doc/manual/src/command-ref/nix-shell.md
+++ b/doc/manual/src/command-ref/nix-shell.md
@@ -101,7 +101,8 @@ The following common options are supported:
 
   - `NIX_BUILD_SHELL`\
     Shell used to start the interactive environment. Defaults to the
-    `bash` found in `PATH`.
+    `bash` found in `<nixpkgs>`, falling back to the `bash` found in
+    `PATH` if not found.
 
 # Examples
 


### PR DESCRIPTION
Source: https://github.com/NixOS/nix/blob/067076287bf601f8fa2ffe4feff3057b96fa5be8/src/nix-build/nix-build.cc#L362-L381