### PR TITLE
Tarball trees: Propagate lastModified

### DIFF
--- a/doc/manual/src/protocols/tarball-fetcher.md
+++ b/doc/manual/src/protocols/tarball-fetcher.md
@@ -20,8 +20,8 @@ Link: <flakeref>; rel="immutable"
 
 (Note the required `<` and `>` characters around *flakeref*.)
 
-*flakeref* must be a tarball flakeref. It can contain flake attributes
-such as `narHash`, `rev` and `revCount`. If `narHash` is included, its
+*flakeref* must be a tarball flakeref. It can contain the tarball flake attributes
+`narHash`, `rev`, `revCount` and `lastModified`. If `narHash` is included, its
 value must be the NAR hash of the unpacked tarball (as computed via
 `nix hash path`). Nix checks the contents of the returned tarball
 against the `narHash` attribute. The `rev` and `revCount` attributes

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -232,7 +232,7 @@ struct CurlInputScheme : InputScheme
         if (type != inputType()) return {};
 
         // FIXME: some of these only apply to TarballInputScheme.
-        std::set<std::string> allowedNames = {"type", "url", "narHash", "name", "unpack", "rev", "revCount"};
+        std::set<std::string> allowedNames = {"type", "url", "narHash", "name", "unpack", "rev", "revCount", "lastModified"};
         for (auto & [name, value] : attrs)
             if (!allowedNames.count(name))
                 throw Error("unsupported %s input attribute '%s'", *type, name);
@@ -309,6 +309,9 @@ struct TarballInputScheme : CurlInputScheme
                 throw Error("tarball 'Link' headers that redirect to non-tarball URLs are not supported");
             input = immutableInput;
         }
+
+        if (result.lastModified && !input.attrs.contains("lastModified"))
+            input.attrs.insert_or_assign("lastModified", uint64_t(result.lastModified));
 
         return {result.tree.storePath, std::move(input)};
     }


### PR DESCRIPTION
# Motivation

This makes tarball flakes behave consistently with GitHub/GitLab flakes, e.g. it makes

```
nix flake metadata https://github.com/NixOS/nix/archive/2.17.0.zip
```

return the same "Last modified" value as

```
nix flake metadata github:NixOS/nix/2.17.0
```

which is important for flakes that depend on `lastModified` to evaluate consistently.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
