### PR TITLE
Allow missing binary caches by default

### DIFF
--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -110,18 +110,12 @@ void PathSubstitutionGoal::tryNext()
         tryNext();
         return;
     } catch (SubstituterDisabled &) {
-        if (settings.tryFallback) {
-            tryNext();
-            return;
-        }
-        throw;
+        tryNext();
+        return;
     } catch (Error & e) {
-        if (settings.tryFallback) {
-            logError(e.info());
-            tryNext();
-            return;
-        }
-        throw;
+        logError(e.info());
+        tryNext();
+        return;
     }
 
     if (info->path != storePath) {

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -82,7 +82,7 @@ protected:
     void maybeDisable()
     {
         auto state(_state.lock());
-        if (state->enabled && settings.tryFallback) {
+        if (state->enabled) {
             int t = 60;
             printError("disabling binary cache '%s' for %s seconds", getUri(), t);
             state->enabled = false;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1158,10 +1158,7 @@ void LocalStore::querySubstitutablePathInfos(const StorePathCAMap & paths, Subst
             } catch (InvalidPath &) {
             } catch (SubstituterDisabled &) {
             } catch (Error & e) {
-                if (settings.tryFallback)
-                    logError(e.info());
-                else
-                    throw;
+                logError(e.info());
             }
         }
     }


### PR DESCRIPTION
This change allows for individual substituters to be unavailable even when `fallback = false` (default). Prior to this change, _any_ unavailable substituters would cause a build failure even if others were reachable. This causes issues when people try to setup occasionally accessible binary caches.

The [fallback](https://nixos.org/manual/nix/unstable/command-ref/conf-file.html#conf-fallback) setting states that it allows Nix to fallback to building from source if a binary substitute fails, and this change makes the behavior now match the description. Prior to this change it actually did two things:

1. Allows for missing/erroring binary substituters
2. Fallback to building from source if no binary substitute is available

Allowing unreachable binary substituters should probably be the expected behavior with or without the `fallback` flag, and is what this change allows.

I've tested simple scenarios locally, but it's not clear to me how to write a test for this. I think it needs a network failure to trigger the new paths, and I'm not sure how to set that up in the tests.

Closes #6901, Closes #7127, Closes #4383