### PR TITLE
Fix progress bar flicker with -L

### DIFF
--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -30,8 +30,11 @@ Logger * makeDefaultLogger() {
         return makeJSONLogger(*makeSimpleLogger(true));
     case LogFormat::bar:
         return makeProgressBar();
-    case LogFormat::barWithLogs:
-        return makeProgressBar(true);
+    case LogFormat::barWithLogs: {
+        auto logger = makeProgressBar();
+        logger->setPrintBuildLogs(true);
+        return logger;
+    }
     default:
         abort();
     }

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -81,14 +81,13 @@ private:
 
     std::condition_variable quitCV, updateCV;
 
-    bool printBuildLogs;
+    bool printBuildLogs = false;
     bool isTTY;
 
 public:
 
-    ProgressBar(bool printBuildLogs, bool isTTY)
-        : printBuildLogs(printBuildLogs)
-        , isTTY(isTTY)
+    ProgressBar(bool isTTY)
+        : isTTY(isTTY)
     {
         state_.lock()->active = isTTY;
         updateThread = std::thread([&]() {
@@ -503,19 +502,21 @@ public:
         draw(*state);
         return s[0];
     }
+
+    virtual void setPrintBuildLogs(bool printBuildLogs)
+    {
+        this->printBuildLogs = printBuildLogs;
+    }
 };
 
-Logger * makeProgressBar(bool printBuildLogs)
+Logger * makeProgressBar()
 {
-    return new ProgressBar(
-        printBuildLogs,
-        shouldANSI()
-    );
+    return new ProgressBar(shouldANSI());
 }
 
-void startProgressBar(bool printBuildLogs)
+void startProgressBar()
 {
-    logger = makeProgressBar(printBuildLogs);
+    logger = makeProgressBar();
 }
 
 void stopProgressBar()

--- a/src/libmain/progress-bar.hh
+++ b/src/libmain/progress-bar.hh
@@ -4,9 +4,9 @@
 
 namespace nix {
 
-Logger * makeProgressBar(bool printBuildLogs = false);
+Logger * makeProgressBar();
 
-void startProgressBar(bool printBuildLogs = false);
+void startProgressBar();
 
 void stopProgressBar();
 

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -111,6 +111,9 @@ public:
 
     virtual std::optional<char> ask(std::string_view s)
     { return {}; }
+
+    virtual void setPrintBuildLogs(bool printBuildLogs)
+    { }
 };
 
 ActivityId getCurActivity();

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -82,7 +82,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
             .shortName = 'L',
             .description = "Print full build logs on standard error.",
             .category = loggingCategory,
-            .handler = {[&]() {setLogFormat(LogFormat::barWithLogs); }},
+            .handler = {[&]() { logger->setPrintBuildLogs(true); }},
         });
 
         addFlag({


### PR DESCRIPTION
This was caused by `-L` calling `setLogFormat()` again, which caused the creation of a new progress bar without destroying the old one. So we had two progress bars clobbering each other.

We should change `logger` to be a smart pointer, but I'll do that in a future PR.

Fixes #6931.