### PR TITLE
Fix Nix installation on older versions of fish

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -1,3 +1,15 @@
+function add_path --argument-names new_path
+    if type -q fish_add_path
+        # fish 3.2.0 or newer
+	fish_add_path --prepend --global $new_path
+    else
+        # older versions of fish
+        if not contains $new_path $fish_user_paths
+            set --global fish_user_paths $new_path $fish_user_paths
+        end
+    end
+end
+
 # Only execute this file once per shell.
 if test -n "$__ETC_PROFILE_NIX_SOURCED"
   exit
@@ -31,5 +43,7 @@ else
   end
 end
 
-fish_add_path --prepend --global "@localstatedir@/nix/profiles/default/bin"
-fish_add_path --prepend --global "$HOME/.nix-profile/bin"
+add_path "@localstatedir@/nix/profiles/default/bin"
+add_path "$HOME/.nix-profile/bin"
+
+functions -e add_path

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,3 +1,15 @@
+function add_path --argument-names new_path
+    if type -q fish_add_path
+        # fish 3.2.0 or newer
+	fish_add_path --prepend --global $new_path
+    else
+        # older versions of fish
+        if not contains $new_path $fish_user_paths
+            set --global fish_user_paths $new_path $fish_user_paths
+        end
+    end
+end
+
 if test -n "$HOME" && test -n "$USER"
 
     # Set up the per-user profile.
@@ -32,6 +44,8 @@ if test -n "$HOME" && test -n "$USER"
       set --export --prepend --path MANPATH "$NIX_LINK/share/man"
     end
 
-    fish_add_path --prepend --global "$NIX_LINK/bin"
+    add_path "$NIX_LINK/bin"
     set --erase NIX_LINK
 end
+
+functions -e add_path


### PR DESCRIPTION
The `fish_add_path` function is only available for fish 3.2.0 or newer, and not on older versions (e.g. 3.1.2, current version on debian stable, bullseye).
This commit adds an alternative way to update the PATH when `fish_add_path` does not exist.

Fixes #7546 