### PR TITLE
fetchTree: Do not re-fetch paths already present + refactor

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -517,6 +517,14 @@ void EvalState::allowPath(const StorePath & storePath)
         allowedPaths->insert(store->toRealPath(storePath));
 }
 
+void EvalState::allowAndSetStorePathString(const StorePath &storePath, Value &v)
+{
+    allowPath(storePath);
+
+    auto path = store->printStorePath(storePath);
+    v.mkString(path, PathSet({path}));
+}
+
 Path EvalState::checkSourcePath(const Path & path_)
 {
     if (!allowedPaths) return path_;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -161,6 +161,9 @@ public:
        the real store path if `store` is a chroot store. */
     void allowPath(const StorePath & storePath);
 
+    /* Allow access to a store path and return it as a string. */
+    void allowAndSetStorePathString(const StorePath & storePath, Value &v);
+
     /* Check whether access to a path is allowed and throw an error if
        not. Otherwise return the canonicalised path. */
     Path checkSourcePath(const Path & path);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1919,20 +1919,15 @@ static void addPath(
         if (expectedHash)
             expectedStorePath = state.store->makeFixedOutputPath(method, *expectedHash, name);
 
-        Path dstPath;
         if (!expectedHash || !state.store->isValidPath(*expectedStorePath)) {
-            dstPath = state.store->printStorePath(settings.readOnlyMode
+            StorePath dstPath = settings.readOnlyMode
                 ? state.store->computeStorePathForPath(name, path, method, htSHA256, filter).first
-                : state.store->addToStore(name, path, method, htSHA256, filter, state.repair, refs));
-            if (expectedHash && expectedStorePath != state.store->parseStorePath(dstPath))
+                : state.store->addToStore(name, path, method, htSHA256, filter, state.repair, refs);
+            if (expectedHash && expectedStorePath != dstPath)
                 throw Error("store path mismatch in (possibly filtered) path added from '%s'", path);
+            state.allowAndSetStorePathString(dstPath, v);
         } else
-            dstPath = state.store->printStorePath(*expectedStorePath);
-
-        v.mkString(dstPath, {dstPath});
-
-        state.allowPath(dstPath);
-
+            state.allowAndSetStorePathString(*expectedStorePath, v);
     } catch (Error & e) {
         e.addTrace(pos, "while adding path '%s'", path);
         throw;

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -185,13 +185,6 @@ static void prim_fetchTree(EvalState & state, const Pos & pos, Value * * args, V
 // FIXME: document
 static RegisterPrimOp primop_fetchTree("fetchTree", 1, prim_fetchTree);
 
-static void setStorePath(EvalState &state, const StorePath &storePath, Value &v) {
-    state.allowPath(storePath);
-
-    auto path = state.store->printStorePath(storePath);
-    v.mkString(path, PathSet({path}));
-}
-
 static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
     const std::string & who, bool unpack, std::string name)
 {
@@ -248,7 +241,7 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
 
         auto validPaths = state.store->queryValidPaths({expectedPath}, NoSubstitute);
         if (!validPaths.empty()) {
-            setStorePath(state, expectedPath, v);
+            state.allowAndSetStorePathString(expectedPath, v);
             return;
         }
     }
@@ -267,7 +260,7 @@ static void fetch(EvalState & state, const Pos & pos, Value * * args, Value & v,
                 *url, expectedHash->to_string(Base32, true), hash.to_string(Base32, true));
     }
 
-    setStorePath(state, storePath, v);
+    state.allowAndSetStorePathString(storePath, v);
 }
 
 static void prim_fetchurl(EvalState & state, const Pos & pos, Value * * args, Value & v)

--- a/tests/fetchurl.sh
+++ b/tests/fetchurl.sh
@@ -9,6 +9,10 @@ outPath=$(nix-build -vvvvv --expr 'import <nix/fetchurl.nix>' --argstr url file:
 
 cmp $outPath fetchurl.sh
 
+# Do not re-fetch paths already present.
+outPath2=$(nix-build -vvvvv --expr 'import <nix/fetchurl.nix>' --argstr url file:///does-not-exist/must-remain-unused/fetchurl.sh --argstr sha256 $hash --no-out-link)
+test "$outPath" == "$outPath2"
+
 # Now using a base-64 hash.
 clearStore
 

--- a/tests/tarball.sh
+++ b/tests/tarball.sh
@@ -26,10 +26,14 @@ test_tarball() {
     nix-build -o $TEST_ROOT/result '<foo>' -I foo=file://$tarball
 
     nix-build -o $TEST_ROOT/result -E "import (fetchTarball file://$tarball)"
+    # Do not re-fetch paths already present
+    nix-build  -o $TEST_ROOT/result -E "import (fetchTarball { url = file:///does-not-exist/must-remain-unused/$tarball; sha256 = \"$hash\"; })"
 
     nix-build  -o $TEST_ROOT/result -E "import (fetchTree file://$tarball)"
     nix-build  -o $TEST_ROOT/result -E "import (fetchTree { type = \"tarball\"; url = file://$tarball; })"
     nix-build  -o $TEST_ROOT/result -E "import (fetchTree { type = \"tarball\"; url = file://$tarball; narHash = \"$hash\"; })"
+    # Do not re-fetch paths already present
+    nix-build  -o $TEST_ROOT/result -E "import (fetchTree { type = \"tarball\"; url = file:///does-not-exist/must-remain-unused/$tarball; narHash = \"$hash\"; })"
     nix-build  -o $TEST_ROOT/result -E "import (fetchTree { type = \"tarball\"; url = file://$tarball; narHash = \"sha256-xdKv2pq/IiwLSnBBJXW8hNowI4MrdZfW+SYqDQs7Tzc=\"; })" 2>&1 | grep 'NAR hash mismatch in input'
 
     nix-instantiate --strict --eval -E "!((import (fetchTree { type = \"tarball\"; url = file://$tarball; narHash = \"$hash\"; })) ? submodules)" >&2


### PR DESCRIPTION
When the expected path is already in the store, we don't need to re-fetch it.

This reduces the amount of fetching required when using flakes repeatedly and beyond the `tarball-ttl`. I believe this can be quite significant, especially as builtin fetchers run sequentially, blocking evaluation.

It is also a first step towards #4313 and a partial solution.