### PR TITLE
Make Value::isTrivial 'if-let aware'

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -9,3 +9,7 @@
   `nix repl --file '<nixpkgs>'` or `nix repl --expr 'import <nixpkgs>{}'`
   
   This is currently guarded by the 'repl-flake' experimental feature
+  
+* Let expressions returning a trivial value are treated as a trivial
+  value in expression evaluation. This allows one, for instance, to
+  use a let-expression in the `outputs` attribute of a Flake.

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -74,8 +74,14 @@ static std::tuple<fetchers::Tree, FlakeRef, FlakeRef> fetchOrSubstituteTree(
 
 static void forceTrivialValue(EvalState & state, Value & value, const PosIdx pos)
 {
-    if (value.isThunk() && value.isTrivial())
+    if (!value.isThunk())
+        return;
+
+    if (value.isTrivial())
         state.forceValue(value, pos);
+    else
+        throw Error("The expression at %s is %s, which may not terminate.",
+                    state.positions[value.determinePos(pos)], showType(value));
 }
 
 


### PR DESCRIPTION
As it stands, isTrivial will not 'descend' through let expressions and treat an expression, e.g.,`let x = 1; in x`, as a non-trivial value. While this makes a bit of conceptual sense, it's got some unwelcome side effects. (See, for instance, #6753.)

Here's the commit message from the relevant change:

```
Value::isTrivial is used in a variety of cases, and mostly
descends throughout thunks. I.e., isTrivial returns true if a
value is a partially evaluated thunk that returns a 'trivially
trivial' value. This patch allows isTrivial to descend into let
expressions, so that if let expressions return a trivial value,
they're treated as such.
```

Hopefully this is applicable! Thanks!