### PR TITLE
local-derivation-goal.cc: enable seccomp filters for mips{32,64}

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1529,6 +1529,22 @@ void setupSeccomp()
         seccomp_arch_add(ctx, SCMP_ARCH_ARM) != 0)
         printError("unable to add ARM seccomp architecture; this may result in spurious build failures if running 32-bit ARM processes");
 
+    if (nativeSystem == "mips64-linux" &&
+        seccomp_arch_add(ctx, SCMP_ARCH_MIPS) != 0)
+        printError("unable to add mips seccomp architecture");
+
+    if (nativeSystem == "mips64-linux" &&
+        seccomp_arch_add(ctx, SCMP_ARCH_MIPS64N32) != 0)
+        printError("unable to add mips64-*abin32 seccomp architecture");
+
+    if (nativeSystem == "mips64el-linux" &&
+        seccomp_arch_add(ctx, SCMP_ARCH_MIPSEL) != 0)
+        printError("unable to add mipsel seccomp architecture");
+
+    if (nativeSystem == "mips64el-linux" &&
+        seccomp_arch_add(ctx, SCMP_ARCH_MIPSEL64N32) != 0)
+        printError("unable to add mips64el-*abin32 seccomp architecture");
+
     /* Prevent builders from creating setuid/setgid binaries. */
     for (int perm : { S_ISUID, S_ISGID }) {
         if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(chmod), 1,


### PR DESCRIPTION
This PR enables seccomp filters for the MIPS family (`mips{32,64}{el}`).

A mips64el Linux MIPS kernel can execute userspace code using any of    three ABIs:

```
      mips64el-linux-*abin64
      mips64el-linux-*abin32
        mipsel-linux-*
```

The first of these is the native 64-bit ABI, and the only ABI with    64-bit pointers; this is sometimes called "n64".  The last of these is    the old legacy 32-bit ABI, whose binaries can execute natively on    32-bit MIPS hardware; this is sometimes called "o32".

The second ABI, "n32" is essentially the 64-bit ABI with 32-bit    pointers and address space.  Hardware 64-bit integer/floating    arithmetic is still allowed, as well as the much larger mips64    register set and more-efficient calling convention.

Let's enable seccomp filters for all of these.  Likewise for big    endian (mips64-linux-*).