### PR TITLE
Feature gate `DownstreamPlaceholder::unknownCaOutput`

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1068,14 +1068,15 @@ void EvalState::mkOutputString(
     Value & value,
     const StorePath & drvPath,
     const std::string outputName,
-    std::optional<StorePath> optOutputPath)
+    std::optional<StorePath> optOutputPath,
+    const ExperimentalFeatureSettings & xpSettings)
 {
     value.mkString(
         optOutputPath
             ? store->printStorePath(*std::move(optOutputPath))
             /* Downstream we would substitute this for an actual path once
                we build the floating CA derivation */
-            : DownstreamPlaceholder::unknownCaOutput(drvPath, outputName).render(),
+            : DownstreamPlaceholder::unknownCaOutput(drvPath, outputName, xpSettings).render(),
         NixStringContext {
             NixStringContextElem::Built {
                 .drvPath = drvPath,

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -689,12 +689,15 @@ public:
      * be passed if and only if output store object is input-addressed.
      * Will be printed to form string if passed, otherwise a placeholder
      * will be used (see `DownstreamPlaceholder`).
+     *
+     * @param xpSettings Stop-gap to avoid globals during unit tests.
      */
     void mkOutputString(
         Value & value,
         const StorePath & drvPath,
         const std::string outputName,
-        std::optional<StorePath> optOutputPath);
+        std::optional<StorePath> optOutputPath,
+        const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
     void concatLists(Value & v, size_t nrLists, Value * * lists, const PosIdx pos, std::string_view errorCtx);
 

--- a/src/libexpr/tests/derived-path.cc
+++ b/src/libexpr/tests/derived-path.cc
@@ -37,8 +37,15 @@ RC_GTEST_FIXTURE_PROP(
     prop_built_path_placeholder_round_trip,
     (const StorePath & drvPath, const StorePathName & outputName))
 {
+    /**
+     * We set these in tests rather than the regular globals so we don't have
+     * to worry about race conditions if the tests run concurrently.
+     */
+    ExperimentalFeatureSettings mockXpSettings;
+    mockXpSettings.set("experimental-features", "ca-derivations");
+
     auto * v = state.allocValue();
-    state.mkOutputString(*v, drvPath, outputName.name, std::nullopt);
+    state.mkOutputString(*v, drvPath, outputName.name, std::nullopt, mockXpSettings);
     auto [d, _] = state.coerceToDerivedPathUnchecked(noPos, *v, "");
     DerivedPath::Built b {
         .drvPath = drvPath,

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -878,9 +878,11 @@ std::optional<BasicDerivation> Derivation::tryResolve(
     for (auto & [inputDrv, inputOutputs] : inputDrvs) {
         for (auto & outputName : inputOutputs) {
             if (auto actualPath = get(inputDrvOutputs, { inputDrv, outputName })) {
-                inputRewrites.emplace(
-                    DownstreamPlaceholder::unknownCaOutput(inputDrv, outputName).render(),
-                    store.printStorePath(*actualPath));
+                if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations)) {
+                    inputRewrites.emplace(
+                        DownstreamPlaceholder::unknownCaOutput(inputDrv, outputName).render(),
+                        store.printStorePath(*actualPath));
+                }
                 resolved.inputSrcs.insert(*actualPath);
             } else {
                 warn("output '%s' of input '%s' missing, aborting the resolving",

--- a/src/libstore/downstream-placeholder.cc
+++ b/src/libstore/downstream-placeholder.cc
@@ -11,8 +11,10 @@ std::string DownstreamPlaceholder::render() const
 
 DownstreamPlaceholder DownstreamPlaceholder::unknownCaOutput(
     const StorePath & drvPath,
-    std::string_view outputName)
+    std::string_view outputName,
+    const ExperimentalFeatureSettings & xpSettings)
 {
+    xpSettings.require(Xp::CaDerivations);
     auto drvNameWithExtension = drvPath.name();
     auto drvName = drvNameWithExtension.substr(0, drvNameWithExtension.size() - 4);
     auto clearText = "nix-upstream-output:" + std::string { drvPath.hashPart() } + ":" + outputPathName(drvName, outputName);

--- a/src/libstore/downstream-placeholder.hh
+++ b/src/libstore/downstream-placeholder.hh
@@ -52,10 +52,13 @@ public:
      *
      * The derivation itself is known (we have a store path for it), but
      * the output doesn't yet have a known store path.
+     *
+     * @param xpSettings Stop-gap to avoid globals during unit tests.
      */
     static DownstreamPlaceholder unknownCaOutput(
         const StorePath & drvPath,
-        std::string_view outputName);
+        std::string_view outputName,
+        const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
     /**
      * Create a placehold for the output of an unknown derivation.

--- a/src/libstore/tests/downstream-placeholder.cc
+++ b/src/libstore/tests/downstream-placeholder.cc
@@ -5,17 +5,24 @@
 namespace nix {
 
 TEST(DownstreamPlaceholder, unknownCaOutput) {
+    /**
+     * We set these in tests rather than the regular globals so we don't have
+     * to worry about race conditions if the tests run concurrently.
+     */
+    ExperimentalFeatureSettings mockXpSettings;
+    mockXpSettings.set("experimental-features", "ca-derivations");
+
     ASSERT_EQ(
         DownstreamPlaceholder::unknownCaOutput(
             StorePath { "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv" },
-            "out").render(),
+            "out",
+            mockXpSettings).render(),
         "/0c6rn30q4frawknapgwq386zq358m8r6msvywcvc89n6m5p2dgbz");
 }
 
 TEST(DownstreamPlaceholder, unknownDerivation) {
     /**
-     * We set these in tests rather than the regular globals so we don't have
-     * to worry about race conditions if the tests run concurrently.
+     * Same reason as above
      */
     ExperimentalFeatureSettings mockXpSettings;
     mockXpSettings.set("experimental-features", "dynamic-derivations ca-derivations");
@@ -24,7 +31,8 @@ TEST(DownstreamPlaceholder, unknownDerivation) {
         DownstreamPlaceholder::unknownDerivation(
             DownstreamPlaceholder::unknownCaOutput(
                 StorePath { "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv.drv" },
-                "out"),
+                "out",
+                mockXpSettings),
             "out",
             mockXpSettings).render(),
         "/0gn6agqxjyyalf0dpihgyf49xq5hqxgw100f0wydnj6yqrhqsb3w");

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -22,11 +22,12 @@ StringPairs resolveRewrites(
     StringPairs res;
     for (auto & dep : dependencies)
         if (auto drvDep = std::get_if<BuiltPathBuilt>(&dep.path))
-            for (auto & [ outputName, outputPath ] : drvDep->outputs)
-                res.emplace(
-                    DownstreamPlaceholder::unknownCaOutput(drvDep->drvPath, outputName).render(),
-                    store.printStorePath(outputPath)
-                );
+            if (experimentalFeatureSettings.isEnabled(Xp::CaDerivations))
+                for (auto & [ outputName, outputPath ] : drvDep->outputs)
+                    res.emplace(
+                        DownstreamPlaceholder::unknownCaOutput(drvDep->drvPath, outputName).render(),
+                        store.printStorePath(outputPath)
+                    );
     return res;
 }
 


### PR DESCRIPTION
# Motivation

This is a part of CA derivations that we forgot to put behind the experimental feature.

# Context

This was caught by @fricklerhandwerk in
https://github.com/NixOS/nix/pull/8369#discussion_r1258133719

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
