### PR TITLE
nix develop: use proper permissions for $TMPDIR

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -298,7 +298,7 @@ struct Common : InstallableCommand, MixProfile
         for (auto & var : savedVars)
             out << fmt("%s=\"$%s:$nix_saved_%s\"\n", var, var, var);
 
-        out << "export NIX_BUILD_TOP=\"$(mktemp -d -t nix-shell.XXXXXX)\"\n";
+        out << "export NIX_BUILD_TOP=\"$(mktemp -d -t nix-shell.XXXXXX)\"\nchmod 1777 \"$NIX_BUILD_TOP\"\n";
         for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})
             out << fmt("export %s=\"$NIX_BUILD_TOP\"\n", i);
 


### PR DESCRIPTION
Before this change, unsandboxed builds that tried to use `passAsFile` would fail when run within a devshell.