### PR TITLE
nix-store: implement --query --unsubstitutable

### DIFF
--- a/doc/manual/src/command-ref/nix-store.md
+++ b/doc/manual/src/command-ref/nix-store.md
@@ -289,7 +289,7 @@ error: cannot delete path `/nix/store/zq0h41l75vlb4z45kzgjjmsjxvcv1qk7-mesa-6.4'
   {`--outputs` | `--requisites` | `-R` | `--references` |
   `--referrers` | `--referrers-closure` | `--deriver` | `-d` |
   `--graph` | `--tree` | `--binding` *name* | `-b` *name* | `--hash` |
-  `--size` | `--roots`}
+  `--size` | `--roots` | `--unsubstitutable` | `-U`}
   [`--use-output`] [`-u`] [`--force-realise`] [`-f`]
   *paths…*
 
@@ -405,6 +405,10 @@ symlink.
     Prints the garbage collector roots that point, directly or
     indirectly, at the store paths *paths*.
 
+  - `--unsubstitutable`; `-U`\
+    Outputs a list of the store paths *paths* which are not available in
+    any configured substituters.
+
 ## Examples
 
 Print the closure (runtime dependencies) of the `svn` program in the
@@ -440,6 +444,16 @@ $ nix-store -q --tree $(nix-store -qd $(which svn))
 +---/nix/store/fmzxmpjx2lh849ph0l36snfj9zdibw67-bash-3.0.drv
 |   +---/nix/store/570hmhmx3v57605cqg9yfvvyh0nnb8k8-bash
 |   +---/nix/store/p3srsbd8dx44v2pg6nbnszab5mcwx03v-builder.sh
+...
+```
+
+Show unsubstitutable build & runtime dependencies:
+
+```console
+$ drv=$(nix-store -qd $(which svn))
+$ nix-store -qU $(nix-store -qR --include-outputs $drv)
+/nix/store/5mbglq5ldqld8sj57273aljwkfvj22mc-subversion-1.1.4
+/nix/store/9lz9yc6zgmc0vlqmn2ipcpkjlmbi51vv-glibc-2.3.4
 ...
 ```
 


### PR DESCRIPTION
Resolves #3946 by providing an efficient means of querying cache status of the passed paths.

For every path passed, it will be returned back on standard output only if it is not available in any of the configured substituters.

~~A threadpool is used to make this as quick as possible.~~

Included in the documentation is a sample command showing how users can now trivially capture any and all uncached build & runtime dependencies of a given derivation. This information is highly useful in CI environments, for example.

Only caveat is that we might hit the OS arg limit until #7437 is fixed.

#### TODO
- [x] implement `nix-store` query
- [ ] write tests

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes