### PR TITLE
nix flake show: Ignore empty attrsets

### DIFF
--- a/tests/flakes/show.sh
+++ b/tests/flakes/show.sh
@@ -37,3 +37,30 @@ in
 assert show_output.legacyPackages.${builtins.currentSystem}.hello.name == "simple";
 true
 '
+
+# Test that attributes are only reported when they have actual content
+cat >flake.nix <<EOF
+{
+  description = "Bla bla";
+
+  outputs = inputs: rec {
+    apps.$system = { };
+    checks.$system = { };
+    devShells.$system = { };
+    legacyPackages.$system = { };
+    packages.$system = { };
+    packages.someOtherSystem = { };
+
+    formatter = { };
+    nixosConfigurations = { };
+    nixosModules = { };
+  };
+}
+EOF
+nix flake show --json --all-systems > show-output.json
+nix eval --impure --expr '
+let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
+in
+assert show_output == { };
+true
+'


### PR DESCRIPTION
# Motivation

For frameworks it's important that structures are as lazy as possible to prevent infinite recursions, performance issues and errors that aren't related to the thing to evaluate. `filterAttrs` makes the set of keys depend on the values. As a consequence, this function can't be used and the framework has to emit more attributes than desirable. However, these attributes with empty values are not useful to the user so we don't add them to the output.

# Context

Closes #7285

Solves the need for these issues that I can't resolve without causing infinite recursions when people use `self`.

 - https://github.com/hercules-ci/flake-parts/issues/66
 - https://github.com/hercules-ci/flake-parts/pull/113
 - https://github.com/hercules-ci/flake-parts/pull/59

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
