### PR TITLE
libexpr: Throw the correct error in toJSON

### DIFF
--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -84,7 +84,8 @@ void printValueAsJSON(EvalState & state, bool strict,
                 .msg = hintfmt("cannot convert %1% to JSON", showType(v)),
                 .errPos = v.determinePos(pos)
             });
-            throw e.addTrace(pos, hintfmt("message for the trace"));
+            e.addTrace(pos, hintfmt("message for the trace"));
+            throw e;
     }
 }
 

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -9,10 +9,9 @@ namespace nix {
 
 const std::string nativeSystem = SYSTEM;
 
-BaseError & BaseError::addTrace(std::optional<ErrPos> e, hintformat hint)
+void BaseError::addTrace(std::optional<ErrPos> e, hintformat hint)
 {
     err.traces.push_front(Trace { .pos = e, .hint = hint });
-    return *this;
 }
 
 // c++ std::exception descendants must have a 'const char* what()' function.

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -175,12 +175,12 @@ public:
     const ErrorInfo & info() const { calcWhat(); return err; }
 
     template<typename... Args>
-    BaseError & addTrace(std::optional<ErrPos> e, const std::string & fs, const Args & ... args)
+    void addTrace(std::optional<ErrPos> e, const std::string & fs, const Args & ... args)
     {
-        return addTrace(e, hintfmt(fs, args...));
+        addTrace(e, hintfmt(fs, args...));
     }
 
-    BaseError & addTrace(std::optional<ErrPos> e, hintformat hint);
+    void addTrace(std::optional<ErrPos> e, hintformat hint);
 
     bool hasTrace() const { return !err.traces.empty(); }
 };


### PR DESCRIPTION
BaseError::addTrace(...) returns a BaseError, but we want to
throw a TypeError instead.

Fixes #6336.