### PR TITLE
fetchers: Try to substitute if curl fails.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -635,6 +635,8 @@
 
         tests.containers = runNixOSTestFor "x86_64-linux" ./tests/nixos/containers/containers.nix;
 
+        tests.fetchers-substitute = runNixOSTestFor "x86_64-linux" ./tests/nixos/fetchers-substitute.nix;
+
         tests.setuid = lib.genAttrs
           ["i686-linux" "x86_64-linux"]
           (system: runNixOSTestFor system ./tests/nixos/setuid.nix);

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -168,7 +168,7 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s)
 {
     if (EvalSettings::isPseudoUrl(s)) {
         auto storePath = fetchers::downloadTarball(
-            state.store, EvalSettings::resolvePseudoUrl(s), "source", false).tree.storePath;
+            state.store, EvalSettings::resolvePseudoUrl(s), "source", std::nullopt).tree.storePath;
         return state.rootPath(CanonPath(state.store->toRealPath(storePath)));
     }
 

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -782,7 +782,7 @@ std::optional<std::string> EvalState::resolveSearchPathPath(const SearchPath::Pa
     if (EvalSettings::isPseudoUrl(value)) {
         try {
             auto storePath = fetchers::downloadTarball(
-                store, EvalSettings::resolvePseudoUrl(value), "source", false).tree.storePath;
+                store, EvalSettings::resolvePseudoUrl(value), "source", std::nullopt).tree.storePath;
             res = { store->toRealPath(storePath) };
         } catch (FileTransferError & e) {
             logWarning({

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -270,8 +270,8 @@ static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v
     //       https://github.com/NixOS/nix/issues/4313
     auto storePath =
         unpack
-        ? fetchers::downloadTarball(state.store, *url, name, (bool) expectedHash).tree.storePath
-        : fetchers::downloadFile(state.store, *url, name, (bool) expectedHash).storePath;
+        ? fetchers::downloadTarball(state.store, *url, name, expectedHash).tree.storePath
+        : fetchers::downloadFile(state.store, *url, name, expectedHash).storePath;
 
     if (expectedHash) {
         auto hash = unpack

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -165,7 +165,7 @@ DownloadFileResult downloadFile(
     ref<Store> store,
     const std::string & url,
     const std::string & name,
-    bool locked,
+    const std::optional<Hash> & expectedHash,
     const Headers & headers = {});
 
 struct DownloadTarballResult
@@ -179,7 +179,7 @@ DownloadTarballResult downloadTarball(
     ref<Store> store,
     const std::string & url,
     const std::string & name,
-    bool locked,
+    const std::optional<Hash> & expectedHash,
     const Headers & headers = {});
 
 }

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -207,7 +207,7 @@ struct GitArchiveInputScheme : InputScheme
 
         auto url = getDownloadUrl(input);
 
-        auto result = downloadTarball(store, url.url, input.getName(), true, url.headers);
+        auto result = downloadTarball(store, url.url, input.getName(), rev, url.headers);
 
         input.attrs.insert_or_assign("lastModified", uint64_t(result.lastModified));
 
@@ -269,7 +269,7 @@ struct GitHubInputScheme : GitArchiveInputScheme
         auto json = nlohmann::json::parse(
             readFile(
                 store->toRealPath(
-                    downloadFile(store, url, "source", false, headers).storePath)));
+                    downloadFile(store, url, "source", std::nullopt, headers).storePath)));
         auto rev = Hash::parseAny(std::string { json["sha"] }, htSHA1);
         debug("HEAD revision for '%s' is %s", url, rev.gitRev());
         return rev;
@@ -341,7 +341,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
         auto json = nlohmann::json::parse(
             readFile(
                 store->toRealPath(
-                    downloadFile(store, url, "source", false, headers).storePath)));
+                    downloadFile(store, url, "source", std::nullopt, headers).storePath)));
         auto rev = Hash::parseAny(std::string(json[0]["id"]), htSHA1);
         debug("HEAD revision for '%s' is %s", url, rev.gitRev());
         return rev;
@@ -404,7 +404,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::string refUri;
         if (ref == "HEAD") {
             auto file = store->toRealPath(
-                downloadFile(store, fmt("%s/HEAD", base_url), "source", false, headers).storePath);
+                downloadFile(store, fmt("%s/HEAD", base_url), "source", std::nullopt, headers).storePath);
             std::ifstream is(file);
             std::string line;
             getline(is, line);
