### PR TITLE
Improve protocol major macro

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -114,7 +114,7 @@ struct TunnelLogger : public Logger
         if (!ex)
             to << STDERR_LAST;
         else {
-            if (GET_PROTOCOL_MINOR(clientVersion) >= 26) {
+            if (PROTOCOL_MINOR(clientVersion) >= 26) {
                 to << STDERR_ERROR << *ex;
             } else {
                 to << STDERR_ERROR << ex->what() << ex->status;
@@ -125,7 +125,7 @@ struct TunnelLogger : public Logger
     void startActivity(ActivityId act, Verbosity lvl, ActivityType type,
         const std::string & s, const Fields & fields, ActivityId parent) override
     {
-        if (GET_PROTOCOL_MINOR(clientVersion) < 20) {
+        if (PROTOCOL_MINOR(clientVersion) < 20) {
             if (!s.empty())
                 log(lvl, s + "...");
             return;
@@ -138,7 +138,7 @@ struct TunnelLogger : public Logger
 
     void stopActivity(ActivityId act) override
     {
-        if (GET_PROTOCOL_MINOR(clientVersion) < 20) return;
+        if (PROTOCOL_MINOR(clientVersion) < 20) return;
         StringSink buf;
         buf << STDERR_STOP_ACTIVITY << act;
         enqueueMsg(buf.s);
@@ -146,7 +146,7 @@ struct TunnelLogger : public Logger
 
     void result(ActivityId act, ResultType type, const Fields & fields) override
     {
-        if (GET_PROTOCOL_MINOR(clientVersion) < 20) return;
+        if (PROTOCOL_MINOR(clientVersion) < 20) return;
         StringSink buf;
         buf << STDERR_RESULT << act << type << fields;
         enqueueMsg(buf.s);
@@ -257,7 +257,7 @@ struct ClientSettings
 static std::vector<DerivedPath> readDerivedPaths(Store & store, unsigned int clientVersion, Source & from)
 {
     std::vector<DerivedPath> reqs;
-    if (GET_PROTOCOL_MINOR(clientVersion) >= 30) {
+    if (PROTOCOL_MINOR(clientVersion) >= 30) {
         reqs = worker_proto::read(store, from, Phantom<std::vector<DerivedPath>> {});
     } else {
         for (auto & s : readStrings<Strings>(from))
@@ -285,7 +285,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         auto paths = worker_proto::read(*store, from, Phantom<StorePathSet> {});
 
         SubstituteFlag substitute = NoSubstitute;
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 27) {
+        if (PROTOCOL_MINOR(clientVersion) >= 27) {
             substitute = readInt(from) ? Substitute : NoSubstitute;
         }
 
@@ -385,7 +385,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     }
 
     case wopAddToStore: {
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 25) {
+        if (PROTOCOL_MINOR(clientVersion) >= 25) {
             auto name = readString(from);
             auto camStr = readString(from);
             auto refs = worker_proto::read(*store, from, Phantom<StorePathSet> {});
@@ -414,7 +414,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
             }();
             logger->stopWork();
 
-            pathInfo->write(to, *store, GET_PROTOCOL_MINOR(clientVersion));
+            pathInfo->write(to, *store, PROTOCOL_MINOR(clientVersion));
         } else {
             HashType hashAlgo;
             std::string baseName;
@@ -520,7 +520,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     case wopBuildPaths: {
         auto drvs = readDerivedPaths(*store, clientVersion, from);
         BuildMode mode = bmNormal;
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 15) {
+        if (PROTOCOL_MINOR(clientVersion) >= 15) {
             mode = (BuildMode) readInt(from);
 
             /* Repairing is not atomic, so disallowed for "untrusted"
@@ -619,10 +619,10 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         auto res = store->buildDerivation(drvPath, drv, buildMode);
         logger->stopWork();
         to << res.status << res.errorMsg;
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 29) {
+        if (PROTOCOL_MINOR(clientVersion) >= 29) {
             to << res.timesBuilt << res.isNonDeterministic << res.startTime << res.stopTime;
         }
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 28) {
+        if (PROTOCOL_MINOR(clientVersion) >= 28) {
             worker_proto::write(*store, to, res.builtOutputs);
         }
         break;
@@ -726,7 +726,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         clientSettings.buildCores = readInt(from);
         clientSettings.useSubstitutes = readInt(from);
 
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 12) {
+        if (PROTOCOL_MINOR(clientVersion) >= 12) {
             unsigned int n = readInt(from);
             for (unsigned int i = 0; i < n; i++) {
                 auto name = readString(from);
@@ -768,7 +768,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     case wopQuerySubstitutablePathInfos: {
         SubstitutablePathInfos infos;
         StorePathCAMap pathsMap = {};
-        if (GET_PROTOCOL_MINOR(clientVersion) < 22) {
+        if (PROTOCOL_MINOR(clientVersion) < 22) {
             auto paths = worker_proto::read(*store, from, Phantom<StorePathSet> {});
             for (auto & path : paths)
                 pathsMap.emplace(path, std::nullopt);
@@ -802,15 +802,15 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         try {
             info = store->queryPathInfo(path);
         } catch (InvalidPath &) {
-            if (GET_PROTOCOL_MINOR(clientVersion) < 17) throw;
+            if (PROTOCOL_MINOR(clientVersion) < 17) throw;
         }
         logger->stopWork();
         if (info) {
-            if (GET_PROTOCOL_MINOR(clientVersion) >= 17)
+            if (PROTOCOL_MINOR(clientVersion) >= 17)
                 to << 1;
-            info->write(to, *store, GET_PROTOCOL_MINOR(clientVersion), false);
+            info->write(to, *store, PROTOCOL_MINOR(clientVersion), false);
         } else {
-            assert(GET_PROTOCOL_MINOR(clientVersion) >= 17);
+            assert(PROTOCOL_MINOR(clientVersion) >= 17);
             to << 0;
         }
         break;
@@ -873,7 +873,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         if (!trusted)
             info.ultimate = false;
 
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 23) {
+        if (PROTOCOL_MINOR(clientVersion) >= 23) {
             logger->startWork();
             {
                 FramedSource source(from);
@@ -886,7 +886,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         else {
             std::unique_ptr<Source> source;
             StringSink saved;
-            if (GET_PROTOCOL_MINOR(clientVersion) >= 21)
+            if (PROTOCOL_MINOR(clientVersion) >= 21)
                 source = std::make_unique<TunnelSource>(from, to);
             else {
                 TeeSource tee { from, saved };
@@ -923,7 +923,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
 
     case wopRegisterDrvOutput: {
         logger->startWork();
-        if (GET_PROTOCOL_MINOR(clientVersion) < 31) {
+        if (PROTOCOL_MINOR(clientVersion) < 31) {
             auto outputId = DrvOutput::parse(readString(from));
             auto outputPath = StorePath(readString(from));
             store->registerDrvOutput(Realisation{
@@ -941,7 +941,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         auto outputId = DrvOutput::parse(readString(from));
         auto info = store->queryRealisation(outputId);
         logger->stopWork();
-        if (GET_PROTOCOL_MINOR(clientVersion) < 31) {
+        if (PROTOCOL_MINOR(clientVersion) < 31) {
             std::set<StorePath> outPaths;
             if (info) outPaths.insert(info->outPath);
             worker_proto::write(*store, to, outPaths);
@@ -1008,15 +1008,15 @@ void processConnection(
         printMsgUsing(prevLogger, lvlDebug, "%d operations", opCount);
     });
 
-    if (GET_PROTOCOL_MINOR(clientVersion) >= 14 && readInt(from)) {
+    if (PROTOCOL_MINOR(clientVersion) >= 14 && readInt(from)) {
         // Obsolete CPU affinity.
         readInt(from);
     }
 
-    if (GET_PROTOCOL_MINOR(clientVersion) >= 11)
+    if (PROTOCOL_MINOR(clientVersion) >= 11)
         readInt(from); // obsolete reserveSpace
 
-    if (GET_PROTOCOL_MINOR(clientVersion) >= 33)
+    if (PROTOCOL_MINOR(clientVersion) >= 33)
         to << nixVersion;
 
     /* Send startup error messages to the client. */

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -98,7 +98,7 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
                     host, chomp(saved.s + msg));
             }
             conn->remoteVersion = readInt(conn->from);
-            if (GET_PROTOCOL_MAJOR(conn->remoteVersion) != 0x200)
+            if (PROTOCOL_MAJOR(conn->remoteVersion) != 2)
                 throw Error("unsupported 'nix-store --serve' protocol version on '%s'", host);
 
         } catch (EndOfFile & e) {
@@ -120,7 +120,7 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
             auto conn(connections->get());
 
             /* No longer support missing NAR hash */
-            assert(GET_PROTOCOL_MINOR(conn->remoteVersion) >= 4);
+            assert(PROTOCOL_MINOR(conn->remoteVersion) >= 4);
 
             debug("querying remote host '%s' for info on '%s'", host, printStorePath(path));
 
@@ -165,7 +165,7 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
 
         auto conn(connections->get());
 
-        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 5) {
+        if (PROTOCOL_MINOR(conn->remoteVersion) >= 5) {
 
             conn->to
                 << cmdAddToStoreNar
@@ -250,15 +250,15 @@ private:
         conn.to
             << settings.maxSilentTime
             << settings.buildTimeout;
-        if (GET_PROTOCOL_MINOR(conn.remoteVersion) >= 2)
+        if (PROTOCOL_MINOR(conn.remoteVersion) >= 2)
             conn.to
                 << settings.maxLogSize;
-        if (GET_PROTOCOL_MINOR(conn.remoteVersion) >= 3)
+        if (PROTOCOL_MINOR(conn.remoteVersion) >= 3)
             conn.to
                 << 0 // buildRepeat hasn't worked for ages anyway
                 << 0;
 
-        if (GET_PROTOCOL_MINOR(conn.remoteVersion) >= 7) {
+        if (PROTOCOL_MINOR(conn.remoteVersion) >= 7) {
             conn.to << ((int) settings.keepFailed);
         }
     }
@@ -283,9 +283,9 @@ public:
         status.status = (BuildResult::Status) readInt(conn->from);
         conn->from >> status.errorMsg;
 
-        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 3)
+        if (PROTOCOL_MINOR(conn->remoteVersion) >= 3)
             conn->from >> status.timesBuilt >> status.isNonDeterministic >> status.startTime >> status.stopTime;
-        if (GET_PROTOCOL_MINOR(conn->remoteVersion) >= 6) {
+        if (PROTOCOL_MINOR(conn->remoteVersion) >= 6) {
             status.builtOutputs = worker_proto::read(*this, conn->from, Phantom<DrvOutputs> {});
         }
         return status;

--- a/src/libstore/serve-protocol.hh
+++ b/src/libstore/serve-protocol.hh
@@ -6,6 +6,9 @@ namespace nix {
 #define SERVE_MAGIC_2 0x5452eecb
 
 #define SERVE_PROTOCOL_VERSION (2 << 8 | 7)
+#define PROTOCOL_MAJOR(x) (((x) & 0xff00) >> 8)
+#define PROTOCOL_MINOR(x) ((x) & 0x00ff)
+// Deprecated:
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -10,6 +10,9 @@ namespace nix {
 #define WORKER_MAGIC_2 0x6478696f
 
 #define PROTOCOL_VERSION (1 << 8 | 34)
+#define PROTOCOL_MAJOR(x) (((x) & 0xff00) >> 8)
+#define PROTOCOL_MINOR(x) ((x) & 0x00ff)
+// Deprecated:
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -805,9 +805,9 @@ static void opServe(Strings opFlags, Strings opArgs)
         settings.useSubstitutes = false;
         settings.maxSilentTime = readInt(in);
         settings.buildTimeout = readInt(in);
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 2)
+        if (PROTOCOL_MINOR(clientVersion) >= 2)
             settings.maxLogSize = readNum<unsigned long>(in);
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 3) {
+        if (PROTOCOL_MINOR(clientVersion) >= 3) {
             auto nrRepeats = readInt(in);
             if (nrRepeats != 0) {
                 throw Error("client requested repeating builds, but this is not currently implemented");
@@ -822,7 +822,7 @@ static void opServe(Strings opFlags, Strings opArgs)
 
             settings.runDiffHook = true;
         }
-        if (GET_PROTOCOL_MINOR(clientVersion) >= 7) {
+        if (PROTOCOL_MINOR(clientVersion) >= 7) {
             settings.keepFailed = (bool) readInt(in);
         }
     };
@@ -865,7 +865,7 @@ static void opServe(Strings opFlags, Strings opArgs)
                         // !!! Maybe we want compression?
                         out << info->narSize // downloadSize
                             << info->narSize;
-                        if (GET_PROTOCOL_MINOR(clientVersion) >= 4)
+                        if (PROTOCOL_MINOR(clientVersion) >= 4)
                             out << info->narHash.to_string(Base32, true)
                                 << renderContentAddress(info->ca)
                                 << info->sigs;
@@ -929,9 +929,9 @@ static void opServe(Strings opFlags, Strings opArgs)
 
                 out << status.status << status.errorMsg;
 
-                if (GET_PROTOCOL_MINOR(clientVersion) >= 3)
+                if (PROTOCOL_MINOR(clientVersion) >= 3)
                     out << status.timesBuilt << status.isNonDeterministic << status.startTime << status.stopTime;
-                if (GET_PROTOCOL_MINOR(clientVersion) >= 6) {
+                if (PROTOCOL_MINOR(clientVersion) >= 6) {
                     worker_proto::write(*store, out, status.builtOutputs);
                 }
 

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -16,8 +16,8 @@ namespace {
 std::string formatProtocol(unsigned int proto)
 {
     if (proto) {
-        auto major = GET_PROTOCOL_MAJOR(proto) >> 8;
-        auto minor = GET_PROTOCOL_MINOR(proto);
+        auto major = PROTOCOL_MAJOR(proto);
+        auto minor = PROTOCOL_MINOR(proto);
         return (format("%1%.%2%") % major % minor).str();
     }
     return "unknown";
@@ -114,7 +114,7 @@ struct CmdDoctor : StoreCommand
 
     bool checkStoreProtocol(unsigned int storeProto)
     {
-        unsigned int clientProto = GET_PROTOCOL_MAJOR(SERVE_PROTOCOL_VERSION) == GET_PROTOCOL_MAJOR(storeProto)
+        unsigned int clientProto = PROTOCOL_MAJOR(SERVE_PROTOCOL_VERSION) == PROTOCOL_MAJOR(storeProto)
             ? SERVE_PROTOCOL_VERSION
             : PROTOCOL_VERSION;
 


### PR DESCRIPTION
## Why


 - Prevent future surprises like https://github.com/NixOS/nix/pull/7515#discussion_r1057882208
 - Fix an exception message in `writeDerivedPaths`

## What

Most significant change: add `PROTOCOL_MAJOR`. All other changes follow from this. From the commit message:

`PROTOCOL_MAJOR` returns a simple major number, rather than the
number multiplied by 256. This is what one would reasonably
expect from `GET_PROTOCOL_MAJOR`, but we can't just change a
macro in a public header; hence the "rename".

