### PR TITLE
Define NixOS tests in `tests/nixos/default.nix` rather than `flake.nix`

### DIFF
--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -1,0 +1,41 @@
+{ lib, nixpkgs, nixpkgsFor }:
+
+let
+
+  nixos-lib = import (nixpkgs + "/nixos/lib") { };
+
+  # https://nixos.org/manual/nixos/unstable/index.html#sec-calling-nixos-tests
+  runNixOSTestFor = system: test: nixos-lib.runTest {
+    imports = [ test ];
+    hostPkgs = nixpkgsFor.${system}.native;
+    defaults = {
+      nixpkgs.pkgs = nixpkgsFor.${system}.native;
+    };
+    _module.args.nixpkgs = nixpkgs;
+  };
+
+in
+
+{
+  authorization = runNixOSTestFor "x86_64-linux" ./authorization.nix;
+
+  remoteBuilds = runNixOSTestFor "x86_64-linux" ./remote-builds.nix;
+
+  nix-copy-closure = runNixOSTestFor "x86_64-linux" ./nix-copy-closure.nix;
+
+  nix-copy = runNixOSTestFor "x86_64-linux" ./nix-copy.nix;
+
+  nssPreload = runNixOSTestFor "x86_64-linux" ./nss-preload.nix;
+
+  githubFlakes = runNixOSTestFor "x86_64-linux" ./github-flakes.nix;
+
+  sourcehutFlakes = runNixOSTestFor "x86_64-linux" ./sourcehut-flakes.nix;
+
+  tarballFlakes = runNixOSTestFor "x86_64-linux" ./tarball-flakes.nix;
+
+  containers = runNixOSTestFor "x86_64-linux" ./containers/containers.nix;
+
+  setuid = lib.genAttrs
+    ["i686-linux" "x86_64-linux"]
+    (system: runNixOSTestFor system ./setuid.nix);
+}


### PR DESCRIPTION
# Motivation

I think the our `flake.nix` is currently too large and too scary looking. I think this matters --- if Nix cannot dog-food itself in a way that is elegant, why should other people have confidence that their own code can be elegant and easy to maintain?

We could do this at many points in time, but I think around now, when we are thinking about stabilizing parts of Flakes, is an especially good time.

This is a first step to make the `flake.nix` smaller, and make individual components responsible for their own packaging. I hope we can do this many more follow-ups like it, until the top-level `flake.nix` is very small and just coordinates between other things.

# Context

#7876 

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
