### PR TITLE
Search any attribute recursively if `recurseForDerivation` is set

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -178,7 +178,7 @@ struct CmdSearch : InstallableCommand, MixJSON
                 else if (initialRecurse)
                     recurse();
 
-                else if (attrPathS[0] == "legacyPackages" && attrPath.size() > 2) {
+                else if (attrPath.size() >= 2) {
                     auto attr = cursor.maybeGetAttr(state->sRecurseForDerivations);
                     if (attr && attr->getBool())
                         recurse();


### PR DESCRIPTION
closes #6938