### PR TITLE
respect allRefs=1 when using `nix flake prefetch`

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -266,7 +266,7 @@ struct GitInputScheme : InputScheme
         for (auto & [name, value] : url.query) {
             if (name == "rev" || name == "ref")
                 attrs.emplace(name, value);
-            else if (name == "shallow" || name == "submodules")
+            else if (name == "shallow" || name == "submodules" || name == "allRefs")
                 attrs.emplace(name, Explicit<bool> { value == "1" });
             else
                 url2.query.emplace(name, value);


### PR DESCRIPTION
# Motivation

So out of tree revisions can be fetched with `nix flake prefetch by using allRefs=1 as a query parameter`

# Context

Makes it possible to work around https://github.com/NixOS/nix/issues/5128 when using `nix flake prefetch`

Here is an example that works after this change:
```bash
nix flake prefetch --extra-experimental-features "nix-command flakes" git+https://github.com/fdehau/tui-rs?allRefs=1&rev=6f4831a769d7adead8c53986cc2255e61c283e70
```


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
