### PR TITLE
nix flakes metadata displays lastModified timestamp of inputs

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -225,9 +225,11 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                     bool last = i + 1 == node.inputs.size();
 
                     if (auto lockedNode = std::get_if<0>(&input.second)) {
-                        logger->cout("%s" ANSI_BOLD "%s" ANSI_NORMAL ": %s",
+                        auto lastModified = (*lockedNode)->lockedRef.input.getLastModified ();
+                        logger->cout("%s" ANSI_BOLD "%s" ANSI_NORMAL ": %s\t(%s)",
                             prefix + (last ? treeLast : treeConn), input.first,
-                            (*lockedNode)->lockedRef);
+                            (*lockedNode)->lockedRef,
+                            std::put_time(std::localtime(&*lastModified), "%F %T"));
 
                         bool firstVisit = visited.insert(*lockedNode).second;
 


### PR DESCRIPTION
# Motivation

IMHO the input's last modified timestamps is more useful than the timestamp of the lockfile.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
