### PR TITLE
make fetchClosure non-experimental

### DIFF
--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -208,7 +208,7 @@ static void prim_fetchClosure(EvalState & state, const PosIdx pos, Value * * arg
 }
 
 static RegisterPrimOp primop_fetchClosure({
-    .name = "__fetchClosure",
+    .name = "fetchClosure",
     .args = {"args"},
     .doc = R"(
       Fetch a store path [closure](@docroot@/glossary.md#gloss-closure) from a binary cache, and return the store path as a string with context.
@@ -279,8 +279,7 @@ static RegisterPrimOp primop_fetchClosure({
       However, `fetchClosure` is more reproducible because it specifies a binary cache from which the path can be fetched.
       Also, using content-addressed store paths does not require users to configure [`trusted-public-keys`](@docroot@/command-ref/conf-file.md#conf-trusted-public-keys) to ensure their authenticity.
     )",
-    .fun = prim_fetchClosure,
-    .experimentalFeature = Xp::FetchClosure,
+    .fun = prim_fetchClosure
 });
 
 }

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -12,7 +12,7 @@ struct ExperimentalFeatureDetails
     std::string_view description;
 };
 
-constexpr std::array<ExperimentalFeatureDetails, 14> xpFeatureDetails = {{
+constexpr std::array<ExperimentalFeatureDetails, 13> xpFeatureDetails = {{
     {
         .tag = Xp::CaDerivations,
         .name = "ca-derivations",
@@ -150,13 +150,6 @@ constexpr std::array<ExperimentalFeatureDetails, 14> xpFeatureDetails = {{
             special properties that distinguish them from regular strings, URLs
             containing parameters have to be quoted anyway, and unquoted URLs
             may confuse external tooling.
-        )",
-    },
-    {
-        .tag = Xp::FetchClosure,
-        .name = "fetch-closure",
-        .description = R"(
-            Enable the use of the [`fetchClosure`](@docroot@/language/builtins.md#builtins-fetchClosure) built-in function in the Nix language.
         )",
     },
     {

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -23,7 +23,6 @@ enum struct ExperimentalFeature
     NixCommand,
     RecursiveNix,
     NoUrlLiterals,
-    FetchClosure,
     ReplFlake,
     AutoAllocateUids,
     Cgroups,

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -358,7 +358,6 @@ void mainWrapped(int argc, char * * argv)
     if (argc == 2 && std::string(argv[1]) == "__dump-language") {
         experimentalFeatureSettings.experimentalFeatures = {
             Xp::Flakes,
-            Xp::FetchClosure,
             Xp::DynamicDerivations,
         };
         evalSettings.pureEval = false;

--- a/tests/fetchClosure.sh
+++ b/tests/fetchClosure.sh
@@ -1,7 +1,5 @@
 source common.sh
 
-enableFeatures "fetch-closure"
-
 clearStore
 clearCacheCache
 


### PR DESCRIPTION
# Motivation

`builtins.fetchClosure` has been around for quite some time already, and is used by various people without any issues.

I think this should finally be removed from the list of experimental features.

# Context

This should be a rather trivial change. Pinging @roberth for review.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).