### PR TITLE
Fix CanonPath::dirOf() returning a string_view of a temporary

### DIFF
--- a/src/libutil/canon-path.hh
+++ b/src/libutil/canon-path.hh
@@ -110,7 +110,7 @@ public:
     std::optional<std::string_view> dirOf() const
     {
         if (isRoot()) return std::nullopt;
-        return path.substr(0, path.rfind('/'));
+        return ((std::string_view) path).substr(0, path.rfind('/'));
     }
 
     std::optional<std::string_view> baseName() const


### PR DESCRIPTION
https://hydra.nixos.org/build/202837872