### PR TITLE
filetransfer: set Accept-Encoding to all values supported by libcurl for transparent compression

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,16 @@ PKG_CHECK_MODULES([SQLITE3], [sqlite3 >= 3.6.19], [CXXFLAGS="$SQLITE3_CFLAGS $CX
 # Look for libcurl, a required dependency.
 PKG_CHECK_MODULES([LIBCURL], [libcurl], [CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"])
 
+# Check whether libcurl supports required features
+PKG_CHECK_VAR([LIBCURL_SUPPORTED_FEATURES], [libcurl], [supported_features], [
+  m4_foreach([LIBCURL_FEATURE], [brotli, zstd], [
+    AC_MSG_CHECKING([whether libcurl supports feature LIBCURL_FEATURE])
+    AS_CASE($LIBCURL_SUPPORTED_FEATURES, [*LIBCURL_FEATURE*], [AC_MSG_RESULT(yes)],
+      [AC_MSG_RESULT(no)
+       AC_MSG_ERROR([Nix requires libcurl to support feature LIBCURL_FEATURE])])
+  ])
+], [AC_MSG_ERROR([Nix requires libcurl to provide a list of supported features])])
+
 # Look for editline, a required dependency.
 # The the libeditline.pc file was added only in libeditline >= 1.15.2,
 # see https://github.com/troglobit/editline/commit/0a8f2ef4203c3a4a4726b9dd1336869cd0da8607,

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -160,7 +160,7 @@ struct curlFileTransfer : public FileTransfer
                 result.bodySize += realSize;
 
                 if (!decompressionSink) {
-                    decompressionSink = makeDecompressionSink(encoding, finalSink);
+                    decompressionSink = makeDecompressionSink("", finalSink);
                     if (! successfulStatuses.count(getHTTPStatus())) {
                         // In this case we want to construct a TeeSink, to keep
                         // the response around (which we figure won't be big

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -288,6 +288,7 @@ struct curlFileTransfer : public FileTransfer
             curl_easy_setopt(req, CURLOPT_USERAGENT,
                 ("curl/" LIBCURL_VERSION " Nix/" + nixVersion +
                     (fileTransferSettings.userAgentSuffix != "" ? " " + fileTransferSettings.userAgentSuffix.get() : "")).c_str());
+            curl_easy_setopt(req, CURLOPT_ACCEPT_ENCODING, "");
             #if LIBCURL_VERSION_NUM >= 0x072b00
             curl_easy_setopt(req, CURLOPT_PIPEWAIT, 1);
             #endif


### PR DESCRIPTION
ref: https://discourse.nixos.org/t/announcing-harmonia-a-nix-binary-cache-written-in-rust/19855
This is especially helpful when fetching large nars from binary caches that does not support compression, or having difficulties implementing it.