### PR TITLE
Disable GC during coroutine execution + test

### DIFF
--- a/boehmgc-coroutine-sp-fallback.diff
+++ b/boehmgc-coroutine-sp-fallback.diff
@@ -1,8 +1,8 @@
 diff --git a/darwin_stop_world.c b/darwin_stop_world.c
-index 3dbaa3fb..36a1d1f7 100644
+index 0468aaec..b348d869 100644
 --- a/darwin_stop_world.c
 +++ b/darwin_stop_world.c
-@@ -352,6 +352,7 @@ GC_INNER void GC_push_all_stacks(void)
+@@ -356,6 +356,7 @@ GC_INNER void GC_push_all_stacks(void)
    int nthreads = 0;
    word total_size = 0;
    mach_msg_type_number_t listcount = (mach_msg_type_number_t)THREAD_TABLE_SZ;
@@ -10,7 +10,7 @@ index 3dbaa3fb..36a1d1f7 100644
    if (!EXPECT(GC_thr_initialized, TRUE))
      GC_thr_init();
  
-@@ -407,6 +408,19 @@ GC_INNER void GC_push_all_stacks(void)
+@@ -411,6 +412,19 @@ GC_INNER void GC_push_all_stacks(void)
              GC_push_all_stack_sections(lo, hi, p->traced_stack_sect);
            }
            if (altstack_lo) {
@@ -30,6 +30,22 @@ index 3dbaa3fb..36a1d1f7 100644
              total_size += altstack_hi - altstack_lo;
              GC_push_all_stack(altstack_lo, altstack_hi);
            }
+diff --git a/include/gc.h b/include/gc.h
+index edab6c22..f2c61282 100644
+--- a/include/gc.h
++++ b/include/gc.h
+@@ -2172,6 +2172,11 @@ GC_API void GC_CALL GC_win32_free_heap(void);
+         (*GC_amiga_allocwrapper_do)(a,GC_malloc_atomic_ignore_off_page)
+ #endif /* _AMIGA && !GC_AMIGA_MAKINGLIB */
+ 
++#if !__APPLE__
++/* Patch doesn't work on apple */
++#define NIX_BOEHM_PATCH_VERSION 1
++#endif
++
+ #ifdef __cplusplus
+   } /* extern "C" */
+ #endif
 diff --git a/pthread_stop_world.c b/pthread_stop_world.c
 index b5d71e62..aed7b0bf 100644
 --- a/pthread_stop_world.c

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -367,6 +367,7 @@ void initGC()
 
 
 #if NIX_BOEHM_PATCH_VERSION != 1
+    printTalkative("Unpatched BoehmGC, disabling GC inside coroutines");
     /* Used to disable GC when entering coroutines on macOS */
     create_coro_gc_hook = []() -> std::shared_ptr<void> {
         return std::make_shared<BoehmDisableGC>();

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -326,6 +326,20 @@ static Symbol getName(const AttrName & name, EvalState & state, Env & env)
 }
 
 
+class BoehmDisableGC : public DisableGC {
+public:
+    BoehmDisableGC() {
+#if HAVE_BOEHMGC
+        GC_disable();
+#endif
+    };
+    virtual ~BoehmDisableGC() override {
+#if HAVE_BOEHMGC
+        GC_enable();
+#endif
+    };
+};
+
 static bool gcInitialised = false;
 
 void initGC()
@@ -348,6 +362,12 @@ void initGC()
     GC_set_oom_fn(oomHandler);
 
     StackAllocator::defaultAllocator = &boehmGCStackAllocator;
+
+
+    /* Used to disable GC when entering coroutines on macOS */
+    DisableGC::create = []() {
+        return std::dynamic_pointer_cast<DisableGC>(std::make_shared<BoehmDisableGC>());
+    };
 
     /* Set the initial heap size to something fairly big (25% of
        physical RAM, up to a maximum of 384 MiB) so that in most cases

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -366,10 +366,12 @@ void initGC()
     StackAllocator::defaultAllocator = &boehmGCStackAllocator;
 
 
+#if NIX_BOEHM_PATCH_VERSION != 1
     /* Used to disable GC when entering coroutines on macOS */
