### PR TITLE
nix repl: make symlinks with the :bl command 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ perl/Makefile.config
 /tests/shell.drv
 /tests/config.nix
 /tests/ca/config.nix
+/tests/repl-result-out
 
 # /tests/lang/
 /tests/lang/*.out

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,1 +1,4 @@
 # Release X.Y (202?-??-??)
+
+* `nix repl` has a new build-'n-link (`:bl`) command that builds a derivation
+  while creating GC root symlinks.


### PR DESCRIPTION
Make a new `nix repl` command build-'n-link (`:bl`) command that creates GC root symlinks
in the working directory after building.

-----

Requested by ppepino [on the Matrix](https://matrix.to/#/!KqkRjyTEzAGRiZFBYT:nixos.org/$Tb32BS3rVE2BSULAX4sPm0h6CDewX2hClOTGzTC7gwM?via=nixos.org&via=matrix.org&via=nixos.dev).

~~I didn't choose to make it toggleable since yet another command seems
bloaty, so it's just *there* which might actually be a bit annoying, but
I guess I'll see what other people think (^:~~

```
ckie@cookiemonster ~/git/nix -> ./outputs/out/bin/nix repl
Welcome to Nix 2.6.0. Type :? for help.

nix-repl> :l <nixpkgs>
Added 16118 variables.

nix-repl> :b runCommand "hello" {} "echo hi > $out"

This derivation produced the following outputs:
  ./repl-result-out -> /nix/store/kidqq2acdpi05c4a9mlbg2baikmzik44-hello
[1 built, 0.0 MiB DL]
ckie@cookiemonster ~/git/nix -> cat ./repl-result-out
hi
```

**Release Notes**
Please include relevant [release notes](https://github.com/NixOS/nix/blob/master/doc/manual/src/release-notes/rl-next.md) as needed.

*Done*.


**Testing**

If this issue is a regression or something that should block release, please consider including a test either in the [testsuite](https://github.com/NixOS/nix/tree/master/tests) or as a [hydraJob]( https://github.com/NixOS/nix/blob/master/flake.nix#L396) so that it can be part of the [automatic checks](https://hydra.nixos.org/jobset/nix/master).

*N/A*.
