### PR TITLE
Check interrupts even when download stalled

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -828,17 +828,18 @@ void FileTransfer::download(FileTransferRequest && request, Sink & sink)
         {
             auto state(_state->lock());
 
-            if (state->quit) {
-                if (state->exc) std::rethrow_exception(state->exc);
-                return;
+            if (state->data.empty()) {
+                if (state->quit) {
+                    if (state->exc) std::rethrow_exception(state->exc);
+                    return;
+                }
+
+                state.wait(state->avail);
+
+                if (state->data.empty()) continue;
             }
 
-            state.wait(state->avail);
-
-            if (state->data.empty()) continue;
-
             chunk = std::move(state->data);
-
             state->request.notify_one();
         }
 

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -829,6 +829,7 @@ void FileTransfer::download(FileTransferRequest && request, Sink & sink)
             auto state(_state->lock());
 
             if (state->data.empty()) {
+
                 if (state->quit) {
                     if (state->exc) std::rethrow_exception(state->exc);
                     return;
@@ -840,6 +841,7 @@ void FileTransfer::download(FileTransferRequest && request, Sink & sink)
             }
 
             chunk = std::move(state->data);
+
             state->request.notify_one();
         }
 

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -828,15 +828,14 @@ void FileTransfer::download(FileTransferRequest && request, Sink & sink)
         {
             auto state(_state->lock());
 
-            while (state->data.empty()) {
-
-                if (state->quit) {
-                    if (state->exc) std::rethrow_exception(state->exc);
-                    return;
-                }
-
-                state.wait(state->avail);
+            if (state->quit) {
+                if (state->exc) std::rethrow_exception(state->exc);
+                return;
             }
+
+            state.wait(state->avail);
+
+            if (state->data.empty()) continue;
 
             chunk = std::move(state->data);
 


### PR DESCRIPTION
# Motivation

Under bad network, downloads can stall forever. This leaves a running nix-daemon fork behind, even when the client disconnects. Even worse, that daemon keeps a lock in the path, preventing other attempts at downloading it.

/cc @thufschmitt 

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