@@ -420,7 +420,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::regex refRegex(refUri);
 
         auto file = store->toRealPath(
-            downloadFile(store, fmt("%s/info/refs", base_url), "source", false, headers).storePath);
+            downloadFile(store, fmt("%s/info/refs", base_url), "source", std::nullopt, headers).storePath);
         std::ifstream is(file);
 
         std::string line;

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -158,7 +158,7 @@ static std::shared_ptr<Registry> getGlobalRegistry(ref<Store> store)
         }
 
         if (!hasPrefix(path, "/")) {
-            auto storePath = downloadFile(store, path, "flake-registry.json", false).storePath;
+            auto storePath = downloadFile(store, path, "flake-registry.json", std::nullopt).storePath;
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
                 store2->addPermRoot(storePath, getCacheDir() + "/nix/flake-registry.json");
             path = store->toRealPath(storePath);

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -112,7 +112,7 @@ static void update(const StringSet & channelNames)
             // We want to download the url to a file to see if it's a tarball while also checking if we
             // got redirected in the process, so that we can grab the various parts of a nix channel
             // definition from a consistent location if the redirect changes mid-download.
-            auto result = fetchers::downloadFile(store, url, std::string(baseNameOf(url)), false);
+            auto result = fetchers::downloadFile(store, url, std::string(baseNameOf(url)), std::nullopt);
             auto filename = store->toRealPath(result.storePath);
             url = result.effectiveUrl;
 
@@ -126,9 +126,9 @@ static void update(const StringSet & channelNames)
             if (!unpacked) {
                 // Download the channel tarball.
                 try {
-                    filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.xz", "nixexprs.tar.xz", false).storePath);
+                    filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.xz", "nixexprs.tar.xz", std::nullopt).storePath);
                 } catch (FileTransferError & e) {
-                    filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.bz2", "nixexprs.tar.bz2", false).storePath);
+                    filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.bz2", "nixexprs.tar.bz2", std::nullopt).storePath);
                 }
             }
             // Regardless of where it came from, add the expression representing this channel to accumulated expression

--- a/tests/nixos/fetchers-substitute.nix
+++ b/tests/nixos/fetchers-substitute.nix
@@ -1,0 +1,69 @@
+{
+  name = "fetchers-substitute";
+
+  nodes.substituter = { pkgs, ... }: {
+    virtualisation.writableStore = true;
+
+    nix.settings.extra-experimental-features = "nix-command";
+
+    networking.firewall.allowedTCPPorts = [ 5000 ];
+
+    services.nix-serve = {
+      enable = true;
+      secretKeyFile = let key = pkgs.writeTextFile {
+        name = "secret-key";
+        text = ''
+          substituter:SerxxAca5NEsYY0DwVo+subokk+OoHcD9m6JwuctzHgSQVfGHe6nCc+NReDjV3QdFYPMGix4FMg0+K/TM1B3aA==
+        '';
+      }; in "${key}";
+    };
+  };
+
+  nodes.importer = { lib, ... }: {
+    virtualisation.writableStore = true;
+
+    nix.settings = {
+      extra-experimental-features = "nix-command";
+      substituters = lib.mkForce [ "http://substituter:5000" ];
+      trusted-public-keys = lib.mkForce [ "substituter:EkFXxh3upwnPjUXg41d0HRWDzBoseBTINPiv0zNQd2g=" ];
+    };
+  };
+
+  testScript = { nodes }: ''
+    import json
+
+    start_all()
+
+    missing = "/only-on-substituter.txt"
+
+    substituter.wait_for_unit("multi-user.target")
+
+    substituter.succeed(f"echo 'this should only exist on the substituter' > {missing}")
+
+    hash = substituter.succeed(f"nix hash file {missing}")
+
+    store_path_json = substituter.succeed(f"""
+      nix-instantiate --eval --json --read-write-mode --expr '
+        builtins.fetchurl {{
+          url = "file://{missing}";
+          sha256 = "{hash}";
+        }}
+      '
+    """)
+
+    store_path = json.loads(store_path_json)
+
+    substituter.succeed(f"nix store sign --key-file ${nodes.substituter.config.services.nix-serve.secretKeyFile} {store_path}")
+
+    importer.wait_for_unit("multi-user.target")
+
+    importer.succeed(f"""
+      nix-instantiate -vvvvv --eval --json --read-write-mode --expr '
+        builtins.fetchurl {{
+          url = "file://{missing}";
+          sha256 = "{hash}";
+        }}
+      '
+    """)
+  '';
+}


### PR DESCRIPTION
# Motivation
Fetchers currently do not try to substitute if downloading via curl fails and there is no cached result.

This is important if using flakes or fetchers in an tightly controlled environment.

# Context
Fixes #4313

<!-- Non-trivial change: Briefly outline the implementation strategy. -->
For performance reasons - only try to substitute when there is an error during curl.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
