### PR TITLE
Improve error on conflict for nix profile install

### DIFF
--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -92,13 +92,11 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
                 if (S_ISLNK(dstSt.st_mode)) {
                     auto prevPriority = state.priorities[dstFile];
                     if (prevPriority == priority)
-                        throw Error(
-                                "files '%1%' and '%2%' have the same priority %3%; "
-                                "use 'nix-env --set-flag priority NUMBER INSTALLED_PKGNAME' "
-                                "or type 'nix profile install --help' if using 'nix profile' to find out how "
-                                "to change the priority of one of the conflicting packages"
-                                " (0 being the highest priority)",
-                                srcFile, readLink(dstFile), priority);
+                        throw BuildEnvFileConflictError(
+                            readLink(dstFile),
+                            srcFile,
+                            priority
+                        );
                     if (prevPriority < priority)
                         continue;
                     if (unlink(dstFile.c_str()) == -1)

--- a/src/libstore/builtins/buildenv.hh
+++ b/src/libstore/builtins/buildenv.hh
@@ -12,6 +12,32 @@ struct Package {
     Package(const Path & path, bool active, int priority) : path{path}, active{active}, priority{priority} {}
 };
 
+class BuildEnvFileConflictError : public Error
+{
+public:
+    const Path fileA;
+    const Path fileB;
+    int priority;
+
+    BuildEnvFileConflictError(
+        const Path fileA,
+        const Path fileB,
+        int priority
+    )
+        : Error(
+            "Unable to build profile. There is a conflict for the following files:\n"
+            "\n"
+            "  %1%\n"
+            "  %2%",
+            fileA,
+            fileB
+        )
+        , fileA(fileA)
+        , fileB(fileB)
+        , priority(priority)
+    {}
+};
+
 typedef std::vector<Package> Packages;
 
 void buildProfile(const Path & out, Packages && pkgs);

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -329,7 +329,61 @@ struct CmdProfileInstall : InstallablesCommand, MixDefaultProfile
             manifest.elements.push_back(std::move(element));
         }
 
