### PR TITLE
fix `nix shell` and namespace nesting with diverted chroot store 

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -44,11 +44,9 @@
 #include <sched.h>
 #include <sys/param.h>
 #include <sys/mount.h>
-#include <sys/syscall.h>
 #if HAVE_SECCOMP
 #include <seccomp.h>
 #endif
-#define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
 #endif
 
 #if __APPLE__

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -50,7 +50,6 @@
 #if HAVE_SECCOMP
 #include <seccomp.h>
 #endif
-#define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
 #endif
 
 #if __APPLE__
@@ -1906,7 +1905,7 @@ void LocalDerivationGoal::runChild()
             if (mkdir("real-root", 0) == -1)
                 throw SysError("cannot create real-root directory");
 
-            if (pivot_root(".", "real-root") == -1)
+            if (syscall(SYS_pivot_root, ".", "real-root") == -1)
                 throw SysError("cannot pivot old root directory onto '%1%'", (chrootRootDir + "/real-root"));
 
             if (chroot(".") == -1)


### PR DESCRIPTION
# Motivation

Fixes two problems when using a chroot store (i.e. if `/nix` can't be created):
1. `nix shell` fails if it has to read a `propagated-user-env-packages`, as it does not take into account the actual location of the store outside the mount namespace.
2. No user namespaces can be created inside a namespace/chroot that was created by `nix`



# Context

`nix shell` failing to read the env packages is obviously just a bug and a trivial fix.

By using `pivot_root` instead of `chroot`, it is possible for child processes to create their own user namespaces. I've needed this in the past when using `nix shell` to run a script that itself tries to call `nix`. This technically changes behavior, as it's quite easy to "escape" `chroot`, but not `pivot_root`. Obviously it's not intended as a security barrier here but as a convenience feature, but it's still worth mentioning.

This enables running another `nix` process inside a `nix shell` as well as running other binaries that need to create a user namespace, such as sandboxing tools.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
