### PR TITLE
Allow auto-calling installables.

### DIFF
--- a/doc/manual/src/command-ref/opt-common.md
+++ b/doc/manual/src/command-ref/opt-common.md
@@ -141,7 +141,8 @@ Most Nix commands accept the following command-line options:
 
   - <span id="opt-arg">[`--arg`](#opt-arg)</span> *name* *value*\
     This option is accepted by `nix-env`, `nix-instantiate`,
-    `nix-shell` and `nix-build`. When evaluating Nix expressions, the
+    `nix-shell` and `nix-build`, as well as any command expecting [installables](@docroot@/glossary.md#gloss-installable).
+    When evaluating Nix expressions, the
     expression evaluator will automatically try to call functions that
     it encounters. It can automatically call functions for which every
     argument has a [default

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -19,3 +19,6 @@
 
 - The JSON output for derived paths with are store paths is now a string, not an object with a single `path` field.
   This only affects `nix-build --json` when "building" non-derivation things like fetched sources, which is a no-op.
+
+- [Installables](@docroot@/glossary.md#gloss-installable) resolving to a function will automatically
+  be called, optionally with [caller-provided arguments](@docroot@/command-ref/opt-common.md#opt-arg).

--- a/src/libcmd/installable-flake.hh
+++ b/src/libcmd/installable-flake.hh
@@ -31,6 +31,7 @@ struct ExtraPathInfoFlake : ExtraPathInfoValue
 
 struct InstallableFlake : InstallableValue
 {
+    SourceExprCommand * cmd;
     FlakeRef flakeRef;
     Strings attrPaths;
     Strings prefixes;

--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -132,6 +132,9 @@ subcommands, these are `packages.`*system*,
 attributes `packages.x86_64-linux.hello`,
 `legacyPackages.x86_64-linux.hello` and `hello`.
 
+If the resolved attribute is a function, it will be automatically
+be called, optionally with [caller-provided arguments](@docroot@/command-ref/opt-common.md#opt-arg).
+
 ### Store path
 
 Example: `/nix/store/v5sv61sszx301i0x6xysaqzla09nksnd-hello-2.10`

--- a/tests/flakes/autocall.sh
+++ b/tests/flakes/autocall.sh
@@ -1,0 +1,40 @@
+source ./common.sh
+
+requireGit
+
+clearStore
+rm -rf $TEST_HOME/.cache $TEST_HOME/.config
+
+flakeDir=$TEST_ROOT/flake-autocall
+
+createGitRepo "$flakeDir"
+
+cat > $flakeDir/flake.nix <<EOF
+{
+  description = "Bla bla";
+
+  outputs = inputs: rec {
+    packages.$system = rec {
+      foo = { name ? "simple" }: with import ./config.nix; mkDerivation {
+        inherit name;
+        builder = ./simple.builder.sh;
+        PATH = "";
+        goodPath = path;
+      };
+      default = foo;
+    };
+  };
+}
+EOF
+
+cp ../simple.builder.sh ../config.nix $flakeDir/
+git -C $flakeDir add flake.nix simple.builder.sh config.nix
+git -C $flakeDir commit -m 'Initial'
+
+# Build with no args set
+nix build -o $TEST_ROOT/result $flakeDir
+[[ $(basename $(readlink $TEST_ROOT/result) | cut -d '-' -f 2) == "simple" ]]
+
+# Set an arg
+nix build --argstr name sample -o $TEST_ROOT/result $flakeDir
+[[ $(basename $(readlink $TEST_ROOT/result) | cut -d '-' -f 2) == "sample" ]]

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -14,6 +14,7 @@ nix_tests = \
   flakes/absolute-paths.sh \
   flakes/build-paths.sh \
   flakes/flake-in-submodule.sh \
+  flakes/autocall.sh \
   gc.sh \
   nix-collect-garbage-d.sh \
   remote-store.sh \


### PR DESCRIPTION
This allows for installable-based interfaces to allow for dynamic configuration at the command line. See e.g.
Gabriella439/terraform-nixos-ng#6 for one use case.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
