### PR TITLE
build-remote: Add brackets to error message

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -186,12 +186,12 @@ static int main_build_remote(int argc, char * * argv)
                         // build the hint template.
                         std::string errorText =
                             "Failed to find a machine for remote build!\n"
-                            "derivation: %s\nrequired (system, features): (%s, %s)";
+                            "derivation: %s\nrequired (system, features): (%s, [%s])";
                         errorText += "\n%s available machines:";
                         errorText += "\n(systems, maxjobs, supportedFeatures, mandatoryFeatures)";
 
                         for (unsigned int i = 0; i < machines.size(); ++i)
-                            errorText += "\n(%s, %s, %s, %s)";
+                            errorText += "\n([%s], %s, [%s], [%s])";
 
                         // add the template values.
                         std::string drvstr;


### PR DESCRIPTION
This change adds brackets around every comma separated list inside this error message. Without this change, nix embeds multiple comma-separated lists inside a comma-separated list.

Before:
```
Failed to find a machine for remote build!
derivation: 9dip5j8qd1f3z5bcjl6xqxhlvrql31x2-unit-dbus.service.drv
required (system, features): (aarch64-linux, )
1 available machines:
(systems, maxjobs, supportedFeatures, mandatoryFeatures)
(aarch64-linux, x86_64-linux, 2, , )
```

After:
```
Failed to find a machine for remote build!
derivation: 9dip5j8qd1f3z5bcjl6xqxhlvrql31x2-unit-dbus.service.drv
required (system, features): (aarch64-linux, [])
1 available machines:
(systems, maxjobs, supportedFeatures, mandatoryFeatures)
([aarch64-linux, x86_64-linux], 2, [], [])
```