### PR TITLE
Stuctured command stability

### DIFF
--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -236,6 +236,8 @@ struct Command : virtual public Args
 
     static constexpr Category catDefault = 0;
 
+    virtual std::optional<ExperimentalFeature> experimentalFeature ();
+
     virtual Category category() { return catDefault; }
 };
 

--- a/src/nix/doctor.cc
+++ b/src/nix/doctor.cc
@@ -39,6 +39,14 @@ struct CmdDoctor : StoreCommand
 {
     bool success = true;
 
+    /**
+     * This command is stable before the others
+     */
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return std::nullopt;
+    }
+
     std::string description() override
     {
         return "check your system for potential problems and print a PASS or FAIL for each check";

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -423,10 +423,8 @@ void mainWrapped(int argc, char * * argv)
     if (!args.command)
         throw UsageError("no subcommand specified");
 
-    if (args.command->first != "repl"
-        && args.command->first != "doctor"
-        && args.command->first != "upgrade-nix")
-        experimentalFeatureSettings.require(Xp::NixCommand);
+    experimentalFeatureSettings.require(
+        args.command->second->experimentalFeature());
 
     if (args.useNet && !haveInternet()) {
         warn("you don't have Internet access; disabling some network-dependent features");

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -12,6 +12,14 @@ struct CmdRepl : RawInstallablesCommand
         evalSettings.pureEval = false;
     }
 
+    /**
+     * This command is stable before the others
+     */
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return std::nullopt;
+    }
+
     std::vector<std::string> files;
 
     Strings getDefaultFlakeAttrPaths() override

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -32,6 +32,14 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         });
     }
 
+    /**
+     * This command is stable before the others
+     */
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return std::nullopt;
+    }
+
     std::string description() override
     {
         return "upgrade Nix to the stable version declared in Nixpkgs";

--- a/tests/experimental-features.sh
+++ b/tests/experimental-features.sh
@@ -15,15 +15,20 @@ function both_ways {
 # Simple case, the configuration effects the running command
 both_ways show-config
 
-# Complicated case, earlier args effect later args
+# Skipping for now, because we actually *do* want these to show up in
+# the manual, just be marked experimental. Will reenable once the manual
+# generation takes advantage of the JSON metadata on this.
 
-both_ways store gc --help
+# both_ways store gc --help
 
 expect 1 nix --experimental-features 'nix-command' show-config --flake-registry 'https://no'
 nix --experimental-features 'nix-command flakes' show-config --flake-registry 'https://no'
 
-# Double check this is stable
+# Double check these are stable
 nix --experimental-features '' --help
+nix --experimental-features '' doctor --help
+nix --experimental-features '' repl --help
+nix --experimental-features '' upgrade-nix --help
 
 # These 3 arguments are currently given to all commands, which is wrong (as not
 # all care). To deal with fixing later, we simply make them require the


### PR DESCRIPTION
Prior to this, there was an ad-hoc whitelist in `main.cc`. Now, every command states its stability.

In a future PR, we will adjust the manual to take advantage of this new
information in the JSON. It will be easier to do that once we have some experimental feature docs to link too; see #5930 and #7798.)