### PR TITLE
libstore/nar-info: drop unused system field

### DIFF
--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -69,8 +69,6 @@ NarInfo::NarInfo(const Store & store, const std::string & s, const std::string &
             if (value != "unknown-deriver")
                 deriver = StorePath(value);
         }
-        else if (name == "System")
-            system = value;
         else if (name == "Sig")
             sigs.insert(value);
         else if (name == "CA") {
@@ -105,9 +103,6 @@ std::string NarInfo::to_string(const Store & store) const
 
     if (deriver)
         res += "Deriver: " + std::string(deriver->to_string()) + "\n";
-
-    if (!system.empty())
-        res += "System: " + system + "\n";
 
     for (auto sig : sigs)
         res += "Sig: " + sig + "\n";

--- a/src/libstore/nar-info.hh
+++ b/src/libstore/nar-info.hh
@@ -14,7 +14,6 @@ struct NarInfo : ValidPathInfo
     std::string compression;
     std::optional<Hash> fileHash;
     uint64_t fileSize = 0;
-    std::string system;
 
     NarInfo() = delete;
     NarInfo(StorePath && path, Hash narHash) : ValidPathInfo(std::move(path), narHash) { }


### PR DESCRIPTION
This was unused everywhere (and even the official NixOS binary cache
did not produce .narinfo files containing a "System:" field).