### PR TITLE
Acknowledge that the macOS tests are flaky

### DIFF
--- a/mk/run_test.sh
+++ b/mk/run_test.sh
@@ -14,9 +14,27 @@ if [ -t 1 ]; then
     yellow="[33;1m"
     normal="[m"
 fi
-(cd tests && env ${TESTS_ENVIRONMENT} init.sh 2>/dev/null > /dev/null)
-log="$(cd $(dirname $1) && env ${TESTS_ENVIRONMENT} $(basename $1) 2>&1)"
-status=$?
+
+run_test () {
+    (cd tests && env ${TESTS_ENVIRONMENT} init.sh 2>/dev/null > /dev/null)
+    log="$(cd $(dirname $1) && env ${TESTS_ENVIRONMENT} $(basename $1) 2>&1)"
+    status=$?
+}
+
+run_test "$1"
+
+# Hack: Retry the test if it fails with “unexpected EOF reading a line” as these
+# appear randomly without anyone knowing why.
+# See https://github.com/NixOS/nix/issues/3605 for more info
+if [[ $status -ne 0 && $status -ne 99 && \
+    "$(uname)" == "Darwin" && \
+    "$log" =~ "unexpected EOF reading a line"
+]]; then
+    echo "$post_run_msg [${yellow}FAIL$normal] (possibly flaky, so will be retried)"
+    echo "$log" | sed 's/^/    /'
+    run_test "$1"
+fi
+
 if [ $status -eq 0 ]; then
   echo "$post_run_msg [${green}PASS$normal]"
 elif [ $status -eq 99 ]; then


### PR DESCRIPTION
Restart the tests (at most once) on `unexpected EOF` errors on OSX.

This is truly ugly, but might prevent half of the CI runs to fail because of <https://github.com/NixOS/nix/issues/3605>.

Since the tests aren’t restarted more than once, we’re still gonna encounter some failures due to that, which will serve as a reminder for the underlying issue (but withouth blocking everything)

/cc @edolstra @roberth