### PR TITLE
Fix `mkString` for empty `string_view`

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -805,7 +805,13 @@ LocalNoInline(void addErrorTrace(Error & e, const Pos & pos, const char * s, con
 
 void Value::mkString(std::string_view s)
 {
-    mkString(dupStringWithLen(s.data(), s.size()));
+    if (s.size() == 0) {
+        // s.data() may not be valid and we don't need to allocate.
+        mkString("");
+    }
+    else {
+        mkString(dupStringWithLen(s.data(), s.size()));
+    }
 }
 
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -842,7 +842,14 @@ void Value::mkStringMove(const char * s, const PathSet & context)
 
 void Value::mkPath(std::string_view s)
 {
-    mkPath(dupStringWithLen(s.data(), s.size()));
+    if (s.size() == 0) {
+        // Pathological, but better than crashing in dupStringWithLen, as
+        // s.data() may be null.
+        mkPath("");
+    }
+    else {
+        mkPath(dupStringWithLen(s.data(), s.size()));
+    }
 }
 
 


### PR DESCRIPTION
The crux of the problem is that the empty `string_view` is {`null`, `0`} and `dupStringWithLen` crashes on the `null`.

Discovered in the hercules-ci-cnix-store Haskell binding test suite, so _possibly_ not an issue in Nix itself _yet_.

This might also improve performance a bit, by not allocating empty strings.

I've had to change the name, because unlike a `dup`-function, it does not always allocate a new string anymore.
