### PR TITLE
Add infra for experimental store implementations

### DIFF
--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -137,11 +137,28 @@ let
 
   storeDocs =
     let
-      showStore = name: { settings, doc }:
-        ''
+      showStore = name: { settings, doc, experimentalFeature }:
+        let
+          experimentalFeatureNote = optionalString (experimentalFeature != null) ''
+            > **Warning**
+            > This store is part of an
+            > [experimental feature](@docroot@/contributing/experimental-features.md).
+
+            To use this store, you need to make sure the corresponding experimental feature,
+            [`${experimentalFeature}`](@docroot@/contributing/experimental-features.md#xp-feature-${experimentalFeature}),
+            is enabled.
+            For example, include the following in [`nix.conf`](#):
+
+            ```
+            extra-experimental-features = ${experimentalFeature}
+            ```
+          '';
+        in ''
           ## ${name}
 
           ${doc}
+
+          ${experimentalFeatureNote}
 
           **Settings**:
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1496,6 +1496,7 @@ ref<Store> openStore(const std::string & uri_,
             if (implem.uriSchemes.count(parsedUri.scheme)) {
                 auto store = implem.create(parsedUri.scheme, baseURI, params);
                 if (store) {
+                    experimentalFeatureSettings.require(store->experimentalFeature());
                     store->init();
                     store->warnUnknownSettings();
                     return ref<Store>(store);

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -109,11 +109,26 @@ struct StoreConfig : public Config
 
     virtual ~StoreConfig() { }
 
+    /**
+     * The name of this type of store.
+     */
     virtual const std::string name() = 0;
 
+    /**
+     * Documentation for this type of store.
+     */
     virtual std::string doc()
     {
         return "";
+    }
+
+    /**
+     * An experimental feature this type store is gated, if it is to be
+     * experimental.
+     */
+    virtual std::optional<ExperimentalFeature> experimentalFeature() const
+    {
+        return std::nullopt;
     }
 
     const PathSetting storeDir_{this, settings.nixStore,

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -180,8 +180,10 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
         for (auto & implem : *Implementations::registered) {
             auto storeConfig = implem.getConfig();
             auto storeName = storeConfig->name();
-            stores[storeName]["doc"] = storeConfig->doc();
-            stores[storeName]["settings"] = storeConfig->toJSON();
+            auto & j = stores[storeName];
+            j["doc"] = storeConfig->doc();
+            j["settings"] = storeConfig->toJSON();
+            j["experimentalFeature"] = storeConfig->experimentalFeature();
         }
         res["stores"] = std::move(stores);
 


### PR DESCRIPTION
# Motivation

This is analogous to that for experimental settings and flags that we have also added as of late.

# Context

This would be useful for both the `overlay-local` store, and also the `mounted-ssh://` store (#7912). Indeed I first wrote this commit for the latter and pushed it onto that branch. Now I am pulling it into a separate PR for the former too.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
