### PR TITLE
add nix-store --query --valid-derivers command

### DIFF
--- a/doc/manual/src/command-ref/nix-store/query.md
+++ b/doc/manual/src/command-ref/nix-store/query.md
@@ -5,8 +5,8 @@
 # Synopsis
 
 `nix-store` {`--query` | `-q`}
-  {`--outputs` | `--requisites` | `-R` | `--references` |
-  `--referrers` | `--referrers-closure` | `--deriver` | `-d` |
+  {`--outputs` | `--requisites` | `-R` | `--references` | `--referrers` |
+  `--referrers-closure` | `--deriver` | `-d` | `--valid-derivers` |
   `--graph` | `--tree` | `--binding` *name* | `-b` *name* | `--hash` |
   `--size` | `--roots`}
   [`--use-output`] [`-u`] [`--force-realise`] [`-f`]
@@ -82,12 +82,20 @@ symlink.
     in the Nix store that are dependent on *paths*.
 
   - `--deriver`; `-d`\
-    Prints the [deriver] of the store paths *paths*. If
+    Prints the [deriver] that was used to build the store paths *paths*. If
     the path has no deriver (e.g., if it is a source file), or if the
     deriver is not known (e.g., in the case of a binary-only
     deployment), the string `unknown-deriver` is printed.
+    The returned deriver is not guaranteed to exist in the local store, for
+    example when *paths* were substituted from a binary cache.
+    Use `--valid-derivers` instead to obtain valid paths only.
 
     [deriver]: ../../glossary.md#gloss-deriver
+
+  - `--valid-derivers`\
+    Prints a set of derivation files (`.drv`) which are supposed produce
+    said paths when realized. Might print nothing, for example for source paths
+    or paths subsituted from a binary cache.
 
   - `--graph`\
     Prints the references graph of the store paths *paths* in the format

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -22,3 +22,7 @@
 
 - Introduce a new [`outputOf`](@docroot@/language/builtins.md#builtins-outputOf) builtin.
   It is part of the [`dynamic-derivations`](@docroot@/contributing/experimental-features.md#xp-feature-dynamic-derivations) experimental feature.
+
+- [`nix-store --query`](@docroot@/command-ref/nix-store/query.md) gained a new type of query: `--valid-derivers`. It returns all `.drv` files in the local store that *can be* used to build the output passed in argument.
+This is in contrast to `--deriver`, which returns the single `.drv` file that *was actually* used to build the output passed in argument. In case the output was substituted from a binary cache,
+this `.drv` file may only exist on said binary cache and not locally.

--- a/tests/check-refs.nix
+++ b/tests/check-refs.nix
@@ -2,7 +2,7 @@ with import ./config.nix;
 
 rec {
 
-  dep = import ./dependencies.nix;
+  dep = import ./dependencies.nix {};
 
   makeTest = nr: args: mkDerivation ({
     name = "check-refs-" + toString nr;

--- a/tests/dependencies.nix
+++ b/tests/dependencies.nix
@@ -1,3 +1,4 @@
+{ hashInvalidator ? "" }:
 with import ./config.nix;
 
 let {
@@ -21,6 +22,17 @@ let {
     '';
   };
 
+  fod_input = mkDerivation {
+    name = "fod-input";
+    buildCommand = ''
+      echo ${hashInvalidator}
+      echo FOD > $out
+    '';
+    outputHashMode = "flat";
+    outputHashAlgo = "sha256";
+    outputHash = "1dq9p0hnm1y75q2x40fws5887bq1r840hzdxak0a9djbwvx0b16d";
+  };
+
   body = mkDerivation {
     name = "dependencies-top";
     builder = ./dependencies.builder0.sh + "/FOOBAR/../.";
@@ -29,6 +41,7 @@ let {
     input1_drv = input1;
     input2_drv = input2;
     input0_drv = input0;
+    fod_input_drv = fod_input;
     meta.description = "Random test package";
   };
 

--- a/tests/dyn-drv/eval-outputOf.sh
+++ b/tests/dyn-drv/eval-outputOf.sh
@@ -13,14 +13,14 @@ nix --experimental-features 'nix-command' eval --impure  --expr \
 # the future so it does work, but there are some design questions to
 # resolve first. Adding a test so we don't liberalise it by accident.
 expectStderr 1 nix --experimental-features 'nix-command dynamic-derivations' eval --impure --expr \
-    'builtins.outputOf (import ../dependencies.nix) "out"' \
+    'builtins.outputOf (import ../dependencies.nix {}) "out"' \
     | grepQuiet "value is a set while a string was expected"
 
 # Test that "DrvDeep" string contexts are not supported at this time
 #
 # Like the above, this is a restriction we could relax later.
 expectStderr 1 nix --experimental-features 'nix-command dynamic-derivations' eval --impure --expr \
-    'builtins.outputOf (import ../dependencies.nix).drvPath "out"' \
+    'builtins.outputOf (import ../dependencies.nix {}).drvPath "out"' \
     | grepQuiet "has a context which refers to a complete source and binary closure. This is not supported at this time"
 
 # Test using `builtins.outputOf` with static derivations

--- a/tests/export-graph.nix
+++ b/tests/export-graph.nix
@@ -17,13 +17,13 @@ rec {
   foo."bar.runtimeGraph" = mkDerivation {
     name = "dependencies";
     builder = builtins.toFile "build-graph-builder" "${printRefs}";
-    exportReferencesGraph = ["refs" (import ./dependencies.nix)];
+    exportReferencesGraph = ["refs" (import ./dependencies.nix {})];
   };
 
   foo."bar.buildGraph" = mkDerivation {
     name = "dependencies";
     builder = builtins.toFile "build-graph-builder" "${printRefs}";
-    exportReferencesGraph = ["refs" (import ./dependencies.nix).drvPath];
+    exportReferencesGraph = ["refs" (import ./dependencies.nix {}).drvPath];
   };
 
 }

--- a/tests/remote-store.sh
+++ b/tests/remote-store.sh
@@ -24,7 +24,7 @@ fi
   import (
     mkDerivation {
       name = "foo";
-      bla = import ./dependencies.nix;
+      bla = import ./dependencies.nix {};
       buildCommand = "
         echo \\\"hi\\\" > $out
       ";


### PR DESCRIPTION
# Motivation
On typical nixos installations, nixos-rebuild creates .drv files for all store paths of the system, but the deriver field of the db comes from hydra. If a dependency of a fixed output derivation changed between the time hydra built something and nixos-rebuild was called, the local .drv and the deriver provided by hydra will not match. In this case,
nix-store --query --deriver /store/path returns a missing .drv file, whereas we have at least one other deriver of this store path locally.

This commit adds a new command `nix-store --query --valid-derivers` which prints .drv files which can build the specified output *and actually exist locally*.
The intended final use case of this contribution is to be able to link an executable in the store to the store path of its source via the src field of its deriver. (specifically: nixseparatedebuginfod uses that to provide source code to gdb)


# Context
This is an alternative to #8538 suggested in https://github.com/NixOS/nix/pull/8538#issuecomment-1676146508

<!-- Non-trivial change: Briefly outline the implementation strategy. -->
This just exposes `Store::queryValidDerivers(const StorePath & path)` in the cli.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
