### PR TITLE
Documentation: fix typo for `Nix database` link in manual

### DIFF
--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -127,7 +127,7 @@
     builder can rely on external inputs such as the network or the
     system time) but the Nix model assumes it.
 
-  - Nix database{#gloss-nix-database}\
+  - [Nix database]{#gloss-nix-database}\
     An SQlite database to track [reference]s between [store object]s.
     This is an implementation detail of the [local store].
 


### PR DESCRIPTION

# Motivation

Fixes broken link for `Nix database` anchor in the Glossary page of the Nix manual.

# Context

See `Motivation` above.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
