### PR TITLE
flake/nixpkgs: nixos-22.05 -> nixos-22.11

### DIFF
--- a/boehmgc-coroutine-sp-fallback.diff
+++ b/boehmgc-coroutine-sp-fallback.diff
@@ -31,19 +31,19 @@ index 3dbaa3fb..36a1d1f7 100644
              GC_push_all_stack(altstack_lo, altstack_hi);
            }
 diff --git a/pthread_stop_world.c b/pthread_stop_world.c
-index 4b2c429..1fb4c52 100644
+index b5d71e62..aed7b0bf 100644
 --- a/pthread_stop_world.c
 +++ b/pthread_stop_world.c
-@@ -673,6 +673,8 @@ GC_INNER void GC_push_all_stacks(void)
-     struct GC_traced_stack_sect_s *traced_stack_sect;
-     pthread_t self = pthread_self();
-     word total_size = 0;
+@@ -768,6 +768,8 @@ STATIC void GC_restart_handler(int sig)
+ /* world is stopped.  Should not fail if it isn't.                      */
+ GC_INNER void GC_push_all_stacks(void)
+ {
 +    size_t stack_limit;
 +    pthread_attr_t pattr;
- 
-     if (!EXPECT(GC_thr_initialized, TRUE))
-       GC_thr_init();
-@@ -722,6 +724,31 @@ GC_INNER void GC_push_all_stacks(void)
+     GC_bool found_me = FALSE;
+     size_t nthreads = 0;
+     int i;
+@@ -851,6 +853,31 @@ GC_INNER void GC_push_all_stacks(void)
            hi = p->altstack + p->altstack_size;
            /* FIXME: Need to scan the normal stack too, but how ? */
            /* FIXME: Assume stack grows down */

--- a/flake.lock
+++ b/flake.lock
@@ -18,16 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1670987525,
+        "narHash": "sha256-v2dpmrpow8fxVLxIsSsecsAqtl7DbM13gLkgPFlxcKc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "9fd324caea445753392bf75afa34cb63068fe50f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
+        "ref": "nixos-22.11-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "The purely functional package manager";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05-small";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11-small";
   inputs.nixpkgs-regression.url = "github:NixOS/nixpkgs/215d4d0fd80ca5163643b03a33fde804a29cc1e2";
   inputs.lowdown-src = { url = "github:kristapsdz/lowdown"; flake = false; };
 
@@ -108,7 +108,7 @@
           ++ lib.optionals stdenv.hostPlatform.isLinux [(buildPackages.util-linuxMinimal or buildPackages.utillinuxMinimal)];
 
         buildDeps =
-          [ (curl.override { patchNetrcRegression = true; })
+          [ curl
             bzip2 xz brotli editline
             openssl sqlite
             libarchive
@@ -364,7 +364,7 @@
 
               buildInputs =
                 [ nix
-                  (curl.override { patchNetrcRegression = true; })
+                  curl
                   bzip2
                   xz
                   pkgs.perl

--- a/tests/fetchGitSubmodules.sh
+++ b/tests/fetchGitSubmodules.sh
@@ -32,7 +32,7 @@ addGitContent $subRepo
 initGitRepo $rootRepo
 
 git -C $rootRepo submodule init
-git -C $rootRepo submodule add $subRepo sub
+GIT_PROTOCOL_FROM_USER=1 git -C $rootRepo submodule add $subRepo sub
 git -C $rootRepo add sub
 git -C $rootRepo commit -m "Add submodule"
 


### PR DESCRIPTION
The boehm-gc patch changes are merged in from <https://github.com/NixOS/nixpkgs/commit/190a5fe56d08fe1474d3975f6c07dbede3d0a6d3>.

Details on the `tests/fetchGitSubmodules.sh` change: <https://vielmetti.typepad.com/logbook/2022/10/git-security-fixes-lead-to-fatal-transport-file-not-allowed-error-in-ci-systems-cve-2022-39253.html>