### PR TITLE
Fix auto-uid-allocation in Docker containers

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -209,10 +209,10 @@ void LocalDerivationGoal::tryLocalBuild()
 
     #if __linux__
     if (useChroot) {
-        if (!mountNamespacesSupported()) {
+        if (!mountNamespacesSupported() || !pidNamespacesSupported()) {
             if (!settings.sandboxFallback)
-                throw Error("this system does not support mount namespaces, which are required for sandboxing");
-            debug("auto-disabling sandboxing because mount namespaces are not available");
+                throw Error("this system does not support the kernel namespaces that are required for sandboxing");
+            debug("auto-disabling sandboxing because the prerequisite namespaces are not available");
             useChroot = false;
         }
     }

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -211,7 +211,7 @@ void LocalDerivationGoal::tryLocalBuild()
     if (useChroot) {
         if (!mountNamespacesSupported() || !pidNamespacesSupported()) {
             if (!settings.sandboxFallback)
-                throw Error("this system does not support the kernel namespaces that are required for sandboxing");
+                throw Error("this system does not support the kernel namespaces that are required for sandboxing; use '--no-sandbox' to disable sandboxing");
             debug("auto-disabling sandboxing because the prerequisite namespaces are not available");
             useChroot = false;
         }

--- a/src/libutil/namespaces.cc
+++ b/src/libutil/namespaces.cc
@@ -1,0 +1,63 @@
+#include "namespaces.hh"
+#include "util.hh"
+
+#if __linux__
+
+namespace nix {
+
+bool userNamespacesSupported()
+{
+    static bool res = [&]() -> bool
+    {
+        if (!pathExists("/proc/self/ns/user")) {
+            notice("'/proc/self/ns/user' does not exist; your kernel was likely built without CONFIG_USER_NS=y, which is required for sandboxing");
+            return false;
+        }
+
+        Path maxUserNamespaces = "/proc/sys/user/max_user_namespaces";
+        if (!pathExists(maxUserNamespaces) ||
+            trim(readFile(maxUserNamespaces)) == "0")
+        {
+            notice("user namespaces appear to be disabled; they are required for sandboxing; check '/proc/sys/user/max_user_namespaces'");
+            return false;
+        }
+
+        Path procSysKernelUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone";
+        if (pathExists(procSysKernelUnprivilegedUsernsClone)
+            && trim(readFile(procSysKernelUnprivilegedUsernsClone)) == "0")
+        {
+            notice("user namespaces appear to be disabled; they are required for sandboxing; check '/proc/sys/kernel/unprivileged_userns_clone'");
+            return false;
+        }
+
+        Pid pid = startProcess([&]()
+        {
+            auto res = unshare(CLONE_NEWUSER);
+            _exit(res ? 1 : 0);
+        });
+
+        return pid.wait() == 0;
+    }();
+    return res;
+}
+
+bool mountNamespacesSupported()
+{
+    static bool res = [&]() -> bool
+    {
+        bool useUserNamespace = userNamespacesSupported();
+
+        Pid pid = startProcess([&]()
+        {
+            auto res = unshare(CLONE_NEWNS | (useUserNamespace ? CLONE_NEWUSER : 0));
+            _exit(res ? 1 : 0);
+        });
+
+        return pid.wait() == 0;
+    }();
+    return res;
+}
+
+}
+
+#endif

--- a/src/libutil/namespaces.cc
+++ b/src/libutil/namespaces.cc
@@ -1,5 +1,8 @@
 #include "namespaces.hh"
 #include "util.hh"
+#include "finally.hh"
+
+#include <mntent.h>
 
 #if __linux__
 
@@ -7,10 +10,10 @@ namespace nix {
 
 bool userNamespacesSupported()
 {
-    static bool res = [&]() -> bool
+    static auto res = [&]() -> bool
     {
         if (!pathExists("/proc/self/ns/user")) {
-            notice("'/proc/self/ns/user' does not exist; your kernel was likely built without CONFIG_USER_NS=y, which is required for sandboxing");
+            debug("'/proc/self/ns/user' does not exist; your kernel was likely built without CONFIG_USER_NS=y");
             return false;
         }
 
@@ -18,7 +21,7 @@ bool userNamespacesSupported()
         if (!pathExists(maxUserNamespaces) ||
             trim(readFile(maxUserNamespaces)) == "0")
         {
-            notice("user namespaces appear to be disabled; they are required for sandboxing; check '/proc/sys/user/max_user_namespaces'");
+            debug("user namespaces appear to be disabled; check '/proc/sys/user/max_user_namespaces'");
             return false;
         }
 
@@ -26,7 +29,7 @@ bool userNamespacesSupported()
         if (pathExists(procSysKernelUnprivilegedUsernsClone)
             && trim(readFile(procSysKernelUnprivilegedUsernsClone)) == "0")
         {
-            notice("user namespaces appear to be disabled; they are required for sandboxing; check '/proc/sys/kernel/unprivileged_userns_clone'");
+            debug("user namespaces appear to be disabled; check '/proc/sys/kernel/unprivileged_userns_clone'");
             return false;
         }
 
@@ -43,7 +46,7 @@ bool userNamespacesSupported()
 
 bool mountNamespacesSupported()
 {
-    static bool res = [&]() -> bool
+    static auto res = [&]() -> bool
     {
         bool useUserNamespace = userNamespacesSupported();
 
@@ -54,6 +57,30 @@ bool mountNamespacesSupported()
         });
 
         return pid.wait() == 0;
+    }();
+    return res;
+}
+
+bool pidNamespacesSupported()
+{
+    static auto res = [&]() -> bool
+    {
+        /* Check whether /proc is fully visible, i.e. there are no
+           filesystems mounted on top of files inside /proc. If this
+           is not the case, then we cannot mount a new /proc inside
+           the sandbox that matches the sandbox's PID namespace.
+           See https://lore.kernel.org/lkml/87tvsrjai0.fsf@xmission.com/T/. */
+        auto fp = fopen("/proc/mounts", "r");
+        if (!fp) return false;
+        Finally delFP = [&]() { fclose(fp); };
+
+        while (auto ent = getmntent(fp))
+            if (hasPrefix(std::string_view(ent->mnt_dir), "/proc/")) {
+                debug("PID namespaces do not work because /proc is not fully visible; disabling sandboxing");
+                return false;
+            }
+
+        return true;
     }();
     return res;
 }

--- a/src/libutil/namespaces.cc
+++ b/src/libutil/namespaces.cc
@@ -39,7 +39,12 @@ bool userNamespacesSupported()
             _exit(res ? 1 : 0);
         });
 
-        return pid.wait() == 0;
+        bool supported = pid.wait() == 0;
+
+        if (!supported)
+            debug("user namespaces do not work on this system");
+
+        return supported;
     }();
     return res;
 }
