### PR TITLE
Move failed outputs out of chroot for build problem troubleshooting

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -819,6 +819,11 @@ bool DerivationGoal::cleanupDecideWhetherDiskFull()
 }
 
 
+void DerivationGoal::cleanupError()
+{
+}
+
+
 void DerivationGoal::cleanupPostOutputsRegisteredModeCheck()
 {
 }
@@ -984,6 +989,7 @@ void DerivationGoal::buildDone()
         done(BuildResult::Built, std::move(builtOutputs));
 
     } catch (BuildError & e) {
+        cleanupError();
         outputLocks.unlock();
 
         BuildResult::Status st = BuildResult::MiscFailure;

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -9,7 +9,6 @@
 #include "archive.hh"
 #include "compression.hh"
 #include "worker-protocol.hh"
-#include "topo-sort.hh"
 #include "callback.hh"
 #include "local-store.hh" // TODO remove, along with remaining downcasts
 

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -284,6 +284,7 @@ struct DerivationGoal : public Goal
     virtual bool cleanupDecideWhetherDiskFull();
     virtual void cleanupPostOutputsRegisteredModeCheck();
     virtual void cleanupPostOutputsRegisteredModeNonCheck();
+    virtual void cleanupError();
 
     virtual bool isReadDesc(int fd);
 

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -364,8 +364,11 @@ void LocalDerivationGoal::cleanupError()
             if (!status.known) continue;
             if (buildMode != bmCheck && status.known->isValid()) continue;
             auto p = worker.store.toRealPath(status.known->path);
-            if (pathExists(chrootRootDir + p))
+            if (pathExists(chrootRootDir + p)) {
+                // print the paths for inspection
+                printMsg(lvlChatty, "moving path %s out of the chroot", p);
                 renameFile((chrootRootDir + p), p);
+            }
         }
 }
 
@@ -2340,7 +2343,6 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
             }, *orifu);
         }},
         {[&](const std::string & path, const std::string & parent) {
-            // TODO with more -vvvv also show the temporary paths for manual inspection.
             throw BuildError(
                 "cycle detected in build of '%s' in the references of output '%s' from output '%s'",
                 worker.store.printStorePath(drvPath), path, parent);

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -349,6 +349,12 @@ bool LocalDerivationGoal::cleanupDecideWhetherDiskFull()
     }
 #endif
 
+    return diskFull;
+}
+
+
+void LocalDerivationGoal::cleanupError()
+{
     deleteTmpDir(false);
 
     /* Move paths out of the chroot for easier debugging of
@@ -361,8 +367,6 @@ bool LocalDerivationGoal::cleanupDecideWhetherDiskFull()
             if (pathExists(chrootRootDir + p))
                 renameFile((chrootRootDir + p), p);
         }
-
-    return diskFull;
 }
 
 
@@ -2336,6 +2340,9 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
             }, *orifu);
         }},
         {[&](const std::string & path, const std::string & parent) {
+            // as the result is cast to an Error, the handler for BuildErrors is not run
+            // this will move paths out of a chroot directory
+            cleanupError();
             // TODO with more -vvvv also show the temporary paths for manual inspection.
             return BuildError(
                 "cycle detected in build of '%s' in the references of output '%s' from output '%s'",

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2340,11 +2340,8 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
             }, *orifu);
         }},
         {[&](const std::string & path, const std::string & parent) {
-            // as the result is cast to an Error, the handler for BuildErrors is not run
-            // this will move paths out of a chroot directory
-            cleanupError();
             // TODO with more -vvvv also show the temporary paths for manual inspection.
-            return BuildError(
+            throw BuildError(
                 "cycle detected in build of '%s' in the references of output '%s' from output '%s'",
                 worker.store.printStorePath(drvPath), path, parent);
         }});

--- a/src/libstore/build/local-derivation-goal.hh
+++ b/src/libstore/build/local-derivation-goal.hh
@@ -262,6 +262,7 @@ struct LocalDerivationGoal : public DerivationGoal
     bool cleanupDecideWhetherDiskFull() override;
     void cleanupPostOutputsRegisteredModeCheck() override;
     void cleanupPostOutputsRegisteredModeNonCheck() override;
+    void cleanupError() override;
 
     bool isReadDesc(int fd) override;
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1133,7 +1133,7 @@ void LocalStore::registerValidPaths(const ValidPathInfos & infos)
                 return i == infos.end() ? StorePathSet() : i->second.references;
             }},
             {[&](const StorePath & path, const StorePath & parent) {
-                return BuildError(
+                throw BuildError(
                     "cycle detected in the references of '%s' from '%s'",
                     printStorePath(path),
                     printStorePath(parent));

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -255,7 +255,7 @@ StorePaths Store::topoSortPaths(const StorePathSet & paths)
             }
         }},
         {[&](const StorePath & path, const StorePath & parent) {
-            return BuildError(
+            throw BuildError(
                 "cycle detected in the references of '%s' from '%s'",
                 printStorePath(path),
                 printStorePath(parent));

--- a/src/libutil/topo-sort.hh
+++ b/src/libutil/topo-sort.hh
@@ -8,7 +8,7 @@ namespace nix {
 template<typename T>
 std::vector<T> topoSort(std::set<T> items,
         std::function<std::set<T>(const T &)> getChildren,
-        std::function<Error(const T &, const T &)> makeCycleError)
+        std::function<void (const T &, const T &)> makeCycleError)
 {
     std::vector<T> sorted;
     std::set<T> visited, parents;
@@ -16,7 +16,7 @@ std::vector<T> topoSort(std::set<T> items,
     std::function<void(const T & path, const T * parent)> dfsVisit;
 
     dfsVisit = [&](const T & path, const T * parent) {
-        if (parents.count(path)) throw makeCycleError(path, *parent);
+        if (parents.count(path)) makeCycleError(path, *parent);
 
         if (!visited.insert(path).second) return;
         parents.insert(path);


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

moves the error handling code out of LocalDerivationGoal::cleanupDecideWhetherDiskFull and calls the error handling code on all build errors

# Context
<!-- Provide context. Reference open issues if available. -->

fixes https://github.com/NixOS/nix/issues/8251

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
