### PR TITLE
'nix profile list' improvements

### DIFF
--- a/src/nix/profile-list.md
+++ b/src/nix/profile-list.md
@@ -6,26 +6,48 @@ R""(
 
   ```console
   # nix profile list
-  0 flake:nixpkgs#legacyPackages.x86_64-linux.spotify github:NixOS/nixpkgs/c23db78bbd474c4d0c5c3c551877523b4a50db06#legacyPackages.x86_64-linux.spotify /nix/store/akpdsid105phbbvknjsdh7hl4v3fhjkr-spotify-1.1.46.916.g416cacf1
-  1 flake:nixpkgs#legacyPackages.x86_64-linux.zoom-us github:NixOS/nixpkgs/c23db78bbd474c4d0c5c3c551877523b4a50db06#legacyPackages.x86_64-linux.zoom-us /nix/store/89pmjmbih5qpi7accgacd17ybpgp4xfm-zoom-us-5.4.53350.1027
-  2 flake:blender-bin#packages.x86_64-linux.default github:edolstra/nix-warez/d09d7eea893dcb162e89bc67f6dc1ced14abfc27?dir=blender#packages.x86_64-linux.default /nix/store/zfgralhqjnam662kqsgq6isjw8lhrflz-blender-bin-2.91.0
+  Index:              0
+  Flake attribute:    legacyPackages.x86_64-linux.gdb
+  Original flake URL: flake:nixpkgs
+  Locked flake URL:   github:NixOS/nixpkgs/7b38b03d76ab71bdc8dc325e3f6338d984cc35ca
+  Store paths:        /nix/store/indzcw5wvlhx6vwk7k4iq29q15chvr3d-gdb-11.1
+
+  Index:              1
+  Flake attribute:    packages.x86_64-linux.default
+  Original flake URL: flake:blender-bin
+  Locked flake URL:   github:edolstra/nix-warez/91f2ffee657bf834e4475865ae336e2379282d34?dir=blender
+  Store paths:        /nix/store/i798sxl3j40wpdi1rgf391id1b5klw7g-blender-bin-3.1.2
   ```
+
+  Note that you can unambiguously rebuild a package from a profile
+  through its locked flake URL and flake attribute, e.g.
+
+  ```console
+  # nix build github:edolstra/nix-warez/91f2ffee657bf834e4475865ae336e2379282d34?dir=blender#packages.x86_64-linux.default
+  ```
+
+  will build the package with index 1 shown above.
 
 # Description
 
 This command shows what packages are currently installed in a
-profile. The output consists of one line per package, with the
-following fields:
+profile. For each installed package, it shows the following
+information:
 
-* An integer that can be used to unambiguously identify the package in
-  invocations of `nix profile remove` and `nix profile upgrade`.
+* `Index`: An integer that can be used to unambiguously identify the
+  package in invocations of `nix profile remove` and `nix profile
+  upgrade`.
 
-* The original ("mutable") flake reference and output attribute path
-  used at installation time.
+* `Flake attribute`: The flake output attribute that provides the
+  package (e.g. `packages.x86_64-linux.hello`).
 
-* The immutable flake reference to which the mutable flake reference
-  was resolved.
+* `Original flake URL`: The original ("unlocked") flake reference
+  specified by the user when the package was first installed via `nix
+  profile install`.
 
-* The store path(s) of the package.
+* `Locked flake URL`: The locked flake reference to which the original
+  flake reference was resolved.
+
+* `Store paths`: The store path(s) of the package.
 
 )""

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -143,7 +143,7 @@ struct ProfileManifest
         }
     }
 
-    std::string toJSON(Store & store) const
+    nlohmann::json toJSON(Store & store) const
     {
         auto array = nlohmann::json::array();
         for (auto & element : elements) {
@@ -164,7 +164,7 @@ struct ProfileManifest
         nlohmann::json json;
         json["version"] = 2;
         json["elements"] = array;
-        return json.dump();
+        return json;
     }
 
     StorePath build(ref<Store> store)
@@ -184,7 +184,7 @@ struct ProfileManifest
 
         buildProfile(tempDir, std::move(pkgs));
 
-        writeFile(tempDir + "/manifest.json", toJSON(*store));
+        writeFile(tempDir + "/manifest.json", toJSON(*store).dump());
 
         /* Add the symlink tree to the store. */
         StringSink sink;
@@ -497,7 +497,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
     }
 };
 
