### PR TITLE
Add missing rethrows in conditional exception handlers

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -135,6 +135,7 @@ void LocalStore::addTempRoot(const StorePath & path)
                     state->fdRootsSocket.close();
                     goto restart;
                 }
+                throw;
             }
         }
 
@@ -153,6 +154,7 @@ void LocalStore::addTempRoot(const StorePath & path)
                 state->fdRootsSocket.close();
                 goto restart;
             }
+            throw;
         } catch (EndOfFile & e) {
             debug("GC socket disconnected");
             state->fdRootsSocket.close();

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -69,6 +69,7 @@ protected:
         } catch (SysError & e) {
             if (e.errNo == ENOENT)
                 throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache", path);
+            throw;
         }
     }
 

--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -37,6 +37,7 @@ void removeOldGenerations(std::string dir)
                 link = readLink(path);
             } catch (SysError & e) {
                 if (e.errNo == ENOENT) continue;
+                throw;
             }
             if (link.find("link") != std::string::npos) {
                 printInfo(format("removing old generations of profile %1%") % path);


### PR DESCRIPTION
If we’re only interested in some exceptions of a given type, we need to rethrow the rest of them instead of swallowing them and continuing execution.