### PR TITLE
Document changes in store path name validity

### DIFF
--- a/doc/manual/src/release-notes/rl-2.4.md
+++ b/doc/manual/src/release-notes/rl-2.4.md
@@ -342,6 +342,9 @@ more than 2800 commits from 195 contributors since release 2.3.
 * We no longer release source tarballs. If you want to build from
   source, please build from the tags in the Git repository.
 
+* Store path names can now start with `.`, producing paths incompatible
+  with Nix 2.3 and earlier.
+
 ## Contributors
 
 This release has contributions from


### PR DESCRIPTION
The underlying change was introduced by @edolstra in 759947bf72c134592f0ce23d385e48095bd0a301, but was previously undocumented, even in the commit message.

Since it affects any Nix tooling that validates names alike to Nix ≤2.3, and impacts evaluation, it seems worth documenting.