### PR TITLE
Remove unused "name" field from Error

### DIFF
--- a/src/libstore/build-result.hh
+++ b/src/libstore/build-result.hh
@@ -31,6 +31,8 @@ struct BuildResult
         ResolvesToAlreadyValid,
         NoSubstituters,
     } status = MiscFailure;
+
+    // FIXME: include entire ErrorInfo object.
     std::string errorMsg;
 
     std::string toString() const {

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -1371,8 +1371,7 @@ void DerivationGoal::done(
 {
     buildResult.status = status;
     if (ex)
-        // FIXME: strip: "error: "
-        buildResult.errorMsg = ex->what();
+        buildResult.errorMsg = fmt("%s", normaltxt(ex->info().msg));
     if (buildResult.status == BuildResult::TimedOut)
         worker.timedOut = true;
     if (buildResult.status == BuildResult::PermanentFailure)

--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -123,8 +123,6 @@ public:
 
     template<typename... Args>
     FileTransferError(FileTransfer::Error error, std::optional<std::string> response, const Args & ... args);
-
-    virtual const char* sname() const override { return "FileTransferError"; }
 };
 
 bool isUri(std::string_view s);

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -215,7 +215,6 @@ void handleSQLiteBusy(const SQLiteBusy & e)
     if (now > lastWarned + 10) {
         lastWarned = now;
         logWarning({
-            .name = "Sqlite busy",
             .msg = hintfmt(e.what())
         });
     }

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -21,12 +21,9 @@ const std::string & BaseError::calcWhat() const
     if (what_.has_value())
         return *what_;
     else {
-        err.name = sname();
-
         std::ostringstream oss;
         showErrorInfo(oss, err, loggerSettings.showTrace);
         what_ = oss.str();
-
         return *what_;
     }
 }

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -161,8 +161,6 @@ public:
         : err(e)
     { }
 
-    virtual const char* sname() const { return "BaseError"; }
-
 #ifdef EXCEPTION_NEEDS_THROW_SPEC
     ~BaseError() throw () { };
     const char * what() const throw () { return calcWhat().c_str(); }
@@ -189,7 +187,6 @@ public:
     {                                                   \
     public:                                             \
         using superClass::superClass;                   \
-        virtual const char* sname() const override { return #newClass; } \
     }
 
 MakeError(Error, BaseError);
@@ -209,8 +206,6 @@ public:
         auto hf = hintfmt(args...);
         err.msg = hintfmt("%1%: %2%", normaltxt(hf.str()), strerror(errNo));
     }
-
-    virtual const char* sname() const override { return "SysError"; }
 };
 
 }

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -109,7 +109,6 @@ struct Trace {
 
 struct ErrorInfo {
     Verbosity level;
-    std::string name; // FIXME: rename
     hintformat msg;
     std::optional<ErrPos> errPos;
     std::list<Trace> traces;

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -49,10 +49,6 @@ public:
     ExperimentalFeature missingFeature;
 
     MissingExperimentalFeature(ExperimentalFeature);
-    virtual const char * sname() const override
-    {
-        return "MissingExperimentalFeature";
-    }
 };
 
 }

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -357,7 +357,7 @@ Sink & operator << (Sink & sink, const Error & ex)
     sink
         << "Error"
         << info.level
-        << info.name
+        << "Error" // removed
         << info.msg.str()
         << 0 // FIXME: info.errPos
         << info.traces.size();
@@ -426,11 +426,10 @@ Error readError(Source & source)
     auto type = readString(source);
     assert(type == "Error");
     auto level = (Verbosity) readInt(source);
-    auto name = readString(source);
+    auto name = readString(source); // removed
     auto msg = readString(source);
     ErrorInfo info {
         .level = level,
-        .name = name,
         .msg = hintformat(std::move(format("%s") % msg)),
     };
     auto havePos = readNum<size_t>(source);


### PR DESCRIPTION
This also fixed the duplicate "error: error: ..." in build failures.