### PR TITLE
Abstract away platform-specific sandbox code

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1213,85 +1213,6 @@ void LocalDerivationGoal::chownToBuilder(const Path & path)
 }
 
 
-void setupSeccomp()
-{
-#if __linux__
-    if (!settings.filterSyscalls) return;
-#if HAVE_SECCOMP
-    scmp_filter_ctx ctx;
-
-    if (!(ctx = seccomp_init(SCMP_ACT_ALLOW)))
-        throw SysError("unable to initialize seccomp mode 2");
-
-    Finally cleanup([&]() {
-        seccomp_release(ctx);
-    });
-
-    if (nativeSystem == "x86_64-linux" &&
-        seccomp_arch_add(ctx, SCMP_ARCH_X86) != 0)
-        throw SysError("unable to add 32-bit seccomp architecture");
-
-    if (nativeSystem == "x86_64-linux" &&
-        seccomp_arch_add(ctx, SCMP_ARCH_X32) != 0)
-        throw SysError("unable to add X32 seccomp architecture");
-
-    if (nativeSystem == "aarch64-linux" &&
-        seccomp_arch_add(ctx, SCMP_ARCH_ARM) != 0)
-        printError("unable to add ARM seccomp architecture; this may result in spurious build failures if running 32-bit ARM processes");
-
-    if (nativeSystem == "mips64-linux" &&
-        seccomp_arch_add(ctx, SCMP_ARCH_MIPS) != 0)
-        printError("unable to add mips seccomp architecture");
-
-    if (nativeSystem == "mips64-linux" &&
-        seccomp_arch_add(ctx, SCMP_ARCH_MIPS64N32) != 0)
-        printError("unable to add mips64-*abin32 seccomp architecture");
-
-    if (nativeSystem == "mips64el-linux" &&
-        seccomp_arch_add(ctx, SCMP_ARCH_MIPSEL) != 0)
-        printError("unable to add mipsel seccomp architecture");
-
-    if (nativeSystem == "mips64el-linux" &&
-        seccomp_arch_add(ctx, SCMP_ARCH_MIPSEL64N32) != 0)
-        printError("unable to add mips64el-*abin32 seccomp architecture");
-
-    /* Prevent builders from creating setuid/setgid binaries. */
-    for (int perm : { S_ISUID, S_ISGID }) {
-        if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(chmod), 1,
-                SCMP_A1(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
-            throw SysError("unable to add seccomp rule");
-
-        if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(fchmod), 1,
-                SCMP_A1(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
-            throw SysError("unable to add seccomp rule");
-
-        if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(fchmodat), 1,
-                SCMP_A2(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
-            throw SysError("unable to add seccomp rule");
-    }
-
-    /* Prevent builders from creating EAs or ACLs. Not all filesystems
-       support these, and they're not allowed in the Nix store because
-       they're not representable in the NAR serialisation. */
-    if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(setxattr), 0) != 0 ||
-        seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(lsetxattr), 0) != 0 ||
-        seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(fsetxattr), 0) != 0)
-        throw SysError("unable to add seccomp rule");
-
-    if (seccomp_attr_set(ctx, SCMP_FLTATR_CTL_NNP, settings.allowNewPrivileges ? 0 : 1) != 0)
-        throw SysError("unable to set 'no new privileges' seccomp attribute");
-
-    if (seccomp_load(ctx) != 0)
-        throw SysError("unable to load seccomp BPF program");
-#else
-    throw Error(
-        "seccomp is not supported on this platform; "
-        "you can bypass this error by setting the option 'filter-syscalls' to false, but note that untrusted builds can then create setuid binaries!");
-#endif
-#endif
-}
-
-
 void LocalDerivationGoal::runChild()
 {
     /* Warning: in the child we should absolutely not make any SQLite
@@ -1304,12 +1225,10 @@ void LocalDerivationGoal::runChild()
         commonChildInit(builderOut);
 
         try {
-            setupSeccomp();
+            sandbox->filterSyscalls();
         } catch (...) {
             if (buildUser) throw;
         }
-
-        bool setUser = true;
 
         /* Make the contents of netrc available to builtin:fetchurl
            (which may run under a different uid and/or in a sandbox). */
@@ -1319,12 +1238,7 @@ void LocalDerivationGoal::runChild()
                 netrcData = readFile(settings.netrcFile);
         } catch (SysError &) { }
 
-        if (useChroot) {
-            sandbox->enterChroot(worker.store, *this);
-#if __linux__
-            setUser = true;
-#endif
-        }
+        bool setUser = !(useChroot && sandbox->enterChroot(worker.store, *this));
 
         if (chdir(tmpDirInSandbox.c_str()) == -1)
             throw SysError("changing into '%1%'", tmpDir);
@@ -1397,16 +1311,10 @@ void LocalDerivationGoal::runChild()
             }
         } else {
             /* Fill in the arguments. */
-            Strings args;
-
-            std::string builder = "invalid";
-
-            if (!drv->isBuiltin()) {
-                std::tie(builder, args) = sandbox->getSandboxArgs(*drv, useChroot, dirsInChroot, worker.store, *this);
-            }
+            auto builderArgs = sandbox->getSandboxArgs(*drv, useChroot, dirsInChroot, worker.store, *this);
 
             for (auto & i : drv->args)
-                args.push_back(rewriteStrings(i, inputRewrites));
+                builderArgs.second.push_back(rewriteStrings(i, inputRewrites));
 
             /* Indicate that we managed to set up the build environment. */
             writeFull(STDERR_FILENO, std::string("\2\n"));
@@ -1414,7 +1322,7 @@ void LocalDerivationGoal::runChild()
             sendException = false;
 
             /* Execute the program.  This should not return. */
-            sandbox->spawn(builder, args, envStrs, drv->platform);
+            sandbox->spawn(builderArgs, envStrs, drv->platform);
         }
 
 

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -93,7 +93,7 @@ LocalDerivationGoal::LocalDerivationGoal(const StorePath &drvPath,
 
     : DerivationGoal(drvPath, wantedOutputs, worker, buildMode)
 #if __APPLE__
-    , platform(createSandboxDarwin())
+    , sandbox(createSandboxDarwin())
 #elif __linux__
     , sandbox(createSandboxLinux())
 #endif
@@ -105,7 +105,7 @@ LocalDerivationGoal::LocalDerivationGoal(const StorePath &drvPath,
                                          Worker &worker, BuildMode buildMode)
     : DerivationGoal(drvPath, drv, wantedOutputs, worker, buildMode)
 #if __APPLE__
-    , platform(createSandboxDarwin())
+    , sandbox(createSandboxDarwin())
 #elif __linux__
     , sandbox(createSandboxLinux())
 #endif
@@ -384,8 +384,10 @@ void LocalDerivationGoal::cleanupPostOutputsRegisteredModeNonCheck()
 void LocalDerivationGoal::startBuilder()
 {
     if ((buildUser && buildUser->getUIDCount() != 1)
-        || (__linux__ && settings.useCgroups))
-    {
+#if __linux__
+        || settings.useCgroups
+#endif
+        ) {
         settings.requireExperimentalFeature(Xp::Cgroups);
         sandbox->createCGroups(buildUser.get());
     }

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1,4 +1,5 @@
 #include "local-derivation-goal.hh"
+#include "derivations.hh"
 #include "gc-store.hh"
 #include "hook-instance.hh"
 #include "worker.hh"
@@ -17,6 +18,7 @@
 #include "cgroup.hh"
 #include "personality.hh"
 #include "namespaces.hh"
+#include "sandbox.hh"
 
 #include <regex>
 #include <queue>
@@ -33,25 +35,8 @@
 #include <sys/statvfs.h>
 #endif
 
-/* Includes required for chroot support. */
-#if __linux__
-#include <sys/ioctl.h>
-#include <net/if.h>
-#include <netinet/ip.h>
-#include <sys/mman.h>
-#include <sched.h>
-#include <sys/param.h>
-#include <sys/mount.h>
-#include <sys/syscall.h>
 #if HAVE_SECCOMP
 #include <seccomp.h>
-#endif
-#define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
-#endif
-
-#if __APPLE__
-#include <spawn.h>
-#include <sys/sysctl.h>
 #endif
 
 #include <pwd.h>
@@ -93,8 +78,38 @@ void handleDiffHook(
     }
 }
 
+static void chmod_(const Path & path, mode_t mode)
+{
+    if (chmod(path.c_str(), mode) == -1)
+        throw SysError("setting permissions on '%s'", path);
+}
+
 const Path LocalDerivationGoal::homeDir = "/homeless-shelter";
 
+
+LocalDerivationGoal::LocalDerivationGoal(const StorePath &drvPath,
+                                         const OutputsSpec &wantedOutputs,
+                                         Worker &worker, BuildMode buildMode)
+
+    : DerivationGoal(drvPath, wantedOutputs, worker, buildMode)
+#if __APPLE__
+    , platform(createSandboxDarwin())
+#elif __linux__
+    , sandbox(createSandboxLinux())
+#endif
+{};
+
+LocalDerivationGoal::LocalDerivationGoal(const StorePath &drvPath,
+                                         const BasicDerivation &drv,
+                                         const OutputsSpec &wantedOutputs,
+                                         Worker &worker, BuildMode buildMode)
+    : DerivationGoal(drvPath, drv, wantedOutputs, worker, buildMode)
+#if __APPLE__
+    , platform(createSandboxDarwin())
+#elif __linux__
+    , sandbox(createSandboxLinux())
+#endif
+{}
 
 LocalDerivationGoal::~LocalDerivationGoal()
 {
@@ -148,22 +163,10 @@ void LocalDerivationGoal::killChild()
 
 void LocalDerivationGoal::killSandbox(bool getStats)
 {
-    if (cgroup) {
-        #if __linux__
-        auto stats = destroyCgroup(*cgroup);
-        if (getStats) {
-            buildResult.cpuUser = stats.cpuUser;
-            buildResult.cpuSystem = stats.cpuSystem;
-        }
-        #else
-        abort();
-        #endif
-    }
-
-    else if (buildUser) {
-        auto uid = buildUser->getUID();
-        assert(uid != 0);
-        killUser(uid);
+    auto stats = sandbox->killSandbox();
+    if (getStats && stats) {
+        buildResult.cpuUser = stats->cpuUser;
+        buildResult.cpuSystem = stats->cpuSystem;
     }
 }
 
@@ -229,6 +232,7 @@ void LocalDerivationGoal::tryLocalBuild()
             worker.waitForAWhile(shared_from_this());
             return;
         }
+        sandbox->buildUser = buildUser.get();
     }
 
     actLock.reset();
@@ -251,12 +255,6 @@ void LocalDerivationGoal::tryLocalBuild()
     state = &DerivationGoal::buildDone;
 
     started();
-}
-
-static void chmod_(const Path & path, mode_t mode)
-{
-    if (chmod(path.c_str(), mode) == -1)
-        throw SysError("setting permissions on '%s'", path);
 }
 
 
@@ -307,8 +305,7 @@ void LocalDerivationGoal::cleanupHookFinally()
 
 void LocalDerivationGoal::cleanupPreChildKill()
 {
-    sandboxMountNamespace = -1;
-    sandboxUserNamespace = -1;
+    if (sandbox) sandbox->cleanupPreChildKill();
 }
 
 
@@ -358,8 +355,7 @@ bool LocalDerivationGoal::cleanupDecideWhetherDiskFull()
             if (!status.known) continue;
             if (buildMode != bmCheck && status.known->isValid()) continue;
             auto p = worker.store.printStorePath(status.known->path);
-            if (pathExists(chrootRootDir + p))
-                renameFile((chrootRootDir + p), p);
+            sandbox->moveOutOfChroot(p);
         }
 
     return diskFull;
@@ -378,85 +374,20 @@ void LocalDerivationGoal::cleanupPostOutputsRegisteredModeNonCheck()
     for (auto & i : redirectedOutputs)
         deletePath(worker.store.Store::toRealPath(i.second));
 
-    /* Delete the chroot (if we were using one). */
-    autoDelChroot.reset(); /* this runs the destructor */
+    sandbox->deleteChroot();
 
     cleanupPostOutputsRegisteredModeCheck();
 }
 
 
