### PR TITLE
fetchTree: handle tarballs with multiple top-level files

### DIFF
--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -151,9 +151,7 @@ DownloadTarballResult downloadTarball(
         AutoDelete autoDelete(tmpDir, true);
         unpackTarfile(store->toRealPath(res.storePath), tmpDir);
         auto members = readDirectory(tmpDir);
-        if (members.size() != 1)
-            throw nix::Error("tarball '%s' contains an unexpected number of top-level files", url);
-        auto topDir = tmpDir + "/" + members.begin()->name;
+        auto topDir = members.size() == 1 ? tmpDir + "/" + members.begin()->name : tmpDir;
         lastModified = lstat(topDir).st_mtime;
         unpackedStorePath = store->addToStore(name, topDir, FileIngestionMethod::Recursive, htSHA256, defaultPathFilter, NoRepair);
     }

--- a/tests/tarball.sh
+++ b/tests/tarball.sh
@@ -16,9 +16,15 @@ hash=$(nix hash path $tarroot)
 test_tarball() {
     local ext="$1"
     local compressor="$2"
+    local noroot="${3:-false}"
 
     tarball=$TEST_ROOT/tarball.tar$ext
-    (cd $TEST_ROOT && tar cf - tarball) | $compressor > $tarball
+    if [ "$noroot" = true ]; then
+        local tarargs="-C tarball ."
+    else
+        local tarargs="tarball"
+    fi
+    (cd $TEST_ROOT && tar cf - $tarargs) | $compressor > $tarball
 
     nix-env -f file://$tarball -qa --out-path | grepQuiet dependencies
 
@@ -55,6 +61,7 @@ test_tarball() {
 }
 
 test_tarball '' cat
+test_tarball '' cat true
 test_tarball .xz xz
 test_tarball .gz gzip
 


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
See #7083. While the issue can be worked around by using the `file` type, it imposes a dependency on nixpkgs and makes implementation of other fetchers based on `downloadTarball` more difficult.

# Context

Issue #7083 suggests two solutions to this problem:

1. If there are multiple top-level files, use the archive root
2. A stripRoot attribute, like in nixpkgs' fetchzip

This patch implements (1). It is forward-compatible with (2) if a missing stripRoot is interpreted as "automatic".

Fixes #7083



<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
