### PR TITLE
Catch eval errors in `hasContent`

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1026,36 +1026,43 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
             auto visitor2 = visitor.getAttr(attrName);
 
-            if ((attrPathS[0] == "apps"
-                    || attrPathS[0] == "checks"
-                    || attrPathS[0] == "devShells"
-                    || attrPathS[0] == "legacyPackages"
-                    || attrPathS[0] == "packages")
-                && (attrPathS.size() == 1 || attrPathS.size() == 2)) {
-                for (const auto &subAttr : visitor2->getAttrs()) {
-                    if (hasContent(*visitor2, attrPath2, subAttr)) {
-                        return true;
+            try {
+                if ((attrPathS[0] == "apps"
+                        || attrPathS[0] == "checks"
+                        || attrPathS[0] == "devShells"
+                        || attrPathS[0] == "legacyPackages"
+                        || attrPathS[0] == "packages")
+                    && (attrPathS.size() == 1 || attrPathS.size() == 2)) {
+                    for (const auto &subAttr : visitor2->getAttrs()) {
+                        if (hasContent(*visitor2, attrPath2, subAttr)) {
+                            return true;
+                        }
                     }
+                    return false;
                 }
-                return false;
-            }
 
-            if ((attrPathS.size() == 1)
-                && (attrPathS[0] == "formatter"
-                    || attrPathS[0] == "nixosConfigurations"
-                    || attrPathS[0] == "nixosModules"
-                    || attrPathS[0] == "overlays"
-                    )) {
-                for (const auto &subAttr : visitor2->getAttrs()) {
-                    if (hasContent(*visitor2, attrPath2, subAttr)) {
-                        return true;
+                if ((attrPathS.size() == 1)
+                    && (attrPathS[0] == "formatter"
+                        || attrPathS[0] == "nixosConfigurations"
+                        || attrPathS[0] == "nixosModules"
+                        || attrPathS[0] == "overlays"
+                        )) {
+                    for (const auto &subAttr : visitor2->getAttrs()) {
+                        if (hasContent(*visitor2, attrPath2, subAttr)) {
+                            return true;
+                        }
                     }
+                    return false;
                 }
-                return false;
-            }
 
-            // If we don't recognize it, it's probably content
-            return true;
+                // If we don't recognize it, it's probably content
+                return true;
+            } catch (EvalError & e) {
+                // Some attrs may contain errors, eg. legacyPackages of
+                // nixpkgs. We still want to recurse into it, instead of
+                // skipping it at all.
+                return true;
+            }
         };
 
         std::function<nlohmann::json(

--- a/tests/flakes/show.sh
+++ b/tests/flakes/show.sh
@@ -65,7 +65,8 @@ assert show_output == { };
 true
 '
 
-# Test that legacyPackages with errors are handled correctly.
+# Test that attributes with errors are handled correctly.
+# nixpkgs.legacyPackages is a particularly prominent instance of this.
 cat >flake.nix <<EOF
 {
   outputs = inputs: {


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

`legacyPackages` of nixpkgs trigger eval errors in `hasContent`, causing the whole `legacyPackages` being skipped. We should treat it as has-content in that case.


# Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

See https://github.com/NixOS/nix/pull/7726#issuecomment-1484098760

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
