### PR TITLE
move uninstall instructions to a separate page

### DIFF
--- a/doc/manual/src/SUMMARY.md.in
+++ b/doc/manual/src/SUMMARY.md.in
@@ -15,6 +15,7 @@
     - [Multi-User Mode](installation/multi-user.md)
   - [Environment Variables](installation/env-variables.md)
   - [Upgrading Nix](installation/upgrading.md)
+  - [Uninstalling Nix](installation/uninstall.md)
 - [Package Management](package-management/package-management.md)
   - [Basic Package Management](package-management/basic-package-mgmt.md)
   - [Profiles](package-management/profiles.md)

--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -47,12 +47,6 @@ The install script will modify the first writable file from amongst
 `NIX_INSTALLER_NO_MODIFY_PROFILE` environment variable before executing
 the install script to disable this behaviour.
 
-You can uninstall Nix simply by running:
-
-```console
-$ rm -rf /nix
-```
-
 # Multi User Installation
 
 The multi-user Nix installation creates system users, and a system
@@ -84,155 +78,8 @@ The installer will modify `/etc/bashrc`, and `/etc/zshrc` if they exist.
 The installer will first back up these files with a `.backup-before-nix`
 extension. The installer will also create `/etc/profile.d/nix.sh`.
 
-## Uninstalling
-
-### Linux
-
-If you are on Linux with systemd:
-
-1. Remove the Nix daemon service:
-
-   ```console
-   sudo systemctl stop nix-daemon.service
-   sudo systemctl disable nix-daemon.socket nix-daemon.service
-   sudo systemctl daemon-reload
-   ```
-
-1. Remove systemd service files:
-
-   ```console
-   sudo rm /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
-   ```
-
-1. The installer script uses systemd-tmpfiles to create the socket directory.
-    You may also want to remove the configuration for that:
-
-   ```console
-   sudo rm /etc/tmpfiles.d/nix-daemon.conf
-   ```
-
-Remove files created by Nix:
-
-```console
-sudo rm -rf /nix /etc/nix /etc/profile/nix.sh ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
-```
-
-Remove build users and their group:
-
-```console
-for i in $(seq 1 32); do
-  sudo userdel nixbld$i
-done
-sudo groupdel nixbld
-```
-
-There may also be references to Nix in
-
-- `/etc/profile`
-- `/etc/bashrc`
-- `/etc/zshrc`
-
-which you may remove.
-
-### macOS
-
-1. Edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing
-   `nix-daemon.sh`, which should look like this:
-
-   ```bash
-   # Nix
-   if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
-     . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-   fi
-   # End Nix
-   ```
-
-   If these files haven't been altered since installing Nix you can simply put
-   the backups back in place:
-
-   ```console
-   sudo mv /etc/zshrc.backup-before-nix /etc/zshrc
-   sudo mv /etc/bashrc.backup-before-nix /etc/bashrc
-   sudo mv /etc/bash.bashrc.backup-before-nix /etc/bash.bashrc
-   ```
-
-   This will stop shells from sourcing the file and bringing everything you
-   installed using Nix in scope.
-
-2. Stop and remove the Nix daemon services:
-
-   ```console
-   sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
-   sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
-   sudo launchctl unload /Library/LaunchDaemons/org.nixos.darwin-store.plist
-   sudo rm /Library/LaunchDaemons/org.nixos.darwin-store.plist
-   ```
-
-   This stops the Nix daemon and prevents it from being started next time you
-   boot the system.
-
-3. Remove the `nixbld` group and the `_nixbuildN` users:
-
-   ```console
-   sudo dscl . -delete /Groups/nixbld
-   for u in $(sudo dscl . -list /Users | grep _nixbld); do sudo dscl . -delete /Users/$u; done
-   ```
-
-   This will remove all the build users that no longer serve a purpose.
-
-4. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store
-   volume on `/nix`, which looks like
-   `UUID=<uuid> /nix apfs rw,noauto,nobrowse,suid,owners` or
-   `LABEL=Nix\040Store /nix apfs rw,nobrowse`. This will prevent automatic
-   mounting of the Nix Store volume.
-
-5. Edit `/etc/synthetic.conf` to remove the `nix` line. If this is the only
-   line in the file you can remove it entirely, `sudo rm /etc/synthetic.conf`.
-   This will prevent the creation of the empty `/nix` directory to provide a
-   mountpoint for the Nix Store volume.
-
-6. Remove the files Nix added to your system:
-
-   ```console
-   sudo rm -rf /etc/nix /var/root/.nix-profile /var/root/.nix-defexpr /var/root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
-   ```
-
-   This gets rid of any data Nix may have created except for the store which is
-   removed next.
-
-7. Remove the Nix Store volume:
-
-   ```console
-   sudo diskutil apfs deleteVolume /nix
-   ```
-
-   This will remove the Nix Store volume and everything that was added to the
-   store.
-
-   If the output indicates that the command couldn't remove the volume, you should
-   make sure you don't have an _unmounted_ Nix Store volume. Look for a
-   "Nix Store" volume in the output of the following command:
-
-   ```console
-   diskutil list
-   ```
-
-   If you _do_ see a "Nix Store" volume, delete it by re-running the diskutil
-   deleteVolume command, but replace `/nix` with the store volume's `diskXsY`
-   identifier.
-
-> **Note**
->
-> After you complete the steps here, you will still have an empty `/nix`
-> directory. This is an expected sign of a successful uninstall. The empty
-> `/nix` directory will disappear the next time you reboot.
->
-> You do not have to reboot to finish uninstalling Nix. The uninstall is
-> complete. macOS (Catalina+) directly controls root directories and its
-> read-only root will prevent you from manually deleting the empty `/nix`
-> mountpoint.
-
 # macOS Installation
