### PR TITLE
Fix more profile dirs in docs

### DIFF
--- a/doc/manual/src/command-ref/nix-channel.md
+++ b/doc/manual/src/command-ref/nix-channel.md
@@ -70,7 +70,7 @@ $ nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
 
 # Files
 
-  - `/nix/var/nix/profiles/per-user/username/channels`\
+  - `${XDG_STATE_HOME-$HOME/.local/state}/nix/profiles/channels`\
     `nix-channel` uses a `nix-env` profile to keep track of previous
     versions of the subscribed channels. Every time you run `nix-channel
     --update`, a new channel generation (that is, a symlink to the
@@ -79,7 +79,7 @@ $ nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
 
   - `~/.nix-defexpr/channels`\
     This is a symlink to
-    `/nix/var/nix/profiles/per-user/username/channels`. It ensures that
+    `${XDG_STATE_HOME-$HOME/.local/state}/nix/profiles/channels`. It ensures that
     `nix-env` can find your channels. In a multi-user installation, you
     may also have `~/.nix-defexpr/channels_root`, which links to the
     channels of the root user.

--- a/doc/manual/src/command-ref/nix-store.md
+++ b/doc/manual/src/command-ref/nix-store.md
@@ -493,7 +493,7 @@ depends on `svn`:
 $ nix-store -q --roots $(which svn)
 /nix/var/nix/profiles/default-81-link
 /nix/var/nix/profiles/default-82-link
-/nix/var/nix/profiles/per-user/eelco/profile-97-link
+/home/eelco/.local/state/nix/profiles/profile-97-link
 ```
 
 # Operation `--add`

--- a/src/nix/upgrade-nix.md
+++ b/src/nix/upgrade-nix.md
@@ -11,7 +11,7 @@ R""(
 * Upgrade Nix in a specific profile:
 
   ```console
-  # nix upgrade-nix -p /nix/var/nix/profiles/per-user/alice/profile
+  # nix upgrade-nix -p ~alice/.local/state/nix/profiles/profile
   ```
 
 # Description


### PR DESCRIPTION
# Motivation

Document the correct path, not the path which is no longer correct.

# Context

Picking up where #8078 left off.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
