### PR TITLE
Pass NIX_SSHOPTS when checking for an ssh master connection.

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -42,7 +42,10 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
 }
 
 bool SSHMaster::isMasterRunning() {
-    auto res = runProgram(RunOptions {.program = "ssh", .args = {"-O", "check", host}, .mergeStderrToStdout = true});
+    Strings args = {"-O", "check", host};
+    addCommonSSHOpts(args);
+
+    auto res = runProgram(RunOptions {.program = "ssh", .args = args, .mergeStderrToStdout = true});
     return res.first == 0;
 }
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This adds NIX_SSHOPTS to the args when calling `ssh -O check`.

# Context
<!-- Provide context. Reference open issues if available. -->

This should fix #8480.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

I'm a little worried about the consequences of this, but the docs don't make any promises about how ssh is called, so I think it's fair to use NIX_SSHOPTS in this way.

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
