### PR TITLE
Multi-User fail if already has /nix

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -58,6 +58,7 @@ readonly EXTRACTED_NIX_PATH="$(dirname "$0")"
 
 readonly ROOT_HOME=~root
 
+
 if [ -t 0 ] && [ -z "${NIX_INSTALLER_YES:-}" ]; then
     readonly IS_HEADLESS='no'
 else
@@ -95,6 +96,12 @@ is_os_darwin() {
         return 1
     fi
 }
+
+if [ -d "/nix" ]; then
+    echo "$(tput setaf 1)Error: /nix already exists on your system.$(tput sgr0)"
+    echo "$(tput setaf 2)To remove it, you can use the following command: sudo rm -rf /nix$(tput sgr0)"
+    exit 1
+fi
 
 contact_us() {
     echo "You can open an issue at"


### PR DESCRIPTION
# Motivation
If a user has already initiated and installed Nix as a single user, we should make sure they remove config files before attempting to install the multi-user variant.

# Context
Rather than letting people double up on files, we should warn them to remove old files first.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
