### PR TITLE
Add doas support to the installation script.

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -137,7 +137,7 @@ echo "performing a single-user installation of Nix..." >&2
 if ! [ -e "$dest" ]; then
     cmd="mkdir -m 0755 $dest && chown $USER $dest"
     echo "directory $dest does not exist; creating it by running '$cmd' using sudo" >&2
-    if ! sudo sh -c "$cmd"; then
+    if ! (sudo sh -c "$cmd" || doas sh -c "$cmd") ; then
         echo "$0: please manually run '$cmd' as root to create $dest" >&2
         exit 1
     fi


### PR DESCRIPTION
Previously the install errored out and told you to manually add `/nix/` and set the perms if you had `doas` installed instead of `sudo`. Well, not any more!