### PR TITLE
libutil: Fix restoring mount namespace

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1698,20 +1698,7 @@ void saveMountNamespace()
 #if __linux__
     static std::once_flag done;
     std::call_once(done, []() {
-#ifdef __GNU__
-        // getcwd allocating its return value is a GNU extension.
-        char *cwd = getcwd(NULL, 0);
-        if (cwd == NULL)
-#else
-        char cwd[PATH_MAX];
-        if (!getcwd(cwd, sizeof(cwd)))
-#endif
-            throw SysError("getting cwd");
-        savedCwd.emplace(cwd);
-#ifdef __GNU__
-        free(cwd);
-#endif
-
+        savedCwd = absPath(".");
         AutoCloseFD fd = open("/proc/self/ns/mnt", O_RDONLY);
         if (!fd)
             throw SysError("saving parent mount namespace");

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1709,13 +1709,11 @@ void restoreMountNamespace()
 {
 #if __linux__
     try {
-        AutoCloseFD fdSavedCwd = open("/proc/self/cwd", O_RDONLY);
-        if (!fdSavedCwd) {
-            throw SysError("saving cwd");
-        }
+        auto savedCwd = absPath(".");
+
         if (fdSavedMountNamespace && setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
             throw SysError("restoring parent mount namespace");
-        if (fdSavedCwd && fchdir(fdSavedCwd.get()) == -1) {
+        if (chdir(savedCwd.c_str()) == -1) {
             throw SysError("restoring cwd");
         }
     } catch (Error & e) {

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1717,11 +1717,11 @@ void restoreMountNamespace()
     try {
         if (fdSavedMountNamespace && setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
             throw SysError("restoring parent mount namespace");
+        if (fdSavedCwd && fchdir(fdSavedCwd.get()) == -1) {
+            throw SysError("restoring cwd");
+        }
     } catch (Error & e) {
         debug(e.msg());
-    }
-    if (fdSavedCwd && fchdir(fdSavedCwd.get()) == -1) {
-        throw SysError("restoring cwd");
     }
 #endif
 }


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/6083.

---

Authored by @aszlig in https://github.com/NixOS/nix/issues/6083. I'd like to see this fixed ASAP, so I'm submitting the PR and will take on the burden of resolving discussions and issues :)

Since aszlig also mentioned it may not be desirable to depend on `std::filesystem`, I looked around the codebase and reworked some of the `std::filesystem`-dependent stuff to use the "typical" `getcwd` and `chdir` functions in 7f5caaa7c0f151520d05d4662415ac09d4cf34b0. I'd honestly prefer to use aszlig's `std::filesystem` variant because it is much cleaner, but the choice is yours.

---

Also, re: aszlig's commit message:

```
The reason for the latter is because running Nix as root means that we
can directly access the store, which makes sure we use a filesystem
namespace to make the store writable. XXX - REWORD!
```

I'm reasonably convinced this is true, but would like somebody to confirm before I remove the `XXX - REWORD!` remark (which is just because [aszlig wasn't sure if it was true](https://github.com/NixOS/nix/issues/6083#issuecomment-1086095212)).