### PR TITLE
flake: Print removed inputs in yellow

### DIFF
--- a/src/libexpr/flake/lockfile.cc
+++ b/src/libexpr/flake/lockfile.cc
@@ -315,7 +315,7 @@ std::string LockFile::diff(const LockFile & oldLocks, const LockFile & newLocks)
                 printInputPath(j->first), j->second);
             ++j;
         } else if (i != oldFlat.end() && (j == newFlat.end() || i->first < j->first)) {
-            res += fmt("• " ANSI_RED "Removed input '%s'" ANSI_NORMAL "\n", printInputPath(i->first));
+            res += fmt("• " ANSI_YELLOW "Removed input '%s'" ANSI_NORMAL "\n", printInputPath(i->first));
             ++i;
         } else {
             if (!equals(i->second, j->second)) {


### PR DESCRIPTION
Red probably was chosen since this is somewhat related to `diff`, but for inputs. I still think that users will not grasp this, especially not when there is no input added in the same run that would provide a green line for contrast.

Instead, I'd argue that users will think that red indicates an error. Removal of an input however is not an error per se, but deserves a warning.

If you want to keep the green/red scheme, consider prepending this with a message like "Differences in inputs follows (<green>added</green>, <red>removed</red>):".