### PR TITLE
Sort build results by severity and message error body

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -580,7 +580,12 @@ std::vector<std::pair<std::shared_ptr<Installable>, BuiltPathWithResult>> Instal
         if (settings.printMissing)
             printMissing(store, pathsToBuild, lvlInfo);
 
-        for (auto & buildResult : store->buildPathsWithResults(pathsToBuild, bMode, evalStore)) {
+        auto results = store->buildPathsWithResults(pathsToBuild, bMode, evalStore);
+
+        std::sort(results.begin(), results.end(),
+            [] (auto a, auto b) { return a.severity() > b.severity() && !a.errorMsg.empty(); });
+
+        for (auto & buildResult : results) {
             if (!buildResult.success())
                 buildResult.rethrow();
 

--- a/src/libstore/build-result.hh
+++ b/src/libstore/build-result.hh
@@ -86,6 +86,36 @@ struct BuildResult
         return status == Built || status == Substituted || status == AlreadyValid || status == ResolvesToAlreadyValid;
     }
 
+    int severity()
+    {
+        switch (status) {
+            case Built:
+            case Substituted:
+            case AlreadyValid:
+            case ResolvesToAlreadyValid:
+                return 0;
+            case TransientFailure:
+                return 1;
+            case LogLimitExceeded:
+                return 2;
+            case InputRejected:
+            case OutputRejected:
+            case CachedFailure:
+                return 3;
+            case TimedOut:
+            case MiscFailure:
+                return 4;
+            case DependencyFailed:
+                return 5;
+            case NotDeterministic:
+            case NoSubstituters:
+                return 6;
+            case PermanentFailure:
+                return 7;
+        }
+        throw Error("Unrecognized BuildResult status: %d", status);
+    }
+
     void rethrow()
     {
         throw Error("%s", errorMsg);


### PR DESCRIPTION
# Motivation
Seeking to show relevant error messages for the developer in order to speed up diagnosis during the troubleshooting of build results.

# Context
In some production code, there was an empty error message during a `nix build` and it turns out that it had a `MiscFailure` before a `PermanentFailure`, and the former contained an empty error message while the latter had the expected error message (the error message was obtained using `nix-build`). Because the first non-success status rethrows an exception, the first error being a `MiscFailure`, it ended with no logs in the console at all, i.e., it only had the prefix `error:` as the entire log message, which led to an excessive amount of time in troubleshooting errors throughout the application.

For the solution, sorting of build results was added, lowering the priority of results with empty error messages, and using a concept of severity based on the status field of build results that contain non-empty error messages. The assumption is that statuses have different levels of severity, such as `MiscFailure` having less severity than `PermanentFailure`.


The long-term solution may involve investigating the daemon to understand why failures, such as `MiscFailure`, are not providing error messages at all for the nix executable.

# High-Level Examples

For each scenario, here are the behaviors with the proposed suggestion:

### Scenario 1: All build results ended up with a failure with empty error messages.
  No change in behavior.
### Scenario 2: All build results ended up with a failure with only one containing a non-empty error message.
  The one with the non-empty error message will be the first in the vector of build results.
### Scenario 3: All build results ended up with a failure with more than one containing non-empty error messages.
  The ones with non-empty error messages will be sorted by the severity of their logs.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
