### PR TITLE
Docs: Add nix develop --command entry

### DIFF
--- a/src/nix/develop.md
+++ b/src/nix/develop.md
@@ -66,6 +66,12 @@ R""(
   `nixpkgs#glibc` in `~/my-glibc` and want to compile another package
   against it.
 
+* Run a series of script commands:
+
+  ```console
+  # nix develop --command bash -c "mkdir build && cmake .. && make"
+  ```
+
 # Description
 
 `nix develop` starts a `bash` shell that provides an interactive build


### PR DESCRIPTION
Add example of nix develop being used to execuate a series of script
commands. This is common when doing things like CI/CD, and should be
represented in the official documentation.

Also useful for people looking for the 'nix develop' equivalent of
'nix-shell --run'.

Related:
 - https://github.com/NixOS/nix/issues/6908
 - https://github.com/NixOS/nix/issues/6908#issuecomment-1229266853