### PR TITLE
add input scheme for forgejo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -550,6 +550,8 @@
 
         tests.sourcehutFlakes = runNixOSTestFor "x86_64-linux" ./tests/nixos/sourcehut-flakes.nix;
 
+        tests.codebergFlakes = runNixOSTestFor "x86_64-linux" ./tests/nixos/codeberg-flakes.nix;
+
         tests.containers = runNixOSTestFor "x86_64-linux" ./tests/nixos/containers/containers.nix;
 
         tests.setuid = lib.genAttrs

--- a/flake.nix
+++ b/flake.nix
@@ -550,7 +550,7 @@
 
         tests.sourcehutFlakes = runNixOSTestFor "x86_64-linux" ./tests/nixos/sourcehut-flakes.nix;
 
-        tests.codebergFlakes = runNixOSTestFor "x86_64-linux" ./tests/nixos/codeberg-flakes.nix;
+        tests.forgejoFlakes = runNixOSTestFor "x86_64-linux" ./tests/nixos/forgejo-flakes.nix;
 
         tests.containers = runNixOSTestFor "x86_64-linux" ./tests/nixos/containers/containers.nix;
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -460,13 +460,13 @@ struct SourceHutInputScheme : GitArchiveInputScheme
     }
 };
 
-struct CodebergInputScheme : GitArchiveInputScheme
+struct ForgejoInputScheme : GitArchiveInputScheme
 {
-    std::string type() const override { return "codeberg"; }
+    std::string type() const override { return "forgejo"; }
 
     std::optional<std::pair<std::string, std::string>> accessHeaderFromToken(const std::string & token) const override
     {
-        // Codeberg supports http and OAuth2 authentication
+        // Forgejo supports http and OAuth2 authentication
         // https://docs.gitea.io/en-us/api-usage/#authentication
         return std::pair<std::string, std::string>("Authorization", fmt("token %s", token));
     }
@@ -547,6 +547,6 @@ struct CodebergInputScheme : GitArchiveInputScheme
 static auto rGitHubInputScheme = OnStartup([] { registerInputScheme(std::make_unique<GitHubInputScheme>()); });
 static auto rGitLabInputScheme = OnStartup([] { registerInputScheme(std::make_unique<GitLabInputScheme>()); });
 static auto rSourceHutInputScheme = OnStartup([] { registerInputScheme(std::make_unique<SourceHutInputScheme>()); });
-static auto rCodebergInputScheme = OnStartup([] { registerInputScheme(std::make_unique<CodebergInputScheme>()); });
+static auto rForgejoInputScheme = OnStartup([] { registerInputScheme(std::make_unique<ForgejoInputScheme>()); });
 
 }

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -260,8 +260,8 @@ Currently the `type` attribute can be one of the following:
   * `sourcehut:~misterio/nix-colors/21c1a380a6915d890d408e9f22203436a35bb2de?host=hg.sr.ht`
 
 
-* `codeberg`: Similar to `github`, is a more efficient way to fetch
-  Codeberg repositories. The following attributes are required:
+* `forgejo`: Similar to `github`, is a more efficient way to fetch
+  Forgejo repositories. The following attributes are required:
 
   * `owner`: The owner of the repository.
 
@@ -269,23 +269,25 @@ Currently the `type` attribute can be one of the following:
 
   Like `github`, these are downloaded as tarball archives.
 
-  The URL syntax for `codeberg` flakes is:
+  The URL syntax for `forgejo` flakes is:
 
-  `codeberg:<owner>/<repo>(/<rev-or-ref>)?(\?<params>)?`
+  `forgejo:<owner>/<repo>(/<rev-or-ref>)?(\?<params>)?`
 
   `<rev-or-ref>` works the same as `github`. Either a branch or tag name
   (`ref`), or a commit hash (`rev`) can be specified.
 
-  Since Codeberg/forgejo allows for self-hosting, you can specify `host` as
-  a parameter, to point to any instances other than `codeberg.org`.
+  Since Forgejo allows for self-hosting, you can specify `host` as
+  a parameter, to point to any instances other than the default `codeberg.org`.
+  You may also be able to specify Gitea instances are they are currently compatible,
+  but this has the possibility of changing in the future.
 
   Some examples:
 
