### PR TITLE
Input::hasAllInfo(): Remove

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -89,11 +89,6 @@ Attrs Input::toAttrs() const
     return attrs;
 }
 
-bool Input::hasAllInfo() const
-{
-    return getNarHash() && scheme && scheme->hasAllInfo(*this);
-}
-
 bool Input::operator ==(const Input & other) const
 {
     return attrs == other.attrs;
@@ -117,7 +112,7 @@ std::pair<Tree, Input> Input::fetch(ref<Store> store) const
     /* The tree may already be in the Nix store, or it could be
        substituted (which is often faster than fetching from the
        original source). So check that. */
-    if (hasAllInfo()) {
+    if (getNarHash()) {
         try {
             auto storePath = computeStorePath(*store);
 
@@ -174,8 +169,6 @@ std::pair<Tree, Input> Input::fetch(ref<Store> store) const
     }
 
     input.locked = true;
-
-    assert(input.hasAllInfo());
 
     return {std::move(tree), input};
 }

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -79,15 +79,6 @@ public:
      */
     bool isLocked() const { return locked; }
 
-    /**
-     * Check whether the input carries all necessary info required
-     * for cache insertion and substitution.
-     * These fields are used to uniquely identify cached trees
-     * within the "tarball TTL" window without necessarily
-     * indicating that the input's origin is unchanged.
-     */
-    bool hasAllInfo() const;
-
     bool operator ==(const Input & other) const;
 
     bool contains(const Input & other) const;
@@ -143,8 +134,6 @@ struct InputScheme
     virtual std::optional<Input> inputFromAttrs(const Attrs & attrs) const = 0;
 
     virtual ParsedURL toURL(const Input & input) const;
-
-    virtual bool hasAllInfo(const Input & input) const = 0;
 
     virtual Input applyOverrides(
         const Input & input,

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -321,15 +321,6 @@ struct GitInputScheme : InputScheme
         return url;
     }
 
-    bool hasAllInfo(const Input & input) const override
-    {
-        bool maybeDirty = !input.getRef();
-        bool shallow = maybeGetBoolAttr(input.attrs, "shallow").value_or(false);
-        return
-            maybeGetIntAttr(input.attrs, "lastModified")
-            && (shallow || maybeDirty || maybeGetIntAttr(input.attrs, "revCount"));
-    }
-
     Input applyOverrides(
         const Input & input,
         std::optional<std::string> ref,

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -132,11 +132,6 @@ struct GitArchiveInputScheme : InputScheme
         };
     }
 
-    bool hasAllInfo(const Input & input) const override
-    {
-        return input.getRev() && maybeGetIntAttr(input.attrs, "lastModified");
-    }
-
     Input applyOverrides(
         const Input & _input,
         std::optional<std::string> ref,

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -78,11 +78,6 @@ struct IndirectInputScheme : InputScheme
         return url;
     }
 
-    bool hasAllInfo(const Input & input) const override
-    {
-        return false;
-    }
-
     Input applyOverrides(
         const Input & _input,
         std::optional<std::string> ref,

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -98,13 +98,6 @@ struct MercurialInputScheme : InputScheme
         return url;
     }
 
-    bool hasAllInfo(const Input & input) const override
-    {
-        // FIXME: ugly, need to distinguish between dirty and clean
-        // default trees.
-        return input.getRef() == "default" || maybeGetIntAttr(input.attrs, "revCount");
-    }
-
     Input applyOverrides(
         const Input & input,
         std::optional<std::string> ref,

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -66,11 +66,6 @@ struct PathInputScheme : InputScheme
         };
     }
 
-    bool hasAllInfo(const Input & input) const override
-    {
-        return true;
-    }
-
     std::optional<Path> getSourcePath(const Input & input) override
     {
         return getStrAttr(input.attrs, "path");

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -253,12 +253,6 @@ struct CurlInputScheme : InputScheme
             url.query.insert_or_assign("narHash", narHash->to_string(HashFormat::SRI, true));
         return url;
     }
-
-    bool hasAllInfo(const Input & input) const override
-    {
-        return true;
-    }
-
 };
 
 struct FileInputScheme : CurlInputScheme


### PR DESCRIPTION
# Motivation

This removes an unneeded function. Backported from lazy-trees.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
