### PR TITLE
cleanup eval.hh/eval.cc

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -67,20 +67,17 @@ static char * dupString(const char * s)
 
 // When there's no need to write to the string, we can optimize away empty
 // string allocations.
-// This function handles makeImmutableStringWithLen(null, 0) by returning the
-// empty string.
-static const char * makeImmutableStringWithLen(const char * s, size_t size)
+// This function handles makeImmutableString(std::string_view()) by returning
+// the empty string.
+static const char * makeImmutableString(std::string_view s)
 {
+    const size_t size = s.size();
     if (size == 0)
         return "";
     auto t = allocString(size + 1);
-    memcpy(t, s, size);
-    t[size] = 0;
+    memcpy(t, s.data(), size);
+    t[size] = '\0';
     return t;
-}
-
-static inline const char * makeImmutableString(std::string_view s) {
-    return makeImmutableStringWithLen(s.data(), s.size());
 }
 
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -60,7 +60,6 @@ void copyContext(const Value & v, PathSet & context);
 typedef std::map<Path, StorePath> SrcToStore;
 
 
-std::ostream & printValue(const EvalState & state, std::ostream & str, const Value & v);
 std::string printValue(const EvalState & state, const Value & v);
 std::ostream & operator << (std::ostream & os, const ValueType t);
 


### PR DESCRIPTION
- Remove unused function `makeImmutableStringWithLen` because its interface is not self explanatory and this could have been one of the reasons of  #7347 .
- Remove another undefined function.