### PR TITLE
tests: Fix the start of the daemon

### DIFF
--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -90,12 +90,18 @@ startDaemon() {
     # Start the daemon, wait for the socket to appear.  !!!
     # ‘nix-daemon’ should have an option to fork into the background.
     rm -f $NIX_DAEMON_SOCKET_PATH
-    PATH=$DAEMON_PATH nix daemon &
+    PATH=$DAEMON_PATH nix-daemon&
+    pidDaemon=$!
     for ((i = 0; i < 300; i++)); do
-        if [[ -S $NIX_DAEMON_SOCKET_PATH ]]; then break; fi
+        if [[ -S $NIX_DAEMON_SOCKET_PATH ]]; then
+          DAEMON_STARTED=1
+          break;
+        fi
         sleep 0.1
     done
-    pidDaemon=$!
+    if [[ -z ${DAEMON_STARTED+x} ]]; then
+      fail "Didn’t manage to start the daemon"
+    fi
     trap "killDaemon" EXIT
     export NIX_REMOTE=daemon
 }


### PR DESCRIPTION
- Make sure that it starts even without the `nix-command` xp feature
- Fail if it doesn’t manage to start

This fixes a 30s wait for every test in `init.sh` as the daemon couldn’t start, but the code was just waiting 30s and continuing as if everything was all right.
