### PR TITLE
remove unncessary cast

### DIFF
--- a/src/libstore/path-with-outputs.cc
+++ b/src/libstore/path-with-outputs.cc
@@ -52,8 +52,8 @@ std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s)
     size_t n = s.find("!");
     return n == s.npos
         ? std::make_pair(s, std::set<std::string>())
-        : std::make_pair(((std::string_view) s).substr(0, n),
-            tokenizeString<std::set<std::string>>(((std::string_view) s).substr(n + 1), ","));
+        : std::make_pair(s.substr(0, n),
+            tokenizeString<std::set<std::string>>(s.substr(n + 1), ","));
 }
 
 


### PR DESCRIPTION
found this while digging around the path handling code. since the argument is already a `string_view`, there seems to be no point re-casting it.