### PR TITLE
Print parent activity field in json log

### DIFF
--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -220,8 +220,8 @@ struct JSONLogger : Logger {
         json["level"] = lvl;
         json["type"] = type;
         json["text"] = s;
+        json["parent"] = parent;
         addFields(json, fields);
-        // FIXME: handle parent
         write(json);
     }
 


### PR DESCRIPTION
# Motivation

For consumers of the json output it can be hard to determine the relation between activities.
This is especially problematic with downloads:

```
@nix {"action":"start","fields":["/nix/store/57j9qf4lr4iqjgp45yn9qy4amm9a244f-nix-output-monitor-2.0.0.6","https://cache.nixos.org","local"],"id":9483167530483720,"level":3,"text":"copying path '/nix/store/57j9qf4lr4iqjgp45yn9qy4amm9a244f-nix-output-monitor-2.0.0.6' from 'https://cache.nixos.org'","type":100}
@nix {"action":"start","fields":["https://cache.nixos.org/nar/163j1156948k3rimk2higcr8nrznsp433zn7aaxn7iqqhacvdd57.nar.xz"],"id":9483167530483721,"level":4,"text":"downloading 'https://cache.nixos.org/nar/163j1156948k3rimk2higcr8nrznsp433zn7aaxn7iqqhacvdd57.nar.xz'","type":101}
```

If there are multiple downloads going in parallel there is no way to tell that those two belong together.
(I have not found a way to do a lookup `hash -> outpath` or `outpath -> hash` without root or network access.)

However, with the `parent` field exposed which conveniently is already present in the source code this looks like this:


```
@nix {"action":"start","fields":["/nix/store/57j9qf4lr4iqjgp45yn9qy4amm9a244f-nix-output-monitor-2.0.0.6","https://cache.nixos.org","local"],"id":9483167530483720,"level":3,"parent":9483167530483719,"text":"copying path '/nix/store/57j9qf4lr4iqjgp45yn9qy4amm9a244f-nix-output-monitor-2.0.0.6' from 'https://cache.nixos.org'","type":100}
@nix {"action":"start","fields":["https://cache.nixos.org/nar/163j1156948k3rimk2higcr8nrznsp433zn7aaxn7iqqhacvdd57.nar.xz"],"id":9483167530483721,"level":4,"parent":9483167530483720,"text":"downloading 'https://cache.nixos.org/nar/163j1156948k3rimk2higcr8nrznsp433zn7aaxn7iqqhacvdd57.nar.xz'","type":101}
```

Now the activity graph can be safely correlated.
For a lot of activities the parent id is 0, but I think that’s fine.

As you see this change removes a “fixme” comment from 2017 by @edolstra.
I quickly talked to him about this at nixcon.
He couldn’t remember why he didn’t do what I am doing in this commit.
Without looking at the code he suspected concurrency issues, but I think since the parent variable is just a local uint64_t I don’t see how this could go wrong.

I believe breakage caused by this PR will be very minimal and the internal-json format is called "internal" for a reason.

Merging this would unblock nix-output-monitor and I would be very grateful if we could do this soon.

<!-- Briefly explain what the change is about and why it is desirable. -->

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
