### PR TITLE
Remove RegisterPrimOp constructor without support for documentation

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4058,18 +4058,6 @@ static RegisterPrimOp primop_splitVersion({
 RegisterPrimOp::PrimOps * RegisterPrimOp::primOps;
 
 
-RegisterPrimOp::RegisterPrimOp(std::string name, size_t arity, PrimOpFun fun)
-{
-    if (!primOps) primOps = new PrimOps;
-    primOps->push_back({
-        .name = name,
-        .args = {},
-        .arity = arity,
-        .fun = fun,
-    });
-}
-
-
 RegisterPrimOp::RegisterPrimOp(Info && info)
 {
     if (!primOps) primOps = new PrimOps;

--- a/src/libexpr/primops.hh
+++ b/src/libexpr/primops.hh
@@ -28,11 +28,6 @@ struct RegisterPrimOp
      * will get called during EvalState initialization, so there
      * may be primops not yet added and builtins is not yet sorted.
      */
-    RegisterPrimOp(
-        std::string name,
-        size_t arity,
-        PrimOpFun fun);
-
     RegisterPrimOp(Info && info);
 };
 

--- a/tests/plugins/plugintest.cc
+++ b/tests/plugins/plugintest.cc
@@ -21,4 +21,8 @@ static void prim_anotherNull (EvalState & state, const PosIdx pos, Value ** args
         v.mkBool(false);
 }
 
-static RegisterPrimOp rp("anotherNull", 0, prim_anotherNull);
+static RegisterPrimOp rp({
+    .name = "anotherNull",
+    .arity = 0,
+    .fun = prim_anotherNull,
+});


### PR DESCRIPTION
# Motivation

The remaining constructor `RegisterPrimOp::RegisterPrimOp(Info && info)` allows specifying the documentation in `.args` and `.doc` members of the `Info` structure.

Commit 8ec1ba02109e removed all uses of the removed constructor in the nix binary. Here, we remove the constructor completely as well as its use in a plugin test. According to #8515, we didn't promis to maintain compatibility with external plugins.

# Context

Fixes #8515


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
