### PR TITLE
src/libutil/util.cc: add missing #include <nlohmann/json.hpp>

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -18,6 +18,7 @@
 
 #include <fcntl.h>
 #include <grp.h>
+#include <nlohmann/json.hpp>
 #include <pwd.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>


### PR DESCRIPTION
Without the change nix fails to build on Gentoo against nlohmann_json-3.10.5:

      CXX    src/libutil/util.o
    src/libutil/util.cc: In function ‘const json* nix::get(const json&, const string&)’:
    src/libutil/util.cc:1591:14: error: invalid use of incomplete type ‘const json’ {aka ‘const class nlohmann::basic_json<>’}
     1591 |     auto i = map.find(key);
          |              ^~~
    In file included from src/libutil/config.hh:7,
                     from src/libutil/logging.hh:5,
                     from src/libutil/util.hh:5,
                     from src/libutil/util.cc:1:
    /usr/include/nlohmann/json_fwd.hpp:40:7: note: declaration of ‘using json = class nlohmann::basic_json<>’ {aka ‘class nlohmann::basic_json<>’}
       40 | class basic_json;
          |       ^~~~~~~~~~
    src/libutil/util.cc:1592:14: error: invalid use of incomplete type ‘const json’ {aka ‘const class nlohmann::basic_json<>’}
     1592 |     if (i == map.end()) return nullptr;
          |              ^~~