### PR TITLE
Use the `nix` command (and flakes) in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix-build -A checks.$(nix-instantiate --eval -E '(builtins.currentSystem)')
+    - run: nix --experimental-features 'nix-command flakes' flake check -L
 
   check_cachix:
     name: Cachix secret present for installer tests
@@ -95,7 +95,7 @@ jobs:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix-build -A checks.$(nix-instantiate --eval -E 'builtins.currentSystem' --json).dockerImage
+    - run: nix --experimental-features 'nix-command flakes' build .#dockerImage -L
     - run: docker load -i ./result/image.tar.gz
     - run: docker tag nix:$NIX_VERSION nixos/nix:$NIX_VERSION
     - run: docker tag nix:$NIX_VERSION nixos/nix:master

--- a/flake.nix
+++ b/flake.nix
@@ -447,19 +447,7 @@
         installerScriptForGHA = installScriptFor [ "x86_64-linux" "x86_64-darwin" "armv6l-linux" "armv7l-linux"];
 
         # docker image with Nix inside
-        dockerImage = nixpkgs.lib.genAttrs linux64BitSystems (system:
-          let
-            pkgs = nixpkgsFor.${system};
-            image = import ./docker.nix { inherit pkgs; tag = version; };
-          in pkgs.runCommand "docker-image-tarball-${version}"
-            { meta.description = "Docker image with Nix for ${system}";
-            }
-            ''
-              mkdir -p $out/nix-support
-              image=$out/image.tar.gz
-              ln -s ${image} $image
-              echo "file binary-dist $image" >> $out/nix-support/hydra-build-products
-            '');
+        dockerImage = nixpkgs.lib.genAttrs linux64BitSystems (system: self.packages.${system}.dockerImage);
 
         # Line coverage analysis.
         coverage =
@@ -606,6 +594,20 @@
 
           hardeningDisable = [ "pie" ];
         };
+        dockerImage =
+          let
+            pkgs = nixpkgsFor.${system};
+            image = import ./docker.nix { inherit pkgs; tag = version; };
+          in
+          pkgs.runCommand
+            "docker-image-tarball-${version}"
+            { meta.description = "Docker image with Nix for ${system}"; }
+            ''
+              mkdir -p $out/nix-support
+              image=$out/image.tar.gz
+              ln -s ${image} $image
+              echo "file binary-dist $image" >> $out/nix-support/hydra-build-products
+            '';
       } // builtins.listToAttrs (map (crossSystem: {
         name = "nix-${crossSystem}";
         value = let


### PR DESCRIPTION
Apart from a slight simplification and a bit of dogfooding, this also make the cache behavior more predictable.
For example `nix build .` and `nix build nix/$(git rev-parse HEAD)` will yield the exact same path, while their “intuitive” non-flake equivalents (`nix-build` and `nix-build https://github.com/nixos/nix/archives/$(git rev-parse HEAD).tar.gz`) don’t.

This was a pain for example in https://github.com/NixOS/nix/pull/5059

Also, the `bar-with-logs` log format is imho nicer (even in an non-interactive context) because prefixing each log line with the name of the derivation that produced it makes it much easier to follow what’s going on.