### PR TITLE
non-function type error, with argument details.

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1666,7 +1666,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
         }
 
         else {
-            auto hf = buildFnTypeError(vCur, nrArgs, args); 
+            auto hf = buildFnTypeHint(vCur, nrArgs, args);
             error_hf(hf).atPos(pos).debugThrow<TypeError>();
         }
     }
@@ -1675,7 +1675,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
 }
 
 // return a unique ptr to avoid putting a hintformat on the stack.
-std::unique_ptr<hintformat> EvalState::buildFnTypeError(const Value & v, size_t nrArgs, Value * * args)
+std::unique_ptr<hintformat> EvalState::buildFnTypeHint(const Value & v, size_t nrArgs, Value * * args)
 {
     std::ostringstream hintstr;
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -184,6 +184,34 @@ void Value::print(const SymbolTable & symbols, std::ostream & str, bool showRepe
     print(symbols, str, showRepeated ? nullptr : &seen);
 }
 
+void Value::printCompact(const SymbolTable &symbols, std::ostream & str) const
+{
+    // avoid printing potentially large values, like sets or lists.
+    switch (type()) {
+        case nThunk:
+        case nInt:
+        case nFloat:
+        case nBool:
+        case nString:
+        case nPath:
+        case nNull:
+        case nFunction:
+            print(symbols, str);
+            break;
+        case nAttrs:
+            str << "<set>";
+            break;
+        case nList:
+            str << "<list>";
+            break;
+        case nExternal:
+            str << "<external>";
+            break;
+        default:
+            abort();
+    }
+}
+
 // Pretty print types for assertion errors
 std::ostream & operator << (std::ostream & os, const ValueType t) {
     os << showType(t);
@@ -1637,11 +1665,37 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
             args++;
         }
 
-        else
-            error("attempt to call something which is not a function but %1%", showType(vCur)).atPos(pos).debugThrow<TypeError>();
+        else {
+            error_hf(buildFnTypeError(vCur, nrArgs, args)).atPos(pos).debugThrow<TypeError>();
+        }
     }
 
     vRes = vCur;
+}
+
+hintformat  EvalState::buildFnTypeError(const Value & v, size_t nrArgs, Value * * args)
+{
+    std::ostringstream hintstr;
+
+    hintstr << "attempt to call something which is not a function but %1%: %2%" << std::endl;
+    hintstr << "function arguments:";
+    for (size_t i = 0; i < nrArgs; ++i) {
+        hintstr << std::endl << "%" << i*2 + 3 << "%: %" << i*2 + 1 + 3 << "%";
+    }
+
+    auto hf = hintformat(hintstr.str().c_str());
+
+    std::ostringstream ps;
+    v.printCompact(symbols, ps);
+    hf % showType(v) % ps.str();
+
+    for (size_t i = 0; i < nrArgs; ++i) {
+        std::ostringstream ps;
+        args[i]->printCompact(symbols, ps);
+        hf % showType(*(args[i])) % ps.str().c_str();
+    }
+
+    return hf;
 }
 
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -103,6 +103,12 @@ class ErrorBuilder
         }
 
         [[nodiscard, gnu::noinline]]
+        static ErrorBuilder * create_hf(EvalState & s, hintformat hf)
+        {
+            return new ErrorBuilder(s, ErrorInfo { .msg = hf });
+        }
+
+        [[nodiscard, gnu::noinline]]
         ErrorBuilder & atPos(PosIdx pos);
 
         [[nodiscard, gnu::noinline]]
@@ -215,8 +221,15 @@ public:
         return *errorBuilder;
     }
 
+    [[nodiscard, gnu::noinline]]
+    ErrorBuilder & error_hf(hintformat hf) {
+        errorBuilder = ErrorBuilder::create_hf(*this, hf);
+        return *errorBuilder;
+    }
+
 private:
     SrcToStore srcToStore;
+    hintformat buildFnTypeError(const Value & v, size_t nrArgs, Value * * args);
 
     /* A cache from path names to parse trees. */
 #if HAVE_BOEHMGC

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -229,7 +229,7 @@ public:
 
 private:
     SrcToStore srcToStore;
-    std::unique_ptr<hintformat> buildFnTypeError(const Value & v, size_t nrArgs, Value * * args);
+    std::unique_ptr<hintformat> buildFnTypeHint(const Value & v, size_t nrArgs, Value * * args);
 
     /* A cache from path names to parse trees. */
 #if HAVE_BOEHMGC

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -103,9 +103,9 @@ class ErrorBuilder
         }
 
         [[nodiscard, gnu::noinline]]
