### PR TITLE
Allow Linux hosts to disable sandbox tests

### DIFF
--- a/tests/build-remote-trustless-should-fail-0.sh
+++ b/tests/build-remote-trustless-should-fail-0.sh
@@ -2,6 +2,7 @@ source common.sh
 
 enableFeatures "daemon-trust-override"
 
+requireSandboxSupport
 restartDaemon
 
 [[ $busybox =~ busybox ]] || skipTest "no busybox"

--- a/tests/common/vars-and-functions.sh.in
+++ b/tests/common/vars-and-functions.sh.in
@@ -141,7 +141,7 @@ restartDaemon() {
     startDaemon
 }
 
-if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user true; then
+if [[ -z "${_NIX_TEST_NO_SANDBOX:-}" ]] && [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user true; then
     _canUseSandbox=1
 fi
 


### PR DESCRIPTION
# Motivation
Sandbox-based tests may fail when building Nix within a containerized environment. This change allows a user to disable those tests.

# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
