### PR TITLE
Add Fish suport to the Nix installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,14 @@ jobs:
       with:
         install_url: '${{needs.installer.outputs.installerURL}}'
         install_options: "--tarball-url-prefix https://${{ env.CACHIX_NAME }}.cachix.org/serve"
-    - run: nix-instantiate -E 'builtins.currentTime' --eval
+    - run: sudo apt install fish zsh
+      if: matrix.os == 'ubuntu-latest'
+    - run: brew install fish
+      if: matrix.os == 'macos-latest'
+    - run: exec bash -c "nix-instantiate -E 'builtins.currentTime' --eval"
+    - run: exec sh -c "nix-instantiate -E 'builtins.currentTime' --eval"
+    - run: exec zsh -c "nix-instantiate -E 'builtins.currentTime' --eval"
+    - run: exec fish -c "nix-instantiate -E 'builtins.currentTime' --eval"
 
   docker_push_image:
     needs: [check_secrets, tests]

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ perl/Makefile.config
 # /scripts/
 /scripts/nix-profile.sh
 /scripts/nix-profile-daemon.sh
+/scripts/nix-profile.fish
+/scripts/nix-profile-daemon.fish
 
 # /src/libexpr/
 /src/libexpr/lexer-tab.cc

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -37,6 +37,19 @@ readonly PROFILE_TARGETS=("/etc/bashrc" "/etc/profile.d/nix.sh" "/etc/zshrc" "/e
 readonly PROFILE_BACKUP_SUFFIX=".backup-before-nix"
 readonly PROFILE_NIX_FILE="$NIX_ROOT/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
 
+# Fish has different syntax than zsh/bash, treat it separate
+readonly PROFILE_FISH_SUFFIX="conf.d/nix.fish"
+readonly PROFILE_FISH_PREFIXES=(
+    # each of these are common values of $__fish_sysconf_dir,
+    # under which Fish will look for a file named
+    # $PROFILE_FISH_SUFFIX.
+    "/etc/fish"              # standard
+    "/usr/local/etc/fish"    # their installer .pkg for macOS
+    "/opt/homebrew/etc/fish" # homebrew
+    "/opt/local/etc/fish"    # macports
+)
+readonly PROFILE_NIX_FILE_FISH="$NIX_ROOT/var/nix/profiles/default/etc/profile.d/nix-daemon.fish"
+
 readonly NIX_INSTALLED_NIX="@nix@"
 readonly NIX_INSTALLED_CACERT="@cacert@"
 #readonly NIX_INSTALLED_NIX="/nix/store/j8dbv5w6jl34caywh2ygdy88knx1mdf7-nix-2.3.6"
@@ -828,6 +841,19 @@ fi
 EOF
 }
 
