### PR TITLE
[2.6] canonPath: fix missing slash when resolving links

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -147,7 +147,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
                 path = {};
             } else {
                 s += path.substr(0, slash);
-                path = path.substr(slash + 1);
+                path = path.substr(slash);
             }
 
             /* If s points to a symlink, resolve it and continue from there */


### PR DESCRIPTION
Backport to 2.6-maintenance of 

* #6018
