### PR TITLE
Don't require .tar/.zip extension for tarball flakerefs

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -105,7 +105,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
         };
 
         return std::make_pair(
-            FlakeRef(Input::fromURL(parsedURL), ""),
+            FlakeRef(Input::fromURL(parsedURL, isFlake), ""),
             percentDecode(match.str(6)));
     }
 
@@ -176,7 +176,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
                             parsedURL.query.insert_or_assign("shallow", "1");
 
                         return std::make_pair(
-                            FlakeRef(Input::fromURL(parsedURL), getOr(parsedURL.query, "dir", "")),
+                            FlakeRef(Input::fromURL(parsedURL, isFlake), getOr(parsedURL.query, "dir", "")),
                             fragment);
                     }
 
@@ -204,7 +204,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
         std::string fragment;
         std::swap(fragment, parsedURL.fragment);
 
-        auto input = Input::fromURL(parsedURL);
+        auto input = Input::fromURL(parsedURL, isFlake);
         input.parent = baseDir;
 
         return std::make_pair(

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -13,9 +13,9 @@ void registerInputScheme(std::shared_ptr<InputScheme> && inputScheme)
     inputSchemes->push_back(std::move(inputScheme));
 }
 
-Input Input::fromURL(const std::string & url)
+Input Input::fromURL(const std::string & url, bool requireTree)
 {
-    return fromURL(parseURL(url));
+    return fromURL(parseURL(url), requireTree);
 }
 
 static void fixupInput(Input & input)
@@ -31,10 +31,10 @@ static void fixupInput(Input & input)
         input.locked = true;
 }
 
