### PR TITLE
doc/hacking: fix `make` target to build the docs

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -228,7 +228,7 @@ This happens late in the process, so `nix build` is not suitable for iterating.
 To build the manual incrementally, run:
 
 ```console
-make html -j $NIX_BUILD_CORES
+make manual-html -j $NIX_BUILD_CORES
 ```
 
 In order to reflect changes to the [Makefile], clear all generated files before re-building:


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Was confused why `make html` didn't work while working on #9032, but then I realized that after this section was written, the target was renamed to `manual-html` in 6910f5dcb6784360589b860b8f80487a5c97fe08.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
