### PR TITLE
Fix issue where `git archive` fails on repositories with Git LFS

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -610,6 +610,11 @@ struct GitInputScheme : InputScheme
             );
         }
 
+        /* Ensure git-lfs can still communicate with the actual remote
+           when gitDir is missing the origin URL.
+         */
+        // runProgram("git", true, { "-C", tmpDir, "config", "remote.origin.lfsurl", actualUrl });
+
         if (submodules) {
             Path tmpGitDir = createTempDir();
             AutoDelete delTmpGitDir(tmpGitDir, true);
@@ -659,7 +664,7 @@ struct GitInputScheme : InputScheme
             auto source = sinkToSource([&](Sink & sink) {
                 runProgram2({
                     .program = "git",
-                    .args = { "-C", repoDir, "--git-dir", gitDir, "archive", input.getRev()->gitRev() },
+                    .args = { "-C", repoDir, "--git-dir", gitDir, "-c", "remote.origin.lfsurl=" + actualUrl, "archive", input.getRev()->gitRev() },
                     .standardOut = &sink
                 });
             });


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Add a flag `-c remote.origin.lfsurl=<actualUrl>` to `git.cc` to support LFS calls end-to-end.

# Context
<!-- Provide context. Reference open issues if available. -->
Resolves: #4623 

Currently `fetchGit` is incapable of calling `git-lfs` during build currently. Fortunately, it *almost* works perfectly as `git` properly hands off necessary calls  to a locally installed `git-lfs` executable, but there is a minor difference in expectations between what is available in the bare Git repository and what `lfs` needs. The error message from LFS is not very descriptive.

In particular, [git-lfs attempts to discover the remote URL that it will communicate with using the `remote.origin.url` Git config](https://github.com/git-lfs/git-lfs/blob/main/lfsapi/endpoint_finder.go#L121), which is not present in the current bare Git repository.

While I think setting the `remote.origin.url` might have undesirable side-effects, [LFS searches for an alternative URL](https://github.com/git-lfs/git-lfs/blob/main/lfsapi/endpoint_finder.go#L116) via the configuration option `remote.origin.lfsurl`.

Since `git.cc` uses a bare `checkout` when pulling from repositories using submodules, Git LFS should work in those cases. It's only for repositories without submodules (i.e. when the `archive` command is invoked) that this configuration option is necessary.

One uncertainty that I have: I'm not exactly sure if this is testable at all. Git LFS usually operates by making an HTTP request to an asset server and I'm not sure if it's feasible to run a test for LFS without needing. I can provide a sample repository with LFS files for a test of this change, but I don't know if there is an easy way to test LFS going forward.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
