### PR TITLE
Enable tests for nix-static

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -571,13 +571,18 @@
           nativeBuildInputs = nativeBuildDeps;
           buildInputs = buildDeps ++ propagatedDeps;
 
+          # Work around pkgsStatic disabling all tests.
+          preHook =
+            ''
+              doCheck=1
+              doInstallCheck=1
+            '';
+
           configureFlags = [ "--sysconfdir=/etc" ];
 
           enableParallelBuilding = true;
 
           makeFlags = "profiledir=$(out)/etc/profile.d";
-
-          doCheck = true;
 
           installFlags = "sysconfdir=$(out)/etc";
 
@@ -588,7 +593,6 @@
             echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
           '';
 
-          doInstallCheck = true;
           installCheckFlags = "sysconfdir=$(out)/etc";
 
           stripAllList = ["bin"];
@@ -597,6 +601,7 @@
 
           hardeningDisable = [ "pie" ];
         };
+
         dockerImage =
           let
             pkgs = nixpkgsFor.${system};

--- a/tests/ca/content-addressed.nix
+++ b/tests/ca/content-addressed.nix
@@ -75,7 +75,7 @@ rec {
     buildCommand = ''
       mkdir -p $out/bin
       echo ${rootCA} # Just to make it depend on it
-      echo "" > $out/bin/${name}
+      echo "#! ${shell}" > $out/bin/${name}
       chmod +x $out/bin/${name}
     '';
   };

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -50,6 +50,8 @@ export busybox="@sandbox_shell@"
 export version=@PACKAGE_VERSION@
 export system=@system@
 
+export BUILD_SHARED_LIBS=@BUILD_SHARED_LIBS@
+
 export IMPURE_VAR1=foo
 export IMPURE_VAR2=bar
 

--- a/tests/fmt.sh
+++ b/tests/fmt.sh
@@ -18,7 +18,12 @@ cat << EOF > flake.nix
       with import ./config.nix;
       mkDerivation {
         name = "formatter";
-        buildCommand = "mkdir -p \$out/bin; cp \${./fmt.simple.sh} \$out/bin/formatter";
+        buildCommand = ''
+          mkdir -p \$out/bin
+          echo "#! ${shell}" > \$out/bin/formatter
+          cat \${./fmt.simple.sh} >> \$out/bin/formatter
+          chmod +x \$out/bin/formatter
+        '';
       };
   };
 }

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -114,4 +114,8 @@ tests-environment = NIX_REMOTE= $(bash) -e
 
 clean-files += $(d)/common.sh $(d)/config.nix $(d)/ca/config.nix
 
-test-deps += tests/common.sh tests/config.nix tests/ca/config.nix tests/plugins/libplugintest.$(SO_EXT)
+test-deps += tests/common.sh tests/config.nix tests/ca/config.nix
+
+ifeq ($(BUILD_SHARED_LIBS), 1)
+  test-deps += tests/plugins/libplugintest.$(SO_EXT)
+endif

--- a/tests/plugins.sh
+++ b/tests/plugins.sh
@@ -2,6 +2,11 @@ source common.sh
 
 set -o pipefail
 
+if [[ $BUILD_SHARED_LIBS != 1 ]]; then
+    echo "plugins are not supported"
+    exit 99
+fi
+
 res=$(nix --option setting-set true --option plugin-files $PWD/plugins/libplugintest* eval --expr builtins.anotherNull)
 
 [ "$res"x = "nullx" ]


### PR DESCRIPTION
The tests weren't running because `pkgsStatic` is apparently considered a cross environment, so `checkPhase` and `installCheckPhase` were disabled even though we enable them explicitly.

Also fix a few tests that were broken with musl.