### PR TITLE
Don't capture `stdout` when launching subshells in `nix repl`

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -111,23 +111,20 @@ NixRepl::~NixRepl()
     write_history(historyFile.c_str());
 }
 
-std::string runNix(Path program, const Strings & args,
+void runNix(Path program, const Strings & args,
     const std::optional<std::string> & input = {})
 {
     auto subprocessEnv = getEnv();
     subprocessEnv["NIX_CONFIG"] = globalConfig.toKeyValue();
 
-    auto res = runProgram(RunOptions {
+    runProgram2(RunOptions {
         .program = settings.nixBinDir+ "/" + program,
         .args = args,
         .environment = subprocessEnv,
         .input = input,
     });
 
-    if (!statusOk(res.first))
-        throw ExecError(res.first, "program '%1%' %2%", program, statusToString(res.first));
-
-    return res.second;
+    return;
 }
 
 static NixRepl * curRepl; // ugly


### PR DESCRIPTION
In [this commit](https://github.com/NixOS/nix/commit/9b9e703df41d75949272059f9b8bc8b763e91fce), the behavior of the `:s` and `:u` commands in `nix repl` changed by capturing `stdout` of the forked process.  This doesn't seem to be an intentional change, since the captured output is discarded.

This change reverts the behavior by having `nix repl`'s invocations of `nix` no longer redirect and capture `stdout` of the forked process.