### PR TITLE
fix(libstore): allow Nix to access all Rosetta 2 paths on MacOS

### DIFF
--- a/src/libstore/sandbox-defaults.sb
+++ b/src/libstore/sandbox-defaults.sb
@@ -98,7 +98,9 @@
 (allow file*
        (literal "/private/var/select/sh"))
 
-; Allow Rosetta 2 to run x86_64 binaries on aarch64-darwin.
+; Allow Rosetta 2 to run x86_64 binaries on aarch64-darwin (and vice versa).
 (allow file-read*
        (subpath "/Library/Apple/usr/libexec/oah")
-       (subpath "/System/Library/Apple/usr/libexec/oah"))
+       (subpath "/System/Library/Apple/usr/libexec/oah")
+       (subpath "/System/Library/LaunchDaemons/com.apple.oahd.plist")
+       (subpath "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist"))


### PR DESCRIPTION
**Release Notes**

Fixes: #5884

I cherry-picked this from @centromere's tree, hopefully they're alright with
that.

This allows building `nix` and `cachix` on macOS with sandboxing enabled, among
other packages.

