### PR TITLE
primop_match: fix example letter case in document

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3529,7 +3529,7 @@ static RegisterPrimOp primop_match({
       builtins.match "[[:space:]]+([[:upper:]]+)[[:space:]]+" "  FOO   "
       ```
 
-      Evaluates to `[ "foo" ]`.
+      Evaluates to `[ "FOO" ]`.
     )s",
     .fun = prim_match,
 });


### PR DESCRIPTION
This is a tiny change that fixes a confusing example of [`match`](https://nixos.org/manual/nix/stable/expressions/builtins.html#builtins-match):

```
nix-repl> builtins.match "[[:space:]]+([[:upper:]]+)[[:space:]]+" "  FOO   "
[ "FOO" ]
```