### PR TITLE
Make 'nix store gc' use the auto-GC policy 

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -20,3 +20,8 @@
   to the embedded store and not to the host's Nix store.
 
   This requires the `discard-references` experimental feature.
+
+* Automatic garbage collection is now only enabled if you set `auto-gc
+  = true` in `nix.conf`. You will probably also want to set `min-free`
+  to configure when the garbage collector kicks in, e.g. `1G` to make
+  it run when free space drops below 1 gigabyte.

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -22,6 +22,6 @@
   This requires the `discard-references` experimental feature.
 
 * Automatic garbage collection is now only enabled if you set `auto-gc
-  = true` in `nix.conf`. You will probably also want to set `min-free`
+  = true` in `nix.conf`. You will probably also want to set `gc-threshold`
   to configure when the garbage collector kicks in, e.g. `1G` to make
   it run when free space drops below 1 gigabyte.

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -250,9 +250,8 @@ void Worker::run(const Goals & _topGoals)
 
         checkInterrupt();
 
-        // TODO GC interface?
-        if (auto localStore = dynamic_cast<LocalStore *>(&store))
-            localStore->autoGC(false);
+        if (auto gcStore = dynamic_cast<GcStore *>(&store))
+            gcStore->autoGC(false);
 
         /* Call every wake goal (in the ordering established by
            CompareGoalPtrs). */

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -317,9 +317,9 @@ void Worker::waitForInput()
        is a build timeout, then wait for input until the first
        deadline for any child. */
     auto nearest = steady_time_point::max(); // nearest deadline
-    if (settings.minFree.get() != 0)
-        // Periodicallty wake up to see if we need to run the garbage collector.
-        nearest = before + std::chrono::seconds(10);
+    if (settings.autoGC)
+        // Periodically wake up to see if we need to run the garbage collector.
+        nearest = before + std::chrono::seconds(settings.autoGCCheckInterval);
     for (auto & i : children) {
         if (!i.respectTimeouts) continue;
         if (0 != settings.maxSilentTime)

--- a/src/libstore/gc-store.hh
+++ b/src/libstore/gc-store.hh
@@ -85,7 +85,7 @@ struct GcStore : public virtual Store
     virtual void collectGarbage(const GCOptions & options, GCResults & results) = 0;
 
     /* Do a garbage collection that observes the policy configured by
-       `min-free` etc.  */
+       `gc-threshold`, `gc-limit`, etc.  */
     void doGC(bool sync = true);
 
     /* Perform an automatic garbage collection, if enabled. */

--- a/src/libstore/gc-store.hh
+++ b/src/libstore/gc-store.hh
@@ -84,8 +84,11 @@ struct GcStore : public virtual Store
     /* Perform a garbage collection. */
     virtual void collectGarbage(const GCOptions & options, GCResults & results) = 0;
 
-    /* If free disk space in /nix/store if below minFree, delete
-       garbage until it exceeds maxFree. */
+    /* Do a garbage collection that observes the policy configured by
+       `min-free` etc.  */
+    void doGC(bool sync = true);
+
+    /* Perform an automatic garbage collection, if enabled. */
     void autoGC(bool sync = true);
 
     /* Return the amount of available disk space in this store. Used

--- a/src/libstore/gc-store.hh
+++ b/src/libstore/gc-store.hh
@@ -2,6 +2,8 @@
 
 #include "store-api.hh"
 
+#include <future>
+
 
 namespace nix {
 
@@ -63,6 +65,8 @@ struct GcStore : public virtual Store
 {
     inline static std::string operationName = "Garbage collection";
 
+    ~GcStore();
+
     /* Add an indirect root, which is merely a symlink to `path' from
        /nix/var/nix/gcroots/auto/<hash of `path'>.  `path' is supposed
        to be a symlink to a store path.  The garbage collector will
@@ -79,6 +83,40 @@ struct GcStore : public virtual Store
 
     /* Perform a garbage collection. */
     virtual void collectGarbage(const GCOptions & options, GCResults & results) = 0;
