### PR TITLE
tests: fix for nixpkgs 22.11

### DIFF
--- a/tests/containers.nix
+++ b/tests/containers.nix
@@ -16,7 +16,7 @@ makeTest ({
         { virtualisation.writableStore = true;
           virtualisation.diskSize = 2048;
           virtualisation.additionalPaths =
-            [ pkgs.stdenv
+            [ pkgs.stdenvNoCC
               (import ./systemd-nspawn.nix { inherit nixpkgs; }).toplevel
             ];
           virtualisation.memorySize = 4096;
@@ -38,30 +38,30 @@ makeTest ({
     # Test that 'id' gives the expected result in various configurations.
 
     # Existing UIDs, sandbox.
-    host.succeed("nix build --no-auto-allocate-uids --sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-1")
+    host.succeed("nix build -v --no-auto-allocate-uids --sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-1")
     host.succeed("[[ $(cat ./result) = 'uid=1000(nixbld) gid=100(nixbld) groups=100(nixbld)' ]]")
 
     # Existing UIDs, no sandbox.
-    host.succeed("nix build --no-auto-allocate-uids --no-sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-2")
+    host.succeed("nix build -v --no-auto-allocate-uids --no-sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-2")
     host.succeed("[[ $(cat ./result) = 'uid=30001(nixbld1) gid=30000(nixbld) groups=30000(nixbld)' ]]")
 
     # Auto-allocated UIDs, sandbox.
-    host.succeed("nix build --auto-allocate-uids --sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-3")
+    host.succeed("nix build -v --auto-allocate-uids --sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-3")
     host.succeed("[[ $(cat ./result) = 'uid=1000(nixbld) gid=100(nixbld) groups=100(nixbld)' ]]")
 
     # Auto-allocated UIDs, no sandbox.
-    host.succeed("nix build --auto-allocate-uids --no-sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-4")
+    host.succeed("nix build -v --auto-allocate-uids --no-sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-4")
     host.succeed("[[ $(cat ./result) = 'uid=872415232 gid=30000(nixbld) groups=30000(nixbld)' ]]")
 
     # Auto-allocated UIDs, UID range, sandbox.
-    host.succeed("nix build --auto-allocate-uids --sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-5 --arg uidRange true")
+    host.succeed("nix build -v --auto-allocate-uids --sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-5 --arg uidRange true")
     host.succeed("[[ $(cat ./result) = 'uid=0(root) gid=0(root) groups=0(root)' ]]")
 
     # Auto-allocated UIDs, UID range, no sandbox.
-    host.fail("nix build --auto-allocate-uids --no-sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-6 --arg uidRange true")
+    host.fail("nix build -v --auto-allocate-uids --no-sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-6 --arg uidRange true")
 
     # Run systemd-nspawn in a Nix build.
-    host.succeed("nix build --auto-allocate-uids --sandbox -L --offline --impure --file ${./systemd-nspawn.nix} --argstr nixpkgs ${nixpkgs}")
+    host.succeed("nix build -v --auto-allocate-uids --sandbox -L --offline --impure --file ${./systemd-nspawn.nix} --argstr nixpkgs ${nixpkgs}")
     host.succeed("[[ $(cat ./result/msg) = 'Hello World' ]]")
   '';
 

--- a/tests/setuid.nix
+++ b/tests/setuid.nix
@@ -15,7 +15,7 @@ makeTest {
     { virtualisation.writableStore = true;
       nix.settings.substituters = lib.mkForce [ ];
       nix.nixPath = [ "nixpkgs=${lib.cleanSource pkgs.path}" ];
-      virtualisation.additionalPaths = [ pkgs.stdenv pkgs.pkgsi686Linux.stdenv ];
+      virtualisation.additionalPaths = [ pkgs.stdenvNoCC pkgs.pkgsi686Linux.stdenvNoCC ];
     };
 
   testScript = { nodes }: ''


### PR DESCRIPTION
runCommand now uses stdenvNoCC by default, so that needs to be included instead of the regular stdenv.