### PR TITLE
`nix store ping` -> `nix store info`

### DIFF
--- a/doc/manual/src/advanced-topics/distributed-builds.md
+++ b/doc/manual/src/advanced-topics/distributed-builds.md
@@ -12,14 +12,14 @@ machine is accessible via SSH and that it has Nix installed. You can
 test whether connecting to the remote Nix instance works, e.g.
 
 ```console
-$ nix store ping --store ssh://mac
+$ nix store info --store ssh://mac
 ```
 
 will try to connect to the machine named `mac`. It is possible to
 specify an SSH identity file as part of the remote store URI, e.g.
 
 ```console
-$ nix store ping --store ssh://mac?ssh-key=/home/alice/my-key
+$ nix store info --store ssh://mac?ssh-key=/home/alice/my-key
 ```
 
 Since builds should be non-interactive, the key should not have a

--- a/doc/manual/src/release-notes/rl-2.15.md
+++ b/doc/manual/src/release-notes/rl-2.15.md
@@ -44,7 +44,7 @@
   (The store always had to check whether it trusts the client, but now the client is informed of the store's decision.)
   This is useful for scripting interactions with (non-legacy-ssh) remote Nix stores.
 
-  `nix store ping` and `nix doctor` now display this information.
+  `nix store info` and `nix doctor` now display this information.
 
 * The new command `nix derivation add` allows adding derivations to the store without involving the Nix language.
   It exists to round out our collection of basic utility/plumbing commands, and allow for a low barrier-to-entry way of experimenting with alternative front-ends to the Nix Store.

--- a/doc/manual/src/release-notes/rl-2.7.md
+++ b/doc/manual/src/release-notes/rl-2.7.md
@@ -24,7 +24,7 @@
   [repository](https://github.com/NixOS/bundlers) has various bundlers
   implemented.
 
-* `nix store ping` now reports the version of the remote Nix daemon.
+* `nix store info` now reports the version of the remote Nix daemon.
 
 * `nix flake {init,new}` now display information about which files have been
   created.

--- a/src/nix/ping-store.cc
+++ b/src/nix/ping-store.cc
@@ -46,5 +46,15 @@ struct CmdPingStore : StoreCommand, MixJSON
     }
 };
 
+struct CmdInfoStore : CmdPingStore
+{
+    void run(nix::ref<nix::Store> store) override
+    {
+        warn("'nix store info' is a deprecated alias for 'nix store ping'");
+        CmdPingStore::run(store);
+    }
+};
+
+
 static auto rCmdPingStore = registerCommand2<CmdPingStore>({"store", "ping"});
-static auto rCmdInfoStore = registerCommand2<CmdPingStore>({"store", "info"});
+static auto rCmdInfoStore = registerCommand2<CmdInfoStore>({"store", "info"});  

--- a/src/nix/ping-store.cc
+++ b/src/nix/ping-store.cc
@@ -47,3 +47,4 @@ struct CmdPingStore : StoreCommand, MixJSON
 };
 
 static auto rCmdPingStore = registerCommand2<CmdPingStore>({"store", "ping"});
+static auto rCmdInfoStore = registerCommand2<CmdPingStore>({"store", "info"});

--- a/src/nix/store-info.cc
+++ b/src/nix/store-info.cc
@@ -17,7 +17,7 @@ struct CmdPingStore : StoreCommand, MixJSON
     std::string doc() override
     {
         return
-          #include "ping-store.md"
+          #include "store-info.md"
           ;
     }
 
@@ -50,11 +50,11 @@ struct CmdInfoStore : CmdPingStore
 {
     void run(nix::ref<nix::Store> store) override
     {
-        warn("'nix store info' is a deprecated alias for 'nix store ping'");
+        warn("'nix store ping' is a deprecated alias for 'nix store info'");
         CmdPingStore::run(store);
     }
 };
 
 
-static auto rCmdPingStore = registerCommand2<CmdPingStore>({"store", "ping"});
-static auto rCmdInfoStore = registerCommand2<CmdInfoStore>({"store", "info"});  
+static auto rCmdPingStore = registerCommand2<CmdPingStore>({"store", "info"});
+static auto rCmdInfoStore = registerCommand2<CmdInfoStore>({"store", "ping"});

