### PR TITLE
evaluate phases in nix develop the same way as genericBuild

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -482,7 +482,7 @@ struct CmdDevelop : Common, MixEnvironment
             // FIXME: foundMakefile is set by buildPhase, need to get
             // rid of that.
             script += fmt("foundMakefile=1\n");
-            script += fmt("runHook %1%Phase\n", *phase);
+            script += fmt("eval \"${!%1%Phase:-$1%1Phase}\";\n", *phase);
         }
 
         else if (!command.empty()) {


### PR DESCRIPTION
This way `nix develop` works with  meson, cmake etc; which set the `xxxPhase=` environment variable instead of overriding the `xxxPhase` function.

open question. I think in these cases `foundMakefile=1` should not be set. But we'd need to fix that in  https://github.com/NixOS/nixpkgs/blob/master/pkgs/stdenv/generic/setup.sh first I think