### PR TITLE
Fix the error message in case of a missing realisation

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -831,8 +831,8 @@ std::vector<std::pair<std::shared_ptr<Installable>, BuiltPath>> Installable::bui
                                 auto realisation = store->queryRealisation(outputId);
                                 if (!realisation)
                                     throw Error(
-                                        "cannot operate on an output of unbuilt "
-                                        "content-addressed derivation '%s'",
+                                        "cannot operate on an output of the "
+                                        "unbuilt derivation '%s'",
                                         outputId.to_string());
                                 outputs.insert_or_assign(output, realisation->outPath);
                             } else {


### PR DESCRIPTION
Don’t say that the derivation is CA as it might happen on a non-ca derivation too.

Technically we could always recover _something_ for a purely input-addressed derivation (like we already do when the `ca-derivations` xp feature isn’t enabled), but it seems better to consistently fail − the end-result wouldn’t really make sense anyways in most cases.

Fix https://github.com/NixOS/nix/issues/6429

cc @mikepurvis
