### PR TITLE
Add Store::isTrustedClient()

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -39,3 +39,9 @@
 
   * `man nix-store-<operation>` and `man nix-env-<operation>`
   * `nix-store --help --<operation>` and `nix-env --help --<operation>`.
+
+* Nix when used as a client now checks whether the store (the server) trusts the client.
+  (The store always had to check whether it trusts the client, but now the client is informed of the store's decision.)
+  This is useful for scripting interactions with (non-legacy-ssh) remote Nix stores.
+
+  `nix store ping` and `nix doctor` now display this information.

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1415,6 +1415,9 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
 
     virtual void addBuildLog(const StorePath & path, std::string_view log) override
     { unsupported("addBuildLog"); }
+
+    std::optional<TrustedFlag> isTrustedClient() override
+    { return NotTrusted; }
 };
 
 
@@ -1467,7 +1470,7 @@ void LocalDerivationGoal::startDaemon()
                 FdSink to(remote.get());
                 try {
                     daemon::processConnection(store, from, to,
-                        daemon::NotTrusted, daemon::Recursive);
+                        NotTrusted, daemon::Recursive);
                     debug("terminated daemon connection");
                 } catch (SysError &) {
                     ignoreException();

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1032,6 +1032,15 @@ void processConnection(
     if (GET_PROTOCOL_MINOR(clientVersion) >= 33)
         to << nixVersion;
 
+    if (GET_PROTOCOL_MINOR(clientVersion) >= 35) {
+        // We and the underlying store both need to trust the client for
+        // it to be trusted.
+        auto temp = trusted
+            ? store->isTrustedClient()
+            : std::optional { NotTrusted };
+        worker_proto::write(*store, to, temp);
+    }
+
     /* Send startup error messages to the client. */
     tunnelLogger->startWork();
 

--- a/src/libstore/daemon.hh
+++ b/src/libstore/daemon.hh
@@ -6,7 +6,6 @@
 
 namespace nix::daemon {
 
-enum TrustedFlag : bool { NotTrusted = false, Trusted = true };
 enum RecursiveFlag : bool { NotRecursive = false, Recursive = true };
 
 void processConnection(

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -39,6 +39,14 @@ struct DummyStore : public virtual DummyStoreConfig, public virtual Store
         callback(nullptr);
     }
 
+    /**
+     * The dummy store is incapable of *not* trusting! :)
+     */
+    virtual std::optional<TrustedFlag> isTrustedClient() override
+    {
+        return Trusted;
+    }
+
     static std::set<std::string> uriSchemes() {
         return {"dummy"};
     }

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -194,6 +194,18 @@ protected:
             }});
     }
 
+    /**
+     * This isn't actually necessary read only. We support "upsert" now, so we
+     * have a notion of authentication via HTTP POST/PUT.
+     *
+     * For now, we conservatively say we don't know.
+     *
+     * \todo try to expose our HTTP authentication status.
+     */
+    std::optional<TrustedFlag> isTrustedClient() override
+    {
+        return std::nullopt;
+    }
 };
 
 static RegisterStoreImplementation<HttpBinaryCacheStore, HttpBinaryCacheStoreConfig> regHttpBinaryCacheStore;

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -389,6 +389,15 @@ public:
         return conn->remoteVersion;
     }
 
+    /**
+     * The legacy ssh protocol doesn't support checking for trusted-user.
+     * Try using ssh-ng:// instead if you want to know.
+     */
+    std::optional<TrustedFlag> isTrustedClient() override
+    {
+        return std::nullopt;
+    }
+
     void queryRealisationUncached(const DrvOutput &,
         Callback<std::shared_ptr<const Realisation>> callback) noexcept override
     // TODO: Implement

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -95,6 +95,10 @@ protected:
         return paths;
     }
 
+    std::optional<TrustedFlag> isTrustedClient() override
+    {
+        return Trusted;
+    }
 };
 
 void LocalBinaryCacheStore::init()

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1685,6 +1685,11 @@ unsigned int LocalStore::getProtocol()
     return PROTOCOL_VERSION;
 }
 
+std::optional<TrustedFlag> LocalStore::isTrustedClient()
+{
+    return Trusted;
+}
+
 
 #if defined(FS_IOC_SETFLAGS) && defined(FS_IOC_GETFLAGS) && defined(FS_IMMUTABLE_FL)
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -204,6 +204,8 @@ public:
 
     unsigned int getProtocol() override;
 
