### PR TITLE
add documentation diagrams

### DIFF
--- a/doc/manual/src/command-ref/command-ref.md
+++ b/doc/manual/src/command-ref/command-ref.md
@@ -1,2 +1,34 @@
 This section lists commands and options that you can use when you work
 with Nix.
+
+
+# Diagrams
+
+## Store, substituters and garbage collector
+
+This diagram explains what happens in the nix-store when you use nix-shell and when garbage collection happens.
+
+```mermaid
+flowchart TB
+    nixshell([nix-shell]) -->|lookup| nix-store
+    nixshell([nix-shell]) -->|fallback to if missing locally| nix-daemon([nix-daemon])
+    nix-daemon -->|store into| nix-store[(nixstore)]
+    nix-daemon --->|build it if not available in a substituter| substituters([substituters server i.e. cache.nixos.org])
+    nix-store -->|derivations can be linked to prevent GC| .links[(.links)]
+     
+    nix-collect-garbage([nix-collect-garbage]) -->|clean derivation not registered in .links| nix-store
+```
+
+## Nix-build
+
+
+The following diagram explains how `nix-build` is a wrapper around `nix-instantiate` + `nix-store --realise`.
+
+```mermaid
+flowchart TB
+
+    hello.nix -->|nix-instantiate| drv
+    drv(/nix/store/somelonghashhere-hello.drv)
+    drv -->|nix-store --realise| drv2(/nix/store/anotherlonghashere-hello)
+    hello.nix -->|nix-build| drv2
+```


### PR DESCRIPTION
The purpose of this PR is to add some diagrams to Nix documentation.

This is still draft work and I'll close #7041 and #7042. I'm not sure about the content and the place to put them. Ultimately, they will be committed as ascii diagrams and not using mermaid.