### PR TITLE
Update uninstall guide involving systemd

### DIFF
--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -88,25 +88,28 @@ extension. The installer will also create `/etc/profile.d/nix.sh`.
 
 ### Linux
 
-To begin, if you are on Linux with systemd, remove the Nix daemon service:
+If you are on Linux with systemd:
 
-```console
-sudo systemctl stop nix-daemon.service
-sudo systemctl disable nix-daemon.socket nix-daemon.service
-sudo systemctl daemon-reload
-```
+1. Remove the Nix daemon service:
 
-Then you can remove systemd service files:
+   ```console
+   sudo systemctl stop nix-daemon.service
+   sudo systemctl disable nix-daemon.socket nix-daemon.service
+   sudo systemctl daemon-reload
+   ```
 
-```console
-sudo rm /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
-```
+1. Remove systemd service files:
 
-Also, the installer script uses systemd-tmpfiles (if presents) to create the socket directory. You may also want to remove the configuration for that:
+   ```console
+   sudo rm /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
+   ```
 
-```console
-sudo rm /etc/tmpfiles.d/nix-daemon.conf
-```
+1. The installer script uses systemd-tmpfiles to create the socket directory.
+    You may also want to remove the configuration for that:
+
+   ```console
+   sudo rm /etc/tmpfiles.d/nix-daemon.conf
+   ```
 
 Remove files created by Nix:
 

--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -88,6 +88,28 @@ extension. The installer will also create `/etc/profile.d/nix.sh`.
 
 ### Linux
 
+To begin, if you are on Linux with systemd, remove the Nix daemon service:
+
+```console
+sudo systemctl stop nix-daemon.socket
+sudo systemctl stop nix-daemon.service
+sudo systemctl disable nix-daemon.socket
+sudo systemctl disable nix-daemon.service
+sudo systemctl daemon-reload
+```
+
+Then you can remove systemd service files:
+
+```console
+sudo rm -f /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
+```
+
+Also, the installer script uses systemd-tmpfiles (if presents) to create the socket directory. You may also want to remove the configuration for that:
+
+```console
+sudo rm -f /etc/tmpfiles.d/nix-daemon.conf
+```
+
 Remove files created by Nix:
 
 ```console
@@ -101,16 +123,6 @@ for i in $(seq 30001 30032); do
   sudo userdel $i
 done
 sudo groupdel 30000
-```
-
-If you are on Linux with systemd, remove the Nix daemon service:
-
-```console
-sudo systemctl stop nix-daemon.socket
-sudo systemctl stop nix-daemon.service
-sudo systemctl disable nix-daemon.socket
-sudo systemctl disable nix-daemon.service
-sudo systemctl daemon-reload
 ```
 
 There may also be references to Nix in

--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -91,23 +91,21 @@ extension. The installer will also create `/etc/profile.d/nix.sh`.
 To begin, if you are on Linux with systemd, remove the Nix daemon service:
 
 ```console
-sudo systemctl stop nix-daemon.socket
 sudo systemctl stop nix-daemon.service
-sudo systemctl disable nix-daemon.socket
-sudo systemctl disable nix-daemon.service
+sudo systemctl disable nix-daemon.socket nix-daemon.service
 sudo systemctl daemon-reload
 ```
 
 Then you can remove systemd service files:
 
 ```console
-sudo rm -f /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
+sudo rm /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
 ```
 
 Also, the installer script uses systemd-tmpfiles (if presents) to create the socket directory. You may also want to remove the configuration for that:
 
 ```console
-sudo rm -f /etc/tmpfiles.d/nix-daemon.conf
+sudo rm /etc/tmpfiles.d/nix-daemon.conf
 ```
 
 Remove files created by Nix:


### PR DESCRIPTION
This is a follow-up of #7279. The PR made two changes to the document regarding the uninstallation process on Linux with systemd:

- Added notes about removing systemd service files and systemd-tmpfiles config files
- Reordered the instructions to make sure we stop, disable and remove systemd services first. The reason is that right now `/etc/systemd/system/nix-daemon.{socket,service}` is symlinked to files inside `/nix`. If we `rm -rf /nix` first, then systemd won't be able to stop the service.