### PR TITLE
Rename `unsafeGetAttrPos` to `tryGetAttrPos`

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -52,3 +52,6 @@
 
 * `nix build --json` now prints some statistics about top-level
   derivations, such as CPU statistics when cgroups are enabled.
+
+* `builtins.unsafeGetAttrPos` was renamed to `builtins.tryGetAttrPos`
+  ([#5557](https://github.com/NixOS/nix/issues/5557)).

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2276,7 +2276,7 @@ static RegisterPrimOp primop_getAttr({
 });
 
 /* Return position information of the specified attribute. */
-static void prim_unsafeGetAttrPos(EvalState & state, const PosIdx pos, Value * * args, Value & v)
+static void prim_tryGetAttrPos(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
     auto attr = state.forceStringNoCtx(*args[0], pos);
     state.forceAttrs(*args[1], pos);
@@ -2287,10 +2287,17 @@ static void prim_unsafeGetAttrPos(EvalState & state, const PosIdx pos, Value * *
         state.mkPos(v, i->pos);
 }
 
+static RegisterPrimOp primop_tryGetAttrPos(RegisterPrimOp::Info {
+    .name = "__tryGetAttrPos",
+    .arity = 2,
+    .fun = prim_tryGetAttrPos,
+});
+
+/* TODO deprecate eventually */
 static RegisterPrimOp primop_unsafeGetAttrPos(RegisterPrimOp::Info {
     .name = "__unsafeGetAttrPos",
     .arity = 2,
-    .fun = prim_unsafeGetAttrPos,
+    .fun = prim_tryGetAttrPos,
 });
 
 /* Dynamic version of the `?' operator. */

--- a/src/libexpr/tests/primops.cc
+++ b/src/libexpr/tests/primops.cc
@@ -147,9 +147,9 @@ namespace nix {
         ASSERT_THROW(eval("builtins.getAttr \"y\" { }"), TypeError);
     }
 
-    TEST_F(PrimOpTest, unsafeGetAttrPos) {
+    TEST_F(PrimOpTest, tryGetAttrPos) {
         // The `y` attribute is at position
-        const char* expr = "builtins.unsafeGetAttrPos \"y\" { y = \"x\"; }";
+        const char* expr = "builtins.tryGetAttrPos \"y\" { y = \"x\"; }";
         auto v = eval(expr);
         ASSERT_THAT(v, IsAttrsOfSize(3));
 
@@ -164,7 +164,7 @@ namespace nix {
 
         auto column = v.attrs->find(createSymbol("column"));
         ASSERT_NE(column, nullptr);
-        ASSERT_THAT(*column->value, IsIntEq(33));
+        ASSERT_THAT(*column->value, IsIntEq(30));
     }
 
     TEST_F(PrimOpTest, hasAttr) {

--- a/tests/lang/eval-okay-getattrpos-functionargs.nix
+++ b/tests/lang/eval-okay-getattrpos-functionargs.nix
@@ -1,4 +1,4 @@
 let
   fun = { foo }: {};
-  pos = builtins.unsafeGetAttrPos "foo" (builtins.functionArgs fun);
+  pos = builtins.tryGetAttrPos "foo" (builtins.functionArgs fun);
 in { inherit (pos) column line; file = baseNameOf pos.file; }

--- a/tests/lang/eval-okay-getattrpos-undefined.nix
+++ b/tests/lang/eval-okay-getattrpos-undefined.nix
@@ -1,1 +1,1 @@
-builtins.unsafeGetAttrPos "abort" builtins
+builtins.tryGetAttrPos "abort" builtins

--- a/tests/lang/eval-okay-getattrpos.nix
+++ b/tests/lang/eval-okay-getattrpos.nix
@@ -2,5 +2,5 @@ let
   as = {
     foo = "bar";
   };
-  pos = builtins.unsafeGetAttrPos "foo" as;
+  pos = builtins.tryGetAttrPos "foo" as;
 in { inherit (pos) column line; file = baseNameOf pos.file; }


### PR DESCRIPTION
"Unsafe" looks scarier than it should, when the only unsafe thing about this is that it violates referential transparency (but so does `./.`).

Fixes https://github.com/NixOS/nix/issues/5557, see also https://github.com/NixOS/nix/issues/5897#issuecomment-1010125472

cc @lilyball @roberth