### PR TITLE
Add .tgz as tarball extension in documentation

### DIFF
--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -177,8 +177,8 @@ Currently the `type` attribute can be one of the following:
   attribute `url`.
 
   In URL form, the schema must be `http://`, `https://` or `file://`
-  URLs and the extension must be `.zip`, `.tar`, `.tar.gz`, `.tar.xz`,
-  `.tar.bz2` or `.tar.zst`.
+  URLs and the extension must be `.zip`, `.tar`, `.tgz`, `.tar.gz`,
+  `.tar.xz`, `.tar.bz2` or `.tar.zst`.
 
 * `github`: A more efficient way to fetch repositories from
   GitHub. The following attributes are required:


### PR DESCRIPTION
Support for the `tgz` shorthand was added in 52f5fa948a4784b6a9b707770f4beee6a8674dee.