### PR TITLE
test precedence for setting the search path

### DIFF
--- a/tests/nix_path.sh
+++ b/tests/nix_path.sh
@@ -12,3 +12,63 @@ nix-instantiate --eval -E '<by-relative-path/simple.nix>' --restrict-eval
 
 [[ $(nix-instantiate --find-file by-absolute-path/simple.nix) = $PWD/simple.nix ]]
 [[ $(nix-instantiate --find-file by-relative-path/simple.nix) = $PWD/simple.nix ]]
+
+tmpfile=$(mktemp)
+echo "nix-path = " > "$tmpfile"
+
+# This should still work because the NIX_PATH environment variable will take
+# precedence over the empty nix path set by the configuration file
+NIX_USER_CONF_FILES="$tmpfile" nix-instantiate --eval -E '<by-relative-path/simple.nix>' --restrict-eval
+
+unset NIX_PATH
+
+mkdir -p $TEST_ROOT/{from-nix-path-file,from-NIX_PATH,from-nix-path,from-extra-nix-path,from-I}
+touch $TEST_ROOT/{from-nix-path-file,from-NIX_PATH,from-nix-path,from-extra-nix-path,from-I}/bar.nix
+
+echo "nix-path = foo=$TEST_ROOT/from-nix-path-file" >> $NIX_CONF_DIR/nix.conf
+
+# Use nix.conf in absence of NIX_PATH
+[[ $(nix-instantiate --find-file foo/bar.nix) = $TEST_ROOT/from-nix-path-file/bar.nix ]]
+
+# Setting nix-path on the command line with an unset NIX_PATH obeys the command-line flag
+[[ $(nix-instantiate --option nix-path by-relative-path=. --find-file by-relative-path/simple.nix) = "$PWD/simple.nix" ]]
+# Setting nix-path on the command line with an empty NIX_PATH also obeys the command-line flag
+[[ $(NIX_PATH= nix-instantiate --option nix-path by-relative-path=. --find-file by-relative-path/simple.nix) = "$PWD/simple.nix" ]]
+
+# NIX_PATH overrides nix.conf
+[[ $(NIX_PATH=foo=$TEST_ROOT/from-NIX_PATH nix-instantiate --find-file foo/bar.nix) = $TEST_ROOT/from-NIX_PATH/bar.nix ]]
+# if NIX_PATH does not have the desired entry, it fails
+(! NIX_PATH=foo=$TEST_ROOT nix-instantiate --find-file foo/bar.nix)
+
+# -I extends nix.conf
+[[ $(nix-instantiate -I foo=$TEST_ROOT/from-I --find-file foo/bar.nix) = $TEST_ROOT/from-I/bar.nix ]]
+# if -I does not have the desired entry, the value from nix.conf is used
+[[ $(nix-instantiate -I foo=$TEST_ROOT --find-file foo/bar.nix) = $TEST_ROOT/from-nix-path-file/bar.nix ]]
+
+# -I extends NIX_PATH
+[[ $(NIX_PATH=foo=$TEST_ROOT/from-NIX_PATH nix-instantiate -I foo=$TEST_ROOT/from-I --find-file foo/bar.nix) = $TEST_ROOT/from-I/bar.nix ]]
+# if -I does not have the desired entry, the value from NIX_PATH is used
+[[ $(NIX_PATH=$TEST_ROOT nix-instantiate -I foo=$TEST_ROOT/from-I --find-file foo/bar.nix) = $TEST_ROOT/from-NIX_PATH/bar.nix ]]
+
+# --extra-nix-path extends NIX_PATH
+[[ $(NIX_PATH=foo=$TEST_ROOT/from-NIX_PATH nix-instantiate --extra-nix-path foo=$TEST_ROOT/from-extra-nix-path --find-file foo/bar.nix) = $TEST_ROOT/from-extra-nix-path/bar.nix ]]
+# if --extra-nix-path does not have the desired entry, the value from NIX_PATH is used
+[[ $(NIX_PATH=$TEST_ROOT/from-NIX_PATH nix-instantiate --extra-nix-path foo=$TEST_ROOT --find-file foo/bar.nix) = $TEST_ROOT/from-NIX_PATH/bar.nix ]]
+
+# --nix-path overrides NIX_PATH
+[[ $(NIX_PATH=foo=$TEST_ROOT/from-NIX_PATH nix-instantiate --nix-path foo=$TEST_ROOT/from-nix-path --find-file foo/bar.nix) = $TEST_ROOT/from-nix-path/bar.nix ]]
+# if --nix-path does not have the desired entry, it fails
+(! NIX_PATH=$TEST_ROOT/from-NIX_PATH nix-instantiate --nix-path foo=$TEST_ROOT --find-file foo/bar.nix)
+
+# --nix-path overrides nix.conf
+[[ $(nix-instantiate --nix-path foo=$TEST_ROOT/from-nix-path --find-file foo/bar.nix) = $TEST_ROOT/from-nix-path/bar.nix ]]
+(! nix-instantiate --nix-path foo=$TEST_ROOT --find-file foo/bar.nix)
+
+# --extra-nix-path extends nix.conf
+[[ $(nix-instantiate --extra-nix-path foo=$TEST_ROOT/from-extra-nix-path --find-file foo/bar.nix) = $TEST_ROOT/from-extra-nix-path/bar.nix ]]
+# if --extra-nix-path does not have the desired entry, it is taken from nix.conf
+[[ $(nix-instantiate --extra-nix-path foo=$TEST_ROOT --find-file foo/bar.nix) = $TEST_ROOT/from-nix-path-file/bar.nix ]]
+
+# -I extends --nix-path
+[[ $(nix-instantiate --nix-path foo=$TEST_ROOT/from-nix-path -I foo=$TEST_ROOT/from-I --find-file foo/bar.nix) = $TEST_ROOT/from-I/bar.nix ]]
+[[ $(nix-instantiate --nix-path foo=$TEST_ROOT/from-nix-path -I foo=$TEST_ROOT --find-file foo/bar.nix) = $TEST_ROOT/from-nix-path/bar.nix ]]

