### PR TITLE
Add automatic migration when use-xdg-base-directories is enabled

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -949,7 +949,7 @@ public:
     Setting<bool> useXDGBaseDirectories{
         this, false, "use-xdg-base-directories",
         R"(
-          If set to `true`, Nix will conform to the [XDG Base Directory Specification] for files in `$HOME`.
+          If set to `true`, Nix will conform to the [XDG base directory specification] for all files in $HOME.
           The environment variables used to implement this are documented in the [Environment Variables section](@docroot@/installation/env-variables.md).
 
           [XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
@@ -964,6 +964,10 @@ public:
           | `~/.nix-profile`  | `$XDG_STATE_HOME/nix/profile`  |
           | `~/.nix-defexpr`  | `$XDG_STATE_HOME/nix/defexpr`  |
           | `~/.nix-channels` | `$XDG_STATE_HOME/nix/channels` |
+
+          If there is no file in the XDG location, but there is a file in the legacy location, it will be migrated automatically.
+          A reverse migration will happen if this setting is set to `false`.
+          If the file is present in both locations, no migration is done.
         )"
     };
 };

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -290,7 +290,7 @@ Path profilesDir()
 
 Path getDefaultProfile()
 {
-    Path profileLink = settings.useXDGBaseDirectories ? createNixStateDir() + "/profile" : getHome() + "/.nix-profile";
+    Path profileLink = getUserNixProfile(settings.useXDGBaseDirectories);
     try {
         auto profile =
             getuid() == 0

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -622,6 +622,58 @@ Path createNixStateDir()
     return dir;
 }
 
+void migrateIfNeeded(Path from, Path to) {
+    if (pathExists(from)) {
+        if (pathExists(to)) {
+            warn("Both %s and %s exist. Did you run an older version of Nix? I will use %s, but you should migrate manually.", from, to, to);
+        } else {
+            warn("Migrating %s to %s", from, to);
+            rename(from.c_str(), to.c_str());
+        }
+    }
+}
+
+Path getUserNixProfile(bool xdg)
+{
+    Path legacyProfile = getHome() + "/.nix-profile";
+    Path xdgProfile = getStateDir() + "/nix/profile";
+    if (xdg) {
+        createNixStateDir();
+        migrateIfNeeded(legacyProfile, xdgProfile);
+        return xdgProfile;
+    } else {
+        migrateIfNeeded(xdgProfile, legacyProfile);
+        return legacyProfile;
+    }
+}
+
+Path getUserNixDefexpr(bool xdg)
+{
+    Path legacyDefexpr = getHome() + "/.nix-defexpr";
+    Path xdgDefexpr = getStateDir() + "/nix/defexpr";
+    if (xdg) {
+        createNixStateDir();
+        migrateIfNeeded(legacyDefexpr, xdgDefexpr);
+        return xdgDefexpr;
+    } else {
+        migrateIfNeeded(xdgDefexpr, legacyDefexpr);
+        return legacyDefexpr;
+    }
+}
+
+Path getUserNixChannels(bool xdg)
+{
+    Path legacyChannels = getHome() + "/.nix-channels";
+    Path xdgChannels = getStateDir() + "/nix/channels";
+    if (xdg) {
+        createNixStateDir();
+        migrateIfNeeded(legacyChannels, xdgChannels);
+        return xdgChannels;
+    } else {
+        migrateIfNeeded(xdgChannels, legacyChannels);
+        return legacyChannels;
+    }
+}
 
 std::optional<Path> getSelfExe()
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -164,6 +164,19 @@ Path getStateDir();
 /* Create the Nix state directory and return the path to it. */
 Path createNixStateDir();
 
+/* Get path to user's Nix profile symlink (~/.nix-profile if argument is false
+  or $XDG_STATE_HOME/ nix/profile), creating parent components if necessary */
+Path getUserNixProfile(bool xdg);
+
+/* Get path to user's Nix defexpr symlink (~/.nix-defexpr if argument is false
+  or $XDG_STATE_HOME/ nix/defexpr), creating parent components if necessary */
+Path getUserNixDefexpr(bool xdg);
+
+/* Get path to user's Nix channels symlink (~/.nix-channels if argument
+  is false or $XDG_STATE_HOME/nix/channels), creating parent components if
+  necessary */
+Path getUserNixChannels(bool xdg);
+
 /* Create a directory and all its parents, if necessary.  Returns the
    list of created directories, in order of creation. */
 Paths createDirs(const Path & path);

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -162,10 +162,8 @@ static void update(const StringSet & channelNames)
 static int main_nix_channel(int argc, char ** argv)
 {
     {
-        // Figure out the name of the `.nix-channels' file to use
-        auto home = getHome();
-        channelsList = settings.useXDGBaseDirectories ? createNixStateDir() + "/channels" : home + "/.nix-channels";
-        nixDefExpr = settings.useXDGBaseDirectories ? createNixStateDir() + "/defexpr" : home + "/.nix-defexpr";
+        channelsList = getUserNixChannels(settings.useXDGBaseDirectories);
+        nixDefExpr = getUserNixDefexpr(settings.useXDGBaseDirectories);
 
         // Figure out the name of the channels profile.
         profile = profilesDir() + "/channels";

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1289,7 +1289,7 @@ static void opSwitchProfile(Globals & globals, Strings opFlags, Strings opArgs)
         throw UsageError("exactly one argument expected");
 
     Path profile = absPath(opArgs.front());
-    Path profileLink = settings.useXDGBaseDirectories ? createNixStateDir() + "/profile" : getHome() + "/.nix-profile";
+    Path profileLink = getUserNixProfile(settings.useXDGBaseDirectories);
 
     switchLink(profileLink, profile);
 }
@@ -1394,7 +1394,7 @@ static int main_nix_env(int argc, char * * argv)
 
         globals.instSource.type = srcUnknown;
         {
-            Path nixExprPath = settings.useXDGBaseDirectories ? createNixStateDir() + "/defexpr" : getHome() + "/.nix-defexpr";
+            Path nixExprPath = getUserNixDefexpr(settings.useXDGBaseDirectories);
             globals.instSource.nixExprPath = nixExprPath;
         }
         globals.instSource.systemFilter = "*";

--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -59,10 +59,24 @@ nix profile diff-closures | grep 'env-manifest.nix: ε → ∅'
 # Test XDG Base Directories support
 
 export NIX_CONFIG="use-xdg-base-directories = true"
+
+# Old profile should be migrated
+nix profile list 2>&1 | grep -q "Migrating"
+[ -e $TEST_HOME/.local/state/nix/profile ]
+[ ! -e $TEST_HOME/.nix-profile ]
+
+# Everything should still work
 nix profile remove 1
 nix profile install $flake1Dir
 [[ $($TEST_HOME/.local/state/nix/profile/bin/hello) = "Hello World" ]]
 unset NIX_CONFIG
+
+# And it should migrate back
+nix profile list 2>&1 | grep -q "Migrating"
+[ -e $TEST_HOME/.nix-profile ]
+[[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello World" ]]
+[ ! -e $TEST_HOME/.local/share/nix/profile ]
+
 
 # Test upgrading a package.
 printf NixOS > $flake1Dir/who


### PR DESCRIPTION
# Motivation

Currently, enabling `use-xdg-base-directories` requires manual migration of old profile, defexpr and channels.
This is not really convenient. Hence, add some simple migration logic.

# Context

`use-xdg-base-directories` has been added as part of <https://github.com/NixOS/nix/pull/5588>

# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
