### PR TITLE
WIP Allow users to change chrootRootDirBase location

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -651,7 +651,10 @@ void LocalDerivationGoal::startBuilder()
            environment using bind-mounts.  We put it in the Nix store
            to ensure that we can create hard-links to non-directory
            inputs in the fake Nix store in the chroot (see below). */
-        chrootRootDir = worker.store.Store::toRealPath(drvPath) + ".chroot";
+        chrootRootDirBase = worker.store.storeDir;
+        createDirs(chrootRootDirBase);
+
+        chrootRootDir = chrootRootDirBase + "/" + drvPath.to_string() + ".chroot";
         deletePath(chrootRootDir);
 
         /* Clean up the chroot directory automatically. */

--- a/src/libstore/build/local-derivation-goal.hh
+++ b/src/libstore/build/local-derivation-goal.hh
@@ -64,6 +64,7 @@ struct LocalDerivationGoal : public DerivationGoal
      */
     bool useChroot = false;
 
+    Path chrootRootDirBase;
     Path chrootRootDir;
 
     /**


### PR DESCRIPTION
Partially depends on https://github.com/NixOS/nix/pull/8965 to not copy files to the chroot, could be merged without it.

WIP Allow users to change chrootRootDirBase location

This allows users to change the location of chrootRootDir, to, for example, a tmpfs.

inspired by trofi on matrix

> It looks like build sandbox created by nix-daemon runs on the same filesystem, as /nix/store including things like /tmp which makes all small temporary files hit the disk. Is it intentional? If it is is there an easy way to redirect chroot's root to be tmpfs?


# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
