### PR TITLE
nix: allow whitespace characters before command in repl

### DIFF
--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -396,6 +396,7 @@ StorePath NixRepl::getDerivationPath(Value & v) {
 
 bool NixRepl::processLine(std::string line)
 {
+    line = trim(line);
     if (line == "") return true;
 
     _isInterrupted = false;


### PR DESCRIPTION
Before this change, processLine always uses the first character
as the start of the line. This cause whitespaces to matter at the
beginning of the line whereas it does not matter anywhere else.

This commit trims leading white spaces of the string line so that
subsequent operations can be performed on the string without explicitly
tracking starting and ending indices of the string.


Fixes https://github.com/NixOS/nix/issues/6269