-    create_disable_gc = []() -> std::shared_ptr<void> {
+    create_coro_gc_hook = []() -> std::shared_ptr<void> {
         return std::make_shared<BoehmDisableGC>();
     };
+#endif
 
     /* Set the initial heap size to something fairly big (25% of
        physical RAM, up to a maximum of 384 MiB) so that in most cases

--- a/src/libexpr/tests/coro-gc.cc
+++ b/src/libexpr/tests/coro-gc.cc
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+#if HAVE_BOEHMGC
+#include <gc/gc.h>
+#endif
+
+#include "eval.hh"
+#include "serialise.hh"
+
+
+#define guard_gc(x) GC_register_finalizer((void*)x, finalizer, x##_collected, nullptr, nullptr)
+
+
+namespace nix {
+#if HAVE_BOEHMGC
+    static bool* uncollectable_bool() {
+        bool* res = (bool*)GC_MALLOC_UNCOLLECTABLE(1);
+        *res = false;
+        return res;
+    }
+
+    static void finalizer(void *obj, void *data) {
+        //printf("finalizer: obj %p data %p\n", obj, data);
+        *((bool*)data) = true;
+    }
+
+    // Generate 2 objects, discard one, run gc,
+    // see if one got collected and the other didn't
+    static void testFinalizerCalls() {
+        bool* do_collect_collected = uncollectable_bool();
+        bool* dont_collect_collected = uncollectable_bool();
+        {
+            volatile void* do_collect = GC_MALLOC_ATOMIC(128);
+            guard_gc(do_collect);
+        }
+        volatile void* dont_collect = GC_MALLOC_ATOMIC(128);
+        guard_gc(dont_collect);
+        GC_gcollect();
+        GC_invoke_finalizers();
+
+        ASSERT_TRUE(*do_collect_collected);
+        ASSERT_FALSE(*dont_collect_collected);
+        ASSERT_NE(nullptr, dont_collect);
+    }
+
+    // This test tests that boehm handles coroutine stacks correctly
+    TEST(CoroGC, CoroutineStackNotGCd) {
+        initGC();
+        testFinalizerCalls();
+
+        bool* dont_collect_collected = uncollectable_bool();
+        bool* do_collect_collected = uncollectable_bool();
+
+        volatile void* dont_collect = GC_MALLOC_ATOMIC(128);
+        guard_gc(dont_collect);
+        {
+            volatile void* do_collect = GC_MALLOC_ATOMIC(128);
+            guard_gc(do_collect);
+        }
+
+        auto source = sinkToSource([&](Sink& sink) {
+            testFinalizerCalls();
+
+            bool* dont_collect_inner_collected = uncollectable_bool();
+            bool* do_collect_inner_collected = uncollectable_bool();
+
+            volatile void* dont_collect_inner = GC_MALLOC_ATOMIC(128);
+            guard_gc(dont_collect_inner);
+            {
+                volatile void* do_collect_inner = GC_MALLOC_ATOMIC(128);
+                guard_gc(do_collect_inner);
+            }
+            // pass control to main
+            writeString("foo", sink);
+
+            ASSERT_TRUE(*do_collect_inner_collected);
+            ASSERT_FALSE(*dont_collect_inner_collected);
+            ASSERT_NE(nullptr, dont_collect_inner);
+
+            // pass control to main
+            writeString("bar", sink);
+        });
+
+        // pass control to coroutine
+        std::string foo = readString(*source);
+        ASSERT_EQ(foo, "foo");
+
+        GC_gcollect();
+        GC_invoke_finalizers();
+
+        // pass control to coroutine
+        std::string bar = readString(*source);
+        ASSERT_EQ(bar, "bar");
+
+        ASSERT_FALSE(*dont_collect_collected);
+        ASSERT_TRUE(*do_collect_collected);
+        ASSERT_NE(nullptr, dont_collect);
+    }
+#endif
+}

--- a/src/libexpr/tests/coro-gc.cc
+++ b/src/libexpr/tests/coro-gc.cc
@@ -1,89 +1,126 @@
 #include <gtest/gtest.h>
 #if HAVE_BOEHMGC
 #include <gc/gc.h>
-#endif
 
 #include "eval.hh"
 #include "serialise.hh"
 
-
-#define guard_gc(x) GC_register_finalizer((void*)x, finalizer, x##_collected, nullptr, nullptr)
+#endif
 
 
 namespace nix {
 #if HAVE_BOEHMGC
-    static bool* uncollectable_bool() {
-        bool* res = (bool*)GC_MALLOC_UNCOLLECTABLE(1);
-        *res = false;
-        return res;
-    }
 
     static void finalizer(void *obj, void *data) {
-        //printf("finalizer: obj %p data %p\n", obj, data);
         *((bool*)data) = true;
+    }
+
+    static bool* make_witness(volatile void* obj) {
+        /* We can't store the witnesses on the stack,
+           since they might be collected long afterwards */
+        bool* res = (bool*)GC_MALLOC_UNCOLLECTABLE(1);
+        *res = false;
+        GC_register_finalizer((void*)obj, finalizer, res, nullptr, nullptr);
+        return res;
     }
 
     // Generate 2 objects, discard one, run gc,
     // see if one got collected and the other didn't
     // GC is disabled inside coroutines on __APPLE__
     static void testFinalizerCalls() {
-        bool* do_collect_collected = uncollectable_bool();
-        bool* dont_collect_collected = uncollectable_bool();
-        {
-            volatile void* do_collect = GC_MALLOC_ATOMIC(128);
-            guard_gc(do_collect);
-        }
+        volatile void* do_collect = GC_MALLOC_ATOMIC(128);
         volatile void* dont_collect = GC_MALLOC_ATOMIC(128);
-        guard_gc(dont_collect);
+
+        bool* do_collect_witness = make_witness(do_collect);
+        bool* dont_collect_witness = make_witness(dont_collect);
         GC_gcollect();
         GC_invoke_finalizers();
 
-#if !__APPLE__
-        ASSERT_TRUE(*do_collect_collected);
-#endif
-        ASSERT_FALSE(*dont_collect_collected);
+        ASSERT_TRUE(GC_is_disabled() || *do_collect_witness);
+        ASSERT_FALSE(*dont_collect_witness);
         ASSERT_NE(nullptr, dont_collect);
     }
 
