### PR TITLE
tests: skip flake search test if no git is present

### DIFF
--- a/tests/flake-searching.sh
+++ b/tests/flake-searching.sh
@@ -1,5 +1,10 @@
 source common.sh
 
+if [[ -z $(type -p git) ]]; then
+    echo "Git not installed; skipping flake search tests"
+    exit 99
+fi
+
 clearStore
 
 cp ./simple.nix ./simple.builder.sh ./config.nix $TEST_HOME


### PR DESCRIPTION
The new test introduced in #5720 fails if no `git` is present. This is unlike all the other tests that require git, which are automatically skipped.

This causes issues in e.g. nixpkgs, which does not provide git during the test phase. I, for example. triggered this when using a newer nix `src` with the `nixUnstable` derivation.

This PR add the same check as all the other git-based test fixtures to fix that issue.