### PR TITLE
src/libstore/globals.hh: add option log-format

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -120,7 +120,7 @@ public:
         R"(
           The default log format to display when buuilding; options are `raw`,
           `raw-with-logs`, `internal-json`, `bar`, and `bar-with-logs`.  `bar`
-          refers to the progress bar showing the build progress."
+          refers to the progress bar showing the build progress.
         )"};
 
     MaxBuildJobsSetting maxBuildJobs{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -119,7 +119,7 @@ public:
     Setting<std::string> logFormat{this, "bar", "log-format",
         R"(
           The default log format to display when buuilding; options are `raw`,
-          `raw-with-logs`, `internal-json`, `bar`, and `bar-with-logs`.  'Bar'
+          `raw-with-logs`, `internal-json`, `bar`, and `bar-with-logs`.  `bar`
           refers to the progress bar showing the build progress."
         )"};
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -116,6 +116,13 @@ public:
         "The number of lines of the tail of "
         "the log to show if a build fails."};
 
+    Setting<std::string> logFormat{this, "bar", "log-format",
+        R"(
+          The default log format to display when buuilding; options are `raw`,
+          `raw-with-logs`, `internal-json`, `bar`, and `bar-with-logs`.  'Bar'
+          refers to the progress bar showing the build progress."
+        )"};
+
     MaxBuildJobsSetting maxBuildJobs{
         this, 1, "max-jobs",
         R"(

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -271,7 +271,7 @@ void mainWrapped(int argc, char * * argv)
 
     evalSettings.pureEval = true;
 
-    setLogFormat("bar");
+    setLogFormat(settings.logFormat);
     settings.verboseBuild = false;
     if (isatty(STDERR_FILENO)) {
         verbosity = lvlNotice;


### PR DESCRIPTION
This allows users to get the old `nix-build` behavior without having
to remember to pass the `-L` flag on every invocation of `nix build`.