### PR TITLE
doc/builtins: Auto link experimental features

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -788,9 +788,6 @@ static RegisterPrimOp r2({
       ```nix
       (builtins.getFlake "github:edolstra/dwarffs").rev
       ```
-
-      This function is only available if you enable the experimental feature
-      `flakes`.
     )",
     .fun = prim_getFlake,
     .experimentalFeature = Xp::Flakes,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4154,7 +4154,14 @@ void EvalState::createBaseEnv()
                     .arity = std::max(primOp.args.size(), primOp.arity),
                     .name = primOp.name,
                     .args = primOp.args,
-                    .doc = primOp.doc,
+                    .doc =
+                        primOp.experimentalFeature
+                        ? strdup(
+                            (std::string(primOp.doc) +
+                            "\n\n      This function is only available if you enable the [experimental](@docroot@/contributing/experimental-features.md) feature [`" + showExperimentalFeature(*primOp.experimentalFeature) +
+                            "`](@docroot@/contributing/experimental-features.md#xp-feature-" + showExperimentalFeature(*primOp.experimentalFeature) +
+                            ").\n").c_str())
+                        : primOp.doc,
                 });
             }
 

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -154,9 +154,6 @@ static RegisterPrimOp primop_fetchClosure({
       specifying a binary cache from which the path can be fetched.
       Also, requiring a content-addressed final store path avoids the
       need for users to configure binary cache public keys.
-
-      This function is only available if you enable the experimental
-      feature `fetch-closure`.
     )",
     .fun = prim_fetchClosure,
     .experimentalFeature = Xp::FetchClosure,


### PR DESCRIPTION
... with links.

It leaks a very small number of C strings, but that's acceptable as they wouldn't get released anyway. When EvalState is done, normally the whole process is done.

# Motivation

Add the appropriate links to the manual.
Make sure we don't forget to mention the experimental nature of new primops, when applicable.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
