### PR TITLE
gc: skip the processes own pid FIXES manually deleting paths

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -357,7 +357,7 @@ void LocalStore::findRuntimeRoots(Roots & roots, bool censor)
         auto storePathRegex = std::regex(quoteRegexChars(storeDir) + R"(/[0-9a-z]+[0-9a-zA-Z\+\-\._\?=]*)");
         while (errno = 0, ent = readdir(procDir.get())) {
             checkInterrupt();
-            if (std::regex_match(ent->d_name, digitsRegex)) {
+            if (std::regex_match(ent->d_name, digitsRegex) && ent->d_name != std::to_string(getpid())) {
                 readProcLink(fmt("/proc/%s/exe" ,ent->d_name), unchecked);
                 readProcLink(fmt("/proc/%s/cwd", ent->d_name), unchecked);
 


### PR DESCRIPTION
fixes manually deleting paths

nix store delete /nix/store/...-zlib-1.2.11-static
error: Cannot delete path '/nix/store/...-zlib-1.2.11-static' since it is still alive. To find out why, use: nix-store --query --roots

it failed due to the function finding itself using that path

Closes https://github.com/NixOS/nix/issues/6141 https://github.com/NixOS/nix/issues/6135


tested with
```nix
(self: super: {
  nixUnstable = super.nixUnstable.overrideAttrs (old: {
    patches = [
      (builtins.toFile "gc.patch" ''
        diff --git a/src/libstore/gc.cc b/src/libstore/gc.cc
        index f65fb1b2e..e25f3ba1f 100644
        --- a/src/libstore/gc.cc
        +++ b/src/libstore/gc.cc
        @@ -357,7 +357,7 @@ void LocalStore::findRuntimeRoots(Roots & roots, bool censor)
                 auto storePathRegex = std::regex(quoteRegexChars(storeDir) + R"(/[0-9a-z]+[0-9a-zA-Z\+\-\._\?=]*)");
                 while (errno = 0, ent = readdir(procDir.get())) {
                     checkInterrupt();
        -            if (std::regex_match(ent->d_name, digitsRegex)) {
        +            if (std::regex_match(ent->d_name, digitsRegex) && ent->d_name != std::to_string(getpid())) {
                         readProcLink(fmt("/proc/%s/exe" ,ent->d_name), unchecked);
                         readProcLink(fmt("/proc/%s/cwd", ent->d_name), unchecked);
                                                                                                                                                
      '')
    ];
  });
})
```