### PR TITLE
Check if NIX_LINK_NEW exists instead of checking that NIX_LINK doesn't exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v19
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v12
       if: needs.check_secrets.outputs.cachix == 'true'
@@ -59,6 +61,8 @@ jobs:
         fetch-depth: 0
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/install-nix-action@v19
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         name: '${{ env.CACHIX_NAME }}'
@@ -103,6 +107,8 @@ jobs:
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v19
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - run: echo NIX_VERSION="$(nix --experimental-features 'nix-command flakes' eval .\#default.version | tr -d \")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v12

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -8,7 +8,7 @@ if [ -n "$XDG_STATE_HOME" ]; then
 else
     NIX_LINK_NEW=$HOME/.local/state/nix/profile
 fi
-if ! [ -e "$NIX_LINK" ]; then
+if [ -e "$NIX_LINK_NEW" ]; then
     NIX_LINK="$NIX_LINK_NEW"
 else
     if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -8,7 +8,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     else
         NIX_LINK_NEW="$HOME/.local/state/nix/profile"
     fi
-    if ! [ -e "$NIX_LINK" ]; then
+    if [ -e "$NIX_LINK_NEW" ]; then
         NIX_LINK="$NIX_LINK_NEW"
     else
         if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then


### PR DESCRIPTION
# Motivation

For brand new installations, neither NIX_LINK_NEW
(`$XDG_STATE_HOME/nix/profile` or `~/.local/state/nix/profile`), nor NIX_LINK (`~/.nix-profile`) will exist.

This restores functionality to nix-env, which is relied upon by GitHub Actions such as https://github.com/cachix/cachix-action and the Nixpkgs EditorConfig (and other) CI.

# Context

Earlier today, Nixpkgs GHA CI started failing because it was relying on `nix-env`. Although this has since been fixed by switching to `nix-shell`, there are other places in the ecosystem that rely on 1) the latest Nix version; and 2) `nix-env`.

See the conversation in https://github.com/NixOS/nix/pull/5588 (starting at https://github.com/NixOS/nix/pull/5588#issuecomment-1448726090).

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

---

This might not be the right solution, but it is _a_ solution that fixes the regression. I'm happy to close this in favor of a more comprehensive solution, however.

There's an extra commit pinning the cachix actions to Nix 2.13.3 to see if that will allow CI to pass (it's failing weirdly on `master` and prior to this change) -- feel free to force-push it away if this overall approach is "good enough" for now.

This should be backported to 2.14.