### PR TITLE
`nix eval`: Add option `--read-only`

### DIFF
--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -85,11 +85,12 @@ struct SourceExprCommand : virtual Args, MixFlakeOptions
 {
     std::optional<Path> file;
     std::optional<std::string> expr;
+    bool readOnlyMode = false;
 
     // FIXME: move this; not all commands (e.g. 'nix run') use it.
     OperateOn operateOn = OperateOn::Output;
 
-    SourceExprCommand();
+    SourceExprCommand(bool supportReadOnlyMode = false);
 
     std::vector<std::shared_ptr<Installable>> parseInstallables(
         ref<Store> store, std::vector<std::string> ss);
@@ -128,7 +129,7 @@ struct InstallableCommand : virtual Args, SourceExprCommand
 {
     std::shared_ptr<Installable> installable;
 
-    InstallableCommand();
+    InstallableCommand(bool supportReadOnlyMode = false);
 
     void prepare() override;
 

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -1,3 +1,4 @@
+#include "globals.hh"
 #include "installables.hh"
 #include "command.hh"
 #include "attr-path.hh"
@@ -129,7 +130,7 @@ MixFlakeOptions::MixFlakeOptions()
     });
 }
 
-SourceExprCommand::SourceExprCommand()
+SourceExprCommand::SourceExprCommand(bool supportReadOnlyMode)
 {
     addFlag({
         .longName = "file",
@@ -157,6 +158,17 @@ SourceExprCommand::SourceExprCommand()
         .category = installablesCategory,
         .handler = {&operateOn, OperateOn::Derivation},
     });
+
+    if (supportReadOnlyMode) {
+        addFlag({
+            .longName = "read-only",
+            .description =
+                "Do not instantiate each evaluated derivation. "
+                "This improves performance, but can cause errors when accessing "
+                "store paths of derivations during evaluation.",
+            .handler = {&readOnlyMode, true},
+        });
+    }
 }
 
 Strings SourceExprCommand::getDefaultFlakeAttrPaths()
@@ -687,6 +699,10 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
 {
     std::vector<std::shared_ptr<Installable>> result;
 
+    if (readOnlyMode) {
+        settings.readOnlyMode = true;
+    }
+
     if (file || expr) {
         if (file && expr)
             throw UsageError("'--file' and '--expr' are exclusive");
@@ -951,7 +967,8 @@ std::optional<FlakeRef> InstallablesCommand::getFlakeRefForCompletion()
     return parseFlakeRef(_installables.front(), absPath("."));
 }
 
-InstallableCommand::InstallableCommand()
+InstallableCommand::InstallableCommand(bool supportReadOnlyMode)
+    : SourceExprCommand(supportReadOnlyMode)
 {
     expectArgs({
         .label = "installable",

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -935,7 +935,7 @@ InstallablesCommand::InstallablesCommand()
 void InstallablesCommand::prepare()
 {
     if (_installables.empty() && useDefaultInstallables())
-        // FIXME: commands like "nix install" should not have a
+        // FIXME: commands like "nix profile install" should not have a
         // default, probably.
         _installables.push_back(".");
     installables = parseInstallables(getStore(), _installables);

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -16,7 +16,7 @@ struct CmdEval : MixJSON, InstallableCommand
     std::optional<std::string> apply;
     std::optional<Path> writeTo;
 
-    CmdEval()
+    CmdEval() : InstallableCommand(true /* supportReadOnlyMode */)
     {
         addFlag({
             .longName = "raw",


### PR DESCRIPTION
This option sets `Settings::readOnlyMode = true`.
Previously, eval'ing with `readOnlyMode` was only possible through `nix-instantiate --eval`. `readOnlyMode` is now also accessible to the `nix` command.

(Quick reminder: With `readOnlyMode = false` (the current default in `nix eval`), Nix instantiates each derivation whose output or drv path is referenced in the evaluation output; i.e. its `.drv` closure is copied to the store. This is required to support [Import From Derivation](https://nixos.wiki/wiki/Import_From_Derivation).)

`readOnlyMode` has the following advantages:

- Preventing unneeded writes to the store.

- Most importantly: Eval performance.
  Evaluation speed is a major bottleneck when developing or debugging NixOS system configurations.
  `nix eval`'ing a basic system takes ~40% more time [^1] compared to `nix eval --read-only` or `nix-instantiate --eval` (with warm caches).
  This issue has so far prevented me from moving my systems to flakes.
  (Using the much faster `nix-instantiate --eval` with flakes requires flake-compat and doesn't support pure evaluations.)

#### Todo
An optimized `nix eval` implementation would instantiate derivations only when they are accessed during evaluation (Import From Derivation).
In this case, `--read-only` would be obsolete and it could be removed.
Currently, `nix eval` serves as the `nix` CLI equivalent to `nix-instantiate` due to its implicit instantiation behavior.
To allow switching `nix eval` to a non-instantiating, optimized implementation in the future, this PR should also add explicit support for instantiating drvs to the `nix` CLI.
A possible choice is `nix build --derivation`. `--derivation` is currently a no-op when passed to `nix build` (`SourceExprCommand::operateOn` is unused).

#### Appendix

`nix eval nixpkgs#hello.outPath --apply builtins.unsafeDiscardStringContext` doesn't prevent the `hello` derivation from being instantiated, so this is no feasible workaround.

[^1]: You can verify this by running `./benchmark.sh nix_eval_vs_instantiate_eval` ([nix-benchmark](https://github.com/erikarvstedt/nix-benchmark)).
See also: #6309.

cc: @edolstra