### PR TITLE
nix shell: document how to invoke multiple commands from the command …

### DIFF
--- a/src/nix/shell.md
+++ b/src/nix/shell.md
@@ -23,6 +23,12 @@ R""(
   Hi everybody!
   ```
 
+* Run multiple commands in a shell environment:
+
+  ```console
+  # nix shell nixpkgs#gnumake -c /bin/sh -c "cd src && make"
+  ```
+
 * Run GNU Hello in a chroot store:
 
   ```console

--- a/src/nix/shell.md
+++ b/src/nix/shell.md
@@ -26,7 +26,7 @@ R""(
 * Run multiple commands in a shell environment:
 
   ```console
-  # nix shell nixpkgs#gnumake -c /bin/sh -c "cd src && make"
+  # nix shell nixpkgs#gnumake -c sh -c "cd src && make"
   ```
 
 * Run GNU Hello in a chroot store:


### PR DESCRIPTION
while `nix-shell` allowed to run multiple commands in a shell environment like this: `nix-shell -p gnumake --run "cd src && make`, this isn't possible anymore with `nix shell`.

This PR adds an example for running multiple commands in a shell environment with `nix shell`