### PR TITLE
Fix typo in fish template environment variable checks

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -20,7 +20,7 @@ set __ETC_PROFILE_NIX_SOURCED 1
 set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
-if test -n "$NIX_SSH_CERT_FILE"
+if test -n "$NIX_SSL_CERT_FILE"
   : # Allow users to override the NIX_SSL_CERT_FILE
 else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
   set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -21,7 +21,7 @@ if test -n "$HOME" && test -n "$USER"
     set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
     # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
-    if test -n "$NIX_SSH_CERT_FILE"
+    if test -n "$NIX_SSL_CERT_FILE"
         : # Allow users to override the NIX_SSL_CERT_FILE
     else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
         set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Looks like this little typo slipped through. Found it when I was investigating ways to work with my company's VPN's SSL certificate mayhem. This did not solve my issue, but it could be a part of it, I suppose.

Thanks!