### PR TITLE
Fix misrendering of 'nix store --help'

### DIFF
--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -7,6 +7,7 @@ let
 
   showCommand = { command, details, filename, toplevel }:
     let
+
       result = ''
         > **Warning** \
         > This program is **experimental** and its interface is subject to change.
@@ -25,6 +26,7 @@ let
 
         ${maybeOptions}
       '';
+
       showSynopsis = command: args:
         let
           showArgument = arg: "*${arg.label}*" + (if arg ? arity then "" else "...");
@@ -32,6 +34,7 @@ let
         in ''
          `${command}` [*option*...] ${arguments}
         '';
+
       maybeSubcommands = if details ? commands && details.commands != {}
         then ''
            where *subcommand* is one of the following:
@@ -39,26 +42,35 @@ let
            ${subcommands}
          ''
         else "";
+
       subcommands = if length categories > 1
         then listCategories
         else listSubcommands details.commands;
+
       categories = sort (x: y: x.id < y.id) (unique (map (cmd: cmd.category) (attrValues details.commands)));
+
       listCategories = concatStrings (map showCategory categories);
+
       showCategory = cat: ''
         **${toString cat.description}:**
 
         ${listSubcommands (filterAttrs (n: v: v.category == cat) details.commands)}
       '';
+
       listSubcommands = cmds: concatStrings (attrValues (mapAttrs showSubcommand cmds));
+
       showSubcommand = name: subcmd: ''
         * [`${command} ${name}`](./${appendName filename name}.md) - ${subcmd.description}
       '';
+
       maybeDocumentation = if details ? doc then details.doc else "";
+
       maybeOptions = if details.flags == {} then "" else ''
         # Options
 
         ${showOptions details.flags toplevel.flags}
       '';
+
       showOptions = options: commonOptions:
         let
           allOptions = options // commonOptions;
@@ -99,7 +111,7 @@ let
     in [ cmd ] ++ concatMap subcommand (attrNames details.commands or {});
 
   parsedToplevel = builtins.fromJSON toplevel;
-  
+
   manpages = processCommand {
     command = "nix";
     details = parsedToplevel;

--- a/src/nix/store-copy-log.cc
+++ b/src/nix/store-copy-log.cc
@@ -24,8 +24,6 @@ struct CmdCopyLog : virtual CopyCommand, virtual InstallablesCommand
           ;
     }
 
-    Category category() override { return catUtility; }
-
     void run(ref<Store> srcStore, Installables && installables) override
     {
         auto & srcLogStore = require<LogStore>(*srcStore);


### PR DESCRIPTION
# Motivation

There are no categories underneath `nix store`, so having `nix store copy-log` in a category rendered as `:`. See https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-store.html.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
