### PR TITLE
Don't print unknown locations unless requested for dev purposes

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -156,6 +156,15 @@ static std::string indent(std::string_view indentFirst, std::string_view indentR
 }
 
 /**
+ * A development aid for finding missing positions, to improve error messages. Example use:
+ *
+ *     NIX_DEVELOPER_SHOW_UNKNOWN_LOCATIONS=1 _NIX_TEST_ACCEPT=1 make tests/lang.sh.test
+ *     git diff -U20 tests
+ *
+ */
+static bool printUnknownLocations = getEnv("_NIX_DEVELOPER_SHOW_UNKNOWN_LOCATIONS").has_value();
+
+/**
  * Print a position, if it is known.
  *
  * @return true if a position was printed.
@@ -170,6 +179,8 @@ static bool printPosMaybe(std::ostream & oss, std::string_view indent, const std
             printCodeLines(oss, "", *pos, *loc);
             oss << "\n";
         }
+    } else if (printUnknownLocations) {
+        oss << "\n" << indent << ANSI_BLUE << "at " ANSI_RED << "UNKNOWN LOCATION" << ANSI_NORMAL << "\n";
     }
     return hasPos;
 }

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -155,6 +155,25 @@ static std::string indent(std::string_view indentFirst, std::string_view indentR
     return res;
 }
 
+/**
+ * Print a position, if it is known.
+ *
+ * @return true if a position was printed.
+ */
+static bool printPosMaybe(std::ostream & oss, std::string_view indent, const std::shared_ptr<AbstractPos> & pos) {
+    bool hasPos = pos && *pos;
+    if (hasPos) {
+        oss << "\n" << indent << ANSI_BLUE << "at " ANSI_WARNING << *pos << ANSI_NORMAL << ":";
+
+        if (auto loc = pos->getCodeLines()) {
+            oss << "\n";
+            printCodeLines(oss, "", *pos, *loc);
+            oss << "\n";
+        }
+    }
+    return hasPos;
+}
+
 std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool showTrace)
 {
     std::string prefix;
@@ -318,32 +337,15 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
 
             oss << "\n" << "… " << trace.hint.str() << "\n";
 
-            if (trace.pos && *trace.pos) {
+            if (printPosMaybe(oss, ellipsisIndent, trace.pos))
                 count++;
-
-                oss << "\n" << ellipsisIndent << ANSI_BLUE << "at " ANSI_WARNING << *trace.pos << ANSI_NORMAL << ":";
-
-                if (auto loc = trace.pos->getCodeLines()) {
-                    oss << "\n";
-                    printCodeLines(oss, "", *trace.pos, *loc);
-                    oss << "\n";
-                }
-            }
         }
         oss << "\n" << prefix;
     }
 
     oss << einfo.msg << "\n";
 
-    if (einfo.errPos && *einfo.errPos) {
-        oss << "\n" << ANSI_BLUE << "at " ANSI_WARNING << *einfo.errPos << ANSI_NORMAL << ":";
-
-        if (auto loc = einfo.errPos->getCodeLines()) {
-            oss << "\n";
-            printCodeLines(oss, "", *einfo.errPos, *loc);
-            oss << "\n";
-        }
-    }
+    printPosMaybe(oss, "", einfo.errPos);
 
     auto suggestions = einfo.suggestions.trim();
     if (!suggestions.suggestions.empty()) {

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -203,8 +203,6 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
 
     std::ostringstream oss;
 
-    auto noSource = ANSI_ITALIC " (source not available)" ANSI_NORMAL "\n";
-
     /*
      * Traces
      * ------
@@ -320,7 +318,7 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
 
             oss << "\n" << "… " << trace.hint.str() << "\n";
 
-            if (trace.pos) {
+            if (trace.pos && *trace.pos) {
                 count++;
 
                 oss << "\n" << ellipsisIndent << ANSI_BLUE << "at " ANSI_WARNING << *trace.pos << ANSI_NORMAL << ":";
@@ -329,8 +327,7 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
                     oss << "\n";
                     printCodeLines(oss, "", *trace.pos, *loc);
                     oss << "\n";
-                } else
-                    oss << noSource;
+                }
             }
         }
         oss << "\n" << prefix;
@@ -338,15 +335,14 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
 
     oss << einfo.msg << "\n";
 
-    if (einfo.errPos) {
+    if (einfo.errPos && *einfo.errPos) {
         oss << "\n" << ANSI_BLUE << "at " ANSI_WARNING << *einfo.errPos << ANSI_NORMAL << ":";
 
         if (auto loc = einfo.errPos->getCodeLines()) {
             oss << "\n";
             printCodeLines(oss, "", *einfo.errPos, *loc);
             oss << "\n";
-        } else
-            oss << noSource;
+        }
     }
 
     auto suggestions = einfo.suggestions.trim();

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -71,6 +71,13 @@ struct AbstractPos
     uint32_t column = 0;
 
     /**
+     * An AbstractPos may be a "null object", representing an unknown position.
+     *
+     * Return true if this position is known.
+     */
+    inline operator bool() const { return line != 0; };
+
+    /**
      * Return the contents of the source file.
      */
     virtual std::optional<std::string> getSource() const

--- a/tests/lang/eval-fail-fromTOML-timestamps.err.exp
+++ b/tests/lang/eval-fail-fromTOML-timestamps.err.exp
@@ -8,5 +8,3 @@ error:
             2|   key = "value"
 
        error: while parsing a TOML string: Dates and times are not supported
-
-       at «none»:0: (source not available)

--- a/tests/lang/eval-fail-hashfile-missing.err.exp
+++ b/tests/lang/eval-fail-hashfile-missing.err.exp
@@ -10,10 +10,6 @@ error:
 
        … while evaluating the first argument passed to builtins.toString
 
-         at «none»:0: (source not available)
-
        … while calling the 'hashFile' builtin
-
-         at «none»:0: (source not available)
 
        error: opening file '/pwd/lang/this-file-is-definitely-not-there-7392097': No such file or directory

--- a/tests/lang/eval-fail-set-override.err.exp
+++ b/tests/lang/eval-fail-set-override.err.exp
@@ -1,6 +1,4 @@
 error:
        … while evaluating the `__overrides` attribute
 
-         at «none»:0: (source not available)
-
        error: value is an integer while a set was expected

--- a/tests/lang/eval-fail-substring.err.exp
+++ b/tests/lang/eval-fail-substring.err.exp
@@ -8,5 +8,3 @@ error:
             2|
 
        error: negative start position in 'substring'
-
-       at «none»:0: (source not available)

--- a/tests/lang/eval-fail-to-path.err.exp
+++ b/tests/lang/eval-fail-to-path.err.exp
@@ -9,6 +9,4 @@ error:
 
        … while evaluating the first argument passed to builtins.toPath
 
-         at «none»:0: (source not available)
-
        error: string 'foo/bar' doesn't represent an absolute path


### PR DESCRIPTION
# Motivation

- Solve a UI annoyance
- Put the "infinite recursion at unknown location" meme to rest (together with #8879).

This does add environment variable `_NIX_DEVELOPER_SHOW_UNKNOWN_LOCATIONS` as it serves a purpose for improving error messages.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
