### PR TITLE
Fix `nix why-depends --derivation`

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -931,10 +931,7 @@ std::vector<std::pair<std::shared_ptr<Installable>, BuiltPathWithResult>> Instal
                                 DrvOutput outputId { *outputHash, output };
                                 auto realisation = store->queryRealisation(outputId);
                                 if (!realisation)
-                                    throw Error(
-                                        "cannot operate on an output of the "
-                                        "unbuilt derivation '%s'",
-                                        outputId.to_string());
+                                    throw MissingRealisation(outputId);
                                 outputs.insert_or_assign(output, realisation->outPath);
                             } else {
                                 // If ca-derivations isn't enabled, assume that

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -93,4 +93,14 @@ struct RealisedPath {
     GENERATE_CMP(RealisedPath, me->raw);
 };
 
+class MissingRealisation : public Error
+{
+public:
+    MissingRealisation(DrvOutput & outputId)
+        : Error( "cannot operate on an output of the "
+                "unbuilt derivation '%s'",
+                outputId.to_string())
+    {}
+};
+
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -879,10 +879,7 @@ std::vector<BuildResult> RemoteStore::buildPathsWithResults(
                                 auto realisation =
                                     queryRealisation(outputId);
                                 if (!realisation)
-                                    throw Error(
-                                        "cannot operate on an output of unbuilt "
-                                        "content-addressed derivation '%s'",
-                                        outputId.to_string());
+                                    throw MissingRealisation(outputId);
                                 res.builtOutputs.emplace(realisation->id, *realisation);
                             } else {
                                 // If ca-derivations isn't enabled, assume that

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -92,6 +92,7 @@ nix_tests = \
   fmt.sh \
   eval-store.sh \
   why-depends.sh \
+  ca/why-depends.sh \
   import-derivation.sh \
   ca/import-derivation.sh \
   nix_path.sh \

--- a/tests/why-depends.sh
+++ b/tests/why-depends.sh
@@ -6,6 +6,9 @@ cp ./dependencies.nix ./dependencies.builder0.sh ./config.nix $TEST_HOME
 
 cd $TEST_HOME
 
+nix why-depends --derivation --file ./dependencies.nix input2_drv input1_drv
+nix why-depends --file ./dependencies.nix input2_drv input1_drv
+
 nix-build ./dependencies.nix -A input0_drv -o dep
 nix-build ./dependencies.nix -o toplevel
 


### PR DESCRIPTION
Reverts #7337 and re-implements it in a different way in order to not break `nix why-depends --derivation`.

Fix #7496

Cc @raphaelr
