### PR TITLE
mk: Fix installation of static libraries

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -130,7 +130,15 @@ define build-library
 
     $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS)
 
-    $(1)_INSTALL_PATH := $$(libdir)/$$($(1)_NAME).a
+    $(1)_INSTALL_PATH := $(DESTDIR)$$($(1)_INSTALL_DIR)/$$($(1)_NAME).a
+
+    $$(eval $$(call create-dir, $$($(1)_INSTALL_DIR)))
+
+    $$($(1)_INSTALL_PATH): $$($(1)_OBJS) | $(DESTDIR)$$($(1)_INSTALL_DIR)/
+	+$$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$^
+	$$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
+
+    install: $$($(1)_INSTALL_PATH)
 
   endif
 

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -69,6 +69,13 @@ $(d)/build.cc:
 
 clean-files += $(d)/schema.sql.gen.hh $(d)/ca-specific-schema.sql.gen.hh
 
+$(d)/nix-store.pc: $(d)/nix-store.pc.in
+	$(trace-gen) rm -f $@ && ./config.status --quiet --file=$@
+ifeq ($(BUILD_SHARED_LIBS), 1)
+	sed -i 's|@LIBS_PRIVATE@||' $@
+else
+	sed -i 's|@LIBS_PRIVATE@|Libs.private: $(libstore_LDFLAGS) $(libstore_LDFLAGS_PROPAGATED) $(foreach lib, $(libstore_LIBS), $($(lib)_LDFLAGS))|' $@
+endif
 $(eval $(call install-file-in, $(d)/nix-store.pc, $(libdir)/pkgconfig, 0644))
 
 $(foreach i, $(wildcard src/libstore/builtins/*.hh), \

--- a/src/libstore/nix-store.pc.in
+++ b/src/libstore/nix-store.pc.in
@@ -7,3 +7,4 @@ Description: Nix Package Manager
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lnixstore -lnixutil
 Cflags: -I${includedir}/nix -std=c++17
+@LIBS_PRIVATE@


### PR DESCRIPTION
This PR fixes the installation of static libraries and adds the private linker flags to libnixstore's `.pc` file so it can be more easily used. Fixes #7021.

Tested that the [Attic](https://github.com/zhaofengli/attic) client, which links against libnixstore, builds statically with this change.