### PR TITLE
tests/impure-derivations.sh: remove unknown experimental feature 'ca-…

### DIFF
--- a/tests/impure-derivations.sh
+++ b/tests/impure-derivations.sh
@@ -2,7 +2,7 @@ source common.sh
 
 requireDaemonNewerThan "2.8pre20220311"
 
-enableFeatures "ca-derivations ca-references impure-derivations"
+enableFeatures "ca-derivations impure-derivations"
 restartDaemon
 
 set -o pipefail


### PR DESCRIPTION
…references'

ca-references was stabilized in d589a6aa8a5d0c9f391400d7e0e209106e89c857

accidentally introduced in https://github.com/NixOS/nix/pull/6227