### PR TITLE
Set AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE on macOS nix-daemon

### DIFF
--- a/doc/manual/src/package-management/s3-substituter.md
+++ b/doc/manual/src/package-management/s3-substituter.md
@@ -50,7 +50,11 @@ For AWS S3 the binary cache URL for example bucket will be exactly
 
 Nix will use the [default credential provider
 chain](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/credentials.html)
-for authenticating requests to Amazon S3.
+for authenticating requests to Amazon S3. *On macOS:* the multi-user nix
+installer configures `nix-daemon` such that the [location of shared `config`
+and `credentials`
+files](https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html) are
+`/etc/nix/aws/config` and `/etc/nix/aws/credentials`, respectively.
 
 Nix supports authenticated reads from Amazon S3 and S3 compatible binary
 caches.
@@ -69,7 +73,11 @@ buckets. The binary cache URL for our example bucket will be
 
 Nix will use the [default credential provider
 chain](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/credentials.html)
-for authenticating requests to Amazon S3.
+for authenticating requests to Amazon S3. *On macOS:* the multi-user nix
+installer configures `nix-daemon` such that the [location of shared `config`
+and `credentials`
+files](https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html) are
+`/etc/nix/aws/config` and `/etc/nix/aws/credentials`, respectively.
 
 Your account will need the following IAM policy to upload to the cache:
 

--- a/misc/launchd/org.nixos.nix-daemon.plist.in
+++ b/misc/launchd/org.nixos.nix-daemon.plist.in
@@ -6,6 +6,10 @@
     <dict>
       <key>OBJC_DISABLE_INITIALIZE_FORK_SAFETY</key>
       <string>YES</string>
+      <key>AWS_CONFIG_FILE</key>
+      <string>/etc/nix/aws/config</string>
+      <key>AWS_SHARED_CREDENTIALS_FILE</key>
+      <string>/etc/nix/aws/credentials</string>
     </dict>
     <key>Label</key>
     <string>org.nixos.nix-daemon</string>


### PR DESCRIPTION
# Motivation

macOS updates often clear unknown files from `/var/root`, including `/var/root/.aws`, which is where credentials for private S3 binary caches are stored. This means that macOS updates can make S3 caches silently stop working, leading to surprisingly long build times. I propose setting the default credential location to `/etc/nix/aws/` to avoid this.

# Context

See https://github.com/NixOS/nix/issues/2161#issuecomment-1610403519.

The intention of this PR is to get the ball rolling on a permanent solution to this annoying problem. I have not tested it.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

- [ ] agreed on idea
- [ ] agreed on implementation strategy
- [ ] tests, as appropriate
  - functional tests - `tests/**.sh`
  - unit tests - `src/*/tests`
  - integration tests - `tests/nixos/*`
- [ ] documentation in the manual
- [ ] documentation in the internal API docs
- [ ] code and comments are self-explanatory
- [ ] commit message explains why the change was made
- [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
