### PR TITLE
docs: fix the nix develop --command example

### DIFF
--- a/src/nix/develop.md
+++ b/src/nix/develop.md
@@ -69,7 +69,7 @@ R""(
 * Run a series of script commands:
 
   ```console
-  # nix develop --command bash --command "mkdir build && cmake .. && make"
+  # nix develop --command bash -c "mkdir build && cmake .. && make"
   ```
 
 # Description


### PR DESCRIPTION
# Motivation
One of the examples in the docs for the nix develop command is:

`nix develop --command bash --command "mkdir build && cmake .. && make"`

- The example can be incorrectly interpreted to mean that `nix develop` accepts multiple --command flags, which it does not. In this example the first --command is a flag for `nix develop` and the second --command is a flag for `bash`
- As far as I can tell bash does not actually have a --command flag, but only a -c flag, so the example does not work

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
