### PR TITLE
Make `initLibStore` a viable alternative

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,7 +184,7 @@ fi
 
 # Look for OpenSSL, a required dependency. FIXME: this is only (maybe)
 # used by S3BinaryCacheStore.
-PKG_CHECK_MODULES([OPENSSL], [libcrypto], [CXXFLAGS="$OPENSSL_CFLAGS $CXXFLAGS"])
+PKG_CHECK_MODULES([OPENSSL], [libcrypto >= 1.1.1], [CXXFLAGS="$OPENSSL_CFLAGS $CXXFLAGS"])
 
 
 # Look for libarchive.

--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -27,7 +27,6 @@ static ref<Store> store()
     if (!_store) {
         try {
             initLibStore();
-            loadConfFile();
             settings.lockCPU = false;
             _store = openStore();
         } catch (Error & e) {

--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -27,7 +27,6 @@ static ref<Store> store()
     if (!_store) {
         try {
             initLibStore();
-            settings.lockCPU = false;
             _store = openStore();
         } catch (Error & e) {
             croak("%s", e.what());

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -118,7 +118,6 @@ void initNix()
     std::cerr.rdbuf()->pubsetbuf(buf, sizeof(buf));
 #endif
 
-    initLibUtil();
     initLibStore();
 
     startSignalHandlerThread();

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -162,6 +162,7 @@ void initNix()
 #endif
 
     initLibUtil();
+    initLibStore();
 
     if (sodium_init() == -1)
         throw Error("could not initialise libsodium");
@@ -223,7 +224,6 @@ void initNix()
 #endif
 
     preloadNSS();
-    initLibStore();
 }
 
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -10,7 +10,6 @@
 #include <cctype>
 #include <exception>
 #include <iostream>
-#include <mutex>
 
 #include <cstdlib>
 #include <sys/time.h>
@@ -19,11 +18,6 @@
 #include <signal.h>
 #ifdef __linux__
 #include <features.h>
-#endif
-#ifdef __GLIBC__
-#include <gnu/lib-names.h>
-#include <nss.h>
-#include <dlfcn.h>
 #endif
 
 #include <openssl/crypto.h>
@@ -113,41 +107,6 @@ std::string getArg(const std::string & opt,
     return *i;
 }
 
-static std::once_flag dns_resolve_flag;
-
-static void preloadNSS() {
-    /* builtin:fetchurl can trigger a DNS lookup, which with glibc can trigger a dynamic library load of
-       one of the glibc NSS libraries in a sandboxed child, which will fail unless the library's already
-       been loaded in the parent. So we force a lookup of an invalid domain to force the NSS machinery to
-       load its lookup libraries in the parent before any child gets a chance to. */
-    std::call_once(dns_resolve_flag, []() {
-#ifdef __GLIBC__
-        /* On linux, glibc will run every lookup through the nss layer.
-         * That means every lookup goes, by default, through nscd, which acts as a local
-         * cache.
-         * Because we run builds in a sandbox, we also remove access to nscd otherwise
-         * lookups would leak into the sandbox.
-         *
-         * But now we have a new problem, we need to make sure the nss_dns backend that
-         * does the dns lookups when nscd is not available is loaded or available.
-         *
-         * We can't make it available without leaking nix's environment, so instead we'll
-         * load the backend, and configure nss so it does not try to run dns lookups
-         * through nscd.
-         *
-         * This is technically only used for builtins:fetch* functions so we only care
-         * about dns.
-         *
-         * All other platforms are unaffected.
-         */
-        if (!dlopen(LIBNSS_DNS_SO, RTLD_NOW))
-            warn("unable to load nss_dns backend");
-        // FIXME: get hosts entry from nsswitch.conf.
-        __nss_configure_lookup("hosts", "files dns");
-#endif
-    });
-}
-
 static void sigHandler(int signo) { }
 
 
@@ -218,7 +177,6 @@ void initNix()
         unsetenv("TMPDIR");
 #endif
 
-    preloadNSS();
 }
 
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -28,8 +28,6 @@
 
 #include <openssl/crypto.h>
 
-#include <sodium.h>
-
 
 namespace nix {
 
@@ -163,9 +161,6 @@ void initNix()
 
     initLibUtil();
     initLibStore();
-
-    if (sodium_init() == -1)
-        throw Error("could not initialise libsodium");
 
     startSignalHandlerThread();
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -169,14 +169,6 @@ void initNix()
     gettimeofday(&tv, 0);
     srandom(tv.tv_usec);
 
-    /* On macOS, don't use the per-session TMPDIR (as set e.g. by
-       sshd). This breaks build users because they don't have access
-       to the TMPDIR, in particular in ‘nix-store --serve’. */
-#if __APPLE__
-    if (hasPrefix(getEnv("TMPDIR").value_or("/tmp"), "/var/folders/"))
-        unsetenv("TMPDIR");
-#endif
-
 }
 
 

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -166,8 +166,6 @@ void initNix()
     if (sodium_init() == -1)
         throw Error("could not initialise libsodium");
 
-    loadConfFile();
-
     startSignalHandlerThread();
 
     /* Reset SIGCHLD to its default. */

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -156,7 +156,10 @@ void initNix()
     if (sigaction(SIGTRAP, &act, 0)) throw SysError("handling SIGTRAP");
 #endif
 
-    /* Register a SIGSEGV handler to detect stack overflows. */
+    /* Register a SIGSEGV handler to detect stack overflows.
+       Why not initLibExpr()? initGC() is essentially that, but
+       detectStackOverflow is not an instance of the init function concept, as
+       it may have to be invoked more than once per process. */
     detectStackOverflow();
 
     /* There is no privacy in the Nix system ;-)  At least not for

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <map>
+#include <mutex>
 #include <thread>
 #include <dlfcn.h>
 #include <sys/utsname.h>
@@ -15,6 +16,11 @@
 
 #include <sodium/core.h>
 
+#ifdef __GLIBC__
+#include <gnu/lib-names.h>
+#include <nss.h>
+#include <dlfcn.h>
+#endif
 
 namespace nix {
 
@@ -283,6 +289,42 @@ void initPlugins()
     settings.pluginFiles.pluginsLoaded = true;
 }
 
+static void preloadNSS()
+{
+    /* builtin:fetchurl can trigger a DNS lookup, which with glibc can trigger a dynamic library load of
+       one of the glibc NSS libraries in a sandboxed child, which will fail unless the library's already
+       been loaded in the parent. So we force a lookup of an invalid domain to force the NSS machinery to
+       load its lookup libraries in the parent before any child gets a chance to. */
+    static std::once_flag dns_resolve_flag;
+
+    std::call_once(dns_resolve_flag, []() {
+#ifdef __GLIBC__
+        /* On linux, glibc will run every lookup through the nss layer.
+         * That means every lookup goes, by default, through nscd, which acts as a local
+         * cache.
+         * Because we run builds in a sandbox, we also remove access to nscd otherwise
+         * lookups would leak into the sandbox.
+         *
+         * But now we have a new problem, we need to make sure the nss_dns backend that
+         * does the dns lookups when nscd is not available is loaded or available.
+         *
+         * We can't make it available without leaking nix's environment, so instead we'll
+         * load the backend, and configure nss so it does not try to run dns lookups
+         * through nscd.
+         *
+         * This is technically only used for builtins:fetch* functions so we only care
+         * about dns.
+         *
+         * All other platforms are unaffected.
+         */
+        if (!dlopen(LIBNSS_DNS_SO, RTLD_NOW))
+            warn("unable to load nss_dns backend");
+        // FIXME: get hosts entry from nsswitch.conf.
+        __nss_configure_lookup("hosts", "files dns");
+#endif
+    });
+}
+
 static bool initLibStoreDone = false;
 
 void assertLibStoreInitialized() {
@@ -298,6 +340,8 @@ void initLibStore() {
         throw Error("could not initialise libsodium");
 
     loadConfFile();
+
+    preloadNSS();
 
     initLibStoreDone = true;
 }

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -343,6 +343,14 @@ void initLibStore() {
 
     preloadNSS();
 
+    /* On macOS, don't use the per-session TMPDIR (as set e.g. by
+       sshd). This breaks build users because they don't have access
+       to the TMPDIR, in particular in ‘nix-store --serve’. */
+#if __APPLE__
+    if (hasPrefix(getEnv("TMPDIR").value_or("/tmp"), "/var/folders/"))
+        unsetenv("TMPDIR");
+#endif
+
     initLibStoreDone = true;
 }
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -336,6 +336,8 @@ void assertLibStoreInitialized() {
 
 void initLibStore() {
 
+    initLibUtil();
+
     if (sodium_init() == -1)
         throw Error("could not initialise libsodium");
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -291,6 +291,9 @@ void assertLibStoreInitialized() {
 }
 
 void initLibStore() {
+
+    loadConfFile();
+
     initLibStoreDone = true;
 }
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -49,7 +49,6 @@ Settings::Settings()
     , nixDaemonSocketFile(canonPath(getEnvNonEmpty("NIX_DAEMON_SOCKET_PATH").value_or(nixStateDir + DEFAULT_SOCKET_PATH)))
 {
     buildUsersGroup = getuid() == 0 ? "nixbld" : "";
-    lockCPU = getEnv("NIX_AFFINITY_HACK") == "1";
     allowSymlinkedStore = getEnv("NIX_IGNORE_SYMLINK_STORE") == "1";
 
     auto sslOverride = getEnv("NIX_SSL_CERT_FILE").value_or(getEnv("SSL_CERT_FILE").value_or(""));

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -13,6 +13,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <sodium/core.h>
+
 
 namespace nix {
 
@@ -291,6 +293,9 @@ void assertLibStoreInitialized() {
 }
 
 void initLibStore() {
+
+    if (sodium_init() == -1)
+        throw Error("could not initialise libsodium");
 
     loadConfFile();
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -478,11 +478,6 @@ public:
         )",
         {"env-keep-derivations"}};
 
-    /**
-     * Whether to lock the Nix client and worker to the same CPU.
-     */
-    bool lockCPU;
-
     Setting<SandboxMode> sandboxMode{
         this,
         #if __linux__

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -17,29 +17,6 @@
 
 namespace nix {
 
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-/* OpenSSL is not thread-safe by default - it will randomly crash
-   unless the user supplies a mutex locking function. So let's do
-   that. */
-static std::vector<std::mutex> opensslLocks;
-
-static void opensslLockCallback(int mode, int type, const char * file, int line)
-{
-    if (mode & CRYPTO_LOCK)
-        opensslLocks[type].lock();
-    else
-        opensslLocks[type].unlock();
-}
-#endif
-
-void initOpenSSL() {
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
-    /* Initialise OpenSSL locking. */
-    opensslLocks = std::vector<std::mutex>(CRYPTO_num_locks());
-    CRYPTO_set_locking_callback(opensslLockCallback);
-#endif
-}
-
 static size_t regularHashSize(HashType type) {
     switch (type) {
     case htMD5: return md5HashSize;

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -48,7 +48,6 @@ extern char * * environ __attribute__((weak));
 namespace nix {
 
 void initLibUtil() {
-    initOpenSSL();
 }
 
 std::optional<std::string> getEnv(const std::string & key)

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1748,13 +1748,39 @@ void triggerInterrupt()
 }
 
 static sigset_t savedSignalMask;
+static bool savedSignalMaskIsSet = false;
+
+void setChildSignalMask(sigset_t * sigs)
+{
+    assert(sigs); // C style function, but think of sigs as a reference
+
+#if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _POSIX_SOURCE
+    sigemptyset(&savedSignalMask);
+    // There's no "assign" or "copy" function, so we rely on (math) idempotence
+    // of the or operator: a or a = a.
+    sigorset(&savedSignalMask, sigs, sigs);
+#else
+    // Without sigorset, our best bet is to assume that sigset_t is a type that
+    // can be assigned directly, such as is the case for a sigset_t defined as
+    // an integer type.
+    savedSignalMask = *sigs;
+#endif
+
+    savedSignalMaskIsSet = true;
+}
+
+void saveSignalMask() {
+    if (sigprocmask(SIG_BLOCK, nullptr, &savedSignalMask))
+        throw SysError("querying signal mask");
+
+    savedSignalMaskIsSet = true;
+}
 
 void startSignalHandlerThread()
 {
     updateWindowSize();
 
-    if (sigprocmask(SIG_BLOCK, nullptr, &savedSignalMask))
-        throw SysError("querying signal mask");
+    saveSignalMask();
 
     sigset_t set;
     sigemptyset(&set);
@@ -1771,6 +1797,20 @@ void startSignalHandlerThread()
 
 static void restoreSignals()
 {
+    // If startSignalHandlerThread wasn't called, that means we're not running
+    // in a proper libmain process, but a process that presumably manages its
+    // own signal handlers. Such a process should call either
+    //  - initNix(), to be a proper libmain process
+    //  - startSignalHandlerThread(), to resemble libmain regarding signal
+    //    handling only
+    //  - saveSignalMask(), for processes that define their own signal handling
+    //    thread
+    // TODO: Warn about this? Have a default signal mask? The latter depends on
+    //       whether we should generally inherit signal masks from the caller.
+    //       I don't know what the larger unix ecosystem expects from us here.
+    if (!savedSignalMaskIsSet)
+        return;
+
     if (sigprocmask(SIG_SETMASK, &savedSignalMask, nullptr))
         throw SysError("restoring signals");
 }

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -47,6 +47,10 @@ extern char * * environ __attribute__((weak));
 
 namespace nix {
 
+void initLibUtil() {
+    initOpenSSL();
+}
+
 std::optional<std::string> getEnv(const std::string & key)
 {
     char * value = getenv(key.c_str());

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -34,8 +34,6 @@ struct Source;
 
 void initLibUtil();
 
-void initOpenSSL();
-
 /**
  * The system for which Nix is compiled.
  */

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -32,6 +32,9 @@ namespace nix {
 struct Sink;
 struct Source;
 
+void initLibUtil();
+
+void initOpenSSL();
 
 /**
  * The system for which Nix is compiled.

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -448,6 +448,8 @@ void setStackSize(size_t stackSize);
 /**
  * Restore the original inherited Unix process context (such as signal
  * masks, stack size).
+
+ * See startSignalHandlerThread(), saveSignalMask().
  */
 void restoreProcessContext(bool restoreMounts = true);
 
@@ -817,8 +819,25 @@ class Callback;
 /**
  * Start a thread that handles various signals. Also block those signals
  * on the current thread (and thus any threads created by it).
+ * Saves the signal mask before changing the mask to block those signals.
+ * See saveSignalMask().
  */
 void startSignalHandlerThread();
+
+/**
+ * Saves the signal mask, which is the signal mask that nix will restore
+ * before creating child processes.
+ * See setChildSignalMask() to set an arbitrary signal mask instead of the
+ * current mask.
+ */
+void saveSignalMask();
+
+/**
+ * Sets the signal mask. Like saveSignalMask() but for a signal set that doesn't
+ * necessarily match the current thread's mask.
+ * See saveSignalMask() to set the saved mask to the current mask.
+ */
+void setChildSignalMask(sigset_t *sigs);
 
 struct InterruptCallback
 {


### PR DESCRIPTION
# Motivation

Refactor `initNix` and `initLibStore` so that it's possible for a non-libmain process to initialize the nix libraries correctly.

# Context

Close #7502 

Implementation strategy:
 - Move calls between initialization functions in tiny commits for bisectability. I have tested at each intermediate step.
 - Expose some functions.

TODO:
 - [ ] decide https://github.com/NixOS/nix/pull/7732/files#r1093559808
 - [x] `reword` some commits to make their context obvious
 - [x] update perl bindings init

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
