### PR TITLE
On macOS with auto-uid-allocation and sandboxing, use the correct gid

### DIFF
--- a/src/libstore/lock.hh
+++ b/src/libstore/lock.hh
@@ -31,7 +31,7 @@ struct UserLock
 
 /* Acquire a user lock for a UID range of size `nrIds`. Note that this
    may return nullptr if no user is available. */
-std::unique_ptr<UserLock> acquireUserLock(uid_t nrIds, bool useChroot);
+std::unique_ptr<UserLock> acquireUserLock(uid_t nrIds, bool useUserNamespace);
 
 bool useBuildUsers();
 


### PR DESCRIPTION
macOS doesn't have user namespacing, so the gid of the builder needs to be `nixbld`. The logic got "has sandboxing enabled" confused with "has user namespaces".

Fixes #7529.