### PR TITLE
src/libexpr/eval.hh: add link for allowed-uris option

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -741,7 +741,8 @@ struct EvalSettings : Config
           If set to `true`, the Nix evaluator will not allow access to any
           files outside of the Nix search path (as set via the `NIX_PATH`
           environment variable or the `-I` option), or to URIs outside of
-          `allowed-uris`. The default is `false`.
+          [`allowed-uris`](../command-ref/conf-file.md#conf-allowed-uris).
+          The default is `false`.
         )"};
 
     Setting<bool> pureEval{this, false, "pure-eval",


### PR DESCRIPTION
# Motivation

This commit adds a link to the documentation for `--option allowed-uris` where that option is mentioned while describing `restrict-eval`.

# Context

As requested by @Ericson2314 here: https://github.com/NixOS/nix/pull/8522#issuecomment-1592866265

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).