### PR TITLE
POC: add support for repl pos.origin

### DIFF
--- a/src/libexpr/comment.cc
+++ b/src/libexpr/comment.cc
@@ -1,0 +1,199 @@
+#include <algorithm>
+#include <climits>
+#include <fstream>
+#include <iostream>
+#include <ostream>
+#include <regex>
+#include <sstream>
+#include <string>
+
+#include "comment.hh"
+#include "nixexpr.hh"
+#include "util.hh"
+
+/* This module looks for documentation comments in the source code.
+
+   Documentation is not retained during parsing, and it should not be,
+   for performance reasons. Because of this the code has to jump
+   through some hoops, to perform its task.
+
+   Adapting the parser was not considered an option, so this code
+   parses the comments from scratch, using regular expressions. These
+   do not support all syntactic constructs, so in rare cases, they
+   will fail and the code will report no documentation.
+
+   One such situation is where documentation is requested for a
+   partially applied function, where the outer lambda pattern
+   matches an attribute set. This is not supported in the regexes
+   because it potentially requires (almost?) the entire grammar.
+
+   This module has been designed not to report the wrong
+   documentation; considering that the wrong documentation is worse
+   than no documentation. The regular expressions will only match
+   simple, well understood syntactic structures, or not match at all.
+
+   This approach to finding documentation does not cause extra runtime
+   overhead, until used.
+
+   This module does not support tab ('\t') characters. In some places
+   they are treated as single spaces. They should be avoided.
+*/
+namespace nix::Comment {
+
+struct Doc emptyDoc("", "");
+
+/* parseDoc will try to recover a Doc by looking at the text that leads up to a
+   term definition.*/
+static struct Doc parseDoc(std::string sourcePrefix, const bool simple);
+
+static std::string readSourceUpToPos(std::istream & source, const uint32_t line, const uint32_t col);
+
+/* Consistent unindenting. It will only remove entire columns. */
+static std::string unindent(std::string s);
+
+static std::string trimUnindent(std::string s) { return trim(unindent(s)); }
+
+static std::string readOriginUpToPos(const Pos &pos) {
+
+  if (auto path = std::get_if<SourcePath>(&pos.origin)) {
+    std::ifstream ifs(path->path.abs());
+    return readSourceUpToPos(ifs, pos.line, pos.column);
+  } else if (auto origin = std::get_if<Pos::String>(&pos.origin)) {
+    auto source = origin->source->data();
+     std::istringstream iss(source);
+    return readSourceUpToPos(iss,pos.line,pos.column);
+  } else {
+    throw std::invalid_argument("This kind of pos.origin cannot be parsed yet.");
+  }
+}
+
+static std::string readSourceUpToPos(std::istream & source, const uint32_t line, const uint32_t col){
+    std::stringstream ret;
+    size_t lineNum = 1;
+    std::string currLine;
+    while (getline(source, currLine) && lineNum <= line) {
+      if (lineNum < line) {
+        ret << currLine << "\n";
+      } else if (lineNum == line) {
+        ret << currLine.substr(0, col - 1);
+      }
+      lineNum++;
+    }
+    return ret.str();
+}
+
+struct Doc lookupDoc(const Pos &pos, const bool simple) {
+  try {
+    return parseDoc(readOriginUpToPos(pos), simple);
+  } catch (std::exception &e) {
+    ignoreException();
+    return emptyDoc;
+  }
+}
+/* Try to recover a Doc by looking at the text that leads up to a term
+   definition */
+static struct Doc parseDoc(std::string sourcePrefix, const bool simple) {
+
+//   std::string spaces("(?:[ \\t]*)");
+//   std::string lineComment("(?:[\\r\\n]*[^\\r\\n]*#" + spaces + "*)");
+  std::string whitespaces("(?:[\\s]*)*");
+  std::string ident("(?:[a-zA-Z0-9_'-][a-zA-Z_]*)");
+  std::string path("(?:(?:" + whitespaces + ident + "\\." + whitespaces + ")*" +
+                   ident + ")");
+  std::string assign("(?:=" + whitespaces + ")");
+  std::string lParen("(?:\\(*" + whitespaces + ")*");
+  std::string lambda("(?:" + whitespaces + ":" + ident + lParen + ")*");
+  std::string doc("([\\s]*\\/\\*(?:.|[\\s])*?(\\*\\*\\/))?");
+
+  // 1. up all whitespaces
+  // 2. eat remaining parenthesis
+  // 3. skip all eventual outer lambdas (Limitation only simple arguments are suppported. e.g. a: NOT {b ? <c> }: )
+  // 4. skip zero or one assignments to a path (Limitation only simple paths are suppported. e.g. a.b  NOT a.${b} )
+  // 5. eat remaining whitespaces
+  // 6. There should be the doc-comment
+  std::string reverseRegex("^" + whitespaces + lParen + lambda +
+                           "(?:" + assign + path + ")?" + whitespaces + doc);
+  std::string simpleRegex("^" + whitespaces + doc);
+
+  // The comment is located at the end of the file
+  // Even with $ (Anchor End) regex starts to search from the beginning of
+  // the file on large files this can cause regex stack overflow / recursion with more than 100k cycle steps.
+  // with certain patterns causing the regex to step back and never reaching the end of the file.
+  //
+  // Solving this we search the comment in reverse order,
+  // such that we can abort the search early. This is also significantly more
+  // performant.
+
+  // A high end solution would include access to the AST and a custom doc-comment parser,
+  // because regex matching is very expensive.
+  std::reverse(sourcePrefix.begin(), sourcePrefix.end());
+
+  std::regex e(simpleRegex);
+  if (!simple) {
+    e = std::regex(reverseRegex);
+  }
+
+#define REGEX_GROUP_COMMENT 1
+
+  std::smatch matches;
+  regex_search(sourcePrefix, matches, e);
+
+  std::stringstream buffer;
+  if (matches.length() < REGEX_GROUP_COMMENT ||
+      matches[REGEX_GROUP_COMMENT].str().empty()) {
+    return emptyDoc;
+  }
+
+  std::string rawComment = matches[REGEX_GROUP_COMMENT];
+  std::reverse(rawComment.begin(), rawComment.end());
+  return Doc(rawComment, Doc::stripComment(rawComment));
+}
+
+std::string Doc::stripComment(std::string rawComment) {
+  rawComment.erase(rawComment.find_last_not_of("\n") + 1);
+
+  std::string s(trimUnindent(rawComment));
+  auto suffixIdx = s.find("/**");
+  if (suffixIdx != std::string::npos) {
+    // Preserve indentation of content in the first line.
+    // Writing directly after /**, without a leading newline is a potential
+    // antipattern.
+    s.replace(suffixIdx, 3, "   ");
+  }
+  // Remove the "*/"
+  if (!s.empty() && *(--s.end()) == '/')
+    s.pop_back();
+  if (!s.empty() && *(--s.end()) == '*')
+    s.pop_back();
+
+  s = trimUnindent(s);
+  return s;
+}
+
+static std::string unindent(std::string s) {
+  size_t maxIndent = 1000;
+  {
+    std::istringstream inStream(s);
+    for (std::string line; std::getline(inStream, line);) {
+      size_t firstNonWS = line.find_first_not_of(" \t\r\n");
+      if (firstNonWS != std::string::npos) {
+        maxIndent = std::min(firstNonWS, maxIndent);
+      }
+    }
+  }
+
+  std::ostringstream unindentedStream;
+  {
+    std::istringstream inStream(s);
+    for (std::string line; std::getline(inStream, line);) {
+      if (line.length() >= maxIndent) {
+        unindentedStream << line.substr(maxIndent) << std::endl;
+      } else {
+        unindentedStream << std::endl;
+      }
+    }
+  }
+  return unindentedStream.str();
+}
+
+} // namespace nix::Comment

