### PR TITLE
let installer blurb to to community page

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -99,11 +99,7 @@ is_os_darwin() {
 contact_us() {
     echo "You can open an issue at https://github.com/nixos/nix/issues"
     echo ""
-    echo "Or feel free to contact the team:"
-    echo " - Matrix: #nix:nixos.org"
-    echo " - IRC: in #nixos on irc.libera.chat"
-    echo " - twitter: @nixos_org"
-    echo " - forum: https://discourse.nixos.org"
+    echo "Or get in touch with the community: https://nixos.org/community"
 }
 get_help() {
     echo "We'd love to help if you need it."


### PR DESCRIPTION
being too specific about it requires more maintenance (or otherwise
produced more confusion and churn), since these points of contact change
over time.