### PR TITLE
`max-substitution-jobs` setting

### DIFF
--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -335,6 +335,8 @@ struct DerivationGoal : public Goal
     void waiteeDone(GoalPtr waitee, ExitCode result) override;
 
     StorePathSet exportReferences(const StorePathSet & storePaths);
+
+    JobCategory jobCategory() override { return JobCategory::Build; };
 };
 
 MakeError(NotDeterministic, BuildError);

--- a/src/libstore/build/drv-output-substitution-goal.hh
+++ b/src/libstore/build/drv-output-substitution-goal.hh
@@ -21,7 +21,7 @@ class Worker;
 class DrvOutputSubstitutionGoal : public Goal {
 
     /**
-     * The drv output we're trying to substitue
+     * The drv output we're trying to substitute
      */
     DrvOutput id;
 
@@ -72,6 +72,8 @@ public:
 
     void work() override;
     void handleEOF(int fd) override;
+
+    JobCategory jobCategory() override { return JobCategory::Substitution; };
 };
 
 }

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -34,6 +34,17 @@ typedef std::set<WeakGoalPtr, std::owner_less<WeakGoalPtr>> WeakGoals;
  */
 typedef std::map<StorePath, WeakGoalPtr> WeakGoalMap;
 
+/**
+ * Used as a hint to the worker on how to schedule a particular goal. For example,
+ * builds are typically CPU- and memory-bound, while substitutions are I/O bound.
+ * Using this information, the worker might decide to schedule more or fewer goals
+ * of each category in parallel.
+ */
+enum struct JobCategory {
+    Build,
+    Substitution,
+};
+
 struct Goal : public std::enable_shared_from_this<Goal>
 {
     typedef enum {ecBusy, ecSuccess, ecFailed, ecNoSubstituters, ecIncompleteClosure} ExitCode;
@@ -150,6 +161,8 @@ public:
     void amDone(ExitCode result, std::optional<Error> ex = {});
 
     virtual void cleanup() { }
+
+    virtual JobCategory jobCategory() = 0;
 };
 
 void addToWeakGoals(WeakGoals & goals, GoalPtr p);

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -204,7 +204,7 @@ void PathSubstitutionGoal::tryToRun()
        if maxBuildJobs == 0 (no local builds allowed), we still allow
        a substituter to run.  This is because substitutions cannot be
        distributed to another machine via the build hook. */
-    if (worker.getNrLocalBuilds() >= std::max(1U, (unsigned int) settings.maxBuildJobs)) {
+    if (worker.getNrSubstitutions() >= std::max(1U, (unsigned int) settings.maxSubstitutionJobs)) {
         worker.waitForBuildSlot(shared_from_this());
         return;
     }

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -115,6 +115,8 @@ public:
     void handleEOF(int fd) override;
 
     void cleanup() override;
+
+    JobCategory jobCategory() override { return JobCategory::Substitution; };
 };
 
 }

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -18,6 +18,7 @@ Worker::Worker(Store & store, Store & evalStore)
 {
     /* Debugging: prevent recursive workers. */
     nrLocalBuilds = 0;
+    nrSubstitutions = 0;
     lastWokenUp = steady_time_point::min();
     permanentFailure = false;
     timedOut = false;
@@ -176,6 +177,12 @@ unsigned Worker::getNrLocalBuilds()
 }
 
 
