### PR TITLE
Add EvalState::coerceToStorePath() helper

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -468,10 +468,10 @@ std::vector<InstallableValue::DerivationInfo> InstallableAttrPath::toDerivations
 
     std::vector<DerivationInfo> res;
     for (auto & drvInfo : drvInfos) {
-        res.push_back({
-            state->store->parseStorePath(drvInfo.queryDrvPath()),
-            drvInfo.queryOutputName()
-        });
+        auto drvPath = drvInfo.queryDrvPath();
+        if (!drvPath)
+            throw Error("'%s' is not a derivation", what());
+        res.push_back({ *drvPath, drvInfo.queryOutputName() });
     }
 
     return res;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2058,6 +2058,18 @@ Path EvalState::coerceToPath(const Pos & pos, Value & v, PathSet & context)
 }
 
 
+StorePath EvalState::coerceToStorePath(const Pos & pos, Value & v, PathSet & context)
+{
+    auto path = coerceToString(pos, v, context, false, false).toOwned();
+    if (auto storePath = store->maybeParseStorePath(path))
+        return *storePath;
+    throw EvalError({
+        .msg = hintfmt("path '%1%' is not in the Nix store", path),
+        .errPos = pos
+    });
+}
+
+
 bool EvalState::eqValues(Value & v1, Value & v2)
 {
     forceValue(v1, noPos);

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -272,6 +272,9 @@ public:
        path.  Nothing is copied to the store. */
     Path coerceToPath(const Pos & pos, Value & v, PathSet & context);
 
+    /* Like coerceToPath, but the result must be a store path. */
+    StorePath coerceToStorePath(const Pos & pos, Value & v, PathSet & context);
+
 public:
 
     /* The base environment, containing the builtin functions and

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "eval.hh"
+#include "path.hh"
 
 #include <string>
 #include <map>
@@ -12,15 +13,15 @@ namespace nix {
 struct DrvInfo
 {
 public:
-    typedef std::map<std::string, Path> Outputs;
+    typedef std::map<std::string, StorePath> Outputs;
 
 private:
     EvalState * state;
 
     mutable std::string name;
     mutable std::string system;
-    mutable std::string drvPath;
-    mutable std::optional<std::string> outPath;
+    mutable std::optional<std::optional<StorePath>> drvPath;
+    mutable std::optional<StorePath> outPath;
     mutable std::string outputName;
     Outputs outputs;
 
@@ -41,8 +42,9 @@ public:
 
     std::string queryName() const;
     std::string querySystem() const;
-    std::string queryDrvPath() const;
-    std::string queryOutPath() const;
+    std::optional<StorePath> queryDrvPath() const;
+    StorePath requireDrvPath() const;
+    StorePath queryOutPath() const;
     std::string queryOutputName() const;
     /** Return the list of outputs. The "outputs to install" are determined by `meta.outputsToInstall`. */
     Outputs queryOutputs(bool onlyOutputsToInstall = false);
@@ -61,8 +63,8 @@ public:
     */
 
     void setName(const std::string & s) { name = s; }
-    void setDrvPath(const std::string & s) { drvPath = s; }
-    void setOutPath(const std::string & s) { outPath = s; }
+    void setDrvPath(StorePath path) { drvPath = {{std::move(path)}}; }
+    void setOutPath(StorePath path) { outPath = {{std::move(path)}}; }
 
     void setFailed() { failed = true; };
     bool hasFailed() { return failed; };

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -346,7 +346,7 @@ static void main_nix_build(int argc, char * * argv)
             throw UsageError("nix-shell requires a single derivation");
 
         auto & drvInfo = drvs.front();
-        auto drv = evalStore->derivationFromPath(evalStore->parseStorePath(drvInfo.queryDrvPath()));
+        auto drv = evalStore->derivationFromPath(drvInfo.requireDrvPath());
 
         std::vector<StorePathWithOutputs> pathsToBuild;
         RealisedPath::Set pathsToCopy;
@@ -369,7 +369,7 @@ static void main_nix_build(int argc, char * * argv)
                 if (!drv)
                     throw Error("the 'bashInteractive' attribute in <nixpkgs> did not evaluate to a derivation");
 
-                auto bashDrv = store->parseStorePath(drv->queryDrvPath());
+                auto bashDrv = drv->requireDrvPath();
                 pathsToBuild.push_back({bashDrv});
                 pathsToCopy.insert(bashDrv);
                 shellDrv = bashDrv;
@@ -458,10 +458,7 @@ static void main_nix_build(int argc, char * * argv)
                 }
             }
 
