### PR TITLE
refine the maintainer's process to unblock discussions more quickly

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -96,8 +96,10 @@ What constitutes a trivial pull request is up to maintainers' judgement.
 Pull requests and issues that are deemed important and controversial are discussed by the team during discussion meetings.
 
 This may be where the merit of the change itself or the implementation strategy is contested by a team member.
+Whenever the discussion opens up questions about the process or this team's goals, this may indicate that the change is too large in scope.
+In that case it is taken off the board to be reconsidered by the author or broken down into smaller pieces that are less far-reaching and can be reviewed independently.
 
-As a general guideline, the order of items is determined as follows:
+As a general guideline, the order of items to discuss is determined as follows:
 
 - Prioritise pull requests over issues
 


### PR DESCRIPTION
# Motivation
this addresses that we're too often running into open-ended discussions
about attempts to solve problems where neither the problem nor the
solution is well-understood enough to make decisions in a reasonable
amount of time.

# Context
<!-- Provide context. Reference open issues if available. -->
this also prevents the @nixos/nix-team from doing more work asynchronously.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).