### PR TITLE
Warn about untracked files in git repositories

### DIFF
--- a/src/libutil/url-parts.hh
+++ b/src/libutil/url-parts.hh
@@ -32,6 +32,10 @@ extern std::regex refRegex;
 const static std::string badGitRefRegexS = "//|^[./]|/\\.|\\.\\.|[[:cntrl:][:space:]:?^~\[]|\\\\|\\*|\\.lock$|\\.lock/|@\\{|[/.]$|^@$|^$";
 extern std::regex badGitRefRegex;
 
+// Git short status shows untracked files in lines starting with ?? followed by space
+const static std::string gitUntrackedRegexS = "(?:^|\n)\\?\\?\\s";
+extern std::regex gitUntrackedRegex;
+
 // A Git revision (a SHA-1 commit hash).
 const static std::string revRegexS = "[0-9a-fA-F]{40}";
 extern std::regex revRegex;

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -7,6 +7,7 @@ namespace nix {
 
 std::regex refRegex(refRegexS, std::regex::ECMAScript);
 std::regex badGitRefRegex(badGitRefRegexS, std::regex::ECMAScript);
+std::regex gitUntrackedRegex(gitUntrackedRegexS, std::regex::ECMAScript);
 std::regex revRegex(revRegexS, std::regex::ECMAScript);
 std::regex flakeIdRegex(flakeIdRegexS, std::regex::ECMAScript);
 


### PR DESCRIPTION
This adds a warning about untracked files in fetched git repositories. Addresses #7107 and hopefully helps to avoid some confusion. Maybe this can help as a simple fix before #6530 gets merged.