### PR TITLE
repl: print a newline on ctrl-D

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -270,7 +270,7 @@ void NixRepl::mainLoop()
             // ctrl-D should exit the debugger.
             state->debugStop = false;
             state->debugQuit = true;
-            std::cout << std::endl;
+            logger->cout("");
             break;
         }
         try {

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -270,6 +270,7 @@ void NixRepl::mainLoop()
             // ctrl-D should exit the debugger.
             state->debugStop = false;
             state->debugQuit = true;
+            std::cout << std::endl;
             break;
         }
         try {


### PR DESCRIPTION
It's annoying to get the shell prompt on the same line as the `nix-repl>` prompt when exiting the REPL.