### PR TITLE
respect print-missing variable in new-style build command

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -919,6 +919,9 @@ std::vector<std::pair<std::shared_ptr<Installable>, BuiltPath>> Installable::bui
         break;
 
     case Realise::Outputs: {
+        if (settings.printMissing)
+          printMissing(store, pathsToBuild, lvlInfo);
+
         for (auto & buildResult : store->buildPathsWithResults(pathsToBuild, bMode, evalStore)) {
             if (!buildResult.success())
                 buildResult.rethrow();


### PR DESCRIPTION
This addresses https://github.com/NixOS/nix/issues/6561

Currently nix-build prints the "printMissing" information by default,
nix build doesn’t. People generally don‘t notice this because the
standard log-format of nix build would not display the printMissing
output long enough to display the information.

Summoning @thufschmitt 