### PR TITLE
WIP: Generalize the fetcher registry to not be flake specific

### DIFF
--- a/src/libfetchers/fetch-settings.hh
+++ b/src/libfetchers/fetch-settings.hh
@@ -71,18 +71,18 @@ struct FetchSettings : public Config
     Setting<bool> warnDirty{this, true, "warn-dirty",
         "Whether to warn about dirty Git/Mercurial trees."};
 
-    Setting<std::string> flakeRegistry{this, "https://channels.nixos.org/flake-registry.json", "flake-registry",
+    Setting<std::string> fetcherRegistry{this, "https://channels.nixos.org/fetcher-registry.json", "fetcher-registry",
         R"(
-          Path or URI of the global flake registry.
+          Path or URI of the global fetcerh registry.
 
-          When empty, disables the global flake registry.
+          When empty, disables the global fetcher registry.
         )",
-        {}, true, Xp::Flakes};
+        {}, true, Xp::FetcherRegistry};
 
 
     Setting<bool> useRegistries{this, true, "use-registries",
-        "Whether to use flake registries to resolve flake references.",
-        {}, true, Xp::Flakes};
+        "Whether to use fetcher registries to resolve fetcher references.",
+        {}, true, Xp::FetcherRegistry};
 
     Setting<bool> acceptFlakeConfig{this, false, "accept-flake-config",
         "Whether to accept nix configuration from a flake without prompting.",

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -23,20 +23,20 @@ struct IndirectInputScheme : InputScheme
             else if (std::regex_match(path[1], refRegex))
                 ref = path[1];
             else
-                throw BadURL("in flake URL '%s', '%s' is not a commit hash or branch/tag name", url.url, path[1]);
+                throw BadURL("in URL '%s', '%s' is not a commit hash or branch/tag name", url.url, path[1]);
         } else if (path.size() == 3) {
             if (!std::regex_match(path[1], refRegex))
-                throw BadURL("in flake URL '%s', '%s' is not a branch/tag name", url.url, path[1]);
+                throw BadURL("in URL '%s', '%s' is not a branch/tag name", url.url, path[1]);
             ref = path[1];
             if (!std::regex_match(path[2], revRegex))
-                throw BadURL("in flake URL '%s', '%s' is not a commit hash", url.url, path[2]);
+                throw BadURL("in URL '%s', '%s' is not a commit hash", url.url, path[2]);
             rev = Hash::parseAny(path[2], htSHA1);
         } else
             throw BadURL("GitHub URL '%s' is invalid", url.url);
 
         std::string id = path[0];
         if (!std::regex_match(id, flakeRegex))
-            throw BadURL("'%s' is not a valid flake ID", id);
+            throw BadURL("'%s' is not a valid registry ID", id);
 
         // FIXME: forbid query params?
 
@@ -60,7 +60,7 @@ struct IndirectInputScheme : InputScheme
 
         auto id = getStrAttr(attrs, "id");
         if (!std::regex_match(id, flakeRegex))
-            throw BadURL("'%s' is not a valid flake ID", id);
+            throw BadURL("'%s' is not a valid registry ID", id);
 
         Input input;
         input.direct = false;
@@ -101,7 +101,7 @@ struct IndirectInputScheme : InputScheme
 
     std::optional<ExperimentalFeature> experimentalFeature() override
     {
-        return Xp::Flakes;
+        return Xp::FetcherRegistry;
     }
 };
 

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -46,12 +46,12 @@ std::shared_ptr<Registry> Registry::read(
         }
 
         else
-            throw Error("flake registry '%s' has unsupported version %d", path, version);
+            throw Error("fetcher registry '%s' has unsupported version %d", path, version);
 
     } catch (nlohmann::json::exception & e) {
-        warn("cannot parse flake registry '%s': %s", path, e.what());
+        warn("cannot parse fetcher registry '%s': %s", path, e.what());
     } catch (Error & e) {
-        warn("cannot read flake registry '%s': %s", path, e.what());
+        warn("cannot read fetcher registry '%s': %s", path, e.what());
     }
 
     return registry;
