### PR TITLE
nix-env: always print output names in JSON and XML

### DIFF
--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -13,7 +13,7 @@ namespace nix {
 struct DrvInfo
 {
 public:
-    typedef std::map<std::string, StorePath> Outputs;
+    typedef std::map<std::string, std::optional<StorePath>> Outputs;
 
 private:
     EvalState * state;
@@ -46,8 +46,9 @@ public:
     StorePath requireDrvPath() const;
     StorePath queryOutPath() const;
     std::string queryOutputName() const;
-    /** Return the list of outputs. The "outputs to install" are determined by `meta.outputsToInstall`. */
-    Outputs queryOutputs(bool onlyOutputsToInstall = false);
+    /** Return the unordered map of output names to (optional) output paths.
+     * The "outputs to install" are determined by `meta.outputsToInstall`. */
+    Outputs queryOutputs(bool withPaths = true, bool onlyOutputsToInstall = false);
 
     StringSet queryMetaNames();
     Value * queryMeta(const std::string & name);

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1057,6 +1057,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
     /* Print the desired columns, or XML output. */
     if (jsonOutput) {
         queryJSON(globals, elems, printOutPath, printMeta);
+        cout << '\n';
         return;
     }
 

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -56,7 +56,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
            output paths, and optionally the derivation path, as well
            as the meta attributes. */
         std::optional<StorePath> drvPath = keepDerivations ? i.queryDrvPath() : std::nullopt;
-        DrvInfo::Outputs outputs = i.queryOutputs(true);
+        DrvInfo::Outputs outputs = i.queryOutputs(true, true);
         StringSet metaNames = i.queryMetaNames();
 
         auto attrs = state.buildBindings(7 + outputs.size());
@@ -76,15 +76,15 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
         for (const auto & [m, j] : enumerate(outputs)) {
             (vOutputs.listElems()[m] = state.allocValue())->mkString(j.first);
             auto outputAttrs = state.buildBindings(2);
-            outputAttrs.alloc(state.sOutPath).mkString(state.store->printStorePath(j.second));
+            outputAttrs.alloc(state.sOutPath).mkString(state.store->printStorePath(*j.second));
             attrs.alloc(j.first).mkAttrs(outputAttrs);
 
             /* This is only necessary when installing store paths, e.g.,
                `nix-env -i /nix/store/abcd...-foo'. */
-            state.store->addTempRoot(j.second);
-            state.store->ensurePath(j.second);
+            state.store->addTempRoot(*j.second);
+            state.store->ensurePath(*j.second);
 
-            references.insert(j.second);
+            references.insert(*j.second);
         }
 
         // Copy the meta attributes.

--- a/tests/user-envs.sh
+++ b/tests/user-envs.sh
@@ -17,6 +17,16 @@ outPath10=$(nix-env -f ./user-envs.nix -qa --out-path --no-name '*' | grep foo-1
 drvPath10=$(nix-env -f ./user-envs.nix -qa --drv-path --no-name '*' | grep foo-1.0)
 [ -n "$outPath10" -a -n "$drvPath10" ]
 
+# Query with json
+nix-env -f ./user-envs.nix -qa --json | jq -e '.[] | select(.name == "bar-0.1") | [
+    .outputName == "out",
+    .outputs.out == null
+] | all'
+nix-env -f ./user-envs.nix -qa --json --out-path | jq -e '.[] | select(.name == "bar-0.1") | [
+    .outputName == "out",
+    (.outputs.out | test("'$NIX_STORE_DIR'.*-0\\.1"))
+] | all'
+
 # Query descriptions.
 nix-env -f ./user-envs.nix -qa '*' --description | grep -q silly
 rm -rf $HOME/.nix-defexpr


### PR DESCRIPTION
The current `--out-path` flag has two disadvantages when one is only concerned with querying the names of outputs:
- it requires evaluating every output's `outPath`, which takes significantly more resources and runs into more failures
- it destroys the information of the order of outputs so we can't tell which one is the main output

Added an `outputNames` field to the JSON output containing the ordered list of output names, and made the XML always contain `<output>` tags, only with a `path` attribute if `--out-path` is given.

Did not touch the column output.

cc @fzakaria 

The motivation is still https://github.com/NixOS/nixos-search/pull/419