### PR TITLE
Fix sourcehut tags refs resolving

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -399,7 +399,9 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::string line;
         std::string id;
         while(getline(is, line)) {
-            std::regex pattern(ref_uri);
+            // Append $ to avoid partial name matches
+            std::regex pattern(fmt("%s$", ref_uri));
+
             if (std::regex_search(line, pattern)) {
                 id = line.substr(0, line.find('\t'));
                 break;

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -390,7 +390,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
 
             ref_uri = line.substr(ref_index+5, line.length()-1);
         } else
-            ref_uri = fmt("refs/heads/%s", ref);
+            ref_uri = fmt("refs/(heads|tags)/%s", ref);
 
         auto file = store->toRealPath(
             downloadFile(store, fmt("%s/info/refs", base_url), "source", false, headers).storePath);
@@ -399,9 +399,9 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::string line;
         std::string id;
         while(getline(is, line)) {
-            auto index = line.find(ref_uri);
-            if (index != std::string::npos) {
-                id = line.substr(0, index-1);
+            std::regex pattern(ref_uri);
+            if (std::regex_search(line, pattern)) {
+                id = line.substr(0, line.find('\t'));
                 break;
             }
         }

--- a/tests/sourcehut-flakes.nix
+++ b/tests/sourcehut-flakes.nix
@@ -59,7 +59,7 @@ let
       echo 'ref: refs/heads/master' > $out/HEAD
 
       mkdir -p $out/info
-      echo '${nixpkgs.rev} refs/heads/master' > $out/info/refs
+      echo -e '${nixpkgs.rev}\trefs/heads/master' > $out/info/refs
     '';
 
 in


### PR DESCRIPTION
Hey folks!

I just noticed an oversight with my [last PR](https://github.com/NixOS/nix/pull/5342). It seems that tags are listed differently on `info/refs` ([example](https://git.sr.ht/~misterio/nix-config/info/refs)) than branches are. This meant my ref resolving implementation worked for branches, but not for tags.

This PR fixes the issue by using regex to match both `refs/heads/ref-name` and `refs/tags/ref-name`.

It also fixes an issue with (unintended) partial matches (by matching until the end of the line). 