### PR TITLE
flake.nix: Remove patchNetrcRegression curl override

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,16 +13,17 @@
       "original": {
         "owner": "kristapsdz",
         "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1664753758,
+        "narHash": "sha256-6Mw2Rk4EWhdz/QmVr7te9/X0jXBYsRCEJVumdG26MmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "038b71b753d54049f40091413215c32e7c507df9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05-small";
   inputs.nixpkgs-regression.url = "github:NixOS/nixpkgs/215d4d0fd80ca5163643b03a33fde804a29cc1e2";
-  inputs.lowdown-src = { url = "github:kristapsdz/lowdown"; flake = false; };
+  inputs.lowdown-src = { url = "github:kristapsdz/lowdown/d2c2b44ff6c27b936ec27358a2653caaef8f73b8"; flake = false; };
 
   outputs = { self, nixpkgs, nixpkgs-regression, lowdown-src }:
 
@@ -108,7 +108,7 @@
           ++ lib.optionals stdenv.hostPlatform.isLinux [(buildPackages.util-linuxMinimal or buildPackages.utillinuxMinimal)];
 
         buildDeps =
-          [ (curl.override { patchNetrcRegression = true; })
+          [ curl
             bzip2 xz brotli editline
             openssl sqlite
             libarchive
@@ -364,7 +364,7 @@
 
               buildInputs =
                 [ nix
-                  (curl.override { patchNetrcRegression = true; })
+                  curl
                   bzip2
                   xz
                   pkgs.perl


### PR DESCRIPTION
Now that the netrc regression has been fixed upstream, this override is no longer needed.

See: https://github.com/NixOS/nixpkgs/pull/189083