-#if __linux__
-static void linkOrCopy(const Path & from, const Path & to)
-{
-    if (link(from.c_str(), to.c_str()) == -1) {
-        /* Hard-linking fails if we exceed the maximum link count on a
-           file (e.g. 32000 of ext3), which is quite possible after a
-           'nix-store --optimise'. FIXME: actually, why don't we just
-           bind-mount in this case?
-
-           It can also fail with EPERM in BeegFS v7 and earlier versions
-           which don't allow hard-links to other directories */
-        if (errno != EMLINK && errno != EPERM)
-            throw SysError("linking '%s' to '%s'", to, from);
-        copyPath(from, to);
-    }
-}
-#endif
-
 
 void LocalDerivationGoal::startBuilder()
 {
     if ((buildUser && buildUser->getUIDCount() != 1)
-        #if __linux__
-        || settings.useCgroups
-        #endif
-        )
+        || (__linux__ && settings.useCgroups))
     {
-        #if __linux__
         settings.requireExperimentalFeature(Xp::Cgroups);
-
-        auto cgroupFS = getCgroupFS();
-        if (!cgroupFS)
-            throw Error("cannot determine the cgroups file system");
-
-        auto ourCgroups = getCgroups("/proc/self/cgroup");
-        auto ourCgroup = ourCgroups[""];
-        if (ourCgroup == "")
-            throw Error("cannot determine cgroup name from /proc/self/cgroup");
-
-        auto ourCgroupPath = canonPath(*cgroupFS + "/" + ourCgroup);
-
-        if (!pathExists(ourCgroupPath))
-            throw Error("expected cgroup directory '%s'", ourCgroupPath);
-
-        static std::atomic<unsigned int> counter{0};
-
-        cgroup = buildUser
-            ? fmt("%s/nix-build-uid-%d", ourCgroupPath, buildUser->getUID())
-            : fmt("%s/nix-build-pid-%d-%d", ourCgroupPath, getpid(), counter++);
-
-        debug("using cgroup '%s'", *cgroup);
-
-        /* When using a build user, record the cgroup we used for that
-           user so that if we got interrupted previously, we can kill
-           any left-over cgroup first. */
-        if (buildUser) {
-            auto cgroupsDir = settings.nixStateDir + "/cgroups";
-            createDirs(cgroupsDir);
-
-            auto cgroupFile = fmt("%s/%d", cgroupsDir, buildUser->getUID());
-
-            if (pathExists(cgroupFile)) {
-                auto prevCgroup = readFile(cgroupFile);
-                destroyCgroup(prevCgroup);
-            }
-
-            writeFile(cgroupFile, *cgroup);
-        }
-
-        #else
-        throw Error("cgroups are not supported on this platform");
-        #endif
+        sandbox->createCGroups(buildUser.get());
     }
 
     /* Make sure that no other processes are executing under the
@@ -639,111 +570,10 @@ void LocalDerivationGoal::startBuilder()
             dirsInChroot[i] = {i, true};
         }
 
-#if __linux__
-        /* Create a temporary directory in which we set up the chroot
-           environment using bind-mounts.  We put it in the Nix store
-           to ensure that we can create hard-links to non-directory
-           inputs in the fake Nix store in the chroot (see below). */
-        chrootRootDir = worker.store.Store::toRealPath(drvPath) + ".chroot";
-        deletePath(chrootRootDir);
-
-        /* Clean up the chroot directory automatically. */
-        autoDelChroot = std::make_shared<AutoDelete>(chrootRootDir);
-
-        printMsg(lvlChatty, "setting up chroot environment in '%1%'", chrootRootDir);
-
-        // FIXME: make this 0700
-        if (mkdir(chrootRootDir.c_str(), buildUser && buildUser->getUIDCount() != 1 ? 0755 : 0750) == -1)
-            throw SysError("cannot create '%1%'", chrootRootDir);
-
-        if (buildUser && chown(chrootRootDir.c_str(), buildUser->getUIDCount() != 1 ? buildUser->getUID() : 0, buildUser->getGID()) == -1)
-            throw SysError("cannot change ownership of '%1%'", chrootRootDir);
-
-        /* Create a writable /tmp in the chroot.  Many builders need
-           this.  (Of course they should really respect $TMPDIR
-           instead.) */
-        Path chrootTmpDir = chrootRootDir + "/tmp";
-        createDirs(chrootTmpDir);
-        chmod_(chrootTmpDir, 01777);
-
-        /* Create a /etc/passwd with entries for the build user and the
-           nobody account.  The latter is kind of a hack to support
-           Samba-in-QEMU. */
-        createDirs(chrootRootDir + "/etc");
-        if (parsedDrv->useUidRange())
-            chownToBuilder(chrootRootDir + "/etc");
-
-        if (parsedDrv->useUidRange() && (!buildUser || buildUser->getUIDCount() < 65536))
-            throw Error("feature 'uid-range' requires the setting '%s' to be enabled", settings.autoAllocateUids.name);
-
-        /* Declare the build user's group so that programs get a consistent
-           view of the system (e.g., "id -gn"). */
-        writeFile(chrootRootDir + "/etc/group",
-            fmt("root:x:0:\n"
-                "nixbld:!:%1%:\n"
-                "nogroup:x:65534:\n", sandboxGid()));
-
-        /* Create /etc/hosts with localhost entry. */
-        if (derivationType.isSandboxed())
-            writeFile(chrootRootDir + "/etc/hosts", "127.0.0.1 localhost\n::1 localhost\n");
-
-        /* Make the closure of the inputs available in the chroot,
-           rather than the whole Nix store.  This prevents any access
-           to undeclared dependencies.  Directories are bind-mounted,
-           while other inputs are hard-linked (since only directories
-           can be bind-mounted).  !!! As an extra security
-           precaution, make the fake Nix store only writable by the
-           build user. */
-        Path chrootStoreDir = chrootRootDir + worker.store.storeDir;
-        createDirs(chrootStoreDir);
-        chmod_(chrootStoreDir, 01775);
-
-        if (buildUser && chown(chrootStoreDir.c_str(), 0, buildUser->getGID()) == -1)
-            throw SysError("cannot change ownership of '%1%'", chrootStoreDir);
-
-        for (auto & i : inputPaths) {
-            auto p = worker.store.printStorePath(i);
-            Path r = worker.store.toRealPath(p);
-            if (S_ISDIR(lstat(r).st_mode))
-                dirsInChroot.insert_or_assign(p, r);
-            else
-                linkOrCopy(r, chrootRootDir + p);
-        }
-
-        /* If we're repairing, checking or rebuilding part of a
-           multiple-outputs derivation, it's possible that we're
-           rebuilding a path that is in settings.dirsInChroot
-           (typically the dependencies of /bin/sh).  Throw them
-           out. */
-        for (auto & i : drv->outputsAndOptPaths(worker.store)) {
-            /* If the name isn't known a priori (i.e. floating
-               content-addressed derivation), the temporary location we use
-               should be fresh.  Freshness means it is impossible that the path
-               is already in the sandbox, so we don't need to worry about
-               removing it.  */
-            if (i.second.second)
-                dirsInChroot.erase(worker.store.printStorePath(*i.second.second));
-        }
-
-        if (cgroup) {
-            if (mkdir(cgroup->c_str(), 0755) != 0)
-                throw SysError("creating cgroup '%s'", *cgroup);
-            chownToBuilder(*cgroup);
-            chownToBuilder(*cgroup + "/cgroup.procs");
-            chownToBuilder(*cgroup + "/cgroup.threads");
-            //chownToBuilder(*cgroup + "/cgroup.subtree_control");
-        }
-
-#else
-        if (parsedDrv->useUidRange())
-            throw Error("feature 'uid-range' is not supported on this platform");
-        #if __APPLE__
-            /* We don't really have any parent prep work to do (yet?)
-               All work happens in the child, instead. */
-        #else
-            throw Error("sandboxing builds is not supported on this platform");
-        #endif
-#endif
+        sandbox->prepareChroot(worker.store, *this);
+        // todo
+        // if (parsedDrv->useUidRange())
+        //     throw Error("feature 'uid-range' is not supported on this platform");
     } else {
         if (parsedDrv->useUidRange())
             throw Error("feature 'uid-range' is only supported in sandboxed builds");
@@ -754,8 +584,7 @@ void LocalDerivationGoal::startBuilder()
 
     if (useChroot && settings.preBuildHook != "" && dynamic_cast<Derivation *>(drv.get())) {
         printMsg(lvlChatty, "executing pre-build hook '%1%'", settings.preBuildHook);
-        auto args = useChroot ? Strings({worker.store.printStorePath(drvPath), chrootRootDir}) :
-            Strings({ worker.store.printStorePath(drvPath) });
+        auto args = sandbox->getPrebuildHookArgs(worker.store, drvPath);
         enum BuildHookState {
             stBegin,
             stExtraChrootDirs
@@ -854,144 +683,9 @@ void LocalDerivationGoal::startBuilder()
 
     /* Fork a child to build the package. */
 
-#if __linux__
     if (useChroot) {
-        /* Set up private namespaces for the build:
-
-           - The PID namespace causes the build to start as PID 1.
-             Processes outside of the chroot are not visible to those
-             on the inside, but processes inside the chroot are
-             visible from the outside (though with different PIDs).
-
-           - The private mount namespace ensures that all the bind
-             mounts we do will only show up in this process and its
-             children, and will disappear automatically when we're
-             done.
-
-           - The private network namespace ensures that the builder
-             cannot talk to the outside world (or vice versa).  It
-             only has a private loopback interface. (Fixed-output
-             derivations are not run in a private network namespace
-             to allow functions like fetchurl to work.)
-
-           - The IPC namespace prevents the builder from communicating
-             with outside processes using SysV IPC mechanisms (shared
-             memory, message queues, semaphores).  It also ensures
-             that all IPC objects are destroyed when the builder
-             exits.
-
-           - The UTS namespace ensures that builders see a hostname of
-             localhost rather than the actual hostname.
-
-           We use a helper process to do the clone() to work around
-           clone() being broken in multi-threaded programs due to
-           at-fork handlers not being run. Note that we use
-           CLONE_PARENT to ensure that the real builder is parented to
-           us.
-        */
-
-        if (derivationType.isSandboxed())
-            privateNetwork = true;
-
-        userNamespaceSync.create();
-
-        usingUserNamespace = userNamespacesSupported();
-
-        Pid helper = startProcess([&]() {
-
-            /* Drop additional groups here because we can't do it
-               after we've created the new user namespace.  FIXME:
-               this means that if we're not root in the parent
-               namespace, we can't drop additional groups; they will
-               be mapped to nogroup in the child namespace. There does
-               not seem to be a workaround for this. (But who can tell
-               from reading user_namespaces(7)?)
-               See also https://lwn.net/Articles/621612/. */
-            if (getuid() == 0 && setgroups(0, 0) == -1)
-                throw SysError("setgroups failed");
-
-            ProcessOptions options;
-            options.cloneFlags = CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWIPC | CLONE_NEWUTS | CLONE_PARENT | SIGCHLD;
-            if (privateNetwork)
-                options.cloneFlags |= CLONE_NEWNET;
-            if (usingUserNamespace)
-                options.cloneFlags |= CLONE_NEWUSER;
-
-            pid_t child = startProcess([&]() { runChild(); }, options);
-
-            writeFull(builderOut.writeSide.get(),
-                fmt("%d %d\n", usingUserNamespace, child));
-            _exit(0);
-        });
-
-        if (helper.wait() != 0)
-            throw Error("unable to start build process");
-
-        userNamespaceSync.readSide = -1;
-
-        /* Close the write side to prevent runChild() from hanging
-           reading from this. */
-        Finally cleanup([&]() {
-            userNamespaceSync.writeSide = -1;
-        });
-
-        auto ss = tokenizeString<std::vector<std::string>>(readLine(builderOut.readSide.get()));
-        assert(ss.size() == 2);
-        usingUserNamespace = ss[0] == "1";
-        pid = string2Int<pid_t>(ss[1]).value();
-
-        if (usingUserNamespace) {
-            /* Set the UID/GID mapping of the builder's user namespace
-               such that the sandbox user maps to the build user, or to
-               the calling user (if build users are disabled). */
-            uid_t hostUid = buildUser ? buildUser->getUID() : getuid();
-            uid_t hostGid = buildUser ? buildUser->getGID() : getgid();
-            uid_t nrIds = buildUser ? buildUser->getUIDCount() : 1;
-
-            writeFile("/proc/" + std::to_string(pid) + "/uid_map",
-                fmt("%d %d %d", sandboxUid(), hostUid, nrIds));
-
-            if (!buildUser || buildUser->getUIDCount() == 1)
-                writeFile("/proc/" + std::to_string(pid) + "/setgroups", "deny");
-
-            writeFile("/proc/" + std::to_string(pid) + "/gid_map",
-                fmt("%d %d %d", sandboxGid(), hostGid, nrIds));
-        } else {
-            debug("note: not using a user namespace");
-            if (!buildUser)
-                throw Error("cannot perform a sandboxed build because user namespaces are not enabled; check /proc/sys/user/max_user_namespaces");
-        }
-
-        /* Now that we now the sandbox uid, we can write
-           /etc/passwd. */
-        writeFile(chrootRootDir + "/etc/passwd", fmt(
-                "root:x:0:0:Nix build user:%3%:/noshell\n"
-                "nixbld:x:%1%:%2%:Nix build user:%3%:/noshell\n"
-                "nobody:x:65534:65534:Nobody:/:/noshell\n",
-                sandboxUid(), sandboxGid(), settings.sandboxBuildDir));
-
-        /* Save the mount- and user namespace of the child. We have to do this
-           *before* the child does a chroot. */
-        sandboxMountNamespace = open(fmt("/proc/%d/ns/mnt", (pid_t) pid).c_str(), O_RDONLY);
-        if (sandboxMountNamespace.get() == -1)
-            throw SysError("getting sandbox mount namespace");
-
-        if (usingUserNamespace) {
-            sandboxUserNamespace = open(fmt("/proc/%d/ns/user", (pid_t) pid).c_str(), O_RDONLY);
-            if (sandboxUserNamespace.get() == -1)
-                throw SysError("getting sandbox user namespace");
-        }
-
-        /* Move the child into its own cgroup. */
-        if (cgroup)
-            writeFile(*cgroup + "/cgroup.procs", fmt("%d", (pid_t) pid));
-
-        /* Signal the builder that we've updated its user namespace. */
-        writeFull(userNamespaceSync.writeSide.get(), "1");
-
-    } else
-#endif
-    {
+        sandbox->runInNamespaces(derivationType, *this);
+    } else {
         pid = startProcess([&]() {
             runChild();
         });
@@ -1205,7 +899,7 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual Lo
         , next(next), goal(goal)
     { }
 
-    Path getRealStoreDir() override
+    Path getRealStoreDir() const override
     { return next->realStoreDir; }
 
     std::string getUri() override
@@ -1505,51 +1199,7 @@ void LocalDerivationGoal::addDependency(const StorePath & path)
 
         debug("materialising '%s' in the sandbox", worker.store.printStorePath(path));
 
-        #if __linux__
-
-            Path source = worker.store.Store::toRealPath(path);
-            Path target = chrootRootDir + worker.store.printStorePath(path);
-            debug("bind-mounting %s -> %s", target, source);
-
-            if (pathExists(target))
-                throw Error("store path '%s' already exists in the sandbox", worker.store.printStorePath(path));
-
-            auto st = lstat(source);
-
-            if (S_ISDIR(st.st_mode)) {
-
-                /* Bind-mount the path into the sandbox. This requires
-                   entering its mount namespace, which is not possible
-                   in multithreaded programs. So we do this in a
-                   child process.*/
-                Pid child(startProcess([&]() {
-
-                    if (usingUserNamespace && (setns(sandboxUserNamespace.get(), 0) == -1))
-                        throw SysError("entering sandbox user namespace");
-
-                    if (setns(sandboxMountNamespace.get(), 0) == -1)
-                        throw SysError("entering sandbox mount namespace");
-
-                    createDirs(target);
-
-                    if (mount(source.c_str(), target.c_str(), "", MS_BIND, 0) == -1)
-                        throw SysError("bind mount from '%s' to '%s' failed", source, target);
-
-                    _exit(0);
-                }));
-
-                int status = child.wait();
-                if (status != 0)
-                    throw Error("could not add path '%s' to sandbox", worker.store.printStorePath(path));
-
-            } else
-                linkOrCopy(source, target);
-
-        #else
-            throw Error("don't know how to make path '%s' (produced by a recursive Nix call) appear in the sandbox",
-                worker.store.printStorePath(path));
-        #endif
-
+        sandbox->addToSandbox(path, worker.store);
     }
 }
 
@@ -1667,242 +1317,12 @@ void LocalDerivationGoal::runChild()
                 netrcData = readFile(settings.netrcFile);
         } catch (SysError &) { }
 
-#if __linux__
         if (useChroot) {
-
-            userNamespaceSync.writeSide = -1;
-
-            if (drainFD(userNamespaceSync.readSide.get()) != "1")
-                throw Error("user namespace initialisation failed");
-
-            userNamespaceSync.readSide = -1;
-
-            if (privateNetwork) {
-
-                /* Initialise the loopback interface. */
-                AutoCloseFD fd(socket(PF_INET, SOCK_DGRAM, IPPROTO_IP));
-                if (!fd) throw SysError("cannot open IP socket");
-
-                struct ifreq ifr;
-                strcpy(ifr.ifr_name, "lo");
-                ifr.ifr_flags = IFF_UP | IFF_LOOPBACK | IFF_RUNNING;
-                if (ioctl(fd.get(), SIOCSIFFLAGS, &ifr) == -1)
-                    throw SysError("cannot set loopback interface flags");
-            }
-
-            /* Set the hostname etc. to fixed values. */
-            char hostname[] = "localhost";
-            if (sethostname(hostname, sizeof(hostname)) == -1)
-                throw SysError("cannot set host name");
-            char domainname[] = "(none)"; // kernel default
-            if (setdomainname(domainname, sizeof(domainname)) == -1)
-                throw SysError("cannot set domain name");
-
-            /* Make all filesystems private.  This is necessary
-               because subtrees may have been mounted as "shared"
-               (MS_SHARED).  (Systemd does this, for instance.)  Even
-               though we have a private mount namespace, mounting
-               filesystems on top of a shared subtree still propagates
-               outside of the namespace.  Making a subtree private is
-               local to the namespace, though, so setting MS_PRIVATE
-               does not affect the outside world. */
-            if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1)
-                throw SysError("unable to make '/' private");
-
-            /* Bind-mount chroot directory to itself, to treat it as a
-               different filesystem from /, as needed for pivot_root. */
-            if (mount(chrootRootDir.c_str(), chrootRootDir.c_str(), 0, MS_BIND, 0) == -1)
-                throw SysError("unable to bind mount '%1%'", chrootRootDir);
-
-            /* Bind-mount the sandbox's Nix store onto itself so that
-               we can mark it as a "shared" subtree, allowing bind
-               mounts made in *this* mount namespace to be propagated
-               into the child namespace created by the
-               unshare(CLONE_NEWNS) call below.
-
-               Marking chrootRootDir as MS_SHARED causes pivot_root()
-               to fail with EINVAL. Don't know why. */
-            Path chrootStoreDir = chrootRootDir + worker.store.storeDir;
-
-            if (mount(chrootStoreDir.c_str(), chrootStoreDir.c_str(), 0, MS_BIND, 0) == -1)
-                throw SysError("unable to bind mount the Nix store", chrootStoreDir);
-
-            if (mount(0, chrootStoreDir.c_str(), 0, MS_SHARED, 0) == -1)
-                throw SysError("unable to make '%s' shared", chrootStoreDir);
-
-            /* Set up a nearly empty /dev, unless the user asked to
-               bind-mount the host /dev. */
-            Strings ss;
-            if (dirsInChroot.find("/dev") == dirsInChroot.end()) {
-                createDirs(chrootRootDir + "/dev/shm");
-                createDirs(chrootRootDir + "/dev/pts");
-                ss.push_back("/dev/full");
-                if (worker.store.systemFeatures.get().count("kvm") && pathExists("/dev/kvm"))
-                    ss.push_back("/dev/kvm");
-                ss.push_back("/dev/null");
-                ss.push_back("/dev/random");
-                ss.push_back("/dev/tty");
-                ss.push_back("/dev/urandom");
-                ss.push_back("/dev/zero");
-                createSymlink("/proc/self/fd", chrootRootDir + "/dev/fd");
-                createSymlink("/proc/self/fd/0", chrootRootDir + "/dev/stdin");
-                createSymlink("/proc/self/fd/1", chrootRootDir + "/dev/stdout");
-                createSymlink("/proc/self/fd/2", chrootRootDir + "/dev/stderr");
-            }
-
-            /* Fixed-output derivations typically need to access the
-               network, so give them access to /etc/resolv.conf and so
-               on. */
-            if (!derivationType.isSandboxed()) {
-                // Only use nss functions to resolve hosts and
-                // services. Don’t use it for anything else that may
-                // be configured for this system. This limits the
-                // potential impurities introduced in fixed-outputs.
-                writeFile(chrootRootDir + "/etc/nsswitch.conf", "hosts: files dns\nservices: files\n");
-
-                /* N.B. it is realistic that these paths might not exist. It
-                   happens when testing Nix building fixed-output derivations
-                   within a pure derivation. */
-                for (auto & path : { "/etc/resolv.conf", "/etc/services", "/etc/hosts" })
-                    if (pathExists(path))
-                        ss.push_back(path);
-            }
-
-            for (auto & i : ss) dirsInChroot.emplace(i, i);
-
-            /* Bind-mount all the directories from the "host"
-               filesystem that we want in the chroot
-               environment. */
-            auto doBind = [&](const Path & source, const Path & target, bool optional = false) {
-                debug("bind mounting '%1%' to '%2%'", source, target);
-                struct stat st;
-                if (stat(source.c_str(), &st) == -1) {
-                    if (optional && errno == ENOENT)
-                        return;
-                    else
-                        throw SysError("getting attributes of path '%1%'", source);
-                }
-                if (S_ISDIR(st.st_mode))
-                    createDirs(target);
-                else {
-                    createDirs(dirOf(target));
-                    writeFile(target, "");
-                }
-                if (mount(source.c_str(), target.c_str(), "", MS_BIND | MS_REC, 0) == -1)
-                    throw SysError("bind mount from '%1%' to '%2%' failed", source, target);
-            };
-
-            for (auto & i : dirsInChroot) {
-                if (i.second.source == "/proc") continue; // backwards compatibility
-
-                #if HAVE_EMBEDDED_SANDBOX_SHELL
-                if (i.second.source == "__embedded_sandbox_shell__") {
-                    static unsigned char sh[] = {
-                        #include "embedded-sandbox-shell.gen.hh"
-                    };
-                    auto dst = chrootRootDir + i.first;
-                    createDirs(dirOf(dst));
-                    writeFile(dst, std::string_view((const char *) sh, sizeof(sh)));
-                    chmod_(dst, 0555);
-                } else
-                #endif
-                    doBind(i.second.source, chrootRootDir + i.first, i.second.optional);
-            }
-
-            /* Bind a new instance of procfs on /proc. */
-            createDirs(chrootRootDir + "/proc");
-            if (mount("none", (chrootRootDir + "/proc").c_str(), "proc", 0, 0) == -1)
-                throw SysError("mounting /proc");
-
-            /* Mount sysfs on /sys. */
-            if (buildUser && buildUser->getUIDCount() != 1) {
-                createDirs(chrootRootDir + "/sys");
-                if (mount("none", (chrootRootDir + "/sys").c_str(), "sysfs", 0, 0) == -1)
-                    throw SysError("mounting /sys");
-            }
-
-            /* Mount a new tmpfs on /dev/shm to ensure that whatever
-               the builder puts in /dev/shm is cleaned up automatically. */
-            if (pathExists("/dev/shm") && mount("none", (chrootRootDir + "/dev/shm").c_str(), "tmpfs", 0,
-                    fmt("size=%s", settings.sandboxShmSize).c_str()) == -1)
-                throw SysError("mounting /dev/shm");
-
-            /* Mount a new devpts on /dev/pts.  Note that this
-               requires the kernel to be compiled with
-               CONFIG_DEVPTS_MULTIPLE_INSTANCES=y (which is the case
-               if /dev/ptx/ptmx exists). */
-            if (pathExists("/dev/pts/ptmx") &&
-                !pathExists(chrootRootDir + "/dev/ptmx")
-                && !dirsInChroot.count("/dev/pts"))
-            {
-                if (mount("none", (chrootRootDir + "/dev/pts").c_str(), "devpts", 0, "newinstance,mode=0620") == 0)
-                {
-                    createSymlink("/dev/pts/ptmx", chrootRootDir + "/dev/ptmx");
-
-                    /* Make sure /dev/pts/ptmx is world-writable.  With some
-                       Linux versions, it is created with permissions 0.  */
-                    chmod_(chrootRootDir + "/dev/pts/ptmx", 0666);
-                } else {
-                    if (errno != EINVAL)
-                        throw SysError("mounting /dev/pts");
-                    doBind("/dev/pts", chrootRootDir + "/dev/pts");
-                    doBind("/dev/ptmx", chrootRootDir + "/dev/ptmx");
-                }
-            }
-
-            /* Make /etc unwritable */
-            if (!parsedDrv->useUidRange())
-                chmod_(chrootRootDir + "/etc", 0555);
-
-            /* Unshare this mount namespace. This is necessary because
-               pivot_root() below changes the root of the mount
-               namespace. This means that the call to setns() in
-               addDependency() would hide the host's filesystem,
-               making it impossible to bind-mount paths from the host
-               Nix store into the sandbox. Therefore, we save the
-               pre-pivot_root namespace in
-               sandboxMountNamespace. Since we made /nix/store a
-               shared subtree above, this allows addDependency() to
-               make paths appear in the sandbox. */
-            if (unshare(CLONE_NEWNS) == -1)
-                throw SysError("unsharing mount namespace");
-
-            /* Unshare the cgroup namespace. This means
-               /proc/self/cgroup will show the child's cgroup as '/'
-               rather than whatever it is in the parent. */
-            if (cgroup && unshare(CLONE_NEWCGROUP) == -1)
-                throw SysError("unsharing cgroup namespace");
-
-            /* Do the chroot(). */
-            if (chdir(chrootRootDir.c_str()) == -1)
-                throw SysError("cannot change directory to '%1%'", chrootRootDir);
-
-            if (mkdir("real-root", 0) == -1)
-                throw SysError("cannot create real-root directory");
-
-            if (pivot_root(".", "real-root") == -1)
-                throw SysError("cannot pivot old root directory onto '%1%'", (chrootRootDir + "/real-root"));
-
-            if (chroot(".") == -1)
-                throw SysError("cannot change root directory to '%1%'", chrootRootDir);
-
-            if (umount2("real-root", MNT_DETACH) == -1)
-                throw SysError("cannot unmount real root filesystem");
-
-            if (rmdir("real-root") == -1)
-                throw SysError("cannot remove real-root directory");
-
-            /* Switch to the sandbox uid/gid in the user namespace,
-               which corresponds to the build user or calling user in
-               the parent namespace. */
-            if (setgid(sandboxGid()) == -1)
-                throw SysError("setgid failed");
-            if (setuid(sandboxUid()) == -1)
-                throw SysError("setuid failed");
-
-            setUser = false;
-        }
+            sandbox->enterChroot(worker.store, *this);
+#if __linux__
+            setUser = true;
 #endif
