### PR TITLE
Revert #7689

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -581,14 +581,7 @@ struct EvalSettings : Config
 
     Setting<Strings> nixPath{
         this, {}, "nix-path",
-        R"(
-          List of directories to be searched for `<...>` file references.
-
-          If [pure evaluation](#conf-pure-eval) is disabled,
-          this is initialised using the [`NIX_PATH`](@docroot@/command-ref/env-common.md#env-NIX_PATH)
-          environment variable, or, if it is unset and [restricted evaluation](#conf-restrict-eval)
-          is disabled, a default search path including the user's and `root`'s channels.
-        )"};
+        "List of directories to be searched for `<...>` file references."};
 
     Setting<bool> restrictEval{
         this, false, "restrict-eval",

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -570,7 +570,7 @@ struct EvalSettings : Config
 {
     EvalSettings();
 
-    Strings getDefaultNixPath();
+    static Strings getDefaultNixPath();
 
     static bool isPseudoUrl(std::string_view s);
 
@@ -580,7 +580,7 @@ struct EvalSettings : Config
         "Whether builtin functions that allow executing native code should be enabled."};
 
     Setting<Strings> nixPath{
-        this, {}, "nix-path",
+        this, getDefaultNixPath(), "nix-path",
         "List of directories to be searched for `<...>` file references."};
 
     Setting<bool> restrictEval{

--- a/tests/nix_path.sh
+++ b/tests/nix_path.sh
@@ -12,8 +12,3 @@ nix-instantiate --eval -E '<by-relative-path/simple.nix>' --restrict-eval
 
 [[ $(nix-instantiate --find-file by-absolute-path/simple.nix) = $PWD/simple.nix ]]
 [[ $(nix-instantiate --find-file by-relative-path/simple.nix) = $PWD/simple.nix ]]
-
-unset NIX_PATH
-
-[[ $(nix-instantiate --option nix-path by-relative-path=. --find-file by-relative-path/simple.nix) = "$PWD/simple.nix" ]]
-[[ $(NIX_PATH= nix-instantiate --option nix-path by-relative-path=. --find-file by-relative-path/simple.nix) = "$PWD/simple.nix" ]]

--- a/tests/restricted.sh
+++ b/tests/restricted.sh
@@ -17,9 +17,6 @@ nix-instantiate --restrict-eval --eval -E 'builtins.readDir ../src/nix-channel' 
 (! nix-instantiate --restrict-eval --eval -E 'let __nixPath = [ { prefix = "foo"; path = ./.; } ]; in <foo>')
 nix-instantiate --restrict-eval --eval -E 'let __nixPath = [ { prefix = "foo"; path = ./.; } ]; in <foo>' -I src=.
 
-# no default NIX_PATH
-(unset NIX_PATH; ! nix-instantiate --restrict-eval --find-file .)
-
 p=$(nix eval --raw --expr "builtins.fetchurl file://$(pwd)/restricted.sh" --impure --restrict-eval --allowed-uris "file://$(pwd)")
 cmp $p restricted.sh
 


### PR DESCRIPTION
# Motivation

This reverts #7689 since it caused `NIX_PATH` to no longer work if `nix-path` is set in nix.conf.

Fixes https://github.com/NixOS/nix/issues/7857. This is an alternative to #7871 which has some unresolved (and probably unresolvable) issues.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
