### PR TITLE
Improve Flakeref for Gitlab repos.

### DIFF
--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -277,6 +277,15 @@ Currently the `type` attribute can be one of the following:
 
   * `gitlab:veloren%2Fdev/rfcs`
 
+  However, if using Attribute set representation slashes are permitted as the ``repo`` value:
+  ```nix
+  inputs.nixpkgs = {
+    type  = "gitlab";
+    owner = "gitlab-org";
+    repo  = "release/tasks";
+  };
+  ```
+
 * `sourcehut`: Similar to `github`, is a more efficient way to fetch
   SourceHut repositories. The following attributes are required:
 


### PR DESCRIPTION
# Motivation
Gitlab has the option to have repos inside folders for example: https://gitlab.com/gitlab-org/build/omnibus-mirror/alertmanager  


Under the current system ([docs](https://github.com/NixOS/nix/blob/3723363697b3908a2f58dce3e706783b1c783414/src/nix/flake.md?plain=1#L275)) we would have to use 
```nix
example = {
  type = "gitlab";
  owner = "gitlab-org";
  repo = "build%2Fomnibus-mirror%2Falertmanager";
};
```
or 
```
example.url = "gitlab:gitlab-org/build%2Fomnibus-mirror%2Falertmanager";
```

# Context
<!-- Provide context. Reference open issues if available. -->
I first encountered the problem myself in #6435 where I learnt about teh work around and that got me going for that time.    
My university's computer society is now using Gitlab and NixOS for our servers and I can foresee that using ``%2F`` will cause some issues for folks being trained/taught NixOS.     
Also I think it looks ugly AF (that alone should be enough reason to fix it).

My ideal solution would have been to allow slashes in the ``example.url`` above, however due to #4061 it could cause breaking changes for any flake using the current implementation.   

So as a result I am targeting the attribute directly.
```nix
example = {
  type = "gitlab";
  owner = "gitlab-org";
  repo = "build/omnibus-mirror/alertmanager";
};
```

In the ``github.cc`` every ``/`` in the ``repo`` field will get replaced with a ``%2f``, maybe not the best but it is functional  
If there is a better way for doing it please let me know.   
I added to the docs as well, not 100% sure its the ebst placement but I figured it was best to keep it close to where teh original mentioned the workaround.

I built nix and tested the changes locally (in wsl) and it works for my example above.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
