### PR TITLE
Warn when using cached input from filesystem

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -455,6 +455,10 @@ LockedFlake lockFlake(
                     {
                         debug("keeping existing input '%s'", inputPathS);
 
+                        if (((*input.ref).input.getType() == "path") ||
+                            ((*input.ref).input.toURL().scheme == "git+file"))
+                            warn("Using input '%s' from cache. Use '--update-input %s' to refresh", inputPathS, inputPathS);
+
                         /* Copy the input from the old lock since its flakeref
                            didn't change and there is no override from a
                            higher level flake. */


### PR DESCRIPTION
# Motivation
Improve the developer experience working with flakes, especially while starting out.

# Context
During development, it can be very convenient to get fast round-trip times while making changes to upstream projects by using local paths as inputs. Inputs are cached, and while I understand this helps purity and unlocks opportunities for caching, it confused me since I was not aware how/when exactly the cache gets invalidated. Judging from the lack of response on Matrix, the very useful `--update-input` option (rather than them more heavy-handed `flake update` or even nuking your `flake.lock`) is not yet very well-known.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