+# Fish has differing syntax
+fish_source_lines() {
+    cat <<EOF
+
+# Nix
+if test -e '$PROFILE_NIX_FILE_FISH'
+  . '$PROFILE_NIX_FILE_FISH'
+end
+# End Nix
+
+EOF
+}
+
 configure_shell_profile() {
     task "Setting up shell profiles: ${PROFILE_TARGETS[*]}"
     for profile_target in "${PROFILE_TARGETS[@]}"; do
@@ -849,6 +875,27 @@ configure_shell_profile() {
                         tee -a "$profile_target"
         fi
     done
+
+    task "Setting up shell profiles for Fish with with ${PROFILE_FISH_SUFFIX} inside ${PROFILE_FISH_PREFIXES[*]}"
+    for fish_prefix in "${PROFILE_FISH_PREFIXES[@]}"; do
+        if [ ! -d "$fish_prefix" ]; then
+            # this specific prefix (ie: /etc/fish) is very likely to exist
+            # if Fish is installed with this sysconfdir.
+            continue
+        fi
+
+        profile_target="${fish_prefix}/${PROFILE_FISH_SUFFIX}"
+        conf_dir=$(dirname "$profile_target")
+        if [ ! -d "$conf_dir" ]; then
+            _sudo "create $conf_dir for our Fish hook" \
+                mkdir "$conf_dir"
+        fi
+
+        fish_source_lines \
+            | _sudo "write nix-daemon settings to $profile_target" \
+                    tee "$profile_target"
+    done
+
     # TODO: should we suggest '. $PROFILE_NIX_FILE'? It would get them on
     # their way less disruptively, but a counter-argument is that they won't
     # immediately notice if something didn't get set up right?

--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -209,31 +209,50 @@ if [ -z "$NIX_INSTALLER_NO_CHANNEL_ADD" ]; then
 fi
 
 added=
-p=$HOME/.nix-profile/etc/profile.d/nix.sh
+p=
+p_sh=$HOME/.nix-profile/etc/profile.d/nix.sh
+p_fish=$HOME/.nix-profile/etc/profile.d/nix.fish
 if [ -z "$NIX_INSTALLER_NO_MODIFY_PROFILE" ]; then
     # Make the shell source nix.sh during login.
     for i in .bash_profile .bash_login .profile; do
         fn="$HOME/$i"
         if [ -w "$fn" ]; then
-            if ! grep -q "$p" "$fn"; then
+            if ! grep -q "$p_sh" "$fn"; then
                 echo "modifying $fn..." >&2
-                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p" "$p" >> "$fn"
+                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p_sh" "$p_sh" >> "$fn"
             fi
             added=1
+            p=${p_sh}
             break
         fi
     done
     for i in .zshenv .zshrc; do
         fn="$HOME/$i"
         if [ -w "$fn" ]; then
-            if ! grep -q "$p" "$fn"; then
+            if ! grep -q "$p_sh" "$fn"; then
                 echo "modifying $fn..." >&2
-                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p" "$p" >> "$fn"
+                printf '\nif [ -e %s ]; then . %s; fi # added by Nix installer\n' "$p_sh" "$p_sh" >> "$fn"
             fi
             added=1
+            p=${p_sh}
             break
         fi
     done
+
+    if [ -d "$HOME/.config/fish" ]; then
+        fishdir=$HOME/.config/fish/conf.d
+        if [ ! -d "$fishdir" ]; then
+            mkdir -p "$fishdir"
+        fi
+
+        fn="$fishdir/nix.fish"
+        echo "placing $fn..." >&2
+        printf '\nif test -e %s; . %s; end # added by Nix installer\n' "$p_fish" "$p_fish" > "$fn"
+        added=1
+        p=${p_fish}
+    fi
+else
+    p=${p_sh}
 fi
 
 if [ -z "$added" ]; then

--- a/scripts/local.mk
+++ b/scripts/local.mk
@@ -6,6 +6,8 @@ noinst-scripts += $(nix_noinst_scripts)
 profiledir = $(sysconfdir)/profile.d
 
 $(eval $(call install-file-as, $(d)/nix-profile.sh, $(profiledir)/nix.sh, 0644))
+$(eval $(call install-file-as, $(d)/nix-profile.fish, $(profiledir)/nix.fish, 0644))
 $(eval $(call install-file-as, $(d)/nix-profile-daemon.sh, $(profiledir)/nix-daemon.sh, 0644))
+$(eval $(call install-file-as, $(d)/nix-profile-daemon.fish, $(profiledir)/nix-daemon.fish, 0644))
 
 clean-files += $(nix_noinst_scripts)

--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -1,0 +1,35 @@
+# Only execute this file once per shell.
+if test -n "$__ETC_PROFILE_NIX_SOURCED"
+  return
+end
+
+set __ETC_PROFILE_NIX_SOURCED 1
+
+set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+
+# Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
+if test -n "$NIX_SSH_CERT_FILE"
+  : # Allow users to override the NIX_SSL_CERT_FILE
+else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
+  set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+else if test -e /etc/ssl/ca-bundle.pem # openSUSE Tumbleweed
+  set --export NIX_SSL_CERT_FILE /etc/ssl/ca-bundle.pem
+else if test -e /etc/ssl/certs/ca-bundle.crt # Old NixOS
+  set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
+else if test -e /etc/pki/tls/certs/ca-bundle.crt # Fedora, CentOS
+  set --export NIX_SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
+else if test -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" # fall back to cacert in Nix profile
+  set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+else if test -e "$NIX_LINK/etc/ca-bundle.crt" # old cacert in Nix profile
+  set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
+else
+  # Fall back to what is in the nix profiles, favouring whatever is defined last.
+  for i in $NIX_PROFILES
+    if test -e "$i/etc/ssl/certs/ca-bundle.crt"
+      set --export NIX_SSL_CERT_FILE "$i/etc/ssl/certs/ca-bundle.crt"
+    end
+  end
+end
+
+fish_add_path --prepend --global "@localstatedir@/nix/profiles/default/bin"
+fish_add_path --prepend --global "$HOME/.nix-profile/bin"

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,0 +1,35 @@
+if test -n "$HOME" && test -n "$USER"
+
+    # Set up the per-user profile.
+
+    set NIX_LINK $HOME/.nix-profile
+
+    # Set up environment.
+    # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
+    set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+
+    # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
+    if test -n "$NIX_SSH_CERT_FILE"
+        : # Allow users to override the NIX_SSL_CERT_FILE
+    else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
+        set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+    else if test -e /etc/ssl/ca-bundle.pem # openSUSE Tumbleweed
+        set --export NIX_SSL_CERT_FILE /etc/ssl/ca-bundle.pem
+    else if test -e /etc/ssl/certs/ca-bundle.crt # Old NixOS
+        set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
+    else if test -e /etc/pki/tls/certs/ca-bundle.crt # Fedora, CentOS
+        set --export NIX_SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
+    else if test -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" # fall back to cacert in Nix profile
+        set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+    else if test -e "$NIX_LINK/etc/ca-bundle.crt" # old cacert in Nix profile
+        set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
+    end
+
+    # Only use MANPATH if it is already set. In general `man` will just simply
+    # pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
+    # which is in the $PATH. For more info, run `manpath -d`.
+    set --export --prepend --path MANPATH "$NIX_LINK/share/man"
+
+    fish_add_path --prepend --global "$NIX_LINK/bin"
+    set --erase NIX_LINK
+end

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,7 +1,6 @@
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     # Set up the per-user profile.
-    # This part should be kept in sync with nixpkgs:nixos/modules/programs/shell.nix
 
     NIX_LINK=$HOME/.nix-profile
 


### PR DESCRIPTION
Before this patch, installing Nix using the Fish shell did not work because Fish wasn't configured to add Nix to the PATH. Some options in #1512 offered workarounds, but they typically involve extra plugins or packages.

This patch adds native, out-of-the-box support for the Fish shell.

Note that Fish supports a `conf.d` directory, which is intended for exactly use cases like this: software projects distributing shell snippets. This patch takes advantage of it. The installer doesn't append any Nix loader behavior to any Fish config file. Because of that, the uninstall process is smooth and a reinstall obliterates the existing nix.fish files that we place instead of bothering the user with a backup / manual removal.

Both single-user and multi-user cases are covered. It has been tested on Ubuntu, and a Mac with MacPorts, homebrew, and the Fish installer pkg.

_Written in collaboration with @hoverbear at DetSys._

Closes #1512