### PR TITLE
update link to label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
 1. Search for related issues that cover what you're going to work on.
    It could help to mention there that you will work on the issue.
 
-   Issues labeled [good first issue](https://github.com/NixOS/nix/labels/good-first-issue) should be relatively easy to fix and are likely to get merged quickly.
+   Issues labeled [good first issue](https://github.com/NixOS/nix/labels/good%20first%20issue) should be relatively easy to fix and are likely to get merged quickly.
    Pull requests addressing issues labeled [idea approved](https://github.com/NixOS/nix/labels/idea%20approved) or [RFC](https://github.com/NixOS/nix/labels/RFC) are especially welcomed by maintainers and will receive prioritised review.
 
    If there is no relevant issue yet and you're not sure whether your change is likely to be accepted, [open an issue](https://github.com/NixOS/nix/issues/new/choose) yourself.


### PR DESCRIPTION
GitHub now displays a banner and has a dedicated page[1] for good first
issues, but that uses a different label name as we had in place.
I renamed the label on GitHub, this is updating the link.

[1]: https://github.com/NixOS/nix/contribute



# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).