### PR TITLE
Don't crash if we can't rename the paths out of the sandbox

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -359,7 +359,7 @@ bool LocalDerivationGoal::cleanupDecideWhetherDiskFull()
             if (buildMode != bmCheck && status.known->isValid()) continue;
             auto p = worker.store.printStorePath(status.known->path);
             if (pathExists(chrootRootDir + p))
-                renameFile((chrootRootDir + p), p);
+                moveFile((chrootRootDir + p), p);
         }
 
     return diskFull;


### PR DESCRIPTION
# Motivation

For some reason (probably linked to https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html?highlight=overlayfs#renaming-directories), renaming the output paths of a derivation from their sandbox location (`/nix/store/abc-foo.drv.chroot/nix/store/def-foo`) to their final one (`/nix/store/def-foo`) fails in some scenarios with `EXDEV` (“invalid cross-device link”).

Work around that by falling back to copying them in that case, which is much less efficient, but correct.

# Context

Fix https://github.com/NixOS/nix/issues/8395

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
