### PR TITLE
src/libstore/globals.hh: trusted-public-keys not needed for FODs

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -524,10 +524,9 @@ public:
         "trusted-public-keys",
         R"(
           A whitespace-separated list of public keys. When paths are
-          copied from another Nix store (such as a binary cache), and
-          are not part of a fixed-output derivation (such as a
-          fetcher), they must be signed with one of these keys. For
-          example:
+          copied from another Nix store (such as a binary cache), they must be
+          signed with one of these keys, unless they are content-addressed (like
+          the outputs of fixed-output derivations). For example:
           `cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=`.
         )",

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -523,9 +523,11 @@ public:
         {"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="},
         "trusted-public-keys",
         R"(
-          A whitespace-separated list of public keys. When paths are copied
-          from another Nix store (such as a binary cache), they must be
-          signed with one of these keys. For example:
+          A whitespace-separated list of public keys. When paths are
+          copied from another Nix store (such as a binary cache), and
+          are not part of a fixed-output derivation (such as a
+          fetcher), they must be signed with one of these keys. For
+          example:
           `cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=`.
         )",


### PR DESCRIPTION
Nix will accept paths for FODs from a substituter without a signature. This is of course safe, since Nix knows and checks the hash of the path it is to receive.  Let's include this exception in the man page.

I noticed this while trying to build the `calibre` expression from nixpkgs.  It attempts to download [this patch](https://raw.githubusercontent.com/debian-calibre/calibre/debian/5.42.0%2Bdfsg-1/debian/patches/0007-Hardening-Qt-code.patch) which is no longer available at the specified URL (I get a 404).  I've had to do this several times in the past.

I prefer to build everything myself, from source.  Hydra isn't failing this build because it has the patch cached, possibly from a very long time ago.

From the manual page, I couldn't figure out how to tell Nix "you can substitute FODs, but nothing else".  It seems to me that setting `trusted-public-keys=""` but leaving the default `substituters=https://cache.nixos.org/` is how you accomplish this.  If this is incorrect please let me know and I will revise or close this PR.

Side question: is it necessary for the default `substituters` to use `https://` rather than `http://`?  Everything downloaded from `cache.nixos.org` ought to be FOD or else signed by the default `trusted-public-key`.  Just wondering.  Debian has always deliberately used `http://` for the same reason, to eliminate the TLS round-trip and to be robust in the face of certificate expiration and the large arsenal of X.509-infrastructure footguns.