### PR TITLE
Respect `NOCOLOR`

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -1515,7 +1515,7 @@ bool shouldANSI()
 {
     return isatty(STDERR_FILENO)
         && getEnv("TERM").value_or("dumb") != "dumb"
-        && !getEnv("NO_COLOR").has_value();
+        && !(getEnv("NO_COLOR").has_value() || getEnv("NOCOLOR").has_value());
 }
 
 std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int width)


### PR DESCRIPTION
While `nix` has always been respectful towards requests for `NO_COLOR=1`, this change adds respect for `NOCOLOR=1`.

<3

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This ideally makes the tool more accessible to folks like me, who are exhausted by guessing whether `NO_COLOR` or `NOCOLOR` is the right environment variable to set.

# Context
<!-- Provide context. Reference open issues if available. -->
Several tools support both.
Some tools such as `grep` have been migrated from supporting `NO_COLOR` over to `NOCOLOR` and emit deprecation warnings.
Developers who use multiple machines and a variety of tools might be setting `NO_COLOR=1` and/or `NOCOLOR=1` and expect either/both to work.

Personally it's no skin off my back to check both, so _why not make everyone happy_?

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
