### PR TITLE
Precise the doc for `--include-outputs`

### DIFF
--- a/doc/manual/src/command-ref/nix-store.md
+++ b/doc/manual/src/command-ref/nix-store.md
@@ -321,8 +321,8 @@ symlink.
     This query has one option:
 
       - `--include-outputs`
-        Also include the output path of store derivations, and their
-        closures.
+        Also include the existing output paths of store derivations,
+        and their closures.
 
     This query can be used to implement various kinds of deployment. A
     *source deployment* is obtained by distributing the closure of a


### PR DESCRIPTION
Make it explicit that it only includes the existing outputs and not the ones that haven’t been realised

Fix #6142 

cc @lukebfox