### PR TITLE
doc/hacking.md: Corrections and additions for cross

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -110,7 +110,7 @@ $ nix-build
 
 You can also build Nix for one of the [supported target platforms](#target-platforms).
 
-## Target platforms
+## Platforms
 
 As specified in [`flake.nix`], Nix can be built for various platforms:
 
@@ -122,14 +122,15 @@ As specified in [`flake.nix`], Nix can be built for various platforms:
 [`flake.nix`]: https://github.com/nixos/nix/blob/master/flake.nix
 
 In order to build Nix for a different platform than the one you're currently
-one, you need to have some way for your system Nix to build code for that
+on, you need to have some way for your system Nix to build code for that
 platform. Common solutions include [remote builders] and [binfmt emulation]
 (only supported on NixOS).
 
 [remote builders]: ../advanced-topics/distributed-builds.md
 [binfmt emulation]: https://nixos.org/manual/nixos/stable/options.html#opt-boot.binfmt.emulatedSystems
 
-Once you are able to build for different platforms, executing the build is as simple as
+These solutions let Nix perform builds as if you're on the native platform, so
+executing the build is as simple as
 
 ```console
 $ nix build .#packages.aarch64-linux.default
@@ -144,6 +145,8 @@ $ nix-build -A packages.aarch64-linux.default
 for classic Nix.
 
 You can use any of the other supported platforms in place of `aarch64-linux`.
+
+Cross-compiled builds are available for ARMv6 and ARMv7, and Nix on unsupported platforms can be bootstrapped by adding more `crossSystems` in `flake.nix`.
 
 ## Compilation environments
 


### PR DESCRIPTION
# Motivation

 - "Target" has a specific meaning in cross-compilation, which does not apply here, and we can avoid the term without loss.
 - Cross compilation wasn't mentioned yet. This isn't a guide to bootstrapping Nix on a platform, but we can't not mention it here, as otherwise the section suggests that emulation is the only way to port Nix.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
