### PR TITLE
nix develop: Request one output of bashInteractive

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -507,7 +507,7 @@ struct CmdDevelop : Common, MixEnvironment
                 state,
                 installable->nixpkgsFlakeRef(),
                 "bashInteractive",
-                DefaultOutputs(),
+                OutputNames{"out"},
                 Strings{},
                 Strings{"legacyPackages." + settings.thisSystem.get() + "."},
                 nixpkgsLockFlags);


### PR DESCRIPTION
Fixes #6500 (the `nix develop` implementation bug part per my description there, I’m assuming the `nix why-depends` doc / semantics part will get its own bug)

I really tried to make a test this time, but while I can verify interactively that the problem was present and is now gone, I just can’t seem to get the test suite to either succeed here or to fail on master. FWIW, the simplest thing I tried was

```diff
diff --git a/tests/nix-shell.sh b/tests/nix-shell.sh                                                                                                           
index 3241d7a0f..96d6cf063 100644                                                                                                                              
--- a/tests/nix-shell.sh                                                                                                                                       
+++ b/tests/nix-shell.sh                                                                                                                                       
@@ -85,7 +85,7 @@ output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)                                                                                 
 [ "$output" = '-e load(ARGV.shift) -- '"$TEST_ROOT"'/spaced \'\''"shell.shebang                                                                               
.rb abc ruby' ]                                                                                                                                                
                                                                                                                                                               
 # Test 'nix develop'.                                                                                                                                         
-nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'                                                                                          
+nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]' |& grep -qv error                                                                        
                                       
 # Ensure `nix develop -c` preserves stdin                                                                                                                     
 echo foo | nix develop -f "$shellDotNix" shellDrv -c cat | grep -q foo                                                                                        

```

but that seems to succeed on master for some reason (?!..).