### PR TITLE
Stack overflow: stack trace and nix debugger support

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -308,7 +308,7 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
         size_t count = 0;
         for (const auto & trace : einfo.traces) {
             if (trace.hint.str().empty()) continue;
-            if (frameOnly && !trace.frame) continue;
+            // if (frameOnly && !trace.frame) continue;
 
             if (!showTrace && count > 3) {
                 oss << "\n" << ANSI_WARNING "(stack trace truncated; use '--show-trace' to show the full trace)" ANSI_NORMAL << "\n";


### PR DESCRIPTION
# Motivation

> **note**
> This is distinct from infinite recursion errors, which are already handled properly.

Provide means to solve stack overflows in Nix code.
 - Stack trace
 - Launch the debugger

TODO:
- [ ] solve the TODOs in the code. (Sorry for the low effort, as I had to write this from my not so great backup laptop for unrelated reasons)
- [ ] figure out what's the deal with `frameOnly`. If I don't comment it out, the trace just stops!
- [ ] add test

# Context

- A problem with the virtual memory-based stack overflow detection. Not the reason I wrote this, but this alternate implementation should sidestep the problem in #8281 (which isn't truly solved as long as we keep the virtual memory based solution around)
- TODO other issue

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
