### PR TITLE
`OutputSpec` for `DerivationGoal` and `DerivedPath`, today's `OutputSpec` -> `ExtendedOutputSpec`

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -479,7 +479,7 @@ struct InstallableAttrPath : InstallableValue
             auto derivedPath = byDrvPath.emplace(*drvPath, DerivedPath::Built {
                 .drvPath = *drvPath,
                 // Not normally legal, but we will merge right below
-                .outputs = OutputsSpec::Names { },
+                .outputs = OutputsSpec::Names { StringSet { } },
             }).first;
 
             derivedPath->second.outputs.merge(std::visit(overloaded {

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -1,5 +1,6 @@
 #include "globals.hh"
 #include "installables.hh"
+#include "outputs-spec.hh"
 #include "util.hh"
 #include "command.hh"
 #include "attr-path.hh"
@@ -796,7 +797,7 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
         }
 
         for (auto & s : ss) {
-            auto [prefix, outputsSpec] = parseOutputsSpec(s);
+            auto [prefix, outputsSpec] = OutputsSpec::parse(s);
             result.push_back(
                 std::make_shared<InstallableAttrPath>(
                     state, *this, vFile,

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -827,7 +827,7 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
                             return storePath.isDerivation()
                                 ? (DerivedPath) DerivedPath::Built {
                                     .drvPath = std::move(storePath),
-                                    .outputs = {},
+                                    .outputs = OutputsSpec::All {},
                                 }
                                 : (DerivedPath) DerivedPath::Opaque {
                                     .path = std::move(storePath),

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -59,7 +59,7 @@ struct ExtraPathInfo
     std::optional<FlakeRef> resolvedRef;
     std::optional<std::string> attrPath;
     // FIXME: merge with DerivedPath's 'outputs' field?
-    std::optional<OutputsSpec> outputsSpec;
+    std::optional<ExtendedOutputsSpec> extendedOutputsSpec;
 };
 
 /* A derived path with any additional info that commands might
@@ -169,7 +169,7 @@ struct InstallableFlake : InstallableValue
     FlakeRef flakeRef;
     Strings attrPaths;
     Strings prefixes;
-    OutputsSpec outputsSpec;
+    ExtendedOutputsSpec extendedOutputsSpec;
     const flake::LockFlags & lockFlags;
     mutable std::shared_ptr<flake::LockedFlake> _lockedFlake;
 
@@ -178,7 +178,7 @@ struct InstallableFlake : InstallableValue
         ref<EvalState> state,
         FlakeRef && flakeRef,
         std::string_view fragment,
-        OutputsSpec outputsSpec,
+        ExtendedOutputsSpec extendedOutputsSpec,
         Strings attrPaths,
         Strings prefixes,
         const flake::LockFlags & lockFlags);

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -641,7 +641,12 @@ bool NixRepl::processLine(std::string line)
         Path drvPathRaw = state->store->printStorePath(drvPath);
 
         if (command == ":b" || command == ":bl") {
-            state->store->buildPaths({DerivedPath::Built{drvPath}});
+            state->store->buildPaths({
+                DerivedPath::Built {
+                    .drvPath = drvPath,
+                    .outputs = OutputsSpec::All { },
+                },
+            });
             auto drv = state->store->readDerivation(drvPath);
             logger->cout("\nThis derivation produced the following outputs:");
             for (auto & [outputName, outputPath] : state->store->queryDerivationOutputMap(drvPath)) {

--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -245,7 +245,7 @@ std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragment
     bool isFlake)
 {
     auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse(url);
-    auto [flakeRef, fragment] = parseFlakeRefWithFragment(prefix, baseDir, allowMissing, isFlake);
+    auto [flakeRef, fragment] = parseFlakeRefWithFragment(std::string { prefix }, baseDir, allowMissing, isFlake);
     return {std::move(flakeRef), fragment, extendedOutputsSpec};
 }
 

--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -238,15 +238,15 @@ std::pair<fetchers::Tree, FlakeRef> FlakeRef::fetchTree(ref<Store> store) const
     return {std::move(tree), FlakeRef(std::move(lockedInput), subdir)};
 }
 
-std::tuple<FlakeRef, std::string, OutputsSpec> parseFlakeRefWithFragmentAndOutputsSpec(
+std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
     const std::string & url,
     const std::optional<Path> & baseDir,
     bool allowMissing,
     bool isFlake)
 {
-    auto [prefix, outputsSpec] = OutputsSpec::parse(url);
+    auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse(url);
     auto [flakeRef, fragment] = parseFlakeRefWithFragment(prefix, baseDir, allowMissing, isFlake);
-    return {std::move(flakeRef), fragment, outputsSpec};
+    return {std::move(flakeRef), fragment, extendedOutputsSpec};
 }
 
 }

--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -244,7 +244,7 @@ std::tuple<FlakeRef, std::string, OutputsSpec> parseFlakeRefWithFragmentAndOutpu
     bool allowMissing,
     bool isFlake)
 {
-    auto [prefix, outputsSpec] = parseOutputsSpec(url);
+    auto [prefix, outputsSpec] = OutputsSpec::parse(url);
     auto [flakeRef, fragment] = parseFlakeRefWithFragment(prefix, baseDir, allowMissing, isFlake);
     return {std::move(flakeRef), fragment, outputsSpec};
 }

--- a/src/libexpr/flake/flakeref.hh
+++ b/src/libexpr/flake/flakeref.hh
@@ -80,7 +80,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
 std::optional<std::pair<FlakeRef, std::string>> maybeParseFlakeRefWithFragment(
     const std::string & url, const std::optional<Path> & baseDir = {});
 
-std::tuple<FlakeRef, std::string, OutputsSpec> parseFlakeRefWithFragmentAndOutputsSpec(
+std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
     const std::string & url,
     const std::optional<Path> & baseDir = {},
     bool allowMissing = false,

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -990,7 +990,7 @@ void DerivationGoal::resolvedFinished()
                 return resolvedDrv.outputNames();
             },
             [&](const OutputsSpec::Names & names) {
-                return names;
+                return static_cast<std::set<std::string>>(names);
             },
         }, wantedOutputs.raw());
 
@@ -1325,7 +1325,7 @@ std::pair<bool, DrvOutputs> DerivationGoal::checkPathValidity()
             return StringSet {};
         },
         [&](const OutputsSpec::Names & names) {
-            return names;
+            return static_cast<StringSet>(names);
         },
     }, wantedOutputs.raw());
     DrvOutputs validOutputs;

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -144,9 +144,10 @@ void DerivationGoal::work()
 
 void DerivationGoal::addWantedOutputs(const OutputsSpec & outputs)
 {
-    bool newOutputs = wantedOutputs.merge(outputs);
-    if (newOutputs)
+    auto newWanted = wantedOutputs.union_(outputs);
+    if (!newWanted.isSubsetOf(wantedOutputs))
         needRestart = true;
+    wantedOutputs = newWanted;
 }
 
 

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -2,6 +2,7 @@
 
 #include "parsed-derivations.hh"
 #include "lock.hh"
+#include "outputs-spec.hh"
 #include "store-api.hh"
 #include "pathlocks.hh"
 #include "goal.hh"
@@ -55,7 +56,7 @@ struct DerivationGoal : public Goal
 
     /* The specific outputs that we need to build.  Empty means all of
        them. */
-    StringSet wantedOutputs;
+    OutputsSpec wantedOutputs;
 
     /* Mapping from input derivations + output names to actual store
        paths. This is filled in by waiteeDone() as each dependency
@@ -128,10 +129,10 @@ struct DerivationGoal : public Goal
     std::string machineName;
 
     DerivationGoal(const StorePath & drvPath,
-        const StringSet & wantedOutputs, Worker & worker,
+        const OutputsSpec & wantedOutputs, Worker & worker,
         BuildMode buildMode = bmNormal);
     DerivationGoal(const StorePath & drvPath, const BasicDerivation & drv,
-        const StringSet & wantedOutputs, Worker & worker,
+        const OutputsSpec & wantedOutputs, Worker & worker,
         BuildMode buildMode = bmNormal);
     virtual ~DerivationGoal();
 
@@ -142,7 +143,7 @@ struct DerivationGoal : public Goal
     void work() override;
 
     /* Add wanted outputs to an already existing derivation goal. */
-    void addWantedOutputs(const StringSet & outputs);
+    void addWantedOutputs(const OutputsSpec & outputs);
 
     /* The states. */
     void getDerivation();

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -130,7 +130,8 @@ void LocalStore::repairPath(const StorePath & path)
         auto info = queryPathInfo(path);
         if (info->deriver && isValidPath(*info->deriver)) {
             goals.clear();
-            goals.insert(worker.makeDerivationGoal(*info->deriver, StringSet(), bmRepair));
+            // FIXME: Should just build the specific output we need.
+            goals.insert(worker.makeDerivationGoal(*info->deriver, OutputsSpec::All { }, bmRepair));
             worker.run(goals);
         } else
             throw Error(worker.exitStatus(), "cannot repair path '%s'", printStorePath(path));

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -80,7 +80,7 @@ BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivat
     BuildMode buildMode)
 {
     Worker worker(*this, *this);
-    auto goal = worker.makeBasicDerivationGoal(drvPath, drv, {}, buildMode);
+    auto goal = worker.makeBasicDerivationGoal(drvPath, drv, OutputsSpec::All {}, buildMode);
 
     try {
         worker.run(Goals{goal});
@@ -89,7 +89,10 @@ BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivat
         return BuildResult {
             .status = BuildResult::MiscFailure,
             .errorMsg = e.msg(),
-            .path = DerivedPath::Built { .drvPath = drvPath },
+            .path = DerivedPath::Built {
+                .drvPath = drvPath,
+                .outputs = OutputsSpec::All { },
+            },
         };
     };
 }

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2735,7 +2735,7 @@ DrvOutputs LocalDerivationGoal::registerOutputs()
             signRealisation(thisRealisation);
             worker.store.registerDrvOutput(thisRealisation);
         }
-        if (wantOutput(outputName, wantedOutputs))
+        if (wantedOutputs.contains(outputName))
             builtOutputs.emplace(thisRealisation.id, thisRealisation);
     }
 

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -42,7 +42,7 @@ Worker::~Worker()
 
 std::shared_ptr<DerivationGoal> Worker::makeDerivationGoalCommon(
     const StorePath & drvPath,
-    const StringSet & wantedOutputs,
+    const OutputsSpec & wantedOutputs,
     std::function<std::shared_ptr<DerivationGoal>()> mkDrvGoal)
 {
     std::weak_ptr<DerivationGoal> & goal_weak = derivationGoals[drvPath];
@@ -59,7 +59,7 @@ std::shared_ptr<DerivationGoal> Worker::makeDerivationGoalCommon(
 
 
 std::shared_ptr<DerivationGoal> Worker::makeDerivationGoal(const StorePath & drvPath,
-    const StringSet & wantedOutputs, BuildMode buildMode)
+    const OutputsSpec & wantedOutputs, BuildMode buildMode)
 {
     return makeDerivationGoalCommon(drvPath, wantedOutputs, [&]() -> std::shared_ptr<DerivationGoal> {
         return !dynamic_cast<LocalStore *>(&store)
@@ -70,7 +70,7 @@ std::shared_ptr<DerivationGoal> Worker::makeDerivationGoal(const StorePath & drv
 
 
 std::shared_ptr<DerivationGoal> Worker::makeBasicDerivationGoal(const StorePath & drvPath,
-    const BasicDerivation & drv, const StringSet & wantedOutputs, BuildMode buildMode)
+    const BasicDerivation & drv, const OutputsSpec & wantedOutputs, BuildMode buildMode)
 {
     return makeDerivationGoalCommon(drvPath, wantedOutputs, [&]() -> std::shared_ptr<DerivationGoal> {
         return !dynamic_cast<LocalStore *>(&store)

--- a/src/libstore/build/worker.hh
+++ b/src/libstore/build/worker.hh
@@ -140,15 +140,15 @@ public:
     /* derivation goal */
 private:
     std::shared_ptr<DerivationGoal> makeDerivationGoalCommon(
-        const StorePath & drvPath, const StringSet & wantedOutputs,
+        const StorePath & drvPath, const OutputsSpec & wantedOutputs,
         std::function<std::shared_ptr<DerivationGoal>()> mkDrvGoal);
 public:
     std::shared_ptr<DerivationGoal> makeDerivationGoal(
         const StorePath & drvPath,
-        const StringSet & wantedOutputs, BuildMode buildMode = bmNormal);
+        const OutputsSpec & wantedOutputs, BuildMode buildMode = bmNormal);
     std::shared_ptr<DerivationGoal> makeBasicDerivationGoal(
         const StorePath & drvPath, const BasicDerivation & drv,
-        const StringSet & wantedOutputs, BuildMode buildMode = bmNormal);
+        const OutputsSpec & wantedOutputs, BuildMode buildMode = bmNormal);
 
     /* substitution goal */
     std::shared_ptr<PathSubstitutionGoal> makePathSubstitutionGoal(const StorePath & storePath, RepairFlag repair = NoRepair, std::optional<ContentAddress> ca = std::nullopt);

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -688,12 +688,6 @@ std::map<std::string, Hash> staticOutputHashes(Store & store, const Derivation &
 }
 
 
-bool wantOutput(const std::string & output, const std::set<std::string> & wanted)
-{
-    return wanted.empty() || wanted.find(output) != wanted.end();
-}
-
-
 static DerivationOutput readDerivationOutput(Source & in, const Store & store)
 {
     const auto pathS = readString(in);

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -294,8 +294,6 @@ typedef std::map<StorePath, DrvHash> DrvHashes;
 // FIXME: global, though at least thread-safe.
 extern Sync<DrvHashes> drvHashes;
 
-bool wantOutput(const std::string & output, const std::set<std::string> & wanted);
-
 struct Source;
 struct Sink;
 

--- a/src/libstore/derived-path.hh
+++ b/src/libstore/derived-path.hh
@@ -3,6 +3,7 @@
 #include "util.hh"
 #include "path.hh"
 #include "realisation.hh"
+#include "outputs-spec.hh"
 
 #include <optional>
 
@@ -44,7 +45,7 @@ struct DerivedPathOpaque {
  */
 struct DerivedPathBuilt {
     StorePath drvPath;
-    std::set<std::string> outputs;
+    OutputsSpec outputs;
 
     std::string to_string(const Store & store) const;
     static DerivedPathBuilt parse(const Store & store, std::string_view, std::string_view);

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -279,7 +279,12 @@ public:
 
         conn->to.flush();
 
-        BuildResult status { .path = DerivedPath::Built { .drvPath = drvPath } };
+        BuildResult status {
+            .path = DerivedPath::Built {
+                .drvPath = drvPath,
+                .outputs = OutputsSpec::All { },
+            },
+        };
         status.status = (BuildResult::Status) readInt(conn->from);
         conn->from >> status.errorMsg;
 

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -317,7 +317,7 @@ OutputPathMap resolveDerivedPath(Store & store, const DerivedPath::Built & bfd, 
             return names;
         },
         [&](const OutputsSpec::Names & names) {
-            return names;
+            return static_cast<std::set<std::string>>(names);
         },
     }, bfd.outputs);
     for (auto & output : outputNames) {

--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -6,19 +6,71 @@
 
 namespace nix {
 
-std::pair<std::string, ExtendedOutputsSpec> ExtendedOutputsSpec::parse(std::string s)
+bool OutputsSpec::contains(const std::string & outputName) const
 {
-    static std::regex regex(R"((.*)\^((\*)|([a-z]+(,[a-z]+)*)))");
+    return std::visit(overloaded {
+        [&](const OutputsSpec::All &) {
+            return true;
+        },
+        [&](const OutputsSpec::Names & outputNames) {
+            return outputNames.count(outputName) > 0;
+        },
+    }, raw());
+}
+
+
+std::optional<OutputsSpec> OutputsSpec::parseOpt(std::string_view s)
+{
+    static std::regex regex(R"((\*)|([a-z]+(,[a-z]+)*))");
 
     std::smatch match;
-    if (!std::regex_match(s, match, regex))
-        return {s, DefaultOutputs()};
+    std::string s2 { s }; // until some improves std::regex
+    if (!std::regex_match(s2, match, regex))
+        return std::nullopt;
 
-    if (match[3].matched)
-        return {match[1], AllOutputs()};
+    if (match[1].matched)
+        return { OutputsSpec::All {} };
 
-    return {match[1], tokenizeString<OutputNames>(match[4].str(), ",")};
+    if (match[2].matched)
+        return { tokenizeString<OutputsSpec::Names>(match[2].str(), ",") };
+
+    assert(false);
 }
+
+
+OutputsSpec OutputsSpec::parse(std::string_view s)
+{
+    std::optional spec = OutputsSpec::parseOpt(s);
+    if (!spec)
+        throw Error("Invalid outputs specifier: '%s'", s);
+    return *spec;
+}
+
+
+std::pair<std::string_view, ExtendedOutputsSpec> ExtendedOutputsSpec::parse(std::string_view s)
+{
+    auto found = s.rfind('^');
+
+    if (found == std::string::npos)
+        return { s, ExtendedOutputsSpec::Default {} };
+
+    auto spec = OutputsSpec::parse(s.substr(found + 1));
+    return { s.substr(0, found), ExtendedOutputsSpec::Explicit { spec } };
+}
+
+
+std::string OutputsSpec::to_string() const
+{
+    return std::visit(overloaded {
+        [&](const OutputsSpec::All &) -> std::string {
+            return "*";
+        },
+        [&](const OutputsSpec::Names & outputNames) -> std::string {
+            return concatStringsSep(",", outputNames);
+        },
+    }, raw());
+}
+
 
 std::string ExtendedOutputsSpec::to_string() const
 {
@@ -26,37 +78,81 @@ std::string ExtendedOutputsSpec::to_string() const
         [&](const ExtendedOutputsSpec::Default &) -> std::string {
             return "";
         },
-        [&](const ExtendedOutputsSpec::All &) -> std::string {
-            return "*";
-        },
-        [&](const ExtendedOutputsSpec::Names & outputNames) -> std::string {
-            return "^" + concatStringsSep(",", outputNames);
+        [&](const ExtendedOutputsSpec::Explicit & outputSpec) -> std::string {
+            return "^" + outputSpec.to_string();
         },
     }, raw());
 }
 
+
+bool OutputsSpec::merge(const OutputsSpec & that)
+{
+    return std::visit(overloaded {
+        [&](OutputsSpec::All &) {
+            /* If we already refer to all outputs, there is nothing to do. */
+            return false;
+        },
+        [&](OutputsSpec::Names & theseNames) {
+            return std::visit(overloaded {
+                [&](const OutputsSpec::All &) {
+                    *this = OutputsSpec::All {};
+                    return true;
+                },
+                [&](const OutputsSpec::Names & thoseNames) {
+                    bool ret = false;
+                    for (auto & i : thoseNames)
+                        if (theseNames.insert(i).second)
+                            ret = true;
+                    return ret;
+                },
+            }, that.raw());
+        },
+    }, raw());
+}
+
+
+void to_json(nlohmann::json & json, const OutputsSpec & outputsSpec)
+{
+    std::visit(overloaded {
+        [&](const OutputsSpec::All &) {
+            json = std::vector<std::string>({"*"});
+        },
+        [&](const OutputsSpec::Names & names) {
+            json = names;
+        },
+    }, outputsSpec);
+}
+
+
 void to_json(nlohmann::json & json, const ExtendedOutputsSpec & extendedOutputsSpec)
 {
-    if (std::get_if<DefaultOutputs>(&extendedOutputsSpec))
-        json = nullptr;
-
-    else if (std::get_if<AllOutputs>(&extendedOutputsSpec))
-        json = std::vector<std::string>({"*"});
-
-    else if (auto outputNames = std::get_if<OutputNames>(&extendedOutputsSpec))
-        json = *outputNames;
+    std::visit(overloaded {
+        [&](const ExtendedOutputsSpec::Default &) {
+            json = nullptr;
+        },
+        [&](const ExtendedOutputsSpec::Explicit & e) {
+            to_json(json, e);
+        },
+    }, extendedOutputsSpec);
 }
+
+
+void from_json(const nlohmann::json & json, OutputsSpec & outputsSpec)
+{
+    auto names = json.get<OutputNames>();
+    if (names == OutputNames({"*"}))
+        outputsSpec = OutputsSpec::All {};
+    else
+        outputsSpec = names;
+}
+
 
 void from_json(const nlohmann::json & json, ExtendedOutputsSpec & extendedOutputsSpec)
 {
     if (json.is_null())
-        extendedOutputsSpec = DefaultOutputs();
+        extendedOutputsSpec = ExtendedOutputsSpec::Default {};
     else {
-        auto names = json.get<OutputNames>();
-        if (names == OutputNames({"*"}))
-            extendedOutputsSpec = AllOutputs();
-        else
-            extendedOutputsSpec = names;
+        extendedOutputsSpec = ExtendedOutputsSpec::Explicit { json.get<OutputsSpec>() };
     }
 }
 

--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -6,7 +6,7 @@
 
 namespace nix {
 
-std::pair<std::string, OutputsSpec> OutputsSpec::parse(std::string s)
+std::pair<std::string, ExtendedOutputsSpec> ExtendedOutputsSpec::parse(std::string s)
 {
     static std::regex regex(R"((.*)\^((\*)|([a-z]+(,[a-z]+)*)))");
 
@@ -20,43 +20,43 @@ std::pair<std::string, OutputsSpec> OutputsSpec::parse(std::string s)
     return {match[1], tokenizeString<OutputNames>(match[4].str(), ",")};
 }
 
-std::string OutputsSpec::to_string() const
+std::string ExtendedOutputsSpec::to_string() const
 {
     return std::visit(overloaded {
-        [&](const OutputsSpec::Default &) -> std::string {
+        [&](const ExtendedOutputsSpec::Default &) -> std::string {
             return "";
         },
-        [&](const OutputsSpec::All &) -> std::string {
+        [&](const ExtendedOutputsSpec::All &) -> std::string {
             return "*";
         },
-        [&](const OutputsSpec::Names & outputNames) -> std::string {
+        [&](const ExtendedOutputsSpec::Names & outputNames) -> std::string {
             return "^" + concatStringsSep(",", outputNames);
         },
     }, raw());
 }
 
-void to_json(nlohmann::json & json, const OutputsSpec & outputsSpec)
+void to_json(nlohmann::json & json, const ExtendedOutputsSpec & extendedOutputsSpec)
 {
-    if (std::get_if<DefaultOutputs>(&outputsSpec))
+    if (std::get_if<DefaultOutputs>(&extendedOutputsSpec))
         json = nullptr;
 
-    else if (std::get_if<AllOutputs>(&outputsSpec))
+    else if (std::get_if<AllOutputs>(&extendedOutputsSpec))
         json = std::vector<std::string>({"*"});
 
-    else if (auto outputNames = std::get_if<OutputNames>(&outputsSpec))
+    else if (auto outputNames = std::get_if<OutputNames>(&extendedOutputsSpec))
         json = *outputNames;
 }
 
-void from_json(const nlohmann::json & json, OutputsSpec & outputsSpec)
+void from_json(const nlohmann::json & json, ExtendedOutputsSpec & extendedOutputsSpec)
 {
     if (json.is_null())
-        outputsSpec = DefaultOutputs();
+        extendedOutputsSpec = DefaultOutputs();
     else {
         auto names = json.get<OutputNames>();
         if (names == OutputNames({"*"}))
-            outputsSpec = AllOutputs();
+            extendedOutputsSpec = AllOutputs();
         else
-            outputsSpec = names;
+            extendedOutputsSpec = names;
     }
 }
 

--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -32,7 +32,7 @@ std::optional<OutputsSpec> OutputsSpec::parseOpt(std::string_view s)
         return { OutputsSpec::All {} };
 
     if (match[2].matched)
-        return { tokenizeString<OutputsSpec::Names>(match[2].str(), ",") };
+        return OutputsSpec::Names { tokenizeString<StringSet>(match[2].str(), ",") };
 
     assert(false);
 }
@@ -139,11 +139,11 @@ void to_json(nlohmann::json & json, const ExtendedOutputsSpec & extendedOutputsS
 
 void from_json(const nlohmann::json & json, OutputsSpec & outputsSpec)
 {
-    auto names = json.get<OutputNames>();
-    if (names == OutputNames({"*"}))
+    auto names = json.get<StringSet>();
+    if (names == StringSet({"*"}))
         outputsSpec = OutputsSpec::All {};
     else
-        outputsSpec = names;
+        outputsSpec = OutputsSpec::Names { std::move(names) };
 }
 
 

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -4,7 +4,7 @@
 #include <set>
 #include <variant>
 
-#include "nlohmann/json_fwd.hpp"
+#include "json-impls.hh"
 
 namespace nix {
 
@@ -34,6 +34,9 @@ typedef std::variant<AllOutputs, OutputNames> _OutputsSpecRaw;
 struct OutputsSpec : _OutputsSpecRaw {
     using Raw = _OutputsSpecRaw;
     using Raw::Raw;
+
+    /* Force choosing a variant */
+    OutputsSpec() = delete;
 
     using Names = OutputNames;
     using All = AllOutputs;
@@ -85,11 +88,7 @@ struct ExtendedOutputsSpec : _ExtendedOutputsSpecRaw {
     std::string to_string() const;
 };
 
-
-void to_json(nlohmann::json &, const OutputsSpec &);
-void from_json(const nlohmann::json &, OutputsSpec &);
-
-void to_json(nlohmann::json &, const ExtendedOutputsSpec &);
-void from_json(const nlohmann::json &, ExtendedOutputsSpec &);
-
 }
+
+JSON_IMPL(OutputsSpec)
+JSON_IMPL(ExtendedOutputsSpec)

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -25,9 +25,7 @@ struct OutputNames : std::set<std::string> {
     OutputNames() = delete;
 };
 
-struct AllOutputs {
-    bool operator < (const AllOutputs & _) const { return false; }
-};
+struct AllOutputs : std::monostate { };
 
 typedef std::variant<AllOutputs, OutputNames> _OutputsSpecRaw;
 
@@ -64,9 +62,7 @@ struct OutputsSpec : _OutputsSpecRaw {
     std::string to_string() const;
 };
 
-struct DefaultOutputs {
-    bool operator < (const DefaultOutputs & _) const { return false; }
-};
+struct DefaultOutputs : std::monostate { };
 
 typedef std::variant<DefaultOutputs, OutputsSpec> _ExtendedOutputsSpecRaw;
 
@@ -84,6 +80,7 @@ struct ExtendedOutputsSpec : _ExtendedOutputsSpecRaw {
     /* Parse a string of the form 'prefix^output1,...outputN' or
        'prefix^*', returning the prefix and the extended outputs spec. */
     static std::pair<std::string_view, ExtendedOutputsSpec> parse(std::string_view s);
+    static std::optional<std::pair<std::string_view, ExtendedOutputsSpec>> parseOpt(std::string_view s);
 
     std::string to_string() const;
 };

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -17,10 +17,10 @@ struct DefaultOutputs {
     bool operator < (const DefaultOutputs & _) const { return false; }
 };
 
-typedef std::variant<DefaultOutputs, AllOutputs, OutputNames> _OutputsSpecRaw;
+typedef std::variant<DefaultOutputs, AllOutputs, OutputNames> _ExtendedOutputsSpecRaw;
 
-struct OutputsSpec : _OutputsSpecRaw {
-    using Raw = _OutputsSpecRaw;
+struct ExtendedOutputsSpec : _ExtendedOutputsSpecRaw {
+    using Raw = _ExtendedOutputsSpecRaw;
     using Raw::Raw;
 
     using Names = OutputNames;
@@ -33,12 +33,12 @@ struct OutputsSpec : _OutputsSpecRaw {
 
     /* Parse a string of the form 'prefix^output1,...outputN' or
        'prefix^*', returning the prefix and the outputs spec. */
-    static std::pair<std::string, OutputsSpec> parse(std::string s);
+    static std::pair<std::string, ExtendedOutputsSpec> parse(std::string s);
 
     std::string to_string() const;
 };
 
-void to_json(nlohmann::json &, const OutputsSpec &);
-void from_json(const nlohmann::json &, OutputsSpec &);
+void to_json(nlohmann::json &, const ExtendedOutputsSpec &);
+void from_json(const nlohmann::json &, ExtendedOutputsSpec &);
 
 }

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <set>
 #include <variant>
 
@@ -13,30 +14,65 @@ struct AllOutputs {
     bool operator < (const AllOutputs & _) const { return false; }
 };
 
+typedef std::variant<AllOutputs, OutputNames> _OutputsSpecRaw;
+
+struct OutputsSpec : _OutputsSpecRaw {
+    using Raw = _OutputsSpecRaw;
+    using Raw::Raw;
+
+    using Names = OutputNames;
+    using All = AllOutputs;
+
+    inline const Raw & raw() const {
+        return static_cast<const Raw &>(*this);
+    }
+
+    inline Raw & raw() {
+        return static_cast<Raw &>(*this);
+    }
+
+    bool contains(const std::string & output) const;
+
+    /* Modify the receiver outputs spec so it is the union of it's old value
+       and the argument. Return whether the output spec needed to be modified
+       --- if it didn't it was already "large enough". */
+    bool merge(const OutputsSpec & outputs);
+
+    /* Parse a string of the form 'output1,...outputN' or
+       '*', returning the outputs spec. */
+    static OutputsSpec parse(std::string_view s);
+    static std::optional<OutputsSpec> parseOpt(std::string_view s);
+
+    std::string to_string() const;
+};
+
 struct DefaultOutputs {
     bool operator < (const DefaultOutputs & _) const { return false; }
 };
 
-typedef std::variant<DefaultOutputs, AllOutputs, OutputNames> _ExtendedOutputsSpecRaw;
+typedef std::variant<DefaultOutputs, OutputsSpec> _ExtendedOutputsSpecRaw;
 
 struct ExtendedOutputsSpec : _ExtendedOutputsSpecRaw {
     using Raw = _ExtendedOutputsSpecRaw;
     using Raw::Raw;
 
-    using Names = OutputNames;
-    using All = AllOutputs;
     using Default = DefaultOutputs;
+    using Explicit = OutputsSpec;
 
     inline const Raw & raw() const {
         return static_cast<const Raw &>(*this);
     }
 
     /* Parse a string of the form 'prefix^output1,...outputN' or
-       'prefix^*', returning the prefix and the outputs spec. */
-    static std::pair<std::string, ExtendedOutputsSpec> parse(std::string s);
+       'prefix^*', returning the prefix and the extended outputs spec. */
+    static std::pair<std::string_view, ExtendedOutputsSpec> parse(std::string_view s);
 
     std::string to_string() const;
 };
+
+
+void to_json(nlohmann::json &, const OutputsSpec &);
+void from_json(const nlohmann::json &, OutputsSpec &);
 
 void to_json(nlohmann::json &, const ExtendedOutputsSpec &);
 void from_json(const nlohmann::json &, ExtendedOutputsSpec &);

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -1,8 +1,7 @@
 #pragma once
 
+#include <set>
 #include <variant>
-
-#include "util.hh"
 
 #include "nlohmann/json_fwd.hpp"
 
@@ -18,13 +17,26 @@ struct DefaultOutputs {
     bool operator < (const DefaultOutputs & _) const { return false; }
 };
 
-typedef std::variant<DefaultOutputs, AllOutputs, OutputNames> OutputsSpec;
+typedef std::variant<DefaultOutputs, AllOutputs, OutputNames> _OutputsSpecRaw;
 
-/* Parse a string of the form 'prefix^output1,...outputN' or
-   'prefix^*', returning the prefix and the outputs spec. */
-std::pair<std::string, OutputsSpec> parseOutputsSpec(const std::string & s);
+struct OutputsSpec : _OutputsSpecRaw {
+    using Raw = _OutputsSpecRaw;
+    using Raw::Raw;
 
-std::string printOutputsSpec(const OutputsSpec & outputsSpec);
+    using Names = OutputNames;
+    using All = AllOutputs;
+    using Default = DefaultOutputs;
+
+    inline const Raw & raw() const {
+        return static_cast<const Raw &>(*this);
+    }
+
+    /* Parse a string of the form 'prefix^output1,...outputN' or
+       'prefix^*', returning the prefix and the outputs spec. */
+    static std::pair<std::string, OutputsSpec> parse(std::string s);
+
+    std::string to_string() const;
+};
 
 void to_json(nlohmann::json &, const OutputsSpec &);
 void from_json(const nlohmann::json &, OutputsSpec &);

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <optional>
 #include <set>
 #include <variant>
@@ -11,13 +12,15 @@ namespace nix {
 struct OutputNames : std::set<std::string> {
     using std::set<std::string>::set;
 
-    // These need to be "inherited manually"
+    /* These need to be "inherited manually" */
+
     OutputNames(const std::set<std::string> & s)
         : std::set<std::string>(s)
-    { }
+    { assert(!empty()); }
+
     OutputNames(std::set<std::string> && s)
         : std::set<std::string>(s)
-    { }
+    { assert(!empty()); }
 
     /* This set should always be non-empty, so we delete this
        constructor in order make creating empty ones by mistake harder.

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -49,10 +49,11 @@ struct OutputsSpec : _OutputsSpecRaw {
 
     bool contains(const std::string & output) const;
 
-    /* Modify the receiver outputs spec so it is the union of it's old value
-       and the argument. Return whether the output spec needed to be modified
-       --- if it didn't it was already "large enough". */
-    bool merge(const OutputsSpec & outputs);
+    /* Create a new OutputsSpec which is the union of this and that. */
+    OutputsSpec union_(const OutputsSpec & that) const;
+
+    /* Whether this OutputsSpec is a subset of that. */
+    bool isSubsetOf(const OutputsSpec & outputs) const;
 
     /* Parse a string of the form 'output1,...outputN' or
        '*', returning the outputs spec. */

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -8,7 +8,22 @@
 
 namespace nix {
 
-typedef std::set<std::string> OutputNames;
+struct OutputNames : std::set<std::string> {
+    using std::set<std::string>::set;
+
+    // These need to be "inherited manually"
+    OutputNames(const std::set<std::string> & s)
+        : std::set<std::string>(s)
+    { }
+    OutputNames(std::set<std::string> && s)
+        : std::set<std::string>(s)
+    { }
+
+    /* This set should always be non-empty, so we delete this
+       constructor in order make creating empty ones by mistake harder.
+       */
+    OutputNames() = delete;
+};
 
 struct AllOutputs {
     bool operator < (const AllOutputs & _) const { return false; }

--- a/src/libstore/path-with-outputs.cc
+++ b/src/libstore/path-with-outputs.cc
@@ -53,7 +53,7 @@ std::variant<StorePathWithOutputs, StorePath> StorePathWithOutputs::tryFromDeriv
                         return {};
                     },
                     [&](const OutputsSpec::Names & outputs) {
-                        return outputs;
+                        return static_cast<StringSet>(outputs);
                     },
                 }, bfd.outputs.raw()),
             };

--- a/src/libstore/path-with-outputs.hh
+++ b/src/libstore/path-with-outputs.hh
@@ -2,7 +2,6 @@
 
 #include "path.hh"
 #include "derived-path.hh"
-#include "nlohmann/json_fwd.hpp"
 
 namespace nix {
 

--- a/src/libstore/path.hh
+++ b/src/libstore/path.hh
@@ -64,7 +64,6 @@ public:
 
 typedef std::set<StorePath> StorePathSet;
 typedef std::vector<StorePath> StorePaths;
-typedef std::map<std::string, StorePath> OutputPathMap;
 
 typedef std::map<StorePath, std::optional<ContentAddress>> StorePathCAMap;
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -910,7 +910,12 @@ BuildResult RemoteStore::buildDerivation(const StorePath & drvPath, const BasicD
     writeDerivation(conn->to, *this, drv);
     conn->to << buildMode;
     conn.processStderr();
-    BuildResult res { .path = DerivedPath::Built { .drvPath = drvPath } };
+    BuildResult res {
+        .path = DerivedPath::Built {
+            .drvPath = drvPath,
+            .outputs = OutputsSpec::All { },
+        },
+    };
     res.status = (BuildResult::Status) readInt(conn->from);
     conn->from >> res.errorMsg;
     if (GET_PROTOCOL_MINOR(conn->daemonVersion) >= 29) {

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -71,6 +71,9 @@ class NarInfoDiskCache;
 class Store;
 
 
+typedef std::map<std::string, StorePath> OutputPathMap;
+
+
 enum CheckSigsFlag : bool { NoCheckSigs = false, CheckSigs = true };
 enum SubstituteFlag : bool { NoSubstitute = false, Substitute = true };
 enum AllowInvalidFlag : bool { DisallowInvalid = false, AllowInvalid = true };
@@ -119,6 +122,8 @@ class Store : public std::enable_shared_from_this<Store>, public virtual StoreCo
 public:
 
     typedef std::map<std::string, std::string> Params;
+
+
 
 protected:
 
@@ -717,6 +722,11 @@ void copyClosure(
    root becomes garbage after this point unless it has been registered
    as a (permanent) root. */
 void removeTempRoots();
+
+
+/* Resolve the derived path completely, failing if any derivation output
+   is unknown. */
+OutputPathMap resolveDerivedPath(Store &, const DerivedPath::Built &, Store * evalStore = nullptr);
 
 
 /* Return a Store object to access the Nix store denoted by

--- a/src/libstore/tests/outputs-spec.cc
+++ b/src/libstore/tests/outputs-spec.cc
@@ -4,42 +4,62 @@
 
 namespace nix {
 
+TEST(OutputsSpec_parse, basic)
+{
+    {
+        auto outputsSpec = OutputsSpec::parse("*");
+        ASSERT_TRUE(std::get_if<OutputsSpec::All>(&outputsSpec));
+    }
+
+    {
+        auto outputsSpec = OutputsSpec::parse("out");
+        ASSERT_TRUE(std::get<OutputsSpec::Names>(outputsSpec) == OutputsSpec::Names({"out"}));
+    }
+
+    {
+        auto outputsSpec = OutputsSpec::parse("out,bin");
+        ASSERT_TRUE(std::get<OutputsSpec::Names>(outputsSpec) == OutputsSpec::Names({"out", "bin"}));
+    }
+
+    {
+        std::optional outputsSpecOpt = OutputsSpec::parseOpt("&*()");
+        ASSERT_FALSE(outputsSpecOpt);
+    }
+}
+
+
 TEST(ExtendedOutputsSpec_parse, basic)
 {
     {
         auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get_if<DefaultOutputs>(&extendedOutputsSpec));
+        ASSERT_TRUE(std::get_if<ExtendedOutputsSpec::Default>(&extendedOutputsSpec));
     }
 
     {
         auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^*");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get_if<AllOutputs>(&extendedOutputsSpec));
+        auto * explicit_p = std::get_if<ExtendedOutputsSpec::Explicit>(&extendedOutputsSpec);
+        ASSERT_TRUE(explicit_p);
+        ASSERT_TRUE(std::get_if<OutputsSpec::All>(explicit_p));
     }
 
     {
         auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^out");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get<OutputNames>(extendedOutputsSpec) == OutputNames({"out"}));
+        ASSERT_TRUE(std::get<OutputsSpec::Names>(std::get<ExtendedOutputsSpec::Explicit>(extendedOutputsSpec)) == OutputsSpec::Names({"out"}));
     }
 
     {
         auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^out,bin");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get<OutputNames>(extendedOutputsSpec) == OutputNames({"out", "bin"}));
+        ASSERT_TRUE(std::get<OutputsSpec::Names>(std::get<ExtendedOutputsSpec::Explicit>(extendedOutputsSpec)) == OutputsSpec::Names({"out", "bin"}));
     }
 
     {
         auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^bar^out,bin");
         ASSERT_EQ(prefix, "foo^bar");
-        ASSERT_TRUE(std::get<OutputNames>(extendedOutputsSpec) == OutputNames({"out", "bin"}));
-    }
-
-    {
-        auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^&*()");
-        ASSERT_EQ(prefix, "foo^&*()");
-        ASSERT_TRUE(std::get_if<DefaultOutputs>(&extendedOutputsSpec));
+        ASSERT_TRUE(std::get<OutputsSpec::Names>(std::get<ExtendedOutputsSpec::Explicit>(extendedOutputsSpec)) == OutputsSpec::Names({"out", "bin"}));
     }
 }
 

--- a/src/libstore/tests/outputs-spec.cc
+++ b/src/libstore/tests/outputs-spec.cc
@@ -4,42 +4,42 @@
 
 namespace nix {
 
-TEST(OutputsSpec_parse, basic)
+TEST(ExtendedOutputsSpec_parse, basic)
 {
     {
-        auto [prefix, outputsSpec] = OutputsSpec::parse("foo");
+        auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get_if<DefaultOutputs>(&outputsSpec));
+        ASSERT_TRUE(std::get_if<DefaultOutputs>(&extendedOutputsSpec));
     }
 
     {
-        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^*");
+        auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^*");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get_if<AllOutputs>(&outputsSpec));
+        ASSERT_TRUE(std::get_if<AllOutputs>(&extendedOutputsSpec));
     }
 
     {
-        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^out");
+        auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^out");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get<OutputNames>(outputsSpec) == OutputNames({"out"}));
+        ASSERT_TRUE(std::get<OutputNames>(extendedOutputsSpec) == OutputNames({"out"}));
     }
 
     {
-        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^out,bin");
+        auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^out,bin");
         ASSERT_EQ(prefix, "foo");
-        ASSERT_TRUE(std::get<OutputNames>(outputsSpec) == OutputNames({"out", "bin"}));
+        ASSERT_TRUE(std::get<OutputNames>(extendedOutputsSpec) == OutputNames({"out", "bin"}));
     }
 
     {
-        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^bar^out,bin");
+        auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^bar^out,bin");
         ASSERT_EQ(prefix, "foo^bar");
-        ASSERT_TRUE(std::get<OutputNames>(outputsSpec) == OutputNames({"out", "bin"}));
+        ASSERT_TRUE(std::get<OutputNames>(extendedOutputsSpec) == OutputNames({"out", "bin"}));
     }
 
     {
-        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^&*()");
+        auto [prefix, extendedOutputsSpec] = ExtendedOutputsSpec::parse("foo^&*()");
         ASSERT_EQ(prefix, "foo^&*()");
-        ASSERT_TRUE(std::get_if<DefaultOutputs>(&outputsSpec));
+        ASSERT_TRUE(std::get_if<DefaultOutputs>(&extendedOutputsSpec));
     }
 }
 

--- a/src/libstore/tests/outputs-spec.cc
+++ b/src/libstore/tests/outputs-spec.cc
@@ -4,6 +4,12 @@
 
 namespace nix {
 
+#ifndef NDEBUG
+TEST(OutputsSpec, no_empty_names) {
+    ASSERT_DEATH(OutputsSpec::Names { std::set<std::string> { } }, "");
+}
+#endif
+
 #define TEST_DONT_PARSE(NAME, STR)           \
     TEST(OutputsSpec, bad_ ## NAME) {        \
         std::optional OutputsSpecOpt =       \

--- a/src/libstore/tests/outputs-spec.cc
+++ b/src/libstore/tests/outputs-spec.cc
@@ -4,40 +4,40 @@
 
 namespace nix {
 
-TEST(parseOutputsSpec, basic)
+TEST(OutputsSpec_parse, basic)
 {
     {
-        auto [prefix, outputsSpec] = parseOutputsSpec("foo");
+        auto [prefix, outputsSpec] = OutputsSpec::parse("foo");
         ASSERT_EQ(prefix, "foo");
         ASSERT_TRUE(std::get_if<DefaultOutputs>(&outputsSpec));
     }
 
     {
-        auto [prefix, outputsSpec] = parseOutputsSpec("foo^*");
+        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^*");
         ASSERT_EQ(prefix, "foo");
         ASSERT_TRUE(std::get_if<AllOutputs>(&outputsSpec));
     }
 
     {
-        auto [prefix, outputsSpec] = parseOutputsSpec("foo^out");
+        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^out");
         ASSERT_EQ(prefix, "foo");
         ASSERT_TRUE(std::get<OutputNames>(outputsSpec) == OutputNames({"out"}));
     }
 
     {
-        auto [prefix, outputsSpec] = parseOutputsSpec("foo^out,bin");
+        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^out,bin");
         ASSERT_EQ(prefix, "foo");
         ASSERT_TRUE(std::get<OutputNames>(outputsSpec) == OutputNames({"out", "bin"}));
     }
 
     {
-        auto [prefix, outputsSpec] = parseOutputsSpec("foo^bar^out,bin");
+        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^bar^out,bin");
         ASSERT_EQ(prefix, "foo^bar");
         ASSERT_TRUE(std::get<OutputNames>(outputsSpec) == OutputNames({"out", "bin"}));
     }
 
     {
-        auto [prefix, outputsSpec] = parseOutputsSpec("foo^&*()");
+        auto [prefix, outputsSpec] = OutputsSpec::parse("foo^&*()");
         ASSERT_EQ(prefix, "foo^&*()");
         ASSERT_TRUE(std::get_if<DefaultOutputs>(&outputsSpec));
     }

--- a/src/libstore/tests/outputs-spec.cc
+++ b/src/libstore/tests/outputs-spec.cc
@@ -40,6 +40,55 @@ TEST(OutputsSpec, names_out_bin) {
     ASSERT_EQ(expected.to_string(), "bin,out");
 }
 
+#define TEST_SUBSET(X, THIS, THAT) \
+    X((OutputsSpec { THIS }).isSubsetOf(THAT));
+
+TEST(OutputsSpec, subsets_all_all) {
+    TEST_SUBSET(ASSERT_TRUE, OutputsSpec::All { }, OutputsSpec::All { });
+}
+
+TEST(OutputsSpec, subsets_names_all) {
+    TEST_SUBSET(ASSERT_TRUE, OutputsSpec::Names { "a" }, OutputsSpec::All { });
+}
+
+TEST(OutputsSpec, subsets_names_names_eq) {
+    TEST_SUBSET(ASSERT_TRUE, OutputsSpec::Names { "a" }, OutputsSpec::Names { "a" });
+}
+
+TEST(OutputsSpec, subsets_names_names_noneq) {
+    TEST_SUBSET(ASSERT_TRUE, OutputsSpec::Names { "a" }, (OutputsSpec::Names { "a", "b" }));
+}
+
+TEST(OutputsSpec, not_subsets_all_names) {
+    TEST_SUBSET(ASSERT_FALSE, OutputsSpec::All { }, OutputsSpec::Names { "a" });
+}
+
+TEST(OutputsSpec, not_subsets_names_names) {
+    TEST_SUBSET(ASSERT_FALSE, (OutputsSpec::Names { "a", "b" }), (OutputsSpec::Names { "a" }));
+}
+
+#undef TEST_SUBSET
+
+#define TEST_UNION(RES, THIS, THAT) \
+    ASSERT_EQ(OutputsSpec { RES }, (OutputsSpec { THIS }).union_(THAT));
+
+TEST(OutputsSpec, union_all_all) {
+    TEST_UNION(OutputsSpec::All { }, OutputsSpec::All { }, OutputsSpec::All { });
+}
+
+TEST(OutputsSpec, union_all_names) {
+    TEST_UNION(OutputsSpec::All { }, OutputsSpec::All { }, OutputsSpec::Names { "a" });
+}
+
+TEST(OutputsSpec, union_names_all) {
+    TEST_UNION(OutputsSpec::All { }, OutputsSpec::Names { "a" }, OutputsSpec::All { });
+}
+
+TEST(OutputsSpec, union_names_names) {
+    TEST_UNION((OutputsSpec::Names { "a", "b" }), OutputsSpec::Names { "a" }, OutputsSpec::Names { "b" });
+}
+
+#undef TEST_UNION
 
 #define TEST_DONT_PARSE(NAME, STR)                   \
     TEST(ExtendedOutputsSpec, bad_ ## NAME) {        \

--- a/src/libutil/json-impls.hh
+++ b/src/libutil/json-impls.hh
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "nlohmann/json_fwd.hpp"
+
+// Following https://github.com/nlohmann/json#how-can-i-use-get-for-non-default-constructiblenon-copyable-types
+#define JSON_IMPL(TYPE)                                                \
+    namespace nlohmann {                                               \
+        using namespace nix;                                           \
+        template <>                                                    \
+        struct adl_serializer<TYPE> {                                  \
+            static TYPE from_json(const json & json);                  \
+            static void to_json(json & json, TYPE t);                  \
+        };                                                             \
+    }

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -421,7 +421,7 @@ static void main_nix_build(int argc, char * * argv)
             {
                 pathsToBuild.push_back(DerivedPath::Built {
                     .drvPath = inputDrv,
-                    .outputs = inputOutputs
+                    .outputs = OutputsSpec::Names { inputOutputs },
                 });
                 pathsToCopy.insert(inputDrv);
             }

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -397,7 +397,7 @@ static void main_nix_build(int argc, char * * argv)
                 auto bashDrv = drv->requireDrvPath();
                 pathsToBuild.push_back(DerivedPath::Built {
                     .drvPath = bashDrv,
-                    .outputs = {"out"},
+                    .outputs = OutputsSpec::Names {"out"},
                 });
                 pathsToCopy.insert(bashDrv);
                 shellDrv = bashDrv;
@@ -591,7 +591,7 @@ static void main_nix_build(int argc, char * * argv)
             if (outputName == "")
                 throw Error("derivation '%s' lacks an 'outputName' attribute", store->printStorePath(drvPath));
 
-            pathsToBuild.push_back(DerivedPath::Built{drvPath, {outputName}});
+            pathsToBuild.push_back(DerivedPath::Built{drvPath, OutputsSpec::Names{outputName}});
             pathsToBuildOrdered.push_back({drvPath, {outputName}});
             drvsToCopy.insert(drvPath);
 

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -478,9 +478,14 @@ static void printMissing(EvalState & state, DrvInfos & elems)
     std::vector<DerivedPath> targets;
     for (auto & i : elems)
         if (auto drvPath = i.queryDrvPath())
-            targets.push_back(DerivedPath::Built{*drvPath});
+            targets.push_back(DerivedPath::Built{
+                .drvPath = *drvPath,
+                .outputs = OutputsSpec::All { },
+            });
         else
-            targets.push_back(DerivedPath::Opaque{i.queryOutPath()});
+            targets.push_back(DerivedPath::Opaque{
+                .path = i.queryOutPath(),
+            });
 
     printMissing(state.store, targets);
 }
@@ -751,8 +756,13 @@ static void opSet(Globals & globals, Strings opFlags, Strings opArgs)
     auto drvPath = drv.queryDrvPath();
     std::vector<DerivedPath> paths {
         drvPath
-        ? (DerivedPath) (DerivedPath::Built { *drvPath })
-        : (DerivedPath) (DerivedPath::Opaque { drv.queryOutPath() }),
+        ? (DerivedPath) (DerivedPath::Built {
+            .drvPath = *drvPath,
+            .outputs = OutputsSpec::All { },
+        })
+        : (DerivedPath) (DerivedPath::Opaque {
+            .path = drv.queryOutPath(),
+        }),
     };
     printMissing(globals.state->store, paths);
     if (globals.dryRun) return;

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -86,13 +86,13 @@ UnresolvedApp Installable::toApp(EvalState & state)
                     /* We want all outputs of the drv */
                     return DerivedPath::Built {
                         .drvPath = d.drvPath,
-                        .outputs = {},
+                        .outputs = OutputsSpec::All {},
                     };
                 },
                 [&](const NixStringContextElem::Built & b) -> DerivedPath {
                     return DerivedPath::Built {
                         .drvPath = b.drvPath,
-                        .outputs = { b.output },
+                        .outputs = OutputsSpec::Names { b.output },
                     };
                 },
                 [&](const NixStringContextElem::Opaque & o) -> DerivedPath {
@@ -127,7 +127,7 @@ UnresolvedApp Installable::toApp(EvalState & state)
         return UnresolvedApp { App {
             .context = { DerivedPath::Built {
                 .drvPath = drvPath,
-                .outputs = {outputName},
+                .outputs = OutputsSpec::Names { outputName },
             } },
             .program = program,
         }};

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -75,10 +75,10 @@ struct CmdBundle : InstallableCommand
 
         auto val = installable->toValue(*evalState).first;
 
-        auto [bundlerFlakeRef, bundlerName, outputsSpec] = parseFlakeRefWithFragmentAndOutputsSpec(bundler, absPath("."));
+        auto [bundlerFlakeRef, bundlerName, extendedOutputsSpec] = parseFlakeRefWithFragmentAndExtendedOutputsSpec(bundler, absPath("."));
         const flake::LockFlags lockFlags{ .writeLockFile = false };
         InstallableFlake bundler{this,
-            evalState, std::move(bundlerFlakeRef), bundlerName, outputsSpec,
+            evalState, std::move(bundlerFlakeRef), bundlerName, extendedOutputsSpec,
             {"bundlers." + settings.thisSystem.get() + ".default",
              "defaultBundler." + settings.thisSystem.get()
             },

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -105,7 +105,12 @@ struct CmdBundle : InstallableCommand
 
         auto outPath = evalState->coerceToStorePath(attr2->pos, *attr2->value, context2, "");
 
-        store->buildPaths({ DerivedPath::Built { drvPath } });
+        store->buildPaths({
+            DerivedPath::Built {
+                .drvPath = drvPath,
+                .outputs = OutputsSpec::All { },
+            },
+        });
 
         auto outPathS = store->printStorePath(outPath);
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -232,7 +232,12 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
     auto shellDrvPath = writeDerivation(*evalStore, drv);
 
     /* Build the derivation. */
-    store->buildPaths({DerivedPath::Built{shellDrvPath}}, bmNormal, evalStore);
+    store->buildPaths(
+        { DerivedPath::Built {
+            .drvPath = shellDrvPath,
+            .outputs = OutputsSpec::All { },
+        }},
+        bmNormal, evalStore);
 
     for (auto & [_0, optPath] : evalStore->queryPartialDerivationOutputMap(shellDrvPath)) {
         assert(optPath);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -513,8 +513,12 @@ struct CmdFlakeCheck : FlakeCommand
                                     auto drvPath = checkDerivation(
                                         fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
                                         *attr2.value, attr2.pos);
-                                    if (drvPath && attr_name == settings.thisSystem.get())
-                                        drvPaths.push_back(DerivedPath::Built{*drvPath});
+                                    if (drvPath && attr_name == settings.thisSystem.get()) {
+                                        drvPaths.push_back(DerivedPath::Built {
+                                            .drvPath = *drvPath,
+                                            .outputs = OutputsSpec::All { },
+                                        });
+                                    }
                                 }
                             }
                         }

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -22,7 +22,7 @@ struct ProfileElementSource
     // FIXME: record original attrpath.
     FlakeRef resolvedRef;
     std::string attrPath;
-    OutputsSpec outputs;
+    ExtendedOutputsSpec outputs;
 
     bool operator < (const ProfileElementSource & other) const
     {
@@ -126,7 +126,7 @@ struct ProfileManifest
                         parseFlakeRef(e[sOriginalUrl]),
                         parseFlakeRef(e[sUrl]),
                         e["attrPath"],
-                        e["outputs"].get<OutputsSpec>()
+                        e["outputs"].get<ExtendedOutputsSpec>()
                     };
                 }
                 elements.emplace_back(std::move(element));
@@ -308,12 +308,12 @@ struct CmdProfileInstall : InstallablesCommand, MixDefaultProfile
 
             auto & [res, info] = builtPaths[installable.get()];
 
-            if (info.originalRef && info.resolvedRef && info.attrPath && info.outputsSpec) {
+            if (info.originalRef && info.resolvedRef && info.attrPath && info.extendedOutputsSpec) {
                 element.source = ProfileElementSource {
                     .originalRef = *info.originalRef,
                     .resolvedRef = *info.resolvedRef,
                     .attrPath = *info.attrPath,
-                    .outputs = *info.outputsSpec,
+                    .outputs = *info.extendedOutputsSpec,
                 };
             }
 
@@ -497,7 +497,7 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixDefaultProfile, MixProf
                     .originalRef = installable->flakeRef,
                     .resolvedRef = *info.resolvedRef,
                     .attrPath = *info.attrPath,
-                    .outputs = installable->outputsSpec,
+                    .outputs = installable->extendedOutputsSpec,
                 };
 
                 installables.push_back(installable);

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -44,7 +44,7 @@ struct ProfileElement
     std::string describe() const
     {
         if (source)
-            return fmt("%s#%s%s", source->originalRef, source->attrPath, printOutputsSpec(source->outputs));
+            return fmt("%s#%s%s", source->originalRef, source->attrPath, source->outputs.to_string());
         StringSet names;
         for (auto & path : storePaths)
             names.insert(DrvName(path.name()).name);
@@ -553,8 +553,8 @@ struct CmdProfileList : virtual EvalCommand, virtual StoreCommand, MixDefaultPro
         for (size_t i = 0; i < manifest.elements.size(); ++i) {
             auto & element(manifest.elements[i]);
             logger->cout("%d %s %s %s", i,
-                element.source ? element.source->originalRef.to_string() + "#" + element.source->attrPath + printOutputsSpec(element.source->outputs) : "-",
-                element.source ? element.source->resolvedRef.to_string() + "#" + element.source->attrPath + printOutputsSpec(element.source->outputs) : "-",
+                element.source ? element.source->originalRef.to_string() + "#" + element.source->attrPath + element.source->outputs.to_string() : "-",
+                element.source ? element.source->resolvedRef.to_string() + "#" + element.source->attrPath + element.source->outputs.to_string() : "-",
                 concatStringsSep(" ", store->printStorePathSet(element.storePaths)));
         }
     }


### PR DESCRIPTION
`DerivedPath::Built` and `DerivationGoal` were previously using a regular `std::set<std::string<` with the convention that the empty set means all outputs. But it is easy to forget about this rule when processing those sets. Using `OutputsSpec` forces us to get it right.

I did this because of the deduplication @edolstra requested in https://github.com/NixOS/nix/pull/4543#discussion_r922164687. We can't do much good code reuse when `DerivedPath` doesn't use `OutputsSpec` like it should.

We need to split `OutputsSpec` from `ExtendedOutputsSpec` because the "default" case only makes sense for high-level installables with an `outputsToInstall` field. For `DerivationGoal`, and `DerivedPath` itself, only concrete sets and the "all" wild-card make sense.