### PR TITLE
completions: pipe stderr to /dev/null

### DIFF
--- a/misc/bash/completion.sh
+++ b/misc/bash/completion.sh
@@ -15,7 +15,7 @@ function _complete_nix {
         else
             COMPREPLY+=("$completion")
         fi
-    done < <(NIX_GET_COMPLETIONS=$cword "${words[@]/#\~/$HOME}")
+    done < <(NIX_GET_COMPLETIONS=$cword "${words[@]/#\~/$HOME}" 2>/dev/null)
     __ltrim_colon_completions "$cur"
 }
 

--- a/misc/zsh/completion.zsh
+++ b/misc/zsh/completion.zsh
@@ -4,7 +4,7 @@ function _nix() {
   local ifs_bk="$IFS"
   local input=("${(Q)words[@]}")
   IFS=$'\n'
-  local res=($(NIX_GET_COMPLETIONS=$((CURRENT - 1)) "$input[@]"))
+  local res=($(NIX_GET_COMPLETIONS=$((CURRENT - 1)) "$input[@]" 2>/dev/null))
   IFS="$ifs_bk"
   local tpe="${${res[1]}%%>	*}"
   local -a suggestions


### PR DESCRIPTION
This fixes weird issues where e.g.

    nix build -L .#<tab>

deletes the current line from the prompt.

cc @edolstra @thufschmitt 