### PR TITLE
Add a straightforward way to determine if inside a nix3 shell

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -361,6 +361,8 @@ void MixEnvironment::setEnviron()
     for (const auto & [name, value] : setVars)
         env[name] = value;
 
+    env["IN_NIX_SHELL"] = ignoreEnvironment ? "pure" : "impure";
+
     if (!unsetVars.empty())
         std::erase_if(env, [&](const auto & var) { return unsetVars.contains(var.first); });
 

--- a/tests/functional/flakes/run.sh
+++ b/tests/functional/flakes/run.sh
@@ -43,6 +43,7 @@ nix run -f shell-hello.nix env > $TEST_ROOT/actual-env
 # - __CF_USER_TEXT_ENCODING is set by macOS and is beyond our control
 sed -i \
   -e 's/PATH=.*/PATH=.../' \
+  -e '/^IN_NIX_SHELL=.*/d' \
   -e 's/_=.*/_=.../' \
   -e '/^TMPDIR=\/var\/folders\/.*/d' \
   -e '/^__CF_USER_TEXT_ENCODING=.*$/d' \

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -36,6 +36,7 @@ nix shell -f shell-hello.nix hello -c env > "$TEST_ROOT/actual-env"
 # - __CF_USER_TEXT_ENCODING is set by macOS and is beyond our control
 sed -i \
   -e 's/PATH=.*/PATH=.../' \
+  -e '/^IN_NIX_SHELL=.*/d' \
   -e 's/_=.*/_=.../' \
   -e '/^TMPDIR=\/var\/folders\/.*/d' \
   -e '/^__CF_USER_TEXT_ENCODING=.*$/d' \


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

I just want to have my Fish prompt tell me if I am in a Nix3 shell.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

See: #6677 #3862

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

Fixes #3862 #6677 
