### PR TITLE
Fix temp dir variable in develop shell

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -282,7 +282,7 @@ struct Common : InstallableCommand, MixProfile
 
         out << "PATH=\"$PATH:$nix_saved_PATH\"\n";
 
-        out << "export NIX_BUILD_TOP=\"$(mktemp -d -t nix-shell.XXXXXX)\"\n";
+        out << "export NIX_BUILD_TOP=\"$(mktemp -d -t nix-shell.XXXXXX)/\"\n";
         for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})
             out << fmt("export %s=\"$NIX_BUILD_TOP\"\n", i);
 


### PR DESCRIPTION
Inside a `nix develop` shell nix commands that refer to a remote flake (that is not cached) construct a faulty tmp path (missing a `/`)

```
getting status of '/private/tmpnix-shell.cTvSGw': No such file or directory
```

should be
```
 '/private/tmp/nix-shell.cTvSGw'
              ^
```

This PR adds the trailing `/` back to `TMP*` variables inside the shell