### PR TITLE
libexpr: use `thread_local` to make the parser thread-safe

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -36,7 +36,7 @@ static inline PosIdx makeCurPos(const YYLTYPE & loc, ParseData * data)
 #define CUR_POS makeCurPos(*yylloc, data)
 
 // backup to recover from yyless(0)
-YYLTYPE prev_yylloc;
+thread_local YYLTYPE prev_yylloc;
 
 static void initLoc(YYLTYPE * loc)
 {


### PR DESCRIPTION
# Motivation

If we call `adjustLoc`, the global variable `prev_yylloc` is shared between threads and racy.

Currently, nix itself does not concurrently parsing files, but this is helpful for libexpr users. (The parser is thread-safe except this.)

# Context

This issue is detected by the thread sanitizer:

```
WARNING: ThreadSanitizer: data race (pid=1956496)
  Write of size 8 at 0x0000005e91e0 by thread T5:
    #0 adjustLoc ../nixd/include/nixd/Lexer/Prologue.h:26 (nixd+0x4e900d)
    #1 yylex(YYSTYPE*, YYLTYPE*, void*, nixd::ParseData*) ../nixd/lib/Parser/Lexer.l:218 (nixd+0x4ec80b)
    #2 yygetToken nixd/lib/Parser/Parser.tab.cpp:1330 (nixd+0x51a2d3)
    #3 yyparse(void*, nixd::ParseData*) nixd/lib/Parser/Parser.tab.cpp:3554 (nixd+0x52b31e)
    #4 nixd::parse(char*, unsigned long, std::variant<nix::Pos::none_tag, nix::Pos::Stdin, nix::Pos::String, nix::SourcePath>, nix::SourcePath const&, nixd::ParseState) ../nixd/include/nixd/Parser/Epilogue.cpp:41 (nixd+0x52c0c7)
    #5 nixd::parse(char*, unsigned long, std::variant<nix::Pos::none_tag, nix::Pos::Stdin, nix::Pos::String, nix::SourcePath>, nix::SourcePath const&) ../nixd/include/nixd/Parser/Parser.h:26 (libnixdServer.so+0x4d9983)
    #6 nixd::parse(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../nixd/include/nixd/Parser/Parser.h:43 (libnixdServer.so+0x4d9bd1)
    #7 nixd::Server::withParseData<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >(nixd::Server::ReplyRAII<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, llvm::unique_function<void (nixd::Server::ReplyRAII<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >&&, std::unique_ptr<nixd::ParseData, std::default_delete<nixd::ParseData> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>)::{lambda(lspserver::DraftStore::Draft const&)#1}::operator()(lspserver::DraftStore::Draft const&) <null> (libnixdServer.so+0x52a0e6)
    #8 void nixd::Server::withParseData<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >(nixd::Server::ReplyRAII<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, llvm::unique_function<void (nixd::Server::ReplyRAII<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >&&, std::unique_ptr<nixd::ParseData, std::default_delete<nixd::ParseData> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>) <null> (libnixdServer.so+0x52a530)
    #9 void nixd::Server::withParseAST<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >(nixd::Server::ReplyRAII<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, llvm::unique_function<void (nixd::Server::ReplyRAII<std::vector<lspserver::DocumentLink, std::allocator<lspserver::DocumentLink> > >&&, nixd::ParseAST&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>) <null> (libnixdServer.so+0x507425)
    #10 operator() ../nixd/lib/Server/Controller.cpp:428 (libnixdServer.so+0x4c4597)
    #11 operator() include/boost/asio/detail/bind_handler.hpp:60 (libnixdServer.so+0x4d43be)
    #12 asio_handler_invoke<boost::asio::detail::binder0<nixd::Server::onDocumentLink(const lspserver::DocumentLinkParams&, lspserver::Callback<std::vector<lspserver::DocumentLink> >)::<lambda()> > > include/boost/asio/handler_invoke_hook.hpp:88 (libnixdServer.so+0x4d3808)
    #13 invoke<boost::asio::detail::binder0<nixd::Server::onDocumentLink(const lspserver::DocumentLinkParams&, lspserver::Callback<std::vector<lspserver::DocumentLink> >)::<lambda()> >, nixd::Server::onDocumentLink(const lspserver::DocumentLinkParams&, lspserver::Callback<std::vector<lspserver::DocumentLink> >)::<lambda()> > include/boost/asio/detail/handler_invoke_helpers.hpp:54 (libnixdServer.so+0x4d2e2d)
    #14 asio_handler_invoke<boost::asio::detail::binder0<nixd::Server::onDocumentLink(const lspserver::DocumentLinkParams&, lspserver::Callback<std::vector<lspserver::DocumentLink> >)::<lambda()> >, nixd::Server::onDocumentLink(const lspserver::DocumentLinkParams&, lspserver::Callback<std::vector<lspserver::DocumentLink> >)::<lambda()> > include/boost/asio/detail/bind_handler.hpp:111 (libnixdServer.so+0x4d0951)
    #15 invoke<boost::asio::detail::binder0<nixd::Server::onDocumentLink(const lspserver::DocumentLinkParams&, lspserver::Callback<std::vector<lspserver::DocumentLink> >)::<lambda()> >, boost::asio::detail::binder0<nixd::Server::onDocumentLink(const lspserver::DocumentLinkParams&, lspserver::Callback<std::vector<lspserver::DocumentLink> >)::<lambda()> > > include/boost/asio/detail/handler_invoke_helpers.hpp:54 (libnixdServer.so+0x4cee74)
    #16 do_complete include/boost/asio/detail/executor_op.hpp:71 (libnixdServer.so+0x4d0c86)
    #17 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) <null> (libnixdServer.so+0x4e5024)
    #18 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) <null> (libnixdServer.so+0x4e92a4)
    #19 boost::asio::detail::scheduler::run(boost::system::error_code&) <null> (libnixdServer.so+0x4e8c0f)
    #20 boost::asio::thread_pool::thread_function::operator()() <null> (libnixdServer.so+0x4e9983)
    #21 boost::asio::detail::posix_thread::func<boost::asio::thread_pool::thread_function>::run() <null> (libnixdServer.so+0x5e394d)
    #22 boost_asio_detail_posix_thread_function <null> (libnixdServer.so+0x4e5568)

  Previous write of size 8 at 0x0000005e91e0 by thread T4:
    [failed to restore the stack]

  Location is global 'prev_yylloc' of size 16 at 0x0000005e91e0 (nixd+0x5e91e0)

  Thread T5 (tid=1956511, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.2+0x62de6)
    #1 boost::asio::detail::posix_thread::start_thread(boost::asio::detail::posix_thread::func_base*) <null> (libnixdServer.so+0x4e5410)
    #2 boost::asio::detail::posix_thread::posix_thread<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function, unsigned int) <null> (libnixdServer.so+0x55c74e)
    #3 boost::asio::detail::thread_group::item::item<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function, boost::asio::detail::thread_group::item*) <null> (libnixdServer.so+0x53af2e)
    #4 void boost::asio::detail::thread_group::create_thread<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function) <null> (libnixdServer.so+0x516aa7)
    #5 void boost::asio::detail::thread_group::create_threads<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function, unsigned long) include/boost/asio/detail/thread_group.hpp:55 (libnixdServer.so+0x4fa731)
    #6 boost::asio::thread_pool::thread_pool() <null> (libnixdServer.so+0x4e9b2f)
    #7 nixd::Server::Server(std::unique_ptr<lspserver::InboundPort, std::default_delete<lspserver::InboundPort> >, std::unique_ptr<lspserver::OutboundPort, std::default_delete<lspserver::OutboundPort> >, int) ../nixd/lib/Server/Controller.cpp:212 (libnixdServer.so+0x4c10ff)
    #8 main ../nixd/tools/nixd/nixd.cpp:133 (nixd+0x56fa0c)

  Thread T4 (tid=1956510, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.2+0x62de6)
    #1 boost::asio::detail::posix_thread::start_thread(boost::asio::detail::posix_thread::func_base*) <null> (libnixdServer.so+0x4e5410)
    #2 boost::asio::detail::posix_thread::posix_thread<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function, unsigned int) <null> (libnixdServer.so+0x55c74e)
    #3 boost::asio::detail::thread_group::item::item<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function, boost::asio::detail::thread_group::item*) <null> (libnixdServer.so+0x53af2e)
    #4 void boost::asio::detail::thread_group::create_thread<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function) <null> (libnixdServer.so+0x516aa7)
    #5 void boost::asio::detail::thread_group::create_threads<boost::asio::thread_pool::thread_function>(boost::asio::thread_pool::thread_function, unsigned long) include/boost/asio/detail/thread_group.hpp:55 (libnixdServer.so+0x4fa731)
    #6 boost::asio::thread_pool::thread_pool() <null> (libnixdServer.so+0x4e9b2f)
    #7 nixd::Server::Server(std::unique_ptr<lspserver::InboundPort, std::default_delete<lspserver::InboundPort> >, std::unique_ptr<lspserver::OutboundPort, std::default_delete<lspserver::OutboundPort> >, int) ../nixd/lib/Server/Controller.cpp:212 (libnixdServer.so+0x4c10ff)
    #8 main ../nixd/tools/nixd/nixd.cpp:133 (nixd+0x56fa0c)

SUMMARY: ThreadSanitizer: data race ../nixd/include/nixd/Lexer/Prologue.h:26 in adjustLoc
```

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
