### PR TITLE
fmt: respect stdin

### DIFF
--- a/src/nix/fmt.cc
+++ b/src/nix/fmt.cc
@@ -36,7 +36,7 @@ struct CmdFmt : SourceExprCommand {
         Strings programArgs{app.program};
 
         // Propagate arguments from the CLI
-        if (args.empty()) {
+        if (args.empty() && isatty(STDIN_FILENO)) {
             // Format the current flake out of the box
             programArgs.push_back(".");
         } else {


### PR DESCRIPTION
Perhaps have the first conditional be `args.empty && isatty(STDIN_FILENO)`
```
cat file.nix | nix fmt
vs
cat file | nix run nixpkgs#nixfmt
cat file | nix run nixpkgs#alejandra
cat file | nix run nixpkgs#nixpkgs-fmt
```
I'd expect this to work in conjunction with https://github.com/NixOS/nix/pull/6270/files using `--file -`, but that would be bigger change.

Doesn't seem to be a way to say "just interpret stdin without adding it as an arg". Things like "/dev/stdin" and "/dev/fd/0" aren't working either.

Or would this be better solved in the formatters themselves or by checking for "-"? (turns out "-" is sometimes recommended by [POSIX](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html#tag_12_02)