### PR TITLE
nix-shell: specify which outputs from bashInteractive to build

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -401,7 +401,7 @@ static void main_nix_build(int argc, char * * argv)
                 auto bashDrv = drv->requireDrvPath();
                 pathsToBuild.push_back(DerivedPath::Built {
                     .drvPath = bashDrv,
-                    .outputs = {},
+                    .outputs = {"out"},
                 });
                 pathsToCopy.insert(bashDrv);
                 shellDrv = bashDrv;


### PR DESCRIPTION
This prevents downloading additional outputs that aren't needed for the shell.