### PR TITLE
Fix repl.md duplicate typo

### DIFF
--- a/src/nix/repl.md
+++ b/src/nix/repl.md
@@ -43,9 +43,6 @@ R""(
   nix-repl> legacyPackages.x86_64-linux.emacs.name
   "emacs-27.1"
 
-  nix-repl> legacyPackages.x86_64-linux.emacs.name
-  "emacs-27.1"
-
   nix-repl> :q
 
   # nix repl --expr 'import <nixpkgs>{}'


### PR DESCRIPTION
Seems like `legacyPackages.x86_64-linux.emacs.name` is accidentally shown twice. Sorry if this is intentional.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
