### PR TITLE
Add a test with flake.nix in a git submodule

### DIFF
--- a/tests/flakes/flake-in-submodule.sh
+++ b/tests/flakes/flake-in-submodule.sh
@@ -24,8 +24,6 @@ git config --global protocol.file.allow always
 rootRepo=$TEST_ROOT/rootRepo
 subRepo=$TEST_ROOT/submodule
 
-rm -rf $rootRepo $subRepo $TEST_HOME/.cache/nix
-
 
 createGitRepo $subRepo
 cat > $subRepo/flake.nix <<EOF

--- a/tests/flakes/flake-in-submodule.sh
+++ b/tests/flakes/flake-in-submodule.sh
@@ -1,0 +1,54 @@
+source common.sh
+
+# Tests that:
+# - flake.nix may reside inside of a git submodule
+# - the flake can access content outside of the submodule
+#
+#   rootRepo
+#   ├── root.nix
+#   └── submodule
+#       ├── flake.nix
+#       └── sub.nix
+
+
+requireGit
+
+clearStore
+
+# Submodules can't be fetched locally by default.
+# See fetchGitSubmodules.sh
+export XDG_CONFIG_HOME=$TEST_HOME/.config
+git config --global protocol.file.allow always
+
+
+rootRepo=$TEST_ROOT/rootRepo
+subRepo=$TEST_ROOT/submodule
+
+rm -rf $rootRepo $subRepo $TEST_HOME/.cache/nix
+
+
+createGitRepo $subRepo
+cat > $subRepo/flake.nix <<EOF
+{
+    outputs = { self }: {
+        sub = import ./sub.nix;
+        root = import ../root.nix;
+    };
+}
+EOF
+echo '"expression in submodule"' > $subRepo/sub.nix
+git -C $subRepo add flake.nix sub.nix
+git -C $subRepo commit -m Initial
+
+createGitRepo $rootRepo
+
+git -C $rootRepo submodule init
+git -C $rootRepo submodule add $subRepo submodule
+echo '"expression in root repo"' > $rootRepo/root.nix
+git -C $rootRepo add root.nix
+git -C $rootRepo commit -m "Add root.nix"
+
+# Flake can live inside a submodule and can be accessed via ?dir=submodule
+[[ $(nix eval --json git+file://$rootRepo\?submodules=1\&dir=submodule#sub ) = '"expression in submodule"' ]]
+# The flake can access content outside of the submodule
+[[ $(nix eval --json git+file://$rootRepo\?submodules=1\&dir=submodule#root ) = '"expression in root repo"' ]]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -13,6 +13,7 @@ nix_tests = \
   flakes/unlocked-override.sh \
   flakes/absolute-paths.sh \
   flakes/build-paths.sh \
+  flakes/flake-in-submodule.sh \
   ca/gc.sh \
   gc.sh \
   remote-store.sh \


### PR DESCRIPTION
# Motivation

I noticed a regression in the `lazy-trees` branch, which I'm trying to capture with this test. While the test succeeds in master, the lazy-trees branch gives the following error message:

    error: access to path
    '/build/nix-test/tests/flakes/flake-in-submodule/rootRepo/submodule/flake.nix'
    is forbidden because it is not under Git control; maybe you should
    'git add' it to the repository
    '/build/nix-test/tests/flakes/flake-in-submodule/rootRepo'?


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
