### PR TITLE
Document ability to disable the global registry

### DIFF
--- a/src/libfetchers/fetch-settings.hh
+++ b/src/libfetchers/fetch-settings.hh
@@ -71,7 +71,10 @@ struct FetchSettings : public Config
         "Whether to warn about dirty Git/Mercurial trees."};
 
     Setting<std::string> flakeRegistry{this, "https://channels.nixos.org/flake-registry.json", "flake-registry",
-        "Path or URI of the global flake registry."};
+        R"(
+          Path or URI of the global flake registry.
+          When the path does not exist, disables the global flake registry.
+        )"};
 
     Setting<bool> useRegistries{this, true, "use-registries",
         "Whether to use flake registries to resolve flake references."};

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -184,6 +184,11 @@ enableFeatures() {
     sed -i 's/experimental-features .*/& '"$features"'/' "$NIX_CONF_DIR"/nix.conf
 }
 
+setGlobalRegistry() {
+    local path_or_url="$1"
+    sed -i 's!flake-registry = .*!flake-registry = '"$path_or_url"'!' "$NIX_CONF_DIR"/nix.conf
+}
+
 set -x
 
 if [[ -n "${NIX_DAEMON_PACKAGE:-}" ]]; then

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -70,8 +70,10 @@ nix registry add --registry $registry flake3 git+file://$flake3Dir
 nix registry add --registry $registry flake4 flake3
 nix registry add --registry $registry nixpkgs flake1
 
-# Test 'nix flake list'.
+# Test 'nix registry list'.
 [[ $(nix registry list | wc -l) == 5 ]]
+nix registry list | grep -q '^global'
+nix registry list | grep -q -v '^user'
 
 # Test 'nix flake metadata'.
 nix flake metadata flake1
@@ -334,6 +336,22 @@ nix registry pin flake1 flake3
 [[ $(nix registry list | wc -l) == 6 ]]
 nix registry remove flake1
 [[ $(nix registry list | wc -l) == 5 ]]
+
+# Test 'nix registry list' without global registry.
+# set empty global registry with user flakes only
+setGlobalRegistry "$TEST_ROOT/not-a-global-registry"
+nix registry add user-flake1 flake3
+nix registry add user-flake2 flake3
+[[ $(nix registry list | wc -l) == 2 ]]
+nix registry list | grep -q -v '^global' # no global flakes
+nix registry list | grep -q    '^user'   # has user flakes
+# reset global registry
+setGlobalRegistry "$registry"
+nix registry remove user-flake1
+nix registry remove user-flake2
+[[ $(nix registry list | wc -l) == 5 ]]
+nix registry list | grep -q    '^global' # has global flakes
+nix registry list | grep -q -v '^user'   # no user flakes
 
 # Test 'nix flake clone'.
 rm -rf $TEST_ROOT/flake1-v2


### PR DESCRIPTION
Closes #4874 
Replaces #5420 

While updating my old PR #5420, I realized it is already possible to disable the global flake registry, due to this line:
https://github.com/NixOS/nix/blob/145e9a81230604baae706371cd19861ba9da3766/src/libfetchers/registry.cc#L19-L20
Which is called in `getGlobalRegistry`, when `path` starts with a `/`:
https://github.com/NixOS/nix/blob/145e9a81230604baae706371cd19861ba9da3766/src/libfetchers/registry.cc#L164

So instead of adding ability to set it to `""` (which I can still add if you think it's a better UX), I figured I'd add some tests and document it in the description of `flake-registry`.