### PR TITLE
debug #6383

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -176,7 +176,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
                             parsedURL.query.insert_or_assign("shallow", "1");
 
                         return std::make_pair(
-                            FlakeRef(Input::fromURL(parsedURL), getOr(parsedURL.query, "dir", "")),
+                            FlakeRef(Input::fromURL(parsedURL), Path(getOr(parsedURL.query, "dir"))),
                             fragment);
                     }
 
@@ -189,7 +189,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
             if (!hasPrefix(path, "/"))
                 throw BadURL("flake reference '%s' is not an absolute path", url);
             auto query = decodeQuery(match[2]);
-            path = canonPath(path + "/" + getOr(query, "dir", ""));
+            path = canonPath(fmt("%s/%s", path, getOr(query, "dir")));
         }
 
         fetchers::Attrs attrs;
@@ -208,7 +208,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
         input.parent = baseDir;
 
         return std::make_pair(
-            FlakeRef(std::move(input), getOr(parsedURL.query, "dir", "")),
+            FlakeRef(std::move(input), Path(getOr(parsedURL.query, "dir"))),
             fragment);
     }
 }

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -34,8 +34,8 @@ DrvInfo::DrvInfo(EvalState & state, ref<Store> store, const std::string & drvPat
 
     outputName =
         selectedOutputs.empty()
-        ? getOr(drv.env, "outputName", "out")
-        : *selectedOutputs.begin();
+        ? getOr(drv.env, "outputName", std::string_view("out"))
+        : std::string_view(*selectedOutputs.begin());
 
     auto i = drv.outputs.find(outputName);
     if (i == drv.outputs.end())

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -481,7 +481,7 @@ void LocalDerivationGoal::startBuilder()
            temporary build directory.  The text files have the format used
            by `nix-store --register-validity'.  However, the deriver
            fields are left empty. */
-        auto s = getOr(drv->env, "exportReferencesGraph", "");
+        auto s = getOr(drv->env, "exportReferencesGraph");
         Strings ss = tokenizeString<Strings>(s);
         if (ss.size() % 2 != 0)
             throw BuildError("odd number of tokens in 'exportReferencesGraph': '%1%'", s);
@@ -988,7 +988,7 @@ void LocalDerivationGoal::initTmpDir() {
        there is no size constraint). */
     if (!parsedDrv->getStructuredAttrs()) {
 
-        StringSet passAsFile = tokenizeString<StringSet>(getOr(drv->env, "passAsFile", ""));
+        StringSet passAsFile = tokenizeString<StringSet>(getOr(drv->env, "passAsFile"));
         for (auto & i : drv->env) {
             if (passAsFile.find(i.first) == passAsFile.end()) {
                 env[i.first] = i.second;

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -24,7 +24,7 @@ void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
 
     Path storePath = getAttr("out");
     auto mainUrl = getAttr("url");
-    bool unpack = getOr(drv.env, "unpack", "") == "1";
+    bool unpack = getOr(drv.env, "unpack") == "1";
 
     /* Note: have to use a fresh fileTransfer here because we're in
        a forked process. */

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -692,10 +692,10 @@ struct curlFileTransfer : public FileTransfer
 #if ENABLE_S3
                 auto [bucketName, key, params] = parseS3Uri(request.uri);
 
-                std::string profile = getOr(params, "profile", "");
-                std::string region = getOr(params, "region", Aws::Region::US_EAST_1);
-                std::string scheme = getOr(params, "scheme", "");
-                std::string endpoint = getOr(params, "endpoint", "");
+                std::string profile(getOr(params, "profile"));
+                std::string region(getOr(params, "region", std::string_view(Aws::Region::US_EAST_1)));
+                std::string scheme(getOr(params, "scheme"));
+                std::string endpoint(getOr(params, "endpoint"));
 
                 S3Helper s3Helper(profile, region, scheme, endpoint);
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1314,8 +1314,8 @@ static bool isNonUriPath(const std::string & spec) {
 std::shared_ptr<Store> openFromNonUri(const std::string & uri, const Store::Params & params)
 {
     if (uri == "" || uri == "auto") {
-        auto stateDir = getOr(params, "state", settings.nixStateDir);
-        if (access(stateDir.c_str(), R_OK | W_OK) == 0)
+        auto stateDir = getOr(params, "state", std::string_view(settings.nixStateDir));
+        if (access(stateDir.data(), R_OK | W_OK) == 0)
             return std::make_shared<LocalStore>(params);
         else if (pathExists(settings.nixDaemonSocketFile))
             return std::make_shared<UDSRemoteStore>(params);

--- a/src/libutil/tests/tests.cc
+++ b/src/libutil/tests/tests.cc
@@ -566,7 +566,7 @@ namespace nix {
         StringMap s = { };
         auto expected = "yi";
 
-        ASSERT_EQ(getOr(s, "one", "yi"), expected);
+        ASSERT_EQ(getOr(s, "one", std::string_view("yi")), expected);
     }
 
     TEST(getOr, getFromContainer) {
@@ -575,7 +575,7 @@ namespace nix {
         s["two"] = "er";
         auto expected = "yi";
 
-        ASSERT_EQ(getOr(s, "one", "nope"), expected);
+        ASSERT_EQ(getOr(s, "one", std::string_view("nope")), expected);
     }
 
     /* ----------------------------------------------------------------------------

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -559,10 +559,11 @@ typename T::mapped_type * get(T & map, const typename T::key_type & key)
 }
 
 /* Get a value for the specified key from an associate container, or a default value if the key isn't present. */
-template <class T>
-const typename T::mapped_type & getOr(T & map,
+// NOTE: we restrict the value to string_views to make sure that use-after-free doesn't happen trivially
+template <class T, class CharT = typename T::mapped_type::value_type>
+std::basic_string_view<CharT> getOr(T & map,
     const typename T::key_type & key,
-    const typename T::mapped_type & defaultValue)
+    const std::basic_string_view<CharT> defaultValue = std::basic_string_view<CharT>())
 {
     auto i = map.find(key);
     if (i == map.end()) return defaultValue;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -440,7 +440,7 @@ static void main_nix_build(int argc, char * * argv)
         env["NIX_STORE"] = store->storeDir;
         env["NIX_BUILD_CORES"] = std::to_string(settings.buildCores);
 
-        auto passAsFile = tokenizeString<StringSet>(getOr(drv.env, "passAsFile", ""));
+        auto passAsFile = tokenizeString<StringSet>(getOr(drv.env, "passAsFile"));
 
         bool keepTmp = false;
         int fileNr = 0;

--- a/src/resolve-system-dependencies/resolve-system-dependencies.cc
+++ b/src/resolve-system-dependencies/resolve-system-dependencies.cc
@@ -176,7 +176,7 @@ int main(int argc, char ** argv)
             impurePaths.insert(argv[2]);
         else {
             auto drv = store->derivationFromPath(store->parseStorePath(argv[1]));
-            impurePaths = tokenizeString<StringSet>(getOr(drv.env, "__impureHostDeps", ""));
+            impurePaths = tokenizeString<StringSet>(getOr(drv.env, "__impureHostDeps"));
             impurePaths.insert("/usr/lib/libSystem.dylib");
         }
 


### PR DESCRIPTION
This PR inserts the missing debug output to better diagnose what went wrong in #6383; and fixes a potential use-after-free via `getOr`.

The main problem is that the error might take a long time to appear, but once it appears is reproducible if the build output is really required (and not just because the output got pulled in by a full build, but is not used by any other derivation)