### PR TITLE
`nix log` should also work if the log didn't provide any output

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -39,28 +39,30 @@ void TarArchive::check(int err, const std::string & reason)
         throw Error(reason, archive_error_string(this->archive));
 }
 
-TarArchive::TarArchive(Source & source, bool raw)
-    : source(&source), buffer(4096)
+TarArchive::TarArchive(Source & source, bool raw) : buffer(4096)
 {
-    init();
-    if (!raw)
+    this->archive = archive_read_new();
+    this->source = &source;
+
+    if (!raw) {
+        archive_read_support_filter_all(archive);
         archive_read_support_format_all(archive);
-    else
+    } else {
+        archive_read_support_filter_all(archive);
         archive_read_support_format_raw(archive);
+        archive_read_support_format_empty(archive);
+    }
     check(archive_read_open(archive, (void *)this, callback_open, callback_read, callback_close), "Failed to open archive (%s)");
 }
 
+
 TarArchive::TarArchive(const Path & path)
 {
-    init();
+    this->archive = archive_read_new();
+
+    archive_read_support_filter_all(archive);
     archive_read_support_format_all(archive);
     check(archive_read_open_filename(archive, path.c_str(), 16384), "failed to open archive: %s");
-}
-
-void TarArchive::init()
-{
-    archive = archive_read_new();
-    archive_read_support_filter_all(archive);
 }
 
 void TarArchive::close()

--- a/src/libutil/tarfile.hh
+++ b/src/libutil/tarfile.hh
@@ -17,13 +17,10 @@ struct TarArchive {
     // disable copy constructor
     TarArchive(const TarArchive &) = delete;
 
-    void init();
-
     void close();
 
     ~TarArchive();
 };
-
 void unpackTarfile(Source & source, const Path & destDir);
 
 void unpackTarfile(const Path & tarFile, const Path & destDir);

--- a/tests/logging.sh
+++ b/tests/logging.sh
@@ -13,3 +13,14 @@ rm -rf $NIX_LOG_DIR
 (! nix-store -l $path)
 nix-build dependencies.nix --no-out-link --compress-build-log
 [ "$(nix-store -l $path)" = FOO ]
+
+# test whether empty logs work fine with `nix log`.
+builder="$(mktemp)"
+echo -e "#!/bin/sh\nmkdir \$out" > "$builder"
+outp="$(nix-build -E \
+    'with import ./config.nix; mkDerivation { name = "fnord"; builder = '"$builder"'; }' \
+    --out-link "$(mktemp -d)/result")"
+
+test -d "$outp"
+
+nix log "$outp"


### PR DESCRIPTION
According to `git bisect` this was introduced by https://github.com/NixOS/nix/commit/50a35860ee9237d341948437c5f70a7f0987d393

To summarize: while trying to update Hydra to use Nix 2.6, I realized that [`yath t/queue-runner/notifications.t`](https://github.com/NixOS/hydra/blob/master/t/queue-runner/notifications.t) is failing because it initially builds a derivation (and the builder doesn't write anything to `stdout`/`stderr`). After that it's checked if e.g. `nix log` succeeds.

While this was the case on the Nix 2.4pre rev of Hydra, it isn't the case anymore on Nix 2.6.

While bisecting I found the problem, it seems as if `init()` wrongly sets `archive_read_support_filter_all` if `raw` would be `true`.

Also added a regression-test that I used for bisecting.

cc @edolstra 