### PR TITLE
Get rid of the `authHook` parameter on `processConnection`

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1516,8 +1516,7 @@ void LocalDerivationGoal::startDaemon()
                 FdSink to(remote.get());
                 try {
                     daemon::processConnection(store, from, to,
-                        daemon::NotTrusted, daemon::Recursive,
-                        [&](Store & store) {});
+                        daemon::NotTrusted, daemon::Recursive);
                     debug("terminated daemon connection");
                 } catch (SysError &) {
                     ignoreException();

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -985,8 +985,7 @@ void processConnection(
     FdSource & from,
     FdSink & to,
     TrustedFlag trusted,
-    RecursiveFlag recursive,
-    std::function<void(Store &)> authHook)
+    RecursiveFlag recursive)
 {
     auto monitor = !recursive ? std::make_unique<MonitorFdHup>(from.fd) : nullptr;
 
@@ -1028,10 +1027,6 @@ void processConnection(
     tunnelLogger->startWork();
 
     try {
-
-        /* If we can't accept clientVersion, then throw an error
-           *here* (not above). */
-        authHook(*store);
 
         tunnelLogger->stopWork();
         to.flush();

--- a/src/libstore/daemon.hh
+++ b/src/libstore/daemon.hh
@@ -13,11 +13,6 @@ void processConnection(
     FdSource & from,
     FdSink & to,
     TrustedFlag trusted,
-    RecursiveFlag recursive,
-    /* Arbitrary hook to check authorization / initialize user data / whatever
-       after the protocol has been negotiated. The idea is that this function
-       and everything it calls doesn't know about this stuff, and the
-       `nix-daemon` handles that instead. */
-    std::function<void(Store &)> authHook);
+    RecursiveFlag recursive);
 
 }

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -241,14 +241,7 @@ static void daemonLoop()
                 //  Handle the connection.
                 FdSource from(remote.get());
                 FdSink to(remote.get());
-                processConnection(openUncachedStore(), from, to, trusted, NotRecursive, [&](Store & store) {
-#if 0
-                    /* Prevent users from doing something very dangerous. */
-                    if (geteuid() == 0 &&
-                        querySetting("build-users-group", "") == "")
-                        throw Error("if you run 'nix-daemon' as root, then you MUST set 'build-users-group'!");
-#endif
-                });
+                processConnection(openUncachedStore(), from, to, trusted, NotRecursive);
 
                 exit(0);
             }, options);
@@ -301,7 +294,7 @@ static void runDaemon(bool stdio)
             /* Auth hook is empty because in this mode we blindly trust the
                standard streams. Limiting access to those is explicitly
                not `nix-daemon`'s responsibility. */
-            processConnection(openUncachedStore(), from, to, Trusted, NotRecursive, [&](Store & _){});
+            processConnection(openUncachedStore(), from, to, Trusted, NotRecursive);
         }
     } else
         daemonLoop();


### PR DESCRIPTION
# Motivation

This is (morally) dead code.

# Context

As @edolstra pointed out in https://github.com/NixOS/nix/pull/5226#discussion_r1073470813, this is no longer needed.

I created this in 8d4162ff9e940ea9e2f97b07f3030a722695901a, so it is fitting that I now destroy it :).

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
