### PR TITLE
Make the default SQLiteError constructor public

### DIFF
--- a/src/libstore/sqlite.hh
+++ b/src/libstore/sqlite.hh
@@ -106,9 +106,9 @@ struct SQLiteError : Error
         throw_(db, hintfmt(fs, args...));
     }
 
-protected:
-
     SQLiteError(const char *path, int errNo, int extendedErrNo, hintformat && hf);
+
+protected:
 
     template<typename... Args>
     SQLiteError(const char *path, int errNo, int extendedErrNo, const std::string & fs, const Args & ... args)


### PR DESCRIPTION
Otherwise the clang builds fail because the constructor of `SQLiteBusy` inherits it, `SQLiteError::_throw` tries to call it, which fails.

Strangely, gcc works fine with it. Not sure what the correct behavior is and who is buggy here, but either way, making it public is at the worst a reasonable workaround

cc @Ericson2314
