### PR TITLE
nix/show-config: allow getting the value of a specific setting

### DIFF
--- a/src/nix/show-config.cc
+++ b/src/nix/show-config.cc
@@ -9,15 +9,44 @@ using namespace nix;
 
 struct CmdShowConfig : Command, MixJSON
 {
+    std::optional<std::string> name;
+
+    CmdShowConfig() {
+        expectArgs({
+            .label = {"name"},
+            .optional = true,
+            .handler = {&name},
+        });
+    }
+
     std::string description() override
     {
-        return "show the Nix configuration";
+        return "show the Nix configuration or the value of a specific setting";
     }
 
     Category category() override { return catUtility; }
 
     void run() override
     {
+        if (name) {
+            if (json) {
+                throw UsageError("'--json' is not supported when specifying a setting name");
+            }
+
+            std::map<std::string, Config::SettingInfo> settings;
+            globalConfig.getSettings(settings);
+            auto setting = settings.find(*name);
+
+            if (setting == settings.end()) {
+                throw Error("could not find setting '%1%'", *name);
+            } else {
+                const auto & value = setting->second.value;
+                logger->cout("%s", value);
+            }
+
+            return;
+        }
+
         if (json) {
             // FIXME: use appropriate JSON types (bool, ints, etc).
             logger->cout("%s", globalConfig.toJSON().dump());

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -51,3 +51,8 @@ exp_features=$(nix show-config | grep '^experimental-features' | cut -d '=' -f 2
 [[ $prev != $exp_cores ]]
 [[ $exp_cores == "4242" ]]
 [[ $exp_features == "flakes nix-command" ]]
+
+# Test that it's possible to retrieve a single setting's value
+val=$(nix show-config | grep '^warn-dirty' | cut -d '=' -f  2 | xargs)
+val2=$(nix show-config warn-dirty)
+[[ $val == $val2 ]]


### PR DESCRIPTION
Instead of needing to run `nix show-config --json | jq -r '."warn-dirty".value'` to view the value of `warn-dirty`, you can now run `nix show-config warn-dirty`.

Fixes #7586.

---

I'm sure this isn't the most beautiful solution (and I couldn't figure out a good way to get JSON support for the single-option mode at this point in time), but it works!