### PR TITLE
Add escape for systemd service in installer script

### DIFF
--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -24,12 +24,17 @@ $1
 EOF
 }
 
+escape_systemd_env() {
+    temp_var="${1//\'/\\\'}"
+    echo "${temp_var//\%/%%}"
+}
+
 # Gather all non-empty proxy environment variables into a string
 create_systemd_proxy_env() {
     vars="http_proxy https_proxy ftp_proxy no_proxy HTTP_PROXY HTTPS_PROXY FTP_PROXY NO_PROXY"
     for v in $vars; do
         if [ "x${!v:-}" != "x" ]; then
-            echo "Environment=${v}=${!v}"
+            echo "Environment=${v}=$(escape_systemd_env ${!v})"
         fi
     done
 }


### PR DESCRIPTION
Among all the characters that are allowed in a URL, both the percentage sign "%" and the single quotation mark "'" needs escaping when written as a environment variable in a systemd service file. While the single quotation mark may be rare, the percentage sign is widely used to escape characters in a URL. This is especially common in proxy setting, where username and password may contain special characters that need percentage escaping. This patch applies the following replacements:
```
  % -> %%
  ' -> \'
```