### PR TITLE
Factor out `InstallableStorePath` to its own file, dedup

### DIFF
--- a/src/libcmd/installable-derived-path.cc
+++ b/src/libcmd/installable-derived-path.cc
@@ -1,0 +1,70 @@
+#include "installable-derived-path.hh"
+#include "derivations.hh"
+
+namespace nix {
+
+std::string InstallableDerivedPath::what() const
+{
+    return derivedPath.to_string(*store);
+}
+
+DerivedPathsWithInfo InstallableDerivedPath::toDerivedPaths()
+{
+    return {{.path = derivedPath, .info = {} }};
+}
+
+std::optional<StorePath> InstallableDerivedPath::getStorePath()
+{
+    return std::visit(overloaded {
+        [&](const DerivedPath::Built & bfd) {
+            return bfd.drvPath;
+        },
+        [&](const DerivedPath::Opaque & bo) {
+            return bo.path;
+        },
+    }, derivedPath.raw());
+}
+
+InstallableDerivedPath InstallableDerivedPath::parse(
+    ref<Store> store,
+    std::string_view prefix,
+    ExtendedOutputsSpec extendedOutputsSpec)
+{
+    auto derivedPath = std::visit(overloaded {
+        // If the user did not use ^, we treat the output more liberally.
+        [&](const ExtendedOutputsSpec::Default &) -> DerivedPath {
+            // First, we accept a symlink chain or an actual store path.
+            auto storePath = store->followLinksToStorePath(prefix);
+            // Second, we see if the store path ends in `.drv` to decide what sort
+            // of derived path they want.
+            //
+            // This handling predates the `^` syntax. The `^*` in
+            // `/nix/store/hash-foo.drv^*` unambiguously means "do the
+            // `DerivedPath::Built` case", so plain `/nix/store/hash-foo.drv` could
+            // also unambiguously mean "do the DerivedPath::Opaque` case".
+            //
+            // Issue #7261 tracks reconsidering this `.drv` dispatching.
+            return storePath.isDerivation()
+                ? (DerivedPath) DerivedPath::Built {
+                    .drvPath = std::move(storePath),
+                    .outputs = OutputsSpec::All {},
+                }
+                : (DerivedPath) DerivedPath::Opaque {
+                    .path = std::move(storePath),
+                };
+        },
+        // If the user did use ^, we just do exactly what is written.
+        [&](const ExtendedOutputsSpec::Explicit & outputSpec) -> DerivedPath {
+            return DerivedPath::Built {
+                .drvPath = store->parseStorePath(prefix),
+                .outputs = outputSpec,
+            };
+        },
+    }, extendedOutputsSpec.raw());
+    return InstallableDerivedPath {
+        store,
+        std::move(derivedPath),
+    };
+}
+
+}

--- a/src/libcmd/installable-derived-path.hh
+++ b/src/libcmd/installable-derived-path.hh
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "installables.hh"
+
+namespace nix {
+
+struct InstallableDerivedPath : Installable
+{
+    ref<Store> store;
+    DerivedPath derivedPath;
+
+    InstallableDerivedPath(ref<Store> store, DerivedPath && derivedPath)
+        : store(store), derivedPath(std::move(derivedPath))
+    { }
+
+    std::string what() const override;
+
+    DerivedPathsWithInfo toDerivedPaths() override;
+
+    std::optional<StorePath> getStorePath() override;
+
+    static InstallableDerivedPath parse(
+        ref<Store> store,
+        std::string_view prefix,
+        ExtendedOutputsSpec extendedOutputsSpec);
+};
+
+}

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -1,5 +1,6 @@
 #include "globals.hh"
 #include "installables.hh"
+#include "installable-derived-path.hh"
 #include "outputs-spec.hh"
 #include "util.hh"
 #include "command.hh"
@@ -396,38 +397,6 @@ static StorePath getDeriver(
     return *derivers.begin();
 }
 
-struct InstallableStorePath : Installable
-{
-    ref<Store> store;
-    DerivedPath req;
-
-    InstallableStorePath(ref<Store> store, DerivedPath && req)
-        : store(store), req(std::move(req))
-    { }
-
-    std::string what() const override
-    {
-        return req.to_string(*store);
-    }
-
-    DerivedPathsWithInfo toDerivedPaths() override
-    {
-        return {{.path = req, .info = {} }};
-    }
-
-    std::optional<StorePath> getStorePath() override
-    {
-        return std::visit(overloaded {
-            [&](const DerivedPath::Built & bfd) {
-                return bfd.drvPath;
-            },
-            [&](const DerivedPath::Opaque & bo) {
-                return bo.path;
-            },
-        }, req.raw());
-    }
-};
-
 struct InstallableAttrPath : InstallableValue
 {
     SourceExprCommand & cmd;
@@ -792,41 +761,10 @@ std::vector<std::shared_ptr<Installable>> SourceExprCommand::parseInstallables(
             auto prefix = std::move(prefix_);
             auto extendedOutputsSpec = std::move(extendedOutputsSpec_);
 
-            auto found = prefix.find('/');
-            if (found != std::string::npos) {
+            if (prefix.find('/') != std::string::npos) {
                 try {
-                    auto derivedPath = std::visit(overloaded {
-                        // If the user did not use ^, we treat the output more liberally.
-                        [&](const ExtendedOutputsSpec::Default &) -> DerivedPath {
-                            // First, we accept a symlink chain or an actual store path.
-                            auto storePath = store->followLinksToStorePath(prefix);
-                            // Second, we see if the store path ends in `.drv` to decide what sort
-                            // of derived path they want.
-                            //
-                            // This handling predates the `^` syntax. The `^*` in
-                            // `/nix/store/hash-foo.drv^*` unambiguously means "do the
-                            // `DerivedPath::Built` case", so plain `/nix/store/hash-foo.drv` could
-                            // also unambiguously mean "do the DerivedPath::Opaque` case".
-                            //
-                            // Issue #7261 tracks reconsidering this `.drv` dispatching.
-                            return storePath.isDerivation()
-                                ? (DerivedPath) DerivedPath::Built {
-                                    .drvPath = std::move(storePath),
-                                    .outputs = OutputsSpec::All {},
-                                }
-                                : (DerivedPath) DerivedPath::Opaque {
-                                    .path = std::move(storePath),
-                                };
-                        },
-                        // If the user did use ^, we just do exactly what is written.
-                        [&](const ExtendedOutputsSpec::Explicit & outputSpec) -> DerivedPath {
-                            return DerivedPath::Built {
-                                .drvPath = store->parseStorePath(prefix),
-                                .outputs = outputSpec,
-                            };
-                        },
-                    }, extendedOutputsSpec.raw());
-                    result.push_back(std::make_shared<InstallableStorePath>(store, std::move(derivedPath)));
+                    result.push_back(std::make_shared<InstallableDerivedPath>(
+                        InstallableDerivedPath::parse(store, prefix, extendedOutputsSpec)));
                     continue;
                 } catch (BadStorePath &) {
                 } catch (...) {


### PR DESCRIPTION
# Motivation

`nix app` had something called `InstallableDerivedPath` which is actually the same thing. We go with the later's name because it has become more correct.

# Context

I originally did this change (more hurriedly) as part of #6225 --- a mini store-only Nix and a full Nix need to share this code. In the first RFC meeting for https://github.com/NixOS/rfcs/pull/134 we discussed how some splitting of the massive `installables.cc` could begin prior, as that is a good thing anyways. (@edolstra's words, not mine!) This would be one such PR.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [x] new feature or bug fix: updated release notes
