### PR TITLE
`hacking.md`: Add library hacking instructions and add `make check`

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -68,6 +68,7 @@ To build Nix itself in this shell:
 To install it in `$(pwd)/outputs` and test it:
 
 ```console
+[nix-shell]$ make check
 [nix-shell]$ make install
 [nix-shell]$ make installcheck -j $NIX_BUILD_CORES
 [nix-shell]$ ./outputs/out/bin/nix --version

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -75,7 +75,7 @@ To install it in `$(pwd)/outputs` and test it:
 nix (Nix) 3.0
 ```
 
-To iterate on for example `libexpr`, prioritizing the most relevant checks:
+For example, to run specific checks first when developing `libexpr`:
 
 ```console
 [nix-shell]$ J="-j $NIX_BUILD_CORES"

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -74,6 +74,13 @@ To install it in `$(pwd)/outputs` and test it:
 nix (Nix) 3.0
 ```
 
+To iterate on for example `libexpr`, prioritizing the most relevant checks:
+
+```console
+[nix-shell]$ J="-j $NIX_BUILD_CORES"
+[nix-shell]$ make $J libexpr-tests_RUN && make $J && make check && make install && make installcheck $J
+```
+
 If you have a flakes-enabled Nix you can replace:
 
 ```console


### PR DESCRIPTION
`make check` wasn't part of my workflow yet, relying on `installcheck` alone like we used to.
This will help future contributors, and probably me too.