### PR TITLE
Make flake metadata evaluation behaviour more discoverable

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1022,7 +1022,9 @@ void EvalState::cacheFile(
         // computation.
         if (mustBeTrivial &&
             !(dynamic_cast<ExprAttrs *>(e)))
-            throw EvalError("file '%s' must be an attribute set", path);
+            throw EvalError("file '%s' must not require evaluation;"
+                            " see Nix issue #4945 or the"
+                            " \"Flake format\" section of `nix flake --help`", path);
         eval(e, v);
     } catch (Error & e) {
         addErrorTrace(e, "while evaluating the file '%1%':", resolvedPath);

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -282,6 +282,14 @@ derivation):
 }
 ```
 
+
+
+`flake.nix` is written in a limited subset of the Nix language
+in order to prevent metadata lookups from hanging; values must
+be written directly and indirect evaluations such as `let..in`
+are not permitted. This does not apply to the body of
+the `outputs` function.
+
 The following attributes are supported in `flake.nix`:
 
 * `description`: A short, one-line description of the flake.


### PR DESCRIPTION
See commit messages. Builds and works for me in a `nix develop` shell.