### PR TITLE
tests/build-dry: re-enable some test

### DIFF
--- a/tests/build-dry.sh
+++ b/tests/build-dry.sh
@@ -18,9 +18,6 @@ nix-build --no-out-link dependencies.nix --dry-run 2>&1 | grep "will be built"
 # Now new command:
 nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
 
-# TODO: XXX: FIXME: #1793
-# Disable this part of the test until the problem is resolved:
-if [ -n "$ISSUE_1795_IS_FIXED" ]; then
 clearStore
 clearCache
 
@@ -28,7 +25,6 @@ clearCache
 nix build -f dependencies.nix --dry-run 2>&1 | grep "will be built"
 # Now old command:
 nix-build --no-out-link dependencies.nix --dry-run 2>&1 | grep "will be built"
-fi
 
 ###################################################
 # Check --dry-run doesn't create links with --dry-run


### PR DESCRIPTION
the comment said the text was skipped until https://github.com/NixOS/nix/issues/1795 was fixed.
It has been fixed, enabling it doesn't break tests.