### PR TITLE
Add anchors to the nix.conf options in the manual

### DIFF
--- a/doc/manual/generate-options.nix
+++ b/doc/manual/generate-options.nix
@@ -6,7 +6,8 @@ options:
 concatStrings (map
   (name:
     let option = options.${name}; in
-    "  - `${name}`  \n\n"
+    "  - [`${name}`](#conf-${name})"
+    + "<p id=\"conf-${name}\"></p>\n\n"
     + concatStrings (map (s: "    ${s}\n") (splitLines option.description)) + "\n\n"
     + (if option.documentDefault
        then "    **Default:** " + (


### PR DESCRIPTION
For each `nix.conf` option, add an empty html node with a unique `id`
that can be used as an anchor target. Also make the name of the option
be a link to that target so that it’s easily discoverable.

We can’t rewrite the whole list as an html definition list like it’s
done for the builtins because these options also appear in a man page,
and the manpage renderer (lowdown) can’t render arbitrary html. But the
hack here allows to keep the manpage and have the links in the html
version.

Fix https://github.com/NixOS/nix/issues/5745
