### PR TITLE
WIP: installer: allow overriding nix user UID on darwin too

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -6,7 +6,7 @@ set -o pipefail
 readonly NIX_DAEMON_DEST=/Library/LaunchDaemons/org.nixos.nix-daemon.plist
 # create by default; set 0 to DIY, use a symlink, etc.
 readonly NIX_VOLUME_CREATE=${NIX_VOLUME_CREATE:-1} # now default
-NIX_FIRST_BUILD_UID="301"
+NIX_FIRST_BUILD_UID="${NIX_FIRST_BUILD_UID:-301}"
 NIX_BUILD_USER_NAME_TEMPLATE="_nixbld%d"
 
 # caution: may update times on / if not run as normal non-root user


### PR DESCRIPTION
Similar to f4d57aa490 ("installer: allow overriding nix user GID and
UIDs"), but for darwin.

(There's no corresponding *_GID in this script though, so skipping
that.)

Ref https://github.com/NixOS/nix/issues/6153.