### PR TITLE
add labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+"documentation":
+  - doc/manual/*
+  - src/nix/**/*.md
+
+"tests":
+  - tests/**/*

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,24 @@
+name: "Label PR"
+
+on:
+  pull_request_target:
+    types: [edited, opened, synchronize, reopened]
+
+# WARNING:
+# When extending this action, be aware that $GITHUB_TOKEN allows some write
+# access to the GitHub API. This means that it should not evaluate user input in
+# a way that allows code injection.
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'NixOS'
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        sync-labels: true


### PR DESCRIPTION
Automatically add labels to pull requests based on the files they touch.

If a label exists in Nixpkgs then use that instead of making a new one.

https://github.com/actions/labeler

