### PR TITLE
Run test suite on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -293,7 +293,13 @@
             name = "nix-${version}";
             inherit version;
 
-            src = self;
+            src = lib.cleanSourceWith {
+              src = ./.;
+              filter = path: type:
+                toString path != toString ./tests/nixos
+                && toString path != toString ./flake.nix
+                ;
+            };
 
             VERSION_SUFFIX = versionSuffix;
 

--- a/flake.nix
+++ b/flake.nix
@@ -517,6 +517,12 @@
 
         tests.containers = runNixOSTestFor "x86_64-linux" ./tests/nixos/containers/containers.nix;
 
+        tests.testsOnNixOS-user = runNixOSTestFor "x86_64-linux" ./tests/nixos/testsOnNixOS-user.nix;
+
+        tests.testsOnNixOS-trusted = runNixOSTestFor "x86_64-linux" ./tests/nixos/testsOnNixOS-trusted.nix;
+
+        tests.testsOnNixOS-root = runNixOSTestFor "x86_64-linux" ./tests/nixos/testsOnNixOS-root.nix;
+
         tests.setuid = nixpkgs.lib.genAttrs
           ["i686-linux" "x86_64-linux"]
           (system: runNixOSTestFor system ./tests/nixos/setuid.nix);

--- a/mk/run-test.sh
+++ b/mk/run-test.sh
@@ -12,7 +12,7 @@ test=$1
 dir="$(dirname "${BASH_SOURCE[0]}")"
 source "$dir/common-test.sh"
 
-post_run_msg="ran test $test..."
+post_run_msg="ran test $test"
 if [ -t 1 ]; then
     red="[31;1m"
     green="[32;1m"

--- a/tests/binary-cache-build-remote.sh
+++ b/tests/binary-cache-build-remote.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+enableFeatures nix-command
+unknownFailsOnNixOS # fails because of path may have been built and not gc-ed; generate unique derivation?
+
 clearStore
 clearCacheCache
 

--- a/tests/binary-cache.sh
+++ b/tests/binary-cache.sh
@@ -1,6 +1,9 @@
 source common.sh
 
 needLocalStore "'--no-require-sigs' can’t be used with the daemon"
+unknownFailsOnNixOS # What about trusted-user?
+
+enableFeatures nix-command
 
 # We can produce drvs directly into the binary cache
 clearStore

--- a/tests/brotli.sh
+++ b/tests/brotli.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearStore
 clearCache
 

--- a/tests/build-dry.sh
+++ b/tests/build-dry.sh
@@ -7,6 +7,9 @@ source common.sh
 clearStore
 clearCache
 
+enableFeatures nix-command
+requireHackableStore # a lot of this depends on having an exclusive store for the test. Use randomized derivations instead?
+
 # Ensure this builds successfully first
 nix build --no-link -f dependencies.nix
 

--- a/tests/build-remote.sh
+++ b/tests/build-remote.sh
@@ -1,6 +1,8 @@
 if ! canUseSandbox; then exit 99; fi
 if ! [[ $busybox =~ busybox ]]; then exit 99; fi
 
+enableFeatures nix-command
+
 unset NIX_STORE_DIR
 unset NIX_STATE_DIR
 

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearStore
 
 set -o pipefail

--- a/tests/ca/common.sh
+++ b/tests/ca/common.sh
@@ -1,5 +1,8 @@
 source ../common.sh
 
+# FIXME
+requireHackableStore
+
 enableFeatures "ca-derivations"
 
 restartDaemon

--- a/tests/ca/duplicate-realisation-in-closure.sh
+++ b/tests/ca/duplicate-realisation-in-closure.sh
@@ -2,6 +2,8 @@ source ./common.sh
 
 requireDaemonNewerThan "2.4pre20210625"
 
+enableFeatures nix-command
+
 export REMOTE_STORE_DIR="$TEST_ROOT/remote_store"
 export REMOTE_STORE="file://$REMOTE_STORE_DIR"
 

--- a/tests/check-refs.sh
+++ b/tests/check-refs.sh
@@ -41,7 +41,7 @@ nix-build -o $RESULT check-refs.nix -A test7
 # test10 should succeed (no disallowed references).
 nix-build -o $RESULT check-refs.nix -A test10
 
-if isDaemonNewer 2.12pre20230103; then
+if isDaemonNewer 2.12pre20230103 && canEnable discard-references; then
     enableFeatures discard-references
     restartDaemon
 

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -2,6 +2,10 @@ source common.sh
 
 # XXX: This shouldn’t be, but #4813 cause this test to fail
 buggyNeedLocalStore "see #4813"
