### PR TITLE
Check for static busybox in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -419,6 +419,25 @@ if test ${cross_compiling:-no} = no && ! test -z ${sandbox_shell+x}; then
   else
     AC_MSG_RESULT(disabled)
   fi
+
+  # system refers to host platform
+  case $system in
+    *-darwin)
+      # ldd unsupported on darwin *build* platform, and
+      # static linking against system libraries not recommended on darwin,
+      # so we don't check that sandbox-shell is statically linked
+      ;;
+    *)
+      # A dynamically linked shell will not work in the sandbox.
+      AC_MSG_CHECKING([whether sandbox-shell is statically linked])
+      if ldd $sandbox_shell 2>&1 | grep -q "not a dynamic executable"; then
+        AC_MSG_RESULT(yes)
+      else
+        AC_MSG_RESULT(no)
+        AC_MSG_ERROR([Please enable busybox STATIC])
+      fi
+      ;;
+  esac
 fi
 
 AC_ARG_ENABLE(embedded-sandbox-shell, AS_HELP_STRING([--enable-embedded-sandbox-shell],[include the sandbox shell in the Nix binary [default=no]]),


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

A dynamically linked shell will not work in the sandbox. This change catches the problem at configure time with a clear error.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
