### PR TITLE
parseInstallables(): Don't try the flake attr path prefixes when no fragment is specified

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -709,7 +709,7 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
                         getEvalState(),
                         std::move(flakeRef),
                         fragment == "" ? getDefaultFlakeAttrPaths() : Strings{fragment},
-                        getDefaultFlakeAttrPathPrefixes(),
+                        fragment == "" ? Strings{} : getDefaultFlakeAttrPathPrefixes(),
                         lockFlags));
                 continue;
             } catch (...) {


### PR DESCRIPTION
Fixes #5880.