### PR TITLE
repl: always print floats with precision >= 1 as fixed-point

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -1008,10 +1008,18 @@ std::ostream & NixRepl::printValue(std::ostream & str, Value & v, unsigned int m
         }
         break;
 
-    case nFloat:
-        str << v.fpoint;
-        break;
+    case nFloat: {
+        std::streamsize p = str.precision();
 
+        // ensure "integer" values like 1.0 are represented as "1.0"
+        if (ceil(v.fpoint) == v.fpoint) {
+            str.precision(1);
+        }
+
+        str << std::fixed << v.fpoint;
+        str.precision(p);
+        break;
+    }
     case nThunk:
     case nExternal:
     default:


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
This is an attempt to resolve #3077 (if it does, then I believe it also incidentally resolves https://github.com/NixOS/nix/issues/5063).

Example output:
```
./result/bin/nix repl
Welcome to Nix 2.17.0pre20230708_dirty. Type :? for help.

nix-repl> 2 + 2.0
4.0

nix-repl> 4
4

nix-repl> 1.23456
1.234560

nix-repl> 1.0e10
10000000000.0
```

I'm not 100% sure if it's appropriate to render as fixed-point or not, but I noticed at least that `toString` sometimes does something similar.

```
nix-repl> toString 1
"1"

nix-repl> toString 1.0
"1.000000"
```

Maybe I should trim (all except one) trailing zeroes?

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
