### PR TITLE
list files used by `nix-channel` on its own man page

### DIFF
--- a/doc/manual/src/command-ref/nix-channel.md
+++ b/doc/manual/src/command-ref/nix-channel.md
@@ -52,6 +52,12 @@ The list of subscribed channels is stored in `~/.nix-channels`.
 
 {{#include ./env-common.md}}
 
+# Files
+
+`nix-channel` operates on the following files.
+
+{{#include ./files/channels.md}}
+
 # Examples
 
 To subscribe to the Nixpkgs channel and install the GNU Hello package:

--- a/doc/manual/src/command-ref/nix-env.md
+++ b/doc/manual/src/command-ref/nix-env.md
@@ -83,6 +83,8 @@ match. Here are some examples:
 
 # Files
 
+`nix-env` operates on the following files.
+
 {{#include ./files/default-nix-expression.md}}
 
 {{#include ./files/profiles.md}}


### PR DESCRIPTION
this is a small fixup to https://github.com/NixOS/nix/pull/8141/


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).