### PR TITLE
Fix `builtins.storePath` in pure mode

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -605,6 +605,31 @@ struct EvalSettings : Config
           builds to take place.
         )"};
 
+    // TODO: (RFC 92) Add dynamic derivations as a use case here. Review the final assertion about non-buildable paths.
+    Setting<bool> enableStorePathReferences{
+        this, true, "allow-store-path-references",
+        R"(
+          Whether to allow references to store paths in the Nix language.
+
+          Usually, store paths are created by adding files to the store and
+          by using the `derivation` primitive. However, the `storePath`
+          primitive allows you to merely assert that a store path exists or
+          can be substituted, and allows you to use it in subsequent expressions.
+
+          This lets you use pre-built derivations, such as pre-built packages
+          that are passed into a NixOS VM test or closed source software that
+          is built and distributed with Nix.
+
+          However, unlike most expressions, it does not inherently provide a
+          means of obtaining, modifying and rebuilding the store path.
+          Unless these needs are covered by some process outside the current
+          evaluation context, use of this primitive suggests a lack of
+          reproducibility. You may disable this option to enforce that all
+          store paths are created by the current Nix evaluator. This ensures
+          that any non-reproducible content in your closure comes from
+          individual local files, built-in fetchers, or fixed-output derivations.
+        )"};
+
     Setting<Strings> allowedUris{this, {}, "allowed-uris",
         R"(
           A list of URI prefixes to which access is allowed in restricted

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1449,8 +1449,9 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value * * args, 
     Path path = state.coerceToPath(pos, *args[0], context, "while evaluating the argument of builtins.storePath");
 
     /* The following branch permits a dependency on a store path to be declared,
-       but in restrict-eval, extending the allowed paths would not be desirable. */
-    if (evalSettings.pureEval && !evalSettings.restrictEval) {
+       but in restrict-eval, extending the allowed paths would not be desirable
+       regardless. */
+    if (evalSettings.pureEval && evalSettings.enableStorePathReferences && !evalSettings.restrictEval) {
 
         /* Reading from the store behaves like a pure function, but we want to
            be careful about symlink resolution, which would otherwise be done

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -103,12 +103,12 @@ static void prim_fetchClosure(EvalState & state, const PosIdx pos, Value * * arg
         toPath = fromPath;
     }
 
-    /* In pure mode, require a CA path. */
-    if (evalSettings.pureEval) {
+    /* In pure mode without enable-store-path-references, require a CA path. */
+    if (evalSettings.pureEval && !evalSettings.enableStorePathReferences) {
         auto info = state.store->queryPathInfo(*toPath);
         if (!info->isContentAddressed(*state.store))
             throw Error({
-                .msg = hintfmt("in pure mode, 'fetchClosure' requires a content-addressed path, which '%s' isn't",
+                .msg = hintfmt("in pure mode, with option 'enable-store-path-references' disabled, 'fetchClosure' requires a content-addressed path, which '%s' isn't",
                     state.store->printStorePath(*toPath)),
                 .errPos = state.positions[pos]
             });

--- a/src/libexpr/tests/error_traces.cc
+++ b/src/libexpr/tests/error_traces.cc
@@ -310,7 +310,7 @@ namespace nix {
         ASSERT_TRACE2("storePath true",
                       TypeError,
                       hintfmt("cannot coerce %s to a string", "a Boolean"),
-                      hintfmt("while evaluating the first argument passed to builtins.storePath"));
+                      hintfmt("while evaluating the argument of builtins.storePath"));
 
     }
 


### PR DESCRIPTION
# Motivation

This allows packaging nix-built proprietary programs without forcing uses to deal with impurities, and unblocks two other use cases.

# Context

This is now blocking a customer of mine, and it is also blocking
 - #7778
 - https://github.com/NixOS/nixpkgs/issues/199162
 - Closes #5868

@edolstra has previously rejected this idea in #5868

> It may not be impure, but it does make builds non-reproducible: it prevents rebuilding a flake unless you already have the store path or you have a substituter that can provide it.

but @tomberek:

> I'm leaning toward the simpler approach and removing the restriction from the builtin. The loss of reproducibility would be identical compared to declaring any src via git/github/url/mirrors with regards to it being possible to be unable to fetch + reproduce the content if the source has changed/moved/permissions/etc. In some ways this would be more resilient due to substituters being utilized as the mechanism to get their output, they are similar to having mirrors available.

If the new behavior is still not acceptable, would a new option be ok? Such an option allows users opt in to this behavior without opening the impure floodgates.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
