### PR TITLE
add fetchTree docs

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -182,8 +182,26 @@ static void prim_fetchTree(EvalState & state, const PosIdx pos, Value * * args, 
     fetchTree(state, pos, args, v, std::nullopt, FetchTreeParams { .allowNameArgument = false });
 }
 
-// FIXME: document
-static RegisterPrimOp primop_fetchTree("fetchTree", 1, prim_fetchTree);
+static RegisterPrimOp primop_fetchTree({
+    .name = "fetchTree",
+    .args = {"args"},
+    .arity = 1,
+    .doc = R"(
+      Introduced in 2.4
+
+      The fetcher infrastructure is exposed via the `fetchTree` built-in.
+
+      `builtins.fetchTree` allows fetching a source tree using any
+      backends supported by the fetcher infrastructure. It subsumes the
+      functionality of existing built-ins like `fetchGit`,
+      `fetchMercurial` and `fetchTarball`.
+
+      `builtins.fetchTree` can be used to fetch
+      plain files over the `http(s)` and `file` protocols in addition to
+      directory tarballs.
+    )",
+    .fun = prim_fetchTree,
+});
 
 static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v,
     const std::string & who, bool unpack, std::string name)

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -187,10 +187,6 @@ static RegisterPrimOp primop_fetchTree({
     .args = {"args"},
     .arity = 1,
     .doc = R"(
-      Introduced in 2.4
-
-      The fetcher infrastructure is exposed via the `fetchTree` built-in.
-
       `builtins.fetchTree` allows fetching a source tree using any
       backends supported by the fetcher infrastructure. It subsumes the
       functionality of existing built-ins like `fetchGit`,


### PR DESCRIPTION
Relates to #6728 and removes the fixme in https://github.com/NixOS/nix/blob/6cb41288ac8df00328865f4c66c324452e5a961c/src/libexpr/primops/fetchTree.cc#L185

Maybe someone can add a few words about what `fetchTree` actually does so we can expand the text

Otherwise I'll rework the text over the next few days