### PR TITLE
Fix nested flake input overrides

### DIFF
--- a/src/libexpr/flake/lockfile.cc
+++ b/src/libexpr/flake/lockfile.cc
@@ -338,7 +338,7 @@ void LockFile::check()
 
     for (auto & [inputPath, input] : inputs) {
         if (auto follows = std::get_if<1>(&input)) {
-            if (!follows->empty() && !get(inputs, *follows))
+            if (!follows->empty() && !findInput(*follows))
                 throw Error("input '%s' follows a non-existent input '%s'",
                     printInputPath(inputPath),
                     printInputPath(*follows));


### PR DESCRIPTION
Currently, `B` in `inputs.A.inputs.B.inputs.C...` is interpreted as registry flake, discarding any of its configuration in `A`, leading to an [unexpected](https://github.com/NixOS/nix/issues/5790) "cannot find flake 'flake:B' in the flake registries". This PR implements the expected behavior:
* input overrides (those nested inside `inputs`) are not defaulted to registry flakes.
* Input overrides do not outright replace the corresponding input of the nested flake, but are recursively merged into it, meaning e.g. `inputs.B.url` set in `A` is preserved by the above config.

Fixes #5790 