### PR TITLE
flakes: move system to top-level of outputs

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -184,20 +184,21 @@ SourceExprCommand::SourceExprCommand(bool supportReadOnlyMode)
 Strings SourceExprCommand::getDefaultFlakeAttrPaths()
 {
     return {
-        "packages." + settings.thisSystem.get() + ".default",
-        "defaultPackage." + settings.thisSystem.get()
+        settings.thisSystem.get() + ".packages.default",
+        settings.thisSystem.get() + ".defaultPackage"
     };
 }
 
 Strings SourceExprCommand::getDefaultFlakeAttrPathPrefixes()
 {
     return {
+        settings.thisSystem.get() + ".",
         // As a convenience, look for the attribute in
         // 'outputs.packages'.
-        "packages." + settings.thisSystem.get() + ".",
+        settings.thisSystem.get() + ".packages.",
         // As a temporary hack until Nixpkgs is properly converted
         // to provide a clean 'packages' set, look in 'legacyPackages'.
-        "legacyPackages." + settings.thisSystem.get() + "."
+        settings.thisSystem.get() + ".legacyPackages."
     };
 }
 

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -53,8 +53,8 @@ struct CmdBundle : InstallableCommand
     Strings getDefaultFlakeAttrPaths() override
     {
         Strings res{
-            "apps." + settings.thisSystem.get() + ".default",
-            "defaultApp." + settings.thisSystem.get()
+            settings.thisSystem.get() + ".apps.default",
+            settings.thisSystem.get() + ".defaultApp"
         };
         for (auto & s : SourceExprCommand::getDefaultFlakeAttrPaths())
             res.push_back(s);
@@ -63,7 +63,7 @@ struct CmdBundle : InstallableCommand
 
     Strings getDefaultFlakeAttrPathPrefixes() override
     {
-        Strings res{"apps." + settings.thisSystem.get() + "."};
+        Strings res{settings.thisSystem.get() + ".apps."};
         for (auto & s : SourceExprCommand::getDefaultFlakeAttrPathPrefixes())
             res.push_back(s);
         return res;
@@ -79,10 +79,10 @@ struct CmdBundle : InstallableCommand
         const flake::LockFlags lockFlags{ .writeLockFile = false };
         InstallableFlake bundler{this,
             evalState, std::move(bundlerFlakeRef), bundlerName, outputsSpec,
-            {"bundlers." + settings.thisSystem.get() + ".default",
-             "defaultBundler." + settings.thisSystem.get()
+            {settings.thisSystem.get() + ".bundlers.default",
+             settings.thisSystem.get() + ".defaultBundler"
             },
-            {"bundlers." + settings.thisSystem.get() + "."},
+            {settings.thisSystem.get() + ".bundlers."},
             lockFlags
         };
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -340,8 +340,8 @@ struct Common : InstallableCommand, MixProfile
     Strings getDefaultFlakeAttrPaths() override
     {
         Strings paths{
-            "devShells." + settings.thisSystem.get() + ".default",
-            "devShell." + settings.thisSystem.get(),
+            settings.thisSystem.get() + ".devShells.default",
+            settings.thisSystem.get() + ".devShell",
         };
         for (auto & p : SourceExprCommand::getDefaultFlakeAttrPaths())
             paths.push_back(p);
@@ -351,7 +351,7 @@ struct Common : InstallableCommand, MixProfile
     Strings getDefaultFlakeAttrPathPrefixes() override
     {
         auto res = SourceExprCommand::getDefaultFlakeAttrPathPrefixes();
-        res.emplace_front("devShells." + settings.thisSystem.get() + ".");
+        res.emplace_front(settings.thisSystem.get() + ".devShells.");
         return res;
     }
 
@@ -525,7 +525,7 @@ struct CmdDevelop : Common, MixEnvironment
                 "bashInteractive",
                 DefaultOutputs(),
                 Strings{},
-                Strings{"legacyPackages." + settings.thisSystem.get() + "."},
+                Strings{settings.thisSystem.get() + ".legacyPackages."},
                 nixpkgsLockFlags);
 
             bool found = false;

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -319,37 +319,29 @@ struct CmdFlakeCheck : FlakeCommand
                 || (hasPrefix(name, "_") && name.substr(1) == expected);
         };
 
-        auto checkSystemName = [&](const std::string & system, const PosIdx pos) {
-            StringSet systems{"aarch64-darwin",    "aarch64-genode", "aarch64-linux",
-                              "aarch64-netbsd",    "aarch64-none",   "aarch64_be-none",
-                              "arm-none",          "armv5tel-linux", "armv6l-linux",
-                              "armv6l-netbsd",     "armv6l-none",    "armv7a-darwin",
-                              "armv7a-linux",      "armv7a-netbsd",  "armv7l-linux",
-                              "armv7l-netbsd",     "avr-none",       "i686-cygwin",
-                              "i686-darwin",       "i686-freebsd",   "i686-genode",
-                              "i686-linux",        "i686-netbsd",    "i686-none",
-                              "i686-openbsd",      "i686-windows",   "js-ghcjs",
-                              "m68k-linux",        "m68k-netbsd",    "m68k-none",
-                              "mips64el-linux",    "mipsel-linux",   "mipsel-netbsd",
-                              "mmix-mmixware",     "msp430-none",    "or1k-none",
-                              "powerpc-netbsd",    "powerpc-none",   "powerpc64-linux",
-                              "powerpc64le-linux", "powerpcle-none", "riscv32-linux",
-                              "riscv32-netbsd",    "riscv32-none",   "riscv64-linux",
-                              "riscv64-netbsd",    "riscv64-none",   "s390-linux",
-                              "s390-none",         "s390x-linux",    "s390x-none",
-                              "vc4-none",          "wasm32-wasi",    "wasm64-wasi",
-                              "x86_64-cygwin",     "x86_64-darwin",  "x86_64-freebsd",
-                              "x86_64-genode",     "x86_64-linux",   "x86_64-netbsd",
-                              "x86_64-none",       "x86_64-openbsd", "x86_64-redox",
-                              "x86_64-solaris",    "x86_64-windows"};
+        StringSet allSystems{"aarch64-darwin",    "aarch64-genode", "aarch64-linux",
+                             "aarch64-netbsd",    "aarch64-none",   "aarch64_be-none",
+                             "arm-none",          "armv5tel-linux", "armv6l-linux",
+                             "armv6l-netbsd",     "armv6l-none",    "armv7a-darwin",
+                             "armv7a-linux",      "armv7a-netbsd",  "armv7l-linux",
+                             "armv7l-netbsd",     "avr-none",       "i686-cygwin",
+                             "i686-darwin",       "i686-freebsd",   "i686-genode",
+                             "i686-linux",        "i686-netbsd",    "i686-none",
+                             "i686-openbsd",      "i686-windows",   "js-ghcjs",
+                             "m68k-linux",        "m68k-netbsd",    "m68k-none",
+                             "mips64el-linux",    "mipsel-linux",   "mipsel-netbsd",
+                             "mmix-mmixware",     "msp430-none",    "or1k-none",
+                             "powerpc-netbsd",    "powerpc-none",   "powerpc64-linux",
+                             "powerpc64le-linux", "powerpcle-none", "riscv32-linux",
+                             "riscv32-netbsd",    "riscv32-none",   "riscv64-linux",
+                             "riscv64-netbsd",    "riscv64-none",   "s390-linux",
+                             "s390-none",         "s390x-linux",    "s390x-none",
+                             "vc4-none",          "wasm32-wasi",    "wasm64-wasi",
+                             "x86_64-cygwin",     "x86_64-darwin",  "x86_64-freebsd",
+                             "x86_64-genode",     "x86_64-linux",   "x86_64-netbsd",
+                             "x86_64-none",       "x86_64-openbsd", "x86_64-redox",
+                             "x86_64-solaris",    "x86_64-windows"};
 
-            if (systems.find(system) == systems.end()) {
-                auto err = Error("'%s' is not a valid system type, at %s", system, resolve(pos)).info();
-                err.suggestions = Suggestions::bestMatches(systems, system);
-
-                logError(err);
-            };
-        };
 
         auto checkDerivation = [&](const std::string & attrPath, Value & v, const PosIdx pos) -> std::optional<StorePath> {
             try {
@@ -534,97 +526,104 @@ struct CmdFlakeCheck : FlakeCommand
                         state->forceValue(vOutput, pos);
 
                         std::string_view replacement =
-                            name == "defaultPackage" ? "packages.<system>.default" :
-                            name == "defaultApp" ? "apps.<system>.default" :
+                            name == "defaultPackage" ? "<system>.packages.default" :
+                            name == "defaultApp" ? "<system>.apps.default" :
                             name == "defaultTemplate" ? "templates.default" :
-                            name == "defaultBundler" ? "bundlers.<system>.default" :
+                            name == "defaultBundler" ? "<system>.bundlers.default" :
                             name == "overlay" ? "overlays.default" :
-                            name == "devShell" ? "devShells.<system>.default" :
+                            name == "devShell" ? "<system>.devShells.default" :
                             name == "nixosModule" ? "nixosModules.default" :
                             "";
                         if (replacement != "")
                             warn("flake output attribute '%s' is deprecated; use '%s' instead", name, replacement);
 
-                        if (name == "checks") {
+                        if (allSystems.find(name) != allSystems.end()) {
                             state->forceAttrs(vOutput, pos);
+                            std::string sys_name = name;
+                            checkSystemName(sys_name, pos);
+
                             for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos);
-                                for (auto & attr2 : *attr.value->attrs) {
-                                    auto drvPath = checkDerivation(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
-                                    if (drvPath && attr_name == settings.thisSystem.get())
-                                        drvPaths.push_back(DerivedPath::Built{*drvPath});
+                                const auto & name = state->symbols[attr.name];
+                                if (name == "checks") {
+                                    state->forceAttrs(vOutput, pos);
+                                    for (auto & attr : *vOutput.attrs) {
+                                        const auto & attr_name = state->symbols[attr.name];
+                                        state->forceAttrs(*attr.value, attr.pos);
+                                        auto drvPath = checkDerivation(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr.name]),
+                                            *attr.value, attr.pos);
+                                        if (drvPath && sys_name == settings.thisSystem.get())
+                                            drvPaths.push_back(DerivedPath::Built{*drvPath});
+                                    }
                                 }
-                            }
-                        }
 
-                        else if (name == "formatter") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                checkApp(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
-                            }
-                        }
+                                else if (name == "formatter") {
+                                  state->forceAttrs(vOutput, pos);
+                                      const auto & attr_name = state->symbols[attr.name];
+                                      checkApp(
+                                          fmt("%s.%s", name, attr_name),
+                                          *attr.value, attr.pos);
+                                }
 
-                        else if (name == "packages" || name == "devShells") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos);
-                                for (auto & attr2 : *attr.value->attrs)
+                                else if (name == "packages" || name == "devShells") {
+                                    state->forceAttrs(vOutput, pos);
+                                    const auto & attr_name = state->symbols[attr.name];
+                                    state->forceAttrs(*attr.value, attr.pos);
+                                    for (auto & attr2 : *attr.value->attrs)
+                                        checkDerivation(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
+                                            *attr2.value, attr2.pos);
+                                }
+
+                                else if (name == "apps") {
+                                    state->forceAttrs(vOutput, pos);
+                                    const auto & attr_name = state->symbols[attr.name];
+                                    state->forceAttrs(*attr.value, attr.pos);
+                                    for (auto & attr2 : *attr.value->attrs)
+                                        checkApp(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
+                                            *attr2.value, attr2.pos);
+                                }
+
+                                else if (name == "defaultPackage" || name == "devShell") {
+                                    state->forceAttrs(vOutput, pos);
+                                    const auto & attr_name = state->symbols[attr.name];
                                     checkDerivation(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
-                            }
-                        }
+                                        fmt("%s.%s", name, attr_name),
+                                        *attr.value, attr.pos);
+                                }
 
