### PR TITLE
Fix `nix build --dry-run` with CA derivations

### DIFF
--- a/src/libstore/derived-path.hh
+++ b/src/libstore/derived-path.hh
@@ -45,6 +45,7 @@ struct DerivedPathBuilt {
 
     std::string to_string(const Store & store) const;
     static DerivedPathBuilt parse(const Store & store, std::string_view);
+    nlohmann::json toJSON(ref<Store> store) const;
 };
 
 using _DerivedPathRaw = std::variant<
@@ -119,5 +120,6 @@ typedef std::vector<DerivedPath> DerivedPaths;
 typedef std::vector<BuiltPath> BuiltPaths;
 
 nlohmann::json derivedPathsWithHintsToJSON(const BuiltPaths & buildables, ref<Store> store);
+nlohmann::json derivedPathsToJSON(const DerivedPaths & , ref<Store> store);
 
 }

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -52,14 +52,25 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
 
     void run(ref<Store> store) override
     {
+        if (dryRun) {
+            std::vector<DerivedPath> pathsToBuild;
+
+            for (auto & i : installables) {
+                auto b = i->toDerivedPaths();
+                pathsToBuild.insert(pathsToBuild.end(), b.begin(), b.end());
+            }
+            printMissing(store, pathsToBuild, lvlError);
+            if (json)
+                logger->cout("%s", derivedPathsToJSON(pathsToBuild, store).dump());
+            return;
+        }
+
         auto buildables = Installable::build(
             getEvalStore(), store,
-            dryRun ? Realise::Derivation : Realise::Outputs,
+            Realise::Outputs,
             installables, buildMode);
 
         if (json) logger->cout("%s", derivedPathsWithHintsToJSON(buildables, store).dump());
-
-        if (dryRun) return;
 
         if (outLink != "")
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())

--- a/tests/build-dry.sh
+++ b/tests/build-dry.sh
@@ -50,3 +50,22 @@ nix build -f dependencies.nix -o $RESULT --dry-run
 nix build -f dependencies.nix -o $RESULT
 
 [[ -h $RESULT ]]
+
+###################################################
+# Check the JSON output
+clearStore
+clearCache
+
+RES=$(nix build -f dependencies.nix --dry-run --json)
+
+if [[ -z "$NIX_TESTS_CA_BY_DEFAULT" ]]; then
+    echo "$RES" | jq '.[0] | [
+        (.drvPath | test("'$NIX_STORE_DIR'.*\\.drv")),
+        (.outputs.out | test("'$NIX_STORE_DIR'"))
+    ] | all'
+else
+    echo "$RES" | jq '.[0] | [
+        (.drvPath | test("'$NIX_STORE_DIR'.*\\.drv")),
+        .outputs.out == null
+    ] | all'
+fi

--- a/tests/ca/build-dry.sh
+++ b/tests/ca/build-dry.sh
@@ -1,0 +1,6 @@
+source common.sh
+
+export NIX_TESTS_CA_BY_DEFAULT=1
+
+cd .. && source build-dry.sh
+


### PR DESCRIPTION
Don’t try and assume that we know the output paths when we’ve just built with `--dry-run`. Instead make `--dry-run` follow a different code path that won’t assume the knowledge of the output paths at all.

Fix #6275

cc @tomberek
