### PR TITLE
nix-shell: Add temp roots for outputs

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -5,3 +5,7 @@
   arguments will be ignored and the resulting derivation will have
   `__impure` set to `true`, making it an impure derivation.
 
+* `nix-shell` now spawns a child process instead of `exec`ing immediately.
+
+* `nix-shell` creates temp roots for as long as the executed shell
+  process is alive.

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -571,14 +571,15 @@ static void main_nix_build(int argc, char * * argv)
 
         logger->stop();
 
-        execvp(shell->c_str(), argPtrs.data());
-
         pid_t pid = fork();
 
         if (pid == -1)
             throw SysError("forking shell");
 
         if (pid == 0) {
+            for (auto & [outputName, output] : drv.outputsAndOptPaths(*store))
+                if (output.second) store->addTempRoot(*output.second);
+
             execvp(shell->c_str(), argPtrs.data());
 
             throw SysError("executing shell '%s'", *shell);

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -84,6 +84,9 @@ chmod a+rx $TEST_ROOT/spaced\ \\\'\"shell.shebang.rb
 output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)
 [ "$output" = '-e load(ARGV.shift) -- '"$TEST_ROOT"'/spaced \'\''"shell.shebang.rb abc ruby' ]
 
+# Text nix-shell --run preserves exit code
+test ! $(nix-shell -p foo --run 'exit 1')
+
 # Test 'nix develop'.
 nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'
 


### PR DESCRIPTION
The garbage collector uses heuristics (i.e. /proc/*/environ) to check for live roots - meaning that a nix-shell should theoretically be safe from gc. In practice this detection does not always work. This change makes nix-shell spawn a child process and creates temproots for the shell.