### PR TITLE
Fix printing of eval errors with two format placeholders

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -904,7 +904,7 @@ void EvalState::throwEvalError(const char * s, const std::string & s2,
     const std::string & s3)
 {
     debugThrowLastTrace(EvalError({
-        .msg = hintfmt(s, s2),
+        .msg = hintfmt(s, s2, s3),
         .errPos = positions[noPos]
     }));
 }
@@ -913,7 +913,7 @@ void EvalState::throwEvalError(const PosIdx pos, const char * s, const std::stri
     const std::string & s3)
 {
     debugThrowLastTrace(EvalError({
-        .msg = hintfmt(s, s2),
+        .msg = hintfmt(s, s2, s3),
         .errPos = positions[pos]
     }));
 }
@@ -922,7 +922,7 @@ void EvalState::throwEvalError(const PosIdx pos, const char * s, const std::stri
     const std::string & s3, Env & env, Expr & expr)
 {
     debugThrow(EvalError({
-        .msg = hintfmt(s, s2),
+        .msg = hintfmt(s, s2, s3),
         .errPos = positions[pos]
     }), env, expr);
 }


### PR DESCRIPTION
With this fix, the error in https://github.com/NixOS/nix/issues/6647#issue-1267677835 becomes slightly more useful:

```
error: the string 'nixos-system-nuc-22.05pre-git' is not allowed to refer to a store path (such as '/nix/store/8x56z90r0h9iwgba93hy2iws4z9rkrgl-nixpkgs-src')
```

It would be nice to enable warnings for unused ~variables~ parameters but it looks like a lot of work to silence them all.