### PR TITLE
add *.md files to makefile install

### DIFF
--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -66,3 +66,6 @@ $(foreach i, $(wildcard src/libstore/builtins/*.hh), \
 
 $(foreach i, $(wildcard src/libstore/build/*.hh), \
   $(eval $(call install-file-in, $(i), $(includedir)/nix/build, 0644)))
+
+$(foreach i, $(wildcard src/libstore/*.md), \
+  $(eval $(call install-file-in, $(i), $(includedir)/nix, 0644)))


### PR DESCRIPTION
# Motivation

After the merge of #8084 the files in `libstore` now include the documentation `*.md` files. These files do not get copied by `make`, which in turn causes errors when linking those header files. (See e.g. https://github.com/zhaofengli/attic/issues/56)

This came apparent after the update of nix stable on `nixpkgs` in https://github.com/NixOS/nixpkgs/pull/233439 which causes a regression for me.

# Context

This trivial change now includes the `*.md` files which fixes the issue. (Tested on current [nixpkgs master](https://github.com/NixOS/nixpkgs/commit/ff3f331e401a080c8a1cc701b224587eafa4f562)). In my case (tested with `attic`, see issue linked above), I run into a different issue later on, but I guess it is unrelated. The follow up issue is
```
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: expected expression
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'me'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'fields1'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'fields2'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: expected expression
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'me'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'fields1'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'fields2'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: expected expression
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'me'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'fields1'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/suggestions.hh:23:5: error: use of undeclared identifier 'fields2'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/content-address.hh:35:5: error: expected expression
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/content-address.hh:35:5: error: use of undeclared identifier 'me'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/content-address.hh:35:5: error: use of undeclared identifier 'fields1'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/content-address.hh:35:5: error: use of undeclared identifier 'fields2'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/content-address.hh:35:5: error: expected expression
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/content-address.hh:35:5: error: use of undeclared identifier 'me'
attic>   /nix/store/n4zhp46qjwmcd0az6pwqs5y6hg7x9ml1-nix-2.18.1-dev/include/nix/content-address.hh:35:5: error: use of undeclared identifier 'fields1
```
(EDIT:
Please ignore the version identifier of `nix`. I overwrote it to test my fork which included the fix)

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
