### PR TITLE
Build nix itself somewhat incrementally, optionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,10 @@ endif
 include mk/lib.mk
 
 GLOBAL_CXXFLAGS += -g -Wall -include config.h -std=c++2a -I src
+
+ifeq ($(missingMakefiles), ok)
+$(makefiles):
+	@echo "WARNING: Touching missing makefile $@"
+	@mkdir -p $(dir $@)
+	@touch $@
+endif

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -421,3 +421,12 @@ can build it yourself:
 
 Metrics about the change in line/function coverage over time are also
 [available](https://hydra.nixos.org/job/nix/master/coverage#tabs-charts).
+
+## Coarse incremental cached build
+
+The flake provides an extra package, `.#quickBuild`, which builds Nix using
+individual derivations for the libraries and such. This allows cached versions
+of those intermediate build steps to be used, so that it builds a lot quicker.
+
+This package is useful for reviewing changes to `/doc`, assuming that the
+base commit is in the binary cache.

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -1,4 +1,4 @@
-default: all
+default: src/libutil/libnixutil.so all
 
 
 # Get rid of default suffixes. FIXME: is this a good idea?

--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -95,7 +95,7 @@ define build-library
 	+$$(trace-ld) $(CXX) -o $$(abspath $$@) -shared $$(LDFLAGS) $$(GLOBAL_LDFLAGS) $$($(1)_OBJS) $$($(1)_LDFLAGS) $$($(1)_LDFLAGS_PROPAGATED) $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LDFLAGS_USE)) $$($(1)_LDFLAGS_UNINSTALLED)
 
     ifndef HOST_DARWIN
-      $(1)_LDFLAGS_USE += -Wl,-rpath,$$(abspath $$(_d))
+      $(1)_LDFLAGS_USE += -Wl,-rpath,'$$$$ORIGIN'
     endif
     $(1)_LDFLAGS_USE += -L$$(_d) -l$$(patsubst lib%,%,$$(strip $$($(1)_NAME)))
 

--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -133,9 +133,9 @@ define build-library
 
     $(1)_INSTALL_PATH := $$(libdir)/$$($(1)_NAME).a
 
-    $(1)_LIB_CLOSURE += $$($(1)_LIBS)
-
   endif
+
+	$(1)_LIB_CLOSURE += $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LIB_CLOSURE))
 
   $(1)_LDFLAGS_USE += $$($(1)_LDFLAGS_PROPAGATED)
   $(1)_LDFLAGS_USE_INSTALLED += $$($(1)_LDFLAGS_PROPAGATED)

--- a/mk/programs.mk
+++ b/mk/programs.mk
@@ -36,7 +36,7 @@ define build-program
   $$(eval $$(call create-dir, $$(_d)))
 
   $$($(1)_PATH): $$($(1)_OBJS) $$(_libs) | $$(_d)/
-	+$$(trace-ld) $(CXX) -o $$@ $$(LDFLAGS) $$(GLOBAL_LDFLAGS) $$($(1)_OBJS) $$($(1)_LDFLAGS) $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LDFLAGS_USE))
+	+$$(trace-ld) $(CXX) -o $$@ $$(LDFLAGS) $$(GLOBAL_LDFLAGS) $$($(1)_OBJS) $$($(1)_LDFLAGS) $$(foreach lib, $$($(1)_LIBS), $$($$(lib)_LDFLAGS_USE)) $$(foreach lib, $$($(1)_LIBS), $$(foreach lib2, $$($$(lib)_LIB_CLOSURE), -Wl,-rpath,$$($$(lib2)_PATH)))
 
   $(1)_INSTALL_DIR ?= $$(bindir)
 

--- a/mk/tracing.mk
+++ b/mk/tracing.mk
@@ -5,7 +5,7 @@ ifeq ($(V), 0)
   trace-gen     = @echo "  GEN   " $@;
   trace-cc      = @echo "  CC    " $@;
   trace-cxx     = @echo "  CXX   " $@;
-  trace-ld      = @echo "  LD    " $@;
+  trace-ld      = @echo "  LD    " $@; set -x;
   trace-ar      = @echo "  AR    " $@;
   trace-install = @echo "  INST  " $@;
   trace-mkdir   = @echo "  MKDIR " $@;

