### PR TITLE
Add builtins.fetchClosure

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,3 +1,6 @@
 # Release X.Y (202?-??-??)
 
 * Various nix commands can now read expressions from stdin with `--file -`.
+
+* `nix store make-content-addressable` has been renamed to `nix store
+  make-content-addressed`.

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -4,3 +4,10 @@
 
 * `nix store make-content-addressable` has been renamed to `nix store
   make-content-addressed`.
+
+* New builtin function `builtins.fetchClosure` that copies a closure
+  from a binary cache at evaluation time and rewrites it to
+  content-addressed form (if it isn't already). Like
+  `builtins.storePath`, this allows importing pre-built store paths;
+  the difference is that it doesn't require the user to configure
+  binary caches and trusted public keys.

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -7,17 +7,17 @@ static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args
 {
     state.forceAttrs(*args[0], pos);
 
-    std::optional<StorePath> storePath;
-    std::optional<std::string> from;
+    std::optional<std::string> fromStoreUrl;
+    std::optional<StorePath> fromPath;
 
     for (auto & attr : *args[0]->attrs) {
-        if (attr.name == "storePath") {
+        if (attr.name == "fromPath") {
             PathSet context;
-            storePath = state.coerceToStorePath(*attr.pos, *attr.value, context);
+            fromPath = state.coerceToStorePath(*attr.pos, *attr.value, context);
         }
 
-        else if (attr.name == "from")
-            from = state.forceStringNoCtx(*attr.value, *attr.pos);
+        else if (attr.name == "fromStore")
+            fromStoreUrl = state.forceStringNoCtx(*attr.value, *attr.pos);
 
         else
             throw Error({
@@ -26,36 +26,36 @@ static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args
             });
     }
 
-    if (!storePath)
+    if (!fromPath)
         throw Error({
-            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "storePath"),
+            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "fromPath"),
             .errPos = pos
         });
 
-    if (!from)
+    if (!fromStoreUrl)
         throw Error({
-            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "from"),
+            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "fromStore"),
             .errPos = pos
         });
 
     // FIXME: only allow some "trusted" store types (like BinaryCacheStore).
-    auto srcStore = openStore(*from);
+    auto fromStore = openStore(*fromStoreUrl);
 
-    copyClosure(*srcStore, *state.store, RealisedPath::Set { *storePath });
+    copyClosure(*fromStore, *state.store, RealisedPath::Set { *fromPath });
 
     /* In pure mode, require a CA path. */
     if (evalSettings.pureEval) {
-        auto info = state.store->queryPathInfo(*storePath);
+        auto info = state.store->queryPathInfo(*fromPath);
         if (!info->isContentAddressed(*state.store))
             throw Error({
                 .msg = hintfmt("in pure mode, 'fetchClosure' requires a content-addressed path, which '%s' isn't",
-                    state.store->printStorePath(*storePath)),
+                    state.store->printStorePath(*fromPath)),
                 .errPos = pos
             });
     }
 
