### PR TITLE
reword documentation on trusted users and substituters

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -700,8 +700,8 @@ public:
 
           At least one of the following conditions must be met for Nix to use a substituter:
 
-          - the substituter is in the [`trusted-substituters`](#conf-trusted-substituters) list
-          - the user calling Nix is in the [`trusted-users`](#conf-trusted-users) list
+          - The substituter is in the [`trusted-substituters`](#conf-trusted-substituters) list
+          - The user calling Nix is in the [`trusted-users`](#conf-trusted-users) list
 
           In addition, each store path should be trusted as described in [`trusted-public-keys`](#conf-trusted-public-keys)
         )",
@@ -710,12 +710,10 @@ public:
     Setting<StringSet> trustedSubstituters{
         this, {}, "trusted-substituters",
         R"(
-          A list of [URLs of Nix stores](@docroot@/command-ref/new-cli/nix3-help-stores.md#store-url-format),
-          separated by whitespace. These are
-          not used by default, but can be enabled by users of the Nix daemon
-          by specifying `--option substituters urls` on the command
-          line. Unprivileged users are only allowed to pass a subset of the
-          URLs listed in `substituters` and `trusted-substituters`.
+          A list of [URLs of Nix stores](@docroot@/command-ref/new-cli/nix3-help-stores.md#store-url-format), separated by whitespace.
+          These are not used by default, but can be enabled by users of the Nix daemon by specifying [`substituters`](#conf-substituters).
+
+          Unprivileged users are only allowed to pass as `substituters` only those URLs listed in `trusted-substituters`.
         )",
         {"trusted-binary-caches"}};
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -711,7 +711,7 @@ public:
         this, {}, "trusted-substituters",
         R"(
           A list of [Nix store URLs](@docroot@/command-ref/new-cli/nix3-help-stores.md#store-url-format), separated by whitespace.
-          These are not used by default, but can be enabled by users of the Nix daemon by specifying [`substituters`](#conf-substituters).
+          These are not used by default, but users of the Nix daemon can enable them by specifying [`substituters`](#conf-substituters).
 
           Unprivileged users (those set in only [`allowed-users`](#conf-allowed-users) but not [`trusted-users`](#conf-trusted-users)) can pass as `substituters` only those URLs listed in `trusted-substituters`.
         )",

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -713,7 +713,7 @@ public:
           A list of [URLs of Nix stores](@docroot@/command-ref/new-cli/nix3-help-stores.md#store-url-format), separated by whitespace.
           These are not used by default, but can be enabled by users of the Nix daemon by specifying [`substituters`](#conf-substituters).
 
-          Unprivileged users are only allowed to pass as `substituters` only those URLs listed in `trusted-substituters`.
+          Unprivileged users are allowed to pass as `substituters` only those URLs listed in `trusted-substituters`.
         )",
         {"trusted-binary-caches"}};
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -710,7 +710,7 @@ public:
     Setting<StringSet> trustedSubstituters{
         this, {}, "trusted-substituters",
         R"(
-          A list of [URLs of Nix stores](@docroot@/command-ref/new-cli/nix3-help-stores.md#store-url-format), separated by whitespace.
+          A list of [Nix store URLs](@docroot@/command-ref/new-cli/nix3-help-stores.md#store-url-format), separated by whitespace.
           These are not used by default, but can be enabled by users of the Nix daemon by specifying [`substituters`](#conf-substituters).
 
           Unprivileged users (those set in only [`allowed-users`](#conf-allowed-users) but not [`trusted-users`](#conf-trusted-users)) can pass as `substituters` only those URLs listed in `trusted-substituters`.

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -713,7 +713,7 @@ public:
           A list of [URLs of Nix stores](@docroot@/command-ref/new-cli/nix3-help-stores.md#store-url-format), separated by whitespace.
           These are not used by default, but can be enabled by users of the Nix daemon by specifying [`substituters`](#conf-substituters).
 
-          Unprivileged users are allowed to pass as `substituters` only those URLs listed in `trusted-substituters`.
+          Unprivileged users (those set in only [`allowed-users`](#conf-allowed-users) but not [`trusted-users`](#conf-trusted-users)) can pass as `substituters` only those URLs listed in `trusted-substituters`.
         )",
         {"trusted-binary-caches"}};
 

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -76,7 +76,8 @@ struct AuthorizationSettings : Config {
           A list user names, separated by whitespace.
           These users are allowed to connect to the Nix daemon.
 
-          As with the [`trusted-users`](#conf-trusted-users) option, you can specify groups by prefixing names with `@`.
+          You can specify groups by prefixing names with `@`.
+          For instance, `@wheel` means all users in the `wheel` group.
           Also, you can allow all users by specifying `*`.
 
           > **Note**

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -64,7 +64,7 @@ struct AuthorizationSettings : Config {
           > **Warning**
           >
           > Adding a user to `trusted-users` is essentially equivalent to giving that user root access to the system.
-          > For example, the user can set [`sandbox-paths`](#conf-sandbox-paths) and thereby obtain read access to directories that are otherwise inacessible to them.
+          > For example, the user can access or replace store path contents that are critical for system security.
         )"};
 
     /**

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -82,7 +82,7 @@ struct AuthorizationSettings : Config {
 
           > **Note**
           >
-          > Trusted users (set in [`trusted-users`](#conf-trusted-users)) can always to connect to the Nix daemon.
+          > Trusted users (set in [`trusted-users`](#conf-trusted-users)) can always connect to the Nix daemon.
         )"};
 };
 

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -55,19 +55,16 @@ struct AuthorizationSettings : Config {
     Setting<Strings> trustedUsers{
         this, {"root"}, "trusted-users",
         R"(
-          A list of names of users (separated by whitespace) that have
-          additional rights when connecting to the Nix daemon, such as the
-          ability to specify additional binary caches, or to import unsigned
-          NARs. You can also specify groups by prefixing them with `@`; for
-          instance, `@wheel` means all users in the `wheel` group. The default
-          is `root`.
+          A list of user names, separated by whitespace.
+          These users will have additional rights when connecting to the Nix daemon, such as the ability to specify additional [substituters](#conf-substituters), or to import unsigned [NAR](@docroot@/glossary.md#gloss-nar)s.
+
+          You can also specify groups by prefixing names with `@`.
+          For instance, `@wheel` means all users in the `wheel` group.
 
           > **Warning**
           >
-          > Adding a user to `trusted-users` is essentially equivalent to
-          > giving that user root access to the system. For example, the user
-          > can set `sandbox-paths` and thereby obtain read access to
-          > directories that are otherwise inacessible to them.
+          > Adding a user to `trusted-users` is essentially equivalent to giving that user root access to the system.
+          > For example, the user can set [`sandbox-paths`](#conf-sandbox-paths) and thereby obtain read access to directories that are otherwise inacessible to them.
         )"};
 
     /**
@@ -76,12 +73,15 @@ struct AuthorizationSettings : Config {
     Setting<Strings> allowedUsers{
         this, {"*"}, "allowed-users",
         R"(
-          A list of names of users (separated by whitespace) that are allowed
-          to connect to the Nix daemon. As with the `trusted-users` option,
-          you can specify groups by prefixing them with `@`. Also, you can
-          allow all users by specifying `*`. The default is `*`.
+          A list user names, separated by whitespace.
+          These users are allowed to connect to the Nix daemon.
 
-          Note that trusted users are always allowed to connect.
+          As with the [`trusted-users`](#conf-trusted-users) option, you can specify groups by prefixing names with `@`.
+          Also, you can allow all users by specifying `*`.
+
+          > **Note**
+          >
+          > Trusted users are always allowed to connect to the Nix daemon.
         )"};
 };
 

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -56,7 +56,7 @@ struct AuthorizationSettings : Config {
         this, {"root"}, "trusted-users",
         R"(
           A list of user names, separated by whitespace.
-          These users will have additional rights when connecting to the Nix daemon, such as the ability to specify additional [substituters](#conf-substituters), or to import unsigned [NAR](@docroot@/glossary.md#gloss-nar)s.
+          These users will have additional rights when connecting to the Nix daemon, such as the ability to specify additional [substituters](#conf-substituters), or to import unsigned [NARs](@docroot@/glossary.md#gloss-nar).
 
           You can also specify groups by prefixing names with `@`.
           For instance, `@wheel` means all users in the `wheel` group.

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -81,7 +81,7 @@ struct AuthorizationSettings : Config {
 
           > **Note**
           >
-          > Trusted users are always allowed to connect to the Nix daemon.
+          > Trusted users (set in [`trusted-users`](#conf-trusted-users)) can always to connect to the Nix daemon.
         )"};
 };
 


### PR DESCRIPTION
# Motivation

found this while sweeping over open PRs.
this is to make it slightly easier to scan over

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).