### PR TITLE
Allow `welcomeText` when checking a flake template

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -463,7 +463,7 @@ struct CmdFlakeCheck : FlakeCommand
 
                 for (auto & attr : *v.attrs) {
                     std::string name(attr.name);
-                    if (name != "path" && name != "description")
+                    if (name != "path" && name != "description" && name != "welcomeText")
                         throw Error("template '%s' has unsupported attribute '%s'", attrPath, name);
                 }
             } catch (Error & e) {

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -376,6 +376,9 @@ cat > $templatesDir/flake.nix <<EOF
       trivial = {
         path = ./trivial;
         description = "A trivial flake";
+        welcomeText = ''
+            Welcome to my trivial flake
+        '';
       };
       default = trivial;
     };


### PR DESCRIPTION
Fix https://github.com/NixOS/nix/issues/6321
