### PR TITLE
fix: `nix shell` multiple commands example

### DIFF
--- a/src/nix/shell.md
+++ b/src/nix/shell.md
@@ -26,7 +26,7 @@ R""(
 * Run multiple commands in a shell environment:
 
   ```console
-  # nix shell nixpkgs#gnumake --command sh --command "cd src && make"
+  # nix shell nixpkgs#gnumake --command sh -c "cd src && make"
   ```
 
 * Run GNU Hello in a chroot store:


### PR DESCRIPTION
As it stands, the command errors with:

```
$ nix shell nixpkgs#gnumake --command sh --command "cd src && make"
sh: --command: invalid option
```

https://github.com/NixOS/nix/pull/8276 was good for readability, but it missed this since that PR used a find/replace script. The `-c` flag originally belonged to `sh` not `nix shell`.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
