### PR TITLE
fix profile backwards compat

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1460,7 +1460,7 @@ void LocalDerivationGoal::startDaemon()
                 FdSink to(remote.get());
                 try {
                     daemon::processConnection(store, from, to,
-                        daemon::NotTrusted, daemon::Recursive);
+                        daemon::NotTrusted, daemon::Recursive, std::nullopt);
                     debug("terminated daemon connection");
                 } catch (SysError &) {
                     ignoreException();

--- a/src/libstore/daemon.hh
+++ b/src/libstore/daemon.hh
@@ -13,6 +13,7 @@ void processConnection(
     FdSource & from,
     FdSink & to,
     TrustedFlag trusted,
-    RecursiveFlag recursive);
+    RecursiveFlag recursive,
+    const std::optional<std::string> & userName);
 
 }

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -2,6 +2,7 @@
 #include "globals.hh"
 #include "archive.hh"
 #include "pathlocks.hh"
+#include "profiles.hh"
 #include "worker-protocol.hh"
 #include "derivations.hh"
 #include "nar-info.hh"
@@ -200,6 +201,8 @@ LocalStore::LocalStore(const Params & params)
         if (chmod(perUserDir.c_str(), 0755) == -1)
             throw SysError("could not set permissions on '%s' to 755", perUserDir);
     }
+
+    createUser(getUserName(), nix::profilesDir(CreateDirsFlag::DontCreate));
 
     /* Optionally, create directories and set permissions for a
        multi-user install. */
@@ -1948,6 +1951,13 @@ void LocalStore::addBuildLog(const StorePath & drvPath, std::string_view log)
 std::optional<std::string> LocalStore::getVersion()
 {
     return nixVersion;
+}
+
+void LocalStore::createUser(const std::string & userName, const std::string & profilesDir) {
+    createLegacyProfileLink(
+            fmt("%s/profiles/per-user/%s", settings.nixStateDir, userName),
+            profilesDir
+    );
 }
 
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -296,6 +296,8 @@ private:
 
     void addBuildLog(const StorePath & drvPath, std::string_view log) override;
 
+    void createUser(const std::string & userName, const std::string & profileDir) override;
+
     friend struct LocalDerivationGoal;
     friend struct PathSubstitutionGoal;
     friend struct SubstitutionGoal;

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -308,5 +308,13 @@ Path getDefaultProfile()
     }
 }
 
+void createLegacyProfileLink(Path oldProfile, Path newProfile)
+{
+    if (pathExists(oldProfile))
+        return;
+    createDirs(dirOf(oldProfile));
+    replaceSymlink(newProfile, oldProfile);
+}
+
 
 }

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -280,17 +280,20 @@ std::string optimisticLockProfile(const Path & profile)
 }
 
 
-Path profilesDir()
+Path profilesDir(CreateDirsFlag create)
 {
-    auto profileRoot = createNixStateDir() + "/profiles";
-    createDirs(profileRoot);
+    auto profileRoot = getNixStateDir(create) + "/profiles";
+    if (create == CreateDirsFlag::Create) {
+        createDirs(profileRoot);
+    }
+    Path dir = getStateDir() + "/nix";
     return profileRoot;
 }
 
 
 Path getDefaultProfile()
 {
-    Path profileLink = settings.useXDGBaseDirectories ? createNixStateDir() + "/profile" : getHome() + "/.nix-profile";
+    Path profileLink = settings.useXDGBaseDirectories ? getNixStateDir() + "/profile" : getHome() + "/.nix-profile";
     try {
         auto profile =
             getuid() == 0

--- a/src/libstore/profiles.hh
+++ b/src/libstore/profiles.hh
@@ -70,7 +70,7 @@ std::string optimisticLockProfile(const Path & profile);
 
 /* Creates and returns the path to a directory suitable for storing the user’s
    profiles. */
-Path profilesDir();
+Path profilesDir(CreateDirsFlag create = CreateDirsFlag::Create);
 
 /* Resolve the default profile (~/.nix-profile by default, $XDG_STATE_HOME/
    nix/profile if XDG Base Directory Support is enabled), and create if doesn't

--- a/src/libstore/profiles.hh
+++ b/src/libstore/profiles.hh
@@ -77,4 +77,5 @@ Path profilesDir(CreateDirsFlag create = CreateDirsFlag::Create);
    exist */
 Path getDefaultProfile();
 
+void createLegacyProfileLink(Path oldProfile, Path newProfile);
 }

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -180,6 +180,8 @@ protected:
 
     virtual void narFromPath(const StorePath & path, Sink & sink) override;
 
+    void createLegacyProfileLink(Connection & conn);
+
 private:
 
     std::atomic_bool failed{false};

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -659,6 +659,8 @@ public:
         return toRealPath(printStorePath(storePath));
     }
 
