### PR TITLE
Allow system certs access to fixed-output derivations

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1715,6 +1715,8 @@ void LocalDerivationGoal::runChild()
                 for (auto & path : { "/etc/resolv.conf", "/etc/services", "/etc/hosts" })
                     if (pathExists(path))
                         ss.push_back(path);
+
+                dirsInChroot.emplace(settings.caFile, "/etc/ssl/certs/ca-certificates.crt");
             }
 
             for (auto & i : ss) dirsInChroot.emplace(i, i);


### PR DESCRIPTION
Allow building fixed-output derivations behind an SSL proxy

This change mounts the system certificates bundle in the sandbox of
fixed-output derivations. This makes sense given that they are already given
network access, and network is pretty much unusable nowadays if you do not have
the right certificates.

The implementation mounts the certificates in a well-known location,
independently of the real location passed to the daemon. This should make it
visible to most tools by default, and still allow overrides if needed.

Other options have been considered, but this seems the most logical one, as it
does not require modification to the nix expressions themselves for something
that is essentially a configuration quirk of the build machine.

Comments ?


**Release Notes**
Please include relevant [release notes](https://github.com/NixOS/nix/blob/master/doc/manual/src/release-notes/rl-next.md) as needed.


**Testing**

If this issue is a regression or something that should block release, please consider including a test either in the [testsuite](https://github.com/NixOS/nix/tree/master/tests) or as a [hydraJob]( https://github.com/NixOS/nix/blob/master/flake.nix#L396) so that it can be part of the [automatic checks](https://hydra.nixos.org/jobset/nix/master).
