### PR TITLE
Temporarily disable the debugger during completion evaluation

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -258,9 +258,8 @@ void SourceExprCommand::completeInstallable(std::string_view prefix)
                 getDefaultFlakeAttrPaths(),
                 prefix);
         }
-    } catch (EvalError& e) {
-        // swallow eval error
-        (void)e;
+    } catch (EvalError&) {
+        // Don't want eval errors to mess-up with the completion engine, so let's just swallow them
     }
 }
 

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -384,6 +384,10 @@ StringSet NixRepl::completePrefix(const std::string & prefix)
             i++;
         }
     } else {
+        /* Temporarily disable the debugger, to avoid re-entering readline. */
+        auto debug_repl = state->debugRepl;
+        state->debugRepl = nullptr;
+        Finally restoreDebug([&]() { state->debugRepl = debug_repl; });
         try {
             /* This is an expression that should evaluate to an
                attribute set.  Evaluate it to get the names of the

--- a/tests/completions.sh
+++ b/tests/completions.sh
@@ -28,6 +28,10 @@ cat <<EOF > bar/flake.nix
     };
 }
 EOF
+mkdir -p err
+cat <<EOF > err/flake.nix
+throw "error"
+EOF
 
 # Test the completion of a subcommand
 [[ "$(NIX_GET_COMPLETIONS=1 nix buil)" == $'normal\nbuild\t' ]]
@@ -60,3 +64,5 @@ NIX_GET_COMPLETIONS=3 nix build --option allow-import-from | grep -- "allow-impo
 # Attr path completions
 [[ "$(NIX_GET_COMPLETIONS=2 nix eval ./foo\#sam)" == $'attrs\n./foo#sampleOutput\t' ]]
 [[ "$(NIX_GET_COMPLETIONS=4 nix eval --file ./foo/flake.nix outp)" == $'attrs\noutputs\t' ]]
+[[ "$(NIX_GET_COMPLETIONS=4 nix eval --file ./err/flake.nix outp 2>&1)" == $'attrs' ]]
+[[ "$(NIX_GET_COMPLETIONS=2 nix eval ./err\# 2>&1)" == $'attrs' ]]


### PR DESCRIPTION
readline/editline is not re-entrant, so entering the debugger from the `completioncallback` results in an eventual segfault.

The workaround is to temporarily disable the debugger when searching for possible completions.

Fixes #6692