### PR TITLE
repl/load-flake: throw error if path isn't specified

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -623,6 +623,9 @@ void NixRepl::loadFile(const Path & path)
 
 void NixRepl::loadFlake(const std::string & flakeRefS)
 {
+    if (flakeRefS.empty())
+        throw Error("cannot use `:load-flake` without a path specified. (Use . for the current working directory.)");
+
     auto flakeRef = parseFlakeRef(flakeRefS, absPath("."), true);
     if (evalSettings.pureEval && !flakeRef.input.isImmutable())
         throw Error("cannot use ':load-flake' on mutable flake reference '%s' (use --impure to override)", flakeRefS);

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -624,7 +624,7 @@ void NixRepl::loadFile(const Path & path)
 void NixRepl::loadFlake(const std::string & flakeRefS)
 {
     if (flakeRefS.empty())
-        throw Error("cannot use `:load-flake` without a path specified. (Use . for the current working directory.)");
+        throw Error("cannot use ':load-flake' without a path specified. (Use '.' for the current working directory.)");
 
     auto flakeRef = parseFlakeRef(flakeRefS, absPath("."), true);
     if (evalSettings.pureEval && !flakeRef.input.isImmutable())


### PR DESCRIPTION
In the repl, `:lf` with no arguments currently throws an error saying that `'' is not a valid URL`. This writes in a special case for an empty URL, giving the imo nicer error "cannot use `:load-flake` without a path specified. (Use . for the current working directory.)".

The other option would be to use the current directory as the flake path, but that could incur a lot of extra copying if the user is unaware of that behavior.