### PR TITLE
Fix error handling for open(2) on gc.lock

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -451,7 +451,7 @@ AutoCloseFD LocalStore::openGCLock()
 {
     Path fnGCLock = stateDir + "/gc.lock";
     auto fdGCLock = open(fnGCLock.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0600);
-    if (!fdGCLock)
+    if (fdGCLock == -1)
         throw SysError("opening global GC lock '%1%'", fnGCLock);
     return fdGCLock;
 }


### PR DESCRIPTION
# Motivation

I tried to setup nix on Arch Linux and got this error:

```
% nix flake init
error: acquiring/releasing lock: Bad file descriptor
```

# Context

Using strace I saw this:

```
[pid 748007] openat(AT_FDCWD, "/nix/var/nix/gc.lock", O_RDWR|O_CREAT|O_CLOEXEC, 0600) = -1 EACCES (Permission denied)
[pid 748007] flock(-1, LOCK_SH|LOCK_NB) = -1 EBADF (Bad file descriptor)
```

This is a common error pattern in C, at this point I had a high suspicion the return value of `openat` is not being checked.

I cloned the repository and found this function with grep:

```c
AutoCloseFD LocalStore::openGCLock()
{
    Path fnGCLock = stateDir + "/gc.lock";
    auto fdGCLock = open(fnGCLock.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0600);
    if (!fdGCLock)
        throw SysError("opening global GC lock '%1%'", fnGCLock);
    return fdGCLock;
}
```

I barely know anything about C++, but assuming this is `open(2)` from libc the documentation says:

```
RETURN VALUE
       On  success,  open(), openat(), and creat() return the new file descriptor (a nonnegative integer).  On er‐
       ror, -1 is returned and errno is set to indicate the error.
```

The current code is:
```c
    if (fdGCLock == 0)
        throw SysError("opening global GC lock '%1%'", fnGCLock);
```

I think this throw is essentially unreachable, 0 is a valid file descriptor but usually always already occupied by `stdin`.

Instead I think it should be:
```c
    if (fdGCLock == -1)
        throw SysError("opening global GC lock '%1%'", fnGCLock);
```

Note this patch is untested and I barely know what I'm doing.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
