### PR TITLE
Fix uninitialized readFromStdIn variable

### DIFF
--- a/src/libcmd/command.hh
+++ b/src/libcmd/command.hh
@@ -128,7 +128,7 @@ struct InstallablesCommand : virtual Args, SourceExprCommand
 
     virtual bool useDefaultInstallables() { return true; }
 
-    bool readFromStdIn;
+    bool readFromStdIn = false;
 
     std::vector<std::string> getFlakesForCompletion() override;
 


### PR DESCRIPTION
# Motivation

This was causing random failures in `tests/ca/substitute.ca`: `nix copy --file ./content-addressed.nix` wouldn't get the default installable `"."` applied in `InstallablesCommand::load()`, so it would do nothing.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
