### PR TITLE
Enable derivation show -> add roundtrip

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -22,3 +22,5 @@
 
 - Introduce a new [`outputOf`](@docroot@/language/builtins.md#builtins-outputOf) builtin.
   It is part of the [`dynamic-derivations`](@docroot@/contributing/experimental-features.md#xp-feature-dynamic-derivations) experimental feature.
+
+- [`derivation add` can add multiple derivations at once by reading the output of `derivation show`](@docroot@/command-ref/new-cli/nix3-derivation-add.md)

--- a/src/nix/derivation-add.cc
+++ b/src/nix/derivation-add.cc
@@ -3,6 +3,7 @@
 #include "command.hh"
 #include "common-args.hh"
 #include "store-api.hh"
+#include "topo-sort.hh"
 #include "archive.hh"
 #include "derivations.hh"
 #include <nlohmann/json.hpp>
@@ -14,7 +15,7 @@ struct CmdAddDerivation : MixDryRun, StoreCommand
 {
     std::string description() override
     {
-        return "Add a store derivation";
+        return "Add derivations to the store";
     }
 
     std::string doc() override
@@ -24,21 +25,179 @@ struct CmdAddDerivation : MixDryRun, StoreCommand
           ;
     }
 
+    enum InputType : bool { InputDrv = true, InputSrc = false };
+    using MissingInputs = std::vector<std::tuple<std::string_view, InputType, std::string_view>>;
+    using DerivationsToAdd = std::map<StorePath, Derivation>;
+
     Category category() override { return catUtility; }
 
-    void run(ref<Store> store) override
+
+    Error makeMissingInputsError(const MissingInputs & missingInputs) {
+        std::ostringstream missingInputsMsg;
+        missingInputsMsg << "Missing inputs:\n";
+
+        bool missingSources = false;
+        bool missingDerivations = false;
+        for (auto& [drv, inputType, missingInputPath] : missingInputs) {
+            if (inputType == InputSrc)
+                missingSources = true;
+            if (inputType == InputDrv)
+                missingDerivations = true;
+
+            missingInputsMsg << hintfmt(
+                "'%s' requires '%s', but it is %s\n",
+                drv,
+                missingInputPath,
+                inputType == InputSrc
+                    ? "not present in the Nix Store"
+                    : "not in the input JSON or the Nix Store");
+        }
+        logError(Error(missingInputsMsg.str()).info());
+
+        std::ostringstream explanation;
+        explanation << "Some inputs are missing, so the derivations can't be added.\n";
+        if (missingSources) {
+            explanation << "- 'nix derivation add' can only add derivations, not sources.\n"
+                "  To easily transfer multiple sources from one store to another, use 'nix copy'.\n";
+        }
+        if (missingDerivations) {
+            explanation << "- All required derivations must be in the store or the JSON input.\n"
+                "  You may want to re-export the JSON with 'nix derivation show -r'.\n";
+        }
+        return Error(explanation.str());
+    }
+
+    void tryToSubstituteInputs(const ref<Store> store, const DerivationsToAdd & derivationsToAdd) {
+        StorePathSet requiredInputs;
+        for (auto& [_storePath, drv] : derivationsToAdd) {
+            for (auto& [inputPath, _] : drv.inputDrvs) {
+                requiredInputs.insert(inputPath);
+            }
+            for (auto& inputPath : drv.inputSrcs) {
+                requiredInputs.insert(inputPath);
+            }
+        }
+        store->queryValidPaths(requiredInputs, Substitute);
+    }
+
+    void addSingleDerivation(
+        const ref<Store> store,
+        const Derivation& drv,
+        const std::optional<StorePath> & expectedPath)
     {
-        auto json = nlohmann::json::parse(drainFD(STDIN_FILENO));
+        auto drvPath = writeDerivation(*store, drv, NoRepair, true);
 
-        auto drv = Derivation::fromJSON(*store, json);
-
-        auto drvPath = writeDerivation(*store, drv, NoRepair, /* read only */ dryRun);
-
+        if (expectedPath.has_value() && expectedPath.value() != drvPath) {
+            throw Error(
+                "Derivation was named '%s' in the input file, but its actual path is '%s'",
+                store->printStorePath(expectedPath.value()),
+                store->printStorePath(drvPath));
+        }
         drv.checkInvariants(*store, drvPath);
 
         writeDerivation(*store, drv, NoRepair, dryRun);
 
         logger->cout("%s", store->printStorePath(drvPath));
+    }
+
+    void run(ref<Store> store) override
+    {
+        nlohmann::json json;
+        try {
+            json = nlohmann::json::parse(drainFD(STDIN_FILENO));
+        } catch (nlohmann::json::exception & e) {
+            throw Error(
+                "Parsing JSON input failed with code '%s': %s",
+                e.id,
+                e.what()
+            );
+        }
+
+        /* Handle the special case where a single unwrapped derivation is received */
+        if (!json.value("name", "").empty()) {
+            debug("Input has 'name' attribute. Will assume it's a single derivation.");
+            try {
+                auto drv = Derivation::fromJSON(*store, json);
+                addSingleDerivation(store, drv, std::optional<StorePath>());
+            } catch (Error & e) {
+                e.addTrace({}, "while adding single anonymous JSON derivation");
+                throw;
+            }
+            return;
+        }
+
+        /* Read all derivations from the input */
+        std::map<StorePath, Derivation> derivationsToAdd;
+        for (auto& [rawStorePath, jsonDrv] : json.items()) {
+            try {
+                auto storePath = store->parseStorePath(rawStorePath);
+                auto drv = Derivation::fromJSON(*store, jsonDrv);
+                derivationsToAdd[storePath] = std::move(drv);
+            } catch (Error & e) {
+                e.addTrace({}, "while reading JSON derivation with key '%s'", rawStorePath);
+                throw;
+            }
+        }
+
+        /* Try substituting the inputs, this might help in some situations */
+        tryToSubstituteInputs(store, derivationsToAdd);
+
+        /* Ensure all inputSrcs are valid and all inputDrvs are valid or will be added.
+           If that isn't the case, adding the derivations would fail.
+           Checking now allows for more comprehensible error messages */
+        MissingInputs missingInputs;
+        for (auto & [storePath, drv] : derivationsToAdd) {
+            for (auto & [inputPath, _] : drv.inputDrvs) {
+                if (!store->isValidPath(inputPath) && !derivationsToAdd.contains(inputPath)) {
+                    missingInputs.push_back({storePath.to_string(), InputDrv, inputPath.to_string()});
+                }
+            }
+            for (auto & inputPath : drv.inputSrcs) {
+                if (!store->isValidPath(inputPath)) {
+                    missingInputs.push_back({storePath.to_string(), InputSrc, inputPath.to_string()});
+                }
+            }
+        }
+        if (!missingInputs.empty()) {
+            throw makeMissingInputsError(missingInputs);
+        }
+
+        /* Derivations can only be added if all their inputs are valid. Sort them
+           into reverse depedency order so they can all be added in one pass. */
+        std::set<StorePath> storePathsToOrder;
+        for (auto & [storePath, _] : derivationsToAdd) {
+            storePathsToOrder.insert(storePath);
+        }
+
+        auto addDrvsListOrdered = topoSort(
+            storePathsToOrder,
+            {[&](const StorePath & drvStorePath){
+                auto derivation = derivationsToAdd[drvStorePath];
+                std::set<StorePath> dependencies{};
+                for (auto & [depStorePath, _] : derivation.inputDrvs ) {
+                    dependencies.insert(depStorePath);
+                }
+                return dependencies;
+            }},
+            {[&](const StorePath & path, const StorePath & parent) {
+                return Error(
+                    "Cicular depedency in JSON input: '%s' has direct depedency on '%s', but the latter is further up the dependency tree",
+                    path.to_string(),
+                    parent.to_string());
+            }}
+        );
+        std::reverse(addDrvsListOrdered.begin(), addDrvsListOrdered.end());
+
+        /* Finally, add all the derivations */
+        for (auto & storePath : addDrvsListOrdered) {
+            auto drv = derivationsToAdd[storePath];
+            try {
+                addSingleDerivation(store, drv, storePath);
+            } catch (Error & e ) {
+                e.addTrace({}, "while trying to add derivation '%s'", storePath.to_string());
+                throw;
+            }
+        }
     }
 };
 

--- a/src/nix/derivation-add.md
+++ b/src/nix/derivation-add.md
@@ -1,9 +1,44 @@
 R""(
 
+# Examples
+
+* Rountrip export and import of a derivation (basically a no-op):
+
+  ```console
+  nix derivation show nixpkgs#hello | nix derivation add
+  /nix/store/8rgfc52k0529kypam0jy5p1a4jsj4dbq-hello-2.12.1.drv
+  ```
+
+* Move a package from one machine to another without transferring the output paths:
+
+  This example serves as an illustration. It is very manual, and will only work
+  if all input and output paths can be substituted on the target machine.
+  Use [`nix copy`] instead for real-life scenarios.
+
+  ```console
+  # nix derivation show -r /nix/store/d26w2dip6kcjpw6dfcrjmpkprrabjz60-hello-2.12.1 > hello.drv.json
+  ```
+
+  Transfer the file via any means conceivable to the target machine and continue there:
+
+  ```console
+  # nix derivation add < hello.drv.json
+  /nix/store/8rgfc52k0529kypam0jy5p1a4jsj4dbq-hello-2.12.1.drv
+  # nix build /nix/store/8rgfc52k0529kypam0jy5p1a4jsj4dbq-hello-2.12.1.drv^out
+  # readlink result
+  /nix/store/d26w2dip6kcjpw6dfcrjmpkprrabjz60-hello-2.12.1
+  ```
+
+  Note that the final output path is equal to the one that we started with.
+
+
+[`nix copy`]: ./nix3-copy.md
+
 # Description
 
-This command reads from standard input a JSON representation of a
-[store derivation] to which an [*installable*](./nix.md#installables) evaluates.
+This command reads from standard input a JSON representation of a single
+[store derivation] to which an [*installable*](./nix.md#installables) evaluates
+or an object containing multiple derivations as output by [`derivation show`].
 
 Store derivations are used internally by Nix. They are store paths with
 extension `.drv` that represent the build-time dependency graph to which
@@ -12,6 +47,31 @@ a Nix expression evaluates.
 [store derivation]: ../../glossary.md#gloss-store-derivation
 
 The JSON format is documented under the [`derivation show`] command.
+
+In addition, a single derivation is not required to be wrapped as
+shown below, though this is how `derivation show` will output it.
+
+```json
+{
+  "/nix/store/s6rn4jz1sin56rf4qj5b5v8jxjm32hlk-hello-2.10.drv": {
+    {
+      "name": "hello-2.10",
+      …
+    }
+  }
+}
+```
+
+Instead, a single unwrapped derivation can also be passed:
+
+```json
+{
+  "name": "hello-2.10",
+  …
+}
+```
+
+Wrapping *is* required to pass multiple derivations, however.
 
 [`derivation show`]: ./nix3-derivation-show.md
 

--- a/tests/derivation-json.sh
+++ b/tests/derivation-json.sh
@@ -2,11 +2,130 @@ source common.sh
 
 drvPath=$(nix-instantiate simple.nix)
 
-nix derivation show $drvPath | jq .[] > $TEST_HOME/simple.json
+function removeDerivationsFromStore () {
+    # Delete derivations until none are left. It must be done like this as deletion
+    # fails if another .drv in the store depends on the one to be deleted.
+    until [ -z "$(ls $NIX_STORE_DIR/*.drv)" ]; do
+        find $NIX_STORE_DIR -name "*.drv" -exec nix store delete {} \;
+    done
+}
 
+# Simple roundtrip export and import
+nix derivation show $drvPath > $TEST_HOME/simple.json
+removeDerivationsFromStore
 drvPath2=$(nix derivation add < $TEST_HOME/simple.json)
-
 [[ "$drvPath" = "$drvPath2" ]]
 
+# Unwrapped single derivation is also supported
+cat $TEST_HOME/simple.json | jq .[] > $TEST_HOME/simple-unwrapped.json
+removeDerivationsFromStore
+drvPath3=$(nix derivation add < $TEST_HOME/simple-unwrapped.json)
+[[ "$drvPath" = "$drvPath3" ]]
+
 # Input addressed derivations cannot be renamed.
-jq '.name = "foo"' < $TEST_HOME/simple.json | expectStderr 1 nix derivation add | grepQuiet "has incorrect output"
+removeDerivationsFromStore
+cat $TEST_HOME/simple-unwrapped.json | jq '.name = "foo"' | expectStderr 1 nix derivation add | grepQuiet "has incorrect output"
+
+# Test recursive show and add with dependencies
+topDrvPath=$(nix-instantiate dependencies.nix)
+
+nix derivation show -r $topDrvPath > $TEST_HOME/depend.json
+[[ $(jq length $TEST_HOME/depend.json) = 4 ]]
+removeDerivationsFromStore
+dependPaths=$(nix derivation add < $TEST_HOME/depend.json | sort)
+[[ "$dependPaths" = "$(jq -r 'keys | .[]' $TEST_HOME/depend.json | sort)" ]]
+
+# Error traces when adding
+diff -u <(
+    cat $TEST_HOME/simple.json \
+    | jq 'map_values( .outputs = { out: .env.out } )' \
+    | nix derivation add 2>&1 \
+    | grep -A 10 -e '^error:' \
+    || true
+) <(cat <<EOF
+error:
+       … while reading JSON derivation with key '$drvPath'
+
+       … while reading key 'outputs'
+
+       error: Expected JSON value to be of type 'object' but it is of type 'string'
+EOF
+)
+
+# nix derivation add can only add derivations that are part of its JSON input
+# If an inputDrv of one derivation is missing and not already valid in the store, it will fail
+function findDrvName() {
+    echo "$(jq -r "to_entries[] | select(.key | endswith(\"$1\")) | .key | split(\"/\") | last" $TEST_HOME/depend.json)"
+}
+drvInput0=$(findDrvName "input-0.drv")
+drvInput1=$(findDrvName "input-1.drv")
+drvInput2=$(findDrvName "input-2.drv")
+drvTop=$(findDrvName "top.drv")
+
+removeDerivationsFromStore
+output="$(
+    cat $TEST_HOME/depend.json \
+    | jq "del(.[\"$NIX_STORE_DIR/$drvInput0\"])" \
+    | nix derivation add 2>&1 \
+    | grep -A 20 -e '^error:' \
+    || true
+)"
+head -1 <<< $output | grepQuiet -Fs "error: Missing inputs:";
+
+missingInputs="$(head -3 <<< $output | tail -2)"
+grepQuiet -Fs "       '$drvTop' requires '$drvInput0', but it is not in the input JSON or the Nix Store" <<< $missingInputs
+grepQuiet -Fs "       '$drvInput2' requires '$drvInput0', but it is not in the input JSON or the Nix Store" <<< $missingInputs
+
+diff -u <(tail -3 <<< $output) <(cat <<EOF
+error: Some inputs are missing, so the derivations can't be added.
+       - All required derivations must be in the store or the JSON input.
+         You may want to re-export the JSON with 'nix derivation show -r'.
+EOF
+);
+
+# nix derivation add can only add derivations. If an inputSrc is missing, it will fail
+removeDerivationsFromStore
+missingInputSrc="$(jq -r 'to_entries[] | select(.key | endswith("input-2.drv")) | .value.inputSrcs[0] | split ("/") | last' $TEST_HOME/depend.json)"
+nix store delete "$NIX_STORE_DIR/$missingInputSrc"
+output="$(
+    cat $TEST_HOME/depend.json \
+    | nix derivation add 2>&1 \
+    | grep -A 20 -e '^error:' \
+    || true
+)"
+head -1 <<< $output | grepQuiet -Fs "error: Missing inputs:";
+
+missingInputs="$(head -2 <<< $output | tail -1)"
+grepQuiet -Fs "       '$drvInput2' requires '$missingInputSrc', but it is not present in the Nix Store" <<< $missingInputs
+
+diff -u <(tail -3 <<< $output) <(cat <<EOF
+error: Some inputs are missing, so the derivations can't be added.
+       - 'nix derivation add' can only add derivations, not sources.
+         To easily transfer multiple sources from one store to another, use 'nix copy'.
+EOF
+)
+
+# If both inputSrcs and inputDrvs are missing, they will be reported together
+removeDerivationsFromStore
+output="$(
+    cat $TEST_HOME/depend.json \
+    | jq "del(.[\"$NIX_STORE_DIR/$drvInput0\"])" \
+    | nix derivation add 2>&1 \
+    | grep -A 20 -e '^error:' \
+    || true
+)"
+head -1 <<< $output | grepQuiet -Fs "error: Missing inputs:";
+
+missingInputs="$(head -4 <<< $output | tail -3)"
+grepQuiet -Fs "       '$drvInput2' requires '$missingInputSrc', but it is not present in the Nix Store" <<< $missingInputs
+grepQuiet -Fs "       '$drvTop' requires '$drvInput0', but it is not in the input JSON or the Nix Store" <<< $missingInputs
+grepQuiet -Fs "       '$drvInput2' requires '$drvInput0', but it is not in the input JSON or the Nix Store" <<< $missingInputs
+
+diff -u <(tail -5 <<< $output) <(cat <<EOF
+error: Some inputs are missing, so the derivations can't be added.
+       - 'nix derivation add' can only add derivations, not sources.
+         To easily transfer multiple sources from one store to another, use 'nix copy'.
+       - All required derivations must be in the store or the JSON input.
+         You may want to re-export the JSON with 'nix derivation show -r'.
+EOF
+);


### PR DESCRIPTION
# Motivation

`derivation add` could not ingest output from `derivation show` directly, it had to be transformed in between. It would fail with a very ugly assertion error:

```
Assertion failed: (it != m_value.object->end()), function operator[], file /nix/store/8h9pxgq1776ns6qi5arx08ifgnhmgl22-nlohmann_json-3.11.2/include/nlohmann/json.hpp, line 2135.
```

When using `derivation show -r`, the situation was even worse, as you would have to write a script the separates the derivations and then calls `derivation add` separately for every single one of them.

This PR fixes all of the issues above:
* `derivation add` can ingest output from `derivation show` and `derivation show -r` directly
* error messages when parsing JSON are not assertion errors anymore, but clearly related to JSON, though they're not perfect yet

Additionally, the tests were made more complete and the documentation for `derivation add` has been updated with examples.

# Context

Fixes #8747

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
