### PR TITLE
override ttl for some git fetchers

### DIFF
--- a/src/libfetchers/cache.hh
+++ b/src/libfetchers/cache.hh
@@ -18,7 +18,8 @@ struct Cache
 
     virtual std::optional<std::pair<Attrs, StorePath>> lookup(
         ref<Store> store,
-        const Attrs & inAttrs) = 0;
+        const Attrs & inAttrs,
+        bool useShortTtl = false) = 0;
 
     struct Result
     {
@@ -29,7 +30,8 @@ struct Cache
 
     virtual std::optional<Result> lookupExpired(
         ref<Store> store,
-        const Attrs & inAttrs) = 0;
+        const Attrs & inAttrs,
+        bool useShortTtl = false) = 0;
 };
 
 ref<Cache> getCache();

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -166,7 +166,8 @@ DownloadFileResult downloadFile(
     const std::string & url,
     const std::string & name,
     bool locked,
-    const Headers & headers = {});
+    const Headers & headers = {},
+    bool useShortTtl = false);
 
 struct DownloadTarballResult
 {

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -496,14 +496,14 @@ struct GitInputScheme : InputScheme
                     unlockedAttrs.insert_or_assign("ref", input.getRef().value());
                 }
             }
-
             if (auto res = getCache()->lookup(store, unlockedAttrs)) {
                 auto rev2 = Hash::parseAny(getStrAttr(res->first, "rev"), htSHA1);
-                if (!input.getRev() || input.getRev() == rev2) {
-                    input.attrs.insert_or_assign("rev", rev2.gitRev());
+                if (input.getRev() == rev2) {
                     return makeResult(res->first, std::move(res->second));
                 }
             }
+
+            // XXX TODO: Do a lightweight fetch to find out what the head and head commit is.
 
             Path cacheDir = getCachePath(actualUrl);
             repoDir = cacheDir;

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -269,7 +269,7 @@ struct GitHubInputScheme : GitArchiveInputScheme
         auto json = nlohmann::json::parse(
             readFile(
                 store->toRealPath(
-                    downloadFile(store, url, "source", false, headers).storePath)));
+                    downloadFile(store, url, "source", false, headers, true).storePath)));
         auto rev = Hash::parseAny(std::string { json["sha"] }, htSHA1);
         debug("HEAD revision for '%s' is %s", url, rev.gitRev());
         return rev;
@@ -341,7 +341,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
         auto json = nlohmann::json::parse(
             readFile(
                 store->toRealPath(
-                    downloadFile(store, url, "source", false, headers).storePath)));
+                    downloadFile(store, url, "source", false, headers, true).storePath)));
         auto rev = Hash::parseAny(std::string(json[0]["id"]), htSHA1);
         debug("HEAD revision for '%s' is %s", url, rev.gitRev());
         return rev;
@@ -404,7 +404,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::string refUri;
         if (ref == "HEAD") {
             auto file = store->toRealPath(
-                downloadFile(store, fmt("%s/HEAD", base_url), "source", false, headers).storePath);
+                downloadFile(store, fmt("%s/HEAD", base_url), "source", false, headers, true).storePath);
             std::ifstream is(file);
             std::string line;
             getline(is, line);
@@ -420,7 +420,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::regex refRegex(refUri);
 
         auto file = store->toRealPath(
-            downloadFile(store, fmt("%s/info/refs", base_url), "source", false, headers).storePath);
+            downloadFile(store, fmt("%s/info/refs", base_url), "source", false, headers, true).storePath);
         std::ifstream is(file);
 
         std::string line;

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -15,7 +15,8 @@ DownloadFileResult downloadFile(
     const std::string & url,
     const std::string & name,
     bool locked,
-    const Headers & headers)
+    const Headers & headers,
+    bool useShortTtl)
 {
     // FIXME: check store
 
@@ -25,7 +26,7 @@ DownloadFileResult downloadFile(
         {"name", name},
     });
 
-    auto cached = getCache()->lookupExpired(store, inAttrs);
+    auto cached = getCache()->lookupExpired(store, inAttrs, useShortTtl);
 
     auto useCached = [&]() -> DownloadFileResult
     {

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -641,19 +641,41 @@ public:
     Setting<unsigned int> tarballTtl{
         this, 60 * 60, "tarball-ttl",
         R"(
-          The number of seconds a downloaded tarball is considered fresh. If
-          the cached tarball is stale, Nix will check whether it is still up
+          The number of seconds a downloaded file is considered fresh. If
+          the cached file is stale, Nix will check whether it is still up
           to date using the ETag header. Nix will download a new version if
           the ETag header is unsupported, or the cached ETag doesn't match.
 
-          Setting the TTL to `0` forces Nix to always check if the tarball is
+          Setting the TTL to `0` forces Nix to always check if the file is
           up to date.
 
-          Nix caches tarballs in `$XDG_CACHE_HOME/nix/tarballs`.
+          Nix caches files in `$XDG_CACHE_HOME/nix`.
 
           Files fetched via `NIX_PATH`, `fetchGit`, `fetchMercurial`,
           `fetchTarball`, and `fetchurl` respect this TTL.
         )"};
+
+    Setting<unsigned int> shortTtl{
+        this, 5, "short-ttl",
+        R"(
+          The number of seconds a downloaded file is considered fresh. If
+          the cached file is stale, Nix will check whether it is still up
+          to date using the ETag header. Nix will download a new version if
+          the ETag header is unsupported, or the cached ETag doesn't match.
+
+          The short TTL is used for files that are expected to change often,
+          such as API calls.
+
+          Setting the TTL to `0` forces Nix to always check if the file is
+          up to date.
+
+          Nix caches files in `$XDG_CACHE_HOME/nix`.
+
+          Currently, only calls that fetch git repository information as part
+          of the implementation of fetchers such as `fetchGit`, `fetchTree`
+          respect this TTL.
+        )"};
+
 
     Setting<bool> requireSigs{
         this, true, "require-sigs",


### PR DESCRIPTION
# Motivation

when you "use a repo in nix, push, use it again" the new commits don't show up

I want a lower ttl where relevant.

# Context

People complained about this in #4007 and #6830

This adds an option called `short-ttl` that is supposed to be used for fetches that are expected to change over the course of a session (git api calls).

I have added using the short ttl for the `getRevFromRef` in `github.cc`, added a `useShortTtl` parameter (optional, look out) to `lookup`,`lookupExpired` and 

In `git.cc` I removed using the cache at all when using a ref, as I did not see a quick way to disentangle `ref` and `rev` code paths for more effort.

I think this PR could be merged without the `git.cc` change, but this could also be a bigger PR that revamps the fetching mechanism for git.cc a bit (it's a bit messy imo)
