### PR TITLE
Populate `$XDG_DATA_DIRS` with appropriate folder from Nix profile

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -22,9 +22,9 @@ set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profi
 # Populate bash completions, .desktop files, etc
 if test -n "$XDG_DATA_DIRS"
     # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
-    set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+    set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:/nix/var/nix/profiles/default/share"
 else
-    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:/nix/var/nix/profiles/default/share"
 end
 
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.

--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -19,6 +19,14 @@ set __ETC_PROFILE_NIX_SOURCED 1
 
 set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
+# Populate bash completions, .desktop files, etc
+if test -n "$NIX_SSH_CERT_FILE"
+    # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
+    set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+else
+    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+end
+
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
 if test -n "$NIX_SSH_CERT_FILE"
   : # Allow users to override the NIX_SSL_CERT_FILE

--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -20,7 +20,7 @@ set __ETC_PROFILE_NIX_SOURCED 1
 set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
 # Populate bash completions, .desktop files, etc
-if test -n "$NIX_SSH_CERT_FILE"
+if test -n "$XDG_DATA_DIRS"
     # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
     set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
 else

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -30,6 +30,14 @@ fi
 
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
 
+# Populate bash completions, .desktop files, etc
+if [ -n "${XDG_DATA_DIRS-}" ]; then
+    # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
+    export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+else
+    export XDG_DATA_DIRS="$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+fi
+
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
 if [ -n "${NIX_SSL_CERT_FILE:-}" ]; then
     : # Allow users to override the NIX_SSL_CERT_FILE

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -20,6 +20,14 @@ if test -n "$HOME" && test -n "$USER"
     # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
     set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
+    # Populate bash completions, .desktop files, etc
+    if test -n "$NIX_SSH_CERT_FILE"
+        # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
+        set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+    else
+        set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+    end
+
     # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
     if test -n "$NIX_SSH_CERT_FILE"
         : # Allow users to override the NIX_SSL_CERT_FILE

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -21,7 +21,7 @@ if test -n "$HOME" && test -n "$USER"
     set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
     # Populate bash completions, .desktop files, etc
-    if test -n "$NIX_SSH_CERT_FILE"
+    if test -n "$XDG_DATA_DIRS"
         # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
         set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
     else

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -32,6 +32,14 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
     export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
 
+    # Populate bash completions, .desktop files, etc
+    if [ -n "${XDG_DATA_DIRS-}" ]; then
+        # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
+        export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+    else
+        export XDG_DATA_DIRS="$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+    fi
+
     # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
     if [ -e /etc/ssl/certs/ca-certificates.crt ]; then # NixOS, Ubuntu, Debian, Gentoo, Arch
         export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
# Motivation

On non-NixOS systems, the default `nix` install does not populate the `$XDG_DATA_DIRS`.

This populates it and enables things like bash-completion  and `.desktop` file detection for `nix` profile installed packages.

With this PR:
* Bash completions like `nix r<tab>` and `nix build .#pro<tab>`, or `nix profile add nixpkgs#ripgrep` then `rg -<tab>` should show the expected output. 
* `nix profile install nixpkgs#firefox` should result in firefox appearing in the user's Desktop environment menus via the `.desktop` file. (This may require a relog in some environments)

This PR sets `XDG_DATA_DIRS` appropriately in currently supported shells, ensuring to include the [spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)-defined defaults should the variable not exist.

This variable is a `PATH` style variable which is `:` separated, with a spec defined default of `/usr/local/share:/usr/share`.

I do not believe the implementation in this PR risks clobbering existing system settings or breaking things for users. We add the `nix` provided directories to the end of the `XDG_DATA_DIRS`, making them the lowest priority, meaning we won't break anything already existing on the user's system. We ensure the spec-defined default is set, meaning we won't break the system if the value is unset. Nix already manipulates the `PATH` variable and this PR manipulates `XDG_DATA_DIRS` in roughly the same way.

### Testing:

I have tested this on:

* [x] Ubuntu 22.04 multi-user install
* [x] Ubuntu 22.04 single-user install
* [x] The full `nix` repo's installer test suite (via `nix --extra-experimental-features 'nix-command flakes' run .#hydraJobs.installTests.x86_64-linux -L -j 8`)

If you'd like to test, you can add the line yourself to the file `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`, or build the appropriate `github:nixpkgs/nix#hydraJobs.binaryTarball.$SYSTEM` output and try it on a VM.

Doing that should result in new shells being able to complete `nix r<tab>` like so:

```bash
ana@ephemeral-ubuntu:~$ nix r<tab>
realisation  registry     repl         run
```

Or `nix build github:nixos/nix#hydraJobs.<tab>` (you may need to be patient here -- takes a sec to do the network):

```bash
ana@ephemeral-ubuntu:~$ nix build github:nixos/nix#hydraJobs.<tab>
nixos/nix#hydraJobs.binaryTarball          nixos/nix#hydraJobs.installerScript
nixos/nix#hydraJobs.binaryTarballCross     nixos/nix#hydraJobs.installerScriptForGHA
nixos/nix#hydraJobs.build                  nixos/nix#hydraJobs.installerTests
nixos/nix#hydraJobs.buildCross             nixos/nix#hydraJobs.installTests
nixos/nix#hydraJobs.buildNoGc              nixos/nix#hydraJobs.internal-api-docs
nixos/nix#hydraJobs.buildNoTests           nixos/nix#hydraJobs.metrics
nixos/nix#hydraJobs.buildStatic            nixos/nix#hydraJobs.perlBindings
nixos/nix#hydraJobs.coverage               nixos/nix#hydraJobs.tests
nixos/nix#hydraJobs.dockerImage
```

You can also test `.desktop` files:

```bash
ana@ephemeral-ubuntu:~$ nix profile install nixpkgs#xfce.thunar
```

Reload your DE (eg, relog) and observe:


![image](https://github.com/NixOS/nix/assets/130903/6e591a5c-8a21-4a53-967a-5842f522310f)



# Context

Previously, https://github.com/NixOS/nix/pull/2443 suggested this change, however it was years ago and initially intermingled with another `man` related change (not present here). In https://github.com/NixOS/nix/pull/2443#issuecomment-423912395 @edolstra offered some insight into why this was not merged, it was focused on the `MANPATH` related changes.

In https://github.com/NixOS/nixpkgs/issues/78822, this issue was once again surfaced and referenced https://github.com/NixOS/nix/pull/2443#issuecomment-423912395.

In https://github.com/DeterminateSystems/nix-installer/issues/614, it was suggested that this be done in order to allow users to do something like `nix profile install nixpkgs#blender` and see blender in their desktop environment's menus.

In https://github.com/DeterminateSystems/nix-installer/issues/486, it was suggested that this be done in order to enable shell completion on an installed Nix.

In https://github.com/NixOS/nix/issues/6098, someone mentioned a gotcha around setting this value such that you don't overwrite the XDG spec defined defaults. (Spec here: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)

In https://github.com/NixOS/nix/issues/4453 someone requested this feature as well, offering an alternative of doing this only inside of a `nix shell`, but that was a more complicated solution.

Despite the PR from several years ago not being merged, I believe it's worth revisiting the discussion in light of the numerous related issues as well as rather substantial potential benefits it can bring to users.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
