### PR TITLE
manual: update docs when NIX_PATH is empty

### DIFF
--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -46,9 +46,13 @@ Most Nix commands interpret the following environment variables:
 
     If `NIX_PATH` is not set at all, Nix will fall back to the following list in impure and unrestricted evaluation mode:
 
-    1. `$HOME/.nix-defexpr/channels`
-    2. `nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
-    3. `/nix/var/nix/profiles/per-user/root/channels`
+      1. `$HOME/.nix-defexpr/channels`
+      2. `nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
+      3. `/nix/var/nix/profiles/per-user/root/channels`
+
+    If `NIX_PATH` is set to an empty string the above fallback will not happen and building will fail with:
+
+      `error: file 'nixpkgs' was not found in the Nix search path`
 
   - [`NIX_IGNORE_SYMLINK_STORE`]{#env-NIX_IGNORE_SYMLINK_STORE}\
     Normally, the Nix store directory (typically `/nix/store`) is not

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -44,7 +44,7 @@ Most Nix commands interpret the following environment variables:
     The Nix search path can also be extended using the `-I` option to
     many Nix commands, which takes precedence over `NIX_PATH`.
 
-    If `NIX_PATH` environment variable is not set, Nix will fall back to the following list in impure and unrestricted evaluation mode:
+    If `NIX_PATH` is not set at all, Nix will fall back to the following list in impure and unrestricted evaluation mode:
 
     1. `$HOME/.nix-defexpr/channels`
     2. `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -44,7 +44,7 @@ Most Nix commands interpret the following environment variables:
     The Nix search path can also be extended using the `-I` option to
     many Nix commands, which takes precedence over `NIX_PATH`.
 
-    If `NIX_PATH` is not set at all, Nix will fall back to the following list in impure and unrestricted evaluation mode:
+    If `NIX_PATH` is not set at all, Nix will fall back to the following list in [impure](./conf-file.md#conf-pure-eval) and [unrestricted](./conf-file.md#conf-restrict-eval) evaluation mode:
 
       1. `$HOME/.nix-defexpr/channels`
       2. `nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixpkgs`

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -44,7 +44,7 @@ Most Nix commands interpret the following environment variables:
     The Nix search path can also be extended using the `-I` option to
     many Nix commands, which takes precedence over `NIX_PATH`.
 
-    If `NIX_PATH` is not set or empty, Nix will look up the following locations for a revision of `nixpkgs`:
+    If `NIX_PATH` environment variable is not set, Nix will fall back to the following list in impure and unrestricted evaluation mode:
 
     1. `$HOME/.nix-defexpr/channels`
     2. `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -47,7 +47,7 @@ Most Nix commands interpret the following environment variables:
     If `NIX_PATH` is not set at all, Nix will fall back to the following list in impure and unrestricted evaluation mode:
 
     1. `$HOME/.nix-defexpr/channels`
-    2. `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
+    2. `nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
     3. `/nix/var/nix/profiles/per-user/root/channels`
 
   - [`NIX_IGNORE_SYMLINK_STORE`]{#env-NIX_IGNORE_SYMLINK_STORE}\

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -44,6 +44,12 @@ Most Nix commands interpret the following environment variables:
     The Nix search path can also be extended using the `-I` option to
     many Nix commands, which takes precedence over `NIX_PATH`.
 
+    If `NIX_PATH` is not set or empty, Nix will look up the following locations for a revision of `nixpkgs`:
+
+    1. `$HOME/.nix-defexpr/channels`
+    2. `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
+    3. `/nix/var/nix/profiles/per-user/root/channels.`
+
   - [`NIX_IGNORE_SYMLINK_STORE`]{#env-NIX_IGNORE_SYMLINK_STORE}\
     Normally, the Nix store directory (typically `/nix/store`) is not
     allowed to contain any symlink components. This is to prevent

--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -50,9 +50,10 @@ Most Nix commands interpret the following environment variables:
       2. `nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
       3. `/nix/var/nix/profiles/per-user/root/channels`
 
-    If `NIX_PATH` is set to an empty string the above fallback will not happen and building will fail with:
+    If `NIX_PATH` is set to an empty string, resolving search paths will always fail.
+    For example, attempting to use `<nixpkgs>` will produce:
 
-      `error: file 'nixpkgs' was not found in the Nix search path`
+        error: file 'nixpkgs' was not found in the Nix search path
 
   - [`NIX_IGNORE_SYMLINK_STORE`]{#env-NIX_IGNORE_SYMLINK_STORE}\
     Normally, the Nix store directory (typically `/nix/store`) is not


### PR DESCRIPTION
Update documentation how Nix resolves <nixpkgs> when `NIX_PATH` is not set