### PR TITLE
Fix link to hacking doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Information on additional installation methods is available on the [Nix download
 
 ## Building And Developing
 
-See our [Hacking guide](https://hydra.nixos.org/job/nix/master/build.x86_64-linux/latest/download-by-type/doc/manual/contributing/hacking.html) in our manual for instruction on how to
+See our [Hacking guide](https://nixos.org/manual/nix/stable/contributing/hacking.html) in our manual for instruction on how to
 build nix from source with nix-build or how to get a development environment.
 
 ## Additional Resources


### PR DESCRIPTION
Right now,
https://hydra.nixos.org/job/nix/master/build.x86_64-linux/latest/download-by-type/doc/manual/contributing/hacking.html
redirects to
https://hydra.nixos.org/build/183877779/download/1/manual/contributing/hacking.html,
which gives me a "500 Internal Server Error". Not super useful =(

Feel free to ignore if someone's working to fix the 500 I was running
into.