### PR TITLE
builtins.substring: fix int overflow

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -170,10 +170,16 @@ static I forceIntChecked(EvalState & state, Value & v, const PosIdx pos, std::st
 
     try {
         return boost::numeric_cast<I>(result);
-    } catch(boost::bad_numeric_cast&) {
-        state.error("integer %1% is out of bounds", result)
-            .withTrace(pos, errorCtx)
-            .debugThrow<TypeError>();
+    } catch(boost::bad_numeric_cast& e) {
+        if (dynamic_cast<boost::numeric::negative_overflow*>(&e)) {
+            state.error("integer %1% is too low", result)
+                .withTrace(pos, errorCtx)
+                .debugThrow<TypeError>();
+        } else {
+            state.error("integer %1% is too high", result)
+                .withTrace(pos, errorCtx)
+                .debugThrow<TypeError>();
+        }
     }
 }
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -25,6 +25,7 @@
 #include <dlfcn.h>
 
 #include <cmath>
+#include <boost/numeric/conversion/cast.hpp>
 
 
 namespace nix {
@@ -159,6 +160,21 @@ static void mkOutputString(
                derivation */
             : downstreamPlaceholder(*state.store, drvPath, o.first),
         {"!" + o.first + "!" + state.store->printStorePath(drvPath)});
+}
+
+/* Try to interpret an argument as an int of the specified type,
+   throwing an error if this fails */
+template <typename I>
+static I forceIntChecked(EvalState & state, Value & v, const PosIdx pos, std::string_view errorCtx) {
+    NixInt result = state.forceInt(v, pos, errorCtx);
+
+    try {
+        return boost::numeric_cast<I>(result);
+    } catch(boost::bad_numeric_cast&) {
+        state.error("integer %1% out of range", result)
+            .withTrace(pos, errorCtx)
+            .debugThrow<TypeError>();
+    }
 }
 
 /* Load and evaluate an expression from path specified by the
@@ -2806,7 +2822,7 @@ static void elemAt(EvalState & state, const PosIdx pos, Value & list, int n, Val
 /* Return the n-1'th element of a list. */
 static void prim_elemAt(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    elemAt(state, pos, *args[0], state.forceInt(*args[1], pos, "while evaluating the second argument passed to builtins.elemAt"), v);
+    elemAt(state, pos, *args[0], forceIntChecked<size_t>(state, *args[1], pos, "while evaluating the second argument passed to builtins.elemAt"), v);
 }
 
 static RegisterPrimOp primop_elemAt({
@@ -3090,7 +3106,7 @@ static RegisterPrimOp primop_all({
 
 static void prim_genList(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    auto len = state.forceInt(*args[1], pos, "while evaluating the second argument passed to builtins.genList");
+    auto len = forceIntChecked<unsigned int>(state, *args[1], pos, "while evaluating the second argument passed to builtins.genList");
 
     if (len < 0)
         state.error("cannot create list of size %1%", len).debugThrow<EvalError>();
@@ -3552,18 +3568,19 @@ static RegisterPrimOp primop_toString({
    non-negative. */
 static void prim_substring(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    int start = state.forceInt(*args[0], pos, "while evaluating the first argument (the start offset) passed to builtins.substring");
-    int len = state.forceInt(*args[1], pos, "while evaluating the second argument (the substring length) passed to builtins.substring");
+    size_t start = forceIntChecked<size_t>(state, *args[0], pos, "while evaluating the first argument (the start offset) passed to builtins.substring");
+    /* length can be negative, we want to map that to `npos` */
+    NixInt len_ = state.forceInt(*args[1], pos, "while evaluating the second argument (the substring length) passed to builtins.substring");
+    size_t len;
+    if (len_ < 0) {
+        len = std::string::npos;
+    } else {
+        len = forceIntChecked<size_t>(state, *args[1], pos, "while evaluating the second argument (the substring length) passed to builtins.substring");
+    }
     PathSet context;
     auto s = state.coerceToString(pos, *args[2], context, "while evaluating the third argument (the string) passed to builtins.substring");
 
-    if (start < 0)
-        state.debugThrowLastTrace(EvalError({
-            .msg = hintfmt("negative start position in 'substring'"),
-            .errPos = state.positions[pos]
-        }));
-
-    v.mkString((unsigned NixInt) start >= s->size() ? "" : s->substr(start, len), context);
+    v.mkString(start >= s->size() ? "" : s->substr(start, len), context);
 }
 
 static RegisterPrimOp primop_substring({

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3563,7 +3563,7 @@ static void prim_substring(EvalState & state, const PosIdx pos, Value * * args, 
             .errPos = state.positions[pos]
         }));
 
-    v.mkString((unsigned int) start >= s->size() ? "" : s->substr(start, len), context);
+    v.mkString((unsigned NixInt) start >= s->size() ? "" : s->substr(start, len), context);
 }
 
 static RegisterPrimOp primop_substring({

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -171,7 +171,7 @@ static I forceIntChecked(EvalState & state, Value & v, const PosIdx pos, std::st
     try {
         return boost::numeric_cast<I>(result);
     } catch(boost::bad_numeric_cast&) {
-        state.error("integer %1% out of range", result)
+        state.error("integer %1% is out of bounds", result)
             .withTrace(pos, errorCtx)
             .debugThrow<TypeError>();
     }
@@ -2809,7 +2809,7 @@ static RegisterPrimOp primop_isList({
 
 static void elemAt(EvalState & state, const PosIdx pos, Value & list, int n, Value & v)
 {
-    state.forceList(list, pos, "while evaluating the first argument passed to builtins.elemAt");
+    state.forceList(list, pos, "while evaluating the first argument (the list) passed to builtins.elemAt");
     if (n < 0 || (unsigned int) n >= list.listSize())
         state.debugThrowLastTrace(Error({
             .msg = hintfmt("list index %1% is out of bounds", n),
@@ -2822,7 +2822,7 @@ static void elemAt(EvalState & state, const PosIdx pos, Value & list, int n, Val
 /* Return the n-1'th element of a list. */
 static void prim_elemAt(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    elemAt(state, pos, *args[0], forceIntChecked<size_t>(state, *args[1], pos, "while evaluating the second argument passed to builtins.elemAt"), v);
+    elemAt(state, pos, *args[0], forceIntChecked<size_t>(state, *args[1], pos, "while evaluating the second argument (the list index) passed to builtins.elemAt"), v);
 }
 
 static RegisterPrimOp primop_elemAt({

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -170,16 +170,14 @@ static I forceIntChecked(EvalState & state, Value & v, const PosIdx pos, std::st
 
     try {
         return boost::numeric_cast<I>(result);
+    } catch(boost::numeric::negative_overflow& e) {
+        state.error("integer %1% is too low", result)
+            .withTrace(pos, errorCtx)
+            .debugThrow<TypeError>();
     } catch(boost::bad_numeric_cast& e) {
-        if (dynamic_cast<boost::numeric::negative_overflow*>(&e)) {
-            state.error("integer %1% is too low", result)
-                .withTrace(pos, errorCtx)
-                .debugThrow<TypeError>();
-        } else {
-            state.error("integer %1% is too high", result)
-                .withTrace(pos, errorCtx)
-                .debugThrow<TypeError>();
-        }
+        state.error("integer %1% is too high", result)
+            .withTrace(pos, errorCtx)
+            .debugThrow<TypeError>();
     }
 }
 

--- a/src/libexpr/tests/error_traces.cc
+++ b/src/libexpr/tests/error_traces.cc
@@ -627,7 +627,7 @@ namespace nix {
 
         ASSERT_TRACE2("elemAt [] (-1)",
                       TypeError,
-                      hintfmt("integer %d is out of bounds", -1),
+                      hintfmt("integer %d is too low", -1),
                       hintfmt("while evaluating the second argument (the list index) passed to builtins.elemAt"));
 
         ASSERT_TRACE1("elemAt [\"foo\"] 3",
@@ -818,7 +818,7 @@ namespace nix {
 
         ASSERT_TRACE2("genList false (-3)",
                       TypeError,
-                      hintfmt("integer %d is out of bounds", -3),
+                      hintfmt("integer %d is too low", -3),
                       hintfmt("while evaluating the second argument passed to builtins.genList"));
 
     }
@@ -1064,7 +1064,7 @@ namespace nix {
 
         ASSERT_TRACE2("substring (-3) 3 \"sometext\"",
                       TypeError,
-                      hintfmt("integer %d is out of bounds", -3),
+                      hintfmt("integer %d is too low", -3),
                       hintfmt("while evaluating the first argument (the start offset) passed to builtins.substring"));
 
     }

--- a/src/libexpr/tests/error_traces.cc
+++ b/src/libexpr/tests/error_traces.cc
@@ -620,14 +620,15 @@ namespace nix {
 
 
     TEST_F(ErrorTraceTest, elemAt) {
-        ASSERT_TRACE2("elemAt \"foo\" (-1)",
+        ASSERT_TRACE2("elemAt \"foo\" 1",
                       TypeError,
                       hintfmt("value is %s while a list was expected", "a string"),
-                      hintfmt("while evaluating the first argument passed to builtins.elemAt"));
+                      hintfmt("while evaluating the first argument (the list) passed to builtins.elemAt"));
 
-        ASSERT_TRACE1("elemAt [] (-1)",
-                      Error,
-                      hintfmt("list index %d is out of bounds", -1));
+        ASSERT_TRACE2("elemAt [] (-1)",
+                      TypeError,
+                      hintfmt("integer %d is out of bounds", -1),
+                      hintfmt("while evaluating the second argument (the list index) passed to builtins.elemAt"));
 
         ASSERT_TRACE1("elemAt [\"foo\"] 3",
                       Error,
@@ -640,7 +641,7 @@ namespace nix {
         ASSERT_TRACE2("head 1",
                       TypeError,
                       hintfmt("value is %s while a list was expected", "an integer"),
-                      hintfmt("while evaluating the first argument passed to builtins.elemAt"));
+                      hintfmt("while evaluating the first argument (the list) passed to builtins.elemAt"));
 
         ASSERT_TRACE1("head []",
                       Error,
@@ -815,9 +816,10 @@ namespace nix {
         //               hintfmt("cannot add %s to an integer", "a string"),
         //               hintfmt("while evaluating anonymous lambda"));
 
-        ASSERT_TRACE1("genList false (-3)",
-                      EvalError,
-                      hintfmt("cannot create list of size %d", -3));
+        ASSERT_TRACE2("genList false (-3)",
+                      TypeError,
+                      hintfmt("integer %d is out of bounds", -3),
+                      hintfmt("while evaluating the second argument passed to builtins.genList"));
 
     }
 
@@ -1060,9 +1062,10 @@ namespace nix {
                       hintfmt("cannot coerce %s to a string", "a set"),
                       hintfmt("while evaluating the third argument (the string) passed to builtins.substring"));
 
-        ASSERT_TRACE1("substring (-3) 3 \"sometext\"",
-                      EvalError,
-                      hintfmt("negative start position in 'substring'"));
+        ASSERT_TRACE2("substring (-3) 3 \"sometext\"",
+                      TypeError,
+                      hintfmt("integer %d is out of bounds", -3),
+                      hintfmt("while evaluating the first argument (the start offset) passed to builtins.substring"));
 
     }
 

--- a/src/libexpr/tests/primops.cc
+++ b/src/libexpr/tests/primops.cc
@@ -562,6 +562,16 @@ namespace nix {
         ASSERT_THAT(v, IsStringEq(""));
     }
 
+    TEST_F(PrimOpTest, substringStartOverflow){
+        auto v = eval("builtins.substring 4294967296 1 \"nixos\"");
+        ASSERT_THAT(v, IsStringEq(""));
+    }
+
+    TEST_F(PrimOpTest, substringUntilEnd){
+        auto v = eval("builtins.substring 1 (-1) \"nixos\"");
+        ASSERT_THAT(v, IsStringEq("ixos"));
+    }
+
     TEST_F(PrimOpTest, stringLength) {
         auto v = eval("builtins.stringLength \"123\"");
         ASSERT_THAT(v, IsIntEq(3));


### PR DESCRIPTION
repro: `builtins.substring 4294967296 1 "umu"`