### PR TITLE
Show full option description in manpages and `--help` output

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -19,3 +19,5 @@
 
 - The JSON output for derived paths with are store paths is now a string, not an object with a single `path` field.
   This only affects `nix-build --json` when "building" non-derivation things like fetched sources, which is a no-op.
+
+- Manpages and `--help` output now contain full descriptions of all overridable options.

--- a/src/libutil/config-impl.hh
+++ b/src/libutil/config-impl.hh
@@ -79,9 +79,10 @@ template<> void BaseSetting<bool>::convertToArg(Args & args, const std::string &
 template<typename T>
 void BaseSetting<T>::convertToArg(Args & args, const std::string & category)
 {
+    auto indentedDescription = indent(2, description);
     args.addFlag({
         .longName = name,
-        .description = fmt("Set the `%s` setting.", name),
+        .description = fmt("Set the `%s` setting:\n%s", name, indentedDescription),
         .category = category,
         .labels = {"value"},
         .handler = {[this](std::string s) { overridden = true; set(s); }},
@@ -91,7 +92,7 @@ void BaseSetting<T>::convertToArg(Args & args, const std::string & category)
     if (isAppendable())
         args.addFlag({
             .longName = "extra-" + name,
-            .description = fmt("Append to the `%s` setting.", name),
+            .description = fmt("Append to the `%s` setting:\n%s", name, indentedDescription),
             .category = category,
             .labels = {"value"},
             .handler = {[this](std::string s) { overridden = true; set(s, true); }},

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -259,16 +259,17 @@ template<> std::string BaseSetting<bool>::to_string() const
 
 template<> void BaseSetting<bool>::convertToArg(Args & args, const std::string & category)
 {
+    auto indentedDescription = indent(2, description);
     args.addFlag({
         .longName = name,
-        .description = fmt("Enable the `%s` setting.", name),
+        .description = fmt("Enable the `%s` setting:\n%s", name, indentedDescription),
         .category = category,
         .handler = {[this]() { override(true); }},
         .experimentalFeature = experimentalFeature,
     });
     args.addFlag({
         .longName = "no-" + name,
-        .description = fmt("Disable the `%s` setting.", name),
+        .description = fmt("Disable the `%s` setting:\n%s", name, indentedDescription),
         .category = category,
         .handler = {[this]() { override(false); }},
         .experimentalFeature = experimentalFeature,

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -14,6 +14,7 @@
 #include <future>
 #include <iostream>
 #include <mutex>
+#include <regex>
 #include <sstream>
 #include <thread>
 
@@ -1670,6 +1671,12 @@ std::string stripIndentation(std::string_view s)
     return res;
 }
 
+std::string indent(u_int8_t indentationSize, const std::string & str)
+{
+    static const std::regex indentRegex {"(^|\r?\n)(.+?)(?=\r?\n|$)"};
+    std::string indent (indentationSize, ' ');
+    return std::regex_replace(str, indentRegex, "$1" + indent + "$2");
+}
 
 std::pair<std::string_view, std::string_view> getLine(std::string_view s)
 {

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -749,6 +749,11 @@ std::string base64Decode(std::string_view s);
  */
 std::string stripIndentation(std::string_view s);
 
+/**
+ * Indent string by specified number of spaces.
+ * This works for multiline strings as well.
+ */
+std::string indent(u_int8_t indentationSize, const std::string & str);
 
 /**
  * Get the prefix of 's' up to and excluding the next line break (LF


### PR DESCRIPTION
# Motivation
The current help text for flags that allow overriding system configuration settings are comically unhelpful:

```
      • --auto-allocate-uids

         Enable the auto-allocate-uids setting.
```

This PR fixes this by embedding the full setting description:

```
    · --auto-allocate-uids

      Enable the auto-allocate-uids setting:

      Whether to select UIDs for builds automatically, instead of using the users in build-users-group.

      UIDs are allocated starting at 872415232 (0x34000000) on Linux and 56930 on macOS.
```

# Context

Fixes #5545
Previous implementation was #6874, but it's almost a year old and didn't indent the configuration properly.

The change itself is quite trivial, it only adds the description of a setting to the flag description.

However, it significantly increases the size of the `man` output, from ~900K on current master to ~2.4M.

This is unavoidable, as the implementation strategy duplicates many description texts between multiple different manpages.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
