### PR TITLE
nix-hash: support base-64 and SRI format

### DIFF
--- a/doc/manual/src/command-ref/nix-hash.md
+++ b/doc/manual/src/command-ref/nix-hash.md
@@ -6,9 +6,7 @@
 
 `nix-hash` [`--flat`] [`--base32`] [`--truncate`] [`--type` *hashAlgo*] *path…*
 
-`nix-hash` `--to-base16` *hash…*
-
-`nix-hash` `--to-base32` *hash…*
+`nix-hash` [`--to-base16`|`--to-base32`|`--to-base64`|`--to-sri`] [`--type` *hashAlgo*] *hash…*
 
 # Description
 
@@ -35,10 +33,22 @@ md5sum`.
     The result is identical to that produced by the GNU commands
     `md5sum` and `sha1sum`.
 
+  - `--base16`\
+    Print the hash in a hexadecimal representation (default).
+
   - `--base32`\
     Print the hash in a base-32 representation rather than hexadecimal.
     This base-32 representation is more compact and can be used in Nix
     expressions (such as in calls to `fetchurl`).
+
+  - `--base64`\
+    Similar to --base32, but print the hash in a base-64 representation,
+    which is more compact than the base-32 one.
+
+  - `--sri`\
+    Print the hash in SRI format with base-64 encoding.
+    The type of hash algorithm will be prepended to the hash string,
+    followed by a hyphen (-) and the base-64 hash body.
 
   - `--truncate`\
     Truncate hashes longer than 160 bits (such as SHA-256) to 160 bits.
@@ -54,6 +64,14 @@ md5sum`.
   - `--to-base32`\
     Don’t hash anything, but convert the hexadecimal hash representation
     *hash* to base-32.
+
+  - `--to-base64`\
+    Don’t hash anything, but convert the hexadecimal hash representation
+    *hash* to base-64.
+
+  - `--to-sri`\
+    Don’t hash anything, but convert the hexadecimal hash representation
+    *hash* to SRI.
 
 # Examples
 
@@ -81,8 +99,17 @@ $ nix-store --dump test/ | md5sum (for comparison)
 $ nix-hash --type sha1 test/
 e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
 
+$ nix-hash --type sha1 --base16 test/
+e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
+
 $ nix-hash --type sha1 --base32 test/
 nvd61k9nalji1zl9rrdfmsmvyyjqpzg4
+
+$ nix-hash --type sha1 --base64 test/
+5P2Lpfe76upazon+ECVVNs1g2rY=
+
+$ nix-hash --type sha1 --sri test/
+sha1-5P2Lpfe76upazon+ECVVNs1g2rY=
 
 $ nix-hash --type sha256 --flat test/
 error: reading file `test/': Is a directory
@@ -91,12 +118,21 @@ $ nix-hash --type sha256 --flat test/world
 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
 ```
 
-Converting between hexadecimal and base-32:
+Converting between hexadecimal, base-32, base-64, and SRI:
 
 ```console
 $ nix-hash --type sha1 --to-base32 e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
 nvd61k9nalji1zl9rrdfmsmvyyjqpzg4
 
 $ nix-hash --type sha1 --to-base16 nvd61k9nalji1zl9rrdfmsmvyyjqpzg4
+e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
+
+$ nix-hash --type sha1 --to-base64 e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
+5P2Lpfe76upazon+ECVVNs1g2rY=
+
+$ nix-hash --type sha1 --to-sri nvd61k9nalji1zl9rrdfmsmvyyjqpzg4
+sha1-5P2Lpfe76upazon+ECVVNs1g2rY=
+
+$ nix-hash --to-base16 sha1-5P2Lpfe76upazon+ECVVNs1g2rY=
 e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
 ```

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -4,6 +4,13 @@
   passed the `--stdin` flag. This is primarily useful when you have a large amount of paths which
   exceed the OS arg limit.
 
