### PR TITLE
Fix fish shell MANPATH creation

### DIFF
--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -28,7 +28,9 @@ if test -n "$HOME" && test -n "$USER"
     # Only use MANPATH if it is already set. In general `man` will just simply
     # pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
     # which is in the $PATH. For more info, run `manpath -d`.
-    set --export --prepend --path MANPATH "$NIX_LINK/share/man"
+    if set --query MANPATH
+      set --export --prepend --path MANPATH "$NIX_LINK/share/man"
+    end
 
     fish_add_path --prepend --global "$NIX_LINK/bin"
     set --erase NIX_LINK


### PR DESCRIPTION
Previously the MANPATH was set even if MANPATH was empty beforehand which resulted in a MANPATH of only ~/.nix-profile/share/man which omitted the default man page directory (commonly /opt/local/share/man) from man page results.

Fixes #7131 