### PR TITLE
"valid signature" -> "signature by a trusted key"

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -560,9 +560,15 @@ public:
         R"(
           If set to `true` (the default), any non-content-addressed path added
           or copied to the Nix store (e.g. when substituting from a binary
-          cache) must have a trustworthy signature, that is, be signed using one of
-          the keys listed in `trusted-public-keys` or `secret-key-files`. Set
-          to `false` to disable signature checking.
+          cache) must have a signature by a key we trust. A trusted key is one
+          listed in `trusted-public-keys`, or a public key counterpart to a
+          private key stored in a file listed in `secret-key-files`.
+          
+          Set to `false` to disable signature checking and trust all
+          non-content-addressed paths unconditionally.
+          
+          (Content-addressed paths are inherently trustworthy and thus
+          unaffected by this configuration option.)
         )"};
 
     Setting<StringSet> extraPlatforms{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -560,7 +560,7 @@ public:
         R"(
           If set to `true` (the default), any non-content-addressed path added
           or copied to the Nix store (e.g. when substituting from a binary
-          cache) must have a signature by a key we trust. A trusted key is one
+          cache) must have a signature by a trusted key. A trusted key is one
           listed in `trusted-public-keys`, or a public key counterpart to a
           private key stored in a file listed in `secret-key-files`.
           

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -560,7 +560,7 @@ public:
         R"(
           If set to `true` (the default), any non-content-addressed path added
           or copied to the Nix store (e.g. when substituting from a binary
-          cache) must have a valid signature, that is, be signed using one of
+          cache) must have a trustworthy signature, that is, be signed using one of
           the keys listed in `trusted-public-keys` or `secret-key-files`. Set
           to `false` to disable signature checking.
         )"};

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -751,7 +751,7 @@ void LocalStore::registerDrvOutput(const Realisation & info, CheckSigsFlag check
     if (checkSigs == NoCheckSigs || !realisationIsUntrusted(info))
         registerDrvOutput(info);
     else
-        throw Error("cannot register realisation '%s' because it lacks a trustworthy signature", info.outPath.to_string());
+        throw Error("cannot register realisation '%s' because it lacks a signature by a trusted key", info.outPath.to_string());
 }
 
 void LocalStore::registerDrvOutput(const Realisation & info)
