### PR TITLE
Fix CI after #7312

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1777,7 +1777,8 @@ void LocalDerivationGoal::runChild()
                     if (pathExists(path))
                         ss.push_back(path);
 
-                dirsInChroot.emplace(settings.caFile, "/etc/ssl/certs/ca-certificates.crt");
+                if (settings.caFile != "")
+                    dirsInChroot.emplace("/etc/ssl/certs/ca-certificates.crt", settings.caFile);
             }
 
             for (auto & i : ss) dirsInChroot.emplace(i, i);


### PR DESCRIPTION
# Motivation

Failing build bad; succeeding build good!

# Context

PR #7312 passed CI, but only on itself --- GitHub Actions doesn't obey https://graydon2.dreamwidth.org/1597.html. Since then, more tests were added, and it appears that those excised this bug.

The first issue is that the argument order was backwards. Target comes first because targets, not sources, must be unique in the map.

The second issue is that if there is no CA file, then (assuming no manual overriding) `settings.caFile` will be an empty string. In that case, we shouldn't try to mount anything in the fixed output derivation sandbox. This occurred during CI because of double sandboxing: the ambient pure derivation the Nix testsuite was running in would of course not include this file, and then it wouldn't be available to mount in the inner fixed output derivation sandbox.

This is a simple fix to fix `master`, but the larger story here is assigning special meaning to empty strings is very error-prone. It is too easy to forget the `== ""` checks, etc. The answer is to use `std::optional` instead, which forces the programmer to do something via the type system.

I wrote #8374 as the first of perhaps multiple follow-up PRs to address this larger issue, so bugs like this are less likely to occur again.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
