### PR TITLE
Revert "fixup: remove boehmgc patch"

### DIFF
--- a/boehmgc-coroutine-sp-fallback.diff
+++ b/boehmgc-coroutine-sp-fallback.diff
@@ -1,0 +1,77 @@
+diff --git a/darwin_stop_world.c b/darwin_stop_world.c
+index 3dbaa3fb..36a1d1f7 100644
+--- a/darwin_stop_world.c
++++ b/darwin_stop_world.c
+@@ -352,6 +352,7 @@ GC_INNER void GC_push_all_stacks(void)
+   int nthreads = 0;
+   word total_size = 0;
+   mach_msg_type_number_t listcount = (mach_msg_type_number_t)THREAD_TABLE_SZ;
++  size_t stack_limit;
+   if (!EXPECT(GC_thr_initialized, TRUE))
+     GC_thr_init();
+ 
+@@ -407,6 +408,19 @@ GC_INNER void GC_push_all_stacks(void)
+             GC_push_all_stack_sections(lo, hi, p->traced_stack_sect);
+           }
+           if (altstack_lo) {
++            // When a thread goes into a coroutine, we lose its original sp until
++            // control flow returns to the thread.
++            // While in the coroutine, the sp points outside the thread stack,
++            // so we can detect this and push the entire thread stack instead,
++            // as an approximation.
++            // We assume that the coroutine has similarly added its entire stack.
++            // This could be made accurate by cooperating with the application
++            // via new functions and/or callbacks.
++            stack_limit = pthread_get_stacksize_np(p->id);
++            if (altstack_lo >= altstack_hi || altstack_lo < altstack_hi - stack_limit) { // sp outside stack
++              altstack_lo = altstack_hi - stack_limit;
++            }
++
+             total_size += altstack_hi - altstack_lo;
+             GC_push_all_stack(altstack_lo, altstack_hi);
+           }
+diff --git a/pthread_stop_world.c b/pthread_stop_world.c
+index 4b2c429..1fb4c52 100644
+--- a/pthread_stop_world.c
++++ b/pthread_stop_world.c
+@@ -673,6 +673,8 @@ GC_INNER void GC_push_all_stacks(void)
+     struct GC_traced_stack_sect_s *traced_stack_sect;
+     pthread_t self = pthread_self();
+     word total_size = 0;
++    size_t stack_limit;
++    pthread_attr_t pattr;
+ 
+     if (!EXPECT(GC_thr_initialized, TRUE))
+       GC_thr_init();
+@@ -722,6 +724,31 @@ GC_INNER void GC_push_all_stacks(void)
+           hi = p->altstack + p->altstack_size;
+           /* FIXME: Need to scan the normal stack too, but how ? */
+           /* FIXME: Assume stack grows down */
++        } else {
++          if (pthread_getattr_np(p->id, &pattr)) {
++            ABORT("GC_push_all_stacks: pthread_getattr_np failed!");
++          }
++          if (pthread_attr_getstacksize(&pattr, &stack_limit)) {
++            ABORT("GC_push_all_stacks: pthread_attr_getstacksize failed!");
++          }
++          if (pthread_attr_destroy(&pattr)) {
++            ABORT("GC_push_all_stacks: pthread_attr_destroy failed!");
++          }
++          // When a thread goes into a coroutine, we lose its original sp until
++          // control flow returns to the thread.
++          // While in the coroutine, the sp points outside the thread stack,
++          // so we can detect this and push the entire thread stack instead,
++          // as an approximation.
++          // We assume that the coroutine has similarly added its entire stack.
++          // This could be made accurate by cooperating with the application
++          // via new functions and/or callbacks.
++          #ifndef STACK_GROWS_UP
++            if (lo >= hi || lo < hi - stack_limit) { // sp outside stack
++              lo = hi - stack_limit;
++            }
++          #else
++          #error "STACK_GROWS_UP not supported in boost_coroutine2 (as of june 2021), so we don't support it in Nix."
++          #endif
+         }
+         GC_push_all_stack_sections(lo, hi, traced_stack_sect);
+ #       ifdef STACK_GROWS_UP

--- a/boehmgc-coroutine-sp-fallback.diff
+++ b/boehmgc-coroutine-sp-fallback.diff
@@ -31,19 +31,19 @@ index 3dbaa3fb..36a1d1f7 100644
              GC_push_all_stack(altstack_lo, altstack_hi);
            }
 diff --git a/pthread_stop_world.c b/pthread_stop_world.c
-index 4b2c429..1fb4c52 100644
+index b5d71e62..aed7b0bf 100644
 --- a/pthread_stop_world.c
 +++ b/pthread_stop_world.c
-@@ -673,6 +673,8 @@ GC_INNER void GC_push_all_stacks(void)
-     struct GC_traced_stack_sect_s *traced_stack_sect;
-     pthread_t self = pthread_self();
-     word total_size = 0;
+@@ -768,6 +768,8 @@ STATIC void GC_restart_handler(int sig)
+ /* world is stopped.  Should not fail if it isn't.                      */
+ GC_INNER void GC_push_all_stacks(void)
+ {
 +    size_t stack_limit;
 +    pthread_attr_t pattr;
- 
-     if (!EXPECT(GC_thr_initialized, TRUE))
-       GC_thr_init();
-@@ -722,6 +724,31 @@ GC_INNER void GC_push_all_stacks(void)
+     GC_bool found_me = FALSE;
+     size_t nthreads = 0;
+     int i;
+@@ -851,6 +853,31 @@ GC_INNER void GC_push_all_stacks(void)
            hi = p->altstack + p->altstack_size;
            /* FIXME: Need to scan the normal stack too, but how ? */
            /* FIXME: Assume stack grows down */

--- a/flake.nix
+++ b/flake.nix
@@ -128,9 +128,14 @@
           });
 
         propagatedDeps =
-          [ (boehmgc.override {
+          [ ((boehmgc.override {
               enableLargeConfig = true;
+            }).overrideAttrs(o: {
+              patches = (o.patches or []) ++ [
+                ./boehmgc-coroutine-sp-fallback.diff
+              ];
             })
+            )
             nlohmann_json
           ];
       };


### PR DESCRIPTION

# Motivation

The patch is still necessary.

Should fix #7644 

# Context

The patch is still necessary.
@lheckemann @bb010g @edolstra, please do your research, or just ask the author (which happens to be me, but that doesn't matter).

An evaluator like this is not an environment where "it compiles, so it works" will ever hold.

This reverts commit 1c40182b12d5fd462c891b597e1a3f9b912502d5.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
   - n/a
 - [ ] agreed on implementation strategy
   - n/a
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
   - n/a
 - [ ] code and comments are self-explanatory
   - can explain later if desired
 - [x] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
    - fix; only after #7665 
