### PR TITLE
Quote reserved keywords when printing expressions

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -94,7 +94,6 @@ RootValue allocRootValue(Value * v)
 #endif
 }
 
-
 void Value::print(const SymbolTable & symbols, std::ostream & str,
     std::set<const void *> * seen) const
 {
@@ -122,7 +121,13 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
         else {
             str << "{ ";
             for (auto & i : attrs->lexicographicOrder(symbols)) {
-                str << symbols[i->name] << " = ";
+                // Quote reserved keywords so that the output can be
+                // re-evaluated later without upsetting the lexer.
+                if (isReservedKeyword(symbols[i->name])) {
+                    str << "\"" << symbols[i->name] << "\" = ";
+                } else {
+                    str << symbols[i->name] << " = ";
+                }
                 i->value->print(symbols, str, seen);
                 str << "; ";
             }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -121,13 +121,7 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
         else {
             str << "{ ";
             for (auto & i : attrs->lexicographicOrder(symbols)) {
-                // Quote reserved keywords so that the output can be
-                // re-evaluated later without upsetting the lexer.
-                if (isReservedKeyword(symbols[i->name])) {
-                    str << "\"" << symbols[i->name] << "\" = ";
-                } else {
-                    str << symbols[i->name] << " = ";
-                }
+                str << symbols[i->name] << " = ";
                 i->value->print(symbols, str, seen);
                 str << "; ";
             }

--- a/src/libexpr/print.hh
+++ b/src/libexpr/print.hh
@@ -36,6 +36,12 @@ namespace nix {
     std::ostream & printAttributeName(std::ostream & o, std::string_view s);
 
     /**
+     * Returns `true' is a string is a reserved keyword which requires quotation
+     * when printing attribute set field names.
+     */
+    bool isReservedKeyword(const std::string_view str);
+
+    /**
      * Print a string as an identifier in the Nix expression language syntax.
      *
      * FIXME: "identifier" is ambiguous. Identifiers do not have a single

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -16,7 +16,7 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 [[ $(nix eval int -f "./eval.nix") == 123 ]]
 [[ $(nix eval str -f "./eval.nix") == '"foo"' ]]
 [[ $(nix eval str --raw -f "./eval.nix") == 'foo' ]]
-[[ $(nix eval attr -f "./eval.nix") == '{ foo = "bar"; }' ]]
+[[ "$(nix eval attr -f "./eval.nix")" == '{ foo = "bar"; }' ]]
 [[ $(nix eval attr --json -f "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix eval int -f - < "./eval.nix") == 123 ]]
 [[ "$(nix eval --expr '{"assert"=1;bar=2;}')" == '{ "assert" = 1; bar = 2; }' ]]
@@ -27,7 +27,7 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
 [[ $(nix-instantiate -A int --eval "./eval.nix") == 123 ]]
 [[ $(nix-instantiate -A str --eval "./eval.nix") == '"foo"' ]]
-[[ $(nix-instantiate -A attr --eval "./eval.nix") == '{ foo = "bar"; }' ]]
+[[ "$(nix-instantiate -A attr --eval "./eval.nix")" == '{ foo = "bar"; }' ]]
 [[ $(nix-instantiate -A attr --eval --json "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix-instantiate -A int --eval - < "./eval.nix") == 123 ]]
 [[ "$(nix-instantiate --eval -E '{"assert"=1;bar=2;}')" == '{ "assert" = 1; bar = 2; }' ]]

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -19,7 +19,7 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 [[ $(nix eval attr -f "./eval.nix") == '{ foo = "bar"; }' ]]
 [[ $(nix eval attr --json -f "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix eval int -f - < "./eval.nix") == 123 ]]
-[[ $(nix eval --expr '{"assert"=1;bar=2;}') == '{ "assert" = 1; bar = 2; }' ]]
+[[ "$(nix eval --expr '{"assert"=1;bar=2;}')" == '{ "assert" = 1; bar = 2; }' ]]
 
 # Check if toFile can be utilized during restricted eval
 [[ $(nix eval --restrict-eval --expr 'import (builtins.toFile "source" "42")') == 42 ]]
@@ -30,7 +30,7 @@ nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
 [[ $(nix-instantiate -A attr --eval "./eval.nix") == '{ foo = "bar"; }' ]]
 [[ $(nix-instantiate -A attr --eval --json "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix-instantiate -A int --eval - < "./eval.nix") == 123 ]]
-[[ $(nix-instantiate --eval -E '{"assert"=1;bar=2;}') == '{ "assert" = 1; bar = 2; }' ]]
+[[ "$(nix-instantiate --eval -E '{"assert"=1;bar=2;}')" == '{ "assert" = 1; bar = 2; }' ]]
 
 # Check that symlink cycles don't cause a hang.
 ln -sfn cycle.nix $TEST_ROOT/cycle.nix

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -19,6 +19,7 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 [[ $(nix eval attr -f "./eval.nix") == '{ foo = "bar"; }' ]]
 [[ $(nix eval attr --json -f "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix eval int -f - < "./eval.nix") == 123 ]]
+[[ $(nix eval --expr '{"assert"=1;bar=2;}') == '{ "assert" = 1; bar = 2; }' ]]
 
 # Check if toFile can be utilized during restricted eval
 [[ $(nix eval --restrict-eval --expr 'import (builtins.toFile "source" "42")') == 42 ]]
@@ -29,6 +30,7 @@ nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
 [[ $(nix-instantiate -A attr --eval "./eval.nix") == '{ foo = "bar"; }' ]]
 [[ $(nix-instantiate -A attr --eval --json "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix-instantiate -A int --eval - < "./eval.nix") == 123 ]]
+[[ $(nix-instantiate --eval -E '{"assert"=1;bar=2;}') == '{ "assert" = 1; bar = 2; }' ]]
 
 # Check that symlink cycles don't cause a hang.
 ln -sfn cycle.nix $TEST_ROOT/cycle.nix


### PR DESCRIPTION
# Motivation
This allows the output of `nix eval` to be re-evaluated without errors when attrsets use keys such as `assert`.

# Context
Related Issue: https://github.com/NixOS/nix/issues/7656

You can compare the output of `nix eval` with these examples:
```console
# Old
$ nix eval --expr '{ "assert" = 1; }';
{ assert = 1; }

# New
$ nix eval --expr '{ "assert" = 1; }';
{ "assert" = 1; }
```

I covered the keyword symbols recognized by the parser, and added `throw` and `import` just for good measure.
The list is : "if", "then", "else", "assert", "with", "let", "in", "rec", "inherit", "or", "throw", "import".


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [x] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
