### PR TITLE
Update filesystem.cc

### DIFF
--- a/src/libutil/filesystem.cc
+++ b/src/libutil/filesystem.cc
@@ -63,20 +63,10 @@ std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix)
     return {std::move(fd), tmpl};
 }
 
-void createSymlink(const Path & target, const Path & link,
-    std::optional<time_t> mtime)
+void createSymlink(const Path & target, const Path & link)
 {
     if (symlink(target.c_str(), link.c_str()))
         throw SysError("creating symlink from '%1%' to '%2%'", link, target);
-    if (mtime) {
-        struct timeval times[2];
-        times[0].tv_sec = *mtime;
-        times[0].tv_usec = 0;
-        times[1].tv_sec = *mtime;
-        times[1].tv_usec = 0;
-        if (lutimes(link.c_str(), times))
-            throw SysError("setting time of symlink '%s'", link);
-    }
 }
 
 void replaceSymlink(const Path & target, const Path & link,
@@ -86,7 +76,7 @@ void replaceSymlink(const Path & target, const Path & link,
         Path tmp = canonPath(fmt("%s/.%d_%s", dirOf(link), n, baseNameOf(link)));
 
         try {
-            createSymlink(target, tmp, mtime);
+            createSymlink(target, tmp);
         } catch (SysError & e) {
             if (e.errNo == EEXIST) continue;
             throw;


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
`filesystem.cc` is the only place where [`createSymlink()` with three arguments](https://github.com/NixOS/nix/blob/041486b11674e0480ad85f63d262c33a09276ef1/src/libutil/filesystem.cc#L89) is used, in the definition of replaceSymlink() with three parameters _is not used at all_.

# Context
<!-- Provide context. Reference open issues if available. -->
https://github.com/NixOS/nix/pull/7048 deals with timestamps, but there are occurrences that we can avoid handling altogether because they are dead code anyway.
<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
