### PR TITLE
feat: support managing submodules via inputs.self

### DIFF
--- a/src/libexpr/flake/flake.hh
+++ b/src/libexpr/flake/flake.hh
@@ -41,6 +41,7 @@ typedef std::map<FlakeId, FlakeInput> FlakeInputs;
 struct FlakeInput
 {
     std::optional<FlakeRef> ref;
+    bool hasSubmodules = false;
     bool isFlake = true;  // true = process flake to get outputs, false = (fetched) static source path
     std::optional<InputPath> follows;
     FlakeInputs overrides;

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -114,6 +114,8 @@ reference types:
 
 * `ref`: A Git or Mercurial branch or tag name.
 
+* `submodules`: A boolean supporting Git submodules.
+
 Finally, some attribute are typically not specified by the user, but
 can occur in *locked* flake references and are available to Nix code:
 

--- a/tests/flakes/submodules.sh
+++ b/tests/flakes/submodules.sh
@@ -1,0 +1,118 @@
+source common.sh
+
+set -u
+
+if [[ -z $(type -p git) ]]; then
+    echo "Git not installed; skipping Git submodule tests"
+    exit 99
+fi
+
+clearStore
+
+rootRepo=$TEST_ROOT/gitSubmodulesRoot
+subRepo=$TEST_ROOT/gitSubmodulesSub
+
+rm -rf ${rootRepo} ${subRepo} $TEST_HOME/.cache/nix
+
+# Submodules can't be fetched locally by default, which can cause
+# information leakage vulnerabilities, but for these tests our
+# submodule is intentionally local and it's all trusted, so we
+# disable this restriction. Setting it per repo is not sufficient, as
+# the repo-local config does not apply to the commands run from
+# outside the repos by Nix.
+export XDG_CONFIG_HOME=$TEST_HOME/.config
+git config --global protocol.file.allow always
+
+initGitRepo() {
+    git init $1
+    git -C $1 config user.email "foobar@example.com"
+    git -C $1 config user.name "Foobar"
+}
+
+addGitContent() {
+    echo "lorem ipsum" > $1/content
+    git -C $1 add content
+    git -C $1 commit -m "Initial commit"
+}
+
+initGitRepo $subRepo
+addGitContent $subRepo
+
+initGitRepo $rootRepo
+
+git -C $rootRepo submodule init
+git -C $rootRepo submodule add $subRepo sub
+git -C $rootRepo add sub
+git -C $rootRepo commit -m "Add submodule"
+
+rev=$(git -C $rootRepo rev-parse HEAD)
+
+cd $rootRepo
+
+touch flake.nix
+git add flake.nix
+
+# Case, CLI parameter
+cat <<EOF > flake.nix
+{
+    outputs = {self}: {
+      sub = self.outPath;
+    };
+}
+EOF
+[ -e  $(nix eval '.?submodules=1#sub' --raw)/sub/content ]
+
+# Case, CLI parameter
+cat <<EOF > flake.nix
+{
+    outputs = {self}: {
+      sub = self.outPath;
+    };
+}
+EOF
+[ ! -e  $(nix eval '.?submodules=0#sub' --raw)/sub/content ]
+
+# Case, flake.nix parameter
+cat <<EOF > flake.nix
+{
+    inputs.self.submodules = false;
+    outputs = {self}: {
+      sub = self.outPath;
+    };
+}
+EOF
+
+[ ! -e  $(nix eval .#sub --raw)/sub/content ]
+
+# Case, flake.nix parameter
+cat <<EOF > flake.nix
+{
+    inputs.self.submodules = true;
+    outputs = {self}: {
+      sub = self.outPath;
+    };
+}
+EOF
+[ -e  $(nix eval .#sub --raw)/sub/content ]
+
+# Case, CLI precedence
+cat <<EOF > flake.nix
+{
+    inputs.self.submodules = true;
+    outputs = {self}: {
+      sub = self.outPath;
+    };
+}
+EOF
+[ ! -e  $(nix eval '.?submodules=0#sub' --raw)/sub/content ]
+
+# Case, CLI precedence
+cat <<EOF > flake.nix
+{
+    inputs.self.submodules = false;
+    outputs = {self}: {
+      sub = self.outPath;
+    };
+}
+EOF
+[ -e  $(nix eval '.?submodules=1#sub' --raw)/sub/content ]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -10,6 +10,7 @@ nix_tests = \
   flakes/unlocked-override.sh \
   flakes/absolute-paths.sh \
   flakes/build-paths.sh \
+  flakes/submodules.sh \
   ca/gc.sh \
   gc.sh \
   remote-store.sh \


### PR DESCRIPTION
Provides special handling for inputs.self. If submodule is set to true, will re-call getFlake as if the original reference was set. The intended behavior is for CLI management of the parameter overrides any direct flake.nix settings.

Thanks to: @x10an14, @aaronchall, @mrene
# Motivation
- https://github.com/NixOS/nix/pull/4922
- https://github.com/NixOS/nix/pull/5284
- https://github.com/NixOS/nix/pull/4423
- https://github.com/NixOS/nix/pull/5434
- https://gist.github.com/mstone/4218e6fa9ef98e5153f543fb8e7b4743

# Context
Provides a mechanism for `inputs.self.submodules` to control the availability of submodules in a local flake.

# Checklist for maintainers

- [x] test with remote resources (@kranzes)
- [ ] provide check/error for that this logic won't work with "github:"
<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
