### PR TITLE
Introducing metadata fields to nix flake show’s json output for search.nixos.org

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -148,7 +148,9 @@ if ! [ -w "$dest" ]; then
     exit 1
 fi
 
-mkdir -p "$dest/store"
+# The auto-chroot code in openFromNonUri() checks for the
+# non-existence of /nix/var/nix, so we need to create it here.
+mkdir -p "$dest/store" "$dest/var/nix"
 
 printf "copying Nix to %s..." "${dest}/store" >&2
 # Insert a newline if no progress is shown.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -452,6 +452,7 @@ EvalState::EvalState(
     , sOutputHashMode(symbols.create("outputHashMode"))
     , sRecurseForDerivations(symbols.create("recurseForDerivations"))
     , sDescription(symbols.create("description"))
+	, sHomepage(symbols.create("homepage"))
     , sSelf(symbols.create("self"))
     , sEpsilon(symbols.create(""))
     , sStartSet(symbols.create("startSet"))

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -102,7 +102,7 @@ public:
         sContentAddressed, sImpure,
         sOutputHash, sOutputHashAlgo, sOutputHashMode,
         sRecurseForDerivations,
-        sDescription, sSelf, sEpsilon, sStartSet, sOperator, sKey, sPath,
+        sDescription, sHomepage, sSelf, sEpsilon, sStartSet, sOperator, sKey, sPath, 
         sPrefix,
         sOutputSpecified;
     Symbol sDerivationNix;

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -353,26 +353,15 @@ LockedFlake lockFlake(
         std::vector<FlakeRef> parents;
 
         std::function<void(
-            const FlakeInputs & flakeInputs,
-            std::shared_ptr<Node> node,
             const InputPath & inputPathPrefix,
-            std::shared_ptr<const Node> oldNode,
-            const InputPath & lockRootPath,
-            const Path & parentPath,
-            bool trustLock)>
-            computeLocks;
+            const FlakeInputs & flakeInputs
+            )>
+            checkFollowsDeclarations;
 
