### PR TITLE
fix(src/nix/main.cc): proper tarball-ttl default value

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -375,7 +375,7 @@ void mainWrapped(int argc, char * * argv)
         if (!settings.useSubstitutes.overridden)
             settings.useSubstitutes = false;
         if (!settings.tarballTtl.overridden)
-            settings.tarballTtl = std::numeric_limits<unsigned int>::max();
+            settings.tarballTtl = 60 * 60;
         if (!fileTransferSettings.tries.overridden)
             fileTransferSettings.tries = 0;
         if (!fileTransferSettings.connectTimeout.overridden)


### PR DESCRIPTION
# Description
https://github.com/NixOS/nix/issues/6359

The [manual](https://nixos.org/manual/nix/unstable/command-ref/conf-file.html?highlight=tarball-ttl#conf-tarball-ttl) reports a `MAXUINT32` for the default value `tarball-ttl` which is a very long time. The purported default is 1 hour. This changes the default value to match the value in [the docs](https://github.com/NixOS/nix/blob/780a4793866b2cac1040d522df514645d01c492f/src/libstore/globals.hh#L542).