### PR TITLE
Fix the flaky `nix-profile` test

### DIFF
--- a/tests/nix-profile.sh
+++ b/tests/nix-profile.sh
@@ -144,6 +144,7 @@ expect 1 nix profile install $flake2Dir
 diff -u <(
     nix --offline profile install $flake2Dir 2>&1 1> /dev/null \
         | grep -vE "^warning: " \
+        | grep -vE "^error \(ignored\): " \
         || true
 ) <(cat << EOF
 error: An existing package already provides the following file:


### PR DESCRIPTION
Exclude the `error (ignored)` from the message that is checked by the
install conflict test.

Fix https://github.com/NixOS/nix/issues/8140

Note that I'm not 100% sure it fixes the issue since it's flaky and I can't reproduce it locally. But it should at least.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
