### PR TITLE
Handle EOFs in string literals correctly

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -198,7 +198,7 @@ or          { return OR_KW; }
                    (...|\$[^\{\"\\]|\\.|\$\\.)+ would have triggered.
                    This is technically invalid, but we leave the problem to the
                    parser who fails with exact location. */
-                return STR;
+                return EOF;
               }
 
 \'\'(\ *\n)?     { PUSH_STATE(IND_STRING); return IND_STRING_OPEN; }

--- a/tests/lang/parse-fail-eof-in-string.nix
+++ b/tests/lang/parse-fail-eof-in-string.nix
@@ -1,0 +1,3 @@
+# https://github.com/NixOS/nix/issues/6562
+# Note that this file must not end with a newline.
+a 1"$


### PR DESCRIPTION
We can't return a `STR` token without setting a valid `StringToken`, otherwise the parser will crash.

Fixes #6562.