### PR TITLE
Mention `--accept-flake-config` in the related warning

### DIFF
--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -68,7 +68,7 @@ void ConfigFile::apply()
                 }
             }
             if (!trusted) {
-                warn("ignoring untrusted flake configuration setting '%s'", name);
+                warn("ignoring untrusted flake configuration setting '%s'.\nPass '%s' to trust it", name, "--accept-flake-config");
                 continue;
             }
         }


### PR DESCRIPTION
Make sure that people who run Nix in non-interactive mode (and so don't have the possibility to interactively accept the individual flake configuration settings) are aware of this flag.

Fix #7086

cc @cole-h 