### PR TITLE
Commit Signature Verification

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -16,7 +16,6 @@
 
 - `builtins.fetchTree` is now marked as stable.
 
-
 - The interface for creating and updating lock files has been overhauled:
 
   - [`nix flake lock`](@docroot@/command-ref/new-cli/nix3-flake-lock.md) only creates lock files and adds missing inputs now.
@@ -29,3 +28,5 @@
 
   - The flake-specific flags `--recreate-lock-file` and `--update-input` have been removed from all commands operating on installables.
     They are superceded by `nix flake update`.
+  
+- Commit signature verification for the [`builtins.fetchGit`](@docroot@/language/builtins.md#builtins-fetchGit) is added as the new [`verified-fetches` experimental feature](@docroot@/contributing/experimental-features.md#xp-feature-verified-fetches).

--- a/flake.nix
+++ b/flake.nix
@@ -185,6 +185,7 @@
             buildPackages.git
             buildPackages.mercurial # FIXME: remove? only needed for tests
             buildPackages.jq # Also for custom mdBook preprocessor.
+            buildPackages.openssh # only needed for tests (ssh-keygen)
           ]
           ++ lib.optionals stdenv.hostPlatform.isLinux [(buildPackages.util-linuxMinimal or buildPackages.utillinuxMinimal)];
 

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -8,6 +8,7 @@
 #include "fetchers.hh"
 #include "finally.hh"
 #include "fetch-settings.hh"
+#include "value-to-json.hh"
 
 namespace nix {
 
@@ -140,8 +141,13 @@ static FlakeInput parseFlakeInput(EvalState & state,
                         attrs.emplace(state.symbols[attr.name], (long unsigned int)attr.value->integer);
                         break;
                     default:
-                        throw TypeError("flake input attribute '%s' is %s while a string, Boolean, or integer is expected",
-                            state.symbols[attr.name], showType(*attr.value));
+                        if (attr.name == state.symbols.create("publicKeys")) {
+                            experimentalFeatureSettings.require(Xp::VerifiedFetches);
+                            NixStringContext emptyContext = {};
+                            attrs.emplace(state.symbols[attr.name], printValueAsJSON(state, true, *attr.value, pos, emptyContext).dump());
+                        } else
+                            throw TypeError("flake input attribute '%s' is %s while a string, Boolean, or integer is expected",
+                                state.symbols[attr.name], showType(*attr.value));
                 }
                 #pragma GCC diagnostic pop
             }

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -360,4 +360,9 @@ std::optional<ExperimentalFeature> InputScheme::experimentalFeature() const
     return {};
 }
 
+std::string publicKeys_to_string(const std::vector<PublicKey>& publicKeys)
+{
+    return ((nlohmann::json) publicKeys).dump();
+}
+
 }

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -182,4 +182,13 @@ void registerInputScheme(std::shared_ptr<InputScheme> && fetcher);
 
 nlohmann::json dumpRegisterInputSchemeInfo();
 
+struct PublicKey
+{
+    std::string type = "ssh-ed25519";
+    std::string key;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(PublicKey, type, key)
+
+std::string publicKeys_to_string(const std::vector<PublicKey>&);
+
 }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -143,6 +143,69 @@ struct WorkdirInfo
     bool hasHead = false;
 };
 
