### PR TITLE
nix-shell: set BASH variable to correct shell

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -500,6 +500,7 @@ static void main_nix_build(int argc, char * * argv)
                 "%3%"
                 "PATH=%4%:\"$PATH\"; "
                 "SHELL=%5%; "
+                "BASH=%5%; "
                 "set +e; "
                 R"s([ -n "$PS1" -a -z "$NIX_SHELL_PRESERVE_PROMPT" ] && PS1='\n\[\033[1;32m\][nix-shell:\w]\$\[\033[0m\] '; )s"
                 "if [ \"$(type -t runHook)\" = function ]; then runHook shellHook; fi; "


### PR DESCRIPTION
Discovered in https://github.com/akinomyoga/ble.sh/issues/169#issuecomment-1029598071 that `SHELL` points to the right binary but not `BASH`.