### PR TITLE
primops: add builtins.toTOML

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,2 +1,5 @@
 # Release X.Y (202?-??-??)
 
+* A new experiemental builtin function `builtins.toTOML` that serializes Nix values to TOML.
+
+  This function is only avaliable if the experimental feature `to-toml` is enabled.

--- a/src/libexpr/local.mk
+++ b/src/libexpr/local.mk
@@ -47,4 +47,5 @@ $(d)/primops.cc: $(d)/imported-drv-to-derivation.nix.gen.hh $(d)/primops/derivat
 
 $(d)/flake/flake.cc: $(d)/flake/call-flake.nix.gen.hh
 
-src/libexpr/primops/fromTOML.o:	ERROR_SWITCH_ENUM =
+$(d)/primops/fromTOML.o: ERROR_SWITCH_ENUM =
+$(d)/value-to-toml.o: ERROR_SWITCH_ENUM =

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -11,6 +11,7 @@
 #include "util.hh"
 #include "value-to-json.hh"
 #include "value-to-xml.hh"
+#include "value-to-toml.hh"
 #include "primops.hh"
 
 #include <boost/container/small_vector.hpp>

--- a/src/libexpr/primops/toTOML.cc
+++ b/src/libexpr/primops/toTOML.cc
@@ -1,0 +1,38 @@
+#include "primops.hh"
+#include "value-to-toml.hh"
+
+namespace nix {
+
+/* Convert the argument (an attribute set) to a TOML string.
+   Not all Nix values can be sensibly or completely represented
+   (e.g., functions). */
+static void prim_toTOML(EvalState & state, const PosIdx pos, Value * * args, Value & v)
+{
+    state.forceAttrs(*args[0], pos, "while evaluating the argument passed to builtins.toTOML");
+
+    std::ostringstream out;
+    NixStringContext context;
+    printValueAsTOML(state, true, *args[0], pos, out, context);
+    v.mkString(out.str(), context);
+}
+
+static RegisterPrimOp primop_toTOML({
+    .name = "__toTOML",
+    .args = {"e"},
+    .doc = R"(
+      Return a string containing a TOML representation of the attribute set *e*.
+      Strings, integers, floats, booleans, and lists are mapped to their
+      TOML equivalents. Null values are not supported in TOML and can not be
+      converted. Attribute sets (except derivations) are represented
+      as tables. Derivations are translated to a TOML string containing the
+      derivation’s output path. Paths are copied to the store and represented
+      as a TOML string of the resulting store path.
+
+      This function is only avaliable if the experimental feature `to-toml` is
+      enabled.
+    )",
+    .fun = prim_toTOML,
+    .experimentalFeature = Xp::ToTOML,
+});
+
+}

