### PR TITLE
Sort the tests by wall time

### DIFF
--- a/tests/local.mk
+++ b/tests/local.mk
@@ -1,72 +1,98 @@
 nix_tests = \
-  hash.sh lang.sh add.sh simple.sh dependencies.sh \
-  config.sh \
-  gc.sh \
+  flakes.sh \
   ca/gc.sh \
-  gc-concurrent.sh \
-  gc-non-blocking.sh \
+  gc.sh \
+  remote-store.sh \
+  lang.sh \
+  fetchMercurial.sh \
   gc-auto.sh \
-  referrers.sh user-envs.sh logging.sh nix-build.sh misc.sh fixed.sh \
-  gc-runtime.sh check-refs.sh filter-source.sh \
-  local-store.sh remote-store.sh export.sh export-graph.sh \
-  db-migration.sh \
-  timeout.sh secure-drv-outputs.sh nix-channel.sh \
-  multiple-outputs.sh import-derivation.sh ca/import-derivation.sh fetchurl.sh optimise-store.sh \
+  user-envs.sh \
   binary-cache.sh \
+  multiple-outputs.sh \
+  ca/build.sh \
+  nix-build.sh \
+  gc-concurrent.sh \
+  repair.sh \
+  fixed.sh \
+  export-graph.sh \
+  timeout.sh \
+  fetchGitRefs.sh \
+  gc-runtime.sh \
+  tarball.sh \
+  fetchGit.sh \
+  fetchurl.sh \
+  simple.sh \
+  referrers.sh \
+  optimise-store.sh \
   substitute-with-invalid-ca.sh \
-  binary-cache-build-remote.sh \
-  nix-profile.sh repair.sh dump-db.sh case-hack.sh \
-  check-reqs.sh pass-as-file.sh tarball.sh restricted.sh \
-  placeholders.sh nix-shell.sh \
-  linux-sandbox.sh \
-  build-dry.sh \
+  ca/concurrent-builds.sh \
+  signing.sh \
+  ca/build-with-garbage-path.sh \
+  hash.sh \
+  gc-non-blocking.sh \
+  check.sh \
+  ca/substitute.sh \
+  nix-shell.sh \
+  ca/signatures.sh \
+  ca/nix-shell.sh \
+  ca/nix-copy.sh \
+  check-refs.sh \
   build-remote-input-addressed.sh \
+  secure-drv-outputs.sh \
+  restricted.sh \
+  fetchGitSubmodules.sh \
+  flake-searching.sh \
+  ca/duplicate-realisation-in-closure.sh \
+  readfile-context.sh \
+  nix-channel.sh \
+  recursive.sh \
+  dependencies.sh \
+  check-reqs.sh \
   build-remote-content-addressed-fixed.sh \
   build-remote-content-addressed-floating.sh \
-  ssh-relay.sh \
   nar-access.sh \
+  pure-eval.sh \
+  ca/post-hook.sh \
+  repl.sh \
+  ca/repl.sh \
+  ca/recursive.sh \
+  binary-cache-build-remote.sh \
+  search.sh \
+  logging.sh \
+  export.sh \
+  config.sh \
+  add.sh \
+  local-store.sh \
+  filter-source.sh \
+  misc.sh \
+  dump-db.sh \
+  linux-sandbox.sh \
+  build-dry.sh \
   structured-attrs.sh \
-  fetchGit.sh \
-  fetchGitRefs.sh \
-  fetchGitSubmodules.sh \
-  fetchMercurial.sh \
-  signing.sh \
   shell.sh \
   brotli.sh \
   zstd.sh \
   compression-levels.sh \
-  pure-eval.sh \
-  check.sh \
-  plugins.sh \
-  search.sh \
   nix-copy-ssh.sh \
   post-hook.sh \
-  ca/post-hook.sh \
   function-trace.sh \
-  recursive.sh \
-  describe-stores.sh \
-  flakes.sh \
   flake-local-settings.sh \
-  flake-searching.sh \
-  flake-bundler.sh \
-  build.sh \
-  repl.sh ca/repl.sh \
-  ca/build.sh \
-  ca/build-with-garbage-path.sh \
-  ca/duplicate-realisation-in-closure.sh \
-  ca/substitute.sh \
-  ca/signatures.sh \
-  ca/nix-shell.sh \
-  ca/nix-run.sh \
-  ca/recursive.sh \
-  ca/concurrent-builds.sh \
-  ca/nix-copy.sh \
   eval-store.sh \
-  readfile-context.sh \
-  store-ping.sh \
+  why-depends.sh \
+  import-derivation.sh \
+  ca/import-derivation.sh \
   nix_path.sh \
-  why-depends.sh
-  # parallel.sh
+  case-hack.sh \
+  placeholders.sh \
+  ssh-relay.sh \
+  plugins.sh \
+  build.sh \
+  ca/nix-run.sh \
+  db-migration.sh \
+  nix-profile.sh \
+  pass-as-file.sh \
+  describe-stores.sh \
+  store-ping.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)
 	nix_tests += compute-levels.sh


### PR DESCRIPTION
The tests are scheduled in the order they appear, so running the long
ones first slightly improves the scheduling.

On my machine, this decreases the time of `make install` from 40s to 36s
