### PR TITLE
nix: allow using --file - to read from stdin

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,1 +1,3 @@
 # Release X.Y (202?-??-??)
+
+* Various nix commands can now read expressions from stdin with `--file -`.

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -134,7 +134,9 @@ SourceExprCommand::SourceExprCommand()
     addFlag({
         .longName = "file",
         .shortName = 'f',
-        .description = "Interpret installables as attribute paths relative to the Nix expression stored in *file*.",
+        .description =
+            "Interpret installables as attribute paths relative to the Nix expression stored in *file*. "
+            "If *file* is the character -, then a Nix expression will be read from standard input.",
         .category = installablesCategory,
         .labels = {"file"},
         .handler = {&file},
@@ -695,7 +697,10 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
         auto state = getEvalState();
         auto vFile = state->allocValue();
 
-        if (file)
+        if (file == "-") {
+            auto e = state->parseStdin();
+            state->eval(e, *vFile);
+        } else if (file)
             state->evalFile(lookupFileArg(*state, *file), *vFile);
         else {
             auto e = state->parseExprFromString(*expr, absPath("."));

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -1,0 +1,5 @@
+{
+  int = 123;
+  str = "foo";
+  attr.foo = "bar";
+}

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -1,0 +1,29 @@
+source common.sh
+
+clearStore
+
+testStdinHeredoc=$(nix eval -f - <<EOF
+{
+  bar = 3 + 1;
+  foo = 2 + 2;
+}
+EOF
+)
+[[ $testStdinHeredoc == '{ bar = 4; foo = 4; }' ]]
+
+nix eval --expr 'assert 1 + 2 == 3; true'
+
+[[ $(nix eval int -f "./eval.nix") == 123 ]]
+[[ $(nix eval str -f "./eval.nix") == '"foo"' ]]
+[[ $(nix eval str --raw -f "./eval.nix") == 'foo' ]]
+[[ $(nix eval attr -f "./eval.nix") == '{ foo = "bar"; }' ]]
+[[ $(nix eval attr --json -f "./eval.nix") == '{"foo":"bar"}' ]]
+[[ $(nix eval int -f - < "./eval.nix") == 123 ]]
+
+
+nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
+[[ $(nix-instantiate -A int --eval "./eval.nix") == 123 ]]
+[[ $(nix-instantiate -A str --eval "./eval.nix") == '"foo"' ]]
+[[ $(nix-instantiate -A attr --eval "./eval.nix") == '{ foo = "bar"; }' ]]
+[[ $(nix-instantiate -A attr --eval --json "./eval.nix") == '{"foo":"bar"}' ]]
+[[ $(nix-instantiate -A int --eval - < "./eval.nix") == 123 ]]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -52,6 +52,7 @@ nix_tests = \
   build-remote-content-addressed-floating.sh \
   nar-access.sh \
   pure-eval.sh \
+  eval.sh \
   ca/post-hook.sh \
   repl.sh \
   ca/repl.sh \


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nix/pull/2583

`echo '{ foo = 1 + 1; }' | nix eval -f - foo`