### PR TITLE
Make print-build-logs a setting

### DIFF
--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -6,7 +6,8 @@ namespace nix {
 
 LogFormat defaultLogFormat = LogFormat::raw;
 
-LogFormat parseLogFormat(const std::string & logFormatStr) {
+LogFormat parseLogFormat(const std::string & logFormatStr)
+{
     if (logFormatStr == "raw" || getEnv("NIX_GET_COMPLETIONS"))
         return LogFormat::raw;
     else if (logFormatStr == "raw-with-logs")
@@ -20,7 +21,8 @@ LogFormat parseLogFormat(const std::string & logFormatStr) {
     throw Error("option 'log-format' has an invalid value '%s'", logFormatStr);
 }
 
-Logger * makeDefaultLogger() {
+Logger * makeDefaultLogger()
+{
     switch (defaultLogFormat) {
     case LogFormat::raw:
         return makeSimpleLogger(false);
@@ -40,16 +42,19 @@ Logger * makeDefaultLogger() {
     }
 }
 
-void setLogFormat(const std::string & logFormatStr) {
+void setLogFormat(const std::string & logFormatStr)
+{
     setLogFormat(parseLogFormat(logFormatStr));
 }
 
-void setLogFormat(const LogFormat & logFormat) {
+void setLogFormat(const LogFormat & logFormat)
+{
     defaultLogFormat = logFormat;
     createDefaultLogger();
 }
 
-void createDefaultLogger() {
+void createDefaultLogger()
+{
     logger = makeDefaultLogger();
 }
 

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -288,6 +288,7 @@ template<> void BaseSetting<bool>::convertToArg(Args & args, const std::string &
 {
     args.addFlag({
         .longName = name,
+        .shortName = shortName,
         .description = fmt("Enable the `%s` setting.", name),
         .category = category,
         .handler = {[this]() { override(true); }},

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -192,6 +192,10 @@ public:
     const std::string description;
     const std::set<std::string> aliases;
 
+    /* Short name for the CLI argument corresponding to this
+       setting. */
+    char shortName = 0;
+
     int created = 123;
 
     bool overridden = false;

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -10,6 +10,11 @@ namespace nix {
 
 LoggerSettings loggerSettings;
 
+LoggerSettings::LoggerSettings()
+{
+    printBuildLogs.shortName = 'L';
+}
+
 static GlobalConfig::Register rLoggerSettings(&loggerSettings);
 
 static thread_local ActivityId curActivity = 0;

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -46,6 +46,14 @@ struct LoggerSettings : Config
           Whether Nix should print out a stack trace in case of Nix
           expression evaluation errors.
         )"};
+
+    Setting<bool> printBuildLogs{
+        this, false, "print-build-logs",
+        R"(
+          Print full build logs on standard error.
+        )"};
+
+    LoggerSettings();
 };
 
 extern LoggerSettings loggerSettings;

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -78,15 +78,6 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
         });
 
         addFlag({
-            .longName = "print-build-logs",
-            .shortName = 'L',
-            .description = "Print full build logs on standard error.",
-            .category = loggingCategory,
-            .handler = {[&]() { logger->setPrintBuildLogs(true); }},
-            .experimentalFeature = Xp::NixCommand,
-        });
-
-        addFlag({
             .longName = "version",
             .description = "Show version information.",
             .category = miscCategory,
@@ -401,6 +392,8 @@ void mainWrapped(int argc, char * * argv)
     } catch (UsageError &) {
         if (!args.helpRequested && !completions) throw;
     }
+
+    logger->setPrintBuildLogs(loggerSettings.printBuildLogs);
 
     if (args.helpRequested) {
         std::vector<std::string> subcommand;

--- a/tests/experimental-features.sh
+++ b/tests/experimental-features.sh
@@ -80,7 +80,7 @@ nix --experimental-features '' upgrade-nix --help 1>/dev/null
 # all care). To deal with fixing later, we simply make them require the
 # nix-command experimental features --- it so happens that the commands we wish
 # stabilizing to do not need them anyways.
-for arg in '--print-build-logs' '--offline' '--refresh'; do
+for arg in '--offline' '--refresh'; do
     nix --experimental-features 'nix-command' "$arg" --help 1>/dev/null
     expect 1 nix --experimental-features '' "$arg" --help 1>/dev/null
 done


### PR DESCRIPTION
# Motivation

This allows you to put `print-build-logs = true` in nix.conf. It also implicitly adds `--no-print-build-logs`.
    
# Context

Issue #5858.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
