### PR TITLE
Build Nix with the GC disabled in hydra

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -420,6 +420,8 @@
         buildCross = nixpkgs.lib.genAttrs crossSystems (crossSystem:
           nixpkgs.lib.genAttrs ["x86_64-linux"] (system: self.packages.${system}."nix-${crossSystem}"));
 
+        buildNoGc = nixpkgs.lib.genAttrs systems (system: self.packages.${system}.nix.overrideAttrs (a: { configureFlags = (a.configureFlags or []) ++ ["--enable-gc=no"];}));
+
         # Perl bindings for various platforms.
         perlBindings = nixpkgs.lib.genAttrs systems (system: self.packages.${system}.nix.perl-bindings);
 


### PR DESCRIPTION
Make sure that it still compiles as it's easy to accidentally break one of the `#if` guarded clauses
