### PR TITLE
Improve shell completion of flake inputs

### DIFF
--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -77,12 +77,16 @@ struct MixFlakeOptions : virtual Args, EvalCommand
 {
     flake::LockFlags lockFlags;
 
+    std::optional<std::string> needsFlakeInputCompletion = {};
+
     MixFlakeOptions();
 
     virtual std::vector<std::string> getFlakesForCompletion()
     { return {}; }
 
     void completeFlakeInput(std::string_view prefix);
+
+    void completionHook() override;
 };
 
 struct SourceExprCommand : virtual Args, MixFlakeOptions

--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -79,8 +79,10 @@ struct MixFlakeOptions : virtual Args, EvalCommand
 
     MixFlakeOptions();
 
-    virtual std::optional<FlakeRef> getFlakeRefForCompletion()
+    virtual std::vector<std::string> getFlakesForCompletion()
     { return {}; }
+
+    void completeFlakeInput(std::string_view prefix);
 };
 
 struct SourceExprCommand : virtual Args, MixFlakeOptions
@@ -119,7 +121,7 @@ struct InstallablesCommand : virtual Args, SourceExprCommand
 
     virtual bool useDefaultInstallables() { return true; }
 
-    std::optional<FlakeRef> getFlakeRefForCompletion() override;
+    std::vector<std::string> getFlakesForCompletion() override;
 
 private:
 
@@ -135,9 +137,9 @@ struct InstallableCommand : virtual Args, SourceExprCommand
 
     void prepare() override;
 
-    std::optional<FlakeRef> getFlakeRefForCompletion() override
+    std::vector<std::string> getFlakesForCompletion() override
     {
-        return parseFlakeRefWithFragment(_installable, absPath(".")).first;
+        return {_installable};
     }
 
 private:

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -124,7 +124,7 @@ bool Args::processFlag(Strings::iterator & pos, Strings::iterator end)
         bool anyCompleted = false;
         for (size_t n = 0 ; n < flag.handler.arity; ++n) {
             if (pos == end) {
-                if (flag.handler.arity == ArityAny) break;
+                if (flag.handler.arity == ArityAny || anyCompleted) break;
                 throw UsageError("flag '%s' requires %d argument(s)", name, flag.handler.arity);
             }
             if (auto prefix = needsCompletion(*pos)) {
@@ -360,6 +360,14 @@ bool MultiCommand::processArgs(const Strings & args, bool finish)
         return command->second->processArgs(args, finish);
     else
         return Args::processArgs(args, finish);
+}
+
+void MultiCommand::completionHook()
+{
+    if (command)
+        return command->second->completionHook();
+    else
+        return Args::completionHook();
 }
 
 nlohmann::json MultiCommand::toJSON()

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -148,6 +148,11 @@ protected:
        argument (if any) have been processed. */
     virtual void initialFlagsProcessed() {}
 
+    /* Called after the command line has been processed if we need to generate
+       completions. Useful for commands that need to know the whole command line
+       in order to know what completions to generate. */
+    virtual void completionHook() { }
+
 public:
 
     void addFlag(Flag && flag);
@@ -222,6 +227,8 @@ public:
     bool processFlag(Strings::iterator & pos, Strings::iterator end) override;
 
     bool processArgs(const Strings & args, bool finish) override;
+
+    void completionHook() override;
 
     nlohmann::json toJSON() override;
 };

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -50,9 +50,9 @@ public:
         return flake::lockFlake(*getEvalState(), getFlakeRef(), lockFlags);
     }
 
-    std::optional<FlakeRef> getFlakeRefForCompletion() override
+    std::vector<std::string> getFlakesForCompletion() override
     {
-        return getFlakeRef();
+        return {flakeUrl};
     }
 };
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -342,7 +342,10 @@ void mainWrapped(int argc, char * * argv)
         if (!completions) throw;
     }
 
-    if (completions) return;
+    if (completions) {
+        args.completionHook();
+        return;
+    }
 
     if (args.showVersion) {
         printVersion(programName);


### PR DESCRIPTION
Makes `nix build ~/flake1 ~/flake2 --update/override-input <Tab>` do the right thing:

1. do tilde expansion
2. defer the completion until all arguments are parsed, otherwise `_installables` is empty and nix assumes we mean the current directory
3. complete inputs of all given flakes instead of just the first one

For 2, I also considered making arguments like `installables` "incremental", i.e. adding arguments to `_installables` as they are parsed, but this turned out to be a mess to implement. Also with the chosen approach we can complete things like `nix build --update-input foo<Tab> flake`, although this is unreliable (e.g. it won't work with an empty prefix because bash apparently does not insert an empty word there. EDIT: probably a bash [bug](https://lists.gnu.org/archive/html/bug-bash/2022-06/msg00068.html)).