### PR TITLE
Build and test fixes for OpenBSD

### DIFF
--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -174,7 +174,7 @@ GitInfo exportGit(ref<Store> store, const std::string & uri,
     Path tmpDir = createTempDir();
     AutoDelete delTmpDir(tmpDir, true);
 
-    runProgram("tar", true, { "x", "-C", tmpDir }, tar);
+    runProgram("tar", true, { "-x", "-f", "-", "-C", tmpDir }, tar);
 
     gitInfo.storePath = store->addToStore(name, tmpDir);
 

--- a/src/libexpr/primops/fetchGit.cc
+++ b/src/libexpr/primops/fetchGit.cc
@@ -6,6 +6,7 @@
 #include "hash.hh"
 
 #include <sys/time.h>
+#include <sys/wait.h>
 
 #include <regex>
 

--- a/src/nix-daemon/nix-daemon.cc
+++ b/src/nix-daemon/nix-daemon.cc
@@ -901,7 +901,11 @@ static PeerInfo getPeerInfo(int remote)
 
 #if defined(SO_PEERCRED)
 
+#if defined(__OpenBSD__)
+    struct sockpeercred cred;
+#else
     ucred cred;
+#endif
     socklen_t credLen = sizeof(cred);
     if (getsockopt(remote, SOL_SOCKET, SO_PEERCRED, &cred, &credLen) == -1)
         throw SysError("getting peer credentials");

--- a/tests/tarball.sh
+++ b/tests/tarball.sh
@@ -11,7 +11,7 @@ cp dependencies.nix $tarroot/default.nix
 cp config.nix dependencies.builder*.sh $tarroot/
 
 tarball=$TEST_ROOT/tarball.tar.xz
-(cd $TEST_ROOT && tar c tarball) | xz > $tarball
+(cd $TEST_ROOT && tar cf - tarball) | xz > $tarball
 
 nix-env -f file://$tarball -qa --out-path | grep -q dependencies
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Reduce amount of local changes in the OpenBSD port `systuils/nix` targeting
the 2.3 release.

# Context
<!-- Provide context. Reference open issues if available. -->

Patches were written against the 2.3.16 release and apply cleanly to the
2.3-maintenance branch, but require more work against master which is not
used on OpenBSD.

5 out of 57 tests currently fail on OpenBSD/amd64 7.3-beta.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
