### PR TITLE
Fix some warnings/bugs found by clang-tidy

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -108,7 +108,8 @@ public:
         stop();
     }
 
-    void stop() override
+    /* Called by destructor, can't be overridden */
+    void stop() override final
     {
         {
             auto state(state_.lock());

--- a/src/libstore/build/local-derivation-goal.hh
+++ b/src/libstore/build/local-derivation-goal.hh
@@ -272,8 +272,10 @@ struct LocalDerivationGoal : public DerivationGoal
 
     /**
      * Forcibly kill the child process, if any.
+     *
+     * Called by destructor, can't be overridden
      */
-    void killChild() override;
+    void killChild() override final;
 
     /**
      * Kill any processes running under the build user UID or in the

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -114,7 +114,8 @@ public:
     void handleChildOutput(int fd, std::string_view data) override;
     void handleEOF(int fd) override;
 
-    void cleanup() override;
+    /* Called by destructor, can't be overridden */
+    void cleanup() override final;
 
     JobCategory jobCategory() override { return JobCategory::Substitution; };
 };

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -863,6 +863,8 @@ void FileTransfer::download(FileTransferRequest && request, Sink & sink)
             }
 
             chunk = std::move(state->data);
+            /* Reset state->data after the move, since we check data.empty() */
+            state->data = "";
 
             state->request.notify_one();
         }

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -410,8 +410,8 @@ nlohmann::json MultiCommand::toJSON()
         auto cat = nlohmann::json::object();
         cat["id"] = command->category();
         cat["description"] = trim(categories[command->category()]);
-        j["category"] = std::move(cat);
         cat["experimental-feature"] = command->experimentalFeature();
+        j["category"] = std::move(cat);
         cmds[name] = std::move(j);
     }
 

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -67,7 +67,7 @@ public:
             case lvlWarn: c = '4'; break;
             case lvlNotice: case lvlInfo: c = '5'; break;
             case lvlTalkative: case lvlChatty: c = '6'; break;
-            case lvlDebug: case lvlVomit: c = '7';
+            case lvlDebug: case lvlVomit: c = '7'; break;
             default: c = '7'; break; // should not happen, and missing enum case is reported by -Werror=switch-enum
             }
             prefix = std::string("<") + c + ">";


### PR DESCRIPTION
# Motivation

I ran clang-tidy (`bear make && run-clang-tidy.py`), it found a few things, ranging from mostly harmless to potential crash.

# Context
- use-after-move in toJSON, cc @Ericson2314
- non-final virtual methods called in destructors, this would be horrible for anyone ever running into it
- use-after-move in FileTransfer::download. Relied on undefined behaviour, might have worked.
- unintended fallthrough in SimpleLogger. Just caused some dead code.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
