### PR TITLE
Improve derivation parsing

### DIFF
--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -154,8 +154,9 @@ static void expect(std::istream & str, std::string_view s)
 {
     char s2[s.size()];
     str.read(s2, s.size());
-    if (std::string(s2, s.size()) != s)
-        throw FormatError("expected string '%1%'", s);
+    std::string_view s2View { s2, s.size() };
+    if (s2View != s)
+        throw FormatError("expected string '%s', got '%s'", s, s2View);
 }
 
 
@@ -223,7 +224,8 @@ static DerivationOutput parseDerivationOutput(const Store & store,
         const auto hashType = parseHashType(hashAlgo);
         if (hashS == "impure") {
             experimentalFeatureSettings.require(Xp::ImpureDerivations);
-            assert(pathS == "");
+            if (pathS != "")
+                throw FormatError("impure derivation output should not specify output path");
             return DerivationOutput::Impure {
                 .method = std::move(method),
                 .hashType = std::move(hashType),
@@ -239,7 +241,8 @@ static DerivationOutput parseDerivationOutput(const Store & store,
             };
         } else {
             experimentalFeatureSettings.require(Xp::CaDerivations);
-            assert(pathS == "");
+            if (pathS != "")
+                throw FormatError("content-addressed derivation output should not specify output path");
             return DerivationOutput::CAFloating {
                 .method = std::move(method),
                 .hashType = std::move(hashType),


### PR DESCRIPTION
# Motivation

- Don't assert: Derivation ATerms are not necessarily produced by Nix, and parsers should always throw graceful errors

- Improve error message from `static void except(..)`, shows both what we expected and what we actually got.

# Context

The intention is that we backport it, and then hopefully a few people might get slightly better errors if they try out new experimental drv files (for RFC 92) with an old version of Nix.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
