### PR TITLE
nix develop: parse multi-line vars in get-env.sh

### DIFF
--- a/src/nix/get-env.sh
+++ b/src/nix/get-env.sh
@@ -38,9 +38,18 @@ __dumpEnv() {
     printf '  "variables": {\n'
     local __first=1
     while read __line; do
-        if ! [[ $__line =~ ^declare\ (-[^ ])\ ([^=]*) ]]; then continue; fi
+        if ! [[ $__line =~ ^declare\ (-[^ ])\ ([^=]*)(=(.*))?$ ]]; then continue; fi
         local type="${BASH_REMATCH[1]}"
         local __var_name="${BASH_REMATCH[2]}"
+        local __value="${BASH_REMATCH[4]}"
+
+        # Eat any string values (not arrays) that might span over multiple lines.
+        if [[ $__value == \"* ]]; then
+            __value="${__value:1}"
+            while ! [[ $__value =~ (^|[^\\])(\\\\)*\"$ ]]; do
+                IFS= read -r __value
+            done
+        fi
 
         if [[ $__var_name =~ ^BASH_ || \
               $__var_name = _ || \

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -94,7 +94,9 @@ echo foo | nix develop -f "$shellDotNix" shellDrv -c cat | grep -q foo
 nix develop -f "$shellDotNix" shellDrv -c echo foo |& grep -q foo
 
 # Test 'nix print-dev-env'.
-[[ $(nix print-dev-env -f "$shellDotNix" shellDrv --json | jq -r .variables.arr1.value[2]) = '3 4' ]]
+output="$(nix print-dev-env -f "$shellDotNix" shellDrv --json)"
+[[ $(jq -nr --argjson output "$output" '$output.variables.arr1.value[2]') = '3 4' ]]
+[[ $(jq -nr --argjson output "$output" '$output.variables | has("MULTILINE_VALUE_1")') = false ]]
 
 source <(nix print-dev-env -f "$shellDotNix" shellDrv)
 [[ -n $stdenv ]]

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -50,6 +50,11 @@ let pkgs = rec {
     VAR_FROM_NIX = "bar";
     ASCII_PERCENT = "%";
     ASCII_AT = "@";
+    MULTILINE_SCRIPT = ''
+      # should not be in derivation environment
+      declare -x MULTILINE_VALUE_1=1
+      declare -x MULTILINE_VALUE_$INVALID=2
+    '';
     TEST_inNixShell = if inNixShell then "true" else "false";
     inherit stdenv;
     outputs = ["dev" "out"];


### PR DESCRIPTION
The `get-env.sh` script parses the output of `declare -p` line-by-line, but some shell variables can span multiple lines. In this case, if one of the variables is script-like (for example, `shellHook`), it can potentially pollute the derivation environment or fail outright. A trivial reproduction of the issue looks like:

```nix
{
  # ...
  shellHook = ''
    declare -x VAR=FOO
    declare -x "TEST_$VAR"=BAR
  '';
}
```

To avoid this problem, we teach `get-env.sh` to identify and ignore the content of multi-line string values when parsing variable declarations.