### PR TITLE
ca: add sqlite index on `RealisationsRefs(realisationReference)`

### DIFF
--- a/src/libstore/ca-specific-schema.sql
+++ b/src/libstore/ca-specific-schema.sql
@@ -32,6 +32,8 @@ create table if not exists RealisationsRefs (
     foreign key (referrer) references Realisations(id) on delete cascade,
     foreign key (realisationReference) references Realisations(id) on delete restrict
 );
+-- used by deletion trigger
+create index if not exists IndexRealisationsRefsRealisationReference on RealisationsRefs(realisationReference);
 
 -- used by QueryRealisationReferences
 create index if not exists IndexRealisationsRefs on RealisationsRefs(referrer);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -152,6 +152,8 @@ void migrateCASchema(SQLite& db, Path schemaPath, AutoCloseFD& lockFd)
                     select id from Realisations where outputPath = old.id
                     );
                 end;
+                -- used by deletion trigger
+                create index if not exists IndexRealisationsRefsRealisationReference on RealisationsRefs(realisationReference);
             )");
             txn.commit();
         }

--- a/tests/build-remote-content-addressed-floating.sh
+++ b/tests/build-remote-content-addressed-floating.sh
@@ -2,7 +2,7 @@ source common.sh
 
 file=build-hook-ca-floating.nix
 
-enableFeatures "ca-derivations ca-references"
+enableFeatures "ca-derivations"
 
 CONTENT_ADDRESSED=true
 

--- a/tests/ca/common.sh
+++ b/tests/ca/common.sh
@@ -1,5 +1,5 @@
 source ../common.sh
 
-enableFeatures "ca-derivations ca-references"
+enableFeatures "ca-derivations"
 
 restartDaemon

--- a/tests/ca/selfref-gc.sh
+++ b/tests/ca/selfref-gc.sh
@@ -4,7 +4,7 @@ source common.sh
 
 requireDaemonNewerThan "2.4pre20210626"
 
-sed -i 's/experimental-features .*/& ca-derivations ca-references nix-command flakes/' "$NIX_CONF_DIR"/nix.conf
+enableFeatures "ca-derivations nix-command flakes"
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 cd ..

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -3,7 +3,7 @@ source common.sh
 clearStore
 clearProfiles
 
-enableFeatures "ca-derivations ca-references"
+enableFeatures "ca-derivations"
 restartDaemon
 
 # Make a flake.


### PR DESCRIPTION
Without the change any CA deletion triggers linear scan on large
RealisationsRefs table:

    sqlite>.eqp full
    sqlite> delete from RealisationsRefs where realisationReference IN ( select id from Realisations where outputPath = 1234567890 );
    QUERY PLAN
    |--SCAN RealisationsRefs
    `--LIST SUBQUERY 1
       `--SEARCH Realisations USING COVERING INDEX IndexRealisationsRefsOnOutputPath (outputPath=?)

With the change it gets turned into a lookup:

    sqlite> CREATE INDEX IndexRealisationsRefsRealisationReference on RealisationsRefs(realisationReference);
    sqlite> delete from RealisationsRefs where realisationReference IN ( select id from Realisations where outputPath = 1234567890 );
    QUERY PLAN
    |--SEARCH RealisationsRefs USING INDEX IndexRealisationsRefsRealisationReference (realisationReference=?)
    `--LIST SUBQUERY 1
       `--SEARCH Realisations USING COVERING INDEX IndexRealisationsRefsOnOutputPath (outputPath=?)