### PR TITLE
flake: add comment explaining when workaround for static compilation can be dropped

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -572,6 +572,10 @@
           buildInputs = buildDeps ++ propagatedDeps;
 
           # Work around pkgsStatic disabling all tests.
+          # This can be changed back to the standard machinery
+          # after 22.11 releases and this flake's Nixpkgs
+          # is bumped to use that, as it will contain
+          # https://github.com/NixOS/nixpkgs/commit/41485e7337baca768dc542c553a9d66030df7b33
           preHook =
             ''
               doCheck=1


### PR DESCRIPTION
So we don't leave cruft like this lying around forever. Thanks @Artturin for pointing out that this was fixed, and providing a link to the commit that fixed it: https://github.com/NixOS/nix/pull/6708#issuecomment-1165912951.