-    // This test tests that boehm handles coroutine stacks correctly
-    TEST(CoroGC, CoroutineStackNotGCd) {
+    TEST(CoroGC, BasicFinalizers) {
         initGC();
         testFinalizerCalls();
+    }
 
-        bool* dont_collect_collected = uncollectable_bool();
-        bool* do_collect_collected = uncollectable_bool();
-
-        volatile void* dont_collect = GC_MALLOC_ATOMIC(128);
-        guard_gc(dont_collect);
-        {
-            volatile void* do_collect = GC_MALLOC_ATOMIC(128);
-            guard_gc(do_collect);
-        }
+    // Run testFinalizerCalls inside a coroutine
+    // this tests that GC works as expected inside a coroutine
+    TEST(CoroGC, CoroFinalizers) {
+        initGC();
 
         auto source = sinkToSource([&](Sink& sink) {
-
-#if __APPLE__
-            ASSERT_TRUE(GC_is_disabled());
-#endif
             testFinalizerCalls();
 
-            bool* dont_collect_inner_collected = uncollectable_bool();
-            bool* do_collect_inner_collected = uncollectable_bool();
-
-            volatile void* dont_collect_inner = GC_MALLOC_ATOMIC(128);
-            guard_gc(dont_collect_inner);
-            {
-                volatile void* do_collect_inner = GC_MALLOC_ATOMIC(128);
-                guard_gc(do_collect_inner);
-            }
             // pass control to main
             writeString("foo", sink);
+        });
+
+        // pass control to coroutine
+        std::string foo = readString(*source);
+        ASSERT_EQ(foo, "foo");
+    }
+
 #if __APPLE__
+    // This test tests that GC is disabled on darwin
+    // to work around the patch not being sufficient there,
+    // causing crashes whenever gc is invoked inside a coroutine
+    TEST(CoroGC, AppleCoroDisablesGC) {
+        initGC();
+        auto source = sinkToSource([&](Sink& sink) {
             ASSERT_TRUE(GC_is_disabled());
+            // pass control to main
+            writeString("foo", sink);
+
+            ASSERT_TRUE(GC_is_disabled());
+
+            // pass control to main
+            writeString("bar", sink);
+        });
+
+        // pass control to coroutine
+        std::string foo = readString(*source);
+        ASSERT_EQ(foo, "foo");
+        ASSERT_FALSE(GC_is_disabled());
+        // pass control to coroutine
+        std::string bar = readString(*source);
+        ASSERT_EQ(bar, "bar");
+
+        ASSERT_FALSE(GC_is_disabled());
+    }
 #endif
 
-            ASSERT_TRUE(*do_collect_inner_collected);
-            ASSERT_FALSE(*dont_collect_inner_collected);
+    // This test tests that boehm handles coroutine stacks correctly
+    // This test tests that coroutine stacks are registered to the GC,
+    // even when the coroutine is not running. It also tests that
+    // the main stack is still registered to the GC when the coroutine is running.
+    TEST(CoroGC, CoroutineStackNotGCd) {
+        initGC();
+
+        volatile void* do_collect = GC_MALLOC_ATOMIC(128);
+        volatile void* dont_collect = GC_MALLOC_ATOMIC(128);
+
+        bool* do_collect_witness = make_witness(do_collect);
+        bool* dont_collect_witness = make_witness(dont_collect);
+
+        do_collect = nullptr;
+
+        auto source = sinkToSource([&](Sink& sink) {
+            volatile void* dont_collect_inner = GC_MALLOC_ATOMIC(128);
+            volatile void* do_collect_inner = GC_MALLOC_ATOMIC(128);
+
+            bool* do_collect_inner_witness = make_witness(do_collect_inner);
+            bool* dont_collect_inner_witness = make_witness(dont_collect_inner);
+
+            do_collect_inner = nullptr;
+
+            // pass control to main
+            writeString("foo", sink);
+
+            ASSERT_FALSE(*dont_collect_inner_witness);
+            ASSERT_TRUE(*do_collect_inner_witness);
             ASSERT_NE(nullptr, dont_collect_inner);
 
             // pass control to main
@@ -102,8 +139,8 @@ namespace nix {
         std::string bar = readString(*source);
         ASSERT_EQ(bar, "bar");
 
-        ASSERT_FALSE(*dont_collect_collected);
-        ASSERT_TRUE(*do_collect_collected);
+        ASSERT_FALSE(*dont_collect_witness);
+        ASSERT_TRUE(*do_collect_witness);
         ASSERT_NE(nullptr, dont_collect);
     }
 #endif

--- a/src/libexpr/tests/local.mk
+++ b/src/libexpr/tests/local.mk
@@ -16,4 +16,4 @@ libexpr-tests_CXXFLAGS += -I src/libexpr -I src/libutil -I src/libstore -I src/l
 
 libexpr-tests_LIBS = libstore-tests libutils-tests libexpr libutil libstore libfetchers
 
-libexpr-tests_LDFLAGS := $(GTEST_LIBS) -lgmock
+libexpr-tests_LDFLAGS := $(GTEST_LIBS) -lgmock -lboost_context

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -186,18 +186,17 @@ static DefaultStackAllocator defaultAllocatorSingleton;
 StackAllocator *StackAllocator::defaultAllocator = &defaultAllocatorSingleton;
 
 
-std::shared_ptr<void> (*create_disable_gc)() = []() -> std::shared_ptr<void> {
+std::shared_ptr<void> (*create_coro_gc_hook)() = []() -> std::shared_ptr<void> {
     return {};
 };
 
 /* This class is used for entry and exit hooks on coroutines */
 class CoroutineContext {
-#if __APPLE__
-    /* Disable GC when entering the coroutine on macOS, since it doesn't find the main thread stack in this case.
+    /* Disable GC when entering the coroutine without the boehm patch,
+     * since it doesn't find the main thread stack in this case.
      * std::shared_ptr<void> performs type-erasure, so it will call the right
      * deleter. */
-    const std::shared_ptr<void> disable_gc = create_disable_gc();
-#endif
+    const std::shared_ptr<void> coro_gc_hook = create_coro_gc_hook();
 public:
     CoroutineContext() {};
     ~CoroutineContext() {};

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -501,10 +501,10 @@ struct StackAllocator {
     static StackAllocator *defaultAllocator;
 };
 
-/* Disabling GC when entering a coroutine (on macos).
+/* Disabling GC when entering a coroutine (without the boehm patch).
    mutable to avoid boehm gc dependency in libutil.
  */
-extern std::shared_ptr<void> (*create_disable_gc)();
+extern std::shared_ptr<void> (*create_coro_gc_hook)();
 
 
 }

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -501,4 +501,14 @@ struct StackAllocator {
     static StackAllocator *defaultAllocator;
 };
 
+/* Disabling GC when entering a coroutine (on macos).
+   ::create is to avoid boehm gc dependency in libutil.
+ */
+class DisableGC {
+public:
+    DisableGC() {};
+    virtual ~DisableGC() {};
+    static std::shared_ptr<DisableGC> (*create)();
+};
+
 }

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -502,13 +502,9 @@ struct StackAllocator {
 };
 
 /* Disabling GC when entering a coroutine (on macos).
-   ::create is to avoid boehm gc dependency in libutil.
+   mutable to avoid boehm gc dependency in libutil.
  */
-class DisableGC {
-public:
-    DisableGC() {};
-    virtual ~DisableGC() {};
-    static std::shared_ptr<DisableGC> (*create)();
-};
+extern std::shared_ptr<void> (*create_disable_gc)();
+
 
 }


### PR DESCRIPTION


# Motivation
Regression test for #7679
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
Without @roberth's boehmgc-coroutine-sp-fallback patch, nix mostly works but sometimes segfaults. This PR provides a test that should catch this bug.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
