### PR TITLE
Stabilize `discard-references`

### DIFF
--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -320,16 +320,6 @@ Derivations can declare some infrequently used optional attributes.
     ```
 
   - [`unsafeDiscardReferences`]{#adv-attr-unsafeDiscardReferences}\
-    > **Warning**
-    > This attribute is part of an [experimental feature](@docroot@/contributing/experimental-features.md).
-    >
-    > To use this attribute, you must enable the
-    > [`discard-references`](@docroot@/contributing/experimental-features.md#xp-feature-discard-references) experimental feature.
-    > For example, in [nix.conf](../command-ref/conf-file.md) you could add:
-    >
-    > ```
-    > extra-experimental-features = discard-references
-    > ```
 
     When using [structured attributes](#adv-attr-structuredAttrs), the
     attribute `unsafeDiscardReferences` is an attribute set with a boolean value for each output name.

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -10,3 +10,9 @@
 - [`builtins.toJSON`](@docroot@/language/builtins.md#builtins-parseFlakeRef) now prints [--show-trace](@docroot@/command-ref/conf-file.html#conf-show-trace) items for the path in which it finds an evaluation error.
 
 - Error messages regarding malformed input to [`derivation add`](@docroot@/command-ref/new-cli/nix3-derivation-add.md) are now clearer and more detailed.
+
+- The `discard-references` feature has been stabilized.
+  This means that the
+  [unsafeDiscardReferences](@docroot@/contributing/experimental-features.md#xp-feature-discard-references)
+  attribute is no longer guarded by an experimental flag and can be used
+  freely.

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2307,7 +2307,6 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
         bool discardReferences = false;
         if (auto structuredAttrs = parsedDrv->getStructuredAttrs()) {
             if (auto udr = get(*structuredAttrs, "unsafeDiscardReferences")) {
-                experimentalFeatureSettings.require(Xp::DiscardReferences);
                 if (auto output = get(*udr, outputName)) {
                     if (!output->is_boolean())
                         throw Error("attribute 'unsafeDiscardReferences.\"%s\"' of derivation '%s' must be a Boolean", outputName, drvPath.to_string());

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -12,7 +12,7 @@ struct ExperimentalFeatureDetails
     std::string_view description;
 };
 
-constexpr std::array<ExperimentalFeatureDetails, 15> xpFeatureDetails = {{
+constexpr std::array<ExperimentalFeatureDetails, 14> xpFeatureDetails = {{
     {
         .tag = Xp::CaDerivations,
         .name = "ca-derivations",
@@ -180,15 +180,6 @@ constexpr std::array<ExperimentalFeatureDetails, 15> xpFeatureDetails = {{
         .description = R"(
             Allows Nix to execute builds inside cgroups. See
             the [`use-cgroups`](#conf-use-cgroups) setting for details.
-        )",
-    },
-    {
-        .tag = Xp::DiscardReferences,
-        .name = "discard-references",
-        .description = R"(
-            Allow the use of the [`unsafeDiscardReferences`](@docroot@/language/advanced-attributes.html#adv-attr-unsafeDiscardReferences) attribute in derivations
-            that use [structured attributes](@docroot@/language/advanced-attributes.html#adv-attr-structuredAttrs). This disables scanning of outputs for
-            runtime dependencies.
         )",
     },
     {

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -27,7 +27,6 @@ enum struct ExperimentalFeature
     ReplFlake,
     AutoAllocateUids,
     Cgroups,
-    DiscardReferences,
     DaemonTrustOverride,
     DynamicDerivations,
     ParseTomlTimestamps,

--- a/tests/check-refs.sh
+++ b/tests/check-refs.sh
@@ -42,8 +42,10 @@ nix-build -o $RESULT check-refs.nix -A test7
 nix-build -o $RESULT check-refs.nix -A test10
 
 if isDaemonNewer 2.12pre20230103; then
-    enableFeatures discard-references
-    restartDaemon
+    if ! isDaemonNewer 2.16.0; then
+        enableFeatures discard-references
+        restartDaemon
+    fi
 
     # test11 should succeed.
     test11=$(nix-build -o $RESULT check-refs.nix -A test11)


### PR DESCRIPTION
# Motivation

It has been there for a few releases now (landed in 2.14.0), doesn't
seem to cause any major issue and is wanted in a few places
(https://github.com/NixOS/nix/pull/7087#issuecomment-1544471346).

# Context

The xp feature got introduced in https://github.com/NixOS/nix/pull/7087

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
