### PR TITLE
docker.nix: Use nixpkgs tarball instead of raw repository

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -612,7 +612,7 @@
         dockerImage =
           let
             pkgs = nixpkgsFor.${system};
-            image = import ./docker.nix { inherit pkgs; tag = version; };
+            image = import ./docker.nix { inherit pkgs nixpkgs; tag = version; };
           in
           pkgs.runCommand
             "docker-image-tarball-${version}"


### PR DESCRIPTION
In CI jobs which use `nixos/nix`, it can be helpful to print out the exact nixpkgs version prior to beginning a build:

```
nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
```

Unfortunately, due to the way nixpkgs is currently bundled in the dockerImage, the version information is not helpful:

```
"21.05pre-git"
```

This change builds and bundles the contents of a nixpkgs tarball rather than the raw repository. This leads to the following, more helpful output:

```
"22.05pre20220531.2fa57ed"
```

This also allows the truncated commit hash (`2fa57ed`) to be compared against what is specified in the `flake.lock` file:

```
"nixpkgs": {
  "locked": {
    ...
    "owner": "NixOS",
    "repo": "nixpkgs",
    "rev": "2fa57ed190fd6c7c746319444f34b5917666e5c1",
    "type": "github"
  },
```