### PR TITLE
Create escape hatch for supplementary group sandboxing woes

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -907,15 +907,10 @@ void LocalDerivationGoal::startBuilder()
             openSlave();
 
             /* Drop additional groups here because we can't do it
-               after we've created the new user namespace.  FIXME:
-               this means that if we're not root in the parent
-               namespace, we can't drop additional groups; they will
-               be mapped to nogroup in the child namespace. There does
-               not seem to be a workaround for this. (But who can tell
-               from reading user_namespaces(7)?)
-               See also https://lwn.net/Articles/621612/. */
-            if (getuid() == 0 && setgroups(0, 0) == -1)
-                throw SysError("setgroups failed");
+               after we've created the new user namespace. */
+            if (settings.dropSupplementaryGroups)
+                if (setgroups(0, 0) == -1)
+                    throw SysError("setgroups failed");
 
             ProcessOptions options;
             options.cloneFlags = CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWIPC | CLONE_NEWUTS | CLONE_PARENT | SIGCHLD;

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -910,7 +910,7 @@ void LocalDerivationGoal::startBuilder()
                after we've created the new user namespace. */
             if (settings.dropSupplementaryGroups)
                 if (setgroups(0, 0) == -1)
-                    throw SysError("setgroups failed");
+                    throw SysError("setgroups failed. Set the drop-supplementary-groups option to false to skip this step.");
 
             ProcessOptions options;
             options.cloneFlags = CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWIPC | CLONE_NEWUTS | CLONE_PARENT | SIGCHLD;

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -515,6 +515,25 @@ public:
     Setting<bool> sandboxFallback{this, true, "sandbox-fallback",
         "Whether to disable sandboxing when the kernel doesn't allow it."};
 
+    Setting<bool> dropSupplementaryGroups{this, getuid() == 0, "drop-supplementary-groups",
+        R"(
+          Whether to drop supplementary groups when building with sandboxing.
+          This is normally a good idea if we are root and have the capability to
+          do so.
+
+          But if this "root" is mapped from a non-root user in a larger
+          namespace, we won't be able drop additional groups; they will be
+          mapped to nogroup in the child namespace. There does not seem to be a
+          workaround for this.
+
+          (But who can tell from reading user_namespaces(7)? See also https://lwn.net/Articles/621612/.)
+
+          TODO: It might be good to create a middle ground option that allows
+          `setgroups` to fail if all additional groups are "nogroup" / the value
+          of `/proc/sys/fs/overflowuid`. This would handle the common
+          nested-sandboxing case identified above.
+        )"};
+
 #if __linux__
     Setting<std::string> sandboxShmSize{
         this, "50%", "sandbox-dev-shm-size",


### PR DESCRIPTION
# Motivation

There is no obvious good solution for this that has occurred to anyone.

Provide a way to hack around trying to drop supplementary groups when root.

# Context

Currently,
```bash
unshare --map-root-user nix-build ...
```
will fail when the outside user is not root, because one doesn't actually have the permission to call `setgroups`. This provides a work-around to skip that step.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
