### PR TITLE
local-derivation-goal.cc: improve error messages when sandboxing fails

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -862,6 +862,13 @@ void LocalDerivationGoal::startBuilder()
                             _exit(1);
                         if (!userNamespacesEnabled && errno==EPERM)
                             warn("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/user/max_user_namespaces");
+                        if (userNamespacesEnabled) {
+                            Path procSysKernelUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone";
+                            if (pathExists(procSysKernelUnprivilegedUsernsClone)
+                                && trim(readFile(procSysKernelUnprivilegedUsernsClone)) == "0") {
+                                warn("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/kernel/unprivileged_userns_clone");
+                            }
+                        }
                         Path procSelfNsUser = "/proc/self/ns/user";
                         if (!pathExists(procSelfNsUser))
                             warn("/proc/self/ns/user does not exist; your kernel was likely built without CONFIG_USER_NS=y, which is required for sandboxing");

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -855,11 +855,6 @@ void LocalDerivationGoal::startBuilder()
                 switch(errno) {
                     case EPERM:
                     case EINVAL: {
-                        /* Otherwise exit with EPERM so we can handle this in the
-                           parent. This is only done when sandbox-fallback is set
-                           to true (the default). */
-                        if (settings.sandboxFallback)
-                            _exit(1);
                         if (!userNamespacesEnabled && errno==EPERM)
                             notice("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/user/max_user_namespaces");
                         if (userNamespacesEnabled) {
@@ -872,6 +867,11 @@ void LocalDerivationGoal::startBuilder()
                         Path procSelfNsUser = "/proc/self/ns/user";
                         if (!pathExists(procSelfNsUser))
                             notice("/proc/self/ns/user does not exist; your kernel was likely built without CONFIG_USER_NS=y, which is required for sandboxing");
+                        /* Otherwise exit with EPERM so we can handle this in the
+                           parent. This is only done when sandbox-fallback is set
+                           to true (the default). */
+                        if (settings.sandboxFallback)
+                            _exit(1);
                         /* Mention sandbox-fallback in the error message so the user
                            knows that having it disabled contributed to the
                            unrecoverability of this failure */

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -859,6 +859,8 @@ void LocalDerivationGoal::startBuilder()
                            to true (the default). */
                         if (settings.sandboxFallback)
                             _exit(1);
+                        if (!userNamespacesEnabled && errno==EPERM)
+                            warn("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/user/max_user_namespaces");
                         /* Mention sandbox-fallback in the error message so the user
                            knows that having it disabled contributed to the
                            unrecoverability of this failure */

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -861,17 +861,17 @@ void LocalDerivationGoal::startBuilder()
                         if (settings.sandboxFallback)
                             _exit(1);
                         if (!userNamespacesEnabled && errno==EPERM)
-                            warn("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/user/max_user_namespaces");
+                            notice("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/user/max_user_namespaces");
                         if (userNamespacesEnabled) {
                             Path procSysKernelUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone";
                             if (pathExists(procSysKernelUnprivilegedUsernsClone)
                                 && trim(readFile(procSysKernelUnprivilegedUsernsClone)) == "0") {
-                                warn("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/kernel/unprivileged_userns_clone");
+                                notice("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/kernel/unprivileged_userns_clone");
                             }
                         }
                         Path procSelfNsUser = "/proc/self/ns/user";
                         if (!pathExists(procSelfNsUser))
-                            warn("/proc/self/ns/user does not exist; your kernel was likely built without CONFIG_USER_NS=y, which is required for sandboxing");
+                            notice("/proc/self/ns/user does not exist; your kernel was likely built without CONFIG_USER_NS=y, which is required for sandboxing");
                         /* Mention sandbox-fallback in the error message so the user
                            knows that having it disabled contributed to the
                            unrecoverability of this failure */

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -861,6 +861,9 @@ void LocalDerivationGoal::startBuilder()
                             _exit(1);
                         if (!userNamespacesEnabled && errno==EPERM)
                             warn("user namespaces appear to be disabled; they are required for sandboxing; check /proc/sys/user/max_user_namespaces");
+                        Path procSelfNsUser = "/proc/self/ns/user";
+                        if (!pathExists(procSelfNsUser))
+                            warn("/proc/self/ns/user does not exist; your kernel was likely built without CONFIG_USER_NS=y, which is required for sandboxing");
                         /* Mention sandbox-fallback in the error message so the user
                            knows that having it disabled contributed to the
                            unrecoverability of this failure */

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -845,6 +845,7 @@ void LocalDerivationGoal::startBuilder()
                 /* Some distros patch Linux to not allow unprivileged
                  * user namespaces. If we get EPERM or EINVAL, try
                  * without CLONE_NEWUSER and see if that works.
+                 * Details: https://salsa.debian.org/kernel-team/linux/-/commit/d98e00eda6bea437e39b9e80444eee84a32438a6
                  */
                 usingUserNamespace = false;
                 flags &= ~CLONE_NEWUSER;

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -204,12 +204,18 @@ public:
     int errNo;
 
     template<typename... Args>
-    SysError(const Args & ... args)
+    SysError(int errNo_, const Args & ... args)
         : Error("")
     {
-        errNo = errno;
+        errNo = errNo_;
         auto hf = hintfmt(args...);
         err.msg = hintfmt("%1%: %2%", normaltxt(hf.str()), strerror(errNo));
+    }
+
+    template<typename... Args>
+    SysError(const Args & ... args)
+        : SysError(errno, args ...)
+    {
     }
 };
 


### PR DESCRIPTION
The failure modes for nix's sandboxing setup are pretty complicated. When nix is unable to set up the sandbox, let's provide more detail about what went wrong.

Specifically, if sandbox setup fails:

* We make sure the error message includes the word "sandbox" so the user   knows that the failure was related to sandboxing.

* If `--option sandbox-fallback false` was provided, and removing it   would have allowed further attempts to make progress, remind the user that they have disabled `sandbox-fallback`.

* If `/proc/sys/user/max_user_namespaces` is missing or zero, `warn()` the user about this, since it is at least part of the reason for the failure.

* If `/proc/self/ns/user` does not exist, `warn()` the user about this, since it is likely an indication that the kernel was compiled without `CONFIG_USER_NS=y`.

* If `/proc/sys/kernel/unprivileged_userns_clone` is present (due to a [patch carried by Debian, Ubuntu, and other distributions](https://salsa.debian.org/kernel-team/linux/-/commit/d98e00eda6bea437e39b9e80444eee84a32438a6)) and is set to `0`, `warn()` the user about this, since it is at least part of the reason for the failure.

Personally, I've stumbled over all but the last of these at one point or another -- especially because there have been [a very large number](https://www.google.com/search?hl=en&q=cve%20%22max_user_namespaces%22) of local privilege escalation vulnerabilities in Linux's user namespaces for which the recommended mitigation was adding `echo 0 > /proc/sys/user/max_user_namespaces` early in the boot process, and I tend to forget about the fact that I've applied these mitigations.

I have exercised all of the above codepaths, including the `/proc/self/ns/user` check on a machine whose kernel did in fact lack `CONFIG_USER_NS=y`, and the `/proc/sys/kernel/unprivileged_userns_clone` check on a machine running a Debian-ified kernel.
