### PR TITLE
Try to fix build failure

### DIFF
--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -319,7 +319,7 @@ OutputPathMap resolveDerivedPath(Store & store, const DerivedPath::Built & bfd, 
         [&](const OutputsSpec::Names & names) {
             return static_cast<std::set<std::string>>(names);
         },
-    }, bfd.outputs);
+    }, bfd.outputs.raw());
     for (auto & output : outputNames) {
         auto outputHash = get(outputHashes, output);
         if (!outputHash)


### PR DESCRIPTION
Failure: https://hydra.nixos.org/build/205357257/nixlog/1

The problem seems to be trying to `std::visit` a derived class of `std::variant`. Per
https://stackoverflow.com/questions/63616709/incomplete-type-stdvariant-used-in-nested-name-specifier certain C++ standard library implementations allow this, but others do not.

The solution is simply to call the `raw` method, which upcasts the reference back to the `std::variant`.