### PR TITLE
Move `BuiltPath` to its own header/C++ file in libcmd

### DIFF
--- a/src/libcmd/built-path.cc
+++ b/src/libcmd/built-path.cc
@@ -1,0 +1,67 @@
+#include "built-path.hh"
+#include "derivations.hh"
+#include "store-api.hh"
+
+#include <nlohmann/json.hpp>
+
+#include <optional>
+
+namespace nix {
+
+nlohmann::json BuiltPath::Built::toJSON(ref<Store> store) const {
+    nlohmann::json res;
+    res["drvPath"] = store->printStorePath(drvPath);
+    for (const auto& [output, path] : outputs) {
+        res["outputs"][output] = store->printStorePath(path);
+    }
+    return res;
+}
+
+StorePathSet BuiltPath::outPaths() const
+{
+    return std::visit(
+        overloaded{
+            [](const BuiltPath::Opaque & p) { return StorePathSet{p.path}; },
+            [](const BuiltPath::Built & b) {
+                StorePathSet res;
+                for (auto & [_, path] : b.outputs)
+                    res.insert(path);
+                return res;
+            },
+        }, raw()
+    );
+}
+
+RealisedPath::Set BuiltPath::toRealisedPaths(Store & store) const
+{
+    RealisedPath::Set res;
+    std::visit(
+        overloaded{
+            [&](const BuiltPath::Opaque & p) { res.insert(p.path); },
+            [&](const BuiltPath::Built & p) {
+                auto drvHashes =
+                    staticOutputHashes(store, store.readDerivation(p.drvPath));
+                for (auto& [outputName, outputPath] : p.outputs) {
+                    if (experimentalFeatureSettings.isEnabled(
+                                Xp::CaDerivations)) {
+                        auto drvOutput = get(drvHashes, outputName);
+                        if (!drvOutput)
+                            throw Error(
+                                "the derivation '%s' has unrealised output '%s' (derived-path.cc/toRealisedPaths)",
+                                store.printStorePath(p.drvPath), outputName);
+                        auto thisRealisation = store.queryRealisation(
+                            DrvOutput{*drvOutput, outputName});
+                        assert(thisRealisation);  // We’ve built it, so we must
+                                                  // have the realisation
+                        res.insert(*thisRealisation);
+                    } else {
+                        res.insert(outputPath);
+                    }
+                }
+            },
+        },
+        raw());
+    return res;
+}
+
+}

--- a/src/libcmd/built-path.hh
+++ b/src/libcmd/built-path.hh
@@ -1,0 +1,47 @@
+#include "derived-path.hh"
+
+namespace nix {
+
+/**
+ * A built derived path with hints in the form of optional concrete output paths.
+ *
+ * See 'BuiltPath' for more an explanation.
+ */
+struct BuiltPathBuilt {
+    StorePath drvPath;
+    std::map<std::string, StorePath> outputs;
+
+    nlohmann::json toJSON(ref<Store> store) const;
+    static BuiltPathBuilt parse(const Store & store, std::string_view);
+
+    GENERATE_CMP(BuiltPathBuilt, me->drvPath, me->outputs);
+};
+
+using _BuiltPathRaw = std::variant<
+    DerivedPath::Opaque,
+    BuiltPathBuilt
+>;
+
+/**
+ * A built path. Similar to a DerivedPath, but enriched with the corresponding
+ * output path(s).
+ */
+struct BuiltPath : _BuiltPathRaw {
+    using Raw = _BuiltPathRaw;
+    using Raw::Raw;
+
+    using Opaque = DerivedPathOpaque;
+    using Built = BuiltPathBuilt;
+
+    inline const Raw & raw() const {
+        return static_cast<const Raw &>(*this);
+    }
+
+    StorePathSet outPaths() const;
+    RealisedPath::Set toRealisedPaths(Store & store) const;
+
+};
+
+typedef std::vector<BuiltPath> BuiltPaths;
+
+}

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -5,6 +5,7 @@
 #include "path.hh"
 #include "outputs-spec.hh"
 #include "derived-path.hh"
+#include "built-path.hh"
 #include "store-api.hh"
 #include "build-result.hh"
 

--- a/src/libstore/derived-path.cc
+++ b/src/libstore/derived-path.cc
@@ -1,5 +1,4 @@
 #include "derived-path.hh"
