### PR TITLE
local-derivation-goal.cc: seccomp filter for powerpc on powerpc64

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1529,6 +1529,11 @@ void setupSeccomp()
         seccomp_arch_add(ctx, SCMP_ARCH_ARM) != 0)
         printError("unable to add ARM seccomp architecture; this may result in spurious build failures if running 32-bit ARM processes");
 
+    /* big-endian only because seccomp does not support powerpcle (32-bit) */
+    if (nativeSystem == "powerpc64-linux" &&
+        seccomp_arch_add(ctx, SCMP_ARCH_PPC) != 0)
+        printError("unable to add powerpc64 (big endian) seccomp architecture");
+
     /* Prevent builders from creating setuid/setgid binaries. */
     for (int perm : { S_ISUID, S_ISGID }) {
         if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(chmod), 1,


### PR DESCRIPTION
This commit should allow 32-bit binaries to execute in sandboxed     builders on big-endian powerpc64.  Unfortunately I am not in a position to test this code due to the fact that all of my powerpc64 machines are running little-endian kernels.

There is no corresponding entry for "powerpcle" on powerpc64le because     seccomp does not support 32-bit little-endian powerpc.

Little-endian 32-bit powerpc is soemthing of an exotic curiosity.     Although most (all?) 32-bit powerpc processors can boot in either     endianness mode, no commerical software system was ever based on the     little-endian variant.  The Linux kernel does have some level of     support for it, mainly due to a few people who had been running Linux     on 32-bit powerpc chips and ran their systems little-endian in order     to get faster emulation of x86_32.
