### PR TITLE
nix flake check: improve error message if overlay is not a lambda

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -386,8 +386,10 @@ struct CmdFlakeCheck : FlakeCommand
         auto checkOverlay = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
             try {
                 state->forceValue(v, pos);
-                if (!v.isLambda()
-                    || v.lambda.fun->hasFormals()
+                if (!v.isLambda()) {
+                    throw Error("overlay is not a function, but %s instead", showType(v));
+                }
+                if (v.lambda.fun->hasFormals()
                     || !argHasName(v.lambda.fun->arg, "final"))
                     throw Error("overlay does not take an argument named 'final'");
                 auto body = dynamic_cast<ExprLambda *>(v.lambda.fun->body);

--- a/tests/flakes/check.sh
+++ b/tests/flakes/check.sh
@@ -27,6 +27,18 @@ EOF
 
 cat > $flakeDir/flake.nix <<EOF
 {
+  outputs = { self, ... }: {
+    overlays.x86_64-linux.foo = final: prev: {
+    };
+  };
+}
+EOF
+
+checkRes=$(nix flake check $flakeDir 2>&1 && fail "nix flake check --all-systems should have failed" || true)
+echo "$checkRes" | grepQuiet "error: overlay is not a function, but a  instead"
+
+cat > $flakeDir/flake.nix <<EOF
+{
   outputs = { self }: {
     nixosModules.foo = {
       a.b.c = 123;

--- a/tests/flakes/check.sh
+++ b/tests/flakes/check.sh
@@ -35,7 +35,7 @@ cat > $flakeDir/flake.nix <<EOF
 EOF
 
 checkRes=$(nix flake check $flakeDir 2>&1 && fail "nix flake check --all-systems should have failed" || true)
-echo "$checkRes" | grepQuiet "error: overlay is not a function, but a  instead"
+echo "$checkRes" | grepQuiet "error: overlay is not a function, but a set instead"
 
 cat > $flakeDir/flake.nix <<EOF
 {


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Suppose you have an overlay like this

    {
      inputs = { /* ... */ };
      outputs = { flake-utils, ... }: flake-utils.lib.eachDefaultSystem
        (system: {
          overlays.default = final: prev: {

          };
        });
    }

then `nix flake check` (correctly) fails because `overlays` are supposed to have the structure `overlays.<name> = final: prev: exp`. However, the error-message is a little bit counter-intuitive:

    error: overlay does not take an argument named 'final'

While one might guess where the error actually comes from because the trace above says `… while checking the overlay 'overlays.x86_64-linux'` this is still pretty confusing because it complains about an argument not being named `final` even though that's evidently the case.

With this change, the error-message actually makes it clear what's wrong:

    [ma27@carsten:~/Projects/nix/tmp]$ nix flake check --extra-experimental-features 'nix-command flakes' path:$(pwd)
    error:
           … while checking flake output 'overlays'

             at /nix/store/clgblnxx003hyrq8qkz5ab6kgqkck6qc-source/flake.nix:4:5:

                3|   outputs = { ... }: {
                4|     overlays.x86_64-linux.fnord = final: prev: {
                 |     ^
                5|       kek = throw "fnord";

           … while checking the overlay 'overlays.x86_64-linux'

             at /nix/store/clgblnxx003hyrq8qkz5ab6kgqkck6qc-source/flake.nix:4:5:

                3|   outputs = { ... }: {
                4|     overlays.x86_64-linux.fnord = final: prev: {
                 |     ^
                5|       kek = throw "fnord";

           error: overlay is not a lambda, but a set instead

# Context
n/a

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
