### PR TITLE
Add optional `date` argument to `builtins.fetchGit`

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -373,6 +373,11 @@ static RegisterPrimOp primop_fetchGit({
           true, it's possible to load a `rev` from *any* `ref` (by default only
           `rev`s from the specified `ref` are supported).
 
+        - date\
+          A `git` date specification which can specify an absolute date (e.g.
+          `2000-01-01`) or a date relative to the specified reference (e.g.
+          `1 week ago`)
+
       Here are some examples of how to use `fetchGit`.
 
         - To fetch a private repository over SSH:

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -236,6 +236,13 @@ std::optional<std::string> Input::getRef() const
     return {};
 }
 
+std::optional<std::string> Input::getDate() const
+{
+    if (auto s = maybeGetStrAttr(attrs, "date"))
+        return *s;
+    return {};
+}
+
 std::optional<Hash> Input::getRev() const
 {
     std::optional<Hash> hash = {};

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -93,6 +93,7 @@ public:
     std::string getType() const;
     std::optional<Hash> getNarHash() const;
     std::optional<std::string> getRef() const;
+    std::optional<std::string> getDate() const;
     std::optional<Hash> getRev() const;
     std::optional<uint64_t> getRevCount() const;
     std::optional<time_t> getLastModified() const;

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -229,6 +229,23 @@ rev_tag2=$(git -C $repo rev-parse refs/tags/tag2)
 [[ $rev_tag2_nix = $rev_tag2 ]]
 unset _NIX_FORCE_HTTP
 
+# The date argument works for both local repos and "remote" repos, returning the
+# first commit preceding the specified commit
+timestamp="$(date '+%s')"
+sleep 1
+git -C $repo commit -m 'Bla6' --allow-empty
+
+rev4_date=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; date = \"$timestamp\"; }).rev")
+[[ $rev4 = $rev4_date ]]
+export _NIX_FORCE_HTTP=1
+rev4_date=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; date = \"$timestamp\"; }).rev")
+[[ $rev4 = $rev4_date ]]
+unset _NIX_FORCE_HTTP
+
+# A date prior to the first commit returns the first commit instead of failing
+rev1_date=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; date = \"1 year ago\"; }).rev")
+[[ $rev1 = $rev1_date ]]
+
 # should fail if there is no repo
 rm -rf $repo/.git
 (! nix eval --impure --raw --expr "(builtins.fetchGit \"file://$repo\").outPath")


### PR DESCRIPTION
This allows users to specify an absolute or relative date (basically, anything that git accepts as a date specification) when fetching a repository.

The motivation for this change is to enable support for incremental builds for Haskell packages for this Nixpkgs branch:

https://github.com/MercuryTechnologies/nixpkgs/tree/gabriella/incremental

… inspired by this blog post:

https://harry.garrood.me/blog/easy-incremental-haskell-ci-builds-with-ghc-9.4/

Keep in mind that this new feature can power incremental builds for other package managers, too.  There is not much that is Haskell-specific about this feature.

The basic idea is that instead of Nix doing a full build for a package, we split every build into two builds:

- A full build at an older point in time

  e.g. a daily or weekly time boundary

- An incremental build relative to the last full build

  This incremental build reuses the build products left over from the most recent full build.

In order to do this, though, we need a way to "snap" a package's `git` source input to an earlier point in time (e.g. a daily boundary or weekly boundary).  This would allow multiple incremental builds to share the same full rebuild if they snap to the same time boundary.

The two main approaches I considered were:

- Approach 1 (this PR)

  Patch Nix to add a `date` argument to `builtins.fetchGit`

- Approach 2

  - Patch `nix-prefetch-git` to support a new `--date` option

  - Disable the sandbox

  - Run `nix-prefetch-git` at evaluation time using import-from-derivation to fetch and rehash the repository at an older point in time

Approach 1 seemed the more desirable of the two.