### PR TITLE
doc: document nix.conf connect-timeout default

### DIFF
--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -31,7 +31,7 @@ struct FileTransferSettings : Config
         R"(
           The timeout (in seconds) for establishing connections in the
           binary cache substituter. It corresponds to `curl`’s
-          `--connect-timeout` option.
+          `--connect-timeout` option. The default 0 means no limit.
         )"};
 
     Setting<unsigned long> stalledDownloadTimeout{

--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -31,7 +31,7 @@ struct FileTransferSettings : Config
         R"(
           The timeout (in seconds) for establishing connections in the
           binary cache substituter. It corresponds to `curl`’s
-          `--connect-timeout` option. The default 0 means no limit.
+          `--connect-timeout` option. A value of 0 means no limit.
         )"};
 
     Setting<unsigned long> stalledDownloadTimeout{


### PR DESCRIPTION
Add note to `nix.conf` documentation and help message for `connect-timeout`, indicating the significance of the default value `0`.