### PR TITLE
nix-profile-daemon.sh: prevent duplicates in $PATH

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -60,5 +60,8 @@ else
   unset -f check_nix_profiles
 fi
 
-export PATH="$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin:$PATH"
+case ":$PATH:" in
+    *:"$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin":*) ;;
+    *) export PATH="$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin:$PATH" ;;
+esac
 unset NIX_LINK


### PR DESCRIPTION
# Motivation

Sometimes nix-profile-daemon.sh gets sourced multiple times which results in duplicate entries in the $PATH variable; e.g. on my system:
```bash
$ echo $PATH | tr : '\n'
# ...
/home/bryan/.nix-profile/bin
/nix/var/nix/profiles/default/bin
/home/bryan/.nix-profile/bin
/nix/var/nix/profiles/default/bin
# ...

$ pacman -Qo /usr/bin/nix 
/usr/bin/nix is owned by nix 2.13.2-1
```
This can cause problems with finding and executing commands.

To avoid this issue, we implement a check in nix-profile-daemon.sh that verifies if $PATH already contains the intended nix entries. If so, we do not modify $PATH further, thus preventing duplication.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
