### PR TITLE
installer: ask for confirmation on multi-user install without systemd

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -423,6 +423,18 @@ EOF
         fi
     done
 
+    if [ "$(uname -s)" = "Linux" ] && [ ! -e /run/systemd/system ]; then
+        warning <<EOF
+We did not detect systemd on your system. With a multi-user install
+without systemd you will have to manually configure your init system to
+launch the Nix daemon after installation.
+EOF
+        if ! ui_confirm "Do you want to proceed with a multi-user installation?"; then
+            failure <<EOF
+You have aborted the installation.
+EOF
+        fi
+    fi
 }
 
 setup_report() {


### PR DESCRIPTION
On Linux a user can go through all the way through the multi-user install and find out at the end that they now have to manually configure their init system to launch the nix daemon.

I ran into this while on-boarding a new user using WSL2. I think that for a significant number of users the current behavior is not what they wanted. They might prefer a single-user install. Now they have to manually uninstall nix before they can go through the single-user install.

This introduces a confirmation dialog before the install in that specific situation to make sure that they want to proceed.

A few notes:
* Since the default behavior of `ui_confirm` is to accept the non-interactive behavior of installer does not change.
* The whole block of could alternatively live as a function in `scripts/multi-user-systemd-install.sh` as well with a corresponding empty function in the Darwin version.

See also: https://github.com/NixOS/nix/issues/4999#issuecomment-1064188080
This closes #4999 but rejecting it and closing that issue anyways would also be valid, since maybe other people disagree that this improves usability and the issue originally described there is actually solved already.

Please leave a thumbs up if you agree that this is an worthwhile improvement and a thumbs down if you disagree.