### PR TITLE
Use exit instead of return in /etc/profile.d/nix-daemon.fish

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -1,6 +1,6 @@
 # Only execute this file once per shell.
 if test -n "$__ETC_PROFILE_NIX_SOURCED"
-  return
+  exit
 end
 
 set __ETC_PROFILE_NIX_SOURCED 1


### PR DESCRIPTION
Older versions of Fish (anything before 3.4) do not support using `return` outside of functions. While Fish 3.3 is a year old, it is the version packaged by Ubuntu LTS 22.04, so still sees significant usage.

Using the equivalent `exit` instead of `return` should add compatibility with older versions.