### PR TITLE
Print the store paths to be fetched sorted by StorePath name()

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -84,8 +84,18 @@ void printMissing(ref<Store> store, const StorePathSet & willBuild,
                 downloadSizeMiB,
                 narSizeMiB);
         }
-        for (auto & i : willSubstitute)
-            printMsg(lvl, "  %s", store->printStorePath(i));
+        std::vector<const StorePath *> willSubstituteSorted = {};
+        std::for_each(willSubstitute.begin(), willSubstitute.end(),
+                   [&](const StorePath &p) { willSubstituteSorted.push_back(&p); });
+        std::sort(willSubstituteSorted.begin(), willSubstituteSorted.end(),
+                  [](const StorePath *lhs, const StorePath *rhs) {
+                    if (lhs->name() == rhs->name())
+                      return lhs->to_string() < rhs->to_string();
+                    else
+                      return lhs->name() < rhs->name();
+                  });
+        for (auto p : willSubstituteSorted)
+            printMsg(lvl, "  %s", store->printStorePath(*p));
     }
 
     if (!unknown.empty()) {


### PR DESCRIPTION
**Print the store paths to be fetched sorted by StorePath name(), rather than by store path baseName.**

Presently when nix says something like:

```
these 486 paths will be fetched (511.54 MiB download, 6458.64 MiB unpacked):
 ...path1
 ...path2
 ...path3
    ...
    ...
 ...path486
```

It sorts path1, path2, path3, ..., path486 in lexicographic order of the store path.

After this commit, nix will show path1, path2, path3, ..., path486 sorted by StorePath name() (basically everything after the hash) rather than the store path.

This makes it easier to review what exactly is being downloaded at a glance, especially when many paths need to be fetched.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This makes it easier to review what exactly is being downloaded at a glance, especially when many paths need to be fetched. See an example of `nix-env -iA nixpkgs.firefox --dry-run` with the PR and without the PR below. (Click to uncollapse)

<details>
<summary>Without PR: nix-env -iA nixpkgs.firefox --dry-run</summary>

```
$ nix-env -iA nixpkgs.firefox --dry-run
(dry run; not doing anything)
installing 'firefox-110.0'
these 135 paths will be fetched (151.75 MiB download, 649.04 MiB unpacked):
  /nix/store/09sblvrc2xgl8ylbpjqvn9q410vazw3k-perl5.36.0-Test-Needs-0.002006
  /nix/store/0fq5vrcm20v4yrkx6apvfziwxj8znsfi-audiofile-0.3.6
  /nix/store/0g7006grqrr1xikp5v3hb8c7rj3iv6b0-vulkan-loader-1.3.236.0
  /nix/store/0iqrjjymjap94i4m2iqzwmd8wm253nw1-sndio-1.9.0
  /nix/store/0myq8g1avprhqcv6026ia49k6yjicfq1-libjack2-1.9.19
  /nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9
  /nix/store/0pzxh4laqmk9as01qxmvaih8brlb8wa1-libdrm-2.4.114
  /nix/store/0s8195j1a7zvbncxfm9sl85yyqz2q8h1-ell-0.55
  /nix/store/0sc99l0b2rpgpjvzyj6qnwsslvzlmpzi-libusb-1.0.26
  /nix/store/1041xfcc245cmgyh3rc0adk517hgx1y1-perl5.36.0-HTML-Parser-3.75
  /nix/store/1997m851rwdz9fywy4y6wa8k7hx4glwz-xdg-utils-unstable-2020-10-21
  /nix/store/1gvgnkpflx4i3np8qnw8n0vpipd7xbl2-firefox-110.0
  /nix/store/1i6la7w4qrjv25wbfqaplhf0ajjwpy58-lttng-ust-2.13.1-bin
  /nix/store/1jw1sj2pc1nr8fdldqvz06gqzdha0119-libXt-1.2.1
  /nix/store/293fi4620wpb81wbh087q91glr977n4r-liburcu-0.13.2
  /nix/store/2lpr2sl6d4lnryldlzwlk2if0ixf7wc4-bluez-5.66
  /nix/store/2y9lsfj3wiqy2am0hrb7akmkpkkb5ql0-x264-unstable-2021-06-13-lib
  /nix/store/2zxqsy84y680khkgn24hd0dafab322jp-gdbm-1.23
  /nix/store/31zbp3ksqyg95cx0a2fvqs2knh50g0v7-libcamera-0.0.3-dev
  /nix/store/32h1jzj2q8b2nq3i3jby65r1bm0m3vv7-hicolor-icon-theme-0.17
  /nix/store/33jql4szczyq8hi9jhql2ilbdg77rh10-perl5.36.0-HTTP-Date-6.05
  /nix/store/37adbzg1l3v65ic48j4j0mw6jzpcj15m-perl5.36.0-HTTP-Message-6.26
  /nix/store/3wsw140f76nkbpc1rnvvfgijh2hrf56i-perl5.36.0-URI-5.05
  /nix/store/4jdg6nbl0ay9ic3a7l2xqizskkrc5a9x-lttng-ust-2.13.1-dev
  /nix/store/4jyyqz0gjfyhkyw8i6q475z3j0cj0n4b-libva-2.17.0
  /nix/store/57c159m5jlg2vr5573g85wlimdx6w4mq-libvdpau-1.5
  /nix/store/58184kign5p3w4wa3iznp119iszi7nrk-perl5.36.0-XML-Parser-2.46
  /nix/store/5aq0a97hgdvl6cqnza9q43gxp244qsnp-ffmpeg-5.1.2-data
  /nix/store/5lkk4nyv9arnf2v8fdra8s469dsj1qvj-nspr-4.35
  /nix/store/5lz7i132mm9rnplj7a3f8lixs0b3m3hn-libmad-0.15.1b
  /nix/store/5wfhdq1vfqr2x555avixghvs8xw0h5bc-libyaml-0.2.5
  /nix/store/64vxypm9r1knwwrwxwpjmqn2shavkb6g-soxr-0.1.3
  /nix/store/66fr4mlfnwym5dw4bx61xs7nb81q58cb-tzdata-2022g
  /nix/store/69hpdw7in39k73kylxk5zypwg2rilmm8-libvpx-1.12.0
  /nix/store/6qxbigdal8rz48fkf3ypzps40kdij6x1-perl5.36.0-XML-Twig-3.52
  /nix/store/7188m7gkw9n4s83jlr1xa5wwbzzrhk8m-perl5.36.0-Net-DBus-1.2.0
  /nix/store/71li30681f5nhnjivzdy83jcay6wgliy-libdecor-0.1.0
  /nix/store/73qj3fn90cad0w7s8gpzn7igbrarvhzi-perl5.36.0-libwww-perl-6.67
  /nix/store/80gw6nm2r6vp1nrn2q51wfb1wcqljybc-perl5.36.0-IO-HTML-1.004
  /nix/store/827yilxvr64r0riq66z10ll4cxggzazr-ffmpeg-headless-4.4.3-data
  /nix/store/8kg1x5vy7wznvda35ssfad40m00w4696-perl5.36.0-Try-Tiny-0.30
  /nix/store/8llbiqm9ymqwdwgrhgm4kcm6wcs0vj29-libcap-2.66-dev
  /nix/store/965zs30i76zry6c6mkacwpmnicqhg9dd-pciutils-3.9.0
  /nix/store/9bq9lxz8rsa0ldpjpx9xs72qrcsijv31-roc-toolkit-0.2.1
  /nix/store/9gis7ibjx73v4wyxxcv16y7kc1wqmsn2-perl5.36.0-X11-Protocol-0.56
  /nix/store/9lk3xp5yjdn57rsq1r6w78ymsg634ar7-libical-3.0.16
  /nix/store/9xnlsb21nfzmkxcjxyhrkjrsq1w29zm0-liblc3-1.0.1
  /nix/store/akjbh77nqqd8l5374qiwszwhibrpg3r4-webrtc-audio-processing-0.3.1
  /nix/store/awx1yg9xs52lydvazsk5g5bvj7vbrh79-speexdsp-1.2.1-dev
  /nix/store/b0g03j9nvf4h2k1pslwxcm2mhbxw006i-sox-unstable-2021-05-09-dev
  /nix/store/b1hqharsbisqd76bm52bq181ix125hw8-srt-1.5.1
  /nix/store/bb5jbir899233wirbcjzxmmq2lih4v0z-perl5.36.0-HTTP-Negotiate-6.01
  /nix/store/bja5fzkjjn26zz742pgkvpm5dq3girv9-perl-5.36.0
  /nix/store/bmw2mik71njf9js2n784q9h9sqc4a13k-opusfile-0.12
  /nix/store/bs3zknv6g0f5s1wsaszhhliwbjys73kd-libfreeaptx-0.1.1
  /nix/store/bv8ib3qn383623rsprcrl64h9gmlrsmy-giflib-5.2.1
  /nix/store/c9zm0jddii56xdx4ssc5vww9kb1549sp-librsvg-2.55.1
  /nix/store/cj6im0ywb4rrywvbhny962kjhxa1r6d2-openfec-1.4.2
  /nix/store/cyvy0d4d6yy8bih4agva5n1yxpagsks4-perl5.36.0-HTTP-Daemon-6.14
  /nix/store/d34h9cm86mhhbayysd6aqrkg7qzvw156-perl5.36.0-File-MimeInfo-0.30
  /nix/store/dff539vggl6dyj5vssn77r5z5ac9c78z-firefox-unwrapped-110.0
  /nix/store/dvpvmvz1ny83x1wmbnp21dkb9rmh8nk8-perl5.36.0-File-DesktopEntry-0.22
  /nix/store/dzh859kyljyvl5bclp9pp0pbgcyhabz4-ffmpeg-headless-4.4.3-lib
  /nix/store/f81zvfglqqv566cw66cx02h43b0vf9mc-libpulseaudio-16.1
  /nix/store/fjpgngh6ahsal2rw3yi0ys9jw1v0aji5-nss-3.88.1
  /nix/store/fqcy8f9y1s3kwivwl6mv973fq7qcxzfa-xorgproto-2021.5
  /nix/store/fx7z3j5w40wwhdpbrwdk6dcd532d4lwv-openfec-1.4.2-dev
  /nix/store/fyqqs8srwix3qag46kn6h2di17xm8znw-perl5.36.0-Test-RequiresInternet-0.05
  /nix/store/gk19a7xkw35hnvrcm1ia0nib8dw2xbsw-perl5.36.0-IPC-System-Simple-1.30
  /nix/store/glykwqjgixglzmq162biqsn3al5hwvv7-x265-3.5
  /nix/store/grailgsqqkhp5a0b8f92l6l6khxaf5vf-libpulseaudio-16.1-dev
  /nix/store/gv2s0vlmrvgm150k6qdzm7zqi2ncq471-xset-1.2.5
  /nix/store/hgkalwffjmm1ijlwwaycnaln2k1mp1r9-pipewire-0.3.65-lib
  /nix/store/hwy15idfyq31j0y1f7iga0rbcr6d1hfy-libcanberra-0.30
  /nix/store/ih35ndii8g86q4hlr2f1ma0z14ga4d0r-mailcap-2.1.53
  /nix/store/j15xicpm19r2li89m08rvq8cxdkarl0j-wavpack-5.5.0
  /nix/store/j5iwlxb4768b3x8i570v52lln75zgavq-perl5.36.0-File-BaseDir-0.08
  /nix/store/j9m6z9lgzsx63j0cjipl97nznacxjla5-fdk-aac-2.0.2
  /nix/store/jha800mczpggly0svnhc8pj7f3yzxc9i-serd-0.30.10
  /nix/store/jy6vqmfkc43slmsd5aq8i38mryqkncpp-libcanberra-0.30
  /nix/store/kg3jg9n0cvjkjwp55qvm2yaxib89k476-flac-1.4.2
  /nix/store/kqzlfxnfx7p9f5wb7fz708514mxjlf9j-openssl-3.0.8
  /nix/store/kr5b6js7k6fm5156k149dpf3a6ibkq04-libsndfile-1.1.0
  /nix/store/kr8d5nx21y9ldacps828amy20gh3f9x3-ldacBT-2.0.2.3
  /nix/store/kx3bjyykf6yd2dl70yr5lcl7a8hrfwdj-attr-2.5.1-bin
  /nix/store/l6wm71iw54clyf31i9qf8x970xav68j5-numactl-2.0.16
  /nix/store/lm7g3czjm9zx579dz8gidvflrb6bhcyi-libva-minimal-2.17.0
  /nix/store/lsvcdxwxhzq9ylk7ylbxpwm44b0jvkn9-sox-unstable-2021-05-09
  /nix/store/m2j47r4by9x7nik47mzllb43qb56jw9x-perl5.36.0-Net-HTTP-6.19
  /nix/store/m6gg8an7wyaqjx1i0zdbc93g21l0xr87-dbus-glib-0.112
  /nix/store/mb04nd317sqkqfxdjq7x9p7mqm235a4l-libao-1.2.2
  /nix/store/mf52h4xxzi2z10zixlzx1hq3qw1idj7f-glib-2.74.3-bin
  /nix/store/n30qg6z729arjlwdz3fdrsyr1ygdnhxw-attr-2.5.1-dev
  /nix/store/ngmhaja4zvbjgd44z0irqqpcgzdxvzvb-mesa-22.3.4
  /nix/store/nljvcd1idzg4fzih8mj2shz33xlbki5b-lilv-0.24.12
  /nix/store/ny2pfzr4v03nndrv01s58rp795rpj0z3-sord-0.16.14
  /nix/store/p2hfdk33lvq6szdznqjb1s0jascnfpki-libuv-1.44.2
  /nix/store/phs35msc79571m6hmmmqmnfziwg8kzaa-sratom-0.6.8
  /nix/store/pvbh2viylbsxh3pl9zfqr7c1f4507s4p-adwaita-icon-theme-43
  /nix/store/pww1xn7s4fjkbr4i0b4h3zmxrsymqhxl-libtool-2.4.7-lib
  /nix/store/pxz8kghf4vlsslxln541d5qa0y7ib0jp-fftw-single-3.3.10
  /nix/store/qcliqiyzbbxf1varncnb5sx9dynrc4mc-libXmu-1.1.3
  /nix/store/r0gm2klqasrffjzr94g9wkbd6hgjasjy-perl5.36.0-LWP-MediaTypes-6.04
  /nix/store/r2riwc23270ffx1g5yzpxfky0wlgb1zy-sox-unstable-2021-05-09-lib
  /nix/store/r704x4zmclbn779zm5fzzrfjcck5sr7j-dav1d-1.0.0
  /nix/store/rf83g2mw8n9qj7rjj1ldwb2p1pvanwzj-perl5.36.0-HTML-Tagset-3.20
  /nix/store/rg6vbpdk9h4vz810xq44ym1ad7vaasfc-speexdsp-1.2.1
  /nix/store/rvcwh7255pja22bsiks4ia06afgdkp2z-gfortran-12.2.0-lib
  /nix/store/rwjzr91hxn81agasym5f2i4yrb1d08r8-file-5.44
  /nix/store/ryqk1zm0ril6dwr2lmhyz16cva33id74-libwebp-1.3.0
  /nix/store/s6cap4wadfb2qgdc71h8yjx72i82y85d-libcamera-0.0.3
  /nix/store/scankdpz0j7rff165bgbgyqn4g83gw2a-xz-5.4.1-dev
  /nix/store/sqi2h406d39kbrifp21fdp4y37gb41l8-libXScrnSaver-1.2.3
  /nix/store/v6jhlqw0p2ay99iizs8gm0jnpg4qz948-wayland-protocols-1.31
  /nix/store/v75533bfzsa95v34f2d15gqh10l55kfc-libass-0.16.0
  /nix/store/vc1y73k223mhgqcr639q36rzfqrj49da-lame-3.100-lib
  /nix/store/w2w42m87w2kixsckgmsg9xkdwjbx0vd5-sbc-1.4
  /nix/store/wbr0xq4qvk1jadd7viqdpp4p4n2bjqhi-perl5.36.0-File-Listing-6.14
  /nix/store/wz51vf82xyds4a26qfb22hlwhwym1z0h-perl5.36.0-Encode-Locale-1.05
  /nix/store/x02c2jm557kagv2ivf5fh4y2skay6kh5-libnotify-0.8.1
  /nix/store/x43s8y7518l8k9kjl7qs2wyx0cyqhdis-perl5.36.0-WWW-RobotRules-6.02
  /nix/store/xbp4a9sfgsx5h58hjz8x2khlb1wraaxx-lttng-ust-2.13.1
  /nix/store/xc5dj3zjqcqyjj3kznwb0wy9g6p4fgb7-libpciaccess-0.16
  /nix/store/xcx4636x02avijwsr34m0ickrzw2rx5j-libcap-2.66
  /nix/store/xrns2hkbp3cjayfx2qg93b7rf164vh9k-zimg-3.0.4
  /nix/store/y7ywcxkckgm9ngkb89gazb719p3w2x7m-perl5.36.0-HTTP-Cookies-6.09
  /nix/store/ycplmx4iis648r0zaw8xdvrk48f4h4ff-libssh-0.10.4
  /nix/store/yfc1fza4h6g5sjvash75qdff1jqsf20w-speex-1.2.1
  /nix/store/yzmqlgb9kl10fh7jpka03ddgkg723qvx-libunwind-1.6.2-dev
  /nix/store/z1jmp9w1rp2rsr5g6fwm6gzs940xdxib-ffmpeg-5.1.2-lib
  /nix/store/zd50nb5a4y0hbmibdq8ndf77kvd7zjzy-perl5.36.0-Test-Fatal-0.016
  /nix/store/zkcpm0p0cyxl30b7k7bc2cq380zjyri3-SDL2-2.24.2
  /nix/store/zmfdjk5v6crf7hx5b8rxmxrwps135n3n-celt-0.11.3
  /nix/store/zmn31wagw80dhvbwx74f8mnjmns2i2zf-xvidcore-1.3.7
  /nix/store/zy9swy7w7w1k386smnwsqbmxg8d9cijm-perl5.36.0-TimeDate-2.33
```

</details>

<details>
<summary>With PR: nix-env -iA nixpkgs.firefox --dry-run</summary>

```
nix-env -iA nixpkgs.firefox --dry-run
(dry run; not doing anything)
installing 'firefox-110.0'
these 135 paths will be fetched (151.75 MiB download, 649.04 MiB unpacked):
  /nix/store/zkcpm0p0cyxl30b7k7bc2cq380zjyri3-SDL2-2.24.2
  /nix/store/pvbh2viylbsxh3pl9zfqr7c1f4507s4p-adwaita-icon-theme-43
  /nix/store/kx3bjyykf6yd2dl70yr5lcl7a8hrfwdj-attr-2.5.1-bin
  /nix/store/n30qg6z729arjlwdz3fdrsyr1ygdnhxw-attr-2.5.1-dev
  /nix/store/0fq5vrcm20v4yrkx6apvfziwxj8znsfi-audiofile-0.3.6
  /nix/store/2lpr2sl6d4lnryldlzwlk2if0ixf7wc4-bluez-5.66
  /nix/store/zmfdjk5v6crf7hx5b8rxmxrwps135n3n-celt-0.11.3
  /nix/store/r704x4zmclbn779zm5fzzrfjcck5sr7j-dav1d-1.0.0
  /nix/store/m6gg8an7wyaqjx1i0zdbc93g21l0xr87-dbus-glib-0.112
  /nix/store/0s8195j1a7zvbncxfm9sl85yyqz2q8h1-ell-0.55
  /nix/store/j9m6z9lgzsx63j0cjipl97nznacxjla5-fdk-aac-2.0.2
  /nix/store/5aq0a97hgdvl6cqnza9q43gxp244qsnp-ffmpeg-5.1.2-data
  /nix/store/z1jmp9w1rp2rsr5g6fwm6gzs940xdxib-ffmpeg-5.1.2-lib
  /nix/store/827yilxvr64r0riq66z10ll4cxggzazr-ffmpeg-headless-4.4.3-data
  /nix/store/dzh859kyljyvl5bclp9pp0pbgcyhabz4-ffmpeg-headless-4.4.3-lib
  /nix/store/pxz8kghf4vlsslxln541d5qa0y7ib0jp-fftw-single-3.3.10
  /nix/store/rwjzr91hxn81agasym5f2i4yrb1d08r8-file-5.44
  /nix/store/1gvgnkpflx4i3np8qnw8n0vpipd7xbl2-firefox-110.0
  /nix/store/dff539vggl6dyj5vssn77r5z5ac9c78z-firefox-unwrapped-110.0
  /nix/store/kg3jg9n0cvjkjwp55qvm2yaxib89k476-flac-1.4.2
  /nix/store/2zxqsy84y680khkgn24hd0dafab322jp-gdbm-1.23
  /nix/store/rvcwh7255pja22bsiks4ia06afgdkp2z-gfortran-12.2.0-lib
  /nix/store/bv8ib3qn383623rsprcrl64h9gmlrsmy-giflib-5.2.1
  /nix/store/mf52h4xxzi2z10zixlzx1hq3qw1idj7f-glib-2.74.3-bin
  /nix/store/32h1jzj2q8b2nq3i3jby65r1bm0m3vv7-hicolor-icon-theme-0.17
  /nix/store/vc1y73k223mhgqcr639q36rzfqrj49da-lame-3.100-lib
  /nix/store/kr8d5nx21y9ldacps828amy20gh3f9x3-ldacBT-2.0.2.3
  /nix/store/sqi2h406d39kbrifp21fdp4y37gb41l8-libXScrnSaver-1.2.3
  /nix/store/qcliqiyzbbxf1varncnb5sx9dynrc4mc-libXmu-1.1.3
  /nix/store/1jw1sj2pc1nr8fdldqvz06gqzdha0119-libXt-1.2.1
  /nix/store/mb04nd317sqkqfxdjq7x9p7mqm235a4l-libao-1.2.2
  /nix/store/v75533bfzsa95v34f2d15gqh10l55kfc-libass-0.16.0
  /nix/store/s6cap4wadfb2qgdc71h8yjx72i82y85d-libcamera-0.0.3
  /nix/store/31zbp3ksqyg95cx0a2fvqs2knh50g0v7-libcamera-0.0.3-dev
  /nix/store/hwy15idfyq31j0y1f7iga0rbcr6d1hfy-libcanberra-0.30
  /nix/store/jy6vqmfkc43slmsd5aq8i38mryqkncpp-libcanberra-0.30
  /nix/store/xcx4636x02avijwsr34m0ickrzw2rx5j-libcap-2.66
  /nix/store/8llbiqm9ymqwdwgrhgm4kcm6wcs0vj29-libcap-2.66-dev
  /nix/store/71li30681f5nhnjivzdy83jcay6wgliy-libdecor-0.1.0
  /nix/store/0pzxh4laqmk9as01qxmvaih8brlb8wa1-libdrm-2.4.114
  /nix/store/bs3zknv6g0f5s1wsaszhhliwbjys73kd-libfreeaptx-0.1.1
  /nix/store/9lk3xp5yjdn57rsq1r6w78ymsg634ar7-libical-3.0.16
  /nix/store/0myq8g1avprhqcv6026ia49k6yjicfq1-libjack2-1.9.19
  /nix/store/9xnlsb21nfzmkxcjxyhrkjrsq1w29zm0-liblc3-1.0.1
  /nix/store/5lz7i132mm9rnplj7a3f8lixs0b3m3hn-libmad-0.15.1b
  /nix/store/x02c2jm557kagv2ivf5fh4y2skay6kh5-libnotify-0.8.1
  /nix/store/xc5dj3zjqcqyjj3kznwb0wy9g6p4fgb7-libpciaccess-0.16
  /nix/store/f81zvfglqqv566cw66cx02h43b0vf9mc-libpulseaudio-16.1
  /nix/store/grailgsqqkhp5a0b8f92l6l6khxaf5vf-libpulseaudio-16.1-dev
  /nix/store/c9zm0jddii56xdx4ssc5vww9kb1549sp-librsvg-2.55.1
  /nix/store/kr5b6js7k6fm5156k149dpf3a6ibkq04-libsndfile-1.1.0
  /nix/store/ycplmx4iis648r0zaw8xdvrk48f4h4ff-libssh-0.10.4
  /nix/store/pww1xn7s4fjkbr4i0b4h3zmxrsymqhxl-libtool-2.4.7-lib
  /nix/store/yzmqlgb9kl10fh7jpka03ddgkg723qvx-libunwind-1.6.2-dev
  /nix/store/293fi4620wpb81wbh087q91glr977n4r-liburcu-0.13.2
  /nix/store/0sc99l0b2rpgpjvzyj6qnwsslvzlmpzi-libusb-1.0.26
  /nix/store/p2hfdk33lvq6szdznqjb1s0jascnfpki-libuv-1.44.2
  /nix/store/4jyyqz0gjfyhkyw8i6q475z3j0cj0n4b-libva-2.17.0
  /nix/store/lm7g3czjm9zx579dz8gidvflrb6bhcyi-libva-minimal-2.17.0
  /nix/store/57c159m5jlg2vr5573g85wlimdx6w4mq-libvdpau-1.5
  /nix/store/69hpdw7in39k73kylxk5zypwg2rilmm8-libvpx-1.12.0
  /nix/store/ryqk1zm0ril6dwr2lmhyz16cva33id74-libwebp-1.3.0
  /nix/store/5wfhdq1vfqr2x555avixghvs8xw0h5bc-libyaml-0.2.5
  /nix/store/nljvcd1idzg4fzih8mj2shz33xlbki5b-lilv-0.24.12
  /nix/store/xbp4a9sfgsx5h58hjz8x2khlb1wraaxx-lttng-ust-2.13.1
  /nix/store/1i6la7w4qrjv25wbfqaplhf0ajjwpy58-lttng-ust-2.13.1-bin
  /nix/store/4jdg6nbl0ay9ic3a7l2xqizskkrc5a9x-lttng-ust-2.13.1-dev
  /nix/store/ih35ndii8g86q4hlr2f1ma0z14ga4d0r-mailcap-2.1.53
  /nix/store/ngmhaja4zvbjgd44z0irqqpcgzdxvzvb-mesa-22.3.4
  /nix/store/5lkk4nyv9arnf2v8fdra8s469dsj1qvj-nspr-4.35
  /nix/store/fjpgngh6ahsal2rw3yi0ys9jw1v0aji5-nss-3.88.1
  /nix/store/l6wm71iw54clyf31i9qf8x970xav68j5-numactl-2.0.16
  /nix/store/cj6im0ywb4rrywvbhny962kjhxa1r6d2-openfec-1.4.2
  /nix/store/fx7z3j5w40wwhdpbrwdk6dcd532d4lwv-openfec-1.4.2-dev
  /nix/store/kqzlfxnfx7p9f5wb7fz708514mxjlf9j-openssl-3.0.8
  /nix/store/bmw2mik71njf9js2n784q9h9sqc4a13k-opusfile-0.12
  /nix/store/965zs30i76zry6c6mkacwpmnicqhg9dd-pciutils-3.9.0
  /nix/store/bja5fzkjjn26zz742pgkvpm5dq3girv9-perl-5.36.0
  /nix/store/wz51vf82xyds4a26qfb22hlwhwym1z0h-perl5.36.0-Encode-Locale-1.05
  /nix/store/j5iwlxb4768b3x8i570v52lln75zgavq-perl5.36.0-File-BaseDir-0.08
  /nix/store/dvpvmvz1ny83x1wmbnp21dkb9rmh8nk8-perl5.36.0-File-DesktopEntry-0.22
  /nix/store/wbr0xq4qvk1jadd7viqdpp4p4n2bjqhi-perl5.36.0-File-Listing-6.14
  /nix/store/d34h9cm86mhhbayysd6aqrkg7qzvw156-perl5.36.0-File-MimeInfo-0.30
  /nix/store/1041xfcc245cmgyh3rc0adk517hgx1y1-perl5.36.0-HTML-Parser-3.75
  /nix/store/rf83g2mw8n9qj7rjj1ldwb2p1pvanwzj-perl5.36.0-HTML-Tagset-3.20
  /nix/store/y7ywcxkckgm9ngkb89gazb719p3w2x7m-perl5.36.0-HTTP-Cookies-6.09
  /nix/store/cyvy0d4d6yy8bih4agva5n1yxpagsks4-perl5.36.0-HTTP-Daemon-6.14
  /nix/store/33jql4szczyq8hi9jhql2ilbdg77rh10-perl5.36.0-HTTP-Date-6.05
  /nix/store/37adbzg1l3v65ic48j4j0mw6jzpcj15m-perl5.36.0-HTTP-Message-6.26
  /nix/store/bb5jbir899233wirbcjzxmmq2lih4v0z-perl5.36.0-HTTP-Negotiate-6.01
  /nix/store/80gw6nm2r6vp1nrn2q51wfb1wcqljybc-perl5.36.0-IO-HTML-1.004
  /nix/store/gk19a7xkw35hnvrcm1ia0nib8dw2xbsw-perl5.36.0-IPC-System-Simple-1.30
  /nix/store/r0gm2klqasrffjzr94g9wkbd6hgjasjy-perl5.36.0-LWP-MediaTypes-6.04
  /nix/store/7188m7gkw9n4s83jlr1xa5wwbzzrhk8m-perl5.36.0-Net-DBus-1.2.0
  /nix/store/m2j47r4by9x7nik47mzllb43qb56jw9x-perl5.36.0-Net-HTTP-6.19
  /nix/store/zd50nb5a4y0hbmibdq8ndf77kvd7zjzy-perl5.36.0-Test-Fatal-0.016
  /nix/store/09sblvrc2xgl8ylbpjqvn9q410vazw3k-perl5.36.0-Test-Needs-0.002006
  /nix/store/fyqqs8srwix3qag46kn6h2di17xm8znw-perl5.36.0-Test-RequiresInternet-0.05
  /nix/store/zy9swy7w7w1k386smnwsqbmxg8d9cijm-perl5.36.0-TimeDate-2.33
  /nix/store/8kg1x5vy7wznvda35ssfad40m00w4696-perl5.36.0-Try-Tiny-0.30
  /nix/store/3wsw140f76nkbpc1rnvvfgijh2hrf56i-perl5.36.0-URI-5.05
  /nix/store/x43s8y7518l8k9kjl7qs2wyx0cyqhdis-perl5.36.0-WWW-RobotRules-6.02
  /nix/store/9gis7ibjx73v4wyxxcv16y7kc1wqmsn2-perl5.36.0-X11-Protocol-0.56
  /nix/store/58184kign5p3w4wa3iznp119iszi7nrk-perl5.36.0-XML-Parser-2.46
  /nix/store/6qxbigdal8rz48fkf3ypzps40kdij6x1-perl5.36.0-XML-Twig-3.52
  /nix/store/73qj3fn90cad0w7s8gpzn7igbrarvhzi-perl5.36.0-libwww-perl-6.67
  /nix/store/hgkalwffjmm1ijlwwaycnaln2k1mp1r9-pipewire-0.3.65-lib
  /nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9
  /nix/store/9bq9lxz8rsa0ldpjpx9xs72qrcsijv31-roc-toolkit-0.2.1
  /nix/store/w2w42m87w2kixsckgmsg9xkdwjbx0vd5-sbc-1.4
  /nix/store/jha800mczpggly0svnhc8pj7f3yzxc9i-serd-0.30.10
  /nix/store/0iqrjjymjap94i4m2iqzwmd8wm253nw1-sndio-1.9.0
  /nix/store/ny2pfzr4v03nndrv01s58rp795rpj0z3-sord-0.16.14
  /nix/store/lsvcdxwxhzq9ylk7ylbxpwm44b0jvkn9-sox-unstable-2021-05-09
  /nix/store/b0g03j9nvf4h2k1pslwxcm2mhbxw006i-sox-unstable-2021-05-09-dev
  /nix/store/r2riwc23270ffx1g5yzpxfky0wlgb1zy-sox-unstable-2021-05-09-lib
  /nix/store/64vxypm9r1knwwrwxwpjmqn2shavkb6g-soxr-0.1.3
  /nix/store/yfc1fza4h6g5sjvash75qdff1jqsf20w-speex-1.2.1
  /nix/store/rg6vbpdk9h4vz810xq44ym1ad7vaasfc-speexdsp-1.2.1
  /nix/store/awx1yg9xs52lydvazsk5g5bvj7vbrh79-speexdsp-1.2.1-dev
  /nix/store/phs35msc79571m6hmmmqmnfziwg8kzaa-sratom-0.6.8
  /nix/store/b1hqharsbisqd76bm52bq181ix125hw8-srt-1.5.1
  /nix/store/66fr4mlfnwym5dw4bx61xs7nb81q58cb-tzdata-2022g
  /nix/store/0g7006grqrr1xikp5v3hb8c7rj3iv6b0-vulkan-loader-1.3.236.0
  /nix/store/j15xicpm19r2li89m08rvq8cxdkarl0j-wavpack-5.5.0
  /nix/store/v6jhlqw0p2ay99iizs8gm0jnpg4qz948-wayland-protocols-1.31
  /nix/store/akjbh77nqqd8l5374qiwszwhibrpg3r4-webrtc-audio-processing-0.3.1
  /nix/store/2y9lsfj3wiqy2am0hrb7akmkpkkb5ql0-x264-unstable-2021-06-13-lib
  /nix/store/glykwqjgixglzmq162biqsn3al5hwvv7-x265-3.5
  /nix/store/1997m851rwdz9fywy4y6wa8k7hx4glwz-xdg-utils-unstable-2020-10-21
  /nix/store/fqcy8f9y1s3kwivwl6mv973fq7qcxzfa-xorgproto-2021.5
  /nix/store/gv2s0vlmrvgm150k6qdzm7zqi2ncq471-xset-1.2.5
  /nix/store/zmn31wagw80dhvbwx74f8mnjmns2i2zf-xvidcore-1.3.7
  /nix/store/scankdpz0j7rff165bgbgyqn4g83gw2a-xz-5.4.1-dev
  /nix/store/xrns2hkbp3cjayfx2qg93b7rf164vh9k-zimg-3.0.4
```

</details>

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
