### PR TITLE
WIP: Support access-tokens for fetching tarballs from private sources

### DIFF
--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -1,4 +1,5 @@
 #include "fetchers.hh"
+#include "fetch-settings.hh"
 #include "cache.hh"
 #include "filetransfer.hh"
 #include "globals.hh"
@@ -285,6 +286,33 @@ struct TarballInputScheme : CurlInputScheme
 {
     const std::string inputType() const override { return "tarball"; }
 
+    std::optional<std::pair<std::string, std::string>> accessHeaderFromToken(const std::string & token) const
+    {
+        return std::make_pair("Authorization", fmt("Bearer %s", token));
+    }
+
+    std::optional<std::string> getAccessToken(const std::string & host) const
+    {
+        auto tokens = fetchSettings.accessTokens.get();
+        if (auto token = get(tokens, host))
+            return *token;
+        return {};
+    }
+
+    Headers makeHeadersWithAuthTokens(const std::string & host) const
+    {
+        Headers headers;
+        auto accessToken = getAccessToken(host);
+        if (accessToken) {
+            auto hdr = accessHeaderFromToken(*accessToken);
+            if (hdr)
+                headers.push_back(*hdr);
+            else
+                warn("Unrecognized access token for host '%s'", host);
+        }
+        return headers;
+    }
+
     bool isValidURL(const ParsedURL & url, bool requireTree) const override
     {
         auto parsedUrlScheme = parseUrlScheme(url.scheme);
@@ -298,8 +326,9 @@ struct TarballInputScheme : CurlInputScheme
     std::pair<StorePath, Input> fetch(ref<Store> store, const Input & _input) override
     {
         Input input(_input);
-        auto url = getStrAttr(input.attrs, "url");
-        auto result = downloadTarball(store, url, input.getName(), false);
+        auto url = parseURL(getStrAttr(input.attrs, "url"));
+        auto headers = makeHeadersWithAuthTokens(*url.authority);
+        auto result = downloadTarball(store, url.url, input.getName(), false, headers);
 
         if (result.immutableUrl) {
             auto immutableInput = Input::fromURL(*result.immutableUrl);


### PR DESCRIPTION
# Motivation
Currently, it is not possible to use the access-tokens option in nix.conf to authenticate fetching tarballs from sources other than a select few such as Github, Gitlab.

# Context
I believe a change like this, or something similar to it would solve #8439. However, ideally we should probably implement a general solution that is configurable, does away with having to support specific platforms explicitly in Nix itself, and supports more authentication methods as discussed in #8635.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
