### PR TITLE
flake: restore binary-dist artifact to Hydra static builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -361,6 +361,10 @@
             postInstall = ''
               mkdir -p $doc/nix-support
               echo "doc manual $doc/share/doc/nix/manual" >> $doc/nix-support/hydra-build-products
+              ${lib.optionalString currentStdenv.hostPlatform.isStatic ''
+              mkdir -p $out/nix-support
+              echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
+              ''}
               ${lib.optionalString currentStdenv.isDarwin ''
               install_name_tool \
                 -change ${boost}/lib/libboost_context.dylib \


### PR DESCRIPTION
# Motivation
It looks like this was lost in https://github.com/NixOS/nix/pull/6538.

# Context
Some third-parties depend on being able to get the static binary-dist artifact (namely, Renovate, as noticed by Amanda on  Matrix).

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

---

I feel like I say this a lot recently, but it would be swell if this could get backported to 2.14 as well... :sweat_smile: 