### PR TITLE
make it possible to add s3 tag to nars when uploading to s3, to allow different retention policy for debug symbols

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -1,5 +1,6 @@
 #include "archive.hh"
 #include "binary-cache-store.hh"
+#include "canon-path.hh"
 #include "compression.hh"
 #include "derivations.hh"
 #include "source-accessor.hh"
@@ -62,9 +63,10 @@ void BinaryCacheStore::init()
 
 void BinaryCacheStore::upsertFile(const std::string & path,
     std::string && data,
-    const std::string & mimeType)
+    const std::string & mimeType,
+    std::map<std::string, std::string> tags)
 {
-    upsertFile(path, std::make_shared<std::stringstream>(std::move(data)), mimeType);
+    upsertFile(path, std::make_shared<std::stringstream>(std::move(data)), mimeType, tags);
 }
 
 void BinaryCacheStore::getFile(const std::string & path,
@@ -105,11 +107,11 @@ std::string BinaryCacheStore::narInfoFileFor(const StorePath & storePath)
     return std::string(storePath.hashPart()) + ".narinfo";
 }
 
-void BinaryCacheStore::writeNarInfo(ref<NarInfo> narInfo)
+void BinaryCacheStore::writeNarInfo(ref<NarInfo> narInfo, std::map<std::string, std::string> tags)
 {
     auto narInfoFile = narInfoFileFor(narInfo->path);
 
-    upsertFile(narInfoFile, narInfo->to_string(*this), "text/x-nix-narinfo");
+    upsertFile(narInfoFile, narInfo->to_string(*this), "text/x-nix-narinfo", tags);
 
     {
         auto state_(state.lock());
@@ -138,6 +140,8 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
 
     AutoDelete autoDelete(fnTemp);
 
+    const CanonPath tagsFile { "/nix-support/tags.json" };
+
     auto now1 = std::chrono::steady_clock::now();
 
     /* Read the NAR simultaneously into a CompressionSink+FileSink (to
@@ -152,7 +156,8 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     auto compressionSink = makeCompressionSink(compression, teeSinkCompressed, parallelCompression, compressionLevel);
     TeeSink teeSinkUncompressed { *compressionSink, narHashSink };
     TeeSource teeSource { narSource, teeSinkUncompressed };
-    narAccessor = makeNarAccessor(teeSource);
+    // index the nar, and keep the content of tagsFile in memory in case it is present.
+    narAccessor = makeNarAccessor(teeSource, [&tagsFile](CanonPath& path) { return path == tagsFile; });
     compressionSink->finish();
     fileSink.flush();
     }
@@ -191,6 +196,23 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
                 printStorePath(info.path), printStorePath(ref));
         }
 
+    /* load tags if applicable */
+    std::map<std::string, std::string> tags;
+    auto lstat = narAccessor->maybeLstat(tagsFile);
+    if (lstat.has_value() && lstat->type == SourceAccessor::Type::tRegular) {
+        std::string tags_str = narAccessor->readFile(tagsFile);
+        try {
+            nlohmann::json tags_json = nlohmann::json::parse(tags_str);
+            for (const auto& kv: tags_json.items()) {
+                std::string key = kv.key();
+                std::string value = kv.value().template get<std::string>();
+                tags[key] = value;
+            }
+        } catch (const nlohmann::json::exception& e) {
+            printMsg(lvlWarn, "could not read nar tags from %s in %s: %s", tagsFile, printStorePath(info.path), e.what());
+        }
+    }
+
     /* Optionally write a JSON file containing a listing of the
        contents of the NAR. */
     if (writeNARListing) {
@@ -199,7 +221,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
             {"root", listNar(ref<SourceAccessor>(narAccessor), CanonPath::root, true)},
         };
 
-        upsertFile(std::string(info.path.hashPart()) + ".ls", j.dump(), "application/json");
+        upsertFile(std::string(info.path.hashPart()) + ".ls", j.dump(), "application/json", tags);
     }
 
     /* Optionally maintain an index of DWARF debug info files
@@ -226,7 +248,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
 
                 printMsg(lvlTalkative, "creating debuginfo link from '%s' to '%s'", key, target);
 
-                upsertFile(key, json.dump(), "application/json");
+                upsertFile(key, json.dump(), "application/json", tags);
             };
 
             std::regex regex1("^[0-9a-f]{2}$");
@@ -264,7 +286,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
         stats.narWrite++;
         upsertFile(narInfo->url,
             std::make_shared<std::fstream>(fnTemp, std::ios_base::in | std::ios_base::binary),
-            "application/x-nix-nar");
+            "application/x-nix-nar", tags);
     } else
         stats.narWriteAverted++;
 
@@ -275,7 +297,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     /* Atomically write the NAR info file.*/
     if (secretKey) narInfo->sign(*this, *secretKey);
 
-    writeNarInfo(narInfo);
+    writeNarInfo(narInfo, tags);
 
     stats.narInfoWrite++;
 

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -73,12 +73,14 @@ public:
 
     virtual void upsertFile(const std::string & path,
         std::shared_ptr<std::basic_iostream<char>> istream,
-        const std::string & mimeType) = 0;
+        const std::string & mimeType,
+        std::map<std::string, std::string> tags = {}) = 0;
 
     void upsertFile(const std::string & path,
         // FIXME: use std::string_view
         std::string && data,
-        const std::string & mimeType);
+        const std::string & mimeType,
+        std::map<std::string, std::string> tags = {});
 
     /**
      * Dump the contents of the specified file to a sink.
@@ -105,7 +107,7 @@ private:
 
     std::string narInfoFileFor(const StorePath & storePath);
 
-    void writeNarInfo(ref<NarInfo> narInfo);
+    void writeNarInfo(ref<NarInfo> narInfo, std::map<std::string, std::string> tags={});
 
     ref<const ValidPathInfo> addToStoreCommon(
         Source & narSource, RepairFlag repair, CheckSigsFlag checkSigs,

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -130,8 +130,11 @@ protected:
 
     void upsertFile(const std::string & path,
         std::shared_ptr<std::basic_iostream<char>> istream,
-        const std::string & mimeType) override
+        const std::string & mimeType,
+        std::map<std::string, std::string> tags) override
     {
+        (void)tags;
+
         auto req = makeRequest(path);
         req.data = StreamToSourceAdapter(istream).drain();
         req.mimeType = mimeType;

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -56,8 +56,11 @@ protected:
 
     void upsertFile(const std::string & path,
         std::shared_ptr<std::basic_iostream<char>> istream,
-        const std::string & mimeType) override
+        const std::string & mimeType,
+        std::map<std::string, std::string> tags) override
     {
+        (void)tags;
+
         auto path2 = binaryCacheDir + "/" + path;
         static std::atomic<int> counter{0};
         Path tmp = fmt("%s.tmp.%d.%d", path2, getpid(), ++counter);

--- a/src/libstore/nar-accessor.hh
+++ b/src/libstore/nar-accessor.hh
@@ -4,6 +4,7 @@
 #include "source-accessor.hh"
 
 #include <functional>
+#include <optional>
 
 #include <nlohmann/json_fwd.hpp>
 
@@ -17,7 +18,16 @@ struct Source;
  */
 ref<SourceAccessor> makeNarAccessor(std::string && nar);
 
