### PR TITLE
Move `test/recursive.sh` nix expr to file

### DIFF
--- a/tests/recursive.nix
+++ b/tests/recursive.nix
@@ -1,0 +1,56 @@
+with import ./config.nix;
+
+mkDerivation rec {
+  name = "recursive";
+  dummy = builtins.toFile "dummy" "bla bla";
+  SHELL = shell;
+
+  # Note: this is a string without context.
+  unreachable = builtins.getEnv "unreachable";
+
+  NIX_TESTS_CA_BY_DEFAULT = builtins.getEnv "NIX_TESTS_CA_BY_DEFAULT";
+
+  requiredSystemFeatures = [ "recursive-nix" ];
+
+  buildCommand = ''
+    mkdir $out
+    opts="--experimental-features nix-command ${if (NIX_TESTS_CA_BY_DEFAULT == "1") then "--extra-experimental-features ca-derivations" else ""}"
+
+    PATH=${builtins.getEnv "NIX_BIN_DIR"}:$PATH
+
+    # Check that we can query/build paths in our input closure.
+    nix $opts path-info $dummy
+    nix $opts build $dummy
+
+    # Make sure we cannot query/build paths not in out input closure.
+    [[ -e $unreachable ]]
+    (! nix $opts path-info $unreachable)
+    (! nix $opts build $unreachable)
+
+    # Add something to the store.
+    echo foobar > foobar
+    foobar=$(nix $opts store add-path ./foobar)
+
+    nix $opts path-info $foobar
+    nix $opts build $foobar
+
+    # Add it to our closure.
+    ln -s $foobar $out/foobar
+
+    [[ $(nix $opts path-info --all | wc -l) -eq 4 ]]
+
+    # Build a derivation.
+    nix $opts build -L --impure --expr '
+      with import ${./config.nix};
+      mkDerivation {
+        name = "inner1";
+        buildCommand = "echo $fnord blaat > $out";
+        fnord = builtins.toFile "fnord" "fnord";
+      }
+    '
+
+    [[ $(nix $opts path-info --json ./result) =~ fnord ]]
+
+    ln -s $(nix $opts path-info ./result) $out/inner1
+  '';
+}

--- a/tests/recursive.sh
+++ b/tests/recursive.sh
@@ -12,63 +12,7 @@ rm -f $TEST_ROOT/result
 
 export unreachable=$(nix store add-path ./recursive.sh)
 
-NIX_BIN_DIR=$(dirname $(type -p nix)) nix --extra-experimental-features 'nix-command recursive-nix' build -o $TEST_ROOT/result -L --impure --expr '
-  with import ./config.nix;
-  mkDerivation rec {
-    name = "recursive";
-    dummy = builtins.toFile "dummy" "bla bla";
-    SHELL = shell;
-
-    # Note: this is a string without context.
-    unreachable = builtins.getEnv "unreachable";
-
-    NIX_TESTS_CA_BY_DEFAULT = builtins.getEnv "NIX_TESTS_CA_BY_DEFAULT";
-
-    requiredSystemFeatures = [ "recursive-nix" ];
-
-    buildCommand = '\'\''
-      mkdir $out
-      opts="--experimental-features nix-command ${if (NIX_TESTS_CA_BY_DEFAULT == "1") then "--extra-experimental-features ca-derivations" else ""}"
-
-      PATH=${builtins.getEnv "NIX_BIN_DIR"}:$PATH
-
-      # Check that we can query/build paths in our input closure.
-      nix $opts path-info $dummy
-      nix $opts build $dummy
-
-      # Make sure we cannot query/build paths not in out input closure.
-      [[ -e $unreachable ]]
-      (! nix $opts path-info $unreachable)
-      (! nix $opts build $unreachable)
-
-      # Add something to the store.
-      echo foobar > foobar
-      foobar=$(nix $opts store add-path ./foobar)
-
-      nix $opts path-info $foobar
-      nix $opts build $foobar
-
-      # Add it to our closure.
-      ln -s $foobar $out/foobar
-
-      [[ $(nix $opts path-info --all | wc -l) -eq 4 ]]
-
-      # Build a derivation.
-      nix $opts build -L --impure --expr '\''
-        with import ${./config.nix};
-        mkDerivation {
-          name = "inner1";
-          buildCommand = "echo $fnord blaat > $out";
-          fnord = builtins.toFile "fnord" "fnord";
-        }
-      '\''
-
-      [[ $(nix $opts path-info --json ./result) =~ fnord ]]
-
-      ln -s $(nix $opts path-info ./result) $out/inner1
-    '\'\'';
-  }
-'
+NIX_BIN_DIR=$(dirname $(type -p nix)) nix --extra-experimental-features 'nix-command recursive-nix' build -o $TEST_ROOT/result -L --impure --file ./recursive.nix
 
 [[ $(cat $TEST_ROOT/result/inner1) =~ blaat ]]
 


### PR DESCRIPTION
# Motivation

I found it hard to read as a big string literal.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
