### PR TITLE
docker: more params: extraPkgs, (trusted)Substituters and extraEnv

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -4,6 +4,7 @@
 , tag ? "latest"
 , channelName ? "nixpkgs"
 , channelURL ? "https://nixos.org/channels/nixpkgs-unstable"
+, extraPkgs ? []
 }:
 let
   defaultPkgs = with pkgs; [
@@ -23,7 +24,7 @@ let
     iana-etc
     git
     openssh
-  ];
+  ] ++ extraPkgs;
 
   users = {
 

--- a/docker.nix
+++ b/docker.nix
@@ -5,6 +5,8 @@
 , channelName ? "nixpkgs"
 , channelURL ? "https://nixos.org/channels/nixpkgs-unstable"
 , extraPkgs ? []
+, substituters ? []
+, trustedSubstituters ? []
 }:
 let
   defaultPkgs = with pkgs; [
@@ -126,8 +128,12 @@ let
     sandbox = "false";
     build-users-group = "nixbld";
     trusted-public-keys = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
-  };
-  nixConfContents = (lib.concatStringsSep "\n" (lib.mapAttrsFlatten (n: v: "${n} = ${v}") nixConf)) + "\n";
+  } // (if substituters == [] then {} else {
+    substituters = substituters;
+  }) // (if trustedSubstituters == [] then {} else {
+    trusted-substituters = trustedSubstituters;
+  });
+  nixConfContents = (lib.concatStringsSep "\n" (lib.mapAttrsFlatten (n: v: "${n} = ${toString v}") nixConf)) + "\n";
 
   baseSystem =
     let

--- a/docker.nix
+++ b/docker.nix
@@ -7,6 +7,7 @@
 , extraPkgs ? []
 , substituters ? []
 , trustedSubstituters ? []
+, extraEnv ? []
 }:
 let
   defaultPkgs = with pkgs; [
@@ -266,7 +267,7 @@ pkgs.dockerTools.buildLayeredImageWithNixDb {
       "GIT_SSL_CAINFO=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
       "NIX_SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
       "NIX_PATH=/nix/var/nix/profiles/per-user/root/channels:/root/.nix-defexpr/channels"
-    ];
+    ] ++ extraEnv;
   };
 
 }


### PR DESCRIPTION
This allows for users to build nix docker images tuned for their substituters, ca and custom packages.

For example, I would use it this way:
```nix
{ nixpkgs }:

let
  nixRepo = ./nix;
  # nixRepo = builtins.fetchTarball { ... };
  proxyChannelURL = "https://github.proxy/channel-nixos-21.11.tar.gz";
  substituterURL = "https://nixos-cache.proxy";
  myCa = ./ca.crt;
in 
(import (nixRepo + "/docker.nix") {
  pkgs = nixpkgs;
  channelURL = proxyChannelURL;
  extraPkgs = [ nixpkgs.nixops ];
  extraEnv = [
    "SSL_CERT_FILE=${myCa}"
    "GIT_SSL_CAINFO=${myCa}"
    "NIX_SSL_CERT_FILE=${myCa}"
  ];
  substituters = [ substituterURL ];
  trustedSubstituters = [ substituterURL ];
})
```