### PR TITLE
Separate `path.hh` from `content-address.hh`

### DIFF
--- a/src/libstore/path.hh
+++ b/src/libstore/path.hh
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "content-address.hh"
+#include <string_view>
+
 #include "types.hh"
 
 namespace nix {
@@ -65,8 +66,6 @@ public:
 
 typedef std::set<StorePath> StorePathSet;
 typedef std::vector<StorePath> StorePaths;
-
-typedef std::map<StorePath, std::optional<ContentAddress>> StorePathCAMap;
 
 /* Extension of derivations in the Nix store. */
 const std::string drvExtension = ".drv";

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <variant>
+
+#include "hash.hh"
 #include "path.hh"
 #include <nlohmann/json_fwd.hpp>
 #include "comparator.hh"

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -87,6 +87,8 @@ enum BuildMode { bmNormal, bmRepair, bmCheck };
 struct BuildResult;
 
 
+typedef std::map<StorePath, std::optional<ContentAddress>> StorePathCAMap;
+
 struct StoreConfig : public Config
 {
     using Config::Config;


### PR DESCRIPTION
# Motivation

It is good to separate concerns; `StorePath` (in general) has nothing to do with `ContentAddress` anyways.

# Context

This reduces the diff from #3746.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
