### PR TITLE
Allow disabling build users by unsetting `build-users-group`

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -281,7 +281,10 @@ public:
           `NIX_REMOTE` is empty, the uid under which the Nix daemon runs if
           `NIX_REMOTE` is `daemon`). Obviously, this should not be used in
           multi-user settings with untrusted users.
-        )"};
+
+          Defaults to `nixbld` when running as root, *empty* otherwise.
+        )",
+        {}, false};
 
     Setting<bool> autoAllocateUids{this, false, "auto-allocate-uids",
         R"(

--- a/src/libstore/lock.cc
+++ b/src/libstore/lock.cc
@@ -185,7 +185,7 @@ std::unique_ptr<UserLock> acquireUserLock(uid_t nrIds, bool useChroot)
 bool useBuildUsers()
 {
     #if __linux__
-    static bool b = (settings.buildUsersGroup != "" || settings.startId.get() != 0) && getuid() == 0;
+    static bool b = (settings.buildUsersGroup != "" || settings.autoAllocateUids) && getuid() == 0;
     return b;
     #elif __APPLE__
     static bool b = settings.buildUsersGroup != "" && getuid() == 0;


### PR DESCRIPTION
Since https://github.com/NixOS/nix/pull/3600, unsetting `build-users-group` (without `auto-allocate-uids` enabled) gives the following error:

```
src/libstore/lock.cc:25: static std::unique_ptr<nix::UserLock> nix::SimpleUserLock::acquire(): Assertion `settings.buildUsersGroup != ""' failed.
```

Fix the logic in `useBuildUsers` and document the [default value](https://github.com/NixOS/nix/blob/9fa8b02c415808f072e2365b76101d9f839d8698/src/libstore/globals.cc#L43) for `build-users-group`.