@@ -152,15 +152,15 @@ void overrideRegistry(
 static std::shared_ptr<Registry> getGlobalRegistry(ref<Store> store)
 {
     static auto reg = [&]() {
-        auto path = fetchSettings.flakeRegistry.get();
+        auto path = fetchSettings.fetcherRegistry.get();
         if (path == "") {
             return std::make_shared<Registry>(Registry::Global); // empty registry
         }
 
         if (!hasPrefix(path, "/")) {
-            auto storePath = downloadFile(store, path, "flake-registry.json", false).storePath;
+            auto storePath = downloadFile(store, path, "fetcher-registry.json", false).storePath;
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
-                store2->addPermRoot(storePath, getCacheDir() + "/nix/flake-registry.json");
+                store2->addPermRoot(storePath, getCacheDir() + "/nix/fetcher-registry.json");
             path = store->toRealPath(storePath);
         }
 
@@ -191,7 +191,7 @@ std::pair<Input, Attrs> lookupInRegistries(
  restart:
 
     n++;
-    if (n > 100) throw Error("cycle detected in flake registry for '%s'", input.to_string());
+    if (n > 100) throw Error("cycle detected in fetcher registry for '%s'", input.to_string());
 
     for (auto & registry : getRegistries(store)) {
         // FIXME: O(n)
@@ -215,7 +215,7 @@ std::pair<Input, Attrs> lookupInRegistries(
     }
 
     if (!input.isDirect())
-        throw Error("cannot find flake '%s' in the flake registries", input.to_string());
+        throw Error("cannot find '%s' in the fetcher registries", input.to_string());
 
     debug("looked up '%s' -> '%s'", _input.to_string(), input.to_string());
 

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -55,6 +55,13 @@ constexpr std::array<ExperimentalFeatureDetails, 14> xpFeatureDetails = {{
         )",
     },
     {
+        .tag = Xp::FetcherRegistry,
+        .name = "fetcher-registry",
+        .description = R"(
+            TODO. And TODO be implied by "flakes"?
+        )",
+    },
+    {
         .tag = Xp::Flakes,
         .name = "flakes",
         .description = R"(

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -19,6 +19,7 @@ enum struct ExperimentalFeature
 {
     CaDerivations,
     ImpureDerivations,
+    FetcherRegistry,
     Flakes,
     NixCommand,
     RecursiveNix,


### PR DESCRIPTION
In https://github.com/NixOS/nix/pull/9063#issuecomment-1740915909 @edolstra said these features are not actually Flake-specific. Here is an extremely crude attempt to rename things / change error messages to make that be the case. However there are a few "flake" left I am not sure how to deal with:
```
$ git grep -i flake src/libfetchers/
src/libfetchers/fetch-settings.hh:          Example `~/code/flake.nix`:
src/libfetchers/fetch-settings.hh:    Setting<bool> acceptFlakeConfig{this, false, "accept-flake-config",
src/libfetchers/fetch-settings.hh:        "Whether to accept nix configuration from a flake without prompting.",
src/libfetchers/fetch-settings.hh:        {}, true, Xp::Flakes};
src/libfetchers/fetch-settings.hh:          The commit summary to use when committing changed flake lock files. If
src/libfetchers/fetch-settings.hh:        {}, true, Xp::Flakes};
src/libfetchers/fetchers.cc:            // usages (e.g. `builtins.fetchTree` calls or flake inputs).
src/libfetchers/indirect.cc:std::regex flakeRegex("[a-zA-Z][a-zA-Z0-9_-]*", std::regex::ECMAScript);
src/libfetchers/indirect.cc:        if (url.scheme != "flake") return {};
src/libfetchers/indirect.cc:        if (!std::regex_match(id, flakeRegex))
src/libfetchers/indirect.cc:        if (!std::regex_match(id, flakeRegex))
src/libfetchers/indirect.cc:        url.scheme = "flake";
src/libfetchers/registry.cc:            for (auto & i : json["flakes"]) {
src/libfetchers/registry.cc:    json["flakes"] = std::move(arr);
src/libfetchers/tarball.cc:            // FIXME: would be nice to support arbitrary flakerefs
src/libfetchers/tarball.cc:            // here, e.g. git flakes
```
I don't really know how this feature works and therefore what does or doesn't make sense to change, so I will need some help with this.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
