### PR TITLE
Experimentally allow forcing `nix-daemon` trust; use this to test

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1067,6 +1067,8 @@ void processConnection(
 
             opCount++;
 
+            debug("performing daemon worker op: %d", op);
+
             try {
                 performOp(tunnelLogger, store, trusted, recursive, clientVersion, from, to, op);
             } catch (Error & e) {

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -12,7 +12,7 @@ struct ExperimentalFeatureDetails
     std::string_view description;
 };
 
-constexpr std::array<ExperimentalFeatureDetails, 11> xpFeatureDetails = {{
+constexpr std::array<ExperimentalFeatureDetails, 12> xpFeatureDetails = {{
     {
         .tag = Xp::CaDerivations,
         .name = "ca-derivations",
@@ -187,6 +187,16 @@ constexpr std::array<ExperimentalFeatureDetails, 11> xpFeatureDetails = {{
             Allow the use of the [`unsafeDiscardReferences`](@docroot@/language/advanced-attributes.html#adv-attr-unsafeDiscardReferences) attribute in derivations
             that use [structured attributes](@docroot@/language/advanced-attributes.html#adv-attr-structuredAttrs). This disables scanning of outputs for
             runtime dependencies.
+        )",
+    },
+    {
+        .tag = Xp::DaemonTrustOverride,
+        .name = "daemon-trust-override",
+        .description = R"(
+            Allow forcing trusting or not trusting clients with
+            `nix-daemon`. This is useful for testing, but possibly also
+            useful for various experiments with `nix-daemon --stdio`
+            networking.
         )",
     },
 }};

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -28,6 +28,7 @@ enum struct ExperimentalFeature
     AutoAllocateUids,
     Cgroups,
     DiscardReferences,
+    DaemonTrustOverride,
 };
 
 /**

--- a/tests/build-remote-trustless-after.sh
+++ b/tests/build-remote-trustless-after.sh
@@ -1,0 +1,2 @@
+outPath=$(readlink -f $TEST_ROOT/result)
+grep 'FOO BAR BAZ' ${remoteDir}/${outPath}

--- a/tests/build-remote-trustless-should-fail-0.sh
+++ b/tests/build-remote-trustless-should-fail-0.sh
@@ -1,0 +1,29 @@
+source common.sh
+
+enableFeatures "daemon-trust-override"
+
+restartDaemon
+
+[[ $busybox =~ busybox ]] || skipTest "no busybox"
+
+unset NIX_STORE_DIR
+unset NIX_STATE_DIR
+
+# We first build a dependency of the derivation we eventually want to
+# build.
+nix-build build-hook.nix -A passthru.input2 \
+  -o "$TEST_ROOT/input2" \
+  --arg busybox "$busybox" \
+  --store "$TEST_ROOT/local" \
+  --option system-features bar
+
+# Now when we go to build that downstream derivation, Nix will fail
+# because we cannot trustlessly build input-addressed derivations with
+# `inputDrv` dependencies.
+
+file=build-hook.nix
+prog=$(readlink -e ./nix-daemon-untrusting.sh)
+proto=ssh-ng
+
+expectStderr 1 source build-remote-trustless.sh \
+    | grepQuiet "you are not privileged to build input-addressed derivations"

--- a/tests/build-remote-trustless-should-pass-0.sh
+++ b/tests/build-remote-trustless-should-pass-0.sh
@@ -1,0 +1,9 @@
+source common.sh
+
+# Remote trusts us
+file=build-hook.nix
+prog=nix-store
+proto=ssh
+
+source build-remote-trustless.sh
+source build-remote-trustless-after.sh

--- a/tests/build-remote-trustless-should-pass-1.sh
+++ b/tests/build-remote-trustless-should-pass-1.sh
@@ -1,0 +1,9 @@
+source common.sh
+
+# Remote trusts us
+file=build-hook.nix
+prog=nix-daemon
+proto=ssh-ng
+
+source build-remote-trustless.sh
+source build-remote-trustless-after.sh

--- a/tests/build-remote-trustless-should-pass-3.sh
+++ b/tests/build-remote-trustless-should-pass-3.sh
@@ -1,0 +1,14 @@
+source common.sh
+
+enableFeatures "daemon-trust-override"
+
+restartDaemon
+
+# Remote doesn't trusts us, but this is fine because we are only
+# building (fixed) CA derivations.
+file=build-hook-ca-fixed.nix
+prog=$(readlink -e ./nix-daemon-untrusting.sh)
+proto=ssh-ng
+
+source build-remote-trustless.sh
+source build-remote-trustless-after.sh

--- a/tests/build-remote-trustless.sh
+++ b/tests/build-remote-trustless.sh
@@ -1,0 +1,14 @@
+requireSandboxSupport
+[[ $busybox =~ busybox ]] || skipTest "no busybox"
+
+unset NIX_STORE_DIR
+unset NIX_STATE_DIR
+
+remoteDir=$TEST_ROOT/remote
+
+# Note: ssh{-ng}://localhost bypasses ssh. See tests/build-remote.sh for
+# more details.
+nix-build $file -o $TEST_ROOT/result --max-jobs 0 \
+  --arg busybox $busybox \
+  --store $TEST_ROOT/local \
+  --builders "$proto://localhost?remote-program=$prog&remote-store=${remoteDir}%3Fsystem-features=foo%20bar%20baz - - 1 1 foo,bar,baz"

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -70,6 +70,10 @@ nix_tests = \
   check-reqs.sh \
   build-remote-content-addressed-fixed.sh \
   build-remote-content-addressed-floating.sh \
+  build-remote-trustless-should-pass-0.sh \
+  build-remote-trustless-should-pass-1.sh \
+  build-remote-trustless-should-pass-3.sh \
+  build-remote-trustless-should-fail-0.sh \
   nar-access.sh \
   pure-eval.sh \
   eval.sh \

--- a/tests/nix-daemon-untrusting.sh
+++ b/tests/nix-daemon-untrusting.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec nix-daemon --force-untrusted "$@"


### PR DESCRIPTION
# Motivation

We finally test the status quo of remote build trust in a number of ways. We create a new experimental feature on `nix-daemon` to do so.

# Context

PR #3921, which improves the situation with trustless remote building, will build upon these changes. This code / tests was pull out of there to make this, so everything is easier to review, and in particular we test before and after so the new behavior in that PR is readily apparent from the testsuite diff alone.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
