### PR TITLE
Revert description of nix -I/--include flag to short sentence

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -32,77 +32,7 @@ MixEvalArgs::MixEvalArgs()
     addFlag({
         .longName = "include",
         .shortName = 'I',
-        .description = R"(
-  Add *path* to the Nix search path. The Nix search path is
-  initialized from the colon-separated [`NIX_PATH`](@docroot@/command-ref/env-common.md#env-NIX_PATH) environment
-  variable, and is used to look up the location of Nix expressions using [paths](@docroot@/language/values.md#type-path) enclosed in angle
-  brackets (i.e., `<nixpkgs>`).
-
-  For instance, passing
-
-  ```
-  -I /home/eelco/Dev
-  -I /etc/nixos
-  ```
-
-  will cause Nix to look for paths relative to `/home/eelco/Dev` and
-  `/etc/nixos`, in that order. This is equivalent to setting the
-  `NIX_PATH` environment variable to
-
-  ```
-  /home/eelco/Dev:/etc/nixos
-  ```
-
-  It is also possible to match paths against a prefix. For example,
-  passing
-
-  ```
-  -I nixpkgs=/home/eelco/Dev/nixpkgs-branch
-  -I /etc/nixos
-  ```
-
-  will cause Nix to search for `<nixpkgs/path>` in
-  `/home/eelco/Dev/nixpkgs-branch/path` and `/etc/nixos/nixpkgs/path`.
-
-  If a path in the Nix search path starts with `http://` or `https://`,
-  it is interpreted as the URL of a tarball that will be downloaded and
-  unpacked to a temporary location. The tarball must consist of a single
-  top-level directory. For example, passing
-
-  ```
-  -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/master.tar.gz
-  ```
-
-  tells Nix to download and use the current contents of the `master`
-  branch in the `nixpkgs` repository.
-
-  The URLs of the tarballs from the official `nixos.org` channels
-  (see [the manual page for `nix-channel`](../nix-channel.md)) can be
-  abbreviated as `channel:<channel-name>`.  For instance, the
-  following two flags are equivalent:
-
-  ```
-  -I nixpkgs=channel:nixos-21.05
-  -I nixpkgs=https://nixos.org/channels/nixos-21.05/nixexprs.tar.xz
-  ```
-
-  You can also fetch source trees using [flake URLs](./nix3-flake.md#url-like-syntax) and add them to the
-  search path. For instance,
-
-  ```
-  -I nixpkgs=flake:nixpkgs
-  ```
-
-  specifies that the prefix `nixpkgs` shall refer to the source tree
-  downloaded from the `nixpkgs` entry in the flake registry. Similarly,
-
-  ```
-  -I nixpkgs=flake:github:NixOS/nixpkgs/nixos-22.05
-  ```
-
-  makes `<nixpkgs>` refer to a particular branch of the
-  `NixOS/nixpkgs` repository on GitHub.
-  )",
+        .description = "Add *path* to the list of locations used to look up `<...>` file names.",
         .category = category,
         .labels = {"path"},
         .handler = {[&](std::string s) { searchPath.push_back(s); }}


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This line was changed by #7421 and breaks `nix` commandline completions for any commandline flags.

# Context
<!-- Provide context. Reference open issues if available. -->

The description for commandline flags is used as an annotation for commandline completions. These descriptions may *not* include any newline characters.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
