### PR TITLE
Disable SA_RESTART for some signals on macOS

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -208,13 +208,7 @@ void initNix()
     if (sigaction(SIGHUP, &act, 0)) throw SysError("handling SIGHUP");
     if (sigaction(SIGPIPE, &act, 0)) throw SysError("handling SIGPIPE");
     if (sigaction(SIGQUIT, &act, 0)) throw SysError("handling SIGQUIT");
-    if (sigaction(SIGILL, &act, 0)) throw SysError("handling SIGILL");
     if (sigaction(SIGTRAP, &act, 0)) throw SysError("handling SIGTRAP");
-    if (sigaction(SIGABRT, &act, 0)) throw SysError("handling SIGABRT");
-    if (sigaction(SIGFPE, &act, 0)) throw SysError("handling SIGFPE");
-    if (sigaction(SIGBUS, &act, 0)) throw SysError("handling SIGBUS");
-    if (sigaction(SIGXCPU, &act, 0)) throw SysError("handling SIGXCPU");
-    if (sigaction(SIGXFSZ, &act, 0)) throw SysError("handling SIGXFSZ");
 #endif
 
     /* Register a SIGSEGV handler to detect stack overflows. */

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -194,9 +194,16 @@ void initNix()
     /* HACK: on darwin, we need can’t use sigprocmask with SIGWINCH.
      * Instead, add a dummy sigaction handler, and signalHandlerThread
      * can handle the rest. */
-    struct sigaction sa;
-    sa.sa_handler = sigHandler;
-    if (sigaction(SIGWINCH, &sa, 0)) throw SysError("handling SIGWINCH");
+    act.sa_handler = sigHandler;
+    if (sigaction(SIGWINCH, &act, 0)) throw SysError("handling SIGWINCH");
+
+    // Disable SA_RESTART for interrupts, so that system calls on this thread
+    // error with EINTR like they do on Linux, and we don’t hang forever.
+    act.sa_handler = SIG_DFL;
+    if (sigaction(SIGINT, &act, 0)) throw SysError("handling SIGINT");
+    if (sigaction(SIGTERM, &act, 0)) throw SysError("handling SIGTERM");
+    if (sigaction(SIGHUP, &act, 0)) throw SysError("handling SIGHUP");
+    if (sigaction(SIGPIPE, &act, 0)) throw SysError("handling SIGPIPE");
 #endif
 
     /* Register a SIGSEGV handler to detect stack overflows. */

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -181,8 +181,9 @@ void initNix()
     /* Reset SIGCHLD to its default. */
     struct sigaction act;
     sigemptyset(&act.sa_mask);
-    act.sa_handler = SIG_DFL;
     act.sa_flags = 0;
+
+    act.sa_handler = SIG_DFL;
     if (sigaction(SIGCHLD, &act, 0))
         throw SysError("resetting SIGCHLD");
 
@@ -197,13 +198,23 @@ void initNix()
     act.sa_handler = sigHandler;
     if (sigaction(SIGWINCH, &act, 0)) throw SysError("handling SIGWINCH");
 
-    // Disable SA_RESTART for interrupts, so that system calls on this thread
-    // error with EINTR like they do on Linux, and we don’t hang forever.
+    /* Disable SA_RESTART for interrupts, so that system calls on this thread
+     * error with EINTR like they do on Linux.
+     * Most signals on BSD systems default to SA_RESTART on, but Nix
+     * expects EINTR from syscalls to properly exit. */
     act.sa_handler = SIG_DFL;
     if (sigaction(SIGINT, &act, 0)) throw SysError("handling SIGINT");
     if (sigaction(SIGTERM, &act, 0)) throw SysError("handling SIGTERM");
     if (sigaction(SIGHUP, &act, 0)) throw SysError("handling SIGHUP");
     if (sigaction(SIGPIPE, &act, 0)) throw SysError("handling SIGPIPE");
+    if (sigaction(SIGQUIT, &act, 0)) throw SysError("handling SIGQUIT");
+    if (sigaction(SIGILL, &act, 0)) throw SysError("handling SIGILL");
+    if (sigaction(SIGTRAP, &act, 0)) throw SysError("handling SIGTRAP");
+    if (sigaction(SIGABRT, &act, 0)) throw SysError("handling SIGABRT");
+    if (sigaction(SIGFPE, &act, 0)) throw SysError("handling SIGFPE");
+    if (sigaction(SIGBUS, &act, 0)) throw SysError("handling SIGBUS");
+    if (sigaction(SIGXCPU, &act, 0)) throw SysError("handling SIGXCPU");
+    if (sigaction(SIGXFSZ, &act, 0)) throw SysError("handling SIGXFSZ");
 #endif
 
     /* Register a SIGSEGV handler to detect stack overflows. */


### PR DESCRIPTION
Disables the SA_RESTART behavior on macOS which causes:

> Restarting of pending calls is requested by setting the SA_RESTART bit
> in sa_flags. The affected system calls include read(2), write(2),
> sendto(2), recvfrom(2), sendmsg(2) and recvmsg(2) on a communications
> channel or a slow device (such as a terminal, but not a regular file)
> and during a wait(2) or ioctl(2).

From: https://man.openbsd.org/sigaction#SA_RESTART

This being set on macOS caused a bug where read() calls on the client to the daemon
socket were blocking after a SIGINT was received. As a result,
checkInterrupt was never reached even though the signal was received
by the signal handler thread.

On Linux, SA_RESTART is disabled by default. This probably effects
other BSDs but I don’t have the ability to test it there right now.

cc @edolstra 