### PR TITLE
Fix deadlocked nix-daemon zombies on darwin #3294

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1561,7 +1561,22 @@ std::pair<unsigned short, unsigned short> getWindowSize()
 }
 
 
-static Sync<std::list<std::function<void()>>> _interruptCallbacks;
+/* We keep track of interrupt callbacks using integer tokens, so we can iterate
+   safely without having to lock the data structure while executing arbitrary
+   functions.
+ */
+struct InterruptCallbacks {
+    typedef int64_t Token;
+
+    /* We use unique tokens so that we can't accidentally delete the wrong
+       handler because of an erroneous double delete. */
+    Token nextToken = 0;
+
+    /* Used as a list, see InterruptCallbacks comment. */
+    std::map<Token, std::function<void()>> callbacks;
+};
+
+static Sync<InterruptCallbacks> _interruptCallbacks;
 
 static void signalHandlerThread(sigset_t set)
 {
@@ -1583,14 +1598,29 @@ void triggerInterrupt()
     _isInterrupted = true;
 
     {
-        auto interruptCallbacks(_interruptCallbacks.lock());
-        for (auto & callback : *interruptCallbacks) {
-            try {
-                callback();
-            } catch (...) {
-                ignoreException();
+        InterruptCallbacks::Token i = 0;
+        std::function<void()> callback;
+        do {
+            {
+                auto interruptCallbacks(_interruptCallbacks.lock());
+                auto lb = interruptCallbacks->callbacks.lower_bound(i);
+                if (lb != interruptCallbacks->callbacks.end()) {
+                    callback = lb->second;
+                    i = lb->first + 1;
+                } else {
+                    callback = nullptr;
+                }
+            }
+
+            if (callback) {
+                try {
+                    callback();
+                } catch (...) {
+                    ignoreException();
+                }
             }
         }
+        while (callback);
     }
 }
 
@@ -1694,21 +1724,22 @@ void restoreProcessContext(bool restoreMounts)
 /* RAII helper to automatically deregister a callback. */
 struct InterruptCallbackImpl : InterruptCallback
 {
-    std::list<std::function<void()>>::iterator it;
+    InterruptCallbacks::Token token;
     ~InterruptCallbackImpl() override
     {
-        _interruptCallbacks.lock()->erase(it);
+        auto interruptCallbacks(_interruptCallbacks.lock());
+        interruptCallbacks->callbacks.erase(token);
     }
 };
 
 std::unique_ptr<InterruptCallback> createInterruptCallback(std::function<void()> callback)
 {
     auto interruptCallbacks(_interruptCallbacks.lock());
-    interruptCallbacks->push_back(callback);
+    auto token = interruptCallbacks->nextToken++;
+    interruptCallbacks->callbacks.emplace(token, callback);
 
     auto res = std::make_unique<InterruptCallbackImpl>();
-    res->it = interruptCallbacks->end();
-    res->it--;
+    res->token = token;
 
     return std::unique_ptr<InterruptCallback>(res.release());
 }

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1599,28 +1599,24 @@ void triggerInterrupt()
 
     {
         InterruptCallbacks::Token i = 0;
-        std::function<void()> callback;
-        do {
+        while (true) {
+            std::function<void()> callback;
             {
                 auto interruptCallbacks(_interruptCallbacks.lock());
                 auto lb = interruptCallbacks->callbacks.lower_bound(i);
-                if (lb != interruptCallbacks->callbacks.end()) {
-                    callback = lb->second;
-                    i = lb->first + 1;
-                } else {
-                    callback = nullptr;
-                }
+                if (lb == interruptCallbacks->callbacks.end())
+                    break;
+
+                callback = lb->second;
+                i = lb->first + 1;
             }
 
-            if (callback) {
-                try {
-                    callback();
-                } catch (...) {
-                    ignoreException();
-                }
+            try {
+                callback();
+            } catch (...) {
+                ignoreException();
             }
         }
-        while (callback);
     }
 }
 


### PR DESCRIPTION
This changes the representation of the interrupt callback list to be safe to use during interrupt handling.

Holding a lock while executing arbitrary functions is something to avoid in general, because of the risk of deadlock.

Such a deadlock occurs in https://github.com/NixOS/nix/issues/3294 where `~CurlDownloader` tries to deregister its interrupt callback.

This happens during what seems to be a `triggerInterrupt()` by the daemon connection's `MonitorFdHup` thread. This bit I can not confirm based on the stack trace though; it's based on reading the code, so no absolute certainty, but a smoking gun nonetheless.

Fixes #3294

At first I've tested this with a simpler solution: to just copy the list of interrupt handlers before running them, however that would still be fragile, as that solution does not satisfy the requirement that inserts/deletions to the interrupt handler list become effective immediately, with disastrous consequences if/when code depends on this for lifetime safety.

It is unclear to me why the deadlock would only occur on darwin, but I can speculate that there might be some nondeterminism involved that just happens to work out fine on Linux, but not on macOS.