### PR TITLE
flake check: Recognize well known community attributes

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -655,6 +655,19 @@ struct CmdFlakeCheck : FlakeCommand
                             }
                         }
 
+                        else if (
+                            name == "lib"
+                            || name == "darwinConfigurations"
+                            || name == "darwinModules"
+                            || name == "flakeModule"
+                            || name == "flakeModules"
+                            || name == "herculesCI"
+                            || name == "homeConfigurations"
+                            || name == "nixopsConfigurations"
+                            )
+                            // Known but unchecked community attribute
+                            ;
+
                         else
                             warn("unknown flake output '%s'", name);
 


### PR DESCRIPTION
This avoids warning fatigue, making `nix flake check` more effective.