### PR TITLE
revert anchor prefix for builtin constants

### DIFF
--- a/doc/manual/generate-builtin-constants.nix
+++ b/doc/manual/generate-builtin-constants.nix
@@ -10,12 +10,14 @@ let
       type' = optionalString (type != null) " (${type})";
 
       impureNotice = optionalString impure-only ''
-        Not available in [pure evaluation mode](@docroot@/command-ref/conf-file.md#conf-pure-eval).
+        > **Note**
+        >
+        > Not available in [pure evaluation mode](@docroot@/command-ref/conf-file.md#conf-pure-eval).
       '';
     in
     squash ''
-      <dt id="builtin-constants-${name}">
-        <a href="#builtin-constants-${name}"><code>${name}</code>${type'}</a>
+      <dt id="builtins-${name}">
+        <a href="#builtins-${name}"><code>${name}</code></a>${type'}
       </dt>
       <dd>
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -806,7 +806,7 @@ struct EvalSettings : Config
           List of directories to be searched for `<...>` file references
 
           In particular, outside of [pure evaluation mode](#conf-pure-evaluation), this determines the value of
-          [`builtins.nixPath`](@docroot@/language/builtin-constants.md#builtin-constants-nixPath).
+          [`builtins.nixPath`](@docroot@/language/builtin-constants.md#builtins-nixPath).
         )"};
 
     Setting<bool> restrictEval{


### PR DESCRIPTION
# Motivation
the original change broke many pre-existing anchor links.

also change formatting of the constants listing slightly:
- the type should not be part of the anchor
- add highlight to the "impure only" note


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).