-                        else if (name == "apps") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos);
-                                for (auto & attr2 : *attr.value->attrs)
+                                else if (name == "defaultApp") {
+                                    state->forceAttrs(vOutput, pos);
+                                    const auto & attr_name = state->symbols[attr.name];
                                     checkApp(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
-                            }
-                        }
+                                        fmt("%s.%s", name, attr_name),
+                                        *attr.value, attr.pos);
+                                }
 
-                        else if (name == "defaultPackage" || name == "devShell") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                checkDerivation(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
-                            }
-                        }
+                                else if (name == "legacyPackages") {
+                                    state->forceAttrs(vOutput, pos);
+                                    // FIXME: do getDerivations?
+                                }
 
-                        else if (name == "defaultApp") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                checkApp(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
-                            }
-                        }
+                                else if (name == "bundlers") {
+                                    state->forceAttrs(vOutput, pos);
+                                    const auto & attr_name = state->symbols[attr.name];
+                                    state->forceAttrs(*attr.value, attr.pos);
+                                    for (auto & attr2 : *attr.value->attrs) {
+                                        checkBundler(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
+                                            *attr2.value, attr2.pos);
+                                    }
+                                }
 
-                        else if (name == "legacyPackages") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                checkSystemName(state->symbols[attr.name], attr.pos);
-                                // FIXME: do getDerivations?
+                                else if (name == "defaultBundler") {
+                                    state->forceAttrs(vOutput, pos);
+                                    const auto & attr_name = state->symbols[attr.name];
+                                    checkBundler(
+                                        fmt("%s.%s", name, attr_name),
+                                        *attr.value, attr.pos);
+                                }
                             }
                         }
 
