### PR TITLE
Fix `isStatic` arguments to `commonDeps`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,11 @@
           cross = forAllCrossSystems (crossSystem: make-pkgs crossSystem "stdenv");
         });
 
-      commonDeps = { pkgs, isStatic ? false }: with pkgs; rec {
+      commonDeps =
+        { pkgs
+        , isStatic ? pkgs.stdenv.hostPlatform.isStatic
+        }:
+        with pkgs; rec {
         # Use "busybox-sandbox-shell" if present,
         # if not (legacy) fallback and hope it's sufficient.
         sh = pkgs.busybox-sandbox-shell or (busybox.override {
@@ -293,7 +297,13 @@
           # Forward from the previous stage as we don’t want it to pick the lowdown override
           nixUnstable = prev.nixUnstable;
 
-          nix = with final; with commonDeps { inherit pkgs; }; let
+          nix =
+          with final;
+          with commonDeps {
+            inherit pkgs;
+            inherit (currentStdenv.hostPlatform) isStatic;
+          };
+          let
             canRunInstalled = currentStdenv.buildPlatform.canExecute currentStdenv.hostPlatform;
           in currentStdenv.mkDerivation {
             name = "nix-${version}";


### PR DESCRIPTION
# Motivation

Some dependencies supposed to be skipped in the cross build, along with not using the gold linker. But in https://github.com/NixOS/nix/pull/6538 this was accidentally not preserved.

# Context

Also since https://github.com/NixOS/nix/pull/6538 we saw some new aarch64-linux static build failures. This is a first attempt to try to fix those failures. If this is not sufficient, there are other things we can try next.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
