### PR TITLE
flakes: adopt repl-flake behavior as default

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -3,3 +3,5 @@
 - [URL flake references](@docroot@/command-ref/new-cli/nix3-flake.md#flake-references) now support [percent-encoded](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) characters.
 
 - [Path-like flake references](@docroot@/command-ref/new-cli/nix3-flake.md#path-like-syntax) now accept arbitrary unicode characters (except `#` and `?`).
+
+- The experimental feature `repl-flake` is no longer needed, as its functionality is now part of the `flakes` experimental feature. To get the previous behavior, use the `--file/--expr` flags accordingly.

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -163,6 +163,8 @@ constexpr std::array<ExperimentalFeatureDetails, 14> xpFeatureDetails = {{
         .tag = Xp::ReplFlake,
         .name = "repl-flake",
         .description = R"(
+            *Enabled with [`flakes`](#xp-feature-flakes) since 2.19*
+
             Allow passing [installables](@docroot@/command-ref/new-cli/nix.md#installables) to `nix repl`, making its interface consistent with the other experimental commands.
         )",
     },

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -47,7 +47,7 @@ struct CmdRepl : RawInstallablesCommand
 
     void applyDefaultInstallables(std::vector<std::string> & rawInstallables) override
     {
-        if (!experimentalFeatureSettings.isEnabled(Xp::ReplFlake) && !(file) && rawInstallables.size() >= 1) {
+        if (!experimentalFeatureSettings.isEnabled(Xp::Flakes) && !(file) && rawInstallables.size() >= 1) {
             warn("future versions of Nix will require using `--file` to load a file");
             if (rawInstallables.size() > 1)
                 warn("more than one input file is not currently supported");

--- a/src/nix/repl.md
+++ b/src/nix/repl.md
@@ -36,7 +36,7 @@ R""(
   Loading Installable ''...
   Added 1 variables.
 
-  # nix repl --extra-experimental-features 'flakes repl-flake' nixpkgs
+  # nix repl --extra-experimental-features 'flakes' nixpkgs
   Loading Installable 'flake:nixpkgs#'...
   Added 5 variables.
 

--- a/tests/repl.sh
+++ b/tests/repl.sh
@@ -105,17 +105,12 @@ testReplResponseNoRegex '
 testReplResponse '
 drvPath
 ' '".*-simple.drv"' \
-$testDir/simple.nix
+--file $testDir/simple.nix
 
 testReplResponse '
 drvPath
 ' '".*-simple.drv"' \
 --file $testDir/simple.nix --experimental-features 'ca-derivations'
-
-testReplResponse '
-drvPath
-' '".*-simple.drv"' \
---file $testDir/simple.nix --extra-experimental-features 'repl-flake ca-derivations'
 
 mkdir -p flake && cat <<EOF > flake/flake.nix
 {
@@ -130,7 +125,7 @@ EOF
 testReplResponse '
 foo + baz
 ' "3" \
-    ./flake ./flake\#bar --experimental-features 'flakes repl-flake'
+    ./flake ./flake\#bar --experimental-features 'flakes'
 
 # Test the `:reload` mechansim with flakes:
 # - Eval `./flake#changingThing`
@@ -143,7 +138,7 @@ sleep 1 # Leave the repl the time to eval 'foo'
 sed -i 's/beforeChange/afterChange/' flake/flake.nix
 echo ":reload"
 echo "changingThing"
-) | nix repl ./flake --experimental-features 'flakes repl-flake')
+) | nix repl ./flake --experimental-features 'flakes')
 echo "$replResult" | grepQuiet -s beforeChange
 echo "$replResult" | grepQuiet -s afterChange
 


### PR DESCRIPTION
# Motivation
I think the behavior of `repl-flake` makes sense to be the default when `flakes` are enabled. Robert and I's idea was to avoid *actually* deprecating the `repl-flake` experimental feature with a warning to avoid annoyance and because it's frankly not the most important thing we want to deal with, so this should be pretty straightforward.

I already discussed with @fricklerhandwerk about making this change at NixCon and I finally implemented it with @roberth at NixCamp.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
