### PR TITLE
nix-store --query --deriver: return a valid deriver if possible

### DIFF
--- a/tests/check-refs.nix
+++ b/tests/check-refs.nix
@@ -2,7 +2,7 @@ with import ./config.nix;
 
 rec {
 
-  dep = import ./dependencies.nix;
+  dep = import ./dependencies.nix {};
 
   makeTest = nr: args: mkDerivation ({
     name = "check-refs-" + toString nr;

--- a/tests/dependencies.nix
+++ b/tests/dependencies.nix
@@ -1,3 +1,4 @@
+{ hashInvalidator ? "" }:
 with import ./config.nix;
 
 let {
@@ -21,6 +22,17 @@ let {
     '';
   };
 
+  fod_input = mkDerivation {
+    name = "fod-input";
+    buildCommand = ''
+      echo ${hashInvalidator}
+      echo FOD > $out
+    '';
+    outputHashMode = "flat";
+    outputHashAlgo = "sha256";
+    outputHash = "1dq9p0hnm1y75q2x40fws5887bq1r840hzdxak0a9djbwvx0b16d";
+  };
+
   body = mkDerivation {
     name = "dependencies-top";
     builder = ./dependencies.builder0.sh + "/FOOBAR/../.";
@@ -29,6 +41,7 @@ let {
     input1_drv = input1;
     input2_drv = input2;
     input0_drv = input0;
+    fod_input_drv = fod_input;
     meta.description = "Random test package";
   };
 

--- a/tests/dependencies.sh
+++ b/tests/dependencies.sh
@@ -50,3 +50,31 @@ nix-store -q --referrers-closure "$input2OutPath" | grep "$outPath"
 # Check that the derivers are set properly.
 test $(nix-store -q --deriver "$outPath") = "$drvPath"
 nix-store -q --deriver "$input2OutPath" | grepQuiet -- "-input-2.drv"
+
+if [[ -n "${NIX_DAEMON_PACKAGE:-}" ]] && ! isDaemonNewer "2.17pre0"; then
+    echo "skipping valid deriver subtest"
+else
+    # instantiate a different drv with the same output
+    drvPath2=$(nix-instantiate dependencies.nix --argstr hashInvalidator yay)
+    nix-store --delete "$drvPath"
+    # check that nix-store --deriver returns an existing drv if available
+    test "$(nix-store -q --deriver "$outPath")" = "$drvPath2"
+
+    nix-store --delete "$outPath"
+    drvPath=$(nix-instantiate dependencies.nix)
+    outPath=$(nix-store -rvv "$drvPath") || fail "build failed"
+
+    # now the deriver of $outPath in the db is $drvPath but $drvPath2 is valid
+    # and was registered sooner in the db
+    # check that nix-store --deriver favors the stored deriver if valid
+    test "$(nix-store -q --deriver "$outPath")" = "$drvPath"
+
+    nix-store --delete "$drvPath"
+    # $drvPath is not valid anymore, but there are others valid derivers
+    # check that nix-store --deriver returns an a valid deriver if available
+    test "$(nix-store -q --deriver "$outPath")" = "$drvPath2"
+
+    nix-store --delete "$drvPath2"
+    # check that nix-store --deriver returns the stored deriver is none is valid
+    test "$(nix-store -q --deriver "$outPath")" = "$drvPath"
+fi

--- a/tests/export-graph.nix
+++ b/tests/export-graph.nix
@@ -17,13 +17,13 @@ rec {
   foo."bar.runtimeGraph" = mkDerivation {
     name = "dependencies";
     builder = builtins.toFile "build-graph-builder" "${printRefs}";
-    exportReferencesGraph = ["refs" (import ./dependencies.nix)];
+    exportReferencesGraph = ["refs" (import ./dependencies.nix {})];
   };
 
   foo."bar.buildGraph" = mkDerivation {
     name = "dependencies";
     builder = builtins.toFile "build-graph-builder" "${printRefs}";
-    exportReferencesGraph = ["refs" (import ./dependencies.nix).drvPath];
+    exportReferencesGraph = ["refs" (import ./dependencies.nix {}).drvPath];
   };
 
 }

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -24,7 +24,7 @@ fi
   import (
     mkDerivation {
       name = "foo";
-      bla = import ./dependencies.nix;
+      bla = import ./dependencies.nix {};
       buildCommand = "
         echo \\\"hi\\\" > $out
       ";


### PR DESCRIPTION
On typical nixos installations, nixos-rebuild creates .drv files for all store paths of the system, but the deriver field of the db comes from hydra. If a dependency of a fixed output derivation changed between the time hydra built something and nixos-rebuild was called, the local .drv and the deriver provided by hydra will not match. In this case, 
`nix-store --query --deriver /store/path` returns a missing .drv file, whereas we have at least one other deriver of this store path locally.

This commit causes nix-store --query --deriver to first check if we have a local .drv file with this output before falling back on the deriver provided by the db.

The intended final use case of this contribution is to be able to link an executable in the store to the store path of its source via the src field of its deriver. (specifically: nixseparatedebuginfod uses that to provide source code to gdb)
# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
