### PR TITLE
tests: Reformat exit code error message

### DIFF
--- a/tests/common/vars-and-functions.sh.in
+++ b/tests/common/vars-and-functions.sh.in
@@ -195,7 +195,7 @@ expect() {
     shift
     "$@" && res=0 || res="$?"
     if [[ $res -ne $expected ]]; then
-        echo "Expected '$expected' but got '$res' while running '${*@Q}'" >&2
+        echo "Expected exit code '$expected' but got '$res' from command ${*@Q}" >&2
         return 1
     fi
     return 0
@@ -209,7 +209,7 @@ expectStderr() {
     shift
     "$@" 2>&1 && res=0 || res="$?"
     if [[ $res -ne $expected ]]; then
-        echo "Expected '$expected' but got '$res' while running '${*@Q}'" >&2
+        echo "Expected exit code '$expected' but got '$res' from command ${*@Q}" >&2
         return 1
     fi
     return 0


### PR DESCRIPTION
Now looks like:

    Expected exit code '123' but got '0' from command 'echo' 'hi'

# Motivation

Just noticed a semantic inconsistency in the wording and a formatting error with the extra quotes that shouldn't have been there.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
