### PR TITLE
configure.ac: Skip -I for RAPIDCHECK_HEADERS when not set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -300,7 +300,9 @@ AC_ARG_VAR([RAPIDCHECK_HEADERS], [include path of gtest headers shipped by RAPID
 # No pkg-config yet, https://github.com/emil-e/rapidcheck/issues/302
 AC_LANG_PUSH(C++)
 AC_SUBST(RAPIDCHECK_HEADERS)
-[CXXFLAGS="-I $RAPIDCHECK_HEADERS $CXXFLAGS"]
+if test "x$RAPIDCHECK_HEADERS" != "x"; then
+   [CXXFLAGS="-I $RAPIDCHECK_HEADERS $CXXFLAGS"]
+fi
 [LIBS="-lrapidcheck -lgtest $LIBS"]
 AC_CHECK_HEADERS([rapidcheck/gtest.h], [], [], [#include <gtest/gtest.h>])
 dnl AC_CHECK_LIB doesn't work for C++ libs with mangled symbols


### PR DESCRIPTION
I was seeing build output which looked like:

```bash
g++ -o src/libcmd/repl.o -c src/libcmd/repl.cc <snip> -I src -I -DREADLINE <snip>
src/libcmd/repl.cc:18:10: fatal error: editline.h: No such file or directory
   18 | #include <editline.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

Notice the second -I is not followed by a path. I think this caused the -DREADLINE to be interpreted as the path, and therefore the READLINE macro wasn't defined. This lead to the incorrect pre-processing of src/libcmd/repl.cc.

I did not test the case where the RAPIDCHECK_HEADERS variable was set.

I encountered this with the debian packaging of nix 2.16.1.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
