### PR TITLE
Don't use `store-api.hh` in `worker-protocol.hh`

### DIFF
--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -1,5 +1,6 @@
 #include "path-info.hh"
 #include "worker-protocol.hh"
+#include "store-api.hh"
 
 namespace nix {
 

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -1,7 +1,6 @@
 #pragma once
 ///@file
 
-#include "store-api.hh"
 #include "serialise.hh"
 
 namespace nix {
@@ -78,6 +77,15 @@ typedef enum {
 
 class Store;
 struct Source;
+
+// items being serialized
+struct DerivedPath;
+struct DrvOutput;
+struct Realisation;
+struct BuildResult;
+struct KeyedBuildResult;
+enum TrustedFlag : bool;
+
 
 /**
  * Used to guide overloading


### PR DESCRIPTION
# Motivation

Using abstract types like can help cut down on compilation time, both from scratch, and especially incremental builds during development. The idea is that `worker-protocol.hh` can declare all the (de)serializers, but only again abstract types; when code needs to use some (de)serializers, it can include headers just for the data types it needs to (de)serialize.

`store-api.hh` in particular is a bit of a sledgehammer, and the data types we want to serialize have their own headers.

# Context

This is part of #6223, which we reviewed in a group this past Monday. It is (hopefully!) a less-controversial part of that PR.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
