### PR TITLE
C++ checked switch using fall through

### DIFF
--- a/local.mk
+++ b/local.mk
@@ -1,6 +1,6 @@
 clean-files += Makefile.config
 
-GLOBAL_CXXFLAGS += -Wno-deprecated-declarations
+GLOBAL_CXXFLAGS += -Wno-deprecated-declarations -Werror=switch
 
 $(foreach i, config.h $(wildcard src/lib*/*.hh), \
   $(eval $(call install-file-in, $(i), $(includedir)/nix, 0644)))

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -102,10 +102,10 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
     switch (internalType) {
     case tInt:
         str << integer;
-        break;
+        return;
     case tBool:
         str << (boolean ? "true" : "false");
-        break;
+        return;
     case tString:
         str << "\"";
         for (const char * i = string.s; *i; i++)
@@ -116,13 +116,13 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
             else if (*i == '$' && *(i+1) == '{') str << "\\" << *i;
             else str << *i;
         str << "\"";
-        break;
+        return;
     case tPath:
         str << path; // !!! escaping?
-        break;
+        return;
     case tNull:
         str << "null";
-        break;
+        return;
     case tAttrs: {
         if (seen && !attrs->empty() && !seen->insert(attrs).second)
             str << "«repeated»";
@@ -135,7 +135,7 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
             }
             str << "}";
         }
-        break;
+        return;
     }
     case tList1:
     case tList2:
@@ -153,26 +153,26 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
             }
             str << "]";
         }
-        break;
+        return;
     case tThunk:
     case tApp:
         str << "<CODE>";
-        break;
+        return;
     case tLambda:
         str << "<LAMBDA>";
-        break;
+        return;
     case tPrimOp:
         str << "<PRIMOP>";
-        break;
+        return;
     case tPrimOpApp:
         str << "<PRIMOP-APP>";
-        break;
+        return;
     case tExternal:
         str << *external;
-        break;
+        return;
     case tFloat:
         str << fpoint;
-        break;
+        return;
     case tBlackhole:
         // Although we know for sure that it's going to be an infinite recursion
         // when this value is accessed _in the current context_, it's likely
@@ -181,11 +181,10 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
         // a valid value after `builtins.trace` and perhaps some other steps
         // have completed.
         str << "«potential infinite recursion»";
-        break;
-    default:
-        printError("Nix evaluator internal error: Value::print(): invalid value type %1%", internalType);
-        abort();
+        return;
     }
+    printError("Nix evaluator internal error: Value::print(): invalid value type %1%", internalType);
+    abort();
 }
 
 


### PR DESCRIPTION
# Motivation

This approach catches programming errors, but relies on contributors to use the right pattern, which is not obvious. We may consider `-Werror=switch-enum` instead, which requires us to rewrite some switches to `if`s or to enumerate more cases.

To be discussed.                        

# Context

Will prevent bugs like #8119
Complements
 - #8148 

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
