### PR TITLE
Drop dead code

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -520,11 +520,6 @@ LockedFlake lockFlake(
                             }
                         }
 
-                        auto localPath(parentPath);
-                        // If this input is a path, recurse it down.
-                        // This allows us to resolve path inputs relative to the current flake.
-                        if ((*input.ref).input.getType() == "path")
-                            localPath = absPath(*input.ref->input.getSourcePath(), parentPath);
                         computeLocks(
                             mustRefetch
                             ? getFlake(state, oldLock->lockedRef, false, flakeCache, inputPath).inputs


### PR DESCRIPTION
@balsoft looks like you added these lines: https://github.com/NixOS/nix/pull/6036/files#diff-d4441d6156ea52c005e1517d6da41bdf989cff029b61d5f3e9f662a51861f5f2R486-R490

I wonder if I'm being stupid and missing something obvious, but as far as I can tell `localPath` is unused. Looks like an identically named variable is used in another call to `computeLocks`, but not this one.