### PR TITLE
libutil: Small improvements

### DIFF
--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -33,9 +33,9 @@ bool Config::set(const std::string & name, const std::string & value)
 
 void Config::addSetting(AbstractSetting * setting)
 {
-    _settings.emplace(setting->name, Config::SettingData(false, setting));
+    _settings.emplace(setting->name, Config::SettingData{false, setting});
     for (auto & alias : setting->aliases)
-        _settings.emplace(alias, Config::SettingData(true, setting));
+        _settings.emplace(alias, Config::SettingData{true, setting});
 
     bool set = false;
 

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -148,9 +148,6 @@ public:
     {
         bool isAlias;
         AbstractSetting * setting;
-        SettingData(bool isAlias, AbstractSetting * setting)
-            : isAlias(isAlias), setting(setting)
-        { }
     };
 
     typedef std::map<std::string, SettingData> Settings;

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -312,8 +312,7 @@ public:
 template<typename T>
 std::ostream & operator <<(std::ostream & str, const BaseSetting<T> & opt)
 {
-    str << (const T &) opt;
-    return str;
+    return str << static_cast<const T &>(opt);
 }
 
 template<typename T>

--- a/src/libutil/config.hh
+++ b/src/libutil/config.hh
@@ -52,9 +52,7 @@ class AbstractConfig
 protected:
     StringMap unknownSettings;
 
-    AbstractConfig(const StringMap & initials = {})
-        : unknownSettings(initials)
-    { }
+    AbstractConfig(StringMap initials = {});
 
 public:
 
@@ -163,9 +161,7 @@ private:
 
 public:
 
-    Config(const StringMap & initials = {})
-        : AbstractConfig(initials)
-    { }
+    Config(StringMap initials = {});
 
     bool set(const std::string & name, const std::string & value) override;
 
@@ -206,12 +202,7 @@ protected:
         const std::set<std::string> & aliases,
         std::optional<ExperimentalFeature> experimentalFeature = std::nullopt);
 
-    virtual ~AbstractSetting()
-    {
-        // Check against a gcc miscompilation causing our constructor
-        // not to run (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80431).
-        assert(created == 123);
-    }
+    virtual ~AbstractSetting();
 
     virtual void set(const std::string & value, bool append = false) = 0;
 
@@ -229,7 +220,7 @@ protected:
 
     virtual void convertToArg(Args & args, const std::string & category);
 
-    bool isOverridden() const { return overridden; }
+    bool isOverridden() const;
 };
 
 /**
@@ -365,11 +356,7 @@ public:
         const Path & def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {})
-        : BaseSetting<Path>(def, true, name, description, aliases)
-    {
-        options->addSetting(this);
-    }
+        const std::set<std::string> & aliases = {});
 
     Path parse(const std::string & str) const override;
 
@@ -391,15 +378,11 @@ public:
         const std::optional<Path> & def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {})
-        : BaseSetting<std::optional<Path>>(def, true, name, description, aliases)
-    {
-        options->addSetting(this);
-    }
+        const std::set<std::string> & aliases = {});
 
     std::optional<Path> parse(const std::string & str) const override;
 
-    void operator =(const std::optional<Path> & v) { this->assign(v); }
+    void operator =(const std::optional<Path> & v);
 };
 
 struct GlobalConfig : public AbstractConfig


### PR DESCRIPTION
# Motivation

While randomly stumbling over the code base i've see a few things and fixed them:

- There were some non-template implementations in `config.hh`. I moved them to `config.cc`
- Dropped one constructor that is not needed
- Rewrote a C-style cast to a c++ cast

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
