### PR TITLE
add information on the system type string

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,8 @@ AC_PROG_SED
 # https://git.savannah.gnu.org/cgit/config.git/tree/config.guess
 # It has the following form, which is not documented anywhere:
 # <cpu>-<vendor>-<os>[<version>][-<abi>]
+# If `./configure` is passed any of the `--host`, `--build`, `--target` options, the value comes from `config.sub` instead:
+# https://git.savannah.gnu.org/cgit/config.git/tree/config.sub
 AC_CANONICAL_HOST
 AC_MSG_CHECKING([for the canonical Nix system name])
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,12 +7,12 @@ AC_PROG_SED
 
 # Construct a Nix system name (like "i686-linux"):
 # https://www.gnu.org/software/autoconf/manual/html_node/Canonicalizing.html#index-AC_005fCANONICAL_005fHOST-1
-# The inital value is produced by the `config.guess` script:
-# https://git.savannah.gnu.org/cgit/config.git/tree/config.guess
+# The inital value is produced by the `config/config.guess` script:
+# upstream: https://git.savannah.gnu.org/cgit/config.git/tree/config.guess
 # It has the following form, which is not documented anywhere:
 # <cpu>-<vendor>-<os>[<version>][-<abi>]
-# If `./configure` is passed any of the `--host`, `--build`, `--target` options, the value comes from `config.sub` instead:
-# https://git.savannah.gnu.org/cgit/config.git/tree/config.sub
+# If `./configure` is passed any of the `--host`, `--build`, `--target` options, the value comes from `config/config.sub` instead:
+# upstream: https://git.savannah.gnu.org/cgit/config.git/tree/config.sub
 AC_CANONICAL_HOST
 AC_MSG_CHECKING([for the canonical Nix system name])
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,12 @@ AC_CONFIG_AUX_DIR(config)
 
 AC_PROG_SED
 
-# Construct a Nix system name (like "i686-linux").
+# Construct a Nix system name (like "i686-linux"):
+# https://www.gnu.org/software/autoconf/manual/html_node/Canonicalizing.html#index-AC_005fCANONICAL_005fHOST-1
+# The inital value is produced by the `config.guess` script:
+# https://git.savannah.gnu.org/cgit/config.git/tree/config.guess
+# It has the following form, which is not documented anywhere:
+# <cpu>-<vendor>-<os>[<version>][-<abi>]
 AC_CANONICAL_HOST
 AC_MSG_CHECKING([for the canonical Nix system name])
 

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -166,7 +166,7 @@ When Nix is built such that `./configure` is passed any of the `--host`, `--buil
 <cpu>-<vendor>[-<kernel>]-<os>
 ```
 
