### PR TITLE
Update env-variables.md with prefix | Issue #7771

### DIFF
--- a/doc/manual/src/installation/env-variables.md
+++ b/doc/manual/src/installation/env-variables.md
@@ -2,7 +2,7 @@
 
 To use Nix, some environment variables should be set. In particular,
 `PATH` should contain the directories `prefix/bin` and
-`~/.nix-profile/bin`. The first directory contains the Nix tools
+`~/.nix-profile/bin`. `prefix` defaults to `/usr/local` and can be set manually by modifying the `lib.mk` file present in the `nix/mk` directory. The first directory contains the Nix tools
 themselves, while `~/.nix-profile` is a symbolic link to the current
 *user environment* (an automatically generated package consisting of
 symlinks to installed packages). The simplest way to set the required


### PR DESCRIPTION
Added details about what the prefix field is and how to set it.

# Motivation
Many environment variables rely on the build prefix, which defaults to [/usr/local in the makefile](https://github.com/NixOS/nix/blob/0d73313c55497f32dcff1546f0f0625391f7a833/mk/lib.mk#L46), but is probably overridden somewhere in the Hydra build to become /nix. But right now in the manual it is only noted as prefix without further explanation.

# Context
Documentation update. Solves Issue #7771 

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
