### PR TITLE
Replace defaultBla.$system with bla.$system.default

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,5 +1,18 @@
 # Release X.Y (202?-??-??)
 
+* A number of "default" flake output attributes have been
+  renamed. These are:
+
+  * `defaultPackage.<system>` → `packages.<system>.default`
+  * `defaultApps.<system>` → `apps.<system>.default`
+  * `defaultTemplate` → `templates.default`
+  * `defaultBundler.<system>` → `bundlers.<system>.default`
+  * `overlay` → `overlays.default`
+  * `devShell.<system>` → `devShells.<system>.default`
+
+  The old flake output attributes still work, but `nix flake check`
+  will warn about them.
+
 * `nix bundle` breaking API change now supports bundlers of the form
   `bundler.<system>.<name>= derivation: another-derivation;`. This supports
   additional functionality to inspect evaluation information during bundling. A

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -158,7 +158,10 @@ SourceExprCommand::SourceExprCommand()
 
 Strings SourceExprCommand::getDefaultFlakeAttrPaths()
 {
-    return {"defaultPackage." + settings.thisSystem.get()};
+    return {
+        "packages." + settings.thisSystem.get() + ".default",
+        "defaultPackage." + settings.thisSystem.get()
+    };
 }
 
 Strings SourceExprCommand::getDefaultFlakeAttrPathPrefixes()

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -49,9 +49,11 @@ struct CmdBundle : InstallableCommand
 
     Category category() override { return catSecondary; }
 
