### PR TITLE
EvalCache: Use Symbol in more places

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -600,7 +600,7 @@ std::tuple<std::string, FlakeRef, InstallableValue::DerivationInfo> InstallableF
 
     auto drvInfo = DerivationInfo {
         std::move(drvPath),
-        attr->getAttr("outputName")->getString()
+        attr->getAttr(state->sOutputName)->getString()
     };
 
     return {attrPath, getLockedFlake()->flake.lockedRef, std::move(drvInfo)};

--- a/src/libexpr/eval-cache.hh
+++ b/src/libexpr/eval-cache.hh
@@ -96,9 +96,13 @@ public:
 
     Suggestions getSuggestionsForAttr(Symbol name);
 
-    std::shared_ptr<AttrCursor> maybeGetAttr(std::string_view name, bool forceErrors = false);
+    std::shared_ptr<AttrCursor> maybeGetAttr(Symbol name, bool forceErrors = false);
 
-    ref<AttrCursor> getAttr(std::string_view name, bool forceErrors = false);
+    std::shared_ptr<AttrCursor> maybeGetAttr(std::string_view name);
+
+    ref<AttrCursor> getAttr(Symbol name, bool forceErrors = false);
+
+    ref<AttrCursor> getAttr(std::string_view name);
 
     /* Get an attribute along a chain of attrsets. Note that this does
        not auto-call functors or functions. */

--- a/src/libexpr/eval-cache.hh
+++ b/src/libexpr/eval-cache.hh
@@ -51,7 +51,7 @@ struct missing_t {};
 struct misc_t {};
 struct failed_t {};
 typedef uint64_t AttrId;
-typedef std::pair<AttrId, std::string> AttrKey;
+typedef std::pair<AttrId, Symbol> AttrKey;
 typedef std::pair<std::string, NixStringContext> string_t;
 
 typedef std::variant<

--- a/src/libexpr/symbol-table.hh
+++ b/src/libexpr/symbol-table.hh
@@ -72,12 +72,14 @@ private:
     ChunkedVector<std::string, 8192> store{16};
 
 public:
+
     Symbol create(std::string_view s)
     {
         // Most symbols are looked up more than once, so we trade off insertion performance
         // for lookup performance.
         // TODO: could probably be done more efficiently with transparent Hash and Equals
         // on the original implementation using unordered_set
+        // FIXME: make this thread-safe.
         auto it = symbols.find(s);
         if (it != symbols.end()) return Symbol(it->second.second + 1);
 

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -85,9 +85,9 @@ UnresolvedApp Installable::toApp(EvalState & state)
 
     else if (type == "derivation") {
         auto drvPath = cursor->forceDerivation();
-        auto outPath = cursor->getAttr("outPath")->getString();
-        auto outputName = cursor->getAttr("outputName")->getString();
-        auto name = cursor->getAttr("name")->getString();
+        auto outPath = cursor->getAttr(state.sOutPath)->getString();
+        auto outputName = cursor->getAttr(state.sOutputName)->getString();
+        auto name = cursor->getAttr(state.sName)->getString();
         auto aPname = cursor->maybeGetAttr("pname");
         auto aMeta = cursor->maybeGetAttr("meta");
         auto aMainProgram = aMeta ? aMeta->maybeGetAttr("mainProgram") : nullptr;

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1012,7 +1012,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
                 auto showDerivation = [&]()
                 {
-                    auto name = visitor.getAttr("name")->getString();
+                    auto name = visitor.getAttr(state->sName)->getString();
                     if (json) {
                         std::optional<std::string> description;
                         if (auto aMeta = visitor.maybeGetAttr("meta")) {

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -156,7 +156,7 @@ struct CmdSearch : InstallableCommand, MixJSON
                     recurse();
 
                 else if (attrPathS[0] == "legacyPackages" && attrPath.size() > 2) {
-                    auto attr = cursor.maybeGetAttr("recurseForDerivations");
+                    auto attr = cursor.maybeGetAttr(state->sRecurseForDerivations);
                     if (attr && attr->getBool())
                         recurse();
                 }


### PR DESCRIPTION
This makes `AttrKey` and `getAttr()` use `Symbol` instead of a string.