### PR TITLE
doc/hacking: note a cause of ./configure failing under zsh

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -46,6 +46,12 @@ To build Nix itself in this shell:
 [nix-shell]$ make -j $NIX_BUILD_CORES
 ```
 
+> **Note**
+>
+> If using zsh and `./configure` is failing, use `${=configureFlags}` in place
+> of `$configureFlags` so the configure flags are expanded to multiple words as
+> they are in `sh` compatible shells.
+
 To install it in `$(pwd)/outputs` and test it:
 
 ```console


### PR DESCRIPTION
In the default configuration of zsh, unquoted parameters do not have field expansion performed, so `./configure $configureFlags` will give ./configure only one argument in argv. The solution to this is to set the shell option `SH_WORD_SPLIT` or, easier, specify it as `${=configureFlags}` to force this behaviour for one expansion.

Omission of this can cause configure to fail at finding rapidcheck.

The practical reason why someone might be using this guide with zsh is for example direnv or executing zsh with `nix develop`.
