### PR TITLE
Fix unnecessary reporting of SQLite busy errors

### DIFF
--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -239,9 +239,11 @@ SQLiteTxn::~SQLiteTxn()
     }
 }
 
-void handleSQLiteBusy(const SQLiteBusy & e, bool shouldWarn)
+void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning)
 {
-    if (shouldWarn) {
+    time_t now = time(0);
+    if (now > nextWarning) {
+        nextWarning = now + 10;
         logWarning({
             .msg = hintfmt(e.what())
         });

--- a/src/libstore/sqlite.hh
+++ b/src/libstore/sqlite.hh
@@ -139,7 +139,7 @@ protected:
 
 MakeError(SQLiteBusy, SQLiteError);
 
-void handleSQLiteBusy(const SQLiteBusy & e, bool shouldWarn);
+void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning);
 
 /**
  * Convenience function for retrying a SQLite transaction when the
@@ -153,17 +153,8 @@ T retrySQLite(F && fun)
     while (true) {
         try {
             return fun();
-
         } catch (SQLiteBusy & e) {
-            time_t now = time(0);
-            bool shouldWarn = false;
-
-            if (now > nextWarning) {
-                nextWarning = now + 10;
-                shouldWarn = true;
-            }
-
-            handleSQLiteBusy(e, shouldWarn);
+            handleSQLiteBusy(e, nextWarning);
         }
     }
 }


### PR DESCRIPTION
# Motivation
Getting the occasional `SQLITE_BUSY` is expected when the database is being accessed concurrently. The retry will likely succeed so it is pointless to warn immediately. Instead we track how long each `retrySQLite` block has been running, and only begin warning after a second has elapsed (and then every 10 seconds subsequently).

# Context
<!-- Provide context. Reference open issues if available. -->
[#7998 SQLite busy reporting is broken](https://github.com/NixOS/nix/issues/7998)

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
