### PR TITLE
nix-shell: use clean rm, not any aliases/functions

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -483,7 +483,7 @@ static void main_nix_build(int argc, char * * argv)
            lose the current $PATH directories. */
         auto rcfile = (Path) tmpDir + "/rc";
         std::string rc = fmt(
-                R"(_nix_shell_clean_tmpdir() { rm -rf %1%; }; )"s +
+                R"(_nix_shell_clean_tmpdir() { command rm -rf %1%; }; )"s +
                 (keepTmp ?
                     "trap _nix_shell_clean_tmpdir EXIT; "
                     "exitHooks+=(_nix_shell_clean_tmpdir); "


### PR DESCRIPTION
If in your shell env `rm` is aliases to ``alias rm='rm -v'`` you get a double output like 

```
$ nix-shell -p hello
user@host:~/src/nixpkgs$ removed '/tmp/nix-shell-366865-0/rc'
removed '/tmp/nix-shell-366865-0/.attr-0'
removed directory '/tmp/nix-shell-366865-0'
```