### PR TITLE
tests: Add command source locations to test log

### DIFF
--- a/tests/common.sh.in
+++ b/tests/common.sh.in
@@ -4,6 +4,8 @@ if [[ -z "$COMMON_SH_SOURCED" ]]; then
 
 COMMON_SH_SOURCED=1
 
+export PS4='+(${BASH_SOURCE[0]}:$LINENO) '
+
 export TEST_ROOT=$(realpath ${TMPDIR:-/tmp}/nix-test)/${TEST_NAME:-default}
 export NIX_STORE_DIR
 if ! NIX_STORE_DIR=$(readlink -f $TEST_ROOT/store 2> /dev/null); then


### PR DESCRIPTION
# Motivation

Ctrl+click to the location of the test failure (heuristically in vscode)

Example:

```
    +(inputs.sh:39) writeSimpleFlake /tmp/nix-shell.VLOn9z/nix-test/tests/flakes/inputs/repo-32653/b-low
    +(./common.sh:13) local flakeDir=/tmp/nix-shell.VLOn9z/nix-test/tests/flakes/inputs/repo-32653/b-low
    +(./common.sh:14) cat
    +(./common.sh:34) cp ../simple.nix ../simple.builder.sh ../config.nix /tmp/nix-shell.VLOn9z/nix-test/tests/flakes/inputs/repo-32653/b-low/
    +(inputs.sh:41) echo all good
    +(inputs.sh:42) cat
    +(inputs.sh:55) cd /tmp/nix-shell.VLOn9z/nix-test/tests/flakes/inputs/repo-32653/b-low
```

# Context



# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
