### PR TITLE
Don't incorrectly assign aarch64-darwin to x86_64-darwin machines

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -156,9 +156,7 @@ StringSet Settings::getDefaultExtraPlatforms()
     // always exec with their own binary preferences.
     if (pathExists("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist") ||
         pathExists("/System/Library/LaunchDaemons/com.apple.oahd.plist")) {
-        if (std::string{SYSTEM} == "x86_64-darwin")
-            extraPlatforms.insert("aarch64-darwin");
-        else if (std::string{SYSTEM} == "aarch64-darwin")
+        if (std::string{SYSTEM} == "aarch64-darwin")
             extraPlatforms.insert("x86_64-darwin");
     }
 #endif


### PR DESCRIPTION
Users on an aarch64 Mac should install an aarch64 copy of Nix. If they'd like to use an x86_64 Nix on an aarch64 Mac and still get the extra-platforms support, they should configure it manually instead of incorrectly configuring x86_64 Macs.