-        computeLocks = [&](
-            const FlakeInputs & flakeInputs,
-            std::shared_ptr<Node> node,
+        checkFollowsDeclarations = [&](
             const InputPath & inputPathPrefix,
-            std::shared_ptr<const Node> oldNode,
-            const InputPath & lockRootPath,
-            const Path & parentPath,
-            bool trustLock)
-        {
-            debug("computing lock file node '%s'", printInputPath(inputPathPrefix));
-
+            const FlakeInputs & flakeInputs
+        ) {
             for (auto [inputPath, inputOverride] : overrides) {
                 auto inputPath2(inputPath);
                 auto follow = inputPath2.back();
@@ -394,6 +383,30 @@ LockedFlake lockFlake(
                     );
                 }
             }
+        };
+
+        std::function<void(
+            const FlakeInputs & flakeInputs,
+            std::shared_ptr<Node> node,
+            const InputPath & inputPathPrefix,
+            std::shared_ptr<const Node> oldNode,
+            const InputPath & lockRootPath,
+            const Path & parentPath,
+            bool trustLock)>
+            computeLocks;
+
+        computeLocks = [&](
+            const FlakeInputs & flakeInputs,
+            std::shared_ptr<Node> node,
+            const InputPath & inputPathPrefix,
+            std::shared_ptr<const Node> oldNode,
+            const InputPath & lockRootPath,
+            const Path & parentPath,
+            bool trustLock)
+        {
+            debug("computing lock file node '%s'", printInputPath(inputPathPrefix));
+
+            checkFollowsDeclarations(inputPathPrefix, flakeInputs);
 
             /* Get the overrides (i.e. attributes of the form
                'inputs.nixops.inputs.nixpkgs.url = ...'). */

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -373,6 +373,29 @@ LockedFlake lockFlake(
         {
             debug("computing lock file node '%s'", printInputPath(inputPathPrefix));
 
+            auto overrides2 = overrides;
+            for (auto & [inputPath, inputOverride] : overrides2) {
+                auto inputPath2(inputPath);
+                auto follow = inputPath2.back();
+                inputPath2.pop_back();
+                if (inputPath2 == inputPathPrefix
+                    && flakeInputs.find(follow) == flakeInputs.end()
+                ) {
+                    std::string root;
+                    for (auto & element : inputPath2) {
+                        root.append(element);
+                        if (element != inputPath2.back()) {
+                            root.append(".inputs.");
+                        }
+                    }
+                    throw Error(
+                        "%s has a `follows'-declaration for a non-existant input %s!",
+                        root,
+                        follow
+                    );
+                }
+            }
+
             /* Get the overrides (i.e. attributes of the form
                'inputs.nixops.inputs.nixpkgs.url = ...'). */
             for (auto & [id, input] : flakeInputs) {

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -373,8 +373,7 @@ LockedFlake lockFlake(
         {
             debug("computing lock file node '%s'", printInputPath(inputPathPrefix));
 
-            auto overrides2 = overrides;
-            for (auto & [inputPath, inputOverride] : overrides2) {
+            for (auto [inputPath, inputOverride] : overrides) {
                 auto inputPath2(inputPath);
                 auto follow = inputPath2.back();
                 inputPath2.pop_back();
@@ -388,7 +387,7 @@ LockedFlake lockFlake(
                             root.append(".inputs.");
                         }
                     }
-                    throw Error(
+                    warn(
                         "%s has a `follows'-declaration for a non-existant input %s!",
                         root,
                         follow

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1029,14 +1029,20 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                     auto name = visitor.getAttr(state->sName)->getString();
                     if (json) {
                         std::optional<std::string> description;
+                        std::optional<std::string> homepage;
                         if (auto aMeta = visitor.maybeGetAttr(state->sMeta)) {
                             if (auto aDescription = aMeta->maybeGetAttr(state->sDescription))
                                 description = aDescription->getString();
+                            if (auto aHomepage = aMeta->maybeGetAttr(state->sHomepage))
+                                homepage = aHomepage->getString();
+
                         }
                         j.emplace("type", "derivation");
                         j.emplace("name", name);
                         if (description)
                             j.emplace("description", *description);
+                        if (homepage)
+                            j.emplace("homepage", *homepage);
                     } else {
                         logger->cout("%s: %s '%s'",
                             headerPrefix,

--- a/tests/flakes.sh
+++ b/tests/flakes.sh
@@ -877,4 +877,4 @@ EOF
 
 git -C $flakeFollowsA add flake.nix
 
-nix flake lock $flakeFollowsA 2>&1 | grep "error: B has a \`follows'-declaration for a non-existant input invalid!"
+nix flake lock $flakeFollowsA 2>&1 | grep "warning: B has a \`follows'-declaration for a non-existant input invalid!"


### PR DESCRIPTION
**Motivation:**
I am working for @garbas on improving search.nixos.org and we are encountering difficulties with importing packages metadata. 
We are currently using some custom nix code that wraps each flake evaluation to export needed metadata. But this custom wrapper doesn’t work with repos that are the size of nixpkgs.
For nixpkgs we are currently resorting to using nix-env to be able to export all the metadata in an efficient way.
Our goal would be to deprecate the usage of nix-env and have nix flake show –json export all output information required for search in an efficient and standardized manner.

**Current Progress:**
I have added a few snippets of code of what adding a homepage field might look like. It currently will not compile as the homepage is not being read in yet. I am looking for expertise in handling the reading of homepage, licenses, and maintainers to the eval state. 

At this point I would only like to focus on metadata for packages as it is being defined (TODO: link) in nixpkgs. This means adding 3 more fields alongside a description field to JSON output (homepage, license, maintainers).

If possible I would like to bring this up for a discussion at some Nix related meeting.
