### PR TITLE
Fix data race in copyPaths

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -10,6 +10,7 @@
 #include "archive.hh"
 #include "callback.hh"
 #include "remote-store.hh"
+#include "sync.hh"
 
 #include <nlohmann/json.hpp>
 #include <regex>
@@ -1101,7 +1102,8 @@ std::map<StorePath, StorePath> copyPaths(
         return storePathForDst;
     };
 
-    uint64_t total = 0;
+    // total is accessed by each copy, which are each handled in separate threads
+    Sync<uint64_t> total = 0;
 
     for (auto & missingPath : sortedMissing) {
         auto info = srcStore.queryPathInfo(missingPath);
@@ -1124,8 +1126,8 @@ std::map<StorePath, StorePath> copyPaths(
             PushActivity pact(act.id);
 
             LambdaSink progressSink([&](std::string_view data) {
-                total += data.size();
-                act.progress(total, info->narSize);
+                *total.lock() += data.size();
+                act.progress(*total.lock(), info->narSize);
             });
             TeeSink tee { sink, progressSink };
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1103,7 +1103,7 @@ std::map<StorePath, StorePath> copyPaths(
     };
 
     // total is accessed by each copy, which are each handled in separate threads
-    Sync<uint64_t> total = 0;
+    Sync<uint64_t> _total = 0;
 
     for (auto & missingPath : sortedMissing) {
         auto info = srcStore.queryPathInfo(missingPath);
@@ -1126,8 +1126,9 @@ std::map<StorePath, StorePath> copyPaths(
             PushActivity pact(act.id);
 
             LambdaSink progressSink([&](std::string_view data) {
-                *total.lock() += data.size();
-                act.progress(*total.lock(), info->narSize);
+                auto total(_total.lock());
+                *total += data.size();
+                act.progress(*total, info->narSize);
             });
             TeeSink tee { sink, progressSink };
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
This change fixes a data race on the variable `total`.

Found using ThreadSanitizer (tsan) with my Meson branch.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
