### PR TITLE
Fix substituters doc page being ambiguous about cache ordering

### DIFF
--- a/doc/manual/src/package-management/binary-cache-substituter.md
+++ b/doc/manual/src/package-management/binary-cache-substituter.md
@@ -41,8 +41,9 @@ $ nix-env -iA nixpkgs.firefox --substituters http://avalon:8080/
 The option `substituters` tells Nix to use this binary cache in
 addition to your default caches, such as <https://cache.nixos.org>.
 Thus, for any path in the closure of Firefox, Nix will first check if
-the path is available on the server `avalon` or another binary caches.
-If not, it will fall back to building from source.
+the path is available on the binary caches, in order of priority (the
+priority of cache.nixos.org is 40). If not, it will fall back to
+building from source.
 
 You can also tell Nix to always use your binary cache by adding a line
 to the `nix.conf` configuration file like this:


### PR DESCRIPTION
# Motivation

This makes it more explicit what the ordering the substituters will be checked in and improves the documentation experience.

# Context

I think this part of the docs played a role in my confusion about extra substituters being checked before cache.nixos.org last night while I was tired and trying to figure a bunch of things out.

This makes it clear that ordering is not necessarily based on the reverse order in the client config, but configured by the server's Priority.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
