### PR TITLE
docs: Clarify uninstall instructions

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -24,17 +24,10 @@ If you are on Linux with systemd:
    sudo systemctl daemon-reload
    ```
 
-1. The installer script uses systemd-tmpfiles to create the socket directory.
-    You may also want to remove the configuration for that:
-
-   ```console
-   sudo rm /etc/tmpfiles.d/nix-daemon.conf
-   ```
-
 Remove files created by Nix:
 
 ```console
-sudo rm -rf /etc/nix /etc/profile.d/nix.sh /nix ~root/.nix-channels ~root/.nix-defexpr ~root/.nix-profile
+sudo rm -rf /etc/nix /etc/profile.d/nix.sh /etc/tmpfiles.d/nix-daemon.conf /nix ~root/.nix-channels ~root/.nix-defexpr ~root/.nix-profile
 ```
 
 Remove build users and their group:

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -34,7 +34,7 @@ If you are on Linux with systemd:
 Remove files created by Nix:
 
 ```console
-sudo rm -rf /nix /etc/nix /etc/profile.d/nix.sh ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
+sudo rm -rf /etc/nix /etc/profile.d/nix.sh /nix ~/.nix-channels ~/.nix-defexpr ~/.nix-profile ~root/.nix-channels ~root/.nix-defexpr ~root/.nix-profile
 ```
 
 Remove build users and their group:
@@ -48,8 +48,8 @@ sudo groupdel nixbld
 
 There may also be references to Nix in
 
-- `/etc/profile`
 - `/etc/bashrc`
+- `/etc/profile`
 - `/etc/zshrc`
 
 which you may remove.

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -24,12 +24,6 @@ If you are on Linux with systemd:
    sudo systemctl daemon-reload
    ```
 
-1. Remove systemd service files:
-
-   ```console
-   sudo rm /etc/systemd/system/nix-daemon.service /etc/systemd/system/nix-daemon.socket
-   ```
-
 1. The installer script uses systemd-tmpfiles to create the socket directory.
     You may also want to remove the configuration for that:
 

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -34,7 +34,7 @@ If you are on Linux with systemd:
 Remove files created by Nix:
 
 ```console
-sudo rm -rf /etc/nix /etc/profile.d/nix.sh /nix ~/.nix-channels ~/.nix-defexpr ~/.nix-profile ~root/.nix-channels ~root/.nix-defexpr ~root/.nix-profile
+sudo rm -rf /etc/nix /etc/profile.d/nix.sh /nix ~root/.nix-channels ~root/.nix-defexpr ~root/.nix-profile
 ```
 
 Remove build users and their group:

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -48,8 +48,10 @@ sudo groupdel nixbld
 
 There may also be references to Nix in
 
+- `/etc/bash.bashrc`
 - `/etc/bashrc`
 - `/etc/profile`
+- `/etc/zsh/zshrc`
 - `/etc/zshrc`
 
 which you may remove.

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -34,7 +34,7 @@ If you are on Linux with systemd:
 Remove files created by Nix:
 
 ```console
-sudo rm -rf /nix /etc/nix /etc/profile/nix.sh ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
+sudo rm -rf /nix /etc/nix /etc/profile.d/nix.sh ~root/.nix-profile ~root/.nix-defexpr ~root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
 ```
 
 Remove build users and their group:


### PR DESCRIPTION
# Motivation

The uninstall instructions were not complete, based on an inspection of someone who had recently installed Nix and was trying to uninstall it. I've gone through the install process using `yes | sh <(curl -L https://nixos.org/nix/install) --daemon` in an Ubuntu 22.04 VM with `inotifywait --event=create --event=modify --event=moved_to --exclude='/(dev|nix|proc|run|sys|tmp|var)/.*' --monitor --no-dereference --quiet --recursive /` in another terminal to detect what else needs cleaning up.

# Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
