### PR TITLE
doc: fix garbage collector roots prefix text

### DIFF
--- a/doc/manual/src/package-management/garbage-collector-roots.md
+++ b/doc/manual/src/package-management/garbage-collector-roots.md
@@ -1,7 +1,7 @@
 # Garbage Collector Roots
 
 The roots of the garbage collector are all store paths to which there
-are symlinks in the directory `prefix/nix/var/nix/gcroots`. For
+are symlinks in the directory prefix `/nix/var/nix/gcroots`. For
 instance, the following command makes the path
 `/nix/store/d718ef...-foo` a root of the collector:
 


### PR DESCRIPTION
# Motivation

I think the word `prefix` doesn't belong to the path.
