### PR TITLE
Make `nix-collect-garbage -d` look into more places

### DIFF
--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -77,7 +77,12 @@ static int main_nix_collect_garbage(int argc, char * * argv)
             return true;
         });
 
-        if (removeOld) removeOldGenerations(profilesDir());
+        if (removeOld) {
+            std::set<Path> dirsToClean = {
+                profilesDir(), settings.nixStateDir + "/profiles", dirOf(getDefaultProfile())};
+            for (auto & dir : dirsToClean)
+                removeOldGenerations(dir);
+        }
 
         // Run the actual garbage collector.
         if (!dryRun) {

--- a/tests/gc.sh
+++ b/tests/gc.sh
@@ -52,9 +52,7 @@ rmdir $NIX_STORE_DIR/.links
 rmdir $NIX_STORE_DIR
 
 ## Test `nix-collect-garbage -d`
-# `nix-env` doesn't work with CA derivations, so let's ignore that bit if we're
-# using them
-if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
+testCollectGarbageD () {
     clearProfiles
     # Run two `nix-env` commands, should create two generations of
     # the profile
@@ -66,4 +64,17 @@ if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
     # left
     nix-collect-garbage -d
     [[ $(nix-env --list-generations | wc -l) -eq 1 ]]
+}
+# `nix-env` doesn't work with CA derivations, so let's ignore that bit if we're
+# using them
+if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
+    testCollectGarbageD
+
+    # Run the same test, but forcing the profiles at their legacy location under
+    # /nix/var/nix.
+    #
+    # Regression test for #8294
+    rm ~/.nix-profile
+    ln -s $NIX_STATE_DIR/profiles/per-user/me ~/.nix-profile
+    testCollectGarbageD
 fi


### PR DESCRIPTION
# Motivation

Make it look into the new-style profiles dir, the old-style one, and the
target of `~/.nix-profile` to be sure that we don't miss anything when running
the GC.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [x] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

Fix #8294 