### PR TITLE
Fix systemctl kill no killing stuck child processes

### DIFF
--- a/misc/systemd/nix-daemon.service.in
+++ b/misc/systemd/nix-daemon.service.in
@@ -6,7 +6,6 @@ ConditionPathIsReadWrite=@localstatedir@/nix/daemon-socket
 
 [Service]
 ExecStart=@@bindir@/nix-daemon nix-daemon --daemon
-KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
For unknown reason I had some stuck daemon child processes today. I wanted to use ``systemctl kill nix-daemon`` which had no affect. This is because `KillMode` was set to `process` which only kills the main process, not child ones. I had to use htop to kill all childs to get my daemon back into a working condition. The systemd man page recommends not to set this.

See https://www.freedesktop.org/software/systemd/man/systemd.kill.html