### PR TITLE
libexpr: fix leaking `es2` in stripIndentation (parser.y)

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -275,7 +275,12 @@ static Expr * stripIndentation(const PosIdx pos, SymbolTable & symbols,
     }
 
     /* If this is a single string, then don't do a concatenation. */
-    return es2->size() == 1 && dynamic_cast<ExprString *>((*es2)[0].second) ? (*es2)[0].second : new ExprConcatStrings(pos, true, es2);
+    if (es2->size() == 1 && dynamic_cast<ExprString *>((*es2)[0].second)) {
+        auto *const result = (*es2)[0].second;
+        delete es2;
+        return result;
+    }
+    return new ExprConcatStrings(pos, true, es2);
 }
 
 


### PR DESCRIPTION
# Motivation

delete the memory allocated by operator `new` of `es2`, this is leaking in case of the first branch.

# Context

Before this patch:

```console
$ valgrind --leak-check=full build/nixd-ast-dump ../nixpkgs/pkgs/top-level/all-packages.nix
==3881399== Memcheck, a memory error detector
==3881399== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==3881399== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==3881399== Command: build/nixd-ast-dump ../nixpkgs/pkgs/top-level/all-packages.nix
==3881399== 

<...>

==3881399== HEAP SUMMARY:
==3881399==     in use at exit: 159,597 bytes in 2,319 blocks
==3881399==   total heap usage: 752,385 allocs, 755,841 frees, 59,543,975 bytes allocated
==3881399== 
==3881399== 120 (72 direct, 48 indirect) bytes in 3 blocks are definitely lost in loss record 2,297 of 2,313
==3881399==    at 0x4842EE1: operator new(unsigned long) (in /nix/store/f38xjnrm8mrwhyy8w1lcg0gy8nk4w6lv-valgrind-3.21.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3881399==    by 0x42B67E: nixd::stripIndentation(nix::PosIdx, nix::SymbolTable&, std::vector<std::pair<nix::PosIdx, std::variant<nix::Expr*, StringToken> >, std::allocator<std::pair<nix::PosIdx, std::variant<nix::Expr*, StringToken> > > >&&) (ParserPrologue.h:174)
==3881399==    by 0x42FE70: yyuserAction(int, int, yyGLRStackItem*, yyGLRStack*, long, YYSTYPE*, YYLTYPE*, void*, nixd::ParseData*) (Parser.y:176)
==3881399==    by 0x435A40: yydoAction(yyGLRStack*, long, int, YYSTYPE*, YYLTYPE*, void*, nixd::ParseData*) (Parser.tab.cpp:2501)
==3881399==    by 0x435C2A: yyglrReduce(yyGLRStack*, long, int, bool, void*, nixd::ParseData*) (Parser.tab.cpp:2547)
==3881399==    by 0x4380A7: yyparse(void*, nixd::ParseData*) (Parser.tab.cpp:3492)
==3881399==    by 0x438A4D: nixd::parse(char*, unsigned long, std::variant<nix::Pos::none_tag, nix::Pos::Stdin, nix::Pos::String, nix::SourcePath>, nix::SourcePath const&, nixd::ParseState) (ParserEpilogue.cpp:40)
==3881399==    by 0x456984: nixd::parse(char*, unsigned long, std::variant<nix::Pos::none_tag, nix::Pos::Stdin, nix::Pos::String, nix::SourcePath>, nix::SourcePath const&) (Parser.h:30)
==3881399==    by 0x456B14: nixd::parse(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::variant<nix::Pos::none_tag, nix::Pos::Stdin, nix::Pos::String, nix::SourcePath>, nix::SourcePath const&) (Parser.h:37)
==3881399==    by 0x452EBE: main (nixd-ast-dump.cpp:96)
==3881399== 
==3881399== LEAK SUMMARY:
==3881399==    definitely lost: 72 bytes in 3 blocks
==3881399==    indirectly lost: 48 bytes in 3 blocks
==3881399==      possibly lost: 0 bytes in 0 blocks
==3881399==    still reachable: 159,477 bytes in 2,313 blocks
==3881399==         suppressed: 0 bytes in 0 blocks
==3881399== Reachable blocks (those to which a pointer was found) are not shown.
==3881399== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==3881399== 
==3881399== For lists of detected and suppressed errors, rerun with: -s
==3881399== ERROR SUMMARY: 170098 errors from 178 contexts (suppressed: 0 from 0)

```

After this patch:

```console
$ valgrind --leak-check=full build/nixd-ast-dump ../nixpkgs/pkgs/top-level/all-packages.nix
==3883831== Memcheck, a memory error detector
==3883831== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==3883831== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==3883831== Command: build/nixd-ast-dump ../nixpkgs/pkgs/top-level/all-packages.nix
==3883831== 

<...>

==3883831== HEAP SUMMARY:
==3883831==     in use at exit: 159,477 bytes in 2,313 blocks
==3883831==   total heap usage: 752,385 allocs, 755,847 frees, 59,543,975 bytes allocated
==3883831== 
==3883831== LEAK SUMMARY:
==3883831==    definitely lost: 0 bytes in 0 blocks
==3883831==    indirectly lost: 0 bytes in 0 blocks
==3883831==      possibly lost: 0 bytes in 0 blocks
==3883831==    still reachable: 159,477 bytes in 2,313 blocks
==3883831==         suppressed: 0 bytes in 0 blocks
==3883831== Reachable blocks (those to which a pointer was found) are not shown.
==3883831== To see them, rerun with: --leak-check=full --show-leak-kinds=al

```

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
