### PR TITLE
dockerImage: fix root shell

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -33,7 +33,7 @@ let
 
     root = {
       uid = 0;
-      shell = "/bin/bash";
+      shell = "${pkgs.bashInteractive}/bin/bash";
       home = "/root";
       gid = 0;
     };


### PR DESCRIPTION
Currently root's shell is set to a path that does not exist; this change sets it to the correct path to bash