-For historic reasons and backward-compatibility, some CPU and OS identifiers are transformed as follows in [`configure.ac`](https://github.com/nixos/nix/blob/master/config/config.sub):
+For historic reasons and backward-compatibility, some CPU and OS identifiers are translated from the GNU Autotools naming convention in [`configure.ac`](https://github.com/nixos/nix/blob/master/config/config.sub) as follows:
 
 | `config.guess`             | Nix                 |
 |----------------------------|---------------------|

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -130,7 +130,7 @@ platform. Common solutions include [remote builders] and [binary format emulatio
 [remote builders]: ../advanced-topics/distributed-builds.md
 [binfmt emulation]: https://nixos.org/manual/nixos/stable/options.html#opt-boot.binfmt.emulatedSystems
 
-Given such a setup, executing the build only requires selecting the respective output attribute.
+Given such a setup, executing the build only requires selecting the respective attribute.
 For example, to compile for `aarch64-linux`:
 
 ```console

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -110,41 +110,72 @@ You can also build Nix for one of the [supported platforms](#platforms).
 
 ## Platforms
 
-As specified in [`flake.nix`], Nix can be built for various platforms:
-
-- `aarch64-linux`
-- `i686-linux`
-- `x86_64-darwin`
-- `x86_64-linux`
+Nix can be built for various platforms, as specified in [`flake.nix`]:
 
 [`flake.nix`]: https://github.com/nixos/nix/blob/master/flake.nix
 
+- `x86_64-linux`
+- `x86_64-darwin`
+- `i686-linux`
+- `aarch64-linux`
+- `aarch64-darwin`
+- `armv6l-linux`
+- `armv7l-linux`
+
 In order to build Nix for a different platform than the one you're currently
-on, you need to have some way for your system Nix to build code for that
-platform. Common solutions include [remote builders] and [binfmt emulation]
+on, you need a way for your current Nix installation to build code for that
+platform. Common solutions include [remote builders] and [binary format emulation]
 (only supported on NixOS).
 
 [remote builders]: ../advanced-topics/distributed-builds.md
 [binfmt emulation]: https://nixos.org/manual/nixos/stable/options.html#opt-boot.binfmt.emulatedSystems
 
-These solutions let Nix perform builds as if you're on the native platform, so
-executing the build is as simple as
-
-```console
-$ nix build .#packages.aarch64-linux.default
-```
-
-for flake-enabled Nix, or
+Given such a setup, executing the build only requires selecting the respective output attribute.
+For example, to compile for `aarch64-linux`:
 
 ```console
 $ nix-build --attr packages.aarch64-linux.default
 ```
 
-for classic Nix.
+or for Nix with the [`flakes`] and [`nix-command`] experimental features enabled:
 
-You can use any of the other supported platforms in place of `aarch64-linux`.
+```console
+$ nix build .#packages.aarch64-linux.default
+```
 
-Cross-compiled builds are available for ARMv6 and ARMv7, and Nix on unsupported platforms can be bootstrapped by adding more `crossSystems` in `flake.nix`.
+Cross-compiled builds are available for ARMv6 (`armv6l-linux`) and ARMv7 (`armv7l-linux`).
+Add more [system types](#system-type) to `crossSystems` in `flake.nix` to bootstrap Nix on unsupported platforms.
+
+## System type
+
+Nix uses a string with he following format to identify the *system type* or *platform* it runs on:
+
+```
+<cpu>-<os>[-<abi>]
+```
+
+It is set when Nix is compiled for the given system, and based on the output of [`config.guess`](https://github.com/nixos/nix/blob/master/config/config.guess) ([upstream](https://git.savannah.gnu.org/cgit/config.git/tree/config.guess)):
+
+```
+<cpu>-<vendor>-<os>[<version>][-<abi>]
+```
+
+When Nix is built such that `./configure` is passed any of the `--host`, `--build`, `--target` options, the value is based on the output of [`config.sub`](https://github.com/nixos/nix/blob/master/config/config.sub) ([upstream](https://git.savannah.gnu.org/cgit/config.git/tree/config.sub)):
+
+```
+<cpu>-<vendor>[-<kernel>]-<os>
+```
+
+For historic reasons and backward-compatibility, some CPU and OS identifiers are transformed as follows in [`configure.ac`](https://github.com/nixos/nix/blob/master/config/config.sub):
+
+| `config.guess`             | Nix                 |
+|----------------------------|---------------------|
+| `amd64`                    | `x86_64`            |
+| `i*86`                     | `i686`              |
+| `arm6`                     | `arm6l`             |
+| `arm7`                     | `arm7l`             |
+| `linux-gnu*`               | `linux`             |
+| `linux-musl*`              | `linux`             |
 
 ## Compilation environments
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -193,18 +193,12 @@ public:
     Setting<std::string> thisSystem{
         this, SYSTEM, "system",
         R"(
-          This option specifies the canonical Nix system name of the current
-          installation, such as `i686-linux` or `x86_64-darwin`. Nix can only
-          build derivations whose `system` attribute equals the value
-          specified here. In general, it never makes sense to modify this
-          value from its default, since you can use it to ‘lie’ about the
-          platform you are building on (e.g., perform a Mac OS build on a
-          Linux machine; the result would obviously be wrong). It only makes
-          sense if the Nix binaries can run on multiple platforms, e.g.,
-          ‘universal binaries’ that run on `x86_64-linux` and `i686-linux`.
+          This option specifies the canonical Nix system name of the current installation, such as `i686-linux` or `x86_64-darwin`.
+          Nix can only build derivations whose `system` attribute equals the value specified here.
+          In general, it never makes sense to modify this value from its default, since you can use it to ‘lie’ about the platform you are building on (e.g., perform a Mac OS build on a Linux machine; the result would obviously be wrong).
+          It only makes sense if the Nix binaries can run on multiple platforms, e.g., ‘universal binaries’ that run on `x86_64-linux` and `i686-linux`.
 
-          It defaults to the canonical Nix system name detected by `configure`
-          at build time.
+          It defaults to the canonical Nix system name detected by `configure` at build time.
         )"};
 
     Setting<time_t> maxSilentTime{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -194,7 +194,7 @@ public:
         this, SYSTEM, "system",
         R"(
           The system type of the current Nix installation.
-          Nix will only build a given [derivation](@docroot@/language/derivations.md) locally when its `system` attribute equals the value specified here or in [`extra-platforms`](@docroot@/command-ref/conf-file.html#conf-extra-platforms).
+          Nix will only build a given [derivation](@docroot@/language/derivations.md) locally when its `system` attribute equals any of the values specified here or in [`extra-platforms`](#conf-extra-platforms).
 
           The default value is set when Nix itself is compiled for the system it will run on.
           The following system types are widely used, as [Nix is actively supported on these platforms](@docroot@/contributing/hacking.md#platforms):
@@ -676,18 +676,20 @@ public:
         getDefaultExtraPlatforms(),
         "extra-platforms",
         R"(
-          Platforms other than the native one which this machine is capable of
-          building for. This can be useful for supporting additional
-          architectures on compatible machines: i686-linux can be built on
-          x86\_64-linux machines (and the default for this setting reflects
-          this); armv7 is backwards-compatible with armv6 and armv5tel; some
-          aarch64 machines can also natively run 32-bit ARM code; and
-          qemu-user may be used to support non-native platforms (though this
-          may be slow and buggy). Most values for this are not enabled by
-          default because build systems will often misdetect the target
-          platform and generate incompatible code, so you may wish to
-          cross-check the results of using this option against proper
-          natively-built versions of your derivations.
+          System types of executables that can be run on this machine.
+
+          Nix will only build a given [derivation](@docroot@/language/derivations.md) locally when its `system` attribute equals any of the values specified here or in the [`system` option](#conf-system).
+
+          Setting this can be useful to build derivations locally on compatible machines:
+          - `i686-linux` executables can be run on `x86_64-linux` machines (set by default)
+          - `x86_64-darwin` executables can be run on macOS `aarch64-darwin` with Rosetta 2 (set by default where applicable)
+          - `armv6` and `armv5tel` executables can be run on `armv7`
+          - some `aarch64` machines can also natively run 32-bit ARM code
+          - `qemu-user` may be used to support non-native platforms (though this
+          may be slow and buggy)
+
+          Build systems will usually detect the target platform to be the current physical system and therefore produce machine code incompatible with what may be intended in the derivation.
+          You should design your derivation's `builder` accordingly and cross-check the results when using this option against natively-built versions of your derivation.
         )", {}, false};
 
     Setting<StringSet> systemFeatures{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -194,7 +194,7 @@ public:
         this, SYSTEM, "system",
         R"(
           The system type of the current Nix installation.
-          Nix will only build [derivations](@docroot@/language/derivations.md) whose `system` attribute equals the value specified here.
+          Nix will only build a given [derivation](@docroot@/language/derivations.md) locally when its `system` attribute equals the value specified here or in [`extra-platforms`](@docroot@/command-ref/conf-file.html#conf-extra-platforms).
 
           The default value is set when Nix itself is compiled for the system it will run on.
           The following system types are widely used, as [Nix is actively supported on these platforms](@docroot@/contributing/hacking.md#platforms):

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -207,7 +207,7 @@ public:
           - `armv6l-linux`
           - `armv7l-linux`
 
-          In general, it never makes sense to modify this value when building derivations.
+          In general, you do not have to modify this setting.
           While you can force Nix to run a Darwin-specific `builder` executable on a Linux machine, the result would obviously be wrong.
 
           This value is available in the Nix language as [`builtins.currentSystem`](@docroot@/language/builtin-constants.md#builtins-currentSystem).

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -193,12 +193,49 @@ public:
     Setting<std::string> thisSystem{
         this, SYSTEM, "system",
         R"(
-          This option specifies the canonical Nix system name of the current installation, such as `i686-linux` or `x86_64-darwin`.
-          Nix can only build derivations whose `system` attribute equals the value specified here.
-          In general, it never makes sense to modify this value from its default, since you can use it to ‘lie’ about the platform you are building on (e.g., perform a Mac OS build on a Linux machine; the result would obviously be wrong).
+          The system type of the current Nix installation.
+
+          Nix can only build [derivations](@docroot@/language/derivations.md) whose `system` attribute equals the value specified here.
+          In general, it never makes sense to modify this value, since you can use it to ‘lie’ about the system you are building on (e.g., perform a macOS build on a Linux machine; the result would obviously be wrong).
           It only makes sense if the Nix binaries can run on multiple platforms, e.g., ‘universal binaries’ that run on `x86_64-linux` and `i686-linux`.
 
-          It defaults to the canonical Nix system name detected by `configure` at build time.
+          The default value is set when Nix itself is compiled for the system it will run on.
+          The following system types are widely used, as Nix is actively supported on these platforms:
+
+          - `x86_64-linux`
+          - `x86_64-darwin`
+          - `i686-linux`
+          - `aarch64-linux`
+          - `aarch64-darwin`
+
+          The concrete value is based on the output of [`config.guess`](https://git.savannah.gnu.org/cgit/config.git/tree/config.guess):
+
+          ```
+          <cpu>-<vendor>-<os>[<version>][-<abi>]
+          ```
+
+          When Nix is built such that `./configure` is passed any of the `--host`, `--build`, `--target` options, the value is based on the output of [`config.sub`](https://git.savannah.gnu.org/cgit/config.git/tree/config.sub):
+
+          ```
+          <cpu>-<vendor>[-<kernel>]-<os>
+          ```
+
+          Nix only uses the CPU and OS identifiers:
+
+          ```
+          <cpu>-<os>[-<abi>]
+          ```
+
+          For historic reasons and backwards-compatibility, some CPU and OS identifiers are transformed as follows:
+
+          | `config.guess`             | Nix                 |
+          |----------------------------|---------------------|
+          | `amd64`                    | `x86_64`            |
+          | `i*86`                     | `i686`              |
+          | `arm6`                     | `arm6l`             |
+          | `arm7`                     | `arm7l`             |
+          | `linux-gnu*`               | `linux`             |
+          | `linux-musl*`              | `linux`             |
         )"};
 
     Setting<time_t> maxSilentTime{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -194,12 +194,12 @@ public:
         this, SYSTEM, "system",
         R"(
           The system type of the current Nix installation.
-
-          Nix can only build [derivations](@docroot@/language/derivations.md) whose `system` attribute equals the value specified here.
-          In general, it never makes sense to modify this value, since you can use it to ‘lie’ about the system you are building on (e.g., perform a macOS build on a Linux machine; the result would obviously be wrong).
-          It only makes sense if the Nix binaries can run on multiple platforms, e.g., ‘universal binaries’ that run on `x86_64-linux` and `i686-linux`.
+          Nix will only build [derivations](@docroot@/language/derivations.md) whose `system` attribute equals the value specified here.
 
           The default value is set when Nix itself is compiled for the system it will run on.
+          In general, it never makes sense to modify this value.
+          While you can force Nix to run a Darwin-specific `builder` executable on a Linux machine, the result would obviously be wrong.
+
           The following system types are widely used, as Nix is actively supported on these platforms:
 
           - `x86_64-linux`
@@ -207,35 +207,9 @@ public:
           - `i686-linux`
           - `aarch64-linux`
           - `aarch64-darwin`
+          - `armv6l-linux`
+          - `armv7l-linux`
 
-          The concrete value is based on the output of [`config.guess`](https://git.savannah.gnu.org/cgit/config.git/tree/config.guess):
-
-          ```
-          <cpu>-<vendor>-<os>[<version>][-<abi>]
-          ```
-
-          When Nix is built such that `./configure` is passed any of the `--host`, `--build`, `--target` options, the value is based on the output of [`config.sub`](https://git.savannah.gnu.org/cgit/config.git/tree/config.sub):
-
-          ```
-          <cpu>-<vendor>[-<kernel>]-<os>
-          ```
-
-          Nix only uses the CPU and OS identifiers:
-
-          ```
-          <cpu>-<os>[-<abi>]
-          ```
-
-          For historic reasons and backwards-compatibility, some CPU and OS identifiers are transformed as follows:
-
-          | `config.guess`             | Nix                 |
-          |----------------------------|---------------------|
-          | `amd64`                    | `x86_64`            |
-          | `i*86`                     | `i686`              |
-          | `arm6`                     | `arm6l`             |
-          | `arm7`                     | `arm7l`             |
-          | `linux-gnu*`               | `linux`             |
-          | `linux-musl*`              | `linux`             |
         )"};
 
     Setting<time_t> maxSilentTime{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -197,10 +197,7 @@ public:
           Nix will only build [derivations](@docroot@/language/derivations.md) whose `system` attribute equals the value specified here.
 
           The default value is set when Nix itself is compiled for the system it will run on.
-          In general, it never makes sense to modify this value.
-          While you can force Nix to run a Darwin-specific `builder` executable on a Linux machine, the result would obviously be wrong.
-
-          The following system types are widely used, as Nix is actively supported on these platforms:
+          The following system types are widely used, as [Nix is actively supported on these platforms](@docroot@/contributing/hacking.md#platforms):
 
           - `x86_64-linux`
           - `x86_64-darwin`
@@ -210,6 +207,10 @@ public:
           - `armv6l-linux`
           - `armv7l-linux`
 
+          In general, it never makes sense to modify this value when building derivations.
+          While you can force Nix to run a Darwin-specific `builder` executable on a Linux machine, the result would obviously be wrong.
+
+          This value is available in the Nix language as [`builtins.currentSystem`](@docroot@/language/builtin-constants.md#builtins-currentSystem).
         )"};
 
     Setting<time_t> maxSilentTime{


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This one in a series of small PRs to slightly restructure documentation on built-in functions, with the ultimate goal of providing a better overview on `builtins.derivation` and an overall more consistent presentation.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
<!-- Provide context. Reference open issues if available. -->

Depends on https://github.com/NixOS/nix/pull/8314

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
This work is sponsored by [Antithesis](https://antithesis.com/) ✨
# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [x] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).