### PR TITLE
Remove GPG-signing of releases

### DIFF
--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -115,10 +115,6 @@ sub downloadFile {
 
     write_file("$tmpFile.sha256", $sha256_actual);
 
-    if (! -e "$tmpFile.asc") {
-        system("gpg2 --detach-sign --armor $tmpFile") == 0 or die "unable to sign $tmpFile\n";
-    }
-
     return $sha256_expected;
 }
 
@@ -194,7 +190,7 @@ for my $fn (glob "$tmpDir/*") {
         my $configuration = ();
         $configuration->{content_type} = "application/octet-stream";
 
-        if ($fn =~ /.sha256|.asc|install/) {
+        if ($fn =~ /.sha256|install/) {
             # Text files
             $configuration->{content_type} = "text/plain";
         }


### PR DESCRIPTION
This makes it easier for others to make releases, and probably few people care about GPG signatures anyway.