### PR TITLE
Add custom to_json and from_json functions for ExperimentalFeature

### DIFF
--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -58,4 +58,18 @@ std::ostream & operator <<(std::ostream & str, const ExperimentalFeature & featu
     return str << showExperimentalFeature(feature);
 }
 
+void to_json(nlohmann::json& j, const ExperimentalFeature& feature) {
+    j = showExperimentalFeature(feature);
+}
+
+void from_json(const nlohmann::json& j, ExperimentalFeature& feature) {
+    const std::string input = j;
+    const auto parsed = parseExperimentalFeature(input);
+
+    if (parsed.has_value())
+        feature = *parsed;
+    else
+        throw Error("Unknown experimental feature '%s' in JSON input", input);
+}
+
 }

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -51,4 +51,11 @@ public:
     MissingExperimentalFeature(ExperimentalFeature);
 };
 
+/**
+ * Semi-magic conversion to and from json.
+ * See the nlohmann/json readme for more details.
+ */
+void to_json(nlohmann::json&, const ExperimentalFeature&);
+void from_json(const nlohmann::json&, ExperimentalFeature&);
+
 }


### PR DESCRIPTION
Fixes #6424 

```
❯ ./outputs/out/bin/nix --experimental-features "nix-command flakes" show-config --json |
      jq .\"experimental-features\".value
[
  "flakes",
  "nix-command"
]



```

nix show-config --json was serializing experimental features as ints.
nlohmann::json will automatically use these definitions to serialize
and deserialize ExperimentalFeatures.

Strictly, we don't use the from_json instance yet, it's provided for
completeness and hopefully future use.