### PR TITLE
Document "Import From Derivation"

### DIFF
--- a/doc/manual/src/SUMMARY.md.in
+++ b/doc/manual/src/SUMMARY.md.in
@@ -33,6 +33,7 @@
   - [Operators](language/operators.md)
   - [Derivations](language/derivations.md)
     - [Advanced Attributes](language/advanced-attributes.md)
+    - [Import From Derivation](language/import-from-derivation.md)
   - [Built-in Constants](language/builtin-constants.md)
   - [Built-in Functions](language/builtins.md)
 - [Advanced Topics](advanced-topics/advanced-topics.md)

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -105,11 +105,14 @@
 
 - [store object]{#gloss-store-object}
 
-
   A store object consists of a [file system object], [reference]s to other store objects, and other metadata.
   It can be referred to by a [store path].
 
   [store object]: #gloss-store-object
+
+- [IFD]{#gloss-ifd}
+
+  [Import From Derivation](./language/import-from-derivation.md)
 
 - [input-addressed store object]{#gloss-input-addressed-store-object}
 

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -14,6 +14,7 @@ Passing an expression `expr` which evaluates to a store path to any built-in fun
 
 - [`import`](./builtins.md#builtins-import)` expr`
 - [`builtins.readFile`](./builtins.md#builtins-readFile)` expr`
+- [`builtins.readFileType`](./builtins.md#builtins-readFileType)` expr`
 - [`builtins.readDir`](./builtins.md#builtins-readDir)` expr`
 - [`builtins.pathExists`](./builtins.md#builtins-pathExists)` expr`
 - [`builtins.filterSource`](./builtins.md#builtins-filterSource)` f expr`

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -11,7 +11,7 @@ This has performance implications:
 Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
 Usually, if store objects are not already present, realisation is orders of magnitude slower than evaluation.
 
-Passing an expression `expr` that evaluates to a store path to any built-in function which reads from the filesystem constitutes Import From Derivation:
+Passing an expression `expr` that evaluates to a [store path](@docroot@/glossary.md#gloss-store-path) to any built-in function which reads from the filesystem constitutes Import From Derivation:
 
 - [`import`](./builtins.md#builtins-import)` expr`
 - [`builtins.readFile`](./builtins.md#builtins-readFile)` expr`
@@ -51,8 +51,8 @@ building '/nix/store/348q1cal6sdgfxs8zqi9v8llrsn4kqkq-hello.drv'...
 "hello world"
 ```
 
-Since `"hello"` is a valid Nix expression, it can be [`import`](./builtins.md#builtins-import)ed.
-That requires reading from the output [store path](@docroot@/glossary.md#gloss-store-path) of `drv`, which has to be [realised] before its contents can be read and evaluated.
+The contents of the derivation's [output path](@docroot@/glossary.md#gloss-output-path) have to be [realised] before they can be read with [`readFile`](./builtins.md#builtins-readFile).
+Only then evaluation can continue to produce the final result.
 
 ## Illustration
 

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -8,8 +8,11 @@ In this case, when that store object is needed, evaluation will be paused, the s
 [realised]: @docroot@/glossary.md#gloss-realise
 
 This has performance implications:
-Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
-Usually, if store objects are not already present, realisation is orders of magnitude slower than evaluation.
+Evaluation can only finish when all required store objects are realised.
+Since the Nix language evaluator is sequential, it only finds [store paths] to read from one at a time.
+While realisation is always parallel, in this case it cannot be done for all required store paths at once, and is therefore much slower than otherwise.
+
+[store paths]: @docroot@/glossary.md#gloss-store-path
 
 Passing an expression `expr` that evaluates to a [store path](@docroot@/glossary.md#gloss-store-path) to any built-in function which reads from the filesystem constitutes Import From Derivation:
 

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -3,22 +3,22 @@
 The value of a Nix expression can depend on the contents of a [store object].
 In this case, when that store object is needed, evaluation will be paused, the store object [realised], and then evaluation resumed.
 
-[store object]: /glossary.md#gloss-store-object
-[derivation]: /glossary.md#gloss-derivation
-[realised]: /glossary.md#gloss-realise
+[store object]: @docroot@/glossary.md#gloss-store-object
+[derivation]: @docroot@/glossary.md#gloss-derivation
+[realised]: @docroot@/glossary.md#gloss-realise
 
 This has performance implications:
 Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
 
 Passing an expression `expr` which evaluates to a store path to any built-in function that reads from the filesystem constitutes Import From Derivation:
 
-- [`import`](./language/builtins.md#builtins-import)` expr`
-- [`builtins.readFile`](./language/builtins.md#builtins-readFile)` expr`
-- [`builtins.readDir`](./language/builtins.md#builtins-readDir)` expr`
-- [`builtins.pathExists`](./language/builtins.md#builtins-pathExists)` expr`
-- [`builtins.filterSource`](./language/builtins.md#builtins-filterSource)` f expr`
-- [`builtins.path`](./language/builtins.md#builtins-path)` { path = expr; }`
-- [`builtins.hashFile`](./language/builtins.md#builtins-hashFile)` t expr`
+- [`import`](./builtins.md#builtins-import)` expr`
+- [`builtins.readFile`](./builtins.md#builtins-readFile)` expr`
+- [`builtins.readDir`](./builtins.md#builtins-readDir)` expr`
+- [`builtins.pathExists`](./builtins.md#builtins-pathExists)` expr`
+- [`builtins.filterSource`](./builtins.md#builtins-filterSource)` f expr`
+- [`builtins.path`](./builtins.md#builtins-path)` { path = expr; }`
+- [`builtins.hashFile`](./builtins.md#builtins-hashFile)` t expr`
 - `builtins.scopedImport x drv`
 
 Realising store objects during evaluation can be disabled by setting [`allow-import-from-derivation`](../command-ref/conf-file.md#conf-allow-import-from-derivation) to `false`.

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -1,20 +1,8 @@
 # Import From Derivation
 
-The value of a Nix expression can depend on the contents of a [store object].
-In this case, when that store object is needed, evaluation will be paused, the store object [realised], and then evaluation resumed.
+The value of a Nix expression can depend on the contents of a [store object](@docroot@/glossary.md#gloss-store-object).
 
-[store object]: @docroot@/glossary.md#gloss-store-object
-[derivation]: @docroot@/glossary.md#gloss-derivation
-[realised]: @docroot@/glossary.md#gloss-realise
-
-This has performance implications:
-Evaluation can only finish when all required store objects are realised.
-Since the Nix language evaluator is sequential, it only finds [store paths] to read from one at a time.
-While realisation is always parallel, in this case it cannot be done for all required store paths at once, and is therefore much slower than otherwise.
-
-[store paths]: @docroot@/glossary.md#gloss-store-path
-
-Passing an expression `expr` that evaluates to a [store path](@docroot@/glossary.md#gloss-store-path) to any built-in function which reads from the filesystem constitutes Import From Derivation:
+Passing an expression `expr` that evaluates to a [store path](@docroot@/glossary.md#gloss-store-path) to any built-in function which reads from the filesystem constitutes Import From Derivation (IFD):
 
 - [`import`](./builtins.md#builtins-import)` expr`
 - [`builtins.readFile`](./builtins.md#builtins-readFile)` expr`
@@ -25,6 +13,15 @@ Passing an expression `expr` that evaluates to a [store path](@docroot@/glossary
 - [`builtins.path`](./builtins.md#builtins-path)` { path = expr; }`
 - [`builtins.hashFile`](./builtins.md#builtins-hashFile)` t expr`
 - `builtins.scopedImport x drv`
+
+When the store path needs to be accessed, evaluation will be paused, the corresponding store object [realised], and then evaluation resumed.
+
+[realised]: @docroot@/glossary.md#gloss-realise
+
+This has performance implications:
+Evaluation can only finish when all required store objects are realised.
+Since the Nix language evaluator is sequential, it only finds store paths to read from one at a time.
+While realisation is always parallel, in this case it cannot be done for all required store paths at once, and is therefore much slower than otherwise.
 
 Realising store objects during evaluation can be disabled by setting [`allow-import-from-derivation`](../command-ref/conf-file.md#conf-allow-import-from-derivation) to `false`.
 Without IFD it is ensured that evaluation is complete and Nix can produce a build plan before starting any realisation.
@@ -59,7 +56,7 @@ Only then evaluation can continue to produce the final result.
 
 ## Illustration
 
-As a first approximation, the following data flow graph shows how evaluation and building are interleaved, if the value of a Nix expression depends on realising a store object.
+As a first approximation, the following data flow graph shows how evaluation and building are interleaved, if the value of a Nix expression depends on realising a [store object].
 Boxes are data structures, arrow labels are transformations.
 
 ```

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -1,0 +1,86 @@
+# Import From Derivation
+
+The value of a Nix expression can depend on the contents of a [store object] produced by a [derivation].
+In this case, when that store object is needed, evaluation will be paused, the store object [realised], and then evaluation resumed.
+
+[store object]: /glossary.md#gloss-store-object
+[derivation]: /glossary.md#gloss-derivation
+[realised]: /glossary.md#gloss-realise
+
+This has performance implications:
+Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
+
+Passing a derivation `drv` to any built-in function that reads from the filesystem constitutes Import From Derivation:
+
+- [`import`](./language/builtins.md#builtins-import)` drv`
+- [`builtins.readFile`](./language/builtins.md#builtins-readFile)` drv`
+- [`builtins.readDir`](./language/builtins.md#builtins-readDir)` drv`
+- [`builtins.pathExists`](./language/builtins.md#builtins-pathExists)` drv`
+- [`builtins.filterSource`](./language/builtins.md#builtins-filterSource)` f drv`
+- [`builtins.path`](./language/builtins.md#builtins-path)` { path = drv; }`
+- [`builtins.hashFile`](./language/builtins.md#builtins-hashFile)` t drv`
+- `builtins.scopedImport x drv`
+
+Building during evaluation can be disabled by setting [`allow-import-from-derivation`](../command-ref/conf-file.md#conf-allow-import-from-derivation) to `false`.
+
+## Example
+
+In the following Nix expression, the inner derivation `drv` produces a file containing `"hello"`.
+
+```nix
+# IFD.nix
+let
+  drv = derivation {
+    name = "hello";
+    builder = /bin/sh;
+    args = [ "-c" ''echo \"hello\" > $out'' ];
+    system = builtins.currentSystem;
+  };
+in "${import drv} world"
+```
+
+```shellSession
+nix-instantiate IFD.nix --eval --read-write-mode
+```
+
+```
+building '/nix/store/348q1cal6sdgfxs8zqi9v8llrsn4kqkq-hello.drv'...
+"hello world"
+```
+
+Since `"hello"` is a valid Nix expression, it can be [`import`](./builtins.md#builtins-import)ed.
+That requires reading from the output [store path](@docroot@/glossary.md#gloss-store-path) of `drv`, which has to be [realised] before its contents can be read and evaluated.
+
+## Illustration
+
+The following diagram shows how evaluation is interrupted by a build, if the value of a Nix expression depends on realising a store object.
+
+```
++----------------------+             +------------------------+
+| Nix language         |             | Nix store              |
+|  .----------------.  |             |                        |
+|  | Nix expression |  |             |                        |
+|  '----------------'  |             |                        |
+|          |           |             |                        |
+|       evaluate       |             |                        |
+|          |           |             |                        |
+|          V           |             |                        |
+|    .------------.    |             |  .------------------.  |
+|    | derivation |----|-instantiate-|->| store derivation |  |
+|    '------------'    |             |  '------------------'  |
+|                      |             |           |            |
+|                      |             |        realise         |
+|                      |             |           |            |
+|                      |             |           V            |
+|  .----------------.  |             |    .--------------.    |
+|  | Nix expression |<-|----read-----|----| store object |    |
+|  '----------------'  |             |    '--------------'    |
+|          |           |             |                        |
+|       evaluate       |             |                        |
+|          |           |             |                        |
+|          V           |             |                        |
+|    .------------.    |             |                        |
+|    |   value    |    |             |                        |
+|    '------------'    |             |                        |
++----------------------+             +------------------------+
+```

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -1,6 +1,6 @@
 # Import From Derivation
 
-The value of a Nix expression can depend on the contents of a [store object] produced by a [derivation].
+The value of a Nix expression can depend on the contents of a [store object].
 In this case, when that store object is needed, evaluation will be paused, the store object [realised], and then evaluation resumed.
 
 [store object]: /glossary.md#gloss-store-object
@@ -10,18 +10,18 @@ In this case, when that store object is needed, evaluation will be paused, the s
 This has performance implications:
 Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
 
-Passing a derivation `drv` to any built-in function that reads from the filesystem constitutes Import From Derivation:
+Passing an expression `expr` which evaluates to a store path to any built-in function that reads from the filesystem constitutes Import From Derivation:
 
-- [`import`](./language/builtins.md#builtins-import)` drv`
-- [`builtins.readFile`](./language/builtins.md#builtins-readFile)` drv`
-- [`builtins.readDir`](./language/builtins.md#builtins-readDir)` drv`
-- [`builtins.pathExists`](./language/builtins.md#builtins-pathExists)` drv`
-- [`builtins.filterSource`](./language/builtins.md#builtins-filterSource)` f drv`
-- [`builtins.path`](./language/builtins.md#builtins-path)` { path = drv; }`
-- [`builtins.hashFile`](./language/builtins.md#builtins-hashFile)` t drv`
+- [`import`](./language/builtins.md#builtins-import)` expr`
+- [`builtins.readFile`](./language/builtins.md#builtins-readFile)` expr`
+- [`builtins.readDir`](./language/builtins.md#builtins-readDir)` expr`
+- [`builtins.pathExists`](./language/builtins.md#builtins-pathExists)` expr`
+- [`builtins.filterSource`](./language/builtins.md#builtins-filterSource)` f expr`
+- [`builtins.path`](./language/builtins.md#builtins-path)` { path = expr; }`
+- [`builtins.hashFile`](./language/builtins.md#builtins-hashFile)` t expr`
 - `builtins.scopedImport x drv`
 
-Building during evaluation can be disabled by setting [`allow-import-from-derivation`](../command-ref/conf-file.md#conf-allow-import-from-derivation) to `false`.
+Realising store objects during evaluation can be disabled by setting [`allow-import-from-derivation`](../command-ref/conf-file.md#conf-allow-import-from-derivation) to `false`.
 
 ## Example
 

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -58,7 +58,7 @@ The following diagram shows how evaluation is interrupted by a build, if the val
 
 ```
 +----------------------+             +------------------------+
-| Nix language         |             | Nix store              |
+| Nix evaluator        |             | Nix store              |
 |  .----------------.  |             |                        |
 |  | Nix expression |  |             |                        |
 |  '----------------'  |             |                        |

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -9,6 +9,7 @@ In this case, when that store object is needed, evaluation will be paused, the s
 
 This has performance implications:
 Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
+Usually, if store objects are not already present, realisation is orders of magnitude slower than evaluation.
 
 Passing an expression `expr` that evaluates to a store path to any built-in function which reads from the filesystem constitutes Import From Derivation:
 
@@ -23,6 +24,7 @@ Passing an expression `expr` that evaluates to a store path to any built-in func
 - `builtins.scopedImport x drv`
 
 Realising store objects during evaluation can be disabled by setting [`allow-import-from-derivation`](../command-ref/conf-file.md#conf-allow-import-from-derivation) to `false`.
+Without IFD it is ensured that evaluation is complete and Nix can produce a build plan before starting any realisation.
 
 ## Example
 

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -10,7 +10,7 @@ In this case, when that store object is needed, evaluation will be paused, the s
 This has performance implications:
 Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
 
-Passing an expression `expr` which evaluates to a store path to any built-in function that reads from the filesystem constitutes Import From Derivation:
+Passing a store path to any built-in function that reads from the filesystem constitutes Import From Derivation:
 
 - [`import`](./builtins.md#builtins-import)` expr`
 - [`builtins.readFile`](./builtins.md#builtins-readFile)` expr`

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -10,7 +10,7 @@ In this case, when that store object is needed, evaluation will be paused, the s
 This has performance implications:
 Since evaluation is sequential, each required store object that is not already in the store will also be realised sequentially.
 
-Passing a store path to any built-in function that reads from the filesystem constitutes Import From Derivation:
+Passing an expression `expr` that evaluates to a store path to any built-in function which reads from the filesystem constitutes Import From Derivation:
 
 - [`import`](./builtins.md#builtins-import)` expr`
 - [`builtins.readFile`](./builtins.md#builtins-readFile)` expr`

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -33,7 +33,7 @@ In the following Nix expression, the inner derivation `drv` produces a file cont
 let
   drv = derivation {
     name = "hello";
-    builder = /bin/sh;
+    builder = "/bin/sh";
     args = [ "-c" ''echo \"hello\" > $out'' ];
     system = builtins.currentSystem;
   };

--- a/doc/manual/src/language/import-from-derivation.md
+++ b/doc/manual/src/language/import-from-derivation.md
@@ -54,7 +54,7 @@ building '/nix/store/348q1cal6sdgfxs8zqi9v8llrsn4kqkq-hello.drv'...
 "hello world"
 ```
 
-The contents of the derivation's [output path](@docroot@/glossary.md#gloss-output-path) have to be [realised] before they can be read with [`readFile`](./builtins.md#builtins-readFile).
+The contents of the derivation's output have to be [realised] before they can be read with [`readFile`](./builtins.md#builtins-readFile).
 Only then evaluation can continue to produce the final result.
 
 ## Illustration

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -47,9 +47,12 @@ struct EvalSettings : Config
     Setting<bool> enableImportFromDerivation{
         this, true, "allow-import-from-derivation",
         R"(
-          By default, Nix allows [Import From Derivation](@docroot@/language/import-from-derivation.md).
+          By default, Nix allows [Import from Derivation](@docroot@/language/import-from-derivation.md).
+
           With this option set to `false`, Nix will throw an error when evaluating an expression that uses this feature,
-          ensuring that evaluation will not require any builds to take place.
+          even when the required store object is readily available.
+          This ensures that evaluation will not require any builds to take place,
+          regardless of the state of the store.
         )"};
 
     Setting<Strings> allowedUris{this, {}, "allowed-uris",

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -47,11 +47,9 @@ struct EvalSettings : Config
     Setting<bool> enableImportFromDerivation{
         this, true, "allow-import-from-derivation",
         R"(
-          By default, Nix allows you to `import` from a derivation, allowing
-          building at evaluation time. With this option set to false, Nix will
-          throw an error when evaluating an expression that uses this feature,
-          allowing users to ensure their evaluation will not require any
-          builds to take place.
+          By default, Nix allows [Import From Derivation](@docroot@/language/import-from-derivation.md).
+          With this option set to `false`, Nix will throw an error when evaluating an expression that uses this feature,
+          ensuring that evaluation will not require any builds to take place.
         )"};
 
     Setting<Strings> allowedUris{this, {}, "allowed-uris",


### PR DESCRIPTION
The term "Import From Derivation" is historic and does not represent the concept well.

This change does not address the adequacy of term, and only explains the concept. Reviewers: Please assess the correctness and completeness of the description and how easy it is to understand.

Renaming can be done in a follow-up PR.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

Related: https://github.com/NixOS/nix/issues/8450 (but won't fix here)