### PR TITLE
libfetchers/path: set `lastModified` to path's mtime

### DIFF
--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -1,6 +1,5 @@
 #include "fetchers.hh"
 #include "store-api.hh"
-#include <filesystem>
 #include "archive.hh"
 
 namespace nix::fetchers {

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -48,6 +48,10 @@ namespace nix {
 void dumpPath(const Path & path, Sink & sink,
     PathFilter & filter = defaultPathFilter);
 
+/* Same as `void dumpPath()`, but returns the last modified date of the path */
+time_t dumpPathAndGetMtime(const Path & path, Sink & sink,
+    PathFilter & filter = defaultPathFilter);
+
 void dumpString(std::string_view s, Sink & sink);
 
 /* FIXME: fix this API, it sucks. */

--- a/tests/fetchPath.sh
+++ b/tests/fetchPath.sh
@@ -1,0 +1,6 @@
+source common.sh
+
+touch foo -t 222211111111
+# We only check whether 2222-11-1* **:**:** is the last modified date since
+# `lastModified` is transformed into UTC in `builtins.fetchTarball`.
+[[ "$(nix eval --impure --raw --expr "(builtins.fetchTree \"path://$PWD/foo\").lastModifiedDate")" =~ 2222111.* ]]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -21,6 +21,7 @@ nix_tests = \
   tarball.sh \
   fetchGit.sh \
   fetchurl.sh \
+  fetchPath.sh \
   simple.sh \
   referrers.sh \
   optimise-store.sh \


### PR DESCRIPTION
When importing e.g. a local `nixpkgs` in a flake to test a change like

    {
      inputs.nixpkgs.url = path:/home/ma27/Projects/nixpkgs;
      outputs = /* ... */
    }

then the input is missing a `lastModified`-field that's e.g. used in
`nixpkgs.lib.nixosSystem`. Due to the missing `lastMoified`-field, the
mtime is set to 19700101:

    result -> /nix/store/b7dg1lmmsill2rsgyv2w7b6cnmixkvc1-nixos-system-nixos-22.05.19700101.dirty

With this change, the `path`-fetcher now sets a `lastModified` attribute
to the `mtime` just like it's the case in the `tarball`-fetcher already.
When building NixOS systems with `nixpkgs` being a `path`-input and this
patch, the output-path now looks like this:

    result -> /nix/store/ld2qf9c1s98dxmiwcaq5vn9k5ylzrm1s-nixos-system-nixos-22.05.20220217.dirty

cc @edolstra 