### PR TITLE
Fix race condition in the language tests

### DIFF
--- a/tests/lang.sh
+++ b/tests/lang.sh
@@ -52,9 +52,10 @@ for i in lang/parse-okay-*.nix; do
     i=$(basename "$i" .nix)
     if
         expect 0 nix-instantiate --parse - < "lang/$i.nix" \
-            1> >(sed "s!$(pwd)!/pwd!g" > "lang/$i.out") \
-            2> >(sed "s!$(pwd)!/pwd!g" > "lang/$i.err")
+            1> "lang/$i.out" \
+            2> "lang/$i.err"
     then
+        sed "s!$(pwd)!/pwd!g" "lang/$i.out" "lang/$i.err"
         diffAndAccept "$i" out exp
         diffAndAccept "$i" err err.exp
     else

--- a/tests/lang/framework.sh
+++ b/tests/lang/framework.sh
@@ -16,7 +16,7 @@ function diffAndAcceptInner() {
     fi
 
     # Diff so we get a nice message
-    if ! diff "$got" "$expectedOrEmpty"; then
+    if ! diff --unified "$got" "$expectedOrEmpty"; then
         echo "FAIL: evaluation result of $testName not as expected"
         badDiff=1
     fi


### PR DESCRIPTION
# Motivation

When we pipe to `>(...)` like that, we unfortunately don't wait for the process to finish. Better to just substitute the file.

Also, use the "unified" diff output that people (including myself) are more familiar with, thanks to Git.

# Context

My https://github.com/NixOS/nix/pull/7954 caused CI to fail intermittently. This should fix it.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
