### PR TITLE
libexpr: Remember intermediate values on exception

### DIFF
--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -98,6 +98,10 @@ void EvalState::forceValue(Value & v, Callable getPos)
             v.mkBlackhole();
             //checkInterrupt();
             expr->eval(*this, *env, v);
+        } catch (Error & e) {
+            if (e.validThunk != &v)
+                v.mkThunk(env, expr);
+            throw;
         } catch (...) {
             v.mkThunk(env, expr);
             throw;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1380,7 +1380,16 @@ void ExprLet::eval(EvalState & state, Env & env, Value & v)
     for (auto & i : attrs->attrs)
         env2.values[displ++] = i.second.e->maybeThunk(state, i.second.inherited ? env : env2);
 
-    body->eval(state, env2, v);
+    try {
+        body->eval(state, env2, v);
+    }
+    catch (Error &e) {
+        if (e.validThunk != &v) {
+            v.mkThunk(&env2, body);
+            e.validThunk = &v;
+        }
+        throw;
+    }
 }
 
 
@@ -1524,6 +1533,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
 
     Value vCur(fun);
 
+    /* Prepare to return a partial application of the remaining arguments. */
     auto makeAppChain = [&]()
     {
         vRes = vCur;
@@ -1531,6 +1541,19 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
             auto fun2 = allocValue();
             *fun2 = vRes;
             vRes.mkPrimOpApp(fun2, args[i]);
+        }
+    };
+
+    /* Like makeAppChain, but produces regular applications that don't come with
+       the implicit assumption that they're partial applications to a primop.
+       When recovering from an exception, the chain may well be complete. */
+    auto makeAppChain2 = [&]()
+    {
+        vRes = vCur;
+        for (size_t i = 0; i < nrArgs; ++i) {
+            auto fun2 = allocValue();
+            *fun2 = vRes;
+            vRes.mkApp(fun2, args[i]);
         }
     };
 
