### PR TITLE
Fix a crash in DerivedPath::Built::toJSON() with impure derivations

### DIFF
--- a/src/libstore/derived-path.cc
+++ b/src/libstore/derived-path.cc
@@ -20,11 +20,12 @@ nlohmann::json DerivedPath::Built::toJSON(ref<Store> store) const {
     // Fallback for the input-addressed derivation case: We expect to always be
     // able to print the output paths, so let’s do it
     const auto knownOutputs = store->queryPartialDerivationOutputMap(drvPath);
-    for (const auto& output : outputs) {
+    for (const auto & output : outputs) {
         auto knownOutput = get(knownOutputs, output);
-        res["outputs"][output] = (knownOutput && *knownOutput)
-          ? store->printStorePath(**knownOutput)
-          : nullptr;
+        if (knownOutput && *knownOutput)
+            res["outputs"][output] = store->printStorePath(**knownOutput);
+        else
+            res["outputs"][output] = nullptr;
     }
     return res;
 }

--- a/tests/impure-derivations.sh
+++ b/tests/impure-derivations.sh
@@ -12,6 +12,7 @@ clearStore
 # Basic test of impure derivations: building one a second time should not use the previous result.
 printf 0 > $TEST_ROOT/counter
 
+nix build --dry-run --json --file ./impure-derivations.nix impure.all
 json=$(nix build -L --no-link --json --file ./impure-derivations.nix impure.all)
 path1=$(echo $json | jq -r .[].outputs.out)
 path1_stuff=$(echo $json | jq -r .[].outputs.stuff)


### PR DESCRIPTION
The use of `nullptr` here didn't result in a null JSON value, but in a `nullptr` being cast to a string, which aborts.