### PR TITLE
`print-dev-env`: stop inadvertently adding `.` to `PATH`

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -313,7 +313,7 @@ struct Common : InstallableCommand, MixProfile
         buildEnvironment.toBash(out, ignoreVars);
 
         for (auto & var : savedVars)
-            out << fmt("%s=\"$%s:$nix_saved_%s\"\n", var, var, var);
+            out << fmt("%s=\"$%s${nix_saved_%s:+:$nix_saved_%s}\"\n", var, var, var, var);
 
         out << "export NIX_BUILD_TOP=\"$(mktemp -d -t nix-shell.XXXXXX)\"\n";
         for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -94,16 +94,43 @@ echo foo | nix develop -f "$shellDotNix" shellDrv -c cat | grepQuiet foo
 nix develop -f "$shellDotNix" shellDrv -c echo foo |& grepQuiet foo
 
 # Test 'nix print-dev-env'.
-[[ $(nix print-dev-env -f "$shellDotNix" shellDrv --json | jq -r .variables.arr1.value[2]) = '3 4' ]]
+
+scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
+function finish {
+    rm -rf "$scratch"
+}
+trap finish EXIT
+
+nix print-dev-env -f "$shellDotNix" shellDrv > "$scratch/dev-env.sh"
+nix print-dev-env -f "$shellDotNix" shellDrv --json > "$scratch/dev-env.json"
+
+# Ensure `nix print-dev-env --json` contains variable assignments.
+[[ $(jq -r .variables.arr1.value[2] "$scratch/dev-env.json") = '3 4' ]]
+
+# Run tests involving `source <(nix print-dev-inv)` in subshells to avoid modifying the current
+# environment.
 
 set +u # FIXME: Make print-dev-env `set -u` compliant (issue #7951)
 
-source <(nix print-dev-env -f "$shellDotNix" shellDrv)
-[[ -n $stdenv ]]
-[[ ${arr1[2]} = "3 4" ]]
-[[ ${arr2[1]} = $'\n' ]]
-[[ ${arr2[2]} = $'x\ny' ]]
-[[ $(fun) = blabla ]]
+# Ensure `source <(nix print-dev-env)` modifies the environment.
+(
+    path=$PATH
+    source "$scratch/dev-env.sh"
+    [[ -n $stdenv ]]
+    [[ ${arr1[2]} = "3 4" ]]
+    [[ ${arr2[1]} = $'\n' ]]
+    [[ ${arr2[2]} = $'x\ny' ]]
+    [[ $(fun) = blabla ]]
+    [[ $PATH = $(jq -r .variables.PATH.value "$scratch/dev-env.json"):$path ]]
+)
+
+# Ensure `source <(nix print-dev-env)` handles the case when PATH is empty.
+(
+    path=$PATH
+    PATH=
+    source "$scratch/dev-env.sh"
+    [[ $PATH = $(PATH=$path jq -r .variables.PATH.value "$scratch/dev-env.json") ]]
+)
 
 # Test nix-shell with ellipsis and no `inNixShell` argument (for backwards compat with old nixpkgs)
 cat >$TEST_ROOT/shell-ellipsis.nix <<EOF

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -95,17 +95,11 @@ nix develop -f "$shellDotNix" shellDrv -c echo foo |& grepQuiet foo
 
 # Test 'nix print-dev-env'.
 
-scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
-function finish {
-    rm -rf "$scratch"
-}
-trap finish EXIT
-
-nix print-dev-env -f "$shellDotNix" shellDrv > "$scratch/dev-env.sh"
-nix print-dev-env -f "$shellDotNix" shellDrv --json > "$scratch/dev-env.json"
+nix print-dev-env -f "$shellDotNix" shellDrv > $TEST_ROOT/dev-env.sh
+nix print-dev-env -f "$shellDotNix" shellDrv --json > $TEST_ROOT/dev-env.json
 
 # Ensure `nix print-dev-env --json` contains variable assignments.
-[[ $(jq -r .variables.arr1.value[2] "$scratch/dev-env.json") = '3 4' ]]
+[[ $(jq -r .variables.arr1.value[2] $TEST_ROOT/dev-env.json) = '3 4' ]]
 
 # Run tests involving `source <(nix print-dev-inv)` in subshells to avoid modifying the current
 # environment.
@@ -115,21 +109,21 @@ set +u # FIXME: Make print-dev-env `set -u` compliant (issue #7951)
 # Ensure `source <(nix print-dev-env)` modifies the environment.
 (
     path=$PATH
-    source "$scratch/dev-env.sh"
+    source $TEST_ROOT/dev-env.sh
     [[ -n $stdenv ]]
     [[ ${arr1[2]} = "3 4" ]]
     [[ ${arr2[1]} = $'\n' ]]
     [[ ${arr2[2]} = $'x\ny' ]]
     [[ $(fun) = blabla ]]
-    [[ $PATH = $(jq -r .variables.PATH.value "$scratch/dev-env.json"):$path ]]
+    [[ $PATH = $(jq -r .variables.PATH.value $TEST_ROOT/dev-env.json):$path ]]
 )
 
 # Ensure `source <(nix print-dev-env)` handles the case when PATH is empty.
 (
     path=$PATH
     PATH=
-    source "$scratch/dev-env.sh"
-    [[ $PATH = $(PATH=$path jq -r .variables.PATH.value "$scratch/dev-env.json") ]]
+    source $TEST_ROOT/dev-env.sh
+    [[ $PATH = $(PATH=$path jq -r .variables.PATH.value $TEST_ROOT/dev-env.json) ]]
 )
 
 # Test nix-shell with ellipsis and no `inNixShell` argument (for backwards compat with old nixpkgs)


### PR DESCRIPTION
# Motivation

Ensure that `. <(nix print-dev-env)` correctly handles the case when `PATH` is empty.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Fixes #8032 by changing the output of

```bash
nix print-dev-env nixpkgs#hello | grep nix_saved_
```
from
```bash
nix_saved_PATH="$PATH"
nix_saved_XDG_DATA_DIRS="$XDG_DATA_DIRS"
PATH="$PATH:$nix_saved_PATH"
XDG_DATA_DIRS="$XDG_DATA_DIRS:$nix_saved_XDG_DATA_DIRS"
```
to
```bash
nix_saved_PATH="$PATH"
nix_saved_XDG_DATA_DIRS="$XDG_DATA_DIRS"
PATH="$PATH${nix_saved_PATH:+:$nix_saved_PATH}"
XDG_DATA_DIRS="$XDG_DATA_DIRS${nix_saved_XDG_DATA_DIRS:+:$nix_saved_XDG_DATA_DIRS}"
```

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
