### PR TITLE
fix: don't call functors in a flake fragment

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -204,7 +204,7 @@ void SourceExprCommand::completeInstallable(std::string_view prefix)
             prefix_ = "";
         }
 
-        auto [v, pos] = findAlongAttrPath(*state, prefix_, *autoArgs, root);
+        auto [v, pos] = findAlongAttrPath(*state, prefix_, *autoArgs, root, false);
         Value &v1(*v);
         state->forceValue(v1, pos);
         Value v2;
@@ -452,7 +452,7 @@ struct InstallableAttrPath : InstallableValue
 
     std::pair<Value *, Pos> toValue(EvalState & state) override
     {
-        auto [vRes, pos] = findAlongAttrPath(state, attrPath, *cmd.getAutoArgs(state), **v);
+        auto [vRes, pos] = findAlongAttrPath(state, attrPath, *cmd.getAutoArgs(state), **v, false);
         state.forceValue(*vRes, pos);
         return {vRes, pos};
     }
@@ -624,7 +624,7 @@ std::pair<Value *, Pos> InstallableFlake::toValue(EvalState & state)
 
     for (auto & attrPath : getActualAttrPaths()) {
         try {
-            auto [v, pos] = findAlongAttrPath(state, attrPath, *emptyArgs, *vOutputs);
+            auto [v, pos] = findAlongAttrPath(state, attrPath, *emptyArgs, *vOutputs, false);
             state.forceValue(*v, pos);
             return {v, pos};
         } catch (AttrPathNotFound & e) {

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -42,7 +42,7 @@ std::vector<Symbol> parseAttrPath(EvalState & state, std::string_view s)
 
 
 std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const std::string & attrPath,
-    Bindings & autoArgs, Value & vIn)
+    Bindings & autoArgs, Value & vIn, bool callFunctors)
 {
     Strings tokens = parseAttrPath(attrPath);
 
@@ -56,7 +56,7 @@ std::pair<Value *, Pos> findAlongAttrPath(EvalState & state, const std::string &
 
         /* Evaluate the expression. */
         Value * vNew = state.allocValue();
-        state.autoCallFunction(autoArgs, *v, *vNew);
+        state.autoCallFunction(autoArgs, *v, *vNew, callFunctors);
         v = vNew;
         state.forceValue(*v, noPos);
 

--- a/src/libexpr/attr-path.hh
+++ b/src/libexpr/attr-path.hh
@@ -14,7 +14,8 @@ std::pair<Value *, Pos> findAlongAttrPath(
     EvalState & state,
     const std::string & attrPath,
     Bindings & autoArgs,
-    Value & vIn);
+    Value & vIn,
+    bool callFunctors = true);
 
 /* Heuristic to find the filename and lineno or a nix value. */
 Pos findPackageFilename(EvalState & state, Value & v, std::string what);

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1513,13 +1513,13 @@ void EvalState::incrFunctionCall(ExprLambda * fun)
 }
 
 
-void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res)
+void EvalState::autoCallFunction(Bindings & args, Value & fun, Value & res, bool callFunctors)
 {
     auto pos = fun.determinePos(noPos);
 
     forceValue(fun, pos);
 
-    if (fun.type() == nAttrs) {
+    if (callFunctors && (fun.type() == nAttrs)) {
         auto found = fun.attrs->find(sFunctor);
         if (found != fun.attrs->end()) {
             Value * v = allocValue();

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -343,7 +343,7 @@ public:
 
     /* Automatically call a function for which each argument has a
        default value or has a binding in the `args' map. */
-    void autoCallFunction(Bindings & args, Value & fun, Value & res);
+    void autoCallFunction(Bindings & args, Value & fun, Value & res, bool callFunctors = true);
 
     /* Allocation primitives. */
     inline Value * allocValue();

--- a/tests/flake-functor.sh
+++ b/tests/flake-functor.sh
@@ -1,0 +1,23 @@
+source common.sh
+
+clearStore
+rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
+
+cp ./simple.nix ./simple.builder.sh ./config.nix $TEST_HOME
+
+cd $TEST_HOME
+
+cat <<EOF > flake.nix
+{
+    outputs = {self}: {
+      __functor = self: a: {};
+      packages.$system = {
+        default = import ./simple.nix;
+      };
+    };
+}
+EOF
+nix eval .#packages.$system.default --json
+
+clearStore
+

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -98,7 +98,8 @@ nix_tests = \
   suggestions.sh \
   store-ping.sh \
   fetchClosure.sh \
-  impure-derivations.sh
+  impure-derivations.sh \
+  flake-functor.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)
 	nix_tests += compute-levels.sh


### PR DESCRIPTION
- flake fragement evaluation is always hermetic
- calling a function underway is not only breaking things
  but also against that principle


This commit adds code path variant invokend on flake fragments that
abstains from auto-calling functions.
