### PR TITLE
Rewrite git fetcher

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -368,9 +368,9 @@ static RegisterPrimOp primop_fetchGit({
 
         The URL of the repo.
 
-      - `name` (default: *basename of the URL*)
+      - `name` (default: `source`)
 
-        The name of the directory the repo should be exported to in the store.
+        The name used for the generated store path.
 
       - `rev` (default: *the tip of `ref`*)
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -22,237 +22,532 @@ namespace nix::fetchers {
 namespace {
 
 // Explicit initial branch of our bare repo to suppress warnings from new version of git.
-// The value itself does not matter, since we always fetch a specific revision or branch.
+// The value itself does not matter, since we always fetch a specific revision.
 // It is set with `-c init.defaultBranch=` instead of `--initial-branch=` to stay compatible with
 // old version of git, which will ignore unrecognized `-c` options.
 const std::string gitInitialBranch = "__nix_dummy_branch";
 
-bool isCacheFileWithinTtl(time_t now, const struct stat & st)
-{
-    return st.st_mtime + settings.tarballTtl > now;
+bool isCacheFileWithinTtl(time_t now, const struct stat &st) { return st.st_mtime + settings.tarballTtl > now; }
+
+Path getCachePath(std::string_view key) { return getCacheDir() + "/nix/gitv3/" + hashString(htSHA256, key).to_string(Base32, false); }
+
+/// Check if a revision is present in a git repository
+///
+/// @param gitDir A path to a bare git repository or .git directory
+/// @param revision A git revision. Usually a commit hash
+/// @return true if the revision is present in the repository
+bool checkIfRevisionIsInRepo(const Path gitDir, const std::string revision) {
+	try {
+		runProgram("git", true, {"-C", gitDir, "cat-file", "-e", revision});
+		return true;
+	} catch (ExecError &e) {
+		if (!WIFEXITED(e.status)) {
+			throw;
+		}
+	}
+	return false;
+
+	// // TODO: It is probably faster to check for the object directly instead of calling git.
+	// //       However that could lead to problems with shallow repositories but im not sure.
+	// std::string path = repoDir + "/objects/" + revision.substr(0, 2) + "/" +
+	// revision.substr(2);
 }
 
-bool touchCacheFile(const Path & path, time_t touch_time)
-{
-    struct timeval times[2];
-    times[0].tv_sec = touch_time;
-    times[0].tv_usec = 0;
-    times[1].tv_sec = touch_time;
-    times[1].tv_usec = 0;
-
-    return lutimes(path.c_str(), times) == 0;
-}
-
-Path getCachePath(std::string_view key)
-{
-    return getCacheDir() + "/nix/gitv3/" +
-        hashString(htSHA256, key).to_string(Base32, false);
-}
-
-// Returns the name of the HEAD branch.
-//
-// Returns the head branch name as reported by git ls-remote --symref, e.g., if
-// ls-remote returns the output below, "main" is returned based on the ref line.
-//
-//   ref: refs/heads/main       HEAD
-//   ...
-std::optional<std::string> readHead(const Path & path)
-{
-    auto [status, output] = runProgram(RunOptions {
-        .program = "git",
-        // FIXME: use 'HEAD' to avoid returning all refs
-        .args = {"ls-remote", "--symref", path},
-        .isInteractive = true,
-    });
-    if (status != 0) return std::nullopt;
-
-    std::string_view line = output;
-    line = line.substr(0, line.find("\n"));
-    if (const auto parseResult = git::parseLsRemoteLine(line)) {
-        switch (parseResult->kind) {
-            case git::LsRemoteRefLine::Kind::Symbolic:
-                debug("resolved HEAD ref '%s' for repo '%s'", parseResult->target, path);
-                break;
-            case git::LsRemoteRefLine::Kind::Object:
-                debug("resolved HEAD rev '%s' for repo '%s'", parseResult->target, path);
-                break;
-        }
-        return parseResult->target;
-    }
-    return std::nullopt;
-}
-
-// Persist the HEAD ref from the remote repo in the local cached repo.
-bool storeCachedHead(const std::string & actualUrl, const std::string & headRef)
-{
-    Path cacheDir = getCachePath(actualUrl);
-    try {
-        runProgram("git", true, { "-C", cacheDir, "--git-dir", ".", "symbolic-ref", "--", "HEAD", headRef });
-    } catch (ExecError &e) {
-        if (!WIFEXITED(e.status)) throw;
-        return false;
-    }
-    /* No need to touch refs/HEAD, because `git symbolic-ref` updates the mtime. */
-    return true;
-}
-
-std::optional<std::string> readHeadCached(const std::string & actualUrl)
-{
-    // Create a cache path to store the branch of the HEAD ref. Append something
-    // in front of the URL to prevent collision with the repository itself.
-    Path cacheDir = getCachePath(actualUrl);
-    Path headRefFile = cacheDir + "/HEAD";
-
-    time_t now = time(0);
-    struct stat st;
-    std::optional<std::string> cachedRef;
-    if (stat(headRefFile.c_str(), &st) == 0) {
-        cachedRef = readHead(cacheDir);
-        if (cachedRef != std::nullopt &&
-            *cachedRef != gitInitialBranch &&
-            isCacheFileWithinTtl(now, st))
-        {
-            debug("using cached HEAD ref '%s' for repo '%s'", *cachedRef, actualUrl);
-            return cachedRef;
-        }
-    }
-
-    auto ref = readHead(actualUrl);
-    if (ref) return ref;
-
-    if (cachedRef) {
-        // If the cached git ref is expired in fetch() below, and the 'git fetch'
-        // fails, it falls back to continuing with the most recent version.
-        // This function must behave the same way, so we return the expired
-        // cached ref here.
-        warn("could not get HEAD ref for repository '%s'; using expired cached ref '%s'", actualUrl, *cachedRef);
-        return *cachedRef;
-    }
-
-    return std::nullopt;
-}
-
-bool isNotDotGitDirectory(const Path & path)
-{
-    return baseNameOf(path) != ".git";
-}
-
-struct WorkdirInfo
-{
-    bool clean = false;
-    bool hasHead = false;
+/// A git revision and the full reference it was resolved from
+struct RevisionWithFullReference {
+	/// A git revision. Typically a commit hash.
+	std::string revision;
+	/// A full git reference. Usually starts with 'refs/' except for some special cases like 'HEAD'
+	std::string fullReference;
 };
 
-// Returns whether a git workdir is clean and has commits.
-WorkdirInfo getWorkdirInfo(const Input & input, const Path & workdir)
-{
-    const bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
-    std::string gitDir(".git");
+/// Resolves the revision and full reference for a given reference in a git repo
+///
+/// If a abbreviated reference is passed (e.g. 'master') it is also resolved to a full reference (e.g. 'refs/heads/master')
+///
+/// @param gitUrl A git url that will be used with `git ls-remote` to resolve the revision.
+/// @param reference A git reference or HEAD.
+/// @return The resolved revision and full reference. nullopt if the reference could not be resolved.
+std::optional<RevisionWithFullReference> readRevision(const Path &gitUrl, const std::string &reference) {
+	// Run ls-remote to find a revision for the reference
+	auto [status, output] = runProgram(RunOptions{
+		.program = "git",
+		.args = {"ls-remote", gitUrl, reference},
+		.isInteractive = true,
+	});
+	if (status != 0)
+		return std::nullopt;
 
-    auto env = getEnv();
-    // Set LC_ALL to C: because we rely on the error messages from git rev-parse to determine what went wrong
-    // that way unknown errors can lead to a failure instead of continuing through the wrong code path
-    env["LC_ALL"] = "C";
+	std::string_view line = output;
+	line = line.substr(0, line.find("\n"));
+	if (const auto parseResult = git::parseLsRemoteLine(line)) {
+		if (parseResult->kind == git::LsRemoteRefLine::Kind::Symbolic) {
+			throw Error("Should git should never resolve a symbolic revision without  '--symref'");
+		}
 
-    /* Check whether HEAD points to something that looks like a commit,
-       since that is the refrence we want to use later on. */
-    auto result = runProgram(RunOptions {
-        .program = "git",
-        .args = { "-C", workdir, "--git-dir", gitDir, "rev-parse", "--verify", "--no-revs", "HEAD^{commit}" },
-        .environment = env,
-        .mergeStderrToStdout = true
-    });
-    auto exitCode = WEXITSTATUS(result.first);
-    auto errorMessage = result.second;
+		// parseResult->reference is always defined if parseResult->kind is not git::LsRemoteRefLine::Kind::Symbolic
+		// which we asserted above
+		auto const fullReference = parseResult->reference.value();
+		auto const revision = parseResult->target;
 
-    if (errorMessage.find("fatal: not a git repository") != std::string::npos) {
-        throw Error("'%s' is not a Git repository", workdir);
-    } else if (errorMessage.find("fatal: Needed a single revision") != std::string::npos) {
-        // indicates that the repo does not have any commits
-        // we want to proceed and will consider it dirty later
-    } else if (exitCode != 0) {
-        // any other errors should lead to a failure
-        throw Error("getting the HEAD of the Git tree '%s' failed with exit code %d:\n%s", workdir, exitCode, errorMessage);
-    }
-
-    bool clean = false;
-    bool hasHead = exitCode == 0;
-
-    try {
-        if (hasHead) {
-            // Using git diff is preferrable over lower-level operations here,
-            // because its conceptually simpler and we only need the exit code anyways.
-            auto gitDiffOpts = Strings({ "-C", workdir, "--git-dir", gitDir, "diff", "HEAD", "--quiet"});
-            if (!submodules) {
-                // Changes in submodules should only make the tree dirty
-                // when those submodules will be copied as well.
-                gitDiffOpts.emplace_back("--ignore-submodules");
-            }
-            gitDiffOpts.emplace_back("--");
-            runProgram("git", true, gitDiffOpts);
-
-            clean = true;
-        }
-    } catch (ExecError & e) {
-        if (!WIFEXITED(e.status) || WEXITSTATUS(e.status) != 1) throw;
-    }
-
-    return WorkdirInfo { .clean = clean, .hasHead = hasHead };
+		debug("resolved reference '%s' in repo '%s' to revision '%s' and full reference '%s'", reference, gitUrl, revision, fullReference);
+		return RevisionWithFullReference{revision, fullReference};
+	}
+	return std::nullopt;
 }
 
-std::pair<StorePath, Input> fetchFromWorkdir(ref<Store> store, Input & input, const Path & workdir, const WorkdirInfo & workdirInfo)
-{
-    const bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
-    auto gitDir = ".git";
+/// Resolves the revision and full reference for a given reference in a git repo.
+///
+/// Tries a lookup in the local git cache first. If the revision is not in the cache it is fetched from the remote.
+///
+/// If a abbreviated reference is passed (e.g. 'something') it is treated as a heads reference (e.g. 'refs/heads/something').
+/// The only supported special reference is 'HEAD'.
+///
+/// @param gitUrl The url of the git repo. Can be any [git url](https://git-scm.com/docs/git-fetch#_git_urls).
+/// @param reference A full git reference or and abbreviated branch (ref/heads) reference.
+/// @return The resolved revision and full reference. nullopt if the reference could not be resolved.
+std::string readRevisionCached(const std::string &gitUrl, const std::string &reference) {
+	Path cacheDir = getCachePath(gitUrl);
 
-    if (!fetchSettings.allowDirty)
-        throw Error("Git tree '%s' is dirty", workdir);
+	// TODO: Currently every input reference is treated as a /ref/heads reference if it is no full ref.
+	// This means that tag references need to be prefixed with 'refs/tags/' otherwise they would not work.
+	// We theoretically fully support abbreviated references, but that may break compatibility with older versions
+	// On the other hand reference resolution is always impure so it probably can be changed without breaking anything.
+	Path fullRef = reference.compare(0, 5, "refs/") == 0 ? reference : reference == "HEAD" ? "HEAD" : "refs/heads/" + reference;
 
-    if (fetchSettings.warnDirty)
-        warn("Git tree '%s' is dirty", workdir);
+	Path referenceFile = cacheDir + "/" + fullRef;
 
-    auto gitOpts = Strings({ "-C", workdir, "--git-dir", gitDir, "ls-files", "-z" });
-    if (submodules)
-        gitOpts.emplace_back("--recurse-submodules");
+	struct stat st;
+	auto existsInCache = (stat(referenceFile.c_str(), &st) == 0);
 
-    auto files = tokenizeString<std::set<std::string>>(
-        runProgram("git", true, gitOpts), "\0"s);
+	std::optional<std::string> cachedRevision;
+	if (existsInCache) {
+		time_t now = time(0);
+		auto cacheIsFresh = isCacheFileWithinTtl(now, st);
 
-    Path actualPath(absPath(workdir));
+		if (cacheIsFresh) {
+			// Returning a cached revision if available and fresh
+			// FIXME: If the repo is local we dont have to call git but can just read the ref file
+			std::string cachedRevision = trim(readFile(referenceFile));
 
-    PathFilter filter = [&](const Path & p) -> bool {
-        assert(hasPrefix(p, actualPath));
-        std::string file(p, actualPath.size() + 1);
+			debug("using cached revision '%s' for reference '%s' in repo '%s'", cachedRevision, fullRef, gitUrl);
+			return cachedRevision;
+		}
 
-        auto st = lstat(p);
+		auto revisionWithFullReference = readRevision(gitUrl, reference);
+		if (revisionWithFullReference) {
+			// Returning a fresh revision if the cache exists but is expired
+			createDirs(dirOf(cacheDir));
+			PathLocks cacheDirLock({cacheDir + ".lock"});
+			if (!pathExists(cacheDir)) {
+				runProgram("git", true, {"-c", "init.defaultBranch=" + gitInitialBranch, "init", "--bare", cacheDir});
+			}
+			createDirs(dirOf(referenceFile));
+			auto const revision = revisionWithFullReference->revision;
+			writeFile(referenceFile, revision);
+			return revision;
+		}
 
-        if (S_ISDIR(st.st_mode)) {
-            auto prefix = file + "/";
-            auto i = files.lower_bound(prefix);
-            return i != files.end() && hasPrefix(*i, prefix);
-        }
+		warn("failed to resolve a fresh revision for reference '%s' in repo '%s'; using expired cached revision '%s'", fullRef, gitUrl, *cachedRevision);
+		auto cachedRevision = trim(readFile(referenceFile));
+		return cachedRevision;
+	}
 
-        return files.count(file);
-    };
+	// Return a fresh revision if there is none in the cache
+	auto const revisionWithFullReference = readRevision(gitUrl, reference);
+	if (!revisionWithFullReference) {
+		throw Error("failed to resolve revision for reference '%s' in repository '%s'", fullRef, gitUrl);
+	}
 
-    auto storePath = store->addToStore(input.getName(), actualPath, FileIngestionMethod::Recursive, htSHA256, filter);
+	createDirs(dirOf(cacheDir));
+	PathLocks cacheDirLock({cacheDir + ".lock"});
+	if (!pathExists(cacheDir)) {
+		runProgram("git", true, {"-c", "init.defaultBranch=" + gitInitialBranch, "init", "--bare", cacheDir});
+	}
+	createDirs(dirOf(referenceFile));
 
-    // FIXME: maybe we should use the timestamp of the last
-    // modified dirty file?
-    input.attrs.insert_or_assign(
-        "lastModified",
-        workdirInfo.hasHead ? std::stoull(runProgram("git", true, { "-C", actualPath, "--git-dir", gitDir, "log", "-1", "--format=%ct", "--no-show-signature", "HEAD" })) : 0);
-
-    if (workdirInfo.hasHead) {
-        input.attrs.insert_or_assign("dirtyRev", chomp(
-            runProgram("git", true, { "-C", actualPath, "--git-dir", gitDir, "rev-parse", "--verify", "HEAD" })) + "-dirty");
-        input.attrs.insert_or_assign("dirtyShortRev", chomp(
-            runProgram("git", true, { "-C", actualPath, "--git-dir", gitDir, "rev-parse", "--verify", "--short", "HEAD" })) + "-dirty");
-    }
-
-    return {std::move(storePath), input};
+	auto const revision = revisionWithFullReference->revision;
+	writeFile(referenceFile, revision);
+	return revision;
 }
-}  // end namespace
+
+/// Helper function to split a string into a vector of strings
+///
+/// @param input The string to split
+/// @param delimiter The delimiter to split at
+/// @return A vector of strings
+std::vector<std::string_view> split(const std::string_view &input, const std::string_view &delimiter) {
+	size_t start = 0, end;
+	auto delimiterLength = delimiter.length();
+	std::vector<std::string_view> res;
+
+	while ((end = input.find(delimiter, start)) != std::string_view::npos) {
+		std::string_view token = input.substr(start, end - start);
+		start = end + delimiterLength;
+		res.push_back(token);
+	}
+
+	res.push_back(input.substr(start));
+	return res;
+}
+
+/// Information about a git submodule
+///
+/// This should contain all information for that is required to fetch the submodule
+struct SubmoduleInfo {
+	/// The name of the submodule
+	std::string name;
+	/// The url of the submodule
+	///
+	/// If the url in .gitmodules is relative it is relative to the origin of the superrepo.
+	std::string url;
+	/// The path of the submodule relative to the root of the superrepo
+	std::string path;
+	/// The revision of the submodule
+	std::string revision;
+};
+
+/// Extracts information about the submodules at a given revision in a git repo
+///
+/// @param revision A git revision. Usually a commit hash.
+/// @param gitDir A path to a bare git repository or .git directory
+/// @return A vector of submodule information. Empty if there are no submodules.
+std::vector<SubmoduleInfo> readGitmodules(const std::string &revision, const Path &gitDir) {
+	auto gitmodulesBlob = revision + ":.gitmodules";
+	// Run ls-remote to find a revision for the reference
+	auto [status, output] = runProgram(RunOptions{
+		.program = "git",
+		.args = {"-C", gitDir, "config", "--blob", gitmodulesBlob, "--name-only", "--get-regexp", "path"},
+		.isInteractive = true,
+	});
+	if (status != 0) {
+		return {};
+	}
+
+	std::vector<std::string> submoduleNames;
+	std::string_view sv = output;
+	auto lines = split(sv, "\n");
+	for (auto line : lines) {
+		if (line.length() == 0) {
+			continue;
+		}
+		const static std::regex line_regex("^submodule[.](.+)[.]path$");
+		std::match_results<std::string_view::const_iterator> match;
+		if (!std::regex_match(line.cbegin(), line.cend(), match, line_regex)) {
+			throw Error(".gitmodules file seems invalid");
+		}
+
+		if (match[1].length() == 0) {
+			throw Error("Gitmodules contains empty line");
+		}
+
+		auto submoduleName = match[1];
+		submoduleNames.push_back(submoduleName);
+	}
+
+	std::vector<SubmoduleInfo> submodules;
+	for (auto submoduleName : submoduleNames) {
+		std::string path;
+		std::string url;
+		std::string submoduleRevision;
+
+		{
+			auto [status, output] = runProgram(RunOptions{
+				.program = "git",
+				.args = {"-C", gitDir, "config", "--blob", gitmodulesBlob, "--get", "submodule." + submoduleName + ".path"},
+				.isInteractive = true,
+			});
+			if (status != 0) {
+				throw Error("Failed to read .gitmodules");
+			}
+			std::string_view lines = output;
+			auto line = lines.substr(0, lines.find("\n"));
+
+			if (line.length() == 0) {
+				throw Error("Length of the path should not be 0");
+			}
+
+			path = line;
+		}
+
+		{
+			auto [status, output] = runProgram(RunOptions{
+				.program = "git",
+				.args = {"-C", gitDir, "config", "--blob", gitmodulesBlob, "--get", "submodule." + submoduleName + ".url"},
+				.isInteractive = true,
+			});
+			if (status != 0) {
+				throw Error("Failed to read .gitmodules");
+			}
+			std::string_view lines = output;
+			auto line = lines.substr(0, lines.find("\n"));
+
+			if (line.length() == 0) {
+				throw Error("Length of the url should not be 0");
+			}
+
+			url = line;
+
+			if (url.rfind("./", 0) == 0 || url.rfind("../", 0) == 0) {
+				// If the submodule is relative its URL is relative to the origin of the superrepo
+				auto [status, output] = runProgram(RunOptions{
+					.program = "git",
+					.args = {"-C", gitDir, "remote", "get-url", "origin"},
+					.isInteractive = true,
+				});
+
+				std::string_view lines = output;
+				auto line = lines.substr(0, lines.find("\n"));
+
+				auto relativeSubmoduleRoot = line.length() ? line : gitDir;
+
+				url = relativeSubmoduleRoot + "/" + url;
+			}
+		}
+
+		{
+			auto [status, output] = runProgram(RunOptions{
+				.program = "git",
+				.args = {"-C", gitDir, "ls-tree", "--object-only", revision, path},
+				.isInteractive = true,
+			});
+			if (status != 0) {
+				throw Error("Failed to get revision for submodule");
+			}
+			std::string_view lines = output;
+			auto line = lines.substr(0, lines.find("\n"));
+
+			if (line.length() == 0) {
+				throw Error("Length of the revision should not be 0");
+			}
+
+			submoduleRevision = line;
+		}
+
+		SubmoduleInfo info({submoduleName, url, path, submoduleRevision});
+
+		submodules.push_back(info);
+	}
+
+	return submodules;
+}
+
+/// Get a path to a bare git repo containing the specified revision
+///
+/// If the cached repo already contains the revision it just returns the path to the repo.
+/// Otherwise it fetches the revision into the repo and returns the path to the repo.
+///
+/// The returned path is a cache dir path without a look. That is fine as long as there are only read-only operations on the fetched revision.
+///
+/// @param gitUrl A [git url](https://git-scm.com/docs/git-fetch#_git_urls) to the repository.
+/// @param revision A git revision. Usually a commit hash.
+/// @return A path to a bare git repo containing the specified revision. The path is to be treated as read-only.
+Path getLocalRepoContainingRevision(const std::string gitUrl, const std::string revision) {
+	Path cacheDir = getCachePath(gitUrl);
+	std::string const repoDir = cacheDir;
+
+	// Create the repo if it does not exist
+	createDirs(dirOf(cacheDir));
+	PathLocks cacheDirLock({cacheDir + ".lock"});
+	if (!pathExists(cacheDir)) {
+		runProgram("git", true, {"-c", "init.defaultBranch=" + gitInitialBranch, "init", "--bare", repoDir});
+	}
+
+	// Return if the revision is already in the repo
+	if (checkIfRevisionIsInRepo(repoDir, revision)) {
+		return repoDir;
+	}
+
+	Activity act(*logger, lvlTalkative, actUnknown, fmt("fetching Git repository '%s'", gitUrl));
+
+	// FIXME: git stderr messes up our progress indicator, so
+	// we're using --quiet for now. Should process its stderr.
+	try {
+		// Fetch the revision into the local repo
+		runProgram("git", true, {"-C", repoDir, "fetch", "--no-tags", "--quiet", "--force", "--", gitUrl, revision}, {}, true);
+	} catch (Error &e) {
+		// Failing the fetch is always fatal.
+		//
+		// Previously there was a check here for whether a old version of the reference was in the
+		// repositiory. In that case a warning was printed and the old reference was used later on.
+		// In the current implementation references are cached in the revision resolution step.
+		//
+		// However in the previous implementation the whole reference was always fetched when the
+		// even when specific revision was requested. This lead to overfetching revisions and putting
+		// them into the cache. This may have lead to more cache hits, but I assume in most cases it
+		// just resulted in increase network traffic and disk usage.
+		throw Error("Failed to fetch revision '%s' from '%s'", revision, gitUrl);
+	}
+
+	return repoDir;
+}
+
+/// Place the tree of a git repo at a given revision at a given path
+///
+/// @param url A [git url](https://git-scm.com/docs/git-fetch#_git_urls) to the repository.
+/// @param targetDir The path to place the tree at.
+/// @param revision A git revision. Usually a commit hash.
+/// @param submodules Whether to recursively fetch submodules.
+/// @param shallow Whether to accept shallow git repositories.
+/// @param isLocal Whether the repo is local or not. If set the repository is not put into cache.
+/// @return A path to a bare git repo containing the specified revision. If the repo is local it is just the path to the repo. The path is to be treated as
+/// read-only.
+Path placeRevisionTreeAtPath(const std::string &url, const Path &targetDir, const std::string &revision, const bool submodules, const bool shallow,
+							 const bool isLocal = false) {
+	printTalkative("using revision %s of repo '%s'", revision, url);
+
+	Path gitDir = isLocal ? url : getLocalRepoContainingRevision(url, revision);
+
+	bool isShallow = chomp(runProgram("git", true, {"-C", gitDir, "rev-parse", "--is-shallow-repository"})) == "true";
+	if (isShallow && !shallow)
+		throw Error("'%s' is a shallow Git repository, but shallow repositories are only allowed when `shallow = true;` is specified.", gitDir);
+
+	// FIXME: should pipe this, or find some better way to extract a
+	// revision.
+	auto source = sinkToSource([&](Sink &sink) { runProgram2({.program = "git", .args = {"-C", gitDir, "archive", revision}, .standardOut = &sink}); });
+	unpackTarfile(*source, targetDir);
+
+	// Also fetch and place all gitmodules
+	if (submodules) {
+		auto gitmodules = readGitmodules(revision, gitDir);
+		for (auto gitmodule : gitmodules) {
+			auto submoduleDir = targetDir + "/" + gitmodule.path;
+			createDirs(submoduleDir);
+			placeRevisionTreeAtPath(gitmodule.url, submoduleDir, gitmodule.revision, submodules, shallow);
+		}
+	}
+
+	return gitDir;
+}
+
+/// Get the revision for a given reference (or HEAD)
+///
+/// Set noCache to true to skip a lookup in the local git cache
+/// This is the expected behaviour for local repositories
+///
+/// @param revision A git revision. Usually a commit hash.
+/// @param reference A git reference (branch or tag name) or HEAD. If unset, `HEAD` is used.
+/// @param gitUrl A git url that will be used with `git ls-remote` to resolve the revision.
+/// @param noCache Do not use the local git cache. Useful for local repositories.
+/// @return The resolved revision. If `revision` is set it is returned. Otherwise `reference` is resolved to a revision.
+std::string getRevision(const std::optional<std::string> &revision, const std::optional<std::string> &reference, const std::string &gitUrl, bool noCache) {
+	if (revision) {
+		return revision.value();
+	}
+
+	auto const referenceOrHead = reference.value_or("HEAD");
+
+	if (noCache) {
+		auto const localRevision = readRevision(gitUrl, referenceOrHead);
+		if (!localRevision) {
+			throw Error("Could not find revision for reference '%s' in repository '%s'", referenceOrHead, gitUrl);
+		}
+		return localRevision->revision;
+	}
+
+	auto const gotRevision = readRevisionCached(gitUrl, referenceOrHead);
+
+	return gotRevision;
+}
+
+std::pair<StorePath, Input> makeResult(const Input &input, StorePath &&storePath, const Attrs &infoAttrs, const std::string &revision, bool shallow) {
+	Input _input = Input(input);
+	_input.attrs.insert_or_assign("rev", revision);
+	if (!shallow)
+		_input.attrs.insert_or_assign("revCount", getIntAttr(infoAttrs, "revCount"));
+	_input.attrs.insert_or_assign("lastModified", getIntAttr(infoAttrs, "lastModified"));
+	return {std::move(storePath), std::move(_input)};
+}
+
+/// Check if a git workdir is dirty
+///
+/// @param workDir A path to a git repo or workdir
+/// @param submodules Whether to check submodules as well
+/// @param gitDir Optional path to a .git directory. Defaults to .git
+/// @return true if the workdir is dirty
+bool isWorkdirDirty(const Path &workDir, bool submodules, const Path &gitDir = ".git") {
+	// If there is no HEAD untracked files should mark the tree as dirty.
+	// If there is a HEAD untracked files should not mark the tree as dirty.
+	// TODO: Remove the inconsistent behaviour
+	auto headExists = readRevision(workDir, "HEAD").has_value();
+	std::string untrackedFlag = headExists ? "-uno" : "-unormal";
+
+	// Using git status --porcelain is preferrable here because it also works with a HEAD pointing to unborn branches.
+	// This way we do not have to check for unborn HEAD seperatly.
+	auto gitStatusOps = Strings({"-C", workDir, "--git-dir", gitDir, "status", "--porcelain", untrackedFlag});
+	if (!submodules) {
+		// Changes in submodules should only make the tree dirty
+		// when those submodules will be copied as well.
+		gitStatusOps.emplace_back("--ignore-submodules");
+	}
+
+	auto [status, output] = runProgram(RunOptions{
+		.program = "git",
+		.args = gitStatusOps,
+		.isInteractive = true,
+	});
+
+	return chomp(output).length() > 0;
+}
+
+/// Fetch git repo from the workdir
+std::pair<StorePath, Input> fetchFromWorkdir(ref<Store> store, const Input &input, const Path &workDir, bool submodules, const Path &gitDir = ".git") {
+	/// TODO: git stash create can probably be used to integrate this branch with the stash
+	Input _input = Input(input);
+	if (!fetchSettings.allowDirty)
+		throw Error("Git tree '%s' is dirty", workDir);
+
+	if (fetchSettings.warnDirty)
+		warn("Git tree '%s' is dirty", workDir);
+
+	Path actualPath(absPath(workDir));
+
+	auto gitOpts = Strings({"-C", actualPath, "--git-dir", gitDir, "ls-files", "-z"});
+	if (submodules)
+		gitOpts.emplace_back("--recurse-submodules");
+
+	auto files = tokenizeString<std::set<std::string>>(runProgram("git", true, gitOpts), "\0"s);
+
+	PathFilter filter = [&](const Path &p) -> bool {
+		assert(hasPrefix(p, actualPath));
+		std::string file(p, actualPath.size() + 1);
+
+		auto st = lstat(p);
+
+		if (S_ISDIR(st.st_mode)) {
+			auto prefix = file + "/";
+			auto i = files.lower_bound(prefix);
+			return i != files.end() && hasPrefix(*i, prefix);
+		}
+
+		return files.count(file);
+	};
+
+	auto storePath = store->addToStore(input.getName(), actualPath, FileIngestionMethod::Recursive, htSHA256, filter);
+
+	try {
+		// FIXME: maybe we should use the timestamp of the last modified dirty file?
+		_input.attrs.insert_or_assign(
+			"lastModified",
+			std::stoull(runProgram("git", true, {"-C", actualPath, "--git-dir", gitDir, "log", "-1", "--format=%ct", "--no-show-signature", "HEAD"})));
+		_input.attrs.insert_or_assign("dirtyRev",
+			chomp(runProgram("git", true, {"-C", actualPath, "--git-dir", gitDir, "rev-parse", "--verify", "HEAD"})) + "-dirty");
+		_input.attrs.insert_or_assign(
+			"dirtyShortRev", chomp(runProgram("git", true, {"-C", actualPath, "--git-dir", gitDir, "rev-parse", "--verify", "--short", "HEAD"})) + "-dirty");
+	} catch (Error &e) {
+		// This path is used if the default branch is unborn. This leads to HEAD not existing. This is usually directly after git init when no commit exists.
+		// I do not think that this case is used a lot in the wild.
+		//
+		// The behaviour for git repos without commits is also inconsistent to the behaviour for git repos with commits.
+		// Without commits even untracked files mark the repo as dirty, with commits they do not.
+		//
+		// TODO: We could avoid a lot of weirdness by just forbidding fetching empty git repositories.
+		_input.attrs.insert_or_assign("lastModified", 0ull);
+	}
+
+	return {std::move(storePath), _input};
+}
+} // end namespace
 
 struct GitInputScheme : InputScheme
 {
@@ -336,6 +631,7 @@ struct GitInputScheme : InputScheme
         auto res(input);
         if (rev) res.attrs.insert_or_assign("rev", rev->gitRev());
         if (ref) res.attrs.insert_or_assign("ref", *ref);
+        // TODO: I do not understand why this check is required
         if (!res.getRef() && res.getRev())
             throw Error("Git input '%s' has a commit hash but no branch/tag name", res.to_string());
         return res;
@@ -396,317 +692,59 @@ struct GitInputScheme : InputScheme
         return {isLocal, isLocal ? url.path : url.base};
     }
 
-    std::pair<StorePath, Input> fetch(ref<Store> store, const Input & _input) override
-    {
-        Input input(_input);
-        auto gitDir = ".git";
+	std::pair<StorePath, Input> fetch(ref<Store> store, const Input &input) override {
+		std::string name = input.getName();
+		auto [isLocal, actualUrl] = getActualUrl(input);
 
-        std::string name = input.getName();
+		// Verify that the hash type is valid if a revision is specified
+		if (input.getRev().has_value() && !(input.getRev()->type == htSHA1 || input.getRev()->type == htSHA256)) {
+			throw Error("Hash '%s' is not supported by Git. Supported types are sha1 and sha256.", input.getRev()->to_string(Base16, true));
+		}
 
-        bool shallow = maybeGetBoolAttr(input.attrs, "shallow").value_or(false);
-        bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
-        bool allRefs = maybeGetBoolAttr(input.attrs, "allRefs").value_or(false);
+		std::optional<std::string> reference = input.getRef();
+		std::optional<std::string> inputRevision = input.getRev() ? std::optional(input.getRev()->gitRev()) : std::nullopt;
 
-        std::string cacheType = "git";
-        if (shallow) cacheType += "-shallow";
-        if (submodules) cacheType += "-submodules";
-        if (allRefs) cacheType += "-all-refs";
+		bool shallow = maybeGetBoolAttr(input.attrs, "shallow").value_or(false);
+		bool submodules = maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
+		auto cacheType = std::string("git") + (shallow ? "-shallow" : "") + (submodules ? "-submodules" : "");
 
-        auto checkHashType = [&](const std::optional<Hash> & hash)
-        {
-            if (hash.has_value() && !(hash->type == htSHA1 || hash->type == htSHA256))
-                throw Error("Hash '%s' is not supported by Git. Supported types are sha1 and sha256.", hash->to_string(Base16, true));
-        };
+		// If this is a local directory and no ref or revision is given, allow
+		// fetching directly from a dirty workdir.
+		if (!reference && !inputRevision && isLocal) {
+			auto dirty = isWorkdirDirty(actualUrl, submodules);
+			if (dirty) {
+				return fetchFromWorkdir(store, input, actualUrl, submodules);
+			}
+		}
 
-        auto getLockedAttrs = [&]()
-        {
-            checkHashType(input.getRev());
+		std::string revision = getRevision(inputRevision, reference, actualUrl, isLocal);
 
-            return Attrs({
-                {"type", cacheType},
-                {"name", name},
-                {"rev", input.getRev()->gitRev()},
-            });
-        };
+		// Lookup resolved revision in cache
+		if (auto res = getCache()->lookup(store, Attrs({{"name", name}, {"type", cacheType}, {"url", actualUrl}, {"rev", revision}}))) {
+			return makeResult(input, std::move(res->second), res->first, revision, shallow);
+		}
 
-        auto makeResult = [&](const Attrs & infoAttrs, StorePath && storePath)
-            -> std::pair<StorePath, Input>
-        {
-            assert(input.getRev());
-            assert(!_input.getRev() || _input.getRev() == input.getRev());
-            if (!shallow)
-                input.attrs.insert_or_assign("revCount", getIntAttr(infoAttrs, "revCount"));
-            input.attrs.insert_or_assign("lastModified", getIntAttr(infoAttrs, "lastModified"));
-            return {std::move(storePath), input};
-        };
+		Path tmpDir = createTempDir();
+		AutoDelete delTmpDir(tmpDir, true);
+		auto repoDir = placeRevisionTreeAtPath(actualUrl, tmpDir, revision, submodules, shallow, isLocal);
+		auto storePath = store->addToStore(name, tmpDir, FileIngestionMethod::Recursive, htSHA256, defaultPathFilter);
 
-        if (input.getRev()) {
-            if (auto res = getCache()->lookup(store, getLockedAttrs()))
-                return makeResult(res->first, std::move(res->second));
-        }
+		auto lastModified = std::stoull(runProgram("git", true, {"-C", repoDir, "log", "-1", "--format=%ct", "--no-show-signature", revision}));
 
-        auto [isLocal, actualUrl_] = getActualUrl(input);
-        auto actualUrl = actualUrl_; // work around clang bug
+		Attrs infoAttrs({
+			{"rev", revision},
+			{"lastModified", lastModified},
+		});
 
-        /* If this is a local directory and no ref or revision is given,
-           allow fetching directly from a dirty workdir. */
-        if (!input.getRef() && !input.getRev() && isLocal) {
-            auto workdirInfo = getWorkdirInfo(input, actualUrl);
-            if (!workdirInfo.clean) {
-                return fetchFromWorkdir(store, input, actualUrl, workdirInfo);
-            }
-        }
+		if (!shallow)
+			infoAttrs.insert_or_assign("revCount", std::stoull(runProgram("git", true, {"-C", repoDir, "rev-list", "--count", revision})));
 
-        Attrs unlockedAttrs({
-            {"type", cacheType},
-            {"name", name},
-            {"url", actualUrl},
-        });
+		getCache()->add(store, Attrs({{"name", name}, {"type", cacheType}, {"url", actualUrl}, {"rev", revision}}), infoAttrs, storePath, true);
 
-        Path repoDir;
-
-        if (isLocal) {
-            if (!input.getRef()) {
-                auto head = readHead(actualUrl);
-                if (!head) {
-                    warn("could not read HEAD ref from repo at '%s', using 'master'", actualUrl);
-                    head = "master";
-                }
-                input.attrs.insert_or_assign("ref", *head);
-                unlockedAttrs.insert_or_assign("ref", *head);
-            }
-
-            if (!input.getRev())
-                input.attrs.insert_or_assign("rev",
-                    Hash::parseAny(chomp(runProgram("git", true, { "-C", actualUrl, "--git-dir", gitDir, "rev-parse", *input.getRef() })), htSHA1).gitRev());
-
-            repoDir = actualUrl;
-        } else {
-            const bool useHeadRef = !input.getRef();
-            if (useHeadRef) {
-                auto head = readHeadCached(actualUrl);
-                if (!head) {
-                    warn("could not read HEAD ref from repo at '%s', using 'master'", actualUrl);
-                    head = "master";
-                }
-                input.attrs.insert_or_assign("ref", *head);
-                unlockedAttrs.insert_or_assign("ref", *head);
-            } else {
-                if (!input.getRev()) {
-                    unlockedAttrs.insert_or_assign("ref", input.getRef().value());
-                }
-            }
-
-            if (auto res = getCache()->lookup(store, unlockedAttrs)) {
-                auto rev2 = Hash::parseAny(getStrAttr(res->first, "rev"), htSHA1);
-                if (!input.getRev() || input.getRev() == rev2) {
-                    input.attrs.insert_or_assign("rev", rev2.gitRev());
-                    return makeResult(res->first, std::move(res->second));
-                }
-            }
-
-            Path cacheDir = getCachePath(actualUrl);
-            repoDir = cacheDir;
-            gitDir = ".";
-
-            createDirs(dirOf(cacheDir));
-            PathLocks cacheDirLock({cacheDir + ".lock"});
-
-            if (!pathExists(cacheDir)) {
-                runProgram("git", true, { "-c", "init.defaultBranch=" + gitInitialBranch, "init", "--bare", repoDir });
-            }
-
-            Path localRefFile =
-                input.getRef()->compare(0, 5, "refs/") == 0
-                ? cacheDir + "/" + *input.getRef()
-                : cacheDir + "/refs/heads/" + *input.getRef();
-
-            bool doFetch;
-            time_t now = time(0);
-
-            /* If a rev was specified, we need to fetch if it's not in the
-               repo. */
-            if (input.getRev()) {
-                try {
-                    runProgram("git", true, { "-C", repoDir, "--git-dir", gitDir, "cat-file", "-e", input.getRev()->gitRev() });
-                    doFetch = false;
-                } catch (ExecError & e) {
-                    if (WIFEXITED(e.status)) {
-                        doFetch = true;
-                    } else {
-                        throw;
-                    }
-                }
-            } else {
-                if (allRefs) {
-                    doFetch = true;
-                } else {
-                    /* If the local ref is older than ‘tarball-ttl’ seconds, do a
-                       git fetch to update the local ref to the remote ref. */
-                    struct stat st;
-                    doFetch = stat(localRefFile.c_str(), &st) != 0 ||
-                        !isCacheFileWithinTtl(now, st);
-                }
-            }
-
-            if (doFetch) {
-                Activity act(*logger, lvlTalkative, actUnknown, fmt("fetching Git repository '%s'", actualUrl));
-
-                // FIXME: git stderr messes up our progress indicator, so
-                // we're using --quiet for now. Should process its stderr.
-                try {
-                    auto ref = input.getRef();
-                    auto fetchRef = allRefs
-                        ? "refs/*"
-                        : ref->compare(0, 5, "refs/") == 0
-                            ? *ref
-                            : ref == "HEAD"
-                                ? *ref
-                                : "refs/heads/" + *ref;
-                    runProgram("git", true, { "-C", repoDir, "--git-dir", gitDir, "fetch", "--quiet", "--force", "--", actualUrl, fmt("%s:%s", fetchRef, fetchRef) }, {}, true);
-                } catch (Error & e) {
-                    if (!pathExists(localRefFile)) throw;
-                    warn("could not update local clone of Git repository '%s'; continuing with the most recent version", actualUrl);
-                }
-
-                if (!touchCacheFile(localRefFile, now))
-                    warn("could not update mtime for file '%s': %s", localRefFile, strerror(errno));
-                if (useHeadRef && !storeCachedHead(actualUrl, *input.getRef()))
-                    warn("could not update cached head '%s' for '%s'", *input.getRef(), actualUrl);
-            }
-
-            if (!input.getRev())
-                input.attrs.insert_or_assign("rev", Hash::parseAny(chomp(readFile(localRefFile)), htSHA1).gitRev());
-
-            // cache dir lock is removed at scope end; we will only use read-only operations on specific revisions in the remainder
-        }
-
-        bool isShallow = chomp(runProgram("git", true, { "-C", repoDir, "--git-dir", gitDir, "rev-parse", "--is-shallow-repository" })) == "true";
-
-        if (isShallow && !shallow)
-            throw Error("'%s' is a shallow Git repository, but shallow repositories are only allowed when `shallow = true;` is specified.", actualUrl);
-
-        // FIXME: check whether rev is an ancestor of ref.
-
-        printTalkative("using revision %s of repo '%s'", input.getRev()->gitRev(), actualUrl);
-
-        /* Now that we know the ref, check again whether we have it in
-           the store. */
-        if (auto res = getCache()->lookup(store, getLockedAttrs()))
-            return makeResult(res->first, std::move(res->second));
-
-        Path tmpDir = createTempDir();
-        AutoDelete delTmpDir(tmpDir, true);
-        PathFilter filter = defaultPathFilter;
-
-        auto result = runProgram(RunOptions {
-            .program = "git",
-            .args = { "-C", repoDir, "--git-dir", gitDir, "cat-file", "commit", input.getRev()->gitRev() },
-            .mergeStderrToStdout = true
-        });
-        if (WEXITSTATUS(result.first) == 128
-            && result.second.find("bad file") != std::string::npos)
-        {
-            throw Error(
-                "Cannot find Git revision '%s' in ref '%s' of repository '%s'! "
-                "Please make sure that the " ANSI_BOLD "rev" ANSI_NORMAL " exists on the "
-                ANSI_BOLD "ref" ANSI_NORMAL " you've specified or add " ANSI_BOLD
-                "allRefs = true;" ANSI_NORMAL " to " ANSI_BOLD "fetchGit" ANSI_NORMAL ".",
-                input.getRev()->gitRev(),
-                *input.getRef(),
-                actualUrl
-            );
-        }
-
-        if (submodules) {
-            Path tmpGitDir = createTempDir();
-            AutoDelete delTmpGitDir(tmpGitDir, true);
-
-            runProgram("git", true, { "-c", "init.defaultBranch=" + gitInitialBranch, "init", tmpDir, "--separate-git-dir", tmpGitDir });
-
-            {
-                // TODO: repoDir might lack the ref (it only checks if rev
-                // exists, see FIXME above) so use a big hammer and fetch
-                // everything to ensure we get the rev.
-                Activity act(*logger, lvlTalkative, actUnknown, fmt("making temporary clone of '%s'", repoDir));
-                runProgram("git", true, { "-C", tmpDir, "fetch", "--quiet", "--force",
-                        "--update-head-ok", "--", repoDir, "refs/*:refs/*" }, {}, true);
-            }
-
-            runProgram("git", true, { "-C", tmpDir, "checkout", "--quiet", input.getRev()->gitRev() });
-
-            /* Ensure that we use the correct origin for fetching
-               submodules. This matters for submodules with relative
-               URLs. */
-            if (isLocal) {
-                writeFile(tmpGitDir + "/config", readFile(repoDir + "/" + gitDir + "/config"));
-
-                /* Restore the config.bare setting we may have just
-                   copied erroneously from the user's repo. */
-                runProgram("git", true, { "-C", tmpDir, "config", "core.bare", "false" });
-            } else
-                runProgram("git", true, { "-C", tmpDir, "config", "remote.origin.url", actualUrl });
-
-            /* As an optimisation, copy the modules directory of the
-               source repo if it exists. */
-            auto modulesPath = repoDir + "/" + gitDir + "/modules";
-            if (pathExists(modulesPath)) {
-                Activity act(*logger, lvlTalkative, actUnknown, fmt("copying submodules of '%s'", actualUrl));
-                runProgram("cp", true, { "-R", "--", modulesPath, tmpGitDir + "/modules" });
-            }
-
-            {
-                Activity act(*logger, lvlTalkative, actUnknown, fmt("fetching submodules of '%s'", actualUrl));
-                runProgram("git", true, { "-C", tmpDir, "submodule", "--quiet", "update", "--init", "--recursive" }, {}, true);
-            }
-
-            filter = isNotDotGitDirectory;
-        } else {
-            // FIXME: should pipe this, or find some better way to extract a
-            // revision.
-            auto source = sinkToSource([&](Sink & sink) {
-                runProgram2({
-                    .program = "git",
-                    .args = { "-C", repoDir, "--git-dir", gitDir, "archive", input.getRev()->gitRev() },
-                    .standardOut = &sink
-                });
-            });
-
-            unpackTarfile(*source, tmpDir);
-        }
-
-        auto storePath = store->addToStore(name, tmpDir, FileIngestionMethod::Recursive, htSHA256, filter);
-
-        auto lastModified = std::stoull(runProgram("git", true, { "-C", repoDir, "--git-dir", gitDir, "log", "-1", "--format=%ct", "--no-show-signature", input.getRev()->gitRev() }));
-
-        Attrs infoAttrs({
-            {"rev", input.getRev()->gitRev()},
-            {"lastModified", lastModified},
-        });
-
-        if (!shallow)
-            infoAttrs.insert_or_assign("revCount",
-                std::stoull(runProgram("git", true, { "-C", repoDir, "--git-dir", gitDir, "rev-list", "--count", input.getRev()->gitRev() })));
-
-        if (!_input.getRev())
-            getCache()->add(
-                store,
-                unlockedAttrs,
-                infoAttrs,
-                storePath,
-                false);
-
-        getCache()->add(
-            store,
-            getLockedAttrs(),
-            infoAttrs,
-            storePath,
-            true);
-
-        return makeResult(infoAttrs, std::move(storePath));
-    }
+		return makeResult(input, std::move(storePath), infoAttrs, revision, shallow);
+	}
 };
 
 static auto rGitInputScheme = OnStartup([] { registerInputScheme(std::make_unique<GitInputScheme>()); });
 
-}
+} // namespace nix::fetchers

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -22,7 +22,27 @@ using namespace std::string_literals;
 // A bit slower for local repositories
 // A lot faster for remote repositories
 //
-// fixes: 8134 by fixing support for shallow fetches
+// Related issues and PRs in no particular order
+// - fixes: 8134 by fixing support for shallow fetches
+//   TODO: Leave comment on the issue to try out PR
+// - 2944: among other things wants support for getting only subdirectories.
+//   afaik this should be possible with sparse checkouts. (fetch --filter=tree:0)
+// - 5811: sparse checkouts.
+// - 4173: Use system ssl certs, probably not related to this
+// - #4313 #https://github.com/NixOS/nix/pull/8246 5407: binary substitutors
+// - 4623: LFS support
+// - 5291: abbreviated references apparently worked for tags at some point and people are mad that it changed.
+//   It is probably ok to reintroduce the old behaviour, because refs are impure anyway. We should just keep
+//   in mind that that can lead to weird caching issues, when there are refs with the same name as tags.
+//   For repos with a lot of refs and without rev, the current implementation is slower, as we do two calls
+//   To the remote repository( ls-remote and fetch)
+// - 6496: Support for sha256
+// - 6929: why do we even have revCount
+// - 7908: git is not available everywhere
+// - 7453: support for netrc file can be added by passing -c credential.helper="netrc -f FILE" to git. In
+//   config files that var can be specified multiple times for multiple helpers, I am not sure how it behaves
+//   as a flag. Also not sure if this would make it harder to switch to gitoxide or libgit2 at some point.
+// - fixes: 7209: Adjusts documentation with correct default value for name.
 //
 // BUG:
 //   fetchGit { url = "local"; ref = "abbreviated tag"} works but
@@ -37,6 +57,7 @@ using namespace std::string_literals;
 // - [x] submodules works
 // - [ ] Documentation is updated
 // - [ ] Debug prints are removed
+// - [ ] Caching behaviour is documented
 //
 // Ideas:
 // - We could significantly speed up the cloning of large repos by only using sparse checkouts. I only see two problems with that:

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -43,6 +43,13 @@ using namespace std::string_literals;
 //   config files that var can be specified multiple times for multiple helpers, I am not sure how it behaves
 //   as a flag. Also not sure if this would make it harder to switch to gitoxide or libgit2 at some point.
 // - fixes: 7209: Adjusts documentation with correct default value for name.
+// - 7195: Trouble with inconsistencies between dirty local, submodule and remote repos. Apparently `git archive`
+//   behaves slightly different to `git clone` because it does not contain things with export-ignore in gitattributes.
+//   Previously clone-like behaviour was used for submodules and dirty local repos and archive-like behavior for
+//   everything else. This PR unifies everything to archive like behavior.
+// - 5863: Wants a spinner for cloning
+// - 5313: Related to 7195 I think. Maybe some transformations are applied in git archive and not in git clone
+//   or vice-versa
 //
 // BUG:
 //   fetchGit { url = "local"; ref = "abbreviated tag"} works but
@@ -58,6 +65,7 @@ using namespace std::string_literals;
 // - [ ] Documentation is updated
 // - [ ] Debug prints are removed
 // - [ ] Caching behaviour is documented
+// - [ ] Remove this comment and open a PR
 //
 // Ideas:
 // - We could significantly speed up the cloning of large repos by only using sparse checkouts. I only see two problems with that:

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -86,10 +86,16 @@ Here are some examples of flake references in their URL-like representation:
 * `git+https://github.com/NixOS/patchelf`: A Git repository.
 * `git+https://github.com/NixOS/patchelf?ref=master`: A specific
   branch of a Git repository.
-* `git+https://github.com/NixOS/patchelf?ref=master&rev=f34751b88bd07d7f44f5cd3200fb4122bf916c7e`:
-  A specific branch *and* revision of a Git repository.
+* `git+https://github.com/NixOS/patchelf?ref=refs/tags/0.18.0`:
+  A specific tag of a Git repository.
+* `git+https://github.com/NixOS/patchelf?rev=f34751b88bd07d7f44f5cd3200fb4122bf916c7e`:
+  A specific revision/commit of a Git repository.
 * `https://github.com/NixOS/patchelf/archive/master.tar.gz`: A tarball
   flake.
+* `git+file:///path/to/local/flake`:
+  A local Git repository at the current working tree
+* `git+file:///path/to/local/flake?ref=main`:
+  A local Git repository at a specific reference
 
 ## Path-like syntax
 
@@ -170,28 +176,24 @@ Currently the `type` attribute can be one of the following:
   They have the URL form
 
   ```
-  git(+http|+https|+ssh|+git|+file|):(//<server>)?<path>(\?<params>)?
+  git(+http|+https|+ssh|+file|):(//<server>)?<path>(\?<params>)?
   ```
 
   The `ref` attribute defaults to resolving the `HEAD` reference.
+  Has no effect if `rev` is specified.
 
-  The `rev` attribute must denote a commit that exists in the branch
-  or tag specified by the `ref` attribute, since Nix doesn't do a full
-  clone of the remote repository by default (and the Git protocol
-  doesn't allow fetching a `rev` without a known `ref`). The default
+  The `rev` attribute denotes a commit/revision. The default
   is the commit currently pointed to by `ref`.
 
-  When `git+file` is used without specifying `ref` or `rev`, files are
-  fetched directly from the local `path` as long as they have been added
-  to the Git repository. If there are uncommitted changes, the reference
-  is treated as dirty and a warning is printed.
+  When `git+file` is used without specifying `ref` and `rev` and the repository includes modified tracked files or
+  staged changes, the dirty state of the repository including will be used and a warning will be printed.
 
   For example, the following are valid Git flake references:
 
   * `git+https://example.org/my/repo`
   * `git+https://example.org/my/repo?dir=flake1`
   * `git+ssh://git@github.com/NixOS/nix?ref=v1.2.3`
-  * `git://github.com/edolstra/dwarffs?ref=unstable&rev=e486d8d40e626a20e06d792db8cc5ac5aba9a5b4`
+  * `git://github.com/edolstra/dwarffs&rev=e486d8d40e626a20e06d792db8cc5ac5aba9a5b4`
   * `git+file:///home/my-user/some-repo/some-repo`
 
 * `mercurial`: Mercurial repositories. The URL form is similar to the

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -51,7 +51,7 @@ git -C $repo checkout master
 devrev=$(git -C $repo rev-parse devtest)
 out=$(nix eval --impure --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; }" 2>&1)
 
-[[ $(nix eval --raw --expr "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; allRefs = true; } + \"/differentbranch\")") = 'different file' ]]
+[[ $(nix eval --raw --expr "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; } + \"/differentbranch\")") = 'different file' ]]
 
 # In pure eval mode, fetchGit without a revision should fail.
 [[ $(nix eval --impure --raw --expr "builtins.readFile (fetchGit file://$repo + \"/hello\")") = world ]]

--- a/tests/fetchGit.sh
+++ b/tests/fetchGit.sh
@@ -49,9 +49,7 @@ git -C $repo add differentbranch
 git -C $repo commit -m 'Test2'
 git -C $repo checkout master
 devrev=$(git -C $repo rev-parse devtest)
-out=$(nix eval --impure --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; }" 2>&1) || status=$?
-[[ $status == 1 ]]
-[[ $out =~ 'Cannot find Git revision' ]]
+out=$(nix eval --impure --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; }" 2>&1)
 
 [[ $(nix eval --raw --expr "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; allRefs = true; } + \"/differentbranch\")") = 'different file' ]]
 


### PR DESCRIPTION
# Motivation
Currently, the git fetcher has a problem with a lot of unexpected behavior that is not well documented (#5291, #7195, #8134, #6929, probably more). It is also nearly impossible to adjust because the code is quite complex. This PR rewrites the built-in git fetcher to improve maintainability and performance. It also tries to document the exact behavior of the git fetcher. 

# Context
The current git fetcher has three relatively independent code paths for dirty local repos, repos with submodules, and repos without submodules. This PR unifies these paths and removes/documents inconsistencies between them. Previously, it was possible to fetch abbreviated tags (`git fetch v0.1.0` instead of full ref `git fetch refs/tags/v0.1.0`) from local repositories but not remote repositories. #7195 documents how all three paths result in a slightly different result. I am pretty sure that there are more inconsistencies like this.

The current git fetcher only fetches Git references(mostly branches or tags). Fetching a specific revision(commit) always requires knowing and fetching a whole reference that it is part of. The only way to fetch a revision without knowing a reference that contains it is by fetching all references (`allRefs` flag). Before Git version 2.5, Git only supported fetching references. Since Git version 2.5 (2015), it supports fetching by revision. It is supported by GitHub and GitLab (probably most other Git hosting providers too). This PR adjusts the Git fetcher to fetch revisions instead of references. It improves performance when fetching remote repositories, as Git only checks out the necessary commits. It can reduce the amount of data transferred, especially when fetching older commits. It also makes it possible to do shallow fetches, which save a ton of data.

The changes should also make the git fetcher easier to maintain and make the code less spaghetti.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

This PR probably contains breaking changes; I will document them once the code is done. For remote or local repositories at a specific reference or revision, I attempt to have everything that worked previously produce the exact same results. Some things that caused errors before may work after this PR (like fetching a revision without specifying allRefs). I think it is okay to break some edge cases for dirty local repositories, but most normal usage should produce the same result as before. There are a lot of changes to caching behavior.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

This PR uses the Git CLI and not libgit2 or gitoxide.

<!-- Large change: Provide instructions to reviewers on how to read the diff. -->

The best way to read the diff is probably to just view it as a new file.

<!-- Provide context. Reference open issues if available. -->

### Some related issues

This should be most issues that are currently open and related to this PR.

- fixes #8134: Add support for shallow fetching
  <!--  TODO: Leave a comment on the issue to try out PR -->
- #5291 #5128: Nix used to resolve abbreviated references before 2.4 but does not anymore. It is probably okay to reintroduce the old behavior because fetching from references is unpredictable anyway. Keep in mind that this can lead to weird caching issues when there are refs with the same name as tags. 
- #6496: Support for sha256
- fixes #7195: The problem with inconsistent behavior. This PR documents and unifies that. Previously, clone-like behavior was used for everything with submodules and dirty local repos, and archive-like behavior for everything else.
- #5313 #4635: Some more inconsistency issues.
- #6929

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

<!-- 
// Checklist:
// - [x] Caching between commits works (when fetching a commit with already fetched ancestors only the missing commits are fetched).
// - [ ] Compared performance to previous implementation
// - [x] Dirty local, local and remote repos behave the same way.
// - [ ] All three layers of caching respect the correct expiration.
// - [x] shallow repos works
// - [x] submodules works
// - [ ] Documentation is updated
// - [ ] Debug prints are removed
// - [ ] Caching behaviour is documented
// - [ ] Remove this comment and open a PR
//
// Ideas:
// - We could significantly speed up the cloning of large repos by only using sparse checkouts. I only see two problems with that:
//   1. Getting revCount
//   2. Significantly more disk usage when fetching revisions in reverse order
//   I currently think that the best way to do this is by having 2 local cache, one with only shallow commits, and one with only commits, but no content (--filter=tree:0). The second repo is only for calculating revCount.
 -->
