### PR TITLE
libexpr: add more precise position information to evaluation error messages

### DIFF
--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -113,6 +113,21 @@ inline void EvalState::evalAttrs(Env & env, Expr * e, Value & v, const PosIdx po
 }
 
 
+template<typename... Args>
+[[gnu::always_inline]]
+inline void EvalState::evalList(Env & env, Expr * e, Value & v, const PosIdx pos, std::string_view errorCtx, const Args & ... args)
+{
+    try {
+        e->eval(*this, env, v);
+        if (v.type() != nList)
+            error("value is %1% while a list was expected", showType(v)).withFrame(env, *e).debugThrow<TypeError>();
+    } catch (Error & e) {
+        e.addTrace(positions[pos], errorCtx, args...);
+        throw;
+    }
+}
+
+
 [[gnu::always_inline]]
 inline void EvalState::forceValue(Value & v, const PosIdx pos)
 {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -394,6 +394,8 @@ public:
     inline bool evalBool(Env & env, Expr * e, const PosIdx pos, std::string_view errorCtx, const Args & ... args);
     template<typename... Args>
     inline void evalAttrs(Env & env, Expr * e, Value & v, const PosIdx pos, std::string_view errorCtx, const Args & ... args);
+    template<typename... Args>
+    inline void evalList(Env & env, Expr * e, Value & v, const PosIdx pos, std::string_view errorCtx, const Args & ... args);
 
     /**
      * If `v` is a thunk, enter it and overwrite `v` with the result
@@ -643,7 +645,7 @@ public:
         const std::string outputName,
         std::optional<StorePath> optOutputPath);
 
-    void concatLists(Value & v, size_t nrLists, Value * * lists, const PosIdx pos, std::string_view errorCtx);
+    void concatLists(Value & v, size_t nrLists, Value * * lists, const PosIdx pos);
 
     /**
      * Print statistics.

--- a/src/libexpr/tests/error_traces.cc
+++ b/src/libexpr/tests/error_traces.cc
@@ -102,6 +102,7 @@ namespace nix {
             , type                                                          \
         )
 
+
     TEST_F(ErrorTraceTest, genericClosure) {
         ASSERT_TRACE2("genericClosure 1",
                       TypeError,
@@ -169,12 +170,12 @@ namespace nix {
         ASSERT_TRACE2("replaceStrings [ 1 ] [ \"new\" ] {}",
                       TypeError,
                       hintfmt("value is %s while a string was expected", "an integer"),
-                      hintfmt("while evaluating one of the strings to replace passed to builtins.replaceStrings"));
+                      hintfmt("while evaluating the element at index %d of the strings to replace passed to builtins.replaceStrings", 0));
 
-        ASSERT_TRACE2("replaceStrings [ \"oo\" ] [ true ] \"foo\"",
+        ASSERT_TRACE2("replaceStrings [ \"a\" \"oo\" ] [ \"b\" true ] \"foo\"",
                       TypeError,
                       hintfmt("value is %s while a string was expected", "a Boolean"),
-                      hintfmt("while evaluating one of the replacement strings passed to builtins.replaceStrings"));
+                      hintfmt("while evaluating the element at index %d of the replacement strings passed to builtins.replaceStrings", 1));
 
         ASSERT_TRACE2("replaceStrings [ \"old\" ] [ \"new\" ] {}",
                       TypeError,
@@ -484,6 +485,10 @@ namespace nix {
                       hintfmt("value is %s while a set was expected", "a string"),
                       hintfmt("while evaluating the first argument passed to builtins.removeAttrs"));
 
+        ASSERT_TRACE2("removeAttrs { foo = 1; } [ \"bar\" \"baz\" 1 ]",
+                      TypeError,
+                      hintfmt("value is %s while a string was expected", "an integer"),
+                      hintfmt("while evaluating the element at index %d of the list of attribute names to remove passed as the second argument to builtins.removeAttrs", 2));
     }
 
 
@@ -496,7 +501,7 @@ namespace nix {
         ASSERT_TRACE2("listToAttrs [ 1 ]",
                       TypeError,
                       hintfmt("value is %s while a set was expected", "an integer"),
-                      hintfmt("while evaluating an element of the list passed to builtins.listToAttrs"));
+                      hintfmt("while evaluating the element at index %d of the list passed to builtins.listToAttrs", 0));
 
         ASSERT_TRACE2("listToAttrs [ {} ]",
                       TypeError,
@@ -544,12 +549,12 @@ namespace nix {
         ASSERT_TRACE2("catAttrs \"foo\" [ 1 ]",
                       TypeError,
                       hintfmt("value is %s while a set was expected", "an integer"),
-                      hintfmt("while evaluating an element in the list passed as second argument to builtins.catAttrs"));
+                      hintfmt("while evaluating the element at index %d of the list of attribute sets passed as the second argument to builtins.catAttrs", 0));
 
-        ASSERT_TRACE2("catAttrs \"foo\" [ { foo = 1; } 1 { bar = 5;} ]",
+        ASSERT_TRACE2("catAttrs \"foo\" [ { foo = 1; } { baz = 4; } 1 { bar = 5;} ]",
                       TypeError,
                       hintfmt("value is %s while a set was expected", "an integer"),
-                      hintfmt("while evaluating an element in the list passed as second argument to builtins.catAttrs"));
+                      hintfmt("while evaluating the element at index %d of the list of attribute sets passed as the second argument to builtins.catAttrs", 2));
 
     }
 
@@ -596,7 +601,13 @@ namespace nix {
         ASSERT_TRACE2("zipAttrsWith (_: 1) [ 1 ]",
                       TypeError,
                       hintfmt("value is %s while a set was expected", "an integer"),
-                      hintfmt("while evaluating a value of the list passed as second argument to builtins.zipAttrsWith"));
+                      hintfmt("while evaluating the element at index %d of the list of attribute sets passed as the second argument to builtins.zipAttrsWith", 0));
+
+        ASSERT_TRACE2("zipAttrsWith (_: builtins.abort \"unreachable\") [ { a = \"foo\"; } 1 ]",
+                      TypeError,
+                      hintfmt("value is %s while a set was expected", "an integer"),
+                      hintfmt("while evaluating the element at index %d of the list of attribute sets passed as the second argument to builtins.zipAttrsWith", 1));
+
 
         // XXX: How to properly tell that the fucntion takes two arguments ?
         // The same question also applies to sort, and maybe others.
@@ -713,12 +724,12 @@ namespace nix {
         ASSERT_TRACE2("concatLists [ 1 ]",
                       TypeError,
                       hintfmt("value is %s while a list was expected", "an integer"),
-                      hintfmt("while evaluating a value of the list passed to builtins.concatLists"));
+                      hintfmt("while evaluating the element at index %d of the list to concatenate", 0));
 
         ASSERT_TRACE2("concatLists [ [1] \"foo\" ]",
                       TypeError,
                       hintfmt("value is %s while a list was expected", "a string"),
-                      hintfmt("while evaluating a value of the list passed to builtins.concatLists"));
+                      hintfmt("while evaluating the element at index %d of the list to concatenate", 1));
 
     }
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

The current evaluation error trace messages are somewhat generic. When evaluating elements of a list or attribute set, we pass a static error context indicating one of the elements is being evaluated. For example, in the `prim_catAttrs` https://github.com/NixOS/nix/blob/27f82ef4a8fc589738ef06040dad5c0e214f97aa/src/libexpr/primops.cc#L2619-L2620 and in `EvalState::concatLists` https://github.com/NixOS/nix/blob/27f82ef4a8fc589738ef06040dad5c0e214f97aa/src/libexpr/eval.cc#L1894-L1910

Since we know the position of the value we are trying to evaluate from the caller side, we can add this information to the error context to give more helpful traces. A naive approach to add this information would be to construct a formatted hint from the caller side and passing it to the `foceValue` functions. However, this means the formatted hint is built on each call even if no error occurs which has a negative performance impact. This PR attempts to workaround this problem by altering the signature of the `forceValue` functions and forwarding the format arguments to their respective callee so that the formatted hint is only constructed when an evaluation error occurs.

# Context
<!-- Provide context. Reference open issues if available. -->

Initiated from the discussion at https://github.com/NixOS/nix/pull/8398#discussion_r1206513778

Benchmarks:
I performed the benchmarks using hyperfine with the current master branch being compared to this PR.

before
```
Benchmark 1: nix eval --extra-experimental-features nix-command -f ../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  Time (mean ± σ):     402.8 ms ±   2.5 ms    [User: 366.8 ms, System: 36.1 ms]
  Range (min … max):   399.6 ms … 407.6 ms    20 runs

Benchmark 2: nix search --extra-experimental-features "nix-command flakes" --no-eval-cache --offline ../nixpkgs hello
  Time (mean ± σ):     17.247 s ±  0.183 s    [User: 15.192 s, System: 2.128 s]
  Range (min … max):   16.958 s … 17.538 s    20 runs
```

after
```
Benchmark 1: nix eval --extra-experimental-features nix-command -f ../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  Time (mean ± σ):     401.2 ms ±   3.2 ms    [User: 363.0 ms, System: 38.2 ms]
  Range (min … max):   397.2 ms … 409.5 ms    20 runs

Benchmark 2: nix search --extra-experimental-features "nix-command flakes" --no-eval-cache --offline ../nixpkgs hello
  Time (mean ± σ):     17.322 s ±  0.374 s    [User: 15.235 s, System: 2.164 s]
  Range (min … max):   16.728 s … 18.134 s    20 runs
```

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
