### PR TITLE
Docs: Explain why `import nixpkgs` works in flakes

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -254,9 +254,14 @@ static RegisterPrimOp primop_import({
     .args = {"path"},
     // TODO turn "normal path values" into link below
     .doc = R"(
-      Load, parse and return the Nix expression in the file *path*. If
-      *path* is a directory, the file ` default.nix ` in that directory
-      is loaded. Evaluation aborts if the file doesn’t exist or contains
+      Load, parse and return the Nix expression in the file *path*.
+
+      The value *path* is conveted to a string as described in `builtins.toString`.
+
+      If *path* is a directory, the file ` default.nix ` in that directory
+      is loaded.
+
+      Evaluation aborts if the file doesn’t exist or contains
       an incorrect Nix expression. `import` implements Nix’s module
       system: you can put any Nix expression (such as a set or a
       function) in a separate file, and use it from Nix expressions in

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -257,7 +257,7 @@ static RegisterPrimOp primop_import({
       Load, parse and return the Nix expression in the file *path*.
 
       The value *path* can be a path, a string, or an attribute set with an
-      `__toString` attribute or a `outPath` attribute (as derivations or falke
+      `__toString` attribute or a `outPath` attribute (as derivations or flake
       inputs typically have).
 
       If *path* is a directory, the file `default.nix` in that directory

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -256,7 +256,7 @@ static RegisterPrimOp primop_import({
     .doc = R"(
       Load, parse and return the Nix expression in the file *path*.
 
-      The value *path* is conveted to a string as described in `builtins.toString`.
+      The value *path* is converted to a string as described in `builtins.toString`.
 
       If *path* is a directory, the file ` default.nix ` in that directory
       is loaded.

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -256,7 +256,9 @@ static RegisterPrimOp primop_import({
     .doc = R"(
       Load, parse and return the Nix expression in the file *path*.
 
-      The value *path* is converted to a string as described in `builtins.toString`.
+      The value *path* can be a path, a string, or an attribute set with an
+      `__toString` attribute or a `outPath` attribute (as derivations or falke
+      inputs typically have).
 
       If *path* is a directory, the file `default.nix` in that directory
       is loaded.

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -258,7 +258,7 @@ static RegisterPrimOp primop_import({
 
       The value *path* is converted to a string as described in `builtins.toString`.
 
-      If *path* is a directory, the file ` default.nix ` in that directory
+      If *path* is a directory, the file `default.nix` in that directory
       is loaded.
 
       Evaluation aborts if the file doesn’t exist or contains

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -317,6 +317,8 @@ The following attributes are supported in `flake.nix`:
   also contains some metadata about the inputs. These are:
 
   * `outPath`: The path in the Nix store of the flake's source tree.
+     This way, the attribute set can be passed to `import` as if it was a path,
+     as in the example above (`import nixpkgs`).
 
   * `rev`: The commit hash of the flake's repository, if applicable.
 


### PR DESCRIPTION
# Motivation

I was surprised that `import nixpkgs` works in a flake, and found the documentation did
not put all puzzle pieces together. After some [help in the forum](https://discourse.nixos.org/t/the-nixpkgs-flake-import/26769) I would like to improve the docs slightly.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