-  * `codeberg:adamcstephens/lxd-nixos`
-  * `codeberg:adamcstephens/lxd-nixos/main`
-  * `codeberg:adamcstephens/lxd-nixos/126b6673cbe8f8b221a27ebc64ae934ded946330`
-  * `codeberg:adamcstephens/lxd-nixos?host=othercodeberg.org`
-  * `codeberg:adamcstephens/lxd-nixos/126b6673cbe8f8b221a27ebc64ae934ded946330?host=othercodeberg.org`
+  * `forgejo:adamcstephens/lxd-nixos`
+  * `forgejo:adamcstephens/lxd-nixos/main`
+  * `forgejo:adamcstephens/lxd-nixos/126b6673cbe8f8b221a27ebc64ae934ded946330`
+  * `forgejo:adamcstephens/lxd-nixos?host=othercodeberg.org`
+  * `forgejo:adamcstephens/lxd-nixos/126b6673cbe8f8b221a27ebc64ae934ded946330?host=othercodeberg.org`
 
 
 * `indirect`: Indirections through the flake registry. These have the

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -259,6 +259,35 @@ Currently the `type` attribute can be one of the following:
   * `sourcehut:~misterio/nix-colors/182b4b8709b8ffe4e9774a4c5d6877bf6bb9a21c`
   * `sourcehut:~misterio/nix-colors/21c1a380a6915d890d408e9f22203436a35bb2de?host=hg.sr.ht`
 
+
+* `codeberg`: Similar to `github`, is a more efficient way to fetch
+  Codeberg repositories. The following attributes are required:
+
+  * `owner`: The owner of the repository.
+
+  * `repo`: The name of the repository.
+
+  Like `github`, these are downloaded as tarball archives.
+
+  The URL syntax for `codeberg` flakes is:
+
+  `codeberg:<owner>/<repo>(/<rev-or-ref>)?(\?<params>)?`
+
+  `<rev-or-ref>` works the same as `github`. Either a branch or tag name
+  (`ref`), or a commit hash (`rev`) can be specified.
+
+  Since Codeberg/forgejo allows for self-hosting, you can specify `host` as
+  a parameter, to point to any instances other than `codeberg.org`.
+
+  Some examples:
+
+  * `codeberg:adamcstephens/lxd-nixos`
+  * `codeberg:adamcstephens/lxd-nixos/main`
+  * `codeberg:adamcstephens/lxd-nixos/126b6673cbe8f8b221a27ebc64ae934ded946330`
+  * `codeberg:adamcstephens/lxd-nixos?host=othercodeberg.org`
+  * `codeberg:adamcstephens/lxd-nixos/126b6673cbe8f8b221a27ebc64ae934ded946330?host=othercodeberg.org`
+
+
 * `indirect`: Indirections through the flake registry. These have the
   form
 

