### PR TITLE
flake: make librapidcheck available in the dev env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -711,6 +711,7 @@
                 PATH=$prefix/bin:$PATH
                 unset PYTHONPATH
                 export MANPATH=$out/share/man:$MANPATH
+                export RAPIDCHECK_HEADERS=${lib.getDev pkgs.rapidcheck}/extras/gtest/include
 
                 # Make bash completion work.
                 XDG_DATA_DIRS+=:$out/share


### PR DESCRIPTION

# Motivation
When running `./configure --prefix=$(pwd)/outputs/out` in a shell opened by `nix develop -L` I get the following error otherwise

    checking for rapidcheck/gtest.h... no
    configure: error: librapidcheck is not found.


# Context
Small change to be able to easily hack on nix as documented in the hacking-notes.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).


cc @NixOS/nix-team 