-Input Input::fromURL(const ParsedURL & url)
+Input Input::fromURL(const ParsedURL & url, bool requireTree)
 {
     for (auto & inputScheme : *inputSchemes) {
-        auto res = inputScheme->inputFromURL(url);
+        auto res = inputScheme->inputFromURL(url, requireTree);
         if (res) {
             res->scheme = inputScheme;
             fixupInput(*res);

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -44,9 +44,9 @@ struct Input
     std::optional<Path> parent;
 
 public:
-    static Input fromURL(const std::string & url);
+    static Input fromURL(const std::string & url, bool requireTree = true);
 
-    static Input fromURL(const ParsedURL & url);
+    static Input fromURL(const ParsedURL & url, bool requireTree = true);
 
     static Input fromAttrs(Attrs && attrs);
 
@@ -129,7 +129,7 @@ struct InputScheme
     virtual ~InputScheme()
     { }
 
-    virtual std::optional<Input> inputFromURL(const ParsedURL & url) const = 0;
+    virtual std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const = 0;
 
     virtual std::optional<Input> inputFromAttrs(const Attrs & attrs) const = 0;
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -256,7 +256,7 @@ std::pair<StorePath, Input> fetchFromWorkdir(ref<Store> store, Input & input, co
 
 struct GitInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const ParsedURL & url) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "git" &&
             url.scheme != "git+http" &&

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -30,7 +30,7 @@ struct GitArchiveInputScheme : InputScheme
 
     virtual std::optional<std::pair<std::string, std::string>> accessHeaderFromToken(const std::string & token) const = 0;
 
-    std::optional<Input> inputFromURL(const ParsedURL & url) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != type()) return {};
 

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -7,7 +7,7 @@ std::regex flakeRegex("[a-zA-Z][a-zA-Z0-9_-]*", std::regex::ECMAScript);
 
 struct IndirectInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const ParsedURL & url) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "flake") return {};
 

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -43,7 +43,7 @@ static std::string runHg(const Strings & args, const std::optional<std::string> 
 
 struct MercurialInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const ParsedURL & url) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "hg+http" &&
             url.scheme != "hg+https" &&

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -6,7 +6,7 @@ namespace nix::fetchers {
 
 struct PathInputScheme : InputScheme
 {
-    std::optional<Input> inputFromURL(const ParsedURL & url) const override
+    std::optional<Input> inputFromURL(const ParsedURL & url, bool requireTree) const override
     {
         if (url.scheme != "path") return {};
 

--- a/tests/fetchTree-file.sh
+++ b/tests/fetchTree-file.sh
@@ -27,6 +27,7 @@ test_file_flake_input () {
 
     mkdir inputs
     echo foo > inputs/test_input_file
+    echo '{ outputs = { self }: { }; }' > inputs/flake.nix
     tar cfa test_input.tar.gz inputs
     cp test_input.tar.gz test_input_no_ext
     input_tarball_hash="$(nix hash path test_input.tar.gz)"
@@ -50,6 +51,9 @@ test_file_flake_input () {
             url = "file+file://$PWD/test_input.tar.gz";
             flake = false;
         };
+        inputs.flake_no_ext = {
+            url = "file://$PWD/test_input_no_ext";
+        };
         outputs = { ... }: {};
     }
 EOF
@@ -58,7 +62,7 @@ EOF
     nix eval --file - <<EOF
     with (builtins.fromJSON (builtins.readFile ./flake.lock));
 
-    # Url inputs whose extension doesn’t match a known archive format should
+    # Non-flake inputs whose extension doesn’t match a known archive format should
     # not be unpacked by default
     assert (nodes.no_ext_default_no_unpack.locked.type == "file");
     assert (nodes.no_ext_default_no_unpack.locked.unpack or false == false);
@@ -75,8 +79,16 @@ EOF
     # Explicitely passing the unpack parameter should enforce the desired behavior
     assert (nodes.no_ext_explicit_unpack.locked.narHash == nodes.tarball_default_unpack.locked.narHash);
     assert (nodes.tarball_explicit_no_unpack.locked.narHash == nodes.no_ext_default_no_unpack.locked.narHash);
+
+    # Flake inputs should always be tarballs
+    assert (nodes.flake_no_ext.locked.type == "tarball");
+
     true
 EOF
+
+    # Test tarball URLs on the command line.
+    [[ $(nix flake metadata --json file://$PWD/test_input_no_ext | jq -r .resolved.type) = tarball ]]
+
     popd
 
     [[ -z "${NIX_DAEMON_PACKAGE-}" ]] && return 0


### PR DESCRIPTION
# Motivation

Special-casing the file name is rather ugly, so we shouldn't do that. So now any {file,http,https} URL is handled by TarballInputScheme, except for non-flake inputs (i.e. inputs that have the attribute `flake = false`).

# Context

This removes the need for tarballs and tarball redirects (see #8477) to end in `.tar`.

E.g. previously:
```
$ nix flake metadata https://flake-test.s3.eu-west-1.amazonaws.com/nix-latest
error: getting status of '/nix/store/qnbi4rgm73j1b1mj0zdim9zmk76jc246-source/flake.nix': Not a directory
```

Now:
```
$ nix flake metadata https://flake-test.s3.eu-west-1.amazonaws.com/nix-latest
Resolved URL:  https://flake-test.s3.eu-west-1.amazonaws.com/nix-latest
Locked URL:    https://flake-test.s3.eu-west-1.amazonaws.com/nix-latest?narHash=sha256-GxfCt/4l2tYo0Qt6pjy%2Bq%2BqiEj08uz2vTY4rnhQR6V4%3D
Description:   The purely functional package manager
Path:          /nix/store/qrgs2hzjlh7r0lq3l2xy8s2qnvn214dn-source
Inputs:
├───flake-compat: github:edolstra/flake-compat/35bb57c0c8d8b62bbfd284272c928ceb64ddbde9
├───lowdown-src: github:kristapsdz/lowdown/d2c2b44ff6c27b936ec27358a2653caaef8f73b8
├───nixpkgs: github:NixOS/nixpkgs/04a75b2eecc0acf6239acf9dd04485ff8d14f425
└───nixpkgs-regression: github:NixOS/nixpkgs/215d4d0fd80ca5163643b03a33fde804a29cc1e2
```


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
