### PR TITLE
Fix markdown error in operators.md

### DIFF
--- a/doc/manual/src/language/operators.md
+++ b/doc/manual/src/language/operators.md
@@ -24,7 +24,7 @@
 | [Equality]                             | *expr* `==` *expr*                         | none          | 11         |
 | Inequality                             | *expr* `!=` *expr*                         | none          | 11         |
 | Logical conjunction (`AND`)            | *bool* `&&` *bool*                         | left          | 12         |
-| Logical disjunction (`OR`)             | *bool* `||` *bool*                         | left          | 13         |
+| Logical disjunction (`OR`)             | *bool* `\|\|` *bool*                       | left          | 13         |
 | [Logical implication]                  | *bool* `->` *bool*                         | none          | 14         |
 
 [string]: ./values.md#type-string


### PR DESCRIPTION
Escape logical or pipe in markdown table according to https://github.github.com/gfm/#example-200