### PR TITLE
nix-daemon.service: don't ignore sigpipe

### DIFF
--- a/misc/systemd/nix-daemon.service.in
+++ b/misc/systemd/nix-daemon.service.in
@@ -9,6 +9,8 @@ ConditionPathIsReadWrite=@localstatedir@/nix/daemon-socket
 [Service]
 ExecStart=@@bindir@/nix-daemon nix-daemon --daemon
 KillMode=process
+# https://github.com/NixOS/nix/issues/2803
+IgnoreSIGPIPE=no
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
to test this i removed the following lines from 
https://github.com/NixOS/nixpkgs/pull/151035/files#diff-989531da859adca1871d385292724e8e0c5b690758c7cd6188e47c869b2b9183R161-R163
and built busybox
additional context: https://lists.freedesktop.org/archives/systemd-devel/2014-August/021982.html

Closes https://github.com/NixOS/nix/issues/2803