--- a/src/libexpr/comment.hh
+++ b/src/libexpr/comment.hh
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "nixexpr.hh"
+
+namespace nix::Comment {
+
+struct Doc {
+  std::string rawComment;
+  std::string comment;
+
+  // Number of times the curried function must be applied to get the value
+  // that this structure documents.
+  //
+  // This is useful when showing the documentation for a partially applied
+  // curried function. The documentation is for the unapplied function, so
+  // this is crucial information.
+  int timesApplied;
+
+  /* stripComment unpacks a comment, by unindenting and stripping " * " prefixes
+   as applicable. The argument should include any preceding whitespace. */
+  static std::string stripComment(std::string rawComment);
+
+  Doc(std::string rawComment, std::string comment) {
+    this->rawComment = rawComment;
+    this->comment = comment;
+  }
+  Doc(std::string str) {
+    this->rawComment = str;
+    this->comment = Doc::stripComment(str);
+  }
+};
+
+extern struct Doc emptyDoc;
+
+// lookupDoc will try to recover a Doc. This will perform perform I/O,
+// because documentation is not retained by the parser.
+//
+// Will return empty values if nothing can be found.
+// For its limitations, see the docs of the implementation.
+struct Doc lookupDoc(const Pos &pos, const bool simple);
+
+} // namespace nix::Comment

