### PR TITLE
flakes: failing follows test case

### DIFF
--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -737,6 +737,7 @@ cat > $flakeFollowsB/flake.nix <<EOF
             url = "path:./flakeC";
             inputs.foobar.follows = "foobar";
         };
+	D.follows = "foobar/D";
     };
     outputs = { ... }: {};
 }
@@ -764,7 +765,9 @@ EOF
 cat > $flakeFollowsE/flake.nix <<EOF
 {
     description = "Flake E";
-    inputs = {};
+    inputs = {
+        D.url = "path:$flakeFollowsA/flakeD";
+    };
     outputs = { ... }: {};
 }
 EOF
@@ -789,6 +792,7 @@ diff <(echo "$newLock") <(echo "$oldLock")
 [[ $(jq -c .nodes.B.inputs.C $flakeFollowsA/flake.lock) = '"C"' ]]
 [[ $(jq -c .nodes.B.inputs.foobar $flakeFollowsA/flake.lock) = '["foobar"]' ]]
 [[ $(jq -c .nodes.C.inputs.foobar $flakeFollowsA/flake.lock) = '["B","foobar"]' ]]
+[[ $(jq -c .nodes.B.inputs.D $flakeFollowsA/flake.lock) = '["foobar","D"]' ]]
 
 # Ensure removing follows from flake.nix removes them from the lockfile
 


### PR DESCRIPTION
this is a bug report in the form of a failing test case

A has input B, B has input foobar, and 

- B: `inputs.D.follows = "foobar/D"`
- A: `inputs.B.inputs.foobar.follows` = "foobar"

Result:

`error: input 'B/D' follows a non-existent input 'B/foobar/D'`

Expected: `['foobar', 'D']`

Tested with v2.6.1 with #6036 cherry-picked, since master is giving me a `SIGBUS` right now.


