### PR TITLE
Don't point to `nix --help` when the config is invalid

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -382,6 +382,10 @@ int handleExceptions(const std::string & programName, std::function<void()> fun)
         }
     } catch (Exit & e) {
         return e.status;
+    } catch (ConfigError & e) {
+        logError(e.info());
+        printError("Try 'man nix.conf' for more information.");
+        return 1;
     } catch (UsageError & e) {
         logError(e.info());
         printError("Try '%1% --help' for more information.", programName);

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -94,7 +94,7 @@ void AbstractConfig::applyConfig(const std::string & contents, const std::string
         if (tokens.empty()) continue;
 
         if (tokens.size() < 2)
-            throw UsageError("illegal configuration line '%1%' in '%2%'", line, path);
+            throw ConfigError("illegal configuration line '%1%' in '%2%'", line, path);
 
         auto include = false;
         auto ignoreMissing = false;
@@ -107,7 +107,7 @@ void AbstractConfig::applyConfig(const std::string & contents, const std::string
 
         if (include) {
             if (tokens.size() != 2)
-                throw UsageError("illegal configuration line '%1%' in '%2%'", line, path);
+                throw ConfigError("illegal configuration line '%1%' in '%2%'", line, path);
             auto p = absPath(tokens[1], dirOf(path));
             if (pathExists(p)) {
                 applyConfigFile(p);
@@ -118,7 +118,7 @@ void AbstractConfig::applyConfig(const std::string & contents, const std::string
         }
 
         if (tokens[1] != "=")
-            throw UsageError("illegal configuration line '%1%' in '%2%'", line, path);
+            throw ConfigError("illegal configuration line '%1%' in '%2%'", line, path);
 
         std::string name = tokens[0];
 
@@ -239,7 +239,7 @@ void BaseSetting<T>::set(const std::string & str, bool append)
     if (auto n = string2Int<T>(str))
         value = *n;
     else
-        throw UsageError("setting '%s' has invalid value '%s'", name, str);
+        throw ConfigError("setting '%s' has invalid value '%s'", name, str);
 }
 
 template<typename T>
@@ -256,7 +256,7 @@ template<> void BaseSetting<bool>::set(const std::string & str, bool append)
     else if (str == "false" || str == "no" || str == "0")
         value = false;
     else
-        throw UsageError("Boolean setting '%s' has invalid value '%s'", name, str);
+        throw ConfigError("Boolean setting '%s' has invalid value '%s'", name, str);
 }
 
 template<> std::string BaseSetting<bool>::to_string() const
@@ -382,7 +382,7 @@ void PathSetting::set(const std::string & str, bool append)
         if (allowEmpty)
             value = "";
         else
-            throw UsageError("setting '%s' cannot be empty", name);
+            throw ConfigError("setting '%s' cannot be empty", name);
     } else
         value = canonPath(str);
 }

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -3,6 +3,7 @@
 #include <set>
 
 #include "types.hh"
+#include "error.hh"
 
 #include <nlohmann/json_fwd.hpp>
 
@@ -352,5 +353,7 @@ struct GlobalConfig : public AbstractConfig
 };
 
 extern GlobalConfig globalConfig;
+
+MakeError(ConfigError, Error);
 
 }

--- a/src/libutil/tests/config.cc
+++ b/src/libutil/tests/config.cc
@@ -245,7 +245,7 @@ namespace nix {
 
     TEST(Config, applyConfigInvalidThrows) {
         Config config;
-        ASSERT_THROW(config.applyConfig("value == key"), UsageError);
-        ASSERT_THROW(config.applyConfig("value "), UsageError);
+        ASSERT_THROW(config.applyConfig("value == key"), ConfigError);
+        ASSERT_THROW(config.applyConfig("value "), ConfigError);
     }
 }


### PR DESCRIPTION
`nix --help` won't run with an invalid config file, so that's not a
really good suggestion. Point to the manpage instead.

This isn't totally ideal either since the man page is arguably less nice
and might not be here at all, but at least it's *something*

Fix #6878
