### PR TITLE
Fix default values in the manual

### DIFF
--- a/doc/manual/generate-options.nix
+++ b/doc/manual/generate-options.nix
@@ -11,16 +11,16 @@ concatStrings (map
     + concatStrings (map (s: "    ${s}\n") (splitLines option.description)) + "\n\n"
     + (if option.documentDefault
        then "    **Default:** " + (
-       if option.value == "" || option.value == []
+       if option.defaultValue == "" || option.defaultValue == []
        then "*empty*"
-       else if isBool option.value
-       then (if option.value then "`true`" else "`false`")
+       else if isBool option.defaultValue
+       then (if option.defaultValue then "`true`" else "`false`")
        else
          # n.b. a StringMap value type is specified as a string, but
          # this shows the value type.  The empty stringmap is "null" in
          # JSON, but that converts to "{ }" here.
-         (if isAttrs option.value then "`\"\"`"
-          else "`" + toString option.value + "`")) + "\n\n"
+         (if isAttrs option.defaultValue then "`\"\"`"
+          else "`" + toString option.defaultValue + "`")) + "\n\n"
        else "    **Default:** *machine-specific*\n")
     + (if option.aliases != []
        then "    **Deprecated alias:** " + (concatStringsSep ", " (map (s: "`${s}`") option.aliases)) + "\n\n"

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -369,13 +369,6 @@ void mainWrapped(int argc, char * * argv)
         && args.command->first != "upgrade-nix")
         settings.requireExperimentalFeature(Xp::NixCommand);
 
-    if (args.command->first == "show-config") {
-        // show-config must run before any settings are modified so that it outputs the defaults
-        args.command->second->prepare();
-        args.command->second->run();
-        return;
-    }
-
     if (args.useNet && !haveInternet()) {
         warn("you don't have Internet access; disabling some network-dependent features");
         args.useNet = false;

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -369,6 +369,13 @@ void mainWrapped(int argc, char * * argv)
         && args.command->first != "upgrade-nix")
         settings.requireExperimentalFeature(Xp::NixCommand);
 
+    if (args.command->first == "show-config") {
+        // show-config must run before any settings are modified so that it outputs the defaults
+        args.command->second->prepare();
+        args.command->second->run();
+        return;
+    }
+
     if (args.useNet && !haveInternet()) {
         warn("you don't have Internet access; disabling some network-dependent features");
         args.useNet = false;


### PR DESCRIPTION
The default values that show up in the manual are generated by dumping the _current_ settings using `nix show-config`. When the manual is built, that command is run in a sandbox with no internet access which caused some of the default settings to be altered before we dump the config. See #6359 for discussion and alternative options.

This change just special cases the `show-config` command to run prior to any settings being altered.

This may not be what we want to do if `nix show-config` needs to show those altered settings. If that's the case I'd suggest we add a `nix show-config --defaults` command.

Closes #6359