### PR TITLE
libstore: Add `apple-virt` to system features when available

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -8,6 +8,8 @@
 
 - Introduce new flake installable syntax `flakeref#.attrPath` where the "." prefix denotes no searching of default attribute prefixes like `packages.<SYSTEM>` or `legacyPackages.<SYSTEM>`.
 
+- Nix adds `apple-virt` to the default system features on macOS systems that support virtualization. This is similar to what's done for the `kvm` system feature on Linux hosts.
+
 - Introduce a new built-in function [`builtins.convertHash`](@docroot@/language/builtins.md#builtins-convertHash).
 
 - `builtins.fetchTree` is now marked as stable.

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -714,6 +714,10 @@ public:
 
           System features are user-defined, but Nix sets the following defaults:
 
+          - `apple-virt`
+
+            Included on darwin if virtualization is available.
+
           - `kvm`
 
             Included by default if `/dev/kvm` is accessible.

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -720,7 +720,7 @@ public:
 
           - `kvm`
 
-            Included by default if `/dev/kvm` is accessible.
+            Included on Linux if `/dev/kvm` is accessible.
 
           - `nixos-test`, `benchmark`, `big-parallel`
 


### PR DESCRIPTION
I'm sure that we'll adjust the implementation over time, but this at least discerns between an apple silicon bare metal machine and a tart VM.
I haven't named the system feature after a specific technology except "apple", because the way this is checked does not seem specific to hvf or avf, as far as I know.

# Motivation

VMs often don't support _nested_ virtualization. When macOS itself is virtualized, most likely it does not support hardware virtualization for its guests.

# Context

- Closes #7619 


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
