### PR TITLE
Forbid the tilde expansion in pure eval mode

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -520,6 +520,12 @@ path_start
     $$ = new ExprPath(path);
   }
   | HPATH {
+    if (evalSettings.pureEval) {
+        throw Error(
+            "the path '%s' can not be resolved in pure mode",
+            std::string_view($1.p, $1.l)
+        );
+    }
     Path path(getHome() + std::string($1.p + 1, $1.l - 1));
     $$ = new ExprPath(path);
   }

--- a/tests/pure-eval.sh
+++ b/tests/pure-eval.sh
@@ -30,3 +30,5 @@ nix eval --store dummy:// --write-to $TEST_ROOT/eval-out --expr '{ x = "foo" + "
 
 rm -rf $TEST_ROOT/eval-out
 (! nix eval --store dummy:// --write-to $TEST_ROOT/eval-out --expr '{ "." = "bla"; }')
+
+(! nix eval --expr '~/foo')


### PR DESCRIPTION
Fix #6684 by throwing an error at parse time when encountering a path that starts with a `~`
