### PR TITLE
Fix typo in example for builtin function map

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2807,7 +2807,7 @@ static RegisterPrimOp primop_map({
       example,
 
       ```nix
-      map (x"foo" + x) [ "bar" "bla" "abc" ]
+      map (x: "foo" + x) [ "bar" "bla" "abc" ]
       ```
 
       evaluates to `[ "foobar" "foobla" "fooabc" ]`.


### PR DESCRIPTION
I noticed a mistake in the example for map:

https://nixos.org/manual/nix/unstable/language/builtins.html#builtins-map

Looks like it got introduced here be accident:

https://github.com/NixOS/nix/commit/e6d07e0d89d964cde22894fca57a95177c085c8d#diff-0f59bb6f197822ef9f19ceae9624989499d170c84dfdc1f486a8959bb4588cafL2698
