### PR TITLE
don't assume that rev is a SHA1 hash

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -238,9 +238,18 @@ std::optional<std::string> Input::getRef() const
 
 std::optional<Hash> Input::getRev() const
 {
-    if (auto s = maybeGetStrAttr(attrs, "rev"))
-        return Hash::parseAny(*s, htSHA1);
-    return {};
+    std::optional<Hash> hash = {};
+
+    if (auto s = maybeGetStrAttr(attrs, "rev")) {
+        try {
+            hash = Hash::parseAnyPrefixed(*s);
+        } catch (BadHash &e) {
+            // Default to sha1 for backwards compatibility with existing flakes
+            hash = Hash::parseAny(*s, htSHA1);
+        }
+    }
+
+    return hash;
 }
 
 std::optional<uint64_t> Input::getRevCount() const

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -155,7 +155,7 @@ static std::pair<std::optional<HashType>, bool> getParsedTypeAndSRI(std::string_
 {
     bool isSRI = false;
 
-    // Parse the has type before the separater, if there was one.
+    // Parse the hash type before the separator, if there was one.
     std::optional<HashType> optParsedType;
     {
         auto hashRaw = splitPrefixTo(rest, ':');

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -93,13 +93,11 @@ public:
 
     std::string gitRev() const
     {
-        assert(type == htSHA1);
         return to_string(Base16, false);
     }
 
     std::string gitShortRev() const
     {
-        assert(type == htSHA1);
         return std::string(to_string(Base16, false), 0, 7);
     }
 


### PR DESCRIPTION
This was a problem when writing a fetcher that uses e.g. sha256 hashes
for revisions. This doesn't actually do anything new, but allows for
creating such fetchers in the future (perhaps when support for Git's
SHA256 object format gains more popularity).

fix #6368 