### PR TITLE
add information on release cycle and backports

### DIFF
--- a/doc/manual/src/release-notes/release-notes.md
+++ b/doc/manual/src/release-notes/release-notes.md
@@ -3,5 +3,9 @@
 Nix has a release cycle of roughly 6 weeks.
 Notable changes and additions are announced in the release notes for each version.
 
-Bugfixes can be backported on request to the Nix version used in the latest NixOS release, which is announced in the [NixOS release notes](https://nixos.org/manual/nixos/stable/release-notes.html#ch-release-notes).
+Bugfixes can be backported on request to previous Nix releases.
+We typically backport only as far back as the Nix version used in the latest NixOS release, which is announced in the [NixOS release notes](https://nixos.org/manual/nixos/stable/release-notes.html#ch-release-notes).
+
+Backports never skip releases (if a feature is backported to `x.y`, it must also be available in `x.(y+1)`;
+This ensures that upgrading from an older version with backports is still safe and no backported functionality will go missing.
 

--- a/doc/manual/src/release-notes/release-notes.md
+++ b/doc/manual/src/release-notes/release-notes.md
@@ -6,6 +6,7 @@ Notable changes and additions are announced in the release notes for each versio
 Bugfixes can be backported on request to previous Nix releases.
 We typically backport only as far back as the Nix version used in the latest NixOS release, which is announced in the [NixOS release notes](https://nixos.org/manual/nixos/stable/release-notes.html#ch-release-notes).
 
-Backports never skip releases (if a feature is backported to `x.y`, it must also be available in `x.(y+1)`;
+Backports never skip releases.
+If a feature is backported to version `x.y`, it must also be available in version `x.(y+1)`.
 This ensures that upgrading from an older version with backports is still safe and no backported functionality will go missing.
 

--- a/doc/manual/src/release-notes/release-notes.md
+++ b/doc/manual/src/release-notes/release-notes.md
@@ -1,1 +1,7 @@
 # Nix Release Notes
+
+Nix has a release cycle of roughly 6 weeks.
+Notable changes and additions are announced in the release notes for each version.
+
+Bugfixes can be backported on request to the Nix version used in the latest NixOS release, which is announced in the [NixOS release notes](https://nixos.org/manual/nixos/stable/release-notes.html#ch-release-notes).
+


### PR DESCRIPTION
closes https://github.com/NixOS/nix/issues/6063

# Motivation

There is currently no information about the release cycle or support status. This is a first attempt at providing it.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).