### PR TITLE
doc: fix anchor links in and to glossary

### DIFF
--- a/doc/manual/src/command-ref/nix-store.md
+++ b/doc/manual/src/command-ref/nix-store.md
@@ -82,8 +82,8 @@ paths. Realisation is a somewhat overloaded term:
     produced through substitutes. If there are no (successful)
     substitutes, realisation fails.
 
-[valid]: ../glossary.md#validity
-[substitutes]: ../glossary.md#substitute
+[valid]: ../glossary.md#gloss-validity
+[substitutes]: ../glossary.md#gloss-substitute
 
 The output path of each derivation is printed on standard output. (For
 non-derivations argument, the argument itself is printed.)

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -156,6 +156,8 @@
     to path `Q`, then `Q` is in the closure of `P`. Further, if `Q`
     references `R` then `R` is also in the closure of `P`.
 
+    [closure]: #gloss-closure
+
   - [output path]{#gloss-output-path}\
     A [store path] produced by a [derivation].
 
@@ -171,6 +173,8 @@
     - The store path leads to an existing [store object] in that [store].
     - The store path is listed in the Nix database as being valid.
     - All paths in the store path's [closure] are valid.
+
+    [validity]: #gloss-validity
 
   - [user environment]{#gloss-user-env}\
     An automatically generated store object that consists of a set of


### PR DESCRIPTION
# Motivation

Some links in the glossary and nix-store help are broken.

<img width="464" alt="Screenshot 2023-01-24 at 00 21 48" src="https://user-images.githubusercontent.com/9742635/214174456-71618594-f447-4b5d-b1bb-b50938ae4ad5.png">
<img width="414" alt="Screenshot 2023-01-24 at 00 22 20" src="https://user-images.githubusercontent.com/9742635/214174528-84b4d4d4-757b-41c1-8089-38fb8b8b0e83.png">

The links in the nix-store help still link to the glossary, but their anchor name is wrong, so you only land at the top of the page.

# Context

Trivial change, only small docs changes with no potential side-effects.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
