### PR TITLE
libexpr: support `:doc` for nixpkgs lambdas

### DIFF
--- a/src/libexpr/comment.hh
+++ b/src/libexpr/comment.hh
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "nixexpr.hh"
+
+namespace nix {
+
+struct Comment
+{
+    /// The raw content
+    std::string content;
+
+    /// The start point of this comment
+    PosIdx start;
+
+    /// The end point of this comment (exclusive)
+    PosIdx end;
+};
+
+} // namespace nix

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -751,6 +751,17 @@ std::optional<EvalState::Doc> EvalState::getDoc(Value & v)
                 .doc = doc,
             };
     }
+    if (v.isLambda()) {
+        ExprLambda * lambda = v.lambda.fun;
+        Expr * e = lambda;
+        if (attachedComments.contains(e)) {
+            return Doc{
+                .pos = positions[lambda->getPos()],
+                .name = "", /* TODO: nix::Symbol */
+                .args = {},
+                .doc = attachedComments[e].content.c_str()};
+        }
+    }
     return {};
 }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include "attr-set.hh"
+#include "comment.hh"
 #include "types.hh"
 #include "value.hh"
 #include "nixexpr.hh"
@@ -185,6 +186,8 @@ class EvalState : public std::enable_shared_from_this<EvalState>
 public:
     SymbolTable symbols;
     PosTable positions;
+
+    std::map<Expr *, Comment> attachedComments;
 
     const Symbol sWith, sOutPath, sDrvPath, sType, sMeta, sName, sValue,
         sSystem, sOverrides, sOutputs, sOutputName, sIgnoreNulls,

--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -33,7 +33,13 @@ static inline PosIdx makeCurPos(const YYLTYPE & loc, ParseData * data)
     return data->state.positions.add(data->origin, loc.first_line, loc.first_column);
 }
 
+static inline PosIdx makeEndPos(const YYLTYPE & loc, ParseData * data)
+{
+    return data->state.positions.add(data->origin, loc.last_line, loc.last_column);
+}
+
 #define CUR_POS makeCurPos(*yylloc, data)
+#define END_POS makeEndPos(*yylloc, data)
 
 // backup to recover from yyless(0)
 thread_local YYLTYPE prev_yylloc;
@@ -303,7 +309,13 @@ or          { return OR_KW; }
 
 [ \t\r\n]+    /* eat up whitespace */
 \#[^\r\n]*    /* single-line comments */
-\/\*([^*]|\*+[^*/])*\*+\/  /* long comments */
+\/\*([^*]|\*+[^*/])*\*+\/  {
+  data->comments.emplace_back(Comment {
+    .content = std::string(yytext, (size_t) yyleng),
+    .start = CUR_POS,
+    .end = END_POS
+  });
+}
 
 {ANY}       {
               /* Don't return a negative number, as this will cause


### PR DESCRIPTION
# Motivation

This is a proof-of-conecpt PR that implements https://github.com/NixOS/rfcs/pull/145. (lambdas only, but we can easily add more types.)

Currently it can display functions like `lib.isList`, `lib.id`

```
 Welcome to Nix 2.19.0. Type :? for help.

nix-repl> lib = (import <nixpkgs> { }).lib              

nix-repl> :doc lib.id                      
/* The identity function For when you need a function that does “nothing”.

    |  Type: id :: a -> a

    */

nix-repl> lib.id
«lambda @ /nix/store/cz973qsjldbw4x7fx0rwcvhr9k645vz2-source/lib/trivial.nix:14:5»

nix-repl> :doc lib.const
/* The constant function

    |  Ignores the second argument. If called with only one argument,
    |  constructs a function that always returns a static value.
    | 
    |  Type: const :: a -> b -> a
    |  Example:
    |    let f = const 5; in f 10
    |    => 5

    */

nix-repl> :doc lib.concat
/* Concatenate two lists

    |  Type: concat :: [a] -> [a] -> [a]
    | 
    |  Example:
    |    concat [ 1 2 ] [ 3 4 ]
    |    => [ 1 2 3 4 ]

    */

nix-repl>
```

![image](https://github.com/NixOS/nix/assets/36667224/7e5e587f-4c42-4660-bda1-9decd4ac0ee1)
![image](https://github.com/NixOS/nix/assets/36667224/03b1f134-124d-4bf4-99dc-4ed580d4b10f)


# Context

Related-to: #5527 #1652
Fixes: #3904 
Link: https://github.com/NixOS/rfcs/pull/145
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
