### PR TITLE
src/libstore/profiles.cc: fix comparison of sign difference

### DIFF
--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -183,7 +183,7 @@ void deleteGenerationsGreaterThan(const Path & profile, GenerationNumber max, bo
     iterDropUntil(gens, i, [&](auto & g) { return g.number == curGen; });
 
     // Skip over `max` generations, preserving them
-    for (auto keep = 0; i != gens.rend() && keep < max; ++i, ++keep);
+    for (GenerationNumber keep = 0; i != gens.rend() && keep < max; ++i, ++keep);
 
     // Delete the rest
     for (; i != gens.rend(); ++i)


### PR DESCRIPTION
Detected by `gcc` as:

      CXX    src/libstore/profiles.o
    src/libstore/profiles.cc: In function 'void nix::deleteGenerationsGreaterThan(const Path&, GenerationNumber, bool)':
    src/libstore/profiles.cc:186:50: warning: comparison of integer expressions of different signedness: 'int' and 'nix::GenerationNumber' {aka 'long unsigned int'} [-Wsign-compare]
      186 |     for (auto keep = 0; i != gens.rend() && keep < max; ++i, ++keep);
          |                                             ~~~~~^~~~~

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
