### PR TITLE
Stabilize fetchTree

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -7,3 +7,5 @@
 - The experimental feature `repl-flake` is no longer needed, as its functionality is now part of the `flakes` experimental feature. To get the previous behavior, use the `--file/--expr` flags accordingly.
 
 - Introduce new flake installable syntax `flakeref#.attrPath` where the "." prefix denotes no searching of default attribute prefixes like `packages.<SYSTEM>` or `legacyPackages.<SYSTEM>`.
+
+- `builtins.fetchTree` is now marked as stable.

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -148,6 +148,11 @@ static void fetchTree(
             attrs.emplace("url", fixGitURL(url));
             input = fetchers::Input::fromAttrs(std::move(attrs));
         } else {
+            if (!experimentalFeatureSettings.isEnabled(Xp::Flakes))
+                state.debugThrowLastTrace(EvalError({
+                    .msg = hintfmt("passing a string argument to 'fetchTree' requires the 'flakes' experimental feature"),
+                    .errPos = state.positions[pos]
+                }));
             input = fetchers::Input::fromURL(url);
         }
     }
@@ -179,6 +184,10 @@ static RegisterPrimOp primop_fetchTree({
       Fetch a source tree or a plain file using one of the supported backends.
       *input* must be a [flake reference](@docroot@/command-ref/new-cli/nix3-flake.md#flake-references), either in attribute set representation or in the URL-like syntax.
       The input should be "locked", that is, it should contain a commit hash or content hash unless impure evaluation (`--impure`) is enabled.
+
+      > **Note**
+      >
+      > The URL-like syntax requires the [`flakes` experimental feature](@docroot@/contributing/experimental-features.md#xp-feature-flakes) to be enabled.
 
       Here are some examples of how to use `fetchTree`:
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -213,7 +213,6 @@ static RegisterPrimOp primop_fetchTree({
           ```
     )",
     .fun = prim_fetchTree,
-    .experimentalFeature = Xp::Flakes,
 });
 
 static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v,

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -223,6 +223,11 @@ struct GitArchiveInputScheme : InputScheme
 
         return {result.tree.storePath, input};
     }
+
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return Xp::Flakes;
+    }
 };
 
 struct GitHubInputScheme : GitArchiveInputScheme

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -125,6 +125,11 @@ struct PathInputScheme : InputScheme
 
         return {std::move(*storePath), input};
     }
+
+    std::optional<ExperimentalFeature> experimentalFeature() override
+    {
+        return Xp::Flakes;
+    }
 };
 
 static auto rPathInputScheme = OnStartup([] { registerInputScheme(std::make_unique<PathInputScheme>()); });


### PR DESCRIPTION
# Motivation

This removes the experimental flag from `fetchTree`. Some features are still experimental:

* The registry (i.e. the "indirect" input type).
* The `github` and related fetchers.
* The `path` fetcher.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
