### PR TITLE
add a nix.conf option to set a download speed limit

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -308,6 +308,9 @@ struct curlFileTransfer : public FileTransfer
 
             curl_easy_setopt(req, CURLOPT_HTTPHEADER, requestHeaders);
 
+            if (settings.downloadSpeed.get() > 0)
+                curl_easy_setopt(req, CURLOPT_MAX_RECV_SPEED_LARGE, (curl_off_t) (settings.downloadSpeed.get() * 1024));
+
             if (request.head)
                 curl_easy_setopt(req, CURLOPT_NOBODY, 1);
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -746,6 +746,13 @@ public:
               /nix/store/xfghy8ixrhz3kyy6p724iv3cxji088dx-bash-4.4-p23`.
         )"};
 
+    Setting<unsigned int> downloadSpeed {
+        this, 0, "download-speed",
+        R"(
+          Specify the maxium transfer rate in kilobytes per second you want
+          nix to use for download.
+        )"};
+
     Setting<std::string> netrcFile{
         this, fmt("%s/%s", nixConfDir, "netrc"), "netrc-file",
         R"(


### PR DESCRIPTION
Hello

This PR adds a new attribute to the options available in nix.conf to defines a download speed limit.
This is particularly useful for people like me behind a slow DSL line who regularly need to download gigabytes of packages with nix, but don't want to make the other LAN Internet users angry.