--- a/prepper.nix
+++ b/prepper.nix
@@ -1,0 +1,191 @@
+/*
+  prepper.nix - mediam grained incremental build while RFC 92 is in progress
+
+  This splits the build into separate derivations that build each component, so
+  that changes to the higher-level components don't need a rebuild of the
+  components they depend on.
+  It achieves this by overriding the simpler original derivation that would
+  build everything in one go.
+
+  It does so by saving the working directory in the output of the intermediate
+  steps.
+
+  Flaws:
+   - The dependency management and source filtering are not super accurate
+     while any mistakes will be caught by the build, it still includes many
+     files that are not needed for the build.
+   - Files are included in every component build by default. This means that
+     changes to the build graph generally work, but may rebuild more than
+     necessary.
+   - Installed files from outputs are not accounted for. The docs build relies
+     on the installed nix binary. This means linking the nix binary in the docs
+     build.
+   - Object files could be built separately, so that their library dependency is
+     only on headers. This will save more rebuilds.
+   - A component might rebuild its dependencies. So this is fail safe in the
+     sense that you don't have to bother with the problem immediately, but it
+     does slow down the build and you'd have to check the logs to make sure it
+     doesn't happen.
+
+  What we should do:
+   - RFC 92. That will let us replace this by a principled solution that is
+     more accurate, more efficient, and easier to maintain.
+   - Low hanging fruit: support installed files in the components.
+   - Short of that, we could make the libraries into individual packages. This
+     way we won't have to copy as many files around.
+*/
+
+{ pkgs }:
+
+let
+  inherit (pkgs) lib;
+
+  composeOverrides = f: g: x:
+    let x2 = g x;
+    in x2 // f (x // x2);
+
+  # removeFile = f: o: {
+  #   buildPhase = o.buildPhase + ''
+  #     rm ${f}
+  #   '';
+  # };
+
+  prep = { drv, componentSpecs }:
+    let
+      depsClosure =
+        let clList = lib.genericClosure {
+              startSet = #
+                lib.concatLists (lib.mapAttrsToList
+                  (name: spec@{deps ? [], ...}: map (dep: { inherit name dep; key = "${name} ---> ${dep}"; }) deps)
+                  componentSpecs);
+              operator = item: map (dep: { inherit (item) name; inherit dep; key = "${item.name} ---> ${dep}";}) componentSpecs.${item.name}.deps or [];
+            };
+        in
+          # Ensure an empty attr exists for each component
+          lib.mapAttrs (name: _: []) componentSpecs
+          # Add the dependencies
+          // lib.zipAttrs (
+            map
+              (item: { ${item.name} = item.dep; })
+              clList
+          );
+
+      nonDeps =
+        lib.mapAttrs
+          (name: deps: lib.attrNames (builtins.removeAttrs componentSpecs ([name] ++ deps)))
+          depsClosure;
+
+      components =
+        lib.mapAttrs
+          (name: spec@{ dirs, deps ? [], attrsOverride ? (o: {}), findFilter ? "", ... }:
+            let prebuiltDeps = lib.genAttrs deps (x: components.${x});
+            in
+            ((addPrebuilt drv prebuiltDeps).overrideAttrs (o: {
+
+              # Remove the reverse dependencies
+              src = lib.cleanSourceWith {
+                src = o.src;
+                filter = path: type:
+                  lib.all
+                    (dep:
+                      let depSpec = componentSpecs.${dep};
+                      in
+                        lib.all
+                          (src:
+                            toString path != toString (o.src.origSrc + ("/" + src)))
+                          depSpec.dirs
+                    )
+                    (nonDeps.${name});
+              };
+              preBuild = ''
+                ${o.preBuild or ""}
+                buildFlagsArray+=( missingMakefiles=ok ${spec.targets or "default"} )
+                echo "Building component ${name}..."
+              '';
+              # TODO hook into setup.sh like in preBuild above
+              # checkPhase = lib.optionalString (spec?checkTargets) ''
+              #   make -j $NIX_BUILD_CORES missingMakefiles=ok $makeFlags ${spec.checkTargets}
+              # '';
+              installPhase = ''
+                runHook preInstall
+                for f in $(find ${lib.escapeShellArgs dirs} -type f ${findFilter}); do
+                  mkdir -p $(dirname $out/progress/$f)
+                  install $f $out/progress/$f
+                done
+                runHook postInstall
+              '';
+              # doInstallCheck can be whatever it needs to be so that it's as much as
+              # possible like a normal build.
+              installCheckPhase = ":";
+            })
+            ).overrideAttrs attrsOverride
+          )
+          componentSpecs;
+
+      copyPrebuilt = layer: ''
+        for f in $(cd ${layer}/progress; find . -type f); do
+          if [[ -e $f ]]; then continue; fi
+          echo Copying pre-built $f
+          mkdir -p $(dirname $f)
+          ${lib.getExe pkgs.buildPackages.perl} -pe "s|\Q${layer}\E|$out|g" \
+            < ${layer}/progress/$f > $f
+          [[ -x ${layer}/progress/$f ]] && chmod +x $f
+          touch --reference=timestamper $f
+        done
+      '';
+
+      addPrebuilt = drv: deps:
+        drv.overrideAttrs (o: {
+          postConfigure = ''
+            ${o.postConfigure or ""}
+            touch timestamper
+            ${lib.concatMapStringsSep "\n" copyPrebuilt (lib.attrValues deps)}
+            rm timestamper
+          '';
+          disallowedReferences = lib.attrValues deps;
+          passthru = o.passthru // {
+            prebuiltDeps = deps;
+          };
+        });
+
+      toplevel = addPrebuilt drv components;
+
+    in {
+      inherit components copyPrebuilt toplevel;
+    };
+in
+{
+  inherit
+    composeOverrides
+    prep
+    ;
+}
+
+  # Unused:
+
+  # revDeps =
+  #   lib.zipAttrs (
+  #     lib.concatLists (
+  #       lib.mapAttrsToList
+  #         (name: spec@{ deps ? [], ... }:
+  #           map
+  #             (dep: { ${dep} = name; })
+  #             deps
+  #         )
+  #         componentSpecs
+  #     )
+  #   );
+
+  # revDepsClosure =
+  #   let clList = lib.genericClosure {
+  #         startSet = #
+  #           lib.concatLists (lib.mapAttrsToList
+  #             (name: rds: map (rd: { inherit name rd; key = "${name} <--- ${rd}"; }) rds)
+  #             revDeps);
+  #         operator = item: map (rd: { inherit (item) name; inherit rd; key = "${item.name} <--- ${rd}";}) revDeps.${item.rd} or [];
+  #       };
+  #   in lib.zipAttrs (
+  #       map
+  #         (item: { ${item.name} = item.rd; })
+  #         clList
+  #     );


