### PR TITLE
`nix flake check`: skip derivations for foreign systems

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -259,7 +259,7 @@ struct CmdFlakeInfo : CmdFlakeMetadata
 struct CmdFlakeCheck : FlakeCommand
 {
     bool build = true;
-    bool checkCurrentSystemOnly = false;
+    bool checkAllSystems = false;
 
     CmdFlakeCheck()
     {
@@ -269,9 +269,9 @@ struct CmdFlakeCheck : FlakeCommand
             .handler = {&build, false}
         });
         addFlag({
-            .longName = "current-system-only",
-            .description = "Check the outputs for only the current system.",
-            .handler = {&checkCurrentSystemOnly, true}
+            .longName = "all-systems",
+            .description = "Check the outputs for all systems.",
+            .handler = {&checkAllSystems, true}
         });
     }
 
@@ -337,7 +337,7 @@ struct CmdFlakeCheck : FlakeCommand
         };
 
         auto checkSystemType = [&](const std::string & system, const PosIdx pos) {
-            if (checkCurrentSystemOnly && system != localSystem) {
+            if (!checkAllSystems && system != localSystem) {
                 omittedSystems.insert(system);
                 return false;
             } else {
@@ -722,7 +722,7 @@ struct CmdFlakeCheck : FlakeCommand
             throw Error("some errors were encountered during the evaluation");
 
         if (!omittedSystems.empty()) {
-            logger->warn("The check omitted these incompatible systems:");
+            logger->warn("The check omitted these incompatible systems (use '--all-systems' to check all):");
             for (auto omittedSystem: omittedSystems)
                 logger->warn(omittedSystem);
         }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -722,11 +722,13 @@ struct CmdFlakeCheck : FlakeCommand
             throw Error("some errors were encountered during the evaluation");
 
         if (!omittedSystems.empty()) {
-            logger->warn("The check omitted these incompatible systems (use '--all-systems' to check all):");
-            for (auto omittedSystem: omittedSystems)
-                logger->warn(omittedSystem);
-        }
-    }
+            warn(
+                "The check omitted these incompatible systems: %s\n"
+                "Use '--all-systems' to check all.",
+                concatStringsSep(", ", omittedSystems)
+            );
+        };
+    };
 };
 
 static Strings defaultTemplateAttrPathsPrefixes{"templates."};

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -259,6 +259,7 @@ struct CmdFlakeInfo : CmdFlakeMetadata
 struct CmdFlakeCheck : FlakeCommand
 {
     bool build = true;
+    bool checkAllSystems = false;
 
     CmdFlakeCheck()
     {
@@ -266,6 +267,11 @@ struct CmdFlakeCheck : FlakeCommand
             .longName = "no-build",
             .description = "Do not build checks.",
             .handler = {&build, false}
+        });
+        addFlag({
+            .longName = "all-systems",
+            .description = "Check the outputs for all systems.",
+            .handler = {&checkAllSystems, true}
         });
     }
 
@@ -292,6 +298,7 @@ struct CmdFlakeCheck : FlakeCommand
 
         lockFlags.applyNixConfig = true;
         auto flake = lockFlake();
+        auto localSystem = std::string(settings.thisSystem.get());
 
         bool hasErrors = false;
         auto reportError = [&](const Error & e) {
@@ -306,6 +313,8 @@ struct CmdFlakeCheck : FlakeCommand
                     throw;
             }
         };
+
+        std::set<std::string> omittedSystems;
 
         // FIXME: rewrite to use EvalCache.
 
@@ -325,6 +334,15 @@ struct CmdFlakeCheck : FlakeCommand
             // FIXME: what's the format of "system"?
             if (system.find('-') == std::string::npos)
                 reportError(Error("'%s' is not a valid system type, at %s", system, resolve(pos)));
+        };
+
+        auto checkSystemType = [&](const std::string & system, const PosIdx pos) {
+            if (!checkAllSystems && system != localSystem) {
+                omittedSystems.insert(system);
+                return false;
+            } else {
+                return true;
+            }
         };
 
         auto checkDerivation = [&](const std::string & attrPath, Value & v, const PosIdx pos) -> std::optional<StorePath> {
@@ -509,16 +527,18 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs) {
-                                    auto drvPath = checkDerivation(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
-                                    if (drvPath && attr_name == settings.thisSystem.get()) {
-                                        drvPaths.push_back(DerivedPath::Built {
-                                            .drvPath = *drvPath,
-                                            .outputs = OutputsSpec::All { },
-                                        });
+                                if (checkSystemType(attr_name, attr.pos)) {
+                                    state->forceAttrs(*attr.value, attr.pos, "");
+                                    for (auto & attr2 : *attr.value->attrs) {
+                                        auto drvPath = checkDerivation(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
+                                            *attr2.value, attr2.pos);
+                                        if (drvPath && attr_name == settings.thisSystem.get()) {
+                                            drvPaths.push_back(DerivedPath::Built {
+                                                    .drvPath = *drvPath,
+                                                        .outputs = OutputsSpec::All { },
+                                                        });
+                                        }
                                     }
                                 }
                             }
@@ -529,9 +549,11 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                checkApp(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
+                                if (checkSystemType(attr_name, attr.pos)) {
+                                    checkApp(
+                                        fmt("%s.%s", name, attr_name),
+                                        *attr.value, attr.pos);
+                                };
                             }
                         }
 
@@ -540,11 +562,13 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs)
-                                    checkDerivation(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
+                                if (checkSystemType(attr_name, attr.pos)) {
+                                    state->forceAttrs(*attr.value, attr.pos, "");
+                                    for (auto & attr2 : *attr.value->attrs)
+                                        checkDerivation(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
+                                            *attr2.value, attr2.pos);
+                                };
                             }
                         }
 
