### PR TITLE
nix-daemon.socket.in: fix condition unit properties

### DIFF
--- a/misc/systemd/nix-daemon.socket.in
+++ b/misc/systemd/nix-daemon.socket.in
@@ -2,7 +2,10 @@
 Description=Nix Daemon Socket
 Before=multi-user.target
 RequiresMountsFor=@storedir@
-ConditionPathIsReadWrite=@localstatedir@/nix/daemon-socket
+# Skip activating nix-daemon.socket in case the socket already exists,
+# which is the case if we invoke a container and bind-mount the daemon
+# socket inside.
+ConditionPathExists=!@localstatedir@/nix/daemon-socket/socket
 
 [Socket]
 ListenStream=@localstatedir@/nix/daemon-socket/socket


### PR DESCRIPTION
nix-daemon.socket is used to socket-activate nix-daemon.service when
/nix/var/nix/daemon-socket/socket is accessed.

Having a ConditionPathIsReadWrite on the /nix/var/nix/daemon-socket
directory will cause systemd to just skip if it's not present yet.

> [  237.187747] systemd[1]: Nix Daemon Socket was skipped because of a failed condition check (ConditionPathIsReadWrite=/nix/var/nix/daemon-socket).

As it's the nix-daemon itself that creates this directory, we're in a
chicken-and-egg problem - as long as the folder isn't created,
nix-daemon won't start (as it's only socket-activated), and the socket
unit will get skipped, as the directory doesn't exist yet.

I think we don't actually want to skip starting the socket unit when the
directory doesn't exist yet.

This has surfaced in the systemd 250 bump (which probably did apply some
more rigid checks), where tests with containers that bind-mount
/nix/var/nix/daemon-socket started to fail.