+        }
 
         if (chdir(tmpDirInSandbox.c_str()) == -1)
             throw SysError("changing into '%1%'", tmpDir);
@@ -1952,144 +1372,9 @@ void LocalDerivationGoal::runChild()
 
         std::string builder = "invalid";
 
-        if (drv->isBuiltin()) {
-            ;
+        if (!drv->isBuiltin()) {
+            std::tie(builder, args) = sandbox->getSandboxArgs(*drv, useChroot, dirsInChroot, worker.store, *this);
         }
-#if __APPLE__
-        else {
-            /* This has to appear before import statements. */
-            std::string sandboxProfile = "(version 1)\n";
-
-            if (useChroot) {
-
-                /* Lots and lots and lots of file functions freak out if they can't stat their full ancestry */
-                PathSet ancestry;
-
-                /* We build the ancestry before adding all inputPaths to the store because we know they'll
-                   all have the same parents (the store), and there might be lots of inputs. This isn't
-                   particularly efficient... I doubt it'll be a bottleneck in practice */
-                for (auto & i : dirsInChroot) {
-                    Path cur = i.first;
-                    while (cur.compare("/") != 0) {
-                        cur = dirOf(cur);
-                        ancestry.insert(cur);
-                    }
-                }
-
-                /* And we want the store in there regardless of how empty dirsInChroot. We include the innermost
-                   path component this time, since it's typically /nix/store and we care about that. */
-                Path cur = worker.store.storeDir;
-                while (cur.compare("/") != 0) {
-                    ancestry.insert(cur);
-                    cur = dirOf(cur);
-                }
-
-                /* Add all our input paths to the chroot */
-                for (auto & i : inputPaths) {
-                    auto p = worker.store.printStorePath(i);
-                    dirsInChroot[p] = p;
-                }
-
-                /* Violations will go to the syslog if you set this. Unfortunately the destination does not appear to be configurable */
-                if (settings.darwinLogSandboxViolations) {
-                    sandboxProfile += "(deny default)\n";
-                } else {
-                    sandboxProfile += "(deny default (with no-log))\n";
-                }
-
-                sandboxProfile +=
-                    #include "sandbox-defaults.sb"
-                    ;
-
-                if (!derivationType.isSandboxed())
-                    sandboxProfile +=
-                        #include "sandbox-network.sb"
-                        ;
-
-                /* Add the output paths we'll use at build-time to the chroot */
-                sandboxProfile += "(allow file-read* file-write* process-exec\n";
-                for (auto & [_, path] : scratchOutputs)
-                    sandboxProfile += fmt("\t(subpath \"%s\")\n", worker.store.printStorePath(path));
-
-                sandboxProfile += ")\n";
-
-                /* Our inputs (transitive dependencies and any impurities computed above)
-
-                   without file-write* allowed, access() incorrectly returns EPERM
-                 */
-                sandboxProfile += "(allow file-read* file-write* process-exec\n";
-                for (auto & i : dirsInChroot) {
-                    if (i.first != i.second.source)
-                        throw Error(
-                            "can't map '%1%' to '%2%': mismatched impure paths not supported on Darwin",
-                            i.first, i.second.source);
-
-                    std::string path = i.first;
-                    struct stat st;
-                    if (lstat(path.c_str(), &st)) {
-                        if (i.second.optional && errno == ENOENT)
-                            continue;
-                        throw SysError("getting attributes of path '%s", path);
-                    }
-                    if (S_ISDIR(st.st_mode))
-                        sandboxProfile += fmt("\t(subpath \"%s\")\n", path);
-                    else
-                        sandboxProfile += fmt("\t(literal \"%s\")\n", path);
-                }
-                sandboxProfile += ")\n";
-
-                /* Allow file-read* on full directory hierarchy to self. Allows realpath() */
-                sandboxProfile += "(allow file-read*\n";
-                for (auto & i : ancestry) {
-                    sandboxProfile += fmt("\t(literal \"%s\")\n", i);
-                }
-                sandboxProfile += ")\n";
-
-                sandboxProfile += additionalSandboxProfile;
-            } else
-                sandboxProfile +=
-                    #include "sandbox-minimal.sb"
-                    ;
-
-            debug("Generated sandbox profile:");
-            debug(sandboxProfile);
-
-            Path sandboxFile = tmpDir + "/.sandbox.sb";
-
-            writeFile(sandboxFile, sandboxProfile);
-
-            bool allowLocalNetworking = parsedDrv->getBoolAttr("__darwinAllowLocalNetworking");
-
-            /* The tmpDir in scope points at the temporary build directory for our derivation. Some packages try different mechanisms
-               to find temporary directories, so we want to open up a broader place for them to dump their files, if needed. */
-            Path globalTmpDir = canonPath(getEnv("TMPDIR").value_or("/tmp"), true);
-
-            /* They don't like trailing slashes on subpath directives */
-            if (globalTmpDir.back() == '/') globalTmpDir.pop_back();
-
-            if (getEnv("_NIX_TEST_NO_SANDBOX") != "1") {
-                builder = "/usr/bin/sandbox-exec";
-                args.push_back("sandbox-exec");
-                args.push_back("-f");
-                args.push_back(sandboxFile);
-                args.push_back("-D");
-                args.push_back("_GLOBAL_TMP_DIR=" + globalTmpDir);
-                if (allowLocalNetworking) {
-                    args.push_back("-D");
-                    args.push_back(std::string("_ALLOW_LOCAL_NETWORKING=1"));
-                }
-                args.push_back(drv->builder);
-            } else {
-                builder = drv->builder;
-                args.push_back(std::string(baseNameOf(drv->builder)));
-            }
-        }
-#else
-        else {
-            builder = drv->builder;
-            args.push_back(std::string(baseNameOf(drv->builder)));
-        }
-#endif
 
         for (auto & i : drv->args)
             args.push_back(rewriteStrings(i, inputRewrites));
@@ -2123,31 +1408,7 @@ void LocalDerivationGoal::runChild()
             }
         }
 
