### PR TITLE
Dedup some markdown -> C++ big literal stuff in build system

### DIFF
--- a/mk/cxx-big-literal.mk
+++ b/mk/cxx-big-literal.mk
@@ -1,0 +1,5 @@
+%.gen.hh: %
+	@echo 'R"foo(' >> $@.tmp
+	$(trace-gen) cat $< >> $@.tmp
+	@echo ')foo"' >> $@.tmp
+	@mv $@.tmp $@

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -101,6 +101,7 @@ include mk/libraries.mk
 include mk/programs.mk
 include mk/patterns.mk
 include mk/templates.mk
+include mk/cxx-big-literal.mk
 include mk/tests.mk
 
 

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -57,12 +57,6 @@ $(d)/local-store.cc: $(d)/schema.sql.gen.hh $(d)/ca-specific-schema.sql.gen.hh
 
 $(d)/build.cc:
 
-%.gen.hh: %
-	@echo 'R"foo(' >> $@.tmp
-	$(trace-gen) cat $< >> $@.tmp
-	@echo ')foo"' >> $@.tmp
-	@mv $@.tmp $@
-
 clean-files += $(d)/schema.sql.gen.hh $(d)/ca-specific-schema.sql.gen.hh
 
 $(eval $(call install-file-in, $(d)/nix-store.pc, $(libdir)/pkgconfig, 0644))

--- a/src/nix/local.mk
+++ b/src/nix/local.mk
@@ -33,8 +33,8 @@ src/nix-channel/nix-channel.cc: src/nix-channel/unpack-channel.nix.gen.hh
 
 src/nix/main.cc: doc/manual/generate-manpage.nix.gen.hh doc/manual/utils.nix.gen.hh
 
-src/nix/profile.cc: src/nix/profile.md src/nix/doc/files/profiles.md
-
 src/nix/doc/files/%.md: doc/manual/src/command-ref/files/%.md
-	mkdir -p $$(dirname $@)
-	( printf 'R""(\n'; cat $^; printf '\n)""' ) > $@
+	@mkdir -p $$(dirname $@)
+	@cp $< $@
+
+src/nix/profile.cc: src/nix/profile.md src/nix/doc/files/profiles.md.gen.hh

--- a/src/nix/profile.md
+++ b/src/nix/profile.md
@@ -11,7 +11,7 @@ them to be rolled back easily.
 
 )""
 
-#include "doc/files/profiles.md"
+#include "doc/files/profiles.md.gen.hh"
 
 R""(
 


### PR DESCRIPTION
# Motivation

This pattern rule was unwisely hidden in `src/libstore/local.mk`. Now it is properly in `mk/` and we reuse it for the profile docs too.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
