### PR TITLE
s3-binary-cache-store: getFile streaming from S3

### DIFF
--- a/src/libstore/s3.hh
+++ b/src/libstore/s3.hh
@@ -3,6 +3,7 @@
 #if ENABLE_S3
 
 #include "ref.hh"
+#include "serialise.hh"
 
 #include <optional>
 #include <string>
@@ -29,6 +30,18 @@ struct S3Helper
 
     FileTransferResult getObject(
         const std::string & bucketName, const std::string & key);
+
+    struct StreamResult
+    {
+        std::streamsize size = 0;
+        unsigned int durationMs = 0;
+        bool streamSuccessful = false;
+    };
+
+    StreamResult getObjectStreamed(
+        const std::string & bucketName, const std::string & key, Sink & sink, size_t bufferSize);
+
+    size_t getObjectSize(const std::string & bucketName, const std::string & key);
 };
 
 }


### PR DESCRIPTION
Before this change `nix copy --from s3://...` would download the entire object into memory before passing it on to the destination store. For bigger derivations this can lead to high memory usage and out-of-memory (OOM) errors. We experienced these OOM failures frequently.

This change adds support to stream objects from S3 to `nix copy`. This keeps the memory usage at a constant low level. We measured resident memory usage of roughly 40MB for packages of any size. To verify this patch works, we created a derivation with 10 GB of random data and did a before and after test. Without the patch we observed memory usage climbing to 10 GB. With the patch memory usage would settle at 40 MB.

We are now running this code in production and are no longer seeing OOM errors.

cc @thufschmitt 