### PR TITLE
RunPager: Stop the progress bar

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -4,6 +4,7 @@
 #include "gc-store.hh"
 #include "util.hh"
 #include "loggers.hh"
+#include "progress-bar.hh"
 
 #include <algorithm>
 #include <cctype>
@@ -421,6 +422,8 @@ RunPager::RunPager()
     char * pager = getenv("NIX_PAGER");
     if (!pager) pager = getenv("PAGER");
     if (pager && ((std::string) pager == "" || (std::string) pager == "cat")) return;
+
+    stopProgressBar();
 
     Pipe toPager;
     toPager.create();


### PR DESCRIPTION
In particular, the progress bar was interfering with `less` rendering in `--help` (e.g. run `nix --help` and hit `/` to search).