### PR TITLE
Handle use-xdg-base-directories for profile link

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -2,30 +2,9 @@
 if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
 __ETC_PROFILE_NIX_SOURCED=1
 
-NIX_LINK=$HOME/.nix-profile
-if [ -n "${XDG_STATE_HOME-}" ]; then
-    NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
-else
-    NIX_LINK_NEW=$HOME/.local/state/nix/profile
-fi
-if [ -e "$NIX_LINK_NEW" ]; then
-    NIX_LINK="$NIX_LINK_NEW"
-else
-    if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then
-        warning="\033[1;35mwarning:\033[0m"
-        printf "$warning Both %s and legacy %s exist; using the latter.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
-        if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
-            printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
-        else
-            # This should be an exceptionally rare occasion: the only way to get it would be to
-            # 1. Update to newer Nix;
-            # 2. Remove .nix-profile;
-            # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
-            # 4. Roll back to older Nix.
-            # If someone did all that, they can probably figure out how to migrate the profile.
-            printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
-        fi
-    fi
+NIX_LINK="$HOME/.nix-profile"
+if [[ $(PATH="$PATH:@localstatedir@/nix/profiles/default/bin" nix --extra-experimental-features nix-command show-config use-xdg-base-directories) == true ]]; then
+    NIX_LINK="${XDG_STATE_HOME-$HOME/.local/state}/nix/profile"
 fi
 
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,31 +1,9 @@
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     # Set up the per-user profile.
-
     NIX_LINK="$HOME/.nix-profile"
-    if [ -n "${XDG_STATE_HOME-}" ]; then
-        NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
-    else
-        NIX_LINK_NEW="$HOME/.local/state/nix/profile"
-    fi
-    if [ -e "$NIX_LINK_NEW" ]; then
-        NIX_LINK="$NIX_LINK_NEW"
-    else
-        if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then
-            warning="\033[1;35mwarning:\033[0m"
-            printf "$warning Both %s and legacy %s exist; using the latter.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
-            if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
-                printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
-            else
-                # This should be an exceptionally rare occasion: the only way to get it would be to
-                # 1. Update to newer Nix;
-                # 2. Remove .nix-profile;
-                # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
-                # 4. Roll back to older Nix.
-                # If someone did all that, they can probably figure out how to migrate the profile.
-                printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
-            fi
-        fi
+    if [[ $(PATH="$PATH:@localstatedir@/nix/profiles/default/bin" nix --extra-experimental-features nix-command show-config use-xdg-base-directories) == true ]]; then
+        NIX_LINK="${XDG_STATE_HOME-$HOME/.local/state}/nix/profile"
     fi
 
     # Set up environment.


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

#5588 broke the `PATH` setting logic in `profile.sh`: https://github.com/NixOS/nix/pull/5588#issuecomment-1448726090

This PR attempts to fix that by checking the `use-xdg-base-directories` config option and deciding whether to use the XDG-compliant location or the old one based on that.

# Context

#5588 introduced a `use-xdg-base-directories` option which, when enabled, makes Nix use the new locations instead of `~/.nix-profile`, `~/.nix-channel` and `~/.nix-defexpr`.
However, the accompanying `profile.sh` change was not quite correct: it chose the new location if the old one didn't exist.
Checking the `use-xdg-base-directories` should enable us to handle this properly (only adding the relevant profile link to `$PATH`).

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
