### PR TITLE
Infer short completion descriptions for commandline flags

### DIFF
--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -29,7 +29,16 @@ void Args::removeFlag(const std::string & longName)
 
 void Completions::add(std::string completion, std::string description)
 {
-    assert(description.find('\n') == std::string::npos);
+    // strip whitespace/empty lines from the front of the description
+    description.erase(0, description.find_first_not_of(" \t\n"));
+    // ellipsize overflowing content on the back of the description
+    auto end_index = description.find_first_of(".\n");
+    if (end_index != std::string::npos) {
+        auto needs_ellipsis = end_index != description.size() - 1;
+        description.resize(end_index);
+        if (needs_ellipsis)
+            description.append(" [...]");
+    }
     insert(Completion {
         .completion = completion,
         .description = description

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -29,8 +29,7 @@ void Args::removeFlag(const std::string & longName)
 
 void Completions::add(std::string completion, std::string description)
 {
-    // strip whitespace/empty lines from the front of the description
-    description.erase(0, description.find_first_not_of(" \t\n"));
+    description = trim(description);
     // ellipsize overflowing content on the back of the description
     auto end_index = description.find_first_of(".\n");
     if (end_index != std::string::npos) {


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Descriptions for commandline flags may not include newlines and should be rather short for display in a shell.
The current completion code asserts that a description does not contain newlines.
Current descriptions for e.g. `-I` trigger that assertion and break commandline flag completion.

# Context
<!-- Provide context. Reference open issues if available. -->
See https://github.com/NixOS/nix/issues/7792

Here I shorten the description by truncating the string on `'\n'` or `'.'` to and add an ellipsis `' [...]'` if sensible.
I chose to split on `\n` as well as `.` to keep the descriptions a single sentence.
I also had to trim at least an empty line from the front of the string to make `-I` work.

This yields something like the following for `fish`:
```fish
$ nix shell -
-c                                     (Command and arguments to be executed, defaulting to `$SHELL`)
-f  (Interpret installables as attribute paths relative to the Nix expression stored in *file* [...])
-I                                                          (Add *path* to the Nix search path [...])
-i                              (Clear the entire environment (except those specified with `--keep`))
-j                                                            (The maximum number of parallel builds)
-k                                                             (Keep the environment variable *name*)
-L                                                          (Print full build logs on standard error)
-u                                                            (Unset the environment variable *name*)
-v                                                             (Increase the logging verbosity level)
--                                                                                                   
```

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
