### PR TITLE
Use  option in seq for zero-padded numbers

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -33,7 +33,7 @@ sudo rm -rf /etc/nix /etc/profile.d/nix.sh /etc/tmpfiles.d/nix-daemon.conf /nix 
 Remove build users and their group:
 
 ```console
-for i in $(seq 1 32); do
+for i in $(seq -w 1 32); do
   sudo userdel nixbld$i
 done
 sudo groupdel nixbld
@@ -145,4 +145,3 @@ which you may remove.
 > complete. macOS (Catalina+) directly controls root directories and its
 > read-only root will prevent you from manually deleting the empty `/nix`
 > mountpoint.
-


### PR DESCRIPTION
# Motivation
The current loop logic in our script doesn't correctly handle numbers less than 10, leading them to be displayed without a preceding zero. This results in inconsistent formatting. The change aims to ensure all numbers in the sequence have consistent formatting, with numbers below 10 having a zero prefix.

# Context
- This change addresses a formatting inconsistency in our sequence generation logic.
- I've faced this issue on my machine which appears as so:
```sh
% for i in $(seq 1 32); do
  sudo userdel nixbld$i
done
sudo groupdel nixbld

userdel: user 'nixbld1' does not exist
userdel: user 'nixbld2' does not exist
userdel: user 'nixbld3' does not exist
userdel: user 'nixbld4' does not exist
userdel: user 'nixbld5' does not exist
userdel: user 'nixbld6' does not exist
userdel: user 'nixbld7' does not exist
userdel: user 'nixbld8' does not exist
userdel: user 'nixbld9' does not exist
userdel: user 'nixbld11' does not exist
userdel: user 'nixbld12' does not exist
userdel: user 'nixbld13' does not exist
userdel: user 'nixbld14' does not exist
userdel: user 'nixbld15' does not exist
userdel: user 'nixbld16' does not exist
userdel: user 'nixbld17' does not exist
userdel: user 'nixbld18' does not exist
userdel: user 'nixbld19' does not exist
userdel: user 'nixbld20' does not exist
userdel: user 'nixbld21' does not exist
userdel: user 'nixbld22' does not exist
userdel: user 'nixbld23' does not exist
userdel: user 'nixbld24' does not exist
userdel: user 'nixbld25' does not exist
userdel: user 'nixbld26' does not exist
userdel: user 'nixbld27' does not exist
userdel: user 'nixbld28' does not exist
userdel: user 'nixbld29' does not exist
userdel: user 'nixbld30' does not exist
userdel: user 'nixbld31' does not exist
userdel: user 'nixbld32' does not exist
groupdel: cannot remove the primary group of user 'nixbld01'
```
- Non-trivial change: The implementation involves the introduction of the `-w` option in the `seq` command, ensuring all generated numbers in the sequence are of the same width, with padding using zeros when necessary.

# Priorities
This is a minor yet essential change to ensure consistency in our scripts. Given its straightforward nature, reviewing this pull request should be quick. 

