### PR TITLE
`nix profile` command support for the `NIX_PROFILE` env var just like `nix-env`

### DIFF
--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -290,6 +290,8 @@ Path profilesDir()
 
 Path getDefaultProfile()
 {
+    if (auto profileLink = getEnv("NIX_PROFILE"))
+        return *profileLink;
     Path profileLink = settings.useXDGBaseDirectories ? createNixStateDir() + "/profile" : getHome() + "/.nix-profile";
     try {
         auto profile =

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1498,9 +1498,6 @@ static int main_nix_env(int argc, char * * argv)
         globals.instSource.autoArgs = myArgs.getAutoArgs(*globals.state);
 
         if (globals.profile == "")
-            globals.profile = getEnv("NIX_PROFILE").value_or("");
-
-        if (globals.profile == "")
             globals.profile = getDefaultProfile();
 
         op(globals, std::move(opFlags), std::move(opArgs));

--- a/src/nix/profile.md
+++ b/src/nix/profile.md
@@ -14,7 +14,8 @@ which, if it does not exist, is created as a symlink to
 `/nix/var/nix/profiles/default` if Nix is invoked by the
 `root` user, or `/nix/var/nix/profiles/per-user/`*username* otherwise.
 
-You can specify another profile location using `--profile` *path*.
+You can specify another profile location using `--profile` *path* or the
+`NIX_PROFILE` environment variable.
 
 # Filesystem layout
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

There is a discrepancy between `nix-env` and `nix profile` in that the former uses the `NIX_PROFILE` environment variable while the latter does not. Making the two commands behave the same seems reasonable here.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
