### PR TITLE
Move `trustedUsers` and `allowedUsers` to separate config struct

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -529,7 +529,14 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
             mode = (BuildMode) readInt(from);
 
             /* Repairing is not atomic, so disallowed for "untrusted"
-               clients.  */
+               clients.
+
+               FIXME: layer violation in this message: the daemon code (i.e.
+               this file) knows whether a client/connection is trusted, but it
+               does not how how the client was authenticated. The mechanism
+               need not be getting the UID of the other end of a Unix Domain
+               Socket.
+              */
             if (mode == bmRepair && !trusted)
                 throw Error("repairing is not allowed because you are not in 'trusted-users'");
         }
@@ -546,7 +553,9 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         mode = (BuildMode) readInt(from);
 
         /* Repairing is not atomic, so disallowed for "untrusted"
-           clients.  */
+           clients.
+
+           FIXME: layer violation; see above. */
         if (mode == bmRepair && !trusted)
             throw Error("repairing is not allowed because you are not in 'trusted-users'");
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -279,8 +279,8 @@ public:
           If the build users group is empty, builds will be performed under
           the uid of the Nix process (that is, the uid of the caller if
           `NIX_REMOTE` is empty, the uid under which the Nix daemon runs if
-          `NIX_REMOTE` is `daemon`). Obviously, this should not be used in
-          multi-user settings with untrusted users.
+          `NIX_REMOTE` is `daemon`). Obviously, this should not be used
+          with a nix daemon accessible to untrusted clients.
 
           Defaults to `nixbld` when running as root, *empty* otherwise.
         )",
@@ -696,24 +696,6 @@ public:
         )",
         {"trusted-binary-caches"}};
 
-    Setting<Strings> trustedUsers{
-        this, {"root"}, "trusted-users",
-        R"(
-          A list of names of users (separated by whitespace) that have
-          additional rights when connecting to the Nix daemon, such as the
-          ability to specify additional binary caches, or to import unsigned
-          NARs. You can also specify groups by prefixing them with `@`; for
-          instance, `@wheel` means all users in the `wheel` group. The default
-          is `root`.
-
-          > **Warning**
-          >
-          > Adding a user to `trusted-users` is essentially equivalent to
-          > giving that user root access to the system. For example, the user
-          > can set `sandbox-paths` and thereby obtain read access to
-          > directories that are otherwise inacessible to them.
-        )"};
-
     Setting<unsigned int> ttlNegativeNarInfoCache{
         this, 3600, "narinfo-cache-negative-ttl",
         R"(
@@ -734,18 +716,6 @@ public:
           collection, in which case having a more frequent cache invalidation
           would prevent trying to pull the path again and failing with a hash
           mismatch if the build isn't reproducible.
-        )"};
-
-    /* ?Who we trust to use the daemon in safe ways */
-    Setting<Strings> allowedUsers{
-        this, {"*"}, "allowed-users",
-        R"(
-          A list of names of users (separated by whitespace) that are allowed
-          to connect to the Nix daemon. As with the `trusted-users` option,
-          you can specify groups by prefixing them with `@`. Also, you can
-          allow all users by specifying `*`. The default is `*`.
-
-          Note that trusted users are always allowed to connect.
         )"};
 
     Setting<bool> printMissing{this, true, "print-missing",

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -34,6 +34,43 @@
 using namespace nix;
 using namespace nix::daemon;
 
+struct UserSettings : Config {
+
+    Setting<Strings> trustedUsers{
+        this, {"root"}, "trusted-users",
+        R"(
+          A list of names of users (separated by whitespace) that have
+          additional rights when connecting to the Nix daemon, such as the
+          ability to specify additional binary caches, or to import unsigned
+          NARs. You can also specify groups by prefixing them with `@`; for
+          instance, `@wheel` means all users in the `wheel` group. The default
+          is `root`.
+
+          > **Warning**
+          >
+          > Adding a user to `trusted-users` is essentially equivalent to
+          > giving that user root access to the system. For example, the user
+          > can set `sandbox-paths` and thereby obtain read access to
+          > directories that are otherwise inacessible to them.
+        )"};
+
+    /* ?Who we trust to use the daemon in safe ways */
+    Setting<Strings> allowedUsers{
+        this, {"*"}, "allowed-users",
+        R"(
+          A list of names of users (separated by whitespace) that are allowed
+          to connect to the Nix daemon. As with the `trusted-users` option,
+          you can specify groups by prefixing them with `@`. Also, you can
+          allow all users by specifying `*`. The default is `*`.
+
+          Note that trusted users are always allowed to connect.
+        )"};
+};
+
+UserSettings userSettings;
+
+static GlobalConfig::Register rSettings(&userSettings);
+
 #ifndef __linux__
 #define SPLICE_F_MOVE 0
 static ssize_t splice(int fd_in, void *off_in, int fd_out, void *off_out, size_t len, unsigned int flags)
@@ -203,8 +240,8 @@ static void daemonLoop()
             struct group * gr = peer.gidKnown ? getgrgid(peer.gid) : 0;
             std::string group = gr ? gr->gr_name : std::to_string(peer.gid);
 
-            Strings trustedUsers = settings.trustedUsers;
-            Strings allowedUsers = settings.allowedUsers;
+            Strings trustedUsers = userSettings.trustedUsers;
+            Strings allowedUsers = userSettings.allowedUsers;
 
             if (matchUser(user, group, trustedUsers))
                 trusted = Trusted;


### PR DESCRIPTION
# Motivation

These settings are not needed for libstore at all, they are just used by the nix daemon *command* for authorization on unix domain sockets. My moving them to a new configuration struct just in that file, we avoid them leaking anywhere else.

Also, it is good to break up the mammoth `Settings` struct in general. Issue #5638 tracks this.

# Context

The message is not changed because I do not want to regress in convenience to the user. Just saying "this connection is not trusted" doesn't tell them out to fix the issue. The ideal thing to do would be to somehow parameterize `processCommand` on how the error should be displayed, so different sorts of connections can display different information to the user based on how authentication is performed for the connection in question. This, however, is a good bit more work, so it is left for the future.

This came up with me thinking about the tcp:// store (#5265). The larger project is not TCP *per se*, but the idea that it should be possible for something else to manage access control to services like the Nix Daemon, and those services simply trust or trust the incoming connection as they are told. This is a more capability-oriented way of thinking about trust than "every server implements its own auth separately" as we are used to today.

Its very great that libstore itself already implements just this model, and so via this refactor I basically want to "enshrine" that so it continues to be the case.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
