### PR TITLE
Fix configure.ac rapidcheck tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -276,8 +276,11 @@ PKG_CHECK_MODULES([GTEST], [gtest_main])
 
 # Look for rapidcheck.
 # No pkg-config yet, https://github.com/emil-e/rapidcheck/issues/302
+AC_LANG_PUSH(C++)
 AC_CHECK_HEADERS([rapidcheck/gtest.h], [], [], [#include <gtest/gtest.h>])
-AC_CHECK_LIB([rapidcheck], [])
+dnl No good for C++ libs with mangled symbols
+dnl AC_CHECK_LIB([rapidcheck], [])
+AC_LANG_POP(C++)
 
 
 # Look for nlohmann/json.


### PR DESCRIPTION
# Motivation

- `AC_LANG_PUSH(C++)` is needed for the header check

- The library check is hopeless (without lots of third-party macros I don't feel like getting) because name mangling

# Context

Pkg-config would make all this easier. I previously opened https://github.com/emil-e/rapidcheck/issues/302, I should write a PR too.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
