### PR TITLE
add descriptive output when creating templates

### DIFF
--- a/src/nix/flake-init.md
+++ b/src/nix/flake-init.md
@@ -37,6 +37,10 @@ A flake can declare templates through its `templates` and
 
 * `path`: The path of the directory to be copied.
 
+* `welcomeText`: A block of text to display when a user initializes a new flake
+  based on this template.
+
+
 Here is an example:
 
 ```
@@ -45,6 +49,10 @@ outputs = { self }: {
   templates.rust = {
     path = ./rust;
     description = "A simple Rust/Cargo project";
+    welcomeText = ''
+      You've created a simple Rust/Cargo template.
+      Visit https://www.rust-lang.org/ for more info.
+    '';
   };
 
   templates.defaultTemplate = self.templates.rust;

--- a/src/nix/flake-init.md
+++ b/src/nix/flake-init.md
@@ -37,8 +37,8 @@ A flake can declare templates through its `templates` and
 
 * `path`: The path of the directory to be copied.
 
-* `welcomeText`: A block of text to display when a user initializes a new flake
-  based on this template.
+* `welcomeText`: A block of markdown text to display when a user initializes a
+  new flake based on this template.
 
 
 Here is an example:
@@ -50,8 +50,14 @@ outputs = { self }: {
     path = ./rust;
     description = "A simple Rust/Cargo project";
     welcomeText = ''
-      You've created a simple Rust/Cargo template.
-      Visit https://www.rust-lang.org/ for more info.
+      # Simple Rust/Cargo Template
+      ## Intended usage
+      The intended usage of this flake is...
+
+      ## More info
+      - [Rust language](https://www.rust-lang.org/)
+      - [Rust on the NixOS Wiki](https://nixos.wiki/wiki/Rust)
+      - ...
     '';
   };
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -13,6 +13,7 @@
 #include "registry.hh"
 #include "json.hh"
 #include "eval-cache.hh"
+#include "markdown.hh"
 
 #include <nlohmann/json.hpp>
 #include <queue>
@@ -741,8 +742,8 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
         }
         auto welcomeText = cursor->maybeGetAttr("welcomeText");
         if (welcomeText) {
-            notice("\n----------\n");
-            notice(welcomeText->getString());
+            notice("\n");
+            notice(renderMarkdownToTerminal(welcomeText->getString()));
         }
     }
 };

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -728,6 +728,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                 else
                     throw Error("file '%s' has unsupported type", from2);
                 files.push_back(to2);
+                notice("wrote: %s", to2);
             }
         };
 
@@ -737,6 +738,11 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
             Strings args = { "-C", flakeDir, "add", "--intent-to-add", "--force", "--" };
             for (auto & s : files) args.push_back(s);
             runProgram("git", true, args);
+        }
+        auto welcomeText = cursor->maybeGetAttr("welcomeText");
+        if (welcomeText) {
+            notice("\n----------\n");
+            notice(welcomeText->getString());
         }
     }
 };


### PR DESCRIPTION
this includes a `welcomeText` attribute which can be set in the
template, as well as outputing which files were created.

#4503 