### PR TITLE
Fix some bounds in rapid check instances

### DIFF
--- a/src/libexpr/tests/value/context.cc
+++ b/src/libexpr/tests/value/context.cc
@@ -95,13 +95,15 @@ Gen<NixStringContextElem::Built> Arbitrary<NixStringContextElem::Built>::arbitra
 
 Gen<NixStringContextElem> Arbitrary<NixStringContextElem>::arbitrary()
 {
-    switch (*gen::inRange<uint8_t>(0, 2)) {
+    switch (*gen::inRange<uint8_t>(0, std::variant_size_v<NixStringContextElem::Raw>)) {
     case 0:
         return gen::just<NixStringContextElem>(*gen::arbitrary<NixStringContextElem::Opaque>());
     case 1:
         return gen::just<NixStringContextElem>(*gen::arbitrary<NixStringContextElem::DrvDeep>());
-    default:
+    case 2:
         return gen::just<NixStringContextElem>(*gen::arbitrary<NixStringContextElem::Built>());
+    default:
+        assert(false);
     }
 }
 

--- a/src/libstore/tests/derived-path.cc
+++ b/src/libstore/tests/derived-path.cc
@@ -27,11 +27,13 @@ Gen<DerivedPath::Built> Arbitrary<DerivedPath::Built>::arbitrary()
 
 Gen<DerivedPath> Arbitrary<DerivedPath>::arbitrary()
 {
-    switch (*gen::inRange<uint8_t>(0, 1)) {
+    switch (*gen::inRange<uint8_t>(0, std::variant_size_v<DerivedPath::Raw>)) {
     case 0:
         return gen::just<DerivedPath>(*gen::arbitrary<DerivedPath::Opaque>());
-    default:
+    case 1:
         return gen::just<DerivedPath>(*gen::arbitrary<DerivedPath::Built>());
+    default:
+        assert(false);
     }
 }
 

--- a/src/libstore/tests/outputs-spec.cc
+++ b/src/libstore/tests/outputs-spec.cc
@@ -206,15 +206,17 @@ using namespace nix;
 
 Gen<OutputsSpec> Arbitrary<OutputsSpec>::arbitrary()
 {
-    switch (*gen::inRange<uint8_t>(0, 1)) {
+    switch (*gen::inRange<uint8_t>(0, std::variant_size_v<OutputsSpec::Raw>)) {
     case 0:
         return gen::just((OutputsSpec) OutputsSpec::All { });
-    default:
+    case 1:
         return gen::just((OutputsSpec) OutputsSpec::Names {
             *gen::nonEmpty(gen::container<StringSet>(gen::map(
                 gen::arbitrary<StorePathName>(),
                 [](StorePathName n) { return n.name; }))),
         });
+    default:
+        assert(false);
     }
 }
 


### PR DESCRIPTION
# Motivation

`inRange` is exclusive not inclusive: https://github.com/emil-e/rapidcheck/blob/master/doc/generators.md#usage

Furthermore, use `std::variant_size_v` so we use the right number automatically.

Finally, make the `switch` assert the discriminant is in bounds as expected.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
