### PR TITLE
Port the flags of nix-daemon to nix daemon

### DIFF
--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -523,8 +523,8 @@ struct CmdDaemon : StoreCommand
         addFlag({
             .longName = "force-untrusted",
             .description = "Causes the daemon to process the connection itself, instead of blindly forwarding it to the next daemon.",
+            .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
-                experimentalFeatureSettings.require(Xp::DaemonTrustOverride);
                 isTrustedOpt = NotTrusted;
             }},
         });

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -532,8 +532,8 @@ struct CmdDaemon : StoreCommand
         addFlag({
             .longName = "default-trust",
             .description = "Use Nix's default trust.",
+            .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
-                experimentalFeatureSettings.require(Xp::DaemonTrustOverride);
                 isTrustedOpt = std::nullopt;
             }},
         });

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -513,7 +513,7 @@ struct CmdDaemon : StoreCommand
 
         addFlag({
             .longName = "force-trusted",
-            .description = "Forces the daemon to trust connecting clients, forwarding the connection without the receiving daemon processing it.",
+            .description = "Force the daemon to trust connecting clients.",
             .handler = {[&]() {
                 isTrustedOpt = Trusted;
             }},
@@ -522,7 +522,7 @@ struct CmdDaemon : StoreCommand
 
         addFlag({
             .longName = "force-untrusted",
-            .description = "Forces the daemon to not trust connecting clients, the connection will be processed by the receiving daemon before forwarding commands.",
+            .description = "Force the daemon to not trust connecting clients. The connection will be processed by the receiving daemon before forwarding commands.",
             .handler = {[&]() {
                 isTrustedOpt = NotTrusted;
             }},

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -507,13 +507,13 @@ struct CmdDaemon : StoreCommand
     {
         addFlag({
             .longName = "stdio",
-            .description = "Attach to standard I/O instead of listening on a socket.",
+            .description = "Attach to standard I/O, instead of trying to bind to a UNIX socket.",
             .handler = {&stdio, true},
         });
 
         addFlag({
             .longName = "force-trusted",
-            .description = "Causes the daemon to blindly forward the connection to the next daemon.",
+            .description = "Forces the daemon to trust connecting clients, forwarding the connection without the receiving daemon processing it.",
             .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
                 isTrustedOpt = Trusted;
@@ -522,7 +522,7 @@ struct CmdDaemon : StoreCommand
 
         addFlag({
             .longName = "force-untrusted",
-            .description = "Causes the daemon to process the connection itself, instead of blindly forwarding it to the next daemon.",
+            .description = "Forces the daemon to not trust connecting clients, the connection will be processed by the receiving daemon before forwarding commands.",
             .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
                 isTrustedOpt = NotTrusted;

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -513,7 +513,7 @@ struct CmdDaemon : StoreCommand
 
         addFlag({
             .longName = "force-trusted",
-            .description = "Causes the daemon to blindly foward the connection to the next daemon.",
+            .description = "Causes the daemon to blindly forward the connection to the next daemon.",
             .handler = {[&]() {
                 experimentalFeatureSettings.require(Xp::DaemonTrustOverride);
                 isTrustedOpt = Trusted;

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -514,28 +514,28 @@ struct CmdDaemon : StoreCommand
         addFlag({
             .longName = "force-trusted",
             .description = "Forces the daemon to trust connecting clients, forwarding the connection without the receiving daemon processing it.",
-            .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
                 isTrustedOpt = Trusted;
             }},
+            .experimentalFeature = Xp::DaemonTrustOverride,
         });
 
         addFlag({
             .longName = "force-untrusted",
             .description = "Forces the daemon to not trust connecting clients, the connection will be processed by the receiving daemon before forwarding commands.",
-            .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
                 isTrustedOpt = NotTrusted;
             }},
+            .experimentalFeature = Xp::DaemonTrustOverride,
         });
 
         addFlag({
             .longName = "default-trust",
             .description = "Use Nix's default trust.",
-            .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
                 isTrustedOpt = std::nullopt;
             }},
+            .experimentalFeature = Xp::DaemonTrustOverride,
         });
     }
 

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -514,8 +514,8 @@ struct CmdDaemon : StoreCommand
         addFlag({
             .longName = "force-trusted",
             .description = "Causes the daemon to blindly forward the connection to the next daemon.",
+            .experimentalFeature = Xp::DaemonTrustOverride,
             .handler = {[&]() {
-                experimentalFeatureSettings.require(Xp::DaemonTrustOverride);
                 isTrustedOpt = Trusted;
             }},
         });

--- a/src/nix/daemon.md
+++ b/src/nix/daemon.md
@@ -1,11 +1,35 @@
 R""(
 
-# Example
+# Examples
 
-* Run the daemon in the foreground:
+* Run the daemon:
 
   ```console
   # nix daemon
+  ```
+
+* Run the daemon and listen on standard I/O instead of binding to a UNIX socket:
+
+  ```console
+  # nix daemon --stdio
+  ```
+
+* Run the daemon and force all connections to be trusted:
+
+  ```console
+  # nix daemon --force-trusted
+  ```
+
+* Run the daemon and force all connections to be untrusted:
+
+  ```console
+  # nix daemon --force-untrusted
+  ```
+
+* Run the daemon, listen on standard I/O, and force all connections to use Nix's default trust:
+
+  ```console
+  # nix daemon --stdio --default-trust
   ```
 
 # Description
@@ -14,7 +38,7 @@ This command runs the Nix daemon, which is a required component in
 multi-user Nix installations. It runs build tasks and other
 operations on the Nix store on behalf of non-root users. Usually you
 don't run the daemon directly; instead it's managed by a service
-management framework such as `systemd`.
+management framework such as `systemd` on Linux, or `launchctl` on Darwin.
 
 Note that this daemon does not fork into the background.
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
The new `nix daemon` command doesn't accept the same flags that `nix-daemon` does.

# Context
<!-- Provide context. Reference open issues if available. -->
Ref #8785
Fixes #7128 

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
