### PR TITLE
doc/manual/local.mk: handle DESTDIR= for inplace builds

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -14,13 +14,14 @@ clean-files += $(d)/*.1 $(d)/*.5 $(d)/*.8
 # Provide a dummy environment for nix, so that it will not access files outside the macOS sandbox.
 # Set cores to 0 because otherwise nix show-config resolves the cores based on the current machine
 dummy-env = env -i \
+	LD_LIBRARY_PATH=$(DESTDIR)$(libdir) \
 	HOME=/dummy \
 	NIX_CONF_DIR=/dummy \
 	NIX_SSL_CERT_FILE=/dummy/no-ca-bundle.crt \
 	NIX_STATE_DIR=/dummy \
 	NIX_CONFIG='cores = 0'
 
-nix-eval = $(dummy-env) $(bindir)/nix eval --experimental-features nix-command -I nix/corepkgs=corepkgs --store dummy:// --impure --raw
+nix-eval = $(dummy-env) $(DESTDIR)$(bindir)/nix eval --experimental-features nix-command -I nix/corepkgs=corepkgs --store dummy:// --impure --raw
 
 $(d)/%.1: $(d)/src/command-ref/%.md
 	@printf "Title: %s\n\n" "$$(basename $@ .1)" > $^.tmp
@@ -44,59 +45,59 @@ $(d)/src/SUMMARY.md: $(d)/src/SUMMARY.md.in $(d)/src/command-ref/new-cli
 	$(trace-gen) cat doc/manual/src/SUMMARY.md.in | while IFS= read line; do if [[ $$line = @manpages@ ]]; then cat doc/manual/src/command-ref/new-cli/SUMMARY.md; else echo "$$line"; fi; done > $@.tmp
 	@mv $@.tmp $@
 
-$(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/generate-manpage.nix $(bindir)/nix
+$(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/generate-manpage.nix $(DESTDIR)$(bindir)/nix
 	@rm -rf $@
 	$(trace-gen) $(nix-eval) --write-to $@ --expr 'import doc/manual/generate-manpage.nix { command = builtins.readFile $<; renderLinks = true; }'
 
-$(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/generate-options.nix $(d)/src/command-ref/conf-file-prefix.md $(bindir)/nix
+$(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/generate-options.nix $(d)/src/command-ref/conf-file-prefix.md $(DESTDIR)$(bindir)/nix
 	@cat doc/manual/src/command-ref/conf-file-prefix.md > $@.tmp
 	$(trace-gen) $(nix-eval) --expr 'import doc/manual/generate-options.nix (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp
 	@mv $@.tmp $@
 
-$(d)/nix.json: $(bindir)/nix
-	$(trace-gen) $(dummy-env) $(bindir)/nix __dump-args > $@.tmp
+$(d)/nix.json: $(DESTDIR)$(bindir)/nix
+	$(trace-gen) $(dummy-env) $(DESTDIR)$(bindir)/nix __dump-args > $@.tmp
 	@mv $@.tmp $@
 
-$(d)/conf-file.json: $(bindir)/nix
-	$(trace-gen) $(dummy-env) $(bindir)/nix show-config --json --experimental-features nix-command > $@.tmp
+$(d)/conf-file.json: $(DESTDIR)$(bindir)/nix
+	$(trace-gen) $(dummy-env) $(DESTDIR)$(bindir)/nix show-config --json --experimental-features nix-command > $@.tmp
 	@mv $@.tmp $@
 
-$(d)/src/expressions/builtins.md: $(d)/builtins.json $(d)/generate-builtins.nix $(d)/src/expressions/builtins-prefix.md $(bindir)/nix
+$(d)/src/expressions/builtins.md: $(d)/builtins.json $(d)/generate-builtins.nix $(d)/src/expressions/builtins-prefix.md $(DESTDIR)$(bindir)/nix
 	@cat doc/manual/src/expressions/builtins-prefix.md > $@.tmp
 	$(trace-gen) $(nix-eval) --expr 'import doc/manual/generate-builtins.nix (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp
 	@cat doc/manual/src/expressions/builtins-suffix.md >> $@.tmp
 	@mv $@.tmp $@
 
-$(d)/builtins.json: $(bindir)/nix
-	$(trace-gen) $(dummy-env) NIX_PATH=nix/corepkgs=corepkgs $(bindir)/nix __dump-builtins > $@.tmp
+$(d)/builtins.json: $(DESTDIR)$(bindir)/nix
+	$(trace-gen) $(dummy-env) NIX_PATH=nix/corepkgs=corepkgs $(DESTDIR)$(bindir)/nix __dump-builtins > $@.tmp
 	@mv $@.tmp $@
 
 # Generate the HTML manual.
-install: $(docdir)/manual/index.html
+install: $(DESTDIR)$(docdir)/manual/index.html
 
 # Generate 'nix' manpages.
-install: $(mandir)/man1/nix3-manpages
+install: $(DESTDIR)$(mandir)/man1/nix3-manpages
 man: doc/manual/generated/man1/nix3-manpages
 all: doc/manual/generated/man1/nix3-manpages
 
-$(mandir)/man1/nix3-manpages: doc/manual/generated/man1/nix3-manpages
-	@mkdir -p $(DESTDIR)$$(dirname $@)
-	$(trace-install) install -m 0644 $$(dirname $<)/* $(DESTDIR)$$(dirname $@)
+$(DESTDIR)$(mandir)/man1/nix3-manpages: doc/manual/generated/man1/nix3-manpages
+	@mkdir -p $$(dirname $@)
+	$(trace-install) install -m 0644 $$(dirname $<)/* $$(dirname $@)
 
 doc/manual/generated/man1/nix3-manpages: $(d)/src/command-ref/new-cli
-	@mkdir -p $(DESTDIR)$$(dirname $@)
+	@mkdir -p $$(dirname $@)
 	$(trace-gen) for i in doc/manual/src/command-ref/new-cli/*.md; do \
 	  name=$$(basename $$i .md); \
 	  tmpFile=$$(mktemp); \
 	  if [[ $$name = SUMMARY ]]; then continue; fi; \
 	  printf "Title: %s\n\n" "$$name" > $$tmpFile; \
 	  cat $$i >> $$tmpFile; \
-	  lowdown -sT man -M section=1 $$tmpFile -o $(DESTDIR)$$(dirname $@)/$$name.1; \
+	  lowdown -sT man -M section=1 $$tmpFile -o $$(dirname $@)/$$name.1; \
 	  rm $$tmpFile; \
 	done
 	@touch $@
 
-$(docdir)/manual/index.html: $(MANUAL_SRCS) $(d)/book.toml $(d)/custom.css $(d)/src/SUMMARY.md $(d)/src/command-ref/new-cli $(d)/src/command-ref/conf-file.md $(d)/src/expressions/builtins.md $(call rwildcard, $(d)/src, *.md)
+$(DESTDIR)$(docdir)/manual/index.html: $(MANUAL_SRCS) $(d)/book.toml $(d)/custom.css $(d)/src/SUMMARY.md $(d)/src/command-ref/new-cli $(d)/src/command-ref/conf-file.md $(d)/src/expressions/builtins.md $(call rwildcard, $(d)/src, *.md)
 	$(trace-gen) RUST_LOG=warn mdbook build doc/manual -d $(DESTDIR)$(docdir)/manual
 
 endif


### PR DESCRIPTION
Linux distributions usually install packages into sandboxed environments before moving packages into live system:

    $ ./configure --prefix=/usr
    $ make install DESTDIR=/sandbox
    $ mv /sandbox/* /

`nix` fails at `make install` stage:

    make: *** No rule to make target '/usr/bin/nix', needed by 'doc/manual/nix.json'.  Stop.
    make: *** Waiting for unfinished jobs....

The change sprinkles enough $(DESTDIR) prefixes to make it work.
To allow nix inplace execution LD_LIBRARY_PATH was added into $DESTDIR location.

Closes: https://github.com/NixOS/nix/issues/5781