+std::vector<PublicKey> getPublicKeys(const Attrs & attrs) {
+    std::vector<PublicKey> publicKeys;
+    if (attrs.contains("publicKeys")) {
+        nlohmann::json publicKeysJson = nlohmann::json::parse(getStrAttr(attrs, "publicKeys"));
+        ensureType(publicKeysJson, nlohmann::json::value_t::array);
+        publicKeys = publicKeysJson.get<std::vector<PublicKey>>();
+    }
+    else {
+        publicKeys = {};
+    }
+    if (attrs.contains("publicKey"))
+        publicKeys.push_back(PublicKey{maybeGetStrAttr(attrs, "keytype").value_or("ssh-ed25519"),getStrAttr(attrs, "publicKey")});
+    return publicKeys;
+}
+
+void doCommitVerification(const Path repoDir, const Path gitDir, const std::string rev, const std::vector<PublicKey>& publicKeys) {
+    // Create ad-hoc allowedSignersFile and populate it with publicKeys
+    auto allowedSignersFile = createTempFile().second;
+    std::string allowedSigners;
+    for (const PublicKey& k : publicKeys) {
+        if (k.type != "ssh-dsa"
+            && k.type != "ssh-ecdsa"
+            && k.type != "ssh-ecdsa-sk"
+            && k.type != "ssh-ed25519"
+            && k.type != "ssh-ed25519-sk"
+            && k.type != "ssh-rsa")
+            warn("Unknow keytype: %s\n"
+                 "Please use one of\n"
+                 "- ssh-dsa\n"
+                 "- ssh-ecdsa\n"
+                 "- ssh-ecdsa-sk\n"
+                 "- ssh-ed25519\n"
+                 "- ssh-ed25519-sk\n"
+                 "- ssh-rsa", k.type);
+        allowedSigners += "* " + k.type + " " + k.key + "\n";
+    }
+    writeFile(allowedSignersFile, allowedSigners);
+
+    // Run verification command
+    auto [status, output] = runProgram(RunOptions {
+            .program = "git",
+            .args = {"-c", "gpg.ssh.allowedSignersFile=" + allowedSignersFile, "-C", repoDir,
+                     "--git-dir", gitDir, "verify-commit", rev},
+            .mergeStderrToStdout = true,
+    });
+
+    /* Evaluate result through status code and checking if public key fingerprints appear on stderr
+     * This is neccessary because the git command might also succeed due to the commit being signed by gpg keys
+     * that are present in the users key agent. */
+    std::string re = R"(Good "git" signature for \* with .* key SHA256:[)";
+    for (const PublicKey& k : publicKeys){
+        // Calculate sha256 fingerprint from public key and escape the regex symbol '+' to match the key literally
+        auto fingerprint = trim(hashString(htSHA256, base64Decode(k.key)).to_string(nix::HashFormat::Base64, false), "=");
+        auto escaped_fingerprint = std::regex_replace(fingerprint, std::regex("\\+"), "\\+" );
+        re += "(" + escaped_fingerprint + ")";
+    }
+    re += "]";
+    if (status == 0 && std::regex_search(output, std::regex(re)))
+        printTalkative("Commit signature verification on commit %s succeeded", rev);
+    else
+        throw Error("Commit signature verification on commit %s failed: \n%s", rev, output);
+}
+
 // Returns whether a git workdir is clean and has commits.
 WorkdirInfo getWorkdirInfo(const Input & input, const Path & workdir)
 {
@@ -272,9 +335,9 @@ struct GitInputScheme : InputScheme
         attrs.emplace("type", "git");
 
         for (auto & [name, value] : url.query) {
-            if (name == "rev" || name == "ref")
+            if (name == "rev" || name == "ref" || name == "keytype" || name == "publicKey" || name == "publicKeys")
                 attrs.emplace(name, value);
-            else if (name == "shallow" || name == "submodules" || name == "allRefs")
+            else if (name == "shallow" || name == "submodules" || name == "allRefs" || name == "verifyCommit")
                 attrs.emplace(name, Explicit<bool> { value == "1" });
             else
                 url2.query.emplace(name, value);
@@ -306,14 +369,26 @@ struct GitInputScheme : InputScheme
             "name",
             "dirtyRev",
             "dirtyShortRev",
+            "verifyCommit",
+            "keytype",
+            "publicKey",
+            "publicKeys",
         };
     }
 
     std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
+        for (auto & [name, _] : attrs)
+            if (name == "verifyCommit"
+                || name == "keytype"
+                || name == "publicKey"
+                || name == "publicKeys")
+                experimentalFeatureSettings.require(Xp::VerifiedFetches);
+
         maybeGetBoolAttr(attrs, "shallow");
         maybeGetBoolAttr(attrs, "submodules");
         maybeGetBoolAttr(attrs, "allRefs");