@@ -1266,7 +1266,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
     RepairFlag repair, CheckSigsFlag checkSigs)
 {
     if (checkSigs && pathInfoIsUntrusted(info))
-        throw Error("cannot add path '%s' because it lacks a trustworthy signature", printStorePath(info.path));
+        throw Error("cannot add path '%s' because it lacks a signature by a trusted key", printStorePath(info.path));
 
     addTempRoot(info.path);
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -751,7 +751,7 @@ void LocalStore::registerDrvOutput(const Realisation & info, CheckSigsFlag check
     if (checkSigs == NoCheckSigs || !realisationIsUntrusted(info))
         registerDrvOutput(info);
     else
-        throw Error("cannot register realisation '%s' because it lacks a valid signature", info.outPath.to_string());
+        throw Error("cannot register realisation '%s' because it lacks a trustworthy signature", info.outPath.to_string());
 }
 
 void LocalStore::registerDrvOutput(const Realisation & info)
@@ -1266,7 +1266,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
     RepairFlag repair, CheckSigsFlag checkSigs)
 {
     if (checkSigs && pathInfoIsUntrusted(info))
-        throw Error("cannot add path '%s' because it lacks a valid signature", printStorePath(info.path));
+        throw Error("cannot add path '%s' because it lacks a trustworthy signature", printStorePath(info.path));
 
     addTempRoot(info.path);
 

--- a/src/nix/make-content-addressed.md
+++ b/src/nix/make-content-addressed.md
@@ -22,7 +22,7 @@ R""(
 
   ```console
   # nix copy --to /tmp/nix --trusted-public-keys '' nixpkgs#hello
-  cannot add path '/nix/store/zy9wbxwcygrwnh8n2w9qbbcr6zk87m26-libunistring-0.9.10' because it lacks a trustworthy signature
+  cannot add path '/nix/store/zy9wbxwcygrwnh8n2w9qbbcr6zk87m26-libunistring-0.9.10' because it lacks a signature by a trusted key
   ```
 
 * Create a content-addressed representation of the current NixOS

--- a/src/nix/make-content-addressed.md
+++ b/src/nix/make-content-addressed.md
@@ -22,7 +22,7 @@ R""(
 
   ```console
   # nix copy --to /tmp/nix --trusted-public-keys '' nixpkgs#hello
-  cannot add path '/nix/store/zy9wbxwcygrwnh8n2w9qbbcr6zk87m26-libunistring-0.9.10' because it lacks a valid signature
+  cannot add path '/nix/store/zy9wbxwcygrwnh8n2w9qbbcr6zk87m26-libunistring-0.9.10' because it lacks a trustworthy signature
   ```
 
 * Create a content-addressed representation of the current NixOS

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -41,7 +41,7 @@ struct CmdVerify : StorePathsCommand
         addFlag({
             .longName = "sigs-needed",
             .shortName = 'n',
-            .description = "Require that each path has at least *n* trustworthy signatures.",
+            .description = "Require that each path has is signed by *n* different keys.",
             .labels = {"n"},
             .handler = {&sigsNeeded}
         });

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -41,7 +41,7 @@ struct CmdVerify : StorePathsCommand
         addFlag({
             .longName = "sigs-needed",
             .shortName = 'n',
-            .description = "Require that each path has at least *n* valid signatures.",
+            .description = "Require that each path has at least *n* trustworthy signatures.",
             .labels = {"n"},
             .handler = {&sigsNeeded}
         });

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -41,7 +41,7 @@ struct CmdVerify : StorePathsCommand
         addFlag({
             .longName = "sigs-needed",
             .shortName = 'n',
-            .description = "Require that each path has is signed by *n* different keys.",
+            .description = "Require that each path is signed by at least *n* different keys.",
             .labels = {"n"},
             .handler = {&sigsNeeded}
         });

--- a/tests/signing.sh
+++ b/tests/signing.sh
@@ -81,7 +81,7 @@ info=$(nix path-info --store file://$cacheDir --json $outPath2)
 [[ $info =~ 'cache1.example.org' ]]
 [[ $info =~ 'cache2.example.org' ]]
 
-# Copying to a diverted store should fail due to a lack of valid signatures.
+# Copying to a diverted store should fail due to a lack of trustworthy signatures.
 chmod -R u+w $TEST_ROOT/store0 || true
 rm -rf $TEST_ROOT/store0
 (! nix copy --to $TEST_ROOT/store0 $outPath)

--- a/tests/signing.sh
+++ b/tests/signing.sh
@@ -81,7 +81,7 @@ info=$(nix path-info --store file://$cacheDir --json $outPath2)
 [[ $info =~ 'cache1.example.org' ]]
 [[ $info =~ 'cache2.example.org' ]]
 
-# Copying to a diverted store should fail due to a lack of trustworthy signatures.
+# Copying to a diverted store should fail due to a lack of signatures by trusted keys.
 chmod -R u+w $TEST_ROOT/store0 || true
 rm -rf $TEST_ROOT/store0
 (! nix copy --to $TEST_ROOT/store0 $outPath)


### PR DESCRIPTION
I just had a colleague get confused by the previous phrase for good reason. "valid" sounds like an *objective* criterion, e.g. and *invalid signature* would be one that would be trusted by no one, e.g. because it misformatted or something.

What is actually going is that there might be a signature which is perfectly valid to *someone else*, but not to the user, because they don't trust the corresponding public key. This is a *subjective* criterion, because it depends on the arbitrary and personal choice of which public keys to trust.

~~I therefore think "trustworthy" is a better adjective to use. Whether something is worthy of trust is clearly subjective, and then "trust" within that word nicely evokes `trusted-public-keys` and friends.~~

"signature by a trusted key" is unambiguous.