-ref<SourceAccessor> makeNarAccessor(Source & source);
+/**
+ * Return an object that provides access to the contents of a NAR
+ * file.
+ *
+ * the readFile() member function only works for files where loadContentsFilter
+ * return true. The content of those files is stored in memory. For
+ * other files, and if loadContentsFilter is nullopt, readFile() throws
+ * an error.
+ */
+ref<SourceAccessor> makeNarAccessor(Source & source, std::optional<std::function<bool(CanonPath&)>> loadContentsFilter = std::nullopt);
 
 /**
  * Create a NAR accessor from a NAR listing (in the format produced by

--- a/src/libstore/s3-binary-cache-store.md
+++ b/src/libstore/s3-binary-cache-store.md
@@ -72,7 +72,8 @@ Your account will need an IAM policy to support uploading to the bucket:
         "s3:ListBucket",
         "s3:ListBucketMultipartUploads",
         "s3:ListMultipartUploadParts",
-        "s3:PutObject"
+        "s3:PutObject",
+        "s3:PutObjectTagging"
       ],
       "Resource": [
         "arn:aws:s3:::example-nix-cache",
@@ -101,4 +102,15 @@ With bucket policies and authentication set up as described above, uploading wor
     's3://example-nix-cache?profile=cache-upload&scheme=https&endpoint=minio.example.com'
   ```
 
+### Tagging
+
+It is possible for a derivation output to be tagged, so that a retention policy can remove some derivations sooner than others from the S3 bucket backing the cache.
+
+Specifically, if a derivation output contains a file `nix-support/tags.json` of the form `{ key1 = "value1"; key2 = "value2"; }`, then all files associated with this output (`.nar`, `.narinfo`, `.ls`...) will be tagged with key-value pairs `("nix:key1", "value1")` and `("nix:key2", "value2")`.
+
+> **Note**
+>
+> There may be restrictions on tags enforced by your cloud provider. See the [S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for example.
+
 )"
+

--- a/src/libutil/url.hh
+++ b/src/libutil/url.hh
@@ -32,6 +32,7 @@ std::string percentDecode(std::string_view in);
 std::string percentEncode(std::string_view s, std::string_view keep="");
 
 std::map<std::string, std::string> decodeQuery(const std::string & query);
+std::string encodeQuery(const std::map<std::string, std::string> & params);
 
 ParsedURL parseURL(const std::string & url);
 


### PR DESCRIPTION
this allows setting a different retention policy for debug symbols in s3 backed binary caches.

# Motivation
We currently have debug symbols for very few libraries in NixOS. Recompiling everything to get debug symbols is non trivial and time consuming. 
The main objection (https://github.com/NixOS/nixpkgs/issues/18530) to enabling debug symbols on a large scale is that they are heavy (on my system, about 50% larger on average than the original libraries) so storage costs for the official binary cache would be unacceptable. One possible idea is to keep debug symbols for a shorter period than other packages (which are currently stores forever), for example 7 months (support duration of a release).
This implies being able to know what nars to remove 7 month from now.

 .narinfo files contain the name of the store path. A naive approach could be to  download all narinfo, read them for paths ending in -debug, and send DELETE queries to amazon but this will take forever and cost many requests.

A better approach is to rely on the ability of s3 to selectively expire objects after a delay
- by directory (prefix)
- by tag

By prefix: it would be possible to move debug related nars to another directory instead of nar/, and point narinfo files to it. Although it's undocumented this breaks the format of binary caches and I fear may have unsuspected consequences. For this reason I tried the approach of tagging debuginfo related nars at upload time.

In terms of implementation, binary caches are given a hint when uploading a file, and this hint is set to debug for debug nars.
Only the s3 implem uses the hint currently. This does not really add special casing for debug nars, as there was already an option about them (index-debug-info).


Note: in my opinion this is of limited usefulness if people in charge of the official binary cache don't like this approach. Can someone confirm that hydra does not use multipart uploads ? I did not find a way to make this work with multipart uploads.

# Context
Alternatives: keep living without debug info on NixOS forever. More seriously see the discussions at https://github.com/NixOS/nixpkgs/issues/18530



# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
