### PR TITLE
Fix the 2.13 changelog

### DIFF
--- a/doc/manual/src/release-notes/rl-2.13.md
+++ b/doc/manual/src/release-notes/rl-2.13.md
@@ -25,11 +25,11 @@
 * Allow explicitly selecting outputs in a store derivation installable, just like we can do with other sorts of installables.
   For example,
   ```shell-session
-  # nix-build /nix/store/gzaflydcr6sb3567hap9q6srzx8ggdgg-glibc-2.33-78.drv^dev
+  # nix build /nix/store/gzaflydcr6sb3567hap9q6srzx8ggdgg-glibc-2.33-78.drv^dev
   ```
   now works just as
   ```shell-session
-  # nix-build glibc^dev
+  # nix build glibc^dev
   ```
   does already.
 

--- a/doc/manual/src/release-notes/rl-2.13.md
+++ b/doc/manual/src/release-notes/rl-2.13.md
@@ -29,7 +29,7 @@
   ```
   now works just as
   ```shell-session
-  # nix build glibc^dev
+  # nix build nixpkgs#glibc^dev
   ```
   does already.
 


### PR DESCRIPTION
# Motivation

It is just the new CLI that gets the `^` syntax. The old CLI already has a (slightly different) `!` syntax.

# Context

Fixes #7682

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
