### PR TITLE
Display valid installable in `InstallableDerivedPath::parse` warning

### DIFF
--- a/src/libcmd/installable-derived-path.cc
+++ b/src/libcmd/installable-derived-path.cc
@@ -47,7 +47,7 @@ InstallableDerivedPath InstallableDerivedPath::parse(
                 };
                 warn(
                     "The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '%s'",
-                    oldDerivedPath.to_string(*store));
+                    oldDerivedPath.to_string(*store, '^'));
             };
             return DerivedPath::Opaque {
                 .path = std::move(storePath),

--- a/src/libcmd/installable-derived-path.cc
+++ b/src/libcmd/installable-derived-path.cc
@@ -47,7 +47,7 @@ InstallableDerivedPath InstallableDerivedPath::parse(
                 };
                 warn(
                     "The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '%s'",
-                    oldDerivedPath.to_string(*store, '^'));
+                    oldDerivedPath.to_string(*store));
             };
             return DerivedPath::Opaque {
                 .path = std::move(storePath),

--- a/src/libstore/derived-path.cc
+++ b/src/libstore/derived-path.cc
@@ -59,18 +59,19 @@ std::string DerivedPath::Opaque::to_string(const Store & store) const
     return store.printStorePath(path);
 }
 
-std::string DerivedPath::Built::to_string(const Store & store) const
+std::string DerivedPath::Built::to_string(const Store & store, char separator) const
 {
     return store.printStorePath(drvPath)
-        + "!"
+        + separator
         + outputs.to_string();
 }
 
-std::string DerivedPath::to_string(const Store & store) const
+std::string DerivedPath::to_string(const Store & store, char separator) const
 {
-    return std::visit(
-        [&](const auto & req) { return req.to_string(store); },
-        this->raw());
+    return std::visit(overloaded {
+        [&](const DerivedPath::Built & req) { return req.to_string(store, separator); },
+        [&](const DerivedPath::Opaque & req) { return req.to_string(store); },
+    }, this->raw());
 }
 
 

--- a/src/libstore/derived-path.cc
+++ b/src/libstore/derived-path.cc
@@ -59,17 +59,32 @@ std::string DerivedPath::Opaque::to_string(const Store & store) const
     return store.printStorePath(path);
 }
 
-std::string DerivedPath::Built::to_string(const Store & store, char separator) const
+std::string DerivedPath::Built::to_string(const Store & store) const
 {
     return store.printStorePath(drvPath)
-        + separator
+        + '^'
         + outputs.to_string();
 }
 
-std::string DerivedPath::to_string(const Store & store, char separator) const
+std::string DerivedPath::Built::to_string_legacy(const Store & store) const
+{
+    return store.printStorePath(drvPath)
+        + '!'
+        + outputs.to_string();
+}
+
+std::string DerivedPath::to_string(const Store & store) const
 {
     return std::visit(overloaded {
-        [&](const DerivedPath::Built & req) { return req.to_string(store, separator); },
+        [&](const DerivedPath::Built & req) { return req.to_string(store); },
+        [&](const DerivedPath::Opaque & req) { return req.to_string(store); },
+    }, this->raw());
+}
+
+std::string DerivedPath::to_string_legacy(const Store & store) const
+{
+    return std::visit(overloaded {
+        [&](const DerivedPath::Built & req) { return req.to_string_legacy(store); },
         [&](const DerivedPath::Opaque & req) { return req.to_string(store); },
     }, this->raw());
 }
@@ -88,12 +103,22 @@ DerivedPath::Built DerivedPath::Built::parse(const Store & store, std::string_vi
     };
 }
 
-DerivedPath DerivedPath::parse(const Store & store, std::string_view s)
+static inline DerivedPath parseWith(const Store & store, std::string_view s, std::string_view separator)
 {
-    size_t n = s.find("!");
+    size_t n = s.find(separator);
     return n == s.npos
         ? (DerivedPath) DerivedPath::Opaque::parse(store, s)
         : (DerivedPath) DerivedPath::Built::parse(store, s.substr(0, n), s.substr(n + 1));
+}
+
+DerivedPath DerivedPath::parse(const Store & store, std::string_view s)
+{
+	return parseWith(store, s, "^");
+}
+
+DerivedPath DerivedPath::parseLegacy(const Store & store, std::string_view s)
+{
+	return parseWith(store, s, "!");
 }
 
 RealisedPath::Set BuiltPath::toRealisedPaths(Store & store) const

