### PR TITLE
Update macOS uninstall instructions

### DIFF
--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -136,7 +136,7 @@ which you may remove.
 
 ### macOS
 
-1. Edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bashrc` to remove the lines sourcing
+1. Edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing
    `nix-daemon.sh`, which should look like this:
 
    ```bash

--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -136,7 +136,7 @@ which you may remove.
 
 ### macOS
 
-1. Edit `/etc/zshrc` and `/etc/bashrc` to remove the lines sourcing
+1. Edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bashrc` to remove the lines sourcing
    `nix-daemon.sh`, which should look like this:
 
    ```bash
@@ -153,6 +153,7 @@ which you may remove.
    ```console
    sudo mv /etc/zshrc.backup-before-nix /etc/zshrc
    sudo mv /etc/bashrc.backup-before-nix /etc/bashrc
+   sudo mv /etc/bash.bashrc.backup-before-nix /etc/bash.bashrc
    ```
 
    This will stop shells from sourcing the file and bringing everything you


### PR DESCRIPTION
Accounting for `/etc/bash.bashrc`

# Motivation
Update the docs to avoid errors when re-installing nix.

# Context
Here's the error message produced after following the existing instructions, and re-running the installer:

```
I back up shell profile/rc scripts before I add Nix to them.
I need to back up /etc/bash.bashrc to /etc/bash.bashrc.backup-before-nix,
but the latter already exists.

Here's how to clean up the old backup file:

1. Back up (copy) /etc/bash.bashrc and /etc/bash.bashrc.backup-before-nix
   to another location, just in case.

2. Ensure /etc/bash.bashrc.backup-before-nix does not have anything
   Nix-related in it. If it does, something is probably quite
   wrong. Please open an issue or get in touch immediately.

3. Once you confirm /etc/bash.bashrc is backed up and
   /etc/bash.bashrc.backup-before-nix doesn't mention Nix, run:
   mv /etc/bash.bashrc.backup-before-nix /etc/bash.bashrc
```

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