--- a/src/nix/store-info.md
+++ b/src/nix/store-info.md
@@ -5,19 +5,19 @@ R""(
 * Test whether connecting to a remote Nix store via SSH works:
 
   ```console
-  # nix store ping --store ssh://mac1
+  # nix store info --store ssh://mac1
   ```
 
 * Test whether a URL is a valid binary cache:
 
   ```console
-  # nix store ping --store https://cache.nixos.org
+  # nix store info --store https://cache.nixos.org
   ```
 
 * Test whether the Nix daemon is up and running:
 
   ```console
-  # nix store ping --store daemon
+  # nix store info --store daemon
   ```
 
 # Description

--- a/tests/functional/legacy-ssh-store.sh
+++ b/tests/functional/legacy-ssh-store.sh
@@ -1,4 +1,4 @@
 source common.sh
 
-# Check that store ping trusted doesn't yet work with ssh://
-nix --store ssh://localhost?remote-store=$TEST_ROOT/other-store store ping --json | jq -e 'has("trusted") | not'
+# Check that store info trusted doesn't yet work with ssh://
+nix --store ssh://localhost?remote-store=$TEST_ROOT/other-store store info --json | jq -e 'has("trusted") | not'

--- a/tests/functional/local-store.sh
+++ b/tests/functional/local-store.sh
@@ -18,5 +18,5 @@ PATH2=$(nix path-info --store "$PWD/x" $CORRECT_PATH)
 PATH3=$(nix path-info --store "local?root=$PWD/x" $CORRECT_PATH)
 [ $CORRECT_PATH == $PATH3 ]
 
-# Ensure store ping trusted works with local store
-nix --store ./x store ping --json | jq -e '.trusted'
+# Ensure store info trusted works with local store
+nix --store ./x store info --json | jq -e '.trusted'

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -113,7 +113,7 @@ nix_tests = \
   pass-as-file.sh \
   nix-profile.sh \
   suggestions.sh \
-  store-ping.sh \
+  store-info.sh \
   fetchClosure.sh \
   completions.sh \
   flakes/show.sh \

--- a/tests/functional/nix-copy-ssh-ng.sh
+++ b/tests/functional/nix-copy-ssh-ng.sh
@@ -9,7 +9,7 @@ rm -rf "$remoteRoot"
 
 outPath=$(nix-build --no-out-link dependencies.nix)
 
-nix store ping --store "ssh-ng://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR"
+nix store info --store "ssh-ng://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR"
 
 # Regression test for https://github.com/NixOS/nix/issues/6253
 nix copy --to "ssh-ng://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR" $outPath --no-check-sigs &

--- a/tests/functional/remote-store.sh
+++ b/tests/functional/remote-store.sh
@@ -5,17 +5,17 @@ clearStore
 # Ensure "fake ssh" remote store works just as legacy fake ssh would.
 nix --store ssh-ng://localhost?remote-store=$TEST_ROOT/other-store doctor
 
-# Ensure that store ping trusted works with ssh-ng://
-nix --store ssh-ng://localhost?remote-store=$TEST_ROOT/other-store store ping --json | jq -e '.trusted'
+# Ensure that store info trusted works with ssh-ng://
+nix --store ssh-ng://localhost?remote-store=$TEST_ROOT/other-store store info --json | jq -e '.trusted'
 
 startDaemon
 
 if isDaemonNewer "2.15pre0"; then
     # Ensure that ping works trusted with new daemon
-    nix store ping --json | jq -e '.trusted'
+    nix store info --json | jq -e '.trusted'
 else
     # And the the field is absent with the old daemon
-    nix store ping --json | jq -e 'has("trusted") | not'
+    nix store info --json | jq -e 'has("trusted") | not'
 fi
 
 # Test import-from-derivation through the daemon.

--- a/tests/functional/store-info.sh
+++ b/tests/functional/store-info.sh
@@ -1,7 +1,7 @@
 source common.sh
 
-STORE_INFO=$(nix store ping 2>&1)
-STORE_INFO_JSON=$(nix store ping --json)
+STORE_INFO=$(nix store info 2>&1)
+STORE_INFO_JSON=$(nix store info --json)
 
 echo "$STORE_INFO" | grep "Store URL: ${NIX_REMOTE}"
 
@@ -11,7 +11,7 @@ if [[ -v NIX_DAEMON_PACKAGE ]] && isDaemonNewer "2.7.0pre20220126"; then
     [[ "$(echo "$STORE_INFO_JSON" | jq -r ".version")" == "$DAEMON_VERSION" ]]
 fi
 
-expect 127 NIX_REMOTE=unix:$PWD/store nix store ping || \
-    fail "nix store ping on a non-existent store should fail"
+expect 127 NIX_REMOTE=unix:$PWD/store nix store info || \
+    fail "nix store info on a non-existent store should fail"
 
 [[ "$(echo "$STORE_INFO_JSON" | jq -r ".url")" == "${NIX_REMOTE:-local}" ]]

--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -213,7 +213,7 @@ let
           source /etc/bashrc || true
 
           nix-env --version
-          nix --extra-experimental-features nix-command store ping
+          nix --extra-experimental-features nix-command store info
 
           out=\$(nix-build --no-substitute -E 'derivation { name = "foo"; system = "x86_64-linux"; builder = "/bin/sh"; args = ["-c" "echo foobar > \$out"]; }')
           [[ \$(cat \$out) = foobar ]]


### PR DESCRIPTION
# Motivation
This change will create alias of `store info`.  

# Context
This fix is part of #8914 
In `ping-store.cc`, I have registered another command for CmdPingStore for store info which will register the command and can be used with store commands.

Implemented as per the discussion in #8975 PR

### Demo:
![image](https://github.com/NixOS/nix/assets/24916780/259fe575-71f5-48a7-8d6f-fda3f1c62526)

cc: @Ericson2314 @fricklerhandwerk 

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
