### PR TITLE
libstore: improve warning message on missing sig

### DIFF
--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -154,7 +154,7 @@ void PathSubstitutionGoal::tryNext()
        only after we've downloaded the path. */
     if (!sub->isTrusted && worker.store.pathInfoIsUntrusted(*info))
     {
-        warn("the substitute for '%s' from '%s' is not signed by any of the keys in 'trusted-public-keys'",
+        warn("igoring substitute for '%s' from '%s', as it's not signed by any of the keys in 'trusted-public-keys'",
             worker.store.printStorePath(storePath), sub->getUri());
         tryNext();
         return;


### PR DESCRIPTION
Clarifies that the substitute will be ignored/skipped.