### PR TITLE
doc: add install test info to hacking.md

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -109,7 +109,7 @@ You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-
 
 ### Installer tests
 
-With just a little one-time setup, the Nix repository's GitHub Actions continuous integration (CI) workflow can easily test the installer each time you push to a branch.
+After a one-time setup, the Nix repository's GitHub Actions continuous integration (CI) workflow can test the installer each time you push to a branch.
 
 Creating a Cachix cache for your installer tests and adding its authorization token to GitHub enables [two installer-specific jobs in the CI workflow](https://github.com/NixOS/nix/blob/88a45d6149c0e304f6eb2efcc2d7a4d0d569f8af/.github/workflows/ci.yml#L50-L91):
 
@@ -123,7 +123,7 @@ Creating a Cachix cache for your installer tests and adding its authorization to
 
 #### One-time setup
 
-1. Have a GitHub account with a fork of the Nix repo.
+1. Have a GitHub account with a fork of the [Nix repository](https://github.com/NixOS/nix).
 2. At cachix.org:
     - Create or log in to an account.
     - Create a Cachix cache using the format `<github-username>-nix-install-tests`.

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -113,11 +113,12 @@ You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-
 
 Testing the install scripts has traditionally been tedious, but you can now do this much more easily via the GitHub Actions CI runs (at least for platforms that Github Actions supports).
 
-If you've already pushed to a fork of Nix on GitHub before, you may have noticed that the CI workflows in your fork list skipped "installer" and "installer_test" jobs. Once your Nix fork is set up correctly, pushing to it will also run these jobs.
-- The `installer` job will generate installers for these platforms: x86_64-linux, armv6l-linux, armv7l-linux, x86_64-darwin. While this installer is in your Cachix cache, you can use it for manual testing on any of these platforms.
+If you've already pushed to a fork of Nix on GitHub before, you may have noticed that the CI workflows in your fork list skipped `installer` and `installer_test` jobs. Once your Nix fork is set up correctly, pushing to it will also run these jobs.
+- The `installer` job will generate installers for these platforms: `x86_64-linux`, `armv6l-linux`, `armv7l-linux`, `x86_64-darwin`. While this installer is in your Cachix cache, you can use it for manual testing on any of these platforms.
 - the `installer_test` job will try to use this installer and run a trivial Nix command on `ubuntu-latest` and `macos-latest`.
 
 ### One-time setup
+
 1. Have a GitHub account with a fork of the Nix repo.
 2. At cachix.org:
     - Create or log in to an account.

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -83,7 +83,7 @@ by:
 $ nix develop
 ```
 
-## Testing Nix
+## Running tests
 
 ### Unit-tests
 
@@ -107,21 +107,21 @@ Because these tests are expensive and require more than what the standard github
 
 You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-build -A hydraJobs.tests.{testName}`
 
-## Testing the install scripts
+### Installer tests
 
-Testing the install scripts has traditionally been tedious, but you can now do this much more easily via the GitHub Actions CI runs (at least for platforms that Github Actions supports).
+With just a little one-time setup, the Nix repository's GitHub Actions continuous integration (CI) workflow can easily test the installer each time you push to a branch.
 
-If you've already pushed to a fork of Nix on GitHub before, you may have noticed that the CI workflows in your fork list skipped `installer` and `installer_test` jobs. Once your Nix fork is set up correctly, pushing to it will also run these jobs.
-- The `installer` job will generate installers for these platforms:
+Creating a Cachix cache for your installer tests and adding its authorization token to GitHub enables [two installer-specific jobs in the CI workflow](https://github.com/NixOS/nix/blob/88a45d6149c0e304f6eb2efcc2d7a4d0d569f8af/.github/workflows/ci.yml#L50-L91):
+
+- The `installer` job generates installers for the platforms below and uploads them to your Cachix cache:
   - `x86_64-linux`
   - `armv6l-linux`
   - `armv7l-linux`
-  - `x86_64-darwin`.
-  
-  While this installer is in your Cachix cache, you can use it for manual testing on any of these platforms.
-- The `installer_test` job will try to use this installer and run a trivial Nix command on `ubuntu-latest` and `macos-latest`.
+  - `x86_64-darwin`
 
-### One-time setup
+- The `installer_test` job (which runs on `ubuntu-latest` and `macos-latest`) will try to install Nix with the cached installer and run a trivial Nix command.
+
+#### One-time setup
 
 1. Have a GitHub account with a fork of the Nix repo.
 2. At cachix.org:
@@ -129,12 +129,12 @@ If you've already pushed to a fork of Nix on GitHub before, you may have noticed
     - Create a Cachix cache using the format `<github-username>-nix-install-tests`.
     - Navigate to the new cache > Settings > Auth Tokens.
     - Generate a new Cachix auth token and copy the generated value.
-4. At github.com:
+3. At github.com:
     - Navigate to your Nix fork > Settings > Secrets > Actions > New repository secret.
-    - Name the secret `CACHIX_AUTH_TOKEN`
+    - Name the secret `CACHIX_AUTH_TOKEN`.
     - Paste the copied value of the Cachix cache auth token.
 
-### Using the CI-generated installer for manual testing
+#### Using the CI-generated installer for manual testing
 
 After the CI run completes, you can check the output to extract the installer URL:
 1. Click into the detailed view of the CI run.
@@ -147,7 +147,7 @@ After the CI run completes, you can check the output to extract the installer UR
     sh <(curl -L <install_url>) --tarball-url-prefix https://<github-username>-nix-install-tests.cachix.org/serve
     ```
 
-<!-- ### Manually generating test installers
+<!-- #### Manually generating test installers
 
 There's obviously a manual way to do this, and it's still the only way for
 platforms that lack GA runners.

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -83,7 +83,7 @@ by:
 $ nix develop
 ```
 
-## Testing
+## Testing Nix
 
 Nix comes with three different flavors of tests: unit, functional and integration.
 
@@ -108,3 +108,65 @@ These tests include everything that needs to interact with external services or 
 Because these tests are expensive and require more than what the standard github-actions setup provides, they only run on the master branch (on <https://hydra.nixos.org/jobset/nix/master>).
 
 You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-build -A hydraJobs.tests.{testName}`
+
+## Testing the install scripts
+
+Testing the install scripts has traditionally been tedious, but you can now do this much more easily via the GitHub Actions CI runs (at least for platforms that Github Actions supports).
+
+If you've already pushed to a fork of Nix on GitHub before, you may have noticed that the CI workflows in your fork list skipped "installer" and "installer_test" jobs. Once your Nix fork is set up correctly, pushing to it will also run these jobs.
+- The `installer` job will generate installers for these platforms: x86_64-linux, armv6l-linux, armv7l-linux, x86_64-darwin. While this installer is in your Cachix cache, you can use it for manual testing on any of these platforms.
+- the `installer_test` job will try to use this installer and run a trivial Nix command on `ubuntu-latest` and `macos-latest`.
+
+### One-time setup
+1. Have a GitHub account with a fork of the Nix repo.
+2. At cachix.org:
+    - Create or log in to an account.
+    - Create a Cachix cache using the format `<github-username>-nix-install-tests`.
+    - Navigate to the new cache > Settings > Auth Tokens.
+    - Generate a new cachix auth token and copy the generated value.
+4. At github.com:
+    - Navigate to your Nix fork > Settings > Secrets > Actions > New repository secret.
+    - Name the secret `CACHIX_AUTH_TOKEN`
+    - Paste the copied value of the Cachix cache auth token.
+
+### Using the CI-generated installer for manual testing
+
+After the CI run completes, you can check the output to extract the installer url:
+1. Click into the detailed view of the CI run.
+2. Click into any `installer_test` run (the URL you're here to extract will be the same in all of them).
+3. Click into the `Run cachix/install-nix-action@v...` step and click the detail triangle next to the first log line (it will also be `Run cachix/install-nix-action@v...`)
+4. Copy the install_url
+5. To generate an install command, plug this install_url and your github username into this template:
+
+    ```console
+    sh <(curl -L <install_url>) --tarball-url-prefix https://<github-username>-nix-install-tests.cachix.org/serve
+    ```
+
+<!-- ### Manually generating test installers
+
+There's obviously a manual way to do this, and it's still the only way for
+platforms that lack GA runners.
+
+I did do this back in Fall 2020 (before the GA approach encouraged here). I'll
+sketch what I recall in case it encourages someone to fill in detail, but: I
+didn't know what I was doing at the time and had to fumble/ask around a lot--
+so I don't want to uphold any of it as "right". It may have been dumb or
+the _hard_ way from the getgo. Fundamentals may have changed since.
+
+Here's the build command I used to do this on and for x86_64-darwin:
+nix build --out-link /tmp/foo ".#checks.x86_64-darwin.binaryTarball"
+
+I used the stable out-link to make it easier to script the next steps:
+link=$(readlink /tmp/foo)
+cp $link/*-darwin.tar.xz ~/somewheres
+
+I've lost the last steps and am just going from memory:
+
+From here, I think I had to extract and modify the `install` script to point
+it at this tarball (which I scped to my own site, but it might make more sense
+to just share them locally). I extracted this script once and then just
+search/replaced in it for each new build.
+
+The installer now supports a `--tarball-url-prefix` flag which _may_ have
+solved this need?
+-->

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -142,8 +142,8 @@ After the CI run completes, you can check the output to extract the installer ur
 1. Click into the detailed view of the CI run.
 2. Click into any `installer_test` run (the URL you're here to extract will be the same in all of them).
 3. Click into the `Run cachix/install-nix-action@v...` step and click the detail triangle next to the first log line (it will also be `Run cachix/install-nix-action@v...`)
-4. Copy the install_url
-5. To generate an install command, plug this install_url and your github username into this template:
+4. Copy the value of `install_url`
+5. To generate an install command, plug this `install_url` and your GitHub username into this template:
 
     ```console
     sh <(curl -L <install_url>) --tarball-url-prefix https://<github-username>-nix-install-tests.cachix.org/serve

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -114,7 +114,13 @@ You can run them manually with `nix build .#hydraJobs.tests.{testName}` or `nix-
 Testing the install scripts has traditionally been tedious, but you can now do this much more easily via the GitHub Actions CI runs (at least for platforms that Github Actions supports).
 
 If you've already pushed to a fork of Nix on GitHub before, you may have noticed that the CI workflows in your fork list skipped `installer` and `installer_test` jobs. Once your Nix fork is set up correctly, pushing to it will also run these jobs.
-- The `installer` job will generate installers for these platforms: `x86_64-linux`, `armv6l-linux`, `armv7l-linux`, `x86_64-darwin`. While this installer is in your Cachix cache, you can use it for manual testing on any of these platforms.
+- The `installer` job will generate installers for these platforms:
+  - `x86_64-linux`
+  - `armv6l-linux`
+  - `armv7l-linux`
+  - `x86_64-darwin`.
+  
+  While this installer is in your Cachix cache, you can use it for manual testing on any of these platforms.
 - the `installer_test` job will try to use this installer and run a trivial Nix command on `ubuntu-latest` and `macos-latest`.
 
 ### One-time setup

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -130,7 +130,7 @@ If you've already pushed to a fork of Nix on GitHub before, you may have noticed
     - Create or log in to an account.
     - Create a Cachix cache using the format `<github-username>-nix-install-tests`.
     - Navigate to the new cache > Settings > Auth Tokens.
-    - Generate a new cachix auth token and copy the generated value.
+    - Generate a new Cachix auth token and copy the generated value.
 4. At github.com:
     - Navigate to your Nix fork > Settings > Secrets > Actions > New repository secret.
     - Name the secret `CACHIX_AUTH_TOKEN`

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -85,8 +85,6 @@ $ nix develop
 
 ## Testing Nix
 
-Nix comes with three different flavors of tests: unit, functional and integration.
-
 ### Unit-tests
 
 The unit-tests for each Nix library (`libexpr`, `libstore`, etc..) are defined

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -138,7 +138,7 @@ If you've already pushed to a fork of Nix on GitHub before, you may have noticed
 
 ### Using the CI-generated installer for manual testing
 
-After the CI run completes, you can check the output to extract the installer url:
+After the CI run completes, you can check the output to extract the installer URL:
 1. Click into the detailed view of the CI run.
 2. Click into any `installer_test` run (the URL you're here to extract will be the same in all of them).
 3. Click into the `Run cachix/install-nix-action@v...` step and click the detail triangle next to the first log line (it will also be `Run cachix/install-nix-action@v...`)

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -121,7 +121,7 @@ If you've already pushed to a fork of Nix on GitHub before, you may have noticed
   - `x86_64-darwin`.
   
   While this installer is in your Cachix cache, you can use it for manual testing on any of these platforms.
-- the `installer_test` job will try to use this installer and run a trivial Nix command on `ubuntu-latest` and `macos-latest`.
+- The `installer_test` job will try to use this installer and run a trivial Nix command on `ubuntu-latest` and `macos-latest`.
 
 ### One-time setup
 


### PR DESCRIPTION
@Artturin [suggested](https://github.com/NixOS/nix/pull/6639#issuecomment-1151841848) _someone_ document installer testing (added in #4549, updated in at least #4577) in hacking.md.

I'm a little ambivalent about doing this because it underscores everything _else_ about generating and testing installers that isn't documented--and I don't grok the big picture here. I'm happy to field organization and phrasing nits/clarifications--but fair warning that I will be grumpy if there's pressure to turn this PR into a vehicle to fully document the status quo.

I did stub out a comment with what I can recall of the manual process in case it encourages someone else to flesh that part out, but I'm not sure if it'll cause any trouble in the manual-building pipeline.