### PR TITLE
docs: fixed the default priority of nix-env --install

### DIFF
--- a/doc/manual/src/command-ref/nix-env/install.md
+++ b/doc/manual/src/command-ref/nix-env/install.md
@@ -30,7 +30,7 @@ a number of possible ways:
     derivation with the highest *priority* is used. A derivation can
     define a priority by declaring the `meta.priority` attribute. This
     attribute should be a number, with a higher value denoting a lower
-    priority. The default priority is `0`.
+    priority. The default priority is `5`.
 
     If there are multiple matching derivations with the same priority,
     then the derivation with the highest version will be installed.


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

The docs says that the default priority of packages installed via nix-env --install is 0, but it's actually 5:

```bash
nix-env -iA nixpkgs.cowsay
nix-env -iA nixpkgs.neo-cowsay ## Fails due to the conflict with the other cowsay package
nix-env --set-flag priority 5 cowsay 
nix-env -iA nixpkgs.neo-cowsay ## Still fails, meaning that the default priority is 5
nix-env --set-flag priority 0 cowsay
nix-env -iA nixpkgs.neo-cowsay ## Succeeds, showing that the default priority can't be 0

```

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
