### PR TITLE
disallow selecting shell prompt in code samples

### DIFF
--- a/doc/manual/custom.css
+++ b/doc/manual/custom.css
@@ -5,3 +5,7 @@ h1:not(:first-of-type) {
 h2 {
     margin-top: 1em;
 }
+
+.hljs-meta {
+    user-select: none;
+}


### PR DESCRIPTION
this is a quick half-fix for command line examples, as discussed
discussed in [1].

[1]: https://github.com/NixOS/nix/pull/7389

examples which look like this

    $ foo bar
    baz

are confusing for Unix shell beginners, because it's hard to discern
what is supposed to be entered into the actual command line when the
convention of prefixing `$` is not known, as barely any real-world shell
looks that way any more.

this change prevents selecting the prompt part with the mouse in the
HTML representation of the Nix manual.

it does not prevent selecting the output part of the shell example.
it also does not address that the copy button provided by mdBook takes
the entire sample, including the prompts, into the clipboard.