### PR TITLE
toJSON: Add attribute path to trace

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -6,3 +6,5 @@
   [`builtins.flakeRefToString`](@docroot@/language/builtins.md#builtins-flakeRefToString),
   have been added.
   These functions are useful for converting between flake references encoded as attribute sets and URLs.
+
+- [`builtins.toJSON`](@docroot@/language/builtins.md#builtins-parseFlakeRef) now prints [--show-trace](@docroot@/command-ref/conf-file.html#conf-show-trace) items for the path in which it finds an evaluation error.

--- a/tests/lang/eval-fail-toJSON.err.exp
+++ b/tests/lang/eval-fail-toJSON.err.exp
@@ -1,0 +1,57 @@
+error:
+       … while calling the 'toJSON' builtin
+
+         at /pwd/lang/eval-fail-toJSON.nix:1:1:
+
+            1| builtins.toJSON {
+             | ^
+            2|   a.b = [
+
+       … while evaluating attribute 'a'
+
+         at /pwd/lang/eval-fail-toJSON.nix:2:3:
+
+            1| builtins.toJSON {
+            2|   a.b = [
+             |   ^
+            3|     true
+
+       … while evaluating attribute 'b'
+
+         at /pwd/lang/eval-fail-toJSON.nix:2:3:
+
+            1| builtins.toJSON {
+            2|   a.b = [
+             |   ^
+            3|     true
+
+       … while evaluating list element at index 3
+
+       … while evaluating attribute 'c'
+
+         at /pwd/lang/eval-fail-toJSON.nix:7:7:
+
+            6|     {
+            7|       c.d = throw "hah no";
+             |       ^
+            8|     }
+
+       … while evaluating attribute 'd'
+
+         at /pwd/lang/eval-fail-toJSON.nix:7:7:
+
+            6|     {
+            7|       c.d = throw "hah no";
+             |       ^
+            8|     }
+
+       … while calling the 'throw' builtin
+
+         at /pwd/lang/eval-fail-toJSON.nix:7:13:
+
+            6|     {
+            7|       c.d = throw "hah no";
+             |             ^
+            8|     }
+
+       error: hah no

--- a/tests/lang/eval-fail-toJSON.nix
+++ b/tests/lang/eval-fail-toJSON.nix
@@ -1,0 +1,10 @@
+builtins.toJSON {
+  a.b = [
+    true
+    false
+    "it's a bird"
+    {
+      c.d = throw "hah no";
+    }
+  ];
+}


### PR DESCRIPTION
# Motivation

Attribute names weren't printed for errors down in the attrsets (and/or lists).

# Context

- For testing depends on #7954

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
