### PR TITLE
Remove almost all noexcept annotations in src/libstore

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -68,7 +68,7 @@ void BinaryCacheStore::upsertFile(const std::string & path,
 }
 
 void BinaryCacheStore::getFile(const std::string & path,
-    Callback<std::optional<std::string>> callback) noexcept
+    Callback<std::optional<std::string>> callback)
 {
     try {
         callback(getFile(path));
@@ -354,7 +354,7 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
 }
 
 void BinaryCacheStore::queryPathInfoUncached(const StorePath & storePath,
-    Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
+    Callback<std::shared_ptr<const ValidPathInfo>> callback)
 {
     auto uri = getUri();
     auto storePathS = printStorePath(storePath);
@@ -449,7 +449,7 @@ StorePath BinaryCacheStore::addTextToStore(
 }
 
 void BinaryCacheStore::queryRealisationUncached(const DrvOutput & id,
-    Callback<std::shared_ptr<const Realisation>> callback) noexcept
+    Callback<std::shared_ptr<const Realisation>> callback)
 {
     auto outputInfoFilePath = realisationsPrefix + "/" + id.to_string() + ".doi";
 

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -68,7 +68,7 @@ public:
        the result. A subclass may implement this asynchronously. */
     virtual void getFile(
         const std::string & path,
-        Callback<std::optional<std::string>> callback) noexcept;
+        Callback<std::optional<std::string>> callback)
 
     std::optional<std::string> getFile(const std::string & path);
 
@@ -93,7 +93,7 @@ public:
     bool isValidPathUncached(const StorePath & path) override;
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback) override;
 
     std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override
     { unsupported("queryPathFromHashPart"); }