+    virtual void createUser(const std::string & userName, const std::string & profileDir) { }
+
     /*
      * Synchronises the options of the client with those of the daemon
      * (a no-op when there’s no daemon)

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 34)
+#define PROTOCOL_VERSION (1 << 8 | 35)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -58,6 +58,7 @@ typedef enum {
     wopAddMultipleToStore = 44,
     wopAddBuildLog = 45,
     wopBuildPathsWithResults = 46,
+    wopCreateProfilesLink = 47,
 } WorkerOp;
 
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -620,10 +620,11 @@ Path getStateDir()
     return stateDir ? *stateDir : getHome() + "/.local/state";
 }
 
-Path createNixStateDir()
+Path getNixStateDir(CreateDirsFlag create)
 {
     Path dir = getStateDir() + "/nix";
-    createDirs(dir);
+    if (create == CreateDirsFlag::Create)
+        createDirs(dir);
     return dir;
 }
 

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -165,8 +165,13 @@ std::optional<Path> getSelfExe();
 /* Return $XDG_STATE_HOME or $HOME/.local/state. */
 Path getStateDir();
 
-/* Create the Nix state directory and return the path to it. */
-Path createNixStateDir();
+enum struct CreateDirsFlag {
+    Create = true,
+    DontCreate = false
+};
+
+/* Return the path to the Nix state directory and optionnally create it if needed. */
+Path getNixStateDir(CreateDirsFlag create = CreateDirsFlag::Create);
 
 /* Create a directory and all its parents, if necessary.  Returns the
    list of created directories, in order of creation. */

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -164,8 +164,8 @@ static int main_nix_channel(int argc, char ** argv)
     {
         // Figure out the name of the `.nix-channels' file to use
         auto home = getHome();
-        channelsList = settings.useXDGBaseDirectories ? createNixStateDir() + "/channels" : home + "/.nix-channels";
-        nixDefExpr = settings.useXDGBaseDirectories ? createNixStateDir() + "/defexpr" : home + "/.nix-defexpr";
+        channelsList = settings.useXDGBaseDirectories ? getNixStateDir() + "/channels" : home + "/.nix-channels";
+        nixDefExpr = settings.useXDGBaseDirectories ? getNixStateDir() + "/defexpr" : home + "/.nix-defexpr";
 
         // Figure out the name of the channels profile.
         profile = profilesDir() + "/channels";

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1289,7 +1289,7 @@ static void opSwitchProfile(Globals & globals, Strings opFlags, Strings opArgs)
         throw UsageError("exactly one argument expected");
 
     Path profile = absPath(opArgs.front());
-    Path profileLink = settings.useXDGBaseDirectories ? createNixStateDir() + "/profile" : getHome() + "/.nix-profile";
+    Path profileLink = settings.useXDGBaseDirectories ? getNixStateDir() + "/profile" : getHome() + "/.nix-profile";
 
     switchLink(profileLink, profile);
 }
@@ -1394,7 +1394,7 @@ static int main_nix_env(int argc, char * * argv)
 
         globals.instSource.type = srcUnknown;
         {
-            Path nixExprPath = settings.useXDGBaseDirectories ? createNixStateDir() + "/defexpr" : getHome() + "/.nix-defexpr";
+            Path nixExprPath = settings.useXDGBaseDirectories ? getNixStateDir() + "/defexpr" : getHome() + "/.nix-defexpr";
             globals.instSource.nixExprPath = nixExprPath;
         }
         globals.instSource.systemFilter = "*";

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -278,7 +278,7 @@ static void daemonLoop()
                 //  Handle the connection.
                 FdSource from(remote.get());
                 FdSink to(remote.get());
-                processConnection(openUncachedStore(), from, to, trusted, NotRecursive);
+                processConnection(openUncachedStore(), from, to, trusted, NotRecursive, {user});
 
                 exit(0);
             }, options);
@@ -331,7 +331,7 @@ static void runDaemon(bool stdio)
             /* Auth hook is empty because in this mode we blindly trust the
                standard streams. Limiting access to those is explicitly
                not `nix-daemon`'s responsibility. */
-            processConnection(openUncachedStore(), from, to, Trusted, NotRecursive);
+            processConnection(openUncachedStore(), from, to, Trusted, NotRecursive, std::nullopt);
         }
     } else
         daemonLoop();

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -30,3 +30,6 @@ NIX_REMOTE= nix-store --dump-db > $TEST_ROOT/d2
 cmp $TEST_ROOT/d1 $TEST_ROOT/d2
 
 killDaemon
+
+user=$(whoami)
+[ -e $NIX_STATE_DIR/profiles/per-user/$user ]


### PR DESCRIPTION
# Motivation

Fix the backwards-compat hack that was butchered as part of https://github.com/NixOS/nix/pull/5226

/cc @rycee @ncfavier

# Context

Upon initializing a local or daemon store, create (if it doesn't exist) a link from `${NIX_STATE_DIR}/profiles/per-user/${currentUser}` to the actual profiles dir (under the user's XDG state dir).

This is a bit involved for the daemon as

1. We need the client to pass the path to its profile directory (since the daemon can't guess it)
2. We don't want the client to be able to impersonate another user as that would give it the ability to create a link from `${NIX_STATE_DIR}/profiles/per-user/${otherUser}` to any place in the file system, effectively controlling this other user's environment for anything that doesn't use the new profiles directory.

So the way we do that is that is that:

1. The `userName` is taken from the Unix socket used for the connection (if there's one. Otherwise this doesn't make sense any way)
2. The creation of the symlink is triggered by a dedicated protocol command which also passes the path to the user's profile directory.

Using a custom command just for that is a bit nasty, but that also seems to be the most reasonable solution.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