+    std::optional<TrustedFlag> isTrustedClient() override;
+
     void vacuumDB();
 
     void repairPath(const StorePath & path) override;

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -144,6 +144,8 @@ public:
 
     unsigned int getProtocol() override;
 
+    std::optional<TrustedFlag> isTrustedClient() override;
+
     void flushBadConnections();
 
     struct Connection
@@ -151,6 +153,7 @@ public:
         FdSink to;
         FdSource from;
         unsigned int daemonVersion;
+        std::optional<TrustedFlag> remoteTrustsUs;
         std::optional<std::string> daemonNixVersion;
         std::chrono::time_point<std::chrono::steady_clock> startTime;
 

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -509,6 +509,16 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStoreConfig, public virtual
         return paths;
     }
 
+    /**
+     * For now, we conservatively say we don't know.
+     *
+     * \todo try to expose our S3 authentication status.
+     */
+    std::optional<TrustedFlag> isTrustedClient() override
+    {
+        return std::nullopt;
+    }
+
     static std::set<std::string> uriSchemes() { return {"s3"}; }
 
 };

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -89,6 +89,7 @@ const uint32_t exportMagic = 0x4558494e;
 
 
 enum BuildMode { bmNormal, bmRepair, bmCheck };
+enum TrustedFlag : bool { NotTrusted = false, Trusted = true };
 
 struct BuildResult;
 
@@ -814,6 +815,17 @@ public:
     {
         return 0;
     };
+
+    /**
+     * @return/ whether store trusts *us*.
+     *
+     * `std::nullopt` means we do not know.
+     *
+     * @note This is the opposite of the StoreConfig::isTrusted
+     * store setting. That is about whether *we* trust the store.
+     */
+    virtual std::optional<TrustedFlag> isTrustedClient() = 0;
+
 
     virtual Path toRealPath(const Path & storePath)
     {

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -10,7 +10,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 34)
+#define PROTOCOL_VERSION (1 << 8 | 35)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -103,6 +103,7 @@ MAKE_WORKER_PROTO(, DerivedPath);
 MAKE_WORKER_PROTO(, Realisation);
 MAKE_WORKER_PROTO(, DrvOutput);
 MAKE_WORKER_PROTO(, BuildResult);
+MAKE_WORKER_PROTO(, std::optional<TrustedFlag>);
 
 MAKE_WORKER_PROTO(template<typename T>, std::vector<T>);
 MAKE_WORKER_PROTO(template<typename T>, std::set<T>);

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -33,6 +33,10 @@ bool checkFail(const std::string & msg) {
     return false;
 }
 
+void checkInfo(const std::string & msg) {
+    notice(ANSI_BLUE "[INFO] " ANSI_NORMAL + msg);
+}
+
 }
 
 struct CmdDoctor : StoreCommand
@@ -63,6 +67,7 @@ struct CmdDoctor : StoreCommand
             success &= checkProfileRoots(store);
         }
         success &= checkStoreProtocol(store->getProtocol());
+        checkTrustedUser(store);
 
         if (!success)
             throw Exit(2);
@@ -137,6 +142,14 @@ struct CmdDoctor : StoreCommand
         }
 
         return checkPass("Client protocol matches store protocol.");
+    }
+
+    void checkTrustedUser(ref<Store> store)
+    {
+        std::string_view trusted = store->isTrustedClient()
+            ? "trusted"
+            : "not trusted";
+        checkInfo(fmt("You are %s by store uri: %s", trusted, store->getUri()));
     }
 };
 

--- a/src/nix/ping-store.cc
+++ b/src/nix/ping-store.cc
@@ -28,15 +28,20 @@ struct CmdPingStore : StoreCommand, MixJSON
             store->connect();
             if (auto version = store->getVersion())
                 notice("Version: %s", *version);
+            if (auto trusted = store->isTrustedClient())
+                notice("Trusted: %s", *trusted);
         } else {
             nlohmann::json res;
             Finally printRes([&]() {
                 logger->cout("%s", res);
             });
+
             res["url"] = store->getUri();
             store->connect();
             if (auto version = store->getVersion())
                 res["version"] = *version;
+            if (auto trusted = store->isTrustedClient())
+                res["trusted"] = *trusted;
         }
     }
 };

