### PR TITLE
nix store ping: add --json flag

### DIFF
--- a/src/nix/ping-store.cc
+++ b/src/nix/ping-store.cc
@@ -2,9 +2,11 @@
 #include "shared.hh"
 #include "store-api.hh"
 
+#include <nlohmann/json.hpp>
+
 using namespace nix;
 
-struct CmdPingStore : StoreCommand
+struct CmdPingStore : StoreCommand, MixJSON
 {
     std::string description() override
     {
@@ -20,10 +22,19 @@ struct CmdPingStore : StoreCommand
 
     void run(ref<Store> store) override
     {
-        notice("Store URL: %s", store->getUri());
-        store->connect();
-        if (auto version = store->getVersion())
-            notice("Version: %s", *version);
+        if (!json) {
+            notice("Store URL: %s", store->getUri());
+            store->connect();
+            if (auto version = store->getVersion())
+                notice("Version: %s", *version);
+        } else {
+            nlohmann::json res;
+            res["url"] = store->getUri();
+            store->connect();
+            if (auto version = store->getVersion())
+                res["version"] = *version;
+            logger->cout("%s", res);
+        }
     }
 };
 

--- a/src/nix/ping-store.cc
+++ b/src/nix/ping-store.cc
@@ -1,6 +1,7 @@
 #include "command.hh"
 #include "shared.hh"
 #include "store-api.hh"
+#include "finally.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -29,11 +30,13 @@ struct CmdPingStore : StoreCommand, MixJSON
                 notice("Version: %s", *version);
         } else {
             nlohmann::json res;
+            Finally printRes([&]() {
+                logger->cout("%s", res);
+            });
             res["url"] = store->getUri();
             store->connect();
             if (auto version = store->getVersion())
                 res["version"] = *version;
-            logger->cout("%s", res);
         }
     }
 };

--- a/tests/store-ping.sh
+++ b/tests/store-ping.sh
@@ -1,13 +1,17 @@
 source common.sh
 
 STORE_INFO=$(nix store ping 2>&1)
+STORE_INFO_JSON=$(nix store ping --json)
 
 echo "$STORE_INFO" | grep "Store URL: ${NIX_REMOTE}"
 
 if [[ -v NIX_DAEMON_PACKAGE ]] && isDaemonNewer "2.7.0pre20220126"; then
     DAEMON_VERSION=$($NIX_DAEMON_PACKAGE/bin/nix-daemon --version | cut -d' ' -f3)
     echo "$STORE_INFO" | grep "Version: $DAEMON_VERSION"
+    [[ "$(echo "$STORE_INFO_JSON" | jq -r ".version")" == "$DAEMON_VERSION" ]]
 fi
 
 expect 127 NIX_REMOTE=unix:$PWD/store nix store ping || \
     fail "nix store ping on a non-existent store should fail"
+
+[[ "$(echo "$STORE_INFO_JSON" | jq -r ".url")" == "${NIX_REMOTE:-local}" ]]


### PR DESCRIPTION
# Motivation
Requested in https://github.com/NixOS/nix/pull/7515#issuecomment-1400287748

# Context
I also tried to add a Finally instance to also print the json in case of error, but the store connection happens (and fails) before the `run()` method is even entered, so this doesn't work.  `nix show-config --json` does work in that case.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
