### PR TITLE
Expand installation.md

### DIFF
--- a/doc/manual/src/installation/installation.md
+++ b/doc/manual/src/installation/installation.md
@@ -1,2 +1,38 @@
-This section describes how to install and configure Nix for first-time
-use.
+# Installation
+
+This section describes how to install and configure Nix for first-time use.
+
+The current recommended option on Linux and MacOS is [multi-user](#multi-user).
+
+## Multi-user
+
+This installation offers better sharing, improved isolation, and more security
+over a single user installation.
+
+This option requires either:
+
+* Linux running systemd, with SELinux disabled
+* MacOS
+
+```console
+$ bash <(curl -L https://nixos.org/nix/install) --daemon
+```
+
+## Single-user
+
+> Single-user is not supported on Mac.
+
+This installation has less requirements than the multi-user install, however it
+cannot offer equivalent sharing, isolation, or security.
+
+This option is suitable for systems without systemd.
+
+```console
+$ bash <(curl -L https://nixos.org/nix/install) --no-daemon
+```
+
+## Distributions
+
+The Nix community maintains installers for several distributions.
+
+They can be found in the [`nix-community/nix-installers`](https://github.com/nix-community/nix-installers) repository.

--- a/doc/manual/src/quick-start.md
+++ b/doc/manual/src/quick-start.md
@@ -4,16 +4,16 @@ This chapter is for impatient people who don't like reading
 documentation.  For more in-depth information you are kindly referred
 to subsequent chapters.
 
-1. Install single-user Nix by running the following:
+1. Install Nix by running the following:
 
    ```console
-   $ bash <(curl -L https://nixos.org/nix/install)
+   $ bash <(curl -L https://nixos.org/nix/install) --daemon
    ```
 
-   This will install Nix in `/nix`. The install script will create
-   `/nix` using `sudo`, so make sure you have sufficient rights.  (For
-   other installation methods, see
-   [here](installation/installation.md).)
+   The install script will use `sudo`, so make sure you have sufficient rights.
+   On Linux, `--daemon` can be omitted for a single-user install.
+
+   For other installation methods, see [here](installation/installation.md).
 
 1. See what installable packages are currently available in the
    channel:


### PR DESCRIPTION
Changes the `quick-start.md` to recommend a multi-user install, since single-user is not supported on MacOS and https://nixos.org/download.html recommends multi-user.

Expands `installation.md` to reflect wording on https://nixos.org/download.html