### PR TITLE
Document usage of MANPATH in nix-profile.sh

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -24,6 +24,9 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         export NIX_SSL_CERT_FILE="$NIX_LINK/etc/ca-bundle.crt"
     fi
 
+    # Only use MANPATH if it is already set. In general `man` will just simply
+    # pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
+    # which is in the $PATH. For more info, run `manpath -d`.
     if [ -n "${MANPATH-}" ]; then
         export MANPATH="$NIX_LINK/share/man:$MANPATH"
     fi


### PR DESCRIPTION
While trying to figure out how `nix-env`/`nix profile` work I had a hard
time understanding how man pages were being installed.

Took me quite some time to figure this out, thought it might be useful
to others too!