-        static ErrorBuilder * create_hf(EvalState & s, hintformat hf)
+        static ErrorBuilder * create_hf(EvalState & s, std::unique_ptr<hintformat> &hf)
         {
-            return new ErrorBuilder(s, ErrorInfo { .msg = hf });
+            return new ErrorBuilder(s, ErrorInfo { .msg = *hf });
         }
 
         [[nodiscard, gnu::noinline]]
@@ -222,14 +222,14 @@ public:
     }
 
     [[nodiscard, gnu::noinline]]
-    ErrorBuilder & error_hf(hintformat hf) {
+    ErrorBuilder & error_hf(std::unique_ptr<hintformat> &hf) {
         errorBuilder = ErrorBuilder::create_hf(*this, hf);
         return *errorBuilder;
     }
 
 private:
     SrcToStore srcToStore;
-    hintformat buildFnTypeError(const Value & v, size_t nrArgs, Value * * args);
+    std::unique_ptr<hintformat> buildFnTypeError(const Value & v, size_t nrArgs, Value * * args);
 
     /* A cache from path names to parse trees. */
 #if HAVE_BOEHMGC

--- a/src/libexpr/tests/error_traces.cc
+++ b/src/libexpr/tests/error_traces.cc
@@ -750,7 +750,10 @@ namespace nix {
 
         ASSERT_TRACE1("foldl' (_: 1) \"foo\" [ true ]",
                       TypeError,
-                      hintfmt("attempt to call something which is not a function but %s", "an integer"));
+                      hintfmt("attempt to call something which is not a function but %s: %s\n"
+                             "function arguments:\n"
+                             "%s: %s", "an integer", "1", "a Boolean", "true"));
+
 
         ASSERT_TRACE2("foldl' (a: b: a && b) \"foo\" [ true ]",
                       TypeError,
@@ -835,7 +838,9 @@ namespace nix {
 
         ASSERT_TRACE1("sort (_: 1) [ \"foo\" \"bar\" ]",
                       TypeError,
-                      hintfmt("attempt to call something which is not a function but %s", "an integer"));
+                      hintfmt("attempt to call something which is not a function but %s: %s\n"
+                             "function arguments:\n"
+                             "%s: %s", "an integer", "1", "a string", "\"foo\""));
 
         ASSERT_TRACE2("sort (_: _: 1) [ \"foo\" \"bar\" ]",
                       TypeError,

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -125,6 +125,7 @@ private:
 public:
 
     void print(const SymbolTable & symbols, std::ostream & str, bool showRepeated = false) const;
+    void printCompact(const SymbolTable &symbols, std::ostream & str) const;
 
     // Functions needed to distinguish the type
     // These should be removed eventually, by putting the functionality that's


### PR DESCRIPTION
# Motivation
Add some extra context when someone mistakenly uses something that isn't a function where a function should be.

# Context
Issue #7405 provides an example where part of the nix expression is evaluated and assumed to be a function, since arguments follow.  In this case, which part of the expression evaluates to the function is arguably unclear to the user.

Current error:
```
nix-repl> {a = 3;}.a or throw "what"  
error: attempt to call something which is not a function but an integer

       at «string»:1:1:

            1| {a = 3;}.a or throw "what"
             | ^
```

Error with extra context:
```
nix-repl> {a = 3;}.a or throw "what"
error: attempt to call something which is not a function but an integer: 3
       function arguments:
       a string: "what"

       at «string»:1:1:

            1| {a = 3;}.a or throw "what"
             | ^
```

To hopefully make cases like this more clear, I print the type and value of the non-function, followed by the type and value of its arguments.  Because printing sets and lists can result in enormous walls of text, I only print the expr types for sets and lists.

```
nix-repl> np = import <nixos-22.11> {}

nix-repl> np
{ AAAAAASomeThingsFailToEvaluate = «error: error:
       … while calling the 'throw' builtin

         at /nix/store/ ^Cerror: interrupted by the user
«derivation
nix-repl> {a = 3;}.a or throw "what" 12 21 34 np
error: attempt to call something which is not a function but an integer: 3
       function arguments:
       a string: "what"
       an integer: 12
       an integer: 21
       an integer: 34
       a set: <set>

       at «string»:1:1:

            1| {a = 3;}.a or throw "what" 12 21 34 np
             | ^
```

# Implementation notes

Because I wanted to make an error message with a dynamic number of arguments, I needed to create a new constructor for ErrorBuilder that takes a hintformat.  Then I added a function to create this hintformat.  Since allocating hintformats on the stack is discouraged, the build function and etc use a unique_ptr<hintformat>.  

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
