### PR TITLE
Revert "flake.nix: Add nixpkgs/lib/tests as regression test"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -544,12 +544,6 @@
               mkdir $out
             '';
 
-        tests.nixpkgsLibTests =
-          nixpkgs.lib.genAttrs systems (system:
-            import (nixpkgs + "/lib/tests/release.nix")
-              { pkgs = nixpkgsFor.${system}; }
-          );
-
         metrics.nixpkgs = import "${nixpkgs-regression}/pkgs/top-level/metrics.nix" {
           pkgs = nixpkgsFor.x86_64-linux;
           nixpkgs = nixpkgs-regression;
@@ -580,7 +574,6 @@
         binaryTarball = self.hydraJobs.binaryTarball.${system};
         perlBindings = self.hydraJobs.perlBindings.${system};
         installTests = self.hydraJobs.installTests.${system};
-        nixpkgsLibTests = self.hydraJobs.tests.nixpkgsLibTests.${system};
       } // (nixpkgs.lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
         dockerImage = self.hydraJobs.dockerImage.${system};
       });


### PR DESCRIPTION
# Motivation

This reverts commit 620e4fb89bd08fb35e83d18d84f5f635a83239d8.

These tests are not suitable as a regression test for Nix, since they do a lot of pattern-matching on the error messages from Nix. But error messages are not a stable interface - they can and do change between releases. But since these tests are defined in another repo, we have no ability to update the tests when needed.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
