### PR TITLE
explicitly set meta.mainProgram

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -515,6 +515,7 @@
             });
 
             meta.platforms = lib.platforms.unix;
+            meta.mainProgram = "nix";
           });
 
           lowdown-nix = with final; currentStdenv.mkDerivation rec {


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Setting `meta.mainProgram` properly allows using `nix run` correctly.

# Context
<!-- Provide context. Reference open issues if available. -->

NixOS/nixpkgs#246386 and `nix run` uses the same field.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
