### PR TITLE
Fix Symbol::'<' to sort alphabetically rather than by symbol pointer

### DIFF
--- a/src/libexpr/symbol-table.hh
+++ b/src/libexpr/symbol-table.hh
@@ -42,7 +42,7 @@ public:
 
     bool operator < (const Symbol & s2) const
     {
-        return s < s2.s;
+        return *s < *s2.s;
     }
 
     operator const std::string & () const


### PR DESCRIPTION
The symbol table is currently sorted by pointer, which has some weird effects (available upon request from @puckipedia). This fixes it to sort by the string contents.