### PR TITLE
SSH: don't erase password prompt if it is displayed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -577,6 +577,8 @@
 
         tests.nix-copy-closure = runNixOSTestFor "x86_64-linux" ./tests/nixos/nix-copy-closure.nix;
 
+        tests.nix-copy = runNixOSTestFor "x86_64-linux" ./tests/nixos/nix-copy.nix;
+
         tests.nssPreload = runNixOSTestFor "x86_64-linux" ./tests/nixos/nss-preload.nix;
 
         tests.githubFlakes = runNixOSTestFor "x86_64-linux" ./tests/nixos/github-flakes.nix;

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -129,6 +129,7 @@ public:
     void resume() override {
         state_.lock()->paused = false;
         writeToStderr("\r\e[K");
+        state_.lock()->haveUpdate = true;
         updateCV.notify_one();
     }
 
@@ -350,9 +351,8 @@ public:
     {
         auto nextWakeup = std::chrono::milliseconds::max();
 
-        if (state.paused) return nextWakeup;
         state.haveUpdate = false;
-        if (!state.active) return nextWakeup;
+        if (state.paused || !state.active) return nextWakeup;
 
         std::string line;
 

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -1,4 +1,5 @@
 #include "ssh.hh"
+#include "finally.hh"
 
 namespace nix {
 
@@ -35,6 +36,9 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
     }
     if (compress)
         args.push_back("-C");
+
+    args.push_back("-oPermitLocalCommand=yes");
+    args.push_back("-oLocalCommand=echo started");
 }
 
 std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string & command)
@@ -48,6 +52,11 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string
     auto conn = std::make_unique<Connection>();
     ProcessOptions options;
     options.dieWithParent = false;
+
+    if (!fakeSSH && !useMaster) {
+        logger->pause();
+    }
+    Finally cleanup = [&]() { logger->resume(); };
 
     conn->sshPid = startProcess([&]() {
         restoreProcessContext();
@@ -86,6 +95,18 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string
     in.readSide = -1;
     out.writeSide = -1;
 
+    // Wait for the SSH connection to be established,
+    // So that we don't overwrite the password prompt with our progress bar.
+    if (!fakeSSH && !useMaster) {
+        std::string reply;
+        try {
+            reply = readLine(out.readSide.get());
+        } catch (EndOfFile & e) { }
+
+        if (reply != "started")
+            throw Error("failed to start SSH connection to '%s'", host);
+    }
+
     conn->out = std::move(out.readSide);
     conn->in = std::move(in.writeSide);
 
@@ -109,6 +130,9 @@ Path SSHMaster::startMaster()
     ProcessOptions options;
     options.dieWithParent = false;
 
+    logger->pause();
+    Finally cleanup = [&]() { logger->resume(); };
+
     state->sshMaster = startProcess([&]() {
         restoreProcessContext();
 
@@ -117,11 +141,7 @@ Path SSHMaster::startMaster()
         if (dup2(out.writeSide.get(), STDOUT_FILENO) == -1)
             throw SysError("duping over stdout");
 
-        Strings args =
-            { "ssh", host.c_str(), "-M", "-N", "-S", state->socketPath
-            , "-o", "LocalCommand=echo started"
-            , "-o", "PermitLocalCommand=yes"
-            };
+        Strings args = { "ssh", host.c_str(), "-M", "-N", "-S", state->socketPath };
         if (verbosity >= lvlChatty)
             args.push_back("-v");
         addCommonSSHOpts(args);

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -72,6 +72,9 @@ public:
 
     virtual void stop() { };
 
+    virtual void pause() { };
+    virtual void resume() { };
+
     // Whether the logger prints the whole build log
     virtual bool isVerbose() { return false; }
 

--- a/tests/nixos/nix-copy.nix
+++ b/tests/nixos/nix-copy.nix
@@ -1,0 +1,85 @@
+# Test that ‘nix copy’ works over ssh.
+
+{ lib, config, nixpkgs, hostPkgs, ... }:
+
+let
+  pkgs = config.nodes.client.nixpkgs.pkgs;
+
+  pkgA = pkgs.cowsay;
+  pkgB = pkgs.wget;
+  pkgC = pkgs.hello;
+  pkgD = pkgs.tmux;
+
+in {
+  name = "nix-copy";
+
+  enableOCR = true;
+
+  nodes =
+    { client =
+        { config, lib, pkgs, ... }:
+        { virtualisation.writableStore = true;
+          virtualisation.additionalPaths = [ pkgA pkgD.drvPath ];
+          nix.settings.substituters = lib.mkForce [ ];
+          nix.settings.experimental-features = [ "nix-command" ];
+          services.getty.autologinUser = "root";
+        };
+
+      server =
+        { config, pkgs, ... }:
+        { services.openssh.enable = true;
+          services.openssh.permitRootLogin = "yes";
+					users.users.root.password = "foobar";
+          virtualisation.writableStore = true;
+          virtualisation.additionalPaths = [ pkgB pkgC ];
+        };
+    };
+
+  testScript = { nodes }: ''
+    # fmt: off
+    import subprocess
+
+    # Create an SSH key on the client.
+    subprocess.run([
+      "${pkgs.openssh}/bin/ssh-keygen", "-t", "ed25519", "-f", "key", "-N", ""
+    ], capture_output=True, check=True)
+
+    start_all()
+
+    server.wait_for_unit("sshd")
+    client.wait_for_unit("network.target")
+    client.wait_for_unit("getty@tty1.service")
+    client.wait_for_text("]#")
+
+    # Copy the closure of package A from the client to the server using password authentication,
+    # and check that all prompts are visible
+    server.fail("nix-store --check-validity ${pkgA}")
+    client.send_chars("nix copy --to ssh://server ${pkgA} >&2; echo done\n")
+    client.wait_for_text("continue connecting")
+    client.send_chars("yes\n")
+    client.wait_for_text("Password:")
+    client.send_chars("foobar\n")
+    client.wait_for_text("done")
+    server.succeed("nix-store --check-validity ${pkgA}")
+
+    client.copy_from_host("key", "/root/.ssh/id_ed25519")
+    client.succeed("chmod 600 /root/.ssh/id_ed25519")
+
+    # Install the SSH key on the server.
+    server.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
+    server.succeed("systemctl restart sshd")
+    client.succeed(f"ssh -o StrictHostKeyChecking=no {server.name} 'echo hello world'")
+
+    # Copy the closure of package B from the server to the client, using ssh-ng.
+    client.fail("nix-store --check-validity ${pkgB}")
+    # Shouldn't download untrusted paths by default
+    client.fail("nix copy --from ssh-ng://server ${pkgB} >&2")
+    client.succeed("nix copy --no-check-sigs --from ssh-ng://server ${pkgB} >&2")
+    client.succeed("nix-store --check-validity ${pkgB}")
+
+    # Copy the derivation of package D's derivation from the client to the server.
+    server.fail("nix-store --check-validity ${pkgD.drvPath}")
+    client.succeed("nix copy --derivation --to ssh://server ${pkgD.drvPath} >&2")
+    server.succeed("nix-store --check-validity ${pkgD.drvPath}")
+  '';
+}


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Currently, the progress bar updates erase the password prompt displayed by ssh,
e.g. during `nix copy`. This looks like the command is stuck.

Add a way to pause and resume progress bar redrawing, pause it before starting
the ssh connection, and resume it after the ssh connection is established.

# Context

Fixes https://github.com/NixOS/nix/issues/7959

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
