### PR TITLE
Add basic json logger

### DIFF
--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -13,6 +13,8 @@ LogFormat parseLogFormat(const std::string & logFormatStr) {
         return LogFormat::rawWithLogs;
     else if (logFormatStr == "internal-json")
         return LogFormat::internalJSON;
+    else if (logFormatStr == "json")
+        return LogFormat::json;
     else if (logFormatStr == "bar")
         return LogFormat::bar;
     else if (logFormatStr == "bar-with-logs")
@@ -27,7 +29,9 @@ Logger * makeDefaultLogger() {
     case LogFormat::rawWithLogs:
         return makeSimpleLogger(true);
     case LogFormat::internalJSON:
-        return makeJSONLogger(*makeSimpleLogger(true));
+        return makeJSONLogger(*makeSimpleLogger(true), true);
+    case LogFormat::json:
+        return makeJSONLogger(*makeSimpleLogger(true), false);
     case LogFormat::bar:
         return makeProgressBar();
     case LogFormat::barWithLogs: {

--- a/src/libmain/loggers.hh
+++ b/src/libmain/loggers.hh
@@ -11,6 +11,7 @@ enum class LogFormat {
   internalJSON,
   bar,
   barWithLogs,
+  json,
 };
 
 void setLogFormat(const std::string & logFormatStr);

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -150,8 +150,9 @@ void to_json(nlohmann::json & json, std::shared_ptr<AbstractPos> pos)
 
 struct JSONLogger : Logger {
     Logger & prevLogger;
+    bool internalJSON;
 
-    JSONLogger(Logger & prevLogger) : prevLogger(prevLogger) { }
+    JSONLogger(Logger & prevLogger, bool internalJSON) : prevLogger(prevLogger) { }
 
     bool isVerbose() override {
         return true;
@@ -172,7 +173,11 @@ struct JSONLogger : Logger {
 
     void write(const nlohmann::json & json)
     {
-        prevLogger.log(lvlError, "@nix " + json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace));
+        if (internalJSON) {
+            prevLogger.log(lvlError, "@nix " + json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace));
+        } else {
+            prevLogger.log(lvlError, json.dump(-1, ' ', true, nlohmann::json::error_handler_t::replace));
+        }
     }
 
     void log(Verbosity lvl, std::string_view s) override
@@ -244,9 +249,9 @@ struct JSONLogger : Logger {
     }
 };
 
-Logger * makeJSONLogger(Logger & prevLogger)
+Logger * makeJSONLogger(Logger & prevLogger, bool internalJSON)
 {
-    return new JSONLogger(prevLogger);
+    return new JSONLogger(prevLogger, internalJSON);
 }
 
 static Logger::Fields getFields(nlohmann::json & json)

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -171,7 +171,7 @@ extern Logger * logger;
 
 Logger * makeSimpleLogger(bool printBuildLogs = true);
 
-Logger * makeJSONLogger(Logger & prevLogger);
+Logger * makeJSONLogger(Logger & prevLogger, bool internalJSON = true);
 
 std::optional<nlohmann::json> parseJSONMessage(const std::string & msg);
 


### PR DESCRIPTION
It closely resembles the current Internal JSON logger, with the exception that we have eliminated the `@nix` prefix.

refs #7853

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