--- a/tests/legacy-ssh-store.sh
+++ b/tests/legacy-ssh-store.sh
@@ -1,0 +1,4 @@
+source common.sh
+
+# Check that store ping trusted doesn't yet work with ssh://
+nix --store ssh://localhost?remote-store=$TEST_ROOT/other-store store ping --json | jq -e 'has("trusted") | not'

--- a/tests/local-store.sh
+++ b/tests/local-store.sh
@@ -17,3 +17,6 @@ PATH2=$(nix path-info --store "$PWD/x" $CORRECT_PATH)
 
 PATH3=$(nix path-info --store "local?root=$PWD/x" $CORRECT_PATH)
 [ $CORRECT_PATH == $PATH3 ]
+
+# Ensure store ping trusted works with local store
+nix --store ./x store ping --json | jq -e '.trusted'

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -17,6 +17,7 @@ nix_tests = \
   ca/gc.sh \
   gc.sh \
   remote-store.sh \
+  legacy-ssh-store.sh \
   lang.sh \
   experimental-features.sh \
   fetchMercurial.sh \

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -5,7 +5,18 @@ clearStore
 # Ensure "fake ssh" remote store works just as legacy fake ssh would.
 nix --store ssh-ng://localhost?remote-store=$TEST_ROOT/other-store doctor
 
+# Ensure that store ping trusted works with ssh-ng://
+nix --store ssh-ng://localhost?remote-store=$TEST_ROOT/other-store store ping --json | jq -e '.trusted'
+
 startDaemon
+
+if isDaemonNewer "2.15pre0"; then
+    # Ensure that ping works trusted with new daemon
+    nix store ping --json | jq -e '.trusted'
+else
+    # And the the field is absent with the old daemon
+    nix store ping --json | jq -e 'has("trusted") | not'
+fi
 
 # Test import-from-derivation through the daemon.
 [[ $(nix eval --impure --raw --expr '


### PR DESCRIPTION
This PR extends the worker protocol in [`worker-protocol-hh`](https://github.com/NixOS/nix/blob/a4604f19284254ac98f19a13ff7c2216de7fe176/src/libstore/worker-protocol.hh) by adding a new operation (47) which permits a client to check if they are trusted. I have needed this for some scripts I'm trying to write which use Nix,  that need to check.

In addition, it also adds a new command `nix store check-trusted` which will make use of this addition. It will return exit code 0 if trusted, 1 if not trusted or 2 if an unexpected error occurs.

I have also added a new `checkInfo` function to [`doctor.cc`](https://github.com/NixOS/nix/blob/9a640afc1e63bed28926cb44fe85137fb7d2d2d1/src/nix/doctor.cc) which will print an inconsequential blue `[INFO]` telling the user whether they are trusted. This does not change the exit status of the `nix doctor` command.

![image](https://user-images.githubusercontent.com/26458780/209582096-0e011a22-d428-4dd5-836f-c455e6e070b3.png)

The following Bash function is an example of a fallback mechanism I've implemented in Bash but do not have the skills to implement in C++.

```bash
function isTrustedUser {
  function writeDummyBuildLog {
    {
      echo 0x6378696e 0x00000000; # WORKER_MAGIC_1
      echo 0x0a010000 0x00000000; # PROTOCOL_VERSION
      echo 0x2d000000 0x00000000; # wopAddBuildlog (45)
      echo 0x26000000 0x00000000; # Length of Store Path (38)
      echo -n "$(echo -n aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-a.drv | xxd -p -c0)00000000000000000000"; # Store Path
    } \
    | xxd -p -r \
    | socat - UNIX-CONNECT:/nix/var/nix/daemon-socket/socket \
    | tr -d '\0'
  }
  x=$(writeDummyBuildLog)
  if (grep -aq "error:" <<< "$x") && (grep -aq "not privileged" <<< "$x")
  then
    echo "You are not a trusted user"
    return 1
  elif (grep -aq "error:" <<< "$x")
    echo "An unknown error occurred whilst checking if you are a trusted user"
    return 2
  else
    :
    return 0
  fi
}
isTrustedUser
```

Thanks a lot to @roberth who introduced me to the C++ codebase and answering a lot of questions. And thanks to @tomberek + @pkharvey + @helicalbytes for helping me understand the daemon protocol.