### PR TITLE
nix: Add forgotten null check in AttrCursor::getListOfStrings()

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -648,7 +648,8 @@ std::vector<std::string> AttrCursor::getListOfStrings()
     for (auto & elem : v.listItems())
         res.push_back(std::string(root->state.forceStringNoCtx(*elem)));
 
-    cachedValue = {root->db->setListOfStrings(getKey(), res), res};
+    if (root->db)
+        cachedValue = {root->db->setListOfStrings(getKey(), res), res};
 
     return res;
 }

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -56,6 +56,13 @@ nix build -f multiple-outputs.nix --json 'e^*' --no-link | jq --exit-status '
     (.outputs | keys == ["a", "b", "c"]))
 '
 
+# Make sure that `--impure` works (regression test for https://github.com/NixOS/nix/issues/6488)
+nix build --impure -f multiple-outputs.nix --json e --no-link | jq --exit-status '
+  (.[0] |
+    (.drvPath | match(".*multiple-outputs-e.drv")) and
+    (.outputs | keys == ["a", "b"]))
+'
+
 testNormalization () {
     clearStore
     outPath=$(nix-build ./simple.nix --no-out-link)


### PR DESCRIPTION
Fixes #6488.

This is in no way perfect (a test would be nice, for one thing), but to my (inexperienced) eyes it seems to point out the problem, so feel free to either tell me how you’d like this packaged or just take and rewrite it.