### PR TITLE
Fix 'make check' inside 'nix develop'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
           ++ lib.optionals (stdenv.isLinux && !(isStatic && stdenv.system == "aarch64-linux")) [
             "LDFLAGS=-fuse-ld=gold"
           ];
+
         testConfigureFlags = [
           "CXXFLAGS=-I${lib.getDev rapidcheck}/extras/gtest/include"
         ];
@@ -651,7 +652,7 @@
 
             buildInputs = buildDeps ++ propagatedDeps ++ awsDeps ++ checkDeps;
 
-            inherit configureFlags;
+            configureFlags = configureFlags ++ testConfigureFlags;
 
             enableParallelBuilding = true;
 


### PR DESCRIPTION
# Motivation

Fixes
```
$ make check -j24
...
src/libutil/tests/hash.cc:5:10: fatal error: rapidcheck/gtest.h: No such file or directory
    5 | #include <rapidcheck/gtest.h>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [mk/patterns.mk:3: src/libutil/tests/hash.o] Error 1
```

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes
