### PR TITLE
Nix Reference Manual: keep nix expressions uptodate with nixpkgs

### DIFF
--- a/doc/manual/src/language/constructs.md
+++ b/doc/manual/src/language/constructs.md
@@ -92,10 +92,10 @@ In this fragment from `all-packages.nix`,
 ```nix
 graphviz = (import ../tools/graphics/graphviz) {
   inherit fetchurl stdenv libpng libjpeg expat x11 yacc;
-  inherit (xlibs) libXaw;
+  inherit (xorg) libXaw;
 };
 
-xlibs = {
+xorg = {
   libX11 = ...;
   libXaw = ...;
   ...
@@ -109,7 +109,7 @@ libjpg = ...;
 the set used in the function call to the function defined in
 `../tools/graphics/graphviz` inherits a number of variables from the
 surrounding scope (`fetchurl` ... `yacc`), but also inherits `libXaw`
-(the X Athena Widgets) from the `xlibs` (X11 client-side libraries) set.
+(the X Athena Widgets) from the `xorg` set.
 
 Summarizing the fragment
 


### PR DESCRIPTION
'xlibs' has been renamed to/replaced by 'xorg'
relevant commits on nixpkgs:
	a36f455905d55838a0d284656e096fbdb857cf3a (2022)
	76ef7a93e302a4a92954e4b40863c6702df5ac8d (2015)

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
