### PR TITLE
Configurable substituter disable time

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -515,6 +515,10 @@ public:
         this, true, "enforce-determinism",
         "Whether to fail if repeated builds produce different output. See `repeat`."};
 
+    Setting<unsigned int> substituterDisableTime{
+        this, 60, "substituter-disable-time",
+            "How long to disable substituters on fail"};
+
     Setting<Strings> trustedPublicKeys{
         this,
         {"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="},

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -83,7 +83,7 @@ protected:
     {
         auto state(_state.lock());
         if (state->enabled && settings.tryFallback) {
-            int t = 60;
+            int t = settings.substituterDisableTime;
             printError("disabling binary cache '%s' for %s seconds", getUri(), t);
             state->enabled = false;
             state->disabledUntil = std::chrono::steady_clock::now() + std::chrono::seconds(t);


### PR DESCRIPTION
Allow to change how long substituters are disabled for based on a nix.conf config option
Still need to add a better explanation to globals.hh