--- a/src/libexpr/value-to-toml.cc
+++ b/src/libexpr/value-to-toml.cc
@@ -1,0 +1,109 @@
+#include "value-to-toml.hh"
+#include "eval-inline.hh"
+#include "util.hh"
+#include "store-api.hh"
+
+#include "../toml11/toml.hpp"
+
+#include <cstdlib>
+#include <iomanip>
+
+
+namespace nix {
+
+using toml_value = toml::basic_value<toml::discard_comments, std::map, std::vector>;
+toml_value printValueAsTOML(EvalState & state, bool strict,
+    Value & v, const PosIdx pos, NixStringContext & context, bool copyToStore)
+{
+    checkInterrupt();
+
+    if (strict) state.forceValue(v, pos);
+
+    toml_value out;
+
+    switch (v.type()) {
+
+        case nInt:
+            out = v.integer;
+            break;
+
+        case nBool:
+            out = v.boolean;
+            break;
+
+        case nString:
+            copyContext(v, context);
+            out = v.string.s;
+            break;
+
+        case nPath:
+            if (copyToStore)
+                out = state.store->printStorePath(state.copyPathToStore(context, v.path()));
+            else
+                out = v.path().path.abs();
+            break;
+
+        case nAttrs: {
+            auto maybeString = state.tryAttrsToString(pos, v, context, false, false);
+            if (maybeString) {
+                out = *maybeString;
+                break;
+            }
+            auto i = v.attrs->find(state.sOutPath);
+            if (i == v.attrs->end()) {
+                out = toml_value::table_type();
+                StringSet names;
+                for (auto & j : *v.attrs)
+                    names.emplace(state.symbols[j.name]);
+                for (auto & j : names) {
+                    Attr & a(*v.attrs->find(state.symbols.create(j)));
+                    out[j] = printValueAsTOML(state, strict, *a.value, a.pos, context, copyToStore);
+                }
+            } else
+                return printValueAsTOML(state, strict, *i->value, i->pos, context, copyToStore);
+            break;
+        }
+
+        case nList: {
+            out = toml_value::array_type();
+            for (auto elem : v.listItems())
+                out.push_back(printValueAsTOML(state, strict, *elem, pos, context, copyToStore));
+            break;
+        }
+
+        case nExternal:
+            return v.external->printValueAsTOML(state, strict, context, copyToStore);
+            break;
+
+        case nFloat:
+            out = v.fpoint;
+            break;
+
+        case nNull:
+        case nThunk:
+        case nFunction:
+            auto e = TypeError({
+                .msg = hintfmt("cannot convert %1% to a TOML value", showType(v)),
+                .errPos = state.positions[v.determinePos(pos)]
+            });
+            e.addTrace(state.positions[pos], hintfmt("message for the trace"));
+            state.debugThrowLastTrace(e);
+            throw e;
+    }
+    return out;
+}
+
+void printValueAsTOML(EvalState & state, bool strict,
+    Value & v, const PosIdx pos, std::ostream & str, NixStringContext & context, bool copyToStore)
+{
+    str << printValueAsTOML(state, strict, v, pos, context, copyToStore);
+}
+
+toml_value ExternalValueBase::printValueAsTOML(EvalState & state, bool strict,
+    NixStringContext & context, bool copyToStore) const
+{
+    state.debugThrowLastTrace(TypeError("cannot convert %1% to a TOML value", showType()));
+}
+
+
+}

--- a/src/libexpr/value-to-toml.hh
+++ b/src/libexpr/value-to-toml.hh
@@ -1,0 +1,20 @@
+#pragma once
+///@file
+
+#include "nixexpr.hh"
+#include "eval.hh"
+
+#include "../toml11/toml/types.hpp"
+
+#include <string>
+#include <map>
+
+namespace nix {
+
+toml::basic_value<toml::discard_comments, std::map, std::vector> printValueAsTOML(EvalState & state, bool strict,
+    Value & v, const PosIdx pos, NixStringContext & context, bool copyToStore = true);
+
+void printValueAsTOML(EvalState & state, bool strict,
+    Value & v, const PosIdx pos, std::ostream & str, NixStringContext & context, bool copyToStore = true);
+
+}

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -11,6 +11,7 @@
 #include <gc/gc_allocator.h>
 #endif
 #include <nlohmann/json_fwd.hpp>
