### PR TITLE
Fix `Connection refused` on daemon socket

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1818,7 +1818,7 @@ AutoCloseFD createUnixDomainSocket(const Path & path, mode_t mode)
     if (chmod(path.c_str(), mode) == -1)
         throw SysError("changing permissions on '%1%'", path);
 
-    if (listen(fdSocket.get(), 5) == -1)
+    if (listen(fdSocket.get(), 100) == -1)
         throw SysError("cannot listen on socket '%1%'", path);
 
     return fdSocket;


### PR DESCRIPTION
This solves the error

    error: cannot connect to socket at '/nix/var/nix/daemon-socket/socket': Connection refused

on build farm systems that are loaded but operating normally.

I've seen this happen on an M1 mac running a loaded hercules-ci-agent.
Hercules CI uses multiple worker processes, which may connect to
the Nix daemon around the same time. It's not unthinkable that
the Nix daemon listening process isn't scheduled until after 6
workers try to connect, especially on a system under load with
many workers.

Is the increase safe?

The number is the number of connections that the kernel will buffer
while the listening process hasn't `accept`-ed them yet.
It did not - and will not - restrict the total number of daemon
forks that a client can create.

History

The number 5 has remained unchanged since the introduction in
nix-worker with 0130ef88ea in 2006.

<!-- https://hercules-ci.com/accounts/github/hercules-ci/derivations/%2Fnix%2Fstore%2F2rw1g4biikd2n48sc69bj83mflaqdr9w-pinpointDependencies.js.drv/log?via-job=801eea28-c63c-46dc-a198-86446a3199dd -->