### PR TITLE
refactor rendering command documentation to markdown

### DIFF
--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -8,12 +8,18 @@ let
   showCommand =
     { command, def, filename }:
     ''
-      **Warning**: This program is **experimental** and its interface is subject to change.
+      > **Warning**
+      > This program is **experimental** and its interface is subject to change.
+
+      # Name
+
+      `${command}` - ${def.description}
+
+      # Synopsis
+
+      ${showSynopsis { inherit command; args = def.args; }}
+
     ''
-    + "# Name\n\n"
-    + "`${command}` - ${def.description}\n\n"
-    + "# Synopsis\n\n"
-    + showSynopsis { inherit command; args = def.args; }
     + (if def.commands or {} != {}
        then
          let
@@ -24,8 +30,10 @@ let
                + "[`${command} ${name}`](./${appendName filename name}.md)"
                + " - ${cmds.${name}.description}\n")
                (attrNames cmds));
-         in
-         "where *subcommand* is one of the following:\n\n"
+         in ''
+         where *subcommand* is one of the following:
+
+         ''
          # FIXME: group by category
          + (if length categories > 1
             then
@@ -76,7 +84,7 @@ let
   showSynopsis =
     { command, args }:
     "`${command}` [*option*...] ${concatStringsSep " "
-      (map (arg: "*${arg.label}*" + (if arg ? arity then "" else "...")) args)}\n\n";
+      (map (arg: "*${arg.label}*" + (if arg ? arity then "" else "...")) args)}";
 
   processCommand = { command, def, filename }:
     [ { name = filename + ".md"; value = showCommand { inherit command def filename; }; inherit command; } ]

--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -7,6 +7,24 @@ let
 
   showCommand = { command, def, filename }:
     let
+      result = ''
+        > **Warning** \
+        > This program is **experimental** and its interface is subject to change.
+
+        # Name
+
+        `${command}` - ${def.description}
+
+        # Synopsis
+
+        ${showSynopsis command def.args}
+
+        ${maybeSubcommands}
+
+        ${maybeDocumentation}
+
+        ${maybeOptions}
+      '';
       showSynopsis = command: args:
         let
           showArgument = arg: "*${arg.label}*" + (if arg ? arity then "" else "...");
@@ -60,24 +78,7 @@ let
             '';
           categories = sort builtins.lessThan (unique (map (cmd: cmd.category) (attrValues options)));
         in concatStrings (map showCategory categories);
-    in squash  ''
-      > **Warning** \
-      > This program is **experimental** and its interface is subject to change.
-
-      # Name
-
-      `${command}` - ${def.description}
-
-      # Synopsis
-
-      ${showSynopsis command def.args}
-
-      ${maybeSubcommands}
-
-      ${maybeDocumentation}
-
-      ${maybeOptions}
-    '';
+    in squash result;
 
   appendName = filename: name: (if filename == "nix" then "nix3" else filename) + "-" + name;
 

--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -105,6 +105,6 @@ let
   tableOfContents = let
     showEntry = page:
       "    - [${page.command}](command-ref/new-cli/${page.name})";
-    in concatStringsSep "\n" (map showEntry manpages);
+    in concatStringsSep "\n" (map showEntry manpages) + "\n";
 
 in (listToAttrs manpages) // { "SUMMARY.md" = tableOfContents; }

--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -5,10 +5,70 @@ with import ./utils.nix;
 
 let
 
-  showCommand =
-    { command, def, filename }:
-    ''
-      > **Warning**
+  showCommand = { command, def, filename }:
+    let
+      showSynopsis = command: args:
+        let
+          showArgument = arg: "*${arg.label}*" + (if arg ? arity then "" else "...");
+          arguments = concatStringsSep " " (map showArgument args);
+        in ''
+         `${command}` [*option*...] ${arguments}
+        '';
+      maybeSubcommands = if def ? commands && def.commands != {}
+        then ''
+           where *subcommand* is one of the following:
+
+           ${subcommands}
+         ''
+        else "";
+      subcommands = if length categories > 1
+        then listCategories
+        else listSubcommands def.commands;
+      categories = sort (x: y: x.id < y.id) (unique (map (cmd: cmd.category) (attrValues def.commands)));
+      listCategories = concatStrings (map showCategory categories);
+      showCategory = cat: ''
+        **${toString cat.description}:**
+
+        ${listSubcommands (filterAttrs (n: v: v.category == cat) def.commands)}
+      '';
+      listSubcommands = cmds: concatStrings (attrValues (mapAttrs showSubcommand cmds));
+      showSubcommand = name: subcmd: ''
+        * [`${command} ${name}`](./${appendName filename name}.md) - ${subcmd.description}
+      '';
+      maybeDocumentation = if def ? doc then def.doc else "";
+      maybeOptions = if def.flags == {} then "" else ''
+        # Options
+
+        ${showOptions def.flags}
+      '';
+      showOptions = flags:
+        let
+          categories = sort builtins.lessThan (unique (map (cmd: cmd.category) (attrValues flags)));
+        in
+          concatStrings (map
+            (cat:
+              (if cat != ""
+               then "**${cat}:**\n\n"
+               else "")
+              + concatStrings
+                (map (longName:
+                  let
+                    flag = flags.${longName};
+                  in
+                    "  - `--${longName}`"
+                    + (if flag ? shortName then " / `-${flag.shortName}`" else "")
+                    + (if flag ? labels then " " + (concatStringsSep " " (map (s: "*${s}*") flag.labels)) else "")
+                    + "  \n"
+                    + "    " + flag.description + "\n\n"
+                ) (attrNames (filterAttrs (n: v: v.category == cat) flags))))
+            categories);
+      squash = string: # squash more than two repeated newlines
+        let
+          replaced = replaceStrings [ "\n\n\n" ] [ "\n\n" ] string;
+        in
+          if replaced == string then string else squash replaced;
+    in squash ''
+      > **Warning** \
       > This program is **experimental** and its interface is subject to change.
 
       # Name
