### PR TITLE
tests: don't refer to TMPDIR

### DIFF
--- a/tests/check.nix
+++ b/tests/check.nix
@@ -44,7 +44,7 @@ with import ./config.nix;
   };
 
   hashmismatch = import <nix/fetchurl.nix> {
-    url = "file://" + builtins.getEnv "TMPDIR" + "/dummy";
+    url = "file://" + builtins.getEnv "TEST_ROOT" + "/dummy";
     sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
   };
 

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -91,13 +91,13 @@ nix-build check.nix -A fetchurl --no-out-link --check
 nix-build check.nix -A fetchurl --no-out-link --repair
 [[ $(cat $path) != foo ]]
 
-echo 'Hello World' > $TMPDIR/dummy
+echo 'Hello World' > $TEST_ROOT/dummy
 nix-build check.nix -A hashmismatch --no-out-link || status=$?
 [ "$status" = "102" ]
 
-echo -n > $TMPDIR/dummy
+echo -n > $TEST_ROOT/dummy
 nix-build check.nix -A hashmismatch --no-out-link
-echo 'Hello World' > $TMPDIR/dummy
+echo 'Hello World' > $TEST_ROOT/dummy
 
 nix-build check.nix -A hashmismatch --no-out-link --check || status=$?
 [ "$status" = "102" ]


### PR DESCRIPTION
`TMPDIR` is unset when using nix-direnv to enter the development shell automatically, because nix-direnv [ignores](https://github.com/nix-community/nix-direnv/pull/31#discussion_r1039588647) the `TMPDIR` variable set by `print-dev-env`. This causes `make tests/check.sh.test` to fail.

Set it globally so we don't have to worry about it.