### PR TITLE
Remove a couple legacy logger->stop() calls

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -569,8 +569,6 @@ static void main_nix_build(int argc, char * * argv)
 
         restoreProcessContext();
 
-        logger->stop();
-
         execvp(shell->c_str(), argPtrs.data());
 
         throw SysError("executing shell '%s'", *shell);
@@ -628,8 +626,6 @@ static void main_nix_build(int argc, char * * argv)
 
             outPaths.push_back(outputPath);
         }
-
-        logger->stop();
 
         for (auto & path : outPaths)
             std::cout << store->printStorePath(path) << '\n';


### PR DESCRIPTION
These were removed by 1461e6cdda06f7f461114cce5b415f6d50381311, and then re-added by 502d7d9092ccf792a27088f31571dbace96f1962.

I noticed a logger getting double-stopped due to this.

Not sure why they were re-added, CC @ncfavier ?