### PR TITLE
flake check: Ignore more attributes + doc

### DIFF
--- a/src/nix/flake-check.md
+++ b/src/nix/flake-check.md
@@ -70,4 +70,38 @@ Hydra's `hydra-eval-jobs` (i.e. as a arbitrarily deeply nested
 attribute set of derivations). Similarly, the
 `legacyPackages`.*system* output is evaluated like `nix-env -qa`.
 
+# Unchecked attributes
+
+Some attributes do not come with checks but are permitted by `nix flake check`;
+they do not cause a warning.
+
+- `lib`: a Nix-language library containing functions and perhaps also constants.
+  No convention has been established for `lib`, so its value is not checked.
+
+- `debug`: Anything that the flake author deems useful for troubleshooting the flake.
+
+- `internals`: Anything that the flake needs for its own purposes, such as attributes that support developer tooling.
+  Consumers of a flake should avoid this attribute, as its author should feel free to alter its contents to their needs.
+
+A number of well known module system applications' attributes is also ignored.
+Configuration values have gained a `_type` tag since NixOS 23.05 and may be checked in the future.
+Modules have such a flexible syntax that checking them is barely worthwhile. For now, `nix flake check` does not check them, so that these attributes' interpretation is up to the module system and its applications. Limited checks might be added later.
+
+- `darwinConfigurations`
+- `darwinModules`
+- `flakeModule`
+- `flakeModules`
+- `homeConfigurations`
+- `nixopsConfigurations`
+
+`nix flake check` also allows for general purpose module system attributes. Module system applications should pick a [*class*](https://nixos.org/manual/nixpkgs/unstable/index.html#module-system-lib-evalModules-param-class) to separate their own modules and configurations from other applications. The subattribute structure below may be subject to change.
+
+- `modules.`*class*`.`*moduleName*: Modules that are compatible with a specific module system application.
+- `modules.generic.`*moduleName*: Generic modules that are not tied to an application.
+- `configurations.`*class*`.`*name*: Concrete configurations. These tend to correspond to single real world objects, or sometimes classes of objects where the same configuration applies.
+
+Some third party attributes are also ignored.
+
+- `herculesCI`
+
 )""

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -658,12 +658,16 @@ struct CmdFlakeCheck : FlakeCommand
 
                         else if (
                             name == "lib"
+                            || name == "configurations"
                             || name == "darwinConfigurations"
                             || name == "darwinModules"
+                            || name == "debug"
                             || name == "flakeModule"
                             || name == "flakeModules"
                             || name == "herculesCI"
                             || name == "homeConfigurations"
+                            || name == "internals"
+                            || name == "modules"
                             || name == "nixopsConfigurations"
                             )
                             // Known but unchecked community attribute


### PR DESCRIPTION
# Motivation

 - Keep flake check warnings relevant
 - Make progress towards #6257 
 - What we *don't* check is relevant behavior that should be documented.

# Context

 - `modules` and `configuration`: #6257
 - previously installment: #7606

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
