### PR TITLE
Describe the `or` operation on attribute sets slightly more

### DIFF
--- a/doc/manual/src/language/operators.md
+++ b/doc/manual/src/language/operators.md
@@ -36,7 +36,7 @@
 ## Attribute selection
 
 Select the attribute denoted by attribute path *attrpath* from [attribute set] *attrset*.
-If the attribute doesn’t exist, return *value* if provided, otherwise abort evaluation.
+If the attribute doesn’t exist, return the *expr* after `or` if provided, otherwise abort evaluation.
 
 <!-- FIXME: the following should to into its own language syntax section, but that needs more work to fit in well -->
 

--- a/doc/manual/src/language/values.md
+++ b/doc/manual/src/language/values.md
@@ -190,13 +190,17 @@ instance,
 ```
 
 evaluates to `"Foo"`. It is possible to provide a default value in an
-attribute selection using the `or` keyword. For example,
+attribute selection using the `or` keyword:
 
 ```nix
 { a = "Foo"; b = "Bar"; }.c or "Xyzzy"
 ```
 
-will evaluate to `"Xyzzy"` because there is no `c` attribute in the set.
+```nix
+{ a = "Foo"; b = "Bar"; }.c.d.e.f.g or "Xyzzy"
+```
+
+will both evaluate to `"Xyzzy"` because there is no `c` attribute in the set.
 
 You can use arbitrary double-quoted strings as attribute names:
 


### PR DESCRIPTION
# Motivation

The `or` operator is slightly undersold in the current documentation.

It doesn't guide users to discover the very handy pattern of:

```nix
let
  a = { something = 1; };
in
  a.b.c.d or false
```

Resulting in code that can look like this:

```nix
let
  a = { something = 1; };
in
  if (a ? b) && (a.b ? c) && (a.b.c ? d) then
    d
  else
    false
```

This PR adds slightly more documentation to the manual to give users that breadcrumb they need to discover this feature.

# Context

N/A

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