+
+    /* If free disk space in /nix/store if below minFree, delete
+       garbage until it exceeds maxFree. */
+    void autoGC(bool sync = true);
+
+    /* Return the amount of available disk space in this store. Used
+       by autoGC(). */
+    virtual uint64_t getAvailableSpace()
+    {
+        return std::numeric_limits<uint64_t>::max();
+    }
+
+private:
+
+    struct State
+    {
+        /* The last time we checked whether to do an auto-GC, or an
+           auto-GC finished. */
+        std::chrono::time_point<std::chrono::steady_clock> lastGCCheck;
+
+        /* Whether auto-GC is running. If so, get gcFuture to wait for
+           the GC to finish. */
+        bool gcRunning = false;
+        std::shared_future<void> gcFuture;
+
+        /* How much disk space was available after the previous
+           auto-GC. If the current available disk space is below
+           minFree but not much below availAfterGC, then there is no
+           point in starting a new GC. */
+        uint64_t availAfterGC = std::numeric_limits<uint64_t>::max();
+    };
+
+    Sync<State> _state;
+
 };
 
 }

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -903,7 +903,7 @@ GcStore::~GcStore()
 }
 
 
-void GcStore::autoGC(bool sync)
+void GcStore::doGC(bool sync)
 {
     std::shared_future<void> future;
 
@@ -968,6 +968,13 @@ void GcStore::autoGC(bool sync)
  sync:
     // Wait for the future outside of the state lock.
     if (sync) future.get();
+}
+
+
+void GcStore::autoGC(bool sync)
+{
+    if (settings.autoGC)
+        doGC(sync);
 }
 
 

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -918,13 +918,13 @@ void GcStore::doGC(bool sync)
 
         auto now = std::chrono::steady_clock::now();
 
-        if (now < state->lastGCCheck + std::chrono::seconds(settings.minFreeCheckInterval)) return;
+        if (now < state->lastGCCheck + std::chrono::seconds(settings.autoGCCheckInterval)) return;
 
         auto avail = getAvailableSpace();
 
         state->lastGCCheck = now;
 
-        if (avail >= settings.minFree || avail >= settings.maxFree) return;
+        if (avail >= settings.gcThreshold || avail >= settings.gcLimit) return;
 
         if (avail > state->availAfterGC * 0.97) return;
 
@@ -946,7 +946,7 @@ void GcStore::doGC(bool sync)
                 });
 
                 GCOptions options;
-                options.maxFreed = settings.maxFree - avail;
+                options.maxFreed = settings.gcLimit - avail;
 
                 printInfo("running auto-GC to free %d bytes", options.maxFreed);
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -877,25 +877,33 @@ public:
           first. If it is not available there, if will try the original URI.
         )"};
 
-    Setting<uint64_t> minFree{
-        this, 0, "min-free",
+    Setting<bool> autoGC{
+        this, false, "auto-gc",
         R"(
-          When free disk space in `/nix/store` drops below `min-free` during a
-          build, Nix performs a garbage-collection until `max-free` bytes are
-          available or there is no more garbage. A value of `0` (the default)
-          disables this feature.
+          Whether to perform automatic garbage collections during builds.
+        )"};
+
+    Setting<uint64_t> minFree{
+        this, std::numeric_limits<uint64_t>::max(), "min-free",
+        R"(
+          The amount of free disk space in `/nix/store` below which
+          Nix will start a garbage collection when `auto-gc` is
+          enabled or when you manually run `nix store gc`. The default
+          value is infinity, meaning Nix will start collecting garbage
+          regardless of the amount of free space.
         )"};
 
     Setting<uint64_t> maxFree{
         this, std::numeric_limits<uint64_t>::max(), "max-free",
         R"(
-          When a garbage collection is triggered by the `min-free` option, it
-          stops as soon as `max-free` bytes are available. The default is
-          infinity (i.e. delete all garbage).
+          During garbage collection, Nix will stop collecting when the
+          amount of free space in `/nix/store` gets above this
+          value. The default value is infinity, meaning that Nix will
+          delete all garbage regardless of free space.
         )"};
 
     Setting<uint64_t> minFreeCheckInterval{this, 5, "min-free-check-interval",
-        "Number of seconds between checking free disk space."};
+        "Number of seconds between checking free disk space, if `auto-gc` is enabled."};
 
     PluginFilesSetting pluginFiles{
         this, {}, "plugin-files",

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -883,27 +883,30 @@ public:
           Whether to perform automatic garbage collections during builds.
         )"};
 
