### PR TITLE
libstore+nix-build: add load-limit setting and use its value for NIX_LOAD_LIMIT en var

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1112,6 +1112,9 @@ void LocalDerivationGoal::initEnv()
     /* The maximum number of cores to utilize for parallel building. */
     env["NIX_BUILD_CORES"] = fmt("%d", settings.buildCores);
 
+    /* The maximum average load to target for buildsystems supporting it. */
+    env["NIX_LOAD_LIMIT"] = fmt("%d", settings.loadLimit);
+
     initTmpDir();
 
     /* Compatibility hack with Nix <= 0.7: if this is a fixed-output

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -189,6 +189,7 @@ struct ClientSettings
     time_t maxSilentTime;
     bool verboseBuild;
     unsigned int buildCores;
+    unsigned int loadLimit;
     bool useSubstitutes;
     StringMap overrides;
 
@@ -202,6 +203,7 @@ struct ClientSettings
         settings.maxSilentTime = maxSilentTime;
         settings.verboseBuild = verboseBuild;
         settings.buildCores = buildCores;
+        settings.loadLimit = loadLimit;
         settings.useSubstitutes = useSubstitutes;
 
         for (auto & i : overrides) {

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -150,6 +150,22 @@ public:
         )",
         {"build-cores"}, false};
 
+    Setting<unsigned int> loadLimit{
+        this,
+        getDefaultCores(),
+        "load-limit",
+        R"(
+          Sets the value of the `NIX_LOAD_LIMIT` environment variable in the
+          invocation of builders. Builders can use this variable at their
+          discretion to schedule jobs based on the average load of the system.
+          For instance, in Nixpkgs, if the derivation attribute
+          `enableParallelBuilding` is set to `true`, the builder passes the
+          `-lN` flag to GNU Make. It can be overriden using the `--max-build-load`
+          command line switch and defaults to `1`. The value `0`means that
+          the builder should ignore the average system load.
+        )",
+        {}, false};
+
     /* Read-only mode.  Don't copy stuff to the store, don't change
        the database. */
     bool readOnlyMode = false;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -465,6 +465,7 @@ static void main_nix_build(int argc, char * * argv)
         env["NIX_BUILD_TOP"] = env["TMPDIR"] = env["TEMPDIR"] = env["TMP"] = env["TEMP"] = *tmp;
         env["NIX_STORE"] = store->storeDir;
         env["NIX_BUILD_CORES"] = std::to_string(settings.buildCores);
+        env["NIX_LOAD_LIMIT"] = std::to_string(settings.loadLimit);
 
         auto passAsFile = tokenizeString<StringSet>(getOr(drv.env, "passAsFile", ""));
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nix/issues/7091

# Motivation & Context
As explained in issue #7091, https://github.com/NixOS/nixpkgs/pull/192447 removed `-l` flag from all buildsystem invocations in nixpkgs, in order to improve Hydra efficiency.

However, this had several drawbacks, as this removed the ability to limit CPU load, causing OOM issues or extreme system loads in some bad scenarios (`ninja` buildsystem building something with `-flto=auto` enabled).

This patch aims to reintroduce the possibility to limit system load (together with PR https://github.com/NixOS/nixpkgs/pull/192799), while still allowing Hydra to have full build efficiency.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
