### PR TITLE
allow setting cgroup memory limits via both nix.conf and pre-build hooks

### DIFF
--- a/src/libstore/build-result.hh
+++ b/src/libstore/build-result.hh
@@ -80,6 +80,7 @@ struct BuildResult
 
     /* User and system CPU time the build took. */
     std::optional<std::chrono::microseconds> cpuUser, cpuSystem;
+    std::optional<uint64_t> memoryHigh;
 
     bool success()
     {

--- a/src/libstore/cgroup.cc
+++ b/src/libstore/cgroup.cc
@@ -113,6 +113,11 @@ static CgroupStats destroyCgroup(const Path & cgroup, bool returnStats)
             }
         }
 
+        auto memoryhighPath = cgroup + "/memory.high";
+        if (pathExists(memoryhighPath)) {
+          stats.memoryHigh = string2Int<uint64_t>(trim(readFile(memoryhighPath)));
+        }
+        debug("memory events %s", readFile(cgroup + "/memory.events"));
     }
 
     if (rmdir(cgroup.c_str()) == -1)

--- a/src/libstore/cgroup.hh
+++ b/src/libstore/cgroup.hh
@@ -14,6 +14,7 @@ std::map<std::string, std::string> getCgroups(const Path & cgroupFile);
 struct CgroupStats
 {
     std::optional<std::chrono::microseconds> cpuUser, cpuSystem;
+    std::optional<uint64_t> memoryHigh;
 };
 
 /* Destroy the cgroup denoted by 'path'. The postcondition is that

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -313,6 +313,22 @@ public:
           `uid-range` system feature.
         )"
     };
+
+    Setting<uint64_t> memoryHigh{
+        this, 0, "memory-high",
+        R"(
+          sets the cgroup memory.high limit, causing the build to throttle if exceeded
+          depends on use-cgroups=true
+        )"
+    };
+
+    Setting<uint64_t> memoryMax{
+        this, 0, "memory-max",
+        R"(
+          sets the cgroup memory.max limit, causing the build to be killed if exceeded
+          depends on use-cgroups=true
+        )"
+    };
     #endif
 
     Setting<bool> impersonateLinux26{this, false, "impersonate-linux-26",

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -34,6 +34,7 @@ nlohmann::json builtPathsWithResultToJSON(const std::vector<BuiltPathWithResult>
                     j["cpuUser"] = ((double) b.result->cpuUser->count()) / 1000000;
                 if (b.result->cpuSystem)
                     j["cpuSystem"] = ((double) b.result->cpuSystem->count()) / 1000000;
+                if (b.result->memoryHigh) j["memoryHigh"] = *b.result->memoryHigh;
             }
             res.push_back(j);
         }, b.path.raw());


### PR DESCRIPTION
allows setting resource limits with `--option use-cgroups true --option memory-max $((1024*1024*1024*5))`
allows a pre-build hook to set limits:
```bash
#!/bin/sh

if [[ -d $NIX_CGROUP ]]; then
  echo $((1024*1024*1024*1)) > $NIX_CGROUP/memory.max
fi
```
such a pre-build hook could fork out a daemon, that watches `memory.events` and dynamically raises `memory.high` while co-operating with a resource manager

note, currently requires that nix-daemon be ran with an extra dir in its cgroup path, such as `/system.slice/nix-daemon.service/actual-daemon`