### PR TITLE
Simplify `ContentAddress`

### DIFF
--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -294,10 +294,8 @@ SV * makeFixedOutputPath(int recursive, char * algo, char * hash, char * name)
             auto h = Hash::parseAny(hash, parseHashType(algo));
             auto method = recursive ? FileIngestionMethod::Recursive : FileIngestionMethod::Flat;
             auto path = store()->makeFixedOutputPath(name, FixedOutputInfo {
-                .hash = {
-                    .method = method,
-                    .hash = h,
-                },
+                .method = method,
+                .hash = h,
                 .references = {},
             });
             XPUSHs(sv_2mortal(newSVpv(store()->printStorePath(path).c_str(), 0)));

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1300,9 +1300,10 @@ drvName, Bindings * attrs, Value & v)
         auto method = ingestionMethod.value_or(FileIngestionMethod::Flat);
 
         DerivationOutput::CAFixed dof {
-            .ca = ContentAddress::fromParts(
-                std::move(method),
-                std::move(h)),
+            .ca = ContentAddress {
+                .method = std::move(method),
+                .hash = std::move(h),
+            },
         };
 
         drv.env["out"] = state.store->printStorePath(dof.path(*state.store, drvName, "out"));
@@ -2162,10 +2163,8 @@ static void addPath(
         std::optional<StorePath> expectedStorePath;
         if (expectedHash)
             expectedStorePath = state.store->makeFixedOutputPath(name, FixedOutputInfo {
-                .hash = {
-                    .method = method,
-                    .hash = *expectedHash,
-                },
+                .method = method,
+                .hash = *expectedHash,
                 .references = {},
             });
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -254,10 +254,8 @@ static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v
         auto expectedPath = state.store->makeFixedOutputPath(
             name,
             FixedOutputInfo {
-                .hash = {
-                    .method = unpack ? FileIngestionMethod::Recursive : FileIngestionMethod::Flat,
-                    .hash = *expectedHash,
-                },
+                .method = unpack ? FileIngestionMethod::Recursive : FileIngestionMethod::Flat,
+                .hash = *expectedHash,
                 .references = {}
             });
 

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -217,10 +217,8 @@ StorePath Input::computeStorePath(Store & store) const
     if (!narHash)
         throw Error("cannot compute store path for unlocked input '%s'", to_string());
     return store.makeFixedOutputPath(getName(), FixedOutputInfo {
-        .hash = {
-            .method = FileIngestionMethod::Recursive,
-            .hash = *narHash,
-        },
+        .method = FileIngestionMethod::Recursive,
+        .hash = *narHash,
         .references = {},
     });
 }

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -77,10 +77,8 @@ DownloadFileResult downloadFile(
             *store,
             name,
             FixedOutputInfo {
-                .hash = {
-                    .method = FileIngestionMethod::Flat,
-                    .hash = hash,
-                },
+                .method = FileIngestionMethod::Flat,
+                .hash = hash,
                 .references = {},
             },
             hashString(htSHA256, sink.s),

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -309,10 +309,8 @@ StorePath BinaryCacheStore::addToStoreFromDump(Source & dump, std::string_view n
             *this,
             name,
             FixedOutputInfo {
-                .hash = {
-                    .method = method,
-                    .hash = nar.first,
-                },
+                .method = method,
+                .hash = nar.first,
                 .references = {
                     .others = references,
                     // caller is not capable of creating a self-reference, because this is content-addressed without modulus
@@ -428,10 +426,8 @@ StorePath BinaryCacheStore::addToStore(
             *this,
             name,
             FixedOutputInfo {
-                .hash = {
-                    .method = method,
-                    .hash = h,
-                },
+                .method = method,
+                .hash = h,
                 .references = {
                     .others = references,
                     // caller is not capable of creating a self-reference, because this is content-addressed without modulus
@@ -465,8 +461,8 @@ StorePath BinaryCacheStore::addTextToStore(
             *this,
             std::string { name },
             TextInfo {
-                { .hash = textHash },
-                references,
+                .hash = textHash,
+                .references = references,
             },
             nar.first,
         };

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2538,16 +2538,16 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
             },
 
             [&](const DerivationOutput::CAFixed & dof) {
-                auto wanted = dof.ca.getHash();
+                auto & wanted = dof.ca.hash;
 
                 auto newInfo0 = newInfoFromCA(DerivationOutput::CAFloating {
-                    .method = dof.ca.getMethod(),
+                    .method = dof.ca.method,
                     .hashType = wanted.type,
                 });
 
                 /* Check wanted hash */
                 assert(newInfo0.ca);
-                auto got = newInfo0.ca->getHash();
+                auto & got = newInfo0.ca->hash;
                 if (wanted != got) {
                     /* Throw an error after registering the path as
                        valid. */

--- a/src/libstore/content-address.cc
+++ b/src/libstore/content-address.cc
@@ -4,11 +4,6 @@
 
 namespace nix {
 
-std::string FixedOutputHash::printMethodAlgo() const
-{
-    return makeFileIngestionPrefix(method) + printHashType(hash.type);
-}
-
 std::string makeFileIngestionPrefix(FileIngestionMethod m)
 {
     switch (m) {
@@ -42,21 +37,6 @@ ContentAddressMethod ContentAddressMethod::parsePrefix(std::string_view & m)
     return method;
 }
 
-std::string ContentAddress::render() const
-{
-    return std::visit(overloaded {
-        [](const TextHash & th) {
-            return "text:"
-                + th.hash.to_string(Base32, true);
-        },
-        [](const FixedOutputHash & fsh) {
-            return "fixed:"
-                + makeFileIngestionPrefix(fsh.method)
-                + fsh.hash.to_string(Base32, true);
-        }
-    }, raw);
-}
-
 std::string ContentAddressMethod::render(HashType ht) const
 {
     return std::visit(overloaded {
@@ -67,6 +47,20 @@ std::string ContentAddressMethod::render(HashType ht) const
             return "fixed:" + makeFileIngestionPrefix(fim) + printHashType(ht);
         }
     }, raw);
+}
+
+std::string ContentAddress::render() const
+{
+    return std::visit(overloaded {
+        [](const TextIngestionMethod &) -> std::string {
+            return "text:";
+        },
+        [](const FileIngestionMethod & method) {
+            return "fixed:"
+                + makeFileIngestionPrefix(method);
+        },
+    }, method.raw)
+        + this->hash.to_string(Base32, true);
 }
 
 /**
@@ -118,22 +112,12 @@ ContentAddress ContentAddress::parse(std::string_view rawCa)
 {
     auto rest = rawCa;
 
-    auto [caMethod, hashType_] = parseContentAddressMethodPrefix(rest);
-    auto hashType = hashType_; // work around clang bug
+    auto [caMethod, hashType] = parseContentAddressMethodPrefix(rest);
 
-    return std::visit(overloaded {
-        [&](TextIngestionMethod &) {
-            return ContentAddress(TextHash {
-                .hash = Hash::parseNonSRIUnprefixed(rest, hashType)
-            });
-        },
-        [&](FileIngestionMethod & fim) {
-            return ContentAddress(FixedOutputHash {
-                .method = fim,
-                .hash = Hash::parseNonSRIUnprefixed(rest, hashType),
-            });
-        },
-    }, caMethod.raw);
+    return ContentAddress {
+        .method = std::move(caMethod).raw,
+        .hash = Hash::parseNonSRIUnprefixed(rest, hashType),
+    };
 }
 
 std::pair<ContentAddressMethod, HashType> ContentAddressMethod::parse(std::string_view caMethod)
@@ -156,52 +140,10 @@ std::string renderContentAddress(std::optional<ContentAddress> ca)
     return ca ? ca->render() : "";
 }
 
-ContentAddress ContentAddress::fromParts(
-    ContentAddressMethod method, Hash hash) noexcept
-{
-    return std::visit(overloaded {
-        [&](TextIngestionMethod _) -> ContentAddress {
-            return TextHash {
-                .hash = std::move(hash),
-            };
-        },
-        [&](FileIngestionMethod m2) -> ContentAddress {
-            return FixedOutputHash {
-                .method = std::move(m2),
-                .hash = std::move(hash),
-            };
-        },
-    }, method.raw);
-}
-
-ContentAddressMethod ContentAddress::getMethod() const
-{
-    return std::visit(overloaded {
-        [](const TextHash & th) -> ContentAddressMethod {
-            return TextIngestionMethod {};
-        },
-        [](const FixedOutputHash & fsh) -> ContentAddressMethod {
-            return fsh.method;
-        },
-    }, raw);
-}
-
-const Hash & ContentAddress::getHash() const
-{
-    return std::visit(overloaded {
-        [](const TextHash & th) -> auto & {
-            return th.hash;
-        },
-        [](const FixedOutputHash & fsh) -> auto & {
-            return fsh.hash;
-        },
-    }, raw);
-}
-
 std::string ContentAddress::printMethodAlgo() const
 {
-    return getMethod().renderPrefix()
-        + printHashType(getHash().type);
+    return method.renderPrefix()
+        + printHashType(hash.type);
 }
 
 bool StoreReferences::empty() const
@@ -217,19 +159,20 @@ size_t StoreReferences::size() const
 ContentAddressWithReferences ContentAddressWithReferences::withoutRefs(const ContentAddress & ca) noexcept
 {
     return std::visit(overloaded {
-        [&](const TextHash & h) -> ContentAddressWithReferences {
+        [&](const TextIngestionMethod &) -> ContentAddressWithReferences {
             return TextInfo {
-                .hash = h,
+                .hash = ca.hash,
                 .references = {},
             };
         },
-        [&](const FixedOutputHash & h) -> ContentAddressWithReferences {
+        [&](const FileIngestionMethod & method) -> ContentAddressWithReferences {
             return FixedOutputInfo {
-                .hash = h,
+                .method = method,
+                .hash = ca.hash,
                 .references = {},
             };
         },
-    }, ca.raw);
+    }, ca.method.raw);
 }
 
 std::optional<ContentAddressWithReferences> ContentAddressWithReferences::fromPartsOpt(
@@ -241,7 +184,7 @@ std::optional<ContentAddressWithReferences> ContentAddressWithReferences::fromPa
                 return std::nullopt;
             return ContentAddressWithReferences {
                 TextInfo {
-                    .hash = { .hash = std::move(hash) },
+                    .hash = std::move(hash),
                     .references = std::move(refs.others),
                 }
             };
@@ -249,10 +192,8 @@ std::optional<ContentAddressWithReferences> ContentAddressWithReferences::fromPa
         [&](FileIngestionMethod m2) -> std::optional<ContentAddressWithReferences> {
             return ContentAddressWithReferences {
                 FixedOutputInfo {
-                    .hash = {
-                        .method = m2,
-                        .hash = std::move(hash),
-                    },
+                    .method = m2,
+                    .hash = std::move(hash),
                     .references = std::move(refs),
                 }
             };
@@ -267,7 +208,7 @@ ContentAddressMethod ContentAddressWithReferences::getMethod() const
             return TextIngestionMethod {};
         },
         [](const FixedOutputInfo & fsh) -> ContentAddressMethod {
-            return fsh.hash.method;
+            return fsh.method;
         },
     }, raw);
 }
@@ -276,10 +217,10 @@ Hash ContentAddressWithReferences::getHash() const
 {
     return std::visit(overloaded {
         [](const TextInfo & th) {
-            return th.hash.hash;
+            return th.hash;
         },
         [](const FixedOutputInfo & fsh) {
-            return fsh.hash.hash;
+            return fsh.hash;
         },
     }, raw);
 }

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -345,13 +345,13 @@ private:
     void signRealisation(Realisation &);
 
     // XXX: Make a generic `Store` method
-    FixedOutputHash hashCAPath(
-        const FileIngestionMethod & method,
+    ContentAddress hashCAPath(
+        const ContentAddressMethod & method,
         const HashType & hashType,
         const StorePath & path);
 
-    FixedOutputHash hashCAPath(
-        const FileIngestionMethod & method,
+    ContentAddress hashCAPath(
+        const ContentAddressMethod & method,
         const HashType & hashType,
         const Path & path,
         const std::string_view pathHash

--- a/src/libstore/make-content-addressed.cc
+++ b/src/libstore/make-content-addressed.cc
@@ -52,10 +52,8 @@ std::map<StorePath, StorePath> makeContentAddressed(
             dstStore,
             path.name(),
             FixedOutputInfo {
-                .hash = {
-                    .method = FileIngestionMethod::Recursive,
-                    .hash = narModuloHash,
-                },
+                .method = FileIngestionMethod::Recursive,
+                .hash = narModuloHash,
                 .references = std::move(refs),
             },
             Hash::dummy,

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -29,14 +29,14 @@ std::optional<ContentAddressWithReferences> ValidPathInfo::contentAddressWithRef
         return std::nullopt;
 
     return std::visit(overloaded {
-        [&](const TextHash & th) -> ContentAddressWithReferences {
+        [&](const TextIngestionMethod &) -> ContentAddressWithReferences {
             assert(references.count(path) == 0);
             return TextInfo {
-                .hash = th,
+                .hash = ca->hash,
                 .references = references,
             };
         },
-        [&](const FixedOutputHash & foh) -> ContentAddressWithReferences {
+        [&](const FileIngestionMethod & m2) -> ContentAddressWithReferences {
             auto refs = references;
             bool hasSelfReference = false;
             if (refs.count(path)) {
@@ -44,14 +44,15 @@ std::optional<ContentAddressWithReferences> ValidPathInfo::contentAddressWithRef
                 refs.erase(path);
             }
             return FixedOutputInfo {
-                .hash = foh,
+                .method = m2,
+                .hash = ca->hash,
                 .references = {
                     .others = std::move(refs),
                     .self = hasSelfReference,
                 },
             };
         },
-    }, ca->raw);
+    }, ca->method.raw);
 }
 
 bool ValidPathInfo::isContentAddressed(const Store & store) const
@@ -110,13 +111,19 @@ ValidPathInfo::ValidPathInfo(
     std::visit(overloaded {
         [this](TextInfo && ti) {
             this->references = std::move(ti.references);
-            this->ca = std::move((TextHash &&) ti);
+            this->ca = ContentAddress {
+                .method = TextIngestionMethod {},
+                .hash = std::move(ti.hash),
+            };
         },
         [this](FixedOutputInfo && foi) {
             this->references = std::move(foi.references.others);
             if (foi.references.self)
                 this->references.insert(path);
-            this->ca = std::move((FixedOutputHash &&) foi);
+            this->ca = ContentAddress {
+                .method = std::move(foi.method),
+                .hash = std::move(foi.hash),
+            };
         },
     }, std::move(ca).raw);
 }

--- a/src/libstore/tests/derivation.cc
+++ b/src/libstore/tests/derivation.cc
@@ -81,7 +81,7 @@ TEST_JSON(DerivationTest, caFixedFlat,
         "path": "/nix/store/rhcg9h16sqvlbpsa6dqm57sbr2al6nzg-drv-name-output-name"
     })",
     (DerivationOutput::CAFixed {
-        .ca = FixedOutputHash {
+        .ca = {
             .method = FileIngestionMethod::Flat,
             .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
         },
@@ -95,7 +95,7 @@ TEST_JSON(DerivationTest, caFixedNAR,
         "path": "/nix/store/c015dhfh5l0lp6wxyvdn7bmwhbbr6hr9-drv-name-output-name"
     })",
     (DerivationOutput::CAFixed {
-        .ca = FixedOutputHash {
+        .ca = {
             .method = FileIngestionMethod::Recursive,
             .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
         },
@@ -109,7 +109,7 @@ TEST_JSON(DynDerivationTest, caFixedText,
         "path": "/nix/store/6s1zwabh956jvhv4w9xcdb5jiyanyxg1-drv-name-output-name"
     })",
     (DerivationOutput::CAFixed {
-        .ca = TextHash {
+        .ca = {
             .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
         },
     }),

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -220,10 +220,8 @@ static void opPrintFixedPath(Strings opFlags, Strings opArgs)
     std::string name = *i++;
 
     cout << fmt("%s\n", store->printStorePath(store->makeFixedOutputPath(name, FixedOutputInfo {
-        .hash = {
-            .method = method,
-            .hash = Hash::parseAny(hash, hashAlgo),
-        },
+        .method = method,
+        .hash = Hash::parseAny(hash, hashAlgo),
         .references = {},
     })));
 }

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -45,10 +45,8 @@ struct CmdAddToStore : MixDryRun, StoreCommand
             *store,
             std::move(*namePart),
             FixedOutputInfo {
-                .hash = {
-                    .method = std::move(ingestionMethod),
-                    .hash = std::move(hash),
-                },
+                .method = std::move(ingestionMethod),
+                .hash = std::move(hash),
                 .references = {},
             },
             narHash,

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -71,10 +71,8 @@ std::tuple<StorePath, Hash> prefetchFile(
     if (expectedHash) {
         hashType = expectedHash->type;
         storePath = store->makeFixedOutputPath(*name, FixedOutputInfo {
-            .hash = {
-                .method = ingestionMethod,
-                .hash = *expectedHash,
-            },
+            .method = ingestionMethod,
+            .hash = *expectedHash,
             .references = {},
         });
         if (store->isValidPath(*storePath))
@@ -127,7 +125,7 @@ std::tuple<StorePath, Hash> prefetchFile(
         auto info = store->addToStoreSlow(*name, tmpFile, ingestionMethod, hashType, expectedHash);
         storePath = info.path;
         assert(info.ca);
-        hash = info.ca->getHash();
+        hash = info.ca->hash;
     }
 
     return {storePath.value(), hash.value()};

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -222,10 +222,8 @@ struct ProfileManifest
             *store,
             "profile",
             FixedOutputInfo {
-                .hash = {
-                    .method = FileIngestionMethod::Recursive,
-                    .hash = narHash,
-                },
+                .method = FileIngestionMethod::Recursive,
+                .hash = narHash,
                 .references = {
                     .others = std::move(references),
                     // profiles never refer to themselves


### PR DESCRIPTION
# Motivation

Whereas `ContentAddressWithReferences` is a sum type complex because different varieties support different notions of reference, and `ContentAddressMethod` is a nested enum to support that, `ContentAddress` can be a simple pair of a method and hash.

`ContentAddress` does not need to be a sum type on the outside because the choice of method doesn't effect what type of hashes we can use.

# Context

#3746 and #3959 got the data types in their current form, but I did not notice that this simplification became possible.

@amjoseph-nixpkgs in https://github.com/NixOS/nix/pull/3959#discussion_r1169404738 raised the goal of flattening the content address data types / making text less "the odd one out". I agree, and this gets us closer.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
