### PR TITLE
Change "while evaluating <fun>" to "while *calling*" in trace

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1646,7 +1646,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                 auto dts = debugRepl
                     ? makeDebugTraceStacker(
                         *this, *lambda.body, env2, positions[lambda.pos],
-                        "while evaluating %s",
+                        "while calling %s",
                         lambda.name
                         ? concatStrings("'", symbols[lambda.name], "'")
                         : "anonymous lambda")
@@ -1655,7 +1655,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                 lambda.body->eval(*this, env2, vCur);
             } catch (Error & e) {
                 if (loggerSettings.showTrace.get()) {
-                    addErrorTrace(e, lambda.pos, "while evaluating %s",
+                    addErrorTrace(e, lambda.pos, "while calling %s",
                         (lambda.name
                             ? concatStrings("'", symbols[lambda.name], "'")
                             : "anonymous lambda"));


### PR DESCRIPTION
The old way was not correct.

Here is an example:
```
 $ nix-instantiate --eval --expr 'let x = a: throw "asdf"; in x 1' --show-trace
error: asdf

       … while evaluating 'x'

       at «string»:1:9:

            1| let x = a: throw "asdf"; in x 1
             |         ^

       … from call site

       at «string»:1:29:

            1| let x = a: throw "asdf"; in x 1
             |                             ^
```
and yet also:
```
 $ nix-instantiate --eval --expr 'let x = a: throw "asdf"; in x' --show-trace
<LAMBDA>
```

Here is the thing: in both cases we are evaluating `x`!

Nix is a higher-order languages, and functions are a sort of value. When we write `x = a: ...`, `a: ...` is the expression that `x` is being defined to be, and that is already a value. Therefore, we should *never* get an trace that says "while evaluating `x`", because evaluating `a: ...` is *trival* and nothing happens during it!

What is actually happening here is we are applying `x` and evaluating its *body* with arguments substituted for parameters. I think the simplest way to say is just "while *calling* `x`", and so that is what I changed it to.