### PR TITLE
Fix Nix build --check flag

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -914,12 +914,6 @@ void DerivationGoal::buildDone()
             outputPaths
         );
 
-        if (buildMode == bmCheck) {
-            cleanupPostOutputsRegisteredModeCheck();
-            done(BuildResult::Built, std::move(builtOutputs));
-            return;
-        }
-
         cleanupPostOutputsRegisteredModeNonCheck();
 
         /* Repeat the build if necessary. */


### PR DESCRIPTION
See #2619 for more context.

Once a derivation goal has been completed, we check whether
this goal was meant to be repeated to check its output reproducibility.

An early return branch was preventing the worker to reach that repeat
code branch, hence breaking the --check command (#2619).

It seems like this early return branch is an artifact of a passed
refactoring. As far as I can tell, buildDone's main branch also
cleanup the tmp directory before returning.

The only difference here being that we are now deleting the output lock
files in a --check build. After reading a bit the code around this part, I think
this is the desired behavior, but I'm not 100% sure about that. If it's not the
case, we can guard the two lines doing that againt a `bmCheck` build.

-----------------------------------

How to test?

```
nix build "nixpkgs#hello" --rebuild --repeat 3
```

It'll only build hello once before this PR, 4 times after applying this patch.