### PR TITLE
path-info: implement --filter-substitutable

### DIFF
--- a/src/nix/path-info.md
+++ b/src/nix/path-info.md
@@ -39,6 +39,15 @@ R""(
 
   ```
 
+* Print all dependant paths which do not exist in any configured binary cache:
+
+  ```console
+  # nix path-info -r --filter-substitutable /nix/store/blzxgyvrk32ki6xga10phr4sby2xf25q-geeqie-1.5.1
+  /nix/store/blzxgyvrk32ki6xga10phr4sby2xf25q-geeqie-1.5.1
+  /nix/store/w2vgpk3rdl6smqz7ixxywqapgagsarjf-fbida-2.14
+  ...
+  ```
+
 * Print the 10 most recently added paths (using --json and the jq(1)
   command):
 


### PR DESCRIPTION
Fixes #3946 

Alternative to #7526 which implements the same logic in the new cli instead of the legacy `nix-store`

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes