### PR TITLE
Fix formatting for options with "machine-specific" defaults

### DIFF
--- a/doc/manual/generate-options.nix
+++ b/doc/manual/generate-options.nix
@@ -20,7 +20,7 @@ concatStrings (map
          # JSON, but that converts to "{ }" here.
          (if isAttrs option.value then "`\"\"`"
           else "`" + toString option.value + "`")) + "\n\n"
-       else "    **Default:** *machine-specific*")
+       else "    **Default:** *machine-specific*\n")
     + (if option.aliases != []
        then "    **Deprecated alias:** " + (concatStringsSep ", " (map (s: "`${s}`") option.aliases)) + "\n\n"
        else "")


### PR DESCRIPTION
Options in the manual with machine specific defaults are missing a trailing newline in their generated markdown output; this causes some oddities in the rendered output.

For example:
  - the next option not having it's own bullet point:
![Screenshot 2022-02-15 at 14-58-11 nix conf](https://user-images.githubusercontent.com/7833358/154154841-78dad054-87ab-4dcc-ab9e-fbfdd20cb010.png)
  - "Deprecated alias" not being on it's own line:
![Screenshot 2022-02-15 at 14-58-27 nix conf](https://user-images.githubusercontent.com/7833358/154154969-ba5e3af4-9162-4f6e-89c0-9c5802841660.png)

This PR tweaks `generate-options.nix` to add this newline.
