### PR TITLE
remove incorrect reference to `NIX_PATH` documentation

### DIFF
--- a/doc/manual/src/command-ref/opt-common.md
+++ b/doc/manual/src/command-ref/opt-common.md
@@ -205,7 +205,7 @@ Most Nix commands accept the following command-line options:
   - <span id="opt-I">[`-I`](#opt-I)</span> *path*\
     Add an entry to the [Nix expression search path](@docroot@/command-ref/conf-file.md#conf-nix-path).
     This option may be given multiple times.
-    Paths added through `-I` take precedence over [`NIX_PATH`](./env-common.md#env-NIX_PATH).
+    Paths added through `-I` take precedence over [`NIX_PATH`](@docroot@/command-ref/env-common.md#env-NIX_PATH).
 
   - <span id="opt-option">[`--option`](#opt-option)</span> *name* *value*\
     Set the Nix configuration option *name* to *value*. This overrides

--- a/doc/manual/src/command-ref/opt-common.md
+++ b/doc/manual/src/command-ref/opt-common.md
@@ -203,7 +203,7 @@ Most Nix commands accept the following command-line options:
     instead.
 
   - <span id="opt-I">[`-I`](#opt-I)</span> *path*\
-    Add a path to the Nix expression search path.
+    Add an entry to the [Nix expression search path](@docroot@/command-ref/conf-file.md#conf-nix-path).
     This option may be given multiple times.
     Paths added through `-I` take precedence over [`NIX_PATH`](./env-common.md#env-NIX_PATH).
 

--- a/doc/manual/src/command-ref/opt-common.md
+++ b/doc/manual/src/command-ref/opt-common.md
@@ -203,10 +203,9 @@ Most Nix commands accept the following command-line options:
     instead.
 
   - <span id="opt-I">[`-I`](#opt-I)</span> *path*\
-    Add a path to the Nix expression search path. This option may be
-    given multiple times. See the `NIX_PATH` environment variable for
-    information on the semantics of the Nix search path. Paths added
-    through `-I` take precedence over `NIX_PATH`.
+    Add a path to the Nix expression search path.
+    This option may be given multiple times.
+    Paths added through `-I` take precedence over [`NIX_PATH`](./env-common.md#env-NIX_PATH).
 
   - <span id="opt-option">[`--option`](#opt-option)</span> *name* *value*\
     Set the Nix configuration option *name* to *value*. This overrides


### PR DESCRIPTION
the semantics are not explained in the referenced section any more.
they have been moved to the documentation for common options in the new CLI in https://github.com/NixOS/nix/pull/7421.

unfortunately I was under the [incorrect impression](https://github.com/NixOS/nix/pull/7421#pullrequestreview-1209302202) that there was only one source for the documentation of common options, so in fact the change made discoverability of that piece of documentation strictly worse.

while I know that de facto the classic command line is not maintained any more, I still suggest to fix that properly. who knows how long it will be around...

This work is sponsored by [Antithesis](https://antithesis.com/) ✨