### PR TITLE
Prioritize testing in the maintainers process docs

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -69,6 +69,7 @@ Issues on the board progress through the following states:
   2. [security](https://github.com/NixOS/nix/labels/security)
   3. [regression](https://github.com/NixOS/nix/labels/regression)
   4. [bug](https://github.com/NixOS/nix/issues?q=is%3Aopen+label%3Abug+sort%3Areactions-%2B1-desc)
+  5. [tests of existing functionality](https://github.com/NixOS/nix/issues?q=is%3Aopen+label%3Atests+-label%3Afeature+sort%3Areactions-%2B1-desc)
 
   - [oldest pull requests](https://github.com/NixOS/nix/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-asc)
   - [most popular pull requests](https://github.com/NixOS/nix/pulls?q=is%3Apr+is%3Aopen+sort%3Areactions-%2B1-desc)
@@ -91,7 +92,7 @@ Issues on the board progress through the following states:
 
     Contributors who took the time to implement concrete change proposals should not wait indefinitely.
 
-  - Prioritise fixing bugs over documentation, improvements or new features
+  - Prioritise fixing bugs and testing over documentation, improvements or new features
 
     The team values stability and accessibility higher than raw functionality.
 


### PR DESCRIPTION
# Motivation

PRs that don't increase our ongoing obligations (i.e. by adding new features) but do increase test coverage of existing features are good things to merge for the health of the project, and thus good to prioritize.

# Context

I brought up the the issue to @fricklerhandwerk, and he gave me the idea to make this PR to formalize it.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
