### PR TITLE
fetchGit: allow fetching annotated tags

### DIFF
--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -63,6 +63,10 @@ out=$(nix eval --impure --raw --expr "builtins.fetchGit { url = file://$repo; re
 path2=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev2\"; }).outPath")
 [[ $path = $path2 ]]
 
+# Fetch using a tag
+path2=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$repo; ref = \"tag2\";}).outPath")
+[[ $path = $path2 ]]
+
 # In pure eval mode, fetchGit with a revision should succeed.
 [[ $(nix eval --raw --expr "builtins.readFile (fetchGit { url = file://$repo; rev = \"$rev2\"; } + \"/hello\")") = world ]]
 


### PR DESCRIPTION
Git doesn't like pointing a branch ref to an annotated tag, however the
other way around is fine. Use this to allow fetchGit to fetch annotated
tags, without specifically annotating them as such.

(hopefully) fixes https://github.com/NixOS/nix/issues/3701

**Please review with care! I'm not sure this doesn't break some important assumption elsewhere.**

Tested by poking around locally.