### PR TITLE
Try again to fix aarch64-linux build failure

### DIFF
--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -163,7 +163,7 @@ void adl_serializer<OutputsSpec>::to_json(json & json, OutputsSpec t) {
         [&](const OutputsSpec::Names & names) {
             json = names;
         },
-    }, t);
+    }, t.raw());
 }
 
 
@@ -183,7 +183,7 @@ void adl_serializer<ExtendedOutputsSpec>::to_json(json & json, ExtendedOutputsSp
         [&](const ExtendedOutputsSpec::Explicit & e) {
             adl_serializer<OutputsSpec>::to_json(json, e);
         },
-    }, t);
+    }, t.raw());
 }
 
 }


### PR DESCRIPTION
f419ab48e6394838097f158265ac3cc531ee7958 was on the right track, but there are a few more missing `raw()` calls to fix.