### PR TITLE
Delete dead code

### DIFF
--- a/src/libstore/build/local-derivation-goal.hh
+++ b/src/libstore/build/local-derivation-goal.hh
@@ -120,14 +120,6 @@ struct LocalDerivationGoal : public DerivationGoal
      */
     OutputPathMap scratchOutputs;
 
-    /**
-     * Path registration info from the previous round, if we're
-     * building multiple times. Since this contains the hash, it
-     * allows us to compare whether two rounds produced the same
-     * result.
-     */
-    std::map<Path, ValidPathInfo> prevInfos;
-
     uid_t sandboxUid() { return usingUserNamespace ? (!buildUser || buildUser->getUIDCount() == 1 ? 1000 : 0) : buildUser->getUID(); }
     gid_t sandboxGid() { return usingUserNamespace ? (!buildUser || buildUser->getUIDCount() == 1 ? 100  : 0) : buildUser->getGID(); }
 

--- a/src/libstore/path-info.hh
+++ b/src/libstore/path-info.hh
@@ -72,14 +72,6 @@ struct ValidPathInfo
      */
     std::optional<ContentAddress> ca;
 
-    bool operator == (const ValidPathInfo & i) const
-    {
-        return
-            path == i.path
-            && narHash == i.narHash
-            && references == i.references;
-    }
-
     /**
      * Return a fingerprint of the store path to be used in binary
      * cache signatures. It contains the store path, the base-32


### PR DESCRIPTION
# Motivation

Neither of these things are in use.

# Context

## Remove `prevInfos` as its dead code

It is unused since 8e0946e8df968391d1430af8377bdb51204e4666 removed support for the repeat and enforce-determinism options.

## Remove the `ValidPathInfo == operator`

It is dead code. It was added in 8e0946e8df968391d1430af8377bdb51204e4666 as part of the repeated / enforce-determinism feature, but that was removed in 8fdd156a650f9b2ce9ae8cd74edcf16225478292.

It is not good because it skips many fields. For testing purposes we will soon want to add a new one that doesn't skip fields, but we want to make sure making == sensitive to those fields won't change how Nix works. Proving in this commit that the old version is dead code achieves that.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
