### PR TITLE
Add security.csm to ignored-acls

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -125,7 +125,6 @@ let
     sandbox = "false";
     build-users-group = "nixbld";
     trusted-public-keys = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
-    ignored-acls = "security.csm";
   };
   nixConfContents = (lib.concatStringsSep "\n" (lib.mapAttrsFlatten (n: v: "${n} = ${v}") nixConf)) + "\n";
 

--- a/docker.nix
+++ b/docker.nix
@@ -125,6 +125,7 @@ let
     sandbox = "false";
     build-users-group = "nixbld";
     trusted-public-keys = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
+    ignored-acls = security.csm;
   };
   nixConfContents = (lib.concatStringsSep "\n" (lib.mapAttrsFlatten (n: v: "${n} = ${v}") nixConf)) + "\n";
 

--- a/docker.nix
+++ b/docker.nix
@@ -125,7 +125,7 @@ let
     sandbox = "false";
     build-users-group = "nixbld";
     trusted-public-keys = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
-    ignored-acls = security.csm;
+    ignored-acls = "security.csm";
   };
   nixConfContents = (lib.concatStringsSep "\n" (lib.mapAttrsFlatten (n: v: "${n} = ${v}") nixConf)) + "\n";
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -802,7 +802,7 @@ public:
         )"};
 
     Setting<StringSet> ignoredAcls{
-        this, {"security.selinux", "system.nfs4_acl"}, "ignored-acls",
+        this, {"security.selinux", "system.nfs4_acl", "security.csm"}, "ignored-acls",
         R"(
           A list of ACLs that should be ignored, normally Nix attempts to
           remove all ACLs from files and directories in the Nix store, but


### PR DESCRIPTION
The security.csm ACL is, as far as I know, never reasonable to remove, so let's add it to the ignore-list in the vanilla nix image.  This makes this image usable on GKE.

I was considering adding a couple of others that seem to be generally added - security.selinux and system.nfs4_acl - but I thought I'd stick with the minimal.  Happy to add them if people think it's better!

Thanks!