### PR TITLE
reword introduction to built-in functions

### DIFF
--- a/doc/manual/src/language/builtins-prefix.md
+++ b/doc/manual/src/language/builtins-prefix.md
@@ -1,16 +1,16 @@
 # Built-in Functions
 
-This section lists the functions built into the Nix expression
-evaluator. (The built-in function `derivation` is discussed above.)
-Some built-ins, such as `derivation`, are always in scope of every Nix
-expression; you can just access them right away. But to prevent
-polluting the namespace too much, most built-ins are not in
-scope. Instead, you can access them through the `builtins` built-in
-value, which is a set that contains all built-in functions and values.
-For instance, `derivation` is also available as `builtins.derivation`.
+This section lists the functions built into the Nix language evaluator.
+All built-in functions are available through the global [`builtins`](./builtin-constants.md#builtins-builtins) constant.
+
+For convenience, some built-ins are can be accessed directly:
+
+- [`derivation`](#builtins-derivation)
+- [`import`](#builtins-import)
+- [`abort`](#builtins-abort)
+- [`throw`](#builtins-throw)
 
 <dl>
-  <dt><code>derivation <var>attrs</var></code>;
-      <code>builtins.derivation <var>attrs</var></code></dt>
+  <dt id="builtins-derivation"><a href="#builtins-derivation"><code>derivation <var>attrs</var></code></a></dt>
   <dd><p><var>derivation</var> is described in
          <a href="derivations.md">its own section</a>.</p></dd>


### PR DESCRIPTION
add anchor to `builtins.derivation` and list some built-in functions that are exposed in the global scope.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Moving some information to `builtins` itself allows phrasing the relevant part more concisely.

# Context
<!-- Provide context. Reference open issues if available. -->

This is the first in a series of small PRs to slightly restructure documentation on built-in functions, with the ultimate goal of providing a better overview on `builtins.derivation` and an overall more consistent presentation.

Depends on #8314

This also partially addresses #7290.
I decided not to list everything, because we probably don't want to encourage people using them that way.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).