### PR TITLE
always show anchors on setting listings

### DIFF
--- a/doc/manual/generate-settings.nix
+++ b/doc/manual/generate-settings.nix
@@ -3,18 +3,21 @@ let
   inherit (import ./utils.nix) concatStrings indent optionalString squash;
 in
 
-prefix: settingsInfo:
+# `inlineHTML` is a hack to accommodate inconsistent output from `lowdown`
+{ prefix, inlineHTML ? true }: settingsInfo:
 
 let
 
   showSetting = prefix: setting: { description, documentDefault, defaultValue, aliases, value, experimentalFeature }:
     let
       result = squash ''
-          - <span id="${prefix}-${setting}">[`${setting}`](#${prefix}-${setting})</span>
+          - ${item}
 
           ${indent "  " body}
         '';
-
+      item = if inlineHTML
+        then ''<span id="${prefix}-${setting}">[`${setting}`](#${prefix}-${setting})</span>''
+        else "`${setting}`";
       # separate body to cleanly handle indentation
       body = ''
           ${description}

--- a/doc/manual/generate-settings.nix
+++ b/doc/manual/generate-settings.nix
@@ -1,0 +1,63 @@
+let
+  inherit (builtins) attrValues concatStringsSep isAttrs isBool mapAttrs;
+  inherit (import ./utils.nix) concatStrings indent optionalString squash;
+in
+
+prefix: settingsInfo:
+
+let
+
+  showSetting = prefix: setting: { description, documentDefault, defaultValue, aliases, value, experimentalFeature }:
+    let
+      result = squash ''
+          - <span id="${prefix}-${setting}">[`${setting}`](#${prefix}-${setting})</span>
+
+          ${indent "  " body}
+        '';
+
+      # separate body to cleanly handle indentation
+      body = ''
+          ${description}
+
+          ${experimentalFeatureNote}
+
+          **Default:** ${showDefault documentDefault defaultValue}
+
+          ${showAliases aliases}
+        '';
+
+      experimentalFeatureNote = optionalString (experimentalFeature != null) ''
+          > **Warning**
+          > This setting is part of an
+          > [experimental feature](@docroot@/contributing/experimental-features.md).
+
+          To change this setting, you need to make sure the corresponding experimental feature,
+          [`${experimentalFeature}`](@docroot@/contributing/experimental-features.md#xp-feature-${experimentalFeature}),
+          is enabled.
+          For example, include the following in [`nix.conf`](#):
+
+          ```
+          extra-experimental-features = ${experimentalFeature}
+          ${setting} = ...
+          ```
+        '';
+
+      showDefault = documentDefault: defaultValue:
+        if documentDefault then
+          # a StringMap value type is specified as a string, but
+          # this shows the value type. The empty stringmap is `null` in
+          # JSON, but that converts to `{ }` here.
+          if defaultValue == "" || defaultValue == [] || isAttrs defaultValue
+            then "*empty*"
+            else if isBool defaultValue then
+              if defaultValue then "`true`" else "`false`"
+            else "`${toString defaultValue}`"
+        else "*machine-specific*";
+
+      showAliases = aliases:
+          optionalString (aliases != [])
+            "**Deprecated alias:** ${(concatStringsSep ", " (map (s: "`${s}`") aliases))}";
+
+    in result;
+
+in concatStrings (attrValues (mapAttrs (showSetting prefix) settingsInfo))

--- a/doc/manual/generate-store-info.nix
+++ b/doc/manual/generate-store-info.nix
@@ -4,7 +4,7 @@ let
   showSettings = import ./generate-settings.nix;
 in
 
-storesInfo:
+inlineHTML: storesInfo:
 
 let
 
@@ -20,7 +20,7 @@ let
 
       ### Settings
 
-      ${showSettings "store-${slug}" settings}
+      ${showSettings { prefix = "store-${slug}"; inherit inlineHTML; } settings}
     '';
 
       # markdown doesn't like spaces in URLs

--- a/doc/manual/generate-store-info.nix
+++ b/doc/manual/generate-store-info.nix
@@ -1,0 +1,45 @@
+let
+  inherit (builtins) attrValues mapAttrs;
+  inherit (import ./utils.nix) concatStrings optionalString;
+  showSettings = import ./generate-settings.nix;
+in
+
+storesInfo:
+
+let
+
+  showStore = name: { settings, doc, experimentalFeature }:
+    let
+
+    result = ''
+      ## ${name}
+
+      ${doc}
+
+      ${experimentalFeatureNote}
+
+      ### Settings
+
+      ${showSettings "store-${slug}" settings}
+    '';
+
+      # markdown doesn't like spaces in URLs
+      slug = builtins.replaceStrings [ " " ] [ "-" ] name;
+
+    experimentalFeatureNote = optionalString (experimentalFeature != null) ''
+      > **Warning**
+      > This store is part of an
+      > [experimental feature](@docroot@/contributing/experimental-features.md).
+
+      To use this store, you need to make sure the corresponding experimental feature,
+      [`${experimentalFeature}`](@docroot@/contributing/experimental-features.md#xp-feature-${experimentalFeature}),
+      is enabled.
+      For example, include the following in [`nix.conf`](#):
+
+      ```
+      extra-experimental-features = ${experimentalFeature}
+      ```
+    '';
+  in result;
+
+in concatStrings (attrValues (mapAttrs showStore storesInfo))

--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -98,12 +98,12 @@ $(d)/src/SUMMARY.md: $(d)/src/SUMMARY.md.in $(d)/src/command-ref/new-cli $(d)/sr
 
 $(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/utils.nix $(d)/generate-manpage.nix $(d)/generate-settings.nix $(d)/generate-store-info.nix $(bindir)/nix
 	@rm -rf $@ $@.tmp
-	$(trace-gen) $(nix-eval) --write-to $@.tmp --expr 'import doc/manual/generate-manpage.nix (builtins.readFile $<)'
+	$(trace-gen) $(nix-eval) --write-to $@.tmp --expr 'import doc/manual/generate-manpage.nix true (builtins.readFile $<)'
 	@mv $@.tmp $@
 
 $(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/utils.nix $(d)/generate-settings.nix $(d)/src/command-ref/conf-file-prefix.md $(d)/src/command-ref/experimental-features-shortlist.md $(bindir)/nix
 	@cat doc/manual/src/command-ref/conf-file-prefix.md > $@.tmp
-	$(trace-gen) $(nix-eval) --expr 'import doc/manual/generate-settings.nix "opt-" (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp;
+	$(trace-gen) $(nix-eval) --expr 'import doc/manual/generate-settings.nix { prefix = "opt-"; } (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp;
 	@mv $@.tmp $@
 
 $(d)/nix.json: $(bindir)/nix

--- a/doc/manual/local.mk
+++ b/doc/manual/local.mk
@@ -96,14 +96,14 @@ $(d)/src/SUMMARY.md: $(d)/src/SUMMARY.md.in $(d)/src/command-ref/new-cli $(d)/sr
 	@cp $< $@
 	@$(call process-includes,$@,$@)
 
-$(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/utils.nix $(d)/generate-manpage.nix $(bindir)/nix
+$(d)/src/command-ref/new-cli: $(d)/nix.json $(d)/utils.nix $(d)/generate-manpage.nix $(d)/generate-settings.nix $(d)/generate-store-info.nix $(bindir)/nix
 	@rm -rf $@ $@.tmp
 	$(trace-gen) $(nix-eval) --write-to $@.tmp --expr 'import doc/manual/generate-manpage.nix (builtins.readFile $<)'
 	@mv $@.tmp $@
 
-$(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/utils.nix $(d)/src/command-ref/conf-file-prefix.md $(d)/src/command-ref/experimental-features-shortlist.md $(bindir)/nix
+$(d)/src/command-ref/conf-file.md: $(d)/conf-file.json $(d)/utils.nix $(d)/generate-settings.nix $(d)/src/command-ref/conf-file-prefix.md $(d)/src/command-ref/experimental-features-shortlist.md $(bindir)/nix
 	@cat doc/manual/src/command-ref/conf-file-prefix.md > $@.tmp
-	$(trace-gen) $(nix-eval) --expr '(import doc/manual/utils.nix).showSettings { useAnchors = true; } (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp;
+	$(trace-gen) $(nix-eval) --expr 'import doc/manual/generate-settings.nix "opt-" (builtins.fromJSON (builtins.readFile $<))' >> $@.tmp;
 	@mv $@.tmp $@
 
 $(d)/nix.json: $(bindir)/nix

--- a/doc/manual/utils.nix
+++ b/doc/manual/utils.nix
@@ -44,63 +44,6 @@ rec {
 
   optionalString = cond: string: if cond then string else "";
 
-  showSetting = { useAnchors }: name: { description, documentDefault, defaultValue, aliases, value, experimentalFeature }:
-    let
-      result = squash ''
-          - ${if useAnchors
-              then ''<span id="conf-${name}">[`${name}`](#conf-${name})</span>''
-              else ''`${name}`''}
-
-          ${indent "  " body}
-        '';
-
-      experimentalFeatureNote = optionalString (experimentalFeature != null) ''
-          > **Warning**
-          > This setting is part of an
-          > [experimental feature](@docroot@/contributing/experimental-features.md).
-
-          To change this setting, you need to make sure the corresponding experimental feature,
-          [`${experimentalFeature}`](@docroot@/contributing/experimental-features.md#xp-feature-${experimentalFeature}),
-          is enabled.
-          For example, include the following in [`nix.conf`](#):
-
-          ```
-          extra-experimental-features = ${experimentalFeature}
-          ${name} = ...
-          ```
-        '';
-
-      # separate body to cleanly handle indentation
-      body = ''
-          ${description}
-
-          ${experimentalFeatureNote}
-
-          **Default:** ${showDefault documentDefault defaultValue}
-
-          ${showAliases aliases}
-        '';
-
-      showDefault = documentDefault: defaultValue:
-        if documentDefault then
-          # a StringMap value type is specified as a string, but
-          # this shows the value type. The empty stringmap is `null` in
-          # JSON, but that converts to `{ }` here.
-          if defaultValue == "" || defaultValue == [] || isAttrs defaultValue
-            then "*empty*"
-            else if isBool defaultValue then
-              if defaultValue then "`true`" else "`false`"
-            else "`${toString defaultValue}`"
-        else "*machine-specific*";
-
-      showAliases = aliases:
-          optionalString (aliases != [])
-            "**Deprecated alias:** ${(concatStringsSep ", " (map (s: "`${s}`") aliases))}";
-
-    in result;
-
   indent = prefix: s:
     concatStringsSep "\n" (map (x: if x == "" then x else "${prefix}${x}") (splitLines s));
-
-  showSettings = args: settingsInfo: concatStrings (attrValues (mapAttrs (showSetting args) settingsInfo));
 }

--- a/src/nix/local.mk
+++ b/src/nix/local.mk
@@ -31,7 +31,7 @@ src/nix/develop.cc: src/nix/get-env.sh.gen.hh
 
 src/nix-channel/nix-channel.cc: src/nix-channel/unpack-channel.nix.gen.hh
 
-src/nix/main.cc: doc/manual/generate-manpage.nix.gen.hh doc/manual/utils.nix.gen.hh
+src/nix/main.cc: doc/manual/generate-manpage.nix.gen.hh doc/manual/utils.nix.gen.hh doc/manual/generate-settings.nix.gen.hh doc/manual/generate-store-info.nix.gen.hh
 
 src/nix/doc/files/%.md: doc/manual/src/command-ref/files/%.md
 	@mkdir -p $$(dirname $@)

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -214,6 +214,22 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
             , CanonPath::root),
         *vUtils);
 
+    auto vSettingsInfo = state.allocValue();
+    state.cacheFile(
+        CanonPath("/generate-settings.nix"), CanonPath("/generate-settings.nix"),
+        state.parseExprFromString(
+            #include "generate-settings.nix.gen.hh"
+            , CanonPath::root),
+        *vSettingsInfo);
+
+    auto vStoreInfo = state.allocValue();
+    state.cacheFile(
+        CanonPath("/generate-store-info.nix"), CanonPath("/generate-store-info.nix"),
+        state.parseExprFromString(
+            #include "generate-store-info.nix.gen.hh"
+            , CanonPath::root),
+        *vStoreInfo);
+
     auto vDump = state.allocValue();
     vDump->mkString(toplevel.dumpCli());
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -234,7 +234,8 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
     vDump->mkString(toplevel.dumpCli());
 
     auto vRes = state.allocValue();
-    state.callFunction(*vGenerateManpage, *vDump, *vRes, noPos);
+    state.callFunction(*vGenerateManpage, state.getBuiltin("false"), *vRes, noPos);
+    state.callFunction(*vRes, *vDump, *vRes, noPos);
 
     auto attr = vRes->attrs->get(state.symbols.create(mdName + ".md"));
     if (!attr)


### PR DESCRIPTION
# Motivation

The `nix store-info` manual page lists store parameters without anchor links. The page is quite long and one can't point readers to a particular parameter, many of which are non-trivial to describe or specific to a particular store.

# Context

This change is also a cleanup refactoring of the manual rendering code. It moves the expressions for formatting general settings listings and the store-specific documentation into separate files, and recovers `utils.nix` to be a little helper library that is not specific to any particular use case in the manual rendering code.

Other than that, the user-visible change is insignificant: it just adds anchors to the list items, with a prefix derived from the store name.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).