### PR TITLE
Trim option descriptions

### DIFF
--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -216,7 +216,7 @@ nlohmann::json Args::toJSON()
         if (flag->shortName)
             j["shortName"] = std::string(1, flag->shortName);
         if (flag->description != "")
-            j["description"] = flag->description;
+            j["description"] = trim(flag->description);
         j["category"] = flag->category;
         if (flag->handler.arity != ArityAny)
             j["arity"] = flag->handler.arity;
@@ -237,7 +237,7 @@ nlohmann::json Args::toJSON()
     }
 
     auto res = nlohmann::json::object();
-    res["description"] = description();
+    res["description"] = trim(description());
     res["flags"] = std::move(flags);
     res["args"] = std::move(args);
     auto s = doc();
@@ -379,7 +379,7 @@ nlohmann::json MultiCommand::toJSON()
         auto j = command->toJSON();
         auto cat = nlohmann::json::object();
         cat["id"] = command->category();
-        cat["description"] = categories[command->category()];
+        cat["description"] = trim(categories[command->category()]);
         j["category"] = std::move(cat);
         cmds[name] = std::move(j);
     }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -325,7 +325,7 @@ void mainWrapped(int argc, char * * argv)
                 std::cout << "attrs\n"; break;
             }
             for (auto & s : *completions)
-                std::cout << s.completion << "\t" << s.description << "\n";
+                std::cout << s.completion << "\t" << trim(s.description) << "\n";
         }
     });
 


### PR DESCRIPTION
This removes unintended blank lines in Markdown when the description is a multiline string literal.