### PR TITLE
Fix build hook error for libstore library users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ perl/Makefile.config
 /tests/ca/config.nix
 /tests/dyn-drv/config.nix
 /tests/repl-result-out
+/tests/test-libstoreconsumer/test-libstoreconsumer
 
 # /tests/lang/
 /tests/lang/*.out

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ makefiles += \
   src/libstore/tests/local.mk \
   src/libexpr/tests/local.mk \
   tests/local.mk \
+  tests/test-libstoreconsumer/local.mk \
   tests/plugins/local.mk
 else
 makefiles += \

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -77,7 +77,30 @@ Settings::Settings()
     allowedImpureHostPrefixes = tokenizeString<StringSet>("/System/Library /usr/lib /dev /bin/sh");
 #endif
 
-    buildHook = getSelfExe().value_or("nix") + " __build-remote";
+    /* Set the build hook location
+
+       For builds we perform a self-invocation, so Nix has to be self-aware.
+       That is, it has to know where it is installed. We don't think it's sentient.
+
+       Normally, nix is installed according to `nixBinDir`, which is set at compile time,
+       but can be overridden. This makes for a great default that works even if this
+       code is linked as a library into some other program whose main is not aware
+       that it might need to be a build remote hook.
+
+       However, it may not have been installed at all. For example, if it's a static build,
+       there's a good chance that it has been moved out of its installation directory.
+       That makes `nixBinDir` useless. Instead, we'll query the OS for the path to the
+       current executable, using `getSelfExe()`.
+
+       As a last resort, we resort to `PATH`. Hopefully we find a `nix` there that's compatible.
+       If you're porting Nix to a new platform, that might be good enough for a while, but
+       you'll want to improve `getSelfExe()` to work on your platform.
+     */
+    std::string nixExePath = nixBinDir + "/nix";
+    if (!pathExists(nixExePath)) {
+        nixExePath = getSelfExe().value_or("nix");
+    }
+    buildHook = nixExePath + " __build-remote";
 }
 
 void loadConfFile()

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -134,6 +134,7 @@ nix_tests = \
   flakes/show.sh \
   impure-derivations.sh \
   path-from-hash-part.sh \
+  test-libstoreconsumer.sh \
   toString-path.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)
@@ -152,6 +153,7 @@ test-deps += \
   tests/common/vars-and-functions.sh \
   tests/config.nix \
   tests/ca/config.nix \
+  tests/test-libstoreconsumer/test-libstoreconsumer \
   tests/dyn-drv/config.nix
 
 ifeq ($(BUILD_SHARED_LIBS), 1)

--- a/tests/test-libstoreconsumer.sh
+++ b/tests/test-libstoreconsumer.sh
@@ -1,0 +1,6 @@
+source common.sh
+
+drv="$(nix-instantiate simple.nix)"
+cat "$drv"
+out="$(./test-libstoreconsumer/test-libstoreconsumer "$drv")"
+cat "$out/hello" | grep -F "Hello World!"

--- a/tests/test-libstoreconsumer/README.md
+++ b/tests/test-libstoreconsumer/README.md
@@ -1,0 +1,6 @@
+
+A very simple C++ consumer of the libstore library.
+
+  - Keep it simple. Library consumers expect something simple.
+  - No build hook, or any other reinvocations.
+  - No more global state than necessary.

--- a/tests/test-libstoreconsumer/local.mk
+++ b/tests/test-libstoreconsumer/local.mk
@@ -1,0 +1,12 @@
+programs += test-libstoreconsumer
+
+test-libstoreconsumer_DIR := $(d)
+
+test-libstoreconsumer_SOURCES := \
+  $(wildcard $(d)/*.cc) \
+
+test-libstoreconsumer_CXXFLAGS += -I src/libutil -I src/libstore
+
+test-libstoreconsumer_LIBS = libstore libutil
+
+test-libstoreconsumer_LDFLAGS = -pthread $(SODIUM_LIBS) $(EDITLINE_LIBS) $(BOOST_LDFLAGS) $(LOWDOWN_LIBS)

--- a/tests/test-libstoreconsumer/main.cc
+++ b/tests/test-libstoreconsumer/main.cc
@@ -1,0 +1,45 @@
+#include "globals.hh"
+#include "store-api.hh"
+#include "build-result.hh"
+#include <iostream>
+
+using namespace nix;
+
+int main (int argc, char **argv)
+{
+    try {
+        if (argc != 2) {
+            std::cerr << "Usage: " << argv[0] << " store/path/to/something.drv\n";
+            return 1;
+        }
+
+        std::string drvPath = argv[1];
+
+        initLibStore();
+
+        auto store = nix::openStore();
+
+        // build the derivation
+
+        std::vector<DerivedPath> paths {
+            DerivedPath::Built {
+                .drvPath = store->parseStorePath(drvPath),
+                .outputs = OutputsSpec::Names{"out"}
+            }
+        };
+
+        const auto results = store->buildPathsWithResults(paths, bmNormal, store);
+
+        for (const auto & result : results) {
+            for (const auto & [outputName, realisation] : result.builtOutputs) {
+                std::cout << store->printStorePath(realisation.outPath) << "\n";
+            }
+        }
+
+        return 0;
+
+    } catch (const std::exception & e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
# Motivation

A library shouldn't require changes to the caller's argument handling, especially if it doesn't have to, and indeed we don't have to.

This changes the lookup order to prioritize the hardcoded path to nix if it exists. The static executable still finds itself through /proc and the like.


# Context

Encountered in hercules-ci-agent when run on a single user installation.

A solution is also required for #7735. It currently contains a workaround, whereas this is a general solution.

`nixos-option` probably also suffers from this problem.

May be obsoleted by #1221, but a simple bugfix should take priority I think.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
