### PR TITLE
Modifies experimental-features.cc w/Useful Error Message

### DIFF
--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -265,7 +265,7 @@ std::set<ExperimentalFeature> parseFeatures(const std::set<std::string> & rawFea
 }
 
 MissingExperimentalFeature::MissingExperimentalFeature(ExperimentalFeature feature)
-    : Error("experimental Nix feature '%1%' is disabled; use '--extra-experimental-features %1%' to override;"
+    : Error("experimental Nix feature '%1%' is disabled; use '--extra-experimental-features %1%' to override; "
             "alternatively, add 'experimental-features = %1%' to '$HOME/.config/nix/nix.conf'"
             , showExperimentalFeature(feature))
     , missingFeature(feature)

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -265,7 +265,9 @@ std::set<ExperimentalFeature> parseFeatures(const std::set<std::string> & rawFea
 }
 
 MissingExperimentalFeature::MissingExperimentalFeature(ExperimentalFeature feature)
-    : Error("experimental Nix feature '%1%' is disabled; use '--extra-experimental-features %1%' to override", showExperimentalFeature(feature))
+    : Error("experimental Nix feature '%1%' is disabled; use '--extra-experimental-features %1%' to override;"
+            "alternatively, add 'experimental-features = %1%' to '$HOME/.config/nix/nix.conf'"
+            , showExperimentalFeature(feature))
     , missingFeature(feature)
 {}
 


### PR DESCRIPTION
# Motivation
Reminds a user how to persist enablement of an experimental feature.

# Context

https://nixos.wiki/wiki/Nix_command

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
