### PR TITLE
Fix #8976

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -580,10 +580,10 @@ LockedFlake lockFlake(
                                     inputFlake.sourceInfo->actualPath
                                      + "/"
                                      + inputFlake.lockedRef.subdir
-                                     + "/flake.lock").root.get_ptr(),
+                                     + "/flake.lock").root.get_ptr();
                             computeLocks(
                                 inputFlake.inputs, childNode, inputPath,
-                                upstreamLock inputPath, localPath, false);
+                                upstreamLock, inputPath, localPath, false);
                         }
 
                         else {


### PR DESCRIPTION
Transitive dependencies (dependencies of inputs) should be considered part of that input, and any time the input is updated, those dependencies need to be updated to match the new upstream lockfile.

What we have now is similar to the inconsistent state you end up in when you checkout a git revision without updating the submodules.

# Motivation

see #8976