### PR TITLE
src/libstore/globals.hh: documentation: no root needed if userns

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -406,10 +406,11 @@ public:
           not run in private network namespace to ensure they can access the
           network).
 
-          Currently, sandboxing only work on Linux and macOS. The use of a
-          sandbox requires that Nix is run as root (so you should use the
-          “build users” feature to perform the actual builds under different
-          users than root).
+          Currently, sandboxing only work on Linux and macOS. The use
+          of a sandbox requires that your system supports "user
+          namespaces" or else that Nix is run as root (so you should
+          use the “build users” feature to perform the actual builds
+          under different users than root).
 
           If this option is set to `relaxed`, then fixed-output derivations
           and derivations that have the `__noChroot` attribute set to `true`


### PR DESCRIPTION
On my Linux system with CONFIG_USER_NS=y and
/proc/sys/user/max_user_namespaces > 0, Nix is definitely doing
sandboxing.  I don't believe that giving root access to Nix is
required in order to get sandboxing in this case.