### PR TITLE
reword documentation on `builtins`

### DIFF
--- a/doc/manual/src/language/builtin-constants.md
+++ b/doc/manual/src/language/builtin-constants.md
@@ -2,19 +2,19 @@
 
 Here are the constants built into the Nix expression evaluator:
 
-  - `builtins`\
-    The set `builtins` contains all the built-in functions and values.
-    You can use `builtins` to test for the availability of features in
-    the Nix installation, e.g.,
-    
-    ```nix
-    if builtins ? getEnv then builtins.getEnv "PATH" else ""
-    ```
-    
-    This allows a Nix expression to fall back gracefully on older Nix
-    installations that don’t have the desired built-in function.
+- `builtins`\
+  The set `builtins` contains all the built-in functions and values.
+  You can use `builtins` to test for the availability of features in
+  the Nix installation, e.g.,
+  
+  ```nix
+  if builtins ? getEnv then builtins.getEnv "PATH" else ""
+  ```
+  
+  This allows a Nix expression to fall back gracefully on older Nix
+  installations that don’t have the desired built-in function.
 
-  - [`builtins.currentSystem`]{#builtins-currentSystem}\
-    The built-in value `currentSystem` evaluates to the Nix platform
-    identifier for the Nix installation on which the expression is being
-    evaluated, such as `"i686-linux"` or `"x86_64-darwin"`.
+- [`builtins.currentSystem`]{#builtins-currentSystem}\
+  The built-in value `currentSystem` evaluates to the Nix platform
+  identifier for the Nix installation on which the expression is being
+  evaluated, such as `"i686-linux"` or `"x86_64-darwin"`.

--- a/doc/manual/src/language/builtin-constants.md
+++ b/doc/manual/src/language/builtin-constants.md
@@ -1,20 +1,19 @@
 # Built-in Constants
 
-Here are the constants built into the Nix expression evaluator:
+These constants are built into the Nix language evaluator:
 
-- `builtins`\
-  The set `builtins` contains all the built-in functions and values.
-  You can use `builtins` to test for the availability of features in
-  the Nix installation, e.g.,
-  
+- [`builtins`]{#builtins-builtins} (attribute set)
+
+  Contains all the [built-in functions](./builtins.md) and values, in order to avoid polluting the global scope.
+
+  Since built-in functions were added over time, [testing for attributes](./operators.md#has-attribute) in `builtins` can be used for graceful fallback on older Nix installations:
+
   ```nix
   if builtins ? getEnv then builtins.getEnv "PATH" else ""
   ```
-  
-  This allows a Nix expression to fall back gracefully on older Nix
-  installations that don’t have the desired built-in function.
 
-- [`builtins.currentSystem`]{#builtins-currentSystem}\
+- [`builtins.currentSystem`]{#builtins-currentSystem} (string)
+
   The built-in value `currentSystem` evaluates to the Nix platform
   identifier for the Nix installation on which the expression is being
   evaluated, such as `"i686-linux"` or `"x86_64-darwin"`.


### PR DESCRIPTION
- add anchor to `builtins`
- add type information
- reword description of `builtins` to offer more information concisely

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This is the first in a series of small PRs to slightly restructure documentation on built-in functions, with the ultimate goal of providing a better overview on `builtins.derivation` and an overall more consistent presentation.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).