--- a/tests/nixos/codeberg-flakes.nix
+++ b/tests/nixos/codeberg-flakes.nix
@@ -1,0 +1,221 @@
+{
+  lib,
+  config,
+  nixpkgs,
+  ...
+}: let
+  inherit (config.nodes.client.nixpkgs) pkgs;
+
+  # Generate a fake root CA and a fake codeberg.org / channels.nixos.org certificate.
+  cert =
+    pkgs.runCommand "cert" {nativeBuildInputs = [pkgs.openssl];}
+    ''
+      mkdir -p $out
+
+      openssl genrsa -out ca.key 2048
+      openssl req -new -x509 -days 36500 -key ca.key \
+        -subj "/C=NL/ST=Denial/L=Springfield/O=Dis/CN=Root CA" -out $out/ca.crt
+
+      openssl req -newkey rsa:2048 -nodes -keyout $out/server.key \
+        -subj "/C=CN/ST=Denial/L=Springfield/O=Dis/CN=codeberg.org" -out server.csr
+      openssl x509 -req -extfile <(printf "subjectAltName=DNS:codeberg.org,DNS:channels.nixos.org") \
+        -days 36500 -in server.csr -CA $out/ca.crt -CAkey ca.key -CAcreateserial -out $out/server.crt
+    '';
+
+  registry = pkgs.writeTextFile {
+    name = "registry";
+    text = ''
+      {
+        "flakes": [
+          {
+            "from": {
+              "type": "indirect",
+              "id": "nixpkgs"
+            },
+            "to": {
+              "type": "codeberg",
+              "owner": "NixOS",
+              "repo": "nixpkgs",
+              "ref": "main"
+            }
+          },
+          {
+            "from": {
+              "type": "indirect",
+              "id": "private-flake"
+            },
+            "to": {
+              "type": "codeberg",
+              "owner": "fancy-enterprise",
+              "repo": "private-flake"
+            }
+          }
+        ],
+        "version": 2
+      }
+    '';
+    destination = "/flake-registry.json";
+  };
+
+  private-flake-rev = "9f1dd0df5b54a7dc75b618034482ed42ce34383d";
+
+  private-flake-info =
+    pkgs.runCommand "private-flake-info" {}
+    ''
+      echo '{"default_branch": "main"}' > $out
+    '';
+
+  private-flake-api =
+    pkgs.runCommand "private-flake" {}
+    ''
+      mkdir -p $out/{archive,branches}
+
+      # Setup https://codeberg.org/api/swagger#/repository/repoListBranches
+      # This is simulating the use of the default HEAD ref
+      echo '{"commit": {"id": "${private-flake-rev}"}}' > $out/branches/main
+
+      # Setup tarball download via API
+      dir=private-flake-${private-flake-rev}
+      mkdir $dir
+      echo '{ outputs = {...}: {}; }' > $dir/flake.nix
+      tar cfz $out/archive/${private-flake-rev}.tar.gz $dir --hard-dereference
+    '';
+
+  nixpkgs-api =
+    pkgs.runCommand "nixpkgs-flake" {}
+    ''
+      mkdir -p $out/branches
+
+      # Setup https://codeberg.org/api/swagger#/repository/repoListGitRefs
+      # This is simulating the use of a specific branch
+      echo '{"commit": {"id": "${nixpkgs.rev}"}}' > $out/branches/main
+    '';
+
+  archive =
+    pkgs.runCommand "nixpkgs-flake" {}
+    ''
+      mkdir -p $out/archive
+
+      dir=NixOS-nixpkgs-${nixpkgs.shortRev}
+      cp -prd ${nixpkgs} $dir
+      # Set the correct timestamp in the tarball.
+      find $dir -print0 | xargs -0 touch -t ${builtins.substring 0 12 nixpkgs.lastModifiedDate}.${builtins.substring 12 2 nixpkgs.lastModifiedDate} --
+      tar cfz $out/archive/${nixpkgs.rev}.tar.gz $dir --hard-dereference
+    '';
+in {
+  name = "codeberg-flakes";
+
+  nodes = {
+    codeberg = {
+      config,
+      pkgs,
+      ...
+    }: {
+      networking.firewall.allowedTCPPorts = [80 443];
+
+      services.httpd.enable = true;
+      services.httpd.adminAddr = "foo@example.org";
+      services.httpd.extraConfig = ''
+        ErrorLog syslog:local6
+      '';
+      services.httpd.virtualHosts."channels.nixos.org" = {
+        forceSSL = true;
+        sslServerKey = "${cert}/server.key";
+        sslServerCert = "${cert}/server.crt";
+        servedDirs = [
+          {
+            urlPath = "/";
+            dir = registry;
+          }
+        ];
+      };
+      services.httpd.virtualHosts."codeberg.org" = {
+        forceSSL = true;
+        sslServerKey = "${cert}/server.key";
+        sslServerCert = "${cert}/server.crt";
+        servedDirs = [
+          {
+            urlPath = "/api/v1/repos/fancy-enterprise/private-flake";
+            dir = private-flake-api;
+          }
+          {
+            urlPath = "/api/v1/repos/NixOS/nixpkgs";
+            dir = nixpkgs-api;
+          }
+          {
+            urlPath = "/NixOS/nixpkgs";
+            dir = archive;
+          }
+        ];
+        locations."/api/v1/repos/fancy-enterprise/private-flake".alias = private-flake-info;
+      };
+    };
+
+    client = {
+      config,
+      lib,
+      pkgs,
+      nodes,
+      ...
+    }: {
+      virtualisation.writableStore = true;
+      virtualisation.diskSize = 2048;
+      virtualisation.additionalPaths = [pkgs.hello pkgs.fuse];
+      virtualisation.memorySize = 4096;
+      nix.settings.substituters = lib.mkForce [];
+      nix.extraOptions = "experimental-features = nix-command flakes";
+      networking.hosts.${(builtins.head nodes.codeberg.config.networking.interfaces.eth1.ipv4.addresses).address} = ["channels.nixos.org" "codeberg.org"];
+      security.pki.certificateFiles = ["${cert}/ca.crt"];
+    };
+  };
+
+  testScript = {nodes}: ''
+    # fmt: off
+    import json
+    import time
+
+    start_all()
+
+    def cat_log():
+         codeberg.succeed("cat /var/log/httpd/*.log >&2")
+
+    codeberg.wait_for_unit("httpd.service")
+
+    client.succeed("curl -v https://codeberg.org/ >&2")
+    out = client.succeed("nix registry list")
+    print(out)
+    assert "codeberg:NixOS/nixpkgs" in out, "nixpkgs flake not found"
+    assert "codeberg:fancy-enterprise/private-flake" in out, "private flake not found"
+    cat_log()
+
+    # If no codeberg access token is provided, nix should use the public archive url...
+    out = client.succeed("nix flake metadata nixpkgs --json")
+    print(out)
+    info = json.loads(out)
+    assert info["revision"] == "${nixpkgs.rev}", f"revision mismatch: {info['revision']} != ${nixpkgs.rev}"
+    cat_log()
+
+    # ... otherwise it should use the API
+    out = client.succeed("nix flake metadata private-flake --json --debug --access-tokens codeberg.org=65eaa9c8ef52460d22a93307fe0aee76289dc675 --tarball-ttl 0")
+    print(out)
+    info = json.loads(out)
+    assert info["revision"] == "${private-flake-rev}", f"revision mismatch: {info['revision']} != ${private-flake-rev}"
+    cat_log()
+
+    client.succeed("nix registry pin nixpkgs")
+    client.succeed("nix flake metadata nixpkgs --tarball-ttl 0 >&2")
+
+    # Shut down the web server. The flake should be cached on the client.
+    codeberg.succeed("systemctl stop httpd.service")
+
+    info = json.loads(client.succeed("nix flake metadata nixpkgs --json"))
+    date = time.strftime("%Y%m%d%H%M%S", time.gmtime(info['lastModified']))
+    assert date == "${nixpkgs.lastModifiedDate}", "time mismatch"
+
+    client.succeed("nix build nixpkgs#hello")
+
+    # The build shouldn't fail even with --tarball-ttl 0 (the server
+    # being down should not be a fatal error).
+    client.succeed("nix build nixpkgs#fuse --tarball-ttl 0")
+  '';
+}


### PR DESCRIPTION
# Motivation
recently, codeberg has become a more popular alternative to git hosting services such as github and gitlab. as people choose to move over and more projects are started there, it would be nice to have an easier way to declare repositories hosted there as inputs - similar to other services.

# Context
<!-- Provide context. Reference open issues if available. -->
no issues mentioning this exist as far as i can tell, but this idea was mentioned [here](https://github.com/NixOS/nix/pull/5342#issuecomment-1071237514) (i hope you're a fan @NomisIV 👍🏻)

<!-- Non-trivial change: Briefly outline the implementation strategy. -->
the implementation of this is similar to other input schemes, with the exception of manually fetching the default branch of the repository. this is due to the forgejo api not accepting `HEAD` as a parameter for [listing refs](https://codeberg.org/api/swagger#/repository/repoListGitRefs), [commits](https://codeberg.org/api/swagger#/repository/repoGetCombinedStatusByRef), or [branches](https://codeberg.org/api/swagger#/repository/repoGetBranch). instead, the default branch (found from the [main repository endpoint](https://codeberg.org/api/swagger#/repository/repoGetBranch)) is used in place of `HEAD` when no ref is specified

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