-#if __APPLE__
-        posix_spawnattr_t attrp;
-
-        if (posix_spawnattr_init(&attrp))
-            throw SysError("failed to initialize builder");
-
-        if (posix_spawnattr_setflags(&attrp, POSIX_SPAWN_SETEXEC))
-            throw SysError("failed to initialize builder");
-
-        if (drv->platform == "aarch64-darwin") {
-            // Unset kern.curproc_arch_affinity so we can escape Rosetta
-            int affinity = 0;
-            sysctlbyname("kern.curproc_arch_affinity", NULL, NULL, &affinity, sizeof(affinity));
-
-            cpu_type_t cpu = CPU_TYPE_ARM64;
-            posix_spawnattr_setbinpref_np(&attrp, 1, &cpu, NULL);
-        } else if (drv->platform == "x86_64-darwin") {
-            cpu_type_t cpu = CPU_TYPE_X86_64;
-            posix_spawnattr_setbinpref_np(&attrp, 1, &cpu, NULL);
-        }
-
-        posix_spawn(NULL, builder.c_str(), NULL, &attrp, stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
-#else
-        execve(builder.c_str(), stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
-#endif
+        sandbox->spawn(builder, args, envStrs, drv->platform);
 
         throw SysError("executing '%1%'", drv->builder);
 
@@ -2199,7 +1460,7 @@ DrvOutputs LocalDerivationGoal::registerOutputs()
        real reason why we aren't using the chroot dir */
     auto toRealPathChroot = [&](const Path & p) -> Path {
         return useChroot && !needsHashRewrite()
-            ? chrootRootDir + p
+            ? sandbox->toRealPath(p)
             : worker.store.toRealPath(p);
     };
 

--- a/src/libstore/build/sandbox-darwin.cc
+++ b/src/libstore/build/sandbox-darwin.cc
@@ -1,0 +1,179 @@
+#include "sandbox.hh"
+
+namespace nix {
+
+class SandboxDarwin : public Sandbox {
+public:
+    void prepareChroot(const Store&, LocalDerivationGoal& goal) override {};
+    void enterChroot(const Store&, LocalDerivationGoal& goal) override {
+        /* We don't really have any parent prep work to do (yet?)
+           All work happens in the child, instead. */
+    };
+    virtual std::pair<std::string, Strings> getSandboxArgs(const Derivation& drv, bool useChroot, LocalDerivationGoal::DirsInChroot &dirsInChroot, const Store& store, const LocalDerivationGoal& goal) override {
+        // FIXME passing LocalDerivationGoal is ugly
+       /* This has to appear before import statements. */
+       std::string sandboxProfile = "(version 1)\n";
+
+       if (useChroot) {
+
+           /* Lots and lots and lots of file functions freak out if they can't stat their full ancestry */
+           PathSet ancestry;
+
+           /* We build the ancestry before adding all inputPaths to the store because we know they'll
+              all have the same parents (the store), and there might be lots of inputs. This isn't
+              particularly efficient... I doubt it'll be a bottleneck in practice */
+           for (auto & i : dirsInChroot) {
+               Path cur = i.first;
+               while (cur.compare("/") != 0) {
+                   cur = dirOf(cur);
+                   ancestry.insert(cur);
+               }
+           }
+
+           /* And we want the store in there regardless of how empty dirsInChroot. We include the innermost
+              path component this time, since it's typically /nix/store and we care about that. */
+           Path cur = store.storeDir;
+           while (cur.compare("/") != 0) {
+               ancestry.insert(cur);
+               cur = dirOf(cur);
+           }
+
+           /* Add all our input paths to the chroot */
+           for (auto & i : goal.inputPaths) {
+               auto p = store.printStorePath(i);
+               dirsInChroot[p] = p;
+           }
+
+           /* Violations will go to the syslog if you set this. Unfortunately the destination does not appear to be configurable */
+#if __APPLE__
+           if (settings.darwinLogSandboxViolations) {
+               sandboxProfile += "(deny default)\n";
+           } else
+#endif
+           {
+               sandboxProfile += "(deny default (with no-log))\n";
+           }
+
+           sandboxProfile +=
+               #include "sandbox-defaults.sb"
+               ;
+
+           if (!drv.type().isSandboxed())
+               sandboxProfile +=
+                   #include "sandbox-network.sb"
+                   ;
+
+           /* Add the output paths we'll use at build-time to the chroot */
+           sandboxProfile += "(allow file-read* file-write* process-exec\n";
+           for (auto & [_, path] : goal.scratchOutputs)
+               sandboxProfile += fmt("\t(subpath \"%s\")\n", store.printStorePath(path));
+
+           sandboxProfile += ")\n";
+
+           /* Our inputs (transitive dependencies and any impurities computed above)
+
+              without file-write* allowed, access() incorrectly returns EPERM
+            */
+           sandboxProfile += "(allow file-read* file-write* process-exec\n";
+           for (auto & i : dirsInChroot) {
+               if (i.first != i.second.source)
+                   throw Error(
+                       "can't map '%1%' to '%2%': mismatched impure paths not supported on Darwin",
+                       i.first, i.second.source);
+
+               std::string path = i.first;
+               struct stat st;
+               if (lstat(path.c_str(), &st)) {
+                   if (i.second.optional && errno == ENOENT)
+                       continue;
+                   throw SysError("getting attributes of path '%s", path);
+               }
+               if (S_ISDIR(st.st_mode))
+                   sandboxProfile += fmt("\t(subpath \"%s\")\n", path);
+               else
+                   sandboxProfile += fmt("\t(literal \"%s\")\n", path);
+           }
+           sandboxProfile += ")\n";
+
+           /* Allow file-read* on full directory hierarchy to self. Allows realpath() */
+           sandboxProfile += "(allow file-read*\n";
+           for (auto & i : ancestry) {
+               sandboxProfile += fmt("\t(literal \"%s\")\n", i);
+           }
+           sandboxProfile += ")\n";
+#if __APPLE__
+           sandboxProfile += goal.additionalSandboxProfile;
+#endif
+       } else
+           sandboxProfile +=
+               #include "sandbox-minimal.sb"
+               ;
+
+       debug("Generated sandbox profile:");
+       debug(sandboxProfile);
+
+       Path sandboxFile = goal.tmpDir + "/.sandbox.sb";
+
+       writeFile(sandboxFile, sandboxProfile);
+
+       bool allowLocalNetworking = goal.parsedDrv->getBoolAttr("__darwinAllowLocalNetworking");
+
+       /* The tmpDir in scope points at the temporary build directory for our derivation. Some packages try different mechanisms
+          to find temporary directories, so we want to open up a broader place for them to dump their files, if needed. */
+       Path globalTmpDir = canonPath(getEnv("TMPDIR").value_or("/tmp"), true);
+
+       /* They don't like trailing slashes on subpath directives */
+       if (globalTmpDir.back() == '/') globalTmpDir.pop_back();
+
+       if (getEnv("_NIX_TEST_NO_SANDBOX") != "1") {
+           auto builder = "/usr/bin/sandbox-exec";
+           Strings args;
+           args.push_back("sandbox-exec");
+           args.push_back("-f");
+           args.push_back(sandboxFile);
+           args.push_back("-D");
+           args.push_back("_GLOBAL_TMP_DIR=" + globalTmpDir);
+           if (allowLocalNetworking) {
+               args.push_back("-D");
+               args.push_back(std::string("_ALLOW_LOCAL_NETWORKING=1"));
+           }
+           args.push_back(drv.builder);
+           return {builder, args};
+       } else {
+           return Sandbox::getSandboxArgs(drv, useChroot, dirsInChroot, store, goal);
+       }
+    };
+
+    void spawn(const std::string& builder, const Strings& args, const Strings& envStrs, std::string_view platform) override {
+#if __APPLE__
+        posix_spawnattr_t attrp;
+
+        if (posix_spawnattr_init(&attrp))
+            throw SysError("failed to initialize builder");
+
+        if (posix_spawnattr_setflags(&attrp, POSIX_SPAWN_SETEXEC))
+            throw SysError("failed to initialize builder");
+
+        if (platform == "aarch64-darwin") {
+            // Unset kern.curproc_arch_affinity so we can escape Rosetta
+            int affinity = 0;
+            sysctlbyname("kern.curproc_arch_affinity", NULL, NULL, &affinity, sizeof(affinity));
+
+            cpu_type_t cpu = CPU_TYPE_ARM64;
+            posix_spawnattr_setbinpref_np(&attrp, 1, &cpu, NULL);
+        } else if (drv->platform == "x86_64-darwin") {
+            cpu_type_t cpu = CPU_TYPE_X86_64;
+            posix_spawnattr_setbinpref_np(&attrp, 1, &cpu, NULL);
+        }
+
+        posix_spawn(NULL, builder.c_str(), NULL, &attrp, stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
+#endif
+    };
+    virtual ~SandboxDarwin() {};
+};
+
+std::unique_ptr<Sandbox> createSandboxDarwin(){
+    return std::make_unique<SandboxDarwin>();
+};
+
+}

--- a/src/libstore/build/sandbox-darwin.cc
+++ b/src/libstore/build/sandbox-darwin.cc
@@ -12,9 +12,10 @@ namespace nix {
 class SandboxDarwin : public Sandbox {
 public:
     void prepareChroot(const Store&, LocalDerivationGoal& goal) override {};
-    void enterChroot(const Store&, LocalDerivationGoal& goal) override {
+    bool enterChroot(const Store&, LocalDerivationGoal& goal) override {
         /* We don't really have any parent prep work to do (yet?)
            All work happens in the child, instead. */
+        return false;
     };
     virtual std::pair<std::string, Strings> getSandboxArgs(const Derivation& drv, bool useChroot, LocalDerivationGoal::DirsInChroot &dirsInChroot, const Store& store, const LocalDerivationGoal& goal) override {
         // FIXME passing LocalDerivationGoal is ugly
@@ -151,7 +152,7 @@ public:
        }
     };
 
-    void spawn(const std::string& builder, const Strings& args, const Strings& envStrs, std::string_view platform) override {
+    void spawn(const std::pair<std::string, Strings>& builderArgs, const nix::Strings& envStrs, std::string_view platform) override {
         posix_spawnattr_t attrp;
 
         if (posix_spawnattr_init(&attrp))
@@ -174,7 +175,7 @@ public:
         }
 
 #endif
-        posix_spawn(NULL, builder.c_str(), NULL, &attrp, stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
+        posix_spawn(NULL, builderArgs.first.c_str(), NULL, &attrp, stringsToCharPtrs(builderArgs.second).data(), stringsToCharPtrs(envStrs).data());
     };
     virtual ~SandboxDarwin() {};
 };

--- a/src/libstore/build/sandbox-linux.cc
+++ b/src/libstore/build/sandbox-linux.cc
@@ -1,0 +1,677 @@
+#include "sandbox.hh"
+#include "cgroup.hh"
+#include "worker.hh"
+#include "namespaces.hh"
+#include "archive.hh"
+#include "finally.hh"
+
+#include <sys/un.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+
+#if HAVE_STATVFS
+#include <sys/statvfs.h>
+#endif
+
+/* Includes required for chroot support. */
+#if __linux__
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <netinet/ip.h>
+#include <sys/mman.h>
+#include <sched.h>
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <sys/syscall.h>
+#if HAVE_SECCOMP
+#include <seccomp.h>
+#endif
+#define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
+#endif
+
+#include <grp.h>
+
+namespace nix {
+
+#if __linux__
+static void linkOrCopy(const Path & from, const Path & to)
+{
+    if (link(from.c_str(), to.c_str()) == -1) {
+        /* Hard-linking fails if we exceed the maximum link count on a
+           file (e.g. 32000 of ext3), which is quite possible after a
+           'nix-store --optimise'. FIXME: actually, why don't we just
+           bind-mount in this case?
+
+           It can also fail with EPERM in BeegFS v7 and earlier versions
+           which don't allow hard-links to other directories */
+        if (errno != EMLINK && errno != EPERM)
+            throw SysError("linking '%s' to '%s'", to, from);
+        copyPath(from, to);
+    }
+}
+#endif
+
+
+static void chmod_(const Path & path, mode_t mode)
+{
+    if (chmod(path.c_str(), mode) == -1)
+        throw SysError("setting permissions on '%s'", path);
+}
+
+class SandboxLinux : public Sandbox {
+    /* Whether to run the build in a private network namespace. */
+    bool privateNetwork = false;
+
+    /* Pipe for synchronising updates to the builder namespaces. */
+    Pipe userNamespaceSync;
+
+    /* The mount namespace and user namespace of the builder, used to add additional
+       paths to the sandbox as a result of recursive Nix calls. */
+    AutoCloseFD sandboxMountNamespace;
+    AutoCloseFD sandboxUserNamespace;
+
+    /* The cgroup of the builder, if any. */
+    std::optional<Path> cgroup;
+
+    /* On Linux, whether we're doing the build in its own user
+       namespace. */
+    bool usingUserNamespace = true;
+
+    Path chrootRootDir;
+
+    uid_t sandboxUid() { return usingUserNamespace ? (!buildUser || buildUser->getUIDCount() == 1 ? 1000 : 0) : buildUser->getUID(); }
+    gid_t sandboxGid() { return usingUserNamespace ? (!buildUser || buildUser->getUIDCount() == 1 ? 100  : 0) : buildUser->getGID(); }
+
+    /* RAII object to delete the chroot directory. */
+    std::shared_ptr<AutoDelete> autoDelChroot;
+public:
+    virtual Path toRealPath(const Path& p) const override {
+        return chrootRootDir + p;
+    };
+    virtual Strings getPrebuildHookArgs(const Store& store, const StorePath& drvPath) override {
+        return { store.printStorePath(drvPath), chrootRootDir };
+    };
+    virtual void cleanupPreChildKill() override {
+        sandboxMountNamespace = -1;
+        sandboxUserNamespace = -1;
+    };
+    virtual void moveOutOfChroot(Path& p) override {
+        if (pathExists(chrootRootDir + p))
+            renameFile((chrootRootDir + p), p);
+    };
+    virtual void deleteChroot() override {
+        /* Delete the chroot (if we were using one). */
+        autoDelChroot.reset(); /* this runs the destructor */
+    };
+
+    virtual std::optional<CgroupStats> killSandbox() override {
+        if (cgroup) {
+            return destroyCgroup(*cgroup);
+        }
+        return Sandbox::killSandbox();
+    }
+    virtual void createCGroups(const UserLock* buildUser) override {
+        auto cgroupFS = getCgroupFS();
+        if (!cgroupFS)
+            throw Error("cannot determine the cgroups file system");
+
+        auto ourCgroups = getCgroups("/proc/self/cgroup");
+        auto ourCgroup = ourCgroups[""];
+        if (ourCgroup == "")
+            throw Error("cannot determine cgroup name from /proc/self/cgroup");
+
+        auto ourCgroupPath = canonPath(*cgroupFS + "/" + ourCgroup);
+
+        if (!pathExists(ourCgroupPath))
+            throw Error("expected cgroup directory '%s'", ourCgroupPath);
+
+        static std::atomic<unsigned int> counter{0};
+
+        std::optional<Path> cgroup = buildUser
+            ? fmt("%s/nix-build-uid-%d", ourCgroupPath, buildUser->getUID())
+            : fmt("%s/nix-build-pid-%d-%d", ourCgroupPath, getpid(), counter++);
+
+        debug("using cgroup '%s'", *cgroup);
+
+        /* When using a build user, record the cgroup we used for that
+           user so that if we got interrupted previously, we can kill
+           any left-over cgroup first. */
+        if (buildUser) {
+            auto cgroupsDir = settings.nixStateDir + "/cgroups";
+            createDirs(cgroupsDir);
+
+            auto cgroupFile = fmt("%s/%d", cgroupsDir, buildUser->getUID());
+
+            if (pathExists(cgroupFile)) {
+                auto prevCgroup = readFile(cgroupFile);
+                destroyCgroup(prevCgroup);
+            }
+
+            writeFile(cgroupFile, *cgroup);
+        }
+        this->cgroup = cgroup;
+    };
+    void prepareChroot(const Store& store, LocalDerivationGoal& goal) override {
+        /* Create a temporary directory in which we set up the chroot
+           environment using bind-mounts.  We put it in the Nix store
+           to ensure that we can create hard-links to non-directory
+           inputs in the fake Nix store in the chroot (see below). */
+        chrootRootDir = store.Store::toRealPath(goal.drvPath) + ".chroot";
+        deletePath(chrootRootDir);
+
+        /* Clean up the chroot directory automatically. */
+        autoDelChroot = std::make_shared<AutoDelete>(chrootRootDir);
+
+        printMsg(lvlChatty, "setting up chroot environment in '%1%'", chrootRootDir);
+
+        // FIXME: make this 0700
+        if (mkdir(chrootRootDir.c_str(), buildUser && buildUser->getUIDCount() != 1 ? 0755 : 0750) == -1)
+            throw SysError("cannot create '%1%'", chrootRootDir);
+
+        if (buildUser && chown(chrootRootDir.c_str(), buildUser->getUIDCount() != 1 ? buildUser->getUID() : 0, buildUser->getGID()) == -1)
+            throw SysError("cannot change ownership of '%1%'", chrootRootDir);
+
+        /* Create a writable /tmp in the chroot.  Many builders need
+           this.  (Of course they should really respect $TMPDIR
+           instead.) */
+        Path chrootTmpDir = chrootRootDir + "/tmp";
+        createDirs(chrootTmpDir);
+        chmod_(chrootTmpDir, 01777);
+
+        /* Create a /etc/passwd with entries for the build user and the
+           nobody account.  The latter is kind of a hack to support
+           Samba-in-QEMU. */
+        createDirs(chrootRootDir + "/etc");
+        if (goal.parsedDrv->useUidRange())
+            goal.chownToBuilder(chrootRootDir + "/etc");
+
+        if (goal.parsedDrv->useUidRange() && (!buildUser || buildUser->getUIDCount() < 65536))
+            throw Error("feature 'uid-range' requires the setting '%s' to be enabled", settings.autoAllocateUids.name);
+
+        /* Declare the build user's group so that programs get a consistent
+           view of the system (e.g., "id -gn"). */
+        writeFile(chrootRootDir + "/etc/group",
+            fmt("root:x:0:\n"
+                "nixbld:!:%1%:\n"
+                "nogroup:x:65534:\n", sandboxGid()));
+
+        /* Create /etc/hosts with localhost entry. */
+        if (goal.derivationType.isSandboxed())
+            writeFile(chrootRootDir + "/etc/hosts", "127.0.0.1 localhost\n::1 localhost\n");
+
+        /* Make the closure of the inputs available in the chroot,
+           rather than the whole Nix store.  This prevents any access
+           to undeclared dependencies.  Directories are bind-mounted,
+           while other inputs are hard-linked (since only directories
+           can be bind-mounted).  !!! As an extra security
+           precaution, make the fake Nix store only writable by the
+           build user. */
+        Path chrootStoreDir = chrootRootDir + store.storeDir;
+        createDirs(chrootStoreDir);
+        chmod_(chrootStoreDir, 01775);
+
+        if (buildUser && chown(chrootStoreDir.c_str(), 0, buildUser->getGID()) == -1)
+            throw SysError("cannot change ownership of '%1%'", chrootStoreDir);
+
+        for (auto & i : goal.inputPaths) {
+            auto p = store.printStorePath(i);
+            Path r = store.toRealPath(p);
+            if (S_ISDIR(lstat(r).st_mode))
+                goal.dirsInChroot.insert_or_assign(p, r);
+            else
+                linkOrCopy(r, chrootRootDir + p);
+        }
+
+        /* If we're repairing, checking or rebuilding part of a
+           multiple-outputs derivation, it's possible that we're
+           rebuilding a path that is in settings.dirsInChroot
+           (typically the dependencies of /bin/sh).  Throw them
+           out. */
+        for (auto & i : goal.drv->outputsAndOptPaths(store)) {
+            /* If the name isn't known a priori (i.e. floating
+               content-addressed derivation), the temporary location we use
+               should be fresh.  Freshness means it is impossible that the path
+               is already in the sandbox, so we don't need to worry about
+               removing it.  */
+            if (i.second.second)
+                goal.dirsInChroot.erase(store.printStorePath(*i.second.second));
+        }
+
+        if (cgroup) {
+            if (mkdir(cgroup->c_str(), 0755) != 0)
+                throw SysError("creating cgroup '%s'", *cgroup);
+            goal.chownToBuilder(*cgroup);
+            goal.chownToBuilder(*cgroup + "/cgroup.procs");
+            goal.chownToBuilder(*cgroup + "/cgroup.threads");
+            //chownToBuilder(*cgroup + "/cgroup.subtree_control");
+        }
+
+    };
+    Pid runInNamespaces(DerivationType& derivationType, LocalDerivationGoal& goal) override {
+        /* Set up private namespaces for the build:
+
+           - The PID namespace causes the build to start as PID 1.
+             Processes outside of the chroot are not visible to those
+             on the inside, but processes inside the chroot are
+             visible from the outside (though with different PIDs).
+
+           - The private mount namespace ensures that all the bind
+             mounts we do will only show up in this process and its
+             children, and will disappear automatically when we're
+             done.
+
+           - The private network namespace ensures that the builder
+             cannot talk to the outside world (or vice versa).  It
+             only has a private loopback interface. (Fixed-output
+             derivations are not run in a private network namespace
+             to allow functions like fetchurl to work.)
+
+           - The IPC namespace prevents the builder from communicating
+             with outside processes using SysV IPC mechanisms (shared
+             memory, message queues, semaphores).  It also ensures
+             that all IPC objects are destroyed when the builder
+             exits.
+
+           - The UTS namespace ensures that builders see a hostname of
+             localhost rather than the actual hostname.
+
+           We use a helper process to do the clone() to work around
+           clone() being broken in multi-threaded programs due to
+           at-fork handlers not being run. Note that we use
+           CLONE_PARENT to ensure that the real builder is parented to
+           us.
+        */
+
+        if (derivationType.isSandboxed())
+            privateNetwork = true;
+
+        userNamespaceSync.create();
+
+        usingUserNamespace = userNamespacesSupported();
+
+        Pid helper = startProcess([&]() {
+
+            /* Drop additional groups here because we can't do it
+               after we've created the new user namespace.  FIXME:
+               this means that if we're not root in the parent
+               namespace, we can't drop additional groups; they will
+               be mapped to nogroup in the child namespace. There does
+               not seem to be a workaround for this. (But who can tell
+               from reading user_namespaces(7)?)
+               See also https://lwn.net/Articles/621612/. */
+            if (getuid() == 0 && setgroups(0, 0) == -1)
+                throw SysError("setgroups failed");
+
+            ProcessOptions options;
+            options.cloneFlags = CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWIPC | CLONE_NEWUTS | CLONE_PARENT | SIGCHLD;
+            if (privateNetwork)
+                options.cloneFlags |= CLONE_NEWNET;
+            if (usingUserNamespace)
+                options.cloneFlags |= CLONE_NEWUSER;
+
+            pid_t child = startProcess([&]() { goal.runChild(); }, options);
+
+            writeFull(goal.builderOut.writeSide.get(),
+                fmt("%d %d\n", usingUserNamespace, child));
+            _exit(0);
+        });
+
+        if (helper.wait() != 0)
+            throw Error("unable to start build process");
+
+        userNamespaceSync.readSide = -1;
+
+        /* Close the write side to prevent runChild() from hanging
+           reading from this. */
+        Finally cleanup([&]() {
+            userNamespaceSync.writeSide = -1;
+        });
+
+        auto ss = tokenizeString<std::vector<std::string>>(readLine(goal.builderOut.readSide.get()));
+        assert(ss.size() == 2);
+        usingUserNamespace = ss[0] == "1";
+        auto pid = string2Int<pid_t>(ss[1]).value();
+
+        if (usingUserNamespace) {
+            /* Set the UID/GID mapping of the builder's user namespace
+               such that the sandbox user maps to the build user, or to
+               the calling user (if build users are disabled). */
+            auto &buildUser = goal.buildUser;
+            uid_t hostUid = buildUser ? buildUser->getUID() : getuid();
+            uid_t hostGid = buildUser ? buildUser->getGID() : getgid();
+            uid_t nrIds = buildUser ? buildUser->getUIDCount() : 1;
+
+            writeFile("/proc/" + std::to_string(pid) + "/uid_map",
+                fmt("%d %d %d", sandboxUid(), hostUid, nrIds));
+
+            if (!buildUser || buildUser->getUIDCount() == 1)
+                writeFile("/proc/" + std::to_string(pid) + "/setgroups", "deny");
+
+            writeFile("/proc/" + std::to_string(pid) + "/gid_map",
+                fmt("%d %d %d", sandboxGid(), hostGid, nrIds));
+        } else {
+            debug("note: not using a user namespace");
+            if (!buildUser)
+                throw Error("cannot perform a sandboxed build because user namespaces are not enabled; check /proc/sys/user/max_user_namespaces");
+        }
+
+        /* Now that we now the sandbox uid, we can write
+           /etc/passwd. */
+        writeFile(chrootRootDir + "/etc/passwd", fmt(
+                "root:x:0:0:Nix build user:%3%:/noshell\n"
+                "nixbld:x:%1%:%2%:Nix build user:%3%:/noshell\n"
+                "nobody:x:65534:65534:Nobody:/:/noshell\n",
+                sandboxUid(), sandboxGid(), settings.sandboxBuildDir));
+
+        /* Make /etc unwritable */
+        if (!goal.parsedDrv->useUidRange())
+            chmod_(chrootRootDir + "/etc", 0555);
+
+        /* Save the mount- and user namespace of the child. We have to do this
+           *before* the child does a chroot. */
+        sandboxMountNamespace = open(fmt("/proc/%d/ns/mnt", (pid_t) goal.pid).c_str(), O_RDONLY);
+        if (sandboxMountNamespace.get() == -1)
+            throw SysError("getting sandbox mount namespace");
+
+        if (usingUserNamespace) {
+            sandboxUserNamespace = open(fmt("/proc/%d/ns/user", (pid_t) goal.pid).c_str(), O_RDONLY);
+            if (sandboxUserNamespace.get() == -1)
+                throw SysError("getting sandbox user namespace");
+        }
+
+        /* Move the child into its own cgroup. */
+        if (cgroup)
+            writeFile(*cgroup + "/cgroup.procs", fmt("%d", (pid_t) pid));
+
+        /* Signal the builder that we've updated its user namespace. */
+        writeFull(userNamespaceSync.writeSide.get(), "1");
+
+        return goal.pid;
+
+    };
+    void enterChroot(const Store& store, LocalDerivationGoal& goal) override {
+            userNamespaceSync.writeSide = -1;
+
+            if (drainFD(userNamespaceSync.readSide.get()) != "1")
+                throw Error("user namespace initialisation failed");
+
+            userNamespaceSync.readSide = -1;
+
+            if (privateNetwork) {
+
+                /* Initialise the loopback interface. */
+                AutoCloseFD fd(socket(PF_INET, SOCK_DGRAM, IPPROTO_IP));
+                if (!fd) throw SysError("cannot open IP socket");
+
+                struct ifreq ifr;
+                strcpy(ifr.ifr_name, "lo");
+                ifr.ifr_flags = IFF_UP | IFF_LOOPBACK | IFF_RUNNING;
+                if (ioctl(fd.get(), SIOCSIFFLAGS, &ifr) == -1)
+                    throw SysError("cannot set loopback interface flags");
+            }
+
+            /* Set the hostname etc. to fixed values. */
+            char hostname[] = "localhost";
+            if (sethostname(hostname, sizeof(hostname)) == -1)
+                throw SysError("cannot set host name");
+            char domainname[] = "(none)"; // kernel default
+            if (setdomainname(domainname, sizeof(domainname)) == -1)
+                throw SysError("cannot set domain name");
+
+            /* Make all filesystems private.  This is necessary
+               because subtrees may have been mounted as "shared"
+               (MS_SHARED).  (Systemd does this, for instance.)  Even
+               though we have a private mount namespace, mounting
+               filesystems on top of a shared subtree still propagates
+               outside of the namespace.  Making a subtree private is
+               local to the namespace, though, so setting MS_PRIVATE
+               does not affect the outside world. */
+            if (mount(0, "/", 0, MS_PRIVATE | MS_REC, 0) == -1)
+                throw SysError("unable to make '/' private");
+
+            /* Bind-mount chroot directory to itself, to treat it as a
+               different filesystem from /, as needed for pivot_root. */
+            if (mount(chrootRootDir.c_str(), chrootRootDir.c_str(), 0, MS_BIND, 0) == -1)
+                throw SysError("unable to bind mount '%1%'", chrootRootDir);
+
+            /* Bind-mount the sandbox's Nix store onto itself so that
+               we can mark it as a "shared" subtree, allowing bind
+               mounts made in *this* mount namespace to be propagated
+               into the child namespace created by the
+               unshare(CLONE_NEWNS) call below.
+
+               Marking chrootRootDir as MS_SHARED causes pivot_root()
+               to fail with EINVAL. Don't know why. */
+            Path chrootStoreDir = chrootRootDir + store.storeDir;
+
+            if (mount(chrootStoreDir.c_str(), chrootStoreDir.c_str(), 0, MS_BIND, 0) == -1)
+                throw SysError("unable to bind mount the Nix store", chrootStoreDir);
+
+            if (mount(0, chrootStoreDir.c_str(), 0, MS_SHARED, 0) == -1)
+                throw SysError("unable to make '%s' shared", chrootStoreDir);
+
+            auto& dirsInChroot = goal.dirsInChroot;
+            /* Set up a nearly empty /dev, unless the user asked to
+               bind-mount the host /dev. */
+            Strings ss;
+            if (dirsInChroot.find("/dev") == dirsInChroot.end()) {
+                createDirs(chrootRootDir + "/dev/shm");
+                createDirs(chrootRootDir + "/dev/pts");
+                ss.push_back("/dev/full");
+                if (store.systemFeatures.get().count("kvm") && pathExists("/dev/kvm"))
+                    ss.push_back("/dev/kvm");
+                ss.push_back("/dev/null");
+                ss.push_back("/dev/random");
+                ss.push_back("/dev/tty");
+                ss.push_back("/dev/urandom");
+                ss.push_back("/dev/zero");
+                createSymlink("/proc/self/fd", chrootRootDir + "/dev/fd");
+                createSymlink("/proc/self/fd/0", chrootRootDir + "/dev/stdin");
+                createSymlink("/proc/self/fd/1", chrootRootDir + "/dev/stdout");
+                createSymlink("/proc/self/fd/2", chrootRootDir + "/dev/stderr");
+            }
+
+            /* Fixed-output derivations typically need to access the
+               network, so give them access to /etc/resolv.conf and so
+               on. */
+            if (!goal.derivationType.isSandboxed()) {
+                // Only use nss functions to resolve hosts and
+                // services. Don’t use it for anything else that may
+                // be configured for this system. This limits the
+                // potential impurities introduced in fixed-outputs.
+                writeFile(chrootRootDir + "/etc/nsswitch.conf", "hosts: files dns\nservices: files\n");
+
+                /* N.B. it is realistic that these paths might not exist. It
+                   happens when testing Nix building fixed-output derivations
+                   within a pure derivation. */
+                for (auto & path : { "/etc/resolv.conf", "/etc/services", "/etc/hosts" })
+                    if (pathExists(path))
+                        ss.push_back(path);
+            }
+
+            for (auto & i : ss) dirsInChroot.emplace(i, i);
+
+            /* Bind-mount all the directories from the "host"
+               filesystem that we want in the chroot
+               environment. */
+            auto doBind = [&](const Path & source, const Path & target, bool optional = false) {
+                debug("bind mounting '%1%' to '%2%'", source, target);
+                struct stat st;
+                if (stat(source.c_str(), &st) == -1) {
+                    if (optional && errno == ENOENT)
+                        return;
+                    else
+                        throw SysError("getting attributes of path '%1%'", source);
+                }
+                if (S_ISDIR(st.st_mode))
+                    createDirs(target);
+                else {
+                    createDirs(dirOf(target));
+                    writeFile(target, "");
+                }
+                if (mount(source.c_str(), target.c_str(), "", MS_BIND | MS_REC, 0) == -1)
+                    throw SysError("bind mount from '%1%' to '%2%' failed", source, target);
+            };
+
+            for (auto & i : dirsInChroot) {
+                if (i.second.source == "/proc") continue; // backwards compatibility
+
+                #if HAVE_EMBEDDED_SANDBOX_SHELL
+                if (i.second.source == "__embedded_sandbox_shell__") {
+                    static unsigned char sh[] = {
+                        #include "embedded-sandbox-shell.gen.hh"
+                    };
+                    auto dst = chrootRootDir + i.first;
+                    createDirs(dirOf(dst));
+                    writeFile(dst, std::string_view((const char *) sh, sizeof(sh)));
+                    chmod_(dst, 0555);
+                } else
+                #endif
+                    doBind(i.second.source, chrootRootDir + i.first, i.second.optional);
+            }
+
+            /* Bind a new instance of procfs on /proc. */
+            createDirs(chrootRootDir + "/proc");
+            if (mount("none", (chrootRootDir + "/proc").c_str(), "proc", 0, 0) == -1)
+                throw SysError("mounting /proc");
+
+            /* Mount sysfs on /sys. */
+            if (buildUser && buildUser->getUIDCount() != 1) {
+                createDirs(chrootRootDir + "/sys");
+                if (mount("none", (chrootRootDir + "/sys").c_str(), "sysfs", 0, 0) == -1)
+                    throw SysError("mounting /sys");
+            }
+
+            /* Mount a new tmpfs on /dev/shm to ensure that whatever
+               the builder puts in /dev/shm is cleaned up automatically. */
+            if (pathExists("/dev/shm") && mount("none", (chrootRootDir + "/dev/shm").c_str(), "tmpfs", 0,
+                    fmt("size=%s", settings.sandboxShmSize).c_str()) == -1)
+                throw SysError("mounting /dev/shm");
+
+            /* Mount a new devpts on /dev/pts.  Note that this
+               requires the kernel to be compiled with
+               CONFIG_DEVPTS_MULTIPLE_INSTANCES=y (which is the case
+               if /dev/ptx/ptmx exists). */
+            if (pathExists("/dev/pts/ptmx") &&
+                !pathExists(chrootRootDir + "/dev/ptmx")
+                && !dirsInChroot.count("/dev/pts"))
+            {
+                if (mount("none", (chrootRootDir + "/dev/pts").c_str(), "devpts", 0, "newinstance,mode=0620") == 0)
+                {
+                    createSymlink("/dev/pts/ptmx", chrootRootDir + "/dev/ptmx");
+
+                    /* Make sure /dev/pts/ptmx is world-writable.  With some
+                       Linux versions, it is created with permissions 0.  */
+                    chmod_(chrootRootDir + "/dev/pts/ptmx", 0666);
+                } else {
+                    if (errno != EINVAL)
+                        throw SysError("mounting /dev/pts");
+                    doBind("/dev/pts", chrootRootDir + "/dev/pts");
+                    doBind("/dev/ptmx", chrootRootDir + "/dev/ptmx");
+                }
+            }
+
+            /* Unshare this mount namespace. This is necessary because
+               pivot_root() below changes the root of the mount
+               namespace. This means that the call to setns() in
+               addDependency() would hide the host's filesystem,
+               making it impossible to bind-mount paths from the host
+               Nix store into the sandbox. Therefore, we save the
+               pre-pivot_root namespace in
+               sandboxMountNamespace. Since we made /nix/store a
+               shared subtree above, this allows addDependency() to
+               make paths appear in the sandbox. */
+            if (unshare(CLONE_NEWNS) == -1)
+                throw SysError("unsharing mount namespace");
+
+            /* Unshare the cgroup namespace. This means
+               /proc/self/cgroup will show the child's cgroup as '/'
+               rather than whatever it is in the parent. */
+            if (cgroup && unshare(CLONE_NEWCGROUP) == -1)
+                throw SysError("unsharing cgroup namespace");
+
+            /* Do the chroot(). */
+            if (chdir(chrootRootDir.c_str()) == -1)
+                throw SysError("cannot change directory to '%1%'", chrootRootDir);
+
+            if (mkdir("real-root", 0) == -1)
+                throw SysError("cannot create real-root directory");
+
+            if (pivot_root(".", "real-root") == -1)
+                throw SysError("cannot pivot old root directory onto '%1%'", (chrootRootDir + "/real-root"));
+
+            if (chroot(".") == -1)
+                throw SysError("cannot change root directory to '%1%'", chrootRootDir);
+
+            if (umount2("real-root", MNT_DETACH) == -1)
+                throw SysError("cannot unmount real root filesystem");
+
+            if (rmdir("real-root") == -1)
+                throw SysError("cannot remove real-root directory");
+
+            /* Switch to the sandbox uid/gid in the user namespace,
+               which corresponds to the build user or calling user in
+               the parent namespace. */
+            if (setgid(sandboxGid()) == -1)
+                throw SysError("setgid failed");
+            if (setuid(sandboxUid()) == -1)
+                throw SysError("setuid failed");
+
+            // todo setUser = false
+    };
+
+    virtual void addToSandbox(const StorePath& path, const Store& store) override {
+            Path source = store.Store::toRealPath(path);
+            Path target = chrootRootDir + store.printStorePath(path);
+            debug("bind-mounting %s -> %s", target, source);
+
+            if (pathExists(target))
+                throw Error("store path '%s' already exists in the sandbox", store.printStorePath(path));
+
+            auto st = lstat(source);
+
+            if (S_ISDIR(st.st_mode)) {
+
+                /* Bind-mount the path into the sandbox. This requires
+                   entering its mount namespace, which is not possible
+                   in multithreaded programs. So we do this in a
+                   child process.*/
+                Pid child(startProcess([&]() {
+
+                    if (usingUserNamespace && (setns(sandboxUserNamespace.get(), 0) == -1))
+                        throw SysError("entering sandbox user namespace");
+
+                    if (setns(sandboxMountNamespace.get(), 0) == -1)
+                        throw SysError("entering sandbox mount namespace");
+
+                    createDirs(target);
+
+                    if (mount(source.c_str(), target.c_str(), "", MS_BIND, 0) == -1)
+                        throw SysError("bind mount from '%s' to '%s' failed", source, target);
+
+                    _exit(0);
+                }));
+
+                int status = child.wait();
+                if (status != 0)
+                    throw Error("could not add path '%s' to sandbox", store.printStorePath(path));
+
+            } else
+                linkOrCopy(source, target);
+
+
+    };
+
+    virtual ~SandboxLinux() {};
+};
+
+std::unique_ptr<Sandbox> createSandboxLinux(){
+    return std::make_unique<SandboxLinux>();
+};
+
+}
+

--- a/src/libstore/build/sandbox-linux.cc
+++ b/src/libstore/build/sandbox-linux.cc
@@ -391,7 +391,7 @@ public:
 
         return goal.pid;
     };
-    void enterChroot(const Store& store, LocalDerivationGoal& goal) override {
+    bool enterChroot(const Store& store, LocalDerivationGoal& goal) override {
             userNamespaceSync.writeSide = -1;
 
             if (drainFD(userNamespaceSync.readSide.get()) != "1")
@@ -621,7 +621,7 @@ public:
             if (setuid(sandboxUid()) == -1)
                 throw SysError("setuid failed");
 
-            // todo setUser = false
+            return true;
     };
 
     virtual void addToSandbox(const StorePath& path, const Store& store) override {
@@ -664,6 +664,80 @@ public:
                 linkOrCopy(source, target);
 
 
+    };
+    void filterSyscalls() const override {
+        if (!settings.filterSyscalls) return;
+#if HAVE_SECCOMP
+        scmp_filter_ctx ctx;
+
+        if (!(ctx = seccomp_init(SCMP_ACT_ALLOW)))
+            throw SysError("unable to initialize seccomp mode 2");
+
+        Finally cleanup([&]() {
+            seccomp_release(ctx);
+        });
+
+        if (nativeSystem == "x86_64-linux" &&
+            seccomp_arch_add(ctx, SCMP_ARCH_X86) != 0)
+            throw SysError("unable to add 32-bit seccomp architecture");
+
+        if (nativeSystem == "x86_64-linux" &&
+            seccomp_arch_add(ctx, SCMP_ARCH_X32) != 0)
+            throw SysError("unable to add X32 seccomp architecture");
+
+        if (nativeSystem == "aarch64-linux" &&
+            seccomp_arch_add(ctx, SCMP_ARCH_ARM) != 0)
+            printError("unable to add ARM seccomp architecture; this may result in spurious build failures if running 32-bit ARM processes");
+
+        if (nativeSystem == "mips64-linux" &&
+            seccomp_arch_add(ctx, SCMP_ARCH_MIPS) != 0)
+            printError("unable to add mips seccomp architecture");
+
+        if (nativeSystem == "mips64-linux" &&
+            seccomp_arch_add(ctx, SCMP_ARCH_MIPS64N32) != 0)
+            printError("unable to add mips64-*abin32 seccomp architecture");
+
+        if (nativeSystem == "mips64el-linux" &&
+            seccomp_arch_add(ctx, SCMP_ARCH_MIPSEL) != 0)
+            printError("unable to add mipsel seccomp architecture");
+
+        if (nativeSystem == "mips64el-linux" &&
+            seccomp_arch_add(ctx, SCMP_ARCH_MIPSEL64N32) != 0)
+            printError("unable to add mips64el-*abin32 seccomp architecture");
+
+        /* Prevent builders from creating setuid/setgid binaries. */
+        for (int perm : { S_ISUID, S_ISGID }) {
+            if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(chmod), 1,
+                    SCMP_A1(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
+                throw SysError("unable to add seccomp rule");
+
+            if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(fchmod), 1,
+                    SCMP_A1(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
+                throw SysError("unable to add seccomp rule");
+
+            if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(fchmodat), 1,
+                    SCMP_A2(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
+                throw SysError("unable to add seccomp rule");
+        }
+
+        /* Prevent builders from creating EAs or ACLs. Not all filesystems
+           support these, and they're not allowed in the Nix store because
+           they're not representable in the NAR serialisation. */
+        if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(setxattr), 0) != 0 ||
+            seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(lsetxattr), 0) != 0 ||
+            seccomp_rule_add(ctx, SCMP_ACT_ERRNO(ENOTSUP), SCMP_SYS(fsetxattr), 0) != 0)
+            throw SysError("unable to add seccomp rule");
+
+        if (seccomp_attr_set(ctx, SCMP_FLTATR_CTL_NNP, settings.allowNewPrivileges ? 0 : 1) != 0)
+            throw SysError("unable to set 'no new privileges' seccomp attribute");
+
+        if (seccomp_load(ctx) != 0)
+            throw SysError("unable to load seccomp BPF program");
+#else
+        throw Error(
+            "seccomp is not supported on this platform; "
+            "you can bypass this error by setting the option 'filter-syscalls' to false, but note that untrusted builds can then create setuid binaries!");
+#endif
     };
 
     virtual ~SandboxLinux() {};

--- a/src/libstore/build/sandbox-linux.cc
+++ b/src/libstore/build/sandbox-linux.cc
@@ -1,3 +1,4 @@
+#if __linux__
 #include "sandbox.hh"
 #include "cgroup.hh"
 #include "worker.hh"
@@ -37,7 +38,6 @@
 
 namespace nix {
 
-#if __linux__
 static void linkOrCopy(const Path & from, const Path & to)
 {
     if (link(from.c_str(), to.c_str()) == -1) {
@@ -53,7 +53,6 @@ static void linkOrCopy(const Path & from, const Path & to)
         copyPath(from, to);
     }
 }
-#endif
 
 
 static void chmod_(const Path & path, mode_t mode)
@@ -391,7 +390,6 @@ public:
         writeFull(userNamespaceSync.writeSide.get(), "1");
 
         return goal.pid;
-
     };
     void enterChroot(const Store& store, LocalDerivationGoal& goal) override {
             userNamespaceSync.writeSide = -1;
@@ -513,8 +511,10 @@ public:
                     createDirs(dirOf(target));
                     writeFile(target, "");
                 }
+#if __linux__
                 if (mount(source.c_str(), target.c_str(), "", MS_BIND | MS_REC, 0) == -1)
                     throw SysError("bind mount from '%1%' to '%2%' failed", source, target);
+#endif
             };
 
             for (auto & i : dirsInChroot) {
@@ -675,3 +675,4 @@ std::unique_ptr<Sandbox> createSandboxLinux(){
 
 }
 
+#endif

--- a/src/libstore/build/sandbox.cc
+++ b/src/libstore/build/sandbox.cc
@@ -24,8 +24,8 @@ std::pair<std::string, Strings> Sandbox::getSandboxArgs(const Derivation& drv, b
     return {builder, args};
 };
 
-void Sandbox::spawn(const std::string& builder, const nix::Strings& args, const nix::Strings& envStrs, std::string_view platform) {
-    execve(builder.c_str(), stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
+void Sandbox::spawn(const std::pair<std::string, Strings>& builderArgs, const nix::Strings& envStrs, std::string_view platform) {
+    execve(builderArgs.first.c_str(), stringsToCharPtrs(builderArgs.second).data(), stringsToCharPtrs(envStrs).data());
 };
 
 void Sandbox::addToSandbox(const StorePath& path, const Store& store) {

--- a/src/libstore/build/sandbox.cc
+++ b/src/libstore/build/sandbox.cc
@@ -1,0 +1,50 @@
+#include "sandbox.hh"
+#include "cgroup.hh"
+
+namespace nix {
+
+void Sandbox::createCGroups(const UserLock*) {
+    throw Error("cgroups are not supported on this platform");
+};
+
+void Sandbox::prepareChroot(const Store&, LocalDerivationGoal& goal) {
+    throw Error("sandboxing builds is not supported on this platform");
+};
+
+Pid Sandbox::runInNamespaces(DerivationType& derivationType, LocalDerivationGoal& goal) {
+    return startProcess([&]() {
+        goal.runChild();
+    });
+};
+
+std::pair<std::string, Strings> Sandbox::getSandboxArgs(const Derivation& drv, bool, LocalDerivationGoal::DirsInChroot&, const nix::Store&, const LocalDerivationGoal&) {
+    Strings args;
+    auto builder = drv.builder;
+    args.push_back(std::string(baseNameOf(drv.builder)));
+    return {builder, args};
+};
+
+void Sandbox::spawn(const std::string& builder, const nix::Strings& args, const nix::Strings& envStrs, std::string_view platform) {
+    execve(builder.c_str(), stringsToCharPtrs(args).data(), stringsToCharPtrs(envStrs).data());
+};
+
+void Sandbox::addToSandbox(const StorePath& path, const Store& store) {
+    throw Error("don't know how to make path '%s' (produced by a recursive Nix call) appear in the sandbox",
+        store.printStorePath(path));
+};
+
+Strings Sandbox::getPrebuildHookArgs(const Store& store, const StorePath& drvPath) {
+    return { store.printStorePath(drvPath) };
+};
+
+std::optional<CgroupStats> Sandbox::killSandbox() {
+    if (buildUser) {
+        auto uid = buildUser->getUID();
+        assert(uid != 0);
+        killUser(uid);
+    }
+    return {};
+};
+
+} // namespace nix
+

--- a/src/libstore/build/sandbox.hh
+++ b/src/libstore/build/sandbox.hh
@@ -20,9 +20,9 @@ public:
     virtual Pid runInNamespaces(DerivationType& derivationType, LocalDerivationGoal& goal);
     virtual void moveOutOfChroot(Path& p) {};
     virtual void deleteChroot() {};
-    virtual void enterChroot(const Store&, LocalDerivationGoal& goal) = 0;
+    virtual bool enterChroot(const Store&, LocalDerivationGoal& goal) = 0;
     virtual std::pair<std::string, Strings> getSandboxArgs(const Derivation& drv, bool, LocalDerivationGoal::DirsInChroot&, const Store&, const LocalDerivationGoal&);
-    virtual void spawn(const std::string& builder, const Strings& args, const Strings& envStrs, std::string_view platform);
+    virtual void spawn(const std::pair<std::string, Strings>& builderArgs, const Strings& envStrs, std::string_view platform);
     virtual void addToSandbox(const StorePath& path, const Store& store);
     virtual void cleanupPreChildKill() {};
     virtual ~Sandbox() {};
@@ -31,6 +31,7 @@ public:
 
     UserLock* buildUser = nullptr;
     virtual std::optional<CgroupStats> killSandbox();
+    virtual void filterSyscalls() const { };
 };
 
 std::unique_ptr<Sandbox> createSandboxLinux();

--- a/src/libstore/build/sandbox.hh
+++ b/src/libstore/build/sandbox.hh
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "types.hh"
+#include "util.hh"
+#include "local-derivation-goal.hh" // LocalDerivationGoal::DirsInChroot
+
+namespace nix {
+
+struct UserLock;
+class Store;
+struct DerivationType;
+struct Derivation;
+class StorePath;
+struct CgroupStats;
+
+class Sandbox {
+public:
+    virtual void createCGroups(const UserLock*);
+    virtual void prepareChroot(const Store&, LocalDerivationGoal& goal);
+    virtual Pid runInNamespaces(DerivationType& derivationType, LocalDerivationGoal& goal);
+    virtual void moveOutOfChroot(Path& p) {};
+    virtual void deleteChroot() {};
+    virtual void enterChroot(const Store&, LocalDerivationGoal& goal) = 0;
+    virtual std::pair<std::string, Strings> getSandboxArgs(const Derivation& drv, bool, LocalDerivationGoal::DirsInChroot&, const Store&, const LocalDerivationGoal&);
+    virtual void spawn(const std::string& builder, const Strings& args, const Strings& envStrs, std::string_view platform);
+    virtual void addToSandbox(const StorePath& path, const Store& store);
+    virtual void cleanupPreChildKill() {};
+    virtual ~Sandbox() {};
+    virtual Strings getPrebuildHookArgs(const Store& store, const StorePath& drvPath);
+    virtual Path toRealPath(const Path& p) const { return p; };
+
+    UserLock* buildUser = nullptr;
+    virtual std::optional<CgroupStats> killSandbox();
+};
+
+std::unique_ptr<Sandbox> createSandboxLinux();
+std::unique_ptr<Sandbox> createSandboxDarwin();
+
+} // namespace nix

--- a/src/libstore/local-fs-store.hh
+++ b/src/libstore/local-fs-store.hh
@@ -42,9 +42,9 @@ public:
     /* Register a permanent GC root. */
     Path addPermRoot(const StorePath & storePath, const Path & gcRoot);
 
-    virtual Path getRealStoreDir() { return realStoreDir; }
+    virtual Path getRealStoreDir() const { return realStoreDir; }
 
-    Path toRealPath(const Path & storePath) override
+    Path toRealPath(const Path & storePath) const override
     {
         assert(isInStore(storePath));
         return getRealStoreDir() + "/" + std::string(storePath, storeDir.size() + 1);

--- a/src/libstore/lock.cc
+++ b/src/libstore/lock.cc
@@ -14,9 +14,9 @@ struct SimpleUserLock : UserLock
     gid_t gid;
     std::vector<gid_t> supplementaryGIDs;
 
-    uid_t getUID() override { assert(uid); return uid; }
-    uid_t getUIDCount() override { return 1; }
-    gid_t getGID() override { assert(gid); return gid; }
+    uid_t getUID() const override { assert(uid); return uid; }
+    uid_t getUIDCount() const override { return 1; }
+    gid_t getGID() const override { assert(gid); return gid; }
 
     std::vector<gid_t> getSupplementaryGIDs() override { return supplementaryGIDs; }
 
@@ -115,11 +115,11 @@ struct AutoUserLock : UserLock
     gid_t firstGid = 0;
     uid_t nrIds = 1;
 
-    uid_t getUID() override { assert(firstUid); return firstUid; }
+    uid_t getUID() const override { assert(firstUid); return firstUid; }
 
-    gid_t getUIDCount() override { return nrIds; }
+    gid_t getUIDCount() const override { return nrIds; }
 
-    gid_t getGID() override { assert(firstGid); return firstGid; }
+    gid_t getGID() const override { assert(firstGid); return firstGid; }
 
     std::vector<gid_t> getSupplementaryGIDs() override { return {}; }
 

--- a/src/libstore/lock.hh
+++ b/src/libstore/lock.hh
@@ -20,11 +20,11 @@ struct UserLock
     }
 
     /* Get the first UID. */
-    virtual uid_t getUID() = 0;
+    virtual uid_t getUID() const = 0;
 
-    virtual uid_t getUIDCount() = 0;
+    virtual uid_t getUIDCount() const = 0;
 
-    virtual gid_t getGID() = 0;
+    virtual gid_t getGID() const = 0;
 
     virtual std::vector<gid_t> getSupplementaryGIDs() = 0;
 };

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -649,12 +649,12 @@ public:
         return 0;
     };
 
-    virtual Path toRealPath(const Path & storePath)
+    virtual Path toRealPath(const Path & storePath) const
     {
         return storePath;
     }
 
-    Path toRealPath(const StorePath & storePath)
+    Path toRealPath(const StorePath & storePath) const
     {
         return toRealPath(printStorePath(storePath));
     }

--- a/src/libutil/cgroup.hh
+++ b/src/libutil/cgroup.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#if __linux__
 
 #include <chrono>
 #include <optional>
@@ -9,21 +8,24 @@
 
 namespace nix {
 
+#if __linux__
 std::optional<Path> getCgroupFS();
 
 std::map<std::string, std::string> getCgroups(const Path & cgroupFile);
+#endif
 
 struct CgroupStats
 {
     std::optional<std::chrono::microseconds> cpuUser, cpuSystem;
 };
 
+#if __linux__
 /* Destroy the cgroup denoted by 'path'. The postcondition is that
    'path' does not exist, and thus any processes in the cgroup have
    been killed. Also return statistics from the cgroup just before
    destruction. */
 CgroupStats destroyCgroup(const Path & cgroup);
+#endif
 
 }
 
-#endif


### PR DESCRIPTION
# Motivation

Currently, the sandbox code strongly coupled to the `LocalDerivationGoal` code, while also being platform specific. This interleaves several code paths and makes it hard to reason about. I'm trying to define an API for the platform-specific sandboxing code.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->
- [x] Move out platform-specific code from LocalDerivationGoal
- [ ] Decouple sandbox code from LocalDerivationGoal
- [ ] Optionally further decouple LocalDerivationGoal from DerivationGoal
- [ ] Format and comment and document

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
