### PR TITLE
github: subscribe nix language changes in libexpr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,13 @@
 
 # Libstore layer
 /src/libstore @thufschmitt
+
+# Libexpr, nix language
+/src/libexpr/parser.y @edolstra @inclyc
+/src/libexpr/lexer.l @edolstra @inclyc
+/src/libexpr/nixexpr.hh @edolstra @inclyc
+/src/libexpr/nixexpr.cc @edolstra @inclyc
+/src/libexpr/symbol-table.hh @edolstra @inclyc
+/src/libexpr/eval.cc @edolstra @inclyc
+/src/libexpr/eval.hh @edolstra @inclyc
+/src/libexpr/eval-inline.hh @edolstra @inclyc


### PR DESCRIPTION
# Motivation

Since I'm maintaining a language server for Nix and the code have shared a lot of parts of these files, I want to subscribe PRs related to them. For example #8664 needs to be sync-ed in the language server.

Disclaimer: github `CODEOWNERS` file does not give any privilege to the owner, but only automatically mentions people if there are changes made to these files. I'm not sure if I'm qualified to join Nix Team to obtain write access in this repo,  just want to get mentioned for those files.

# Context

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
