### PR TITLE
fix documentation for `clang11Stdenv` dev shell

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -45,13 +45,13 @@ To get a shell with a different compilation environment (e.g. stdenv,
 gccStdenv, clangStdenv, clang11Stdenv, ccacheStdenv):
 
 ```console
-$ nix-shell -A devShells.x86_64-linux.clang11StdenvPackages
+$ nix-shell -A devShells.x86_64-linux.clang11Stdenv
 ```
 
 or if you have a flake-enabled nix:
 
 ```console
-$ nix develop .#clang11StdenvPackages
+$ nix develop .#clang11Stdenv
 ```
 
 Note: you can use `ccacheStdenv` to drastically improve rebuild


### PR DESCRIPTION

# Motivation

Changes references in documentation from `clang11StdenvPackages` to `clang11Stdenv`


This works:
```
$ nix develop .#clang11Stdenv   

peterbecich@neptune:~/nix/nix$ 
```

# Context

`clang11StdenvPackages` does not exist

```
$ nix flake show
.
.
.
devShells
.
.
.
│   └───x86_64-linux
│       ├───ccacheStdenv: development environment 'nix'
│       ├───clang11Stdenv: development environment 'nix'
│       ├───clangStdenv: development environment 'nix'
│       ├───default: development environment 'nix'
│       ├───gccStdenv: development environment 'nix'
│       ├───libcxxStdenv: development environment 'nix'
│       └───stdenv: development environment 'nix'
```


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
