### PR TITLE
[backport] libfetchers/git: hardcode `--git-dir`

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -23,11 +23,7 @@ const std::string gitInitialBranch = "__nix_dummy_branch";
 
 static std::string getGitDir()
 {
-    auto gitDir = getEnv("GIT_DIR");
-    if (!gitDir) {
-        return ".git";
-    }
-    return *gitDir;
+    return getEnv("GIT_DIR").value_or(".git");
 }
 
 static std::string readHead(const Path & path)


### PR DESCRIPTION
Backport #6440 and #6470 

Mostly trivial, but someone should check what I did about the `commonGitDir` hack that no longer exists in Nix master.

cc @Ma27 @thufschmitt