### PR TITLE
Don’t add a space after attrs completion in zsh

### DIFF
--- a/misc/zsh/completion.zsh
+++ b/misc/zsh/completion.zsh
@@ -10,14 +10,15 @@ function _nix() {
   local -a suggestions
   declare -a suggestions
   for suggestion in ${res:1}; do
-    # FIXME: This doesn't work properly if the suggestion word contains a `:`
-    # itself
-    suggestions+="${suggestion/	/:}"
+    suggestions+=("${suggestion%%	*}")
   done
+  local -a args
   if [[ "$tpe" == filenames ]]; then
-    compadd -f
+    args+=('-f')
+  elif [[ "$tpe" == attrs ]]; then
+    args+=('-S' '')
   fi
-  _describe 'nix' suggestions
+  compadd -J nix "${args[@]}" -a suggestions
 }
 
-_nix "$@"
+# _nix "$@"

--- a/misc/zsh/completion.zsh
+++ b/misc/zsh/completion.zsh
@@ -21,4 +21,4 @@ function _nix() {
   compadd -J nix "${args[@]}" -a suggestions
 }
 
-# _nix "$@"
+_nix "$@"


### PR DESCRIPTION
This matches the behavior of bash. We don’t want to add a space after
completion on attrs. Uses -S.

Switches to new compadd style comppletions instead of _describe.
Shouldn’t have any negative issues from what I can tell.