### PR TITLE
Fix code block formatting in man page

### DIFF
--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -102,6 +102,7 @@ way:
   available in the flake. If this is undesirable, specify `path:<directory>` explicitly;
 
   For example, if `/foo/bar` is a git repository with the following structure:
+
   ```
   .
   └── baz


### PR DESCRIPTION
# Motivation

closes #6711

# Context

This is the fix mentioned in the issue, but I didn't get the result @yoriksar got. The indentation still looks a bit off, but at least the following bullet point has the correct indentation, maybe the bug was fixed at some point.

```
       • If the path is within a Git repository, then the url will be of the form git+file://[GIT_REPO_ROOT]?dir=[RELATIVE_FLAKE_DIR_PATH] where GIT_REPO_ROOT is the path
         to the root of the git repository, and RELATIVE_FLAKE_DIR_PATH is the path (relative to the directory root) of the closest parent of the given path that contains
         a flake.nix within the git repository.  If no such directory exists, then Nix will error-out.

         Note  that  the  search  will  only  include files indexed by git. In particular, files which are matched by .gitignore or have never been git add-ed will not be
         available in the flake. If this is undesirable, specify path:<directory> explicitly;

         For example, if /foo/bar is a git repository with the following structure:

       .
       └── baz
         ├── blah
         │   └── file.txt
         └── flake.nix

              Then /foo/bar/baz/blah will resolve to git+file:///foo/bar?dir=baz

       • If the supplied path is not a git repository, then the url will have the form path:FLAKE_DIR_PATH where FLAKE_DIR_PATH is the closest parent of the supplied path
         that contains a flake.nix file (within the same file-system).  If no such directory exists, then Nix will error-out.

         For example, if /foo/bar/flake.nix exists, then /foo/bar/baz/ will resolve to path:/foo/bar
```

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
