### PR TITLE
Rename `nixosModule` to `nixosModules.default` consistent with other outputs

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -32,3 +32,11 @@
   paths. Like fixed-output derivations, impure derivations have access
   to the network. Only fixed-output derivations and impure derivations
   can depend on an impure derivation.
+
+* The `nixosModule` flake output attribute has been renamed consistent
+  with the `.default` renames in nix 2.7.
+
+  * `nixosModule` → `nixosModules.default`
+
+  As before, the old output will continue to work, but `nix flake check` will
+  issue a warning about it.

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -508,6 +508,7 @@ struct CmdFlakeCheck : FlakeCommand
                             name == "defaultBundler" ? "bundlers.<system>.default" :
                             name == "overlay" ? "overlays.default" :
                             name == "devShell" ? "devShells.<system>.default" :
+                            name == "nixosModule" ? "nixosModules.default" :
                             "";
                         if (replacement != "")
                             warn("flake output attribute '%s' is deprecated; use '%s' instead", name, replacement);


### PR DESCRIPTION
Following #6089 I couldn't see any particular reason why `nixosModule` should remain the only exception.

With this change:

* No flake outputs are singular anymore, they're all consistently plural.
* We are future-proof so that tools that operate on `default` outputs can rely on this being consistent throughout.
* Flake authors are subtly nudged to export all of their modules so that you don't need to awkwardly fish into the source via `import "${inputs.foo}/nixos-modules/foo.nix"` (or even more awkward things like `import "${inputs.foo}/nixos-modules/foo.nix" { flake = inputs.foo; }`).

I expect a common pattern for the the `default` nixosModule may be to import everything:

E.g.

```nix
{
  description = "Fancy Operating System";
  outputs = {
    nixosModules = rec {
      default = {
        imports = [
          moduleA
          moduleB
          moduleC
        ];
      };
      moduleA = import ./nixos-modules/module-a;
      moduleB = import ./nixos-modules/module-b;
      moduleC = import ./nixos-modules/module-c;
    };
  };
}
```

or

```nix
{
  description = "Fancy Operating System";
  outputs = {
    nixosModules = 
      let modules = import ./nixos-modules;
      in modules // {
        default = { imports = builtins.attrValues modules; };
      };
  };
}
```