### PR TITLE
Set up user namespace in builder, not in parent

### DIFF
--- a/src/libstore/build/local-derivation-goal.hh
+++ b/src/libstore/build/local-derivation-goal.hh
@@ -16,6 +16,23 @@ struct LocalDerivationGoal : public DerivationGoal
     std::unique_ptr<UserLock> buildUser;
 
     /**
+     * The uid we will use for the build, outside any sandboxing.
+     */
+    uid_t hostUid;
+
+    /**
+     * The gid we will use for the build, outside any sandboxing.
+     */
+    gid_t hostGid;
+
+    /**
+     * The number of user IDS for the build.
+     *
+     * Used for user namespaces.
+     */
+    uid_t nrIds;
+
+    /**
      * The process ID of the builder.
      */
     Pid pid;
@@ -40,11 +57,6 @@ struct LocalDerivationGoal : public DerivationGoal
      * standard output/error.
      */
     AutoCloseFD builderOut;
-
-    /**
-     * Pipe for synchronising updates to the builder namespaces.
-     */
-    Pipe userNamespaceSync;
 
     /**
      * The mount namespace and user namespace of the builder, used to add additional


### PR DESCRIPTION
# Motivation

*This is a rebase of #2717. The following is @catern's original PR description*

This is a minor simplification; there's now slightly less handshaking required between the builder and the parent, and we create one less pipe when starting the builder.

As a niche benefit, this also replaces our access to `/proc/builder_pid` in the parent with an access to `/proc/self` in the builder. The former access could fail if `/proc` was mounted in a different pid namespace from the one we are running in; now we will work even if there is such a misconfiguration.

# Context

Rebaser's (@Ericson2314's) notes:

A good questions why it was ever done the old way, since this is simpler and easier to write. The original commit doing this was c68e5913c71badc89ff346d1c6948517ba720c93, adding user namespace support for the first time, and referencing issue #625. But neither mention this design decision.

In https://github.com/NixOS/nix/pull/2717#issuecomment-1438709254 @edolstra said:

> I don't remember why it's done this way. Maybe the kernel required it at the time?

That seems to me like a likely explanation. User namespaces were famously fiddly for many years.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
