### PR TITLE
Include "original" and "locked" in nix flake prefetch --json

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1342,6 +1342,8 @@ struct CmdFlakePrefetch : FlakeCommand, MixJSON
             auto res = nlohmann::json::object();
             res["storePath"] = store->printStorePath(tree.storePath);
             res["hash"] = hash.to_string(SRI, true);
+            res["original"] = fetchers::attrsToJSON(resolvedRef.toAttrs());
+            res["locked"] = fetchers::attrsToJSON(lockedRef.toAttrs());
             logger->cout(res.dump());
         } else {
             notice("Downloaded '%s' to '%s' (hash '%s').",


### PR DESCRIPTION
# Motivation

For 3rd party tools, it is important to be able to follow the same basic mechanisms behind `nix flake`. In particular, two things I have struggled with in the past are:

1. a solution to parse the flake uri
2. a solution to resolve flake inputs to their locked version

Efforts like [rime](https://github.com/aakropotkin/rime) make me think I am not the only one trying to do this.

# Context

I tried to twist the cli into giving me the right information but the only way seems to be creating an ad-hoc temporary flake with a single input and read the lock file, which is not something I am comfortable building on top of.

With `nix flake prefect --json` gets us very close:

```
❯ nix flake prefetch github:input-output-hk/haskell.nix
Downloaded 'github:input-output-hk/haskell.nix/717cf3915d86023c0d029ac1dd27d9ba7dbc43ed' to '/nix/store/vj07b8cx98pbysa5l4mhj6ail8j9fdzh-source' (hash 'sha256-bJyJnFKG3damZ36tbCv5TfQ2xgI8T/j35cMNO+ZgAnk=').
```

But its structured output does not include the locked url just printed above!

```
❯ nix flake prefetch github:input-output-hk/haskell.nix --json
{"hash":"sha256-bJyJnFKG3damZ36tbCv5TfQ2xgI8T/j35cMNO+ZgAnk=","storePath":"/nix/store/vj07b8cx98pbysa5l4mhj6ail8j9fdzh-source"}
```

This (minimal) change adds two fields to the output of `nix flake prefetch --json`: the original url as parsed by `nix flake` and its locked version.

```
nix-env ❯ ./outputs/out/bin/nix flake prefetch github:input-output-hk/haskell.nix --json | jq
{
  "hash": "sha256-bJyJnFKG3damZ36tbCv5TfQ2xgI8T/j35cMNO+ZgAnk=",
  "locked": {
    "lastModified": 1695084617,
    "narHash": "sha256-bJyJnFKG3damZ36tbCv5TfQ2xgI8T/j35cMNO+ZgAnk=",
    "owner": "input-output-hk",
    "repo": "haskell.nix",
    "rev": "717cf3915d86023c0d029ac1dd27d9ba7dbc43ed",
    "type": "github"
  },
  "original": {
    "owner": "input-output-hk",
    "repo": "haskell.nix",
    "type": "github"
  },
  "storePath": "/nix/store/vj07b8cx98pbysa5l4mhj6ail8j9fdzh-source"
}
```

Note: doing this introduces a duplication of the `hash` field, now represented both at the top-level and inside `locked`. I agree this is unoptimal but I didn't want to make start with a breaking change (let me say this glossing over the experimental/unstable discussion). I can remove the top-level hash field if it's deemed acceptable.

Another solution could be obtained by changing `builtins.fetchTree` to interpret strings as flake uris. Currently it is not possible to call `builtins.fetchTree "github:input-output-hk/haskell.nix"` but if the uri gets parsed as `nix flake` would do, then it would turn into
```
nix-repl> builtins.fetchTree { type = "github"; owner = "input-output-hk"; repo = "haskell.nix"; }
{ lastModified = 1695084617; lastModifiedDate = "20230919005017"; narHash = "sha256-bJyJnFKG3damZ36tbCv5TfQ2xgI8T/j35cMNO+ZgAnk="; outPath = "/nix/store/vj07b8cx98pbysa5l4mhj6ail8j9fdzh-source"; rev = "717cf3915d86023c0d029ac1dd27d9ba7dbc43ed"; shortRev = "717cf39"; }
```
which exposes all the information I am looking for. This could even be preferable as the information exposed be reused in nix logic while still being accessible from the command line.

I think this make it a great feature for third party tooling since it (almost?) allows one to reimplement flake-locking externally.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
