### PR TITLE
Fix follow path checking at depths greater than 2

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -22,3 +22,5 @@
 
 - Introduce a new [`outputOf`](@docroot@/language/builtins.md#builtins-outputOf) builtin.
   It is part of the [`dynamic-derivations`](@docroot@/contributing/experimental-features.md#xp-feature-dynamic-derivations) experimental feature.
+
+- Flake follow paths at depths greater than 2 are now handled correctly, preventing "follows a non-existent input" errors.

--- a/src/libexpr/flake/lockfile.cc
+++ b/src/libexpr/flake/lockfile.cc
@@ -345,7 +345,7 @@ void LockFile::check()
 
     for (auto & [inputPath, input] : inputs) {
         if (auto follows = std::get_if<1>(&input)) {
-            if (!follows->empty() && !get(inputs, *follows))
+            if (!follows->empty() && !findInput(*follows))
                 throw Error("input '%s' follows a non-existent input '%s'",
                     printInputPath(inputPath),
                     printInputPath(*follows));

--- a/tests/flakes/follow-paths.sh
+++ b/tests/flakes/follow-paths.sh
@@ -146,8 +146,8 @@ EOF
 
 git -C $flakeFollowsA add flake.nix
 
-nix flake lock $flakeFollowsA 2>&1 | grep "warning: input 'B' has an override for a non-existent input 'invalid'"
-nix flake lock $flakeFollowsA 2>&1 | grep "warning: input 'B' has an override for a non-existent input 'invalid2'"
+nix flake lock "$flakeFollowsA" 2>&1 | grep "warning: input 'B' has an override for a non-existent input 'invalid'"
+nix flake lock "$flakeFollowsA" 2>&1 | grep "warning: input 'B' has an override for a non-existent input 'invalid2'"
 
 # Now test follow path overloading
 # This tests a lockfile checking regression https://github.com/NixOS/nix/pull/8819
@@ -169,18 +169,18 @@ nix flake lock $flakeFollowsA 2>&1 | grep "warning: input 'B' has an override fo
 #    error: input 'B/D' follows a non-existent input 'B/C/D'
 # 
 # Note that for `B` to resolve its follow for `D`, it needs `C/D`, for which it needs to resolve the follow on `C` first.
-flakeFollowsOverloadA=$TEST_ROOT/follows/overload/flakeA
-flakeFollowsOverloadB=$TEST_ROOT/follows/overload/flakeA/flakeB
-flakeFollowsOverloadC=$TEST_ROOT/follows/overload/flakeA/flakeB/flakeC
-flakeFollowsOverloadD=$TEST_ROOT/follows/overload/flakeA/flakeB/flakeC/flakeD
+flakeFollowsOverloadA="$TEST_ROOT/follows/overload/flakeA"
+flakeFollowsOverloadB="$TEST_ROOT/follows/overload/flakeA/flakeB"
+flakeFollowsOverloadC="$TEST_ROOT/follows/overload/flakeA/flakeB/flakeC"
+flakeFollowsOverloadD="$TEST_ROOT/follows/overload/flakeA/flakeB/flakeC/flakeD"
 
 # Test following path flakerefs.
-createGitRepo $flakeFollowsOverloadA
-mkdir -p $flakeFollowsOverloadB
-mkdir -p $flakeFollowsOverloadC
-mkdir -p $flakeFollowsOverloadD
+createGitRepo "$flakeFollowsOverloadA"
+mkdir -p "$flakeFollowsOverloadB"
+mkdir -p "$flakeFollowsOverloadC"
+mkdir -p "$flakeFollowsOverloadD"
 
-cat > $flakeFollowsOverloadD/flake.nix <<EOF
+cat > "$flakeFollowsOverloadD/flake.nix" <<EOF
 {
     description = "Flake D";
     inputs = {};
@@ -188,7 +188,7 @@ cat > $flakeFollowsOverloadD/flake.nix <<EOF
 }
 EOF
 
-cat > $flakeFollowsOverloadC/flake.nix <<EOF
+cat > "$flakeFollowsOverloadC/flake.nix" <<EOF
 {
     description = "Flake C";
     inputs.D.url = "path:./flakeD";
@@ -196,7 +196,7 @@ cat > $flakeFollowsOverloadC/flake.nix <<EOF
 }
 EOF
 
-cat > $flakeFollowsOverloadB/flake.nix <<EOF
+cat > "$flakeFollowsOverloadB/flake.nix" <<EOF
 {
     description = "Flake B";
     inputs = {
@@ -210,7 +210,7 @@ cat > $flakeFollowsOverloadB/flake.nix <<EOF
 EOF
 
 # input B/D should be able to be found...
-cat > $flakeFollowsOverloadA/flake.nix <<EOF
+cat > "$flakeFollowsOverloadA/flake.nix" <<EOF
 {
     description = "Flake A";
     inputs = {
@@ -224,9 +224,9 @@ cat > $flakeFollowsOverloadA/flake.nix <<EOF
 }
 EOF
 
-git -C $flakeFollowsOverloadA add flake.nix flakeB/flake.nix \
+git -C "$flakeFollowsOverloadA" add flake.nix flakeB/flake.nix \
   flakeB/flakeC/flake.nix flakeB/flakeC/flakeD/flake.nix
 
-nix flake metadata $flakeFollowsOverloadA
-nix flake update $flakeFollowsOverloadA
-nix flake lock $flakeFollowsOverloadA
+nix flake metadata "$flakeFollowsOverloadA"
+nix flake update "$flakeFollowsOverloadA"
+nix flake lock "$flakeFollowsOverloadA"

--- a/tests/flakes/follow-paths.sh
+++ b/tests/flakes/follow-paths.sh
@@ -148,3 +148,66 @@ git -C $flakeFollowsA add flake.nix
 
 nix flake lock $flakeFollowsA 2>&1 | grep "warning: input 'B' has an override for a non-existent input 'invalid'"
 nix flake lock $flakeFollowsA 2>&1 | grep "warning: input 'B' has an override for a non-existent input 'invalid2'"
+
+# Now test follow path overloading
+flakeFollowsOverloadA=$TEST_ROOT/follows/overload/flakeA
+flakeFollowsOverloadB=$TEST_ROOT/follows/overload/flakeA/flakeB
+flakeFollowsOverloadC=$TEST_ROOT/follows/overload/flakeA/flakeB/flakeC
+flakeFollowsOverloadD=$TEST_ROOT/follows/overload/flakeA/flakeB/flakeC/flakeD
+
+# Test following path flakerefs.
+createGitRepo $flakeFollowsOverloadA
+mkdir -p $flakeFollowsOverloadB
+mkdir -p $flakeFollowsOverloadC
+mkdir -p $flakeFollowsOverloadD
+
+cat > $flakeFollowsOverloadD/flake.nix <<EOF
+{
+    description = "Flake D";
+    inputs = {};
+    outputs = { ... }: {};
+}
+EOF
+
+cat > $flakeFollowsOverloadC/flake.nix <<EOF
+{
+    description = "Flake C";
+    inputs.D.url = "path:./flakeD";
+    outputs = { ... }: {};
+}
+EOF
+
+cat > $flakeFollowsOverloadB/flake.nix <<EOF
+{
+    description = "Flake B";
+    inputs = {
+        C = {
+            url = "path:./flakeC";
+        };
+        D.follows = "C/D";
+    };
+    outputs = { ... }: {};
+}
+EOF
+
+# input B/D should be able to be found...
+cat > $flakeFollowsOverloadA/flake.nix <<EOF
+{
+    description = "Flake A";
+    inputs = {
+        B = {
+            url = "path:./flakeB";
+            inputs.C.follows = "C";
+        };
+        C.url = "path:./flakeB/flakeC";
+    };
+    outputs = { ... }: {};
+}
+EOF
+
+git -C $flakeFollowsOverloadA add flake.nix flakeB/flake.nix \
+  flakeB/flakeC/flake.nix flakeB/flakeC/flakeD/flake.nix
+
+nix flake metadata $flakeFollowsOverloadA
+nix flake update $flakeFollowsOverloadA
+nix flake lock $flakeFollowsOverloadA

--- a/tests/flakes/follow-paths.sh
+++ b/tests/flakes/follow-paths.sh
@@ -150,6 +150,25 @@ nix flake lock $flakeFollowsA 2>&1 | grep "warning: input 'B' has an override fo
 nix flake lock $flakeFollowsA 2>&1 | grep "warning: input 'B' has an override for a non-existent input 'invalid2'"
 
 # Now test follow path overloading
+# This tests a lockfile checking regression https://github.com/NixOS/nix/pull/8819
+#
+# We construct the following graph, where p->q means p has input q.
+# A double edge means that the edge gets overridden using `follows`.
+#
+#      A
+#     / \
+#    /   \
+#   v     v
+#   B ==> C   --- follows declared in A
+#    \\  /
+#     \\/     --- follows declared in B
+#      v
+#      D
+#
+# The message was
+#    error: input 'B/D' follows a non-existent input 'B/C/D'
+# 
+# Note that for `B` to resolve its follow for `D`, it needs `C/D`, for which it needs to resolve the follow on `C` first.
 flakeFollowsOverloadA=$TEST_ROOT/follows/overload/flakeA
 flakeFollowsOverloadB=$TEST_ROOT/follows/overload/flakeA/flakeB
 flakeFollowsOverloadC=$TEST_ROOT/follows/overload/flakeA/flakeB/flakeC


### PR DESCRIPTION
# Motivation
Currently, you can't have follows paths with depths greater than 2 - you get an error along the lines of `error: input 'B/D' follows a non-existent input 'B/C/D'`.

# Context
We need to recurse into the input tree to handle follows paths that trarverse multiple inputs that may or may not be follow paths themselves. I've added tests for the problem.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [x] agreed on idea
 - [x] agreed on implementation strategy
 - [x] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [x] code and comments are self-explanatory
 - [x] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
