### PR TITLE
Gitignore or don’t create some build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ perl/Makefile.config
 
 /misc/systemd/nix-daemon.service
 /misc/systemd/nix-daemon.socket
+/misc/systemd/nix-daemon.conf
 /misc/upstart/nix-daemon.conf
 
 /src/resolve-system-dependencies/resolve-system-dependencies

--- a/tests/fetchPath.sh
+++ b/tests/fetchPath.sh
@@ -1,6 +1,6 @@
 source common.sh
 
-touch foo -t 202211111111
+touch $TEST_ROOT/foo -t 202211111111
 # We only check whether 2022-11-1* **:**:** is the last modified date since
 # `lastModified` is transformed into UTC in `builtins.fetchTarball`.
-[[ "$(nix eval --impure --raw --expr "(builtins.fetchTree \"path://$PWD/foo\").lastModifiedDate")" =~ 2022111.* ]]
+[[ "$(nix eval --impure --raw --expr "(builtins.fetchTree \"path://$TEST_ROOT/foo\").lastModifiedDate")" =~ 2022111.* ]]


### PR DESCRIPTION
The build creates a couple of files that aren’t gitignored (so the git worktree isn’t clean anymore after running `make install && make installcheck`.

Cleans that by
- Not creating a temporary test file in the worktree
- Gitignoring a build output that wasn’t
