### PR TITLE
Mark flakes with .type = "flake".

### DIFF
--- a/src/libexpr/flake/call-flake.nix
+++ b/src/libexpr/flake/call-flake.nix
@@ -43,7 +43,7 @@ let
 
           outputs = flake.outputs (inputs // { self = result; });
 
-          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; };
+          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; type = "flake"; };
         in
           if node.flake or true then
             assert builtins.isFunction flake.outputs;


### PR DESCRIPTION
Fixes #7186