### PR TITLE
doc/glossary: Define output closure and runtime closure

### DIFF
--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -215,6 +215,9 @@
 
   [output path]: #gloss-output-path
 
+- [output closure]{#gloss-output-closure}\
+  The [closure] of an [output path]. It only contains what is [reachable] from the output.
+
 - [deriver]{#gloss-deriver}
 
   The [store derivation] that produced an [output path].


### PR DESCRIPTION
# Motivation

I'd like to reference a definition of output closure from a new NixOS option description; no PR for that yet.

# Context

- Has a TODO. I've already spent my scope creep budget by defining _runtime closure_ as well.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
