### PR TITLE
Fix user namespace detection with old kernels

### DIFF
--- a/src/libutil/namespaces.cc
+++ b/src/libutil/namespaces.cc
@@ -18,19 +18,28 @@ bool userNamespacesSupported()
         }
 
         Path maxUserNamespaces = "/proc/sys/user/max_user_namespaces";
-        if (!pathExists(maxUserNamespaces) ||
-            trim(readFile(maxUserNamespaces)) == "0")
-        {
-            debug("user namespaces appear to be disabled; check '/proc/sys/user/max_user_namespaces'");
-            return false;
+        if (pathExists(maxUserNamespaces) {
+            /* If the file exists, we should respect what it says. */
+            if (trim(readFile(maxUserNamespaces)) == "0") {
+                debug("user namespaces appear to be disabled; check '/proc/sys/user/max_user_namespaces'");
+                return false;
+            }
+        } else {
+            /* Older Linux kernels never produce this file, whether or
+               not user namespaces are available. Assume we are running
+               an older kernel and continue. */
         }
 
         Path procSysKernelUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone";
-        if (pathExists(procSysKernelUnprivilegedUsernsClone)
-            && trim(readFile(procSysKernelUnprivilegedUsernsClone)) == "0")
-        {
-            debug("user namespaces appear to be disabled; check '/proc/sys/kernel/unprivileged_userns_clone'");
-            return false;
+        if (pathExists(procSysKernelUnprivilegedUsernsClone) {
+            /* If the file exists, we should respect what it says. */
+            if (trim(readFile(procSysKernelUnprivilegedUsernsClone)) == "0")
+            {
+                debug("user namespaces appear to be disabled; check '/proc/sys/kernel/unprivileged_userns_clone'");
+                return false;
+            }
+        } else {
+            /* Assume all good, just like above. */
         }
 
         try {


### PR DESCRIPTION
The current mechanism to detect the presence of user namespaces assumes they are not available when the file `/proc/sys/user/max_user_namespaces` doesn't exist. This file is only present since Linux 4.9, so older versions which still support namespaces cause the check to return false. In particular, our machine has the version 4.4.

This patch adds another detection check when the max_user_namespaces fails, by testing the presence of `/proc/self/ns/user`, which should exist since 3.8 (see namespaces(7)).

The particular problem occured to @aleixrocks when running some python tests that call `getgrgid`. The group id doesn't have an entry in /etc/group when the user namespaces are not in use, which causes an error in getgrgid.

This is a reproducer we used to test (with an old nixpkgs version), where we use getent instead, to get the information of the effective group:

```nix
let
  commit = "1614b96a68dd210919865abe78bda56b501eb1ef";

  # Pin the nixpkgs
  nixpkgsPath = builtins.fetchTarball {
    # Descriptive name to make the store path easier to identify
    name = "nixpkgs-${commit}";
    # Commit hash for nixpkgs as of 2021-09-01
    url = "https://github.com/nixos/nixpkgs/archive/${commit}.tar.gz";
    # Hash obtained using `nix-prefetch-url --unpack <url>`
    sha256 = "17c4a6cg0xmnp6hl76h8fvxglngh66s8nfm3qq2iqv6iay4a92qz";
  };

  pkgs = import nixpkgsPath { };

  test = pkgs.stdenv.mkDerivation {
    name = "test";
    buildInputs = [ pkgs.glibc.bin ];
    src = ./repro.nix;
    dontUnpack = true;
    buildPhase = ''
      set -x
      cat /etc/group
      cat /etc/passwd
      id -g
      id -gr
      cat /proc/self/uid_map
      cat /proc/self/gid_map
      getent group $(id -g) || echo not found
      getent group 100 || echo not found
      set +x
    '';
  };

in test
```

The difference of the output is as follows when applying the patch:

```diff
--- bad 2022-10-28 17:39:41.389428541 +0200
+++ ok  2022-10-28 17:40:33.740893984 +0200
@@ -11,20 +11,19 @@
 nogroup:x:65534:
 ++ cat /etc/passwd
 root:x:0:0:Nix build user:/build:/noshell
-nixbld:x:30001:30000:Nix build user:/build:/noshell
+nixbld:x:1000:100:Nix build user:/build:/noshell
 nobody:x:65534:65534:Nobody:/:/noshell
 ++ id -g
-30000
+100
 ++ id -gr
-30000
+100
 ++ cat /proc/self/uid_map
-         0          0 4294967295
+      1000      30001          1
 ++ cat /proc/self/gid_map
-         0          0 4294967295
+       100      30000          1
 +++ id -g
-++ getent group 30000
-++ echo not found
-not found
+++ getent group 100
+nixbld:!:100:
 ++ getent group 100
 nixbld:!:100:
 ++ set +x

```
The uid and gid maps are set properly after the patch and now the getent command succeeds.

This test also suggest that running the build without user namespaces may result in non reproducible builds, as the user id of the nix builder is visible from the build sandbox.