### PR TITLE
Fix `uname -m` return value for armv6l/armv7l

### DIFF
--- a/scripts/install.in
+++ b/scripts/install.in
@@ -40,12 +40,12 @@ case "$(uname -s).$(uname -m)" in
         path=@tarballPath_aarch64-linux@
         system=aarch64-linux
         ;;
-    Linux.armv6l_linux)
+    Linux.armv6l)
         hash=@tarballHash_armv6l-linux@
         path=@tarballPath_armv6l-linux@
         system=armv6l-linux
         ;;
-    Linux.armv7l_linux)
+    Linux.armv7l)
         hash=@tarballHash_armv7l-linux@
         path=@tarballPath_armv7l-linux@
         system=armv7l-linux


### PR DESCRIPTION
## About

This PR adds additional support to the install script for armv6l/armv7l machine 

## Reason

I tried to install nix to arm machine with `sh <(curl -L https://nixos.org/nix/install) --no-daemon` , it failed with error message `sorry, there is no binary distribution of Nix for your platform`

I noticed that `uname -m` expected `armv6l_linux` in this line (https://github.com/NixOS/nix/blob/a38a55babee876dc9392a2abc3c42768a40f24db/scripts/install.in#L43), but in my environment `uname -m`  returns `armv6l`.

I don't know in which environment`uname -m` returns `armv6l_linux`, so I  just add support for `armv6l` and `armv7l`.

## Test

I tried 3 environment.

- MacOS with docker desktop
- RaspberryPi Zero with RaspberryPiOS
- kindle white paper

### MacOS with docker desktop

Docker Desktop in MacOS has QEMU feature,  so I test with this command ` docker run -it --platform linux/arm/v6 arm32v6/alpine:3.16.0` .

```
/ # uname -m
armv7l
```

### Raspberry Pi OS
My RaspberryPi  model is RaspberryPiZero

it returns `armv6l`.

### Kindle White Paper

My Kindle device model is `Kindle PaperWhite 3 (2015) WiFi`

It is jailbroken, I can use ssh to it.

it returns `armv7l`

