### PR TITLE
Don't allow writing to /etc

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -670,7 +670,6 @@ void LocalDerivationGoal::startBuilder()
            nobody account.  The latter is kind of a hack to support
            Samba-in-QEMU. */
         createDirs(chrootRootDir + "/etc");
-        chownToBuilder(chrootRootDir + "/etc");
 
         if (parsedDrv->useUidRange() && (!buildUser || buildUser->getUIDCount() < 65536))
             throw Error("feature 'uid-range' requires the setting '%s' to be enabled", settings.autoAllocateUids.name);
@@ -969,6 +968,9 @@ void LocalDerivationGoal::startBuilder()
                 "nixbld:x:%1%:%2%:Nix build user:%3%:/noshell\n"
                 "nobody:x:65534:65534:Nobody:/:/noshell\n",
                 sandboxUid(), sandboxGid(), settings.sandboxBuildDir));
+
+        /* Make /etc unwritable */
+        chmod_(chrootRootDir + "/etc", 0555);
 
         /* Save the mount- and user namespace of the child. We have to do this
            *before* the child does a chroot. */

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -670,6 +670,8 @@ void LocalDerivationGoal::startBuilder()
            nobody account.  The latter is kind of a hack to support
            Samba-in-QEMU. */
         createDirs(chrootRootDir + "/etc");
+        if (parsedDrv->useUidRange())
+            chownToBuilder(chrootRootDir + "/etc");
 
         if (parsedDrv->useUidRange() && (!buildUser || buildUser->getUIDCount() < 65536))
             throw Error("feature 'uid-range' requires the setting '%s' to be enabled", settings.autoAllocateUids.name);
@@ -970,7 +972,8 @@ void LocalDerivationGoal::startBuilder()
                 sandboxUid(), sandboxGid(), settings.sandboxBuildDir));
 
         /* Make /etc unwritable */
-        chmod_(chrootRootDir + "/etc", 0555);
+        if (!parsedDrv->useUidRange())
+            chmod_(chrootRootDir + "/etc", 0555);
 
         /* Save the mount- and user namespace of the child. We have to do this
            *before* the child does a chroot. */

--- a/tests/linux-sandbox.sh
+++ b/tests/linux-sandbox.sh
@@ -37,3 +37,6 @@ nix-build check.nix -A nondeterministic --sandbox-paths /nix/store --no-out-link
 (! nix-build check.nix -A nondeterministic --sandbox-paths /nix/store --no-out-link --check -K 2> $TEST_ROOT/log)
 if grep -q 'error: renaming' $TEST_ROOT/log; then false; fi
 grep -q 'may not be deterministic' $TEST_ROOT/log
+
+# Test that sandboxed builds cannot write to /etc easily
+(! nix-build -E 'with import ./config.nix; mkDerivation { name = "etc-write"; buildCommand = "echo > /etc/test"; }' --no-out-link --sandbox-paths /nix/store)

--- a/tests/nixos/containers/systemd-nspawn.nix
+++ b/tests/nixos/containers/systemd-nspawn.nix
@@ -62,6 +62,7 @@ runCommand "test"
 
     mkdir -p $out
 
+    chmod +w /etc
     touch /etc/os-release
     echo a5ea3f98dedc0278b6f3cc8c37eeaeac > /etc/machine-id
 

--- a/tests/nixos/containers/systemd-nspawn.nix
+++ b/tests/nixos/containers/systemd-nspawn.nix
@@ -56,7 +56,6 @@ runCommand "test"
     # Make /run a tmpfs to shut up a systemd warning.
     mkdir /run
     mount -t tmpfs none /run
-    chmod 0700 /run
 
     mount -t cgroup2 none /sys/fs/cgroup
 


### PR DESCRIPTION
# Motivation
Nix was setting chown nixbld /etc + chmod 0755, which meant that builds could change it.


# Context
#7813

This change removes the chown and removes the write bit after the sandbox setup. It also provides a test for this case.

I don't fully understand why the chown was there. Everything seems to work without it. @edolstra?

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
