### PR TITLE
nix store make-content-addressed: Fix JSON construction

### DIFF
--- a/src/nix/make-content-addressed.cc
+++ b/src/nix/make-content-addressed.cc
@@ -43,7 +43,7 @@ struct CmdMakeContentAddressed : virtual CopyCommand, virtual StorePathsCommand,
                 assert(i != remappings.end());
                 jsonRewrites[srcStore->printStorePath(path)] = srcStore->printStorePath(i->second);
             }
-            std::cout << json::object({"rewrites", jsonRewrites}).dump();
+            std::cout << nlohmann::json{"rewrites", jsonRewrites}.dump();
         } else {
             for (auto & path : storePaths) {
                 auto i = remappings.find(path);


### PR DESCRIPTION
Fixes

```
error: [json.exception.type_error.301] cannot create object from initializer list
```

in `tests/fetchClosure.sh`.