### PR TITLE
Move hiliteMatches into a separate header

### DIFF
--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -2,7 +2,6 @@
 
 #include <boost/format.hpp>
 #include <string>
-#include <regex>
 #include "ansicolor.hh"
 
 
@@ -154,16 +153,5 @@ inline hintformat hintfmt(std::string plain_string)
     // we won't be receiving any args in this case, so just print the original string
     return hintfmt("%s", normaltxt(plain_string));
 }
-
-/* Highlight all the given matches in the given string `s` by wrapping
-   them between `prefix` and `postfix`.
-
-   If some matches overlap, then their union will be wrapped rather
-   than the individual matches. */
-std::string hiliteMatches(
-    std::string_view s,
-    std::vector<std::smatch> matches,
-    std::string_view prefix,
-    std::string_view postfix);
 
 }

--- a/src/libutil/hilite.cc
+++ b/src/libutil/hilite.cc
@@ -1,6 +1,4 @@
-#include "fmt.hh"
-
-#include <regex>
+#include "hilite.hh"
 
 namespace nix {
 

--- a/src/libutil/hilite.hh
+++ b/src/libutil/hilite.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <regex>
+#include <vector>
+#include <string>
+
+namespace nix {
+
+/* Highlight all the given matches in the given string `s` by wrapping
+   them between `prefix` and `postfix`.
+
+   If some matches overlap, then their union will be wrapped rather
+   than the individual matches. */
+std::string hiliteMatches(
+    std::string_view s,
+    std::vector<std::smatch> matches,
+    std::string_view prefix,
+    std::string_view postfix);
+
+}

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -9,7 +9,7 @@
 #include "shared.hh"
 #include "eval-cache.hh"
 #include "attr-path.hh"
-#include "fmt.hh"
+#include "hilite.hh"
 
 #include <regex>
 #include <fstream>


### PR DESCRIPTION
This is mostly so that we don't `#include <regex>` everywhere (which adds quite a bit of compilation time).