### PR TITLE
distributed-builds.md: Clarify warning ssh access requirements

### DIFF
--- a/doc/manual/src/advanced-topics/distributed-builds.md
+++ b/doc/manual/src/advanced-topics/distributed-builds.md
@@ -39,10 +39,11 @@ contains Nix.
 > **Warning**
 >
 > If you are building via the Nix daemon, it is the Nix daemon user
-> account (that is, `root`) that should have SSH access to the remote
+> account (that is, `root`) that should have SSH access to a user (not necessarily `root`) on the remote
 > machine. If you can’t or don’t want to configure `root` to be able to
-> access to remote machine, you can use a private Nix store instead by
-> passing e.g. `--store ~/my-nix`.
+> access the remote machine, you can use a private Nix store instead by
+> passing e.g. `--store ~/my-nix` when running a nix command from the
+> local machine.
 
 The list of remote machines can be specified on the command line or in
 the Nix configuration file. The former is convenient for testing. For

--- a/doc/manual/src/advanced-topics/distributed-builds.md
+++ b/doc/manual/src/advanced-topics/distributed-builds.md
@@ -38,12 +38,9 @@ contains Nix.
 
 > **Warning**
 >
-> If you are building via the Nix daemon, it is the Nix daemon user
-> account (that is, `root`) that should have SSH access to a user (not necessarily `root`) on the remote
-> machine. If you can’t or don’t want to configure `root` to be able to
-> access the remote machine, you can use a private Nix store instead by
-> passing e.g. `--store ~/my-nix` when running a nix command from the
-> local machine.
+> If you are building via the Nix daemon, it is the Nix daemon user account (that is, `root`) that should have SSH access to a user (not necessarily `root`) on the remote machine.
+>
+> If you can’t or don’t want to configure `root` to be able to access the remote machine, you can use a private Nix store instead by passing e.g. `--store ~/my-nix` when running a Nix command from the local machine.
 
 The list of remote machines can be specified on the command line or in
 the Nix configuration file. The former is convenient for testing. For


### PR DESCRIPTION
# Motivation

Makes a bit clearer a misunderstanding I've had when I read that warning.

# Context

Somewhat related: https://github.com/NixOS/nix/issues/7380 .

# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
