### PR TITLE
Fix empty "error:" message when a top-level goal is never built

### DIFF
--- a/src/libstore/build-result.hh
+++ b/src/libstore/build-result.hh
@@ -30,6 +30,7 @@ struct BuildResult
         NotDeterministic,
         ResolvesToAlreadyValid,
         NoSubstituters,
+        Abandoned,
     } status = MiscFailure;
 
     // FIXME: include entire ErrorInfo object.
@@ -52,6 +53,8 @@ struct BuildResult
                 case LogLimitExceeded: return "LogLimitExceeded";
                 case NotDeterministic: return "NotDeterministic";
                 case ResolvesToAlreadyValid: return "ResolvesToAlreadyValid";
+                case NoSubstituters: return "NoSubstituters";
+                case Abandoned: return "Abandoned";
                 default: return "Unknown";
             };
         }();

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -62,6 +62,8 @@ void Goal::amDone(ExitCode result, std::optional<Error> ex)
 
     if (ex) {
         if (!waiters.empty())
+            // FIXME: don't print errors for top-level goals here,
+            // since they'll presumably be shown by the caller.
             logError(ex->info());
         else
             this->ex = std::move(*ex);

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -130,12 +130,17 @@ void Worker::removeGoal(GoalPtr goal)
     else
         assert(false);
 
-    if (topGoals.find(goal) != topGoals.end()) {
+    if (topGoals.contains(goal)) {
         topGoals.erase(goal);
         /* If a top-level goal failed, then kill all other goals
            (unless keepGoing was set). */
-        if (goal->exitCode == Goal::ecFailed && !settings.keepGoing)
+        if (goal->exitCode == Goal::ecFailed && !settings.keepGoing) {
+            for (auto & topGoal : topGoals) {
+                topGoal->buildResult.status = BuildResult::Status::Abandoned;
+                topGoal->buildResult.errorMsg = fmt("%s abandoned because another build or substitution failed, and 'keep-going' is set to 'false'", topGoal->getName());
+            }
             topGoals.clear();
+        }
     }
 
     /* Wake up goals waiting for any goal to finish. */


### PR DESCRIPTION
# Motivation

E.g.

```
# nix build --store /tmp/nix --file tests/ca/content-addressed.nix
error: builder for '/nix/store/da7d4sy5lmppl9a173hc8h00xd8vbng6-simple-input-addressed.drv' failed with exit code 1;
       last 1 log lines:
       > error: executing '/nix/store/dsd5gz46hdbdk2rfdimqddhq6m8m8fqs-bash-5.1-p16/bin/bash': No such file or directory
       For full logs, run 'nix log /nix/store/da7d4sy5lmppl9a173hc8h00xd8vbng6-simple-input-addressed.drv'.
error:
```

This is because the file contains multiple goals, one of which fails, and the others are never built because of that, and therefore have status `MiscFailure` and an empty `errorMsg`.

This introduces an "abandoned" status and sets `errorMsg` accordingly.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
