### PR TITLE
Do not gate or hide experimental settings

### DIFF
--- a/tests/experimental-features.sh
+++ b/tests/experimental-features.sh
@@ -1,25 +1,27 @@
 source common.sh
 
-# Without flakes, flake options should not show up
-# With flakes, flake options should show up
-
-function both_ways {
-    nix --experimental-features 'nix-command' "$@" | grepQuietInverse flake
-    nix --experimental-features 'nix-command flakes' "$@" | grepQuiet flake
-
-    # Also, the order should not matter
-    nix "$@" --experimental-features 'nix-command' | grepQuietInverse flake
-    nix "$@" --experimental-features 'nix-command flakes' | grepQuiet flake
-}
-
-# Simple case, the configuration effects the running command
-both_ways show-config
-
-# Skipping for now, because we actually *do* want these to show up in
-# the manual, just be marked experimental. Will reenable once the manual
-# generation takes advantage of the JSON metadata on this.
-
-# both_ways store gc --help
+# Skipping these two for now, because we actually *do* want flags and
+# config settings to always show up in the manual, just be marked
+# experimental. Will reenable once the manual generation takes advantage
+# of the JSON metadata on this.
+#
+# # Without flakes, flake options should not show up
+# # With flakes, flake options should show up
+#
+# function grep_both_ways {
+#     nix --experimental-features 'nix-command' "$@" | grepQuietInverse flake
+#     nix --experimental-features 'nix-command flakes' "$@" | grepQuiet flake
+#
+#     # Also, the order should not matter
+#     nix "$@" --experimental-features 'nix-command' | grepQuietInverse flake
+#     nix "$@" --experimental-features 'nix-command flakes' | grepQuiet flake
+# }
+#
+# # Simple case, the configuration effects the running command
+# grep_both_ways show-config
+#
+# # Medium case, the configuration effects --help
+# grep_both_ways store gc --help
 
 expect 1 nix --experimental-features 'nix-command' show-config --flake-registry 'https://no'
 nix --experimental-features 'nix-command flakes' show-config --flake-registry 'https://no'


### PR DESCRIPTION
# Motivation

This is somewhat hacky fix just for 2.15. I unintentionally hid them from the manual, when no one wanted to hide them that (including myself). I also required the experimental feature to be enabled in an order-dependent way, which is not good.

The simplest fix for this immanent release is just to always show them, and always allow them to be set.

# Context

Effectively undoes some changes from aa663b7e89d3d02248d37ee9f68b52770b247018

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