-    Setting<uint64_t> minFree{
-        this, std::numeric_limits<uint64_t>::max(), "min-free",
+    Setting<uint64_t> gcThreshold{
+        this, std::numeric_limits<uint64_t>::max(), "gc-threshold",
         R"(
           The amount of free disk space in `/nix/store` below which
           Nix will start a garbage collection when `auto-gc` is
           enabled or when you manually run `nix store gc`. The default
           value is infinity, meaning Nix will start collecting garbage
           regardless of the amount of free space.
-        )"};
+        )",
+        {"min-free"}};
 
-    Setting<uint64_t> maxFree{
-        this, std::numeric_limits<uint64_t>::max(), "max-free",
+    Setting<uint64_t> gcLimit{
+        this, std::numeric_limits<uint64_t>::max(), "gc-limit",
         R"(
           During garbage collection, Nix will stop collecting when the
           amount of free space in `/nix/store` gets above this
           value. The default value is infinity, meaning that Nix will
           delete all garbage regardless of free space.
-        )"};
+        )",
+        {"max-free"}};
 
-    Setting<uint64_t> minFreeCheckInterval{this, 5, "min-free-check-interval",
-        "Number of seconds between checking free disk space, if `auto-gc` is enabled."};
+    Setting<uint64_t> autoGCCheckInterval{this, 5, "auto-gc-check-interval",
+        "Number of seconds between checking free disk space, if `auto-gc` is enabled.",
+        {"min-free-check-interval"}};
 
     PluginFilesSetting pluginFiles{
         this, {}, "plugin-files",

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -236,10 +236,7 @@ template<typename T>
 void BaseSetting<T>::set(const std::string & str, bool append)
 {
     static_assert(std::is_integral<T>::value, "Integer required.");
-    if (auto n = string2Int<T>(str))
-        value = *n;
-    else
-        throw UsageError("setting '%s' has invalid value '%s'", name, str);
+    value = string2IntWithUnitPrefix<T>(str);
 }
 
 template<typename T>

--- a/src/nix/store-gc.cc
+++ b/src/nix/store-gc.cc
@@ -27,13 +27,9 @@ struct CmdStoreGC : StoreCommand
 
     void run(ref<Store> store) override
     {
-        /* The default threshold of 0 makes sense for auto-GC, but not
-           when the garbage collector is invoked manually. */
-        settings.minFree.setDefault(std::numeric_limits<uint64_t>::max());
-
         auto & gcStore = require<GcStore>(*store);
 
-        gcStore.autoGC(true);
+        gcStore.doGC(true);
     }
 };
 

--- a/src/nix/store-gc.cc
+++ b/src/nix/store-gc.cc
@@ -7,18 +7,10 @@
 
 using namespace nix;
 
-struct CmdStoreGC : StoreCommand, MixDryRun
+struct CmdStoreGC : StoreCommand
 {
-    GCOptions options;
-
     CmdStoreGC()
     {
-        addFlag({
-            .longName = "max",
-            .description = "Stop after freeing *n* bytes of disk space.",
-            .labels = {"n"},
-            .handler = {&options.maxFreed}
-        });
     }
 
     std::string description() override
@@ -35,12 +27,13 @@ struct CmdStoreGC : StoreCommand, MixDryRun
 
     void run(ref<Store> store) override
     {
+        /* The default threshold of 0 makes sense for auto-GC, but not
+           when the garbage collector is invoked manually. */
+        settings.minFree.setDefault(std::numeric_limits<uint64_t>::max());
+
         auto & gcStore = require<GcStore>(*store);
 
-        options.action = dryRun ? GCOptions::gcReturnDead : GCOptions::gcDeleteDead;
-        GCResults results;
-        PrintFreed freed(options.action == GCOptions::gcDeleteDead, results);
-        gcStore.collectGarbage(options, results);
+        gcStore.autoGC(true);
     }
 };
 

