### PR TITLE
libexpr/fetchurl.nix: allow __impure fetch

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,2 +1,7 @@
 # Release X.Y (202?-??-??)
 
+* `<nix/fetchurl.nix>` now accepts an additional argument `impure` which
+  defaults to `false`.  If it is set to `true`, the `hash` and `sha256`
+  arguments will be ignored and the resulting derivation will have
+  `__impure` set to `true`, making it an impure derivation.
+

--- a/src/libexpr/fetchurl.nix
+++ b/src/libexpr/fetchurl.nix
@@ -12,7 +12,7 @@
 , executable ? false
 , unpack ? false
 , name ? baseNameOf (toString url)
-, __impure ? false
+, impure ? false
 }:
 
 derivation ({

--- a/src/libexpr/fetchurl.nix
+++ b/src/libexpr/fetchurl.nix
@@ -38,6 +38,6 @@ derivation ({
 
   # To make "nix-prefetch-url" work.
   urls = [ url ];
-} // (if __impure
-      then { inherit __impure; }
+} // (if impure
+      then { __impure = true; }
       else { inherit outputHashAlgo outputHash; }))

--- a/src/libexpr/fetchurl.nix
+++ b/src/libexpr/fetchurl.nix
@@ -12,13 +12,13 @@
 , executable ? false
 , unpack ? false
 , name ? baseNameOf (toString url)
+, __impure ? false
 }:
 
-derivation {
+derivation ({
   builder = "builtin:fetchurl";
 
   # New-style output content requirements.
-  inherit outputHashAlgo outputHash;
   outputHashMode = if unpack || executable then "recursive" else "flat";
 
   inherit name url executable unpack;
@@ -38,4 +38,6 @@ derivation {
 
   # To make "nix-prefetch-url" work.
   urls = [ url ];
-}
+} // (if __impure
+      then { inherit __impure; }
+      else { inherit outputHashAlgo outputHash; }))


### PR DESCRIPTION
This commit adds an optional `__impure` parameter to fetchurl.nix, which allows the caller to use `libfetcher`'s fetcher in an impure derivation.  This allows nixpkgs' patch-normalizing fetcher (fetchpatch) to be rewritten to use nix's internal fetchurl, thereby eliminating the awkward "you can't use fetchpatch here" banners scattered all over the place.

See also: https://github.com/NixOS/nixpkgs/pull/188587