-#include "derivations.hh"
 #include "store-api.hh"
 
 #include <nlohmann/json.hpp>
@@ -28,30 +27,6 @@ nlohmann::json DerivedPath::Built::toJSON(ref<Store> store) const {
             res["outputs"][output] = nullptr;
     }
     return res;
-}
-
-nlohmann::json BuiltPath::Built::toJSON(ref<Store> store) const {
-    nlohmann::json res;
-    res["drvPath"] = store->printStorePath(drvPath);
-    for (const auto& [output, path] : outputs) {
-        res["outputs"][output] = store->printStorePath(path);
-    }
-    return res;
-}
-
-StorePathSet BuiltPath::outPaths() const
-{
-    return std::visit(
-        overloaded{
-            [](const BuiltPath::Opaque & p) { return StorePathSet{p.path}; },
-            [](const BuiltPath::Built & b) {
-                StorePathSet res;
-                for (auto & [_, path] : b.outputs)
-                    res.insert(path);
-                return res;
-            },
-        }, raw()
-    );
 }
 
 std::string DerivedPath::Opaque::to_string(const Store & store) const
@@ -121,35 +96,4 @@ DerivedPath DerivedPath::parseLegacy(const Store & store, std::string_view s)
 	return parseWith(store, s, "!");
 }
 
-RealisedPath::Set BuiltPath::toRealisedPaths(Store & store) const
-{
-    RealisedPath::Set res;
-    std::visit(
-        overloaded{
-            [&](const BuiltPath::Opaque & p) { res.insert(p.path); },
-            [&](const BuiltPath::Built & p) {
-                auto drvHashes =
-                    staticOutputHashes(store, store.readDerivation(p.drvPath));
-                for (auto& [outputName, outputPath] : p.outputs) {
-                    if (experimentalFeatureSettings.isEnabled(
-                                Xp::CaDerivations)) {
-                        auto drvOutput = get(drvHashes, outputName);
-                        if (!drvOutput)
-                            throw Error(
-                                "the derivation '%s' has unrealised output '%s' (derived-path.cc/toRealisedPaths)",
-                                store.printStorePath(p.drvPath), outputName);
-                        auto thisRealisation = store.queryRealisation(
-                            DrvOutput{*drvOutput, outputName});
-                        assert(thisRealisation);  // We’ve built it, so we must
-                                                  // have the realisation
-                        res.insert(*thisRealisation);
-                    } else {
-                        res.insert(outputPath);
-                    }
-                }
-            },
-        },
-        raw());
-    return res;
-}
 }

--- a/src/libstore/derived-path.hh
+++ b/src/libstore/derived-path.hh
@@ -109,47 +109,6 @@ struct DerivedPath : _DerivedPathRaw {
     static DerivedPath parseLegacy(const Store & store, std::string_view);
 };
 
-/**
- * A built derived path with hints in the form of optional concrete output paths.
- *
- * See 'BuiltPath' for more an explanation.
- */
-struct BuiltPathBuilt {
-    StorePath drvPath;
-    std::map<std::string, StorePath> outputs;
-
-    nlohmann::json toJSON(ref<Store> store) const;
-    static BuiltPathBuilt parse(const Store & store, std::string_view);
-
-    GENERATE_CMP(BuiltPathBuilt, me->drvPath, me->outputs);
-};
-
-using _BuiltPathRaw = std::variant<
-    DerivedPath::Opaque,
-    BuiltPathBuilt
->;
-
-/**
- * A built path. Similar to a DerivedPath, but enriched with the corresponding
- * output path(s).
- */
-struct BuiltPath : _BuiltPathRaw {
-    using Raw = _BuiltPathRaw;
-    using Raw::Raw;
-
-    using Opaque = DerivedPathOpaque;
-    using Built = BuiltPathBuilt;
-
-    inline const Raw & raw() const {
-        return static_cast<const Raw &>(*this);
-    }
-
-    StorePathSet outPaths() const;
-    RealisedPath::Set toRealisedPaths(Store & store) const;
-
-};
-
 typedef std::vector<DerivedPath> DerivedPaths;
-typedef std::vector<BuiltPath> BuiltPaths;
 
 }


### PR DESCRIPTION
# Motivation

It is less important, and used less widely, than `DerivedPath`.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
