### PR TITLE
Mention internal API docs in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Maintainers: tick if completed or explain if not relevant
    - unit tests - `src/*/tests`
    - integration tests - `tests/nixos/*`
  - [ ] documentation in the manual
+ - [ ] documentation in the internal API docs
  - [ ] code and comments are self-explanatory
  - [ ] commit message explains why the change was made
  - [ ] new feature or incompatible change: updated release notes


### PR DESCRIPTION
# Motivation

I think we want to ensure that all new items in headers are documented, and the documentation on modified items is kept up to date.

It will take a while to document the backlog of undocumented things, but we can at least ensure that new items don't extend that backlog.

# Context

After https://github.com/NixOS/nix/pull/8146 all existing documentation in headers should be converted, so my focus changes from looking backward to looking forward.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
