### PR TITLE
Move documentation for impure derivation

### DIFF
--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -332,20 +332,20 @@ Derivations can declare some infrequently used optional attributes.
 
   - [`__impure`]{#adv-attr-__impure}\
     > **Warning**
-	  > This is an experimental feature.
+    > This is an experimental feature.
     >
     > To enable it, add the following to [nix.conf](../command-ref/conf-file.md):
     >
     > ```
-  	> extra-experimental-features = impure-derivations
-	  > ```
+    > extra-experimental-features = impure-derivations
+    > ```
 
     If the attribute `__impure` is set to `true`, then the
     derivation won't produce a fixed output. This means that an impure
     derivation can have different outputs each time it is built.
 
     Example:
-    
+
     ```
     derivation {
       name = "impure";
@@ -355,12 +355,10 @@ Derivations can declare some infrequently used optional attributes.
       system = builtins.currentSystem;
     }
     ```
-    
+
     Each time this derivation is built it produces a different output,
     since the builder outputs random bytes to $out.
-   
-    > **Note**
-    > 
+
     > Impure derivations have the following traits:
     >   - They have access to the network
     >   - Only fixed-output and other impure derivations can depend on

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -340,7 +340,7 @@ Derivations can declare some infrequently used optional attributes.
   	> extra-experimental-features = impure-derivations
 	  > ```
 
-    If the **experimental** attribute `__impure` is set to `true`, then the
+    If the attribute `__impure` is set to `true`, then the
     derivation won't produce a fixed output. This means that an impure
     derivation can have different outputs each time it is built.
 

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -331,18 +331,18 @@ Derivations can declare some infrequently used optional attributes.
     to the embedded store and not to the host's Nix store.
 
   - [`__impure`]{#adv-attr-__impure}\
-    > **Warning**
-    > This is an experimental feature.
+	> **Warning** > This is an experimental feature.
     >
-    > To enable it, add the following to [nix.conf](../command-ref/conf-file.md):
+    > To enable it, add the following to
+    > [nix.conf](../command-ref/conf-file.md):
     >
     > ```
-    > extra-experimental-features = impure-derivations
-    > ```
+	> extra-experimental-features = impure-derivations
+	> ```
 
-    If the attribute `__impure` is set to `true`, then the
-    derivation won't produce a fixed output. This means that an impure
-    derivation can have different outputs each time it is built.
+    If the attribute `__impure` is set to `true`, then the derivation
+    won't produce a fixed output. This means that an impure derivation
+    can have different outputs each time it is built.
 
     Example:
 
@@ -357,10 +357,26 @@ Derivations can declare some infrequently used optional attributes.
     ```
 
     Each time this derivation is built it produces a different output,
-    since the builder outputs random bytes to $out.
+    since the builder outputs random bytes to $out. The [pull request
+    introducing impure
+    derivations](https://github.com/NixOS/nix/pull/6227) has more
+    examples.
 
-    > Impure derivations have the following traits:
-    >   - They have access to the network
-    >   - Only fixed-output and other impure derivations can depend on
-    >     impure derivations
-    >   - They cannot be [content-addressed](@docroot@/contributing/experimental-features.md#xp-feature-ca-derivations)
+    Impure derivations have the following traits:
+	- Only impure or fixed-output derivations are allowed to depend on
+      impure derivations directly. "Pure" (i.e. input-addressed or
+      floating CA derivations) can depend on impure derivations
+      indirectly, if there is a fixed-output derivation in
+      between. Thus the fixed-output derivation forms an "impurity
+      barrier" in the dependency graph.
+	- They cannot be
+      [content-addressed](@docroot@/contributing/experimental-features.md#xp-feature-ca-derivations)
+	- Impure derivations are not "cached". Thus, running "nix-build"
+      on the example above multiple times will cause a rebuild every
+      time.
+	- They are implemented similar to CA derivations, i.e. the output
+      is moved to a content-addressed path in the store. The
+      difference is that we don't register a realisation in the Nix database.
+	- When sandboxing is enabled, impure derivations can access the
+      network in the same way as fixed-output derivations. In relaxed
+      sandboxing mode, they can access the local filesystem.

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -329,3 +329,40 @@ Derivations can declare some infrequently used optional attributes.
     This is useful, for example, when generating self-contained filesystem images with
     their own embedded Nix store: hashes found inside such an image refer
     to the embedded store and not to the host's Nix store.
+
+  - [`__impure`]{#adv-attr-__impure}\
+    > **Warning**
+	  > This is an experimental feature.
+    >
+    > To enable it, add the following to [nix.conf](../command-ref/conf-file.md):
+    >
+    > ```
+  	> extra-experimental-features = impure-derivations
+	  > ```
+
+    If the **experimental** attribute `__impure` is set to `true`, then the
+    derivation won't produce a fixed output. This means that an impure
+    derivation can have different outputs each time it is built.
+
+    Example:
+    
+    ```
+    derivation {
+      name = "impure";
+      builder = /bin/sh;
+      __impure = true; # mark this derivation as impure
+      args = [ "-c" "read -n 10 random < /dev/random; echo $random > $out" ];
+      system = builtins.currentSystem;
+    }
+    ```
+    
+    Each time this derivation is built it produces a different output,
+    since the builder outputs random bytes to $out.
+   
+    > **Note**
+    > 
+    > Impure derivations have the following traits:
+    >   - They have access to the network
+    >   - Only fixed-output and other impure derivations can depend on
+    >     impure derivations
+    >   - They cannot be [content-addressed](@docroot@/contributing/experimental-features.md#xp-feature-ca-derivations)

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -331,7 +331,8 @@ Derivations can declare some infrequently used optional attributes.
     to the embedded store and not to the host's Nix store.
 
   - [`__impure`]{#adv-attr-__impure}\
-	> **Warning** > This is an experimental feature.
+	> **Warning**
+	> This is an experimental feature.
     >
     > To enable it, add the following to
     > [nix.conf](../command-ref/conf-file.md):

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -28,28 +28,8 @@ constexpr std::array<ExperimentalFeatureDetails, 11> xpFeatureDetails = {{
         .tag = Xp::ImpureDerivations,
         .name = "impure-derivations",
         .description = R"(
-            Allow derivations to produce non-fixed outputs by setting the
-            `__impure` derivation attribute to `true`. An impure derivation can
-            have differing outputs each time it is built.
-
-            Example:
-
-            ```
-            derivation {
-              name = "impure";
-              builder = /bin/sh;
-              __impure = true; # mark this derivation as impure
-              args = [ "-c" "read -n 10 random < /dev/random; echo $random > $out" ];
-              system = builtins.currentSystem;
-            }
-            ```
-
-            Each time this derivation is built, it can produce a different
-            output (as the builder outputs random bytes to `$out`).  Impure
-            derivations also have access to the network, and only fixed-output
-            or other impure derivations can rely on impure derivations. Finally,
-            an impure derivation cannot also be
-            [content-addressed](#xp-feature-ca-derivations).
+            Allow derivations to produce non-fixed outputs. See
+            [__impure](@docroot@/language/advanced-attributes.md#adv-attr-__impure) for details.
         )",
     },
     {


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

The documentation of impure derivations was only available under the experimental features section. The feature adds an attribute to derivation, so I thought it made sense to also document it under the special attributes section.

# Context
<!-- Provide context. Reference open issues if available. -->

Be more consistent with documenting the attributes available to derivation.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
