### PR TITLE
Fix fish shell issue with NIX_SSL_CERT_FILE

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -36,7 +36,7 @@ else if test -e "$NIX_LINK/etc/ca-bundle.crt" # old cacert in Nix profile
   set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
 else
   # Fall back to what is in the nix profiles, favouring whatever is defined last.
-  for i in $NIX_PROFILES
+  for i in (string split ' ' $NIX_PROFILES)
     if test -e "$i/etc/ssl/certs/ca-bundle.crt"
       set --export NIX_SSL_CERT_FILE "$i/etc/ssl/certs/ca-bundle.crt"
     end


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

I noticed this while debugging my reinstallation of Nix which was not working. `nix-shell -p nix-info --run "nix-info -m"` was failing with an SSL error. I added some tracing to this script and noticed it was behaving unexpectedly. Making this change did not fix my underlying issue unfortunately, I will open a separate issue for that once I have more information. I am on MacOS 12.6.6 and fish version 3.6.1.


# Context
<!-- Provide context. Reference open issues if available. -->

Fish does not split on spaces in variable values automatically.

    $ set VAR "foo bar"
    $ for i in $VAR; echo "$i/baz/"; end
    foo bar/baz/

Fish can handle multiple values if the spaces are unquoted,

    $ set VAR foo bar
    $ for i in $VAR; echo "$i/baz/"; end
    foo/baz/
    bar/baz/

or by using the command `string split ' ' $VAR`.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
