### PR TITLE
Make nix develop -c able to call shell functions

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -507,7 +507,8 @@ struct CmdDevelop : Common, MixEnvironment
             std::vector<std::string> args;
             for (auto s : command)
                 args.push_back(shellEscape(s));
-            script += fmt("exec %s\n", concatStringsSep(" ", args));
+            auto argString = concatStringsSep(" ", args);
+            script += fmt("if [ \"$(type -t %s)\" = file ]; then exec %s; else %s; fi\n", args[0], argString, argString);
         }
 
         else {

--- a/tests/nix-shell.sh
+++ b/tests/nix-shell.sh
@@ -93,6 +93,12 @@ echo foo | nix develop -f "$shellDotNix" shellDrv -c cat | grepQuiet foo
 # Ensure `nix develop -c` actually executes the command if stdout isn't a terminal
 nix develop -f "$shellDotNix" shellDrv -c echo foo |& grepQuiet foo
 
+# Ensure `nix develop -c` can execute shell functions and builtins
+nix develop -f "$shellDotNix" shellDrv -c fun | grepQuiet blabla
+
+# Ensure `nix develop -c` returns exit code when calling shell function
+(nix develop -f "$shellDotNix" shellDrv -c funFail && false) || [[ $? -eq 42 ]]
+
 # Test 'nix print-dev-env'.
 
 nix print-dev-env -f "$shellDotNix" shellDrv > $TEST_ROOT/dev-env.sh

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -34,6 +34,9 @@ let pkgs = rec {
     fun() {
       echo blabla
     }
+    funFail() {
+      exit 42
+    }
   '';
 
   stdenv = mkDerivation {


### PR DESCRIPTION
# Motivation

For example, `nix develop nixpkgs#hello -c unpackPhase` did not work before this change, and resulted in “exec: unpackPhase: not found”. This is un-intuitive, since just `nix develop nixpkgs#hello` then running `unpackPhase` at the interactive shell succeeds.

While we have `--unpack`, that [does not always work](https://github.com/NixOS/nix/issues/7361), and of course it seems reasonable for someone to want to run *any* shell function available in the env, not just those of phases.

# Context

Mostly covered above. This change is fairly small and self-contained and I have red-greened the test cases.

I wonder, though, if we should instead have an `--eval` option or similar to allow for more complex constructions e.g. `unpackPhase && patchPhase`?

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