@@ -553,11 +577,13 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs)
-                                    checkApp(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
+                                if (checkSystemType(attr_name, attr.pos)) {
+                                    state->forceAttrs(*attr.value, attr.pos, "");
+                                    for (auto & attr2 : *attr.value->attrs)
+                                        checkApp(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
+                                            *attr2.value, attr2.pos);
+                                };
                             }
                         }
 
@@ -566,9 +592,11 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                checkDerivation(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
+                                if (checkSystemType(attr_name, attr.pos)) {
+                                    checkDerivation(
+                                        fmt("%s.%s", name, attr_name),
+                                        *attr.value, attr.pos);
+                                };
                             }
                         }
 
@@ -577,9 +605,11 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                checkApp(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
+                                if (checkSystemType(attr_name, attr.pos) ) {
+                                    checkApp(
+                                        fmt("%s.%s", name, attr_name),
+                                        *attr.value, attr.pos);
+                                };
                             }
                         }
 
@@ -587,6 +617,7 @@ struct CmdFlakeCheck : FlakeCommand
                             state->forceAttrs(vOutput, pos, "");
                             for (auto & attr : *vOutput.attrs) {
                                 checkSystemName(state->symbols[attr.name], attr.pos);
+                                checkSystemType(state->symbols[attr.name], attr.pos);
                                 // FIXME: do getDerivations?
                             }
                         }
@@ -636,9 +667,11 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                checkBundler(
-                                    fmt("%s.%s", name, attr_name),
-                                    *attr.value, attr.pos);
+                                if (checkSystemType(attr_name, attr.pos)) {
+                                    checkBundler(
+                                        fmt("%s.%s", name, attr_name),
+                                        *attr.value, attr.pos);
+                                };
                             }
                         }
 
@@ -647,12 +680,14 @@ struct CmdFlakeCheck : FlakeCommand
                             for (auto & attr : *vOutput.attrs) {
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs) {
-                                    checkBundler(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value, attr2.pos);
-                                }
+                                if (checkSystemType(attr_name, attr.pos)) {
+                                    state->forceAttrs(*attr.value, attr.pos, "");
+                                    for (auto & attr2 : *attr.value->attrs) {
+                                        checkBundler(
+                                            fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
+                                            *attr2.value, attr2.pos);
+                                    }
+                                };
                             }
                         }
 
@@ -685,6 +720,12 @@ struct CmdFlakeCheck : FlakeCommand
         }
         if (hasErrors)
             throw Error("some errors were encountered during the evaluation");
+
+        if (!omittedSystems.empty()) {
+            logger->warn("The check omitted these incompatible systems (use '--all-systems' to check all):");
+            for (auto omittedSystem: omittedSystems)
+                logger->warn(omittedSystem);
+        }
     }
 };
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -259,7 +259,7 @@ struct CmdFlakeInfo : CmdFlakeMetadata
 struct CmdFlakeCheck : FlakeCommand
 {
     bool build = true;
-    bool checkAllSystems = false;
+    bool checkCurrentSystemOnly = false;
 
     CmdFlakeCheck()
     {
@@ -269,9 +269,9 @@ struct CmdFlakeCheck : FlakeCommand
             .handler = {&build, false}
         });
         addFlag({
-            .longName = "all-systems",
-            .description = "Check the outputs for all systems.",
-            .handler = {&checkAllSystems, true}
+            .longName = "current-system-only",
+            .description = "Check the outputs for only the current system.",
+            .handler = {&checkCurrentSystemOnly, true}
         });
     }
 
