### PR TITLE
configure.ac: check for sandbox-shell's FEATURE_SH_STANDALONE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,7 +294,7 @@ esac
 AC_ARG_WITH(sandbox-shell, AS_HELP_STRING([--with-sandbox-shell=PATH],[path of a statically-linked shell to use as /bin/sh in sandboxes]),
   sandbox_shell=$withval)
 AC_SUBST(sandbox_shell)
-if ! test -z ${sandbox_shell+x}; then
+if test ${cross_compiling:-no} = no && ! test -z ${sandbox_shell+x}; then
   AC_MSG_CHECKING([whether sandbox-shell has the standalone feature])
   # busybox shell sometimes allows executing other busybox applets,
   # even if they are not in the path, breaking our sandbox

--- a/configure.ac
+++ b/configure.ac
@@ -294,6 +294,17 @@ esac
 AC_ARG_WITH(sandbox-shell, AS_HELP_STRING([--with-sandbox-shell=PATH],[path of a statically-linked shell to use as /bin/sh in sandboxes]),
   sandbox_shell=$withval)
 AC_SUBST(sandbox_shell)
+if ! test -z ${sandbox_shell+x}; then
+  AC_MSG_CHECKING([whether sandbox-shell has the standalone feature])
+  # busybox shell sometimes allows executing other busybox applets,
+  # even if they are not in the path, breaking our sandbox
+  if PATH= $sandbox_shell -c "busybox" 2>&1 | grep -qv "not found"; then
+    AC_MSG_RESULT(enabled)
+    AC_MSG_ERROR([Please disable busybox FEATURE_SH_STANDALONE])
+  else
+    AC_MSG_RESULT(disabled)
+  fi
+fi
 
 # Expand all variables in config.status.
 test "$prefix" = NONE && prefix=$ac_default_prefix


### PR DESCRIPTION
See also: https://bugs.archlinux.org/task/73998.
Busybox's FEATURE_SH_STANDALONE feature causes other busybox applets to
leak into the sandbox, where system() calls will start preferring them over tools in $PATH. On arch, this even includes `ar`.

Let's check for this evil feature and disallow using this as a sandbox shell.