### PR TITLE
Mention that `tarball-ttl` affects global flake registry

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -629,6 +629,11 @@ public:
 
           Files fetched via `NIX_PATH`, `fetchGit`, `fetchMercurial`,
           `fetchTarball`, and `fetchurl` respect this TTL.
+
+          This option also affects how often the global flake registry is
+          updated.  For example, a flake URI like `nixpkgs#hello` will trigger
+          a new download of Nixpkgs if the last download is older than the
+          `tarball-ttl`.
         )"};
 
     Setting<bool> requireSigs{

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -627,13 +627,27 @@ public:
 
           Nix caches tarballs in `$XDG_CACHE_HOME/nix/tarballs`.
 
-          Files fetched via `NIX_PATH`, `fetchGit`, `fetchMercurial`,
-          `fetchTarball`, and `fetchurl` respect this TTL.
+          This option affects:
 
-          This option also affects how often the global flake registry is
-          updated.  For example, a flake URI like `nixpkgs#hello` will trigger
-          a new download of Nixpkgs if the last download is older than the
-          `tarball-ttl`.
+          - files fetched via `NIX_PATH`, `fetchGit`, `fetchMercurial`,
+            `fetchTarball`, and `fetchurl`
+
+          - how often the global flake registry is updated (i.e. how often
+            indirect flake references are updated)
+
+          - how often unpinned flake references (e.g. `github:NixOS/nixpkgs`)
+            are updated
+
+          For example, for a flake reference like `nixpkgs#hello` this option
+          affects how that flake resolves in two separate ways:
+
+          - It affects how often the `nixpkgs` indirect flake reference is
+            updated (which is rare: it usually resolves to
+            `github:NixOS/nixpkgs/nixpkgs-unstable`).
+
+          - It affects how often the `github:NixOS/nixpkgs/nixpkgs-unstable`
+            flake reference is updated (which is common: the `nixpkgs-unstable`
+            branch of the repository changes frequently).
         )"};
 
     Setting<bool> requireSigs{


### PR DESCRIPTION
This updates the documentation for `tarball-ttl` to mention that global flake registry references (e.g. `nixpkgs#hello`) respect the `tarball-ttl` setting when determining whether to lock the reference again.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
