### PR TITLE
Add an owner check when searching for the flake root

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,3 +1,5 @@
 # Release X.Y (202?-??-??)
 
-- [`nix-channel`](../command-ref/nix-channel.md) now supports a `--list-generations` subcommand
+* When searching upwards for the root of the flake, Nix doesn’t consider
+  anything that’s not owned by the current user anymore as it’s a
+  security hazard.

--- a/flake.nix
+++ b/flake.nix
@@ -598,6 +598,8 @@
           ["i686-linux" "x86_64-linux"]
           (system: runNixOSTestFor system ./tests/nixos/setuid.nix);
 
+        tests.cve-2022-24765 = runNixOSTestFor "x86_64-linux" ./tests/nixos/cve-2022-24765.nix;
+
 
         # Make sure that nix-env still produces the exact same result
         # on a particular version of Nixpkgs.

--- a/tests/nixos/cve-2022-24765.nix
+++ b/tests/nixos/cve-2022-24765.nix
@@ -1,0 +1,64 @@
+{ lib, config, nixpkgs, ... }:
+
+let
+  pkgs = config.nodes.machine.nixpkgs.pkgs;
+
+  flakeDotNix = pkgs.writeTextFile {
+    name = "flake.nix";
+    destination = "/flake.nix";
+    text = ''
+      {
+        outputs = { self }: { foo = 1; };
+      }
+      '';
+    };
+in
+{
+  name = "cve-2022-24765";
+
+  nodes.machine =
+    { config, lib, pkgs, ... }:
+    {
+      virtualisation.writableStore = true;
+      virtualisation.additionalPaths = [ flakeDotNix ];
+      nix.settings.experimental-features = [ "nix-command" "flakes" ];
+      users.users.user1.isNormalUser = true;
+      users.users.user2.isNormalUser = true;
+    };
+
+  testScript = { nodes }: ''
+    # fmt: off
+    start_all()
+
+    # Evaluating a flake in the store. Should just work
+    machine.succeed('nix eval ${flakeDotNix}#foo')
+
+    # Create the following hierarchy:
+    #
+    # /flakeRoot (owned by `user1`)
+    #     /flake.nix (owned by `user1`)
+    #     /subdir (owned by `user2`)
+    #
+    machine.execute(r"""
+    mkdir -p /flakeRoot/subdir
+    chown -R user1 /flakeRoot
+    cp -r ${flakeDotNix}/flake.nix /flakeRoot
+    chown -R user2 /flakeRoot/subdir
+    """.strip())
+
+    # Evaluating `/flakeRoot#foo` should work even if we're not `user1` since
+    # we've specified the exact path
+    machine.succeed("su user1 -c 'nix eval /flakeRoot\#foo'")
+    machine.succeed("su user2 -c 'nix eval /flakeRoot\#foo'")
+    # But when we have to resort to searching upwards in the tree, then Nix
+    # should error out if we're not `user1` since the `flake.nix` isn't owned
+    # by us
+    machine.succeed("su user1 -c 'nix eval /flakeRoot/subdir\#foo'")
+    inSubdirStdout = machine.fail(
+      "su user2 -c 'nix eval /flakeRoot/subdir\#foo' 2>&1"
+    )
+    print(inSubdirStdout)
+    assert "owned by us" in inSubdirStdout
+  '';
+}
+


### PR DESCRIPTION
# Motivation

When searching up the filesystem for the root of the flake (the directory that contains the `flake.nix`), don’t go anywhere up if we encounter a directory owned by a different user, as otherwise this other user could craft an arbitrary flake, potentially causing bad stuff to happen (shouldn’t in most cases since all it could do is run sandboxed builds, but there’s probably a lot of edge-cases that would make this very undesirable).

This is to fix Nix’s equivalent of CVE-2022-24765

This check is intentionally not applied to the exact directory specified since:
1. It’s up to the user to not point to an untrusted input
2. In multi-user Nix installations, that would prevent from using a flake in the Nix store (since it’s owned by root and not the current user)

# Context

Fix #6408

# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [x] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [x] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).