### PR TITLE
initLibUtil: Add exception handling self-check

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -14,6 +14,11 @@ void BaseError::addTrace(std::shared_ptr<AbstractPos> && e, hintformat hint, boo
     err.traces.push_front(Trace { .pos = std::move(e), .hint = hint, .frame = frame });
 }
 
+void throwExceptionSelfCheck(){
+    // This is meant to be caught in initLibUtil()
+    throw SysError("C++ exception handling is broken. This would appear to be a problem with the way Nix was compiled and/or linked and/or loaded.");
+}
+
 // c++ std::exception descendants must have a 'const char* what()' function.
 // This stringifies the error and caches it for use by what(), or similarly by msg().
 const std::string & BaseError::calcWhat() const

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -214,4 +214,8 @@ public:
     }
 };
 
+/** Throw an exception for the purpose of checking that exception handling works; see 'initLibUtil()'.
+ */
+void throwExceptionSelfCheck();
+
 }

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -48,6 +48,23 @@ extern char * * environ __attribute__((weak));
 namespace nix {
 
 void initLibUtil() {
+    // Check that exception handling works. Exception handling has been observed
+    // not to work on darwin when the linker flags aren't quite right.
+    // In this case we don't want to expose the user to some unrelated uncaught
+    // exception, but rather tell them exactly that exception handling is
+    // broken.
+    // When exception handling fails, the message tends to be printed by the
+    // C++ runtime, followed by an abort.
+    // For example on macOS we might see an error such as
+    // libc++abi: terminating with uncaught exception of type nix::SysError: error: C++ exception handling is broken. This would appear to be a problem with the way Nix was compiled and/or linked and/or loaded.
+    bool caught = false;
+    try {
+        throwExceptionSelfCheck();
+    } catch (nix::Error _e) {
+        caught = true;
+    }
+    // This is not actually the main point of this check, but let's make sure anyway:
+    assert(caught);
 }
 
 std::optional<std::string> getEnv(const std::string & key)


### PR DESCRIPTION
This checks a very basic expectation about our C++ environment; that exceptions work. We can't entirely take this for granted, unfortunately.

# Motivation

- Report a very serious condition if it occurs, instead of reporting an unrelated non-error
- If exception handling does work, increase our confidence that it works

# Context

Such a situation was observed in a Nixpkgs-packaged nix version accidentally used in
 - https://github.com/NixOS/nix/pull/8569
   - https://github.com/NixOS/nix/actions/runs/5727468173/job/15519945737
   - (_most likely_, and a PR like this helps with diagnosing such strange error in the future)
 - as well as a similar error in hercules-ci-agent on macOS before GHC was made to stop passing no-compact-unwind to the linker.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
