### PR TITLE
Allow specifying alternative paths for reading/writing flake locks

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -104,7 +104,7 @@ MixFlakeOptions::MixFlakeOptions()
 
     addFlag({
         .longName = "reference-lock-file",
-        .description = "Read the given lock file instead of `flake.lock` within the top-level flake",
+        .description = "Read the given lock file instead of `flake.lock` within the top-level flake.",
         .category = category,
         .labels = {"flake-lock-path"},
         .handler = {[&](std::string lockFilePath) {
@@ -115,7 +115,7 @@ MixFlakeOptions::MixFlakeOptions()
 
     addFlag({
         .longName = "output-lock-file",
-        .description = "Write the given lock file instead of `flake.lock` within the top-level flake",
+        .description = "Write the given lock file instead of `flake.lock` within the top-level flake.",
         .category = category,
         .labels = {"flake-lock-path"},
         .handler = {[&](std::string lockFilePath) {

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -103,6 +103,28 @@ MixFlakeOptions::MixFlakeOptions()
     });
 
     addFlag({
+        .longName = "reference-lock-file",
+        .description = "Read the given lock file instead of `flake.lock` within the top-level flake",
+        .category = category,
+        .labels = {"flake-lock-path"},
+        .handler = {[&](std::string lockFilePath) {
+            lockFlags.referenceLockFilePath = lockFilePath;
+        }},
+        .completer = completePath
+    });
+
+    addFlag({
+        .longName = "output-lock-file",
+        .description = "Write the given lock file instead of `flake.lock` within the top-level flake",
+        .category = category,
+        .labels = {"flake-lock-path"},
+        .handler = {[&](std::string lockFilePath) {
+            lockFlags.outputLockFilePath = lockFilePath;
+        }},
+        .completer = completePath
+    });
+
+    addFlag({
         .longName = "inputs-from",
         .description = "Use the inputs of the specified flake as registry entries.",
         .category = category,

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -334,6 +334,9 @@ LockedFlake lockFlake(
     }
 
     try {
+        if (!fetchSettings.allowDirty && lockFlags.referenceLockFilePath) {
+            throw Error("reference lock file was provided, but the `allow-dirty` setting is set to false");
+        }
 
         // FIXME: symlink attack
         auto oldLockFile = LockFile::read(

--- a/src/libexpr/flake/flake.hh
+++ b/src/libexpr/flake/flake.hh
@@ -118,10 +118,10 @@ struct LockFlags
     bool commitLockFile = false;
 
     /* The path to a lock file to read instead of the `flake.lock` file in the top-level flake */
-    std::optional<std::string> referenceLockFilePath = std::nullopt;
+    std::optional<std::string> referenceLockFilePath;
 
     /* The path to a lock file to write to instead of the `flake.lock` file in the top-level flake */
-    std::optional<Path> outputLockFilePath = std::nullopt;
+    std::optional<Path> outputLockFilePath;
 
     /* Flake inputs to be overridden. */
     std::map<InputPath, FlakeRef> inputOverrides;

--- a/src/libexpr/flake/flake.hh
+++ b/src/libexpr/flake/flake.hh
@@ -117,6 +117,12 @@ struct LockFlags
     /* Whether to commit changes to flake.lock. */
     bool commitLockFile = false;
 
+    /* The path to a lock file to read instead of the `flake.lock` file in the top-level flake */
+    std::optional<std::string> referenceLockFilePath = std::nullopt;
+
+    /* The path to a lock file to write to instead of the `flake.lock` file in the top-level flake */
+    std::optional<Path> outputLockFilePath = std::nullopt;
+
     /* Flake inputs to be overridden. */
     std::map<InputPath, FlakeRef> inputOverrides;
 

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -96,7 +96,9 @@ json=$(nix flake metadata flake1 --json | jq .)
 hash1=$(echo "$json" | jq -r .revision)
 
 echo -n '# foo' >> $flake1Dir/flake.nix
+flake1OriginalCommit=$(git -C $flake1Dir rev-parse HEAD)
 git -C $flake1Dir commit -a -m 'Foo'
+flake1NewCommit=$(git -C $flake1Dir rev-parse HEAD)
 hash2=$(nix flake metadata flake1 --json --refresh | jq -r .revision)
 [[ $hash1 != $hash2 ]]
 
@@ -491,3 +493,14 @@ nix store delete $(nix store add-path $badFlakeDir)
 [[ $(nix-instantiate --eval flake:git+file://$flake3Dir -A x) = 123 ]]
 [[ $(nix-instantiate -I flake3=flake:flake3 --eval '<flake3>' -A x) = 123 ]]
 [[ $(NIX_PATH=flake3=flake:flake3 nix-instantiate --eval '<flake3>' -A x) = 123 ]]
+
+# Test alternate lockfile paths.
+nix flake lock $flake2Dir --output-lock-file flake2.lock
+cmp $flake2Dir/flake.lock flake2.lock >/dev/null # lockfiles should be identical, since we're referencing flake2's original one
+
+nix flake lock $flake2Dir --output-lock-file flake2-overridden.lock --override-input flake1 git+file://$flake1Dir?rev=$flake1OriginalCommit
+expectStderr 1 cmp $flake2Dir/flake.lock flake2-overridden.lock
+nix flake metadata $flake2Dir --reference-lock-file flake2-overridden.lock | grepQuiet $flake1OriginalCommit
+
+# reference-lock-file can only be used if allow-dirty is set.
+expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-file flake2-overridden.lock

--- a/tests/flakes/flakes.sh
+++ b/tests/flakes/flakes.sh
@@ -495,12 +495,12 @@ nix store delete $(nix store add-path $badFlakeDir)
 [[ $(NIX_PATH=flake3=flake:flake3 nix-instantiate --eval '<flake3>' -A x) = 123 ]]
 
 # Test alternate lockfile paths.
-nix flake lock $flake2Dir --output-lock-file flake2.lock
-cmp $flake2Dir/flake.lock flake2.lock >/dev/null # lockfiles should be identical, since we're referencing flake2's original one
+nix flake lock $flake2Dir --output-lock-file $TEST_ROOT/flake2.lock
+cmp $flake2Dir/flake.lock $TEST_ROOT/flake2.lock >/dev/null # lockfiles should be identical, since we're referencing flake2's original one
 
-nix flake lock $flake2Dir --output-lock-file flake2-overridden.lock --override-input flake1 git+file://$flake1Dir?rev=$flake1OriginalCommit
-expectStderr 1 cmp $flake2Dir/flake.lock flake2-overridden.lock
-nix flake metadata $flake2Dir --reference-lock-file flake2-overridden.lock | grepQuiet $flake1OriginalCommit
+nix flake lock $flake2Dir --output-lock-file $TEST_ROOT/flake2-overridden.lock --override-input flake1 git+file://$flake1Dir?rev=$flake1OriginalCommit
+expectStderr 1 cmp $flake2Dir/flake.lock $TEST_ROOT/flake2-overridden.lock
+nix flake metadata $flake2Dir --reference-lock-file $TEST_ROOT/flake2-overridden.lock | grepQuiet $flake1OriginalCommit
 
 # reference-lock-file can only be used if allow-dirty is set.
-expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-file flake2-overridden.lock
+expectStderr 1 nix flake metadata $flake2Dir --no-allow-dirty --reference-lock-file $TEST_ROOT/flake2-overridden.lock


### PR DESCRIPTION
# Motivation
This allows having multiple separate lockfiles for a single project, which can be useful for testing against different versions of nixpkgs; it also allows tracking custom input overrides for remote flakes without requiring local clones of these flakes.

For example, if I want to build Nix against my locally pinned nixpkgs, and have a lock file tracking this override independently of future updates to said nixpkgs:

```
nix flake lock --output-lock-file /tmp/nix-flake.lock --override-input nixpkgs flake:nixpkgs
nix build --reference-lock-file /tmp/nix-flake.lock
```

# Context

Hydra's current flake support is mediocre at best, and we think supporting alternative lock files would be extremely helpful to allow Hydra (and other CI systems!) to build jobsets against alternative input sets, update inputs (individually or all at once), etc.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
