### PR TITLE
Switch from std::regex to boost::regex

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,7 +154,7 @@
 
         configureFlags =
           lib.optionals stdenv.isLinux [
-            "--with-boost=${boost}/lib"
+            "--with-boost=${boost-nix}/lib"
             "--with-sandbox-shell=${sh}/bin/busybox"
           ]
           ++ lib.optionals (stdenv.isLinux && !(isStatic && stdenv.system == "aarch64-linux")) [
@@ -202,7 +202,7 @@
               version = libgit2.lastModifiedDate;
               cmakeFlags = (attrs.cmakeFlags or []) ++ ["-DUSE_SSH=exec"];
             }))
-            boost
+            boost-nix
             lowdown-nix
             libsodium
           ]
@@ -423,14 +423,14 @@
 
             propagatedBuildInputs = propagatedDeps;
 
-            disallowedReferences = [ boost ];
+            disallowedReferences = [ boost-nix ];
 
             preConfigure = lib.optionalString (! currentStdenv.hostPlatform.isStatic)
               ''
                 # Copy libboost_context so we don't get all of Boost in our closure.
                 # https://github.com/NixOS/nixpkgs/issues/45462
                 mkdir -p $out/lib
-                cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
+                cp -pd ${boost-nix}/lib/{libboost_context*,libboost_thread*,libboost_system*,libboost_regex*} $out/lib
                 rm -f $out/lib/*.a
                 ${lib.optionalString currentStdenv.hostPlatform.isLinux ''
                   chmod u+w $out/lib/*.so.*
@@ -440,9 +440,9 @@
                   for LIB in $out/lib/*.dylib; do
                     chmod u+w $LIB
                     install_name_tool -id $LIB $LIB
-                    install_name_tool -delete_rpath ${boost}/lib/ $LIB || true
+                    install_name_tool -delete_rpath ${boost-nix}/lib/ $LIB || true
                   done
-                  install_name_tool -change ${boost}/lib/libboost_system.dylib $out/lib/libboost_system.dylib $out/lib/libboost_thread.dylib
+                  install_name_tool -change ${boost-nix}/lib/libboost_system.dylib $out/lib/libboost_system.dylib $out/lib/libboost_thread.dylib
                 ''}
               '';
 
@@ -470,9 +470,13 @@
               ''}
               ${lib.optionalString currentStdenv.isDarwin ''
               install_name_tool \
-                -change ${boost}/lib/libboost_context.dylib \
+                -change ${boost-nix}/lib/libboost_context.dylib \
                 $out/lib/libboost_context.dylib \
                 $out/lib/libnixutil.dylib
+              install_name_tool \
+                -change ${boost-nix}/lib/libboost_regex.dylib \
+                $out/lib/libboost_regex.dylib \
+                $out/lib/libnixexpr.dylib
               ''}
             '';
 
@@ -494,6 +498,12 @@
             meta.platforms = lib.platforms.unix;
             meta.mainProgram = "nix";
           });
+
+          boost-nix = final.boost.override {
+            # enableIcu arg is not yet supported
+            # but will be with next nixpkgs update
+            enableIcu = false;
+          };
 
           lowdown-nix = with final; currentStdenv.mkDerivation rec {
             name = "lowdown-0.9.0";

--- a/flake.nix
+++ b/flake.nix
@@ -500,8 +500,6 @@
           });
 
           boost-nix = final.boost.override {
-            # enableIcu arg is not yet supported
-            # but will be with next nixpkgs update
             enableIcu = false;
           };
 

--- a/src/libexpr/local.mk
+++ b/src/libexpr/local.mk
@@ -16,7 +16,7 @@ libexpr_CXXFLAGS += -I src/libutil -I src/libstore -I src/libfetchers -I src/lib
 
 libexpr_LIBS = libutil libstore libfetchers
 
-libexpr_LDFLAGS += -lboost_context -pthread
+libexpr_LDFLAGS += -lboost_context -lboost_regex -pthread
 ifdef HOST_LINUX
  libexpr_LDFLAGS += -ldl
 endif

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -16,6 +16,7 @@
 #include "primops.hh"
 
 #include <boost/container/small_vector.hpp>
+#include <boost/regex.hpp>
 #include <nlohmann/json.hpp>
 
 #include <sys/types.h>
@@ -24,7 +25,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <regex>
 #include <dlfcn.h>
 
 #include <cmath>
@@ -3885,19 +3885,30 @@ static RegisterPrimOp primop_convertHash({
     .fun = prim_convertHash,
 });
 
+// regex aliases, switch between boost and std
+using regex = boost::regex;
+using regex_error = boost::regex_error;
+using cmatch = boost::cmatch;
+using cregex_iterator = boost::cregex_iterator;
+namespace regex_constants = boost::regex_constants;
+// overloaded function alias
+constexpr auto regex_match = [] (auto &&...args) {
+    return boost::regex_match(std::forward<decltype(args)>(args)...);
+ };
+
 struct RegexCache
 {
     // TODO use C++20 transparent comparison when available
-    std::unordered_map<std::string_view, std::regex> cache;
+    std::unordered_map<std::string_view, regex> cache;
     std::list<std::string> keys;
 
-    std::regex get(std::string_view re)
+    regex get(std::string_view re)
     {
         auto it = cache.find(re);
         if (it != cache.end())
             return it->second;
         keys.emplace_back(re);
-        return cache.emplace(keys.back(), std::regex(keys.back(), std::regex::extended)).first->second;
+        return cache.emplace(keys.back(), regex(keys.back(), regex::extended)).first->second;
     }
 };
 
@@ -3917,8 +3928,8 @@ void prim_match(EvalState & state, const PosIdx pos, Value * * args, Value & v)
         NixStringContext context;
         const auto str = state.forceString(*args[1], context, pos, "while evaluating the second argument passed to builtins.match");
 
-        std::cmatch match;
-        if (!std::regex_match(str.begin(), str.end(), match, regex)) {
+        cmatch match;
+        if (!regex_match(str.begin(), str.end(), match, regex)) {
             v.mkNull();
             return;
         }
@@ -3933,8 +3944,8 @@ void prim_match(EvalState & state, const PosIdx pos, Value * * args, Value & v)
                 (v.listElems()[i] = state.allocValue())->mkString(match[i + 1].str());
         }
 
-    } catch (std::regex_error & e) {
-        if (e.code() == std::regex_constants::error_space) {
+    } catch (regex_error & e) {
+        if (e.code() == regex_constants::error_space) {
             // limit is _GLIBCXX_REGEX_STATE_LIMIT for libstdc++
             state.debugThrowLastTrace(EvalError({
                 .msg = hintfmt("memory limit exceeded by regular expression '%s'", re),
@@ -3997,8 +4008,8 @@ void prim_split(EvalState & state, const PosIdx pos, Value * * args, Value & v)
         NixStringContext context;
         const auto str = state.forceString(*args[1], context, pos, "while evaluating the second argument passed to builtins.split");
 
-        auto begin = std::cregex_iterator(str.begin(), str.end(), regex);
-        auto end = std::cregex_iterator();
+        auto begin = cregex_iterator(str.begin(), str.end(), regex);
+        auto end = cregex_iterator();
 
         // Any matches results are surrounded by non-matching results.
         const size_t len = std::distance(begin, end);
@@ -4037,8 +4048,8 @@ void prim_split(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 
         assert(idx == 2 * len + 1);
 
-    } catch (std::regex_error & e) {
-        if (e.code() == std::regex_constants::error_space) {
+    } catch (regex_error & e) {
+        if (e.code() == regex_constants::error_space) {
             // limit is _GLIBCXX_REGEX_STATE_LIMIT for libstdc++
             state.debugThrowLastTrace(EvalError({
                 .msg = hintfmt("memory limit exceeded by regular expression '%s'", re),


### PR DESCRIPTION
# Motivation
Requested in #7336


# Context
Fixes https://github.com/NixOS/nix/issues/2147, fixes https://github.com/NixOS/nix/issues/4758
See also https://github.com/NixOS/nix/pull/3826.

- `s/std::regex/regex/g`, added aliases to enable switching back and forth in the future.
- Disabled enableIcu on boost dep, but this hasn't taken effect yet because this change isn't in nixpkgs 22.11.


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
