### PR TITLE
libexpr: extend `Value::print` to allow limited depth

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -95,11 +95,16 @@ RootValue allocRootValue(Value * v)
 #endif
 }
 
-void Value::print(const SymbolTable & symbols, std::ostream & str,
-    std::set<const void *> * seen) const
+void Value::print(const SymbolTable &symbols, std::ostream &str,
+                  std::set<const void *> *seen, int depth) const
+
 {
     checkInterrupt();
 
+    if (depth <= 0) {
+        str << "«too deep»";
+        return;
+    }
     switch (internalType) {
     case tInt:
         str << integer;
@@ -123,7 +128,7 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
             str << "{ ";
             for (auto & i : attrs->lexicographicOrder(symbols)) {
                 str << symbols[i->name] << " = ";
-                i->value->print(symbols, str, seen);
+                i->value->print(symbols, str, seen, depth - 1);
                 str << "; ";
             }
             str << "}";
@@ -139,7 +144,7 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
             str << "[ ";
             for (auto v2 : listItems()) {
                 if (v2)
-                    v2->print(symbols, str, seen);
+                    v2->print(symbols, str, seen, depth - 1);
                 else
                     str << "(nullptr)";
                 str << " ";
@@ -181,11 +186,10 @@ void Value::print(const SymbolTable & symbols, std::ostream & str,
     }
 }
 
-
-void Value::print(const SymbolTable & symbols, std::ostream & str, bool showRepeated) const
-{
+void Value::print(const SymbolTable &symbols, std::ostream &str,
+                  bool showRepeated, int depth) const {
     std::set<const void *> seen;
-    print(symbols, str, showRepeated ? nullptr : &seen);
+    print(symbols, str, showRepeated ? nullptr : &seen, depth);
 }
 
 // Pretty print types for assertion errors

--- a/src/libexpr/tests/value/print.cc
+++ b/src/libexpr/tests/value/print.cc
@@ -1,0 +1,170 @@
+#include "tests/libexpr.hh"
+
+#include "value.hh"
+
+namespace nix {
+
+using namespace testing;
+
+struct ValuePrintingTests : LibExprTest
+{
+    template<class... A>
+    void test(Value v, std::string_view expected, A... args)
+    {
+        std::stringstream out;
+        v.print(state.symbols, out, args...);
+        ASSERT_EQ(out.str(), expected);
+    }
+};
+
+TEST_F(ValuePrintingTests, tInt)
+{
+    Value vInt;
+    vInt.mkInt(10);
+    test(vInt, "10");
+}
+
+TEST_F(ValuePrintingTests, tBool)
+{
+    Value vBool;
+    vBool.mkBool(true);
+    test(vBool, "true");
+}
+
+TEST_F(ValuePrintingTests, tString)
+{
+    Value vString;
+    vString.mkString("some-string");
+    test(vString, "\"some-string\"");
+}
+
+TEST_F(ValuePrintingTests, tPath)
+{
+    Value vPath;
+    vPath.mkString("/foo");
+    test(vPath, "\"/foo\"");
+}
+
+TEST_F(ValuePrintingTests, tNull)
+{
+    Value vNull;
+    vNull.mkNull();
+    test(vNull, "null");
+}
+
+TEST_F(ValuePrintingTests, tAttrs)
+{
+    Value vOne;
+    vOne.mkInt(1);
+
+    Value vTwo;
+    vTwo.mkInt(2);
+
+    BindingsBuilder builder(state, state.allocBindings(10));
+    builder.insert(state.symbols.create("one"), &vOne);
+    builder.insert(state.symbols.create("two"), &vTwo);
+
+    Value vAttrs;
+    vAttrs.mkAttrs(builder.finish());
+
+    test(vAttrs, "{ one = 1; two = 2; }");
+}
+
+TEST_F(ValuePrintingTests, tList)
+{
+    Value vOne;
+    vOne.mkInt(1);
+
+    Value vTwo;
+    vTwo.mkInt(2);
+
+    Value vList;
+    state.mkList(vList, 5);
+    vList.bigList.elems[0] = &vOne;
+    vList.bigList.elems[1] = &vTwo;
+    vList.bigList.size = 3;
+
+    test(vList, "[ 1 2 (nullptr) ]");
+}
+
+TEST_F(ValuePrintingTests, vThunk)
+{
+    Value vThunk;
+    vThunk.mkThunk(nullptr, nullptr);
+
+    test(vThunk, "<CODE>");
+}
+
+TEST_F(ValuePrintingTests, vApp)
+{
+    Value vApp;
+    vApp.mkApp(nullptr, nullptr);
+
+    test(vApp, "<CODE>");
+}
+
+TEST_F(ValuePrintingTests, vLambda)
+{
+    Value vLambda;
+    vLambda.mkLambda(nullptr, nullptr);
+
+    test(vLambda, "<LAMBDA>");
+}
+
+TEST_F(ValuePrintingTests, vPrimOp)
+{
+    Value vPrimOp;
+    vPrimOp.mkPrimOp(nullptr);
+
+    test(vPrimOp, "<PRIMOP>");
+}
+
+TEST_F(ValuePrintingTests, vPrimOpApp)
+{
+    Value vPrimOpApp;
+    vPrimOpApp.mkPrimOpApp(nullptr, nullptr);
+
+    test(vPrimOpApp, "<PRIMOP-APP>");
+}
+
+TEST_F(ValuePrintingTests, vExternal)
+{
+    struct MyExternal : ExternalValueBase
+    {
+    public:
+        std::string showType() const override
+        {
+            return "";
+        }
+        std::string typeOf() const override
+        {
+            return "";
+        }
+        virtual std::ostream & print(std::ostream & str) const override
+        {
+            str << "testing-external!";
+            return str;
+        }
+    } myExternal;
+    Value vExternal;
+    vExternal.mkExternal(&myExternal);
+
+    test(vExternal, "testing-external!");
+}
+
+TEST_F(ValuePrintingTests, vFloat)
+{
+    Value vFloat;
+    vFloat.mkFloat(2.0);
+
+    test(vFloat, "2");
+}
+
+TEST_F(ValuePrintingTests, vBlackhole)
+{
+    Value vBlackhole;
+    vBlackhole.mkBlackhole();
+    test(vBlackhole, "«potential infinite recursion»");
+}
+
+} // namespace nix

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include <cassert>
+#include <climits>
 
 #include "symbol-table.hh"
 #include "value/context.hh"
@@ -137,11 +138,11 @@ private:
 
     friend std::string showType(const Value & v);
 
-    void print(const SymbolTable & symbols, std::ostream & str, std::set<const void *> * seen) const;
+    void print(const SymbolTable &symbols, std::ostream &str, std::set<const void *> *seen, int depth) const;
 
 public:
 
-    void print(const SymbolTable & symbols, std::ostream & str, bool showRepeated = false) const;
+    void print(const SymbolTable &symbols, std::ostream &str, bool showRepeated = false, int depth = INT_MAX) const;
 
     // Functions needed to distinguish the type
     // These should be removed eventually, by putting the functionality that's


### PR DESCRIPTION
# Motivation

This is an extension for setting limited depth for `nix::Value` printing. Sometimes this list is fairly large because of recursive set inside nix, and printing in a desired depth make things much easier for users who just want to see limited depth (for example, when using `nix repl`, we may only want to see `depth = 1`  attribute fields, instead of digging into it (basically unreadable). Maybe we can extend `nix repl` after this change, for limited depth printing.

# Context

I'm writting a nix language server which would like to provide consistent developer experience between editors and official nix implementation, and `nix::Value::print` seems a good way to show values (there is no other good public method to do so). And this method may take long time to finish.

Related PR: https://github.com/nix-community/nixd/pull/149

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
