### PR TITLE
tests: Fix flake- and sandbox-based build on Darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -326,6 +326,15 @@
 
             makeFlags = "profiledir=$(out)/etc/profile.d PRECOMPILE_HEADERS=1";
 
+            preCheck = ''
+              export prefixDir=$TMPDIR/dummy
+              export NIX_STORE_DIR=$prefixDir/store
+              export NIX_DATA_DIR=$prefixDir/share
+              export NIX_STATE_DIR=$prefixDir/var/nix
+
+              mkdir -p $NIX_STORE_DIR $NIX_DATA_DIR $NIX_STATE_DIR
+            '';
+
             doCheck = true;
 
             installFlags = "sysconfdir=$(out)/etc";

--- a/src/libexpr/tests/value/context.cc
+++ b/src/libexpr/tests/value/context.cc
@@ -42,7 +42,7 @@ TEST_F(NixStringContextElemTest, slash_invalid) {
 }
 
 TEST_F(NixStringContextElemTest, opaque) {
-    std::string_view opaque = "/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x";
+    std::string opaque = settings.nixStore + "/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x";
     auto elem = NixStringContextElem::parse(store(), opaque);
     auto * p = std::get_if<NixStringContextElem::Opaque>(&elem);
     ASSERT_TRUE(p);
@@ -51,7 +51,7 @@ TEST_F(NixStringContextElemTest, opaque) {
 }
 
 TEST_F(NixStringContextElemTest, drvDeep) {
-    std::string_view drvDeep = "=/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x.drv";
+    std::string drvDeep = "=" + settings.nixStore + "/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x.drv";
     auto elem = NixStringContextElem::parse(store(), drvDeep);
     auto * p = std::get_if<NixStringContextElem::DrvDeep>(&elem);
     ASSERT_TRUE(p);
@@ -60,7 +60,7 @@ TEST_F(NixStringContextElemTest, drvDeep) {
 }
 
 TEST_F(NixStringContextElemTest, built) {
-    std::string_view built = "!foo!/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x.drv";
+    std::string built = "!foo!" + settings.nixStore + "/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-x.drv";
     auto elem = NixStringContextElem::parse(store(), built);
     auto * p = std::get_if<NixStringContextElem::Built>(&elem);
     ASSERT_TRUE(p);

--- a/src/libutil/tests/tests.cc
+++ b/src/libutil/tests/tests.cc
@@ -202,7 +202,7 @@ namespace nix {
     }
 
     TEST(pathExists, bogusPathDoesNotExist) {
-        ASSERT_FALSE(pathExists("/home/schnitzel/darmstadt/pommes"));
+        ASSERT_FALSE(pathExists("/nonexistent"));
     }
 
     /* ----------------------------------------------------------------------------


### PR DESCRIPTION
The following changes permit nix to be built properly in a sandboxed environment via `nix build .#`.