+#include "../toml11/toml/types.hpp"
 
 namespace nix {
 
@@ -113,6 +114,12 @@ class ExternalValueBase
      * Print the value as JSON. Defaults to unconvertable, i.e. throws an error
      */
     virtual nlohmann::json printValueAsJSON(EvalState & state, bool strict,
+        NixStringContext & context, bool copyToStore = true) const;
+
+    /**
+     * Print the value as TOML. Defaults to unconvertable, i.e. throws an error
+     */
+    virtual toml::basic_value<toml::discard_comments, std::map, std::vector> printValueAsTOML(EvalState & state, bool strict,
         NixStringContext & context, bool copyToStore = true) const;
 
     /**

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -12,7 +12,7 @@ struct ExperimentalFeatureDetails
     std::string_view description;
 };
 
-constexpr std::array<ExperimentalFeatureDetails, 13> xpFeatureDetails = {{
+constexpr std::array<ExperimentalFeatureDetails, 14> xpFeatureDetails = {{
     {
         .tag = Xp::CaDerivations,
         .name = "ca-derivations",
@@ -214,6 +214,13 @@ constexpr std::array<ExperimentalFeatureDetails, 13> xpFeatureDetails = {{
                 derivations that are themselves derivations outputs.
         )",
     },
+    {
+        .tag = Xp::ToTOML,
+        .name = "to-toml",
+        .description = R"(
+            Enable the use of the [`toTOML`](@docroot@/language/builtins.md#builtins-toTOML) built-in function in the Nix language.
+        )",
+    },
 }};
 
 static_assert(
@@ -248,7 +255,7 @@ std::string_view showExperimentalFeature(const ExperimentalFeature tag)
     return xpFeatureDetails[(size_t)tag].name;
 }
 
-nlohmann::json documentExperimentalFeatures() 
+nlohmann::json documentExperimentalFeatures()
 {
     StringMap res;
     for (auto & xpFeature : xpFeatureDetails)

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -30,6 +30,7 @@ enum struct ExperimentalFeature
     DiscardReferences,
     DaemonTrustOverride,
     DynamicDerivations,
+    ToTOML,
 };
 
 /**

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -356,6 +356,7 @@ void mainWrapped(int argc, char * * argv)
         experimentalFeatureSettings.experimentalFeatures = {
             Xp::Flakes,
             Xp::FetchClosure,
+            Xp::ToTOML,
         };
         evalSettings.pureEval = false;
         EvalState state({}, openStore("dummy://"));

--- a/tests/lang/eval-okay-totoml.exp
+++ b/tests/lang/eval-okay-totoml.exp
@@ -1,0 +1,1 @@
+"a = 123\nb = -456\nc = \"foo\"\nd = \"\"\"\nfoo\n\"bar\"\\\n\"\"\"\ne = true\nf = false\ng = [\n1,\n2,\n3,\n]\nh = [\n\"a\",\n[\n\"b\",\n{\"foo\\nbar\"={}},\n],\n]\ni = 3\nj = 1.44\nk = nan\nl = nan\nm = inf\nn = -inf\no = \"foo\"\np = [\n{},\n\"foobar\",\n{x=1,y=0.0,z=\"\"},\n]\n"

--- a/tests/lang/eval-okay-totoml.flags
+++ b/tests/lang/eval-okay-totoml.flags
@@ -1,0 +1,1 @@
+--extra-experimental-features to-toml

--- a/tests/lang/eval-okay-totoml.nix
+++ b/tests/lang/eval-okay-totoml.nix
@@ -1,0 +1,27 @@
+# Hack to get nan, inf/-inf values
+let
+  values = builtins.fromTOML "nan = nan\ninf = inf";
+  inherit (values) nan inf;
+in
+builtins.toTOML
+  { a = 123;
+    b = -456;
+    c = "foo";
+    d = "foo\n\"bar\"";
+    e = true;
+    f = false;
+    g = [ 1 2 3 ];
+    h = [ "a" [ "b" { "foo\nbar" = {}; } ] ];
+    i = 1 + 2;
+    j = 1.44;
+    k = nan;
+    l = -nan;
+    m = inf;
+    n = -inf;
+    o = { __toString = self: self.a; a = "foo"; };
+    p = [
+      {}
+      { outPath = "foobar"; a = { b = builtins.abort "unreachable"; }; }
+      { x = 1; y = 0.0; z = ""; }
+    ];
+  }


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This commit introduces the a new experimental builtin function: `builtins.toTOML`.
The builtin is guarded by an experimental feature `to-toml` to allow
more time for testing that round-trips with `builtins.fromTOML` works
properly.

The functions printValueAsTOML were introduced to serialize Nix
values to TOML with a slight difference in behavior from printValueAsJSON
being null values are not supported.

In order to match the global table structure TOML imposes, the argument of
`builtins.toTOML` was restricted to an attribute set but sublevels values
have no restriction.

A language test was added and the release notes were updated to document the addition.

# Context
<!-- Provide context. Reference open issues if available. -->
 - Closes: https://github.com/NixOS/nix/issues/3929
 - Related: https://github.com/NixOS/nix/pull/8120

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [x] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