@@ -337,7 +337,7 @@ struct CmdFlakeCheck : FlakeCommand
         };
 
         auto checkSystemType = [&](const std::string & system, const PosIdx pos) {
-            if (!checkAllSystems && system != localSystem) {
+            if (checkCurrentSystemOnly && system != localSystem) {
                 omittedSystems.insert(system);
                 return false;
             } else {
@@ -722,7 +722,7 @@ struct CmdFlakeCheck : FlakeCommand
             throw Error("some errors were encountered during the evaluation");
 
         if (!omittedSystems.empty()) {
-            logger->warn("The check omitted these incompatible systems (use '--all-systems' to check all):");
+            logger->warn("The check omitted these incompatible systems:");
             for (auto omittedSystem: omittedSystems)
                 logger->warn(omittedSystem);
         }

--- a/tests/flakes/check.sh
+++ b/tests/flakes/check.sh
@@ -72,8 +72,8 @@ cat > $flakeDir/flake.nix <<EOF
 }
 EOF
 
-nix flake check --current-system-only $flakeDir
+nix flake check $flakeDir
 
-checkRes=$(nix flake check --keep-going $flakeDir 2>&1 && fail "nix flake check should have failed" || true)
+checkRes=$(nix flake check --all-systems --keep-going $flakeDir 2>&1 && fail "nix flake check --all-systems should have failed" || true)
 echo "$checkRes" | grepQuiet "packages.system-1.default"
 echo "$checkRes" | grepQuiet "packages.system-2.default"

--- a/tests/flakes/check.sh
+++ b/tests/flakes/check.sh
@@ -72,8 +72,8 @@ cat > $flakeDir/flake.nix <<EOF
 }
 EOF
 
-nix flake check $flakeDir
+nix flake check --current-system-only $flakeDir
 
-checkRes=$(nix flake check --all-systems --keep-going $flakeDir 2>&1 && fail "nix flake check --all-systems should have failed" || true)
+checkRes=$(nix flake check --keep-going $flakeDir 2>&1 && fail "nix flake check should have failed" || true)
 echo "$checkRes" | grepQuiet "packages.system-1.default"
 echo "$checkRes" | grepQuiet "packages.system-2.default"

--- a/tests/flakes/check.sh
+++ b/tests/flakes/check.sh
@@ -72,6 +72,8 @@ cat > $flakeDir/flake.nix <<EOF
 }
 EOF
 
-checkRes=$(nix flake check --keep-going $flakeDir 2>&1 && fail "nix flake check should have failed" || true)
+nix flake check $flakeDir
+
+checkRes=$(nix flake check --all-systems --keep-going $flakeDir 2>&1 && fail "nix flake check --all-systems should have failed" || true)
 echo "$checkRes" | grepQuiet "packages.system-1.default"
 echo "$checkRes" | grepQuiet "packages.system-2.default"


### PR DESCRIPTION
# Context

> nix flake check breaks on IFD in multi-platform flake
> https://github.com/NixOS/nix/issues/4265

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

This PR changes the default behavior of `nix flake check`. 

The same change was already approved for `nix flake show`: https://github.com/NixOS/nix/pull/6988

<!-- Large change: Provide instructions to reviewers how to read the diff. -->


# Motivation

`nix flake show` now skips derivations for foreign systems: https://github.com/NixOS/nix/pull/6988

This PR borrows from that PR to implement the same behavior for `nix flake check`.


Here is a Flake project which I believe uses IFD: https://github.com/srid/haskell-template

Using Nix 2.12.0 on a `x86_64-linux`, the result of `nix flake check` is:

```
$ nix flake check
warning: Git tree '/home/peterbecich/haskell/libraries/haskell-template' is dirty
error: a 'aarch64-linux' with features {} is required to build 
'/nix/store/jlcg48nsm1dpblvg9wj6zq19c3mswg40-cabal2nix-haskell-template.drv',
 but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test, uid-range}
(use '--show-trace' to show detailed location information)
```

With this PR, `nix flake check` produces:

```
~/nix/nix/outputs/out/bin/nix flake check
warning: Git tree '/home/peterbecich/haskell/libraries/haskell-template' is dirty
warning: The check omitted these incompatible systems (use '--all-systems' to check all):
warning: aarch64-darwin
warning: aarch64-linux
warning: armv5tel-linux
warning: armv6l-linux
warning: armv7l-linux
warning: i686-linux
warning: mipsel-linux
warning: powerpc64le-linux
warning: riscv64-linux
warning: x86_64-darwin
```

With this PR and the `--all-systems` flag, it produces an error like before:
```
 ~/nix/nix/outputs/out/bin/nix flake check --all-systems
warning: Git tree '/home/peterbecich/haskell/libraries/haskell-template' is dirty
error:
       … while checking flake output 'packages'

         at «none»:0: (source not available)

       … while checking the derivation 'packages.aarch64-linux.default'

         at «none»:0: (source not available)

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: a 'aarch64-linux' with features {} is required to build 
'/nix/store/jlcg48nsm1dpblvg9wj6zq19c3mswg40-cabal2nix-haskell-template.drv',
 but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test, uid-range}
```


The current system is acquired this way, copied from https://github.com/NixOS/nix/pull/6988:
https://github.com/NixOS/nix/blob/513d8a1d7452d0a733b8cf9899567faae0ae6e92/src/nix/flake.cc#L300

For a Nix system with remote builders, could this change to the default behavior of `nix flake check` be a problem?

This PR copies the existing check `checkSystemName`.
Wherever `checkSystemName` is applied in `nix flake check`, the system type is now also checked by `checkSystemType`. I have not thought very carefully about where these checks are placed. Example:
https://github.com/NixOS/nix/blob/8be71bc5950cd4732ebc18cfc2dcb96a10c887f1/src/nix/flake.cc#L528-L542


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
