### PR TITLE
Improve --profile description

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -226,7 +226,7 @@ MixProfile::MixProfile()
 {
     addFlag({
         .longName = "profile",
-        .description = "The profile to update.",
+        .description = "The profile to operate on.",
         .labels = {"path"},
         .handler = {&profile},
         .completer = completePath


### PR DESCRIPTION
The description of the `--profile` option talks about the "update" operation. This is probably meant for operations such as `nix profile install`, but the same option is reused in other subcommands, which do not update the profile, such as `nix profile {list,history,diff-closures}`.

We update the description to make sense in both contexts.