### PR TITLE
fetchClosure: Don't allow URL query parameters

### DIFF
--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -61,6 +61,12 @@ static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args
             .errPos = pos
         });
 
+    if (!parsedURL.query.empty())
+        throw Error({
+            .msg = hintfmt("'fetchClosure' does not support URL query parameters (in '%s')", *fromStoreUrl),
+            .errPos = pos
+        });
+
     auto fromStore = openStore(parsedURL.to_string());
 
     if (toCA) {
@@ -87,7 +93,8 @@ static void prim_fetchClosure(EvalState & state, const Pos & pos, Value * * args
                 });
         }
     } else {
-        copyClosure(*fromStore, *state.store, RealisedPath::Set { *fromPath });
+        if (!state.store->isValidPath(*fromPath))
+            copyClosure(*fromStore, *state.store, RealisedPath::Set { *fromPath });
         toPath = fromPath;
     }
 

--- a/tests/fetchClosure.sh
+++ b/tests/fetchClosure.sh
@@ -56,3 +56,15 @@ nix copy --to file://$cacheDir $caPath
     fromPath = $caPath;
   }
 ") = $caPath ]]
+
+# Check that URL query parameters aren't allowed.
+clearStore
+narCache=$TEST_ROOT/nar-cache
+rm -rf $narCache
+(! nix eval -v --raw --expr "
+  builtins.fetchClosure {
+    fromStore = \"file://$cacheDir?local-nar-cache=$narCache\";
+    fromPath = $caPath;
+  }
+")
+(! [ -e $narCache ])


### PR DESCRIPTION
Allowing this is a potential security hole, since it allows the user to specify parameters like `local-nar-cache`.