-struct CmdProfileList : virtual EvalCommand, virtual StoreCommand, MixDefaultProfile
+struct CmdProfileList : virtual EvalCommand, virtual StoreCommand, MixDefaultProfile, MixJSON
 {
     std::string description() override
     {
@@ -515,18 +515,22 @@ struct CmdProfileList : virtual EvalCommand, virtual StoreCommand, MixDefaultPro
     {
         ProfileManifest manifest(*getEvalState(), *profile);
 
-        for (size_t i = 0; i < manifest.elements.size(); ++i) {
-            auto & element(manifest.elements[i]);
-            if (i) logger->cout("");
-            logger->cout("Index:              " ANSI_BOLD "%s" ANSI_NORMAL "%s",
-                i,
-                element.active ? "" : " " ANSI_RED "(inactive)" ANSI_NORMAL);
-            if (element.source) {
-                logger->cout("Flake attribute:    %s%s", element.source->attrPath, printOutputsSpec(element.source->outputs));
-                logger->cout("Original flake URL: %s", element.source->originalRef.to_string());
-                logger->cout("Locked flake URL:   %s", element.source->lockedRef.to_string());
+        if (json) {
+            std::cout << manifest.toJSON(*store).dump() << "\n";
+        } else {
+            for (size_t i = 0; i < manifest.elements.size(); ++i) {
+                auto & element(manifest.elements[i]);
+                if (i) logger->cout("");
+                logger->cout("Index:              " ANSI_BOLD "%s" ANSI_NORMAL "%s",
+                    i,
+                    element.active ? "" : " " ANSI_RED "(inactive)" ANSI_NORMAL);
+                if (element.source) {
+                    logger->cout("Flake attribute:    %s%s", element.source->attrPath, printOutputsSpec(element.source->outputs));
+                    logger->cout("Original flake URL: %s", element.source->originalRef.to_string());
+                    logger->cout("Locked flake URL:   %s", element.source->lockedRef.to_string());
+                }
+                logger->cout("Store paths:        %s", concatStringsSep(" ", store->printStorePathSet(element.storePaths)));
             }
-            logger->cout("Store paths:        %s", concatStringsSep(" ", store->printStorePathSet(element.storePaths)));
         }
     }
 };

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -517,10 +517,16 @@ struct CmdProfileList : virtual EvalCommand, virtual StoreCommand, MixDefaultPro
 
         for (size_t i = 0; i < manifest.elements.size(); ++i) {
             auto & element(manifest.elements[i]);
-            logger->cout("%d %s %s %s", i,
-                element.source ? element.source->originalRef.to_string() + "#" + element.source->attrPath + printOutputsSpec(element.source->outputs) : "-",
-                element.source ? element.source->resolvedRef.to_string() + "#" + element.source->attrPath + printOutputsSpec(element.source->outputs) : "-",
-                concatStringsSep(" ", store->printStorePathSet(element.storePaths)));
+            if (i) logger->cout("");
+            logger->cout("Index:              " ANSI_BOLD "%s" ANSI_NORMAL "%s",
+                i,
+                element.active ? "" : " " ANSI_RED "(inactive)" ANSI_NORMAL);
+            if (element.source) {
+                logger->cout("Flake attribute:    %s%s", element.source->attrPath, printOutputsSpec(element.source->outputs));
+                logger->cout("Original flake URL: %s", element.source->originalRef.to_string());
+                logger->cout("Locked flake URL:   %s", element.source->resolvedRef.to_string());
+            }
+            logger->cout("Store paths:        %s", concatStringsSep(" ", store->printStorePathSet(element.storePaths)));
         }
     }
 };

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -47,8 +47,9 @@ cp ./config.nix $flake1Dir/
 
 # Test upgrading from nix-env.
 nix-env -f ./user-envs.nix -i foo-1.0
-nix profile list | grep '0 - - .*-foo-1.0'
+nix profile list | grep -A2 'Index:.*0' | grep 'Store paths:.*foo-1.0'
 nix profile install $flake1Dir -L
+nix profile list | grep -A4 'Index:.*1' | grep 'Locked flake URL:.*narHash'
 [[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello World" ]]
 [ -e $TEST_HOME/.nix-profile/share/man ]
 (! [ -e $TEST_HOME/.nix-profile/include ])


### PR DESCRIPTION
This makes `nix profile list` output more readable. Instead of one package per line like
```
6 flake:nixpkgs#legacyPackages.x86_64-linux.gdb path:/nix/store/4dng3sm5c3rxxw10vhx9lr9fclisz3zv-source?lastModified=1650244918&narHash=sha256-DsS5nxjTpnoUC4pNXJI1rit7TnDTij8vQDa5PtcDCD0=&rev=7b38b03d76ab71bdc8dc325e3f6338d984cc35ca#legacyPackages.x86_64-linux.gdb /nix/store/indzcw5wvlhx6vwk7k4iq29q15chvr3d-gdb-11.1
```
you get
```
Index:              6
Flake attribute:    legacyPackages.x86_64-linux.gdb
Original flake URL: flake:nixpkgs
Locked flake URL:   path:/nix/store/4dng3sm5c3rxxw10vhx9lr9fclisz3zv-source?lastModified=1650244918&narHash=sha256-DsS5nxjTpnoUC4pNXJI1rit7TnDTij8vQDa5PtcDCD0=&rev=7b38b03d76ab71bdc8dc325e3f6338d984cc35ca
Store paths:        /nix/store/indzcw5wvlhx6vwk7k4iq29q15chvr3d-gdb-11.1
```

It also adds a `--json` flag (which just dumps the profile manifest to stdout).