### PR TITLE
Stop the logger properly in legacy commands

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -543,8 +543,6 @@ static void main_nix_build(int argc, char * * argv)
 
         restoreProcessContext();
 
-        logger->stop();
-
         execvp(shell->c_str(), argPtrs.data());
 
         throw SysError("executing shell '%s'", *shell);
@@ -602,8 +600,6 @@ static void main_nix_build(int argc, char * * argv)
 
             outPaths.push_back(outputPath);
         }
-
-        logger->stop();
 
         for (auto & path : outPaths)
             std::cout << store->printStorePath(path) << '\n';

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1489,8 +1489,6 @@ static int main_nix_env(int argc, char * * argv)
 
         globals.state->printStats();
 
-        logger->stop();
-
         return 0;
     }
 }

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -1095,8 +1095,6 @@ static int main_nix_store(int argc, char * * argv)
 
         op(opFlags, opArgs);
 
-        logger->stop();
-
         return 0;
     }
 }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -261,6 +261,8 @@ void mainWrapped(int argc, char * * argv)
     }
     #endif
 
+    Finally f([] { logger->stop(); });
+
     programPath = argv[0];
     auto programName = std::string(baseNameOf(programPath));
 
@@ -278,8 +280,6 @@ void mainWrapped(int argc, char * * argv)
     } else {
         verbosity = lvlInfo;
     }
-
-    Finally f([] { logger->stop(); });
 
     NixArgs args;
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/6521

Ensures the logger is stopped on exit in legacy commands. Without this, when using `nix-build --log-format bar` and stopping nix with CTRL+C, the bar is not cleared from the screen.

Tested.