### PR TITLE
Fix/remove some bad std::moves

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2290,7 +2290,7 @@ BackedStringView EvalState::coerceToString(
                     && (!v2->isList() || v2->listSize() != 0))
                     result += " ";
             }
-            return std::move(result);
+            return result;
         }
     }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -539,7 +539,7 @@ EvalState::EvalState(
             auto r = resolveSearchPathPath(i.path);
             if (!r) continue;
 
-            auto path = *std::move(r);
+            auto path = std::move(*r);
 
             if (store->isInStore(path)) {
                 try {
@@ -1035,7 +1035,7 @@ std::string EvalState::mkOutputStringRaw(
     /* In practice, this is testing for the case of CA derivations, or
        dynamic derivations. */
     return optStaticOutputPath
-        ? store->printStorePath(*std::move(optStaticOutputPath))
+        ? store->printStorePath(std::move(*optStaticOutputPath))
         /* Downstream we would substitute this for an actual path once
            we build the floating CA derivation */
         : DownstreamPlaceholder::fromSingleDerivedPathBuilt(b, xpSettings).render();

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -4,7 +4,7 @@ namespace nix {
 
 SourcePath EvalState::rootPath(CanonPath path)
 {
-    return std::move(path);
+    return path;
 }
 
 }

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -561,7 +561,7 @@ void DerivationGoal::inputsRealised()
               attempt = fullDrv.tryResolve(worker.store);
             }
             assert(attempt);
-            Derivation drvResolved { *std::move(attempt) };
+            Derivation drvResolved { std::move(*attempt) };
 
             auto pathResolved = writeDerivation(worker.store, drvResolved);
 

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2521,7 +2521,7 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
             ValidPathInfo newInfo0 {
                 worker.store,
                 outputPathName(drv->name, outputName),
-                *std::move(optCA),
+                std::move(*optCA),
                 Hash::dummy,
             };
             if (*scratchPath != newInfo0.path) {

--- a/src/libstore/content-address.cc
+++ b/src/libstore/content-address.cc
@@ -83,7 +83,7 @@ static std::pair<ContentAddressMethod, HashType> parseContentAddressMethodPrefix
         if (!hashTypeRaw)
             throw UsageError("content address hash must be in form '<algo>:<hash>', but found: %s", wholeInput);
         HashType hashType = parseHashType(*hashTypeRaw);
-        return std::move(hashType);
+        return hashType;
     };
 
     // Switch on prefix

--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -63,7 +63,7 @@ std::optional<std::pair<std::string_view, ExtendedOutputsSpec>> ExtendedOutputsS
     auto specOpt = OutputsSpec::parseOpt(s.substr(found + 1));
     if (!specOpt)
         return std::nullopt;
-    return std::pair { s.substr(0, found), ExtendedOutputsSpec::Explicit { *std::move(specOpt) } };
+    return std::pair { s.substr(0, found), ExtendedOutputsSpec::Explicit { std::move(*specOpt) } };
 }
 
 


### PR DESCRIPTION
# Motivation

While being at it, I grepped through the source to identify more positions with bad `std::move` usage.

I particularly fixed 2 types of moves (grouped in two different commits):

- `bla = *std::move(some_optional);` - this moves an optional and then copies its content. The dereference operator must go into the move
- `return std::move(some_stack_var)` - these moves are superfluous as they would be moved to the caller anyway, but they even forbid named return value optimization (NRVO) where it would otherwise be applicable.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
