### PR TITLE
Fix build aarch64-darwin for static library

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -126,7 +126,7 @@ define build-library
     $(1)_PATH := $$(_d)/$$($(1)_NAME).a
 
     $$($(1)_PATH): $$($(1)_OBJS) | $$(_d)/
-	+$$(trace-ld) $(LD) -Ur -o $$(_d)/$$($(1)_NAME).o $$^
+	$$(trace-ld) $(LD) $$(ifndef $(HOST_DARWIN),-U) -r -o $$(_d)/$$($(1)_NAME).o $$^
 	$$(trace-ar) $(AR) crs $$@ $$(_d)/$$($(1)_NAME).o
 
     $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS) $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LDFLAGS_USE))


### PR DESCRIPTION
# Motivation
I'd like to build static libraries on aarch64-darwin. This seems like it's broken.

# Context

I'd like to access the `.a` files nix generates when building. E.g.

```
libnixcmd.a
libnixexpr.a
libnixfetchers.a
libnixmain.a
libnixstore.a
libnixutil.a
```

To do this on my m1 mbp, I did the following:

```sh
git clone https://github.com/NixOS/nix.git
cd nix
nix develop .#native-clang11StdenvPackages
./boostrap.sh
./configure --prefix=$(pwd)/outputs/out --enable-shared=no
make -j16 install
```

This fails at the linking stage. Initially the error is:

```
ld: unknown option: -Ur
make: *** [mk/lib.mk:117: src/libutil/libnixutil.a] Error 1
```

It looks like `-Ur` is specific to the gnu linker. I'm not sure what the equivalent flag combo is on darwin. But, if I entirely drop the `-U` flag then I'm able to compile on aarch64-darwin. Not sure if this is the right thing to do, but the resulting executable seems to work fine 🤔 


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
