### PR TITLE
nix/why-depends: fix output of `--precise`

### DIFF
--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -239,7 +239,7 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
                         if (pos != std::string::npos) {
                             size_t margin = 32;
                             auto pos2 = pos >= margin ? pos - margin : 0;
-                            hits[hash].emplace_back(fmt("%s: …%s…\n",
+                            hits[hash].emplace_back(fmt("%s: …%s…",
                                     p2,
                                     hilite(filterPrintable(
                                             std::string(contents, pos2, pos - pos2 + hash.size() + margin)),
@@ -255,7 +255,7 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
                     for (auto & hash : hashes) {
                         auto pos = target.find(hash);
                         if (pos != std::string::npos)
-                            hits[hash].emplace_back(fmt("%s -> %s\n", p2,
+                            hits[hash].emplace_back(fmt("%s -> %s", p2,
                                     hilite(target, pos, StorePath::HashLen, getColour(hash))));
                     }
                 }
@@ -272,9 +272,9 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
 
                 for (auto & hit : hits[hash]) {
                     bool first = hit == *hits[hash].begin();
-                    std::cout << tailPad
-                              << (first ? (last ? treeLast : treeConn) : (last ? treeNull : treeLine))
-                              << hit;
+                    logger->cout("%s%s%s", tailPad,
+                              (first ? (last ? treeLast : treeConn) : (last ? treeNull : treeLine)),
+                              hit);
                     if (!all) break;
                 }
 

--- a/tests/why-depends.sh
+++ b/tests/why-depends.sh
@@ -22,3 +22,8 @@ echo "$PRECISE_WHY_DEPENDS_OUTPUT" | grepQuiet input-2
 # But only the “precise” one should refer to `reference-to-input-2`
 echo "$FAST_WHY_DEPENDS_OUTPUT" | grepQuietInverse reference-to-input-2
 echo "$PRECISE_WHY_DEPENDS_OUTPUT" | grepQuiet reference-to-input-2
+
+<<<"$PRECISE_WHY_DEPENDS_OUTPUT" sed -n '2p' | grepQuiet "└───reference-to-input-2 -> "
+<<<"$PRECISE_WHY_DEPENDS_OUTPUT" sed -n '3p' | grep "    →" | grepQuiet "dependencies-input-2"
+<<<"$PRECISE_WHY_DEPENDS_OUTPUT" sed -n '4p' | grepQuiet "    └───input0: …"                          # in input-2, file input0
+<<<"$PRECISE_WHY_DEPENDS_OUTPUT" sed -n '5p' | grep "        →" | grepQuiet "dependencies-input-0"    # is dependencies-input-0 referenced


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

I'd like to have a proper output on `nix why-depends --precise` back %) 

# Context
<!-- Provide context. Reference open issues if available. -->
I haven't checked when this was exactly introduced, but on Nix 2.16 I realized that the additional lines inserted when using `--precise` are completely separated from the tree:

    nix why-depends /nix/store/ccgr4faaxys39s091qridxg1947lggh4-evcxr-0.14.2 /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0 --precise --extra-experimental-features nix-command
    /nix/store/ccgr4faaxys39s091qridxg1947lggh4-evcxr-0.14.2
        → /nix/store/lcf37pgp3rgww67v9x2990hbfwx96c1w-gcc-wrapper-12.2.0
            → /nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0
    └───bin/evcxr: …':'}.PATH=${PATH/':''/nix/store/lcf37pgp3rgww67v9x2990hbfwx96c1w-gcc-wrapper-12.2.0/bin'':'/':'}…
        └───bin/cpp: …k disable=SC2193.[[ "/nix/store/b7hvml0m3qmqraz1022fwvyyg6fc1vdy-gcc-12.2.0/bin/cpp" = *++ ]] &&…

This is apparently because `std::cout` is buffered and flushed in the end whereas the rest of the output isn't. The fix is rather simple, just use `logger->cout` as it's already the case for the rest of the code.

This way we also don't need to insert additional newlines in the `hits` map since that's something the logger takes care of.

Also added a small test to make sure that the layout of this is somehow tested to reduce the risk of further regressions here.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
