### PR TITLE
support building with --enable-gc=no

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -45,7 +45,7 @@ static char * allocString(size_t size)
 #if HAVE_BOEHMGC
     t = (char *) GC_MALLOC_ATOMIC(size);
 #else
-    t = malloc(size);
+    t = (char *) malloc(size);
 #endif
     if (!t) throw std::bad_alloc();
     return t;
@@ -471,9 +471,6 @@ EvalState::EvalState(
 #if HAVE_BOEHMGC
     , valueAllocCache(std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr))
     , env1AllocCache(std::allocate_shared<void *>(traceable_allocator<void *>(), nullptr))
-#else
-    , valueAllocCache(std::make_shared<void *>(nullptr))
-    , env1AllocCache(std::make_shared<void *>(nullptr))
 #endif
     , baseEnv(allocEnv(128))
     , staticBaseEnv{std::make_shared<StaticEnv>(false, nullptr)}


### PR DESCRIPTION
Some minor changes fixing the build without boehm.
Fixes https://github.com/NixOS/nix/issues/6250.

Would be nice to test this (building without boehm) somehow (in hydra maybe), but haven't looked at that yet and IMO that can be added separately. Could help prevent or reduce regressions on this configuration.

I'm interested in this to possibly make ASAN builds more reliable. Not sure if this will really help, but since I was looking at it anyway and the fixes are low-hanging fruit, I've submitted it :smile: .

Not 100% sure about the AllocCache members, but in the cc file there's a path for both boehm enabled and disabled where the members are needed, so I just assumed that that was correct and this corresponds to that.