### PR TITLE
[Backport 2.15-maintenance] ci: Always run with sandbox, even on Darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v20
+      with:
+        # The sandbox would otherwise be disabled by default on Darwin
+        extra_nix_config: "sandbox = true"
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV
     - uses: cachix/cachix-action@v12
       if: needs.check_secrets.outputs.cachix == 'true'

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2525,12 +2525,17 @@ Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;
     auto add = [&](const Path & p, const std::string & s = std::string()) {
-        if (pathExists(p)) {
-            if (s.empty()) {
-                res.push_back(p);
-            } else {
-                res.push_back(s + "=" + p);
+        try {
+            if (pathExists(p)) {
+                if (s.empty()) {
+                    res.push_back(p);
+                } else {
+                    res.push_back(s + "=" + p);
+                }
             }
+        } catch (SysError & e) {
+            // swallow EPERM
+            if (e.errNo != EPERM) throw;
         }
     };
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2525,17 +2525,12 @@ Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;
     auto add = [&](const Path & p, const std::string & s = std::string()) {
-        try {
-            if (pathExists(p)) {
-                if (s.empty()) {
-                    res.push_back(p);
-                } else {
-                    res.push_back(s + "=" + p);
-                }
+        if (pathAccessible(p)) {
+            if (s.empty()) {
+                res.push_back(p);
+            } else {
+                res.push_back(s + "=" + p);
             }
-        } catch (SysError & e) {
-            // swallow EPERM
-            if (e.errNo != EPERM) throw;
         }
     };
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -47,6 +47,8 @@ Settings::Settings()
     auto sslOverride = getEnv("NIX_SSL_CERT_FILE").value_or(getEnv("SSL_CERT_FILE").value_or(""));
     if (sslOverride != "")
         caFile = sslOverride;
+    else if (caFile == "")
+        caFile = getDefaultSSLCertFile();
 
     /* Backwards compatibility. */
     auto s = getEnv("NIX_REMOTE_SYSTEMS");

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -47,8 +47,6 @@ Settings::Settings()
     auto sslOverride = getEnv("NIX_SSL_CERT_FILE").value_or(getEnv("SSL_CERT_FILE").value_or(""));
     if (sslOverride != "")
         caFile = sslOverride;
-    else if (caFile == "")
-        caFile = getDefaultSSLCertFile();
 
     /* Backwards compatibility. */
     auto s = getEnv("NIX_REMOTE_SYSTEMS");
@@ -175,7 +173,7 @@ bool Settings::isWSL1()
 Path Settings::getDefaultSSLCertFile()
 {
     for (auto & fn : {"/etc/ssl/certs/ca-certificates.crt", "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"})
-        if (pathExists(fn)) return fn;
+        if (pathAccessible(fn)) return fn;
     return "";
 }
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -858,7 +858,7 @@ public:
         )"};
 
     Setting<Path> caFile{
-        this, getDefaultSSLCertFile(), "ssl-cert-file",
+        this, "", "ssl-cert-file",
         R"(
           The path of a file containing CA certificates used to
           authenticate `https://` downloads. Nix by default will use

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -858,7 +858,7 @@ public:
         )"};
 
     Setting<Path> caFile{
-        this, "", "ssl-cert-file",
+        this, getDefaultSSLCertFile(), "ssl-cert-file",
         R"(
           The path of a file containing CA certificates used to
           authenticate `https://` downloads. Nix by default will use

--- a/src/libutil/tests/tests.cc
+++ b/src/libutil/tests/tests.cc
@@ -202,7 +202,7 @@ namespace nix {
     }
 
     TEST(pathExists, bogusPathDoesNotExist) {
-        ASSERT_FALSE(pathExists("/home/schnitzel/darmstadt/pommes"));
+        ASSERT_FALSE(pathExists("/schnitzel/darmstadt/pommes"));
     }
 
     /* ----------------------------------------------------------------------------

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -263,6 +263,17 @@ bool pathExists(const Path & path)
     return false;
 }
 
+bool pathAccessible(const Path & path)
+{
+    try {
+        return pathExists(path);
+    } catch (SysError & e) {
+        // swallow EPERM
+        if (e.errNo == EPERM) return false;
+        throw;
+    }
+}
+
 
 Path readLink(const Path & path)
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -120,6 +120,14 @@ struct stat lstat(const Path & path);
 bool pathExists(const Path & path);
 
 /**
+ * A version of pathExists that returns false on a permission error.
+ * Useful for inferring default paths across directories that might not
+ * be readable.
+ * @return true iff the given path can be accessed and exists
+ */
+bool pathAccessible(const Path & path);
+
+/**
  * Read the contents (target) of a symbolic link.  The result is not
  * in any way canonicalised.
  */


### PR DESCRIPTION
Despite the title of #8240, it fixes a regression caused by #8062 that broke running Nix inside sandboxed Nix builds on macOS. This leads to an obscure error activating Home Manager configurations due to [the documentation generator](https://git.sr.ht/~rycee/nmd/tree/07a6db31ae19d728ef1e4dc02b9687a6c359c216/item/lib/modules-docbook.nix#L34-59), so I think backporting this is important (as 2.16 hasn't yet reached `pkgs.nix` and 2.15 will be used on the stable branches for even longer). I've verified that the Home Manager documentation builds correctly after applying this PR.

Fixes #8485.