### PR TITLE
reword definition of "reference"

### DIFF
--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -115,7 +115,7 @@
     then be built.
 
   - [reference]{#gloss-reference}\
-    A [store object] `O` is said to have a *reference* to a store object `P` if the [store path] of `P` appears in the contents of `O`.
+    A [store object] `O` is said to have a *reference* to a store object `P` if a [store path] to `P` appears in the contents of `O`.
     The *references* of a store object `O` are the set of store objects to which `O` has a reference.
 
     Store objects can refer to both other store objects and themselves.

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -138,7 +138,7 @@
     files could be missing. The command `nix-store -qR` prints out
     closures of store paths.
 
-    As an example, if the store object at path `P` contains a [reference]
+    As an example, if the [store object] at path `P` contains a [reference]
     to store object `Q`, then `Q` is in the closure of `P`. Further, if `Q`
     references `R` then `R` is also in the closure of `P`.
 

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -115,14 +115,12 @@
     then be built.
 
   - [reference]{#gloss-reference}\
-    A store path `P` is said to have a reference to a store path `Q` if
-    the store object at `P` contains the path `Q` somewhere. The
-    *references* of a store path are the set of store paths to which it
-    has a reference.
+    A [store path] `P` is said to have a *reference* to a store path `Q` if the string `Q` appears in the [store object] at `P`.
+    The *references* of a store path `P` are the set of store paths to which `P` has a reference.
 
-    A derivation can reference other derivations and sources (but not
-    output paths), whereas an output path only references other output
-    paths.
+    A [derivation] can reference other derivations and source files, but not [output path]s, whereas an output path can only reference other output paths.
+
+    [reference]: #gloss-reference
 
   - [reachable]{#gloss-reachable}\
     A store path `Q` is reachable from another store path `P` if `Q`

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -140,7 +140,7 @@
     closures of store paths.
 
     As an example, if the store object at path `P` contains a [reference]
-    to path `Q`, then `Q` is in the closure of `P`. Further, if `Q`
+    to store object `Q`, then `Q` is in the closure of `P`. Further, if `Q`
     references `R` then `R` is also in the closure of `P`.
 
   - [output path]{#gloss-output-path}\

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -118,9 +118,9 @@
     A [store object] `O` is said to have a *reference* to a store object `P` if the [store path] of `P` appears in the contents of `O`.
     The *references* of a store object `O` are the set of store objects to which `O` has a reference.
 
-    Source files have no references.
-    A [store derivation] can only reference source files and other store derivations, including itself.
-    In contrast, a store object that was produced from a [derivation] can only reference other "derived" store objects.
+    Store objects can refer to both other store objects and themselves.
+    References from a store object to itself are called *self-references*.
+    References other than a self-reference must not form a cycle.
 
     [reference]: #gloss-reference
 

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -116,7 +116,6 @@
 
   - [reference]{#gloss-reference}\
     A [store object] `O` is said to have a *reference* to a store object `P` if a [store path] to `P` appears in the contents of `O`.
-    The *references* of a store object `O` are the set of store objects to which `O` has a reference.
 
     Store objects can refer to both other store objects and themselves.
     References from a store object to itself are called *self-references*.

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -115,10 +115,12 @@
     then be built.
 
   - [reference]{#gloss-reference}\
-    A [store path] `P` is said to have a *reference* to a store path `Q` if the string `Q` appears in the [store object] at `P`.
-    The *references* of a store path `P` are the set of store paths to which `P` has a reference.
+    A [store object] `O` is said to have a *reference* to a store object `P` if the [store path] of `P` appears in the contents of `O`.
+    The *references* of a store object `O` are the set of store objects to which `O` has a reference.
 
-    A [derivation] can reference other derivations and source files, but not [output path]s, whereas an output path can only reference other output paths.
+    Source files have no references.
+    A [store derivation] can only reference source files and other store derivations, including itself.
+    In contrast, a store object that was produced from a [derivation] can only reference other "derived" store objects.
 
     [reference]: #gloss-reference
 
@@ -137,7 +139,7 @@
     files could be missing. The command `nix-store -qR` prints out
     closures of store paths.
 
-    As an example, if the store object at path `P` contains a reference
+    As an example, if the store object at path `P` contains a [reference]
     to path `Q`, then `Q` is in the closure of `P`. Further, if `Q`
     references `R` then `R` is also in the closure of `P`.
 

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -139,7 +139,7 @@
     closures of store paths.
 
     As an example, if the [store object] at path `P` contains a [reference]
-    to store object `Q`, then `Q` is in the closure of `P`. Further, if `Q`
+    to a store object at path `Q`, then `Q` is in the closure of `P`. Further, if `Q`
     references `R` then `R` is also in the closure of `P`.
 
   - [output path]{#gloss-output-path}\


### PR DESCRIPTION
this corrects the definition to make a clearer distinction between store paths and store objects. it's not the paths that have references to each other, but the store objects.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