### PR TITLE
Remove impractical statement about backports

### DIFF
--- a/doc/manual/src/release-notes/release-notes.md
+++ b/doc/manual/src/release-notes/release-notes.md
@@ -5,8 +5,3 @@ Notable changes and additions are announced in the release notes for each versio
 
 Bugfixes can be backported on request to previous Nix releases.
 We typically backport only as far back as the Nix version used in the latest NixOS release, which is announced in the [NixOS release notes](https://nixos.org/manual/nixos/stable/release-notes.html#ch-release-notes).
-
-Backports never skip releases.
-If a feature is backported to version `x.y`, it must also be available in version `x.(y+1)`.
-This ensures that upgrading from an older version with backports is still safe and no backported functionality will go missing.
-


### PR DESCRIPTION
# Motivation

It has never been our policy to do backports for all intermediate versions. It goes against a rapid release scheme: if we release every few weeks, it's impractical to have to do backports against a gazillion releases between the latest stable version used by NixOS and the current Nix release.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
