### PR TITLE
Fix noexcept violations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -348,7 +348,7 @@
 
             strictDeps = true;
 
-            passthru.perl-bindings = with final; currentStdenv.mkDerivation {
+            passthru.perl-bindings = with final; perl.pkgs.toPerlModule (currentStdenv.mkDerivation {
               name = "nix-perl-${version}";
 
               src = self;
@@ -378,7 +378,7 @@
               enableParallelBuilding = true;
 
               postUnpack = "sourceRoot=$sourceRoot/perl";
-            };
+            });
 
             meta.platforms = systems;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -380,6 +380,7 @@
               postUnpack = "sourceRoot=$sourceRoot/perl";
             };
 
+            meta.platforms = systems;
           };
 
           lowdown-nix = with final; currentStdenv.mkDerivation rec {

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -161,7 +161,12 @@ protected:
     void getFile(const std::string & path,
         Callback<std::optional<std::string>> callback) noexcept override
     {
-        checkEnabled();
+        try {
+            checkEnabled();
+        } catch (...) {
+            callback.rethrow();
+            return;
+        }
 
         auto request(makeRequest(path));
 


### PR DESCRIPTION
`HttpBinaryCacheStore::getFile()` shouldn't throw an exception since it's marked as `noexcept`. Fixes #6445.

Also ensure `RemoteStore::queryRealisationUncached()` doesn't throw an exception.