### PR TITLE
Fix use normal wikipedia links

### DIFF
--- a/doc/manual/src/architecture/architecture.md
+++ b/doc/manual/src/architecture/architecture.md
@@ -7,11 +7,11 @@ It should help users understand why Nix behaves as it does, and it should help d
 
 Nix consists of [hierarchical layers].
 
-[hierarchical layers]: https://en.m.wikipedia.org/wiki/Multitier_architecture#Layers
+[hierarchical layers]: https://en.wikipedia.org/wiki/Multitier_architecture#Layers
 
 The following [concept map] shows its main components (rectangles), the objects they operate on (rounded rectangles), and their interactions (connecting phrases):
 
-[concept map]: https://en.m.wikipedia.org/wiki/Concept_map
+[concept map]: https://en.wikipedia.org/wiki/Concept_map
 
 ```
 
@@ -76,7 +76,7 @@ The result of a build task can be input to another build task.
 The following [data flow diagram] shows a build plan for illustration.
 Build inputs used as instructions to a build task are marked accordingly:
 
-[data flow diagram]: https://en.m.wikipedia.org/wiki/Data-flow_diagram
+[data flow diagram]: https://en.wikipedia.org/wiki/Data-flow_diagram
 
 ```
 +--------------------------------------------------------------------+

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -378,7 +378,7 @@ rm $(git ls-files doc/manual/ -o | grep -F '.md') && rmdir doc/manual/src/comman
 [`mdbook-linkcheck`] does not implement checking [URI fragments] yet.
 
 [`mdbook-linkcheck`]: https://github.com/Michael-F-Bryan/mdbook-linkcheck
-[URI fragments]: https://en.m.wikipedia.org/wiki/URI_fragment
+[URI fragments]: https://en.wikipedia.org/wiki/URI_fragment
 
 #### `@docroot@` variable
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Before, links where for some reason to en.m.wikipedia.org instead of just en.wikipedia.org

This is perhaps not appropriate, as going to en.wikipedia.org on a phone will automatically redirect to en.m.wikipedia.org, but going to en.m.wikipedia.org will not automatically redirect to the desktop version.

This change seems trivial.

# Context
Files touched:
- doc/manual/src/contributing/hacking.md
- doc/manual/src/architecture/architecture.md

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