-            ParsedDerivation parsedDrv(
-                StorePath(store->parseStorePath(drvInfo.queryDrvPath())),
-                drv
-            );
+            ParsedDerivation parsedDrv(drvInfo.requireDrvPath(), drv);
 
             if (auto structAttrs = parsedDrv.prepareStructuredAttrs(*store, inputs)) {
                 auto json = structAttrs.value();
@@ -553,7 +550,7 @@ static void main_nix_build(int argc, char * * argv)
         std::map<StorePath, std::pair<size_t, StringSet>> drvMap;
 
         for (auto & drvInfo : drvs) {
-            auto drvPath = store->parseStorePath(drvInfo.queryDrvPath());
+            auto drvPath = drvInfo.requireDrvPath();
 
             auto outputName = drvInfo.queryOutputName();
             if (outputName == "")

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -953,7 +953,7 @@ static void queryJSON(Globals & globals, std::vector<DrvInfo> & elems, bool prin
 
 static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
 {
-    auto & store(*globals.state->store);
+    auto & store { *globals.state->store };
 
     Strings remaining;
     std::string attrPath;

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -38,8 +38,8 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
        exist already. */
     std::vector<StorePathWithOutputs> drvsToBuild;
     for (auto & i : elems)
-        if (i.queryDrvPath() != "")
-            drvsToBuild.push_back({state.store->parseStorePath(i.queryDrvPath())});
+        if (auto drvPath = i.queryDrvPath())
+            drvsToBuild.push_back({*drvPath});
 
     debug(format("building user environment dependencies"));
     state.store->buildPaths(
@@ -55,7 +55,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         /* Create a pseudo-derivation containing the name, system,
            output paths, and optionally the derivation path, as well
            as the meta attributes. */
-        Path drvPath = keepDerivations ? i.queryDrvPath() : "";
+        std::optional<StorePath> drvPath = keepDerivations ? i.queryDrvPath() : std::nullopt;
         DrvInfo::Outputs outputs = i.queryOutputs(true);
         StringSet metaNames = i.queryMetaNames();
 
@@ -66,9 +66,9 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         auto system = i.querySystem();
         if (!system.empty())
             attrs.alloc(state.sSystem).mkString(system);
-        attrs.alloc(state.sOutPath).mkString(i.queryOutPath());
-        if (drvPath != "")
-            attrs.alloc(state.sDrvPath).mkString(i.queryDrvPath());
+        attrs.alloc(state.sOutPath).mkString(state.store->printStorePath(i.queryOutPath()));
+        if (drvPath)
+            attrs.alloc(state.sDrvPath).mkString(state.store->printStorePath(*drvPath));
 
         // Copy each output meant for installation.
         auto & vOutputs = attrs.alloc(state.sOutputs);
@@ -76,15 +76,15 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         for (const auto & [m, j] : enumerate(outputs)) {
             (vOutputs.listElems()[m] = state.allocValue())->mkString(j.first);
             auto outputAttrs = state.buildBindings(2);
-            outputAttrs.alloc(state.sOutPath).mkString(j.second);
+            outputAttrs.alloc(state.sOutPath).mkString(state.store->printStorePath(j.second));
             attrs.alloc(j.first).mkAttrs(outputAttrs);
 
             /* This is only necessary when installing store paths, e.g.,
                `nix-env -i /nix/store/abcd...-foo'. */
-            state.store->addTempRoot(state.store->parseStorePath(j.second));
-            state.store->ensurePath(state.store->parseStorePath(j.second));
+            state.store->addTempRoot(j.second);
+            state.store->ensurePath(j.second);
 
-            references.insert(state.store->parseStorePath(j.second));
+            references.insert(j.second);
         }
 
         // Copy the meta attributes.
@@ -99,7 +99,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
 
         (manifest.listElems()[n++] = state.allocValue())->mkAttrs(attrs);
 
-        if (drvPath != "") references.insert(state.store->parseStorePath(drvPath));
+        if (drvPath) references.insert(*drvPath);
     }
 
     /* Also write a copy of the list of user environment elements to
@@ -132,9 +132,9 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
     state.forceValue(topLevel, [&]() { return topLevel.determinePos(noPos); });
     PathSet context;
     Attr & aDrvPath(*topLevel.attrs->find(state.sDrvPath));
-    auto topLevelDrv = state.store->parseStorePath(state.coerceToPath(*aDrvPath.pos, *aDrvPath.value, context));
+    auto topLevelDrv = state.coerceToStorePath(*aDrvPath.pos, *aDrvPath.value, context);
     Attr & aOutPath(*topLevel.attrs->find(state.sOutPath));
-    Path topLevelOut = state.coerceToPath(*aOutPath.pos, *aOutPath.value, context);
+    auto topLevelOut = state.coerceToStorePath(*aOutPath.pos, *aOutPath.value, context);
 
     /* Realise the resulting store expression. */
     debug("building user environment");
@@ -158,8 +158,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         }
 
         debug(format("switching to new user environment"));
-        Path generation = createGeneration(ref<LocalFSStore>(store2), profile,
-            store2->parseStorePath(topLevelOut));
+        Path generation = createGeneration(ref<LocalFSStore>(store2), profile, topLevelOut);
         switchLink(profile, generation);
     }
 

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -61,12 +61,13 @@ void processExpr(EvalState & state, const Strings & attrPaths,
             DrvInfos drvs;
             getDerivations(state, v, "", autoArgs, drvs, false);
             for (auto & i : drvs) {
-                Path drvPath = i.queryDrvPath();
+                auto drvPath = i.requireDrvPath();
+                auto drvPathS = state.store->printStorePath(drvPath);
 
                 /* What output do we want? */
                 std::string outputName = i.queryOutputName();
                 if (outputName == "")
-                    throw Error("derivation '%1%' lacks an 'outputName' attribute ", drvPath);
+                    throw Error("derivation '%1%' lacks an 'outputName' attribute", drvPathS);
 
                 if (gcRoot == "")
                     printGCWarning();
@@ -75,9 +76,9 @@ void processExpr(EvalState & state, const Strings & attrPaths,
                     if (++rootNr > 1) rootName += "-" + std::to_string(rootNr);
                     auto store2 = state.store.dynamic_pointer_cast<LocalFSStore>();
                     if (store2)
-                        drvPath = store2->addPermRoot(store2->parseStorePath(drvPath), rootName);
+                        drvPathS = store2->addPermRoot(drvPath, rootName);
                 }
-                std::cout << fmt("%s%s\n", drvPath, (outputName != "out" ? "!" + outputName : ""));
+                std::cout << fmt("%s%s\n", drvPathS, (outputName != "out" ? "!" + outputName : ""));
             }
         }
     }

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -97,13 +97,13 @@ struct CmdBundle : InstallableCommand
             throw Error("the bundler '%s' does not produce a derivation", bundler.what());
 
         PathSet context2;
-        StorePath drvPath = store->parseStorePath(evalState->coerceToPath(*attr1->pos, *attr1->value, context2));
+        auto drvPath = evalState->coerceToStorePath(*attr1->pos, *attr1->value, context2);
 
         auto attr2 = vRes->attrs->get(evalState->sOutPath);
         if (!attr2)
             throw Error("the bundler '%s' does not produce a derivation", bundler.what());
 
-        StorePath outPath = store->parseStorePath(evalState->coerceToPath(*attr2->pos, *attr2->value, context2));
+        auto outPath = evalState->coerceToStorePath(*attr2->pos, *attr2->value, context2);
 
         store->buildPaths({ DerivedPath::Built { drvPath } });
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -327,7 +327,7 @@ struct CmdFlakeCheck : FlakeCommand
                 if (!drvInfo)
                     throw Error("flake attribute '%s' is not a derivation", attrPath);
                 // FIXME: check meta attributes
-                return std::make_optional(store->parseStorePath(drvInfo->queryDrvPath()));
+                return drvInfo->queryDrvPath();
             } catch (Error & e) {
                 e.addTrace(pos, hintfmt("while checking the derivation '%s'", attrPath));
                 reportError(e);

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -126,7 +126,7 @@ struct ProfileManifest
 
             for (auto & drvInfo : drvInfos) {
                 ProfileElement element;
-                element.storePaths = {state.store->parseStorePath(drvInfo.queryOutPath())};
+                element.storePaths = {drvInfo.queryOutPath()};
                 elements.emplace_back(std::move(element));
             }
         }

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -384,13 +384,12 @@ StorePath NixRepl::getDerivationPath(Value & v) {
     auto drvInfo = getDerivation(*state, v, false);
     if (!drvInfo)
         throw Error("expression does not evaluate to a derivation, so I can't build it");
-    Path drvPathRaw = drvInfo->queryDrvPath();
-    if (drvPathRaw == "")
-        throw Error("expression did not evaluate to a valid derivation (no drv path)");
-    StorePath drvPath = state->store->parseStorePath(drvPathRaw);
-    if (!state->store->isValidPath(drvPath))
-        throw Error("expression did not evaluate to a valid derivation (invalid drv path)");
-    return drvPath;
+    auto drvPath = drvInfo->queryDrvPath();
+    if (!drvPath)
+        throw Error("expression did not evaluate to a valid derivation (no 'drvPath' attribute)");
+    if (!state->store->isValidPath(*drvPath))
+        throw Error("expression evaluated to invalid derivation '%s'", state->store->printStorePath(*drvPath));
+    return *drvPath;
 }
 
 
@@ -780,8 +779,11 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
             str << "«derivation ";
             Bindings::iterator i = v.attrs->find(state->sDrvPath);
             PathSet context;
-            Path drvPath = i != v.attrs->end() ? state->coerceToPath(*i->pos, *i->value, context) : "???";
-            str << drvPath << "»";
+            if (i != v.attrs->end())
+                str << state->store->printStorePath(state->coerceToStorePath(*i->pos, *i->value, context));
+            else
+                str << "???";
+            str << "»";
         }
 
         else if (maxDepth > 0) {


### PR DESCRIPTION
This is useful whenever we want to evaluate something to a store path (e.g. in `get-drvs.cc`).

Extracted from the lazy-trees branch (where we can require that a store path must come from a store source tree accessor).