### PR TITLE
libstore: enable fuse in a sandbox

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1666,6 +1666,7 @@ void LocalDerivationGoal::runChild()
                 ss.push_back("/dev/null");
                 ss.push_back("/dev/random");
                 ss.push_back("/dev/tty");
+                ss.push_back("/dev/fuse");
                 ss.push_back("/dev/urandom");
                 ss.push_back("/dev/zero");
                 createSymlink("/proc/self/fd", chrootRootDir + "/dev/fd");

--- a/src/libstore/sandbox-defaults.sb
+++ b/src/libstore/sandbox-defaults.sb
@@ -69,6 +69,7 @@
        (literal "/dev/stdin")
        (literal "/dev/stdout")
        (literal "/dev/tty")
+       (literal "/dev/fuse")
        (literal "/dev/urandom")
        (literal "/dev/zero")
        (subpath "/dev/fd"))


### PR DESCRIPTION
WIP, not yet tested

I need fuse in a build sandbox, so I can merge build layers (just like docker does) in multi-layer builds.
This will open path to easier stage caching, and allow for disk space optimizations in many cases.