### PR TITLE
Re-enable systemd-nspawn test

### DIFF
--- a/tests/nixos/containers/containers.nix
+++ b/tests/nixos/containers/containers.nix
@@ -56,8 +56,8 @@
     host.fail("nix build -v --auto-allocate-uids --no-sandbox -L --offline --impure --file ${./id-test.nix} --argstr name id-test-6 --arg uidRange true")
 
     # Run systemd-nspawn in a Nix build.
-    #host.succeed("nix build -v --auto-allocate-uids --sandbox -L --offline --impure --file ${./systemd-nspawn.nix} --argstr nixpkgs ${nixpkgs}")
-    #host.succeed("[[ $(cat ./result/msg) = 'Hello World' ]]")
+    host.succeed("nix build -v --auto-allocate-uids --sandbox -L --offline --impure --file ${./systemd-nspawn.nix} --argstr nixpkgs ${nixpkgs}")
+    host.succeed("[[ $(cat ./result/msg) = 'Hello World' ]]")
   '';
 
 }

--- a/tests/nixos/containers/systemd-nspawn.nix
+++ b/tests/nixos/containers/systemd-nspawn.nix
@@ -73,6 +73,8 @@ runCommand "test"
       --resolv-conf=off \
       --bind-ro=/nix/store \
       --bind=$out \
+      --bind=/proc:/run/host/proc \
+      --bind=/sys:/run/host/sys \
       --private-network \
       $toplevel/init
   ''


### PR DESCRIPTION
# Motivation
More tests is better than less tests.

# Context
It was disabled in c6953d1ff62fb6dc4fbd89c03e7949c552c19382 because a recent Nixpkgs bump brought in a new systemd which changed how systemd-nspawn worked.

As far as I can tell, the issue was caused by this upstream systemd commit:
https://github.com/systemd/systemd/commit/b71a0192c040f585397cfc6fc2ca025bf839733d

Bind-mounting the host's `/sys` and `/proc` into the container's `/run/host/{sys,proc}` fixes the issue and allows the test to succeed.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
