### PR TITLE
add ccacheStdenv

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -42,7 +42,7 @@ $ nix develop
 ```
 
 To get a shell with a different compilation environment (e.g. stdenv,
-gccStdenv, clangStdenv, clang11Stdenv):
+gccStdenv, clangStdenv, clang11Stdenv, ccacheStdenv):
 
 ```console
 $ nix-shell -A devShells.x86_64-linux.clang11StdenvPackages
@@ -53,6 +53,9 @@ or if you have a flake-enabled nix:
 ```console
 $ nix develop .#clang11StdenvPackages
 ```
+
+Note: you can use `ccacheStdenv` to drastically improve rebuild
+time. By default, ccache keeps artifacts in `~/.cache/ccache/`.
 
 To build Nix itself in this shell:
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
 
       crossSystems = [ "armv6l-linux" "armv7l-linux" ];
 
-      stdenvs = [ "gccStdenv" "clangStdenv" "clang11Stdenv" "stdenv" "libcxxStdenv" ];
+      stdenvs = [ "gccStdenv" "clangStdenv" "clang11Stdenv" "stdenv" "libcxxStdenv" "ccacheStdenv" ];
 
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
       forAllSystemsAndStdenvs = f: forAllSystems (system:


### PR DESCRIPTION
when using ccache, rebuild time has been measured
89% faster while not slowing the speed of cold builds

Using `make -j 6` with an i7-1165G7, I got the following results:
- ccache first build: 428 seconds
- ccache rebuild: 48s (= 89% speedup)
- no ccache build: 426 seconds
- another no ccache build: 424 seconds

Just use `nix develop .#ccacheStdenv` and you have ccache enabled, using GCC. A bit more work could be done to have a clang ccache if desired.