+        maybeGetBoolAttr(attrs, "verifyCommit");
 
         if (auto ref = maybeGetStrAttr(attrs, "ref")) {
             if (std::regex_search(*ref, badGitRefRegex))
@@ -336,6 +411,15 @@ struct GitInputScheme : InputScheme
         if (auto ref = input.getRef()) url.query.insert_or_assign("ref", *ref);
         if (maybeGetBoolAttr(input.attrs, "shallow").value_or(false))
             url.query.insert_or_assign("shallow", "1");
+        if (maybeGetBoolAttr(input.attrs, "verifyCommit").value_or(false))
+            url.query.insert_or_assign("verifyCommit", "1");
+        auto publicKeys = getPublicKeys(input.attrs);
+        if (publicKeys.size() == 1) {
+            url.query.insert_or_assign("keytype", publicKeys.at(0).type);
+            url.query.insert_or_assign("publicKey", publicKeys.at(0).key);
+        }
+        else if (publicKeys.size() > 1)
+            url.query.insert_or_assign("publicKeys", publicKeys_to_string(publicKeys));
         return url;
     }
 
@@ -425,6 +509,8 @@ struct GitInputScheme : InputScheme
         bool shallow = maybeGetBoolAttr(input.attrs, "shallow").value_or(false);
         bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
         bool allRefs = maybeGetBoolAttr(input.attrs, "allRefs").value_or(false);
+        std::vector<PublicKey> publicKeys = getPublicKeys(input.attrs);
+        bool verifyCommit = maybeGetBoolAttr(input.attrs, "verifyCommit").value_or(!publicKeys.empty());
 
         std::string cacheType = "git";
         if (shallow) cacheType += "-shallow";
@@ -445,6 +531,8 @@ struct GitInputScheme : InputScheme
                 {"type", cacheType},
                 {"name", name},
                 {"rev", input.getRev()->gitRev()},
+                {"verifyCommit", verifyCommit},
+                {"publicKeys", publicKeys_to_string(publicKeys)},
             });
         };
 
@@ -467,12 +555,15 @@ struct GitInputScheme : InputScheme
         auto [isLocal, actualUrl_] = getActualUrl(input);
         auto actualUrl = actualUrl_; // work around clang bug
 
-        /* If this is a local directory and no ref or revision is given,
+        /* If this is a local directory, no ref or revision is given and no signature verification is needed,
            allow fetching directly from a dirty workdir. */
         if (!input.getRef() && !input.getRev() && isLocal) {
             auto workdirInfo = getWorkdirInfo(input, actualUrl);
             if (!workdirInfo.clean) {
-                return fetchFromWorkdir(store, input, actualUrl, workdirInfo);
+                if (verifyCommit)
+                    throw Error("Can't fetch from a dirty workdir with commit signature verification enabled.");
+                else
+                    return fetchFromWorkdir(store, input, actualUrl, workdirInfo);
             }
         }
 
@@ -480,6 +571,8 @@ struct GitInputScheme : InputScheme
             {"type", cacheType},
             {"name", name},
             {"url", actualUrl},
+            {"verifyCommit", verifyCommit},
+            {"publicKeys", publicKeys_to_string(publicKeys)},
         });
 
         Path repoDir;
@@ -636,6 +729,9 @@ struct GitInputScheme : InputScheme
                 actualUrl
             );
         }
+
+        if (verifyCommit)
+            doCommitVerification(repoDir, gitDir, input.getRev()->gitRev(), publicKeys);
 
         if (submodules) {
             Path tmpGitDir = createTempDir();

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -169,14 +169,14 @@ void doCommitVerification(const Path repoDir, const Path gitDir, const std::stri
             && k.type != "ssh-ed25519"
             && k.type != "ssh-ed25519-sk"
             && k.type != "ssh-rsa")
-            warn("Unknow keytype: %s\n"
+            warn("Unknown keytype: %s\n"
                  "Please use one of\n"
                  "- ssh-dsa\n"
-                 "- ssh-ecdsa\n"
-                 "- ssh-ecdsa-sk\n"
-                 "- ssh-ed25519\n"
-                 "- ssh-ed25519-sk\n"
-                 "- ssh-rsa", k.type);
+                 "  ssh-ecdsa\n"
+                 "  ssh-ecdsa-sk\n"
+                 "  ssh-ed25519\n"
+                 "  ssh-ed25519-sk\n"
+                 "  ssh-rsa", k.type);
         allowedSigners += "* " + k.type + " " + k.key + "\n";
     }
     writeFile(allowedSignersFile, allowedSigners);
