### PR TITLE
Draft: `#! nix-shell -i bash` use bash from shell.nix

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -506,7 +506,7 @@ static void main_nix_build(int argc, char * * argv)
                 + structuredAttrsRC +
                 "\n[ -e $stdenv/setup ] && source $stdenv/setup; "
                 "%3%"
-                "PATH=%4%:\"$PATH\"; "
+                "%4%"
                 "SHELL=%5%; "
                 "BASH=%5%; "
                 "set +e; "
@@ -520,7 +520,7 @@ static void main_nix_build(int argc, char * * argv)
                 shellEscape(tmpDir),
                 (pure ? "" : "p=$PATH; "),
                 (pure ? "" : "PATH=$PATH:$p; unset p; "),
-                shellEscape(dirOf(*shell)),
+                (interactive && shell->substr(0, 1) == "/" ? "PATH=" + shellEscape(dirOf(*shell)) + ":\"$PATH\"; " : ""),
                 shellEscape(*shell),
                 (getenv("TZ") ? (std::string("export TZ=") + shellEscape(getenv("TZ")) + "; ") : ""),
                 envCommand);


### PR DESCRIPTION
When nix-shell is non-interactive, we don't need to make sure we launch
an interactive bash, and it's more important to get the pinned bash

I'm a little worried this will break https://github.com/NixOS/nixpkgs/issues/27493

@domenkozar (from that nixpkgs issue)

@edolstra @regnat (discussed the problem & solution earlier)

TODO:
- [ ] communicate better what is going on to the user. if they `unset NIX_PATH`, they still get a scary error message despite it not really being an issue in shebang mode.