### PR TITLE
configure.ac: don't clobber CFLAGS=/CXXFLAGS= and allow users to pass…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,8 +41,6 @@ AC_DEFINE_UNQUOTED(SYSTEM, ["$system"], [platform identifier ('cpu-os')])
 test "$localstatedir" = '${prefix}/var' && localstatedir=/nix/var
 
 
-CFLAGS=
-CXXFLAGS=
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_CPP


### PR DESCRIPTION
… in custom flags

Reported-by: 0n-s
Bug: https://github.com/trofi/nix-guix-gentoo/issues/26