### PR TITLE
In pure mode, set builtins.nixVersion to a constant

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3822,7 +3822,7 @@ void EvalState::createBaseEnv()
         addConstant("__currentSystem", v);
     }
 
-    v.mkString(nixVersion);
+    v.mkString(evalSettings.pureEval ? "2.6.0" : nixVersion);
     addConstant("__nixVersion", v);
 
     v.mkString(store->storeDir);


### PR DESCRIPTION
This prevents issues like
https://github.com/NixOS/nixpkgs/pull/156527. Eventually we should do
this in impure mode as well. 

Issue #5970.

Depends on #8330 