### PR TITLE
docker.nix: Use JSON format for profile manifest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -612,7 +612,11 @@
         dockerImage =
           let
             pkgs = nixpkgsFor.${system};
-            image = import ./docker.nix { inherit pkgs; tag = version; };
+            image = import ./docker.nix {
+              inherit pkgs;
+              inherit (nixpkgs) sourceInfo;
+              tag = version;
+            };
           in
           pkgs.runCommand
             "docker-image-tarball-${version}"


### PR DESCRIPTION
This commit causes the profile manifest in the Docker image to be emitted in the newer `manifest.json` format instead of `manifest.nix`.