+
 []{#sect-macos-installation-change-store-prefix}[]{#sect-macos-installation-encrypted-volume}[]{#sect-macos-installation-symlink}[]{#sect-macos-installation-recommended-notes}
 <!-- Note: anchors above to catch permalinks to old explanations -->
 
@@ -281,18 +128,15 @@ this to run the installer, but it may help if you run into trouble:
 
 # Installing a pinned Nix version from a URL
 
-NixOS.org hosts version-specific installation URLs for all Nix versions
-since 1.11.16, at `https://releases.nixos.org/nix/nix-version/install`.
+Version-specific installation URLs for all Nix versions
+since 1.11.16 can be found at [releases.nixos.org](https://releases.nixos.org/?prefix=nix/).
+The corresponding SHA-256 hash can be found in the directory for the given version.
 
-These install scripts can be used the same as the main NixOS.org
-installation script:
+These install scripts can be used the same as usual:
 
 ```console
-$ curl -L https://nixos.org/nix/install | sh
+$ curl -L https://releases.nixos.org/nix/nix-<version>/install | sh
 ```
-
-In the same directory of the install script are sha256 sums, and gpg
-signature files.
 
 # Installing from a binary tarball
 

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -1,0 +1,159 @@
+# Uninstalling Nix
+
+## Single User
+
+If you have a [single-user installation](./installing-binary.md#single-user-installation) of Nix, uninstall it by running:
+
+```console
+$ rm -rf /nix
+```
+
+## Multi User
+
+Removing a [multi-user installation](./installing-binary.md#multi-user-installation) of Nix is more involved, and depends on the operating system.
+
+### Linux
+
+If you are on Linux with systemd:
+
+1. Remove the Nix daemon service:
+
+   ```console
+   sudo systemctl stop nix-daemon.service
+   sudo systemctl disable nix-daemon.socket nix-daemon.service
+   sudo systemctl daemon-reload
+   ```
+
+1. Remove systemd service files:
+
+   ```console
+   sudo rm /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
+   ```
+
+1. The installer script uses systemd-tmpfiles to create the socket directory.
+    You may also want to remove the configuration for that:
+
+   ```console
+   sudo rm /etc/tmpfiles.d/nix-daemon.conf
+   ```
+
+Remove files created by Nix:
+
+```console
+sudo rm -rf /nix /etc/nix /etc/profile/nix.sh ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
+```
+
+Remove build users and their group:
+
+```console
+for i in $(seq 1 32); do
+  sudo userdel nixbld$i
+done
+sudo groupdel nixbld
+```
+
+There may also be references to Nix in
+
+- `/etc/profile`
+- `/etc/bashrc`
+- `/etc/zshrc`
+
+which you may remove.
+
+### macOS
+
+1. Edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing `nix-daemon.sh`, which should look like this:
+
+   ```bash
+   # Nix
+   if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+     . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+   fi
+   # End Nix
+   ```
+
+   If these files haven't been altered since installing Nix you can simply put
+   the backups back in place:
+
+   ```console
+   sudo mv /etc/zshrc.backup-before-nix /etc/zshrc
+   sudo mv /etc/bashrc.backup-before-nix /etc/bashrc
+   sudo mv /etc/bash.bashrc.backup-before-nix /etc/bash.bashrc
+   ```
+
+   This will stop shells from sourcing the file and bringing everything you
+   installed using Nix in scope.
+
+2. Stop and remove the Nix daemon services:
+
+   ```console
+   sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+   sudo rm /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+   sudo launchctl unload /Library/LaunchDaemons/org.nixos.darwin-store.plist
+   sudo rm /Library/LaunchDaemons/org.nixos.darwin-store.plist
+   ```
+
+   This stops the Nix daemon and prevents it from being started next time you
+   boot the system.
+
+3. Remove the `nixbld` group and the `_nixbuildN` users:
+
+   ```console
+   sudo dscl . -delete /Groups/nixbld
+   for u in $(sudo dscl . -list /Users | grep _nixbld); do sudo dscl . -delete /Users/$u; done
+   ```
+
+   This will remove all the build users that no longer serve a purpose.
+
+4. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store
+   volume on `/nix`, which looks like
+   `UUID=<uuid> /nix apfs rw,noauto,nobrowse,suid,owners` or
+   `LABEL=Nix\040Store /nix apfs rw,nobrowse`. This will prevent automatic
+   mounting of the Nix Store volume.
+
+5. Edit `/etc/synthetic.conf` to remove the `nix` line. If this is the only
+   line in the file you can remove it entirely, `sudo rm /etc/synthetic.conf`.
+   This will prevent the creation of the empty `/nix` directory to provide a
+   mountpoint for the Nix Store volume.
+
+6. Remove the files Nix added to your system:
+
+   ```console
+   sudo rm -rf /etc/nix /var/root/.nix-profile /var/root/.nix-defexpr /var/root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
+   ```
+
+   This gets rid of any data Nix may have created except for the store which is
+   removed next.
+
+7. Remove the Nix Store volume:
+
+   ```console
+   sudo diskutil apfs deleteVolume /nix
+   ```
+
+   This will remove the Nix Store volume and everything that was added to the
+   store.
+
+   If the output indicates that the command couldn't remove the volume, you should
+   make sure you don't have an _unmounted_ Nix Store volume. Look for a
+   "Nix Store" volume in the output of the following command:
+
+   ```console
+   diskutil list
+   ```
+
+   If you _do_ see a "Nix Store" volume, delete it by re-running the diskutil
+   deleteVolume command, but replace `/nix` with the store volume's `diskXsY`
+   identifier.
+
+> **Note**
+>
+> After you complete the steps here, you will still have an empty `/nix`
+> directory. This is an expected sign of a successful uninstall. The empty
+> `/nix` directory will disappear the next time you reboot.
+>
+> You do not have to reboot to finish uninstalling Nix. The uninstall is
+> complete. macOS (Catalina+) directly controls root directories and its
+> read-only root will prevent you from manually deleting the empty `/nix`
+> mountpoint.
+


### PR DESCRIPTION
# Motivation
Placed in a subsection of the binary install, the instructions are hard
to find. Putting them in a separate page that is shown in the table of
contents should make it easier for users to find what they need when
they need it.

# Context

Helping multiple people with their Nix setups required re-installing Nix now and then, and it was always quite an effort to even find the official uninstall instructions.


<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).