### PR TITLE
Revert "Check whether we can use PID namespaces"

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -209,7 +209,7 @@ void LocalDerivationGoal::tryLocalBuild()
 
     #if __linux__
     if (useChroot) {
-        if (!mountNamespacesSupported() || !pidNamespacesSupported()) {
+        if (!mountNamespacesSupported()) {
             if (!settings.sandboxFallback)
                 throw Error("this system does not support the kernel namespaces that are required for sandboxing; use '--no-sandbox' to disable sandboxing");
             debug("auto-disabling sandboxing because the prerequisite namespaces are not available");

--- a/src/libutil/namespaces.hh
+++ b/src/libutil/namespaces.hh
@@ -11,5 +11,4 @@ bool mountNamespacesSupported();
 bool pidNamespacesSupported();
 
 #endif
-
 }


### PR DESCRIPTION
# Motivation

This reverts commit bc1d9fd8b5a14334af1d0455e6b4d595cae959d5 as it is breaking the sandbox for people using `binfmt`.

Fixes #7783

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
