### PR TITLE
Allow numeric uids/gids in allowed-users and trusted-users

### DIFF
--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -181,7 +181,6 @@ static bool matchUser(std::optional<uid_t> uid, std::optional<gid_t> gid, const 
 
         if (gid) {
             auto gr = getgrgid(gid.value());
-            //std::string group = gr ? gr->gr_name : std::to_string(peer.gid.value());
 
             /* Don't allow connecting as the build users group. */
             if (gr && gr->gr_name == settings.buildUsersGroup)

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -237,7 +237,7 @@ static PeerInfo getPeerInfo(int remote)
     socklen_t credLen = sizeof(cred);
     if (getsockopt(remote, SOL_LOCAL, LOCAL_PEERCRED, &cred, &credLen) == -1)
         throw SysError("getting peer credentials");
-    peer = { false, 0, true, cred.cr_uid, false, 0 };
+    peer = { .uid = cred.cr_uid };
 
 #endif
 

--- a/tests/functional/bash-profile.sh
+++ b/tests/functional/bash-profile.sh
@@ -2,8 +2,7 @@ source common.sh
 
 sed -e "s|@localstatedir@|$TEST_ROOT/profile-var|g" -e "s|@coreutils@|$coreutils|g" < ../../scripts/nix-profile.sh.in > $TEST_ROOT/nix-profile.sh
 
-user=$(whoami)
 rm -rf $TEST_HOME $TEST_ROOT/profile-var
 mkdir -p $TEST_HOME
-USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh; set"
-USER=$user $SHELL -e -c ". $TEST_ROOT/nix-profile.sh" # test idempotency
+USER=foobar $SHELL -e -c ". $TEST_ROOT/nix-profile.sh; set"
+USER=foobar $SHELL -e -c ". $TEST_ROOT/nix-profile.sh" # test idempotency

--- a/tests/functional/init.sh
+++ b/tests/functional/init.sh
@@ -26,7 +26,7 @@ substituters =
 flake-registry = $TEST_ROOT/registry.json
 show-trace = true
 include nix.conf.extra
-trusted-users = $(whoami)
+trusted-users = $(id -u)
 EOF
 
 cat > "$NIX_CONF_DIR"/nix.conf.extra <<EOF


### PR DESCRIPTION
# Motivation

Also, don't use `whoami`.  It doesn't work when auto-uid-allocation is enabled and sandboxing is disabled, since then the build UID doesn't have a matching entry in `/etc/passwd`.

This also does some cleanups in `PeerInfo`, replacing the bool guards with `std::optional`. There was at least a theoretical possibility that we were using uninitialized uid/gid fields.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
