### PR TITLE
nix-build: stop logger when appropriate

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -543,6 +543,8 @@ static void main_nix_build(int argc, char * * argv)
 
         restoreProcessContext();
 
+        logger->stop();
+
         execvp(shell->c_str(), argPtrs.data());
 
         throw SysError("executing shell '%s'", *shell);
@@ -600,6 +602,8 @@ static void main_nix_build(int argc, char * * argv)
 
             outPaths.push_back(outputPath);
         }
+
+        logger->stop();
 
         for (auto & path : outPaths)
             std::cout << store->printStorePath(path) << '\n';


### PR DESCRIPTION
Reverts b944b588fa280b0555b8269c0f6d097352f8716f in `nix-build.cc`.

I got a bit carried away in https://github.com/NixOS/nix/pull/6523 and removed `logger->stop()`s that were not done at the end of the program's execution.

For example, in Nix 2.9:

```
$ nix-build --log-format bar -A hello
querying info about missing paths/nix/store/14z9fms0ag980vck7p7lf8bzrc0c3y16-hello-2.12
```

```
$ nix-shell --log-format bar -p hello
querying info about missing paths$ # prompt is here
```

This fixes both issues.

cc @thufschmitt 