@@ -1626,6 +1649,26 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
 
                 lambda.body->eval(*this, env2, vCur);
             } catch (Error & e) {
+
+                { /* Preserve partially completed evaluation in vRes */
+
+                    if (e.validThunk == &vCur) {
+                        /* vCur is in a good state, so we get to keep the progress
+                        we made in body->eval() */
+                    } else {
+                        /* At least retain what we were able to compute in env2 */
+                        vCur.mkThunk(&env2, lambda.body);
+                    }
+                    /* vCur already contains a "succesful" application, so we
+                    complete this iteration... */
+                    nrArgs--;
+                    args += 1;
+                    /* ... and then preserve any remaining arguments as mkApp thunks.
+                    from vRes (root) to vCur (leaf in this context). */
+                    makeAppChain2();
+                    e.validThunk = &vRes;
+                }
+
                 if (loggerSettings.showTrace.get()) {
                     addErrorTrace(
                         e,
@@ -1655,6 +1698,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
             } else {
                 /* We have all the arguments, so call the primop. */
                 auto name = vCur.primOp->name;
+                Value vCurOrig = vCur;
 
                 nrPrimOpCalls++;
                 if (countCalls) primOpCalls[name]++;
@@ -1662,6 +1706,19 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                 try {
                     vCur.primOp->fun(*this, noPos, args, vCur);
                 } catch (Error & e) {
+
+                    /* Preserve partially completed evaluation */
+                    if (e.validThunk == &vCur) {
+                        /* vCur already contains a good representation of the
+                           partially evaluated result. */
+                        vRes = vCur;
+                    } else {
+                        /* vCur is garbage. Reinitialize it and wrap it in mkApp. */
+                        vCur = vCurOrig;
+                        makeAppChain2(); // assigns vRes
+                    }
+                    e.validThunk = &vRes;
+
                     addErrorTrace(e, pos, "while calling the '%1%' builtin", name);
                     throw;
                 }
@@ -1710,6 +1767,13 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                     //    so the debugger allows to inspect the wrong parameters passed to the builtin.
                     primOp->primOp->fun(*this, noPos, vArgs, vCur);
                 } catch (Error & e) {
+
+                    // TODO:
+                    // Preserve partially completed evaluation like above?
+                    // I haven't managed to reproduce this in memoize-despite-exception.sh,
+                    // and it seems to be covered by the other logic.
+                    // Maybe it's because of the redundancy described in the TODO above?
+
                     addErrorTrace(e, pos, "while calling the '%1%' builtin", name);
                     throw;
                 }
@@ -1728,6 +1792,20 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
             try {
                 callFunction(*functor->value, 2, args2, vCur, functor->pos);
             } catch (Error & e) {
+
+                /* Preserve partially completed evaluation */
+                if (e.validThunk == &vCur) {
+                    /* vCur already contains a good representation of the
+                        partially evaluated result. We pass it through. */
+                    vRes = vCur;
+                    e.validThunk = &vRes;
+                } else {
+                    /* callFunction should be able to preserve the partial
+                       evaluation in vCur, so this branch should not be entered.
+                       If it is, e.validThunk ensures that the thunk is reset
+                       for a possible retry. */
+                }
+
                 e.addTrace(positions[pos], "while calling a functor (an attribute set with a '__functor' attribute)");
                 throw;
             }

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -41,6 +41,7 @@
 
 namespace nix {
 
+struct Value;
 
 typedef enum {
     lvlError = 0,
@@ -130,6 +131,18 @@ protected:
 
 public:
     unsigned int status = 1; // exit status
+
+    /* `validThunk` signals that the Value at this optional address contains a
+       valid thunk. We generally can not assume a the return value to be valid
+       in case of an exception, but by making this explicit, we can preserve
+       partially evaluated expressions, which is crucial for performance if we
+       want to retry later.
+
+       For example, `forceValue()` has a `catch` clause that prevents garbage
+       from ending up in the value. If `validThunk` does not match the address
+       of the value in `forceValue()`, the value will be reset to the original
+       thunk. Similar logic exists elsewhere, including `callFunction`. */
+    mutable Value * validThunk = nullptr;
 
     BaseError(const BaseError &) = default;
 

--- a/tests/functional/common/vars-and-functions.sh.in
+++ b/tests/functional/common/vars-and-functions.sh.in
@@ -271,6 +271,19 @@ grepQuietInverse() {
     ! grep "$@" > /dev/null
 }
 
+# Forward stdin not just to stdout, but also to stderr.
+# tee /dev/stderr may not work on darwin
+if test -w /dev/stderr && type -p tee > /dev/null; then
+spy() {
+    tee /dev/stderr
+}
+else
+spy() {
+    # nobody suspects a cat https://en.wikipedia.org/wiki/Acoustic_Kitty
+    cat
+}
+fi
+
 trap onError ERR
 
 fi # COMMON_VARS_AND_FUNCTIONS_SH_SOURCED

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -31,6 +31,8 @@ nix-instantiate --eval -E 'let x = builtins.trace { x = x; } true; in x' \
 nix-instantiate --eval -E 'let x = { repeating = x; tracing = builtins.trace x true; }; in x.tracing'\
   2>&1 | grepQuiet -F 'trace: { repeating = «repeated»; tracing = «potential infinite recursion»; }'
 
+source lang/memoize-despite-exception.sh
+
 set +x
 
 badDiff=0

--- a/tests/functional/lang/memoize-despite-exception.sh
+++ b/tests/functional/lang/memoize-despite-exception.sh
@@ -39,11 +39,11 @@ app_and_let_are_memoized() {
 
     # The expensive computation is only performed once, despite evaluating the
     # `mem` thunk twice.
-    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | spy | grep 'trace: the expensive computation' | wc -l)"
     [[ "$n" == "1" ]]
 
     # The result is as expected, confirming that the saved thunk is correct.
-    expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'error: nope!'
+    expectStderr 1 nix-instantiate --eval -E "$expr" | spy | grep 'error: nope!'
 }
 app_and_let_are_memoized
 
@@ -111,11 +111,11 @@ app_and_let_are_memoized_functor() {
 
     # The expensive computation is only performed once, despite evaluating the
     # `mem` thunk twice.
-    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | spy | grep 'trace: the expensive computation' | wc -l)"
     [[ "$n" == "1" ]]
 
     # The result is as expected, confirming that the saved thunk is correct.
-    expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'error: nope!'
+    expectStderr 1 nix-instantiate --eval -E "$expr" | spy | grep 'error: nope!'
 }
 app_and_let_are_memoized_functor
 
@@ -130,11 +130,11 @@ app_and_let_are_memoized_primop_app() {
 
     # The expensive computation is only performed once, despite evaluating the
     # `mem` thunk twice.
-    n="$(nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    n="$(nix-instantiate --eval -E "$expr" 2>&1 | spy | grep 'trace: the expensive computation' | wc -l)"
     [[ "$n" == "1" ]]
 
     # The result is as expected, confirming that the saved thunk is correct.
-    nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep '"result is ok"'
+    nix-instantiate --eval -E "$expr" 2>&1 | spy | grep '"result is ok"'
 }
 app_and_let_are_memoized_primop_app
 
@@ -150,10 +150,10 @@ app_and_let_are_memoized_primop_app_complete() {
 
     # The expensive computation is only performed once, despite evaluating the
     # `mem` thunk twice.
-    n="$(nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    n="$(nix-instantiate --eval -E "$expr" 2>&1 | spy | grep 'trace: the expensive computation' | wc -l)"
     [[ "$n" == "1" ]]
 
     # The result is as expected, confirming that the saved thunk is correct.
-    nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep '"result is ok"'
+    nix-instantiate --eval -E "$expr" 2>&1 | spy | grep '"result is ok"'
 }
 app_and_let_are_memoized_primop_app_complete

--- a/tests/functional/lang/memoize-despite-exception.sh
+++ b/tests/functional/lang/memoize-despite-exception.sh
@@ -1,0 +1,159 @@
+# We want the rules about memoization of let bindings to hold even when an
+# exception occurs.
+#
+# This is slightly counterintuitive, because we might think that we'd have better
+# luck next time if we didn't memoize the result of the let binding.
+# However this contradicts the design goal of having a declarative language and
+# therefore idempotent evaluation.
+#
+# So instead of maintaining doubt about this situation, we choose to lean into
+# the language semantics and exploit the idempotency. This improves the
+# performance asymptotically and significantly in scenarios where we may
+# evaluate more than once. These scenarios include:
+#
+#  - `tryEval` has been used, such as in these test cases, or
+#  - traversal of multiple attributes, such as in `nix-build` with `recurseForDerivations`,
+#  - applications that handle missing information by throwing an exception to be handled by a convergent main loop,
+#  - re-parsing a file that used to have a syntax error in nix repl, without using `:r`.
+#
+# The latter is particularly useful for manual testing with real-world expressions:
+#
+#   1. Introduce a syntax error in a file that's imported somewhere deep/interesting
+#   2. `nix repl`
+#   3. Assign the expression to a variable, e.g. `x = haskellPackages.foo`
+#   4. Evaluate partially and observe the syntax error by typing `x`
+#   5. Fix the syntax error
+#   6. Type `x` again and observe that the expression is now evaluated correctly,
+#      and check that the result is the same as before the syntax error was introduced.
+
+app_and_let_are_memoized() {
+    expr='
+      let
+        f = { msg }:
+            let expensive = builtins.trace "the ${"expensive"} computation" true;
+            in builtins.seq expensive (throw (msg + exclaim));
+        mem = f { msg = "nope"; };
+        exclaim = "!";
+      in builtins.seq (builtins.tryEval mem) mem
+    '
+
+    # The expensive computation is only performed once, despite evaluating the
+    # `mem` thunk twice.
+    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    [[ "$n" == "1" ]]
+
+    # The result is as expected, confirming that the saved thunk is correct.
+    expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'error: nope!'
+}
+app_and_let_are_memoized
+
+app_and_let_are_memoized_eta_expanded_subexpr_call() {
+    expr='
+      let
+        f = { msg }:
+            let expensive = builtins.trace "the ${"expensive"} computation" true;
+                second = a: builtins.trace "the second expensive computation" a;
+            in builtins.seq expensive (second throw (msg + exclaim));
+        mem = f { msg = "nope"; };
+        exclaim = "!";
+      in builtins.seq (builtins.tryEval mem) mem
+    '
+
+    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | grep 'trace: the second expensive computation' | wc -l)"
+    [[ "$n" == "1" ]]
+}
+app_and_let_are_memoized_eta_expanded_subexpr_call
+
+app_and_let_are_memoized_subexpr_call() {
+    expr='
+      let
+        f = { msg }:
+            let expensive = builtins.trace "the ${"expensive"} computation" true;
+            in builtins.seq expensive (builtins.trace "the second expensive computation" throw (msg + exclaim));
+        mem = f { msg = "nope"; };
+        exclaim = "!";
+      in builtins.seq (builtins.tryEval mem) mem
+    '
+
+    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | grep 'trace: the second expensive computation' | wc -l)"
+    [[ "$n" == "1" ]]
+}
+app_and_let_are_memoized_subexpr_call
+
+app_and_let_are_memoized_let_partial_subexpr_call() {
+    expr='
+      let
+        f = { msg }:
+            let expensive = builtins.trace "the ${"expensive"} computation" true;
+                second = builtins.trace "the second expensive computation";
+            in builtins.seq expensive (second throw (msg + exclaim));
+        mem = f { msg = "nope"; };
+        exclaim = "!";
+      in builtins.seq (builtins.tryEval mem) mem
+    '
+
+    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | grep 'trace: the second expensive computation' | wc -l)"
+    [[ "$n" == "1" ]]
+}
+app_and_let_are_memoized_let_partial_subexpr_call
+
+app_and_let_are_memoized_functor() {
+    expr='
+      let
+        trivialFunctor = f: { __functor = _: f; };
+        f = { msg }:
+            let expensive = builtins.trace "the ${"expensive"} computation" true;
+            in builtins.seq expensive (throw (msg + exclaim));
+        mem = trivialFunctor f { msg = "nope"; };
+        exclaim = "!";
+      in builtins.seq (builtins.tryEval mem) mem
+    '
+
+    # The expensive computation is only performed once, despite evaluating the
+    # `mem` thunk twice.
+    n="$(expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    [[ "$n" == "1" ]]
+
+    # The result is as expected, confirming that the saved thunk is correct.
+    expectStderr 1 nix-instantiate --eval -E "$expr" | tee /dev/stderr | grep 'error: nope!'
+}
+app_and_let_are_memoized_functor
+
+app_and_let_are_memoized_primop_app() {
+    expr='
+      let
+        trivialFunctor = f: { __functor = _: f; };
+        f = builtins.seq (builtins.trace "the ${"expensive"} computation" true);
+        exclaim = "!";
+      in builtins.seq (builtins.tryEval (f (throw "app_and_let_are_memoized_primop_app"))) f "result ${"is ok"}"
+    '
+
+    # The expensive computation is only performed once, despite evaluating the
+    # `mem` thunk twice.
+    n="$(nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    [[ "$n" == "1" ]]
+
+    # The result is as expected, confirming that the saved thunk is correct.
+    nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep '"result is ok"'
+}
+app_and_let_are_memoized_primop_app
+
+app_and_let_are_memoized_primop_app_complete() {
+    expr='
+      let
+        f = builtins.seq (builtins.trace "the ${"expensive"} computation" true) (throw "not ok");
+      in
+        builtins.seq (builtins.tryEval f)
+        builtins.seq (builtins.tryEval f)
+        "result ${"is ok"}"
+    '
+
+    # The expensive computation is only performed once, despite evaluating the
+    # `mem` thunk twice.
+    n="$(nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep 'trace: the expensive computation' | wc -l)"
+    [[ "$n" == "1" ]]
+
+    # The result is as expected, confirming that the saved thunk is correct.
+    nix-instantiate --eval -E "$expr" 2>&1 | tee /dev/stderr | grep '"result is ok"'
+}
+app_and_let_are_memoized_primop_app_complete


### PR DESCRIPTION

# Motivation

Preserve sharing in case of an exception. When an exception occurs, the original expression, or a similar expression with shared values may be retried. Intermediate values should be retained as much as possible.

TODO:
 - [ ] Thoroughly check that this code is correct and that the tests cover all the changes. I originally wrote this as an experiment and I don't think it is ready for production.

# Context

 - Does not solve #8530 (yet?)

We want the rules about memoization of let bindings to hold even when an exception occurs.

This is slightly counterintuitive, because we might think that we'd have better luck next time if we didn't memoize the result of the let binding.
However this contradicts the design goal of having a declarative language and therefore idempotent evaluation.

So instead of maintaining doubt about this situation, we choose to lean into the language semantics and exploit the idempotency. This improves the performance asymptotically and significantly in scenarios where we may evaluate more than once. These scenarios include:

  - `tryEval` has been used, such as in these test cases, or
  - traversal of multiple attributes, such as in `nix-build` with `recurseForDerivations`,
  - applications that handle missing information by throwing an exception to be handled by a convergent main loop,
  - re-parsing a file that used to have a syntax error in nix repl, without using `:r`.


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