@@ -201,7 +201,7 @@ void doCommitVerification(const Path repoDir, const Path gitDir, const std::stri
     }
     re += "]";
     if (status == 0 && std::regex_search(output, std::regex(re)))
-        printTalkative("Commit signature verification on commit %s succeeded", rev);
+        printTalkative("Signature verification on commit %s succeeded", rev);
     else
         throw Error("Commit signature verification on commit %s failed: \n%s", rev, output);
 }

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -12,7 +12,7 @@ struct ExperimentalFeatureDetails
     std::string_view description;
 };
 
-constexpr std::array<ExperimentalFeatureDetails, 15> xpFeatureDetails = {{
+constexpr std::array<ExperimentalFeatureDetails, 16> xpFeatureDetails = {{
     {
         .tag = Xp::CaDerivations,
         .name = "ca-derivations",
@@ -227,7 +227,14 @@ constexpr std::array<ExperimentalFeatureDetails, 15> xpFeatureDetails = {{
         .description = R"(
             Allow the use of the [impure-env](@docroot@/command-ref/conf-file.md#conf-impure-env) setting.
         )",
-    }
+    },
+    {
+        .tag = Xp::VerifiedFetches,
+        .name = "verified-fetches",
+        .description = R"(
+            Enables verification of git commit signatures through the [`fetchGit`](@docroot@/language/builtins.md#builtins-fetchGit) built-in.
+        )",
+    },
 }};
 
 static_assert(

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -32,6 +32,7 @@ enum struct ExperimentalFeature
     ParseTomlTimestamps,
     ReadOnlyLocalStore,
     ConfigurableImpureEnv,
+    VerifiedFetches,
 };
 
 /**

--- a/tests/functional/fetchGitVerification.sh
+++ b/tests/functional/fetchGitVerification.sh
@@ -1,0 +1,76 @@
+source common.sh
+
+requireGit
+[[ $(type -p ssh-keygen) ]] || skipTest "ssh-keygen not installed" # require ssh-keygen
+
+enableFeatures "verified-fetches"
+
+clearStore
+
+repo="$TEST_ROOT/git"
+
+# generate signing keys
+keysDir=$TEST_ROOT/.ssh
+mkdir -p "$keysDir"
+ssh-keygen -f "$keysDir/testkey1" -t ed25519 -P "" -C "test key 1"
+key1File="$keysDir/testkey1.pub"
+publicKey1=$(awk '{print $2}' "$key1File")
+ssh-keygen -f "$keysDir/testkey2" -t rsa -P "" -C "test key 2"
+key2File="$keysDir/testkey2.pub"
+publicKey2=$(awk '{print $2}' "$key2File")
+
+git init $repo
+git -C $repo config user.email "foobar@example.com"
+git -C $repo config user.name "Foobar"
+git -C $repo config gpg.format ssh
+
+echo 'hello' > $repo/text
+git -C $repo add text
+git -C $repo -c "user.signingkey=$key1File" commit -S -m 'initial commit'
+
+out=$(nix eval --impure --raw --expr "builtins.fetchGit { url = \"file://$repo\"; keytype = \"ssh-rsa\"; publicKey = \"$publicKey2\"; }" 2>&1) || status=$?
+[[ $status == 1 ]]
+[[ $out =~ 'No principal matched.' ]]
+[[ $(nix eval --impure --raw --expr "builtins.readFile (builtins.fetchGit { url = \"file://$repo\"; publicKey = \"$publicKey1\"; } + \"/text\")") = 'hello' ]]
+
+echo 'hello world' > $repo/text
+git -C $repo add text
+git -C $repo -c "user.signingkey=$key2File" commit -S -m 'second commit'
+
+[[ $(nix eval --impure --raw --expr "builtins.readFile (builtins.fetchGit { url = \"file://$repo\"; publicKeys = [{key = \"$publicKey1\";} {type = \"ssh-rsa\"; key = \"$publicKey2\";}]; } + \"/text\")") = 'hello world' ]]
+
+# Flake input test
+flakeDir="$TEST_ROOT/flake"
+mkdir -p "$flakeDir"
+cat > "$flakeDir/flake.nix" <<EOF
+{
+  inputs.test = {
+    type = "git";
+    url = "file://$repo";
+    flake = false;
+    publicKeys = [
+      { type = "ssh-rsa"; key = "$publicKey2"; }
+    ];
+  };
+
+  outputs = { test, ... }: { test = test.outPath; };
+}
+EOF
+nix build --out-link "$flakeDir/result" "$flakeDir#test"
+[[ $(cat "$flakeDir/result/text") = 'hello world' ]]
+
+cat > "$flakeDir/flake.nix" <<EOF
+{
+  inputs.test = {
+    type = "git";
+    url = "file://$repo";
+    flake = false;
+    publicKey= "$publicKey1";
+  };
+
+  outputs = { test, ... }: { test = test.outPath; };
+}
+EOF
+out=$(nix build "$flakeDir#test" 2>&1) || status=$?
+[[ $status == 1 ]]
+[[ $out =~ 'No principal matched.' ]]

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -55,6 +55,7 @@ nix_tests = \
   secure-drv-outputs.sh \
   restricted.sh \
   fetchGitSubmodules.sh \
+  fetchGitVerification.sh \
   flakes/search-root.sh \
   readfile-context.sh \
   nix-channel.sh \


### PR DESCRIPTION
**I don't have a lot of experience developing C++ and am completly new to this project so I'd be really grateful for feedback on this.**

# Motivation
When fetching a derivation from a git repository it is desirable to verify that the commit was made by the code owner and not altered by the git server.
Commit signatures are a [git-native](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work) way of verifying this.

This can be useful for 
1. administering systems through untrusted git servers (by verifying with your own public key)
2. having a second check when building a program from source (by verifying with the developers key)

# Context
 Mainly #2849, although this implementation is only restricted to the `git` fetcher.
Since this can also be used for source code signature verification:  #613 and https://discourse.nixos.org/t/any-interest-in-checkings-signatures-while-building-packages/8918

This is much simpler and more limited than what https://github.com/NixOS/rfcs/pull/100 suggests since this PR is only about verifying the current commit with a provided public key.

# Implementation
To implement this change I added `verifyCommit`, `keytype`, `publicKey` and `publicKeys` as an additional git input attributes.
To avoid having unverified fetches cached and substituted for verified fetches, I added the attributes to `unlockedAttributes` as well as `lockedAttributes`. I'm still not certain on how the caching exactly works and it could be improved slightly by having verified fetches store a cache entry for unverified fetches as well, but I'm not sure it is worth the trouble.
`publicKeys`, as its supposted to unambiguously define a list of public keys, is a parsed as a json string. I did not implement it as a list since those can't be given directly as part of a flake uri. The json can, provided it is percent-encoded. The json string is also used for cache lookups.
It can be given to fetchGit and as flake input attribute in the form of a normal list of attributes, which is then turned into a json string by the flake or fetchTree parser. This is immediately reparsed to `std::vector<publicKey>` by the fetch-method in `git.cc`, which feels hacky to me, but I didn't find a better way to do this while still keeping the current seperation of concerns between `flake.cc` and `git.cc`.

To keep this PR small I consider the following out-of-scope
- gpg signatures
- fetchers other than git
- tag signature verification (though it should be easy to implement this once `verifyCommit` is implemented)

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
