### PR TITLE
__allowNetwork when sandbox==relaxed

### DIFF
--- a/src/libstore/build/local-derivation-goal.hh
+++ b/src/libstore/build/local-derivation-goal.hh
@@ -41,6 +41,9 @@ struct LocalDerivationGoal : public DerivationGoal
 
     Path chrootRootDir;
 
+    /* Whether we allow network access during a chroot build. */
+    bool allowNetwork = false;
+
     /* RAII object to delete the chroot directory. */
     std::shared_ptr<AutoDelete> autoDelChroot;
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -412,6 +412,10 @@ public:
           and derivations that have the `__noChroot` attribute set to `true`
           do not run in sandboxes.
 
+          If this option is set to `relaxed`, then fixed-output derivations
+          and derivations that have the `__allowNetwork` attribute set to
+          `true` will have host network access.
+
           The default is `true` on Linux and `false` on all other platforms.
         )",
         {"build-use-chroot", "build-use-sandbox"}};


### PR DESCRIPTION
This patch allows for derivations to be build with privateNetworking distabled when sandbox == relaxed, much in the same way as __noChroot works.

This is motivated by the desire to run EDA tools that need network access to checkout license tokens, but still have filesystem and process isolation from the host.

I'm not sure this is the *best* solution, and the builders have no resolver setup (which is maybe a good thing?). 