### PR TITLE
nix edit: support kakoune

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -204,7 +204,8 @@ Strings editorFor(const Pos & pos)
     if (pos.line > 0 && (
         editor.find("emacs") != std::string::npos ||
         editor.find("nano") != std::string::npos ||
-        editor.find("vim") != std::string::npos))
+        editor.find("vim") != std::string::npos ||
+        editor.find("kak") != std::string::npos))
         args.push_back(fmt("+%d", pos.line));
     args.push_back(pos.file);
     return args;

--- a/src/nix/edit.md
+++ b/src/nix/edit.md
@@ -24,8 +24,8 @@ this attribute to the location of the definition of the
 `meta.description`, `version` or `name` derivation attributes.
 
 The editor to invoke is specified by the `EDITOR` environment
-variable. It defaults to `cat`. If the editor is `emacs`, `nano` or
-`vim`, it is passed the line number of the derivation using the
-argument `+<lineno>`.
+variable. It defaults to `cat`. If the editor is `emacs`, `nano`,
+`vim` or `kak`, it is passed the line number of the derivation using
+the argument `+<lineno>`.
 
 )""


### PR DESCRIPTION
An editor [kakoune](https://kakoune.org/) also accepts `+<lineno>` argument.

This PR updates "nix edit" command and passes `+<lineno>` argument when `EDITOR` is set `kak`.