### PR TITLE
Print common flags in --help

### DIFF
--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -50,7 +50,7 @@ $(d)/src/SUMMARY.md: $(d)/src/SUMMARY.md.in $(d)/src/command-ref/new-cli
 
 $(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/generate-manpage.nix $(bindir)/nix
 	@rm -rf $@
-	$(trace-gen) $(nix-eval) --write-to $@ --expr 'import doc/manual/generate-manpage.nix { command = builtins.readFile $<; }'
+	$(trace-gen) $(nix-eval) --write-to $@ --expr 'import doc/manual/generate-manpage.nix { toplevel = builtins.readFile $<; }'
 
 $(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/generate-options.nix $(d)/src/command-ref/conf-file-prefix.md $(bindir)/nix
 	@cat doc/manual/src/command-ref/conf-file-prefix.md > $@.tmp

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -187,7 +187,7 @@ static void showHelp(std::vector<std::string> subcommand, MultiCommand & topleve
         *vUtils);
 
     auto attrs = state.buildBindings(16);
-    attrs.alloc("command").mkString(toplevel.toJSON().dump());
+    attrs.alloc("toplevel").mkString(toplevel.toJSON().dump());
 
     auto vRes = state.allocValue();
     state.callFunction(*vGenerateManpage, state.allocValue()->mkAttrs(attrs), *vRes, noPos);


### PR DESCRIPTION
Currently, the output of commands like `nix develop --help` do not necessarily list all the possible options a user could pass to the command. For example, `--print-build-logs`. This also happens in https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-develop.html, which new users may believe is a full reference.

This obscures discoverability for newer users. A new user may need to consult multiple help locations to find options such as `--refresh` or `--cores`, if they discover them at all.

While speaking with @grahamc and @edolstra about the topic, we pondered if we should display all common args.

I believe this PR does that. I have some worries that it may list irrelevant options though. I haven't yet tested them all.