### PR TITLE
Whitelist commit-lockfile-summary in flake nixConfig

### DIFF
--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -31,7 +31,7 @@ static void writeTrustedList(const TrustedList & trustedList)
 
 void ConfigFile::apply()
 {
-    std::set<std::string> whitelist{"bash-prompt", "bash-prompt-prefix", "bash-prompt-suffix", "flake-registry"};
+    std::set<std::string> whitelist{"bash-prompt", "bash-prompt-prefix", "bash-prompt-suffix", "flake-registry", "commit-lockfile-summary"};
 
     for (auto & [name, value] : settings) {
 

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -382,9 +382,9 @@ The following attributes are supported in `flake.nix`:
 * `nixConfig`: a set of `nix.conf` options to be set when evaluating any
   part of a flake. In the interests of security, only a small set of
   whitelisted options (currently `bash-prompt`, `bash-prompt-prefix`,
-  `bash-prompt-suffix`, and `flake-registry`) are allowed to be set without
-  confirmation so long as `accept-flake-config` is not set in the global
-  configuration.
+  `bash-prompt-suffix`, `flake-registry`, and `commit-lockfile-summary`)
+  are allowed to be set without confirmation so long as `accept-flake-config`
+  is not set in the global configuration.
 
 ## Flake inputs
 


### PR DESCRIPTION
# Motivation
Git repos with flakes may have their own commit title conventions. In those cases, when using `nix flake update --commit-lock-file`, the user needs the commit-lockfile-summary nix option set to an appropriate commit title. 

Using `--commit-lock-file` rather than manually creating a commit is still desirable as it sets an useful commit description. In order to set this setting, a flake can set in in the flakes `nixConfig` attribute. However, since this is not a whitelisted option, it will come up with a prompt or warning for most nix commands. 

Since this option only sets the commit title for `--commit-lock-file`, and setting it in a flake would only affect commits for that repo, it is safe to use. Therefore, it should be whitelisted to make setting it painless for flake authors.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
