### PR TITLE
fetchTree cleanup

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -177,12 +177,12 @@ static RegisterPrimOp primop_fetchTree({
     .args = {"input"},
     .doc = R"(
       Fetch a source tree or a plain file using one of the supported backends.
-      *input* can be an attribute set representation of [flake reference](@docroot@/command-ref/new-cli/nix3-flake.md#flake-references) or a URL.
-      The input should be "locked", that is, it should contain a commit hash or content hash unless impure evaluation (`--impure`) is allowed.
+      *input* must be a [flake reference](@docroot@/command-ref/new-cli/nix3-flake.md#flake-references), either in attribute set representation or in the URL-like syntax.
+      The input should be "locked", that is, it should contain a commit hash or content hash unless impure evaluation (`--impure`) is enabled.
 
       Here are some examples of how to use `fetchTree`:
 
-      - Fetch a GitHub repository:
+      - Fetch a GitHub repository using the attribute set representation:
 
           ```nix
           builtins.fetchTree {
@@ -193,7 +193,7 @@ static RegisterPrimOp primop_fetchTree({
           }
           ```
 
-        This evaluates to attribute set:
+        This evaluates to the following attribute set:
 
           ```
           {
@@ -205,15 +205,12 @@ static RegisterPrimOp primop_fetchTree({
             shortRev = "ae2e6b3";
           }
           ```
-      - Fetch a single file from a URL:
 
-          ```nix
-          builtins.fetchTree "https://example.com/"
+      - Fetch the same GitHub repository using the URL-like syntax:
+
           ```
-
-      > **Note**
-      >
-      > This function requires the [`flakes` experimental feature](@docroot@/contributing/experimental-features.md#xp-feature-flakes) to be enabled.
+          builtins.fetchTree "github:NixOS/nixpkgs/ae2e6b3958682513d28f7d633734571fb18285dd"
+          ```
     )",
     .fun = prim_fetchTree,
     .experimentalFeature = Xp::Flakes,

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -152,7 +152,7 @@ static void fetchTree(
         }
     }
 
-    if (!evalSettings.pureEval && !input.isDirect())
+    if (!evalSettings.pureEval && !input.isDirect() && experimentalFeatureSettings.isEnabled(Xp::Flakes))
         input = lookupInRegistries(state.store, input).first;
 
     if (evalSettings.pureEval && !input.isLocked())

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -236,6 +236,10 @@ static RegisterPrimOp primop_fetchTree({
           ```nix
           builtins.fetchTree "https://example.com/"
           ```
+
+      > **Note**
+      >
+      > This function requires the [`flakes` experimental feature](@docroot@/contributing/experimental-features.md#xp-feature-flakes) to be enabled.
     )",
     .fun = prim_fetchTree,
     .experimentalFeature = Xp::Flakes,

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -293,7 +293,6 @@ struct GitInputScheme : InputScheme
             if (name != "type" && name != "url" && name != "ref" && name != "rev" && name != "shallow" && name != "submodules" && name != "lastModified" && name != "revCount" && name != "narHash" && name != "allRefs" && name != "name" && name != "dirtyRev" && name != "dirtyShortRev")
                 throw Error("unsupported Git input attribute '%s'", name);
 
-        parseURL(getStrAttr(attrs, "url"));
         maybeGetBoolAttr(attrs, "shallow");
         maybeGetBoolAttr(attrs, "submodules");
         maybeGetBoolAttr(attrs, "allRefs");
@@ -305,6 +304,9 @@ struct GitInputScheme : InputScheme
 
         Input input;
         input.attrs = attrs;
+        auto url = fixGitURL(getStrAttr(attrs, "url"));
+        parseURL(url);
+        input.attrs["url"] = url;
         return input;
     }
 

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -158,4 +158,21 @@ ParsedUrlScheme parseUrlScheme(std::string_view scheme)
     };
 }
 
+std::string fixGitURL(const std::string & url)
+{
+    std::regex scpRegex("([^/]*)@(.*):(.*)");
+    if (!hasPrefix(url, "/") && std::regex_match(url, scpRegex))
+        return std::regex_replace(url, scpRegex, "ssh://$1@$2/$3");
+    else {
+        if (url.find("://") == std::string::npos) {
+            return (ParsedURL {
+                .scheme = "file",
+                .authority = "",
+                .path = url
+            }).to_string();
+        } else
+            return url;
+    }
+}
+
 }

--- a/src/libutil/url.hh
+++ b/src/libutil/url.hh
@@ -45,4 +45,9 @@ struct ParsedUrlScheme {
 
 ParsedUrlScheme parseUrlScheme(std::string_view scheme);
 
+/* Detects scp-style uris (e.g. git@github.com:NixOS/nix) and fixes
+   them by removing the `:` and assuming a scheme of `ssh://`. Also
+   changes absolute paths into file:// URLs. */
+std::string fixGitURL(const std::string & url);
+
 }

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -182,6 +182,12 @@ Currently the `type` attribute can be one of the following:
   git(+http|+https|+ssh|+git|+file|):(//<server>)?<path>(\?<params>)?
   ```
 
+  or
+
+  ```
+  <user>@<server>:<path>
+  ```
+
   The `ref` attribute defaults to resolving the `HEAD` reference.
 
   The `rev` attribute must denote a commit that exists in the branch

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -35,6 +35,8 @@ unset _NIX_FORCE_HTTP
 path0=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$TEST_ROOT/worktree).outPath")
 path0_=$(nix eval --impure --raw --expr "(builtins.fetchTree { type = \"git\"; url = file://$TEST_ROOT/worktree; }).outPath")
 [[ $path0 = $path0_ ]]
+path0_=$(nix eval --impure --raw --expr "(builtins.fetchTree git+file://$TEST_ROOT/worktree).outPath")
+[[ $path0 = $path0_ ]]
 export _NIX_FORCE_HTTP=1
 [[ $(tail -n 1 $path0/hello) = "hello" ]]
 

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -186,6 +186,10 @@ in
     client.succeed("nix registry pin nixpkgs")
     client.succeed("nix flake metadata nixpkgs --tarball-ttl 0 >&2")
 
+    # Test fetchTree on a github URL.
+    hash = client.succeed(f"nix eval --raw --expr '(fetchTree {info['url']}).narHash'")
+    assert hash == info['locked']['narHash']
+
     # Shut down the web server. The flake should be cached on the client.
     github.succeed("systemctl stop httpd.service")
 


### PR DESCRIPTION
# Motivation

Reviewing current `builtins.fetchTree` behaviour, I made a few changes:

* The (probably unintentional) hack to handle paths as tarballs has been removed. This is almost certainly not what users expect and is inconsistent with flakeref handling everywhere else.

* The hack to support scp-style Git URLs has been moved to the Git  fetcher, so it's now supported not just by fetchTree but by flake inputs.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
