### PR TITLE
Make the NIX_PATH environment variable take precedence over config files

### DIFF
--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -5,50 +5,6 @@
 
 namespace nix {
 
-/* Very hacky way to parse $NIX_PATH, which is colon-separated, but
-   can contain URLs (e.g. "nixpkgs=https://bla...:foo=https://"). */
-static Strings parseNixPath(const std::string & s)
-{
-    Strings res;
-
-    auto p = s.begin();
-
-    while (p != s.end()) {
-        auto start = p;
-        auto start2 = p;
-
-        while (p != s.end() && *p != ':') {
-            if (*p == '=') start2 = p + 1;
-            ++p;
-        }
-
-        if (p == s.end()) {
-            if (p != start) res.push_back(std::string(start, p));
-            break;
-        }
-
-        if (*p == ':') {
-            auto prefix = std::string(start2, s.end());
-            if (EvalSettings::isPseudoUrl(prefix) || hasPrefix(prefix, "flake:")) {
-                ++p;
-                while (p != s.end() && *p != ':') ++p;
-            }
-            res.push_back(std::string(start, p));
-            if (p == s.end()) break;
-        }
-
-        ++p;
-    }
-
-    return res;
-}
-
-EvalSettings::EvalSettings()
-{
-    auto var = getEnv("NIX_PATH");
-    if (var) nixPath = parseNixPath(*var);
-}
-
 Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -5,8 +5,6 @@ namespace nix {
 
 struct EvalSettings : Config
 {
-    EvalSettings();
-
     static Strings getDefaultNixPath();
 
     static bool isPseudoUrl(std::string_view s);

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -420,6 +420,43 @@ void initGC()
     gcInitialised = true;
 }
 
+/* Very hacky way to parse $NIX_PATH, which is colon-separated, but
+   can contain URLs (e.g. "nixpkgs=https://bla...:foo=https://"). */
+static Strings parseNixPath(const std::string & s)
+{
+    Strings res;
+
+    auto p = s.begin();
+
+    while (p != s.end()) {
+        auto start = p;
+        auto start2 = p;
+
+        while (p != s.end() && *p != ':') {
+            if (*p == '=') start2 = p + 1;
+            ++p;
+        }
+
+        if (p == s.end()) {
+            if (p != start) res.push_back(std::string(start, p));
+            break;
+        }
+
+        if (*p == ':') {
+            auto prefix = std::string(start2, s.end());
+            if (EvalSettings::isPseudoUrl(prefix) || hasPrefix(prefix, "flake:")) {
+                ++p;
+                while (p != s.end() && *p != ':') ++p;
+            }
+            res.push_back(std::string(start, p));
+            if (p == s.end()) break;
+        }
+
+        ++p;
+    }
+
+    return res;
+}
 
 ErrorBuilder & ErrorBuilder::atPos(PosIdx pos)
 {
@@ -526,8 +563,15 @@ EvalState::EvalState(
 
     /* Initialise the Nix expression search path. */
     if (!evalSettings.pureEval) {
+        // Command line specification
         for (auto & i : _searchPath.elements)
             searchPath.elements.emplace_back(SearchPath::Elem {i});
+        // Environment variable
+        auto environment = getEnv("NIX_PATH");
+        if (environment)
+            for (auto & i : parseNixPath(*environment))
+                searchPath.elements.emplace_back(SearchPath::Elem::parse(i));
+        // Config files and defaults
         for (auto & i : evalSettings.nixPath.get())
             searchPath.elements.emplace_back(SearchPath::Elem::parse(i));
     }

--- a/tests/nix_path.sh
+++ b/tests/nix_path.sh
@@ -7,6 +7,15 @@ export NIX_PATH=non-existent=/non-existent/but-unused-anyways:by-absolute-path=$
 nix-instantiate --eval -E '<by-absolute-path/simple.nix>' --restrict-eval
 nix-instantiate --eval -E '<by-relative-path/simple.nix>' --restrict-eval
 
+tmpfile=$(mktemp)
+echo "nix-path = " > "$tmpfile"
+export NIX_USER_CONF_FILES="$tmpfile"
+
+# This should still work because the NIX_PATH environment variable will take
+# precedence over the empty nix path set by the configuration file
+nix-instantiate --eval -E '<by-relative-path/simple.nix>' --restrict-eval
+
+
 # Should ideally also test this, but there’s no pure way to do it, so just trust me that it works
 # nix-instantiate --eval -E '<nixpkgs>' -I nixpkgs=channel:nixos-unstable --restrict-eval
 


### PR DESCRIPTION
Fixes #8890 #8784

# Motivation

Almost every program that I can think of takes configuration parameters in this order of precedence:

1. Command line arguments
2. Environment variables
3. Configuration files

This ordering is based roughly on how dynamic/persistent each of these types of values are, which gives the user a lot of flexibility to override things in the way they see fit. It also feels like the most obvious and intuitive order. Chat GPT agrees with me that this is the standard and most intuitive way to do things:

https://chat.openai.com/share/68fb24c9-2b91-47bd-9fab-baa956702cca

There is some discussion here that seems to imply that maybe this is a deliberate behavior:

https://github.com/NixOS/nixpkgs/pull/242098#discussion_r1269891427

but this position doesn't make a ton of sense to me, given that, as I pointed out here:

https://github.com/NixOS/nixpkgs/pull/242098#discussion_r1314086627

users must opt in to impure behavior with the --impure flag for flake aware commands.



There is one open question in my mind, which is whether or not a NIX_PATH setting should actually clobber any settings from configuration files, or if the configuration file values should also be used.

As the code is currently written, the values in the configuration files will still take effect.

This is actually arguably inconsistent with what is written here:

https://github.com/NixOS/nix/blob/197afd08a1075d0bd34ba76d5b5f40b4b36966a2/doc/manual/src/command-ref/env-common.md#L22

The thing is, the current behavior is ALSO inconsistent with what is written there. If you set NIX_PATH="" but have values in your nix.conf files, those paths will still be searched (as things stand atm).

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
