### PR TITLE
nix/why-depends: fix output when not using `--precise`

### DIFF
--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -171,12 +171,6 @@ struct CmdWhyDepends : SourceExprCommand
                     node.visited ? "\e[38;5;244m" : "",
                     firstPad != "" ? "→ " : "",
                     pathS);
-            } else {
-                logger->cout("%s%s%s%s" ANSI_NORMAL,
-                    firstPad,
-                    node.visited ? "\e[38;5;244m" : "",
-                    firstPad != "" ? treeLast : "",
-                    pathS);
             }
 
             if (node.path == dependencyPath && !all
@@ -184,7 +178,7 @@ struct CmdWhyDepends : SourceExprCommand
                 throw BailOut();
 
             if (node.visited) return;
-            node.visited = true;
+            if (precise) node.visited = true;
 
             /* Sort the references by distance to `dependency` to
                ensure that the shortest path is printed first. */
@@ -267,6 +261,16 @@ struct CmdWhyDepends : SourceExprCommand
                     if (!all) break;
                 }
 
+                if (!precise) {
+                    auto pathS = store->printStorePath(ref.second->path);
+                    logger->cout("%s%s%s%s" ANSI_NORMAL,
+                        firstPad,
+                        ref.second->visited ? "\e[38;5;244m" : "",
+                        last ? treeLast : treeConn,
+                        pathS);
+                    node.visited = true;
+                }
+
                 printNode(*ref.second,
                     tailPad + (last ? treeNull : treeLine),
                     tailPad + (last ? treeNull : treeLine));
@@ -275,6 +279,9 @@ struct CmdWhyDepends : SourceExprCommand
 
         RunPager pager;
         try {
+            if (!precise) {
+                logger->cout("%s", store->printStorePath(graph.at(packagePath).path));
+            }
             printNode(graph.at(packagePath), "", "");
         } catch (BailOut & ) { }
     }


### PR DESCRIPTION
On Nix 2.6 the output of `nix why-depends --all` seems to be somewhat
off:

    $ nix why-depends /nix/store/kn47hayxab8gc01jhr98dwyywbx561aq-nixos-system-roflmayr-21.11.20220207.6c202a9.drv /nix/store/srn5jbs1q30jpybdmxqrwskyny659qgc-nix-2.6.drv --derivation  --extra-experimental-features nix-command  --all
    /nix/store/kn47hayxab8gc01jhr98dwyywbx561aq-nixos-system-roflmayr-21.11.20220207.6c202a9.drv
        └───/nix/store/g8bpgfjhh5vxrdq0w6r6s64f9kkm9z6c-etc.drv
        │   └───/nix/store/hm0jmhp8shbf3cl846a685nv4f5cp3fy-nspawn-inst.drv
        | [...]
            └───/nix/store/2d6q3ygiim9ijl5d4h0qqx6vnjgxywyr-system-units.drv
                └───/nix/store/dil014y1b8qyjhhhf5fpaah5fzdf0bzs-unit-systemd-nspawn-hydra.service.drv
                    └───/nix/store/a9r72wwx8qrxyp7hjydyg0gsrwnn26zb-activate.drv
                        └───/nix/store/99hlc7i4gl77wq087lbhag4hkf3kvssj-nixos-system-hydra-21.11pre-git.drv

Please note that `[...]-system-units.drv` is supposed to be a direct
child of `[...]-etc.drv`.

The reason for that is that each new level printed by `printNode` is
four spaces off in comparison to `nix why-depends --precise` because the
recursive `printNode()` only prints the path and not the `tree*`-chars in
the case of `--precise` and in this format the path is four spaces further
indented, i.e. on a newline, but on the same level as the path's children, i.e.

    /nix/store/kn47hayxab8gc01jhr98dwyywbx561aq-nixos-system-roflmayr-21.11.20220207.6c202a9.drv
    └───/: …1-p8.drv",["out"]),("/nix/store/g8bpgfjhh5vxrdq0w6r6s64f9kkm9z6c-etc.drv",["out"]),("/nix/store/…
        → /nix/store/g8bpgfjhh5vxrdq0w6r6s64f9kkm9z6c-etc.drv

As you can see `[...]-etc.drv` is a direct child of the root, but four
spaces indented. This logic was directly applied to the code-path with
`precise=false` which resulted in `tree*` being printed four spaces too
deep.

In case of no `--precise`, `hits[hash]` is empty and the path itself
should be printed rather than hits using the same logic as for `hits[hash]`.

With this fix, the output looks correct now:

    /nix/store/kn47hayxab8gc01jhr98dwyywbx561aq-nixos-system-roflmayr-21.11.20220207.6c202a9.drv
    └───/nix/store/g8bpgfjhh5vxrdq0w6r6s64f9kkm9z6c-etc.drv
        ├───/nix/store/hm0jmhp8shbf3cl846a685nv4f5cp3fy-nspawn-inst.drv
        | [...]
        └───/nix/store/2d6q3ygiim9ijl5d4h0qqx6vnjgxywyr-system-units.drv
            └───/nix/store/dil014y1b8qyjhhhf5fpaah5fzdf0bzs-unit-systemd-nspawn-hydra.service.drv
                └───/nix/store/a9r72wwx8qrxyp7hjydyg0gsrwnn26zb-activate.drv
                    └───/nix/store/99hlc7i4gl77wq087lbhag4hkf3kvssj-nixos-system-hydra-21.11pre-git.drv


cc @thufschmitt @edolstra 