### PR TITLE
Document manual migration for use-xdg-base-directories

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -974,7 +974,7 @@ public:
           | `~/.nix-defexpr`  | `$XDG_STATE_HOME/nix/defexpr`  |
           | `~/.nix-channels` | `$XDG_STATE_HOME/nix/channels` |
 
-          If you already have Nix installed and are using [Profiles] or [Channels], you should migrate manually when you enable this option.
+          If you already have Nix installed and are using [profiles](@docroot@/package-management/profiles.md) or [channels](@docroot@/package-management/channels.md), you should migrate manually when you enable this option.
           If `$XDG_STATE_HOME` is not set, use `$HOME/.local/state/nix` instead of `$XDG_STATE_HOME/nix`.
           This can be achieved with the following shell commands:
 
@@ -985,8 +985,6 @@ public:
           mv $HOME/.nix-defexpr $nix_state_home/defexpr
           mv $HOME/.nix-channels $nix_state_home/channels
           ```
-          [Profiles]: @docroot@/package-management/profiles.md
-          [Channels]: @docroot@/package-management/channels.md
         )"
     };
 };

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -973,6 +973,19 @@ public:
           | `~/.nix-profile`  | `$XDG_STATE_HOME/nix/profile`  |
           | `~/.nix-defexpr`  | `$XDG_STATE_HOME/nix/defexpr`  |
           | `~/.nix-channels` | `$XDG_STATE_HOME/nix/channels` |
+
+          If you already have Nix installed and are using Profiles or Channels, you should migrate manually when you enable this option.
+          To do so, create `$XDG_STATE_HOME/nix`, then move `.nix-profile`, `.nix-defexpr` and `.nix-channels` as specified in the table above.
+          If `$XDG_STATE_HOME` is not set, use `$HOME/.local/state/nix` instead of `$XDG_STATE_HOME/nix`.
+          This can be achieved with the following shell commands:
+
+          ```sh
+          nix_state_home=${XDG_STATE_HOME-$HOME/.local/state}/nix
+          mkdir -p $nix_state_home
+          mv $HOME/.nix-profile $nix_state_home/profile
+          mv $HOME/.nix-defexpr $nix_state_home/defexpr
+          mv $HOME/.nix-channels $nix_state_home/channels
+          ```
         )"
     };
 };

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -974,9 +974,7 @@ public:
           | `~/.nix-defexpr`  | `$XDG_STATE_HOME/nix/defexpr`  |
           | `~/.nix-channels` | `$XDG_STATE_HOME/nix/channels` |
 
-          If you already have Nix installed and are using Profiles or Channels, you should migrate manually when you enable this option.
-          To do so, create `$XDG_STATE_HOME/nix`, then move `.nix-profile`, `.nix-defexpr` and `.nix-channels` as specified in the table above.
-          If `$XDG_STATE_HOME` is not set, use `$HOME/.local/state/nix` instead of `$XDG_STATE_HOME/nix`.
+          If you already have Nix installed and are using profiles or channels, you should migrate manually when enabling this option.
           This can be achieved with the following shell commands:
 
           ```sh

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -974,7 +974,8 @@ public:
           | `~/.nix-defexpr`  | `$XDG_STATE_HOME/nix/defexpr`  |
           | `~/.nix-channels` | `$XDG_STATE_HOME/nix/channels` |
 
-          If you already have Nix installed and are using profiles or channels, you should migrate manually when enabling this option.
+          If you already have Nix installed and are using [Profiles] or [Channels], you should migrate manually when you enable this option.
+          If `$XDG_STATE_HOME` is not set, use `$HOME/.local/state/nix` instead of `$XDG_STATE_HOME/nix`.
           This can be achieved with the following shell commands:
 
           ```sh
@@ -984,6 +985,8 @@ public:
           mv $HOME/.nix-defexpr $nix_state_home/defexpr
           mv $HOME/.nix-channels $nix_state_home/channels
           ```
+          [Profiles]: @docroot@/package-management/profiles.md
+          [Channels]: @docroot@/package-management/channels.md
         )"
     };
 };


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

As there's currently no automatic migration for use-xdg-base-directories
option, add instructions for manual migration to the option's
description.

# Context

This PR is a stop-gap solution until the fate of https://github.com/NixOS/nix/pull/7840 is decided.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
