### PR TITLE
Only fail if selinux is in enforcing

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -640,7 +640,7 @@ place_channel_configuration() {
 
 check_selinux() {
     if command -v getenforce > /dev/null 2>&1; then
-        if ! [ "$(getenforce)" = "Disabled" ]; then
+        if [ "$(getenforce)" = "Enforcing" ]; then
             failure <<EOF
 Nix does not work with selinux enabled yet!
 see https://github.com/NixOS/nix/issues/2374


### PR DESCRIPTION
In #6639 (which was implemented because of issue #2374) a bug was introduced where the installer will fail even if SELinux is set to permissive. The check is explicitly checking if SELinux is disabled but this is not accurate. SELinux can have three states:

* Disabled
* Permissive
* Enforcing

Disable means SELinux is not running at all.
Permissive means that SELinux is running, but it won't prevent any actions, even if they would be denied.
Enforcing means that SELinux is running and will deny any actions which don't match a rule.

In our environment we are required to have SELinux set to permissive, therefore, we are unable to install nix. Even though beforehand we were able too. I've worked around this by manually downloading the install bundle and then changing the check, but I thought I would also update the repo to prevent other people having this problem.

It's not right to mandate that SELinux should be disabled because this prevents the file system from getting the right file contexts applied. Which means if a SysAdmin wants to ever go back to enforcing this becomes a lot harder. Whereas, with SELinux set to permissive the file system still keeps it's contexts etc.

The real solution would be to provide SELinux rules for the application, but I understand at this current time that is not feasible.

I have checked on my fedora system and the install will now continue if SELinux is set to Disabled or Permissive, but will show the same error as in #6639 if the system is set to enforcing.

Many Thanks,
Tom Franklin.