@@ -56,7 +61,12 @@ bool mountNamespacesSupported()
             _exit(res ? 1 : 0);
         });
 
-        return pid.wait() == 0;
+        bool supported = pid.wait() == 0;
+
+        if (!supported)
+            debug("mount namespaces do not work on this system");
+
+        return supported;
     }();
     return res;
 }

--- a/src/libutil/namespaces.cc
+++ b/src/libutil/namespaces.cc
@@ -1,10 +1,10 @@
+#if __linux__
+
 #include "namespaces.hh"
 #include "util.hh"
 #include "finally.hh"
 
 #include <mntent.h>
-
-#if __linux__
 
 namespace nix {
 

--- a/src/libutil/namespaces.hh
+++ b/src/libutil/namespaces.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace nix {
+
+bool userNamespacesSupported();
+
+bool mountNamespacesSupported();
+
+}

--- a/src/libutil/namespaces.hh
+++ b/src/libutil/namespaces.hh
@@ -6,4 +6,6 @@ bool userNamespacesSupported();
 
 bool mountNamespacesSupported();
 
+bool pidNamespacesSupported();
+
 }

--- a/src/libutil/namespaces.hh
+++ b/src/libutil/namespaces.hh
@@ -2,10 +2,14 @@
 
 namespace nix {
 
+#if __linux__
+
 bool userNamespacesSupported();
 
 bool mountNamespacesSupported();
 
 bool pidNamespacesSupported();
+
+#endif
 
 }


### PR DESCRIPTION
# Motivation

Fixes

```
# nix build --extra-experimental-features 'auto-allocate-uids nix-command flakes' --auto-allocate-uids --impure --expr 'with import <nixpkgs> {}; runCommand "foo" {} "mkdir $out"'
foo> /tmp/nix-build-foo.drv-0/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 1: /nix/store/2fhbn9q5q3r96p9jmrnwh36a7m3iwvar-foo: Permission denied
```

This didn't work because sandboxing doesn't work in Docker. However, the sandboxing check is done lazily - after `clone(CLONE_NEWNS)` fails, we retry with sandboxing disabled. But at that point, we've already done UID allocation under the assumption that user namespaces are enabled.

So let's get rid of the "goto fallback" logic and just detect early whether user / mount namespaces are enabled.

This commit also gets rid of a compatibility hack for some ancient Linux kernels (<2.13).

It also adds a check to automatically disable sandboxing in unprivileged podman containers, since that doesn't work.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