--- a/src/nix/store-gc.md
+++ b/src/nix/store-gc.md
@@ -8,14 +8,20 @@ R""(
   # nix store gc
   ```
 
-* Delete up to 1 gigabyte of garbage:
+* Perform garbage collection if there is less than 1 GiB of free space
+  in `/nix/store`, and stop once there is at least 5 GiB of free
+  space.
 
   ```console
-  # nix store gc --max-free 1G
+  # nix store gc --gc-threshold 1G --gc-limit 5G
   ```
 
 # Description
 
-This command deletes unreachable paths in the Nix store.
+This command deletes unreachable paths in the Nix store, observing the
+GC policy configured by the
+[`gc-threshold`](../conf-file.md#conf-gc-threshold) and
+[`gc-limit`](../conf-file.md#conf-gc-limit) configuration
+settings. By default, all unreachable paths will be deleted.
 
 )""

--- a/src/nix/store-gc.md
+++ b/src/nix/store-gc.md
@@ -11,7 +11,7 @@ R""(
 * Delete up to 1 gigabyte of garbage:
 
   ```console
-  # nix store gc --max 1G
+  # nix store gc --max-free 1G
   ```
 
 # Description

--- a/tests/gc-auto.sh
+++ b/tests/gc-auto.sh
@@ -62,11 +62,11 @@ EOF
 )
 
 nix build --impure -v -o $TEST_ROOT/result-A -L --expr "$expr" \
-    --min-free 1K --max-free 2K --min-free-check-interval 1 &
+    --auto-gc --min-free 1K --max-free 2K --min-free-check-interval 1 &
 pid1=$!
 
 nix build --impure -v -o $TEST_ROOT/result-B -L --expr "$expr2" \
-    --min-free 1K --max-free 2K --min-free-check-interval 1 &
+    --auto-gc --min-free 1K --max-free 2K --min-free-check-interval 1 &
 pid2=$!
 
 # Once the first build is done, unblock the second one.

--- a/tests/gc-auto.sh
+++ b/tests/gc-auto.sh
@@ -62,11 +62,11 @@ EOF
 )
 
 nix build --impure -v -o $TEST_ROOT/result-A -L --expr "$expr" \
-    --min-free 1000 --max-free 2000 --min-free-check-interval 1 &
+    --min-free 1K --max-free 2K --min-free-check-interval 1 &
 pid1=$!
 
 nix build --impure -v -o $TEST_ROOT/result-B -L --expr "$expr2" \
-    --min-free 1000 --max-free 2000 --min-free-check-interval 1 &
+    --min-free 1K --max-free 2K --min-free-check-interval 1 &
 pid2=$!
 
 # Once the first build is done, unblock the second one.

--- a/tests/gc-auto.sh
+++ b/tests/gc-auto.sh
@@ -1,6 +1,6 @@
 source common.sh
 
-needLocalStore "“min-free” and “max-free” are daemon options"
+needLocalStore "'gc-threshold' and 'gc-limit' are daemon options"
 
 clearStore
 
@@ -62,11 +62,11 @@ EOF
 )
 
 nix build --impure -v -o $TEST_ROOT/result-A -L --expr "$expr" \
-    --auto-gc --min-free 1K --max-free 2K --min-free-check-interval 1 &
+    --auto-gc --gc-threshold 1K --gc-limit 2K --auto-gc-check-interval 1 &
 pid1=$!
 
 nix build --impure -v -o $TEST_ROOT/result-B -L --expr "$expr2" \
-    --auto-gc --min-free 1K --max-free 2K --min-free-check-interval 1 &
+    --auto-gc --gc-threshold 1K --gc-limit 2K --auto-gc-check-interval 1 &
 pid2=$!
 
 # Once the first build is done, unblock the second one.


### PR DESCRIPTION
# Motivation

I.e. `nix store gc` will observe the `min-free` and `max-free` settings, which have been renamed to `gc-threshold` and `gc-limit`. To remove inconsistency in handling `gc-threshold`, auto-GC now must be enabled using the new `auto-gc` setting.

This PR also allows unit prefix in configuration settings, e.g. `min-free = 5G`.

Fixes #7822, #7608.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
