### PR TITLE
add a sublist primop

### DIFF
--- a/src/libexpr/tests/primops.cc
+++ b/src/libexpr/tests/primops.cc
@@ -204,6 +204,25 @@ namespace nix {
         ASSERT_THAT(*key->value, IsIntEq(123));
     }
 
+    TEST_F(PrimOpTest, sublist) {
+        auto v = eval("builtins.sublist 3 5 [ 1 2 3 4 5 6 7 8 9 10 ]");
+        ASSERT_THAT(v, IsListOfSize(5));
+        ASSERT_THAT(*v.listElems()[0], IsIntEq(4));
+        ASSERT_THAT(*v.listElems()[4], IsIntEq(8));
+    }
+
+    TEST_F(PrimOpTest, sublistTooLong) {
+        auto v = eval("builtins.sublist 5 10 [ 1 2 3 4 5 6 7 8 9 10 ]");
+        ASSERT_THAT(v, IsListOfSize(5));
+        ASSERT_THAT(*v.listElems()[0], IsIntEq(6));
+        ASSERT_THAT(*v.listElems()[4], IsIntEq(10));
+    }
+
+    TEST_F(PrimOpTest, sublistTooShifted) {
+        auto v = eval("builtins.sublist 11 10 [ 1 2 3 4 5 6 7 8 9 10 ]");
+        ASSERT_THAT(v, IsListOfSize(0));
+    }
+
     TEST_F(PrimOpTest, intersectAttrs) {
         auto v = eval("builtins.intersectAttrs { a = 1; b = 2; } { b = 3; c = 4; }");
         ASSERT_THAT(v, IsAttrsOfSize(1));

--- a/tests/lang/eval-okay-sublist.nix
+++ b/tests/lang/eval-okay-sublist.nix
@@ -1,0 +1,10 @@
+with builtins;
+
+let
+  l = [ 1 2 3 4 5 6 7 8 9 10 ];
+in
+
+sublist 0 0 l
+++ sublist 0 10 l
+++ sublist 0 1 l
+++ sublist 11 10 l


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Adds a __sublist primop, which replaces lib.sublist from nixpkgs.

According to the original PR, this should improve performance of various list-related operations a lot.

# Context
<!-- Provide context. Reference open issues if available. -->

This is a rebased and fixed version of https://github.com/NixOS/nix/pull/2459.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
