### PR TITLE
fetchTree: add lastModifiedDateISO8601 to sourceInfo

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -22,7 +22,7 @@ void emitTreeAttrs(
 {
     assert(input.isLocked());
 
-    auto attrs = state.buildBindings(8);
+    auto attrs = state.buildBindings(9);
 
 
     state.mkStorePathString(tree.storePath, attrs.alloc(state.sOutPath));
@@ -60,6 +60,8 @@ void emitTreeAttrs(
         attrs.alloc("lastModified").mkInt(*lastModified);
         attrs.alloc("lastModifiedDate").mkString(
             fmt("%s", std::put_time(std::gmtime(&*lastModified), "%Y%m%d%H%M%S")));
+        attrs.alloc("lastModifiedDateISO8601").mkString(
+            fmt("%s", std::put_time(std::gmtime(&*lastModified), "%Y-%m-%d")));
     }
 
     v.mkAttrs(attrs);

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -367,6 +367,9 @@ The following attributes are supported in `flake.nix`:
     useful for generating (hopefully) monotonically increasing version
     strings.
 
+  * `lastModifiedDateISO8601`: This is similar to `lastModifiedDate`, but
+    it is in the ISO 8601 format, `%Y-%m-%d` (e.g. `2023-04-29`).
+
   * `lastModified`: The commit time of the revision `rev` as an integer
     denoting the number of seconds since 1970.
 

--- a/tests/fetchPath.sh
+++ b/tests/fetchPath.sh
@@ -1,6 +1,8 @@
 source common.sh
 
 touch $TEST_ROOT/foo -t 202211111111
-# We only check whether 2022-11-1* **:**:** is the last modified date since
+# We only check whether 2022-11-11 **:**:** is the last modified date since
 # `lastModified` is transformed into UTC in `builtins.fetchTarball`.
-[[ "$(nix eval --impure --raw --expr "(builtins.fetchTree \"path://$TEST_ROOT/foo\").lastModifiedDate")" =~ 2022111.* ]]
+[[ "$(nix eval --impure --raw --expr "(builtins.fetchTree \"path://$TEST_ROOT/foo\").lastModifiedDate")" =~ 20221111* ]]
+# Also check that lastModifiedDateISO8601 is correct.
+[[ "$(nix eval --impure --raw --expr "(builtins.fetchTree \"path://$TEST_ROOT/foo\").lastModifiedDateISO8601")" == "2022-11-11" ]]


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
I thought it would make sense to have fetchTree's `sourceInfo` provide a variant of `lastModifiedDate` in the ISO 8601 format that is already used many times across nixpkgs for packages with a version of `unstable-YYYY-MM-DD`.

# Context
<!-- Provide context. Reference open issues if available. -->

https://github.com/NixOS/nix/issues/8163

https://github.com/NixOS/nixpkgs/pull/228802#discussion_r1181235673 (Initially made it as a nixpkgs lib but @infinisil suggested to make it in Nix itself)

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
