### PR TITLE
libutil: fix double-encoding of URLs

### DIFF
--- a/src/libexpr/tests/flakeref.cc
+++ b/src/libexpr/tests/flakeref.cc
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+
+#include "flake/flakeref.hh"
+
+namespace nix {
+
+/* ----------- tests for flake/flakeref.hh --------------------------------------------------*/
+
+    /* ----------------------------------------------------------------------------
+     * to_string
+     * --------------------------------------------------------------------------*/
+
+    TEST(to_string, doesntReencodeUrl) {
+        auto s = "http://localhost:8181/test/+3d.tar.gz";
+        auto flakeref = parseFlakeRef(s);
+        auto parsed = flakeref.to_string();
+        auto expected = "http://localhost:8181/test/%2B3d.tar.gz";
+
+        ASSERT_EQ(parsed, expected);
+    }
+
+}

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -44,7 +44,7 @@ ParsedURL parseURL(const std::string & url)
             .base = base,
             .scheme = scheme,
             .authority = authority,
-            .path = path,
+            .path = percentDecode(path),
             .query = decodeQuery(query),
             .fragment = percentDecode(std::string(fragment))
         };


### PR DESCRIPTION
If you have a URL that needs to be percent-encoded, such as
`http://localhost:8181/test/+3d.tar.gz`, and try to lock that in a Nix
flake such as the following:

    {
      inputs.test = { url = "http://localhost:8181/test/+3d.tar.gz"; flake = false; };
      outputs = { test, ... }: {
        t = builtins.readFile test;
      };
    }

running `nix flake metadata` shows that the input URL has been
incorrectly double-encoded (despite the flake.lock being correctly
encoded only once):

    [...snip...]
    Inputs:
    └───test: http://localhost:8181/test/%252B3d.tar.gz?narHash=sha256-EFUdrtf6Rn0LWIJufrmg8q99aT3jGfLvd1//zaJEufY%3D

(Notice the `%252B`? That's just `%2B` but percent-encoded again)

With this patch, the double-encoding is gone; running `nix flake
metadata` will show the proper URL:

    [...snip...]
    Inputs:
    └───test: http://localhost:8181/test/%2B3d.tar.gz?narHash=sha256-EFUdrtf6Rn0LWIJufrmg8q99aT3jGfLvd1//zaJEufY%3D

---

As far as I can tell, this happens because Nix already percent-encodes
the URL and stores this as the value of `inputs.asdf.url`.

However, when Nix later tries to read this out of the eval state as a
string (via `getStrAttr`), it has to run it through `parseURL` again to
get the `ParsedURL` structure.

Now, this itself isn't a problem -- the true problem arises when using
`ParsedURL::to_string` later, which then _re-escapes the URL_. It is
at this point that what would have been `%2B` (`+`) becomes `%252B`
(`%2B`).

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

---

While this may not be the best solution, at least this will hopefully spark conversation (and also inform me of additional test cases that my naive "just percent-decode the URL string before we start manipulating it" breaks).

I can also upload the small Rust program I wrote to help test this, if anybody would like to verify.

Also note that I committed the test first, so that you can checkout prior to the "fix" commit and test that it is indeed broken without my fix :)