### PR TITLE
Try to realise CA derivations during queryMissing

### DIFF
--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -200,6 +200,36 @@ void Store::queryMissing(const std::vector<DerivedPath> & targets,
             auto drv = make_ref<Derivation>(derivationFromPath(bfd.drvPath));
             ParsedDerivation parsedDrv(StorePath(bfd.drvPath), *drv);
 
+            if (!knownOutputPaths && settings.useSubstitutes && parsedDrv.substitutesAllowed()) {
+                experimentalFeatureSettings.require(Xp::CaDerivations);
+
+                // If there are unknown output paths, attempt to find if the
+                // paths are known to substituters through a realisation.
+                auto outputHashes = staticOutputHashes(*this, *drv);
+                knownOutputPaths = true;
+
+                for (auto [outputName, hash] : outputHashes) {
+                    if (!bfd.outputs.contains(outputName))
+                        continue;
+
+                    bool found = false;
+                    for (auto &sub : getDefaultSubstituters()) {
+                        auto realisation = sub->queryRealisation({hash, outputName});
+                        if (!realisation)
+                            continue;
+                        found = true;
+                        if (!isValidPath(realisation->outPath))
+                            invalid.insert(realisation->outPath);
+                        break;
+                    }
+                    if (!found) {
+                        // Some paths did not have a realisation, this must be built.
+                        knownOutputPaths = false;
+                        break;
+                    }
+                }
+            }
+
             if (knownOutputPaths && settings.useSubstitutes && parsedDrv.substitutesAllowed()) {
                 auto drvState = make_ref<Sync<DrvState>>(DrvState(invalid.size()));
                 for (auto & output : invalid)

--- a/tests/ca/build-cache.sh
+++ b/tests/ca/build-cache.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# The substituters didn't work prior to this time.
+requireDaemonNewerThan "2.18.0pre20230808"
+
+drv=$(nix-instantiate ./content-addressed.nix -A rootCA --arg seed 1)^out
+nix derivation show "$drv" --arg seed 1
+
+buildAttr () {
+    local derivationPath=$1
+    local seedValue=$2
+    shift; shift
+    local args=("./content-addressed.nix" "-A" "$derivationPath" --arg seed "$seedValue" "--no-out-link")
+    args+=("$@")
+    nix-build "${args[@]}"
+}
+
+copyAttr () {
+    local derivationPath=$1
+    local seedValue=$2
+    shift; shift
+    local args=("-f" "./content-addressed.nix" "$derivationPath" --arg seed "$seedValue")
+    args+=("$@")
+    # Note: to copy CA derivations, we need to copy the realisations, which
+    # currently requires naming the installables, not just the derivation output
+    # path.
+    nix copy --to file://$cacheDir "${args[@]}"
+}
+
+testRemoteCacheFor () {
+    local derivationPath=$1
+    clearCache
+    copyAttr "$derivationPath" 1
+    clearStore
+    # Check nothing gets built.
+    buildAttr "$derivationPath" 1 --option substituters file://$cacheDir --no-require-sigs |& grepQuietInverse " will be built:"
+}
+
+testRemoteCache () {
+    testRemoteCacheFor rootCA
+    testRemoteCacheFor dependentCA
+    testRemoteCacheFor dependentNonCA
+    testRemoteCacheFor dependentFixedOutput
+    testRemoteCacheFor dependentForBuildCA
+    testRemoteCacheFor dependentForBuildNonCA
+}
+
+clearStore
+testRemoteCache

--- a/tests/ca/build.sh
+++ b/tests/ca/build.sh
@@ -2,7 +2,7 @@
 
 source common.sh
 
-drv=$(nix-instantiate ./content-addressed.nix -A rootCA --arg seed 1)
+drv=$(nix-instantiate ./content-addressed.nix -A rootCA --arg seed 1)^out
 nix derivation show "$drv" --arg seed 1
 
 buildAttr () {
@@ -12,14 +12,6 @@ buildAttr () {
     local args=("./content-addressed.nix" "-A" "$derivationPath" --arg seed "$seedValue" "--no-out-link")
     args+=("$@")
     nix-build "${args[@]}"
-}
-
-testRemoteCache () {
-    clearCache
-    local outPath=$(buildAttr dependentNonCA 1)
-    nix copy --to file://$cacheDir $outPath
-    clearStore
-    buildAttr dependentNonCA 1 --option substituters file://$cacheDir --no-require-sigs |& grepQuietInverse "building dependent-non-ca"
 }
 
 testDeterministicCA () {
@@ -66,8 +58,6 @@ testNormalization () {
     test "$(stat -c %Y $outPath)" -eq 1
 }
 
-# Disabled until we have it properly working
-# testRemoteCache
 clearStore
 testNormalization
 testDeterministicCA

--- a/tests/ca/content-addressed.nix
+++ b/tests/ca/content-addressed.nix
@@ -61,6 +61,24 @@ rec {
       echo ${rootCA}/non-ca-hello > $out/dep
     '';
   };
+  dependentForBuildCA = mkCADerivation {
+    name = "dependent-for-build-ca";
+    buildCommand = ''
+      echo "Depends on rootCA for building only"
+      mkdir -p $out
+      echo ${rootCA}
+      touch $out
+    '';
+  };
+  dependentForBuildNonCA = mkDerivation {
+    name = "dependent-for-build-non-ca";
+    buildCommand = ''
+      echo "Depends on rootCA for building only"
+      mkdir -p $out
+      echo ${rootCA}
+      touch $out
+    '';
+  };
   dependentFixedOutput = mkDerivation {
     name = "dependent-fixed-output";
     outputHashMode = "recursive";

--- a/tests/ca/local.mk
+++ b/tests/ca/local.mk
@@ -1,6 +1,7 @@
 ca-tests := \
   $(d)/build-with-garbage-path.sh \
   $(d)/build.sh \
+  $(d)/build-cache.sh \
   $(d)/concurrent-builds.sh \
   $(d)/derivation-json.sh \
   $(d)/duplicate-realisation-in-closure.sh \


### PR DESCRIPTION
This enables nix to correctly report what will be fetched in the case
that everything is a cache hit.

Note however that if an intermediate build of something which is not
cached could still cause products to end up being substituted if the
intermediate build results in a CA path which is in the cache.

Fixes #8615.

Signed-off-by: Peter Waller <p@pwaller.net>

# Motivation

* Give a better user experience
* Improve performance
* educe the number of HTTP requests to caches.

# Context

See #8615. TL;DR: If you use content-addressed derivations, the behaviour of cache hits was poor, and nix would spend quite a bit of time to incorrectly report that things needed to be built when they were cache hits.

This is my first contribution to nix. I've applied some basic level of reasoning to the fix, but you should assume the logic of the first implementation is completely incorrect until proven otherwise: please help me to get it correct.

I also have not yet had time to write a test for this, which I intend to do, but I wanted to send the PR early to avoid wasting time on this if the approach is somehow wrong.

Please see the TODO notes within the PR and comment on them. I intend to remove these before taking the PR out of draft.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
