### PR TITLE
redirect old platform uninstall instruction links

### DIFF
--- a/doc/manual/redirects.js
+++ b/doc/manual/redirects.js
@@ -340,6 +340,8 @@ const redirects = {
     "attribute-sets": "#attribute-set"
   },
   "installation/installing-binary.html": {
+    "linux": "uninstall.html#linux",
+    "macos": "uninstall.html#macos",
     "uninstalling": "uninstall.html"
   }
 };


### PR DESCRIPTION
# Motivation
Redirect old to the uninstall instructions broken by moving them to a separate page in #8267. @fricklerhandwerk 

# Context

The overall section link was redirected in #8286, but platform-specific links (which I give out frequently when I triage installer trouble) weren't included.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
