### PR TITLE
Ignore readonly variables used in ZSH for `nix print-dev-env`

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -240,6 +240,9 @@ struct Common : InstallableCommand, MixProfile
 {
     std::set<std::string> ignoreVars{
         "BASHOPTS",
+        "EPOCHREALTIME",
+        "EPOCHSECONDS",
+        "LINENO",
         "HOME", // FIXME: don't ignore in pure mode?
         "NIX_BUILD_TOP",
         "NIX_ENFORCE_PURITY",


### PR DESCRIPTION
EPOCHREALTIME, EPOCHSECONDS, and LINENO are read only variables in zsh.
When attempting to eval `nix print-dev-env` in ZSH it will raise an error saying the script is trying set read-only variables.