@@ -668,30 +667,6 @@ struct CmdFlakeCheck : FlakeCommand
                                     *attr.value, attr.pos);
                         }
 
-                        else if (name == "defaultBundler") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                checkBundler(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
-                            }
-                        }
-
-                        else if (name == "bundlers") {
-                            state->forceAttrs(vOutput, pos);
-                            for (auto & attr : *vOutput.attrs) {
-                                const auto & attr_name = state->symbols[attr.name];
-                                checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos);
-                                for (auto & attr2 : *attr.value->attrs) {
-                                    checkBundler(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
-                                }
-                            }
-                        }
 
                         else
                             warn("unknown flake output '%s'", name);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -320,9 +320,35 @@ struct CmdFlakeCheck : FlakeCommand
         };
 
         auto checkSystemName = [&](const std::string & system, const PosIdx pos) {
-            // FIXME: what's the format of "system"?
-            if (system.find('-') == std::string::npos)
-                reportError(Error("'%s' is not a valid system type, at %s", system, resolve(pos)));
+            StringSet systems{"aarch64-darwin",    "aarch64-genode", "aarch64-linux",
+                              "aarch64-netbsd",    "aarch64-none",   "aarch64_be-none",
+                              "arm-none",          "armv5tel-linux", "armv6l-linux",
+                              "armv6l-netbsd",     "armv6l-none",    "armv7a-darwin",
+                              "armv7a-linux",      "armv7a-netbsd",  "armv7l-linux",
+                              "armv7l-netbsd",     "avr-none",       "i686-cygwin",
+                              "i686-darwin",       "i686-freebsd",   "i686-genode",
+                              "i686-linux",        "i686-netbsd",    "i686-none",
+                              "i686-openbsd",      "i686-windows",   "js-ghcjs",
+                              "m68k-linux",        "m68k-netbsd",    "m68k-none",
+                              "mips64el-linux",    "mipsel-linux",   "mipsel-netbsd",
+                              "mmix-mmixware",     "msp430-none",    "or1k-none",
+                              "powerpc-netbsd",    "powerpc-none",   "powerpc64-linux",
+                              "powerpc64le-linux", "powerpcle-none", "riscv32-linux",
+                              "riscv32-netbsd",    "riscv32-none",   "riscv64-linux",
+                              "riscv64-netbsd",    "riscv64-none",   "s390-linux",
+                              "s390-none",         "s390x-linux",    "s390x-none",
+                              "vc4-none",          "wasm32-wasi",    "wasm64-wasi",
+                              "x86_64-cygwin",     "x86_64-darwin",  "x86_64-freebsd",
+                              "x86_64-genode",     "x86_64-linux",   "x86_64-netbsd",
+                              "x86_64-none",       "x86_64-openbsd", "x86_64-redox",
+                              "x86_64-solaris",    "x86_64-windows"};
+
+            if (systems.find(system) == systems.end()) {
+                auto err = Error("'%s' is not a valid system type, at %s", system, resolve(pos)).info();
+                err.suggestions = Suggestions::bestMatches(systems, system);
+
+                logError(err);
+            };
         };
 
         auto checkDerivation = [&](const std::string & attrPath, Value & v, const PosIdx pos) -> std::optional<StorePath> {

--- a/src/nix/fmt.cc
+++ b/src/nix/fmt.cc
@@ -21,7 +21,7 @@ struct CmdFmt : SourceExprCommand {
     Category category() override { return catSecondary; }
 
     Strings getDefaultFlakeAttrPaths() override {
-        return Strings{"formatter." + settings.thisSystem.get()};
+        return Strings{settings.thisSystem.get() + ".formatter."};
     }
 
     Strings getDefaultFlakeAttrPathPrefixes() override { return Strings{}; }

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -162,8 +162,8 @@ struct CmdRun : InstallableCommand
     Strings getDefaultFlakeAttrPaths() override
     {
         Strings res{
-            "apps." + settings.thisSystem.get() + ".default",
-            "defaultApp." + settings.thisSystem.get(),
+            settings.thisSystem.get() + ".apps.default",
+            settings.thisSystem.get() + ".defaultApp",
         };
         for (auto & s : SourceExprCommand::getDefaultFlakeAttrPaths())
             res.push_back(s);
@@ -172,7 +172,7 @@ struct CmdRun : InstallableCommand
 
     Strings getDefaultFlakeAttrPathPrefixes() override
     {
-        Strings res{"apps." + settings.thisSystem.get() + "."};
+        Strings res{settings.thisSystem.get() + ".apps."};
         for (auto & s : SourceExprCommand::getDefaultFlakeAttrPathPrefixes())
             res.push_back(s);
         return res;

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -55,8 +55,8 @@ struct CmdSearch : InstallableCommand, MixJSON
     Strings getDefaultFlakeAttrPaths() override
     {
         return {
-            "packages." + settings.thisSystem.get() + ".",
-            "legacyPackages." + settings.thisSystem.get() + "."
+            settings.thisSystem.get() + ".packages.",
+            settings.thisSystem.get() + ".legacyPackages."
         };
     }
 


### PR DESCRIPTION
## Motivation
There has been a lot of discussion around re-working the way systems are handled in the flake output schema. Some of the suggested modifications are a bit contentious and not everybody seems to agree with how to best handle this.

I wanted to suggest a possible modification that I believe is sane and minimal, while also leaving the door open for other solutions such as #6773 or something similar to build on top of it.

All this PR aims to achieve is to move the expected location for system outputs to the toplevel of `outputs`, e.g. `outputs.<system>.packages` instead of `outputs.packages.<system>`.

To me, it just makes more sense to have a single attribute for each system rather than having several different `<system>` attributes nested in various outputs.


## TODO:
I decided to open as a partially complete draft to collect some feedback on whether or not this is a desired approach before going through the trouble of updating all the docs.

Since flakes are currently considered unstable, I have not maintained backwards compatibility for the previous schema, but if this would be desired I can easily do so.

- [x] modify the cli commands to look for outputs in the new location
- [x] modify `nix flake check` (and others?) logic to account for the new schema (needs test fixes)
- [ ] update relevant documentation