### PR TITLE
tests: switch to non-deprecated nix.settings.* module parameters

### DIFF
--- a/tests/containers.nix
+++ b/tests/containers.nix
@@ -20,7 +20,7 @@ makeTest ({
               (import ./systemd-nspawn.nix { inherit nixpkgs; }).toplevel
             ];
           virtualisation.memorySize = 4096;
-          nix.binaryCaches = lib.mkForce [ ];
+          nix.settings.substituters = lib.mkForce [ ];
           nix.extraOptions =
             ''
               extra-experimental-features = nix-command auto-allocate-uids cgroups

--- a/tests/github-flakes.nix
+++ b/tests/github-flakes.nix
@@ -149,7 +149,7 @@ makeTest (
           virtualisation.diskSize = 2048;
           virtualisation.additionalPaths = [ pkgs.hello pkgs.fuse ];
           virtualisation.memorySize = 4096;
-          nix.binaryCaches = lib.mkForce [ ];
+          nix.settings.substituters = lib.mkForce [ ];
           nix.extraOptions = "experimental-features = nix-command flakes";
           networking.hosts.${(builtins.head nodes.github.config.networking.interfaces.eth1.ipv4.addresses).address} =
             [ "channels.nixos.org" "api.github.com" "github.com" ];

--- a/tests/nix-copy-closure.nix
+++ b/tests/nix-copy-closure.nix
@@ -15,7 +15,7 @@ makeTest (let pkgA = pkgs.cowsay; pkgB = pkgs.wget; pkgC = pkgs.hello; pkgD = pk
         { config, lib, pkgs, ... }:
         { virtualisation.writableStore = true;
           virtualisation.additionalPaths = [ pkgA pkgD.drvPath ];
-          nix.binaryCaches = lib.mkForce [ ];
+          nix.settings.substituters = lib.mkForce [ ];
         };
 
       server =

--- a/tests/nss-preload.nix
+++ b/tests/nss-preload.nix
@@ -98,9 +98,9 @@ rec {
         { address = "192.168.0.10"; prefixLength = 24; }
       ];
 
-      nix.sandboxPaths = lib.mkForce [];
-      nix.binaryCaches = lib.mkForce [];
-      nix.useSandbox = lib.mkForce true;
+      nix.settings.extra-sandbox-paths = lib.mkForce [];
+      nix.settings.substituters = lib.mkForce [];
+      nix.settings.sandbox = lib.mkForce true;
     };
   };
 

--- a/tests/remote-builds.nix
+++ b/tests/remote-builds.nix
@@ -16,7 +16,7 @@ let
     { config, pkgs, ... }:
     { services.openssh.enable = true;
       virtualisation.writableStore = true;
-      nix.useSandbox = true;
+      nix.settings.sandbox = true;
     };
 
   # Trivial Nix expression to build remotely.
@@ -44,7 +44,7 @@ in
 
       client =
         { config, lib, pkgs, ... }:
-        { nix.maxJobs = 0; # force remote building
+        { nix.settings.max-jobs = 0; # force remote building
           nix.distributedBuilds = true;
           nix.buildMachines =
             [ { hostName = "builder1";
@@ -62,7 +62,7 @@ in
             ];
           virtualisation.writableStore = true;
           virtualisation.additionalPaths = [ config.system.build.extraUtils ];
-          nix.binaryCaches = lib.mkForce [ ];
+          nix.settings.substituters = lib.mkForce [ ];
           programs.ssh.extraConfig = "ConnectTimeout 30";
         };
     };

--- a/tests/setuid.nix
+++ b/tests/setuid.nix
@@ -13,7 +13,7 @@ makeTest {
   nodes.machine =
     { config, lib, pkgs, ... }:
     { virtualisation.writableStore = true;
-      nix.binaryCaches = lib.mkForce [ ];
+      nix.settings.substituters = lib.mkForce [ ];
       nix.nixPath = [ "nixpkgs=${lib.cleanSource pkgs.path}" ];
       virtualisation.additionalPaths = [ pkgs.stdenv pkgs.pkgsi686Linux.stdenv ];
     };

--- a/tests/sourcehut-flakes.nix
+++ b/tests/sourcehut-flakes.nix
@@ -108,7 +108,7 @@ makeTest (
             virtualisation.diskSize = 2048;
             virtualisation.additionalPaths = [ pkgs.hello pkgs.fuse ];
             virtualisation.memorySize = 4096;
-            nix.binaryCaches = lib.mkForce [ ];
+            nix.settings.substituters = lib.mkForce [ ];
             nix.extraOptions = ''
               experimental-features = nix-command flakes
               flake-registry = https://git.sr.ht/~NixOS/flake-registry/blob/master/flake-registry.json


### PR DESCRIPTION
Without the change checks issue the fllowing warning:

    $ nix flake check
    trace: warning: The option `nix.useSandbox' defined in `makeTest parameters' has been renamed to `nix.settings.sandbox'.
    trace: warning: The option `nix.useSandbox' defined in `makeTest parameters' has been renamed to `nix.settings.sandbox'.
    trace: warning: The option `nix.maxJobs' defined in `makeTest parameters' has been renamed to `nix.settings.max-jobs'.
    ...