### PR TITLE
nix repl: warn if creating dir for history fails

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -242,7 +242,11 @@ void NixRepl::mainLoop()
 
     // Allow nix-repl specific settings in .inputrc
     rl_readline_name = "nix-repl";
-    createDirs(dirOf(historyFile));
+    try {
+        createDirs(dirOf(historyFile));
+    } catch (SysError & e) {
+        logWarning(e.info());
+    }
 #ifndef READLINE
     el_hist_size = 1000;
 #endif


### PR DESCRIPTION
The history is not critical to the functionality of nix repl, so it's enough to warn here, rather than refuse to start if the directory Nix thinks the history should live in can't be created.