### PR TITLE
Fix the installer VM tests

### DIFF
--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -17,7 +17,7 @@ let
       script = ''
         tar -xf ./nix.tar.xz
         mv ./nix-* nix
-        ./nix/install --no-daemon
+        ./nix/install --no-daemon --no-channel-add
       '';
     };
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

The installer tests are broken on hydra since https://github.com/NixOS/nix/pull/8073 (mostly my fault, I didn't test all the combinations, and also a bit the CI's fault for not testing this earlier).
Fix the two issues that caused this, namely

- Don't add a channel for the force-no-daemon installer variant
- Make the installer work on old rhel versions

# Context

https://hydra.nixos.org/eval/1792649

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
