### PR TITLE
Prevent tempdir from being GC-ed before addToStoreFromDump completes

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -622,9 +622,8 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
         /* There may be temp directories in the store that are still in use
            by another process. We need to be sure that we can acquire an
            exclusive lock before deleting them. */
-        AutoCloseFD tmpDirFd;
-        if (baseName.rfind("add-", 0) == 0) {
-            tmpDirFd = open(realPath.c_str(), O_RDONLY | O_DIRECTORY);
+        if (baseName.find("tmp-", 0) == 0) {
+            AutoCloseFD tmpDirFd = open(realPath.c_str(), O_RDONLY | O_DIRECTORY);
             if (tmpDirFd.get() == -1 || !lockFile(tmpDirFd.get(), ltWrite, false)) {
                 debug("skipping locked tempdir '%s'", realPath);
                 return;

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -619,6 +619,18 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
         Path path = storeDir + "/" + std::string(baseName);
         Path realPath = realStoreDir + "/" + std::string(baseName);
 
+        /* There may be temp directories in the store that are still in use
+           by another process. We need to be sure that we can acquire an
+           exclusive lock before deleting them. */
+        AutoCloseFD tmpDirFd;
+        if (baseName.rfind("add-", 0) == 0) {
+            tmpDirFd = open(realPath.c_str(), O_RDONLY | O_DIRECTORY);
+            if (tmpDirFd.get() == -1 || !lockFile(tmpDirFd.get(), ltWrite, false)) {
+                debug("skipping locked tempdir '%s'", realPath);
+                return;
+            }
+        }
+
         printInfo("deleting '%1%'", path);
 
         results.paths.insert(path);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1388,7 +1388,7 @@ StorePath LocalStore::addToStoreFromDump(Source & source0, std::string_view name
         StringSource dumpSource { dump };
         ChainSource bothSource { dumpSource, source };
 
-        auto tempDir = createTempDir(realStoreDir, "add");
+        auto tempDir = createTempDir("", "add");
         delTempDir = std::make_unique<AutoDelete>(tempDir);
         tempPath = tempDir + "/x";
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1433,7 +1433,6 @@ StorePath LocalStore::addToStoreFromDump(Source & source0, std::string_view name
             } else {
                 /* Move the temporary path we restored above. */
                 moveFile(tempPath, realPath);
-                tempDirFd.close();
             }
 
             /* For computing the nar hash. In recursive SHA-256 mode, this
@@ -1520,7 +1519,7 @@ std::pair<Path, AutoCloseFD> LocalStore::createTempDirInStore()
         /* There is a slight possibility that `tmpDir' gets deleted by
            the GC between createTempDir() and when we acquire a lock on it.
            We'll repeat until 'tmpDir' exists and we've locked it. */
-        tmpDirFn = createTempDir(realStoreDir, "add");
+        tmpDirFn = createTempDir(realStoreDir, "tmp");
         tmpDirFd = open(tmpDirFn.c_str(), O_RDONLY | O_DIRECTORY);
         if (tmpDirFd.get() < 0) {
             continue;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1382,13 +1382,15 @@ StorePath LocalStore::addToStoreFromDump(Source & source0, std::string_view name
 
     std::unique_ptr<AutoDelete> delTempDir;
     Path tempPath;
+    Path tempDir;
+    AutoCloseFD tempDirFd;
 
     if (!inMemory) {
         /* Drain what we pulled so far, and then keep on pulling */
         StringSource dumpSource { dump };
         ChainSource bothSource { dumpSource, source };
 
-        auto tempDir = createTempDir("", "add");
+        std::tie(tempDir, tempDirFd) = createTempDirInStore();
         delTempDir = std::make_unique<AutoDelete>(tempDir);
         tempPath = tempDir + "/x";
 
@@ -1431,6 +1433,7 @@ StorePath LocalStore::addToStoreFromDump(Source & source0, std::string_view name
             } else {
                 /* Move the temporary path we restored above. */
                 moveFile(tempPath, realPath);
+                tempDirFd.close();
             }
 
             /* For computing the nar hash. In recursive SHA-256 mode, this
@@ -1507,18 +1510,24 @@ StorePath LocalStore::addTextToStore(
 
 
 /* Create a temporary directory in the store that won't be
-   garbage-collected. */
-Path LocalStore::createTempDirInStore()
+   garbage-collected until the returned FD is closed. */
+std::pair<Path, AutoCloseFD> LocalStore::createTempDirInStore()
 {
-    Path tmpDir;
+    Path tmpDirFn;
+    AutoCloseFD tmpDirFd;
+    bool lockedByUs = false;
     do {
         /* There is a slight possibility that `tmpDir' gets deleted by
-           the GC between createTempDir() and addTempRoot(), so repeat
-           until `tmpDir' exists. */
-        tmpDir = createTempDir(realStoreDir);
-        addTempRoot(parseStorePath(tmpDir));
-    } while (!pathExists(tmpDir));
-    return tmpDir;
+           the GC between createTempDir() and when we acquire a lock on it.
+           We'll repeat until 'tmpDir' exists and we've locked it. */
+        tmpDirFn = createTempDir(realStoreDir, "add");
+        tmpDirFd = open(tmpDirFn.c_str(), O_RDONLY | O_DIRECTORY);
+        if (tmpDirFd.get() < 0) {
+            continue;
+        }
+        lockedByUs = lockFile(tmpDirFd.get(), ltWrite, true);
+    } while (!pathExists(tmpDirFn) || !lockedByUs);
+    return {tmpDirFn, std::move(tmpDirFd)};
 }
 
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -256,7 +256,7 @@ private:
 
     void findRuntimeRoots(Roots & roots, bool censor);
 
-    Path createTempDirInStore();
+    std::pair<Path, AutoCloseFD> createTempDirInStore();
 
     void checkDerivationOutputs(const StorePath & drvPath, const Derivation & drv);
 


### PR DESCRIPTION
This fixes [issue 6823](https://github.com/NixOS/nix/issues/6823) by creating the temp directory used in `LocalStore::addToStoreFromDump` outside of the Nix store. Otherwise, it's possible for the temporary directory to be prematurely garbage-collected when automatic GC is enabled.

I've written up a few more details and a typical presentation of the bug in the linked issue.

