### PR TITLE
Better error message for nix search when attr is not found

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -379,10 +379,9 @@ Installable::getCursors(EvalState & state)
 ref<eval_cache::AttrCursor>
 Installable::getCursor(EvalState & state)
 {
-    auto cursors = getCursors(state);
-    if (cursors.empty())
-        throw Error("cannot find flake attribute '%s'", what());
-    return cursors[0];
+    /* Although getCursors should return at least one element, in case it doesn't,
+       bound check to avoid an undefined behavior for vector[0] */
+    return getCursors(state).at(0);
 }
 
 static StorePath getDeriver(

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -696,46 +696,28 @@ InstallableFlake::getCursors(EvalState & state)
 
     std::vector<ref<eval_cache::AttrCursor>> res;
 
-    for (auto & attrPath : getActualAttrPaths()) {
-        auto attr = root->findAlongAttrPath(parseAttrPath(state, attrPath));
-        if (attr) res.push_back(ref(*attr));
-    }
-
-    return res;
-}
-
-ref<eval_cache::AttrCursor> InstallableFlake::getCursor(EvalState & state)
-{
-    auto lockedFlake = getLockedFlake();
-
-    auto cache = openEvalCache(state, lockedFlake);
-    auto root = cache->getRoot();
-
     Suggestions suggestions;
-
     auto attrPaths = getActualAttrPaths();
 
     for (auto & attrPath : attrPaths) {
         debug("trying flake output attribute '%s'", attrPath);
 
-        auto attrOrSuggestions = root->findAlongAttrPath(
-            parseAttrPath(state, attrPath),
-            true
-        );
-
-        if (!attrOrSuggestions) {
-            suggestions += attrOrSuggestions.getSuggestions();
-            continue;
+        auto attr = root->findAlongAttrPath(parseAttrPath(state, attrPath));
+        if (attr) {
+            res.push_back(ref(*attr));
+        } else {
+            suggestions += attr.getSuggestions();
         }
-
-        return *attrOrSuggestions;
     }
 
-    throw Error(
-        suggestions,
-        "flake '%s' does not provide attribute %s",
-        flakeRef,
-        showAttrPaths(attrPaths));
+    if (res.size() == 0)
+        throw Error(
+            suggestions,
+            "flake '%s' does not provide attribute %s",
+            flakeRef,
+            showAttrPaths(attrPaths));
+
+    return res;
 }
 
 std::shared_ptr<flake::LockedFlake> InstallableFlake::getLockedFlake() const

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -198,10 +198,6 @@ struct InstallableFlake : InstallableValue
     std::vector<ref<eval_cache::AttrCursor>>
     getCursors(EvalState & state) override;
 
-    /* Get a cursor to the first attrpath in getActualAttrPaths() that
-       exists, or throw an exception with suggestions if none exists. */
-    ref<eval_cache::AttrCursor> getCursor(EvalState & state) override;
-
     std::shared_ptr<flake::LockedFlake> getLockedFlake() const;
 
     FlakeRef nixpkgsFlakeRef() const override;

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -103,9 +103,13 @@ struct Installable
         return {};
     }
 
+    /* Get a cursor to each value this Installable could refer to. However
+       if none exists, throw exception instead of returning empty vector. */
     virtual std::vector<ref<eval_cache::AttrCursor>>
     getCursors(EvalState & state);
 
+    /* Get the first and most preferred cursor this Installable could refer
+       to, or throw an exception if none exists. */
     virtual ref<eval_cache::AttrCursor>
     getCursor(EvalState & state);
 
@@ -193,8 +197,8 @@ struct InstallableFlake : InstallableValue
 
     std::pair<Value *, PosIdx> toValue(EvalState & state) override;
 
-    /* Get a cursor to every attrpath in getActualAttrPaths() that
-       exists. */
+    /* Get a cursor to every attrpath in getActualAttrPaths()
+       that exists. However if none exists, throw an exception. */
     std::vector<ref<eval_cache::AttrCursor>>
     getCursors(EvalState & state) override;
 

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -56,8 +56,8 @@ struct CmdSearch : InstallableCommand, MixJSON
     Strings getDefaultFlakeAttrPaths() override
     {
         return {
-            "packages." + settings.thisSystem.get() + ".",
-            "legacyPackages." + settings.thisSystem.get() + "."
+            "packages." + settings.thisSystem.get(),
+            "legacyPackages." + settings.thisSystem.get()
         };
     }
 


### PR DESCRIPTION
# Motivation

`nix search {flake}#{attr}` can be used to look up information about or search in a specific package set. Unlike other commands taking installables, however, `nix search` doesn't. This PR fixes this.

Before:

```console
$ nix run nix -- search nixpkgs#python3Package                
error: no results for the given search term(s)!
```

After:

```console
$ nix search nixpkgs#python3Package
error: flake 'flake:nixpkgs' does not provide attribute 'packages.x86_64-linux.python3Package', 'legacyPackages.x86_64-linux.python3Package' or 'python3Package'
       Did you mean one of python3Packages, python2Packages, python38Packages, python39Packages or pythonPackages?
```

The 'Fix extra "." ...' commit fixes the default attr paths so that if a fragment is not provided, the error messages says e.g. `packages.x86_64-linux` instead of with an extra dot like `packages.x86_64-linux.` .

TODO?: Do we need a test for this?

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
