### PR TITLE
feat: add pre-http-request-hooks config entry and handle it

### DIFF
--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -26,6 +26,35 @@ struct FileTransferSettings : Config
         )",
         {"binary-caches-parallel-connections"}};
 
+    Setting<StringMap> preHTTPRequestHooks{this, {}, "pre-http-request-hooks",
+        R"(
+          Optional. A whitespace-separated list of tuples (`host=<path to a program>`) where 
+          the program can set extra URL-specific HTTP headers. This is used for URLs
+          that can't be accessed publically.
+
+          The hook is passed wth the resource URL and the verb (`upload` or `download`).
+          It can then add https headers to the HTTP request by send them to stdout. 
+          
+          When using the nix-daemon, the daemon executes the hook as `root`.
+          If the nix-daemon is not involved, the hook runs as the user
+          executing the nix-build.
+
+          Example:
+              `#!/usr/bin/env bash
+
+              source /my/lib.sh
+
+              url=$1
+              verb=$2
+
+              host=$(parse_host ${url})
+              token=$(get_cached_CF_token_for ${url} ${verb})
+
+              echo Cookie: CF_Authorization=${token}; Domain=${host}; Secure; HttpOnly
+              echo Origin: ${host}
+              `.
+          )"};
+
     Setting<unsigned long> connectTimeout{
         this, 0, "connect-timeout",
         R"(


### PR DESCRIPTION
## Motivation 

Currently, the model of how resources are being pulled/pushed via HTTP is not supposed to use short-living tokens for private endpoints. Only a `netrc` file with basic access auth credentials is supported. At the company, I am working for we would like to have this access model extended in order to make use of short-living tokens, issues per URL, or even more, one-off disposable tokens per request to make the secure posture stronger.

The problem with that approach is that it's file-based, ie. a physical file needs to be stored on the machine and it serves for the basic access auth (`Authorization: Basic <credentials>`) so it's pretty limited and the last but not least, it is hard to implement rotation of such files on developer's machine.

## In this PR

This PR introduces another global option in `nix.conf` that allows defining tuples of host and a path to the program to execute, in order to obtain additional HTTP headers for a particular URL and action, that is being requested by the Nix process. 

The hooks are defined as a map with a hook per host, for example:

```
pre-http-request-hooks = nix.private.big-corp.com=/nix/store/g47h1ll8vmc4ip5lm8lmnhibhbxbn7j9-pre-http-request-hook
```

Where the `/nix/store/g47h1ll8vmc4ip5lm8lmnhibhbxbn7j9-pre-http-request-hook` is a bash executable:
```shell
#!/nix/store/y3hpcrb8gnx6b6pb5b6s247rs13i1rgv-bash-5.1-p16/bin/bash

set -euo pipefail

url="${1}"  # the current URL that the hook is being executed for
verb="${2}" # the verb, can be `upload` or `download`

token="$(/nix/store/g47h1ll8vmc4ip5lm8lmnhibhbxbn7j9-cf-creds-helper "${url} "${verb}")"

echo "Cf-Access-Token: ${token}"
echo "Origin: nix.private.big-corp.com"
```

These hooks will be executed for each HTTP request that matches the `host`. By that, it's become possible to have short-living access tokens per each URL,action tuple which is a more secure access model and it allows managing short-living tokens with ease.

This PR is a proof of concept that does work for us. I am happy to discuss possible options and implement something that can address the original issue.