### PR TITLE
Improve error message for non-existing store path

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -585,7 +585,7 @@ void Store::queryPathInfo(const StorePath & storePath,
             if (res && res->isKnownNow()) {
                 stats.narInfoReadAverted++;
                 if (!res->didExist())
-                    throw InvalidPath("path '%s' is not valid", printStorePath(storePath));
+                    throw InvalidPath("path '%s' does not exist", printStorePath(storePath));
                 return callback(ref<const ValidPathInfo>(res->value));
             }
         }


### PR DESCRIPTION
If the store path doesn't exist then say that, instead of the more generic "invalid".