### PR TITLE
libfetchers: Add pijul fetcher

### DIFF
--- a/src/libfetchers/pijul.cc
+++ b/src/libfetchers/pijul.cc
@@ -1,0 +1,76 @@
+// #include "cache.hh"
+#include "fetchers.hh"
+#include "store-api.hh"
+
+// #include "fetch-settings.hh"
+
+#include <string.h>
+
+using namespace std::string_literals;
+
+namespace nix::fetchers {
+
+struct PijulInputScheme : InputScheme {
+  std::optional<Input> inputFromURL(const ParsedURL &url) const override {
+    if (url.scheme != "pijul+http" && url.scheme != "pijul+https")
+      return {};
+
+    auto url2(url);
+    url2.scheme = std::string(url2.scheme, 6);
+    url2.query.clear();
+
+    Attrs attrs;
+    attrs.emplace("type", "pijul");
+    attrs.emplace("url", url2.to_string());
+
+    return inputFromAttrs(attrs);
+  }
+
+  std::optional<Input> inputFromAttrs(const Attrs &attrs) const override {
+    if (maybeGetStrAttr(attrs, "type") != "pijul")
+      return {};
+
+    for (auto &[name, _] : attrs)
+      if (name != "type" && name != "url")
+        throw Error("unsupported Pijul input attribute '%s'", name);
+
+    parseURL(getStrAttr(attrs, "url"));
+
+    Input input;
+    input.attrs = attrs;
+    return input;
+  }
+
+  bool hasAllInfo(const Input &input) const override { return true; }
+
+  ParsedURL toURL(const Input &input) const override {
+    auto url = parseURL(getStrAttr(input.attrs, "url"));
+    if (url.scheme != "pijul")
+      url.scheme = "pijul+" + url.scheme;
+    return url;
+  }
+
+  std::pair<StorePath, Input> fetch(ref<Store> store,
+                                    const Input &_input) override {
+    Input input(_input);
+
+    Path tmpDir = createTempDir();
+    AutoDelete delTmpDir(tmpDir, true);
+    auto repoDir = tmpDir + "/source";
+
+    auto url = parseURL(getStrAttr(input.attrs, "url"));
+    auto repoUrl = url.base;
+
+    runProgram("pijul", true, {"clone", repoUrl, repoDir}, {}, true);
+    deletePath(repoDir + "/.pijul");
+
+    auto storePath = store->addToStore(input.getName(), repoDir);
+
+    return {std::move(storePath), input};
+  }
+};
+
+static auto rPijulInputScheme = OnStartup(
+    [] { registerInputScheme(std::make_unique<PijulInputScheme>()); });
+
+} // namespace nix::fetchers


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Pijul is a free and open source (GPL2) distributed version control system. Its distinctive feature is to be based on a theory of patches, while still being fast and scalable. This makes it easy to learn and use, without any compromise on power or features.[^1]
Currently, despite Pijul slowly but surely gaining traction, it's very inconvenient to host projects there if you want to contribute to the community. That has been made easier with the recent addition of [`fetchpijul`](https://github.com/NixOS/nixpkgs/commit/080e97c7f970544d5dbb94164b1df3a5a62da864) to nixpkgs, but it's still less than ideal for people utilising the flakes mechanism. The only options available as of now are git and mercurial, with git being realistically the only one being widely used.

[^1]: [Pijul website](https://pijul.org)

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
The implementation will be non-trivial though there already is code to reference that being the git and the mercurial fetchers. The only concerning thing may be I currently don't see there being a way to cache the repositories as aggressively as the current fetchers do, as there's no way to "checkout" at a particular set of changes in pijul, unless it's the latest state on a given branch or a tag on a given branch.
The PR is open as a draft to show that the work is already in progress and to get early feedback from maintainers.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