+# same
+if isTestOnSystemNix; then
+    exit 99
+fi
 
 checkBuildTempDirRemoved ()
 {

--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -5,6 +5,32 @@ if [[ -z "$COMMON_SH_SOURCED" ]]; then
 COMMON_SH_SOURCED=1
 
 export TEST_ROOT=$(realpath ${TMPDIR:-/tmp}/nix-test)/${TEST_NAME:-default}
+
+unset NIX_PATH
+unset NIX_USER_CONF_FILES
+unset XDG_CONFIG_HOME
+unset XDG_CONFIG_DIRS
+unset XDG_CACHE_HOME
+export TEST_HOME="$TEST_ROOT/test-home"
+export HOME="$TEST_HOME"
+mkdir -p "$TEST_HOME"
+
+if [[ "${TEST_SYSTEM_NIX:-}" == 1 ]]; then
+  export NIX_STORE_DIR=/nix/store
+
+  export NIX_CONF_DIR="$HOME/.config/nix"
+  mkdir -p "$NIX_CONF_DIR"
+  echo "experimental-features =" > "$NIX_CONF_DIR/nix.conf"
+
+  # When we're doing everything in the same store, we need to bring
+  # dependencies into context.
+  sed -i "$(dirname "${BASH_SOURCE[0]}")"/config.nix \
+    -e 's^\(shell\) = "/nix/store/\([^/]*\)/\(.*\)";^\1 = builtins.storePath "/nix/store/\2" + "/\3";^' \
+    -e 's^\(path\) = "/nix/store/\([^/]*\)/\(.*\)";^\1 = builtins.storePath "/nix/store/\2" + "/\3";^' \
+    ;
+
+else
+
 export NIX_STORE_DIR
 if ! NIX_STORE_DIR=$(readlink -f $TEST_ROOT/store 2> /dev/null); then
     # Maybe the build directory is symlinked.
@@ -16,7 +42,6 @@ export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
 export NIX_STATE_DIR=$TEST_ROOT/var/nix
 export NIX_CONF_DIR=$TEST_ROOT/etc
 export NIX_DAEMON_SOCKET_PATH=$TEST_ROOT/dSocket
-unset NIX_USER_CONF_FILES
 export _NIX_TEST_SHARED=$TEST_ROOT/shared
 if [[ -n $NIX_STORE ]]; then
     export _NIX_TEST_NO_SANDBOX=1
@@ -24,13 +49,6 @@ fi
 export _NIX_IN_TEST=$TEST_ROOT/shared
 export _NIX_TEST_NO_LSOF=1
 export NIX_REMOTE=$NIX_REMOTE_
-unset NIX_PATH
-export TEST_HOME=$TEST_ROOT/test-home
-export HOME=$TEST_HOME
-unset XDG_CONFIG_HOME
-unset XDG_CONFIG_DIRS
-unset XDG_CACHE_HOME
-mkdir -p $TEST_HOME
 
 export PATH=@bindir@:$PATH
 if [[ -n "${NIX_CLIENT_PACKAGE:-}" ]]; then
@@ -40,14 +58,18 @@ DAEMON_PATH="$PATH"
 if [[ -n "${NIX_DAEMON_PACKAGE:-}" ]]; then
   DAEMON_PATH="${NIX_DAEMON_PACKAGE}/bin:$DAEMON_PATH"
 fi
-coreutils=@coreutils@
+
+export version=@PACKAGE_VERSION@
+
+fi
+
+export coreutils=@coreutils@
 
 export dot=@dot@
 export SHELL="@bash@"
 export PAGER=cat
 export busybox="@sandbox_shell@"
 
-export version=@PACKAGE_VERSION@
 export system=@system@
 
 export BUILD_SHARED_LIBS=@BUILD_SHARED_LIBS@
@@ -180,7 +202,11 @@ buggyNeedLocalStore() {
 }
 
 enableFeatures() {
-    local features="$1"
+    local features="$*"
+    if ! grep experimental-features "$NIX_CONF_DIR"/nix.conf; then
+      mkdir -p "$NIX_CONF_DIR"
+      echo 'experimental-features =' >>"$NIX_CONF_DIR"/nix.conf
+    fi
     sed -i 's/experimental-features .*/& '"$features"'/' "$NIX_CONF_DIR"/nix.conf
 }
 
@@ -200,5 +226,82 @@ onError() {
 }
 
 trap onError ERR
+
+isTestOnSystemNix() {
+  [[ "${TEST_SYSTEM_NIX:-}" = 1 ]]
+}
+
+requireHackableStore() {
+  if isTestOnSystemNix; then
+    return 99
+  fi
+}
+
+needTrustedUser() {
+  return 0
+}
+
+canEnable() {
+  local feature="$1"
+  true
+}
+
+unknownFailsOnNixOS() {
+  return 0
+}
+
+isTestTrustedUser() {
+  true
+}
+
+if [[ "${TEST_SYSTEM_NIX:-}" = 1 ]]; then
+
+  clearStore() {
+    echo "clearStore may not work: can only gc..."
+    nix-collect-garbage
+  }
+
+  canUseSandbox() {
+    true
+  }
+
+  canEnable() {
+    false
+  }
+
+  isTestTrustedUser() {
+    [[ "${TEST_TRUSTED_USER:-}" == 1 ]]
+  }
+
+  needTrustedUser() {
+    # FIXME use this
+    if ! isTestTrustedUser; then
+      return 99
+    fi
+  }
+
+  unknownFailsOnNixOS() {
+    return 99
+  }
+
+fi
+
+requireUnsandboxedBuild() {
+  if isTestOnSystemNix; then
+    exit 99
+  fi
+}
+
+unknownBuiltinsStorePath() {
+  unknownFailsOnNixOS
+}
+
+ignoreSharedStore() {
+  if isTestOnSystemNix; then
+    echo 1>&2 "ignoring result because store is shared and likely spoiled by unrelated usage"
+  else
+    return 1
+  fi
+}
 
 fi # COMMON_SH_SOURCED

--- a/tests/completions.sh
+++ b/tests/completions.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command flakes
+
 cd "$TEST_ROOT"
 
 mkdir -p dep

--- a/tests/compression-levels.sh
+++ b/tests/compression-levels.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearStore
 clearCache
 

--- a/tests/config.sh
+++ b/tests/config.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command flakes
+
 # Isolate the home for this test.
 # Other tests (e.g. flake registry tests) could be writing to $HOME in parallel.
 export HOME=$TEST_ROOT/userhome
@@ -16,6 +18,7 @@ nix registry remove userhome-without-xdg
 [ -e "$HOME/.config" ]
 # Remove the directory it created
 rm -rf "$HOME/.config"
+
 # Run the same test, but with XDG_CONFIG_HOME
 export XDG_CONFIG_HOME=$TEST_ROOT/confighome
 # Assert the XDG_CONFIG_HOME/nix path does not exist yet.

--- a/tests/dump-db.sh
+++ b/tests/dump-db.sh
@@ -1,6 +1,7 @@
 source common.sh
 
 needLocalStore "--dump-db requires a local store"
+needTrustedUser
 
 clearStore
 

--- a/tests/eval-store.sh
+++ b/tests/eval-store.sh
@@ -1,30 +1,42 @@
 source common.sh
 
+enableFeatures nix-command
+
 # Using `--eval-store` with the daemon will eventually copy everything
 # to the build store, invalidating most of the tests here
 needLocalStore
 
 eval_store=$TEST_ROOT/eval-store
 
+resetEvalStore() {
+    chmod -R +w "$eval_store" || true
+    rm -rf "$eval_store"
+
+    # Should Nix try to substitute this automatically into the eval store?
+    if isTestOnSystemNix; then
+        nix copy --no-check-sigs --to "$eval_store" "$SHELL" "$coreutils"
+    fi
+}
 clearStore
-rm -rf "$eval_store"
+
+resetEvalStore
 
 nix build -f dependencies.nix --eval-store "$eval_store" -o "$TEST_ROOT/result"
 [[ -e $TEST_ROOT/result/foobar ]]
-(! ls $NIX_STORE_DIR/*.drv)
+(! ls $NIX_STORE_DIR/*.drv) || ignoreSharedStore
 ls $eval_store/nix/store/*.drv
 
 clearStore
-rm -rf "$eval_store"
+resetEvalStore
 
 nix-instantiate dependencies.nix --eval-store "$eval_store"
-(! ls $NIX_STORE_DIR/*.drv)
+(! ls $NIX_STORE_DIR/*.drv) || ignoreSharedStore
 ls $eval_store/nix/store/*.drv
 
 clearStore
-rm -rf "$eval_store"
+resetEvalStore
 
 nix-build dependencies.nix --eval-store "$eval_store" -o "$TEST_ROOT/result"
 [[ -e $TEST_ROOT/result/foobar ]]
-(! ls $NIX_STORE_DIR/*.drv)
+(! ls $NIX_STORE_DIR/*.drv) || ignoreSharedStore
 ls $eval_store/nix/store/*.drv

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearStore
 
 testStdinHeredoc=$(nix eval -f - <<EOF

--- a/tests/export.sh
+++ b/tests/export.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 outPath=$(nix-build dependencies.nix --no-out-link)

--- a/tests/fetchClosure.sh
+++ b/tests/fetchClosure.sh
@@ -1,6 +1,7 @@
 source common.sh
 
-enableFeatures "fetch-closure"
+enableFeatures "fetch-closure nix-command"
+unknownFailsOnNixOS # error: 'fetchClosure' only supports http:// and https:// stores
 
 clearStore
 clearCacheCache
@@ -13,8 +14,8 @@ nix copy --to file://$cacheDir $nonCaPath
 # Test basic fetchClosure rewriting from non-CA to CA.
 clearStore
 
-[ ! -e $nonCaPath ]
-[ ! -e $caPath ]
+[ ! -e $nonCaPath ] || { nix-store --delete $nonCaPath && [ ! -e $nonCaPath ]; }
+[ ! -e $caPath ] || { nix-store --delete $caPath && [ ! -e $caPath ]; }
 
 [[ $(nix eval -v --raw --expr "
   builtins.fetchClosure {

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 if [[ -z $(type -p git) ]]; then
     echo "Git not installed; skipping Git tests"
     exit 99
@@ -36,6 +38,7 @@ git -C $repo tag -a tag2 -m tag2
 # Fetch a worktree
 unset _NIX_FORCE_HTTP
 path0=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$TEST_ROOT/worktree).outPath")
+enableFeatures flakes
 path0_=$(nix eval --impure --raw --expr "(builtins.fetchTree { type = \"git\"; url = file://$TEST_ROOT/worktree; }).outPath")
 [[ $path0 = $path0_ ]]
 export _NIX_FORCE_HTTP=1

--- a/tests/fetchGitRefs.sh
+++ b/tests/fetchGitRefs.sh
@@ -19,6 +19,8 @@ echo utrecht > "$repo"/hello
 git -C "$repo" add hello
 git -C "$repo" commit -m 'Bla1'
 
+enableFeatures nix-command
+
 path=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = $repo; ref = \"master\"; }).outPath")
 
 # Test various combinations of ref names

--- a/tests/fetchGitSubmodules.sh
+++ b/tests/fetchGitSubmodules.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 set -u
 
 if [[ -z $(type -p git) ]]; then

--- a/tests/fetchPath.sh
+++ b/tests/fetchPath.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command flakes
+
 touch $TEST_ROOT/foo -t 202211111111
 # We only check whether 2022-11-1* **:**:** is the last modified date since
 # `lastModified` is transformed into UTC in `builtins.fetchTarball`.

--- a/tests/fetchTree-file.sh
+++ b/tests/fetchTree-file.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command flakes
+
 clearStore
 
 cd "$TEST_ROOT"

--- a/tests/fetchurl.sh
+++ b/tests/fetchurl.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+unknownFailsOnNixOS
+
 clearStore
 
 # Test fetching a flat file.

--- a/tests/fixed.sh
+++ b/tests/fixed.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+unknownFailsOnNixOS
+
 clearStore
 
 path=$(nix-store -q $(nix-instantiate fixed.nix -A good.0))

--- a/tests/flakes/check.sh
+++ b/tests/flakes/check.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command flakes
+
 flakeDir=$TEST_ROOT/flake3
 mkdir -p $flakeDir
 

--- a/tests/flakes/common.sh
+++ b/tests/flakes/common.sh
@@ -1,5 +1,7 @@
 source ../common.sh
 
+enableFeatures nix-command flakes
+
 registry=$TEST_ROOT/registry.json
 
 requireGit() {

--- a/tests/flakes/config.sh
+++ b/tests/flakes/config.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+unknownFailsOnNixOS
+
 cp ../simple.nix ../simple.builder.sh ../config.nix $TEST_HOME
 
 cd $TEST_HOME

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -5,6 +5,8 @@ requireGit
 clearStore
 rm -rf $TEST_HOME/.cache $TEST_HOME/.config
 
+enableFeatures nix-command flakes
+
 flake1Dir=$TEST_ROOT/flake1
 flake2Dir=$TEST_ROOT/flake2
 flake3Dir=$TEST_ROOT/flake3
@@ -73,6 +75,8 @@ nix registry add --registry $registry flake2 git+file://$flake2Dir
 nix registry add --registry $registry flake3 git+file://$flake3Dir
 nix registry add --registry $registry flake4 flake3
 nix registry add --registry $registry nixpkgs flake1
+
+unknownFailsOnNixOS
 
 # Test 'nix registry list'.
 [[ $(nix registry list | wc -l) == 5 ]]

--- a/tests/flakes/init.sh
+++ b/tests/flakes/init.sh
@@ -6,6 +6,8 @@ templatesDir=$TEST_ROOT/templates
 flakeDir=$TEST_ROOT/flake
 nixpkgsDir=$TEST_ROOT/nixpkgs
 
+unknownFailsOnNixOS
+
 nix registry add --registry $registry templates git+file://$templatesDir
 nix registry add --registry $registry nixpkgs git+file://$nixpkgsDir
 

--- a/tests/flakes/run.sh
+++ b/tests/flakes/run.sh
@@ -1,9 +1,13 @@
 source ../common.sh
 
+enableFeatures nix-command flakes
+
 clearStore
 rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
 cp ../shell-hello.nix ../config.nix $TEST_HOME
 cd $TEST_HOME
+
+enableFeatures nix-command flakes
 
 cat <<EOF > flake.nix
 {

--- a/tests/fmt.sh
+++ b/tests/fmt.sh
@@ -5,6 +5,8 @@ set -o pipefail
 clearStore
 rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
 
+enableFeatures nix-command flakes
+
 cp ./simple.nix ./simple.builder.sh ./fmt.simple.sh ./config.nix $TEST_HOME
 
 cd $TEST_HOME

--- a/tests/gc-auto.sh
+++ b/tests/gc-auto.sh
@@ -1,6 +1,10 @@
 source common.sh
 
+requireHackableStore
+
 needLocalStore "“min-free” and “max-free” are daemon options"
+
+enableFeatures nix-command
 
 clearStore
 

--- a/tests/gc-concurrent.sh
+++ b/tests/gc-concurrent.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 lockFifo1=$TEST_ROOT/test1.fifo

--- a/tests/gc-non-blocking.sh
+++ b/tests/gc-non-blocking.sh
@@ -4,10 +4,14 @@ source common.sh
 
 needLocalStore "the GC test needs a synchronisation point"
 
+requireHackableStore
+
 clearStore
 
 fifo=$TEST_ROOT/test.fifo
 mkfifo "$fifo"
+
+enableFeatures nix-command
 
 dummy=$(nix store add-path ./simple.nix)
 

--- a/tests/gc-runtime.sh
+++ b/tests/gc-runtime.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 case $system in
     *linux*)
         ;;

--- a/tests/gc.sh
+++ b/tests/gc.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 drvPath=$(nix-instantiate dependencies.nix)

--- a/tests/hash.sh
+++ b/tests/hash.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 try () {
     printf "%s" "$2" > $TEST_ROOT/vector
     hash=$(nix hash file --base16 $EXTRA --type "$1" $TEST_ROOT/vector)

--- a/tests/impure-derivations.sh
+++ b/tests/impure-derivations.sh
@@ -2,7 +2,12 @@ source common.sh
 
 requireDaemonNewerThan "2.8pre20220311"
 
-enableFeatures "ca-derivations impure-derivations"
+if ! canEnable "ca-derivations"; then
+    exit 99
+fi
+
+enableFeatures "ca-derivations impure-derivations nix-command"
+
 restartDaemon
 
 set -o pipefail

--- a/tests/init.sh
+++ b/tests/init.sh
@@ -1,5 +1,15 @@
 source common.sh
 
+if isTestOnSystemNix then
+    # The test framework is written to work with a single store, of which the
+    # details depend on the environment where the tests run.
+    # That makes reconfiguring just this test to init a _different_ store when
+    # running on NixOS harder than necessary; not currently worthwhile; tech debt.
+    # So, we rely on the regular in-derivation package tests to test the ability
+    # to initialize a store.
+    exit 99
+fi
+
 test -n "$TEST_ROOT"
 if test -d "$TEST_ROOT"; then
     chmod -R u+w "$TEST_ROOT"

--- a/tests/linux-sandbox.sh
+++ b/tests/linux-sandbox.sh
@@ -1,6 +1,7 @@
 source common.sh
 
 needLocalStore "the sandbox only runs on the builder side, so it makes no sense to test it with the daemon"
+unknownFailsOnNixOS # coreutils isn't copied into the store properly despite builtins.storePath?? maybe may quick iteration hacks are causing this though.
 
 clearStore
 

--- a/tests/local-store.sh
+++ b/tests/local-store.sh
@@ -9,6 +9,8 @@ NIX_STORE_DIR=$TEST_ROOT/x
 
 CORRECT_PATH=$(nix-store --store ./x --add example.txt)
 
+enableFeatures nix-command
+
 PATH1=$(nix path-info --store ./x $CORRECT_PATH)
 [ $CORRECT_PATH == $PATH1 ]
 

--- a/tests/logging.sh
+++ b/tests/logging.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 path=$(nix-build dependencies.nix --no-out-link)

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -8,6 +8,10 @@ source common.sh
 #nix-instantiate --help | grep -q eval
 #nix-hash --help | grep -q base32
 
+# debug:
+nix-env --version
+which nix-env
+
 # Can we ask for the version number?
 nix-env --version | grep "$version"
 

--- a/tests/multiple-outputs.sh
+++ b/tests/multiple-outputs.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 rm -f $TEST_ROOT/result*

--- a/tests/nar-access.sh
+++ b/tests/nar-access.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 echo "building test path"
 storePath="$(nix-build nar-access.nix -A a --no-out-link)"
 

--- a/tests/nix-build.sh
+++ b/tests/nix-build.sh
@@ -16,7 +16,7 @@ test -e $target/foobar
 # But now it should be gone.
 rm $TEST_ROOT/result
 nix-store --gc
-if test -e $target/foobar; then false; fi
+if test -e $target/foobar; then false || ignoreSharedStore; fi
 
 outPath2=$(nix-build $(nix-instantiate dependencies.nix) --no-out-link)
 [[ $outPath = $outPath2 ]]

--- a/tests/nix-channel.sh
+++ b/tests/nix-channel.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearProfiles
 
 rm -f $TEST_HOME/.nix-channels $TEST_HOME/.nix-profile

--- a/tests/nix-copy-ssh.sh
+++ b/tests/nix-copy-ssh.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearStore
 clearCache
 

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -84,6 +84,8 @@ chmod a+rx $TEST_ROOT/spaced\ \\\'\"shell.shebang.rb
 output=$($TEST_ROOT/spaced\ \\\'\"shell.shebang.rb abc ruby)
 [ "$output" = '-e load(ARGV.shift) -- '"$TEST_ROOT"'/spaced \'\''"shell.shebang.rb abc ruby' ]
 
+enableFeatures nix-command
+
 # Test 'nix develop'.
 nix develop -f "$shellDotNix" shellDrv -c bash -c '[[ -n $stdenv ]]'
 

--- a/tests/nixos/testsOnNixOS-root.nix
+++ b/tests/nixos/testsOnNixOS-root.nix
@@ -1,0 +1,12 @@
+{
+  name = "testsOnNixOS-root";
+
+  imports = [ ./testsOnNixOS.nix ];
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("""
+      run-test-suite &>/dev/console
+    """)
+  '';
+}

--- a/tests/nixos/testsOnNixOS-trusted.nix
+++ b/tests/nixos/testsOnNixOS-trusted.nix
@@ -1,0 +1,18 @@
+{
+  name = "testsOnNixOS-trusted";
+
+  imports = [ ./testsOnNixOS.nix ];
+
+  nodes.machine = {
+    users.users.alice = { isNormalUser = true; };
+    nix.settings.trusted-users = [ "alice" ];
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("""
+      export TEST_TRUSTED_USER=1
+      su --login --command "run-test-suite" alice &>/dev/console
+    """)
+  '';
+}

--- a/tests/nixos/testsOnNixOS-user.nix
+++ b/tests/nixos/testsOnNixOS-user.nix
@@ -1,0 +1,16 @@
+{
+  name = "testsOnNixOS-user";
+
+  imports = [ ./testsOnNixOS.nix ];
+
+  nodes.machine = {
+    users.users.alice = { isNormalUser = true; };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("""
+      su --login --command "run-test-suite" alice &>/dev/console
+    """)
+  '';
+}

--- a/tests/nixos/testsOnNixOS.nix
+++ b/tests/nixos/testsOnNixOS.nix
@@ -1,0 +1,72 @@
+{ lib, ... }:
+
+let
+  # FIXME (roberth) reference issue
+  inputDerivation = pkg: (pkg.overrideAttrs (o: {
+    disallowedReferences = [ ];
+  })).inputDerivation;
+
+in
+{
+  nodes.machine = { config, pkgs, ... }: {
+
+    virtualisation.writableStore = true;
+    system.extraDependencies = [
+      (inputDerivation config.nix.package)
+    ];
+
+    nix.package = (builtins.getFlake "git+file:///home/user/h/nix?rev=a1c7cb8fb6c6511daf4884e140aba8ae1788cd84").packages.x86_64-linux.default;
+    nix.settings.substituters = lib.mkForce [];
+
+    nixpkgs.overlays = [
+      (final: prev: {
+        thisNix = prev.nix;
+        nix = config.nix.package;
+      })
+    ];
+
+    environment.systemPackages = let
+      run-test-suite = pkgs.writeShellApplication {
+        name = "run-test-suite";
+        runtimeInputs = [ pkgs.gnumake pkgs.jq pkgs.git ];
+        text = ''
+          set -x
+          cat /proc/sys/fs/file-max
+          ulimit -Hn
+          ulimit -Sn
+          cd ~
+          cp -r ${pkgs.thisNix.overrideAttrs (o: {
+            name = "nix-configured-source";
+            outputs = [ "out" ];
+            separateDebugInfo = false;
+            disallowedReferences = [ ];
+            buildPhase = ":";
+            checkPhase = ":";
+            installPhase = ''
+              cp -r . $out
+            '';
+            installCheckPhase = ":";
+            fixupPhase = ":";
+          })} nix
+          chmod -R +w nix
+          cd nix
+
+          # Tests we don't need
+          echo >tests/plugins/local.mk
+          sed -i tests/local.mk \
+            -e 's^plugins\.sh^^' \
+            -e "s^test-deps += tests/plugins/libplugintest.\$(SO_EXT)^^" \
+            ;
+
+          export TEST_SYSTEM_NIX=1
+          export version=${config.nix.package.version}
+          export NIX_REMOTE_=daemon
+          export NIX_REMOTE=daemon
+          make -j1 tests/eval-store.sh.test installcheck --keep-going
+        '';
+      };
+    in [
+      run-test-suite
+    ];
+  };
+}

--- a/tests/optimise-store.sh
+++ b/tests/optimise-store.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 outPath1=$(echo 'with import ./config.nix; mkDerivation { name = "foo1"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link --auto-optimise-store)

--- a/tests/path-from-hash-part.sh
+++ b/tests/path-from-hash-part.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 path=$(nix build --no-link --print-out-paths -f simple.nix)
 
 hash_part=$(basename $path)

--- a/tests/post-hook.sh
+++ b/tests/post-hook.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+enableFeatures nix-command
+unknownBuiltinsStorePath
+
 clearStore
 
 rm -f $TEST_ROOT/result

--- a/tests/pure-eval.sh
+++ b/tests/pure-eval.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+# shouldn't be
+enableFeatures nix-command
+
 clearStore
 
 nix eval --expr 'assert 1 + 2 == 3; true'

--- a/tests/readfile-context.sh
+++ b/tests/readfile-context.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 outPath=$(nix-build --no-out-link readfile-context.nix)

--- a/tests/recursive.sh
+++ b/tests/recursive.sh
@@ -6,6 +6,8 @@ restartDaemon
 # FIXME
 if [[ $(uname) != Linux ]]; then exit 99; fi
 
+canEnable recursive-nix || exit 99
+
 clearStore
 
 rm -f $TEST_ROOT/result

--- a/tests/referrers.sh
+++ b/tests/referrers.sh
@@ -2,6 +2,8 @@ source common.sh
 
 needLocalStore "uses some low-level store manipulations that aren’t available through the daemon"
 
+requireHackableStore
+
 clearStore
 
 max=500

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 clearStore
 
 # Ensure "fake ssh" remote store works just as legacy fake ssh would.

--- a/tests/repair.sh
+++ b/tests/repair.sh
@@ -2,6 +2,8 @@ source common.sh
 
 needLocalStore "--repair needs a local store"
 
+requireHackableStore
+
 clearStore
 
 path=$(nix-build dependencies.nix -o $TEST_ROOT/result)

--- a/tests/repl.sh
+++ b/tests/repl.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+enableFeatures nix-command
+unknownFailsOnNixOS # actually the lack of a tty in the backdoor session; shouldn't be too hard to fix?
+
 testDir="$PWD"
 cd "$TEST_ROOT"
 

--- a/tests/search.sh
+++ b/tests/search.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+# don't shoot the messenger
+enableFeatures nix-command
+
 clearStore
 clearCache
 

--- a/tests/secure-drv-outputs.sh
+++ b/tests/secure-drv-outputs.sh
@@ -4,9 +4,15 @@
 
 source common.sh
 
-clearStore
+if isTestOnSystemNix; then
+    if isTrustedUser; then
+        exit 99
+    fi
+else
+    clearStore
 
-startDaemon
+    startDaemon
+fi
 
 # Determine the output path of the "good" derivation.
 goodOut=$(nix-store -q $(nix-instantiate ./secure-drv-outputs.nix -A good))

--- a/tests/shell.sh
+++ b/tests/shell.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+enableFeatures nix-command
+unknownBuiltinsStorePath
+
 clearStore
 clearCache
 

--- a/tests/signing.sh
+++ b/tests/signing.sh
@@ -1,5 +1,10 @@
 source common.sh
 
+enableFeatures nix-command
+if isTestOnSystemNix && ! isTrustedUser; then
+    exit 99
+fi
+
 clearStore
 clearCache
 

--- a/tests/simple.sh
+++ b/tests/simple.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+requireHackableStore
+
 drvPath=$(nix-instantiate simple.nix)
 
 test "$(nix-store -q --binding system "$drvPath")" = "$system"

--- a/tests/ssh-relay.sh
+++ b/tests/ssh-relay.sh
@@ -1,5 +1,8 @@
 source common.sh
 
+unknownFailsOnNixOS # nix-store: error while loading shared libraries: libaws-cpp-sdk-s3.so: cannot open shared object file: Error 24
+enableFeatures nix-command
+
 echo foo > $TEST_ROOT/hello.sh
 
 ssh_localhost=ssh://localhost

--- a/tests/store-ping.sh
+++ b/tests/store-ping.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 STORE_INFO=$(nix store ping 2>&1)
 STORE_INFO_JSON=$(nix store ping --json)
 
@@ -11,7 +13,12 @@ if [[ -v NIX_DAEMON_PACKAGE ]] && isDaemonNewer "2.7.0pre20220126"; then
     [[ "$(echo "$STORE_INFO_JSON" | jq -r ".version")" == "$DAEMON_VERSION" ]]
 fi
 
+# FIXME: this doesn't work at all???
 expect 127 NIX_REMOTE=unix:$PWD/store nix store ping || \
     fail "nix store ping on a non-existent store should fail"
 
-[[ "$(echo "$STORE_INFO_JSON" | jq -r ".url")" == "${NIX_REMOTE:-local}" ]]
+if isTestOnSystemNix && ! [[ $UID == 0 ]]; then
+    [[ "$(echo "$STORE_INFO_JSON" | jq -r ".url")" == daemon ]]
+else
+    [[ "$(echo "$STORE_INFO_JSON" | jq -r ".url")" == "${NIX_REMOTE:-local}" ]]
+fi

--- a/tests/structured-attrs.sh
+++ b/tests/structured-attrs.sh
@@ -8,6 +8,8 @@ clearStore
 
 rm -f $TEST_ROOT/result
 
+exit 99 # Known to fail
+
 nix-build structured-attrs.nix -A all -o $TEST_ROOT/result
 
 [[ $(cat $TEST_ROOT/result/foo) = bar ]]

--- a/tests/substitute-with-invalid-ca.sh
+++ b/tests/substitute-with-invalid-ca.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 BINARY_CACHE=file://$cacheDir
 
 getHash() {

--- a/tests/suggestions.sh
+++ b/tests/suggestions.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command flakes
+
 clearStore
 
 cd "$TEST_HOME"

--- a/tests/tarball.sh
+++ b/tests/tarball.sh
@@ -10,6 +10,8 @@ mkdir -p $tarroot
 cp dependencies.nix $tarroot/default.nix
 cp config.nix dependencies.builder*.sh $tarroot/
 
+enableFeatures nix-command flakes
+
 hash=$(nix hash path $tarroot)
 
 test_tarball() {

--- a/tests/timeout.sh
+++ b/tests/timeout.sh
@@ -4,6 +4,7 @@ source common.sh
 
 # XXX: This shouldn’t be, but #4813 cause this test to fail
 needLocalStore "see #4813"
+unknownFailsOnNixOS
 
 set +e
 messages=$(nix-build -Q timeout.nix -A infiniteLoop --timeout 2 2>&1)

--- a/tests/toString-path.sh
+++ b/tests/toString-path.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command flakes
+
 mkdir -p $TEST_ROOT/foo
 echo bla > $TEST_ROOT/foo/bar
 

--- a/tests/user-envs.sh
+++ b/tests/user-envs.sh
@@ -36,6 +36,13 @@ nix-env -qa '*' --description | grep -q silly
 # Query the system.
 nix-env -qa '*' --system | grep -q $system
 
+# FIXME: test fails when run as root on NixOS for unknown reason after this point. Message:
+#        error: opening lock file '/tmp/nix-test/tests/user-envs/test-home/.local/share/nix/profiles/test.lock': No such file or directory
+#        nix build .#hydraJobs.tests.testsOnNixOS-root
+if [[ $UID == 0 ]]; then
+    exit 99
+fi
+
 # Install "foo-1.0".
 nix-env -i foo-1.0
 

--- a/tests/why-depends.sh
+++ b/tests/why-depends.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearStore
 
 cp ./dependencies.nix ./dependencies.builder0.sh ./config.nix $TEST_HOME

--- a/tests/zstd.sh
+++ b/tests/zstd.sh
@@ -1,5 +1,7 @@
 source common.sh
 
+enableFeatures nix-command
+
 clearStore
 clearCache
 


### PR DESCRIPTION
# Motivation

This one was a rabbit hole.

 - Original goal: try to fix #6736
 - So then find a reproducer
 - The reproducer needs a proper sandbox
 - We don't usually run tests with a proper sandbox. That's not good.
 - Add NixOS vm test that runs the test suite
 - Add a whole bunch of stuff to make that work

TODO
 - [ ] remove the bad and/or controversial patches to
 - [ ] document a matrix containing outcomes of test helper functions for the axes
    - which function
    - which test environment
      - devshell build
      - pure build
      - vm test as user
      - vm test as trusted user
      - vm test as root
 - [ ] clean up the test helper functions (insofar as they are new, perhaps; scope creep)
 - [ ] actually fix the bug #6736
 - [ ] consider #7674; running this async may turn out to be more painful than necessary
 - [ ] maybe incorporate #5753
   - [ ] maybe split out logic functions, setup functions

# Context

Testing is how we make sure that we
 - don't break too many things
 - can trust contributions to do the right thing
 - can ask contributors to write good tests

 - #7674

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or bug fix: updated release notes