### PR DESCRIPTION
# Motivation

Add an extra build that produces a build of nix, built in nix, reusing components that will have been built by hydra.nixos.org.

This speeds up the build that's required when changes are made to just the manual, ie all within `/doc`.
Reviewing those has been frustrating because
 - in `nix develop`, you don't get incremental builds because doc prs tend to have different base commits.
 - `nix build` never matches anything in the binary cache

This leaves the normal build untouched.

The way the expression works is by building sets of files in separate derivations and then copying them in. The speedup is achieved when the intermediate derivations are cached.

Numbers
 - build a change in `/doc`: 0:42
 - rebuild everything: 8:24
 - a normal build including tests: TBD
 - 1 top level build and 8 component derivations which are mostly sequential

TODO:
 - [ ] normal build currently fails with `src/libstore/tests/libnixstore-tests: error while loading shared libraries: libnixstore-tests.so: cannot open shared object file: No such file or directory`.
     - I promised not to touch the regular build, and that's within reach (modulo one or two parameters)
 - [ ] what's up with `rpath`/`rpath-link`?
 - [ ] speed up the copying; bash impl is slow

# Context

- Partially solves https://github.com/NixOS/nix/issues/8518
   - changes to `.md` files in sources still require a rebuild. Nonetheless this PR provides infrastructure that may be helpful for solving that

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
