### PR TITLE
libmain: Make stack overflow handler configurable

### DIFF
--- a/src/libmain/shared.hh
+++ b/src/libmain/shared.hh
@@ -113,14 +113,15 @@ struct PrintFreed
 /* Install a SIGSEGV handler to detect stack overflows. */
 void detectStackOverflow();
 
-/* Pluggable behavior to run before _exit(1) in case of a stack overflow.
+/* Pluggable behavior to run in case of a stack overflow.
 
-   Default value: do nothing, return immediately.
+   Default value: defaultStackOverflowHandler.
 
    This is called by the handler installed by detectStackOverflow().
 
    This gives Nix library consumers a limit opportunity to report the error
-   condition.
+   condition. The handler should exit the process.
+   See defaultStackOverflowHandler() for a reference implementation.
 
    NOTE: Use with diligence, because this runs in the signal handler, with very
    limited stack space and a potentially a corrupted heap, all while the failed

--- a/src/libmain/shared.hh
+++ b/src/libmain/shared.hh
@@ -113,5 +113,24 @@ struct PrintFreed
 /* Install a SIGSEGV handler to detect stack overflows. */
 void detectStackOverflow();
 
+/* Pluggable behavior to run before _exit(1) in case of a stack overflow.
+
+   Default value: do nothing, return immediately.
+
+   This is called by the handler installed by detectStackOverflow().
+
+   This gives Nix library consumers a limit opportunity to report the error
+   condition.
+
+   NOTE: Use with diligence, because this runs in the signal handler, with very
+   limited stack space and a potentially a corrupted heap, all while the failed
+   thread is blocked indefinitely. All functions called must be reentrant. */
+extern std::function<void(siginfo_t * info, void * ctx)> stackOverflowHandler;
+
+/* The default, robust implementation of stackOverflowHandler.
+
+   Prints an error message directly to stderr using a syscall instead of the
+   logger. Exits the process immediately after. */
+void defaultStackOverflowHandler(siginfo_t * info, void * ctx);
 
 }

--- a/src/libmain/stack.cc
+++ b/src/libmain/stack.cc
@@ -1,4 +1,5 @@
 #include "error.hh"
+#include "shared.hh"
 
 #include <cstring>
 #include <cstddef>
@@ -31,6 +32,7 @@ static void sigsegvHandler(int signo, siginfo_t * info, void * ctx)
         if (diff < 4096) {
             char msg[] = "error: stack overflow (possible infinite recursion)\n";
             [[gnu::unused]] auto res = write(2, msg, strlen(msg));
+            nix::extraStackOverflowHandler(info, ctx);
             _exit(1); // maybe abort instead?
         }
     }
@@ -67,5 +69,9 @@ void detectStackOverflow()
 #endif
 }
 
+std::function<void(siginfo_t * info, void * ctx)> extraStackOverflowHandler(
+    [](siginfo_t * info, void * ctx) {
+    }
+);
 
 }

--- a/src/libmain/stack.cc
+++ b/src/libmain/stack.cc
@@ -30,10 +30,7 @@ static void sigsegvHandler(int signo, siginfo_t * info, void * ctx)
         ptrdiff_t diff = (char *) info->si_addr - sp;
         if (diff < 0) diff = -diff;
         if (diff < 4096) {
-            char msg[] = "error: stack overflow (possible infinite recursion)\n";
-            [[gnu::unused]] auto res = write(2, msg, strlen(msg));
-            nix::extraStackOverflowHandler(info, ctx);
-            _exit(1); // maybe abort instead?
+            nix::stackOverflowHandler(info, ctx);
         }
     }
 
@@ -69,9 +66,12 @@ void detectStackOverflow()
 #endif
 }
 
-std::function<void(siginfo_t * info, void * ctx)> extraStackOverflowHandler(
-    [](siginfo_t * info, void * ctx) {
-    }
-);
+std::function<void(siginfo_t * info, void * ctx)> stackOverflowHandler(defaultStackOverflowHandler);
+
+void defaultStackOverflowHandler(siginfo_t * info, void * ctx) {
+    char msg[] = "error: stack overflow (possible infinite recursion)\n";
+    [[gnu::unused]] auto res = write(2, msg, strlen(msg));
+    _exit(1); // maybe abort instead?
+}
 
 }


### PR DESCRIPTION
This make the code to run in the stack overflow handler configurable.
It is useful for libmain / libexpr consumers that want to report the stack overflow differently.
The doc describes some of the risks and requirements for writing your own handler. It is the responsibility of the caller to use it appropriately.
