### PR TITLE
review process: all PRs must be triaged

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -79,7 +79,8 @@ Items on the board progress through the following states:
 
   If there is disagreement on the general idea behind an issue or pull request, it is moved to _To discuss_, otherwise to _In review_.
 
-  To ensure process quality and reliability, all pull requests must be triaged before merging.
+  To ensure process quality and reliability, all non-trivial pull requests must be triaged before merging.
+  What constitutes a trivial pull request is up to maintainers' judgement.
 
 - To discuss
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -56,7 +56,7 @@ Meeting notes are collected on a [collaborative scratchpad](https://pad.lassul.u
 
 The team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19/views/1) for tracking its work.
 
-Issues on the board progress through the following states:
+Items on the board progress through the following states:
 
 - No Status
 
@@ -78,6 +78,8 @@ Issues on the board progress through the following states:
   Team members can also add pull requests or issues they would like the whole team to consider.
 
   If there is disagreement on the general idea behind an issue or pull request, it is moved to _To discuss_, otherwise to _In review_.
+
+  To ensure process quality and reliability, all pull requests must be triaged before merging.
 
 - To discuss
 


### PR DESCRIPTION
This is only a proposal picking up [@roberth's question](https://github.com/NixOS/nix/pull/7515#issuecomment-1368988316) in order to lead a traceable discussion and come to a decision the team can follow:

in order to make the development process more transparent for everyone,
all pull requests should go through the triage process before getting
merged.

this ensures that all team members are aware of what is going on, and
that rationale for decisions is kept track of in the meeting notes for
posterity. (ideally all that should go into the commit history, but this
is a more invasive process change that needs further deliberation.)

having all team members take at least a brief but conscious look at each
change may also help with keeping our quality standards, as more
reviewers are more likely to remind each other of our shared values.