### PR TITLE
pathExists: Do not throw exception if lstat returns EPERM

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -252,7 +252,7 @@ bool pathExists(const Path & path)
     struct stat st;
     res = lstat(path.c_str(), &st);
     if (!res) return true;
-    if (errno != ENOENT && errno != ENOTDIR)
+    if (errno != ENOENT && errno != ENOTDIR && errno != EPERM)
         throw SysError("getting status of %1%", path);
     return false;
 }


### PR DESCRIPTION
Nix fails to build in a sandboxed MacOS environment:

```
[ RUN      ] pathExists.bogusPathDoesNotExist
unknown file: Failure
C++ exception with description "error: getting status of /home/schnitzel/darmstadt/pommes: Operation not permitted" thrown in the test body.
[  FAILED  ] pathExists.bogusPathDoesNotExist (0 ms)
[----------] 3 tests from pathExists (0 ms total)
```

```
libc++abi: terminating with uncaught exception of type nix::SysError: error: getting status of /nix/var/nix/profiles/per-user/root/channels/nixpkgs: Operation not permitted
make: *** [mk/lib.mk:118: libexpr-tests_RUN] Abort trap: 6
```

This change ensures that an exception is not thrown if a file is unable to be accessed because of its permissions.