### PR TITLE
Stabilise nix nar subcommands

### DIFF
--- a/src/nix/nar-pack.md
+++ b/src/nix/nar-pack.md
@@ -5,7 +5,7 @@ R""(
 * To serialise directory `foo` as a NAR:
 
   ```console
-  # nix nar dump-path ./foo > foo.nar
+  # nix nar pack ./foo > foo.nar
   ```
 
 # Description

--- a/src/nix/pack.cc
+++ b/src/nix/pack.cc
@@ -28,11 +28,11 @@ struct CmdDumpPath : StorePathCommand
 
 static auto rDumpPath = registerCommand2<CmdDumpPath>({"store", "dump-path"});
 
-struct CmdDumpPath2 : Command
+struct CmdNarPack : Command
 {
     Path path;
 
-    CmdDumpPath2()
+    CmdNarPack()
     {
         expectArgs({
             .label = "path",
@@ -49,7 +49,7 @@ struct CmdDumpPath2 : Command
     std::string doc() override
     {
         return
-          #include "nar-dump-path.md"
+          #include "nar-pack.md"
           ;
     }
 
@@ -61,4 +61,4 @@ struct CmdDumpPath2 : Command
     }
 };
 
-static auto rDumpPath2 = registerCommand2<CmdDumpPath2>({"nar", "dump-path"});
+static auto rNarPack = registerCommand2<CmdNarPack>({"nar", "pack"});


### PR DESCRIPTION
# Motivation
* Renamed the command `nar dump-path` to `nar pack`

# Context
This change is required in #8875 

# Changes made:
* Renamed `dump-path.cc` to `pack.cc`
* Renamed `nar-dump-path.md` to `nar-pack.md`

# Screenshot
![image](https://github.com/NixOS/nix/assets/24916780/2afbc3bc-223d-4afd-920c-6e2f9eb83e1a)


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
