### PR TITLE
Fix handling of $NIX_LINK{,_NEW} in nix-profile*.sh

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -9,9 +9,7 @@ else
     NIX_LINK_NEW=$HOME/.local/state/nix/profile
 fi
 if [ -e "$NIX_LINK_NEW" ]; then
-    NIX_LINK="$NIX_LINK_NEW"
-else
-    if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then
+    if [ -t 2 ] && [ -e "$NIX_LINK" ]; then
         warning="\033[1;35mwarning:\033[0m"
         printf "$warning Both %s and legacy %s exist; using the latter.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
         if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
@@ -26,6 +24,7 @@ else
             printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
         fi
     fi
+    NIX_LINK="$NIX_LINK_NEW"
 fi
 
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
@@ -61,4 +60,4 @@ else
 fi
 
 export PATH="$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin:$PATH"
-unset NIX_LINK
+unset NIX_LINK NIX_LINK_NEW

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -9,9 +9,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         NIX_LINK_NEW="$HOME/.local/state/nix/profile"
     fi
     if [ -e "$NIX_LINK_NEW" ]; then
-        NIX_LINK="$NIX_LINK_NEW"
-    else
-        if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then
+        if [ -t 2 ] && [ -e "$NIX_LINK" ]; then
             warning="\033[1;35mwarning:\033[0m"
             printf "$warning Both %s and legacy %s exist; using the latter.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
             if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
@@ -26,6 +24,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
                 printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
             fi
         fi
+        NIX_LINK="$NIX_LINK_NEW"
     fi
 
     # Set up environment.


### PR DESCRIPTION
# Motivation

In the profile file added for non-NixOS installations of Nix, there is a warning that is to be emitted it two (`$NIX_LINK{,_NEW}`) profile links exist.
Currently, it would never be printed.


# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
