### PR TITLE
perl: run `initLibStore()` on `openStore()`

### DIFF
--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -26,6 +26,7 @@ static ref<Store> store()
     static std::shared_ptr<Store> _store;
     if (!_store) {
         try {
+            initLibStore();
             loadConfFile();
             settings.lockCPU = false;
             _store = openStore();


### PR DESCRIPTION
# Motivation

Fix calling `openStore()` from Perl code (needed e.g. in Hydra)

# Context
Since #7478 it's mandatory that `initLibStore()` is called for store operations. However that's not the case when running `openStore()` in Perl using the perl-bindings. That breaks e.g. `hydra-eval-jobset` when built against Nix 2.13 which uses small portions of the store API.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
