### PR TITLE
Improve Rosetta detection

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -1050,7 +1050,7 @@ struct CmdRepl : InstallablesCommand
         evalSettings.pureEval = false;
     }
 
-    void prepare()
+    void prepare() override
     {
         if (!settings.isExperimentalFeatureEnabled(Xp::ReplFlake) && !(file) && this->_installables.size() >= 1) {
             warn("future versions of Nix will require using `--file` to load a file");

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -503,7 +503,7 @@ public:
         return s[0];
     }
 
-    virtual void setPrintBuildLogs(bool printBuildLogs)
+    void setPrintBuildLogs(bool printBuildLogs) override
     {
         this->printBuildLogs = printBuildLogs;
     }

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -154,12 +154,12 @@ StringSet Settings::getDefaultExtraPlatforms()
     // machines. Note that we can’t force processes from executing
     // x86_64 in aarch64 environments or vice versa since they can
     // always exec with their own binary preferences.
-    if (pathExists("/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist") ||
-        pathExists("/System/Library/LaunchDaemons/com.apple.oahd.plist")) {
-        if (std::string{SYSTEM} == "x86_64-darwin")
-            extraPlatforms.insert("aarch64-darwin");
-        else if (std::string{SYSTEM} == "aarch64-darwin")
+    if (std::string{SYSTEM} == "aarch64-darwin") {
+        if (runProgram(RunOptions {.program = "arch", .args = {"-arch", "x86_64", "/bin/pwd"}, .mergeStderrToStdout = true}).first == 0) {
+            debug("Rosetta detected");
             extraPlatforms.insert("x86_64-darwin");
+        } else
+            debug("Rosetta not detected");
     }
 #endif
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -155,7 +155,7 @@ StringSet Settings::getDefaultExtraPlatforms()
     // x86_64 in aarch64 environments or vice versa since they can
     // always exec with their own binary preferences.
     if (std::string{SYSTEM} == "aarch64-darwin") {
-        if (runProgram(RunOptions {.program = "arch", .args = {"-arch", "x86_64", "/bin/pwd"}, .mergeStderrToStdout = true}).first == 0) {
+        if (runProgram(RunOptions {.program = "arch", .args = {"-arch", "x86_64", "/usr/bin/true"}, .mergeStderrToStdout = true}).first == 0) {
             debug("Rosetta detected");
             extraPlatforms.insert("x86_64-darwin");
         } else

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -154,13 +154,9 @@ StringSet Settings::getDefaultExtraPlatforms()
     // machines. Note that we can’t force processes from executing
     // x86_64 in aarch64 environments or vice versa since they can
     // always exec with their own binary preferences.
-    if (std::string{SYSTEM} == "aarch64-darwin") {
-        if (runProgram(RunOptions {.program = "arch", .args = {"-arch", "x86_64", "/usr/bin/true"}, .mergeStderrToStdout = true}).first == 0) {
-            debug("Rosetta detected");
-            extraPlatforms.insert("x86_64-darwin");
-        } else
-            debug("Rosetta not detected");
-    }
+    if (std::string{SYSTEM} == "aarch64-darwin" &&
+        runProgram(RunOptions {.program = "arch", .args = {"-arch", "x86_64", "/usr/bin/true"}, .mergeStderrToStdout = true}).first == 0)
+        extraPlatforms.insert("x86_64-darwin");
 #endif
 
     return extraPlatforms;


### PR DESCRIPTION
Turns out that one of those *.plist files can exist even if Rosetta is not installed. So let's just try to run an x86_64-darwin binary directly.