### PR TITLE
Make `nix log` respect NO_COLOR=1

### DIFF
--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -4,6 +4,7 @@
 #include "store-api.hh"
 #include "log-store.hh"
 #include "progress-bar.hh"
+#include "util.hh"
 
 using namespace nix;
 
@@ -53,6 +54,9 @@ struct CmdLog : InstallableCommand
             if (!log) continue;
             stopProgressBar();
             printInfo("got build log for '%s' from '%s'", installable->what(), logSub.getUri());
+            if (!shouldANSI()) {
+                log = filterANSIEscapes(*log, true);
+            }
             std::cout << *log;
             return;
         }


### PR DESCRIPTION
Some parts of nix already respect NO_COLOR=1.
It seems however this functionality is desired, yet missing from `nix log`.
See: https://discourse.nixos.org/t/disabling-colors-for-nix-log-output/17480
