### PR TITLE
Automatically use a chroot store if /nix doesn't exist

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1326,9 +1326,9 @@ std::shared_ptr<Store> openFromNonUri(const std::string & uri, const Store::Para
                store in ~/.local/share/nix/root. */
             auto chrootStore = getDataDir() + "/nix/root";
             if (!pathExists(chrootStore))
-                warn("'/nix' does not exists, so Nix will use '%s' as a chroot store", chrootStore);
+                warn("'/nix' does not exist, so Nix will use '%s' as a chroot store", chrootStore);
             else
-                debug("'/nix' does not exists, so Nix will use '%s' as a chroot store", chrootStore);
+                debug("'/nix' does not exist, so Nix will use '%s' as a chroot store", chrootStore);
             Store::Params params2;
             params2["root"] = chrootStore;
             return std::make_shared<LocalStore>(params2);

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1320,6 +1320,7 @@ std::shared_ptr<Store> openFromNonUri(const std::string & uri, const Store::Para
             return std::make_shared<LocalStore>(params);
         else if (pathExists(settings.nixDaemonSocketFile))
             return std::make_shared<UDSRemoteStore>(params);
+        #if __linux__
         else if (!pathExists(stateDir) && params.empty() && getuid() != 0) {
             /* If /nix doesn't exist, there is no daemon socket, and
                we're not root, then automatically set up a chroot
@@ -1332,7 +1333,9 @@ std::shared_ptr<Store> openFromNonUri(const std::string & uri, const Store::Para
             Store::Params params2;
             params2["root"] = chrootStore;
             return std::make_shared<LocalStore>(params2);
-        } else
+        }
+        #endif
+        else
             return std::make_shared<LocalStore>(params);
     } else if (uri == "daemon") {
         return std::make_shared<UDSRemoteStore>(params);


### PR DESCRIPTION
Specifically, if we're not root and /nix and the daemon socket do not exist, then we use `~/.local/share/nix/root` as a chroot store. This enables non-root users to download nix-static and have it work out of the box, e.g.

```
ubuntu@ip-10-13-1-146:~$ ~/nix run nixpkgs#hello
warning: '/nix' does not exist, so Nix will use '/home/ubuntu/.local/share/nix/root' as a chroot store
Hello, world!
```