### PR TITLE
docker: publish images to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
     - run: docker load -i ./result/image.tar.gz
     - run: docker tag nix:$NIX_VERSION nixos/nix:$NIX_VERSION
     - run: docker tag nix:$NIX_VERSION nixos/nix:master
+    # We'll deploy the newly built image to both Docker Hub and Github Container Registry.
+    #
+    # Push to Docker Hub first
     - name: Login to Docker Hub
       uses: docker/login-action@v2
       with:
@@ -126,3 +129,16 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - run: docker push nixos/nix:$NIX_VERSION
     - run: docker push nixos/nix:master
+    # Push to GitHub Container Registry as well
+    - name: Log in to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+    - name: Push image
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/nix
+        # Change all uppercase to lowercase
+        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+        docker tag nix:$NIX_VERSION $IMAGE_ID:$NIX_VERSION
+        docker tag nix:$NIX_VERSION $IMAGE_ID:master
+        docker push $IMAGE_ID:$NIX_VERSION
+        docker push $IMAGE_ID:master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
 
   docker_push_image:
     needs: [check_secrets, tests]
+    permissions:
+      contents: read
+      packages: write
     if: >-
       github.event_name == 'push' &&
       github.ref_name == 'master' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,12 @@ jobs:
     - run: docker push nixos/nix:$NIX_VERSION
     - run: docker push nixos/nix:master
     # Push to GitHub Container Registry as well
-    - name: Log in to registry
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Push image
       run: |
         IMAGE_ID=ghcr.io/${{ github.repository_owner }}/nix

--- a/doc/manual/src/installation/installing-docker.md
+++ b/doc/manual/src/installation/installing-docker.md
@@ -3,14 +3,14 @@
 To run the latest stable release of Nix with Docker run the following command:
 
 ```console
-$ docker run -ti nixos/nix
-Unable to find image 'nixos/nix:latest' locally
-latest: Pulling from nixos/nix
+$ docker run -ti ghcr.io/nixos/nix
+Unable to find image 'ghcr.io/nixos/nix:latest' locally
+latest: Pulling from ghcr.io/nixos/nix
 5843afab3874: Pull complete
 b52bf13f109c: Pull complete
 1e2415612aa3: Pull complete
 Digest: sha256:27f6e7f60227e959ee7ece361f75d4844a40e1cc6878b6868fe30140420031ff
-Status: Downloaded newer image for nixos/nix:latest
+Status: Downloaded newer image for ghcr.io/nixos/nix:latest
 35ca4ada6e96:/# nix --version
 nix (Nix) 2.3.12
 35ca4ada6e96:/# exit


### PR DESCRIPTION
# Motivation

docker.com announced their intention to remove the free plan used by OSS. The `nixos/nix` image is essential to various CI runs to build with nix. To provide a continuity plan, this commit pushes the image to ghcr.io as well.

# Context

Fixes #5778

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
