### PR TITLE
nix run: fix "'defaultApp.x86_64-linux' should have type 'derivation'"

### DIFF
--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -66,7 +66,9 @@ UnresolvedApp Installable::toApp(EvalState & state)
 
     auto type = cursor->getAttr("type")->getString();
 
-    std::string expected = !attrPath.empty() && state.symbols[attrPath[0]] == "apps" ? "app" : "derivation";
+    std::string expected = !attrPath.empty() &&
+        (state.symbols[attrPath[0]] == "apps" || state.symbols[attrPath[0]] == "defaultApp")
+        ? "app" : "derivation";
     if (type != expected)
         throw Error("attribute '%s' should have type '%s'", cursor->getAttrPathStr(), expected);
 


### PR DESCRIPTION
repo: `nix run github:serokell/nixfmt/v0.5.0`
See https://github.com/serokell/nixfmt/issues/106