### PR TITLE
nix build: add --print-out-paths flag

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -2,3 +2,6 @@
 
 * `nix repl` has a new build-'n-link (`:bl`) command that builds a derivation
   while creating GC root symlinks.
+
+* `nix build` has a new `--print-out-paths` flag to print the resulting output paths.
+  This matches the default behaviour of `nix-build`.

--- a/src/nix/build.md
+++ b/src/nix/build.md
@@ -25,6 +25,13 @@ R""(
   lrwxrwxrwx 1 … result-1 -> /nix/store/rkfrm0z6x6jmi7d3gsmma4j53h15mg33-cowsay-3.03+dfsg2
   ```
 
+* Build GNU Hello and print the resulting store path.
+
+  ```console
+  # nix build nixpkgs#hello --print-out-paths
+  /nix/store/v5sv61sszx301i0x6xysaqzla09nksnd-hello-2.10
+  ```
+
 * Build a specific output:
 
   ```console

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -34,6 +34,14 @@ outPath=$(readlink -f $TEST_ROOT/result)
 
 grep 'FOO BAR BAZ' $TEST_ROOT/machine0/$outPath
 
+testPrintOutPath=$(nix build -L -v -f $file --print-out-paths --max-jobs 0 \
+  --arg busybox $busybox \
+  --store $TEST_ROOT/machine0 \
+  --builders "$(join_by '; ' "${builders[@]}")"
+)
+
+[[ $testPrintOutPath =~ store.*build-remote ]]
+
 set -o pipefail
 
 # Ensure that input1 was built on store1 due to the required feature.


### PR DESCRIPTION
has the same functionality as default nix-build

$ nix-build . -A "bash" -A "bash.dev" -A "tinycc"
/nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12
/nix/store/c49i1ggnr5cc8gxmk9xm0cn961z104dn-bash-5.1-p12-dev
/nix/store/dbapb08862ajgaax3621fz8hly9fdah3-tcc-0.9.27+date=2022-01-11

$ nix-build . -A "bash"
/nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12

$ $HOME/nixgits/nix/result/bin/nix build "nixpkgs#bash" "nixpkgs#bash.dev" "nixpkgs#tinycc" --print-store-paths
/nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12
/nix/store/c49i1ggnr5cc8gxmk9xm0cn961z104dn-bash-5.1-p12-dev
/nix/store/dbapb08862ajgaax3621fz8hly9fdah3-tcc-0.9.27+date=2022-01-11

$ $HOME/nixgits/nix/result/bin/nix build "nixpkgs#bash" --print-store-paths
/nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12


Supersedes https://github.com/NixOS/nix/pull/2622
Closes https://github.com/NixOS/nix/issues/5601 https://github.com/NixOS/nix/issues/1930

view the first commit for code changes.

@Mic92 @makefu @mickours @domenkozar @fzakaria @tomberek @edolstra 

this was a really useful feature of `nix-build` and may be the reason why scripts haven't switched over to `nix build`
it would be really really useful to have this feature in `nix build`

one of my use cases
```bash
font=$(nix-build '<nixos>' -A liberation_ttf)/share/fonts/truetype/LiberationSans-Regular.ttf
mogrify -font $font -pointsize 50 -fill white -draw 'text 100,100'$COLOR /tmp/tmpcolor.png
```


i wasn't sure where to put the test so i just put it in the remote build test