@@ -122,7 +122,7 @@ public:
     void registerDrvOutput(const Realisation & info) override;
 
     void queryRealisationUncached(const DrvOutput &,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept override;
+        Callback<std::shared_ptr<const Realisation>> callback) override;
 
     void narFromPath(const StorePath & path, Sink & sink) override;
 

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1161,7 +1161,7 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
     }
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override
+        Callback<std::shared_ptr<const ValidPathInfo>> callback) override
     {
         if (goal.isAllowed(path)) {
             try {
@@ -1253,7 +1253,7 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
     { throw Error("registerDrvOutput"); }
 
     void queryRealisationUncached(const DrvOutput & id,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept override
+        Callback<std::shared_ptr<const Realisation>> callback) override
     // XXX: This should probably be allowed if the realisation corresponds to
     // an allowed derivation
     {

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -27,7 +27,7 @@ struct DummyStore : public virtual DummyStoreConfig, public virtual Store
     }
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override
+        Callback<std::shared_ptr<const ValidPathInfo>> callback) override
     {
         callback(nullptr);
     }
@@ -54,7 +54,7 @@ struct DummyStore : public virtual DummyStoreConfig, public virtual Store
     { unsupported("narFromPath"); }
 
     void queryRealisationUncached(const DrvOutput &,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept override
+        Callback<std::shared_ptr<const Realisation>> callback) override
     { callback(nullptr); }
 };
 

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -159,7 +159,7 @@ protected:
     }
 
     void getFile(const std::string & path,
-        Callback<std::optional<std::string>> callback) noexcept override
+        Callback<std::optional<std::string>> callback) override
     {
         checkEnabled();
 

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -114,7 +114,7 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
     }
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override
+        Callback<std::shared_ptr<const ValidPathInfo>> callback) override
     {
         try {
             auto conn(connections->get());
@@ -377,7 +377,7 @@ public:
     }
 
     void queryRealisationUncached(const DrvOutput &,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept override
+        Callback<std::shared_ptr<const Realisation>> callback) override
     // TODO: Implement
     { unsupported("queryRealisation"); }
 };

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -872,7 +872,7 @@ uint64_t LocalStore::addValidPath(State & state,
 
 
 void LocalStore::queryPathInfoUncached(const StorePath & path,
-    Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
+    Callback<std::shared_ptr<const ValidPathInfo>> callback)
 {
     try {
         callback(retrySQLite<std::shared_ptr<const ValidPathInfo>>([&]() {
@@ -1873,7 +1873,7 @@ std::optional<const Realisation> LocalStore::queryRealisation_(
 }
 
 void LocalStore::queryRealisationUncached(const DrvOutput & id,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept
+        Callback<std::shared_ptr<const Realisation>> callback)
 {
     try {
         auto maybeRealisation

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -124,7 +124,7 @@ public:
     StorePathSet queryAllValidPaths() override;
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback) override;
 
     void queryReferrers(const StorePath & path, StorePathSet & referrers) override;
 
@@ -217,7 +217,7 @@ public:
     std::optional<const Realisation> queryRealisation_(State & state, const DrvOutput & id);
     std::optional<std::pair<int64_t, Realisation>> queryRealisationCore_(State & state, const DrvOutput & id);
     void queryRealisationUncached(const DrvOutput&,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept override;
+        Callback<std::shared_ptr<const Realisation>> callback) override;
 
     std::optional<std::string> getVersion() override;
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -435,7 +435,7 @@ void RemoteStore::querySubstitutablePathInfos(const StorePathCAMap & pathsMap, S
 
 
 void RemoteStore::queryPathInfoUncached(const StorePath & path,
-    Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
+    Callback<std::shared_ptr<const ValidPathInfo>> callback)
 {
     try {
         std::shared_ptr<const ValidPathInfo> info;
@@ -716,7 +716,7 @@ void RemoteStore::registerDrvOutput(const Realisation & info)
 }
 
 void RemoteStore::queryRealisationUncached(const DrvOutput & id,
-    Callback<std::shared_ptr<const Realisation>> callback) noexcept
+    Callback<std::shared_ptr<const Realisation>> callback)
 {
     auto conn(getConnection());
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -52,7 +52,7 @@ public:
     StorePathSet queryAllValidPaths() override;
 
     void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback) override;
 
     void queryReferrers(const StorePath & path, StorePathSet & referrers) override;
 
@@ -97,7 +97,7 @@ public:
     void registerDrvOutput(const Realisation & info) override;
 
     void queryRealisationUncached(const DrvOutput &,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept override;
+        Callback<std::shared_ptr<const Realisation>> callback) override;
 
     void buildPaths(const std::vector<DerivedPath> & paths, BuildMode buildMode, std::shared_ptr<Store> evalStore) override;
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -497,7 +497,7 @@ static bool goodStorePath(const StorePath & expected, const StorePath & actual)
 
 
 void Store::queryPathInfo(const StorePath & storePath,
-    Callback<ref<const ValidPathInfo>> callback) noexcept
+    Callback<ref<const ValidPathInfo>> callback)
 {
     auto hashPart = std::string(storePath.hashPart());
 
@@ -557,7 +557,7 @@ void Store::queryPathInfo(const StorePath & storePath,
 }
 
 void Store::queryRealisation(const DrvOutput & id,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept
+        Callback<std::shared_ptr<const Realisation>> callback)
 {
 
     try {

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -278,14 +278,14 @@ public:
 
     /* Asynchronous version of queryPathInfo(). */
     void queryPathInfo(const StorePath & path,
-        Callback<ref<const ValidPathInfo>> callback) noexcept;
+        Callback<ref<const ValidPathInfo>> callback);
 
     /* Query the information about a realisation. */
     std::shared_ptr<const Realisation> queryRealisation(const DrvOutput &);
 
     /* Asynchronous version of queryRealisation(). */
     void queryRealisation(const DrvOutput &,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept;
+        Callback<std::shared_ptr<const Realisation>> callback);
 
 
     /* Check whether the given valid path info is sufficiently attested, by
@@ -311,9 +311,9 @@ public:
 protected:
 
     virtual void queryPathInfoUncached(const StorePath & path,
-        Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept = 0;
+        Callback<std::shared_ptr<const ValidPathInfo>> callback) = 0;
     virtual void queryRealisationUncached(const DrvOutput &,
-        Callback<std::shared_ptr<const Realisation>> callback) noexcept = 0;
+        Callback<std::shared_ptr<const Realisation>> callback) = 0;
 
 public:
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/6445

The `checkEnabled` function can throw a `SubstituterDisabled`
exception and that function is used by `getFile`, so any
function that transitively uses `getFile` can throw an
exception.  This means that we need to remove the `noexcept`
annotations for most of the methods underneath `src/libstore`
since they are not correct.

Otherwise what happens is that a client will core dump when
a substituter dies because the `SubstituterDisabled` exception
cannot propagate up to the `tryNext` functions and will instead
terminate the program when it his a `noexcept` annotation in the
callstack.

It is possible that not all of these annotations needed to be removed
as there might be a few functions that don't transitively depend on
`getFile`.  However, rather than carefully audit which ones needed
the annotation or not I removed all of the annotations.  My reasoning
was that even if some `noexcept` annotations might be technically
correct right now, they might no longer hold after a refactor.

Also, as noted here:

https://github.com/NixOS/nix/issues/6445#issuecomment-1110780076

… we can rely on the fact that the `Callback::operator()` is marked
`noexcept` anyway.