### PR TITLE
Don't use GC_STRNDUP

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -69,15 +69,11 @@ static char * dupString(const char * s)
 // empty string.
 static const char * makeImmutableStringWithLen(const char * s, size_t size)
 {
-    char * t;
     if (size == 0)
         return "";
-#if HAVE_BOEHMGC
-    t = GC_STRNDUP(s, size);
-#else
-    t = strndup(s, size);
-#endif
-    if (!t) throw std::bad_alloc();
+    auto t = allocString(size + 1);
+    memcpy(t, s, size);
+    t[size] = 0;
     return t;
 }
 


### PR DESCRIPTION
It calls `strlen()` on the input (rather than simply copying at most `size` bytes), which can fail if the input is not zero-terminated and is inefficient in any case.

Fixes #7347.