### PR TITLE
docker.nix: Pin nixpkgs in flake registry

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -612,7 +612,11 @@
         dockerImage =
           let
             pkgs = nixpkgsFor.${system};
-            image = import ./docker.nix { inherit pkgs; tag = version; };
+            image = import ./docker.nix {
+              inherit pkgs;
+              inherit (nixpkgs) sourceInfo;
+              tag = version;
+            };
           in
           pkgs.runCommand
             "docker-image-tarball-${version}"


### PR DESCRIPTION
This patch allows the currently selected `nixpkgs` to be pinned in the Docker image's flake registry.