@@ -17,74 +77,16 @@ let
 
       # Synopsis
 
-      ${showSynopsis { inherit command; args = def.args; }}
+      ${showSynopsis command def.args}
 
-    ''
-    + (if def.commands or {} != {}
-       then
-         let
-           categories = sort (x: y: x.id < y.id) (unique (map (cmd: cmd.category) (attrValues def.commands)));
-           listCommands = cmds:
-             concatStrings (map (name:
-               "* "
-               + "[`${command} ${name}`](./${appendName filename name}.md)"
-               + " - ${cmds.${name}.description}\n")
-               (attrNames cmds));
-         in ''
-         where *subcommand* is one of the following:
+      ${maybeSubcommands}
 
-         ''
-         # FIXME: group by category
-         + (if length categories > 1
-            then
-              concatStrings (map
-                (cat:
-                  "**${toString cat.description}:**\n\n"
-                  + listCommands (filterAttrs (n: v: v.category == cat) def.commands)
-                  + "\n"
-                ) categories)
-              + "\n"
-            else
-              listCommands def.commands
-              + "\n")
-       else "")
-    + (if def ? doc
-       then def.doc + "\n\n"
-       else "")
-    + (let s = showOptions def.flags; in
-       if s != ""
-       then "# Options\n\n${s}"
-       else "")
-  ;
+      ${maybeDocumentation}
+
+      ${maybeOptions}
+    '';
 
   appendName = filename: name: (if filename == "nix" then "nix3" else filename) + "-" + name;
-
-  showOptions = flags:
-    let
-      categories = sort builtins.lessThan (unique (map (cmd: cmd.category) (attrValues flags)));
-    in
-      concatStrings (map
-        (cat:
-          (if cat != ""
-           then "**${cat}:**\n\n"
-           else "")
-          + concatStrings
-            (map (longName:
-              let
-                flag = flags.${longName};
-              in
-                "  - `--${longName}`"
-                + (if flag ? shortName then " / `-${flag.shortName}`" else "")
-                + (if flag ? labels then " " + (concatStringsSep " " (map (s: "*${s}*") flag.labels)) else "")
-                + "  \n"
-                + "    " + flag.description + "\n\n"
-            ) (attrNames (filterAttrs (n: v: v.category == cat) flags))))
-        categories);
-
-  showSynopsis =
-    { command, args }:
-    "`${command}` [*option*...] ${concatStringsSep " "
-      (map (arg: "*${arg.label}*" + (if arg ? arity then "" else "...")) args)}";
 
   processCommand = { command, def, filename }:
     [ { name = filename + ".md"; value = showCommand { inherit command def filename; }; inherit command; } ]

--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -91,9 +91,6 @@ let
       })
       (attrNames def.commands or {});
 
-in
-
-let
   manpages = processCommand { filename = "nix"; command = "nix"; def = builtins.fromJSON command; };
   summary = concatStrings (map (manpage: "    - [${manpage.command}](command-ref/new-cli/${manpage.name})\n") manpages);
 in

--- a/doc/manual/utils.nix
+++ b/doc/manual/utils.nix
@@ -5,6 +5,32 @@ rec {
 
   concatStrings = concatStringsSep "";
 
+  replaceStringsRec = from: to: string:
+    # recursively replace occurrences of `from` with `to` within `string`
+    # example:
+    #     replaceStringRec "--" "-" "hello-----world"
+    #     => "hello-world"
+    let
+      replaced = replaceStrings [ from ] [ to ] string;
+    in
+      if replaced == string then string else replaceStringsRec from to replaced;
+
+  squash = replaceStringsRec "\n\n\n" "\n\n";
+
+  trim = string:
+    # trim trailing spaces and squash non-leading spaces
+    let
+      trimLine = line:
+        let
+          # separate leading spaces from the rest
+          parts = split "(^ *)" line;
+          spaces = head (elemAt parts 1);
+          rest = elemAt parts 2;
+          # drop trailing spaces
+          body = head (split " *$" rest);
+        in spaces + replaceStringsRec "  " " " body;
+    in concatStringsSep "\n" (map trimLine (splitLines string));
+
   # FIXME: O(n^2)
   unique = foldl' (acc: e: if elem e acc then acc else acc ++ [ e ]) [];
 


### PR DESCRIPTION
idea:
- make document structure visible, like in a template
- separate processing from formatting (structure/content vs. presentation)
- order functions by descending abstraction
- use self-explanatory names
- avoid broadly scoped or deeply nested let bindings

this allows readers to enter the code starting with what is visible from
the outside, instead of working themselves up from purely technical
details.