### PR TITLE
Document nix-prefetch-url defaults

### DIFF
--- a/doc/manual/src/command-ref/nix-prefetch-url.md
+++ b/doc/manual/src/command-ref/nix-prefetch-url.md
@@ -31,15 +31,18 @@ store already contains a file with the same hash and base name.
 Otherwise, the file is downloaded, and an error is signaled if the
 actual hash of the file does not match the specified hash.
 
-This command prints the hash on standard output. Additionally, if the
-option `--print-path` is used, the path of the downloaded file in the
-Nix store is also printed.
+This command prints the hash on standard output.
+The hash is printed using base-32 unless `--type md5` is specified,
+in which case it's printed using base-16.
+Additionally, if the option `--print-path` is used,
+the path of the downloaded file in the Nix store is also printed.
 
 # Options
 
   - `--type` *hashAlgo*\
-    Use the specified cryptographic hash algorithm, which can be one of
-    `md5`, `sha1`, `sha256`, and `sha512`.
+    Use the specified cryptographic hash algorithm,
+    which can be one of `md5`, `sha1`, `sha256`, and `sha512`.
+    The default is `sha256`.
 
   - `--print-path`\
     Print the store path of the downloaded file on standard output.


### PR DESCRIPTION
# Motivation
Was frustrated by this not being there.

# Context

# Checklist for maintainers

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
