### PR TITLE
Don't assume the type of string::size_type

### DIFF
--- a/src/libutil/references.cc
+++ b/src/libutil/references.cc
@@ -75,7 +75,7 @@ RewritingSink::RewritingSink(const std::string & from, const std::string & to, S
 RewritingSink::RewritingSink(const StringMap & rewrites, Sink & nextSink)
     : rewrites(rewrites), nextSink(nextSink)
 {
-    long unsigned int maxRewriteSize = 0;
+    std::string::size_type maxRewriteSize = 0;
     for (auto & [from, to] : rewrites) {
         assert(from.size() == to.size());
         maxRewriteSize = std::max(maxRewriteSize, from.size());

--- a/src/libutil/references.hh
+++ b/src/libutil/references.hh
@@ -26,7 +26,7 @@ public:
 struct RewritingSink : Sink
 {
     const StringMap rewrites;
-    long unsigned int maxRewriteSize;
+    std::string::size_type maxRewriteSize;
     std::string prev;
     Sink & nextSink;
     uint64_t pos = 0;


### PR DESCRIPTION
# Motivation

The code accidentally conflated `std::string::size_type` and `long unsigned int`.
This was fine on 64bits machines where they are apparently the same in
practice, but not on 32bits. Fix that by using `std::string::size_type`
everywhere.

# Context

Part of https://github.com/NixOS/nix/issues/8523

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
