### PR TITLE
Fix `nix __build-remote`

### DIFF
--- a/src/libstore/build/hook-instance.cc
+++ b/src/libstore/build/hook-instance.cc
@@ -16,11 +16,11 @@ HookInstance::HookInstance()
     buildHookArgs.pop_front();
 
     Strings args;
+    args.push_back(std::string(baseNameOf(buildHook)));
 
     for (auto & arg : buildHookArgs)
         args.push_back(arg);
 
-    args.push_back(std::string(baseNameOf(settings.buildHook.get())));
     args.push_back(std::to_string(verbosity));
 
     /* Create a pipe to get the output of the child. */

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -270,7 +270,7 @@ void mainWrapped(int argc, char * * argv)
     programPath = argv[0];
     auto programName = std::string(baseNameOf(programPath));
 
-    if (argc > 0 && std::string_view(argv[0]) == "__build-remote") {
+    if (argc > 1 && std::string_view(argv[1]) == "__build-remote") {
         programName = "build-remote";
         argv++; argc--;
     }


### PR DESCRIPTION
Because of a wrong index, `nix __build-remote` wasn't working.

Fix the index to restore the command (and the build hook).

@edolstra any idea why the tests (and apparently most stuff since no one complained until last week) were still OK despite that? Are we using something else in the general case?

Fix #7193 

cc @Gerschtli