### PR TITLE
do not show configuration override flags for each command

### DIFF
--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -79,6 +79,10 @@ let
         # Options
 
         ${showOptions details.flags toplevel.flags}
+
+        > **Note**
+        >
+        > See [`man nix.conf`](@docroot@/command-ref/conf-file.md#command-line-flags) for overriding configuration settings with command line flags.
       '';
 
       showOptions = options: commonOptions:

--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -148,7 +148,7 @@ let
             To use this store, you need to make sure the corresponding experimental feature,
             [`${experimentalFeature}`](@docroot@/contributing/experimental-features.md#xp-feature-${experimentalFeature}),
             is enabled.
-            For example, include the following in [`nix.conf`](#):
+            For example, include the following in [`nix.conf`](@docroot@/command-ref/conf-file.md):
 
             ```
             extra-experimental-features = ${experimentalFeature}

--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -70,6 +70,7 @@ let
         * [`${command} ${name}`](./${appendName filename name}.md) - ${subcmd.description}
       '';
 
+      # TODO: move this confusing special case out of here when implementing #8496
       maybeDocumentation = optionalString
         (details ? doc)
         (replaceStrings ["@stores@"] [storeDocs] details.doc);

--- a/doc/manual/src/command-ref/opt-common.md
+++ b/doc/manual/src/command-ref/opt-common.md
@@ -203,3 +203,7 @@ Most Nix commands accept the following command-line options:
   Fix corrupted or missing store paths by redownloading or rebuilding them.
   Note that this is slow because it requires computing a cryptographic hash of the contents of every path in the closure of the build.
   Also note the warning under `nix-store --repair-path`.
+
+> **Note**
+>
+> See [`man nix.conf`](@docroot@/command-ref/conf-file.md#command-line-flags) for overriding configuration settings with command line flags.

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -236,6 +236,7 @@ nlohmann::json Args::toJSON()
 
     for (auto & [name, flag] : longFlags) {
         auto j = nlohmann::json::object();
+        if (hiddenCategories.count(flag->category)) continue;
         if (flag->aliases.count(name)) continue;
         if (flag->shortName)
             j["shortName"] = std::string(1, flag->shortName);


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
this removes a lot of noise from the web search, which precludes finding
the actual documentation.

# Context
@iFreilicht tried the alternative of including full setting documentation in each
command page, and we concluded that it doesn't make sense: https://github.com/NixOS/nix/pull/8818#issuecomment-1676145044

some configuration settings have enough documentation to warrant individual
pages.

this change technically means that the command line flags to override
settings are "invisible", and not exported as JSON. this may or may not
be desirable. a more explicit approach would be adding a `hidden` field
to the flag's JSON output, but would also require adjusting
post-processing of that JSON for manual rendering.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).