### PR TITLE
src/libexpr/eval.hh: fix typo

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -741,7 +741,7 @@ struct EvalSettings : Config
           If set to `true`, the Nix evaluator will not allow access to any
           files outside of the Nix search path (as set via the `NIX_PATH`
           environment variable or the `-I` option), or to URIs outside of
-          `allowed-uri`. The default is `false`.
+          `allowed-uris`. The default is `false`.
         )"};
 
     Setting<bool> pureEval{this, false, "pure-eval",


### PR DESCRIPTION
# Motivation

Typos are annoying.

# Context

Discovered here:

- https://github.com/NixOS/nixpkgs/pull/232576/#issuecomment-1592356726

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The option name is `allowed-uris`, not `allowed-uri`.