### PR TITLE
Flake follows: resolve all follows to absolute

### DIFF
--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -730,6 +730,7 @@ cat > $flakeFollowsB/flake.nix <<EOF
     description = "Flake B";
     inputs = {
         foobar.url = "path:$flakeFollowsA/flakeE";
+        goodoo.follows = "C/goodoo";
         C = {
             url = "path:./flakeC";
             inputs.foobar.follows = "foobar";
@@ -744,6 +745,7 @@ cat > $flakeFollowsC/flake.nix <<EOF
     description = "Flake C";
     inputs = {
         foobar.url = "path:$flakeFollowsA/flakeE";
+        goodoo.follows = "foobar";
     };
     outputs = { ... }: {};
 }
@@ -759,7 +761,7 @@ EOF
 
 cat > $flakeFollowsE/flake.nix <<EOF
 {
-    description = "Flake D";
+    description = "Flake E";
     inputs = {};
     outputs = { ... }: {};
 }
@@ -767,6 +769,8 @@ EOF
 
 git -C $flakeFollowsA add flake.nix flakeB/flake.nix \
   flakeB/flakeC/flake.nix flakeD/flake.nix flakeE/flake.nix
+
+nix flake metadata $flakeFollowsA
 
 nix flake update $flakeFollowsA
 


### PR DESCRIPTION
It's not possible in general to know in computeLocks, relative to
which path the follows was intended to be. So, we always resolve
follows to their absolute states when we encounter them (which can
either be in parseFlakeInput or computeLocks' fake input population).

Fixes https://github.com/NixOS/nix/issues/6013
Fixes https://github.com/NixOS/nix/issues/5609
Fixes https://github.com/NixOS/nix/issues/5697 (again)
