### PR TITLE
Make warning about chroot store location more accurate

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1363,9 +1363,9 @@ std::shared_ptr<Store> openFromNonUri(const std::string & uri, const Store::Para
                 } catch (Error & e) {
                     return std::make_shared<LocalStore>(params);
                 }
-                warn("'/nix' does not exist, so Nix will use '%s' as a chroot store", chrootStore);
+                warn("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
             } else
-                debug("'/nix' does not exist, so Nix will use '%s' as a chroot store", chrootStore);
+                debug("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
             Store::Params params2;
             params2["root"] = chrootStore;
             return std::make_shared<LocalStore>(params2);


### PR DESCRIPTION
While trying to use an alternate directory for my Nix installation, I noticed that nix's output didn't reflect the updated state directory. This patch corrects that and now prints the warning before attempting to create the directory (if the directory creation fails, it wouldn't have been obvious why nix was attempting to create the directory in the first place).

With this patch, I now get the following warning:

    warning: '/home/deck/.var/app/org.nixos.nix/var/nix' does not
    exist, so Nix will use '/home/deck/.local/share/nix/root' as a
    chroot store