-        updateProfile(manifest.build(store));
+        try {
+            updateProfile(manifest.build(store));
+        } catch (BuildEnvFileConflictError & conflictError) {
+            auto findRefByFilePath = [&]<typename Iterator>(Iterator begin, Iterator end) {
+                for (auto it = begin; it != end; it++) {
+                    auto profileElement = *it;
+                    for (auto & storePath : profileElement.storePaths) {
+                        if (conflictError.fileA.starts_with(store->printStorePath(storePath))) {
+                            return std::pair(conflictError.fileA, profileElement.source->originalRef);
+                        }
+                        if (conflictError.fileB.starts_with(store->printStorePath(storePath))) {
+                            return std::pair(conflictError.fileB, profileElement.source->originalRef);
+                        }
+                    }
+                }
+                throw conflictError;
+            };
+            // There are 2 conflicting files. We need to find out which one is from the already installed package and
+            // which one is the package that is the new package that is being installed.
+            // The first matching package is the one that was already installed (original).
+            auto [originalConflictingFilePath, originalConflictingRef] = findRefByFilePath(manifest.elements.begin(), manifest.elements.end());
+            // The last matching package is the one that was going to be installed (new).
+            auto [newConflictingFilePath, newConflictingRef] = findRefByFilePath(manifest.elements.rbegin(), manifest.elements.rend());
+
+            throw Error(
+                "An existing package already provides the following file:\n"
+                "\n"
+                "  %1%\n"
+                "\n"
+                "This is the conflicting file from the new package:\n"
+                "\n"
+                "  %2%\n"
+                "\n"
+                "To remove the existing package:\n"
+                "\n"
+                "  nix profile remove %3%\n"
+                "\n"
+                "The new package can also be installed next to the existing one by assigning a different priority.\n"
+                "The conflicting packages have a priority of %5%.\n"
+                "To prioritise the new package:\n"
+                "\n"
+                "  nix profile install %4% --priority %6%\n"
+                "\n"
+                "To prioritise the existing package:\n"
+                "\n"
+                "  nix profile install %4% --priority %7%\n",
+                originalConflictingFilePath,
+                newConflictingFilePath,
+                originalConflictingRef.to_string(),
+                newConflictingRef.to_string(),
+                conflictError.priority,
+                conflictError.priority - 1,
+                conflictError.priority + 1
+            );
+        }
     }
 };
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -332,6 +332,8 @@ struct CmdProfileInstall : InstallablesCommand, MixDefaultProfile
         try {
             updateProfile(manifest.build(store));
         } catch (BuildEnvFileConflictError & conflictError) {
+            // FIXME use C++20 std::ranges once macOS has it
+            //       See https://github.com/NixOS/nix/compare/3efa476c5439f8f6c1968a6ba20a31d1239c2f04..1fe5d172ece51a619e879c4b86f603d9495cc102
             auto findRefByFilePath = [&]<typename Iterator>(Iterator begin, Iterator end) {
                 for (auto it = begin; it != end; it++) {
                     auto profileElement = *it;

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -140,6 +140,32 @@ printf World2 > $flake2Dir/who
 
 nix profile install $flake1Dir
 [[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello World" ]]
+expect 1 nix profile install $flake2Dir
+diff -u <(nix profile install $flake2Dir 2>&1 1> /dev/null || true) <(cat << EOF
+error: An existing package already provides the following file:
+
+         $(nix build --no-link --print-out-paths ${flake1Dir}"#default.out")/bin/hello
+
+       This is the conflicting file from the new package:
+
+         $(nix build --no-link --print-out-paths ${flake2Dir}"#default.out")/bin/hello
+
+       To remove the existing package:
+
+         nix profile remove path:${flake1Dir}
+
+       The new package can also be installed next to the existing one by assigning a different priority.
+       The conflicting packages have a priority of 5.
+       To prioritise the new package:
+
+         nix profile install path:${flake2Dir} --priority 4
+
+       To prioritise the existing package:
+
+         nix profile install path:${flake2Dir} --priority 6
+EOF
+)
+[[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello World" ]]
 nix profile install $flake2Dir --priority 100
 [[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello World" ]]
 nix profile install $flake2Dir --priority 0

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -141,7 +141,11 @@ printf World2 > $flake2Dir/who
 nix profile install $flake1Dir
 [[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello World" ]]
 expect 1 nix profile install $flake2Dir
-diff -u <(nix profile install $flake2Dir 2>&1 1> /dev/null || true) <(cat << EOF
+diff -u <(
+    nix --offline profile install $flake2Dir 2>&1 1> /dev/null \
+        | grep -vE "^warning: " \
+        || true
+) <(cat << EOF
 error: An existing package already provides the following file:
 
          $(nix build --no-link --print-out-paths ${flake1Dir}"#default.out")/bin/hello


### PR DESCRIPTION
# Motivation

Currently `nix profile install` gives a confusing and unhelpful error message whenever a package is installed that has conflicting files. This often happens when installing a different version of the same package.

This PR is an attempt to improve the experience in such situations to some extend. I see this as a small improvement, but it doesn't really reach the end-goal of a good UX yet.

As an example, this is what happens before this PR:

```console
$ nix profile install github:cachix/devenv/v0.5
$ nix profile install github:cachix/devenv/v0.4
error: files '/nix/store/k0gwhiwfs8c218kph78vx75bph51iw31-devenv/bin/devenv' and '/nix/store/7i4hxhw44lr7r64zlmp4zq7cqpsx7smw-devenv/bin/devenv' have the same priority 5; use 'nix-env --set-flag priority NUMBER INSTALLED_PKGNAME' or type 'nix profile install --help' if using 'nix profile' to find out how to change the priority of one of the conflicting packages (0 being the highest priority)
```

This is what happens after this PR:

```console
$ nix profile install github:cachix/devenv/v0.5
$ nix profile install github:cachix/devenv/v0.4
error: There is an existing package that has a conflicting file:

         /nix/store/7i4hxhw44lr7r64zlmp4zq7cqpsx7smw-devenv/bin/devenv

       The conflicting file:

         /nix/store/k0gwhiwfs8c218kph78vx75bph51iw31-devenv/bin/devenv

       You can remove the existing package using:

         nix profile remove github:cachix/devenv/v0.4

       You can also install the new package next to the existing package by assigning a priority to the package.
       The conflicting packages have a priority of 5.
       You can prioritize the new package using:

         nix profile install github:cachix/devenv/v0.4 --priority 4

       You can prioritize the existing package using:

         nix profile install github:cachix/devenv/v0.4 --priority 6
```

The new changes allows `nix profile install` to give more context.

This also avoids mentions of `nix-env` and `nix profile` when using `builtins.buildEnv`. Since `buildEnv` can be used in other places (unrelated to the Nix profile), it makes sense to avoid mentioning `nix-env` and `nix profile`, as they likely do not apply in these cases.

# Context

Related to https://github.com/NixOS/nix/issues/7530

See [my suggestion](https://github.com/NixOS/nix/issues/7530#issuecomment-1419123524) for a good UX on `nix profile`s. The current PR is merely an improvement for the error message on conflicts.

# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
