### PR TITLE
Stack trace improvements

### DIFF
--- a/doc/manual/rl-next/infinite-recursion-start.md
+++ b/doc/manual/rl-next/infinite-recursion-start.md
@@ -1,0 +1,11 @@
+---
+synopsis: "Nix now marks the start of infinite recursions"
+prs: 8623
+---
+Nix can now mark the start of an infinite recursion when printing the evaluation stack with `--show-trace`. Look for
+
+```
+… entering the infinite recursion
+```
+
+This line is not printed if the infinite recursion does not coincide with a trace item.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1343,7 +1343,12 @@ Value * ExprList::maybeThunk(EvalState & state, Env & env)
 void ExprVar::eval(EvalState & state, Env & env, Value & v)
 {
     Value * v2 = state.lookupVar(&env, *this, false);
-    state.forceValue(*v2, pos);
+    try {
+        state.forceValue(*v2, pos);
+    } catch (Error & e) {
+        e.addTrace(&v, state.positions[pos], "while evaluating variable '%1%'", state.symbols[name]);
+        throw;
+    }
     v = *v2;
 }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -176,6 +176,9 @@ class ErrorBuilder
         ErrorBuilder & withTrace(PosIdx pos, const std::string_view text);
 
         [[nodiscard, gnu::noinline]]
+        ErrorBuilder & withTrace(Value *vRes, PosIdx pos, const std::string_view text);
+
+        [[nodiscard, gnu::noinline]]
         ErrorBuilder & withFrameTrace(PosIdx pos, const std::string_view text);
 
         [[nodiscard, gnu::noinline]]
@@ -184,9 +187,16 @@ class ErrorBuilder
         [[nodiscard, gnu::noinline]]
         ErrorBuilder & withFrame(const Env & e, const Expr & ex);
 
+        [[nodiscard, gnu::noinline]]
+        ErrorBuilder & withInfiniteRecursion(Value *v);
+
         template<class ErrorType>
         [[gnu::noinline, gnu::noreturn]]
         void debugThrow();
+
+        inline ErrorInfo &getErrorInfo() {
+            return info;
+        }
 };
 
 
@@ -495,6 +505,8 @@ public:
     void addErrorTrace(Error & e, const char * s, const std::string & s2) const;
     [[gnu::noinline]]
     void addErrorTrace(Error & e, const PosIdx pos, const char * s, const std::string & s2, bool frame = false) const;
