### PR TITLE
--ignore-try flag for debugger mode

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -91,6 +91,12 @@ EvalCommand::EvalCommand()
         .description = "start an interactive environment if evaluation fails",
         .handler = {&startReplOnEvalErrors, true},
     });
+
+    addFlag({
+        .longName = "ignore-try",
+        .description = "ignore exceptions in try clauses during debug",
+        .handler = {&ignoreExceptionsDuringTry, true},
+    });
 }
 
 EvalCommand::~EvalCommand()
@@ -120,7 +126,10 @@ ref<EvalState> EvalCommand::getEvalState()
             ;
 
         if (startReplOnEvalErrors) {
-            evalState->debugRepl = &runRepl;        
+            evalState->debugRepl = &runRepl;
+        };
+        if (ignoreExceptionsDuringTry) {
+            evalState->ignoreTry = ignoreExceptionsDuringTry;
         };
     }
     return ref<EvalState>(evalState);

--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -58,6 +58,7 @@ struct CopyCommand : virtual StoreCommand
 struct EvalCommand : virtual StoreCommand, MixEvalArgs
 {
     bool startReplOnEvalErrors = false;
+    bool ignoreExceptionsDuringTry = false;
 
     EvalCommand();
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -467,6 +467,7 @@ EvalState::EvalState(
     , debugRepl(0)
     , debugStop(false)
     , debugQuit(false)
+    , ignoreTry(false)
     , regexCache(makeRegexCache())
 #if HAVE_BOEHMGC
     , valueAllocCache(std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr))

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -464,10 +464,11 @@ EvalState::EvalState(
     , emptyBindings(0)
     , store(store)
     , buildStore(buildStore ? buildStore : store)
-    , debugRepl(0)
+    , debugRepl(nullptr)
     , debugStop(false)
     , debugQuit(false)
     , ignoreTry(false)
+    , trylevel(0)
     , regexCache(makeRegexCache())
 #if HAVE_BOEHMGC
     , valueAllocCache(std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr))
@@ -833,7 +834,14 @@ void EvalState::runDebugRepl(const Error * error, const Env & env, const Expr & 
         : nullptr;
 
     if (error)
-        printError("%s\n\n" ANSI_BOLD "Starting REPL to allow you to inspect the current state of the evaluator.\n" ANSI_NORMAL, error->what());
+    {
+        printError("%s\n\n", error->what());
+
+        if (trylevel > 0 && error->info().level != lvlInfo)
+            printError("This exception occurred in a try clause. use " ANSI_GREEN "--ignore-try" ANSI_NORMAL " to skip these.\n");
+
+        printError(ANSI_BOLD "Starting REPL to allow you to inspect the current state of the evaluator.\n" ANSI_NORMAL, error->what());
+    }
 
     auto se = getStaticEnv(expr);
     if (se) {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -131,6 +131,7 @@ public:
     bool debugStop;
     bool debugQuit;
     bool ignoreTry;
+    int trylevel;
     std::list<DebugTrace> debugTraces;
     std::map<const Expr*, const std::shared_ptr<const StaticEnv>> exprEnvs;
     const std::shared_ptr<const StaticEnv> getStaticEnv(const Expr & expr) const

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -130,6 +130,7 @@ public:
     void (* debugRepl)(ref<EvalState> es, const ValMap & extraEnv);
     bool debugStop;
     bool debugQuit;
+    bool ignoreTry;
     std::list<DebugTrace> debugTraces;
     std::map<const Expr*, const std::shared_ptr<const StaticEnv>> exprEnvs;
     const std::shared_ptr<const StaticEnv> getStaticEnv(const Expr & expr) const

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -853,11 +853,15 @@ static void prim_tryEval(EvalState & state, const PosIdx pos, Value * * args, Va
     auto attrs = state.buildBindings(2);
 
     void (* savedDebugRepl)(ref<EvalState> es, const ValMap & extraEnv) = nullptr;
-    if (state.debugRepl && state.ignoreTry)
+    if (state.debugRepl)
     {
-        // to prevent starting the repl from exceptions withing a tryEval, null it.
-        savedDebugRepl = state.debugRepl;
-        state.debugRepl = nullptr;
+        state.trylevel++;
+        if (state.ignoreTry)
+        {
+            // to prevent starting the repl from exceptions withing a tryEval, null it.
+            savedDebugRepl = state.debugRepl;
+            state.debugRepl = nullptr;
+        }
     }
 
     try {
@@ -872,6 +876,9 @@ static void prim_tryEval(EvalState & state, const PosIdx pos, Value * * args, Va
     // restore the debugRepl pointer if we saved it earlier.
     if (savedDebugRepl)
         state.debugRepl = savedDebugRepl;
+
+    if (state.debugRepl)
+        state.trylevel--;
 
     v.mkAttrs(attrs);
 }


### PR DESCRIPTION
This is one way to address #6594.  

Added an --ignore-try flag, that causes the debugger to skip exceptions that occur in a tryEval.  

Also it prints an extra message is an exception occurs during tryEval, and --ignore-try is not used.  