### PR TITLE
Use a struct not `std::pair` for `SearchPathElem`

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -65,8 +65,12 @@ std::string printValue(const EvalState & state, const Value & v);
 std::ostream & operator << (std::ostream & os, const ValueType t);
 
 
-// FIXME: maybe change this to an std::variant<SourcePath, URL>.
-typedef std::pair<std::string, std::string> SearchPathElem;
+struct SearchPathElem
+{
+    std::string prefix;
+    // FIXME: maybe change this to an std::variant<SourcePath, URL>.
+    std::string path;
+};
 typedef std::list<SearchPathElem> SearchPath;
 
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1656,7 +1656,10 @@ static void prim_findFile(EvalState & state, const PosIdx pos, Value * * args, V
             }));
         }
 
-        searchPath.emplace_back(prefix, path);
+        searchPath.emplace_back(SearchPathElem {
+            .prefix = prefix,
+            .path = path,
+        });
     }
 
     auto path = state.forceStringNoCtx(*args[1], pos, "while evaluating the second argument passed to builtins.findFile");
@@ -4129,8 +4132,8 @@ void EvalState::createBaseEnv()
     int n = 0;
     for (auto & i : searchPath) {
         auto attrs = buildBindings(2);
-        attrs.alloc("path").mkString(i.second);
-        attrs.alloc("prefix").mkString(i.first);
+        attrs.alloc("path").mkString(i.path);
+        attrs.alloc("prefix").mkString(i.prefix);
         (v.listElems()[n++] = allocValue())->mkAttrs(attrs);
     }
     addConstant("__nixPath", v);


### PR DESCRIPTION
# Motivation

I got very confused trying to keep all the `first` and `second` straight reading the code, *especially* as there is also another `(boolean, string)` pair type also being used.

Named fields is much better.

# Context

There are other cleanups that we can do (for example, the existing TODO), but we can do them later. Doing them now would just make this harder to review.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [x] documentation in the manual
 - [x] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [x] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
