### PR TITLE
Allow pass max-silent-time and build-poll-interval to daemon untrusted

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -239,6 +239,8 @@ struct ClientSettings
                 else if (trusted
                     || name == settings.buildTimeout.name
                     || name == settings.buildRepeat.name
+                    || name == settings.maxSilentTime.name
+                    || name == settings.pollInterval.name
                     || name == "connect-timeout"
                     || (name == "builders" && value == ""))
                     settings.set(name, value);


### PR DESCRIPTION
These settings seem harmless, they control the same polling functionality that timeout does, but with different behavior. Should be safe for untrusted users to pass in.