### PR TITLE
Add ./configure --disable-tests option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,10 @@ makefiles = \
   mk/precompiled-headers.mk \
   local.mk \
   src/libutil/local.mk \
-  src/libutil/tests/local.mk \
   src/libstore/local.mk \
-  src/libstore/tests/local.mk \
   src/libfetchers/local.mk \
   src/libmain/local.mk \
   src/libexpr/local.mk \
-  src/libexpr/tests/local.mk \
   src/libcmd/local.mk \
   src/nix/local.mk \
   src/resolve-system-dependencies/local.mk \
@@ -19,11 +16,21 @@ makefiles = \
   misc/systemd/local.mk \
   misc/launchd/local.mk \
   misc/upstart/local.mk \
-  doc/manual/local.mk \
-  tests/local.mk \
-  tests/plugins/local.mk
+  doc/manual/local.mk
 
 -include Makefile.config
+
+ifeq ($(tests), yes)
+makefiles += \
+  src/libutil/tests/local.mk \
+  src/libstore/tests/local.mk \
+  src/libexpr/tests/local.mk \
+  tests/local.mk \
+  tests/plugins/local.mk
+else
+makefiles += \
+  mk/disable-tests.mk
+endif
 
 OPTIMIZE = 1
 

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -45,3 +45,4 @@ sandbox_shell = @sandbox_shell@
 storedir = @storedir@
 sysconfdir = @sysconfdir@
 system = @system@
+tests = @tests@

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,13 @@ if test "x$GCC_ATOMIC_BUILTINS_NEED_LIBATOMIC" = xyes; then
     LDFLAGS="-latomic $LDFLAGS"
 fi
 
+# Building without tests is useful for bootstrapping with a smaller footprint
+# or running the tests in a separate derivation. Otherwise, we do compile and
+# run them.
+AC_ARG_ENABLE(tests, AS_HELP_STRING([--disable-tests],[Do not build the tests]),
+  tests=$enableval, tests=yes)
+AC_SUBST(tests)
+
 # LTO is currently broken with clang for unknown reasons; ld segfaults in the llvm plugin
 AC_ARG_ENABLE(lto, AS_HELP_STRING([--enable-lto],[Enable LTO (only supported with GCC) [default=no]]),
   lto=$enableval, lto=no)
@@ -270,6 +277,8 @@ if test "$gc" = yes; then
 fi
 
 
+if test "$tests" = yes; then
+
 # Look for gtest.
 PKG_CHECK_MODULES([GTEST], [gtest_main])
 
@@ -282,6 +291,7 @@ dnl No good for C++ libs with mangled symbols
 dnl AC_CHECK_LIB([rapidcheck], [])
 AC_LANG_POP(C++)
 
+fi
 
 # Look for nlohmann/json.
 PKG_CHECK_MODULES([NLOHMANN_JSON], [nlohmann_json >= 3.9])

--- a/doc/manual/src/installation/prerequisites-source.md
+++ b/doc/manual/src/installation/prerequisites-source.md
@@ -71,3 +71,8 @@
     <http://libcpuid.sourceforge.net>.
     This is an optional dependency and can be disabled
     by providing a `--disable-cpuid` to the `configure` script.
+
+  - Unless `./configure --disable-tests` is specified, GoogleTest (GTest) and
+    RapidCheck are required, which are available at
+    <https://google.github.io/googletest/> and
+    <https://github.com/emil-e/rapidcheck> respectively.

--- a/flake.nix
+++ b/flake.nix
@@ -353,7 +353,8 @@
             configureFlags = configureFlags ++
               [ "--sysconfdir=/etc" ] ++
               lib.optional stdenv.hostPlatform.isStatic "--enable-embedded-sandbox-shell" ++
-              (if finalAttrs.doCheck then testConfigureFlags else [ "--disable-tests" ]) ++
+              [ (lib.enableFeature finalAttrs.doCheck "tests") ] ++
+              lib.optionals finalAttrs.doCheck testConfigureFlags ++
               lib.optional (!canRunInstalled) "--disable-doc-gen";
 
             enableParallelBuilding = true;

--- a/mk/disable-tests.mk
+++ b/mk/disable-tests.mk
@@ -1,0 +1,12 @@
+# This file is only active for `./configure --disable-tests`.
+# Running `make check` or `make installcheck` would indicate a mistake in the
+# caller.
+
+installcheck:
+	@echo "Tests are disabled. Configure without '--disable-tests', or avoid calling 'make installcheck'."
+	@exit 1
+
+# This currently has little effect.
+check:
+	@echo "Tests are disabled. Configure without '--disable-tests', or avoid calling 'make check'."
+	@exit 1


### PR DESCRIPTION

# Motivation

Make incremental progress towards a more testable Nix.
 - Taken from #7870 

# Context

From the commit message:

Building without tests is useful for bootstrapping with a smaller footprint or running the tests in a separate derivation. Otherwise, we do compile and run them.

This isn't fine grained as to allow picking `check` but not `installcheck` or vice versa, but it's good enough for now.

I've tried to use Nixpkgs' `checkInputs`, but those inputs weren't discovered properly by the configure script. We can emulate its behavior very well though.


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
