### PR TITLE
disable gc on coroutine

### DIFF
--- a/boehmgc-coroutine-sp-fallback.diff
+++ b/boehmgc-coroutine-sp-fallback.diff
@@ -1,8 +1,8 @@
 diff --git a/darwin_stop_world.c b/darwin_stop_world.c
-index 3dbaa3fb..36a1d1f7 100644
+index 0468aaec..b348d869 100644
 --- a/darwin_stop_world.c
 +++ b/darwin_stop_world.c
-@@ -352,6 +352,7 @@ GC_INNER void GC_push_all_stacks(void)
+@@ -356,6 +356,7 @@ GC_INNER void GC_push_all_stacks(void)
    int nthreads = 0;
    word total_size = 0;
    mach_msg_type_number_t listcount = (mach_msg_type_number_t)THREAD_TABLE_SZ;
@@ -10,7 +10,7 @@ index 3dbaa3fb..36a1d1f7 100644
    if (!EXPECT(GC_thr_initialized, TRUE))
      GC_thr_init();
  
-@@ -407,6 +408,19 @@ GC_INNER void GC_push_all_stacks(void)
+@@ -411,6 +412,19 @@ GC_INNER void GC_push_all_stacks(void)
              GC_push_all_stack_sections(lo, hi, p->traced_stack_sect);
            }
            if (altstack_lo) {
@@ -30,6 +30,22 @@ index 3dbaa3fb..36a1d1f7 100644
              total_size += altstack_hi - altstack_lo;
              GC_push_all_stack(altstack_lo, altstack_hi);
            }
+diff --git a/include/gc.h b/include/gc.h
+index edab6c22..f2c61282 100644
+--- a/include/gc.h
++++ b/include/gc.h
+@@ -2172,6 +2172,11 @@ GC_API void GC_CALL GC_win32_free_heap(void);
+         (*GC_amiga_allocwrapper_do)(a,GC_malloc_atomic_ignore_off_page)
+ #endif /* _AMIGA && !GC_AMIGA_MAKINGLIB */
+ 
++#if !__APPLE__
++/* Patch doesn't work on apple */
++#define NIX_BOEHM_PATCH_VERSION 1
++#endif
++
+ #ifdef __cplusplus
+   } /* extern "C" */
+ #endif
 diff --git a/pthread_stop_world.c b/pthread_stop_world.c
 index b5d71e62..aed7b0bf 100644
 --- a/pthread_stop_world.c

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -344,20 +344,22 @@ static Symbol getName(const AttrName & name, EvalState & state, Env & env)
     }
 }
 
-
-class BoehmDisableGC : public DisableGC {
+#if HAVE_BOEHMGC
+/* Disable GC while this object lives. Used by CoroutineContext.
+ *
+ * Boehm keeps a count of GC_disable() and GC_enable() calls,
+ * and only enables GC when the count matches.
+ */
+class BoehmDisableGC {
 public:
     BoehmDisableGC() {
-#if HAVE_BOEHMGC
         GC_disable();
-#endif
     };
-    virtual ~BoehmDisableGC() override {
-#if HAVE_BOEHMGC
+    ~BoehmDisableGC() {
         GC_enable();
-#endif
     };
 };
+#endif
 
 static bool gcInitialised = false;
 
@@ -384,8 +386,8 @@ void initGC()
 
 
     /* Used to disable GC when entering coroutines on macOS */
-    DisableGC::create = []() {
-        return std::dynamic_pointer_cast<DisableGC>(std::make_shared<BoehmDisableGC>());
+    create_disable_gc = []() -> std::shared_ptr<void> {
+        return std::make_shared<BoehmDisableGC>();
     };
 
     /* Set the initial heap size to something fairly big (25% of

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -386,6 +386,7 @@ void initGC()
 
 
 #if NIX_BOEHM_PATCH_VERSION != 1
+    printTalkative("Unpatched BoehmGC, disabling GC inside coroutines");
     /* Used to disable GC when entering coroutines on macOS */
     create_coro_gc_hook = []() -> std::shared_ptr<void> {
         return std::make_shared<BoehmDisableGC>();

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -385,10 +385,12 @@ void initGC()
     StackAllocator::defaultAllocator = &boehmGCStackAllocator;
 
 
+#if NIX_BOEHM_PATCH_VERSION != 1
     /* Used to disable GC when entering coroutines on macOS */
-    create_disable_gc = []() -> std::shared_ptr<void> {
+    create_coro_gc_hook = []() -> std::shared_ptr<void> {
         return std::make_shared<BoehmDisableGC>();
     };
+#endif
 
     /* Set the initial heap size to something fairly big (25% of
        physical RAM, up to a maximum of 384 MiB) so that in most cases

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -186,18 +186,17 @@ static DefaultStackAllocator defaultAllocatorSingleton;
 StackAllocator *StackAllocator::defaultAllocator = &defaultAllocatorSingleton;
 
 
-std::shared_ptr<void> (*create_disable_gc)() = []() -> std::shared_ptr<void> {
+std::shared_ptr<void> (*create_coro_gc_hook)() = []() -> std::shared_ptr<void> {
     return {};
 };
 
 /* This class is used for entry and exit hooks on coroutines */
 class CoroutineContext {
-#if __APPLE__
-    /* Disable GC when entering the coroutine on macOS, since it doesn't find the main thread stack in this case.
+    /* Disable GC when entering the coroutine without the boehm patch,
+     * since it doesn't find the main thread stack in this case.
      * std::shared_ptr<void> performs type-erasure, so it will call the right
      * deleter. */
-    const std::shared_ptr<void> disable_gc = create_disable_gc();
-#endif
+    const std::shared_ptr<void> coro_gc_hook = create_coro_gc_hook();
 public:
     CoroutineContext() {};
     ~CoroutineContext() {};

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -551,10 +551,10 @@ struct StackAllocator {
     static StackAllocator *defaultAllocator;
 };
 
-/* Disabling GC when entering a coroutine (on macos).
+/* Disabling GC when entering a coroutine (without the boehm patch).
    mutable to avoid boehm gc dependency in libutil.
  */
-extern std::shared_ptr<void> (*create_disable_gc)();
+extern std::shared_ptr<void> (*create_coro_gc_hook)();
 
 
 }

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -551,4 +551,14 @@ struct StackAllocator {
     static StackAllocator *defaultAllocator;
 };
 
+/* Disabling GC when entering a coroutine (on macos).
+   ::create is to avoid boehm gc dependency in libutil.
+ */
+class DisableGC {
+public:
+    DisableGC() {};
+    virtual ~DisableGC() {};
+    static std::shared_ptr<DisableGC> (*create)();
+};
+
 }

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -552,13 +552,9 @@ struct StackAllocator {
 };
 
 /* Disabling GC when entering a coroutine (on macos).
-   ::create is to avoid boehm gc dependency in libutil.
+   mutable to avoid boehm gc dependency in libutil.
  */
-class DisableGC {
-public:
-    DisableGC() {};
-    virtual ~DisableGC() {};
-    static std::shared_ptr<DisableGC> (*create)();
-};
+extern std::shared_ptr<void> (*create_disable_gc)();
+
 
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/NixOS/nix/pull/7725 (without the tests part as it was problematic on some architectures). All credits go to @yorickvp.

This _seems to fix_ https://github.com/NixOS/nix/issues/8175 (at least I couldn't reproduce it any more when using a Nix with these patches).

Really fixing it would mean backporting this to the stable release though because that's the one causing the segfault in the CI.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