--- a/tests/restricted.sh
+++ b/tests/restricted.sh
@@ -17,6 +17,9 @@ nix-instantiate --restrict-eval --eval -E 'builtins.readDir ../src/nix-channel' 
 (! nix-instantiate --restrict-eval --eval -E 'let __nixPath = [ { prefix = "foo"; path = ./.; } ]; in <foo>')
 nix-instantiate --restrict-eval --eval -E 'let __nixPath = [ { prefix = "foo"; path = ./.; } ]; in <foo>' -I src=.
 
+# no default NIX_PATH
+(unset NIX_PATH; ! nix-instantiate --restrict-eval --find-file .)
+
 p=$(nix eval --raw --expr "builtins.fetchurl file://$(pwd)/restricted.sh" --impure --restrict-eval --allowed-uris "file://$(pwd)")
 cmp $p restricted.sh
 


### PR DESCRIPTION
this is just to show the principle for now.
the test cases are incomplete and way too manual.
the complete specification should follow this table, and the tests ideally be generated from that automatically:

| precedence             | hard-coded | nix.conf: nix-path | nix.conf: extra-nix-path | NIX_CONFIG: nix-path | NIX_CONFIG: extra-nix-path | NIX_PATH  | --nix-path  | --extra-nix-path  | -I              |
|------------------------|------------|------------------|------------------------|-----------------|-----------------------|-----------|-----------|-----------------|-----------------|
| hard-coded             | x          | ^override        | ^append                | ^override       | ^append               | ^override | ^override | ^append         | ^append         |
| nix.conf: nix-path       |            | last wins        | ^append                | ^override       | ^append               | ^override | ^override | ^append         | ^append         |
| nix.conf: extra-nix-path |            |                  | append in order        | ^override       | ^append               | ^override | ^override | ^append         | ^append         |
| NIX_CONFIG: nix-path        |            |                  |                        | last wins       | ^append               | ^override | ^override | ^append         | ^append         |
| NIX_CONFIG: extra-nix-path  |            |                  |                        |                 | append in order       | ^override | ^override | ^append         | ^append         |
| NIX_PATH               |            |                  |                        |                 |                       | x         | ^override | ^append         | ^append         |
| --nix-path               |            |                  |                        |                 |                       |           | last wins | ^append         | ^append         |
| --extra-nix-path         |            |                  |                        |                 |                       |           |           | append in order | append in order |
| -I                     |            |                  |                        |                 |                       |           |           |                 | append in order |


# Motivation

The current behavior being inconsistent and surprising (#8890 #8784) has spawned multiple competing and conflicting attempts of fixing it:

- https://github.com/NixOS/nix/pull/8902
- https://github.com/NixOS/nix/pull/7871
- https://github.com/NixOS/nix/pull/7689
  - https://github.com/NixOS/nix/pull/7911

# Context

developed together with @thufschmitt

this should also resolve the confusion around behavior of `restrict-eval`, as that is supposed to only allow explicitly defined search paths.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).