### PR TITLE
Scope down `--derivation` to just the commands that use it

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -127,6 +127,16 @@ ref<EvalState> EvalCommand::getEvalState()
     return ref<EvalState>(evalState);
 }
 
+MixOperateOnOptions::MixOperateOnOptions()
+{
+    addFlag({
+        .longName = "derivation",
+        .description = "Operate on the [store derivation](../../glossary.md#gloss-store-derivation) rather than its outputs.",
+        .category = installablesCategory,
+        .handler = {&operateOn, OperateOn::Derivation},
+    });
+}
+
 BuiltPathsCommand::BuiltPathsCommand(bool recursive)
     : recursive(recursive)
 {

--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -96,9 +96,6 @@ struct SourceExprCommand : virtual Args, MixFlakeOptions
     std::optional<std::string> expr;
     bool readOnlyMode = false;
 
-    // FIXME: move this; not all commands (e.g. 'nix run') use it.
-    OperateOn operateOn = OperateOn::Output;
-
     SourceExprCommand(bool supportReadOnlyMode = false);
 
     std::vector<std::shared_ptr<Installable>> parseInstallables(
@@ -153,8 +150,15 @@ private:
     std::string _installable{"."};
 };
 
+struct MixOperateOnOptions : virtual Args
+{
+    OperateOn operateOn = OperateOn::Output;
+
+    MixOperateOnOptions();
+};
+
 /* A command that operates on zero or more store paths. */
-struct BuiltPathsCommand : public InstallablesCommand
+struct BuiltPathsCommand : InstallablesCommand, virtual MixOperateOnOptions
 {
 private:
 

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -167,13 +167,6 @@ SourceExprCommand::SourceExprCommand(bool supportReadOnlyMode)
         .handler = {&expr}
     });
 
-    addFlag({
-        .longName = "derivation",
-        .description = "Operate on the [store derivation](../../glossary.md#gloss-store-derivation) rather than its outputs.",
-        .category = installablesCategory,
-        .handler = {&operateOn, OperateOn::Derivation},
-    });
-
     if (supportReadOnlyMode) {
         addFlag({
             .longName = "read-only",

--- a/src/nix/diff-closures.cc
+++ b/src/nix/diff-closures.cc
@@ -106,7 +106,7 @@ void printClosureDiff(
 
 using namespace nix;
 
-struct CmdDiffClosures : SourceExprCommand
+struct CmdDiffClosures : SourceExprCommand, MixOperateOnOptions
 {
     std::string _before, _after;
 

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -27,7 +27,7 @@ static std::string filterPrintable(const std::string & s)
     return res;
 }
 
-struct CmdWhyDepends : SourceExprCommand
+struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
 {
     std::string _package, _dependency;
     bool all = false;

--- a/tests/ca/build.sh
+++ b/tests/ca/build.sh
@@ -3,7 +3,7 @@
 source common.sh
 
 drv=$(nix-instantiate --experimental-features ca-derivations ./content-addressed.nix -A rootCA --arg seed 1)
-nix --experimental-features 'nix-command ca-derivations' show-derivation --derivation "$drv" --arg seed 1
+nix --experimental-features 'nix-command ca-derivations' show-derivation "$drv" --arg seed 1
 
 buildAttr () {
     local derivationPath=$1


### PR DESCRIPTION
# Motivation

Per the old FIXME, this flag was on too many commands, and mostly ignored. Now it is just on the commands where it actually has an effect.

----

Previous commit:

Remove `--derivation` from test

It doesn't do anything here, and in the next commit `show-derivation`
will no longer accept this flag.

# Context

Per https://github.com/NixOS/nix/issues/7261, I would still like to get rid of it entirely, but that is a separate project. This change should be good with or without doing that.

Also working towards https://github.com/NixOS/rfcs/pull/134

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
