### PR TITLE
nix key: Add a newline to the output

### DIFF
--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -173,7 +173,7 @@ struct CmdKeyGenerateSecret : Command
         if (!keyName)
             throw UsageError("required argument '--key-name' is missing");
 
-        writeFull(STDOUT_FILENO, SecretKey::generate(*keyName).to_string());
+        logger->cout(SecretKey::generate(*keyName).to_string());
     }
 };
 
@@ -194,7 +194,7 @@ struct CmdKeyConvertSecretToPublic : Command
     void run() override
     {
         SecretKey secretKey(drainFD(STDIN_FILENO));
-        writeFull(STDOUT_FILENO, secretKey.toPublicKey().to_string());
+        logger->cout(secretKey.toPublicKey().to_string());
     }
 };
 


### PR DESCRIPTION
# Motivation

Without the newline, the progress bar will overwrite the output on stdout. The alternative is to call stopProgressBar().

Fixes #8844.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
