### PR TITLE
Get rid of `bootstrap.sh`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,0 @@
-#! /bin/sh -e
-rm -f aclocal.m4
-mkdir -p config
-exec autoreconf -vfi

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -42,8 +42,8 @@ $ nix develop .#native-clang11StdenvPackages
 To build Nix itself in this shell:
 
 ```console
-[nix-shell]$ ./bootstrap.sh
-[nix-shell]$ ./configure $configureFlags --prefix=$(pwd)/outputs/out
+[nix-shell]$ autoreconfPhase
+[nix-shell]$ configurePhase
 [nix-shell]$ make -j $NIX_BUILD_CORES
 ```
 
@@ -86,7 +86,7 @@ $ nix-shell --attr devShells.x86_64-linux.native-clang11StdenvPackages
 To build Nix itself in this shell:
 
 ```console
-[nix-shell]$ ./bootstrap.sh
+[nix-shell]$ autoreconfPhase
 [nix-shell]$ ./configure $configureFlags --prefix=$(pwd)/outputs/out
 [nix-shell]$ make -j $NIX_BUILD_CORES
 ```

--- a/doc/manual/src/installation/building-source.md
+++ b/doc/manual/src/installation/building-source.md
@@ -3,7 +3,7 @@
 After cloning Nix's Git repository, issue the following commands:
 
 ```console
-$ ./bootstrap.sh
+$ autoreconf -vfi
 $ ./configure options...
 $ make
 $ make install


### PR DESCRIPTION
# Motivation
For people working on Nix with `nix develop`, it's better to just use `autoreconfPhase` and `configurePhase`, which is standard Nixpkgs / nix shell make from Nixpkgs practice --- it is good to emphasize the degree to which Nix is *just* a regular C++ project which can be worked on in the regular way.

(For people running `nix-shell`, the story is similar, except `configurePhase` would use non-writable store paths, which matters for hte times we use output paths before `make install`, so I kept the existing `./configure ...` instruction.)

For people building Nix without Nix (e.g. packaging it for another distro) they also don't need `bootstrap.sh`, and can just run `autoreconf -vfi` directly. (More likely, they have their own idioms to do this just as we have `autoreconfPhase`.)

# Context

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