-    auto storePathS = state.store->printStorePath(*storePath);
-    v.mkString(storePathS, {storePathS});
+    auto fromPathS = state.store->printStorePath(*fromPath);
+    v.mkString(fromPathS, {fromPathS});
 }
 
 static RegisterPrimOp primop_fetchClosure({

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -53,7 +53,9 @@ static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args
 
     auto parsedURL = parseURL(*fromStoreUrl);
 
-    if (parsedURL.scheme != "http" && parsedURL.scheme != "https")
+    if (parsedURL.scheme != "http" &&
+        parsedURL.scheme != "https" &&
+        !(getEnv("_NIX_IN_TEST").has_value() && parsedURL.scheme == "file"))
         throw Error({
             .msg = hintfmt("'fetchClosure' only supports http:// and https:// stores"),
             .errPos = pos

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -7,6 +7,8 @@ namespace nix {
 
 static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
+    settings.requireExperimentalFeature(Xp::FetchClosure);
+
     state.forceAttrs(*args[0], pos);
 
     std::optional<std::string> fromStoreUrl;

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -110,6 +110,39 @@ static RegisterPrimOp primop_fetchClosure({
     .name = "__fetchClosure",
     .args = {"args"},
     .doc = R"(
+      Fetch a Nix store closure from a binary cache, rewriting it into
+      content-addressed form. For example,
+
+      ```nix
+      builtins.fetchClosure {
+        fromStore = "https://cache.nixos.org";
+        fromPath = /nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1;
+        toPath = /nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1;
+      }
+      ```
+
+      fetches `/nix/store/r2jd...` from the specified binary cache,
+      and rewrites it into the content-addressed store path
+      `/nix/store/ldbh...`.
+
+      If `fromPath` is already content-addressed, or if you are
+      allowing impure evaluation (`--impure`), then `toPath` may be
+      omitted.
+
+      To find out the correct value for `toPath` given a `fromPath`,
+      you can use `nix store make-content-addressed`:
+
+      ```console
+      # nix store make-content-addressed /nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1
+      rewrote '/nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1' to '/nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1'
+      ```
+
+      This function is similar to `builtins.storePath` in that it
+      allows you to use a previously built store path in a Nix
+      expression. However, it is more reproducible because it requires
+      specifying a binary cache from which the path can be fetched.
+      Also, requiring a content-addressed final store path avoids the
+      need for users to configure binary cache public keys.
     )",
     .fun = prim_fetchClosure,
 });

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -1,0 +1,62 @@
+#include "primops.hh"
+#include "store-api.hh"
+
+namespace nix {
+
+static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args, Value & v)
+{
+    state.forceAttrs(*args[0], pos);
+
+    std::optional<StorePath> storePath;
+    std::optional<std::string> from;
+
+    for (auto & attr : *args[0]->attrs) {
+        if (attr.name == "storePath") {
+            PathSet context;
+            storePath = state.coerceToStorePath(*attr.pos, *attr.value, context);
+        }
+
+        else if (attr.name == "from")
+            from = state.forceStringNoCtx(*attr.value, *attr.pos);
+
+        else
+            throw Error({
+                .msg = hintfmt("attribute '%s' isn't supported in call to 'fetchClosure'", attr.name),
+                .errPos = pos
+            });
+    }
+
+    if (!storePath)
+        throw Error({
+            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "storePath"),
+            .errPos = pos
+        });
+
+    if (!from)
+        throw Error({
+            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "from"),
+            .errPos = pos
+        });
+
+    // FIXME: only allow some "trusted" store types (like BinaryCacheStore).
+    auto srcStore = openStore(*from);
+
+    copyClosure(*srcStore, *state.store, RealisedPath::Set { *storePath });
+
+    auto storePathS = state.store->printStorePath(*storePath);
+
+    v.mkString(storePathS, {storePathS});
+
+    // FIXME: in pure mode, require a CA path or a NAR hash of the
+    // top-level path.
+}
+
+static RegisterPrimOp primop_fetchClosure({
+    .name = "__fetchClosure",
+    .args = {"args"},
+    .doc = R"(
+    )",
+    .fun = prim_fetchClosure,
+});
+
+}

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -133,7 +133,7 @@ static RegisterPrimOp primop_fetchClosure({
       you can use `nix store make-content-addressed`:
 
       ```console
-      # nix store make-content-addressed /nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1
+      # nix store make-content-addressed --from https://cache.nixos.org /nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1
       rewrote '/nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1' to '/nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1'
       ```
 

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -1,5 +1,6 @@
 #include "primops.hh"
 #include "store-api.hh"
+#include "make-content-addressed.hh"
 
 namespace nix {
 
@@ -9,11 +10,22 @@ static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args
 
     std::optional<std::string> fromStoreUrl;
     std::optional<StorePath> fromPath;
+    bool toCA = false;
+    std::optional<StorePath> toPath;
 
     for (auto & attr : *args[0]->attrs) {
         if (attr.name == "fromPath") {
             PathSet context;
             fromPath = state.coerceToStorePath(*attr.pos, *attr.value, context);
+        }
+
+        else if (attr.name == "toPath") {
+            state.forceValue(*attr.value, *attr.pos);
+            toCA = true;
+            if (attr.value->type() != nString || attr.value->string.s != std::string("")) {
+                PathSet context;
+                toPath = state.coerceToStorePath(*attr.pos, *attr.value, context);
+            }
         }
 
         else if (attr.name == "fromStore")
@@ -41,21 +53,45 @@ static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args
     // FIXME: only allow some "trusted" store types (like BinaryCacheStore).
     auto fromStore = openStore(*fromStoreUrl);
 
-    copyClosure(*fromStore, *state.store, RealisedPath::Set { *fromPath });
+    if (toCA) {
+        auto remappings = makeContentAddressed(*fromStore, *state.store, { *fromPath });
+        auto i = remappings.find(*fromPath);
+        assert(i != remappings.end());
+        if (toPath && *toPath != i->second)
+            throw Error({
+                .msg = hintfmt("rewriting '%s' to content-addressed form yielded '%s', while '%s' was expected",
+                    state.store->printStorePath(*fromPath),
+                    state.store->printStorePath(i->second),
+                    state.store->printStorePath(*toPath)),
+                .errPos = pos
+            });
+        if (!toPath)
+            throw Error({
+                .msg = hintfmt(
+                    "rewriting '%s' to content-addressed form yielded '%s'; "
+                    "please set this in the 'toPath' attribute passed to 'fetchClosure'",
+                    state.store->printStorePath(*fromPath),
+                    state.store->printStorePath(i->second)),
+                .errPos = pos
+            });
+    } else {
+        copyClosure(*fromStore, *state.store, RealisedPath::Set { *fromPath });
+        toPath = fromPath;
+    }
 
     /* In pure mode, require a CA path. */
     if (evalSettings.pureEval) {
-        auto info = state.store->queryPathInfo(*fromPath);
+        auto info = state.store->queryPathInfo(*toPath);
         if (!info->isContentAddressed(*state.store))
             throw Error({
                 .msg = hintfmt("in pure mode, 'fetchClosure' requires a content-addressed path, which '%s' isn't",
-                    state.store->printStorePath(*fromPath)),
+                    state.store->printStorePath(*toPath)),
                 .errPos = pos
             });
     }
 
-    auto fromPathS = state.store->printStorePath(*fromPath);
-    v.mkString(fromPathS, {fromPathS});
+    auto toPathS = state.store->printStorePath(*toPath);
+    v.mkString(toPathS, {toPathS});
 }
 
 static RegisterPrimOp primop_fetchClosure({

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -145,7 +145,7 @@ static void fetchTree(
         if (!params.allowNameArgument)
             if (auto nameIter = attrs.find("name"); nameIter != attrs.end())
                 throw Error({
-                    .msg = hintfmt("attribute 'name' isn’t supported in call to 'fetchTree'"),
+                    .msg = hintfmt("attribute 'name' isn't supported in call to 'fetchTree'"),
                     .errPos = pos
                 });
 
@@ -329,7 +329,7 @@ static RegisterPrimOp primop_fetchTarball({
     .fun = prim_fetchTarball,
 });
 
-static void prim_fetchGit(EvalState &state, const Pos &pos, Value **args, Value &v)
+static void prim_fetchGit(EvalState & state, const Pos & pos, Value * * args, Value & v)
 {
     fetchTree(state, pos, args, v, "git", FetchTreeParams { .emptyRevFallback = true, .allowNameArgument = true });
 }

--- a/src/libstore/make-content-addressed.cc
+++ b/src/libstore/make-content-addressed.cc
@@ -1,0 +1,79 @@
+#include "make-content-addressed.hh"
+#include "references.hh"
+
+namespace nix {
+
+std::map<StorePath, StorePath> makeContentAddressed(
+    Store & srcStore,
+    Store & dstStore,
+    const StorePathSet & storePaths)
+{
+    // FIXME: use closure of storePaths.
+
+    auto paths = srcStore.topoSortPaths(storePaths);
+
+    std::reverse(paths.begin(), paths.end());
+
+    std::map<StorePath, StorePath> remappings;
+
+    for (auto & path : paths) {
+        auto pathS = srcStore.printStorePath(path);
+        auto oldInfo = srcStore.queryPathInfo(path);
+        std::string oldHashPart(path.hashPart());
+
+        StringSink sink;
+        srcStore.narFromPath(path, sink);
+
+        StringMap rewrites;
+
+        StorePathSet references;
+        bool hasSelfReference = false;
+        for (auto & ref : oldInfo->references) {
+            if (ref == path)
+                hasSelfReference = true;
+            else {
+                auto i = remappings.find(ref);
+                auto replacement = i != remappings.end() ? i->second : ref;
+                // FIXME: warn about unremapped paths?
+                if (replacement != ref)
+                    rewrites.insert_or_assign(srcStore.printStorePath(ref), srcStore.printStorePath(replacement));
+                references.insert(std::move(replacement));
+            }
+        }
+
+        sink.s = rewriteStrings(sink.s, rewrites);
+
+        HashModuloSink hashModuloSink(htSHA256, oldHashPart);
+        hashModuloSink(sink.s);
+
+        auto narHash = hashModuloSink.finish().first;
+
+        ValidPathInfo info {
+            dstStore.makeFixedOutputPath(FileIngestionMethod::Recursive, narHash, path.name(), references, hasSelfReference),
+            narHash,
+        };
+        info.references = std::move(references);
+        if (hasSelfReference) info.references.insert(info.path);
+        info.narSize = sink.s.size();
+        info.ca = FixedOutputHash {
+            .method = FileIngestionMethod::Recursive,
+            .hash = info.narHash,
+        };
+
+        printInfo("rewrote '%s' to '%s'", pathS, srcStore.printStorePath(info.path));
+
+        auto source = sinkToSource([&](Sink & nextSink) {
+            RewritingSink rsink2(oldHashPart, std::string(info.path.hashPart()), nextSink);
+            rsink2(sink.s);
+            rsink2.flush();
+        });
+
+        dstStore.addToStore(info, *source);
+
+        remappings.insert_or_assign(std::move(path), std::move(info.path));
+    }
+
+    return remappings;
+}
+
+}

--- a/src/libstore/make-content-addressed.cc
+++ b/src/libstore/make-content-addressed.cc
@@ -52,7 +52,7 @@ std::map<StorePath, StorePath> makeContentAddressed(
         auto dstPath = dstStore.makeFixedOutputPath(
             FileIngestionMethod::Recursive, narModuloHash, path.name(), references, hasSelfReference);
 
-        printInfo("rewroting '%s' to '%s'", pathS, srcStore.printStorePath(dstPath));
+        printInfo("rewriting '%s' to '%s'", pathS, srcStore.printStorePath(dstPath));
 
         StringSink sink2;
         RewritingSink rsink2(oldHashPart, std::string(dstPath.hashPart()), sink2);

--- a/src/libstore/make-content-addressed.hh
+++ b/src/libstore/make-content-addressed.hh
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "store-api.hh"
+
+namespace nix {
+
+std::map<StorePath, StorePath> makeContentAddressed(
+    Store & srcStore,
+    Store & dstStore,
+    const StorePathSet & storePaths);
+
+}

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -11,6 +11,7 @@ std::map<ExperimentalFeature, std::string> stringifiedXpFeatures = {
     { Xp::NixCommand, "nix-command" },
     { Xp::RecursiveNix, "recursive-nix" },
     { Xp::NoUrlLiterals, "no-url-literals" },
+    { Xp::FetchClosure, "fetch-closure" },
 };
 
 const std::optional<ExperimentalFeature> parseExperimentalFeature(const std::string_view & name)

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -19,7 +19,8 @@ enum struct ExperimentalFeature
     Flakes,
     NixCommand,
     RecursiveNix,
-    NoUrlLiterals
+    NoUrlLiterals,
+    FetchClosure,
 };
 
 /**

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -117,7 +117,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
         {"hash-path", {"hash", "path"}},
         {"ls-nar", {"nar", "ls"}},
         {"ls-store", {"store", "ls"}},
-        {"make-content-addressable", {"store", "make-content-addressable"}},
+        {"make-content-addressable", {"store", "make-content-addressed"}},
         {"optimise-store", {"store", "optimise"}},
         {"ping-store", {"store", "ping"}},
         {"sign-paths", {"store", "sign"}},

--- a/src/nix/make-content-addressed.cc
+++ b/src/nix/make-content-addressed.cc
@@ -6,9 +6,9 @@
 
 using namespace nix;
 
-struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
+struct CmdMakeContentAddressed : StorePathsCommand, MixJSON
 {
-    CmdMakeContentAddressable()
+    CmdMakeContentAddressed()
     {
         realiseMode = Realise::Outputs;
     }
@@ -21,7 +21,7 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
     std::string doc() override
     {
         return
-          #include "make-content-addressable.md"
+          #include "make-content-addressed.md"
           ;
     }
 
@@ -50,4 +50,4 @@ struct CmdMakeContentAddressable : StorePathsCommand, MixJSON
     }
 };
 
-static auto rCmdMakeContentAddressable = registerCommand2<CmdMakeContentAddressable>({"store", "make-content-addressable"});
+static auto rCmdMakeContentAddressed = registerCommand2<CmdMakeContentAddressed>({"store", "make-content-addressed"});

--- a/src/nix/make-content-addressed.md
+++ b/src/nix/make-content-addressed.md
@@ -5,7 +5,7 @@ R""(
 * Create a content-addressed representation of the closure of GNU Hello:
 
   ```console
-  # nix store make-content-addressable -r nixpkgs#hello
+  # nix store make-content-addressed nixpkgs#hello
   …
   rewrote '/nix/store/v5sv61sszx301i0x6xysaqzla09nksnd-hello-2.10' to '/nix/store/5skmmcb9svys5lj3kbsrjg7vf2irid63-hello-2.10'
   ```
@@ -29,7 +29,7 @@ R""(
   system closure:
 
   ```console
-  # nix store make-content-addressable -r /run/current-system
+  # nix store make-content-addressed /run/current-system
   ```
 
 # Description

--- a/tests/binary-cache.sh
+++ b/tests/binary-cache.sh
@@ -1,6 +1,6 @@
 source common.sh
 
-needLocalStore "“--no-require-sigs” can’t be used with the daemon"
+needLocalStore "'--no-require-sigs' can’t be used with the daemon"
 
 # We can produce drvs directly into the binary cache
 clearStore

--- a/tests/fetchClosure.sh
+++ b/tests/fetchClosure.sh
@@ -1,0 +1,57 @@
+source common.sh
+
+needLocalStore "'--no-require-sigs' can’t be used with the daemon"
+
+clearStore
+clearCacheCache
+
+# Initialize binary cache.
+nonCaPath=$(nix build --json --file ./dependencies.nix | jq -r .[].outputs.out)
+caPath=$(nix store make-content-addressed --json $nonCaPath | jq -r '.rewrites | map(.) | .[]')
+nix copy --to file://$cacheDir $nonCaPath
+
+# Test basic fetchClosure rewriting from non-CA to CA.
+clearStore
+
+[ ! -e $nonCaPath ]
+[ ! -e $caPath ]
+
+[[ $(nix eval -v --raw --expr "
+  builtins.fetchClosure {
+    fromStore = \"file://$cacheDir\";
+    fromPath = $nonCaPath;
+    toPath = $caPath;
+  }
+") = $caPath ]]
+
+[ ! -e $nonCaPath ]
+[ -e $caPath ]
+
+# In impure mode, we can use non-CA paths.
+[[ $(nix eval --raw --no-require-sigs --impure --expr "
+  builtins.fetchClosure {
+    fromStore = \"file://$cacheDir\";
+    fromPath = $nonCaPath;
+  }
+") = $nonCaPath ]]
+
+[ -e $nonCaPath ]
+
+# 'toPath' set to empty string should fail but print the expected path.
+nix eval -v --json --expr "
+  builtins.fetchClosure {
+    fromStore = \"file://$cacheDir\";
+    fromPath = $nonCaPath;
+    toPath = \"\";
+  }
+" 2>&1 | grep "error: rewriting.*$nonCaPath.*yielded.*$caPath"
+
+# If fromPath is CA, then toPath isn't needed.
+nix copy --to file://$cacheDir $caPath
+
+[[ $(nix eval -v --raw --expr "
+  builtins.fetchClosure {
+    fromStore = \"file://$cacheDir\";
+    fromPath = $caPath;
+  }
+") = $caPath ]]

--- a/tests/fetchClosure.sh
+++ b/tests/fetchClosure.sh
@@ -1,5 +1,6 @@
 source common.sh
 
+enableFeatures "fetch-closure"
 needLocalStore "'--no-require-sigs' can’t be used with the daemon"
 
 clearStore

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -96,7 +96,8 @@ nix_tests = \
   describe-stores.sh \
   nix-profile.sh \
   suggestions.sh \
-  store-ping.sh
+  store-ping.sh \
+  fetchClosure.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)
 	nix_tests += compute-levels.sh


### PR DESCRIPTION
This function allows fetching a previously built closure from a binary cache at evaluation time. For instance:
```
builtins.fetchClosure {
  fromStore = "https://cache.nixos.org";
  fromPath = /nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1;
  toPath = /nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1;
}
```
fetches `/nix/store/r2jd...` from the specified binary cache, and rewrites it into the content-addressed store path `/nix/store/ldbh...`. This is similar to `builtins.storePath` in that it allows you to use a previously built store path in a Nix expression. However, it is more reproducible because it requires specifying a binary cache from which the path can be fetched (so it's a better alternative to #5868). Also, requiring a content-addressed final store path avoids the need for users to configure binary cache public keys.

This PR also renames `nix store make-content-addressable` to `nix store make-content-addressed`, fixes #6300, and allows it to rewrite a closure from another store in one operation.