### PR TITLE
runProgram(): Show the entire failing command

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1088,13 +1088,20 @@ std::vector<char *> stringsToCharPtrs(const Strings & ss)
     return res;
 }
 
+std::string showProgram(const Path & program, const Strings & args)
+{
+    Strings ss{program};
+    for (auto & s : args) ss.push_back(s);
+    return concatStringsSep(" ", ss);
+}
+
 std::string runProgram(Path program, bool searchPath, const Strings & args,
     const std::optional<std::string> & input)
 {
     auto res = runProgram(RunOptions {.program = program, .searchPath = searchPath, .args = args, .input = input});
 
     if (!statusOk(res.first))
-        throw ExecError(res.first, "program '%1%' %2%", program, statusToString(res.first));
+        throw ExecError(res.first, "program '%s' " + statusToString(res.first), showProgram(program, args));
 
     return res.second;
 }
@@ -1222,7 +1229,7 @@ void runProgram2(const RunOptions & options)
     if (source) promise.get_future().get();
 
     if (status)
-        throw ExecError(status, "program '%1%' %2%", options.program, statusToString(status));
+        throw ExecError(status, "program '%s' " + statusToString(status), showProgram(options.program, options.args));
 }
 
 


### PR DESCRIPTION
# Motivation

This changes an error like

```
error: program 'git' failed with exit code 128
```

to

```
error: program 'git -C /home/eelco/.cache/nix/gitv3/1y63h3x49w7h40lvdwdwb09sf41rblh417lrilkrjywmc3b49vi6 --git-dir . fetch --quiet --force -- file:///home/eelco/...:refs/heads/master' failed with exit code 128
```

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