--- a/test.nix
+++ b/test.nix
@@ -1,0 +1,231 @@
+/*
+  Contains many example for doc-comments
+  From basic to more complex problems.
+*/
+rec {
+
+  #############################################
+
+  # Parenthesis
+
+  /**Doc*/
+  f = (( ( ( a: 1))));
+
+  #############################################
+
+  # Long Documentation
+
+  /**
+  # Return an attribute from nested attribute sets.
+
+  # Example
+
+    x = { a = { b = 3; }; }
+    # ["a" "b"] is equivalent to x.a.b
+    # 6 is a default value to return if the path does not exist in attrset
+    attrByPath ["a" "b"] 6 x
+    => 3
+    attrByPath ["z" "z"] 6 x
+    => 6
+
+  # Type
+    attrByPath :: [String] -> Any -> AttrSet -> Any
+
+  */
+  map = x: x;
+
+  /**
+    Like builtins.foldl' but for attribute sets.
+    Iterates over every name-value pair in the given attribute set.
+    The result of the callback function is often called `acc` for accumulator. It is passed between callbacks from left to right and the final `acc` is the return value of `foldlAttrs`.
+
+    Attention:
+    There is a completely different function
+    `lib.foldAttrs`
+    which has nothing to do with this function, despite the similar name.
+
+    # Example
+
+    ```nix
+    foldlAttrs
+      (acc: name: value: {
+        sum = acc.sum + value;
+        names = acc.names ++ [name];
+      })
+      { sum = 0; names = []; }
+      {
+        foo = 1;
+        bar = 10;
+      }
+    ->
+      {
+        sum = 11;
+        names = ["bar" "foo"];
+      }
+
+    foldlAttrs
+      (throw "function not needed")
+      123
+      {};
+    ->
+      123
+
+    foldlAttrs
+      (_: _: v: v)
+      (throw "initial accumulator not needed")
+      { z = 3; a = 2; };
+    ->
+      3
+
+    The accumulator doesn't have to be an attrset.
+    It can be as simple as a number or string.
+
+    foldlAttrs
+      (acc: _: v: acc * 10 + v)
+      1
+      { z = 1; a = 2; };
+    ->
+      121
+    ```
+
+    # Type
+
+    ```
+    foldlAttrs :: ( a -> String -> b -> a ) -> a -> { ... :: b } -> a
+    ```
+  */
+  foldlAttrs = f: init: set:
+    builtins.foldl'
+      (acc: name: f acc name set.${name})
+      init
+      (builtins.attrNames set);
+
+  /**Dense docs*/name=x: x;
+
+
+  ident = builtins.indent or (x: x);
+
+  one = ident 1;
+
+  error = rec {
+    expr = builtins.unsafeGetLambdaDoc ({
+        /**
+        Foo docs
+        */
+        foo = a: b: c: a;
+      }.foo "1");
+    expected = {
+      content = "Foo docs";
+      isPrimop = false;
+      position = expr.position;
+    };
+  };
+
+
+  /**
+   This is a deprecated function aliasing the new one
+  */
+  deprecatedMap = map;
+
+  foo =
+    builtins.unsafeGetLambdaDoc
+    {
+      /**
+      # The id function
+
+      * Bullet item
+      * another item
+
+      ## h2 markdown heading
+
+      some more docs
+      */
+      foo = x: x;
+    }
+    .foo;
+
+  /**
+    Function behind a path
+  */
+  a.b = a: {b ? null}: a b;
+
+  /**
+    Doc 2 (should not be shown
+  */
+  fn =
+    /**
+    Doc 1
+    */
+    f: (x: f + x);
+
+  /**
+    Docs
+  */
+  attrDoc = 1;
+
+  lambdaDoc =
+    builtins.id
+    or
+    /**
+      Docs
+    */
+    (x: x);
+
+
+  /*
+    With this implementation you can also use 'unsafeGetAttrDoc' on 'functionArgs fn'
+    Although this was unintenional it is suprsingly powerfull.
+
+    Example
+    let
+      args = functionArgs mkDerivation;
+    in
+      mapAttrs (n: _: unsafeGetAttrDoc n args) args;
+    =>
+    {
+      outputs = <docs>;
+      buildPhase = <docs>;
+    }
+
+    > Note: In practice this wont work on mkDerivation because mkDerivation is non discoverable: `functionArgs pkgs.stdenv.mkDerivation => { }`
+  */
+  mkDerivation = {
+    /**
+    Output Docs
+    */
+    outputs,
+    /**
+    BuildPhase Docs
+    */
+    buildPhase,
+  }:
+    derivation;
+
+  /**
+  Docs
+  */
+  specialLambdaDoc = z: ({
+    a,
+    v,
+  }: (x: x));
+
+
+  /**
+    Specialization of fn
+  */
+  alias = fn 1;
+
+  ###################################
+
+  # NOT SUPPORTED
+
+  /**
+    Doc Comment with complex path
+  */
+  ${"id"} = x: x;
+
+  /**
+    Doc Comment with an argument pattern
+  */
+  patFn = { a ? 1 }: a;
+}


### PR DESCRIPTION
This PR show one of the many possible implementation paths

Work in Progress, not ready to be merged.

Uses the already existing position tracking in nix to extract the comment from the specified places. (comes with some limitations)
This doesn't add any overhead to the evaluation. Only doc-comment retrieval is relatively slow, but not performance critical.

This adds two new builtins:

- `unsafeGetLambdaDoc` Uses Attribute position tracking.
- `unsafeGetAttrDoc` Uses Lambda Position tracking.

See ./test.nix 

Future Work:

- Migrate unit tests. Currently I have them here: https://github.com/hsjobeki/nix-doc-comments/tree/main/examples.
- Access the AST (via AST Cache)
- Add methods to the AST to walk up and sideways in the AST.