### PR TITLE
docs: Fix small formatting errors

### DIFF
--- a/doc/manual/src/language/operators.md
+++ b/doc/manual/src/language/operators.md
@@ -24,7 +24,7 @@
 | [Equality]                             | *expr* `==` *expr*                         | none          | 11         |
 | Inequality                             | *expr* `!=` *expr*                         | none          | 11         |
 | Logical conjunction (`AND`)            | *bool* `&&` *bool*                         | left          | 12         |
-| Logical disjunction (`OR`)             | *bool* `\|\|` *bool*                       | left          | 13         |
+| Logical disjunction (`OR`)             | *bool* <code>\|\|</code> *bool*            | left          | 13         |
 | [Logical implication]                  | *bool* `->` *bool*                         | none          | 14         |
 
 [string]: ./values.md#type-string

--- a/doc/manual/src/language/operators.md
+++ b/doc/manual/src/language/operators.md
@@ -116,7 +116,7 @@ The result is a string.
 [store path]: ../glossary.md#gloss-store-path
 [store]: ../glossary.md#gloss-store
 
-[Path and string concatenation]: #path-and-string-concatenation
+[String and path concatenation]: #string-and-path-concatenation
 
 ## Update
 
@@ -133,7 +133,7 @@ If an attribute name is present in both, the attribute value from the latter is 
 
 Comparison is
 
-- [arithmetic] for [number]s 
+- [arithmetic] for [number]s
 - lexicographic for [string]s and [path]s
 - item-wise lexicographic for [list]s:
   elements at the same index in both lists are compared according to their type and skipped if they are equal.


### PR DESCRIPTION
The MD preview on GitHub is incorrectly formatting the `||` operator as part of the table. mdbook correctly interprets this as code.

# Motivation
Small formatting errors. See screenshots below.
![Screenshot 2023-01-26 at 22 52 30](https://user-images.githubusercontent.com/9742635/214958921-c04ab207-6516-43de-829c-6b1e5566bd9c.png)
![Screenshot 2023-01-26 at 22 52 57](https://user-images.githubusercontent.com/9742635/214958999-4665b4a1-0791-44f6-8136-7050dcba4967.png)



# Context
Trivial docs change.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
