### PR TITLE
Tighten up the `exportReferencesGraph` tests

### DIFF
--- a/tests/export-graph.sh
+++ b/tests/export-graph.sh
@@ -4,7 +4,7 @@ clearStore
 clearProfiles
 
 checkRef() {
-    nix-store -q --references $TEST_ROOT/result | grep -q "$1" || fail "missing reference $1"
+    nix-store -q --references $TEST_ROOT/result | grep -q "$1"'$' || fail "missing reference $1"
 }
 
 # Test the export of the runtime dependency graph.


### PR DESCRIPTION
# Motivation

Add an `$` at the end of the `grep` regex. Without it, `checkRef foo` would always imply `checkRef foo.drv`. We want to tell these situations apart to more precisely test what is going on.

# Context

The came up while @aciceri was kindly helping me out with #7330, in draft PR #7339. Unfortunately the solution I envisioned was *not* correct, so we'll have to go back to the drawing board. Still, this first commit from that attempt is plain good, and so we should merge it rather than letting it go to waste.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
   - n/a 
 - [x] code and comments are self-explanatory
   - test suite assumes grep knowledge 
 - [x] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
   - n/a

------

CC @aciceri @L-as 
