### PR TITLE
ssh-ng: also store build logs to make them accessible by `nix log`

### DIFF
--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -266,49 +266,61 @@ static Logger::Fields getFields(nlohmann::json & json)
     return fields;
 }
 
-bool handleJSONLogMessage(const std::string & msg,
-    const Activity & act, std::map<ActivityId, Activity> & activities, bool trusted)
+std::optional<nlohmann::json> parseJSONMessage(const std::string & msg)
 {
-    if (!hasPrefix(msg, "@nix ")) return false;
-
+    if (!hasPrefix(msg, "@nix ")) return std::nullopt;
     try {
-        auto json = nlohmann::json::parse(std::string(msg, 5));
-
-        std::string action = json["action"];
-
-        if (action == "start") {
-            auto type = (ActivityType) json["type"];
-            if (trusted || type == actFileTransfer)
-                activities.emplace(std::piecewise_construct,
-                    std::forward_as_tuple(json["id"]),
-                    std::forward_as_tuple(*logger, (Verbosity) json["level"], type,
-                        json["text"], getFields(json["fields"]), act.id));
-        }
-
-        else if (action == "stop")
-            activities.erase((ActivityId) json["id"]);
-
-        else if (action == "result") {
-            auto i = activities.find((ActivityId) json["id"]);
-            if (i != activities.end())
-                i->second.result((ResultType) json["type"], getFields(json["fields"]));
-        }
-
-        else if (action == "setPhase") {
-            std::string phase = json["phase"];
-            act.result(resSetPhase, phase);
-        }
-
-        else if (action == "msg") {
-            std::string msg = json["msg"];
-            logger->log((Verbosity) json["level"], msg);
-        }
-
+        return nlohmann::json::parse(std::string(msg, 5));
     } catch (std::exception & e) {
         printError("bad JSON log message from builder: %s", e.what());
     }
+    return std::nullopt;
+}
+
+bool handleJSONLogMessage(nlohmann::json & json,
+    const Activity & act, std::map<ActivityId, Activity> & activities,
+    bool trusted)
+{
+    std::string action = json["action"];
+
+    if (action == "start") {
+        auto type = (ActivityType) json["type"];
+        if (trusted || type == actFileTransfer)
+            activities.emplace(std::piecewise_construct,
+                std::forward_as_tuple(json["id"]),
+                std::forward_as_tuple(*logger, (Verbosity) json["level"], type,
+                    json["text"], getFields(json["fields"]), act.id));
+    }
+
+    else if (action == "stop")
+        activities.erase((ActivityId) json["id"]);
+
+    else if (action == "result") {
+        auto i = activities.find((ActivityId) json["id"]);
+        if (i != activities.end())
+            i->second.result((ResultType) json["type"], getFields(json["fields"]));
+    }
+
+    else if (action == "setPhase") {
+        std::string phase = json["phase"];
+        act.result(resSetPhase, phase);
+    }
+
+    else if (action == "msg") {
+        std::string msg = json["msg"];
+        logger->log((Verbosity) json["level"], msg);
+    }
 
     return true;
+}
+
+bool handleJSONLogMessage(const std::string & msg,
+    const Activity & act, std::map<ActivityId, Activity> & activities, bool trusted)
+{
+    auto json = parseJSONMessage(msg);
+    if (!json) return false;
+
+    return handleJSONLogMessage(*json, act, activities, trusted);
 }
 
 Activity::~Activity()

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -4,7 +4,7 @@
 #include "error.hh"
 #include "config.hh"
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace nix {
 

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -4,6 +4,8 @@
 #include "error.hh"
 #include "config.hh"
 
+#include <nlohmann/json.hpp>
+
 namespace nix {
 
 typedef enum {
@@ -165,6 +167,12 @@ extern Logger * logger;
 Logger * makeSimpleLogger(bool printBuildLogs = true);
 
 Logger * makeJSONLogger(Logger & prevLogger);
+
+std::optional<nlohmann::json> parseJSONMessage(const std::string & msg);
+
+bool handleJSONLogMessage(nlohmann::json & json,
+    const Activity & act, std::map<ActivityId, Activity> & activities,
+    bool trusted);
 
 bool handleJSONLogMessage(const std::string & msg,
     const Activity & act, std::map<ActivityId, Activity> & activities,

--- a/tests/build-hook-ca-fixed.nix
+++ b/tests/build-hook-ca-fixed.nix
@@ -17,7 +17,7 @@ let
   input1 = mkDerivation {
     shell = busybox;
     name = "build-remote-input-1";
-    buildCommand = "echo hi; echo FOO > $out";
+    buildCommand = "echo hi-input1; echo FOO > $out";
     requiredSystemFeatures = ["foo"];
     outputHash = "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=";
   };
@@ -34,7 +34,7 @@ let
     shell = busybox;
     name = "build-remote-input-3";
     buildCommand = ''
-      echo hi
+      echo hi-input3
       read x < ${input2}
       echo $x BAZ > $out
     '';

--- a/tests/build-hook-ca-fixed.nix
+++ b/tests/build-hook-ca-fixed.nix
@@ -11,13 +11,13 @@ let
       args = ["sh" "-e" args.builder or (builtins.toFile "builder-${args.name}.sh" "if [ -e .attrs.sh ]; then source .attrs.sh; fi; eval \"$buildCommand\"")];
       outputHashMode = "recursive";
       outputHashAlgo = "sha256";
-    } // removeAttrs args ["builder" "meta"])
-    // { meta = args.meta or {}; };
+    } // removeAttrs args ["builder" "meta" "passthru"])
+    // { meta = args.meta or {}; passthru = args.passthru or {}; };
 
   input1 = mkDerivation {
     shell = busybox;
     name = "build-remote-input-1";
-    buildCommand = "echo FOO > $out";
+    buildCommand = "echo hi; echo FOO > $out";
     requiredSystemFeatures = ["foo"];
     outputHash = "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=";
   };
@@ -25,7 +25,7 @@ let
   input2 = mkDerivation {
     shell = busybox;
     name = "build-remote-input-2";
-    buildCommand = "echo BAR > $out";
+    buildCommand = "echo hi; echo BAR > $out";
     requiredSystemFeatures = ["bar"];
     outputHash = "sha256-XArauVH91AVwP9hBBQNlkX9ccuPpSYx9o0zeIHb6e+Q=";
   };
@@ -34,6 +34,7 @@ let
     shell = busybox;
     name = "build-remote-input-3";
     buildCommand = ''
+      echo hi
       read x < ${input2}
       echo $x BAZ > $out
     '';
@@ -46,6 +47,7 @@ in
   mkDerivation {
     shell = busybox;
     name = "build-remote";
+    passthru = { inherit input1 input2 input3; };
     buildCommand =
       ''
         read x < ${input1}

--- a/tests/build-hook.nix
+++ b/tests/build-hook.nix
@@ -15,7 +15,7 @@ let
   input1 = mkDerivation {
     shell = busybox;
     name = "build-remote-input-1";
-    buildCommand = "echo hi; echo FOO > $out";
+    buildCommand = "echo hi-input1; echo FOO > $out";
     requiredSystemFeatures = ["foo"];
   };
 
@@ -30,7 +30,7 @@ let
     shell = busybox;
     name = "build-remote-input-3";
     buildCommand = ''
-      echo hi
+      echo hi-input3
       read x < ${input2}
       echo $x BAZ > $out
     '';

--- a/tests/build-hook.nix
+++ b/tests/build-hook.nix
@@ -9,20 +9,20 @@ let
       inherit system;
       builder = busybox;
       args = ["sh" "-e" args.builder or (builtins.toFile "builder-${args.name}.sh" "if [ -e .attrs.sh ]; then source .attrs.sh; fi; eval \"$buildCommand\"")];
-    } // removeAttrs args ["builder" "meta"])
-    // { meta = args.meta or {}; };
+    } // removeAttrs args ["builder" "meta" "passthru"])
+    // { meta = args.meta or {}; passthru = args.passthru or {}; };
 
   input1 = mkDerivation {
     shell = busybox;
     name = "build-remote-input-1";
-    buildCommand = "echo FOO > $out";
+    buildCommand = "echo hi; echo FOO > $out";
     requiredSystemFeatures = ["foo"];
   };
 
   input2 = mkDerivation {
     shell = busybox;
     name = "build-remote-input-2";
-    buildCommand = "echo BAR > $out";
+    buildCommand = "echo hi; echo BAR > $out";
     requiredSystemFeatures = ["bar"];
   };
 
@@ -30,6 +30,7 @@ let
     shell = busybox;
     name = "build-remote-input-3";
     buildCommand = ''
+      echo hi
       read x < ${input2}
       echo $x BAZ > $out
     '';
@@ -41,6 +42,7 @@ in
   mkDerivation {
     shell = busybox;
     name = "build-remote";
+    passthru = { inherit input1 input2 input3; };
     buildCommand =
       ''
         read x < ${input1}

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -54,6 +54,14 @@ nix path-info --store $TEST_ROOT/machine3 --all \
   | grep -v builder-build-remote-input-2.sh \
   | grep builder-build-remote-input-3.sh
 
+
+if [[ -z "$CONTENT_ADDRESSED" ]]; then
+  for i in input1 input3; do
+    drv="$(nix-instantiate $file -A passthru.$i --store $TEST_ROOT/machine0 --arg busybox $busybox)"
+    nix log --store $TEST_ROOT/machine0 "$drv"
+  done
+fi
+
 # Behavior of keep-failed
 out="$(nix-build 2>&1 failing.nix \
   --builders "$(join_by '; ' "${builders[@]}")"  \

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -57,8 +57,7 @@ nix path-info --store $TEST_ROOT/machine3 --all \
 
 if [[ -z "$CONTENT_ADDRESSED" ]]; then
   for i in input1 input3; do
-    drv="$(nix-instantiate $file -A passthru.$i --store $TEST_ROOT/machine0 --arg busybox $busybox)"
-    nix log --store $TEST_ROOT/machine0 "$drv"
+    nix log --store $TEST_ROOT/machine0 --file "$file" --arg busybox $busybox passthru."$i" | grep hi-$i
   done
 fi
 

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -55,6 +55,7 @@ nix path-info --store $TEST_ROOT/machine3 --all \
   | grep builder-build-remote-input-3.sh
 
 
+# Temporarily disabled because of https://github.com/NixOS/nix/issues/6209
 if [[ -z "$CONTENT_ADDRESSED" ]]; then
   for i in input1 input3; do
     nix log --store $TEST_ROOT/machine0 --file "$file" --arg busybox $busybox passthru."$i" | grep hi-$i


### PR DESCRIPTION
Right now when building a derivation remotely via

    $ nix build -j0 -f . hello -L --builders 'ssh://builder'

it's possible later to read through the entire build-log by running
`nix log -f . hello`. This isn't possible however when using `ssh-ng`
rather than `ssh`.

The reason for that is that there are two different ways to transfer
logs in Nix through e.g. an SSH tunnel (that are used by `ssh`/`ssh-ng`
respectively):

* `ssh://` receives its logs from the fd pointing to `builderOut`. This
  is directly passed to the "log-sink" (and to the logger on each `\n`),
  hence `nix log` works here.
* `ssh-ng://` however expects JSON-like messages (i.e. `@nix {log data
  in here}`) and passes it directly to the logger without doing anything
  with the `logSink`. However it's certainly possible to extract
  log-lines from this format as these have their own message-type in the
  JSON payload (i.e. `resBuildLogLine`).

  This is basically what I changed in this patch: if the code-path for
  `builderOut` is not reached and a `logSink` is initialized, the
  message was successfully processed by the JSON logger (i.e. it's in
  the expected format) and the line is of the expected type (i.e.
  `resBuildLogLine`), the line will be written to the log-sink as well.

Closes #5079

cc @edolstra @thufschmitt @Ericson2314 @symphorien 