### PR TITLE
Save cwd fd instead of path

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1801,11 +1801,13 @@ void restoreMountNamespace()
 {
 #if __linux__
     try {
-        auto savedCwd = absPath(".");
-
+        AutoCloseFD fdSavedCwd = open("/proc/self/cwd", O_RDONLY);
+        if (!fdSavedCwd) {
+            throw SysError("saving cwd");
+        }
         if (fdSavedMountNamespace && setns(fdSavedMountNamespace.get(), CLONE_NEWNS) == -1)
             throw SysError("restoring parent mount namespace");
-        if (chdir(savedCwd.c_str()) == -1) {
+        if (fdSavedCwd && fchdir(fdSavedCwd.get()) == -1) {
             throw SysError("restoring cwd");
         }
     } catch (Error & e) {


### PR DESCRIPTION
This reverts commit 56009b2639dc878be11f94d096fae56ac14dcd1d.

---

Submitted as a draft at the behest of @Ericson2314.

Note that this does _not_ work, for some reason. See some of the discussion in #6348 for what went wrong (specifically, it appears to strip `/home/vin` from `/home/vin/workspace/vcs/nix` for some unknown reason).