### PR TITLE
Restore NIX_PATH taking precedence over nix-path

### DIFF
--- a/doc/manual/src/command-ref/env-common.md
+++ b/doc/manual/src/command-ref/env-common.md
@@ -10,8 +10,9 @@ Most Nix commands interpret the following environment variables:
     A colon-separated list of directories used to look up the location of Nix
     expressions using [paths](../language/values.md#type-path)
     enclosed in angle brackets (i.e., `<path>`),
-    e.g. `/home/eelco/Dev:/etc/nixos`. It can be extended using the
-    [`-I` option](./opt-common.md#opt-I).
+    e.g. `/home/eelco/Dev:/etc/nixos`. It overrides the
+    [`nix-path` setting](./conf-file.md#conf-nix-path).
+    It can be extended using the [`-I` option](./opt-common.md#opt-I).
 
   - [`NIX_IGNORE_SYMLINK_STORE`]{#env-NIX_IGNORE_SYMLINK_STORE}\
     Normally, the Nix store directory (typically `/nix/store`) is not

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -149,7 +149,7 @@ public:
 
     /* The allowed filesystem paths in restricted or pure evaluation
        mode. */
-    std::optional<PathSet> allowedPaths;
+    std::optional<PathSet> allowedPaths = PathSet();
 
     Bindings emptyBindings;
 
@@ -580,23 +580,24 @@ struct EvalSettings : Config
         "Whether builtin functions that allow executing native code should be enabled."};
 
     Setting<Strings> nixPath{
-        this, {}, "nix-path",
+        this, getDefaultNixPath(), "nix-path",
         R"(
-          List of directories to be searched for `<...>` file references.
-
-          If [pure evaluation](#conf-pure-eval) is disabled,
-          this is initialised using the [`NIX_PATH`](@docroot@/command-ref/env-common.md#env-NIX_PATH)
-          environment variable, or, if it is unset and [restricted evaluation](#conf-restrict-eval)
-          is disabled, a default search path including the user's and `root`'s channels.
+          List of directories to be searched for `<...>` file
+          references. It defaults to the user's and `root`'s channels.
+          It can be overriden using the
+          [`NIX_PATH`](@docroot@/command-ref/env-common.md#env-NIX_PATH)
+          environment variable and extended using the `-I` option. It
+          is ignored if [pure evaluation](#conf-pure-eval) or
+          [restricted evaluation](#conf-restrict-eval) is enabled.
         )"};
 
     Setting<bool> restrictEval{
         this, false, "restrict-eval",
         R"(
-          If set to `true`, the Nix evaluator will not allow access to any
-          files outside of the Nix search path (as set via the `NIX_PATH`
-          environment variable or the `-I` option), or to URIs outside of
-          `allowed-uri`. The default is `false`.
+          If set to `true`, the Nix evaluator will not allow access to
+          any files outside of the paths specified by the `NIX_PATH`
+          environment variable or the `-I` option, or to URIs outside
+          of `allowed-uri`. The default is `false`.
         )"};
 
     Setting<bool> pureEval{this, false, "pure-eval",

--- a/tests/nix_path.sh
+++ b/tests/nix_path.sh
@@ -16,4 +16,34 @@ nix-instantiate --eval -E '<by-relative-path/simple.nix>' --restrict-eval
 unset NIX_PATH
 
 [[ $(nix-instantiate --option nix-path by-relative-path=. --find-file by-relative-path/simple.nix) = "$PWD/simple.nix" ]]
-[[ $(NIX_PATH= nix-instantiate --option nix-path by-relative-path=. --find-file by-relative-path/simple.nix) = "$PWD/simple.nix" ]]
+(! NIX_PATH= nix-instantiate --option nix-path by-relative-path=. --find-file by-relative-path/simple.nix)
+
+mkdir -p $TEST_ROOT/{a,b,c,d}
+touch $TEST_ROOT/{a,b,c,d}/bar.nix
+touch $TEST_ROOT/c/xyzzy.nix
+
+echo "nix-path = foo=$TEST_ROOT/a" >> $NIX_CONF_DIR/nix.conf
+
+# Use nix.conf.
+[[ $(nix-instantiate --find-file foo/bar.nix) = $TEST_ROOT/a/bar.nix ]]
+
+# NIX_PATH overrides nix.conf.
+[[ $(NIX_PATH=foo=$TEST_ROOT/b nix-instantiate --find-file foo/bar.nix) = $TEST_ROOT/b/bar.nix ]]
+
+# -I extends NIX_PATH.
+[[ $(NIX_PATH=foo=$TEST_ROOT/b nix-instantiate -I foo=$TEST_ROOT/d --find-file foo/bar.nix) = $TEST_ROOT/d/bar.nix ]]
+[[ $(NIX_PATH=$TEST_ROOT nix-instantiate -I foo=$TEST_ROOT/d --find-file b/bar.nix) = $TEST_ROOT/b/bar.nix ]]
+
+# NIX_PATH overrides --extra-nix-path.
+[[ $(NIX_PATH=$TEST_ROOT nix-instantiate --extra-nix-path foo=$TEST_ROOT/c --find-file b/bar.nix) = $TEST_ROOT/b/bar.nix ]]
+
+# --nix-path overrides nix.conf.
+[[ $(nix-instantiate --nix-path foo=$TEST_ROOT/c --find-file foo/bar.nix) = $TEST_ROOT/c/bar.nix ]]
+
+# --extra-nix-path extends nix.conf.
+[[ $(nix-instantiate --extra-nix-path foo=$TEST_ROOT/c --find-file foo/bar.nix) = $TEST_ROOT/a/bar.nix ]]
+[[ $(nix-instantiate --extra-nix-path foo=$TEST_ROOT/c --find-file foo/xyzzy.nix) = $TEST_ROOT/c/xyzzy.nix ]]
+
+# -I overrides --nix-path.
+[[ $(nix-instantiate --nix-path foo=$TEST_ROOT/c -I foo=$TEST_ROOT/d --find-file foo/bar.nix) = $TEST_ROOT/d/bar.nix ]]
+[[ $(nix-instantiate --nix-path $TEST_ROOT -I foo=$TEST_ROOT/d --find-file c/bar.nix) = $TEST_ROOT/c/bar.nix ]]


### PR DESCRIPTION
# Motivation

This restores the Nix <= 2.13 behaviour. Environment variables (which are dynamic) should take precedence over configuration file settings (which are static).

- Fixes #7857.
- Fixes #8902 (duplicate?)
- Fixes #8784

Note however that it does make `NIX_PATH` take precedence over the `--nix-path` and `--extra-nix-path` command line options, due to the way settings are implemented.  There really is no correct behaviour here, e.g. should `--extra-nix-path` override `NIX_PATH` or the configuration file? If `--extra-nix-path` is used in restricted eval mode, should it extend the default value (which includes the channels)?

Bottom line: it's best to stop using restricted eval and/or `NIX_PATH`.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
