### PR TITLE
docs: mention UID issues with login managers

### DIFF
--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -70,6 +70,14 @@ will invoke `sudo` as needed.
 
 > **Note**
 >
+> If you are using a graphical login manager (e.g, GDM or SDDM), it's
+> recommended to adjust the accepted UID range to avoid displaying
+> these system users on the login screen. For example, in SDDM, you can
+> lower the [MaximumUID](https://man.archlinux.org/man/sddm.conf.5.en#MaximumUid=)
+> to 30000.
+
+> **Note**
+>
 > If you need Nix to use a different group ID or user ID set, you will
 > have to download the tarball manually and [edit the install
 > script](#installing-from-a-binary-tarball).

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -700,6 +700,8 @@ EOF
 }
 
 welcome_to_nix() {
+    local -r NIX_UID_RANGES="(${NIX_FIRST_BUILD_UID} ~ $((NIX_FIRST_BUILD_UID + NIX_USER_COUNT - 1)))"
+
     ok "Welcome to the Multi-User Nix Installation"
 
     cat <<EOF
@@ -714,7 +716,10 @@ manager. This will happen in a few stages:
    if you are ready to continue.
 
 3. Create the system users and groups that the Nix daemon uses to run
-   builds.
+   builds. Their UIDs will be $(_textout ${BLUE} ${NIX_UID_RANGES}.)
+   If you're using a graphical environment, it's recommended to
+   adjust the UID ranges in your login manager (e.g., GDM or SDDM)'s
+   configuration to avoid displaying these system users on the login screen.
 
 4. Perform the basic installation of the Nix files daemon.
 


### PR DESCRIPTION
# Motivation

[![asciicast](https://asciinema.org/a/589469.svg)](https://asciinema.org/a/589469)

`nixbld` user UID for multi-user installation are relatively low (30000), which often tricks display managers like GDM or SDDM, into including `nixbld` as actual users and display 32 new users on their login screen.

Until the fix from https://github.com/NixOS/nix/issues/7068#issuecomment-1337713871 is released, adding a warning to beginners would be a good idea.

# Context

- fix #7068
- fix https://github.com/NixOS/nixpkgs/issues/235546

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
