### PR TITLE
parseDrvName: remove doc/impl discrepancy, add test covering the gap

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3821,8 +3821,8 @@ static RegisterPrimOp primop_parseDrvName({
     .args = {"s"},
     .doc = R"(
       Split the string *s* into a package name and version. The package
-      name is everything up to but not including the first dash followed
-      by a digit, and the version is everything following that dash. The
+      name is everything up to but not including the first dash not followed
+      by a letter, and the version is everything following that dash. The
       result is returned in a set `{ name, version }`. Thus,
       `builtins.parseDrvName "nix-0.12pre12876"` returns `{ name =
       "nix"; version = "0.12pre12876"; }`.

--- a/tests/lang/eval-okay-versions.nix
+++ b/tests/lang/eval-okay-versions.nix
@@ -4,6 +4,7 @@ let
   name2 = "hello";
   name3 = "915resolution-0.5.2";
   name4 = "xf86-video-i810-1.7.4";
+  name5 = "name-that-ends-with-dash--1.0";
 
   eq = 0;
   lt = builtins.sub 0 1;
@@ -23,6 +24,8 @@ let
     ((builtins.parseDrvName name3).version == "0.5.2")
     ((builtins.parseDrvName name4).name == "xf86-video-i810")
     ((builtins.parseDrvName name4).version == "1.7.4")
+    ((builtins.parseDrvName name5).name == "name-that-ends-with-dash")
+    ((builtins.parseDrvName name5).version == "-1.0")
     (versionTest "1.0" "2.3" lt)
     (versionTest "2.1" "2.3" lt)
     (versionTest "2.3" "2.3" eq)


### PR DESCRIPTION
The documentation for `parseDrvName` does not agree with the implementation when the derivation name contains a dash which is followed by something that is neither a letter nor a digit.

The first commit corrects the documentation so it agrees with the implementation.

The second commit adds a test covering the case where there had previously been a discrepancy.