### PR TITLE
Update install-systemd-multi-user.sh

### DIFF
--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -87,7 +87,7 @@ poly_configure_nix_daemon_service() {
         task "Setting up the nix-daemon systemd service"
 
         _sudo "to create the nix-daemon tmpfiles config" \
-              ln -sfn /nix/var/nix/profiles/default$TMPFILES_SRC $TMPFILES_DEST
+              ln -sfn "/nix/var/nix/profiles/default$TMPFILES_SRC" "$TMPFILES_DEST"
 
         _sudo "to run systemd-tmpfiles once to pick that path up" \
              systemd-tmpfiles --create --prefix=/nix/var/nix

--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -87,7 +87,7 @@ poly_configure_nix_daemon_service() {
         task "Setting up the nix-daemon systemd service"
 
         _sudo "to create the nix-daemon tmpfiles config" \
-              ln -sfn /nix/var/nix/profiles/default/$TMPFILES_SRC $TMPFILES_DEST
+              ln -sfn /nix/var/nix/profiles/default$TMPFILES_SRC $TMPFILES_DEST
 
         _sudo "to run systemd-tmpfiles once to pick that path up" \
              systemd-tmpfiles --create --prefix=/nix/var/nix


### PR DESCRIPTION
https://github.com/NixOS/nix/blob/04e74f7c8bb5589dec578dd049013d3cd2554e65/scripts/install-systemd-multi-user.sh#L90

The symlink **should be referencing this** `default$TMPFILES_SRC` **_not this_** `default/$TMPFILES_SRC` based on how the variable was set:

https://github.com/NixOS/nix/blob/04e74f7c8bb5589dec578dd049013d3cd2554e65/scripts/install-systemd-multi-user.sh#L12

---

See [Issue 6960](https://github.com/NixOS/nix/issues/6952)

Closes #6952