### PR TITLE
local-store.cc: suggest `nix store repair` on hash mismatch

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1306,11 +1306,11 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
             auto hashResult = hashSink.finish();
 
             if (hashResult.first != info.narHash)
-                throw Error("hash mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+                throw Error("hash mismatch importing path '%s' (try `nix store repair`);\n  specified: %s\n  got:       %s",
                     printStorePath(info.path), info.narHash.to_string(Base32, true), hashResult.first.to_string(Base32, true));
 
             if (hashResult.second != info.narSize)
-                throw Error("size mismatch importing path '%s';\n  specified: %s\n  got:       %s",
+                throw Error("size mismatch importing path '%s' (try `nix store repair`);\n  specified: %s\n  got:       %s",
                     printStorePath(info.path), info.narSize, hashResult.second);
 
             if (info.ca) {

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1306,11 +1306,11 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
             auto hashResult = hashSink.finish();
 
             if (hashResult.first != info.narHash)
-                throw Error("hash mismatch importing path '%s' (try `nix store repair`);\n  specified: %s\n  got:       %s",
+                throw Error("hash mismatch importing path '%s' (try: nix store repair);\n  specified: %s\n  got:       %s",
                     printStorePath(info.path), info.narHash.to_string(Base32, true), hashResult.first.to_string(Base32, true));
 
             if (hashResult.second != info.narSize)
-                throw Error("size mismatch importing path '%s' (try `nix store repair`);\n  specified: %s\n  got:       %s",
+                throw Error("size mismatch importing path '%s' (try: nix store repair);\n  specified: %s\n  got:       %s",
                     printStorePath(info.path), info.narSize, hashResult.second);
 
             if (info.ca) {


### PR DESCRIPTION
Recently my buildfarm tripped a circuit breaker and I wound up with a bunch of zero-length files in /nix/store.  This is no big deal, of course, and easy to fix.

However I spent quite a lot of time thinking that Nix's hash mismatch error was a message from my local `nix`, informing me that the remote builder had sent back invalid data.  In fact my local `nix` was informing me that it had discovered corrupted paths in `/nix/store`.

Let's add a suggestion to this error message.  This will make it clear that the problem is (at least partly) an issue with the local store, and also put the user on course towards the most likely solution to their problems.