### PR TITLE
fix: builtins.toFile adds path to allowedPaths

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -2,3 +2,7 @@
 
 * `nix repl` has a new build-'n-link (`:bl`) command that builds a derivation
   while creating GC root symlinks.
+
+* The path produced by `builtins.toFile` is now allowed to be imported or read
+  even with restricted evaluation. Note that this will not work with a
+  read-only store.

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1798,15 +1798,16 @@ static void prim_toFile(EvalState & state, const Pos & pos, Value * * args, Valu
         refs.insert(state.store->parseStorePath(path));
     }
 
-    auto storePath = state.store->printStorePath(settings.readOnlyMode
+    auto storePath = settings.readOnlyMode
         ? state.store->computeStorePathForText(name, contents, refs)
-        : state.store->addTextToStore(name, contents, refs, state.repair));
+        : state.store->addTextToStore(name, contents, refs, state.repair);
 
     /* Note: we don't need to add `context' to the context of the
        result, since `storePath' itself has references to the paths
        used in args[1]. */
 
-    v.mkString(storePath, {storePath});
+    /* Add the output of this to the allowed paths. */
+    state.allowAndSetStorePathString(storePath, v);
 }
 
 static RegisterPrimOp primop_toFile({

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -20,6 +20,8 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 [[ $(nix eval attr --json -f "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix eval int -f - < "./eval.nix") == 123 ]]
 
+# Check if toFile can be utilized during restricted eval
+[[ $(nix eval --restrict-eval --expr 'import (builtins.toFile "source" "42")') == 42 ]]
 
 nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
 [[ $(nix-instantiate -A int --eval "./eval.nix") == 123 ]]


### PR DESCRIPTION
The produced path is then allowed be imported or utilized elsewhere:
```
assert (43 == import (builtins.toFile "source" "43")); "good"
```

This will still fail on read-only stores.

Can be used to implement "eval": Fixes https://github.com/NixOS/nix/issues/5211

Potential concerns:
- [ ] read-only stores
- [ ] distributed builds
- [ ] `--store /some/path` usage
- [ ] eval-store
- [ ] Hydra?
- [ ] interaction with lazy copy to store PR?