### PR TITLE
Fix --keep-going stopping on some build failures

### DIFF
--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -60,6 +60,7 @@ MakeError(SubstError, Error);
  * denotes a permanent build failure
  */
 MakeError(BuildError, Error);
+MakeError(MissingFeatures, Error);
 MakeError(InvalidPath, Error);
 MakeError(Unsupported, Error);
 MakeError(SubstituteGone, Error);


### PR DESCRIPTION
# Motivation
Fixes #8321

# Context
From the comments on the issue linked above:

> Triaged in Nix team meeting:
>
>    @edolstra: missing system features should not be a build error, but the overall build should still keep going
>    @thufschmitt: the problem is just that it's thrown in a place where it's not caught, just a small logic error

My solution was to add the error type `MissingFeatures` and catch that as well. I'm not entirely sure if this should also be an `InputRejected` as well, the intent of the `BuildResults` values doesn't seem to be documented anywhere.

I also took the opportunity to fix some other Error types that seemed incorrect, though I may be wrong on some of those. Unfortunately, git blame is broken in that file, so I can't tell if the discrepancies are intentional or historical.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
