### PR TITLE
Avoid some `StorePath` <-> `Path` round trips

### DIFF
--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -81,14 +81,14 @@ struct CmdVerify : StorePathsCommand
 
         ThreadPool pool;
 
-        auto doPath = [&](const Path & storePath) {
+        auto doPath = [&](const StorePath & storePath) {
             try {
                 checkInterrupt();
 
                 MaintainCount<std::atomic<size_t>> mcActive(active);
                 update();
 
-                auto info = store->queryPathInfo(store->parseStorePath(storePath));
+                auto info = store->queryPathInfo(storePath);
 
                 // Note: info->path can be different from storePath
                 // for binary cache stores when using --all (since we
@@ -173,7 +173,7 @@ struct CmdVerify : StorePathsCommand
         };
 
         for (auto & storePath : storePaths)
-            pool.enqueue(std::bind(doPath, store->printStorePath(storePath)));
+            pool.enqueue(std::bind(doPath, storePath));
 
         pool.process();
 


### PR DESCRIPTION
# Motivation

Avoid needless work and throwing away invariants.

# Context

These conversions date back to when `StorePath` was in Rust and there were issues with it missing utility methods.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - indirect, good enough
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
   - n/a
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
   - n/a