### PR TITLE
Search improvements for --file and --expr

### DIFF
--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -181,15 +181,21 @@ struct CmdSearch : InstallableCommand, MixJSON
                 else if (initialRecurse)
                     recurse();
 
-                else if (attrPathS[0] == "legacyPackages" && attrPath.size() > 2) {
+                else if (file || expr || (attrPathS[0] == "legacyPackages" && attrPath.size() > 2))
+                {
                     auto attr = cursor.maybeGetAttr(state->sRecurseForDerivations);
                     if (attr && attr->getBool())
                         recurse();
                 }
-
             } catch (EvalError & e) {
-                if (!(attrPath.size() > 0 && attrPathS[0] == "legacyPackages"))
-                    throw;
+                if (file || expr) {
+                    // For non-flake inputs, ignore non-top-level eval errors
+                    if (initialRecurse) throw;
+                } else {
+                    // For flakes, ignore eval errors under legacyPackages
+                    if (!(attrPath.size() > 0 && attrPathS[0] == "legacyPackages"))
+                        throw;
+                }
             }
         };
 

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -71,6 +71,7 @@ nix_tests = \
   ca/recursive.sh \
   binary-cache-build-remote.sh \
   search.sh \
+  search-recurse.sh \
   logging.sh \
   export.sh \
   config.sh \

--- a/tests/search-recurse.nix
+++ b/tests/search-recurse.nix
@@ -1,0 +1,24 @@
+with import ./config.nix;
+
+{ foo }:
+
+{
+  # These should be ignored by 'nix search -f'
+  throws = throw "This fails to evaluate";
+  randomFunction = name: "Hello, ${name}!";
+
+  nestNoRecurse = {
+    hidden = mkDerivation rec {
+      name = "hidden-1";
+      buildCommand = "echo ${name} > $out";
+    };
+  };
+
+  nestRecurse = {
+    recurseForDerivations = true;
+    inner = mkDerivation rec {
+      name = "inner-1";
+      buildCommand = "echo ${name} > $out";
+    };
+  };
+}

--- a/tests/search-recurse.sh
+++ b/tests/search-recurse.sh
@@ -1,0 +1,14 @@
+source common.sh
+
+clearStore
+clearCache
+
+(( $(nix search --argstr foo unused -f search-recurse.nix '' inner | wc -l) > 0 ))
+(( $(nix search --argstr foo unused -f search-recurse.nix '' hidden | wc -l) == 0 ))
+(( $(nix search --impure --expr 'import ./search-recurse.nix { foo = "unused"; }' '' inner | wc -l) > 0 ))
+
+# If missing auto-call args, the error message should mention '--arg'
+(! nix search -f search-recurse.nix '') |& grep -q -- '--arg'
+
+nix search --argstr foo unused -f search-recurse.nix nestRecurse |& grep -q 'nestRecurse.inner'
+nix search --argstr foo unused -f search-recurse.nix nestNoRecurse |& grep -q 'nestNoRecurse.hidden'

--- a/tests/search.sh
+++ b/tests/search.sh
@@ -44,3 +44,6 @@ e=$'\x1b' # grep doesn't support \e, \033 or even \x1b
 (( $(nix search -f search.nix foo --exclude 'foo|bar' | grep -Ec 'foo|bar') == 0 ))
 (( $(nix search -f search.nix foo -e foo --exclude bar | grep -Ec 'foo|bar') == 0 ))
 [[ $(nix search -f search.nix -e bar --json | jq -c 'keys') == '["foo","hello"]' ]]
+
+# When searching for nonexistent attrpath, the error message should mention the attrpath
+(! nix search -f search.nix nonexistent) |& grep -q 'nonexistent'


### PR DESCRIPTION
# Motivation

The new `nix search` no longer works without flakes without some hacks. This PR fixes this so that this would work:

```console
$ nix search --file '<nixpkgs>' '' hello-unfree
```

Still a slight mouthful, but now it's at least working as much as `--file` could.

# Context

<!-- Provide context. Reference open issues if available. -->

Discussed in: https://discourse.nixos.org/t/nix-search-broken/24447

A workaround is possible, which uses the special handling of `legacyPackages` to ignore evaluation errors, but it's pretty ugly and relies on a weird internal behavior:

```console
$ nix search --impure --expr '{ legacyPackages.${builtins.currentSystem} = import <nixpkgs> {};}' '' hello-unfree
```

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

There are two main changes:

- `CmdSearch` now recurses into `recurseForDerivations = true` if `file || expr`. For better error messages, top-level eval errors are not ignored.
- `InstallableAttrPath::getCursors` now has a custom implementation that auto-calls the value and provides the full attribute path in the cursor (`root->findAlongAttrPath` so that is has a correct `parent`).

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