+    [[gnu::noinline]]
+    void addErrorTrace(Value *vRes, Error & e, const PosIdx pos, const char * s, const std::string & s2, bool frame = false) const;
 
 public:
     /**

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -22,6 +22,12 @@ MakeError(TypeError, EvalError);
 MakeError(UndefinedVarError, Error);
 MakeError(MissingArgumentError, EvalError);
 
+/**
+ * Thrown when an infinite recursion is detected.
+ *
+ * These are detected by checking for a tBlackhole.
+ * It is not thrown for a stack overflow.
+ */
 class InfiniteRecursionError : public EvalError
 {
     friend class EvalState;

--- a/tests/functional/lang/eval-fail-blackhole-2.err.exp
+++ b/tests/functional/lang/eval-fail-blackhole-2.err.exp
@@ -1,4 +1,13 @@
 error:
+       … while evaluating variable 'P'
+
+         at /pwd/lang/eval-fail-blackhole-2.nix:15:4:
+
+           14|
+           15| in P
+             |    ^
+           16|
+
        … from call site
          at /pwd/lang/eval-fail-blackhole-2.nix:5:7:
             4|   # this part is ok

--- a/tests/functional/lang/eval-fail-blackhole-2.err.exp
+++ b/tests/functional/lang/eval-fail-blackhole-2.err.exp
@@ -1,0 +1,107 @@
+error:
+       … from call site
+         at /pwd/lang/eval-fail-blackhole-2.nix:5:7:
+            4|   # this part is ok
+            5|   P = increment Q;
+             |       ^
+            6|   Q = increment R;
+
+       … while calling 'increment'
+         at /pwd/lang/eval-fail-blackhole-2.nix:2:15:
+            1| let
+            2|   increment = x: x + 1;
+             |               ^
+            3|
+
+       … from call site
+         at /pwd/lang/eval-fail-blackhole-2.nix:6:7:
+            5|   P = increment Q;
+            6|   Q = increment R;
+             |       ^
+            7|   R = increment a;
+
+       … while calling 'increment'
+         at /pwd/lang/eval-fail-blackhole-2.nix:2:15:
+            1| let
+            2|   increment = x: x + 1;
+             |               ^
+            3|
+
+       … from call site
+         at /pwd/lang/eval-fail-blackhole-2.nix:7:7:
+            6|   Q = increment R;
+            7|   R = increment a;
+             |       ^
+            8|
+
+       … entering the infinite recursion
+
+       … while calling 'increment'
+         at /pwd/lang/eval-fail-blackhole-2.nix:2:15:
+            1| let
+            2|   increment = x: x + 1;
+             |               ^
+            3|
+
+       … from call site
+         at /pwd/lang/eval-fail-blackhole-2.nix:10:7:
+            9|   # `a` is where it loops back to
+           10|   a = increment b;
+             |       ^
+           11|   b = increment c;
+
+       … while calling 'increment'
+         at /pwd/lang/eval-fail-blackhole-2.nix:2:15:
+            1| let
+            2|   increment = x: x + 1;
+             |               ^
+            3|
+
+       … from call site
+         at /pwd/lang/eval-fail-blackhole-2.nix:11:7:
+           10|   a = increment b;
+           11|   b = increment c;
+             |       ^
+           12|   c = increment d;
+
+       … while calling 'increment'
+         at /pwd/lang/eval-fail-blackhole-2.nix:2:15:
+            1| let
+            2|   increment = x: x + 1;
+             |               ^
+            3|
+
+       … from call site
+         at /pwd/lang/eval-fail-blackhole-2.nix:12:7:
+           11|   b = increment c;
+           12|   c = increment d;
+             |       ^
+           13|   d = increment a;
+
+       … while calling 'increment'
+         at /pwd/lang/eval-fail-blackhole-2.nix:2:15:
+            1| let
+            2|   increment = x: x + 1;
+             |               ^
+            3|
+
+       … from call site
+         at /pwd/lang/eval-fail-blackhole-2.nix:13:7:
+           12|   c = increment d;
+           13|   d = increment a;
+             |       ^
+           14|
+
+       … while calling 'increment'
+         at /pwd/lang/eval-fail-blackhole-2.nix:2:15:
+            1| let
+            2|   increment = x: x + 1;
+             |               ^
+            3|
+
+       error: infinite recursion encountered
+       at /pwd/lang/eval-fail-blackhole-2.nix:2:18:
+            1| let
+            2|   increment = x: x + 1;
+             |                  ^
+            3|

--- a/tests/functional/lang/eval-fail-blackhole-2.nix
+++ b/tests/functional/lang/eval-fail-blackhole-2.nix
@@ -1,0 +1,15 @@
+let
+  increment = x: x + 1;
+
+  # this part is ok
+  P = increment Q;
+  Q = increment R;
+  R = increment a;
+
+  # `a` is where it loops back to
+  a = increment b;
+  b = increment c;
+  c = increment d;
+  d = increment a;
+
+in P

--- a/tests/functional/lang/eval-fail-blackhole.err.exp
+++ b/tests/functional/lang/eval-fail-blackhole.err.exp
@@ -6,6 +6,17 @@ error:
              |   ^
             3|   x = y;
 
+       … entering the infinite recursion
+
+       … while evaluating variable 'y'
+
+         at /pwd/lang/eval-fail-blackhole.nix:3:7:
+
+            2|   body = x;
+            3|   x = y;
+             |       ^
+            4|   y = x;
+
        error: infinite recursion encountered
        at /pwd/lang/eval-fail-blackhole.nix:3:7:
             2|   body = x;

--- a/tests/functional/lang/eval-fail-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-recursion.err.exp
@@ -1,8 +1,24 @@
 error:
+       … while evaluating variable 'a'
+
+         at /pwd/lang/eval-fail-recursion.nix:1:21:
+
+            1| let a = {} // a; in a.foo
+             |                     ^
+            2|
+
        … in the right operand of the update (//) operator
          at /pwd/lang/eval-fail-recursion.nix:1:12:
             1| let a = {} // a; in a.foo
              |            ^
+            2|
+
+       … while evaluating variable 'a'
+
+         at /pwd/lang/eval-fail-recursion.nix:1:15:
+
+            1| let a = {} // a; in a.foo
+             |               ^
             2|
 
        error: infinite recursion encountered


### PR DESCRIPTION
# Motivation

Stack traces can be better.

This includes
 - mark the start of the infinite recursion
    - usually not the whole trace is part of the loop, and that's relevant info. Implementation not guaranteed to find the start, but see commit message for possibly better implementation strategy
    - working example in `tests/lang/eval-fail-blackhole-2.err.exp`
 - add variable references to the stack trace. Might seem verbose but is actually quite helpful; see `tests/lang/eval-fail-scope-5.err.exp`

More info in the commit messages.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
