### PR TITLE
nix-store: Use `long` for `narSize` in graphml output

### DIFF
--- a/src/nix-store/graphml.cc
+++ b/src/nix-store/graphml.cc
@@ -57,7 +57,7 @@ void printGraphML(ref<Store> store, StorePathSet && roots)
          << "<graphml xmlns='http://graphml.graphdrawing.org/xmlns'\n"
          << "    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'\n"
          << "    xsi:schemaLocation='http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd'>\n"
-         << "<key id='narSize' for='node' attr.name='narSize' attr.type='int'/>"
+         << "<key id='narSize' for='node' attr.name='narSize' attr.type='long'/>"
          << "<key id='name' for='node' attr.name='name' attr.type='string'/>"
          << "<key id='type' for='node' attr.name='type' attr.type='string'/>"
          << "<graph id='G' edgedefault='directed'>\n";


### PR DESCRIPTION
# Motivation

Using an int for filesizes is not a good idea. Trying to read a graphml file generated from `nix-store --query --graphml ...`
into tinkerpop failed with:
```
java.lang.NumberFormatException: For input string: "2556963720"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:652)
	at java.base/java.lang.Integer.valueOf(Integer.java:983)
	at org.apache.tinkerpop.gremlin.structure.io.graphml.GraphMLReader.typeCastValue(GraphMLReader.java:324)
	at org.apache.tinkerpop.gremlin.structure.io.graphml.GraphMLReader.readGraph(GraphMLReader.java:150)
```

Editing the graphml file and using `long` resolved this problem.

# Context

# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