--- a/src/libstore/derived-path.hh
+++ b/src/libstore/derived-path.hh
@@ -48,8 +48,18 @@ struct DerivedPathBuilt {
     StorePath drvPath;
     OutputsSpec outputs;
 
-    std::string to_string(const Store & store, char separator = '!') const;
-    static DerivedPathBuilt parse(const Store & store, std::string_view, std::string_view);
+    /**
+     * Uses `^` as the separator
+     */
+    std::string to_string(const Store & store) const;
+    /**
+     * Uses `!` as the separator
+     */
+    std::string to_string_legacy(const Store & store) const;
+    /**
+     * The caller splits on the separator, so it works for both variants.
+     */
+    static DerivedPathBuilt parse(const Store & store, std::string_view drvPath, std::string_view outputs);
     nlohmann::json toJSON(ref<Store> store) const;
 
     GENERATE_CMP(DerivedPathBuilt, me->drvPath, me->outputs);
@@ -81,8 +91,22 @@ struct DerivedPath : _DerivedPathRaw {
         return static_cast<const Raw &>(*this);
     }
 
-    std::string to_string(const Store & store, char separator = '!') const;
+    /**
+     * Uses `^` as the separator
+     */
+    std::string to_string(const Store & store) const;
+    /**
+     * Uses `!` as the separator
+     */
+    std::string to_string_legacy(const Store & store) const;
+    /**
+     * Uses `^` as the separator
+     */
     static DerivedPath parse(const Store & store, std::string_view);
+    /**
+     * Uses `!` as the separator
+     */
+    static DerivedPath parseLegacy(const Store & store, std::string_view);
 };
 
 /**

--- a/src/libstore/derived-path.hh
+++ b/src/libstore/derived-path.hh
@@ -48,7 +48,7 @@ struct DerivedPathBuilt {
     StorePath drvPath;
     OutputsSpec outputs;
 
-    std::string to_string(const Store & store) const;
+    std::string to_string(const Store & store, char separator = '!') const;
     static DerivedPathBuilt parse(const Store & store, std::string_view, std::string_view);
     nlohmann::json toJSON(ref<Store> store) const;
 
@@ -81,7 +81,7 @@ struct DerivedPath : _DerivedPathRaw {
         return static_cast<const Raw &>(*this);
     }
 
-    std::string to_string(const Store & store) const;
+    std::string to_string(const Store & store, char separator = '!') const;
     static DerivedPath parse(const Store & store, std::string_view);
 };
 

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -90,12 +90,12 @@ void write(const Store & store, Sink & out, const ContentAddress & ca)
 DerivedPath read(const Store & store, Source & from, Phantom<DerivedPath> _)
 {
     auto s = readString(from);
-    return DerivedPath::parse(store, s);
+    return DerivedPath::parseLegacy(store, s);
 }
 
 void write(const Store & store, Sink & out, const DerivedPath & req)
 {
-    out << req.to_string(store);
+    out << req.to_string_legacy(store);
 }
 
 

--- a/src/libstore/tests/derived-path.cc
+++ b/src/libstore/tests/derived-path.cc
@@ -53,6 +53,14 @@ TEST_F(DerivedPathTest, force_init)
 
 RC_GTEST_FIXTURE_PROP(
     DerivedPathTest,
+    prop_legacy_round_rip,
+    (const DerivedPath & o))
+{
+    RC_ASSERT(o == DerivedPath::parseLegacy(*store, o.to_string_legacy(*store)));
+}
+
+RC_GTEST_FIXTURE_PROP(
+    DerivedPathTest,
     prop_round_rip,
     (const DerivedPath & o))
 {


### PR DESCRIPTION
# Motivation
The warning message should produce an installable name that can be passed to `nix build`, `nix path-info`, etc. again. Since the CLI expects that the .drv path and the output names are separated by a caret, the warning message must also separate the .drv path and output names with a caret.

However, `DerivedPath::Built.to_string()` uses an exclamation point as the separator instead.

This changes the warning message from:
> If this command is now failing try again with '/nix/store/foo.drv!*'

to:
> If this command is now failing try again with '/nix/store/foo.drv^*'

# Context
<!-- Provide context. Reference open issues if available. -->
https://github.com/NixOS/nix/pull/7600#issuecomment-1506443774

<!-- Non-trivial change: Briefly outline the implementation strategy. -->
~~`DerivedPath::to_string()` now accepts a `char separator` argument.~~

There are separate legacy (`!`) and non-legacy (`^`) code paths.


Note that during development I (@Ericson2314, not @raphaelr) temporary renamed `to_string` to `to_string_modern`. This let me better audit the ones that were switched from `!` to `^`. Report:

- They all appeared to be diagnostics for humans, except for the one in `Store::queryMissing` which is neither exposed to other processes or humans (and thus should also be safe to change).
- Just the daemon protocol is using the legacy root.
- The legacy SSH protocol uses `StorePathWithOutputs` which is "even more legacy" (also uses `!` FWIW).

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