+* The `nix-hash` command now supports Base64 and SRI. Use the flags `--base64`
+  or `--sri` to specify the format of output hash as Base64 or SRI, and `--to-base64`
+  or `--to-sri` to convert a hash to Base64 or SRI format, respectively.
+
+  As the choice of hash formats is no longer binary, the `--base16` flag is also added
+  to explicitly specify the Base16 format, which is still the default.
+
 * The special handling of an [installable](../command-ref/new-cli/nix.md#installables) with `.drv` suffix being interpreted as all of the given [store derivation](../glossary.md#gloss-store-derivation)'s output paths is removed, and instead taken as the literal store path that it represents.
 
   The new `^` syntax for store paths introduced in Nix 2.13 allows explicitly referencing output paths of a derivation.

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -161,11 +161,11 @@ static auto rCmdHash = registerCommand<CmdHash>("hash");
 /* Legacy nix-hash command. */
 static int compatNixHash(int argc, char * * argv)
 {
-    HashType ht = htMD5;
+    std::optional<HashType> ht;
     bool flat = false;
-    bool base32 = false;
+    Base base = Base16;
     bool truncate = false;
-    enum { opHash, opTo32, opTo16 } op = opHash;
+    enum { opHash, opTo } op = opHash;
     std::vector<std::string> ss;
 
     parseCmdLine(argc, argv, [&](Strings::iterator & arg, const Strings::iterator & end) {
@@ -174,14 +174,31 @@ static int compatNixHash(int argc, char * * argv)
         else if (*arg == "--version")
             printVersion("nix-hash");
         else if (*arg == "--flat") flat = true;
-        else if (*arg == "--base32") base32 = true;
+        else if (*arg == "--base16") base = Base16;
+        else if (*arg == "--base32") base = Base32;
+        else if (*arg == "--base64") base = Base64;
+        else if (*arg == "--sri") base = SRI;
         else if (*arg == "--truncate") truncate = true;
         else if (*arg == "--type") {
             std::string s = getArg(*arg, arg, end);
             ht = parseHashType(s);
         }
-        else if (*arg == "--to-base16") op = opTo16;
-        else if (*arg == "--to-base32") op = opTo32;
+        else if (*arg == "--to-base16") {
+            op = opTo;
+            base = Base16;
+        }
+        else if (*arg == "--to-base32") {
+            op = opTo;
+            base = Base32;
+        }
+        else if (*arg == "--to-base64") {
+            op = opTo;
+            base = Base64;
+        }
+        else if (*arg == "--to-sri") {
+            op = opTo;
+            base = SRI;
+        }
         else if (*arg != "" && arg->at(0) == '-')
             return false;
         else
@@ -191,17 +208,18 @@ static int compatNixHash(int argc, char * * argv)
 
     if (op == opHash) {
         CmdHashBase cmd(flat ? FileIngestionMethod::Flat : FileIngestionMethod::Recursive);
-        cmd.ht = ht;
-        cmd.base = base32 ? Base32 : Base16;
+        if (!ht.has_value()) ht = htMD5;
+        cmd.ht = ht.value();
+        cmd.base = base;
         cmd.truncate = truncate;
         cmd.paths = ss;
         cmd.run();
     }
 
     else {
-        CmdToBase cmd(op == opTo32 ? Base32 : Base16);
+        CmdToBase cmd(base);
         cmd.args = ss;
-        cmd.ht = ht;
+        if (ht.has_value()) cmd.ht = ht;
         cmd.run();
     }
 

--- a/tests/hash.sh
+++ b/tests/hash.sh
@@ -80,6 +80,8 @@ try3() {
     [ "$sri" = "$1-$4" ]
     h32=$(nix-hash --type "$1" --to-base32 "$2")
     [ "$h32" = "$3" ]
+    h32=$(nix hash to-base32 --type "$1" "$2")
+    [ "$h32" = "$3" ]
     h16=$(nix-hash --type "$1" --to-base16 "$h32")
     [ "$h16" = "$2" ]
     h16=$(nix hash to-base16 --type "$1" "$h64")

--- a/tests/hash.sh
+++ b/tests/hash.sh
@@ -2,13 +2,14 @@ source common.sh
 
 try () {
     printf "%s" "$2" > $TEST_ROOT/vector
-    hash=$(nix hash file --base16 ${EXTRA-} --type "$1" $TEST_ROOT/vector)
+    hash="$(nix hash file ${FORMAT_FLAG-} --type "$1" "$TEST_ROOT/vector")"
     if test "$hash" != "$3"; then
         echo "hash $1, expected $3, got $hash"
         exit 1
     fi
 }
 
+FORMAT_FLAG=--base16
 try md5 "" "d41d8cd98f00b204e9800998ecf8427e"
 try md5 "a" "0cc175b9c0f1b6a831c399e269772661"
 try md5 "abc" "900150983cd24fb0d6963f7d28e17f72"
@@ -28,16 +29,20 @@ try sha256 "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" "248d6a61d
 try sha512 "" "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
 try sha512 "abc" "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
 try sha512 "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" "204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445"
+unset FORMAT_FLAG
 
-EXTRA=--base32
+FORMAT_FLAG=--base32
 try sha256 "abc" "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
-EXTRA=
+unset FORMAT_FLAG
 
-EXTRA=--sri
+FORMAT_FLAG=--sri
 try sha512 "" "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg=="
 try sha512 "abc" "sha512-3a81oZNherrMQXNJriBBMRLm+k6JqX6iCp7u5ktV05ohkpkqJ0/BqDa6PCOj/uu9RU1EI2Q86A4qmslPpUyknw=="
 try sha512 "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" "sha512-IEqPxt2oLwoM7XvrjgikFlfBbvRosiioJ5vjMacDwzWW/RXBOxsH+aodO+pXeJygMa2Fx6cd1wNU7GMSOMo0RQ=="
 try sha256 "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" "sha256-JI1qYdIGOLjlwCaTDD5gOaM85Flk/yFn9uzt1BnbBsE="
+unset FORMAT_FLAG
+
+try sha512 "abc" "sha512-3a81oZNherrMQXNJriBBMRLm+k6JqX6iCp7u5ktV05ohkpkqJ0/BqDa6PCOj/uu9RU1EI2Q86A4qmslPpUyknw=="
 
 try2 () {
     hash=$(nix-hash --type "$1" $TEST_ROOT/hash-path)


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This PR provides `nix-hash` with base-64 and SRI format support, equivalent to that of `nix hash`.

If applied, users with a `nix-channel`-based setup would be able to compute hashes in base-64 and SRI format without having to type `nix --extra-experimental-features hash ...`

```console
$ nix-hash --type sha256 --base64 /nix/store/g2m8kfw7kpgpph05v2fxcx4d5an09hl3-hello-2.12.1
p7JaKoco7c2MM+1zHW1B5ebUUnt9rGVc3GaTsu1QYfE=

$ nix-hash --type sha256 --sri /nix/store/g2m8kfw7kpgpph05v2fxcx4d5an09hl3-hello-2.12.1
sha256-p7JaKoco7c2MM+1zHW1B5ebUUnt9rGVc3GaTsu1QYfE=

$ nix-hash --type sha1 --to-base64 e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
5P2Lpfe76upazon+ECVVNs1g2rY=

$ nix-hash --type sha1 --to-sri nvd61k9nalji1zl9rrdfmsmvyyjqpzg4
sha1-5P2Lpfe76upazon+ECVVNs1g2rY=

$ nix-hash --to-base16 sha1-5P2Lpfe76upazon+ECVVNs1g2rY=
e4fd8ba5f7bbeaea5ace89fe10255536cd60dab6
```

# Context
<!-- Provide context. Reference open issues if available. -->
Solves #7688

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
