### PR TITLE
Add OpenRC service for Nix

### DIFF
--- a/misc/openrc/nix-daemon.service.in
+++ b/misc/openrc/nix-daemon.service.in
@@ -1,0 +1,7 @@
+#!/sbin/openrc-run
+
+name=$RC_SVCNAME
+description="Nix Daemon"
+command_args_background="--daemon"
+pidfile="/var/run/nix-daemon.pid"
+command="/nix/var/nix/profiles/default/bin/nix-daemon"


### PR DESCRIPTION
I'm not a huge expert on OpenRC, however, this service, more or less, works. 
Encountered only one issue with it - it shows `accepted connection from pid [number], user [username]` when doing anything nix-related, such as nix-shells, unless the current shell instance is not restarted. After that, it never shows up any more. I have no idea how to fix that, but I think it's just a cosmetic issue.

I have no idea whether my approach to add a service like this is okay, so correct me if I'm wrong - I've just followed the naming scheme according to other thing which can be found in `misc` and it's subfolders for init systems.