### PR TITLE
introduce lookup paths as a distinct language construct

### DIFF
--- a/doc/manual/src/SUMMARY.md.in
+++ b/doc/manual/src/SUMMARY.md.in
@@ -30,6 +30,7 @@
   - [Data Types](language/values.md)
   - [Language Constructs](language/constructs.md)
     - [String interpolation](language/string-interpolation.md)
+    - [Lookup path](language/constructs/lookup-path.md)
   - [Operators](language/operators.md)
   - [Derivations](language/derivations.md)
     - [Advanced Attributes](language/advanced-attributes.md)

--- a/doc/manual/src/language/constructs/lookup-path.md
+++ b/doc/manual/src/language/constructs/lookup-path.md
@@ -1,0 +1,27 @@
+# Lookup path
+
+> **Syntax**
+>
+> *lookup-path* = `<` *identifier* [ `/` *identifier* `]`... `>`
+
+A lookup path is an identifier with an optional path suffix that resolves to a [path value](@docroot@/language/values.md#type-path) if the identifier matches a search path entry.
+
+The value of a lookup path is determined by [`builtins.nixPath`](@docroot@/language/builtin-constants.md#builtins-nixPath).
+
+See [`builtins.findFile`](@docroot@/language/builtins.md#builtins-findFile) for details on lookup path resolution.
+
+> **Example**
+>
+> ```nix
+> <nixpkgs>
+>```
+>
+>     /nix/var/nix/profiles/per-user/root/channels/nixpkgs
+
+> **Example**
+>
+> ```nix
+> <nixpkgs/nixos>
+>```
+>
+>     /nix/var/nix/profiles/per-user/root/channels/nixpkgs/nixos

--- a/doc/manual/src/language/values.md
+++ b/doc/manual/src/language/values.md
@@ -107,11 +107,6 @@
   e.g. `~/foo` would be equivalent to `/home/edolstra/foo` for a user
   whose home directory is `/home/edolstra`.
 
-  Paths can also be specified between angle brackets, e.g.
-  `<nixpkgs>`. This means that the directories listed in the
-  environment variable `NIX_PATH` will be searched for the given file
-  or directory name.
-
   When an [interpolated string][string interpolation] evaluates to a path, the path is first copied into the Nix store and the resulting string is the [store path] of the newly created [store object].
 
   [store path]: ../glossary.md#gloss-store-path
@@ -123,12 +118,14 @@
   For example, assume you used a file path in an interpolated string during a `nix repl` session.
   Later in the same session, after having changed the file contents, evaluating the interpolated string with the file path again might not return a new store path, since Nix might not re-read the file contents.
 
-  Paths themselves, except those in angle brackets (`< >`), support [string interpolation].
+  Paths support [string interpolation].
 
   At least one slash (`/`) must appear *before* any interpolated expression for the result to be recognized as a path.
 
   `a.${foo}/b.${bar}` is a syntactically valid division operation.
   `./a.${foo}/b.${bar}` is a path.
+
+  [Lookup paths](./constructs/lookup-path.md) such as `<nixpkgs>` resolve to path values.
 
 - <a id="type-boolean" href="#type-boolean">Boolean</a>
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1723,7 +1723,7 @@ static RegisterPrimOp primop_findFile(PrimOp {
       If the suffix is found inside that directory, then the entry is a match;
       the combined absolute path of the directory (now downloaded if need be) and the suffix is returned.
 
-      The syntax
+      [Lookup path](@docroot@/language/constructs/lookup-path.md) expressions can be [desugared](https://en.wikipedia.org/wiki/Syntactic_sugar) using this and [`builtins.nixPath`](@docroot@/language/builtin-constants.md#builtins-nixPath):
 
       ```nix
       <nixpkgs>
@@ -4389,9 +4389,9 @@ void EvalState::createBaseEnv()
     addConstant("__nixPath", v, {
         .type = nList,
         .doc = R"(
-          The search path used to resolve angle bracket path lookups.
+          List of search path entries used to resolve [lookup paths](@docroot@/language/constructs/lookup-path.md).
 
-          Angle bracket expressions can be
+          Lookup path expressions can be
           [desugared](https://en.wikipedia.org/wiki/Syntactic_sugar)
           using this and
           [`builtins.findFile`](./builtins.html#builtins-findFile):


### PR DESCRIPTION
# Motivation

so far they did not really have a name, and were at best referred to as "angle bracket syntax".


# Context

the situation with documentation around what I propose to call lookup paths (following @Ericson2314's recent additions to documentation on `builtins.nixPath`) is far from ideal, and giving them a name and a place to point to immediately makes everything easier to show, explain, and work with.

this change adds a new page for the language construct, to start a habit of breaking out large-ish pages. the language reference is too big as it is, and it will only continue accumulating information and examples.

I deliberately didn't move the string interpolation page here, to avoid blocking the change on fixing up redirects.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).