### PR TITLE
Fix derivation load assertion errors

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -8,3 +8,5 @@
   These functions are useful for converting between flake references encoded as attribute sets and URLs.
 
 - [`builtins.toJSON`](@docroot@/language/builtins.md#builtins-parseFlakeRef) now prints [--show-trace](@docroot@/command-ref/conf-file.html#conf-show-trace) items for the path in which it finds an evaluation error.
+
+- Error messages regarding malformed input to [`derivation add`](@docroot@/command-ref/new-cli/nix3-derivation-add.md) are now clearer and more detailed.

--- a/src/libutil/json-utils.cc
+++ b/src/libutil/json-utils.cc
@@ -1,4 +1,5 @@
 #include "json-utils.hh"
+#include "error.hh"
 
 namespace nix {
 
@@ -16,4 +17,27 @@ nlohmann::json * get(nlohmann::json & map, const std::string & key)
     return &*i;
 }
 
+const nlohmann::json & valueAt(
+    const nlohmann::json & map,
+    const std::string & key)
+{
+    if (!map.contains(key))
+        throw Error("Expected JSON object to contain key '%s' but it doesn't", key);
+
+    return map[key];
+}
+
+const nlohmann::json & ensureType(
+    const nlohmann::json & value,
+    nlohmann::json::value_type expectedType
+    )
+{
+    if (value.type() != expectedType)
+        throw Error(
+            "Expected JSON value to be of type '%s' but it is of type '%s'",
+            nlohmann::json(expectedType).type_name(),
+            value.type_name());
+
+    return value;
+}
 }

--- a/src/libutil/json-utils.hh
+++ b/src/libutil/json-utils.hh
@@ -11,6 +11,28 @@ const nlohmann::json * get(const nlohmann::json & map, const std::string & key);
 nlohmann::json * get(nlohmann::json & map, const std::string & key);
 
 /**
+ * Get the value of a json object at a key safely, failing
+ * with a Nix Error if the key does not exist.
+ *
+ * Use instead of nlohmann::json::at() to avoid ugly exceptions.
+ *
+ * _Does not check whether `map` is an object_, use `ensureType` for that.
+ */
+const nlohmann::json & valueAt(
+    const nlohmann::json & map,
+    const std::string & key);
+
+/**
+ * Ensure the type of a json object is what you expect, failing
+ * with a Nix Error if it isn't.
+ *
+ * Use before type conversions and element access to avoid ugly exceptions.
+ */
+const nlohmann::json & ensureType(
+    const nlohmann::json & value,
+    nlohmann::json::value_type expectedType);
+
+/**
  * For `adl_serializer<std::optional<T>>` below, we need to track what
  * types are not already using `null`. Only for them can we use `null`
  * to represent `std::nullopt`.


### PR DESCRIPTION
Display nice error messages instead and give some indication where the error happened.

*Before:*

```
$ echo 4 | nix derivation add
error: [json.exception.type_error.305] cannot use operator[] with a string argument with number

$ nix derivation show nixpkgs#hello | nix derivation add
Assertion failed: (it != m_value.object->end()), function operator[], file /nix/store/8h9pxgq1776ns6qi5arx08ifgnhmgl22-nlohmann_json-3.11.2/include/nlohmann/json.hpp, line 2135.

$ nix derivation show nixpkgs#hello | jq '.[] | .name = 5' | nix derivation add
error: [json.exception.type_error.302] type must be string, but is object

$ nix derivation show nixpkgs#hello | jq '.[] | .outputs = { out: "/nix/store/8j3f8j-hello" }' | nix derivation add
error: [json.exception.type_error.302] type must be object, but is string

```

*After:*

```
$ echo 4 | nix derivation add
error: Expected JSON of derivation to be of type 'object', but it is of type 'number'

$ nix derivation show nixpkgs#hello | nix derivation add
error: Expected JSON object to contain key 'name' but it doesn't

$ nix derivation show nixpkgs#hello | jq '.[] | .name = 5' | nix derivation add
error:
       … while reading value with key 'name'

       error: Expected JSON value to be of type 'string' but it is of type 'number'

$ nix derivation show nixpkgs#hello | jq '.[] | .outputs = { out: "/nix/store/8j3f8j-hello" }' | nix derivation add
error:
       … while reading key 'outputs'

       … while reading value with key 'out'

       error: Expected JSON value to be of type 'object' but it is of type 'string'
```

# Motivation
When loading a derivation from a JSON, malformed input would trigger cryptic "assertion failed" errors. Simply replacing calls to `operator []` with calls to `.at()` was not good enough IMO, as this would cause json.execptions to be printed verbatim.

# Context
Fixes the complaint about bad error messages in https://github.com/NixOS/nix/issues/8747 as requested in [this comment](https://github.com/NixOS/nix/pull/8756#issuecomment-1656836828).

The PR adds a new method `valueOfTypeAt` that accesses the value via a key in a JSON object, ensures it is of a certain type and errors with a decent explanation text if the key does not exist or it is of the wrong type.
It specifically does ***not*** check whether `map` is actually an object. This should be done at the callsite, where information about the context of `map` is available.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
