### PR TITLE
doc: listToAttrs: document repeated keys

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2420,8 +2420,12 @@ static RegisterPrimOp primop_listToAttrs({
       Construct a set from a list specifying the names and values of each
       attribute. Each element of the list should be a set consisting of a
       string-valued attribute `name` specifying the name of the attribute,
-      and an attribute `value` specifying its value. In case of duplicate
-      occurrences of the same name, the first takes precedence. Example:
+      and an attribute `value` specifying its value.
+
+      In case of duplicate occurrences of the same name, the first
+      takes precedence.
+
+      Example:
 
       ```nix
       builtins.listToAttrs

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2420,9 +2420,8 @@ static RegisterPrimOp primop_listToAttrs({
       Construct a set from a list specifying the names and values of each
       attribute. Each element of the list should be a set consisting of a
       string-valued attribute `name` specifying the name of the attribute,
-      and an attribute `value` specifying its value.
-      In case of duplicate occurrences of the same name, the first
-      takes precedence.  Example:
+      and an attribute `value` specifying its value. In case of duplicate
+      occurrences of the same name, the first takes precedence. Example:
 
       ```nix
       builtins.listToAttrs

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2420,12 +2420,15 @@ static RegisterPrimOp primop_listToAttrs({
       Construct a set from a list specifying the names and values of each
       attribute. Each element of the list should be a set consisting of a
       string-valued attribute `name` specifying the name of the attribute,
-      and an attribute `value` specifying its value. Example:
+      and an attribute `value` specifying its value.
+      In case of duplicate occurrences of the same name, the first
+      takes precedence.  Example:
 
       ```nix
       builtins.listToAttrs
         [ { name = "foo"; value = 123; }
           { name = "bar"; value = 456; }
+          { name = "bar"; value = 420; }
         ]
       ```
 


### PR DESCRIPTION
Previously I had thought this was implemented as the first example below ( I was wrong ):
```
# WRONG
listToAttrs = attrs:
  builtins.foldl' ( acc: key: acc // { ${key} = attrs.${key}; } ) {}
                  ( builtins.attrNames attrs );
# RIGHT
listToAttrs = attrs:
  builtins.foldl' ( acc: key: { ${key} = attrs.${key}; } // acc ) {}
                  ( builtins.attrNames attrs );
```
I was browsing the `primops.cc` sources and bumped into an inline comment that mentioned that it was actually the opposite behavior: `listToAttrs` preserves the "first instance" of a key.

This change adds a note to the docstring, and extends the existing example to make the behavior clear to users.