### PR TITLE
Implement support for percent encoded filepaths for flakerefs

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,1 +1,5 @@
 # Release X.Y (202?-??-??)
+
+- [URL flake references](@docroot@/command-ref/new-cli/nix3-flake.md#flake-references) now support [percent-encoded](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) characters.
+
+- [Path-like flake references](@docroot@/command-ref/new-cli/nix3-flake.md#path-like-syntax) now accept arbitrary unicode characters (except `#` and `?`).

--- a/src/libutil/tests/url.cc
+++ b/src/libutil/tests/url.cc
@@ -335,4 +335,13 @@ namespace nix {
         ASSERT_EQ(d, s);
     }
 
+    TEST(percentEncode, yen) {
+        // https://en.wikipedia.org/wiki/Percent-encoding#Character_data
+        std::string s = reinterpret_cast<const char*>(u8"円");
+        std::string e = "%E5%86%86";
+
+        ASSERT_EQ(percentEncode(s), e);
+        ASSERT_EQ(percentDecode(e), s);
+    }
+
 }

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -103,7 +103,7 @@ std::string percentEncode(std::string_view s, std::string_view keep)
             || keep.find(c) != std::string::npos)
             res += c;
         else
-            res += fmt("%%%02X", (unsigned int) c);
+            res += fmt("%%%02X", c & 0xFF);
     return res;
 }
 

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -68,11 +68,9 @@ inputs.nixpkgs = {
 ```
 
 Following [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1),
-characters outside of the allowed range (i.e. are neither [reserved
-character](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) or
-[unreserved
-characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3)) must be
-percent-encoded.
+characters outside of the allowed range (i.e. neither [reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2)
+nor [unreserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3))
+must be percent-encoded.
 
 ### Examples
 
@@ -110,8 +108,7 @@ The semantic of such a path is as follows:
     2. The filesystem root (/), or
     3. A folder on a different mount point.
 
-Contrary to URL-like reference, path-like flake references can contain
-arbitrary unicode characters (except `#` and `?`).
+Contrary to URL-like references, path-like flake references can contain arbitrary unicode characters (except `#` and `?`).
 
 ### Examples
 

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -67,6 +67,13 @@ inputs.nixpkgs = {
 };
 ```
 
+Following [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1),
+characters outside of the allowed range (i.e. are neither [reserved
+character](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) or
+[unreserved
+characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3)) must be
+percent-encoded.
+
 ### Examples
 
 Here are some examples of flake references in their URL-like representation:
@@ -103,10 +110,15 @@ The semantic of such a path is as follows:
     2. The filesystem root (/), or
     3. A folder on a different mount point.
 
+Contrary to URL-like reference, path-like flake references can contain
+arbitrary unicode characters (except `#` and `?`).
+
 ### Examples
 
 * `.`: The flake to which the current directory belongs to.
 * `/home/alice/src/patchelf`: A flake in some other directory.
+* `./../sub directory/with Ûñî©ôδ€`: A flake in another relative directory that
+  has Unicode characters in its name.
 
 ## Flake reference attributes
 

--- a/tests/flakes/common.sh
+++ b/tests/flakes/common.sh
@@ -61,10 +61,10 @@ createGitRepo() {
     local repo="$1"
     local extraArgs="${2-}"
 
-    rm -rf $repo $repo.tmp
-    mkdir -p $repo
+    rm -rf "$repo" "$repo".tmp
+    mkdir -p "$repo"
 
-    git -C $repo init $extraArgs
-    git -C $repo config user.email "foobar@example.com"
-    git -C $repo config user.name "Foobar"
+    git -C "$repo" init $extraArgs
+    git -C "$repo" config user.email "foobar@example.com"
+    git -C "$repo" config user.name "Foobar"
 }

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -6,27 +6,29 @@ clearStore
 rm -rf $TEST_HOME/.cache $TEST_HOME/.config
 
 flake1Dir=$TEST_ROOT/flake1
-flake2Dir=$TEST_ROOT/flake2
-flake3Dir=$TEST_ROOT/flake3
+flake2Dir=$TEST_ROOT/flake\ 2
+percentEncodedFlake2Dir=$TEST_ROOT/flake%202
+flake3Dir=$TEST_ROOT/flake%20
+percentEncodedFlake3Dir=$TEST_ROOT/flake%2520
 flake5Dir=$TEST_ROOT/flake5
 flake7Dir=$TEST_ROOT/flake7
 nonFlakeDir=$TEST_ROOT/nonFlake
 badFlakeDir=$TEST_ROOT/badFlake
 flakeGitBare=$TEST_ROOT/flakeGitBare
 
-for repo in $flake1Dir $flake2Dir $flake3Dir $flake7Dir $nonFlakeDir; do
+for repo in "$flake1Dir" "$flake2Dir" "$flake3Dir" "$flake7Dir" "$nonFlakeDir"; do
     # Give one repo a non-main initial branch.
     extraArgs=
-    if [[ $repo == $flake2Dir ]]; then
+    if [[ "$repo" == "$flake2Dir" ]]; then
       extraArgs="--initial-branch=main"
     fi
 
     createGitRepo "$repo" "$extraArgs"
 done
 
-createSimpleGitFlake $flake1Dir
+createSimpleGitFlake "$flake1Dir"
 
-cat > $flake2Dir/flake.nix <<EOF
+cat > "$flake2Dir/flake.nix" <<EOF
 {
   description = "Fnord";
 
@@ -36,10 +38,10 @@ cat > $flake2Dir/flake.nix <<EOF
 }
 EOF
 
-git -C $flake2Dir add flake.nix
-git -C $flake2Dir commit -m 'Initial'
+git -C "$flake2Dir" add flake.nix
+git -C "$flake2Dir" commit -m 'Initial'
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   description = "Fnord";
 
@@ -53,26 +55,26 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-cat > $flake3Dir/default.nix <<EOF
+cat > "$flake3Dir/default.nix" <<EOF
 { x = 123; }
 EOF
 
-git -C $flake3Dir add flake.nix default.nix
-git -C $flake3Dir commit -m 'Initial'
+git -C "$flake3Dir" add flake.nix default.nix
+git -C "$flake3Dir" commit -m 'Initial'
 
-cat > $nonFlakeDir/README.md <<EOF
+cat > "$nonFlakeDir/README.md" <<EOF
 FNORD
 EOF
 
-git -C $nonFlakeDir add README.md
-git -C $nonFlakeDir commit -m 'Initial'
+git -C "$nonFlakeDir" add README.md
+git -C "$nonFlakeDir" commit -m 'Initial'
 
 # Construct a custom registry, additionally test the --registry flag
-nix registry add --registry $registry flake1 git+file://$flake1Dir
-nix registry add --registry $registry flake2 git+file://$flake2Dir
-nix registry add --registry $registry flake3 git+file://$flake3Dir
-nix registry add --registry $registry flake4 flake3
-nix registry add --registry $registry nixpkgs flake1
+nix registry add --registry "$registry" flake1 "git+file://$flake1Dir"
+nix registry add --registry "$registry" flake2 "git+file://$percentEncodedFlake2Dir"
+nix registry add --registry "$registry" flake3 "git+file://$percentEncodedFlake3Dir"
+nix registry add --registry "$registry" flake4 flake3
+nix registry add --registry "$registry" nixpkgs flake1
 
 # Test 'nix registry list'.
 [[ $(nix registry list | wc -l) == 5 ]]
@@ -84,100 +86,100 @@ nix flake metadata flake1
 nix flake metadata flake1 | grepQuiet 'Locked URL:.*flake1.*'
 
 # Test 'nix flake metadata' on a local flake.
-(cd $flake1Dir && nix flake metadata) | grepQuiet 'URL:.*flake1.*'
-(cd $flake1Dir && nix flake metadata .) | grepQuiet 'URL:.*flake1.*'
-nix flake metadata $flake1Dir | grepQuiet 'URL:.*flake1.*'
+(cd "$flake1Dir" && nix flake metadata) | grepQuiet 'URL:.*flake1.*'
+(cd "$flake1Dir" && nix flake metadata .) | grepQuiet 'URL:.*flake1.*'
+nix flake metadata "$flake1Dir" | grepQuiet 'URL:.*flake1.*'
 
 # Test 'nix flake metadata --json'.
 json=$(nix flake metadata flake1 --json | jq .)
 [[ $(echo "$json" | jq -r .description) = 'Bla bla' ]]
 [[ -d $(echo "$json" | jq -r .path) ]]
-[[ $(echo "$json" | jq -r .lastModified) = $(git -C $flake1Dir log -n1 --format=%ct) ]]
+[[ $(echo "$json" | jq -r .lastModified) = $(git -C "$flake1Dir" log -n1 --format=%ct) ]]
 hash1=$(echo "$json" | jq -r .revision)
 
-echo foo > $flake1Dir/foo
-git -C $flake1Dir add $flake1Dir/foo
+echo foo > "$flake1Dir/foo"
+git -C "$flake1Dir" add $flake1Dir/foo
 [[ $(nix flake metadata flake1 --json --refresh | jq -r .dirtyRevision) == "$hash1-dirty" ]]
 
-echo -n '# foo' >> $flake1Dir/flake.nix
-flake1OriginalCommit=$(git -C $flake1Dir rev-parse HEAD)
-git -C $flake1Dir commit -a -m 'Foo'
-flake1NewCommit=$(git -C $flake1Dir rev-parse HEAD)
+echo -n '# foo' >> "$flake1Dir/flake.nix"
+flake1OriginalCommit=$(git -C "$flake1Dir" rev-parse HEAD)
+git -C "$flake1Dir" commit -a -m 'Foo'
+flake1NewCommit=$(git -C "$flake1Dir" rev-parse HEAD)
 hash2=$(nix flake metadata flake1 --json --refresh | jq -r .revision)
 [[ $(nix flake metadata flake1 --json --refresh | jq -r .dirtyRevision) == "null" ]]
 [[ $hash1 != $hash2 ]]
 
 # Test 'nix build' on a flake.
-nix build -o $TEST_ROOT/result flake1#foo
-[[ -e $TEST_ROOT/result/hello ]]
+nix build -o "$TEST_ROOT/result" flake1#foo
+[[ -e "$TEST_ROOT/result/hello" ]]
 
 # Test packages.default.
-nix build -o $TEST_ROOT/result flake1
-[[ -e $TEST_ROOT/result/hello ]]
+nix build -o "$TEST_ROOT/result" flake1
+[[ -e "$TEST_ROOT/result/hello" ]]
 
-nix build -o $TEST_ROOT/result $flake1Dir
-nix build -o $TEST_ROOT/result git+file://$flake1Dir
+nix build -o "$TEST_ROOT/result" "$flake1Dir"
+nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir"
 
 # Check that store symlinks inside a flake are not interpreted as flakes.
-nix build -o $flake1Dir/result git+file://$flake1Dir
-nix path-info $flake1Dir/result
+nix build -o "$flake1Dir/result" "git+file://$flake1Dir"
+nix path-info "$flake1Dir/result"
 
 # 'getFlake' on an unlocked flakeref should fail in pure mode, but
 # succeed in impure mode.
-(! nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default")
-nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default" --impure
+(! nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default")
+nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default" --impure
 
 # 'getFlake' on a locked flakeref should succeed even in pure mode.
-nix build -o $TEST_ROOT/result --expr "(builtins.getFlake \"git+file://$flake1Dir?rev=$hash2\").packages.$system.default"
+nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1Dir?rev=$hash2\").packages.$system.default"
 
 # Building a flake with an unlocked dependency should fail in pure mode.
-(! nix build -o $TEST_ROOT/result flake2#bar --no-registries)
-(! nix build -o $TEST_ROOT/result flake2#bar --no-use-registries)
+(! nix build -o "$TEST_ROOT/result" flake2#bar --no-registries)
+(! nix build -o "$TEST_ROOT/result" flake2#bar --no-use-registries)
 (! nix eval --expr "builtins.getFlake \"$flake2Dir\"")
 
 # But should succeed in impure mode.
-(! nix build -o $TEST_ROOT/result flake2#bar --impure)
-nix build -o $TEST_ROOT/result flake2#bar --impure --no-write-lock-file
+(! nix build -o "$TEST_ROOT/result" flake2#bar --impure)
+nix build -o "$TEST_ROOT/result" flake2#bar --impure --no-write-lock-file
 nix eval --expr "builtins.getFlake \"$flake2Dir\"" --impure
 
 # Building a local flake with an unlocked dependency should fail with --no-update-lock-file.
-expect 1 nix build -o $TEST_ROOT/result $flake2Dir#bar --no-update-lock-file 2>&1 | grep 'requires lock file changes'
+expect 1 nix build -o "$TEST_ROOT/result" "$flake2Dir#bar" --no-update-lock-file 2>&1 | grep 'requires lock file changes'
 
 # But it should succeed without that flag.
-nix build -o $TEST_ROOT/result $flake2Dir#bar --no-write-lock-file
-expect 1 nix build -o $TEST_ROOT/result $flake2Dir#bar --no-update-lock-file 2>&1 | grep 'requires lock file changes'
-nix build -o $TEST_ROOT/result $flake2Dir#bar --commit-lock-file
-[[ -e $flake2Dir/flake.lock ]]
-[[ -z $(git -C $flake2Dir diff main || echo failed) ]]
+nix build -o "$TEST_ROOT/result" "$flake2Dir#bar" --no-write-lock-file
+expect 1 nix build -o "$TEST_ROOT/result" "$flake2Dir#bar" --no-update-lock-file 2>&1 | grep 'requires lock file changes'
+nix build -o "$TEST_ROOT/result" "$flake2Dir#bar" --commit-lock-file
+[[ -e "$flake2Dir/flake.lock" ]]
+[[ -z $(git -C "$flake2Dir" diff main || echo failed) ]]
 
 # Rerunning the build should not change the lockfile.
-nix build -o $TEST_ROOT/result $flake2Dir#bar
-[[ -z $(git -C $flake2Dir diff main || echo failed) ]]
+nix build -o "$TEST_ROOT/result" "$flake2Dir#bar"
+[[ -z $(git -C "$flake2Dir" diff main || echo failed) ]]
 
 # Building with a lockfile should not require a fetch of the registry.
-nix build -o $TEST_ROOT/result --flake-registry file:///no-registry.json $flake2Dir#bar --refresh
-nix build -o $TEST_ROOT/result --no-registries $flake2Dir#bar --refresh
-nix build -o $TEST_ROOT/result --no-use-registries $flake2Dir#bar --refresh
+nix build -o "$TEST_ROOT/result" --flake-registry file:///no-registry.json "$flake2Dir#bar" --refresh
+nix build -o "$TEST_ROOT/result" --no-registries "$flake2Dir#bar" --refresh
+nix build -o "$TEST_ROOT/result" --no-use-registries "$flake2Dir#bar" --refresh
 
 # Updating the flake should not change the lockfile.
-nix flake lock $flake2Dir
-[[ -z $(git -C $flake2Dir diff main || echo failed) ]]
+nix flake lock "$flake2Dir"
+[[ -z $(git -C "$flake2Dir" diff main || echo failed) ]]
 
 # Now we should be able to build the flake in pure mode.
-nix build -o $TEST_ROOT/result flake2#bar
+nix build -o "$TEST_ROOT/result" flake2#bar
 
 # Or without a registry.
-nix build -o $TEST_ROOT/result --no-registries git+file://$flake2Dir#bar --refresh
-nix build -o $TEST_ROOT/result --no-use-registries git+file://$flake2Dir#bar --refresh
+nix build -o "$TEST_ROOT/result" --no-registries "git+file://$percentEncodedFlake2Dir#bar" --refresh
+nix build -o "$TEST_ROOT/result" --no-use-registries "git+file://$percentEncodedFlake2Dir#bar" --refresh
 
 # Test whether indirect dependencies work.
-nix build -o $TEST_ROOT/result $flake3Dir#xyzzy
-git -C $flake3Dir add flake.lock
+nix build -o "$TEST_ROOT/result" "$flake3Dir#xyzzy"
+git -C "$flake3Dir" add flake.lock
 
 # Add dependency to flake3.
-rm $flake3Dir/flake.nix
+rm "$flake3Dir/flake.nix"
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   description = "Fnord";
 
@@ -188,44 +190,44 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-git -C $flake3Dir add flake.nix
-git -C $flake3Dir commit -m 'Update flake.nix'
+git -C "$flake3Dir" add flake.nix
+git -C "$flake3Dir" commit -m 'Update flake.nix'
 
 # Check whether `nix build` works with an incomplete lockfile
-nix build -o $TEST_ROOT/result $flake3Dir#"sth sth"
-nix build -o $TEST_ROOT/result $flake3Dir#"sth%20sth"
+nix build -o $TEST_ROOT/result "$flake3Dir#sth sth"
+nix build -o $TEST_ROOT/result "$flake3Dir#sth%20sth"
 
 # Check whether it saved the lockfile
-[[ -n $(git -C $flake3Dir diff master) ]]
+[[ -n $(git -C "$flake3Dir" diff master) ]]
 
-git -C $flake3Dir add flake.lock
+git -C "$flake3Dir" add flake.lock
 
-git -C $flake3Dir commit -m 'Add lockfile'
+git -C "$flake3Dir" commit -m 'Add lockfile'
 
 # Test whether registry caching works.
-nix registry list --flake-registry file://$registry | grepQuiet flake3
-mv $registry $registry.tmp
+nix registry list --flake-registry "file://$registry" | grepQuiet flake3
+mv "$registry" "$registry.tmp"
 nix store gc
-nix registry list --flake-registry file://$registry --refresh | grepQuiet flake3
-mv $registry.tmp $registry
+nix registry list --flake-registry "file://$registry" --refresh | grepQuiet flake3
+mv "$registry.tmp" "$registry"
 
 # Test whether flakes are registered as GC roots for offline use.
 # FIXME: use tarballs rather than git.
-rm -rf $TEST_HOME/.cache
+rm -rf "$TEST_HOME/.cache"
 nix store gc # get rid of copies in the store to ensure they get fetched to our git cache
-_NIX_FORCE_HTTP=1 nix build -o $TEST_ROOT/result git+file://$flake2Dir#bar
-mv $flake1Dir $flake1Dir.tmp
-mv $flake2Dir $flake2Dir.tmp
+_NIX_FORCE_HTTP=1 nix build -o "$TEST_ROOT/result" "git+file://$percentEncodedFlake2Dir#bar"
+mv "$flake1Dir" "$flake1Dir.tmp"
+mv "$flake2Dir" "$flake2Dir.tmp"
 nix store gc
-_NIX_FORCE_HTTP=1 nix build -o $TEST_ROOT/result git+file://$flake2Dir#bar
-_NIX_FORCE_HTTP=1 nix build -o $TEST_ROOT/result git+file://$flake2Dir#bar --refresh
-mv $flake1Dir.tmp $flake1Dir
-mv $flake2Dir.tmp $flake2Dir
+_NIX_FORCE_HTTP=1 nix build -o "$TEST_ROOT/result" "git+file://$percentEncodedFlake2Dir#bar"
+_NIX_FORCE_HTTP=1 nix build -o "$TEST_ROOT/result" "git+file://$percentEncodedFlake2Dir#bar" --refresh
+mv "$flake1Dir.tmp" "$flake1Dir"
+mv "$flake2Dir.tmp" "$flake2Dir"
 
 # Add nonFlakeInputs to flake3.
-rm $flake3Dir/flake.nix
+rm "$flake3Dir/flake.nix"
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   inputs = {
     flake1 = {};
@@ -266,46 +268,46 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-cp ../config.nix $flake3Dir
+cp ../config.nix "$flake3Dir"
 
-git -C $flake3Dir add flake.nix config.nix
-git -C $flake3Dir commit -m 'Add nonFlakeInputs'
+git -C "$flake3Dir" add flake.nix config.nix
+git -C "$flake3Dir" commit -m 'Add nonFlakeInputs'
 
 # Check whether `nix build` works with a lockfile which is missing a
 # nonFlakeInputs.
-nix build -o $TEST_ROOT/result $flake3Dir#sth --commit-lock-file
+nix build -o "$TEST_ROOT/result" "$flake3Dir#sth" --commit-lock-file
 
-nix build -o $TEST_ROOT/result flake3#fnord
+nix build -o "$TEST_ROOT/result" flake3#fnord
 [[ $(cat $TEST_ROOT/result) = FNORD ]]
 
 # Check whether flake input fetching is lazy: flake3#sth does not
 # depend on flake2, so this shouldn't fail.
-rm -rf $TEST_HOME/.cache
+rm -rf "$TEST_HOME/.cache"
 clearStore
-mv $flake2Dir $flake2Dir.tmp
-mv $nonFlakeDir $nonFlakeDir.tmp
-nix build -o $TEST_ROOT/result flake3#sth
-(! nix build -o $TEST_ROOT/result flake3#xyzzy)
-(! nix build -o $TEST_ROOT/result flake3#fnord)
-mv $flake2Dir.tmp $flake2Dir
-mv $nonFlakeDir.tmp $nonFlakeDir
-nix build -o $TEST_ROOT/result flake3#xyzzy flake3#fnord
+mv "$flake2Dir" "$flake2Dir.tmp"
+mv "$nonFlakeDir" "$nonFlakeDir.tmp"
+nix build -o "$TEST_ROOT/result" flake3#sth
+(! nix build -o "$TEST_ROOT/result" flake3#xyzzy)
+(! nix build -o "$TEST_ROOT/result" flake3#fnord)
+mv "$flake2Dir.tmp" "$flake2Dir"
+mv "$nonFlakeDir.tmp" "$nonFlakeDir"
+nix build -o "$TEST_ROOT/result" flake3#xyzzy flake3#fnord
 
 # Test doing multiple `lookupFlake`s
-nix build -o $TEST_ROOT/result flake4#xyzzy
+nix build -o "$TEST_ROOT/result" flake4#xyzzy
 
 # Test 'nix flake update' and --override-flake.
-nix flake lock $flake3Dir
-[[ -z $(git -C $flake3Dir diff master || echo failed) ]]
+nix flake lock "$flake3Dir"
+[[ -z $(git -C "$flake3Dir" diff master || echo failed) ]]
 
-nix flake update $flake3Dir --override-flake flake2 nixpkgs
-[[ ! -z $(git -C $flake3Dir diff master || echo failed) ]]
+nix flake update "$flake3Dir" --override-flake flake2 nixpkgs
+[[ ! -z $(git -C "$flake3Dir" diff master || echo failed) ]]
 
 # Make branch "removeXyzzy" where flake3 doesn't have xyzzy anymore
-git -C $flake3Dir checkout -b removeXyzzy
-rm $flake3Dir/flake.nix
+git -C "$flake3Dir" checkout -b removeXyzzy
+rm "$flake3Dir/flake.nix"
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   inputs = {
     nonFlake = {
@@ -330,14 +332,14 @@ cat > $flake3Dir/flake.nix <<EOF
   };
 }
 EOF
-nix flake lock $flake3Dir
-git -C $flake3Dir add flake.nix flake.lock
-git -C $flake3Dir commit -m 'Remove packages.xyzzy'
-git -C $flake3Dir checkout master
+nix flake lock "$flake3Dir"
+git -C "$flake3Dir" add flake.nix flake.lock
+git -C "$flake3Dir" commit -m 'Remove packages.xyzzy'
+git -C "$flake3Dir" checkout master
 
 # Test whether fuzzy-matching works for registry entries.
-(! nix build -o $TEST_ROOT/result flake4/removeXyzzy#xyzzy)
-nix build -o $TEST_ROOT/result flake4/removeXyzzy#sth
+(! nix build -o "$TEST_ROOT/result" flake4/removeXyzzy#xyzzy)
+nix build -o "$TEST_ROOT/result" flake4/removeXyzzy#sth
 
 # Testing the nix CLI
 nix registry add flake1 flake3
@@ -351,7 +353,7 @@ nix registry remove flake1
 
 # Test 'nix registry list' with a disabled global registry.
 nix registry add user-flake1 git+file://$flake1Dir
-nix registry add user-flake2 git+file://$flake2Dir
+nix registry add user-flake2 "git+file://$percentEncodedFlake2Dir"
 [[ $(nix --flake-registry "" registry list | wc -l) == 2 ]]
 nix --flake-registry "" registry list | grepQuietInverse '^global' # nothing in global registry
 nix --flake-registry "" registry list | grepQuiet '^user'
@@ -365,7 +367,7 @@ nix flake clone flake1 --dest $TEST_ROOT/flake1-v2
 [ -e $TEST_ROOT/flake1-v2/flake.nix ]
 
 # Test 'follows' inputs.
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   inputs.foo = {
     type = "indirect";
@@ -378,10 +380,10 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-nix flake lock $flake3Dir
-[[ $(jq -c .nodes.root.inputs.bar $flake3Dir/flake.lock) = '["foo"]' ]]
+nix flake lock "$flake3Dir"
+[[ $(jq -c .nodes.root.inputs.bar "$flake3Dir/flake.lock") = '["foo"]' ]]
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   inputs.bar.follows = "flake2/flake1";
 
@@ -390,10 +392,10 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-nix flake lock $flake3Dir
-[[ $(jq -c .nodes.root.inputs.bar $flake3Dir/flake.lock) = '["flake2","flake1"]' ]]
+nix flake lock "$flake3Dir"
+[[ $(jq -c .nodes.root.inputs.bar "$flake3Dir/flake.lock") = '["flake2","flake1"]' ]]
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   inputs.bar.follows = "flake2";
 
@@ -402,15 +404,15 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-nix flake lock $flake3Dir
-[[ $(jq -c .nodes.root.inputs.bar $flake3Dir/flake.lock) = '["flake2"]' ]]
+nix flake lock "$flake3Dir"
+[[ $(jq -c .nodes.root.inputs.bar "$flake3Dir/flake.lock") = '["flake2"]' ]]
 
 # Test overriding inputs of inputs.
 writeTrivialFlake $flake7Dir
 git -C $flake7Dir add flake.nix
 git -C $flake7Dir commit -m 'Initial'
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   inputs.flake2.inputs.flake1 = {
     type = "git";
@@ -422,10 +424,10 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-nix flake lock $flake3Dir
-[[ $(jq .nodes.flake1.locked.url $flake3Dir/flake.lock) =~ flake7 ]]
+nix flake lock "$flake3Dir"
+[[ $(jq .nodes.flake1.locked.url "$flake3Dir/flake.lock") =~ flake7 ]]
 
-cat > $flake3Dir/flake.nix <<EOF
+cat > "$flake3Dir/flake.nix" <<EOF
 {
   inputs.flake2.inputs.flake1.follows = "foo";
   inputs.foo.url = git+file://$flake7Dir;
@@ -435,9 +437,9 @@ cat > $flake3Dir/flake.nix <<EOF
 }
 EOF
 
-nix flake update $flake3Dir
-[[ $(jq -c .nodes.flake2.inputs.flake1 $flake3Dir/flake.lock) =~ '["foo"]' ]]
-[[ $(jq .nodes.foo.locked.url $flake3Dir/flake.lock) =~ flake7 ]]
+nix flake update "$flake3Dir"
+[[ $(jq -c .nodes.flake2.inputs.flake1 "$flake3Dir/flake.lock") =~ '["foo"]' ]]
+[[ $(jq .nodes.foo.locked.url "$flake3Dir/flake.lock") =~ flake7 ]]
 
 # Test git+file with bare repo.
 rm -rf $flakeGitBare
@@ -464,25 +466,25 @@ nix build -o $TEST_ROOT/result $url
 expectStderr 102 nix build -o $TEST_ROOT/result "file://$TEST_ROOT/flake.tar.gz?narHash=sha256-qQ2Zz4DNHViCUrp6gTS7EE4+RMqFQtUfWF2UNUtJKS0=" | grep 'NAR hash mismatch'
 
 # Test --override-input.
-git -C $flake3Dir reset --hard
-nix flake lock $flake3Dir --override-input flake2/flake1 file://$TEST_ROOT/flake.tar.gz -vvvvv
-[[ $(jq .nodes.flake1_2.locked.url $flake3Dir/flake.lock) =~ flake.tar.gz ]]
+git -C "$flake3Dir" reset --hard
+nix flake lock "$flake3Dir" --override-input flake2/flake1 file://$TEST_ROOT/flake.tar.gz -vvvvv
+[[ $(jq .nodes.flake1_2.locked.url "$flake3Dir/flake.lock") =~ flake.tar.gz ]]
 
-nix flake lock $flake3Dir --override-input flake2/flake1 flake1
-[[ $(jq -r .nodes.flake1_2.locked.rev $flake3Dir/flake.lock) =~ $hash2 ]]
+nix flake lock "$flake3Dir" --override-input flake2/flake1 flake1
+[[ $(jq -r .nodes.flake1_2.locked.rev "$flake3Dir/flake.lock") =~ $hash2 ]]
 
-nix flake lock $flake3Dir --override-input flake2/flake1 flake1/master/$hash1
-[[ $(jq -r .nodes.flake1_2.locked.rev $flake3Dir/flake.lock) =~ $hash1 ]]
+nix flake lock "$flake3Dir" --override-input flake2/flake1 flake1/master/$hash1
+[[ $(jq -r .nodes.flake1_2.locked.rev "$flake3Dir/flake.lock") =~ $hash1 ]]
 
 # Test --update-input.
-nix flake lock $flake3Dir
-[[ $(jq -r .nodes.flake1_2.locked.rev $flake3Dir/flake.lock) = $hash1 ]]
+nix flake lock "$flake3Dir"
+[[ $(jq -r .nodes.flake1_2.locked.rev "$flake3Dir/flake.lock") = $hash1 ]]
 
-nix flake lock $flake3Dir --update-input flake2/flake1
-[[ $(jq -r .nodes.flake1_2.locked.rev $flake3Dir/flake.lock) =~ $hash2 ]]
+nix flake lock "$flake3Dir" --update-input flake2/flake1
+[[ $(jq -r .nodes.flake1_2.locked.rev "$flake3Dir/flake.lock") =~ $hash2 ]]
 
 # Test 'nix flake metadata --json'.
-nix flake metadata $flake3Dir --json | jq .
+nix flake metadata "$flake3Dir" --json | jq .
 
 # Test flake in store does not evaluate.
 rm -rf $badFlakeDir
@@ -495,17 +497,17 @@ nix store delete $(nix store add-path $badFlakeDir)
 
 # Test fetching flakerefs in the legacy CLI.
 [[ $(nix-instantiate --eval flake:flake3 -A x) = 123 ]]
-[[ $(nix-instantiate --eval flake:git+file://$flake3Dir -A x) = 123 ]]
+[[ $(nix-instantiate --eval "flake:git+file://$percentEncodedFlake3Dir" -A x) = 123 ]]
 [[ $(nix-instantiate -I flake3=flake:flake3 --eval '<flake3>' -A x) = 123 ]]
 [[ $(NIX_PATH=flake3=flake:flake3 nix-instantiate --eval '<flake3>' -A x) = 123 ]]
 
 # Test alternate lockfile paths.
-nix flake lock $flake2Dir --output-lock-file $TEST_ROOT/flake2.lock
-cmp $flake2Dir/flake.lock $TEST_ROOT/flake2.lock >/dev/null # lockfiles should be identical, since we're referencing flake2's original one
+nix flake lock "$flake2Dir" --output-lock-file $TEST_ROOT/flake2.lock
+cmp "$flake2Dir/flake.lock" $TEST_ROOT/flake2.lock >/dev/null # lockfiles should be identical, since we're referencing flake2's original one
 
-nix flake lock $flake2Dir --output-lock-file $TEST_ROOT/flake2-overridden.lock --override-input flake1 git+file://$flake1Dir?rev=$flake1OriginalCommit
-expectStderr 1 cmp $flake2Dir/flake.lock $TEST_ROOT/flake2-overridden.lock
-nix flake metadata $flake2Dir --reference-lock-file $TEST_ROOT/flake2-overridden.lock | grepQuiet $flake1OriginalCommit
+nix flake lock "$flake2Dir" --output-lock-file $TEST_ROOT/flake2-overridden.lock --override-input flake1 git+file://$flake1Dir?rev=$flake1OriginalCommit
+expectStderr 1 cmp "$flake2Dir/flake.lock" $TEST_ROOT/flake2-overridden.lock
+nix flake metadata "$flake2Dir" --reference-lock-file $TEST_ROOT/flake2-overridden.lock | grepQuiet $flake1OriginalCommit
 
 # reference-lock-file can only be used if allow-dirty is set.
-expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-file $TEST_ROOT/flake2-overridden.lock
+expectStderr 1 nix flake metadata "$flake2Dir" --no-allow-dirty --reference-lock-file $TEST_ROOT/flake2-overridden.lock


### PR DESCRIPTION
To support using nix flakes in paths with spaces, this introduces the convention that the `path` part of the URL should be percent-encoded when dealing with paths, and that it's the responsibility of fetchers that use a local path to decode it.

It follows the convention of firefox, which uses percent encoding when encoding a local path to an URL.

Eventually, this might also allow paths with arbitrary unicode characters (#4563, #5759), if the percent encoding and decoding methods are improved such that they can handle them.

This closes #6394.

I can get rid of the hijacked test if you'd prefer it.