### PR TITLE
nix-env: A small std::move() optimization

### DIFF
--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1485,7 +1485,7 @@ static int main_nix_env(int argc, char * * argv)
         if (globals.profile == "")
             globals.profile = getDefaultProfile();
 
-        op(globals, opFlags, opArgs);
+        op(globals, std::move(opFlags), std::move(opArgs));
 
         globals.state->printStats();
 


### PR DESCRIPTION
(Found another location)

Avoids doing a O(n) copy of Strings i.e. `std::list<std::string>`

