### PR TITLE
nix develop: do not assume that saved vars are set

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -288,8 +288,10 @@ struct Common : InstallableCommand, MixProfile
 
         out << "unset shellHook\n";
 
-        for (auto & var : savedVars)
+        for (auto & var : savedVars) {
+            out << fmt("%s=${%s:-}\n", var, var);
             out << fmt("nix_saved_%s=\"$%s\"\n", var, var);
+        }
 
         buildEnvironment.toBash(out, ignoreVars);
 


### PR DESCRIPTION
This fixes https://github.com/NixOS/nix/issues/6809