### PR TITLE
Test and begin documentation of the ATerm format for derivations

### DIFF
--- a/doc/manual/src/SUMMARY.md.in
+++ b/doc/manual/src/SUMMARY.md.in
@@ -100,6 +100,7 @@
   - [File System Object](architecture/file-system-object.md)
 - [Protocols](protocols/protocols.md)
   - [Serving Tarball Flakes](protocols/tarball-fetcher.md)
+  - [Derivation on-disk "ATerm" format](protocols/derivation-aterm.md)
 - [Glossary](glossary.md)
 - [Contributing](contributing/contributing.md)
   - [Hacking](contributing/hacking.md)

--- a/doc/manual/src/SUMMARY.md.in
+++ b/doc/manual/src/SUMMARY.md.in
@@ -100,7 +100,7 @@
   - [File System Object](architecture/file-system-object.md)
 - [Protocols](protocols/protocols.md)
   - [Serving Tarball Flakes](protocols/tarball-fetcher.md)
-  - [Derivation on-disk "ATerm" format](protocols/derivation-aterm.md)
+  - [Derivation "ATerm" file format](protocols/derivation-aterm.md)
 - [Glossary](glossary.md)
 - [Contributing](contributing/contributing.md)
   - [Hacking](contributing/hacking.md)

--- a/doc/manual/src/protocols/derivation-aterm.md
+++ b/doc/manual/src/protocols/derivation-aterm.md
@@ -1,4 +1,4 @@
-# Derivation on-disk "ATerm" format
+# Derivation "ATerm" file format
 
 For historical reasons, [derivations](@docroot@/glossary.md#gloss-store-derivation) are stored on-disk in [ATerm](https://homepages.cwi.nl/~daybuild/daily-books/technology/aterm-guide/aterm-guide.html) format.
 

--- a/doc/manual/src/protocols/derivation-aterm.md
+++ b/doc/manual/src/protocols/derivation-aterm.md
@@ -1,0 +1,9 @@
+# Derivation on-disk "ATerm" format
+
+For historical reasons, [derivations](@docroot@/glossary.md#gloss-store-derivation) are stored on-disk in [ATerm](https://homepages.cwi.nl/~daybuild/daily-books/technology/aterm-guide/aterm-guide.html) format.
+
+Derivations are serialised in the following format:
+
+```
+Derive(...)
+```


### PR DESCRIPTION
# Motivation

Wanted to do this before the last dynamic derivations PR when I introduce a variation, to make sure I wasn't changing the old version by mistake.

# Context

#4628 is the next one.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
