### PR TITLE
More useful error when command not found on remote

### DIFF
--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -73,9 +73,12 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
     ref<Connection> openConnection()
     {
         auto conn = make_ref<Connection>();
-        conn->sshConn = master.startCommand(
-            fmt("%s --serve --write", remoteProgram)
-            + (remoteStore.get() == "" ? "" : " --store " + shellEscape(remoteStore.get())));
+        Strings args = {"--serve", "--write"};
+        if (remoteStore.get() != "") {
+            args.push_back("--store");
+            args.push_back(remoteStore.get());
+        }
+        conn->sshConn = master.startCommand(remoteProgram, args);
         conn->to = FdSink(conn->sshConn->in.get());
         conn->from = FdSource(conn->sshConn->out.get());
 

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -88,9 +88,12 @@ private:
 ref<RemoteStore::Connection> SSHStore::openConnection()
 {
     auto conn = make_ref<Connection>();
-    conn->sshConn = master.startCommand(
-        fmt("%s --stdio", remoteProgram)
-        + (remoteStore.get() == "" ? "" : " --store " + shellEscape(remoteStore.get())));
+    Strings args = {"--stdio"};
+    if (remoteStore.get() != "") {
+        args.push_back("--store");
+        args.push_back(remoteStore.get());
+    }
+    conn->sshConn = master.startCommand(remoteProgram, args);
     conn->to = FdSink(conn->sshConn->in.get());
     conn->from = FdSource(conn->sshConn->out.get());
     return conn;

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -37,7 +37,7 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
         args.push_back("-C");
 }
 
-std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string & command, Strings args)
+std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string & command, Strings & args)
 {
     Path socketPath = startMaster();
 

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -37,7 +37,7 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
         args.push_back("-C");
 }
 
-std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string & command)
+std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string & command, Strings args)
 {
     Path socketPath = startMaster();
 
@@ -62,21 +62,58 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string
         if (logFD != -1 && dup2(logFD, STDERR_FILENO) == -1)
             throw SysError("duping over stderr");
 
-        Strings args;
+        Strings execargs;
 
         if (fakeSSH) {
-            args = { "bash", "-c" };
+            execargs.push_back(command);
+            execargs.splice(execargs.end(), args);
         } else {
-            args = { "ssh", host.c_str(), "-x" };
-            addCommonSSHOpts(args);
+            std::string escapedCommand = shellEscape(command);
+
+            std::string script = {escapedCommand};
+
+            for (std::string arg: args) {
+                script.push_back(' ');
+                script.append(shellEscape(arg));
+            }
+
+            // This is really ugly, but it's less ugly then trying to catch the
+            // error thrown by this process when ssh it can't find the command.
+            // We would have to first of all catch this error (which is not
+            // trivial, since it will only be thrown to the parent process
+            // during blocking communication), then redirect the stderr, search
+            // it for "command not found" and then ssh again and try to find the
+            // command.
+            script.append(
+                fmt(
+                    " || ( \
+                    code=$?;\
+                    if ! [ $code -eq 127 ]; then exit $code; fi;\
+                    PATH=\"$PATH:$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin\";\
+                    cmd=\"$(command -v %s)\";\
+                    if [ -n \"$cmd\" ]; then\
+                        printf \"Executable %s not found in PATH on the remote host, but it was found in %%s.\\nPerhaps try adding '\\e[35;1m&remote-program=%%s\\e[0m' at the end of your SSH url.\n\" \"$cmd\" \"$cmd\" > /dev/stderr; \
+                    else\
+                        printf \"Executable %s was not found on the remote host. Are you sure you have Nix installed there?\n\" > /dev/stderr;\
+                    fi;\
+                    exit $code;\
+                    )",
+                    escapedCommand,
+                    escapedCommand,
+                    escapedCommand
+                )
+            );
+
+            execargs = { "ssh", host.c_str(), "-x" };
+            addCommonSSHOpts(execargs);
             if (socketPath != "")
-                args.insert(args.end(), {"-S", socketPath});
+                execargs.insert(args.end(), {"-S", socketPath});
             if (verbosity >= lvlChatty)
-                args.push_back("-v");
+                execargs.push_back("-v");
+            execargs.push_back(script);
         }
 
-        args.push_back(command);
-        execvp(args.begin()->c_str(), stringsToCharPtrs(args).data());
+        execvp(execargs.begin()->c_str(), stringsToCharPtrs(execargs).data());
 
         // could not exec ssh/bash
         throw SysError("unable to execute '%s'", args.front());

--- a/src/libstore/ssh.hh
+++ b/src/libstore/ssh.hh
@@ -38,7 +38,7 @@ public:
         AutoCloseFD out, in;
     };
 
-    std::unique_ptr<Connection> startCommand(const std::string & command);
+    std::unique_ptr<Connection> startCommand(const std::string & command, Strings args);
 
     Path startMaster();
 };


### PR DESCRIPTION
    On macOS and some versions of Linux, shells started in non-interactive
    mode don't execute their RC files, resulting in errors like

      zsh:1: command not found: nix-store

    This is confusing to new users.

    If the executable does exist somewhere we would expect the installer to
    put it, but that location is not in PATH, show a more detailed error
    instructing the user to add '&remote-program' to the URL.