### PR TITLE
Track parsing and evaluation activities

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -499,6 +499,7 @@ struct InstallableAttrPath : InstallableValue
 std::vector<InstallableValue::DerivationInfo> InstallableAttrPath::toDerivations()
 {
     auto v = toValue(*state).first;
+    Activity act(*logger, lvlTalkative, actUnknown, "evaluate expressions into derivations");
 
     Bindings & autoArgs = *cmd.getAutoArgs(*state);
 
@@ -760,6 +761,7 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
 {
     std::vector<std::shared_ptr<Installable>> result;
 
+    Activity act(*logger, lvlTalkative, actUnknown, "parsing expressions");
     if (readOnlyMode) {
         settings.readOnlyMode = true;
     }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1029,6 +1029,7 @@ static void prim_derivationStrict(EvalState & state, const PosIdx pos, Value * *
         e.addTrace(state.positions[posDrvName], "while evaluating the derivation attribute 'name'");
         throw;
     }
+    Activity act(*logger, lvlTalkative, actUnknown, fmt("instantiate '%s'", drvName), {});
 
     /* Check whether attributes should be passed as a JSON file. */
     std::ostringstream jsonBuf;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -283,7 +283,7 @@ static void main_nix_build(int argc, char * * argv)
 
     /* Parse the expressions. */
     std::vector<Expr *> exprs;
-
+    auto parseActivity = Activity(*logger, lvlTalkative, actUnknown, "parsing expressions");
     if (readStdin)
         exprs = {state->parseStdin()};
     else
@@ -305,8 +305,9 @@ static void main_nix_build(int argc, char * * argv)
                                         inShebang && !packages ? absPath(i, absPath(dirOf(script))) : i)))));
             }
         }
-
+    logger->stopActivity(parseActivity.id);
     /* Evaluate them into derivations. */
+    auto evaluateActivity = Activity(*logger, lvlTalkative, actUnknown, "evaluate expressions into derivations");
     if (attrPaths.empty()) attrPaths = {""};
 
     for (auto e : exprs) {
@@ -348,8 +349,8 @@ static void main_nix_build(int argc, char * * argv)
             );
         }
     }
-
     state->printStats();
+    logger->stopActivity(evaluateActivity.id);
 
     auto buildPaths = [&](const std::vector<DerivedPath> & paths) {
         /* Note: we do this even when !printMissing to efficiently


### PR DESCRIPTION
Enable better instrumentation of the steps before the drv building step

We are working on [nix-otel](https://github.com/lf-/nix-otel) which instrument the nix code through a plugin to send trace using the OpenTelemetry protocol.
The precision of the trace data is directly related to the amount of activity we have. 
As such, logging these activities during the execution of nix-build and nix build would be highly beneficial in improving the accuracy of the traces that we can generate.