### PR TITLE
Fix arity of `--exclude` flag in `nix search`

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -34,7 +34,9 @@ struct CmdSearch : InstallableCommand, MixJSON
             .shortName = 'e',
             .description = "Hide packages whose attribute path, name or description contain *regex*.",
             .labels = {"regex"},
-            .handler = Handler(&excludeRes),
+            .handler = {[this](std::string s) {
+                excludeRes.push_back(s);
+            }},
         });
     }
 

--- a/tests/search.sh
+++ b/tests/search.sh
@@ -43,3 +43,4 @@ e=$'\x1b' # grep doesn't support \e, \033 or even \x1b
 
 (( $(nix search -f search.nix foo --exclude 'foo|bar' | grep -Ec 'foo|bar') == 0 ))
 (( $(nix search -f search.nix foo -e foo --exclude bar | grep -Ec 'foo|bar') == 0 ))
+[[ $(nix search -f search.nix -e bar --json | jq -c 'keys') == '["foo","hello"]' ]]


### PR DESCRIPTION
Due to incorrectly using the `Handler(std::vector<std::string>*)` constructor `--exclude` would swallow all proceeding arguments and treat all of them as patterns instead of just one.