### PR TITLE
nix: add `nix flake root`

### DIFF
--- a/src/nix/flake-root.md
+++ b/src/nix/flake-root.md
@@ -1,0 +1,34 @@
+R""(
+
+# Limitations
+- This subcommand doesn't support codebases that keep the flake.nix in a subdirectory.
+
+# Examples
+
+* Get the root folder of a codebase with the shell in folder /path/to/folder and flake.nix in /path/to:
+
+```console
+/path/to/folder$ nix flake root
+/path/to
+
+/path/to/folder$ nix flake root -r
+path:/tmp/eoq
+```
+
+* Get the root folder of a codebase with the shell in folder /path/to/folder, a flake.nix in /path/to and a git repo initialized
+
+```console
+/path/to/folder$ nix flake root
+/path/to
+
+/path/to/folder$ nix flake root -r
+git+file:///path/to
+```
+
+# Description
+
+This command uses the logic used to find flake.nix for commands
+such as `nix build` and shows the absolute path, or optionally,
+the flake reference.
+
+)""

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1343,6 +1343,46 @@ struct CmdFlakePrefetch : FlakeCommand, MixJSON
     }
 };
 
+struct CmdFlakeRoot : FlakeCommand
+{
+    bool asRef = true;
+    CmdFlakeRoot()
+    {
+        addFlag({
+            .longName = "as-ref",
+            .shortName = 'r',
+            .description = "Show the root as a flakeref in URL-like representation.",
+            .handler = {&asRef, false}
+        });
+    }
+
+    std::string description() override
+    {
+        return "get the root directory of a flake";
+    }
+
+    std::string doc() override
+    {
+        return
+          #include "flake-root.md"
+          ;
+    }
+
+    void run(nix::ref<nix::Store> store) override
+    {
+        std::string rootRef = getFlakeRef().to_string();
+        if (asRef) {
+            int slashIndex = rootRef.find('/');
+            while (rootRef[slashIndex + 1] == '/') {
+                slashIndex++;
+            }
+            rootRef = rootRef.substr(slashIndex);
+        }
+        std::cout << rootRef << std::endl;
+    }
+};
+
+
 struct CmdFlake : NixMultiCommand
 {
     CmdFlake()
@@ -1358,6 +1398,7 @@ struct CmdFlake : NixMultiCommand
                 {"archive", []() { return make_ref<CmdFlakeArchive>(); }},
                 {"show", []() { return make_ref<CmdFlakeShow>(); }},
                 {"prefetch", []() { return make_ref<CmdFlakePrefetch>(); }},
+                {"root", []() { return make_ref<CmdFlakeRoot>(); }},
             })
     {
     }


### PR DESCRIPTION
# Motivation
Nix already has a logic to go up levels and find the flake.nix. This subcommand just exposes what it finds.

# Context

<!-- Provide context. Reference open issues if available. -->
Implementation guide for #8034
Consumes logic introduced in #5720

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
