### PR TITLE
Add reloadability to nix develop

### DIFF
--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -13,6 +13,7 @@ namespace nix {
 extern std::string programPath;
 
 extern char * * savedArgv;
+extern int savedArgc;
 
 class EvalState;
 struct Pos;

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -54,6 +54,7 @@ static bool haveInternet()
 
 std::string programPath;
 char * * savedArgv;
+int savedArgc;
 
 struct HelpRequested { };
 
@@ -244,6 +245,7 @@ static auto rCmdHelp = registerCommand<CmdHelp>("help");
 void mainWrapped(int argc, char * * argv)
 {
     savedArgv = argv;
+    savedArgc = argc;
 
     /* The chroot helper needs to be run before any threads have been
        started. */


### PR DESCRIPTION
This is my attempt to provide reloadability to Nix develop. There are three parts:

- Adds a "reload" bash function to nix develop which execs with the same command nix develop was called with, destroying the old shell.
- Adds a "--print-out-path" option to nix develop which prints the out path of the dev shell and exists.
- Adds a "--auto-reload" option which checks if the shell out path has changed and calls reload if it does (experimental, it does make your shell kinda slow).