### PR TITLE
annotate admonitions showing syntax

### DIFF
--- a/doc/manual/src/language/constructs/lookup-path.md
+++ b/doc/manual/src/language/constructs/lookup-path.md
@@ -2,7 +2,7 @@
 
 > **Syntax**
 >
-> *lookup-path* = `<` *identifier* [ `/` *identifier* `]`... `>`
+> *lookup-path* = `<` *identifier* [ `/` *identifier* ]... `>`
 
 A lookup path is an identifier with an optional path suffix that resolves to a [path value](@docroot@/language/values.md#type-path) if the identifier matches a search path entry.
 

--- a/doc/manual/src/language/operators.md
+++ b/doc/manual/src/language/operators.md
@@ -35,6 +35,8 @@
 
 ## Attribute selection
 
+> **Syntax**
+>
 > *attrset* `.` *attrpath* \[ `or` *expr* \]
 
 Select the attribute denoted by attribute path *attrpath* from [attribute set] *attrset*.
@@ -42,12 +44,16 @@ If the attribute doesn’t exist, return the *expr* after `or` if provided, othe
 
 An attribute path is a dot-separated list of [attribute names](./values.md#attribute-set).
 
+> **Syntax**
+>
 > *attrpath* = *name* [ `.` *name* ]...
 
 [Attribute selection]: #attribute-selection
 
 ## Has attribute
 
+> **Syntax**
+>
 > *attrset* `?` *attrpath*
 
 Test whether [attribute set] *attrset* contains the attribute denoted by *attrpath*.
@@ -70,6 +76,8 @@ The `+` operator is overloaded to also work on strings and paths.
 
 ## String concatenation
 
+> **Syntax**
+>
 > *string* `+` *string*
 
 Concatenate two [string]s and merge their string contexts.
@@ -78,6 +86,8 @@ Concatenate two [string]s and merge their string contexts.
 
 ## Path concatenation
 
+> **Syntax**
+>
 > *path* `+` *path*
 
 Concatenate two [path]s.
@@ -87,6 +97,8 @@ The result is a path.
 
 ## Path and string concatenation
 
+> **Syntax**
+>
 > *path* + *string*
 
 Concatenate *[path]* with *[string]*.
@@ -100,6 +112,8 @@ The result is a path.
 
 ## String and path concatenation
 
+> **Syntax**
+>
 > *string* + *path*
 
 Concatenate *[string]* with *[path]*.
@@ -117,6 +131,8 @@ The result is a string.
 
 ## Update
 
+> **Syntax**
+>
 > *attrset1* // *attrset2*
 
 Update [attribute set] *attrset1* with names and values from *attrset2*.

--- a/doc/manual/src/language/values.md
+++ b/doc/manual/src/language/values.md
@@ -162,13 +162,17 @@ An attribute set is a collection of name-value-pairs (called *attributes*) enclo
 An attribute name can be an identifier or a [string](#string).
 An identifier must start with a letter (`a-z`, `A-Z`) or underscore (`_`), and can otherwise contain letters (`a-z`, `A-Z`), numbers (`0-9`), underscores (`_`), apostrophes (`'`), or dashes (`-`).
 
+> **Syntax**
+>
 > *name* = *identifier* | *string* \
 > *identifier* ~ `[a-zA-Z_][a-zA-Z0-9_'-]*`
 
 Names and values are separated by an equal sign (`=`).
 Each value is an arbitrary expression terminated by a semicolon (`;`).
 
-> *attrset* = `{` [ *name* `=` *expr* `;` `]`... `}`
+> **Syntax**
+>
+> *attrset* = `{` [ *name* `=` *expr* `;` ]... `}`
 
 Attributes can appear in any order.
 An attribute name may only occur once.


### PR DESCRIPTION
also fix typos


# Motivation
it allows easier search for syntax definitions in user-facing documentation

# Context
this sets a few examples for the future where we'd hopefully have better (i.e. more complete an precise) coverage of the language in the manual

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).