### PR TITLE
libexpr: add debugRepl hook for binary ops

### DIFF
--- a/src/libexpr/binops.inc.hh
+++ b/src/libexpr/binops.inc.hh
@@ -1,0 +1,9 @@
+#ifdef BinOp
+BinOp(ExprOpEq, "==")
+BinOp(ExprOpNEq, "!=")
+BinOp(ExprOpAnd, "&&")
+BinOp(ExprOpOr, "||")
+BinOp(ExprOpImpl, "->")
+BinOp(ExprOpUpdate, "//")
+BinOp(ExprOpConcatLists, "++")
+#endif

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -584,4 +584,14 @@ size_t SymbolTable::totalSize() const
     return n;
 }
 
+#define BinOp(OP, S) \
+    void OP::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env) \
+    { \
+        if (es.debugRepl) \
+            es.exprEnvs.insert(std::make_pair(this, env)); \
+        e1->bindVars(es, env); \
+        e2->bindVars(es, env); \
+    }
+#include "binops.inc.hh"
+#undef BinOp
 }

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -403,7 +403,7 @@ struct ExprOpNot : Expr
     COMMON_METHODS
 };
 
-#define MakeBinOp(name, s) \
+#define BinOp(name, s) \
     struct name : Expr \
     { \
         PosIdx pos; \
@@ -414,21 +414,13 @@ struct ExprOpNot : Expr
         { \
             str << "("; e1->show(symbols, str); str << " " s " "; e2->show(symbols, str); str << ")"; \
         } \
-        void bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env) override \
-        { \
-            e1->bindVars(es, env); e2->bindVars(es, env);    \
-        } \
+        void bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env) override; \
         void eval(EvalState & state, Env & env, Value & v) override; \
         PosIdx getPos() const override { return pos; } \
     };
 
-MakeBinOp(ExprOpEq, "==")
-MakeBinOp(ExprOpNEq, "!=")
-MakeBinOp(ExprOpAnd, "&&")
-MakeBinOp(ExprOpOr, "||")
-MakeBinOp(ExprOpImpl, "->")
-MakeBinOp(ExprOpUpdate, "//")
-MakeBinOp(ExprOpConcatLists, "++")
+#include "binops.inc.hh"
+#undef BinOp
 
 struct ExprConcatStrings : Expr
 {


### PR DESCRIPTION
# Motivation

We are missing the debugRepl hook (i.e.):

    if (es.debugRepl)
        es.exprEnvs.insert(std::make_pair(this, env));

For all binary ops.

This patch adds these hook in nixexpr.cc

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
