### PR TITLE
nix-shell: Support --out-link

### DIFF
--- a/doc/manual/src/command-ref/nix-shell.md
+++ b/doc/manual/src/command-ref/nix-shell.md
@@ -13,6 +13,8 @@
   [`--exclude` *regexp*]
   [`--pure`]
   [`--keep` *name*]
+  [`--no-out-link`]
+  [{`--out-link` | `-o`} *outlink*]
   {{`--packages` | `-p`} {*packages* | *expressions*} … | [*path*]}
 
 # Disambiguation
@@ -100,6 +102,16 @@ All options not listed here are passed to `nix-store
   - `--keep` *name*\
     When a `--pure` shell is started, keep the listed environment
     variables.
+
+  - [`--no-out-link`]{#opt-no-out-link}\
+    Do not create a symlink to the output path. This is the default.
+    Note that as a result the output does not become a root of the
+    garbage collector, and so might be deleted by `nix-store --gc`.
+
+  - [`--out-link`]{#opt-out-link} / `-o` *outlink*\
+    Create a symlink to the output path of the shell environment. The
+    output will then become a root of the garbage collector and will
+    not be deleted by `nix-store --gc`.
 
 The following common options are supported:
 

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -5,3 +5,4 @@
   arguments will be ignored and the resulting derivation will have
   `__impure` set to `true`, making it an impure derivation.
 
+* `nix-shell` now accepts `--out-link` and `--no-out-link` flags.

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -99,7 +99,7 @@ static void main_nix_build(int argc, char * * argv)
 
     AutoDelete tmpDir(createTempDir("", myName));
 
-    std::string outLink = "./result";
+    std::optional<std::string> outLink = runEnv ? std::nullopt : std::optional{"./result"};
 
     // List of environment variables kept for --pure
     std::set<std::string> keepVars{
@@ -155,7 +155,7 @@ static void main_nix_build(int argc, char * * argv)
             ; // obsolete
 
         else if (*arg == "--no-out-link" || *arg == "--no-link")
-            outLink = (Path) tmpDir + "/result";
+            outLink = std::nullopt;
 
         else if (*arg == "--attr" || *arg == "-A")
             attrPaths.push_back(getArg(*arg, arg, end));
@@ -610,7 +610,7 @@ static void main_nix_build(int argc, char * * argv)
 
         for (auto & [drvPath, outputName] : pathsToBuildOrdered) {
             auto & [counter, _wantedOutputs] = drvMap.at({drvPath});
-            std::string drvPrefix = outLink;
+            std::string drvPrefix = outLink.value_or((Path) tmpDir + "/result");
             if (counter)
                 drvPrefix += fmt("-%d", counter + 1);
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -453,10 +453,7 @@ static void main_nix_build(int argc, char * * argv)
 
         if (shellDrv) {
             auto shellDrvOutputs = store->queryPartialDerivationOutputMap(shellDrv.value());
-            auto shellDrvOut = shellDrvOutputs.at("out").value();
-            shell = store->printStorePath(shellDrvOut) + "/bin/bash";
-
-            if (outLink) writeOutLink(*outLink + "-shell", shellDrvOut, "out");
+            shell = store->printStorePath(shellDrvOutputs.at("out").value()) + "/bin/bash";
         }
 
         if (settings.isExperimentalFeatureEnabled(Xp::CaDerivations)) {

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -85,12 +85,12 @@ output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)
 [ "$output" = '-e load(ARGV.shift) -- '"$TEST_ROOT"'/spaced \'\''"shell.shebang.rb abc ruby' ]
 
 # Test nix-shell --out-link -p creates gcroot
-nix-shell --pure -p foo --out-link $TEST_ROOT/gcroots/foo-root
-[ -L $TEST_ROOT/gcroots/foo-root ]
+nix-shell --pure -p foo --out-link foo-root
+[ -L foo-root ] && rm foo-root
 
 # Test nix-shell --out-link -A creates gcroot
-nix-shell --pure -A foo --out-link $TEST_ROOT/gcroots/foo-attr-root
-[ -L $TEST_ROOT/gcroots/foo-attr-root ]
+nix-shell --pure -A foo --out-link foo-root
+[ -L foo-root ] && rm foo-root
 
 # Test 'nix develop'.
 nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -84,6 +84,10 @@ chmod a+rx $TEST_ROOT/spaced\ \\\'\"shell.shebang.rb
 output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)
 [ "$output" = '-e load(ARGV.shift) -- '"$TEST_ROOT"'/spaced \'\''"shell.shebang.rb abc ruby' ]
 
+# Test nix-shell --out-link -p creates gcroot
+nix-shell --pure -p foo --out-link $TEST_ROOT/gcroots/foo-root
+[ -L $TEST_ROOT/gcroots/foo-root ] && [ -L $TEST_ROOT/gcroots/foo-root-shell ]
+
 # Test 'nix develop'.
 nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'
 

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -86,11 +86,11 @@ output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)
 
 # Test nix-shell --out-link -p creates gcroot
 nix-shell --pure -p foo --out-link $TEST_ROOT/gcroots/foo-root
-[ -L $TEST_ROOT/gcroots/foo-root ] && [ -L $TEST_ROOT/gcroots/foo-root-shell ]
+[ -L $TEST_ROOT/gcroots/foo-root ]
 
 # Test nix-shell --out-link -A creates gcroot
 nix-shell --pure -A foo --out-link $TEST_ROOT/gcroots/foo-attr-root
-[ -L $TEST_ROOT/gcroots/foo-attr-root ] && [ -L $TEST_ROOT/gcroots/foo-attr-root-shell ]
+[ -L $TEST_ROOT/gcroots/foo-attr-root ]
 
 # Test 'nix develop'.
 nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -88,6 +88,10 @@ output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)
 nix-shell --pure -p foo --out-link $TEST_ROOT/gcroots/foo-root
 [ -L $TEST_ROOT/gcroots/foo-root ] && [ -L $TEST_ROOT/gcroots/foo-root-shell ]
 
+# Test nix-shell --out-link -A creates gcroot
+nix-shell --pure -A foo --out-link $TEST_ROOT/gcroots/foo-attr-root
+[ -L $TEST_ROOT/gcroots/foo-attr-root ] && [ -L $TEST_ROOT/gcroots/foo-attr-root-shell ]
+
 # Test 'nix develop'.
 nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'
 


### PR DESCRIPTION
Closes #2208.

`nix-shell` previously had no way of creating gcroots for shell derivation. This can cause problems if a garbage collection happens concurrently with a `nix-shell` incantation that runs long enough.  `nix develop` solves this, as far as I understand it, but `--out-link` functionality would still be useful in some circumstances.