### PR TITLE
eval: add `NIX_VALIDATE_EVAL_NONDETERMINISM` know for attrset comparison

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -727,6 +727,8 @@ private:
 
     bool countCalls;
 
+    bool validateNondeterminism;
+
     typedef std::map<std::string, size_t> PrimOpCalls;
     PrimOpCalls primOpCalls;
 

--- a/tests/misc.sh
+++ b/tests/misc.sh
@@ -30,3 +30,7 @@ expectStderr 1 nix-instantiate --eval -E '[]' -A 'x' | grepQuiet "should be a se
 expectStderr 1 nix-instantiate --eval -E '{}' -A '1' | grepQuiet "should be a list"
 expectStderr 1 nix-instantiate --eval -E '{}' -A '.' | grepQuiet "empty attribute name"
 expectStderr 1 nix-instantiate --eval -E '[]' -A '1' | grepQuiet "out of range"
+
+# Validate deterministic attrset comparison:
+NIX_VALIDATE_EVAL_NONDETERMINISM=1 expectStderr 1 nix-instantiate --eval -E '{ a = 1; b = assert false; 1; } == { a = 2; b = 1; }' | grepQuiet "assertion 'false' failed"
+NIX_VALIDATE_EVAL_NONDETERMINISM=1 expectStderr 1 nix-instantiate --eval -E '{ b = 1; a = assert false; 1; } == { b = 2; a = 1; }' | grepQuiet "assertion 'false' failed"


### PR DESCRIPTION
This change adds an extra knob to detect nin-determinism in attrset comparison. It follows real problem discovered by Vladimir Kryachko in current `nixpkgs` that fails evaluation non-deterministically based on internal state of the eval:

This works:

    $ nix-instantiate -E 'let pkgs = import <nixpkgs> {}; in pkgs.nix'
    /nix/store/6gzxax0rl0k1n3hg0s22jnj6c1c0aj3b-nix-2.15.1.drv

This fails:

    $ nix-instantiate -E 'let pkgs = import <nixpkgs> {}; in let aaaaaaaaaaa = { bbbbbbbbbbbbbb.extensions = []; }; in pkgs.nix'
    error: assertion '(final).hasSharedLibraries' failed

Note that `let aaaaaaaaaaa = { ... }` binding should not be able to affect evaluation of `pkgs.nix`.

This happens because attrsets are implementing lazy attrset comparison. The change implements eager comparison when `NIX_VALIDATE_EVAL_NONDETERMINISM` is set to ease debugging such failures.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
