### PR TITLE
Don't send plugin-files to the daemon.

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -236,6 +236,10 @@ struct ClientSettings
                     // the daemon, as that could cause some pretty weird stuff
                     if (parseFeatures(tokenizeString<StringSet>(value)) != settings.experimentalFeatures.get())
                         debug("Ignoring the client-specified experimental features");
+                } else if (name == settings.pluginFiles.name) {
+                    if (tokenizeString<Paths>(value) != settings.pluginFiles.get())
+                        warn("Ignoring the client-specified plugin-files.\n"
+                             "The client specifying plugins to the daemon never made sense, and was removed in Nix >=2.14.");
                 }
                 else if (trusted
                     || name == settings.buildTimeout.name

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -266,6 +266,7 @@ void RemoteStore::setOptions(Connection & conn)
         overrides.erase(settings.useSubstitutes.name);
         overrides.erase(loggerSettings.showTrace.name);
         overrides.erase(settings.experimentalFeatures.name);
+        overrides.erase(settings.pluginFiles.name);
         conn.to << overrides.size();
         for (auto & i : overrides)
             conn.to << i.first << i.second.value;


### PR DESCRIPTION
This is radically unsafe and the daemon has already loaded its plugins anyway.

Fixes cachix/devenv#276