### PR TITLE
Move the `getBuildLog` implementation to its own implementation file

### DIFF
--- a/src/libstore/log-store.cc
+++ b/src/libstore/log-store.cc
@@ -1,0 +1,12 @@
+#include "log-store.hh"
+
+namespace nix {
+
+std::optional<std::string> LogStore::getBuildLog(const StorePath & path) {
+    auto maybePath = getBuildDerivationPath(path);
+    if (!maybePath)
+        return std::nullopt;
+    return getBuildLogExact(maybePath.value());
+}
+
+}

--- a/src/libstore/log-store.hh
+++ b/src/libstore/log-store.hh
@@ -11,12 +11,7 @@ struct LogStore : public virtual Store
 
     /* Return the build log of the specified store path, if available,
        or null otherwise. */
-    std::optional<std::string> getBuildLog(const StorePath & path) {
-      auto maybePath = getBuildDerivationPath(path);
-      if (!maybePath)
-          return std::nullopt;
-      return getBuildLogExact(maybePath.value());
-    }
+    std::optional<std::string> getBuildLog(const StorePath & path);
 
     virtual std::optional<std::string> getBuildLogExact(const StorePath & path) = 0;
 


### PR DESCRIPTION
Keep the header minimal and clean.

Addresses https://github.com/NixOS/nix/pull/7430#discussion_r1069169733.
