### PR TITLE
Fix static build

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -67,6 +67,7 @@ define build-library
 
   $(1)_LDFLAGS_USE :=
   $(1)_LDFLAGS_USE_INSTALLED :=
+  $(1)_LIB_CLOSURE := $(1)
 
   $$(eval $$(call create-dir, $$(_d)))
 
@@ -128,9 +129,11 @@ define build-library
 	+$$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$^
 	$$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
 
-    $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS)
+    $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS) $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LDFLAGS_USE))
 
     $(1)_INSTALL_PATH := $$(libdir)/$$($(1)_NAME).a
+
+    $(1)_LIB_CLOSURE += $$($(1)_LIBS)
 
   endif
 

--- a/mk/programs.mk
+++ b/mk/programs.mk
@@ -30,7 +30,7 @@ define build-program
   _d := $(buildprefix)$$($(1)_DIR)
   _srcs := $$(sort $$(foreach src, $$($(1)_SOURCES), $$(src)))
   $(1)_OBJS := $$(addprefix $(buildprefix), $$(addsuffix .o, $$(basename $$(_srcs))))
-  _libs := $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_PATH))
+  _libs := $$(foreach lib, $$($(1)_LIBS), $$(foreach lib2, $$($$(lib)_LIB_CLOSURE), $$($$(lib2)_PATH)))
   $(1)_PATH := $$(_d)/$$($(1)_NAME)
 
   $$(eval $$(call create-dir, $$(_d)))
@@ -58,7 +58,7 @@ define build-program
     else
 
       $(DESTDIR)$$($(1)_INSTALL_PATH): $$($(1)_PATH) | $(DESTDIR)$$($(1)_INSTALL_DIR)/
-	install -t $(DESTDIR)$$($(1)_INSTALL_DIR) $$<
+	+$$(trace-install) install -t $(DESTDIR)$$($(1)_INSTALL_DIR) $$<
 
     endif
   endif


### PR DESCRIPTION

# Motivation

For static builds, we need to propagate all the static library dependencies to the link of the program. E.g. if `libstore-tests-exe` depends on `libnixstore-tests`, and `libnixstore-tests` depends on `libstore`, then `libstore-tests-exe` needs to link against `libstore`.

https://hydra.nixos.org/build/209007480

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
