### PR TITLE
Support `repairPath` on most stores.

### DIFF
--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -119,7 +119,7 @@ void Store::ensurePath(const StorePath & path)
 }
 
 
-void LocalStore::repairPath(const StorePath & path)
+void Store::repairPath(const StorePath & path)
 {
     Worker worker(*this, *this);
     GoalPtr goal = worker.makePathSubstitutionGoal(path, Repair);

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -345,6 +345,17 @@ public:
     virtual ref<FSAccessor> getFSAccessor() override
     { unsupported("getFSAccessor"); }
 
+    /**
+     * The default instance would schedule the work on the client side, but
+     * for consistency with `buildPaths` and `buildDerivation` it should happen
+     * on the remote side.
+     *
+     * We make this fail for now so we can add implement this properly later
+     * without it being a breaking change.
+     */
+    void repairPath(const StorePath & path) override
+    { unsupported("repairPath"); }
+
     void computeFSClosure(const StorePathSet & paths,
         StorePathSet & out, bool flipDirection = false,
         bool includeOutputs = false, bool includeDerivers = false) override

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -240,8 +240,6 @@ public:
 
     void vacuumDB();
 
-    void repairPath(const StorePath & path) override;
-
     void addSignatures(const StorePath & storePath, const StringSet & sigs) override;
 
     /**

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -136,6 +136,17 @@ public:
 
     bool verifyStore(bool checkContents, RepairFlag repair) override;
 
+    /**
+     * The default instance would schedule the work on the client side, but
+     * for consistency with `buildPaths` and `buildDerivation` it should happen
+     * on the remote side.
+     *
+     * We make this fail for now so we can add implement this properly later
+     * without it being a breaking change.
+     */
+    void repairPath(const StorePath & path) override
+    { unsupported("repairPath"); }
+
     void addSignatures(const StorePath & storePath, const StringSet & sigs) override;
 
     void queryMissing(const std::vector<DerivedPath> & targets,

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -684,8 +684,7 @@ public:
      * Repair the contents of the given path by redownloading it using
      * a substituter (if available).
      */
-    virtual void repairPath(const StorePath & path)
-    { unsupported("repairPath"); }
+    virtual void repairPath(const StorePath & path);
 
     /**
      * Add signatures to the specified store path. The signatures are


### PR DESCRIPTION
# Motivation

More progress on issue #5729

The method trivially generalizes to be store-implementation-agnostic, in fact.

However, we force it to continue to be unimplemented with `RemoteStore` and `LegacySSHStore` because the implementation we'd get via the generalization is probably not the one users expect. This keeps our hands untied to do it right going forward.

# Context

For more about the tension between the scheduler logic being store-type-agnostic and remote stores doing their own scheduling, see issues #5025 and #5056.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
