### PR TITLE
Fix evaluation cache

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -507,11 +507,6 @@ std::shared_ptr<AttrCursor> AttrCursor::maybeGetAttr(Symbol name, bool forceErro
         return nullptr;
         //throw TypeError("'%s' is not an attribute set", getAttrPathStr());
 
-    for (auto & attr : *v.attrs) {
-        if (root->db)
-            root->db->setPlaceholder({cachedValue->first, attr.name});
-    }
-
     auto attr = v.attrs->get(name);
 
     if (!attr) {


### PR DESCRIPTION
98e361ad4c1a26d4ffe4762a6f33bb9e39321a39 introduced a regression where previously stored attributes were replaced by placeholders. As a result, a command like `nix build nixpkgs#hello` had to be executed at least twice to get caching.

This code does not seem necessary for suggestions to work.