### PR TITLE
fix some nix commands not creating the user's default profile if missing

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -252,7 +252,7 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
     throw Error("get-env.sh failed to produce an environment");
 }
 
-struct Common : InstallableCommand, MixProfile
+struct Common : InstallableCommand, MixDefaultProfile
 {
     std::set<std::string> ignoreVars{
         "BASHOPTS",

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -743,7 +743,7 @@ struct CmdFlakeCheck : FlakeCommand
 static Strings defaultTemplateAttrPathsPrefixes{"templates."};
 static Strings defaultTemplateAttrPaths = {"templates.default", "defaultTemplate"};
 
-struct CmdFlakeInitCommon : virtual Args, EvalCommand
+struct CmdFlakeInitCommon : virtual Args, EvalCommand, MixDefaultProfile
 {
     std::string templateUrl = "templates";
     Path destDir;

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -64,7 +64,7 @@ void runProgramInStore(ref<Store> store,
 
 }
 
-struct CmdShell : InstallablesCommand, MixEnvironment
+struct CmdShell : InstallablesCommand, MixEnvironment, MixDefaultProfile
 {
 
     using InstallablesCommand::run;
@@ -137,7 +137,7 @@ struct CmdShell : InstallablesCommand, MixEnvironment
 
 static auto rCmdShell = registerCommand<CmdShell>("shell");
 
-struct CmdRun : InstallableValueCommand
+struct CmdRun : InstallableValueCommand, MixDefaultProfile
 {
     using InstallableCommand::run;
 

--- a/tests/flakes/commands-create-profile.sh
+++ b/tests/flakes/commands-create-profile.sh
@@ -1,0 +1,51 @@
+source ../common.sh
+
+clearStore
+rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
+cp ../shell-hello.nix ../config.nix $TEST_HOME
+cd $TEST_HOME
+
+mkdir -p template
+
+cat >flake.nix <<EOF
+{
+  description = "Bla bla";
+
+  outputs = inputs: rec {
+    checks.$system = { };
+    devShells.$system = { };
+    legacyPackages.$system = { };
+    packages.$system.pkgAsPkg = (import ./shell-hello.nix).hello;
+    packages.someOtherSystem = { };
+
+    formatter = { };
+    nixosConfigurations = { };
+    nixosModules = { };
+    templates.default = { path = ./template; };
+  };
+}
+
+EOF
+
+declare -A subtests=(
+  ["nix run"]="nix run --no-write-lock-file .#pkgAsPkg"
+  ["nix shell"]="nix shell -f shell-hello.nix hello -c hello | grep 'Hello World'"
+  ["nix develop"]="nix develop -f shell-hello.nix hello -c echo test | grep 'test'"
+  ["nix flake init"]="nix flake init -t .#"
+  ["nix flake new"]="nix flake new $TEST_HOME/ -t .#"
+  ["nix profile list"]="nix profile list"
+  ["nix profile install"]="nix profile install .#pkgAsPkg"
+  ["nix-env -q"]="nix-env -q"
+)
+
+for test_name in "${!subtests[@]}"; do
+  clearStore
+  clearProfiles
+  rm -rf $TEST_HOME/.local
+
+  [[ ! -e $TEST_HOME/.local ]] || fail "The nix profile should not exist yet"
+
+  ${subtests[$test_name]}
+
+  [[ -e $TEST_HOME/.local/state/nix/profiles ]] || fail "\'$test_name\' should create the user's default profile if it doesn't exist yet"
+done

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -3,6 +3,7 @@ nix_tests = \
   init.sh \
   flakes/flakes.sh \
   flakes/run.sh \
+  flakes/commands-create-profile.sh \
   flakes/mercurial.sh \
   flakes/circular.sh \
   flakes/init.sh \


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

In nix versions prior to 2.14.0, the default profile location was `/nix/var/nix/profiles/per-user/$USER` and the following commands used to create it if it did not already exist:
- `nix run ...`
- `nix shell ...`
- `nix develop ...`
- `nix flake init ...`
- `nix flake new ...`

After the default profile location changed to `$HOME/.local/state/nix/profiles` those commands no longer create the profile. This causes issues on new nix installations when executing a `nix run ... ` command that expects the profile to exist, e.g. installing home-manager via `nix run home-manager/master -- init --switch`

This PR fixes that

# Context
Fixes https://github.com/NixOS/nix/issues/8978.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
