### PR TITLE
legacy-ssh-store.cc: suggest using ssh-ng:// to the user

### DIFF
--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -380,6 +380,12 @@ public:
         Callback<std::shared_ptr<const Realisation>> callback) noexcept override
     // TODO: Implement
     { unsupported("queryRealisation"); }
+
+    /* Unsupported methods. */
+    [[noreturn]] void unsupported(const std::string & op) override
+    {
+        throw Unsupported("operation '%s' is not supported by store '%s' (hint: try ssh-ng:// instead of ssh:// for a newer implementation)", op, getUri());
+    }
 };
 
 static RegisterStoreImplementation<LegacySSHStore, LegacySSHStoreConfig> regLegacySSHStore;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -650,7 +650,7 @@ protected:
     Stats stats;
 
     /* Unsupported methods. */
-    [[noreturn]] void unsupported(const std::string & op)
+    [[noreturn]] virtual void unsupported(const std::string & op)
     {
         throw Unsupported("operation '%s' is not supported by store '%s'", op, getUri());
     }


### PR DESCRIPTION
I've been using nix for about a year now, and after getting this message several times I assumed that there was some fundamental reason why this couldn't be supported:

```
$ nix copy --from ssh://...
error: operation 'getFSAccessor' is not supported by store 'ssh://...'
```

Today I decided to figure out what that fundamental reason was.  It turns out there is no fundamental obstacle!  The problem is that 'ssh://' is really 'legacy-ssh://' and the user ought to be using 'ssh-ng://' (for which the above command works wonderfully).

Unfortunately the user is never informed of this.

Let's suggest using 'ssh-ng://' to the user.  This is done by overriding `unsupported()` in `LegacySSHStore` so we don't have to remember to keep adding new suggestions every time the store API expands.