### PR TITLE
Make command infra less stateful and more regular

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -165,7 +165,7 @@ BuiltPathsCommand::BuiltPathsCommand(bool recursive)
     });
 }
 
-void BuiltPathsCommand::run(ref<Store> store)
+void BuiltPathsCommand::run(ref<Store> store, Installables && installables)
 {
     BuiltPaths paths;
     if (all) {
@@ -211,7 +211,7 @@ void StorePathsCommand::run(ref<Store> store, BuiltPaths && paths)
     run(store, std::move(sorted));
 }
 
-void StorePathCommand::run(ref<Store> store, std::vector<StorePath> && storePaths)
+void StorePathCommand::run(ref<Store> store, StorePaths && storePaths)
 {
     if (storePaths.size() != 1)
         throw UsageError("this command requires exactly one store path");
@@ -246,7 +246,7 @@ void MixProfile::updateProfile(const BuiltPaths & buildables)
 {
     if (!profile) return;
 
-    std::vector<StorePath> result;
+    StorePaths result;
 
     for (auto & buildable : buildables) {
         std::visit(overloaded {

--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -29,6 +29,9 @@ struct NixMultiCommand : virtual MultiCommand, virtual Command
     nlohmann::json toJSON() override;
 };
 
+// For the overloaded run methods
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+
 /* A command that requires a Nix store. */
 struct StoreCommand : virtual Command
 {
@@ -97,10 +100,10 @@ struct SourceExprCommand : virtual Args, MixFlakeOptions
 
     SourceExprCommand();
 
-    std::vector<std::shared_ptr<Installable>> parseInstallables(
+    Installables parseInstallables(
         ref<Store> store, std::vector<std::string> ss);
 
-    std::shared_ptr<Installable> parseInstallable(
+    ref<Installable> parseInstallable(
         ref<Store> store, const std::string & installable);
 
     virtual Strings getDefaultFlakeAttrPaths();
@@ -115,36 +118,43 @@ struct MixReadOnlyOption : virtual Args
     MixReadOnlyOption();
 };
 
-/* A command that operates on a list of "installables", which can be
-   store paths, attribute paths, Nix expressions, etc. */
-struct InstallablesCommand : virtual Args, SourceExprCommand
+/* Like InstallablesCommand but the installables are not loaded */
+struct RawInstallablesCommand : virtual Args, SourceExprCommand
 {
-    std::vector<std::shared_ptr<Installable>> installables;
+    RawInstallablesCommand();
 
-    InstallablesCommand();
+    virtual void run(ref<Store> store, std::vector<std::string> && rawInstallables) = 0;
 
-    void prepare() override;
-    Installables load();
+    void run(ref<Store> store) override;
 
-    virtual bool useDefaultInstallables() { return true; }
+    // FIXME make const after CmdRepl's override is fixed up
+    virtual void applyDefaultInstallables(std::vector<std::string> & rawInstallables);
 
     bool readFromStdIn = false;
 
     std::vector<std::string> getFlakesForCompletion() override;
 
-protected:
+private:
 
-    std::vector<std::string> _installables;
+    std::vector<std::string> rawInstallables;
+};
+/* A command that operates on a list of "installables", which can be
+   store paths, attribute paths, Nix expressions, etc. */
+struct InstallablesCommand : RawInstallablesCommand
+{
+    virtual void run(ref<Store> store, Installables && installables) = 0;
+
+    void run(ref<Store> store, std::vector<std::string> && rawInstallables) override;
 };
 
 /* A command that operates on exactly one "installable" */
 struct InstallableCommand : virtual Args, SourceExprCommand
 {
-    std::shared_ptr<Installable> installable;
-
     InstallableCommand();
 
-    void prepare() override;
+    virtual void run(ref<Store> store, ref<Installable> installable) = 0;
+
+    void run(ref<Store> store) override;
 
     std::vector<std::string> getFlakesForCompletion() override
     {
@@ -179,22 +189,18 @@ public:
 
     BuiltPathsCommand(bool recursive = false);
 
-    using StoreCommand::run;
-
     virtual void run(ref<Store> store, BuiltPaths && paths) = 0;
 
-    void run(ref<Store> store) override;
+    void run(ref<Store> store, Installables && installables) override;
 
-    bool useDefaultInstallables() override { return !all; }
+    void applyDefaultInstallables(std::vector<std::string> & rawInstallables) override;
 };
 
 struct StorePathsCommand : public BuiltPathsCommand
 {
     StorePathsCommand(bool recursive = false);
 
-    using BuiltPathsCommand::run;
-
-    virtual void run(ref<Store> store, std::vector<StorePath> && storePaths) = 0;
+    virtual void run(ref<Store> store, StorePaths && storePaths) = 0;
 
     void run(ref<Store> store, BuiltPaths && paths) override;
 };
@@ -202,11 +208,9 @@ struct StorePathsCommand : public BuiltPathsCommand
 /* A command that operates on exactly one store path. */
 struct StorePathCommand : public StorePathsCommand
 {
-    using StorePathsCommand::run;
-
     virtual void run(ref<Store> store, const StorePath & storePath) = 0;
 
-    void run(ref<Store> store, std::vector<StorePath> && storePaths) override;
+    void run(ref<Store> store, StorePaths && storePaths) override;
 };
 
 /* A helper class for registering commands globally. */

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -79,6 +79,9 @@ struct BuiltPathWithResult
 
 typedef std::vector<DerivedPathWithInfo> DerivedPathsWithInfo;
 
+struct Installable;
+typedef std::vector<ref<Installable>> Installables;
+
 struct Installable
 {
     virtual ~Installable() { }
@@ -122,14 +125,14 @@ struct Installable
         ref<Store> evalStore,
         ref<Store> store,
         Realise mode,
-        const std::vector<std::shared_ptr<Installable>> & installables,
+        const Installables & installables,
         BuildMode bMode = bmNormal);
 
-    static std::vector<std::pair<std::shared_ptr<Installable>, BuiltPathWithResult>> build2(
+    static std::vector<std::pair<ref<Installable>, BuiltPathWithResult>> build2(
         ref<Store> evalStore,
         ref<Store> store,
         Realise mode,
-        const std::vector<std::shared_ptr<Installable>> & installables,
+        const Installables & installables,
         BuildMode bMode = bmNormal);
 
     static std::set<StorePath> toStorePaths(
@@ -137,18 +140,18 @@ struct Installable
         ref<Store> store,
         Realise mode,
         OperateOn operateOn,
-        const std::vector<std::shared_ptr<Installable>> & installables);
+        const Installables & installables);
 
     static StorePath toStorePath(
         ref<Store> evalStore,
         ref<Store> store,
         Realise mode,
         OperateOn operateOn,
-        std::shared_ptr<Installable> installable);
+        ref<Installable> installable);
 
     static std::set<StorePath> toDerivations(
         ref<Store> store,
-        const std::vector<std::shared_ptr<Installable>> & installables,
+        const Installables & installables,
         bool useDeriver = false);
 
     static BuiltPaths toBuiltPaths(
@@ -156,9 +159,7 @@ struct Installable
         ref<Store> store,
         Realise mode,
         OperateOn operateOn,
-        const std::vector<std::shared_ptr<Installable>> & installables);
+        const Installables & installables);
 };
-
-typedef std::vector<std::shared_ptr<Installable>> Installables;
 
 }

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -198,7 +198,6 @@ struct Command : virtual public Args
 
     virtual ~Command() { }
 
-    virtual void prepare() { };
     virtual void run() = 0;
 
     typedef int Category;

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -119,11 +119,11 @@ App UnresolvedApp::resolve(ref<Store> evalStore, ref<Store> store)
 {
     auto res = unresolved;
 
-    std::vector<std::shared_ptr<Installable>> installableContext;
+    Installables installableContext;
 
     for (auto & ctxElt : unresolved.context)
         installableContext.push_back(
-            std::make_shared<InstallableDerivedPath>(store, DerivedPath { ctxElt }));
+            make_ref<InstallableDerivedPath>(store, DerivedPath { ctxElt }));
 
     auto builtContext = Installable::build(evalStore, store, Realise::Outputs, installableContext);
     res.program = resolveString(*store, unresolved.program, builtContext);

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -89,7 +89,7 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
           ;
     }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, Installables && installables) override
     {
         if (dryRun) {
             std::vector<DerivedPath> pathsToBuild;

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -70,7 +70,7 @@ struct CmdBundle : InstallableCommand
         return res;
     }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
         auto evalState = getEvalState();
 

--- a/src/nix/copy.cc
+++ b/src/nix/copy.cc
@@ -10,8 +10,6 @@ struct CmdCopy : virtual CopyCommand, virtual BuiltPathsCommand
 
     SubstituteFlag substitute = NoSubstitute;
 
-    using BuiltPathsCommand::run;
-
     CmdCopy()
         : BuiltPathsCommand(true)
     {

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -374,7 +374,7 @@ struct Common : InstallableCommand, MixProfile
         return res;
     }
 
-    StorePath getShellOutPath(ref<Store> store)
+    StorePath getShellOutPath(ref<Store> store, ref<Installable> installable)
     {
         auto path = installable->getStorePath();
         if (path && hasSuffix(path->to_string(), "-env"))
@@ -392,9 +392,10 @@ struct Common : InstallableCommand, MixProfile
         }
     }
 
-    std::pair<BuildEnvironment, std::string> getBuildEnvironment(ref<Store> store)
+    std::pair<BuildEnvironment, std::string>
+    getBuildEnvironment(ref<Store> store, ref<Installable> installable)
     {
-        auto shellOutPath = getShellOutPath(store);
+        auto shellOutPath = getShellOutPath(store, installable);
 
         auto strPath = store->printStorePath(shellOutPath);
 
@@ -480,9 +481,9 @@ struct CmdDevelop : Common, MixEnvironment
           ;
     }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
-        auto [buildEnvironment, gcroot] = getBuildEnvironment(store);
+        auto [buildEnvironment, gcroot] = getBuildEnvironment(store, installable);
 
         auto [rcFileFd, rcFilePath] = createTempFile("nix-shell");
 
@@ -537,7 +538,7 @@ struct CmdDevelop : Common, MixEnvironment
             nixpkgsLockFlags.inputOverrides = {};
             nixpkgsLockFlags.inputUpdates = {};
 
-            auto bashInstallable = std::make_shared<InstallableFlake>(
+            auto bashInstallable = make_ref<InstallableFlake>(
                 this,
                 state,
                 installable->nixpkgsFlakeRef(),
@@ -573,7 +574,7 @@ struct CmdDevelop : Common, MixEnvironment
         // Need to chdir since phases assume in flake directory
         if (phase) {
             // chdir if installable is a flake of type git+file or path
-            auto installableFlake = std::dynamic_pointer_cast<InstallableFlake>(installable);
+            auto installableFlake = installable.dynamic_pointer_cast<InstallableFlake>();
             if (installableFlake) {
                 auto sourcePath = installableFlake->getLockedFlake()->flake.resolvedRef.input.getSourcePath();
                 if (sourcePath) {
@@ -604,9 +605,9 @@ struct CmdPrintDevEnv : Common, MixJSON
 
     Category category() override { return catUtility; }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
-        auto buildEnvironment = getBuildEnvironment(store).first;
+        auto buildEnvironment = getBuildEnvironment(store, installable).first;
 
         stopProgressBar();
 

--- a/src/nix/edit.cc
+++ b/src/nix/edit.cc
@@ -25,7 +25,7 @@ struct CmdEdit : InstallableCommand
 
     Category category() override { return catSecondary; }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
         auto state = getEvalState();
 

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -54,7 +54,7 @@ struct CmdEval : MixJSON, InstallableCommand, MixReadOnlyOption
 
     Category category() override { return catSecondary; }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
         if (raw && json)
             throw UsageError("--raw and --json are mutually exclusive");

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1329,7 +1329,6 @@ struct CmdFlake : NixMultiCommand
         if (!command)
             throw UsageError("'nix flake' requires a sub-command.");
         settings.requireExperimentalFeature(Xp::Flakes);
-        command->second->prepare();
         command->second->run();
     }
 };

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -151,7 +151,6 @@ struct CmdHash : NixMultiCommand
     {
         if (!command)
             throw UsageError("'nix hash' requires a sub-command.");
-        command->second->prepare();
         command->second->run();
     }
 };

--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -23,7 +23,7 @@ struct CmdLog : InstallableCommand
 
     Category category() override { return catSecondary; }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
         settings.readOnlyMode = true;
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -394,7 +394,6 @@ void mainWrapped(int argc, char * * argv)
     if (args.command->second->forceImpureByDefault() && !evalSettings.pureEval.overridden) {
         evalSettings.pureEval = false;
     }
-    args.command->second->prepare();
     args.command->second->run();
 }
 

--- a/src/nix/make-content-addressed.cc
+++ b/src/nix/make-content-addressed.cc
@@ -28,7 +28,6 @@ struct CmdMakeContentAddressed : virtual CopyCommand, virtual StorePathsCommand,
           ;
     }
 
-    using StorePathsCommand::run;
     void run(ref<Store> srcStore, StorePaths && storePaths) override
     {
         auto dstStore = dstUri.empty() ? openStore() : openStore(dstUri);

--- a/src/nix/nar.cc
+++ b/src/nix/nar.cc
@@ -25,7 +25,6 @@ struct CmdNar : NixMultiCommand
     {
         if (!command)
             throw UsageError("'nix nar' requires a sub-command.");
-        command->second->prepare();
         command->second->run();
     }
 };

--- a/src/nix/realisation.cc
+++ b/src/nix/realisation.cc
@@ -21,7 +21,6 @@ struct CmdRealisation : virtual NixMultiCommand
     {
         if (!command)
             throw UsageError("'nix realisation' requires a sub-command.");
-        command->second->prepare();
         command->second->run();
     }
 };

--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -227,7 +227,6 @@ struct CmdRegistry : virtual NixMultiCommand
         settings.requireExperimentalFeature(Xp::Flakes);
         if (!command)
             throw UsageError("'nix registry' requires a sub-command.");
-        command->second->prepare();
         command->second->run();
     }
 };

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -97,7 +97,7 @@ struct CmdShell : InstallablesCommand, MixEnvironment
           ;
     }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, Installables && installables) override
     {
         auto outPaths = Installable::toStorePaths(getEvalStore(), store, Realise::Outputs, OperateOn::Output, installables);
 
@@ -183,7 +183,7 @@ struct CmdRun : InstallableCommand
         return res;
     }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
         auto state = getEvalState();
 

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -61,7 +61,7 @@ struct CmdSearch : InstallableCommand, MixJSON
         };
     }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, ref<Installable> installable) override
     {
         settings.readOnlyMode = true;
         evalSettings.enableImportFromDerivation.setDefault(false);

--- a/src/nix/show-derivation.cc
+++ b/src/nix/show-derivation.cc
@@ -39,7 +39,7 @@ struct CmdShowDerivation : InstallablesCommand
 
     Category category() override { return catUtility; }
 
-    void run(ref<Store> store) override
+    void run(ref<Store> store, Installables && installables) override
     {
         auto drvPaths = Installable::toDerivations(store, installables, true);
 

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -219,7 +219,6 @@ struct CmdKey : NixMultiCommand
     {
         if (!command)
             throw UsageError("'nix key' requires a sub-command.");
-        command->second->prepare();
         command->second->run();
     }
 };

--- a/src/nix/store-copy-log.cc
+++ b/src/nix/store-copy-log.cc
@@ -26,7 +26,7 @@ struct CmdCopyLog : virtual CopyCommand, virtual InstallablesCommand
 
     Category category() override { return catUtility; }
 
-    void run(ref<Store> srcStore) override
+    void run(ref<Store> srcStore, Installables && installables) override
     {
         auto & srcLogStore = require<LogStore>(*srcStore);
 

--- a/src/nix/store-delete.cc
+++ b/src/nix/store-delete.cc
@@ -32,7 +32,7 @@ struct CmdStoreDelete : StorePathsCommand
           ;
     }
 
-    void run(ref<Store> store, std::vector<StorePath> && storePaths) override
+    void run(ref<Store> store, StorePaths && storePaths) override
     {
         auto & gcStore = require<GcStore>(*store);
 

--- a/src/nix/store-repair.cc
+++ b/src/nix/store-repair.cc
@@ -17,7 +17,7 @@ struct CmdStoreRepair : StorePathsCommand
           ;
     }
 
-    void run(ref<Store> store, std::vector<StorePath> && storePaths) override
+    void run(ref<Store> store, StorePaths && storePaths) override
     {
         for (auto & path : storePaths)
             store->repairPath(path);

--- a/src/nix/store.cc
+++ b/src/nix/store.cc
@@ -18,7 +18,6 @@ struct CmdStore : virtual NixMultiCommand
     {
         if (!command)
             throw UsageError("'nix store' requires a sub-command.");
-        command->second->prepare();
         command->second->run();
     }
 };


### PR DESCRIPTION
# Motivation

Already, we had classes like `BuiltPathsCommand` and `StorePathsCommand` which provided alternative `run` virtual functions providing the implementation with more arguments. This was a very nice and easy way to make writing command; just fill in the virtual functions and it is fairly clear what to do.

However, exception to this pattern were `Installable{,s}Command`. These two classes instead just had a field where the installables would be stored, and various side-effecting `prepare` and `load` machinery too fill them in. Command would wish out those fields.

This isn't so clear to use.

What this commit does is make those command classes like the others, with richer `run` functions.

Not only does this restore the pattern making commands easier to write, it has a number of other benefits:

- `prepare` and `load` are gone entirely! One command just hands just hands off to the next.

- `useDefaultInstallables` because `defaultInstallables`. This takes over `prepare` for the one case that needs it, and provides enough flexiblity to handle `nix repl`'s idiosyncratic migration.

- We can use `ref` instead of `std::shared_ptr`. The former must be initialized (so it is like Rust's `Box` rather than `Option<Box>`, This expresses the invariant that the installable are in fact initialized much better.

  This is possible because since we just have local variables not fields, we can stop worrying about the not-yet-initialized case.

- Fewer lines of code! (Finally I have a large refactor that makes the number go down not up...)

- `nix repl` is now implemented in a clearer way.

The last item deserves further mention. `nix repl` is not like the other installable commands because instead working from once-loaded installables, it needs to be able to load them again and again.

To properly support this, we make a new superclass `RawInstallablesCommand`. This class has the argument parsing and completion logic, but does *not* hand off parsed installables but instead just the raw string arguments.

This is exactly what `nix repl` needs, and allows us to instead of having the logic awkwardly split between `prepare`, `useDefaultInstallables,` and `load`, have everything right next to each other. I think this will enable future simplifications of that argument defaulting logic, but I am saving those for a future PR --- best to keep code motion and more complicated boolean expression rewriting separate steps.

The "diagnostic ignored `-Woverloaded-virtual`" pragma helps because C++ doesn't like our many `run` methods. In our case, we don't mind the shadowing it all --- it is *intentional* that the derived class only provides a `run` method, and doesn't call any of the overridden `run` methods.

# Context

Helps with https://github.com/NixOS/rfcs/pull/134

Depends on #7748

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
