### PR TITLE
fix(libstore): allow access to trustd on macOS

### DIFF
--- a/src/libstore/sandbox-network.sb
+++ b/src/libstore/sandbox-network.sb
@@ -14,3 +14,7 @@
 
 ; Allow DNS lookups.
 (allow network-outbound (remote unix-socket (path-literal "/private/var/run/mDNSResponder")))
+
+; Allow access to trustd.
+(allow mach-lookup (global-name "com.apple.trustd"))
+(allow mach-lookup (global-name "com.apple.trustd.agent"))


### PR DESCRIPTION
It seems that some Security.framework calls require access to `trustd`.

This fixes https://github.com/NixOS/nixpkgs/issues/182889.

I'm not sure if this would be more appropriate going in the default sandbox profile, though I think it might be a good idea? The function in question (`SecCertificateCopyData`) isn't network-specific:
> Returns a DER representation of a certificate given a certificate object.

So maybe adding it to the default profile will increase compatibility within the sandbox?

Let me know if this is the better option (which I suspect it is, though since I originally had this in the network profile, I figured I'd keep it there for right now).