+unsigned Worker::getNrSubstitutions()
+{
+    return nrSubstitutions;
+}
+
+
 void Worker::childStarted(GoalPtr goal, const std::set<int> & fds,
     bool inBuildSlot, bool respectTimeouts)
 {
@@ -187,7 +194,10 @@ void Worker::childStarted(GoalPtr goal, const std::set<int> & fds,
     child.inBuildSlot = inBuildSlot;
     child.respectTimeouts = respectTimeouts;
     children.emplace_back(child);
-    if (inBuildSlot) nrLocalBuilds++;
+    if (inBuildSlot) {
+        if (dynamic_cast<PathSubstitutionGoal *>(child.goal2)) nrSubstitutions++;
+        else nrLocalBuilds++;
+    }
 }
 
 
@@ -198,8 +208,13 @@ void Worker::childTerminated(Goal * goal, bool wakeSleepers)
     if (i == children.end()) return;
 
     if (i->inBuildSlot) {
-        assert(nrLocalBuilds > 0);
-        nrLocalBuilds--;
+        if (dynamic_cast<PathSubstitutionGoal *>(goal)) {
+            assert(nrSubstitutions > 0);
+            nrSubstitutions--;
+        } else {
+            assert(nrLocalBuilds > 0);
+            nrLocalBuilds--;
+        }
     }
 
     children.erase(i);
@@ -220,7 +235,9 @@ void Worker::childTerminated(Goal * goal, bool wakeSleepers)
 void Worker::waitForBuildSlot(GoalPtr goal)
 {
     debug("wait for build slot");
-    if (getNrLocalBuilds() < settings.maxBuildJobs)
+    bool isSubstitutionGoal = dynamic_cast<PathSubstitutionGoal *>(goal.get());
+    if ((!isSubstitutionGoal && getNrLocalBuilds() < settings.maxBuildJobs) ||
+        (isSubstitutionGoal && getNrSubstitutions() < settings.maxSubstitutionJobs))
         wakeUp(goal); /* we can do it right away */
     else
         addToWeakGoals(wantingToBuild, goal);

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -195,7 +195,7 @@ void Worker::childStarted(GoalPtr goal, const std::set<int> & fds,
     child.respectTimeouts = respectTimeouts;
     children.emplace_back(child);
     if (inBuildSlot) {
-        if (dynamic_cast<PathSubstitutionGoal *>(child.goal2)) nrSubstitutions++;
+        if (goal->jobCategory() == JobCategory::Substitution) nrSubstitutions++;
         else nrLocalBuilds++;
     }
 }
@@ -208,7 +208,7 @@ void Worker::childTerminated(Goal * goal, bool wakeSleepers)
     if (i == children.end()) return;
 
     if (i->inBuildSlot) {
-        if (dynamic_cast<PathSubstitutionGoal *>(goal)) {
+        if (goal->jobCategory() == JobCategory::Substitution) {
             assert(nrSubstitutions > 0);
             nrSubstitutions--;
         } else {
@@ -235,7 +235,7 @@ void Worker::childTerminated(Goal * goal, bool wakeSleepers)
 void Worker::waitForBuildSlot(GoalPtr goal)
 {
     debug("wait for build slot");
-    bool isSubstitutionGoal = dynamic_cast<PathSubstitutionGoal *>(goal.get());
+    bool isSubstitutionGoal = goal->jobCategory() == JobCategory::Substitution;
     if ((!isSubstitutionGoal && getNrLocalBuilds() < settings.maxBuildJobs) ||
         (isSubstitutionGoal && getNrSubstitutions() < settings.maxSubstitutionJobs))
         wakeUp(goal); /* we can do it right away */

--- a/src/libstore/build/worker.hh
+++ b/src/libstore/build/worker.hh
@@ -88,10 +88,15 @@ private:
     std::list<Child> children;
 
     /**
-     * Number of build slots occupied.  This includes local builds and
-     * substitutions but not remote builds via the build hook.
+     * Number of build slots occupied.  This includes local builds but does not
+     * include substitutions or remote builds via the build hook.
      */
     unsigned int nrLocalBuilds;
+
+    /**
+     * Number of substitution slots occupied.
+     */
+    unsigned int nrSubstitutions;
 
     /**
      * Maps used to prevent multiple instantiations of a goal for the
@@ -220,11 +225,15 @@ public:
     void wakeUp(GoalPtr goal);
 
     /**
-     * Return the number of local build and substitution processes
-     * currently running (but not remote builds via the build
-     * hook).
+     * Return the number of local build processes currently running (but not
+     * remote builds via the build hook).
      */
     unsigned int getNrLocalBuilds();
+
+    /**
+     * Return the number of substitution processes currently running.
+     */
+    unsigned int getNrSubstitutions();
 
     /**
      * Registers a running child process.  `inBuildSlot` means that

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -249,6 +249,17 @@ unsigned int MaxBuildJobsSetting::parse(const std::string & str) const
     }
 }
 
+unsigned int MaxSubstitutionJobsSetting::parse(const std::string & str) const
+{
+    if (str == "auto") return std::max(1U, std::thread::hardware_concurrency());
+    else {
+        if (auto n = string2Int<decltype(value)>(str))
+            return std::max(1U, *n);
+        else
+            throw UsageError("configuration setting '%s' should be 'auto' or an integer", name);
+    }
+}
+
 
 Paths PluginFilesSetting::parse(const std::string & str) const
 {

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -249,17 +249,6 @@ unsigned int MaxBuildJobsSetting::parse(const std::string & str) const
     }
 }
 
-unsigned int MaxSubstitutionJobsSetting::parse(const std::string & str) const
-{
-    if (str == "auto") return std::max(1U, std::thread::hardware_concurrency());
-    else {
-        if (auto n = string2Int<decltype(value)>(str))
-            return std::max(1U, *n);
-        else
-            throw UsageError("configuration setting '%s' should be 'auto' or an integer", name);
-    }
-}
-
 
 Paths PluginFilesSetting::parse(const std::string & str) const
 {

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -29,6 +29,21 @@ struct MaxBuildJobsSetting : public BaseSetting<unsigned int>
     unsigned int parse(const std::string & str) const override;
 };
 
+struct MaxSubstitutionJobsSetting : public BaseSetting<unsigned int>
+{
+    MaxSubstitutionJobsSetting(Config * options,
+        unsigned int def,
+        const std::string & name,
+        const std::string & description,
+        const std::set<std::string> & aliases = {})
+        : BaseSetting<unsigned int>(def, true, name, description, aliases)
+    {
+        options->addSetting(this);
+    }
+
+    unsigned int parse(const std::string & str) const override;
+};
+
 struct PluginFilesSetting : public BaseSetting<Paths>
 {
     bool pluginsLoaded = false;
@@ -158,6 +173,18 @@ public:
           command line switch.
         )",
         {"build-max-jobs"}};
+
+    MaxSubstitutionJobsSetting maxSubstitutionJobs{
+        this, 16, "max-substitution-jobs",
+        R"(
+          This option defines the maximum number of substitution jobs that Nix
+          will try to run in parallel. The default is `16`. The minimum value
+          one can choose is `1` and lower values will be interpreted as `1`. The
+          special value `auto` causes Nix to use the number of CPUs in your
+          system. It can be overridden using the `--max-substitution-jobs`
+          command line switch.
+        )",
+        {"substitution-max-jobs"}};
 
     Setting<unsigned int> buildCores{
         this,

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -29,21 +29,6 @@ struct MaxBuildJobsSetting : public BaseSetting<unsigned int>
     unsigned int parse(const std::string & str) const override;
 };
 
-struct MaxSubstitutionJobsSetting : public BaseSetting<unsigned int>
-{
-    MaxSubstitutionJobsSetting(Config * options,
-        unsigned int def,
-        const std::string & name,
-        const std::string & description,
-        const std::set<std::string> & aliases = {})
-        : BaseSetting<unsigned int>(def, true, name, description, aliases)
-    {
-        options->addSetting(this);
-    }
-
-    unsigned int parse(const std::string & str) const override;
-};
-
 struct PluginFilesSetting : public BaseSetting<Paths>
 {
     bool pluginsLoaded = false;
@@ -174,15 +159,12 @@ public:
         )",
         {"build-max-jobs"}};
 
-    MaxSubstitutionJobsSetting maxSubstitutionJobs{
+    Setting<unsigned int> maxSubstitutionJobs{
         this, 16, "max-substitution-jobs",
         R"(
           This option defines the maximum number of substitution jobs that Nix
           will try to run in parallel. The default is `16`. The minimum value
-          one can choose is `1` and lower values will be interpreted as `1`. The
-          special value `auto` causes Nix to use the number of CPUs in your
-          system. It can be overridden using the `--max-substitution-jobs`
-          command line switch.
+          one can choose is `1` and lower values will be interpreted as `1`.
         )",
         {"substitution-max-jobs"}};
 


### PR DESCRIPTION
# Motivation

Addresses #3379.

A good example of why `max-substitution-jobs` is needed is the case where we set `max-jobs` to 0 to force derivations to be built on remote stores. Unfortunately, this limits the number of concurrent substitutions to 1 (not 0 because there's an extra provision to allow at least 1 substitution goal in the case when `max-jobs` is set to 0). This slows down substitutions.

Another motivating example is the fact that `max-jobs` default is set to `1`, which means that substitution parallelism will be `1` by default. Again, this unnecessarily slows down substitutions.

# Context

Currently the maximum number of concurrent substitutions is determined by the `max-jobs` setting. This PR is in agreement with issue #3379 and proposed a new setting named `--max-substitution-jobs`.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

cc: @domenkozar @Mic92 