### PR TITLE
Don't read HOME from environment

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -573,17 +573,13 @@ Path getHome()
 {
     static Path homeDir = []()
     {
-        auto homeDir = getEnv("HOME");
-        if (!homeDir) {
-            std::vector<char> buf(16384);
-            struct passwd pwbuf;
-            struct passwd * pw;
-            if (getpwuid_r(geteuid(), &pwbuf, buf.data(), buf.size(), &pw) != 0
-                || !pw || !pw->pw_dir || !pw->pw_dir[0])
-                throw Error("cannot determine user's home directory");
-            homeDir = pw->pw_dir;
-        }
-        return *homeDir;
+        std::vector<char> buf(16384);
+        struct passwd pwbuf;
+        struct passwd * pw;
+        if (getpwuid_r(geteuid(), &pwbuf, buf.data(), buf.size(), &pw) != 0
+            || !pw || !pw->pw_dir || !pw->pw_dir[0])
+            throw Error("cannot determine user's home directory");
+        return Path(pw->pw_dir);
     }();
     return homeDir;
 }


### PR DESCRIPTION
On darwin, sudo does not clear HOME, so HOME will still be set to a
user's home directory rather than root's.

util::getHome reads that value of HOME and is used in a number of
different places, which causes unexpected behavior in quite a few ways

See https://github.com/NixOS/nix/issues/1548 for some issues with
nix-channel

nix profile will symlink ~/.nix-profile to the default system profile

nix will create ~/.cache owned by root:
$ rm -r ~/.cache
$ sudo nix --extra-experimental-features "nix-command flakes" run nixpkgs#hello
Hello, world!
$ ls -ld ~/.cache
drwxr-xr-x 3 root staff 96 Jun  6 17:14 /Users/matthew/.cache

I'm guessing similar problems occur elsewhere getHome is used