### PR TITLE
Fix a segfault in the git fetcher

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -449,11 +449,10 @@ struct GitInputScheme : InputScheme
             }
         }
 
-        const Attrs unlockedAttrs({
+        Attrs unlockedAttrs({
             {"type", cacheType},
             {"name", name},
             {"url", actualUrl},
-            {"ref", *input.getRef()},
         });
 
         Path repoDir;
@@ -466,6 +465,7 @@ struct GitInputScheme : InputScheme
                     head = "master";
                 }
                 input.attrs.insert_or_assign("ref", *head);
+                unlockedAttrs.insert_or_assign("ref", *head);
             }
 
             if (!input.getRev())
@@ -482,6 +482,7 @@ struct GitInputScheme : InputScheme
                     head = "master";
                 }
                 input.attrs.insert_or_assign("ref", *head);
+                unlockedAttrs.insert_or_assign("ref", *head);
             }
 
             if (auto res = getCache()->lookup(store, unlockedAttrs)) {


### PR DESCRIPTION
The git fetcher code used to dereference the (potentially empty) `ref`
input attribute. This was magically working, probably because the
compiler somehow outsmarted us, but is now blowing up with newer nixpkgs
versions.

Fix that by not trying to access this field while we don't know for sure
that it has been defined.

Fix #6554

@harrisonthorne if you have a way to reproduce the original issue, can you confirm that the fix is correct?

Related to #6509
