### PR TITLE
InstallableFlake: Default attr paths cleanup

### DIFF
--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -102,8 +102,9 @@ struct InstallableFlake : InstallableValue
         SourceExprCommand * cmd,
         ref<EvalState> state,
         FlakeRef && flakeRef,
-        Strings && attrPaths,
-        Strings && prefixes,
+        std::string_view fragment,
+        Strings attrPaths,
+        Strings prefixes,
         const flake::LockFlags & lockFlags);
 
     std::string what() const override { return flakeRef.to_string() + "#" + *attrPaths.begin(); }

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -74,21 +74,16 @@ struct CmdBundle : InstallableCommand
     {
         auto evalState = getEvalState();
 
-        auto [progFlakeRef, progName] = parseFlakeRefWithFragment(installable->what(), absPath("."));
-        const flake::LockFlags lockFlagsProg{ .writeLockFile = false };
-        auto programInstallable = InstallableFlake(this,
-            evalState, std::move(progFlakeRef),
-            Strings{progName == "" ? "defaultApp" : progName},
-            Strings(this->getDefaultFlakeAttrPathPrefixes()),
-            lockFlagsProg);
-        auto val = programInstallable.toValue(*evalState).first;
+        auto val = installable->toValue(*evalState).first;
 
         auto [bundlerFlakeRef, bundlerName] = parseFlakeRefWithFragment(bundler, absPath("."));
         const flake::LockFlags lockFlags{ .writeLockFile = false };
-        auto bundler = InstallableFlake(this,
-            evalState, std::move(bundlerFlakeRef),
-            Strings{bundlerName == "" ? "defaultBundler." + settings.thisSystem.get() : settings.thisSystem.get() + "." + bundlerName, bundlerName},
-            Strings({"","bundlers."}), lockFlags);
+        InstallableFlake bundler{this,
+            evalState, std::move(bundlerFlakeRef), bundlerName,
+            {"defaultBundler." + settings.thisSystem.get()},
+            {"bundlers." + settings.thisSystem.get() + "."},
+            lockFlags
+        };
 
         auto vRes = evalState->allocValue();
         evalState->callFunction(*bundler.toValue(*evalState).first, *val, *vRes, noPos);

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -498,7 +498,8 @@ struct CmdDevelop : Common, MixEnvironment
                 this,
                 state,
                 installable->nixpkgsFlakeRef(),
-                Strings{"bashInteractive"},
+                "bashInteractive",
+                Strings{},
                 Strings{"legacyPackages." + settings.thisSystem.get() + "."},
                 nixpkgsLockFlags);
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -649,12 +649,14 @@ struct CmdFlakeCheck : FlakeCommand
     }
 };
 
+static Strings defaultTemplateAttrPathsPrefixes{"templates."};
+static Strings defaultTemplateAttrPaths = {"defaultTemplate"};
+
 struct CmdFlakeInitCommon : virtual Args, EvalCommand
 {
     std::string templateUrl = "templates";
     Path destDir;
 
-    const Strings attrsPathPrefixes{"templates."};
     const LockFlags lockFlags{ .writeLockFile = false };
 
     CmdFlakeInitCommon()
@@ -669,8 +671,8 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                 completeFlakeRefWithFragment(
                     getEvalState(),
                     lockFlags,
-                    attrsPathPrefixes,
-                    {"defaultTemplate"},
+                    defaultTemplateAttrPathsPrefixes,
+                    defaultTemplateAttrPaths,
                     prefix);
             }}
         });
@@ -685,9 +687,10 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
         auto [templateFlakeRef, templateName] = parseFlakeRefWithFragment(templateUrl, absPath("."));
 
         auto installable = InstallableFlake(nullptr,
-            evalState, std::move(templateFlakeRef),
-            Strings{templateName == "" ? "defaultTemplate" : templateName},
-            Strings(attrsPathPrefixes), lockFlags);
+            evalState, std::move(templateFlakeRef), templateName,
+            defaultTemplateAttrPaths,
+            defaultTemplateAttrPathsPrefixes,
+            lockFlags);
 
         auto [cursor, attrPath] = installable.getCursor(*evalState);
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -423,6 +423,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
                     this,
                     getEvalState(),
                     FlakeRef(element.source->originalRef),
+                    "",
                     {element.source->attrPath},
                     {},
                     lockFlags);


### PR DESCRIPTION
This removes some duplicated logic, and fixes `nix bundle` parsing its installable twice.

Extracted from #6089.