### PR TITLE
Example uses gitlab.com thus clarify the comment

### DIFF
--- a/src/libfetchers/fetch-settings.hh
+++ b/src/libfetchers/fetch-settings.hh
@@ -57,7 +57,7 @@ struct FetchSettings : public Config
           ```
 
           This example specifies three tokens, one each for accessing
-          github.com, gitlab.mycompany.com, and sourceforge.net.
+          github.com, gitlab.mycompany.com, and gitlab.com.
 
           The `input.foo` uses the "gitlab" fetcher, which might
           requires specifying the token type along with the token


### PR DESCRIPTION
# Motivation
The example in this document is incorrect