+    // FIXME: cut&paste from CmdRun.
     Strings getDefaultFlakeAttrPaths() override
     {
         Strings res{
+            "apps." + settings.thisSystem.get() + ".default",
             "defaultApp." + settings.thisSystem.get()
         };
         for (auto & s : SourceExprCommand::getDefaultFlakeAttrPaths())
@@ -61,10 +63,7 @@ struct CmdBundle : InstallableCommand
 
     Strings getDefaultFlakeAttrPathPrefixes() override
     {
-        Strings res{
-            "apps." + settings.thisSystem.get() + "."
-
-        };
+        Strings res{"apps." + settings.thisSystem.get() + "."};
         for (auto & s : SourceExprCommand::getDefaultFlakeAttrPathPrefixes())
             res.push_back(s);
         return res;
@@ -80,7 +79,9 @@ struct CmdBundle : InstallableCommand
         const flake::LockFlags lockFlags{ .writeLockFile = false };
         InstallableFlake bundler{this,
             evalState, std::move(bundlerFlakeRef), bundlerName,
-            {"defaultBundler." + settings.thisSystem.get()},
+            {"bundlers." + settings.thisSystem.get() + ".default",
+             "defaultBundler." + settings.thisSystem.get()
+            },
             {"bundlers." + settings.thisSystem.get() + "."},
             lockFlags
         };

--- a/src/nix/bundle.md
+++ b/src/nix/bundle.md
@@ -42,24 +42,26 @@ homepage](https://github.com/NixOS/bundlers) for more details.
 If no flake output attribute is given, `nix bundle` tries the following
 flake output attributes:
 
-* `defaultBundler.<system>`
+* `bundlers.<system>.default`
 
 If an attribute *name* is given, `nix run` tries the following flake
 output attributes:
 
-* `bundler.<system>.<name>`
+* `bundlers.<system>.<name>`
 
 # Bundlers
 
 A bundler is specified by a flake output attribute named
-`bundlers.<system>.<name>` or `defaultBundler.<system>`. It looks like this:
+`bundlers.<system>.<name>`. It looks like this:
 
 ```nix
-bundlers.x86_64-linux.identity = drv: drv;
+bundlers.x86_64-linux = rec {
+  identity = drv: drv;
 
-bundlers.x86_64-linux.blender_2_79 = drv: self.packages.x86_64-linux.blender_2_79;
+  blender_2_79 = drv: self.packages.x86_64-linux.blender_2_79;
 
-defaultBundler.x86_64-linux = drv: drv;
+  default = identity;
+};
 ```
 
 A bundler must be a function that accepts an arbitrary value (typically a

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -325,8 +325,15 @@ struct Common : InstallableCommand, MixProfile
 
     Strings getDefaultFlakeAttrPaths() override
     {
-        return {"devShell." + settings.thisSystem.get(), "defaultPackage." + settings.thisSystem.get()};
+        Strings paths{
+            "devShells." + settings.thisSystem.get() + ".default",
+            "devShell." + settings.thisSystem.get(),
+        };
+        for (auto & p : SourceExprCommand::getDefaultFlakeAttrPaths())
+            paths.push_back(p);
+        return paths;
     }
+
     Strings getDefaultFlakeAttrPathPrefixes() override
     {
         auto res = SourceExprCommand::getDefaultFlakeAttrPathPrefixes();

--- a/src/nix/develop.md
+++ b/src/nix/develop.md
@@ -88,9 +88,9 @@ the flake's `nixConfig` attribute.
 If no flake output attribute is given, `nix develop` tries the following
 flake output attributes:
 
-* `devShell.<system>`
+* `devShells.<system>.default`
 
-* `defaultPackage.<system>`
+* `packages.<system>.default`
 
 If a flake output *name* is given, `nix develop` tries the following flake
 output attributes:

--- a/src/nix/flake-init.md
+++ b/src/nix/flake-init.md
@@ -24,13 +24,13 @@ R""(
 
 This command creates a flake in the current directory by copying the
 files of a template. It will not overwrite existing files. The default
-template is `templates#defaultTemplate`, but this can be overridden
+template is `templates#templates.default`, but this can be overridden
 using `-t`.
 
 # Template definitions
 
-A flake can declare templates through its `templates` and
-`defaultTemplate` output attributes. A template has two attributes:
+A flake can declare templates through its `templates` output
+attribute. A template has two attributes:
 
 * `description`: A one-line description of the template, in CommonMark
   syntax.
@@ -61,7 +61,7 @@ outputs = { self }: {
     '';
   };
 
-  templates.defaultTemplate = self.templates.rust;
+  templates.default = self.templates.rust;
 }
 ```
 

--- a/src/nix/flake-show.md
+++ b/src/nix/flake-show.md
@@ -13,10 +13,13 @@ R""(
   │   │   └───build: derivation 'patchelf-0.12.20201207.f34751b'
   │   └───x86_64-linux
   │       └───build: derivation 'patchelf-0.12.20201207.f34751b'
-  ├───defaultPackage
-  │   ├───aarch64-linux: package 'patchelf-0.12.20201207.f34751b'
-  │   ├───i686-linux: package 'patchelf-0.12.20201207.f34751b'
-  │   └───x86_64-linux: package 'patchelf-0.12.20201207.f34751b'
+  ├───packages
+  │   ├───aarch64-linux
+  │   │   └───default: package 'patchelf-0.12.20201207.f34751b'
+  │   ├───i686-linux
+  │   │   └───default: package 'patchelf-0.12.20201207.f34751b'
+  │   └───x86_64-linux
+  │       └───default: package 'patchelf-0.12.20201207.f34751b'
   ├───hydraJobs
   │   ├───build
   │   │   ├───aarch64-linux: derivation 'patchelf-0.12.20201207.f34751b'

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -501,6 +501,17 @@ struct CmdFlakeCheck : FlakeCommand
 
                         state->forceValue(vOutput, pos);
 
+                        std::string_view replacement =
+                            name == "defaultPackage" ? "packages.<system>.default" :
+                            name == "defaultApps" ? "apps.<system>.default" :
+                            name == "defaultTemplate" ? "templates.default" :
+                            name == "defaultBundler" ? "bundlers.<system>.default" :
+                            name == "overlay" ? "overlays.default" :
+                            name == "devShell" ? "devShells.<system>.default" :
+                            "";
+                        if (replacement != "")
+                            warn("flake output attribute '%s' is deprecated; use '%s' instead", name, replacement);
+
                         if (name == "checks") {
                             state->forceAttrs(vOutput, pos);
                             for (auto & attr : *vOutput.attrs) {

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -651,7 +651,7 @@ struct CmdFlakeCheck : FlakeCommand
 };
 
 static Strings defaultTemplateAttrPathsPrefixes{"templates."};
-static Strings defaultTemplateAttrPaths = {"defaultTemplate"};
+static Strings defaultTemplateAttrPaths = {"templates.default", "defaultTemplate"};
 
 struct CmdFlakeInitCommon : virtual Args, EvalCommand
 {

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -236,7 +236,7 @@ derivation):
 
   outputs = { self, nixpkgs }: {
 
-    defaultPackage.x86_64-linux =
+    packages.x86_64-linux.default =
       # Notice the reference to nixpkgs here.
       with import nixpkgs { system = "x86_64-linux"; };
       stdenv.mkDerivation {

--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -97,11 +97,9 @@ the Nix store. Here are the recognised types of installables:
     For example, if `/foo/bar/flake.nix` exists, then `/foo/bar/baz/` will resolve to
    `path:/foo/bar`
 
-
-
   If *attrpath* is omitted, Nix tries some default values; for most
-  subcommands, the default is `defaultPackage.`*system*
-  (e.g. `defaultPackage.x86_64-linux`), but some subcommands have
+  subcommands, the default is `packages.`*system*`.default`
+  (e.g. `packages.x86_64-linux.default`), but some subcommands have
   other defaults. If *attrpath* *is* specified, *attrpath* is
   interpreted as relative to one or more prefixes; for most
   subcommands, these are `packages.`*system*,

--- a/src/nix/profile-list.md
+++ b/src/nix/profile-list.md
@@ -8,7 +8,7 @@ R""(
   # nix profile list
   0 flake:nixpkgs#legacyPackages.x86_64-linux.spotify github:NixOS/nixpkgs/c23db78bbd474c4d0c5c3c551877523b4a50db06#legacyPackages.x86_64-linux.spotify /nix/store/akpdsid105phbbvknjsdh7hl4v3fhjkr-spotify-1.1.46.916.g416cacf1
   1 flake:nixpkgs#legacyPackages.x86_64-linux.zoom-us github:NixOS/nixpkgs/c23db78bbd474c4d0c5c3c551877523b4a50db06#legacyPackages.x86_64-linux.zoom-us /nix/store/89pmjmbih5qpi7accgacd17ybpgp4xfm-zoom-us-5.4.53350.1027
-  2 flake:blender-bin#defaultPackage.x86_64-linux github:edolstra/nix-warez/d09d7eea893dcb162e89bc67f6dc1ced14abfc27?dir=blender#defaultPackage.x86_64-linux /nix/store/zfgralhqjnam662kqsgq6isjw8lhrflz-blender-bin-2.91.0
+  2 flake:blender-bin#packages.x86_64-linux.default github:edolstra/nix-warez/d09d7eea893dcb162e89bc67f6dc1ced14abfc27?dir=blender#packages.x86_64-linux.default /nix/store/zfgralhqjnam662kqsgq6isjw8lhrflz-blender-bin-2.91.0
   ```
 
 # Description

--- a/src/nix/profile.md
+++ b/src/nix/profile.md
@@ -96,7 +96,7 @@ has the following fields:
   user specified, but the one resulting from applying the default
   attribute paths and prefixes; for instance, `hello` might resolve to
   `packages.x86_64-linux.hello` and the empty string to
-  `defaultPackage.x86_64-linux`.
+  `packages.x86_64-linux.default`.
 
 * `storePath`: The paths in the Nix store containing the package.
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -158,7 +158,10 @@ struct CmdRun : InstallableCommand
 
     Strings getDefaultFlakeAttrPaths() override
     {
-        Strings res{"defaultApp." + settings.thisSystem.get()};
+        Strings res{
+            "apps." + settings.thisSystem.get() + ".default",
+            "defaultApp." + settings.thisSystem.get(),
+        };
         for (auto & s : SourceExprCommand::getDefaultFlakeAttrPaths())
             res.push_back(s);
         return res;

--- a/src/nix/run.md
+++ b/src/nix/run.md
@@ -58,9 +58,9 @@ For instance, if `name` is set to `hello-1.10`, `nix run` will run
 If no flake output attribute is given, `nix run` tries the following
 flake output attributes:
 
-* `defaultApp.<system>`
+* `apps.<system>.default`
 
-* `defaultPackage.<system>`
+* `packages.<system>.default`
 
 If an attribute *name* is given, `nix run` tries the following flake
 output attributes:
@@ -74,7 +74,7 @@ output attributes:
 # Apps
 
 An app is specified by a flake output attribute named
-`apps.<system>.<name>` or `defaultApp.<system>`. It looks like this:
+`apps.<system>.<name>`. It looks like this:
 
 ```nix
 apps.x86_64-linux.blender_2_79 = {

--- a/tests/flake-local-settings.sh
+++ b/tests/flake-local-settings.sh
@@ -21,7 +21,7 @@ cat <<EOF > flake.nix
     nixConfig.allow-dirty = false; # See #5621
 
     outputs = a: {
-       defaultPackage.$system = import ./simple.nix;
+       packages.$system.default = import ./simple.nix;
     };
 }
 EOF

--- a/tests/flake-searching.sh
+++ b/tests/flake-searching.sh
@@ -15,8 +15,10 @@ cat <<EOF > flake.nix
 {
     inputs.foo.url = "$PWD/foo";
     outputs = a: {
-       defaultPackage.$system = import ./simple.nix;
-       packages.$system.test = import ./simple.nix;
+       packages.$system = rec {
+         test = import ./simple.nix;
+         default = test;
+       };
     };
 }
 EOF

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -41,8 +41,10 @@ cat > $flake1Dir/flake.nix <<EOF
   description = "Bla bla";
 
   outputs = inputs: rec {
-    packages.$system.foo = import ./simple.nix;
-    defaultPackage.$system = packages.$system.foo;
+    packages.$system = rec {
+      foo = import ./simple.nix;
+      default = foo;
+    };
 
     # To test "nix flake init".
     legacyPackages.x86_64-linux.hello = import ./simple.nix;
@@ -128,7 +130,7 @@ hash2=$(nix flake metadata flake1 --json --refresh | jq -r .revision)
 nix build -o $TEST_ROOT/result flake1#foo
 [[ -e $TEST_ROOT/result/hello ]]
 
-# Test defaultPackage.
+# Test packages.default.
 nix build -o $TEST_ROOT/result flake1
 [[ -e $TEST_ROOT/result/hello ]]
 
@@ -140,11 +142,11 @@ nix build -o $flake1Dir/result git+file://$flake1Dir
 nix path-info $flake1Dir/result
 
 # 'getFlake' on a mutable flakeref should fail in pure mode, but succeed in impure mode.
-(! nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"$flake1Dir\").defaultPackage.$system")
-nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"$flake1Dir\").defaultPackage.$system" --impure
+(! nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default")
+nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default" --impure
 
 # 'getFlake' on an immutable flakeref should succeed even in pure mode.
-nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"git+file://$flake1Dir?rev=$hash2\").defaultPackage.$system"
+nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"git+file://$flake1Dir?rev=$hash2\").packages.$system.default"
 
 # Building a flake with an unlocked dependency should fail in pure mode.
 (! nix build -o $TEST_ROOT/result flake2#bar --no-registries)
@@ -370,13 +372,13 @@ cat > $templatesDir/flake.nix <<EOF
   description = "Some templates";
 
   outputs = { self }: {
-    templates = {
+    templates = rec {
       trivial = {
         path = ./trivial;
         description = "A trivial flake";
       };
+      default = trivial;
     };
-    defaultTemplate = self.templates.trivial;
   };
 }
 EOF
@@ -388,8 +390,10 @@ cat > $templatesDir/trivial/flake.nix <<EOF
   description = "A flake for building Hello World";
 
   outputs = { self, nixpkgs }: {
-    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
+    packages.x86_64-linux = rec {
+      hello = nixpkgs.legacyPackages.x86_64-linux.hello;
+      default = hello;
+    };
   };
 }
 EOF
@@ -496,17 +500,15 @@ EOF
 cat > $flake3Dir/flake.nix <<EOF
 {
   outputs = { flake1, self }: {
-    defaultPackage = {
-        system-1 = "foo";
-        system-2 = "bar";
-    };
+    packages.system-1.default = "foo";
+    packages.system-2.default = "bar";
   };
 }
 EOF
 
 checkRes=$(nix flake check --keep-going $flake3Dir 2>&1 && fail "nix flake check should have failed" || true)
-echo "$checkRes" | grep -q "defaultPackage.system-1"
-echo "$checkRes" | grep -q "defaultPackage.system-2"
+echo "$checkRes" | grep -q "packages.system-1.default"
+echo "$checkRes" | grep -q "packages.system-2.default"
 
 # Test 'follows' inputs.
 cat > $flake3Dir/flake.nix <<EOF
@@ -591,7 +593,7 @@ mkdir $flake5Dir
 cat > $flake5Dir/flake.nix <<EOF
 {
   outputs = { self, flake1 }: {
-    defaultPackage.$system = flake1.defaultPackage.$system;
+    packages.$system.default = flake1.packages.$system.default;
     expr = assert builtins.pathExists ./flake.lock; 123;
   };
 }


### PR DESCRIPTION
This also simplifies some `InstallableFlake` logic and fixes `nix bundle` parsing its installable twice.
    
Fixes #5532.

## TODO
- [x] make `nix flake check` warn about the old `defaultX` outputs.
- [x] update documentation
- [x] release note (bonus for examples)