### PR TITLE
Prevent fetchGit from using incorrect cached rev for different refs

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -485,6 +485,10 @@ struct GitInputScheme : InputScheme
                 }
                 input.attrs.insert_or_assign("ref", *head);
                 unlockedAttrs.insert_or_assign("ref", *head);
+            } else {
+                if (!input.getRev()) {
+                    unlockedAttrs.insert_or_assign("ref", input.getRef().value());
+                }
             }
 
             if (auto res = getCache()->lookup(store, unlockedAttrs)) {

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -24,12 +24,14 @@ touch $repo/.gitignore
 git -C $repo add hello .gitignore
 git -C $repo commit -m 'Bla1'
 rev1=$(git -C $repo rev-parse HEAD)
+git -C $repo tag -a tag1 -m tag1
 
 echo world > $repo/hello
 git -C $repo commit -m 'Bla2' -a
 git -C $repo worktree add $TEST_ROOT/worktree
 echo hello >> $TEST_ROOT/worktree/hello
 rev2=$(git -C $repo rev-parse HEAD)
+git -C $repo tag -a tag2 -m tag2
 
 # Fetch a worktree
 unset _NIX_FORCE_HTTP
@@ -216,6 +218,16 @@ rev4_nix=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$
 # The name argument should be handled
 path9=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"HEAD\"; name = \"foo\"; }).outPath")
 [[ $path9 =~ -foo$ ]]
+
+# Specifying a ref without a rev shouldn't pick a cached rev for a different ref
+export _NIX_FORCE_HTTP=1
+rev_tag1_nix=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"refs/tags/tag1\"; }).rev")
+rev_tag1=$(git -C $repo rev-parse refs/tags/tag1)
+[[ $rev_tag1_nix = $rev_tag1 ]]
+rev_tag2_nix=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"refs/tags/tag2\"; }).rev")
+rev_tag2=$(git -C $repo rev-parse refs/tags/tag2)
+[[ $rev_tag2_nix = $rev_tag2 ]]
+unset _NIX_FORCE_HTTP
 
 # should fail if there is no repo
 rm -rf $repo/.git


### PR DESCRIPTION
# Background
This is a fix for #7146. 

When using `fetchGit` on a non-local repository and using a `ref` (but no `rev`), `fetchGit` will decide that any cached `rev` for that repository is usable (if not too stale).

This is potentially really disruptive. If a user uses `fetchGit` to fetch both the `nixos-22.05` and `nixos-21.11` branches of `nixpkgs` back-to-back, and they don't specify a `rev`, they'll wind up with `nixos-22.05` sources in both cases (!!):

```
nix-repl> builtins.fetchGit { url = "git@github.com:nixos/nixpkgs"; ref = "refs/heads/nixos-22.05"; }
{ lastModified = 1665613119; lastModifiedDate = "20221012221839"; narHash = "sha256-VTutbv5YKeBGWou6ladtgfx11h6et+Wlkdyh4jPJ3p0="; outPath = "/nix/store/xc6s7iccz5nkm8vl9nybz698nq2ngxlc-source"; rev = "e06bd4b64bbfda91d74f13cb5eca89485d47528f"; revCount = 383579; shortRev = "e06bd4b"; submodules = false; }

nix-repl> builtins.fetchGit { url = "git@github.com:nixos/nixpkgs"; ref = "refs/heads/nixos-21.11"; } 
{ lastModified = 1665613119; lastModifiedDate = "20221012221839"; narHash = "sha256-VTutbv5YKeBGWou6ladtgfx11h6et+Wlkdyh4jPJ3p0="; outPath = "/nix/store/xc6s7iccz5nkm8vl9nybz698nq2ngxlc-source"; rev = "e06bd4b64bbfda91d74f13cb5eca89485d47528f"; revCount = 383579; shortRev = "e06bd4b"; submodules = false; }
```

# The fix
The fix I'm suggesting is pretty straightforward: when no `rev` is provided for a remote repo fetched with fetchGit, incorporate the `ref` into the `input` attrs to differentiate cached revs between different refs.

To illustrate, here's the fetcher cache after running the example above in Nix 2.9.1:
```
sqlite3 ~/.cache/nix/fetcher-cache-v1.sqlite 'SELECT * FROM Cache;'
input                                                                            info                                                                                            path                                                immutable  timestamp 
-------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------  --------------------------------------------------  ---------  ----------
{"name":"source","type":"git","url":"ssh://git@github.com/nixos/nixpkgs"}        {"lastModified":1665613119,"rev":"e06bd4b64bbfda91d74f13cb5eca89485d47528f","revCount":383579}  /nix/store/xc6s7iccz5nkm8vl9nybz698nq2ngxlc-source  0          1665789700
{"name":"source","rev":"e06bd4b64bbfda91d74f13cb5eca89485d47528f","type":"git"}  {"lastModified":1665613119,"rev":"e06bd4b64bbfda91d74f13cb5eca89485d47528f","revCount":383579}  /nix/store/xc6s7iccz5nkm8vl9nybz698nq2ngxlc-source  1          1665789700
```

and this is how it looks on my bugfix branch:
```
sqlite3 ~/.cache/nix/fetcher-cache-v1.sqlite 'SELECT * FROM Cache;'
input                                                                                                     info                                                                                            path                                                immutable  timestamp 
--------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------  --------------------------------------------------  ---------  ----------
{"name":"source","ref":"refs/heads/nixos-22.05","type":"git","url":"ssh://git@github.com/nixos/nixpkgs"}  {"lastModified":1665613119,"rev":"e06bd4b64bbfda91d74f13cb5eca89485d47528f","revCount":383579}  /nix/store/xc6s7iccz5nkm8vl9nybz698nq2ngxlc-source  0          1665789958
{"name":"source","rev":"e06bd4b64bbfda91d74f13cb5eca89485d47528f","type":"git"}                           {"lastModified":1665613119,"rev":"e06bd4b64bbfda91d74f13cb5eca89485d47528f","revCount":383579}  /nix/store/xc6s7iccz5nkm8vl9nybz698nq2ngxlc-source  1          1665789958
{"name":"source","ref":"refs/heads/nixos-21.11","type":"git","url":"ssh://git@github.com/nixos/nixpkgs"}  {"lastModified":1659446231,"rev":"eabc38219184cc3e04a974fe31857d8e0eac098d","revCount":337975}  /nix/store/9ks8076lanzwp09dmwy5r3racihsc1ip-source  0          1665790070
{"name":"source","rev":"eabc38219184cc3e04a974fe31857d8e0eac098d","type":"git"}                           {"lastModified":1659446231,"rev":"eabc38219184cc3e04a974fe31857d8e0eac098d","revCount":337975}  /nix/store/9ks8076lanzwp09dmwy5r3racihsc1ip-source  1          1665790070
```