### PR TITLE
Delete dead code

### DIFF
--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -134,7 +134,6 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
             /* Hash will be set below. FIXME construct ValidPathInfo at end. */
             auto info = std::make_shared<ValidPathInfo>(path, Hash::dummy);
 
-            PathSet references;
             auto deriver = readString(conn->from);
             if (deriver != "")
                 info->deriver = parseStorePath(deriver);

--- a/src/libstore/path-info.hh
+++ b/src/libstore/path-info.hh
@@ -81,12 +81,6 @@ struct ValidPathInfo
     /* Return true iff the path is verifiably content-addressed. */
     bool isContentAddressed(const Store & store) const;
 
-    /* Functions to view references + hasSelfReference as one set, mainly for
-       compatibility's sake. */
-    StorePathSet referencesPossiblyToSelf() const;
-    void insertReferencePossiblyToSelf(StorePath && ref);
-    void setReferencesPossiblyToSelf(StorePathSet && refs);
-
     static const size_t maxSigs = std::numeric_limits<size_t>::max();
 
     /* Return the number of signatures on this .narinfo that were


### PR DESCRIPTION
# Motivation

Dead code bad!

# Context

The references set seems to have been unused since `LegacySSHStore` references were first created in
caa5793b4a74049ee37dd88eb1c5b785456ce40d.

The method decls never were upstream, and accidentally added by me in 062533f7cdb74026096ca8c7d5b6e393893d59ef (probably due to `git rerere`). Sorry!

This reduces the diff from #3746.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
