### PR TITLE
archive: check close errors when extracting nars

### DIFF
--- a/src/libstore/nar-accessor.cc
+++ b/src/libstore/nar-accessor.cc
@@ -75,6 +75,9 @@ struct NarAccessor : public FSAccessor
             createMember(path, {FSAccessor::Type::tRegular, false, 0, 0});
         }
 
+        void closeRegularFile() override
+        { }
+
         void isExecutable() override
         {
             parents.top()->isExecutable = true;

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -234,6 +234,7 @@ static void parse(ParseSink & sink, Source & source, const Path & path)
 
         else if (s == "contents" && type == tpRegular) {
             parseContents(sink, source, path);
+            sink.closeRegularFile();
         }
 
         else if (s == "executable" && type == tpRegular) {
@@ -322,6 +323,12 @@ struct RestoreSink : ParseSink
         Path p = dstPath + path;
         fd = open(p.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0666);
         if (!fd) throw SysError("creating file '%1%'", p);
+    }
+
+    void closeRegularFile() override
+    {
+        /* Call close explicitly to make sure the error is checked */
+        fd.close();
     }
 
     void isExecutable() override

--- a/src/libutil/archive.hh
+++ b/src/libutil/archive.hh
@@ -60,6 +60,7 @@ struct ParseSink
     virtual void createDirectory(const Path & path) { };
 
     virtual void createRegularFile(const Path & path) { };
+    virtual void closeRegularFile() { };
     virtual void isExecutable() { };
     virtual void preallocateContents(uint64_t size) { };
     virtual void receiveContents(std::string_view data) { };


### PR DESCRIPTION
Call `close(2)` explicitly while extracting NAR files to make sure that the error gets checked.

From `man close`:
> Failing to check the return value when closing a file may lead to silent loss of data.

#1218