### PR TITLE
error.cc: Only suggest `--show-trace` when relevant

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -302,13 +302,13 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
     if (!einfo.traces.empty()) {
         size_t count = 0;
         for (const auto & trace : einfo.traces) {
+            if (trace.hint.str().empty()) continue;
+            if (frameOnly && !trace.frame) continue;
+
             if (!showTrace && count > 3) {
                 oss << "\n" << ANSI_WARNING "(stack trace truncated; use '--show-trace' to show the full trace)" ANSI_NORMAL << "\n";
                 break;
             }
-
-            if (trace.hint.str().empty()) continue;
-            if (frameOnly && !trace.frame) continue;
 
             count++;
             frameOnly = trace.frame;


### PR DESCRIPTION
 Only suggest show-trace when truncated trace items would be printed

Otherwise, a trace consisting of

frame
frame
frame
non-frame

... would reach the non-frame and print the suggestion, even though it would have ignored the non-frame anyway.

This resulted in a peculiar situation where `--show-trace` would have no apparent effect, as the trace was actually already complete.

# Motivation

Fix a papercut.

# Context

Was part of another pr at first.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
