### PR TITLE
Flake schemas

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -140,6 +140,7 @@
   - [Nix Cache Info Format](protocols/nix-cache-info.md)
   - [Derivation "ATerm" file format](protocols/derivation-aterm.md)
   - [Nix32 Encoding](protocols/nix32.md)
+  - [Flake Schemas](protocols/flake-schemas.md)
 - [C API](c-api.md)
 - [Glossary](glossary.md)
 - [Development](development/index.md)

--- a/doc/manual/source/protocols/flake-schemas.md
+++ b/doc/manual/source/protocols/flake-schemas.md
@@ -1,0 +1,65 @@
+# Flake Schemas
+
+Flake schemas are a mechanism to allow tools like `nix flake show` and `nix flake check` to enumerate and check the contents of a flake
+in a generic way, without requiring built-in knowledge of specific flake output types like `packages` or `nixosConfigurations`.
+
+A flake can define schemas for its outputs by defining a `schemas` output. `schemas` should be an attribute set with an attribute for
+every output type that you want to be supported. If a flake does not have a `schemas` attribute, Nix uses a built-in set of schemas (namely https://github.com/DeterminateSystems/flake-schemas).
+
+A schema is an attribute set with the following attributes:
+
+| Attribute   | Description                                                                                     | Default |
+| :---------- | :---------------------------------------------------------------------------------------------- | :------ |
+| `version`   | Should be set to 1                                                                              |         |
+| `doc`       | A string containing documentation about the flake output type in Markdown format.               |         |
+| `allowIFD`  | Whether the evaluation of the output attributes of this flake can read from derivation outputs. | `true`  |
+| `inventory` | A function that returns the contents of the flake output (described [below](#inventory)).       |         |
+
+# Inventory
+
+The `inventory` function returns a _node_ describing the contents of the flake output. A node is either a _leaf node_ or a _non-leaf node_. This allows nested flake output attributes to be described (e.g. `x86_64-linux.hello` inside a `packages` output).
+
+Non-leaf nodes must have the following attribute:
+
+| Attribute  | Description                                                                            |
+| :--------- | :------------------------------------------------------------------------------------- |
+| `children` | An attribute set of nodes. If this attribute is missing, the attribute is a leaf node. |
+
+Leaf nodes can have the following attributes:
+
+| Attribute            | Description                                                                                                                                                                                      |
+| :------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `derivationAttrPath` | If not null, a list of strings denoting the attribute path of the "main" derivation of this node.                                                                                                |
+| `evalChecks`         | An attribute set of Boolean values, used by `nix flake check`. Each attribute must evaluate to `true`.                                                                                           |
+| `isFlakeCheck`       | Whether `nix flake check` should build the attribute denoted by `derivationAttrPath`.                                                                                                            |
+| `shortDescription`   | A one-sentence description of the node (such as the `meta.description` attribute in Nixpkgs).                                                                                                    |
+| `what`               | A brief human-readable string describing the type of the node, e.g. `"package"` or `"development environment"`. This is used by tools like `nix flake show` to describe the contents of a flake. |
+
+Both leaf and non-leaf nodes can have the following attributes:
+
+| Attribute    | Description                                                                                                                                                                                                                                                                                                                                            |
+| :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `forSystems` | A list of Nix system types (e.g. `["x86_64-linux"]`) supported by this node. This is used by tools to skip nodes that cannot be built on the user's system. Setting this on a non-leaf node allows all the children to be skipped, regardless of the `forSystems` attributes of the children. If this attribute is not set, the node is never skipped. |
+| `isLegacy`   | If set to true, this node is skipped unless the `--legacy` CLI flag is set. |
+
+# Example
+
+Here is a schema that checks that every element of the `nixosConfigurations` flake output evaluates and builds correctly (meaning that it has a `config.system.build.toplevel` attribute that yields a buildable derivation).
+
+```nix
+outputs = {
+  schemas.nixosConfigurations = {
+    version = 1;
+    doc = ''
+      The `nixosConfigurations` flake output defines NixOS system configurations.
+    '';
+    inventory = output: {
+      children = builtins.mapAttrs (configName: machine:
+        {
+          what = "NixOS configuration";
+          derivationAttrPath = [ "config" "system" "build" "toplevel" ];
+        }) output;
+    };
+  };
+};
+```

--- a/doc/manual/source/protocols/flake-schemas.md
+++ b/doc/manual/source/protocols/flake-schemas.md
@@ -8,12 +8,15 @@ every output type that you want to be supported. If a flake does not have a `sch
 
 A schema is an attribute set with the following attributes:
 
-| Attribute   | Description                                                                                     | Default |
-| :---------- | :---------------------------------------------------------------------------------------------- | :------ |
-| `version`   | Should be set to 1                                                                              |         |
-| `doc`       | A string containing documentation about the flake output type in Markdown format.               |         |
-| `allowIFD`  | Whether the evaluation of the output attributes of this flake can read from derivation outputs. | `true`  |
-| `inventory` | A function that returns the contents of the flake output (described [below](#inventory)).       |         |
+| Attribute         | Description                                                                                                                  | Default |
+| :---------------- | :----------------------------------------------------------------------------------------------------------------------------| :------ |
+| `version`         | Should be set to 1                                                                                                           |         |
+| `doc`             | A string containing documentation about the flake output type in Markdown format.                                            |         |
+| `allowIFD`        | Whether the evaluation of the output attributes of this flake can read from derivation outputs.                              | `true`  |
+| `inventory`       | A function that returns the contents of the flake output (described [below](#inventory)).                                    |         |
+| `roles`           | The roles supported by this flake output type (see [below](#roles)).                                                         |         |
+| `appendSystem`    | Whether the current system type is appended to the flake output attribute path, as in outputs like `packages`.               |         |
+| `defaultAttrPath` | A default flake output attribute path suffix. For example, `packages` will look for `default` if no attribute path is given. |         |
 
 # Inventory
 
@@ -41,6 +44,25 @@ Both leaf and non-leaf nodes can have the following attributes:
 | :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `forSystems` | A list of Nix system types (e.g. `["x86_64-linux"]`) supported by this node. This is used by tools to skip nodes that cannot be built on the user's system. Setting this on a non-leaf node allows all the children to be skipped, regardless of the `forSystems` attributes of the children. If this attribute is not set, the node is never skipped. |
 | `isLegacy`   | If set to true, this node is skipped unless the `--legacy` CLI flag is set. |
+
+# Roles
+
+Roles allow schemas to declare what commands operate on them. For instance, to have the `nix build` command build a flake output, the schema should declare:
+```nix
+roles.nix-build = { };
+```
+
+The following roles are used by various Nix commands:
+
+* `nix-build`: Used by `nix build`, `nix shell`, and `nix develop`.
+* `nix-bundler`: Denotes bundler functions used by `nix bundle`.
+* `nix-develop`: Used by `nix develop`.
+* `nix-fmt`: Used by `nix formatter`.
+* `nix-run`: Used by `nix run` and `nix bundle`.
+* `nix-search`: Denotes an output that will be searched by `nix search`.
+* `nix-template`: Used by `nix flake init` and `nix flake new`.
+
+Tools are free to define new roles. For instance, instead of hard-coding a flake output type like `nixosConfigurations`, `nixos-rebuild --flake` could use any flake output that implements a `nixos-configuration` role.
 
 # Example
 

--- a/src/libcmd/builtin-flake-schemas.nix
+++ b/src/libcmd/builtin-flake-schemas.nix
@@ -1,0 +1,495 @@
+{
+  description = "Schemas for well-known Nix flake output types";
+
+  outputs =
+    { self }:
+    let
+      mapAttrsToList = f: attrs: map (name: f name attrs.${name}) (builtins.attrNames attrs);
+
+      checkModule =
+        module_:
+        let
+          module = if builtins.isPath module_ then import module_ else module_;
+        in
+        builtins.isAttrs module || builtins.isFunction module;
+
+      mkApp = system: app: {
+        forSystems = [ system ];
+        evalChecks.isValidApp =
+          app ? type
+          && app.type == "app"
+          && app ? program
+          && builtins.isString app.program
+          &&
+            builtins.removeAttrs app [
+              "type"
+              "program"
+              "meta"
+            ] == { };
+        what = "app";
+        shortDescription = app.meta.description or "";
+      };
+
+      mkPackage = isFlakeCheck: what: system: package: {
+        forSystems = [ system ];
+        shortDescription = package.meta.description or "";
+        derivationAttrPath = [ ];
+        inherit what isFlakeCheck;
+      };
+
+      singleDerivationInventory =
+        what: isFlakeCheck: output:
+        self.lib.mkChildren (builtins.mapAttrs (mkPackage isFlakeCheck what) output);
+
+      schemasSchema = doc: {
+        version = 1;
+        inherit doc;
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (schemaName: schemaDef: {
+              shortDescription = "A schema checker for the `${schemaName}` flake output";
+              evalChecks.isValidSchema =
+                schemaDef.version or 0 == 1
+                && schemaDef ? doc
+                && builtins.isString (schemaDef.doc)
+                && schemaDef ? inventory
+                && builtins.isFunction (schemaDef.inventory);
+              what = "flake schema";
+            }) output
+          );
+      };
+
+      appsSchema = {
+        version = 1;
+        doc = ''
+          The `apps` output provides commands available via `nix run`.
+        '';
+        roles.nix-run = { };
+        appendSystem = true;
+        defaultAttrPath = [ "default" ];
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (system: apps: {
+              forSystems = [ system ];
+              children = builtins.mapAttrs (appName: app: mkApp system app) apps;
+            }) output
+          );
+      };
+
+      defaultAppSchema = {
+        version = 1;
+        doc = ''
+          **DEPRECATED**. Use `apps.<system>.default` instead.
+        '';
+        roles.nix-run = { };
+        appendSystem = true;
+        defaultAttrPath = [ ];
+        inventory = output: self.lib.mkChildren (builtins.mapAttrs mkApp output);
+      };
+
+      packagesSchema = {
+        version = 1;
+        doc = ''
+          The `packages` flake output contains packages that can be added to a shell using `nix shell`.
+        '';
+        roles.nix-build = { };
+        roles.nix-run = { };
+        roles.nix-develop = { };
+        roles.nix-search = { };
+        appendSystem = true;
+        defaultAttrPath = [ "default" ];
+        inventory = self.lib.derivationsInventory "package" false;
+      };
+
+      defaultPackageSchema = {
+        version = 1;
+        doc = ''
+          **DEPRECATED**. Use `packages.<system>.default` instead.
+        '';
+        roles.nix-build = { };
+        roles.nix-run = { };
+        roles.nix-develop = { };
+        roles.nix-search = { };
+        appendSystem = true;
+        defaultAttrPath = [ ];
+        inventory = singleDerivationInventory "package" false;
+      };
+
+      ociImagesSchema = {
+        version = 1;
+        doc = ''
+          The `ociImages` flake output contains derivations that build valid Open Container Initiative images.
+        '';
+        inventory = self.lib.derivationsInventory "OCI image" false;
+      };
+
+      legacyPackagesSchema = {
+        version = 1;
+        doc = ''
+          The `legacyPackages` flake output is similar to `packages` but different in that it can be nested and thus contain attribute sets that contain more packages.
+          Since enumerating packages in nested attribute sets can be inefficient, you should favor `packages` over `legacyPackages`.
+        '';
+        roles.nix-build = { };
+        roles.nix-run = { };
+        roles.nix-search = { };
+        roles.nix-develop = { };
+        appendSystem = true;
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (systemType: packagesForSystem: {
+              forSystems = [ systemType ];
+              isLegacy = true;
+              children =
+                let
+                  recurse =
+                    prefix: attrs:
+                    builtins.mapAttrs (
+                      attrName: attrs:
+                      # Necessary to deal with `AAAAAASomeThingsFailToEvaluate` etc. in Nixpkgs.
+                      self.lib.try (
+                        if attrs.type or null == "derivation" then
+                          {
+                            forSystems = [ attrs.system ];
+                            shortDescription = attrs.meta.description or "";
+                            derivationAttrPath = [ ];
+                            what = "package";
+                          }
+                        else
+                        # Recurse at the first and second levels, or if the
+                        # recurseForDerivations attribute if set.
+                        if attrs.recurseForDerivations or false then
+                          {
+                            children = recurse (prefix + attrName + ".") attrs;
+                          }
+                        else
+                          {
+                            what = "unknown";
+                          }
+                      ) (throw "failed")
+                    ) attrs;
+                in
+                # The top-level cannot be a derivation.
+                assert packagesForSystem.type or null != "derivation";
+                recurse (systemType + ".") packagesForSystem;
+            }) output
+          );
+      };
+
+      checksSchema = {
+        version = 1;
+        doc = ''
+          The `checks` flake output contains derivations that will be built by `nix flake check`.
+        '';
+        # FIXME: add role
+        inventory = self.lib.derivationsInventory "CI test" true;
+      };
+
+      devShellsSchema = {
+        version = 1;
+        doc = ''
+          The `devShells` flake output contains derivations that provide a development environment for `nix develop`.
+        '';
+        roles.nix-develop = { };
+        appendSystem = true;
+        defaultAttrPath = [ "default" ];
+        inventory = self.lib.derivationsInventory "development environment" false;
+      };
+
+      devShellSchema = {
+        version = 1;
+        doc = ''
+          **DEPRECATED**. Use `devShells.<system>.default` instead.
+        '';
+        roles.nix-develop = { };
+        appendSystem = true;
+        defaultAttrPath = [ ];
+        inventory = singleDerivationInventory "development environment" false;
+      };
+
+      formatterSchema = {
+        version = 1;
+        doc = ''
+          The `formatter` output specifies the package to use to format the project.
+        '';
+        roles.nix-fmt = { };
+        appendSystem = true;
+        defaultAttrPath = [ ];
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (system: formatter: {
+              forSystems = [ system ];
+              shortDescription = formatter.meta.description or "";
+              derivationAttrPath = [ ];
+              what = "formatter";
+              isFlakeCheck = false;
+            }) output
+          );
+      };
+
+      templatesSchema = {
+        version = 1;
+        doc = ''
+          The `templates` output provides project templates.
+        '';
+        roles.nix-template = { };
+        defaultAttrPath = [ "default" ];
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (templateName: template: {
+              shortDescription = template.description or "";
+              evalChecks.isValidTemplate =
+                template ? path
+                && builtins.isPath template.path
+                && template ? description
+                && builtins.isString template.description;
+              what = "template";
+            }) output
+          );
+      };
+
+      hydraJobsSchema = {
+        version = 1;
+        doc = ''
+          The `hydraJobs` flake output defines derivations to be built by the Hydra continuous integration system.
+        '';
+        allowIFD = false;
+        inventory =
+          output:
+          let
+            recurse =
+              prefix: attrs:
+              self.lib.mkChildren (
+                builtins.mapAttrs (
+                  attrName: attrs:
+                  if attrs.type or null == "derivation" then
+                    {
+                      forSystems = [ attrs.system ];
+                      shortDescription = attrs.meta.description or "";
+                      derivationAttrPath = [ ];
+                      what = "Hydra CI test";
+                    }
+                  else
+                    recurse (prefix + attrName + ".") attrs
+                ) attrs
+              );
+          in
+          # The top-level cannot be a derivation.
+          assert output.type or null != "derivation";
+          recurse "" output;
+      };
+
+      overlaysSchema = {
+        version = 1;
+        doc = ''
+          The `overlays` flake output defines ["overlays"](https://nixos.org/manual/nixpkgs/stable/#chap-overlays) that can be plugged into Nixpkgs.
+          Overlays add additional packages or modify or replace existing packages.
+        '';
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (overlayName: overlay: {
+              what = "Nixpkgs overlay";
+              evalChecks.isOverlay =
+                # FIXME: should try to apply the overlay to an actual
+                # Nixpkgs.  But we don't have access to a nixpkgs
+                # flake here. Maybe this schema should be moved to the
+                # nixpkgs flake, where it does have access.
+                if !builtins.isFunction overlay then
+                  throw "Overlay is not a function. It should be structured like: `final: previous: { /* ... */ }`."
+                else
+                  true;
+            }) output
+          );
+      };
+
+      nixosConfigurationsSchema = {
+        version = 1;
+        doc = ''
+          The `nixosConfigurations` flake output defines [NixOS system configurations](https://nixos.org/manual/nixos/stable/#ch-configuration).
+        '';
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (configName: machine: {
+              what = "NixOS configuration";
+              derivationAttrPath = [
+                "config"
+                "system"
+                "build"
+                "toplevel"
+              ];
+              forSystems = [ machine.pkgs.stdenv.system ];
+            }) output
+          );
+      };
+
+      nixosModulesSchema = {
+        version = 1;
+        doc = ''
+          The `nixosModules` flake output defines importable [NixOS modules](https://nixos.org/manual/nixos/stable/#sec-writing-modules).
+        '';
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (moduleName: module: {
+              what = "NixOS module";
+              evalChecks.isFunctionOrAttrs = checkModule module;
+            }) output
+          );
+      };
+
+      homeConfigurationsSchema = {
+        version = 1;
+        doc = ''
+          The `homeConfigurations` flake output defines [Home Manager configurations](https://github.com/nix-community/home-manager).
+        '';
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (configName: this: {
+              what = "Home Manager configuration";
+              derivationAttrPath = [ "activationPackage" ];
+              forSystems = [ this.activationPackage.system ];
+            }) output
+          );
+      };
+
+      homeModulesSchema = {
+        version = 1;
+        doc = ''
+          The `homeModules` flake output defines importable [Home Manager](https://github.com/nix-community/home-manager) modules.
+        '';
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (moduleName: module: {
+              what = "Home Manager module";
+              evalChecks.isFunctionOrAttrs = checkModule module;
+            }) output
+          );
+      };
+
+      darwinConfigurationsSchema = {
+        version = 1;
+        doc = ''
+          The `darwinConfigurations` flake output defines [nix-darwin configurations](https://github.com/nix-darwin/nix-darwin).
+        '';
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (configName: this: {
+              what = "nix-darwin configuration";
+              derivationAttrPath = [ "system" ];
+              forSystems = [ this.system.system ];
+            }) output
+          );
+      };
+
+      darwinModulesSchema = {
+        version = 1;
+        doc = ''
+          The `darwinModules` flake output defines importable [nix-darwin modules](https://github.com/nix-darwin/nix-darwin).
+        '';
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (moduleName: module: {
+              what = "nix-darwin module";
+              evalChecks.isFunctionOrAttrs = checkModule module;
+            }) output
+          );
+      };
+
+      bundlersSchema = {
+        version = 1;
+        doc = ''
+          The `bundlers` flake output defines ["bundlers"](https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-bundle) that transform derivation outputs into other formats, typically self-extracting executables or container images.
+        '';
+        roles.nix-bundler = { };
+        appendSystem = true;
+        defaultAttrPath = [ "default" ];
+        inventory =
+          output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (
+              system: bundlers:
+              let
+                forSystems = [ system ];
+              in
+              {
+                inherit forSystems;
+                children = builtins.mapAttrs (bundlerName: bundler: {
+                  inherit forSystems;
+                  evalChecks.isValidBundler = builtins.isFunction bundler;
+                  what = "bundler";
+                }) bundlers;
+              }
+            ) output
+          );
+      };
+
+    in
+
+    {
+      # Helper functions
+      lib = {
+        try =
+          e: default:
+          let
+            res = builtins.tryEval e;
+          in
+          if res.success then res.value else default;
+
+        mkChildren = children: { inherit children; };
+
+        derivationsInventory =
+          what: isFlakeCheck: output:
+          self.lib.mkChildren (
+            builtins.mapAttrs (systemType: packagesForSystem: {
+              forSystems = [ systemType ];
+              children = builtins.mapAttrs (
+                packageName: mkPackage isFlakeCheck what systemType
+              ) packagesForSystem;
+            }) output
+          );
+      };
+
+      exportedSchemas = {
+        schemas = schemasSchema ''
+          The `schemas` flake output is used to define and document flake outputs.
+          For the expected format, consult the Nix manual.
+        '';
+        exportedSchemas = schemasSchema ''
+          The `exportedSchemas` flake output is used to define flake schemas that you
+          intend for other flakes to use.
+        '';
+        apps = appsSchema;
+        defaultApp = defaultAppSchema;
+        packages = packagesSchema;
+        defaultPackage = defaultPackageSchema;
+        legacyPackages = legacyPackagesSchema;
+        checks = checksSchema;
+        devShells = devShellsSchema;
+        devShell = devShellSchema;
+        formatter = formatterSchema;
+        templates = templatesSchema;
+        hydraJobs = hydraJobsSchema;
+        overlays = overlaysSchema;
+        nixosConfigurations = nixosConfigurationsSchema;
+        nixosModules = nixosModulesSchema;
+        homeConfigurations = homeConfigurationsSchema;
+        homeModules = homeModulesSchema;
+        darwinConfigurations = darwinConfigurationsSchema;
+        darwinModules = darwinModulesSchema;
+        ociImages = ociImagesSchema;
+        bundlers = bundlersSchema;
+      };
+
+      schemas = self.exportedSchemas;
+    };
+}

--- a/src/libcmd/call-flake-schemas.nix
+++ b/src/libcmd/call-flake-schemas.nix
@@ -1,0 +1,38 @@
+# The flake providing default schemas.
+defaultSchemasFlake:
+
+# The flake whose contents we want to extract.
+flake:
+
+let
+
+  # Helper functions.
+
+  mapAttrsToList = f: attrs: map (name: f name attrs.${name}) (builtins.attrNames attrs);
+
+  outputNames = builtins.attrNames flake.outputs;
+
+  schemas = flake.outputs.schemas or defaultSchemasFlake.exportedSchemas;
+
+in
+
+{
+  outputs = flake.outputs;
+
+  inventory = builtins.mapAttrs (
+    outputName: _:
+    if schemas ? ${outputName} && schemas.${outputName}.version == 1 then
+      schemas.${outputName}
+      // (
+        if flake.outputs ? ${outputName} then
+          {
+            output = schemas.${outputName}.inventory flake.outputs.${outputName};
+          }
+        else
+          {
+          }
+      )
+    else
+      { unknown = true; }
+  ) (schemas // flake.outputs);
+}

--- a/src/libcmd/flake-schemas.cc
+++ b/src/libcmd/flake-schemas.cc
@@ -1,0 +1,380 @@
+#include "nix/cmd/flake-schemas.hh"
+#include "nix/expr/eval-settings.hh"
+#include "nix/fetchers/fetch-to-store.hh"
+#include "nix/util/memory-source-accessor.hh"
+#include "nix/util/mounted-source-accessor.hh"
+
+namespace nix::flake_schemas {
+
+using namespace eval_cache;
+using namespace flake;
+
+static LockedFlake getBuiltinDefaultSchemasFlake(EvalState & state)
+{
+    auto accessor = make_ref<MemorySourceAccessor>();
+
+    accessor->setPathDisplay("«builtin-flake-schemas»");
+
+    accessor->addFile(
+        CanonPath("flake.nix"),
+#include "builtin-flake-schemas.nix.gen.hh"
+    );
+
+    auto [storePath, narHash] = state.store->computeStorePath("source", {accessor});
+
+    state.allowPath(storePath); // FIXME: should just whitelist the entire virtual store
+
+    state.storeFS->mount(CanonPath(state.store->printStorePath(storePath)), accessor);
+
+    // Construct a dummy flakeref.
+    auto flakeRef = parseFlakeRef(
+        fetchSettings,
+        fmt("tarball+https://builtin-flake-schemas?narHash=%s", narHash.to_string(HashFormat::SRI, true)));
+
+    auto flake = readFlake(state, flakeRef, flakeRef, flakeRef, state.storePath(storePath), {});
+
+    return lockFlake(flakeSettings, state, flakeRef, {}, flake);
+}
+
+ref<EvalCache> call(
+    EvalState & state,
+    std::shared_ptr<flake::LockedFlake> lockedFlake,
+    std::optional<FlakeRef> defaultSchemasFlake,
+    bool allowEvalCache)
+{
+    auto fingerprint = lockedFlake->getFingerprint(*state.store, state.fetchSettings);
+
+    std::string callFlakeSchemasNix =
+#include "call-flake-schemas.nix.gen.hh"
+        ;
+
+    auto lockedDefaultSchemasFlake = defaultSchemasFlake
+                                         ? flake::lockFlake(flakeSettings, state, *defaultSchemasFlake, {})
+                                         : getBuiltinDefaultSchemasFlake(state);
+    auto lockedDefaultSchemasFlakeFingerprint =
+        lockedDefaultSchemasFlake.getFingerprint(*state.store, state.fetchSettings);
+
+    std::optional<Fingerprint> fingerprint2;
+    if (allowEvalCache && evalSettings.useEvalCache && evalSettings.pureEval && fingerprint
+        && lockedDefaultSchemasFlakeFingerprint)
+        fingerprint2 = hashString(
+            HashAlgorithm::SHA256,
+            fmt("app:%s:%s:%s",
+                hashString(HashAlgorithm::SHA256, callFlakeSchemasNix).to_string(HashFormat::Base16, false),
+                fingerprint->to_string(HashFormat::Base16, false),
+                lockedDefaultSchemasFlakeFingerprint->to_string(HashFormat::Base16, false)));
+
+    if (fingerprint2) {
+        auto i = state.evalCaches.find(*fingerprint2);
+        if (i != state.evalCaches.end())
+            return i->second;
+    }
+
+    auto cache = make_ref<EvalCache>(
+        fingerprint2, state, [&state, lockedFlake, callFlakeSchemasNix, lockedDefaultSchemasFlake]() {
+            auto vCallFlakeSchemas = state.allocValue();
+            state.eval(
+                state.parseExprFromString(callFlakeSchemasNix, state.rootPath(CanonPath::root)), *vCallFlakeSchemas);
+
+            auto vFlake = state.allocValue();
+            flake::callFlake(state, *lockedFlake, *vFlake);
+
+            auto vDefaultSchemasFlake = state.allocValue();
+            if (vFlake->type() == nAttrs && vFlake->attrs()->get(state.symbols.create("schemas")))
+                vDefaultSchemasFlake->mkNull();
+            else
+                flake::callFlake(state, lockedDefaultSchemasFlake, *vDefaultSchemasFlake);
+
+            auto vRes = state.allocValue();
+            Value * args[] = {vDefaultSchemasFlake, vFlake};
+            state.callFunction(*vCallFlakeSchemas, args, *vRes, noPos);
+
+            return vRes;
+        });
+
+    /* Derive the flake output attribute path from the cursor used to
+       traverse the inventory. We do this so we don't have to maintain
+       a separate attrpath for that. */
+    cache->cleanupAttrPath = [&](AttrPath && attrPath) {
+        AttrPath res;
+        auto i = attrPath.begin();
+        if (i == attrPath.end())
+            return attrPath;
+
+        if (state.symbols[*i] == "inventory") {
+            ++i;
+            if (i != attrPath.end()) {
+                res.push_back(*i++); // copy output name
+                if (i != attrPath.end())
+                    ++i; // skip "outputs"
+                while (i != attrPath.end()) {
+                    ++i; // skip "children"
+                    if (i != attrPath.end())
+                        res.push_back(*i++);
+                }
+            }
+        }
+
+        else if (state.symbols[*i] == "outputs") {
+            res.insert(res.begin(), ++i, attrPath.end());
+        }
+
+        else
+            abort();
+
+        return res;
+    };
+
+    if (fingerprint2)
+        state.evalCaches.emplace(*fingerprint2, cache);
+
+    return cache;
+}
+
+void forEachOutput(
+    ref<AttrCursor> inventory,
+    std::function<void(Symbol outputName, std::shared_ptr<AttrCursor> output, const std::string & doc, bool isLast)> f)
+{
+    auto outputNames = inventory->getAttrs();
+
+    auto doOutputs = [&](bool allowIFD) {
+        evalSettings.enableImportFromDerivation.setDefault(allowIFD);
+        for (const auto & [i, outputName] : enumerate(outputNames)) {
+            auto outputInfo = inventory->getAttr(outputName);
+            try {
+                auto allowIFDAttr = outputInfo->maybeGetAttr("allowIFD");
+                if (allowIFD != (!allowIFDAttr || allowIFDAttr->getBool()))
+                    continue;
+                auto isUnknown = (bool) outputInfo->maybeGetAttr("unknown");
+                auto output = outputInfo->maybeGetAttr("output");
+                if (!output && !isUnknown)
+                    // We have a schema but no corresponding output, so skip this.
+                    continue;
+                Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", outputInfo->getAttrPathStr()));
+                f(outputName,
+                  isUnknown ? std::shared_ptr<AttrCursor>() : output,
+                  isUnknown ? "" : outputInfo->getAttr("doc")->getString(),
+                  i + 1 == outputNames.size());
+            } catch (Error & e) {
+                e.addTrace(nullptr, "while evaluating the flake output '%s':", outputInfo->getAttrPathStr());
+                throw;
+            }
+        }
+    };
+
+    // Do outputs that disallow import-from-derivation first. That way, they can't depend on outputs that do allow it.
+    doOutputs(false);
+    doOutputs(true);
+}
+
+void visit(
+    std::optional<std::string> system,
+    bool includeLegacy,
+    ref<AttrCursor> node,
+    std::function<void(const Leaf & leaf)> visitLeaf,
+    std::function<void(std::function<void(ForEachChild)>)> visitNonLeaf,
+    std::function<void(ref<AttrCursor> node, const std::vector<std::string> & systems)> visitFiltered,
+    std::function<void(ref<AttrCursor> node)> visitLegacy)
+{
+    Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", node->getAttrPathStr()));
+
+    /* Filter out legacy outputs, unless --legacy is enabled. */
+    if (!includeLegacy) {
+        if (auto b = node->maybeGetAttr("isLegacy"); b && b->getBool()) {
+            visitLegacy(node);
+            return;
+        }
+    }
+
+    /* Apply the system type filter. */
+    if (system) {
+        if (auto forSystems = Node(node).forSystems()) {
+            if (std::find(forSystems->begin(), forSystems->end(), *system) == forSystems->end()) {
+                visitFiltered(node, *forSystems);
+                return;
+            }
+        }
+    }
+
+    if (auto children = node->maybeGetAttr("children")) {
+        visitNonLeaf([&](ForEachChild f) {
+            auto attrNames = children->getAttrs();
+            for (const auto & [i, attrName] : enumerate(attrNames)) {
+                try {
+                    f(attrName, children->getAttr(attrName), i + 1 == attrNames.size());
+                } catch (Error & e) {
+                    // FIXME: use the `isLegacy` attribute.
+                    if (node->root->state.symbols[node->getAttrPath()[0]] != "legacyPackages") {
+                        e.addTrace(
+                            nullptr, "while evaluating the flake output attribute '%s':", node->getAttrPathStr());
+                        throw;
+                    }
+                }
+            }
+        });
+    }
+
+    else
+        visitLeaf(Leaf(node));
+}
+
+std::optional<std::vector<std::string>> Node::forSystems() const
+{
+    if (auto forSystems = node->maybeGetAttr("forSystems"))
+        return forSystems->getListOfStrings();
+    else
+        return std::nullopt;
+}
+
+ref<AttrCursor> Node::getOutput(const ref<AttrCursor> & outputs) const
+{
+    auto res = outputs->findAlongAttrPath(node->getAttrPath());
+    if (!res)
+        throw Error("flake output '%s' should exist according to its schema, but it doesn't", node->getAttrPathStr());
+    return *res;
+}
+
+std::optional<std::string> Leaf::what() const
+{
+    if (auto what = node->maybeGetAttr("what"))
+        return what->getString();
+    else
+        return std::nullopt;
+}
+
+std::optional<std::string> Leaf::shortDescription() const
+{
+    if (auto what = node->maybeGetAttr("shortDescription"))
+        return what->getString();
+    return std::nullopt;
+}
+
+std::optional<AttrPath> Leaf::derivationAttrPath() const
+{
+    auto n = node->maybeGetAttr("derivationAttrPath");
+    if (!n)
+        return std::nullopt;
+    return AttrPath::fromStrings(node->root->state, n->getListOfStrings());
+}
+
+std::shared_ptr<AttrCursor> Leaf::derivation(const ref<AttrCursor> & outputs) const
+{
+    auto path = derivationAttrPath();
+    if (!path) {
+        auto n = node->maybeGetAttr("derivation");
+        if (n)
+            warn(
+                "Flake output '%s' has a schema that uses the deprecated 'derivation' attribute instead of 'derivationAttrPath'. "
+                "Please update the schema to use 'derivationAttrPath' instead. "
+                "You may want to upgrade to version 0.3.0 or higher of https://github.com/DeterminateSystems/flake-schemas.",
+                node->getAttrPathStr());
+        return n;
+    }
+    auto drv = getOutput(outputs)->findAlongAttrPath(*path);
+    if (!drv)
+        throw Error(
+            "flake output '%s' does not have a derivation attribute '%s'",
+            node->getAttrPathStr(),
+            path->to_string(node->root->state));
+    return *drv;
+}
+
+bool Leaf::isFlakeCheck() const
+{
+    auto isFlakeCheck = node->maybeGetAttr("isFlakeCheck");
+    return isFlakeCheck && isFlakeCheck->getBool();
+}
+
+std::optional<OutputInfo> getOutputInfo(ref<AttrCursor> inventory, AttrPath attrPath)
+{
+    if (attrPath.empty())
+        return std::nullopt;
+
+    auto outputName = attrPath.front();
+
+    auto schemaInfo = inventory->maybeGetAttr(outputName);
+    if (!schemaInfo)
+        return std::nullopt;
+
+    auto node = schemaInfo->maybeGetAttr("output");
+    if (!node)
+        return std::nullopt;
+
+    auto pathLeft = std::span(attrPath).subspan(1);
+
+    while (!pathLeft.empty()) {
+        auto children = node->maybeGetAttr("children");
+        if (!children)
+            break;
+        auto attr = pathLeft.front();
+        node = children->maybeGetAttr(attr);
+        if (!node)
+            return std::nullopt;
+        pathLeft = pathLeft.subspan(1);
+    }
+
+    return OutputInfo{
+        .schemaInfo = ref(schemaInfo),
+        .nodeInfo = ref(node),
+        .leafAttrPath = AttrPath(pathLeft.begin(), pathLeft.end()),
+    };
+}
+
+Schemas getSchemas(ref<AttrCursor> inventory)
+{
+    auto & state(inventory->root->state);
+
+    Schemas schemas;
+
+    for (auto & schemaName : inventory->getAttrs()) {
+        auto schema = inventory->getAttr(schemaName);
+
+        SchemaInfo schemaInfo;
+
+        if (auto roles = schema->maybeGetAttr("roles")) {
+            for (auto & roleName : roles->getAttrs()) {
+                schemaInfo.roles.insert(std::string(state.symbols[roleName]));
+            }
+        }
+
+        if (auto appendSystem = schema->maybeGetAttr("appendSystem"))
+            schemaInfo.appendSystem = appendSystem->getBool();
+
+        if (auto defaultAttrPath = schema->maybeGetAttr("defaultAttrPath")) {
+            AttrPath attrPath;
+            for (auto & s : defaultAttrPath->getListOfStrings())
+                attrPath.push_back(state.symbols.create(s));
+            schemaInfo.defaultAttrPath = std::move(attrPath);
+        }
+
+        schemas.insert_or_assign(std::string(state.symbols[schemaName]), std::move(schemaInfo));
+    }
+
+    return schemas;
+}
+
+} // namespace nix::flake_schemas
+
+namespace nix {
+
+MixFlakeSchemas::MixFlakeSchemas()
+{
+    addFlag(
+        {.longName = "default-flake-schemas",
+         .description = "The URL of the flake providing default flake schema definitions.",
+         .labels = {"flake-ref"},
+         .handler = {&defaultFlakeSchemas},
+         .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
+             completeFlakeRef(completions, getStore(), prefix);
+         }}});
+}
+
+std::optional<FlakeRef> MixFlakeSchemas::getDefaultFlakeSchemas()
+{
+    if (!defaultFlakeSchemas)
+        return std::nullopt;
+    else
+        return parseFlakeRef(fetchSettings, *defaultFlakeSchemas, absPath(getCommandBaseDir()));
+}
+
+} // namespace nix

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -148,7 +148,16 @@ struct MixFlakeOptions : virtual Args, EvalCommand
     }
 };
 
-struct SourceExprCommand : virtual Args, MixFlakeOptions
+struct MixFlakeSchemas : virtual Args, virtual StoreCommand
+{
+    std::optional<std::string> defaultFlakeSchemas;
+
+    MixFlakeSchemas();
+
+    std::optional<FlakeRef> getDefaultFlakeSchemas();
+};
+
+struct SourceExprCommand : virtual Args, MixFlakeOptions, MixFlakeSchemas
 {
     std::optional<std::filesystem::path> file;
     std::optional<std::string> expr;
@@ -159,9 +168,13 @@ struct SourceExprCommand : virtual Args, MixFlakeOptions
 
     ref<Installable> parseInstallable(ref<Store> store, const std::string & installable);
 
-    virtual Strings getDefaultFlakeAttrPaths();
-
-    virtual Strings getDefaultFlakeAttrPathPrefixes();
+    /**
+     * Return a set of "roles" that this command implements
+     * (e.g. `nix-build` or `nix-develop`). This is used by flake
+     * schemas to determine which flake outputs are used as default
+     * attrpath prefixes.
+     */
+    virtual StringSet getRoles();
 
     /**
      * Complete an installable from the given prefix.
@@ -388,8 +401,7 @@ void completeFlakeRefWithFragment(
     AddCompletions & completions,
     ref<EvalState> evalState,
     flake::LockFlags lockFlags,
-    Strings attrPathPrefixes,
-    const Strings & defaultFlakeAttrPaths,
+    const StringSet & roles,
     std::string_view prefix);
 
 std::string showVersions(const StringSet & versions);

--- a/src/libcmd/include/nix/cmd/flake-schemas.hh
+++ b/src/libcmd/include/nix/cmd/flake-schemas.hh
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "nix/expr/eval-cache.hh"
+#include "nix/flake/flake.hh"
+#include "nix/cmd/command.hh"
+
+namespace nix::flake_schemas {
+
+using namespace eval_cache;
+
+ref<eval_cache::EvalCache> call(
+    EvalState & state,
+    std::shared_ptr<flake::LockedFlake> lockedFlake,
+    std::optional<FlakeRef> defaultSchemasFlake,
+    bool allowEvalCache = true);
+
+void forEachOutput(
+    ref<AttrCursor> inventory,
+    std::function<void(Symbol outputName, std::shared_ptr<AttrCursor> output, const std::string & doc, bool isLast)> f);
+
+/**
+ * A convenience wrapper around `AttrCursor` for nodes in the `inventory` tree returned by call-flake-schemas.nix.
+ */
+struct Node
+{
+    const ref<AttrCursor> node;
+
+    Node(const ref<AttrCursor> & node)
+        : node(node)
+    {
+    }
+
+    /**
+     * Return the `forSystems` attribute. This can be null, which
+     * means "all systems".
+     */
+    std::optional<std::vector<std::string>> forSystems() const;
+
+    /**
+     * Return the actual output corresponding to this info node.
+     */
+    ref<AttrCursor> getOutput(const ref<AttrCursor> & outputs) const;
+};
+
+struct Leaf : Node
+{
+    using Node::Node;
+
+    std::optional<std::string> what() const;
+
+    std::optional<std::string> shortDescription() const;
+
+    std::optional<AttrPath> derivationAttrPath() const;
+
+    /**
+     * Return the attribute corresponding to `derivationAttrPath`, if set.
+     */
+    std::shared_ptr<AttrCursor> derivation(const ref<AttrCursor> & outputs) const;
+
+    bool isFlakeCheck() const;
+};
+
+typedef std::function<void(Symbol attrName, ref<AttrCursor> attr, bool isLast)> ForEachChild;
+
+void visit(
+    std::optional<std::string> system,
+    bool includeLegacy,
+    ref<AttrCursor> node,
+    std::function<void(const Leaf & leaf)> visitLeaf,
+    std::function<void(std::function<void(ForEachChild)>)> visitNonLeaf,
+    std::function<void(ref<AttrCursor> node, const std::vector<std::string> & systems)> visitFiltered,
+    std::function<void(ref<AttrCursor> node)> visitLegacy);
+
+struct OutputInfo
+{
+    ref<AttrCursor> schemaInfo;
+    ref<AttrCursor> nodeInfo;
+    AttrPath leafAttrPath;
+};
+
+std::optional<OutputInfo> getOutputInfo(ref<AttrCursor> inventory, AttrPath attrPath);
+
+struct SchemaInfo
+{
+    std::string doc;
+    StringSet roles;
+    bool appendSystem = false;
+    std::optional<AttrPath> defaultAttrPath;
+};
+
+using Schemas = std::map<std::string, SchemaInfo>;
+
+Schemas getSchemas(ref<AttrCursor> root);
+
+} // namespace nix::flake_schemas

--- a/src/libcmd/include/nix/cmd/installable-flake.hh
+++ b/src/libcmd/include/nix/cmd/installable-flake.hh
@@ -36,11 +36,14 @@ struct ExtraPathInfoFlake : ExtraPathInfoValue
 struct InstallableFlake : InstallableValue
 {
     FlakeRef flakeRef;
-    Strings attrPaths;
-    Strings prefixes;
+    std::string fragment;
+    AttrPath parsedFragment;
+    StringSet roles;
     ExtendedOutputsSpec extendedOutputsSpec;
     const flake::LockFlags & lockFlags;
     mutable std::shared_ptr<flake::LockedFlake> _lockedFlake;
+    bool useEvalCache = true;
+    std::optional<FlakeRef> defaultFlakeSchemas;
 
     InstallableFlake(
         SourceExprCommand * cmd,
@@ -48,16 +51,14 @@ struct InstallableFlake : InstallableValue
         FlakeRef && flakeRef,
         std::string_view fragment,
         ExtendedOutputsSpec extendedOutputsSpec,
-        Strings attrPaths,
-        Strings prefixes,
-        const flake::LockFlags & lockFlags);
+        StringSet roles,
+        const flake::LockFlags & lockFlags,
+        std::optional<FlakeRef> defaultFlakeSchemas);
 
     std::string what() const override
     {
-        return flakeRef.to_string() + "#" + *attrPaths.begin();
+        return flakeRef.to_string() + "#" + fragment;
     }
-
-    std::vector<std::string> getActualAttrPaths();
 
     DerivedPathsWithInfo toDerivedPaths() override;
 
@@ -67,11 +68,21 @@ struct InstallableFlake : InstallableValue
      * Get a cursor to every attrpath in getActualAttrPaths() that
      * exists. However if none exists, throw an exception.
      */
-    std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state) override;
+    std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state, bool useDefaultAttrPath) override;
+
+    void getCompletions(const std::string & flakeRefS, AddCompletions & completions);
 
     ref<flake::LockedFlake> getLockedFlake() const;
 
     FlakeRef nixpkgsFlakeRef() const;
+
+    ref<eval_cache::EvalCache> openEvalCache() const;
+
+private:
+
+    mutable std::shared_ptr<eval_cache::EvalCache> _evalCache;
+
+    std::vector<AttrPath> getAttrPaths(bool useDefaultAttrPath, ref<eval_cache::AttrCursor> inventory);
 };
 
 /**

--- a/src/libcmd/include/nix/cmd/installable-value.hh
+++ b/src/libcmd/include/nix/cmd/installable-value.hh
@@ -93,7 +93,7 @@ struct InstallableValue : Installable
      * However if none exists, throw exception instead of returning
      * empty vector.
      */
-    virtual std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state);
+    virtual std::vector<ref<eval_cache::AttrCursor>> getCursors(EvalState & state, bool useDefaultAttrPath = true);
 
     /**
      * Get the first and most preferred cursor this Installable could

--- a/src/libcmd/include/nix/cmd/meson.build
+++ b/src/libcmd/include/nix/cmd/meson.build
@@ -9,6 +9,7 @@ headers = files(
   'common-eval-args.hh',
   'compatibility-settings.hh',
   'editor-for.hh',
+  'flake-schemas.hh',
   'get-build-log.hh',
   'installable-attr-path.hh',
   'installable-derived-path.hh',

--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -9,37 +9,21 @@
 #include "nix/expr/eval-error.hh"
 #include "nix/flake/flake.hh"
 #include "nix/expr/eval-cache.hh"
+#include "nix/cmd/flake-schemas.hh"
+#include "nix/store/globals.hh"
 
 #include <nlohmann/json.hpp>
 
 namespace nix {
 
-std::vector<std::string> InstallableFlake::getActualAttrPaths()
-{
-    std::vector<std::string> res;
-    if (attrPaths.size() == 1 && attrPaths.front().starts_with(".")) {
-        attrPaths.front().erase(0, 1);
-        res.push_back(attrPaths.front());
-        return res;
-    }
-
-    for (auto & prefix : prefixes)
-        res.push_back(prefix + *attrPaths.begin());
-
-    for (auto & s : attrPaths)
-        res.push_back(s);
-
-    return res;
-}
-
-static std::string showAttrPaths(const std::vector<std::string> & paths)
+static std::string showAttrPaths(EvalState & state, const std::vector<AttrPath> & paths)
 {
     std::string s;
     for (const auto & [n, i] : enumerate(paths)) {
         if (n > 0)
             s += n + 1 == paths.size() ? " or " : ", ";
         s += '\'';
-        s += i;
+        s += i.to_string(state);
         s += '\'';
     }
     return s;
@@ -51,15 +35,17 @@ InstallableFlake::InstallableFlake(
     FlakeRef && flakeRef,
     std::string_view fragment,
     ExtendedOutputsSpec extendedOutputsSpec,
-    Strings attrPaths,
-    Strings prefixes,
-    const flake::LockFlags & lockFlags)
+    StringSet roles,
+    const flake::LockFlags & lockFlags,
+    std::optional<FlakeRef> defaultFlakeSchemas)
     : InstallableValue(state)
     , flakeRef(flakeRef)
-    , attrPaths(fragment == "" ? attrPaths : Strings{(std::string) fragment})
-    , prefixes(fragment == "" ? Strings{} : prefixes)
+    , fragment(fragment)
+    , parsedFragment(AttrPath::parse(*state, fragment))
+    , roles(roles)
     , extendedOutputsSpec(std::move(extendedOutputsSpec))
     , lockFlags(lockFlags)
+    , defaultFlakeSchemas(defaultFlakeSchemas)
 {
     if (cmd && cmd->getAutoArgs(*state)->size())
         throw UsageError("'--arg' and '--argstr' are incompatible with flakes");
@@ -146,37 +132,159 @@ std::pair<Value *, PosIdx> InstallableFlake::toValue(EvalState & state)
     return {&getCursor(state)->forceValue(), noPos};
 }
 
-std::vector<ref<eval_cache::AttrCursor>> InstallableFlake::getCursors(EvalState & state)
+std::vector<AttrPath> InstallableFlake::getAttrPaths(bool useDefaultAttrPath, ref<eval_cache::AttrCursor> inventory)
 {
-    auto evalCache = openEvalCache(state, getLockedFlake());
+    if (fragment.starts_with("."))
+        return {AttrPath::parse(*state, fragment.substr(1))};
 
-    auto root = evalCache->getRoot();
+    std::vector<AttrPath> attrPaths;
+
+    auto schemas = flake_schemas::getSchemas(inventory);
+
+    // FIXME: Ugly hack to preserve the historical precedence
+    // between outputs. We should add a way for schemas to declare
+    // priorities.
+    std::vector<std::string> schemasSorted;
+    std::set<std::string> schemasSeen;
+    auto doSchema = [&](const std::string & schema) {
+        if (schemas.contains(schema)) {
+            schemasSorted.push_back(schema);
+            schemasSeen.insert(schema);
+        }
+    };
+    doSchema("apps");
+    doSchema("defaultApp");
+    doSchema("devShells");
+    doSchema("devShell");
+    doSchema("packages");
+    doSchema("defaultPackage");
+    doSchema("legacyPackages");
+    for (auto & schema : schemas)
+        if (!schemasSeen.contains(schema.first))
+            schemasSorted.push_back(schema.first);
+
+    for (auto & role : roles) {
+        for (auto & schemaName : schemasSorted) {
+            auto & schema = schemas.find(schemaName)->second;
+            if (schema.roles.contains(role)) {
+                AttrPath attrPath{state->symbols.create(schemaName)};
+                if (schema.appendSystem)
+                    attrPath.push_back(state->symbols.create(settings.thisSystem.get()));
+
+                if (useDefaultAttrPath && parsedFragment.empty()) {
+                    if (schema.defaultAttrPath) {
+                        auto attrPath2{attrPath};
+                        for (auto & x : *schema.defaultAttrPath)
+                            attrPath2.push_back(x);
+                        attrPaths.push_back(attrPath2);
+                    }
+                } else {
+                    auto attrPath2{attrPath};
+                    for (auto & x : parsedFragment)
+                        attrPath2.push_back(x);
+                    attrPaths.push_back(attrPath2);
+                }
+            }
+        }
+    }
+
+    if (!parsedFragment.empty())
+        attrPaths.push_back(parsedFragment);
+
+    // FIXME: compatibility hack to get `nix repl` to return all
+    // outputs by default.
+    if (parsedFragment.empty() && roles.contains("nix-repl"))
+        attrPaths.push_back({});
+
+    return attrPaths;
+}
+
+std::vector<ref<eval_cache::AttrCursor>> InstallableFlake::getCursors(EvalState & state, bool useDefaultAttrPath)
+{
+    auto cache = openEvalCache();
+
+    auto inventory = cache->getRoot()->getAttr("inventory");
+    auto outputs = cache->getRoot()->getAttr("outputs");
+
+    auto attrPaths = getAttrPaths(useDefaultAttrPath, inventory);
+
+    if (attrPaths.empty())
+        throw Error(
+            "Flake '%s' does not have any schema that provides a default output for the role(s) %s.",
+            flakeRef,
+            concatStringsSep(", ", roles));
 
     std::vector<ref<eval_cache::AttrCursor>> res;
 
     Suggestions suggestions;
-    auto attrPaths = getActualAttrPaths();
 
     for (auto & attrPath : attrPaths) {
-        debug("trying flake output attribute '%s'", attrPath);
+        debug("trying flake output attribute '%s'", attrPath.to_string(state));
 
         try {
-            auto attr = root->findAlongAttrPath(AttrPath::parse(state, attrPath));
-            if (attr) {
+            auto attr = outputs->findAlongAttrPath(attrPath);
+            if (attr)
                 res.push_back(ref(*attr));
-            } else {
+            else
                 suggestions += attr.getSuggestions();
-            }
         } catch (TypeError & e) {
-            debug("error resolving attribute '%s': %s", attrPath, e.msg());
+            debug("error resolving attribute '%s': %s", attrPath.to_string(state), e.msg());
             // Continue to next attribute path
         }
     }
 
     if (res.size() == 0)
-        throw Error(suggestions, "flake '%s' does not provide attribute %s", flakeRef, showAttrPaths(attrPaths));
+        throw Error(suggestions, "flake '%s' does not provide attribute %s", flakeRef, showAttrPaths(state, attrPaths));
 
     return res;
+}
+
+void InstallableFlake::getCompletions(const std::string & flakeRefS, AddCompletions & completions)
+{
+    auto cache = openEvalCache();
+
+    auto inventory = cache->getRoot()->getAttr("inventory");
+    auto outputs = cache->getRoot()->getAttr("outputs");
+
+    if (fragment.ends_with(".") || fragment.empty())
+        // Represent that we're looking for attributes starting with the empty prefix (i.e. all attributes inside the
+        // parent.
+        parsedFragment.push_back(state->symbols.create(""));
+
+    auto attrPaths = getAttrPaths(true, inventory);
+
+    if (fragment.empty())
+        // Return all top-level flake outputs.
+        attrPaths.push_back(AttrPath{state->symbols.create("")});
+
+    auto lastAttr = fragment.ends_with(".") || parsedFragment.empty() ? std::string_view("")
+                                                                      : state->symbols[parsedFragment.back()];
+    std::string prefix;
+    if (auto dot = fragment.rfind('.'); dot != std::string::npos)
+        prefix = fragment.substr(0, dot);
+    if (fragment.starts_with(".") && !prefix.starts_with("."))
+        prefix = "." + prefix;
+
+    for (auto attrPath : attrPaths) {
+        if (attrPath.empty())
+            attrPath.push_back(state->symbols.create(""));
+
+        auto attrPathParent{attrPath};
+        attrPathParent.pop_back();
+
+        auto attr = outputs->findAlongAttrPath(attrPathParent);
+        if (!attr)
+            continue;
+
+        for (auto & childName : (*attr)->getAttrs()) {
+            if (hasPrefix(state->symbols[childName], lastAttr)) {
+                auto attrPathChild = (*attr)->getAttrPath(childName);
+                completions.add(
+                    flakeRefS + "#" + prefix + (prefix.empty() || prefix.ends_with(".") ? "" : ".")
+                    + state->symbols[childName]);
+            }
+        }
+    }
 }
 
 ref<flake::LockedFlake> InstallableFlake::getLockedFlake() const
@@ -189,6 +297,14 @@ ref<flake::LockedFlake> InstallableFlake::getLockedFlake() const
     }
     // _lockedFlake is now non-null but still just a shared_ptr
     return ref<flake::LockedFlake>(_lockedFlake);
+}
+
+ref<eval_cache::EvalCache> InstallableFlake::openEvalCache() const
+{
+    if (!_evalCache) {
+        _evalCache = flake_schemas::call(*state, getLockedFlake(), defaultFlakeSchemas, useEvalCache);
+    }
+    return ref(_evalCache);
 }
 
 FlakeRef InstallableFlake::nixpkgsFlakeRef() const

--- a/src/libcmd/installable-value.cc
+++ b/src/libcmd/installable-value.cc
@@ -4,7 +4,7 @@
 
 namespace nix {
 
-std::vector<ref<eval_cache::AttrCursor>> InstallableValue::getCursors(EvalState & state)
+std::vector<ref<eval_cache::AttrCursor>> InstallableValue::getCursors(EvalState & state, bool useDefaultAttrPath)
 {
     auto evalCache =
         std::make_shared<nix::eval_cache::EvalCache>(std::nullopt, state, [&]() { return toValue(state).first; });
@@ -15,7 +15,7 @@ ref<eval_cache::AttrCursor> InstallableValue::getCursor(EvalState & state)
 {
     /* Although getCursors should return at least one element, in case it doesn't,
        bound check to avoid an undefined behavior for vector[0] */
-    return getCursors(state).at(0);
+    return getCursors(state, true).at(0);
 }
 
 static UsageError nonValueInstallable(Installable & installable)

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -236,19 +236,9 @@ MixReadOnlyOption::MixReadOnlyOption()
     });
 }
 
-Strings SourceExprCommand::getDefaultFlakeAttrPaths()
+StringSet SourceExprCommand::getRoles()
 {
-    return {"packages." + settings.thisSystem.get() + ".default", "defaultPackage." + settings.thisSystem.get()};
-}
-
-Strings SourceExprCommand::getDefaultFlakeAttrPathPrefixes()
-{
-    return {// As a convenience, look for the attribute in
-            // 'outputs.packages'.
-            "packages." + settings.thisSystem.get() + ".",
-            // As a temporary hack until Nixpkgs is properly converted
-            // to provide a clean 'packages' set, look in 'legacyPackages'.
-            "legacyPackages." + settings.thisSystem.get() + "."};
+    return {"nix-build"};
 }
 
 Args::CompleterClosure SourceExprCommand::getCompleteInstallable()
@@ -302,13 +292,7 @@ void SourceExprCommand::completeInstallable(AddCompletions & completions, std::s
                 }
             }
         } else {
-            completeFlakeRefWithFragment(
-                completions,
-                getEvalState(),
-                lockFlags,
-                getDefaultFlakeAttrPathPrefixes(),
-                getDefaultFlakeAttrPaths(),
-                prefix);
+            completeFlakeRefWithFragment(completions, getEvalState(), lockFlags, getRoles(), prefix);
         }
     } catch (EvalError &) {
         // Don't want eval errors to mess-up with the completion engine, so let's just swallow them
@@ -319,84 +303,33 @@ void completeFlakeRefWithFragment(
     AddCompletions & completions,
     ref<EvalState> evalState,
     flake::LockFlags lockFlags,
-    Strings attrPathPrefixes,
-    const Strings & defaultFlakeAttrPaths,
+    const StringSet & roles,
     std::string_view prefix)
-{
-    /* Look for flake output attributes that match the
-       prefix. */
-    try {
-        auto hash = prefix.find('#');
-        if (hash == std::string::npos) {
-            completeFlakeRef(completions, evalState->store, prefix);
-        } else {
-            completions.setType(AddCompletions::Type::Attrs);
-
-            auto fragment = prefix.substr(hash + 1);
-            std::string prefixRoot = "";
-            if (fragment.starts_with(".")) {
-                fragment = fragment.substr(1);
-                prefixRoot = ".";
-            }
-            auto flakeRefS = std::string(prefix.substr(0, hash));
-
-            // TODO: ideally this would use the command base directory instead of assuming ".".
-            auto flakeRef =
-                parseFlakeRef(fetchSettings, expandTilde(flakeRefS), std::filesystem::current_path().string());
-
-            auto evalCache = openEvalCache(
-                *evalState, make_ref<flake::LockedFlake>(lockFlake(flakeSettings, *evalState, flakeRef, lockFlags)));
-
-            auto root = evalCache->getRoot();
-
-            if (prefixRoot == ".") {
-                attrPathPrefixes.clear();
-            }
-            /* Complete 'fragment' relative to all the
-               attrpath prefixes as well as the root of the
-               flake. */
-            attrPathPrefixes.push_back("");
-
-            for (auto & attrPathPrefixS : attrPathPrefixes) {
-                auto attrPathPrefix = AttrPath::parse(*evalState, attrPathPrefixS);
-                auto attrPathS = attrPathPrefixS + std::string(fragment);
-                auto attrPath = AttrPath::parse(*evalState, attrPathS);
-
-                std::string lastAttr;
-                if (!attrPath.empty() && !hasSuffix(attrPathS, ".")) {
-                    lastAttr = evalState->symbols[attrPath.back()];
-                    attrPath.pop_back();
-                }
-
-                auto attr = root->findAlongAttrPath(attrPath);
-                if (!attr)
-                    continue;
-
-                for (auto & attr2 : (*attr)->getAttrs()) {
-                    if (hasPrefix(evalState->symbols[attr2], lastAttr)) {
-                        auto attrPath2 = (*attr)->getAttrPath(attr2);
-                        /* Strip the attrpath prefix. */
-                        attrPath2.erase(attrPath2.begin(), attrPath2.begin() + attrPathPrefix.size());
-                        // FIXME: handle names with dots
-                        completions.add(flakeRefS + "#" + prefixRoot + attrPath2.to_string(*evalState));
-                    }
-                }
-            }
-
-            /* And add an empty completion for the default
-               attrpaths. */
-            if (fragment.empty()) {
-                for (auto & attrPath : defaultFlakeAttrPaths) {
-                    auto attr = root->findAlongAttrPath(AttrPath::parse(*evalState, attrPath));
-                    if (!attr)
-                        continue;
-                    completions.add(flakeRefS + "#" + prefixRoot);
-                }
-            }
-        }
-    } catch (Error & e) {
-        logWarning(e.info());
+try {
+    auto hash = prefix.find('#');
+    if (hash == std::string::npos) {
+        completeFlakeRef(completions, evalState->store, prefix);
+        return;
     }
+
+    completions.setType(AddCompletions::Type::Attrs);
+
+    auto fragment = prefix.substr(hash + 1);
+    auto flakeRefS = std::string(prefix.substr(0, hash));
+
+    InstallableFlake{
+        nullptr,
+        evalState,
+        // TODO: ideally this would use the command base directory instead of assuming ".".
+        parseFlakeRef(fetchSettings, expandTilde(flakeRefS), std::filesystem::current_path().string()),
+        fragment,
+        ExtendedOutputsSpec::Default{}, // FIXME: could be that we're completing the outputs spec...
+        roles,
+        lockFlags,
+        {}}
+        .getCompletions(flakeRefS, completions);
+} catch (Error & e) {
+    logWarning(e.info());
 }
 
 void completeFlakeRef(AddCompletions & completions, ref<Store> store, std::string_view prefix)
@@ -513,9 +446,9 @@ Installables SourceExprCommand::parseInstallables(ref<Store> store, std::vector<
                         std::move(flakeRef),
                         fragment,
                         std::move(extendedOutputsSpec),
-                        getDefaultFlakeAttrPaths(),
-                        getDefaultFlakeAttrPathPrefixes(),
-                        lockFlags));
+                        getRoles(),
+                        lockFlags,
+                        getDefaultFlakeSchemas()));
                 continue;
             } catch (...) {
                 ex = std::current_exception();

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -71,6 +71,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/generate-header')
 
 sources = files(
   'built-path.cc',
@@ -78,6 +79,7 @@ sources = files(
   'command.cc',
   'common-eval-args.cc',
   'editor-for.cc',
+  'flake-schemas.cc',
   'get-build-log.cc',
   'installable-attr-path.cc',
   'installable-derived-path.cc',
@@ -96,6 +98,11 @@ if host_machine.system() != 'windows'
     'unix/unix-socket-server.cc',
   )
 endif
+
+sources += [
+  gen_header.process('call-flake-schemas.nix'),
+  gen_header.process('builtin-flake-schemas.nix'),
+]
 
 subdir('include/nix/cmd')
 

--- a/src/libcmd/package.nix
+++ b/src/libcmd/package.nix
@@ -49,6 +49,8 @@ mkMesonLibrary (finalAttrs: {
     ./include/nix/cmd/meson.build
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
+    ./call-flake-schemas.nix
+    ./builtin-flake-schemas.nix
   ];
 
   buildInputs = [

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -44,6 +44,14 @@ AttrPath AttrPath::parse(EvalState & state, std::string_view s)
     return res;
 }
 
+AttrPath AttrPath::fromStrings(EvalState & state, const std::vector<std::string> & attrNames)
+{
+    AttrPath res;
+    for (auto & attrName : attrNames)
+        res.push_back(state.symbols.create(attrName));
+    return res;
+}
+
 std::string AttrPath::to_string(EvalState & state) const
 {
     return dropEmptyInitThenConcatStringsSep(".", state.symbols.resolve({*this}));

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -366,21 +366,31 @@ void AttrCursor::fetchCachedValue()
         throw CachedEvalError(parent->first, parent->second);
 }
 
-AttrPath AttrCursor::getAttrPath() const
+AttrPath AttrCursor::getAttrPathRaw() const
 {
     if (parent) {
-        auto attrPath = parent->first->getAttrPath();
+        auto attrPath = parent->first->getAttrPathRaw();
         attrPath.push_back(parent->second);
         return attrPath;
     } else
         return {};
 }
 
-AttrPath AttrCursor::getAttrPath(Symbol name) const
+AttrPath AttrCursor::getAttrPath() const
 {
-    auto attrPath = getAttrPath();
+    return root->cleanupAttrPath(getAttrPathRaw());
+}
+
+AttrPath AttrCursor::getAttrPathRaw(Symbol name) const
+{
+    auto attrPath = getAttrPathRaw();
     attrPath.push_back(name);
     return attrPath;
+}
+
+AttrPath AttrCursor::getAttrPath(Symbol name) const
+{
+    return root->cleanupAttrPath(getAttrPathRaw(name));
 }
 
 std::string AttrCursor::getAttrPathStr() const

--- a/src/libexpr/include/nix/expr/attr-path.hh
+++ b/src/libexpr/include/nix/expr/attr-path.hh
@@ -25,6 +25,8 @@ struct AttrPath : std::vector<Symbol>
 
     static AttrPath parse(EvalState & state, std::string_view s);
 
+    static AttrPath fromStrings(EvalState & state, const std::vector<std::string> & attrNames);
+
     std::string to_string(EvalState & state) const;
 
     std::vector<SymbolStr> resolve(EvalState & state) const;

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -38,7 +38,13 @@ class EvalCache : public std::enable_shared_from_this<EvalCache>
     friend struct CachedEvalError;
 
     std::shared_ptr<AttrDb> db;
+
+public:
     EvalState & state;
+
+    std::function<AttrPath(AttrPath &&)> cleanupAttrPath = [](AttrPath && attrPath) { return std::move(attrPath); };
+
+private:
     typedef fun<Value *()> RootLoader;
     RootLoader rootLoader;
     RootValue value;
@@ -102,7 +108,10 @@ class AttrCursor : public std::enable_shared_from_this<AttrCursor>
     friend class EvalCache;
     friend struct CachedEvalError;
 
+public:
     ref<EvalCache> root;
+
+private:
     using Parent = std::optional<std::pair<ref<AttrCursor>, Symbol>>;
     Parent parent;
     RootValue _value;
@@ -130,7 +139,11 @@ public:
 
     AttrPath getAttrPath() const;
 
+    AttrPath getAttrPathRaw() const;
+
     AttrPath getAttrPath(Symbol name) const;
+
+    AttrPath getAttrPathRaw(Symbol name) const;
 
     std::string getAttrPathStr() const;
 

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -109,11 +109,11 @@ class AttrCursor : public std::enable_shared_from_this<AttrCursor>
     friend struct CachedEvalError;
 
 public:
-    ref<EvalCache> root;
+    const ref<EvalCache> root;
 
 private:
     using Parent = std::optional<std::pair<ref<AttrCursor>, Symbol>>;
-    Parent parent;
+    const Parent parent;
     RootValue _value;
     std::optional<std::pair<AttrId, AttrValue>> cachedValue;
 

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -237,7 +237,7 @@ static std::pair<std::map<FlakeId, FlakeInput>, fetchers::Attrs> parseFlakeInput
     return {inputs, selfAttrs};
 }
 
-static Flake readFlake(
+Flake readFlake(
     EvalState & state,
     const FlakeRef & originalRef,
     const FlakeRef & resolvedRef,
@@ -1017,41 +1017,6 @@ std::optional<Fingerprint> LockedFlake::getFingerprint(Store & store, const fetc
 }
 
 Flake::~Flake() {}
-
-ref<eval_cache::EvalCache> openEvalCache(EvalState & state, ref<const LockedFlake> lockedFlake)
-{
-    auto fingerprint = state.settings.useEvalCache && state.settings.pureEval
-                           ? lockedFlake->getFingerprint(*state.store, state.fetchSettings)
-                           : std::nullopt;
-    auto rootLoader = [&state, lockedFlake]() {
-        /* For testing whether the evaluation cache is
-           complete. */
-        if (getEnv("NIX_ALLOW_EVAL").value_or("1") == "0")
-            throw Error("not everything is cached, but evaluation is not allowed");
-
-        auto vFlake = state.allocValue();
-        callFlake(state, *lockedFlake, *vFlake);
-
-        state.forceAttrs(*vFlake, noPos, "while parsing cached flake data");
-
-        auto aOutputs = vFlake->attrs()->get(state.symbols.create("outputs"));
-        assert(aOutputs);
-
-        return aOutputs->value;
-    };
-
-    if (fingerprint) {
-        auto search = state.evalCaches.find(fingerprint.value());
-        if (search == state.evalCaches.end()) {
-            search = state.evalCaches
-                         .emplace(fingerprint.value(), make_ref<eval_cache::EvalCache>(fingerprint, state, rootLoader))
-                         .first;
-        }
-        return search->second;
-    } else {
-        return make_ref<eval_cache::EvalCache>(std::nullopt, state, rootLoader);
-    }
-}
 
 } // namespace flake
 

--- a/src/libflake/include/nix/flake/flake.hh
+++ b/src/libflake/include/nix/flake/flake.hh
@@ -214,6 +214,18 @@ struct LockFlags
     std::set<NonEmptyInputAttrPath> inputUpdates;
 };
 
+/**
+ * Return a `Flake` object representing the flake read from the
+ * `flake.nix` file in `rootDir`.
+ */
+Flake readFlake(
+    EvalState & state,
+    const FlakeRef & originalRef,
+    const FlakeRef & resolvedRef,
+    const FlakeRef & lockedRef,
+    const SourcePath & rootDir,
+    const InputAttrPath & lockRootPath);
+
 /*
  * Compute an in-memory lock file for the specified top-level flake, and optionally write it to file, if the flake is
  * writable.
@@ -221,15 +233,13 @@ struct LockFlags
 LockedFlake
 lockFlake(const Settings & settings, EvalState & state, const FlakeRef & flakeRef, const LockFlags & lockFlags);
 
+LockedFlake lockFlake(
+    const Settings & settings, EvalState & state, const FlakeRef & topRef, const LockFlags & lockFlags, Flake flake);
+
 LockedFlake
 lockFlake(const Settings & settings, EvalState & state, const SourcePath & flakeDir, const LockFlags & lockFlags);
 
 void callFlake(EvalState & state, const LockedFlake & lockedFlake, Value & v);
-
-/**
- * Open an evaluation cache for a flake.
- */
-ref<eval_cache::EvalCache> openEvalCache(EvalState & state, ref<const LockedFlake> lockedFlake);
 
 } // namespace flake
 

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -54,21 +54,9 @@ struct CmdBundle : InstallableValueCommand
         return catSecondary;
     }
 
-    // FIXME: cut&paste from CmdRun.
-    Strings getDefaultFlakeAttrPaths() override
+    StringSet getRoles() override
     {
-        Strings res{"apps." + settings.thisSystem.get() + ".default", "defaultApp." + settings.thisSystem.get()};
-        for (auto & s : SourceExprCommand::getDefaultFlakeAttrPaths())
-            res.push_back(s);
-        return res;
-    }
-
-    Strings getDefaultFlakeAttrPathPrefixes() override
-    {
-        Strings res{"apps." + settings.thisSystem.get() + "."};
-        for (auto & s : SourceExprCommand::getDefaultFlakeAttrPathPrefixes())
-            res.push_back(s);
-        return res;
+        return {"nix-run"};
     }
 
     void run(ref<Store> store, ref<InstallableValue> installable) override
@@ -86,9 +74,9 @@ struct CmdBundle : InstallableValueCommand
             std::move(bundlerFlakeRef),
             bundlerName,
             std::move(extendedOutputsSpec),
-            {"bundlers." + settings.thisSystem.get() + ".default", "defaultBundler." + settings.thisSystem.get()},
-            {"bundlers." + settings.thisSystem.get() + "."},
-            lockFlags};
+            {"nix-bundler"},
+            lockFlags,
+            getDefaultFlakeSchemas()};
 
         auto vRes = evalState->allocValue();
         evalState->callFunction(*bundler.toValue(*evalState).first, *val, *vRes, noPos);

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -456,22 +456,9 @@ struct Common : InstallableCommand, MixProfile
         rewrites.insert({BuildEnvironment::getString(fileInBuilderEnv->second), targetFilePath.string()});
     }
 
-    Strings getDefaultFlakeAttrPaths() override
+    StringSet getRoles() override
     {
-        Strings paths{
-            "devShells." + settings.thisSystem.get() + ".default",
-            "devShell." + settings.thisSystem.get(),
-        };
-        for (auto & p : SourceExprCommand::getDefaultFlakeAttrPaths())
-            paths.push_back(p);
-        return paths;
-    }
-
-    Strings getDefaultFlakeAttrPathPrefixes() override
-    {
-        auto res = SourceExprCommand::getDefaultFlakeAttrPathPrefixes();
-        res.emplace_front("devShells." + settings.thisSystem.get() + ".");
-        return res;
+        return {"nix-develop"};
     }
 
     StorePath getShellOutPath(ref<Store> store, ref<Installable> installable)
@@ -654,9 +641,9 @@ struct CmdDevelop : Common, MixEnvironment
                 std::move(nixpkgs),
                 "bashInteractive",
                 ExtendedOutputsSpec::Default(),
-                Strings{},
-                Strings{"legacyPackages." + settings.thisSystem.get() + "."},
-                nixpkgsLockFlags);
+                StringSet{"nix-build"},
+                nixpkgsLockFlags,
+                std::nullopt);
 
             for (auto & path : Installable::toStorePathSet(
                      getEvalStore(), store, Realise::Outputs, OperateOn::Output, {bashInstallable})) {

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -21,6 +21,9 @@
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/store/globals.hh"
+#include "nix/util/exit.hh"
+#include "nix/cmd/flake-schemas.hh"
+#include "nix/store/names.hh"
 
 #include <filesystem>
 #include <nlohmann/json.hpp>
@@ -170,33 +173,6 @@ struct CmdFlakeLock : FlakeCommand
     }
 };
 
-static void enumerateOutputs(
-    EvalState & state,
-    Value & vFlake,
-    std::function<void(std::string_view name, Value & vProvide, const PosIdx pos)> callback)
-{
-    auto pos = vFlake.determinePos(noPos);
-    state.forceAttrs(vFlake, pos, "while evaluating a flake to get its outputs");
-
-    auto aOutputs = vFlake.attrs()->get(state.symbols.create("outputs"));
-    assert(aOutputs);
-
-    state.forceAttrs(*aOutputs->value, pos, "while evaluating the outputs of a flake");
-
-    auto sHydraJobs = state.symbols.create("hydraJobs");
-
-    /* Hack: ensure that hydraJobs is evaluated before anything
-       else. This way we can disable IFD for hydraJobs and then enable
-       it for other outputs. */
-    if (auto attr = aOutputs->value->attrs()->get(sHydraJobs))
-        callback(state.symbols[attr->name], *attr->value, attr->pos);
-
-    for (auto & attr : *aOutputs->value->attrs()) {
-        if (attr.name != sHydraJobs)
-            callback(state.symbols[attr.name], *attr.value, attr.pos);
-    }
-}
-
 struct CmdFlakeMetadata : FlakeCommand, MixJSON
 {
     std::string description() override
@@ -311,9 +287,26 @@ struct CmdFlakeInfo : CmdFlakeMetadata
     }
 };
 
-struct CmdFlakeCheck : FlakeCommand
+/**
+ * Log the current exception, after forcing cached evaluation errors.
+ */
+static void logEvalError()
+{
+    try {
+        try {
+            throw;
+        } catch (eval_cache::CachedEvalError & e) {
+            e.force();
+        }
+    } catch (Error & e) {
+        logError(e.info());
+    }
+}
+
+struct CmdFlakeCheck : FlakeCommand, MixFlakeSchemas
 {
     bool build = true;
+    bool buildAll = false;
     bool checkAllSystems = false;
 
     CmdFlakeCheck()
@@ -322,6 +315,11 @@ struct CmdFlakeCheck : FlakeCommand
             .longName = "no-build",
             .description = "Do not build checks.",
             .handler = {&build, false},
+        });
+        addFlag({
+            .longName = "build-all",
+            .description = "Build all derivations, not just checks.",
+            .handler = {&buildAll, true},
         });
         addFlag({
             .longName = "all-systems",
@@ -352,441 +350,119 @@ struct CmdFlakeCheck : FlakeCommand
         auto state = getEvalState();
 
         lockFlags.applyNixConfig = true;
-        auto flake = lockFlake();
+        auto flake = std::make_shared<flake::LockedFlake>(lockFlake());
         auto localSystem = std::string(settings.thisSystem.get());
 
-        bool hasErrors = false;
-        auto reportError = [&](const Error & e) {
-            try {
-                throw e;
-            } catch (Interrupted & e) {
-                throw;
-            } catch (Error & e) {
-                if (settings.getWorkerSettings().keepGoing) {
-                    logError(e.info());
-                    hasErrors = true;
-                } else
-                    throw;
-            }
-        };
+        auto cache = flake_schemas::call(*state, flake, getDefaultFlakeSchemas());
 
-        StringSet omittedSystems;
+        auto inventory = cache->getRoot()->getAttr("inventory");
+        auto outputs = cache->getRoot()->getAttr("outputs");
 
-        // FIXME: rewrite to use EvalCache.
+        Sync<std::vector<DerivedPath>> drvPaths_;
+        Sync<std::set<std::string>> uncheckedOutputs;
+        Sync<std::set<std::string>> omittedSystems;
+        Sync<std::map<DerivedPath, std::vector<AttrPath>>> derivedPathToAttrPaths_;
 
-        auto resolve = [&](PosIdx p) { return state->positions[p]; };
+        std::function<void(ref<eval_cache::AttrCursor> node)> visit;
 
-        auto argHasName = [&](Symbol arg, std::string_view expected) {
-            std::string_view name = state->symbols[arg];
-            return name == expected || name == "_" || (hasPrefix(name, "_") && name.substr(1) == expected);
-        };
+        std::atomic_bool hasErrors = false;
 
-        auto checkSystemName = [&](std::string_view system, const PosIdx pos) {
-            // FIXME: what's the format of "system"?
-            if (system.find('-') == std::string::npos)
-                reportError(Error("'%s' is not a valid system type, at %s", system, resolve(pos)));
-        };
+        visit = [&](ref<eval_cache::AttrCursor> node) {
+            flake_schemas::visit(
+                checkAllSystems ? std::optional<std::string>() : localSystem,
+                false, // FIXME: add a --legacy flag?
+                node,
 
-        auto checkSystemType = [&](std::string_view system, const PosIdx pos) {
-            if (!checkAllSystems && system != localSystem) {
-                omittedSystems.insert(std::string(system));
-                return false;
-            } else {
-                return true;
-            }
-        };
+                [&](const flake_schemas::Leaf & leaf) {
+                    try {
+                        bool done = true;
+                        bool buildSkipped = false;
 
-        auto checkDerivation =
-            [&](const std::string & attrPath, Value & v, const PosIdx pos) -> std::optional<StorePath> {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking derivation %s", attrPath));
-                auto packageInfo = getDerivation(*state, v, false);
-                if (!packageInfo)
-                    throw Error("flake attribute '%s' is not a derivation", attrPath);
-                else {
-                    // FIXME: check meta attributes
-                    auto storePath = packageInfo->queryDrvPath();
-                    if (storePath) {
-                        logger->log(
-                            lvlInfo, fmt("derivation evaluated to %s", store->printStorePath(storePath.value())));
-                    }
-                    return storePath;
-                }
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the derivation '%s'", attrPath));
-                reportError(e);
-            }
-            return std::nullopt;
-        };
-
-        std::map<DerivedPath, std::vector<AttrPath>> attrPathsByDrv;
-
-        auto checkApp = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking app '%s'", attrPath));
-                state->forceAttrs(v, pos, "");
-                if (auto attr = v.attrs()->get(state->symbols.create("type")))
-                    state->forceStringNoCtx(*attr->value, attr->pos, "");
-                else
-                    throw Error("app '%s' lacks attribute 'type'", attrPath);
-
-                if (auto attr = v.attrs()->get(state->symbols.create("program"))) {
-                    if (attr->name == state->symbols.create("program")) {
-                        NixStringContext context;
-                        state->forceString(*attr->value, context, attr->pos, "");
-                    }
-                } else
-                    throw Error("app '%s' lacks attribute 'program'", attrPath);
-
-                if (auto attr = v.attrs()->get(state->symbols.create("meta"))) {
-                    state->forceAttrs(*attr->value, attr->pos, "");
-                    if (auto dAttr = attr->value->attrs()->get(state->symbols.create("description")))
-                        state->forceStringNoCtx(*dAttr->value, dAttr->pos, "");
-                    else
-                        logWarning({
-                            .msg = HintFmt("app '%s' lacks attribute 'meta.description'", attrPath),
-                        });
-                } else
-                    logWarning({
-                        .msg = HintFmt("app '%s' lacks attribute 'meta'", attrPath),
-                    });
-
-                for (auto & attr : *v.attrs()) {
-                    std::string_view name(state->symbols[attr.name]);
-                    if (name != "type" && name != "program" && name != "meta")
-                        throw Error("app '%s' has unsupported attribute '%s'", attrPath, name);
-                }
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the app definition '%s'", attrPath));
-                reportError(e);
-            }
-        };
-
-        auto checkOverlay = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking overlay '%s'", attrPath));
-                state->forceValue(v, pos);
-                if (!v.isLambda()) {
-                    throw Error("overlay is not a function, but %s instead", showType(v));
-                }
-                if (v.lambda().fun->getFormals() || !argHasName(v.lambda().fun->arg, "final"))
-                    throw Error("overlay does not take an argument named 'final'");
-                // FIXME: if we have a 'nixpkgs' input, use it to
-                // evaluate the overlay.
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the overlay '%s'", attrPath));
-                reportError(e);
-            }
-        };
-
-        auto checkModule = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking NixOS module '%s'", attrPath));
-                state->forceValue(v, pos);
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the NixOS module '%s'", attrPath));
-                reportError(e);
-            }
-        };
-
-        std::function<void(std::string_view attrPath, Value & v, const PosIdx pos)> checkHydraJobs;
-
-        checkHydraJobs = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking Hydra job '%s'", attrPath));
-                state->forceAttrs(v, pos, "");
-
-                if (state->isDerivation(v))
-                    throw Error("jobset should not be a derivation at top-level");
-
-                for (auto & attr : *v.attrs()) {
-                    state->forceAttrs(*attr.value, attr.pos, "");
-                    auto attrPath2 = concatStrings(attrPath, ".", state->symbols[attr.name]);
-                    if (state->isDerivation(*attr.value)) {
-                        Activity act(*logger, lvlInfo, actUnknown, fmt("checking Hydra job '%s'", attrPath2));
-                        checkDerivation(attrPath2, *attr.value, attr.pos);
-                    } else
-                        checkHydraJobs(attrPath2, *attr.value, attr.pos);
-                }
-
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the Hydra jobset '%s'", attrPath));
-                reportError(e);
-            }
-        };
-
-        auto checkNixOSConfiguration = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking NixOS configuration '%s'", attrPath));
-                Bindings & bindings = Bindings::emptyBindings;
-                auto vToplevel = findAlongAttrPath(*state, "config.system.build.toplevel", bindings, v).first;
-                state->forceValue(*vToplevel, pos);
-                if (!state->isDerivation(*vToplevel))
-                    throw Error("attribute 'config.system.build.toplevel' is not a derivation");
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the NixOS configuration '%s'", attrPath));
-                reportError(e);
-            }
-        };
-
-        auto checkTemplate = [&](std::string_view attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking template '%s'", attrPath));
-
-                state->forceAttrs(v, pos, "");
-
-                if (auto attr = v.attrs()->get(state->symbols.create("path"))) {
-                    if (attr->name == state->symbols.create("path")) {
-                        NixStringContext context;
-                        auto path = state->coerceToPath(attr->pos, *attr->value, context, "");
-                        if (!path.pathExists())
-                            throw Error("template '%s' refers to a non-existent path '%s'", attrPath, path);
-                        // TODO: recursively check the flake in 'path'.
-                    }
-                } else
-                    throw Error("template '%s' lacks attribute 'path'", attrPath);
-
-                if (auto attr = v.attrs()->get(state->symbols.create("description")))
-                    state->forceStringNoCtx(*attr->value, attr->pos, "");
-                else
-                    throw Error("template '%s' lacks attribute 'description'", attrPath);
-
-                for (auto & attr : *v.attrs()) {
-                    std::string_view name(state->symbols[attr.name]);
-                    if (name != "path" && name != "description" && name != "welcomeText")
-                        throw Error("template '%s' has unsupported attribute '%s'", attrPath, name);
-                }
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the template '%s'", attrPath));
-                reportError(e);
-            }
-        };
-
-        auto checkBundler = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
-            try {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking bundler '%s'", attrPath));
-                state->forceValue(v, pos);
-                if (!v.isLambda())
-                    throw Error("bundler must be a function");
-                // TODO: check types of inputs/outputs?
-            } catch (Error & e) {
-                e.addTrace(resolve(pos), HintFmt("while checking the template '%s'", attrPath));
-                reportError(e);
-            }
-        };
-
-        {
-            Activity act(*logger, lvlInfo, actUnknown, "evaluating flake");
-
-            auto vFlake = state->allocValue();
-            flake::callFlake(*state, flake, *vFlake);
-
-            enumerateOutputs(*state, *vFlake, [&](std::string_view name, Value & vOutput, const PosIdx pos) {
-                Activity act(*logger, lvlInfo, actUnknown, fmt("checking flake output '%s'", name));
-
-                try {
-                    evalSettings.enableImportFromDerivation.setDefault(name != "hydraJobs");
-
-                    state->forceValue(vOutput, pos);
-
-                    std::string_view replacement = name == "defaultPackage"    ? "packages.<system>.default"
-                                                   : name == "defaultApp"      ? "apps.<system>.default"
-                                                   : name == "defaultTemplate" ? "templates.default"
-                                                   : name == "defaultBundler"  ? "bundlers.<system>.default"
-                                                   : name == "overlay"         ? "overlays.default"
-                                                   : name == "devShell"        ? "devShells.<system>.default"
-                                                   : name == "nixosModule"     ? "nixosModules.default"
-                                                                               : "";
-                    if (replacement != "")
-                        warn("flake output attribute '%s' is deprecated; use '%s' instead", name, replacement);
-
-                    if (name == "checks") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            std::string_view attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs()) {
-                                    auto drvPath = checkDerivation(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value,
-                                        attr2.pos);
-                                    if (drvPath && attr_name == settings.thisSystem.get()) {
-                                        auto path = DerivedPath::Built{
-                                            .drvPath = makeConstantStorePathRef(*drvPath),
-                                            .outputs = OutputsSpec::All{},
-                                        };
-
-                                        // Build and store the attribute path for error reporting
-                                        AttrPath attrPath{state->symbols.create(name), attr.name, attr2.name};
-                                        attrPathsByDrv[path].push_back(std::move(attrPath));
-                                    }
-                                }
+                        if (auto evalChecks = leaf.node->maybeGetAttr("evalChecks")) {
+                            auto checkNames = evalChecks->getAttrs();
+                            for (auto & checkName : checkNames) {
+                                auto cursor = evalChecks->getAttr(checkName);
+                                Activity act(
+                                    *logger,
+                                    lvlInfo,
+                                    actUnknown,
+                                    fmt("running flake check '%s'", cursor->getAttrPathStr()));
+                                auto b = cursor->getBool();
+                                if (!b)
+                                    throw Error("Evaluation check '%s' failed.", cursor->getAttrPathStr());
                             }
                         }
-                    }
 
-                    else if (name == "formatter") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            const auto & attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                checkDerivation(fmt("%s.%s", name, attr_name), *attr.value, attr.pos);
-                            };
+                        if (auto drv = leaf.derivation(outputs)) {
+
+                            /* Check whether this is a valid derivation. */
+                            if (!drv->maybeGetAttr("drvPath") || drv->getAttr("type")->getString() != "derivation")
+                                throw Error("Flake output '%s' is not a derivation.", drv->getAttrPathStr());
+
+                            DrvName parsedDrvName(drv->getAttr("name")->getString());
+
+                            if (buildAll || leaf.isFlakeCheck()) {
+                                auto drvPath = drv->forceDerivation();
+                                auto derivedPath = DerivedPath::Built{
+                                    .drvPath = makeConstantStorePathRef(drvPath),
+                                    .outputs = OutputsSpec::All{},
+                                };
+                                (*derivedPathToAttrPaths_.lock())[derivedPath].push_back(leaf.node->getAttrPath());
+                                drvPaths_.lock()->push_back(std::move(derivedPath));
+                                if (build)
+                                    done = false;
+                            } else
+                                buildSkipped = true;
                         }
+
+                        if (done)
+                            notice(
+                                "✅ " ANSI_BOLD "%s" ANSI_NORMAL "%s",
+                                leaf.node->getAttrPathStr(),
+                                buildSkipped ? ANSI_ITALIC ANSI_FAINT " (build skipped)" : "");
+                    } catch (Interrupted & e) {
+                        throw;
+                    } catch (Error & e) {
+                        printError("❌ " ANSI_RED "%s" ANSI_NORMAL, leaf.node->getAttrPathStr());
+                        if (settings.getWorkerSettings().keepGoing) {
+                            logEvalError();
+                            hasErrors = true;
+                        } else
+                            throw;
                     }
+                },
 
-                    else if (name == "packages" || name == "devShells") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            const auto & attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs())
-                                    checkDerivation(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value,
-                                        attr2.pos);
-                            };
-                        }
-                    }
+                [&](std::function<void(flake_schemas::ForEachChild)> forEachChild) {
+                    forEachChild([&](Symbol attrName, ref<eval_cache::AttrCursor> node, bool isLast) { visit(node); });
+                },
 
-                    else if (name == "apps") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            const auto & attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs())
-                                    checkApp(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value,
-                                        attr2.pos);
-                            };
-                        }
-                    }
+                [&](ref<eval_cache::AttrCursor> node, const std::vector<std::string> & systems) {
+                    for (auto & s : systems)
+                        omittedSystems.lock()->insert(s);
+                },
 
-                    else if (name == "defaultPackage" || name == "devShell") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            const auto & attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                checkDerivation(fmt("%s.%s", name, attr_name), *attr.value, attr.pos);
-                            };
-                        }
-                    }
+                [&](ref<eval_cache::AttrCursor> node) {});
+        };
 
-                    else if (name == "defaultApp") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            const auto & attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                checkApp(fmt("%s.%s", name, attr_name), *attr.value, attr.pos);
-                            };
-                        }
-                    }
-
-                    else if (name == "legacyPackages") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            checkSystemName(state->symbols[attr.name], attr.pos);
-                            checkSystemType(state->symbols[attr.name], attr.pos);
-                            // FIXME: do getDerivations?
-                        }
-                    }
-
-                    else if (name == "overlay")
-                        checkOverlay(name, vOutput, pos);
-
-                    else if (name == "overlays") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs())
-                            checkOverlay(fmt("%s.%s", name, state->symbols[attr.name]), *attr.value, attr.pos);
-                    }
-
-                    else if (name == "nixosModule")
-                        checkModule(name, vOutput, pos);
-
-                    else if (name == "nixosModules") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs())
-                            checkModule(fmt("%s.%s", name, state->symbols[attr.name]), *attr.value, attr.pos);
-                    }
-
-                    else if (name == "nixosConfigurations") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs())
-                            checkNixOSConfiguration(
-                                fmt("%s.%s", name, state->symbols[attr.name]), *attr.value, attr.pos);
-                    }
-
-                    else if (name == "hydraJobs")
-                        checkHydraJobs(name, vOutput, pos);
-
-                    else if (name == "defaultTemplate")
-                        checkTemplate(name, vOutput, pos);
-
-                    else if (name == "templates") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs())
-                            checkTemplate(fmt("%s.%s", name, state->symbols[attr.name]), *attr.value, attr.pos);
-                    }
-
-                    else if (name == "defaultBundler") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            const auto & attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                checkBundler(fmt("%s.%s", name, attr_name), *attr.value, attr.pos);
-                            };
-                        }
-                    }
-
-                    else if (name == "bundlers") {
-                        state->forceAttrs(vOutput, pos, "");
-                        for (auto & attr : *vOutput.attrs()) {
-                            const auto & attr_name = state->symbols[attr.name];
-                            checkSystemName(attr_name, attr.pos);
-                            if (checkSystemType(attr_name, attr.pos)) {
-                                state->forceAttrs(*attr.value, attr.pos, "");
-                                for (auto & attr2 : *attr.value->attrs()) {
-                                    checkBundler(
-                                        fmt("%s.%s.%s", name, attr_name, state->symbols[attr2.name]),
-                                        *attr2.value,
-                                        attr2.pos);
-                                }
-                            };
-                        }
-                    }
-
-                    else if (
-                        name == "lib" || name == "darwinConfigurations" || name == "darwinModules"
-                        || name == "flakeModule" || name == "flakeModules" || name == "herculesCI"
-                        || name == "homeConfigurations" || name == "homeModule" || name == "homeModules"
-                        || name == "nixopsConfigurations")
-                        // Known but unchecked community attribute
-                        ;
-
-                    else
-                        warn("unknown flake output '%s'", name);
-
-                } catch (Error & e) {
-                    e.addTrace(resolve(pos), HintFmt("while checking flake output '%s'", name));
-                    reportError(e);
-                }
+        flake_schemas::forEachOutput(
+            inventory,
+            [&](Symbol outputName,
+                std::shared_ptr<eval_cache::AttrCursor> output,
+                const std::string & doc,
+                bool isLast) {
+                if (output)
+                    visit(ref(output));
+                else
+                    uncheckedOutputs.lock()->insert(std::string(state->symbols[outputName]));
             });
-        }
 
-        if (build && !attrPathsByDrv.empty()) {
-            auto keys = std::views::keys(attrPathsByDrv);
-            std::vector<DerivedPath> drvPaths(keys.begin(), keys.end());
+        if (!uncheckedOutputs.lock()->empty())
+            warn("The following flake outputs are unchecked: %s.", concatStringsSep(", ", *uncheckedOutputs.lock()));
+
+        auto drvPaths(drvPaths_.lock());
+        auto derivedPathToAttrPaths(derivedPathToAttrPaths_.lock());
+
+        if (build && !drvPaths->empty()) {
             // TODO: This filtering of substitutable paths is a temporary workaround until
             // https://github.com/NixOS/nix/issues/5025 (union stores) is implemented.
             //
@@ -798,59 +474,61 @@ struct CmdFlakeCheck : FlakeCommand
             // For now, we skip building derivations whose outputs are already available
             // via substitution, as `nix flake check` only needs to verify buildability,
             // not actually produce the outputs.
-            auto missing = store->queryMissing(drvPaths);
+            auto missing = store->queryMissing(*drvPaths);
 
             std::vector<DerivedPath> toBuild;
+            std::set<DerivedPath> toBuildSet;
             for (auto & path : missing.willBuild) {
-                toBuild.emplace_back(
-                    DerivedPath::Built{
-                        .drvPath = makeConstantStorePathRef(path),
-                        .outputs = OutputsSpec::All{},
-                    });
+                auto derivedPath = DerivedPath::Built{
+                    .drvPath = makeConstantStorePathRef(path),
+                    .outputs = OutputsSpec::All{},
+                };
+                toBuild.emplace_back(derivedPath);
+                toBuildSet.insert(std::move(derivedPath));
             }
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("running %d flake checks", toBuild.size()));
-            auto results = store->buildPathsWithResults(toBuild);
+            for (auto & [derivedPath, attrPaths] : *derivedPathToAttrPaths)
+                if (!toBuildSet.contains(derivedPath))
+                    for (auto & attrPath : attrPaths)
+                        notice(
+                            "✅ " ANSI_BOLD "%s" ANSI_NORMAL ANSI_ITALIC ANSI_FAINT " (previously built)" ANSI_NORMAL,
+                            attrPath.to_string(*state));
 
-            // Report build failures with attribute paths
-            for (auto & result : results) {
-                if (auto * failure = result.tryGetFailure()) {
-                    auto it = attrPathsByDrv.find(result.path);
-                    if (it != attrPathsByDrv.end() && !it->second.empty()) {
-                        for (auto & attrPath : it->second) {
-                            reportError(Error(
-                                "failed to build attribute '%s', build of '%s' failed: %s",
-                                attrPath.to_string(*state),
-                                result.path.to_string(*store),
-                                failure->message()));
-                        }
-                    } else {
-                        // Derivation has no attribute path (e.g., a build dependency)
-                        reportError(
-                            Error("build of '%s' failed: %s", result.path.to_string(*store), failure->message()));
+            // FIXME: should start building while evaluating.
+            Activity act(*logger, lvlInfo, actUnknown, fmt("running %d flake checks", toBuild.size()));
+
+            auto buildResults = store->buildPathsWithResults(toBuild);
+
+            for (auto & buildResult : buildResults) {
+                if (auto failure = buildResult.tryGetFailure())
+                    try {
+                        hasErrors = true;
+                        for (auto & attrPath : (*derivedPathToAttrPaths)[buildResult.path])
+                            printError("❌ " ANSI_RED "%s" ANSI_NORMAL, attrPath.to_string(*state));
+                        throw *failure;
+                    } catch (Error & e) {
+                        logError(e.info());
                     }
-                }
+                else
+                    for (auto & attrPath : (*derivedPathToAttrPaths)[buildResult.path])
+                        notice("✅ " ANSI_BOLD "%s" ANSI_NORMAL, attrPath.to_string(*state));
             }
         }
-        if (hasErrors)
-            throw Error("some errors were encountered during the evaluation");
 
-        logger->log(lvlInfo, ANSI_GREEN "all checks passed!" ANSI_NORMAL);
-
-        if (!omittedSystems.empty()) {
+        if (!omittedSystems.lock()->empty()) {
             // TODO: empty system is not visible; render all as nix strings?
             warn(
                 "The check omitted these incompatible systems: %s\n"
                 "Use '--all-systems' to check all.",
-                concatStringsSep(", ", omittedSystems));
-        };
+                concatStringsSep(", ", *omittedSystems.lock()));
+        }
+
+        if (hasErrors)
+            throw Exit(1);
     };
 };
 
-static Strings defaultTemplateAttrPathsPrefixes{"templates."};
-static Strings defaultTemplateAttrPaths = {"templates.default", "defaultTemplate"};
-
-struct CmdFlakeInitCommon : virtual Args, EvalCommand
+struct CmdFlakeInitCommon : virtual Args, EvalCommand, MixFlakeSchemas
 {
     std::string templateUrl = "templates";
     std::filesystem::path destDir;
@@ -866,13 +544,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
             .labels = {"template"},
             .handler = {&templateUrl},
             .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
-                completeFlakeRefWithFragment(
-                    completions,
-                    getEvalState(),
-                    lockFlags,
-                    defaultTemplateAttrPathsPrefixes,
-                    defaultTemplateAttrPaths,
-                    prefix);
+                completeFlakeRefWithFragment(completions, getEvalState(), lockFlags, {"nix-template"}, prefix);
             }},
         });
     }
@@ -892,9 +564,9 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
             std::move(templateFlakeRef),
             templateName,
             ExtendedOutputsSpec::Default(),
-            defaultTemplateAttrPaths,
-            defaultTemplateAttrPathsPrefixes,
-            lockFlags);
+            {"nix-template"},
+            lockFlags,
+            {});
 
         auto cursor = installable.getCursor(*evalState);
 
@@ -1142,10 +814,13 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun, MixNoCheckSigs
     }
 };
 
-struct CmdFlakeShow : FlakeCommand, MixJSON
+struct CmdFlakeShow : FlakeCommand, MixJSON, MixFlakeSchemas
 {
     bool showLegacy = false;
     bool showAllSystems = false;
+    bool showOutputPaths = false;
+    bool showDrvPaths = false;
+    bool showDrvNames = false;
 
     CmdFlakeShow()
     {
@@ -1158,6 +833,21 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
             .longName = "all-systems",
             .description = "Show the contents of outputs for all systems.",
             .handler = {&showAllSystems, true},
+        });
+        addFlag({
+            .longName = "output-paths",
+            .description = "Include the store paths of derivation outputs in the JSON output.",
+            .handler = {&showOutputPaths, true},
+        });
+        addFlag({
+            .longName = "drv-paths",
+            .description = "Include the store paths of derivations in the JSON output.",
+            .handler = {&showDrvPaths, true},
+        });
+        addFlag({
+            .longName = "drv-names",
+            .description = "Show the names and versions of derivations.",
+            .handler = {&showDrvNames, true},
         });
     }
 
@@ -1175,298 +865,175 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
     void run(nix::ref<nix::Store> store) override
     {
-        evalSettings.enableImportFromDerivation.setDefault(false);
+        if (showOutputPaths && !json)
+            throw UsageError("The '--output-paths' flag requires '--json'.");
+
+        if (showDrvPaths && !json)
+            throw UsageError("The '--drv-paths' flag requires '--json'.");
 
         auto state = getEvalState();
         auto flake = make_ref<flake::LockedFlake>(lockFlake());
         auto localSystem = std::string(settings.thisSystem.get());
 
-        std::function<bool(eval_cache::AttrCursor & visitor, const AttrPath & attrPath, const Symbol & attr)>
-            hasContent;
+        auto cache = flake_schemas::call(*state, flake, getDefaultFlakeSchemas());
 
-        // For frameworks it's important that structures are as lazy as possible
-        // to prevent infinite recursions, performance issues and errors that
-        // aren't related to the thing to evaluate. As a consequence, they have
-        // to emit more attributes than strictly (sic) necessary.
-        // However, these attributes with empty values are not useful to the user
-        // so we omit them.
-        hasContent = [&](eval_cache::AttrCursor & visitor, const AttrPath & attrPath, const Symbol & attr) -> bool {
-            auto attrPath2(attrPath);
-            attrPath2.push_back(attr);
-            auto attrPathS = attrPath2.resolve(*state);
-            const auto & attrName = state->symbols[attr];
+        auto inventory = cache->getRoot()->getAttr("inventory");
+        auto outputs = cache->getRoot()->getAttr("outputs");
 
-            auto visitor2 = visitor.getAttr(attrName);
+        std::function<void(ref<eval_cache::AttrCursor> node, nlohmann::json & obj)> visit;
 
-            try {
-                if ((attrPathS[0] == "apps" || attrPathS[0] == "checks" || attrPathS[0] == "devShells"
-                     || attrPathS[0] == "legacyPackages" || attrPathS[0] == "packages")
-                    && (attrPathS.size() == 1 || attrPathS.size() == 2)) {
-                    for (const auto & subAttr : visitor2->getAttrs()) {
-                        if (hasContent(*visitor2, attrPath2, subAttr)) {
-                            return true;
+        visit = [&](ref<eval_cache::AttrCursor> node, nlohmann::json & obj) {
+            flake_schemas::visit(
+                showAllSystems ? std::optional<std::string>() : localSystem,
+                showLegacy,
+                node,
+
+                [&](const flake_schemas::Leaf & leaf) {
+                    if (auto what = leaf.what())
+                        obj.emplace("what", *what);
+
+                    if (auto shortDescription = leaf.shortDescription())
+                        obj.emplace("shortDescription", *shortDescription);
+
+                    if (auto drv = leaf.derivation(outputs)) {
+                        auto drvObj = nlohmann::json::object();
+
+                        if (json || showDrvNames)
+                            drvObj.emplace("name", drv->getAttr(state->s.name)->getString());
+
+                        if (showDrvPaths) {
+                            auto drvPath = drv->forceDerivation();
+                            drvObj.emplace("path", store->printStorePath(drvPath));
                         }
-                    }
-                    return false;
-                }
 
-                if ((attrPathS.size() == 1)
-                    && (attrPathS[0] == "formatter" || attrPathS[0] == "nixosConfigurations"
-                        || attrPathS[0] == "nixosModules" || attrPathS[0] == "overlays")) {
-                    for (const auto & subAttr : visitor2->getAttrs()) {
-                        if (hasContent(*visitor2, attrPath2, subAttr)) {
-                            return true;
+                        if (showOutputPaths) {
+                            auto outputs = nlohmann::json::object();
+                            auto drvPath = drv->forceDerivation();
+                            auto drv = getEvalStore()->derivationFromPath(drvPath);
+                            for (auto & i : drv.outputsAndOptPaths(*store)) {
+                                if (auto outPath = i.second.second)
+                                    outputs.emplace(i.first, store->printStorePath(*outPath));
+                                else
+                                    outputs.emplace(i.first, nullptr);
+                            }
+                            drvObj.emplace("outputs", std::move(outputs));
                         }
-                    }
-                    return false;
-                }
 
-                // If we don't recognize it, it's probably content
-                return true;
-            } catch (EvalError & e) {
-                // Some attrs may contain errors, e.g. legacyPackages of
-                // nixpkgs. We still want to recurse into it, instead of
-                // skipping it at all.
-                return true;
-            }
+                        obj.emplace("derivation", std::move(drvObj));
+                    }
+
+                    if (auto forSystems = leaf.forSystems())
+                        obj.emplace("forSystems", *forSystems);
+                },
+
+                [&](std::function<void(flake_schemas::ForEachChild)> forEachChild) {
+                    auto children = nlohmann::json::object();
+                    forEachChild([&](Symbol attrName, ref<eval_cache::AttrCursor> node, bool isLast) {
+                        auto & j = children.emplace(state->symbols[attrName], nlohmann::json::object()).first.value();
+                        {
+                            try {
+                                visit(node, j);
+                            } catch (EvalError & e) {
+                                // FIXME: make it a flake schema attribute whether to ignore evaluation errors.
+                                if (node->root->state.symbols[node->getAttrPath()[0]] == "legacyPackages")
+                                    j.emplace("failed", true);
+                                else
+                                    throw;
+                            }
+                        }
+                    });
+                    obj.emplace("children", std::move(children));
+                },
+
+                [&](ref<eval_cache::AttrCursor> node, const std::vector<std::string> & systems) {
+                    obj.emplace("filtered", true);
+                },
+
+                [&](ref<eval_cache::AttrCursor> node) { obj.emplace("isLegacy", true); });
         };
 
-        std::function<nlohmann::json(
-            eval_cache::AttrCursor & visitor,
-            const AttrPath & attrPath,
-            const std::string & headerPrefix,
-            const std::string & nextPrefix)>
-            visit;
+        auto inv = nlohmann::json::object();
 
-        visit = [&](eval_cache::AttrCursor & visitor,
-                    const AttrPath & attrPath,
-                    const std::string & headerPrefix,
-                    const std::string & nextPrefix) -> nlohmann::json {
-            auto j = nlohmann::json::object();
+        flake_schemas::forEachOutput(
+            inventory,
+            [&](Symbol outputName,
+                std::shared_ptr<eval_cache::AttrCursor> output,
+                const std::string & doc,
+                bool isLast) {
+                auto & j = inv.emplace(state->symbols[outputName], nlohmann::json::object()).first.value();
 
-            auto attrPathS = attrPath.resolve(*state);
+                if (output) {
+                    j.emplace("doc", doc);
+                    auto & j2 = j.emplace("output", nlohmann::json::object()).first.value();
+                    visit(ref(output), j2);
+                } else
+                    j.emplace("unknown", true);
+            });
 
-            Activity act(*logger, lvlInfo, actUnknown, fmt("evaluating '%s'", attrPath.to_string(*state)));
+        if (json) {
+            auto res = nlohmann::json{{"version", 2}, {"inventory", std::move(inv)}};
+            printJSON(res);
+        } else {
 
-            try {
-                auto recurse = [&]() {
-                    if (!json)
-                        logger->cout("%s", headerPrefix);
-                    std::vector<Symbol> attrs;
-                    for (const auto & attr : visitor.getAttrs()) {
-                        if (hasContent(visitor, attrPath, attr))
-                            attrs.push_back(attr);
-                    }
+            // Render the JSON into a tree representation.
+            std::function<void(nlohmann::json j, const std::string & headerPrefix, const std::string & nextPrefix)>
+                render;
 
-                    for (const auto & [last, attr] : markLast(attrs)) {
-                        const auto & attrName = state->symbols[attr];
-                        auto visitor2 = visitor.getAttr(attrName);
-                        auto attrPath2(attrPath);
-                        attrPath2.push_back(attr);
-                        auto j2 = visit(
-                            *visitor2,
-                            attrPath2,
+            render = [&](nlohmann::json j, const std::string & headerPrefix, const std::string & nextPrefix) {
+                auto what = j.find("what");
+                auto filtered = j.find("filtered");
+                auto isLegacy = j.find("isLegacy");
+                auto derivation = j.find("derivation");
+
+                auto s = headerPrefix;
+
+                if (what != j.end())
+                    s += fmt(": %s", (std::string) *what);
+
+                if (derivation != j.end()) {
+                    auto name = derivation->find("name");
+                    if (name != derivation->end())
+                        s += fmt(ANSI_ITALIC " [%s]" ANSI_NORMAL, (std::string) *name);
+                }
+
+                if (filtered != j.end() && (bool) *filtered)
+                    s += " " ANSI_WARNING "omitted" ANSI_NORMAL " (use '--all-systems' to show)";
+
+                if (isLegacy != j.end() && (bool) *isLegacy)
+                    s += " " ANSI_WARNING "omitted" ANSI_NORMAL " (use '--legacy' to show)";
+
+                logger->cout(s);
+
+                auto children = j.find("children");
+
+                if (children != j.end()) {
+                    for (const auto & [i, child] : enumerate(children->items())) {
+                        bool last = i + 1 == children->size();
+                        render(
+                            child.value(),
                             fmt(ANSI_GREEN "%s%s" ANSI_NORMAL ANSI_BOLD "%s" ANSI_NORMAL,
                                 nextPrefix,
                                 last ? treeLast : treeConn,
-                                attrName),
+                                child.key()),
                             nextPrefix + (last ? treeNull : treeLine));
-                        if (json)
-                            j.emplace(attrName, std::move(j2));
-                    }
-                };
-
-                auto showDerivation = [&]() {
-                    auto name = visitor.getAttr(state->s.name)->getString();
-
-                    if (json) {
-                        std::optional<std::string> description;
-                        if (auto aMeta = visitor.maybeGetAttr(state->s.meta)) {
-                            if (auto aDescription = aMeta->maybeGetAttr(state->s.description))
-                                description = aDescription->getString();
-                        }
-                        j.emplace("type", "derivation");
-                        j.emplace("name", name);
-                        j.emplace("description", description ? *description : "");
-                    } else {
-                        logger->cout(
-                            "%s: %s '%s'",
-                            headerPrefix,
-                            attrPath.size() == 2 && attrPathS[0] == "devShell"    ? "development environment"
-                            : attrPath.size() >= 2 && attrPathS[0] == "devShells" ? "development environment"
-                            : attrPath.size() == 3 && attrPathS[0] == "checks"    ? "derivation"
-                            : attrPath.size() >= 1 && attrPathS[0] == "hydraJobs" ? "derivation"
-                                                                                  : "package",
-                            name);
-                    }
-                };
-
-                if (attrPath.size() == 0
-                    || (attrPath.size() == 1
-                        && (attrPathS[0] == "defaultPackage" || attrPathS[0] == "devShell"
-                            || attrPathS[0] == "formatter" || attrPathS[0] == "nixosConfigurations"
-                            || attrPathS[0] == "nixosModules" || attrPathS[0] == "defaultApp"
-                            || attrPathS[0] == "templates" || attrPathS[0] == "overlays"))
-                    || ((attrPath.size() == 1 || attrPath.size() == 2)
-                        && (attrPathS[0] == "checks" || attrPathS[0] == "packages" || attrPathS[0] == "devShells"
-                            || attrPathS[0] == "apps"))) {
-                    recurse();
-                }
-
-                else if (
-                    (attrPath.size() == 2
-                     && (attrPathS[0] == "defaultPackage" || attrPathS[0] == "devShell" || attrPathS[0] == "formatter"))
-                    || (attrPath.size() == 3
-                        && (attrPathS[0] == "checks" || attrPathS[0] == "packages" || attrPathS[0] == "devShells"))) {
-                    if (!showAllSystems && std::string(attrPathS[1]) != localSystem) {
-                        if (!json)
-                            logger->cout(
-                                fmt("%s " ANSI_WARNING "omitted" ANSI_NORMAL " (use '--all-systems' to show)",
-                                    headerPrefix));
-                        else {
-                            logger->warn(fmt("%s omitted (use '--all-systems' to show)", attrPath.to_string(*state)));
-                        }
-                    } else {
-                        try {
-                            if (visitor.isDerivation())
-                                showDerivation();
-                            else {
-                                auto name = visitor.getAttrPathStr(state->s.name);
-                                logger->warn(fmt("%s is not a derivation", name));
-                            }
-                        } catch (IFDError & e) {
-                            if (!json) {
-                                logger->cout(
-                                    fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL,
-                                        headerPrefix));
-                            } else {
-                                logger->warn(
-                                    fmt("%s omitted due to use of import from derivation", attrPath.to_string(*state)));
-                            }
-                        }
                     }
                 }
+            };
 
-                else if (attrPath.size() > 0 && attrPathS[0] == "hydraJobs") {
-                    try {
-                        if (visitor.isDerivation())
-                            showDerivation();
-                        else
-                            recurse();
-                    } catch (IFDError & e) {
-                        if (!json) {
-                            logger->cout(
-                                fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL,
-                                    headerPrefix));
-                        } else {
-                            logger->warn(
-                                fmt("%s omitted due to use of import from derivation", attrPath.to_string(*state)));
-                        }
-                    }
-                }
+            logger->cout("%s", fmt(ANSI_BOLD "%s" ANSI_NORMAL, flake->flake.lockedRef));
 
-                else if (attrPath.size() > 0 && attrPathS[0] == "legacyPackages") {
-                    if (attrPath.size() == 1)
-                        recurse();
-                    else if (!showLegacy) {
-                        if (!json)
-                            logger->cout(fmt(
-                                "%s " ANSI_WARNING "omitted" ANSI_NORMAL " (use '--legacy' to show)", headerPrefix));
-                        else {
-                            logger->warn(fmt("%s omitted (use '--legacy' to show)", attrPath.to_string(*state)));
-                        }
-                    } else if (!showAllSystems && std::string(attrPathS[1]) != localSystem) {
-                        if (!json)
-                            logger->cout(
-                                fmt("%s " ANSI_WARNING "omitted" ANSI_NORMAL " (use '--all-systems' to show)",
-                                    headerPrefix));
-                        else {
-                            logger->warn(fmt("%s omitted (use '--all-systems' to show)", attrPath.to_string(*state)));
-                        }
-                    } else {
-                        try {
-                            if (visitor.isDerivation())
-                                showDerivation();
-                            else if (attrPath.size() <= 2)
-                                // FIXME: handle recurseIntoAttrs
-                                recurse();
-                        } catch (IFDError & e) {
-                            if (!json) {
-                                logger->cout(
-                                    fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL,
-                                        headerPrefix));
-                            } else {
-                                logger->warn(
-                                    fmt("%s omitted due to use of import from derivation", attrPath.to_string(*state)));
-                            }
-                        }
-                    }
-                }
-
-                else if (
-                    (attrPath.size() == 2 && attrPathS[0] == "defaultApp")
-                    || (attrPath.size() == 3 && attrPathS[0] == "apps")) {
-                    auto aType = visitor.maybeGetAttr("type");
-                    std::optional<std::string> description;
-                    if (auto aMeta = visitor.maybeGetAttr(state->s.meta)) {
-                        if (auto aDescription = aMeta->maybeGetAttr(state->s.description))
-                            description = aDescription->getString();
-                    }
-                    if (!aType || aType->getString() != "app")
-                        state->error<EvalError>("not an app definition").debugThrow();
-                    if (json) {
-                        j.emplace("type", "app");
-                        if (description)
-                            j.emplace("description", *description);
-                    } else {
-                        logger->cout(
-                            "%s: app: " ANSI_BOLD "%s" ANSI_NORMAL,
-                            headerPrefix,
-                            description ? *description : "no description");
-                    }
-                }
-
-                else if (
-                    (attrPath.size() == 1 && attrPathS[0] == "defaultTemplate")
-                    || (attrPath.size() == 2 && attrPathS[0] == "templates")) {
-                    auto description = visitor.getAttr("description")->getString();
-                    if (json) {
-                        j.emplace("type", "template");
-                        j.emplace("description", description);
-                    } else {
-                        logger->cout("%s: template: " ANSI_BOLD "%s" ANSI_NORMAL, headerPrefix, description);
-                    }
-                }
-
-                else {
-                    auto [type, description] = (attrPath.size() == 1 && attrPathS[0] == "overlay")
-                                                       || (attrPath.size() == 2 && attrPathS[0] == "overlays")
-                                                   ? std::make_pair("nixpkgs-overlay", "Nixpkgs overlay")
-                                               : attrPath.size() == 2 && attrPathS[0] == "nixosConfigurations"
-                                                   ? std::make_pair("nixos-configuration", "NixOS configuration")
-                                               : (attrPath.size() == 1 && attrPathS[0] == "nixosModule")
-                                                       || (attrPath.size() == 2 && attrPathS[0] == "nixosModules")
-                                                   ? std::make_pair("nixos-module", "NixOS module")
-                                                   : std::make_pair("unknown", "unknown");
-                    if (json) {
-                        j.emplace("type", type);
-                    } else {
-                        logger->cout("%s: " ANSI_WARNING "%s" ANSI_NORMAL, headerPrefix, description);
-                    }
-                }
-            } catch (EvalError & e) {
-                if (!(attrPath.size() > 0 && attrPathS[0] == "legacyPackages"))
-                    throw;
+            for (const auto & [i, child] : enumerate(inv.items())) {
+                bool last = i + 1 == inv.size();
+                auto nextPrefix = last ? treeNull : treeLine;
+                auto output = child.value().find("output");
+                auto headerPrefix = fmt(
+                    ANSI_GREEN "%s" ANSI_NORMAL ANSI_BOLD "%s" ANSI_NORMAL, last ? treeLast : treeConn, child.key());
+                if (output != child.value().end())
+                    render(*output, headerPrefix, nextPrefix);
+                else if (child.value().contains("unknown"))
+                    logger->cout(headerPrefix + ANSI_WARNING " unknown flake output" ANSI_NORMAL);
             }
-
-            return j;
-        };
-
-        auto cache = openEvalCache(*state, ref<flake::LockedFlake>(flake));
-
-        auto j = visit(*cache->getRoot(), {}, fmt(ANSI_BOLD "%s" ANSI_NORMAL, flake->flake.lockedRef), "");
-        if (json)
-            printJSON(j);
+        }
     }
 };
 

--- a/src/nix/formatter.cc
+++ b/src/nix/formatter.cc
@@ -32,14 +32,9 @@ static auto rCmdFormatter = registerCommand<CmdFormatter>("formatter");
 /** Common implementation bits for the `nix formatter` subcommands. */
 struct MixFormatter : SourceExprCommand
 {
-    Strings getDefaultFlakeAttrPaths() override
+    StringSet getRoles() override
     {
-        return Strings{"formatter." + settings.thisSystem.get()};
-    }
-
-    Strings getDefaultFlakeAttrPathPrefixes() override
-    {
-        return Strings{};
+        return {"nix-fmt"};
     }
 };
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -745,11 +745,11 @@ struct CmdProfileUpgrade : virtual SourceExprCommand, MixProfileElementMatchers,
                 this,
                 getEvalState(),
                 FlakeRef(element.source->originalRef),
-                "",
+                "." + element.source->attrPath, // absolute lookup
                 element.source->outputs,
-                Strings{element.source->attrPath},
-                Strings{},
-                lockFlags);
+                StringSet{},
+                lockFlags,
+                getDefaultFlakeSchemas());
 
             auto derivedPaths = installable->toDerivedPaths();
             if (derivedPaths.empty())

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -44,9 +44,9 @@ struct CmdRepl : RawInstallablesCommand
 
     std::vector<std::string> files;
 
-    Strings getDefaultFlakeAttrPaths() override
+    StringSet getRoles() override
     {
-        return {""};
+        return {"nix-repl"};
     }
 
     bool forceImpureByDefault() override

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -129,23 +129,9 @@ struct CmdRun : InstallableValueCommand, MixEnvironment
             ;
     }
 
-    Strings getDefaultFlakeAttrPaths() override
+    StringSet getRoles() override
     {
-        Strings res{
-            "apps." + settings.thisSystem.get() + ".default",
-            "defaultApp." + settings.thisSystem.get(),
-        };
-        for (auto & s : SourceExprCommand::getDefaultFlakeAttrPaths())
-            res.push_back(s);
-        return res;
-    }
-
-    Strings getDefaultFlakeAttrPathPrefixes() override
-    {
-        Strings res{"apps." + settings.thisSystem.get() + "."};
-        for (auto & s : SourceExprCommand::getDefaultFlakeAttrPathPrefixes())
-            res.push_back(s);
-        return res;
+        return {"nix-run"};
     }
 
     void run(ref<Store> store, ref<InstallableValue> installable) override

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -55,9 +55,9 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             ;
     }
 
-    Strings getDefaultFlakeAttrPaths() override
+    StringSet getRoles() override
     {
-        return {"packages." + settings.thisSystem.get(), "legacyPackages." + settings.thisSystem.get()};
+        return {"nix-search"};
     }
 
     void run(ref<Store> store, ref<InstallableValue> installable) override
@@ -186,7 +186,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             }
         };
 
-        for (auto & cursor : installable->getCursors(*state))
+        for (auto & cursor : installable->getCursors(*state, false))
             visit(*cursor, cursor->getAttrPath(), true);
 
         if (json)

--- a/tests/functional/flakes/check.sh
+++ b/tests/functional/flakes/check.sh
@@ -18,17 +18,6 @@ nix flake check "$flakeDir"
 
 cat > "$flakeDir"/flake.nix <<EOF
 {
-  outputs = { self }: {
-    overlay = finalll: prev: {
-    };
-  };
-}
-EOF
-
-(! nix flake check "$flakeDir")
-
-cat > "$flakeDir"/flake.nix <<EOF
-{
   outputs = { self, ... }: {
     overlays.x86_64-linux.foo = final: prev: {
     };
@@ -38,7 +27,7 @@ EOF
 
 # shellcheck disable=SC2015
 checkRes=$(nix flake check "$flakeDir" 2>&1 && fail "nix flake check --all-systems should have failed" || true)
-echo "$checkRes" | grepQuiet "error: overlay is not a function, but a set instead"
+echo "$checkRes" | grepQuiet "error: Overlay is not a function."
 
 cat > "$flakeDir"/flake.nix <<EOF
 {
@@ -126,7 +115,7 @@ EOF
 
 # shellcheck disable=SC2015
 checkRes=$(nix flake check --all-systems "$flakeDir" 2>&1 && fail "nix flake check --all-systems should have failed" || true)
-echo "$checkRes" | grepQuiet "unknown-attr"
+echo "$checkRes" | grepQuiet "Evaluation check.*apps.system-1.default.isValidApp.*failed"
 
 cat > "$flakeDir"/flake.nix <<EOF
 {
@@ -148,6 +137,10 @@ cat > "$flakeDir"/flake.nix <<EOF
       name = "simple";
       buildCommand = "mkdir \$out";
     };
+    packages.$system.bar = with import ./config.nix; mkDerivation {
+      name = "bad";
+      buildCommand = "exit 1";
+    };
   };
 }
 EOF
@@ -155,6 +148,11 @@ EOF
 cp "${config_nix}" "$flakeDir/"
 
 expectStderr 0 nix flake check "$flakeDir" | grepQuiet 'running 1 flake check'
+
+# FIXME: error code 100 doesn't get propagated from the daemon.
+if ! isTestOnNixOS && $NIX_REMOTE != daemon; then
+    expectStderr 100 nix flake check --build-all "$flakeDir" | grepQuiet 'Cannot build.*bad'
+fi
 
 cat > "$flakeDir"/flake.nix <<EOF
 {

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -97,7 +97,13 @@ writeIfdFlake() {
     cat > "$flakeDir/flake.nix" <<EOF
 {
   outputs = { self }: {
-    packages.$system.default = import ./ifd.nix;
+    packages.$system.default =
+      with import ./config.nix;
+      mkDerivation {
+        name = "top";
+        system = "$system";
+        ifd = import ./ifd.nix;
+      };
   };
 }
 EOF

--- a/tests/functional/flakes/develop.sh
+++ b/tests/functional/flakes/develop.sh
@@ -192,3 +192,20 @@ sed -i "$TEST_HOME/flake.nix" -e 's/devShells/devShells2/' # remove devShells
 [[ $(nix develop . -L --command sh -c "echo \$x") == "bar" ]]
 sed -i "$TEST_HOME/flake.nix" -e 's/devShell/devShell2/' # remove devShell
 [[ $(nix develop . -L --command sh -c "echo \$x") == "xyzzy" ]]
+
+# Check that legacyPackages is used, but only when specifying an explicit package.
+cat <<EOF >"$TEST_HOME/flake.nix"
+{
+  inputs.nixpkgs.url = "$TEST_HOME/nixpkgs";
+  outputs = {self, nixpkgs}: {
+    legacyPackages.$system.default = (import ./config.nix).mkDerivation {
+      name = "hello";
+      buildCommand = "set -x; mkdir \$out";
+      x = "foo";
+    };
+  };
+}
+EOF
+
+(! nix develop . -L --command sh -c "echo \$x")
+[[ $(nix develop .#default -L --command sh -c "echo \$x") == "foo" ]]

--- a/tests/functional/flakes/dubious-query.sh
+++ b/tests/functional/flakes/dubious-query.sh
@@ -17,7 +17,7 @@ expectStderr 0 nix --offline build --dry-run "git+file://$repoDir?bar#foo" \
 
 # Check that the anchor (#) is taken as a whole, not split, and throws an error.
 expectStderr 1 nix --offline build --dry-run "git+file://$repoDir#foo?bar" \
-  | grepQuiet "error: flake 'git+file://$repoDir' does not provide attribute 'packages.$system.foo?bar', 'legacyPackages.$system.foo?bar' or 'foo?bar'"
+  | grepQuiet "error: flake 'git+file://$repoDir' does not provide attribute 'packages.$system.foo?bar', 'defaultPackage.$system.foo?bar', 'legacyPackages.$system.foo?bar' or 'foo?bar'"
 
 # Check that a literal `?` in the query  doesn't print dubious query warning.
 expectStderr 0 nix --offline build --dry-run "git+file://$repoDir?#foo" \

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -16,9 +16,9 @@ nix flake show --json > show-output.json
 nix eval --impure --expr '
 let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
 in
-assert show_output.packages.someOtherSystem.default == {};
-assert show_output.packages.${builtins.currentSystem}.default.name == "simple";
-assert show_output.legacyPackages.${builtins.currentSystem} == {};
+assert show_output.inventory.packages.output.children.someOtherSystem.filtered;
+assert show_output.inventory.packages.output.children.${builtins.currentSystem}.children.default.derivation.name == "simple";
+assert show_output.inventory.legacyPackages.output.children.${builtins.currentSystem}.isLegacy;
 true
 '
 
@@ -28,8 +28,8 @@ nix flake show --json --all-systems > show-output.json
 nix eval --impure --expr '
 let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
 in
-assert show_output.packages.someOtherSystem.default.name == "simple";
-assert show_output.legacyPackages.${builtins.currentSystem} == {};
+assert show_output.inventory.packages.output.children.someOtherSystem.children.default.derivation.name == "simple";
+assert show_output.inventory.legacyPackages.output.children.${builtins.currentSystem}.isLegacy;
 true
 '
 
@@ -39,34 +39,7 @@ nix flake show --json --legacy > show-output.json
 nix eval --impure --expr '
 let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
 in
-assert show_output.legacyPackages.${builtins.currentSystem}.hello.name == "simple";
-true
-'
-
-# Test that attributes are only reported when they have actual content
-cat >flake.nix <<EOF
-{
-  description = "Bla bla";
-
-  outputs = inputs: rec {
-    apps.$system = { };
-    checks.$system = { };
-    devShells.$system = { };
-    legacyPackages.$system = { };
-    packages.$system = { };
-    packages.someOtherSystem = { };
-
-    formatter = { };
-    nixosConfigurations = { };
-    nixosModules = { };
-  };
-}
-EOF
-nix flake show --json --all-systems > show-output.json
-nix eval --impure --expr '
-let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
-in
-assert show_output == { };
+assert show_output.inventory.legacyPackages.output.children.${builtins.currentSystem}.children.hello.derivation.name == "simple";
 true
 '
 
@@ -87,8 +60,8 @@ nix flake show --json --legacy --all-systems > show-output.json
 nix eval --impure --expr '
 let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
 in
-assert show_output.legacyPackages.${builtins.currentSystem}.AAAAAASomeThingsFailToEvaluate == { };
-assert show_output.legacyPackages.${builtins.currentSystem}.simple.name == "simple";
+assert show_output.inventory.legacyPackages.output.children.${builtins.currentSystem}.children.AAAAAASomeThingsFailToEvaluate.failed;
+assert show_output.inventory.legacyPackages.output.children.${builtins.currentSystem}.children.simple.derivation.name == "simple";
 true
 '
 
@@ -98,35 +71,4 @@ popd
 writeIfdFlake "$flakeDir"
 pushd "$flakeDir"
 
-
-nix flake show --json > show-output.json
-# shellcheck disable=SC2016
-nix eval --impure --expr '
-let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
-in
-assert show_output.packages.${builtins.currentSystem}.default == { };
-true
-'
-
-
-# Test that nix keeps going even when packages.$SYSTEM contains not derivations
-cat >flake.nix <<EOF
-{
-  outputs = inputs: {
-    packages.$system = {
-      drv1 = import ./simple.nix;
-      not-a-derivation = 42;
-      drv2 = import ./simple.nix;
-    };
-  };
-}
-EOF
-nix flake show --json --all-systems > show-output.json
-# shellcheck disable=SC2016
-nix eval --impure --expr '
-let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
-in
-assert show_output.packages.${builtins.currentSystem}.not-a-derivation == {};
-true
-'
-
+[[ $(nix flake show --json | jq -r ".inventory.packages.output.children.\"$system\".children.default.derivation.name") = top ]]

--- a/tests/functional/formatter.sh
+++ b/tests/functional/formatter.sh
@@ -85,4 +85,6 @@ rm ./my-result
 
 # Flake outputs check.
 nix flake check
-nix flake show | grep -P "package 'formatter'"
+
+clearStore
+expectStderr 0 nix flake show | grepQuiet ": formatter"


### PR DESCRIPTION
# Motivation

A big problem with current flakes is that commands like `nix flake check` and `nix flake show` have built-in support for a limited set of flake output types. For instance, they know about `nixosConfigurations` but not `homeConfigurations`.

This PR moves support for flake output types out of C++ and into Nix functions supplied by a new `schemas` flake output. This allows users to define their own flake output types, and have them show up in `nix flake show` and checked by `nix flake check`. As a result, there are no more flake output types that are more "blessed" than others.

There is no central registry of schemas. Instead a flake should add an appropriate `schemas` flake output for the outputs it wants to have checked. Typically this will include schemas from other flakes. In particular, I've made a [flake-schemas](https://github.com/DeterminateSystems/flake-schemas/) flake with schemas for the flake output types that were previously built into Nix.

The format of schemas is documented in `doc/manual/src/protocols/flake-schemas.md`.

To do: 

* The `evalChecks` schema attribute need to be refined to allow checkers to return warnings/errors in a more sensible way than an assertion failure.

# Context

Fixes #3487, #6453, #6454.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
