### PR TITLE
Add RAPIDCHECK_HEADERS to nix-shell environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -714,6 +714,8 @@
 
                 # Make bash completion work.
                 XDG_DATA_DIRS+=:$out/share
+
+                export RAPIDCHECK_HEADERS=${lib.getDev pkgs.rapidcheck}/extras/gtest/include
               '';
           };
         in


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Running `./configure` in `nix-shell` environment currently ends up with this error:

```
checking for rapidcheck/gtest.h... no
configure: error: librapidcheck is not found.
```

There are workarounds in https://github.com/NixOS/nix/issues/7809, this change allows to run `./configure` without them.


# Context

See https://github.com/NixOS/nix/issues/7809 for more context.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
