### PR TITLE
Fix #7655

### DIFF
--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -83,15 +83,13 @@ static void prim_getContext(EvalState & state, const PosIdx pos, Value * * args,
     state.forceString(*args[0], context, pos);
     auto contextInfos = std::map<StorePath, ContextInfo>();
     for (const auto & p : context) {
-        Path drv;
-        std::string output;
         NixStringContextElem ctx = NixStringContextElem::parse(*state.store, p);
         std::visit(overloaded {
             [&](NixStringContextElem::DrvDeep & d) {
                 contextInfos[d.drvPath].allOutputs = true;
             },
             [&](NixStringContextElem::Built & b) {
-                contextInfos[b.drvPath].outputs.emplace_back(std::move(output));
+                contextInfos[b.drvPath].outputs.emplace_back(std::move(b.output));
             },
             [&](NixStringContextElem::Opaque & o) {
                 contextInfos[o.path].path = true;

--- a/tests/lang/eval-okay-context-introspection.exp
+++ b/tests/lang/eval-okay-context-introspection.exp
@@ -1,1 +1,1 @@
-true
+[ true true true true true true ]

--- a/tests/lang/eval-okay-context-introspection.nix
+++ b/tests/lang/eval-okay-context-introspection.nix
@@ -18,7 +18,24 @@ let
     };
   };
 
-  legit-context = builtins.getContext "${path}${drv.outPath}${drv.foo.outPath}${drv.drvPath}";
+  combo-path = "${path}${drv.outPath}${drv.foo.outPath}${drv.drvPath}";
+  legit-context = builtins.getContext combo-path;
 
-  constructed-context = builtins.getContext (builtins.appendContext "" desired-context);
-in legit-context == constructed-context
+  reconstructed-path = builtins.appendContext
+    (builtins.unsafeDiscardStringContext combo-path)
+    desired-context;
+
+  # Eta rule for strings with context.
+  etaRule = str:
+    str == builtins.appendContext
+      (builtins.unsafeDiscardStringContext str)
+      (builtins.getContext str);
+
+in [
+  (legit-context == desired-context)
+  (reconstructed-path == combo-path)
+  (etaRule "foo")
+  (etaRule drv.drvPath)
+  (etaRule drv.foo.outPath)
+  (etaRule (builtins.unsafeDiscardOutputDependency drv.drvPath))
+]


### PR DESCRIPTION
# Motivation

Fixing a bug. Here's how:

We had some local variables left over from the older (more complicated) implementation of this function. They should all be unused, but one wasn't by mistake.

Delete them all, and replace the one that was still in use as intended.

The first commit fixes the test, reproducing the bug. The second commit fixes the bug, with the now-passing test as proof.

# Context

Fix #7655

Here is why this wasn't caught before, despite having a test for these functions:

The original `builtins.getContext` test from https://github.com/NixOS/nix/commit/1d757292d0cb78beec32fcdfe15c2944a4bc4a95 would have caught this. The problem is that https://github.com/NixOS/nix/commit/b30be6b450f872f8be6dc8afa28f4b030fa8d1d1 adding `builtins.appendContext` modified that test to make it test too much at once, rather than adding a separate test.

We now have isolated tests for both functions, and also a property test showing everything put together (in the form of an eta rule for strings with context). This is better coverage and properly reproduces the bug.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [x] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
   - blocked on #7665 