### PR TITLE
Set `HOME` var to `root`'s home when running `nix-store` as `root`

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -810,7 +810,7 @@ EOF
         fi
 
         _sudo "to load data for the first time in to the Nix Database" \
-              "$NIX_INSTALLED_NIX/bin/nix-store" --load-db < ./.reginfo
+              HOME="$ROOT_HOME" "$NIX_INSTALLED_NIX/bin/nix-store" --load-db < ./.reginfo
 
         echo "      Just finished getting the nix database ready."
     )


### PR DESCRIPTION
A [recent-ish change](https://github.com/NixOS/nix/pull/6676) logs a warning when a potentially counterintuitive situation happens.

This now causes the multi-user installer to [emit a warning](https://github.com/NixOS/nixpkgs/issues/189043) when it's doing
the "seed the Nix database" step via a low-level `nix-store --load-db` invocation.

`nix-store` functionality implementations don't actually use profiles or channels or homedir as far as i can tell.  So why are we 
hitting this code at all?  

Well, the current command approach for functionality here builds a [fat `nix` binary](https://github.com/NixOS/nix/blob/master/src/nix/local.mk#L23-L26) which has _all_ the functionality of
previous individual binaries (nix-env, nix-store, etc) bundled in, then [uses the invocation name](https://github.com/NixOS/nix/blob/master/src/nix/main.cc#L274-L277) to select the
set of commands to expose.  `nix` itself has this behavior, even when just trying to parse the (sub)command and arguments:

```
dave @ davembp2
$ nix
error: no subcommand specified
Try 'nix --help' for more information.

dave @ davembp2
$ sudo nix
warning: $HOME ('/Users/dave') is not owned by you, falling back to the one defined in the 'passwd' file
error: no subcommand specified
Try 'nix --help' for more information.

dave @ davembp2
$ HOME=~root sudo nix
error: no subcommand specified
Try 'nix --help' for more information.
```

This behavior can also be seen pretty easily with an arbitrary `nix-store` invocation:
```
dave @ davembp2 
$ nix-store --realize

dave @ davembp2 
$ sudo nix-store --realize  # what installer is doing now
warning: $HOME ('/Users/dave') is not owned by you, falling back to the one defined in the 'passwd' file

dave @ davembp2
$ sudo HOME=~root nix-store --realize  # what this PR effectively does

dave @ davembp2
$ 
```