### PR TITLE
remove maintainers checklist in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,24 +10,6 @@
 
 <!-- Large change: Provide instructions to reviewers how to read the diff. -->
 
-# Checklist for maintainers
-
-<!-- Contributors: please leave this as is -->
-
-Maintainers: tick if completed or explain if not relevant
-
- - [ ] agreed on idea
- - [ ] agreed on implementation strategy
- - [ ] tests, as appropriate
-   - functional tests - `tests/**.sh`
-   - unit tests - `src/*/tests`
-   - integration tests - `tests/nixos/*`
- - [ ] documentation in the manual
- - [ ] documentation in the internal API docs
- - [ ] code and comments are self-explanatory
- - [ ] commit message explains why the change was made
- - [ ] new feature or incompatible change: updated release notes
-
 # Priorities
 
 Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
 
 2. Search for related issues that cover what you're going to work on. It could help to mention there that you will work on the issue.
 
-   Issues labeled ["good first issue"](https://github.com/NixOS/nix/labels/good-first-issue) should be relatively easy to fix and are likely to get merged quickly.
-   Pull requests addressing issues labeled ["idea approved"](https://github.com/NixOS/nix/labels/idea%20approved) are especially welcomed by maintainers and will receive prioritised review.
+   Issues labeled [good first issue](https://github.com/NixOS/nix/labels/good-first-issue) should be relatively easy to fix and are likely to get merged quickly.
+   Pull requests addressing issues labeled [idea approved](https://github.com/NixOS/nix/labels/idea%20approved) are especially welcomed by maintainers and will receive prioritised review.
 
 3. Check the [Nix reference manual](https://nixos.org/manual/nix/unstable/contributing/hacking.html) for information on building Nix and running its tests.
 
@@ -40,10 +40,10 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
 4. Make your changes!
 
 5. [Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) for your changes.
-   * [Mark the pull request as draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) if you're not done with the changes.
-   * Make sure to have [a clean history of commits on your branch by using rebase](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request).
    * Link related issues in your pull request to inform interested parties and future contributors about your change.
+   * Make sure to have [a clean history of commits on your branch by using rebase](https://www.digitalocean.com/community/tutorials/how-to-rebase-and-update-a-pull-request).
      If your pull request closes one or multiple issues, note that in the description using `Closes: #<number>`, as it will then happen automatically when your change is merged.
+   * [Mark the pull request as draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) if you're not done with the changes.
 
 6. Do not expect your pull request to be reviewed immediately.
    Nix maintainers follow a [structured process for reviews and design decisions](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol), which may or may not prioritise your work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,19 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
 6. Do not expect your pull request to be reviewed immediately.
    Nix maintainers follow a [structured process for reviews and design decisions](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol), which may or may not prioritise your work.
 
+   Following this checklist will make the process smoother for everyone:
+
+   - [ ] Fixes an [idea approved](https://github.com/NixOS/nix/labels/idea%20approved) issue
+   - [ ] Tests, as appropriate:
+     - Functional tests – [`tests/**.sh`](./tests)
+     - Unit tests – [`src/*/tests`](./src/)
+     - Integration tests – [`tests/nixos/*`](./tests/nixos)
+   - [ ] User documentation in the [manual](..doc/manual/src)
+   - [ ] API documentation in header files
+   - [ ] Code and comments are self-explanatory
+   - [ ] Commit message explains **why** the change was made
+   - [ ] New feature or incompatible change: updated [release notes](./doc/manual/src/release-notes/rl-next.md)
+
 7. If you need additional feedback or help to getting pull request into shape, ask other contributors using [@mentions](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#mentioning-people-and-teams).
 
 ## Making changes to the Nix manual


### PR DESCRIPTION
# Motivation
maintainers are not really using it, and it produces a lot of noise when opening PRs.

# Context

it seems good enough for maintainers to follow internalised best practices.
it doesn't always work out and we skip details, but a checklist won't help if it's ignored.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).