### PR TITLE
Fix broken move

### DIFF
--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -68,6 +68,7 @@ void AbstractConfig::warnUnknownSettings()
 void AbstractConfig::reapplyUnknownSettings()
 {
     auto unknownSettings2 = std::move(unknownSettings);
+    unknownSettings = {};
     for (auto & s : unknownSettings2)
         set(s.first, s.second);
 }


### PR DESCRIPTION
# Motivation

While randomly reading code, i discovered this bug.

# Context

A moved-from object in C++ is in valid, but undefined state. This means that you can for example destruct or reassign it, but not use it in any context that has certain assumptions on its content.
The `set(...)` function uses the `emplace` method on the moved-from object (which is a map), and that is not allowed in that context before reassigning an empty map.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
