### PR TITLE
Command alias implementation

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -115,7 +115,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs
     /**
      * In aliases map, the key should be a string of the command to alias combined with # character.
      * For Example, If alias need to be created for command:
-     * "store info", then the key should be "store#info" 
+     * "store info", then the key should be "store#info#" 
      * 
      * The reason key was configured in this way is to reduce the complexity if vector was used as a key, 
      * then we need to keep track of where a vector starting command is present in the args list 


### PR DESCRIPTION
# Motivation
* Command alias implemented for sub commands
* If a command need to be aliased, we need to add the alias and the command to aliases map in main.cc.
* The key should be combined with a `#` character

Related to #8914 #8875 

# Screenshots:
![image](https://github.com/NixOS/nix/assets/24916780/dd02e933-600e-4167-9624-7237136edce9)


## Description
* I have created an alias with `store ping` to `store info`.  After adding the alias in aliases map, the application was able to recognize both the commands and giving the same result
