### PR TITLE
Defer to SSH config files for ForwardAgent option

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -67,7 +67,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string
         if (fakeSSH) {
             args = { "bash", "-c" };
         } else {
-            args = { "ssh", host.c_str(), "-x", "-a" };
+            args = { "ssh", host.c_str(), "-x" };
             addCommonSSHOpts(args);
             if (socketPath != "")
                 args.insert(args.end(), {"-S", socketPath});


### PR DESCRIPTION
Currently, Nix passes `-a` when it runs commands on a remote machine via SSH, which disables agent forwarding. This causes issues when the `ForwardAgent` option is set in SSH config files, as the command line operation always overrides those.

In particular, this causes issues if the command being run is `sudo` and the remote machine is configured with the equivalent of NixOS's `security.pam.enableSSHAgentAuth` option. Not allowing SSH agent forwarding can cause authentication to fail unexpectedly.

This can currently be worked around by setting `NIX_SSHOPTS="-A"`, but we should defer to the options in the SSH config files to be least surprising for users.