### PR TITLE
filterANSIEscapes: Ignore BEL character

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1412,7 +1412,7 @@ std::string filterANSIEscapes(const std::string & s, bool filterAll, unsigned in
             }
         }
 
-        else if (*i == '\r')
+        else if (*i == '\r' || *i == '\a')
             // do nothing for now
             i++;
 


### PR DESCRIPTION
GCC is not as good at music as it seems to think it is. Fixes #4546.