### PR TITLE
Fix PID namespace support check

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -209,7 +209,7 @@ void LocalDerivationGoal::tryLocalBuild()
 
     #if __linux__
     if (useChroot) {
-        if (!mountNamespacesSupported() || !pidNamespacesSupported()) {
+        if (!mountAndPidNamespacesSupported()) {
             if (!settings.sandboxFallback)
                 throw Error("this system does not support the kernel namespaces that are required for sandboxing; use '--no-sandbox' to disable sandboxing");
             debug("auto-disabling sandboxing because the prerequisite namespaces are not available");

--- a/src/libutil/namespaces.hh
+++ b/src/libutil/namespaces.hh
@@ -6,9 +6,7 @@ namespace nix {
 
 bool userNamespacesSupported();
 
-bool mountNamespacesSupported();
-
-bool pidNamespacesSupported();
+bool mountAndPidNamespacesSupported();
 
 #endif
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1085,6 +1085,7 @@ pid_t startProcess(std::function<void()> fun, const ProcessOptions & options)
     pid_t pid = -1;
 
     if (options.cloneFlags) {
+        #ifdef __linux__
         // Not supported, since then we don't know when to free the stack.
         assert(!(options.cloneFlags & CLONE_VM));
 
@@ -1096,6 +1097,9 @@ pid_t startProcess(std::function<void()> fun, const ProcessOptions & options)
         Finally freeStack([&]() { munmap(stack, stackSize); });
 
         pid = clone(childEntry, stack + stackSize, options.cloneFlags | SIGCHLD, &wrapper);
+        #else
+        throw Error("clone flags are only supported on Linux");
+        #endif
     } else
         pid = doFork(options.allowVfork, wrapper);
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -36,6 +36,7 @@
 #ifdef __linux__
 #include <sys/prctl.h>
 #include <sys/resource.h>
+#include <sys/mman.h>
 
 #include <cmath>
 #endif
@@ -1051,9 +1052,17 @@ static pid_t doFork(bool allowVfork, std::function<void()> fun)
 }
 
 
+static int childEntry(void * arg)
+{
+    auto main = (std::function<void()> *) arg;
+    (*main)();
+    return 1;
+}
+
+
 pid_t startProcess(std::function<void()> fun, const ProcessOptions & options)
 {
-    auto wrapper = [&]() {
+    std::function<void()> wrapper = [&]() {
         if (!options.allowVfork)
             logger = makeSimpleLogger();
         try {
@@ -1073,7 +1082,23 @@ pid_t startProcess(std::function<void()> fun, const ProcessOptions & options)
             _exit(1);
     };
 
-    pid_t pid = doFork(options.allowVfork, wrapper);
+    pid_t pid = -1;
+
+    if (options.cloneFlags) {
+        // Not supported, since then we don't know when to free the stack.
+        assert(!(options.cloneFlags & CLONE_VM));
+
+        size_t stackSize = 1 * 1024 * 1024;
+        auto stack = (char *) mmap(0, stackSize,
+            PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+        if (stack == MAP_FAILED) throw SysError("allocating stack");
+
+        Finally freeStack([&]() { munmap(stack, stackSize); });
+
+        pid = clone(childEntry, stack + stackSize, options.cloneFlags | SIGCHLD, &wrapper);
+    } else
+        pid = doFork(options.allowVfork, wrapper);
+
     if (pid == -1) throw SysError("unable to fork");
 
     return pid;

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -301,6 +301,7 @@ struct ProcessOptions
     bool dieWithParent = true;
     bool runExitHandlers = false;
     bool allowVfork = false;
+    int cloneFlags = 0; // use clone() with the specified flags (Linux only)
 };
 
 pid_t startProcess(std::function<void()> fun, const ProcessOptions & options = ProcessOptions());

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -11,6 +11,11 @@ let
     { services.openssh.enable = true;
       virtualisation.writableStore = true;
       nix.settings.sandbox = true;
+
+      # Regression test for use of PID namespaces when /proc has
+      # filesystems mounted on top of it
+      # (i.e. /proc/sys/fs/binfmt_misc).
+      boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
     };
 
   # Trivial Nix expression to build remotely.


### PR DESCRIPTION
# Motivation

Fixes #7783 by actually checking whether /proc can be remounted in a mount+PID namespace.

Includes some refactoring to add `clone()` support to `startProcess()`.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
