### PR TITLE
Only push Docker image when Docker secrets are set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
 
   tests:
-    needs: [check_cachix]
+    needs: [check_secrets]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -22,30 +22,34 @@ jobs:
     - uses: cachix/install-nix-action@v17
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v10
-      if: needs.check_cachix.outputs.secret == 'true'
+      if: needs.check_secrets.outputs.cachix == 'true'
       with:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix --experimental-features 'nix-command flakes' flake check -L
 
-  check_cachix:
+  check_secrets:
     permissions:
       contents: none
-    name: Cachix secret present for installer tests
+    name: Check Cachix and Docker secrets present for installer tests
     runs-on: ubuntu-latest
     outputs:
-      secret: ${{ steps.secret.outputs.secret }}
+      cachix: ${{ steps.secret.outputs.cachix }}
+      docker: ${{ steps.secret.outputs.docker }}
     steps:
-      - name: Check for Cachix secret
+      - name: Check for secrets
         id: secret
         env:
           _CACHIX_SECRETS: ${{ secrets.CACHIX_SIGNING_KEY }}${{ secrets.CACHIX_AUTH_TOKEN }}
-        run: echo "::set-output name=secret::${{ env._CACHIX_SECRETS != '' }}"
+          _DOCKER_SECRETS: ${{ secrets.DOCKERHUB_USERNAME }}${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          echo "::set-output name=cachix::${{ env._CACHIX_SECRETS != '' }}"
+          echo "::set-output name=docker::${{ env._DOCKER_SECRETS != '' }}"
 
   installer:
-    needs: [tests, check_cachix]
-    if: github.event_name == 'push' && needs.check_cachix.outputs.secret == 'true'
+    needs: [tests, check_secrets]
+    if: github.event_name == 'push' && needs.check_secrets.outputs.cachix == 'true'
     runs-on: ubuntu-latest
     outputs:
       installerURL: ${{ steps.prepare-installer.outputs.installerURL }}
@@ -64,8 +68,8 @@ jobs:
       run: scripts/prepare-installer-for-github-actions
 
   installer_test:
-    needs: [installer, check_cachix]
-    if: github.event_name == 'push' && needs.check_cachix.outputs.secret == 'true'
+    needs: [installer, check_secrets]
+    if: github.event_name == 'push' && needs.check_secrets.outputs.cachix == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -80,11 +84,12 @@ jobs:
     - run: nix-instantiate -E 'builtins.currentTime' --eval
 
   docker_push_image:
-    needs: [check_cachix, tests]
+    needs: [check_secrets, tests]
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'master' &&
-      needs.check_cachix.outputs.secret == 'true'
+      needs.check_secrets.outputs.cachix == 'true' &&
+      needs.check_secrets.outputs.docker == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -94,7 +99,7 @@ jobs:
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - run: echo NIX_VERSION="$(nix --experimental-features 'nix-command flakes' eval .\#default.version | tr -d \")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v10
-      if: needs.check_cachix.outputs.secret == 'true'
+      if: needs.check_secrets.outputs.cachix == 'true'
       with:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
When following the instructions in #6652 I ran into the issue that when Docker secrets aren't set, the `docker_push_image` step would fail and cause the workflow to fail and cancel the `installer_tests` steps. 