### PR TITLE
getMaxCPU: fix cgroup path

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -730,7 +730,7 @@ unsigned int getMaxCPU()
         auto cgroupFS = getCgroupFS();
         if (!cgroupFS) return 0;
 
-        auto cgroups = getCgroups("/proc/self/cgroupp");
+        auto cgroups = getCgroups("/proc/self/cgroup");
         auto cgroup = cgroups[""];
         if (cgroup == "") return 0;
 


### PR DESCRIPTION
Given this typo I am not sure if it has been tested. Introduced in https://github.com/NixOS/nix/pull/7394