### PR TITLE
ci: Always run with sandbox, even on Darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v20
+      with:
+        # The sandbox would otherwise be disabled by default on Darwin
+        extra_nix_config: "sandbox = true"
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v12
       if: needs.check_secrets.outputs.cachix == 'true'

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2620,12 +2620,17 @@ Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;
     auto add = [&](const Path & p, const std::string & s = std::string()) {
-        if (pathExists(p)) {
-            if (s.empty()) {
-                res.push_back(p);
-            } else {
-                res.push_back(s + "=" + p);
+        try {
+            if (pathExists(p)) {
+                if (s.empty()) {
+                    res.push_back(p);
+                } else {
+                    res.push_back(s + "=" + p);
+                }
             }
+        } catch (SysError & e) {
+            // swallow EPERM
+            if (e.errNo != EPERM) throw;
         }
     };
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2620,17 +2620,12 @@ Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;
     auto add = [&](const Path & p, const std::string & s = std::string()) {
-        try {
-            if (pathExists(p)) {
-                if (s.empty()) {
-                    res.push_back(p);
-                } else {
-                    res.push_back(s + "=" + p);
-                }
+        if (pathAccessible(p)) {
+            if (s.empty()) {
+                res.push_back(p);
+            } else {
+                res.push_back(s + "=" + p);
             }
-        } catch (SysError & e) {
-            // swallow EPERM
-            if (e.errNo != EPERM) throw;
         }
     };
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -57,6 +57,8 @@ Settings::Settings()
     auto sslOverride = getEnv("NIX_SSL_CERT_FILE").value_or(getEnv("SSL_CERT_FILE").value_or(""));
     if (sslOverride != "")
         caFile = sslOverride;
+    else if (caFile == "")
+        caFile = getDefaultSSLCertFile();
 
     /* Backwards compatibility. */
     auto s = getEnv("NIX_REMOTE_SYSTEMS");

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -57,8 +57,6 @@ Settings::Settings()
     auto sslOverride = getEnv("NIX_SSL_CERT_FILE").value_or(getEnv("SSL_CERT_FILE").value_or(""));
     if (sslOverride != "")
         caFile = sslOverride;
-    else if (caFile == "")
-        caFile = getDefaultSSLCertFile();
 
     /* Backwards compatibility. */
     auto s = getEnv("NIX_REMOTE_SYSTEMS");
@@ -185,7 +183,7 @@ bool Settings::isWSL1()
 Path Settings::getDefaultSSLCertFile()
 {
     for (auto & fn : {"/etc/ssl/certs/ca-certificates.crt", "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"})
-        if (pathExists(fn)) return fn;
+        if (pathAccessible(fn)) return fn;
     return "";
 }
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -842,7 +842,7 @@ public:
         )"};
 
     Setting<Path> caFile{
-        this, "", "ssl-cert-file",
+        this, getDefaultSSLCertFile(), "ssl-cert-file",
         R"(
           The path of a file containing CA certificates used to
           authenticate `https://` downloads. Nix by default will use

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -842,7 +842,7 @@ public:
         )"};
 
     Setting<Path> caFile{
-        this, getDefaultSSLCertFile(), "ssl-cert-file",
+        this, "", "ssl-cert-file",
         R"(
           The path of a file containing CA certificates used to
           authenticate `https://` downloads. Nix by default will use

--- a/src/libutil/tests/tests.cc
+++ b/src/libutil/tests/tests.cc
@@ -202,7 +202,7 @@ namespace nix {
     }
 
     TEST(pathExists, bogusPathDoesNotExist) {
-        ASSERT_FALSE(pathExists("/home/schnitzel/darmstadt/pommes"));
+        ASSERT_FALSE(pathExists("/schnitzel/darmstadt/pommes"));
     }
 
     /* ----------------------------------------------------------------------------

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -266,6 +266,17 @@ bool pathExists(const Path & path)
     return false;
 }
 
+bool pathAccessible(const Path & path)
+{
+    try {
+        return pathExists(path);
+    } catch (SysError & e) {
+        // swallow EPERM
+        if (e.errNo == EPERM) return false;
+        throw;
+    }
+}
+
 
 Path readLink(const Path & path)
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -121,6 +121,14 @@ struct stat lstat(const Path & path);
 bool pathExists(const Path & path);
 
 /**
+ * A version of pathExists that returns false on a permission error.
+ * Useful for inferring default paths across directories that might not
+ * be readable.
+ * @return true iff the given path can be accessed and exists
+ */
+bool pathAccessible(const Path & path);
+
+/**
  * Read the contents (target) of a symbolic link.  The result is not
  * in any way canonicalised.
  */


### PR DESCRIPTION
And fix a test failure in the sandbox due to /home existing on Darwin but not being accessible in the sandbox since it's a symlink to /System/Volumes/Data/home, see
https://github.com/NixOS/nix/actions/runs/4205378453/jobs/7297384658#step:6:2127:

    C++ exception with description "error: getting status of /home/schnitzel/darmstadt/pommes: Operation not permitted" thrown in the test body.

On Linux this wasn't a problem because there /home doesn't exist in the sandbox

# Motivation
https://github.com/NixOS/nix/pull/7735#issuecomment-1435066191

# Context
originally by @infinisil 
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
