### PR TITLE
ssh-ng: Set log-fd for ssh to `4` by default

### DIFF
--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -61,10 +61,10 @@ ref<Store> Machine::openStore() const
     Store::Params storeParams;
     if (hasPrefix(storeUri, "ssh://")) {
         storeParams["max-connections"] = "1";
-        storeParams["log-fd"] = "4";
     }
 
     if (hasPrefix(storeUri, "ssh://") || hasPrefix(storeUri, "ssh-ng://")) {
+        storeParams["log-fd"] = "4";
         if (sshKey != "")
             storeParams["ssh-key"] = sshKey;
         if (sshPublicHostKey != "")

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -30,6 +30,10 @@ struct SSHStoreConfig : virtual RemoteStoreConfig, virtual CommonSSHStoreConfig
 class SSHStore : public virtual SSHStoreConfig, public virtual RemoteStore
 {
 public:
+    // Hack for getting remote build log output.
+    // Intentionally not in `LegacySSHStoreConfig` so that it doesn't appear in
+    // the documentation
+    const Setting<int> logFD{(StoreConfig*) this, -1, "log-fd", "file descriptor to which SSH's stderr is connected"};
 
     SSHStore(const std::string & scheme, const std::string & host, const Params & params)
         : StoreConfig(params)
@@ -45,7 +49,8 @@ public:
             sshPublicHostKey,
             // Use SSH master only if using more than 1 connection.
             connections->capacity() > 1,
-            compress)
+            compress,
+            logFD)
     {
     }
 


### PR DESCRIPTION

# Motivation
That's expected by `build-remote` and makes sure that errors are correctly forwarded to the user.

For instance, let's say that the host-key of `example.org` is unknown and

    nix-build ../nixpkgs -A hello -j0 --builders 'ssh-ng://example.org'

is issued, then you get the following, somewhat cryptic error:

    error: cannot open connection to remote store 'ssh-ng://example.org': error: unexpected end-of-file

The relevant information (`Host key verification failed`) ends up in the daemon's log, but that's not very obvious considering that the daemon isn't very chatty normally.

This can be fixed - the same way as its done for legacy-ssh - by passing fd 4 to the SSH wrapper. Now you'd get the following error:

    error: cannot open connection to remote store 'ssh-ng://example.org': error: unexpected end-of-file: Host key verification failed.

...and now it's clear what's wrong.

# Context

See https://github.com/NixOS/nix/commit/feefcb3a982d3e3b8e89798d72d8afa996169569 for the corresponding fix in `ssh://`.

cc @edolstra @thufschmitt

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
