### PR TITLE
ssh: Pass the user-specified ssh options last

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -23,8 +23,6 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
 {
     auto state(state_.lock());
 
-    for (auto & i : tokenizeString<Strings>(getEnv("NIX_SSHOPTS").value_or("")))
-        args.push_back(i);
     if (!keyFile.empty())
         args.insert(args.end(), {"-i", keyFile});
     if (!sshPublicHostKey.empty()) {
@@ -39,6 +37,9 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
 
     args.push_back("-oPermitLocalCommand=yes");
     args.push_back("-oLocalCommand=echo started");
+
+    for (auto & i : tokenizeString<Strings>(getEnv("NIX_SSHOPTS").value_or("")))
+        args.push_back(i);
 }
 
 std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(const std::string & command)

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -90,8 +90,9 @@ in
 
     # Perform a build and check that it was performed on the builder.
     out = client.succeed(
-      "nix-build ${expr nodes.client.config 1} 2> build-output",
+      "NIX_SSHOPTS='echo bar &>2;' nix-build ${expr nodes.client.config 1} 2> build-output",
       "grep -q Hello build-output"
+      "grep -q bar build-output"
     )
     builder1.succeed(f"test -e {out}")
 


### PR DESCRIPTION
# Motivation

When `NIX_SSHOPTS` is set, append it to the generate it `ssh` command-line rather than adding it in the middle. This allows doing nasty things like prepending anything to the command than Nix runs, and provides a workaround for https://github.com/NixOS/nix/issues/1078.

# Context

Fix https://github.com/NixOS/nix/issues/8292

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
