### PR TITLE
Fix the build without GC

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -49,9 +49,9 @@ extern "C" {
 namespace nix {
 
 struct NixRepl
-    : AbstractNixRepl,
+    : AbstractNixRepl
     #if HAVE_BOEHMGC
-    gc
+    , gc
     #endif
 {
     std::string curDir;


### PR DESCRIPTION
# Motivation

I had given it an improper trailing comma in
1bd03ad100e8813751b6c08b0c21ae8cf5a9c21d.

# Context

1bd03ad100e8813751b6c08b0c21ae8cf5a9c21d is from https://github.com/NixOS/nix/pull/7748

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
