### PR TITLE
Avoid producing incomplete JSON

### DIFF
--- a/src/libutil/json.cc
+++ b/src/libutil/json.cc
@@ -193,7 +193,11 @@ JSONObject JSONPlaceholder::object()
 
 JSONPlaceholder::~JSONPlaceholder()
 {
-    assert(!first || std::uncaught_exceptions());
+    if (first) {
+        assert(std::uncaught_exceptions());
+        if (state->stack != 0)
+            write(nullptr);
+    }
 }
 
 }

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -940,12 +940,12 @@ static void queryJSON(Globals & globals, std::vector<DrvInfo> & elems, bool prin
                 JSONObject metaObj = pkgObj.object("meta");
                 StringSet metaNames = i.queryMetaNames();
                 for (auto & j : metaNames) {
-                    auto placeholder = metaObj.placeholder(j);
                     Value * v = i.queryMeta(j);
                     if (!v) {
                         printError("derivation '%s' has invalid meta attribute '%s'", i.queryName(), j);
-                        placeholder.write(nullptr);
+                        metaObj.attr(j, nullptr);
                     } else {
+                        auto placeholder = metaObj.placeholder(j);
                         PathSet context;
                         printValueAsJSON(*globals.state, true, *v, noPos, placeholder, context);
                     }


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/6922, *generally* by writing `null` if a placeholder is destructed before it was written to, and *specifically* by not creating the placeholder until after the evaluation.
