### PR TITLE
nix-profile{,-daemon}.sh.in: Allow XDG_STATE_HOME to be unset

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -3,7 +3,7 @@ if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
 __ETC_PROFILE_NIX_SOURCED=1
 
 NIX_LINK=$HOME/.nix-profile
-if [ -n "$XDG_STATE_HOME" ]; then
+if [ -n "${XDG_STATE_HOME-}" ]; then
     NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
 else
     NIX_LINK_NEW=$HOME/.local/state/nix/profile

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -3,7 +3,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     # Set up the per-user profile.
 
     NIX_LINK="$HOME/.nix-profile"
-    if [ -n "$XDG_STATE_HOME" ]; then
+    if [ -n "${XDG_STATE_HOME-}" ]; then
         NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
     else
         NIX_LINK_NEW="$HOME/.local/state/nix/profile"


### PR DESCRIPTION


# Motivation
XDG_STATE_HOME being unset should not cause the profile scripts to error, especially since they have fallback branches.

# Context
One of our CI machines installs Nix via the official script and then sources the nix-profile.sh script to setup the environment. However, it doesn't have XDG_STATE_HOME set, which causes sourcing the script to fail.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
