### PR TITLE
fix sourcehut brach/tag resolving regression

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -381,7 +381,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
 
         Headers headers = makeHeadersWithAuthTokens(host);
 
-        std::string ref_uri;
+        std::string refUri;
         if (ref == "HEAD") {
             auto file = store->toRealPath(
                 downloadFile(store, fmt("%s/HEAD", base_url), "source", false, headers).storePath);
@@ -393,10 +393,11 @@ struct SourceHutInputScheme : GitArchiveInputScheme
             if (!remoteLine) {
                 throw BadURL("in '%d', couldn't resolve HEAD ref '%d'", input.to_string(), ref);
             }
-            ref_uri = remoteLine->target;
+            refUri = remoteLine->target;
         } else {
-            ref_uri = fmt("refs/(heads|tags)/%s", ref);
+            refUri = fmt("refs/(heads|tags)/%s", ref);
         }
+        std::regex refRegex(refUri);
 
         auto file = store->toRealPath(
             downloadFile(store, fmt("%s/info/refs", base_url), "source", false, headers).storePath);
@@ -406,7 +407,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::optional<std::string> id;
         while(!id && getline(is, line)) {
             auto parsedLine = git::parseLsRemoteLine(line);
-            if (parsedLine && parsedLine->reference == ref_uri)
+            if (parsedLine && parsedLine->reference && std::regex_match(*parsedLine->reference, refRegex))
                 id = parsedLine->target;
         }
 

--- a/tests/sourcehut-flakes.nix
+++ b/tests/sourcehut-flakes.nix
@@ -59,7 +59,7 @@ let
       echo 'ref: refs/heads/master' > $out/HEAD
 
       mkdir -p $out/info
-      echo -e '${nixpkgs.rev}\trefs/heads/master' > $out/info/refs
+      echo -e '${nixpkgs.rev}\trefs/heads/master\n${nixpkgs.rev}\trefs/tags/foo-bar' > $out/info/refs
     '';
 
 in
@@ -132,6 +132,17 @@ makeTest (
       client.succeed("curl -v https://git.sr.ht/ >&2")
       client.succeed("nix registry list | grep nixpkgs")
 
+      # Test that it resolves HEAD
+      rev = client.succeed("nix flake info sourcehut:~NixOS/nixpkgs --json | jq -r .revision")
+      assert rev.strip() == "${nixpkgs.rev}", "revision mismatch"
+      # Test that it resolves branches
+      rev = client.succeed("nix flake info sourcehut:~NixOS/nixpkgs/master --json | jq -r .revision")
+      assert rev.strip() == "${nixpkgs.rev}", "revision mismatch"
+      # Test that it resolves tags
+      rev = client.succeed("nix flake info sourcehut:~NixOS/nixpkgs/foo-bar --json | jq -r .revision")
+      assert rev.strip() == "${nixpkgs.rev}", "revision mismatch"
+
+      # Registry and pinning test
       rev = client.succeed("nix flake info nixpkgs --json | jq -r .revision")
       assert rev.strip() == "${nixpkgs.rev}", "revision mismatch"
 


### PR DESCRIPTION
nixos/nix#6290 introduced a regex pattern to account for tags when resolving sourcehut refs.

nixos/nix#4638 (more specifically https://github.com/NixOS/nix/commit/9bf296c970bf33b7ed53d7e2d8fbe44197482518) reafactored the code, accidentally treating the pattern as a regular string, causing all non-HEAD ref resolving to break.

This fixes the regression and adds more test cases to avoid future breakage.

Fixes https://github.com/NixOS/nix/issues/6650.

The issue affects nix 2.9.0 and 2.9.1. Can we maybe backport the fix?