### PR TITLE
Input: Remove 'direct' field

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -84,6 +84,11 @@ std::string Input::to_string() const
     return toURL().to_string();
 }
 
+bool Input::isDirect() const
+{
+    return !scheme || scheme->isDirect(*this);
+}
+
 Attrs Input::toAttrs() const
 {
     return attrs;

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -35,7 +35,6 @@ struct Input
     std::shared_ptr<InputScheme> scheme; // note: can be null
     Attrs attrs;
     bool locked = false;
-    bool direct = true;
 
     /**
      * path of the parent of this input, used for relative path resolution
@@ -71,7 +70,7 @@ public:
      * Check whether this is a "direct" input, that is, not
      * one that goes through a registry.
      */
-    bool isDirect() const { return direct; }
+    bool isDirect() const;
 
     /**
      * Check whether this is a "locked" input, that is,
@@ -152,6 +151,9 @@ struct InputScheme
      * Is this `InputScheme` part of an experimental feature?
      */
     virtual std::optional<ExperimentalFeature> experimentalFeature();
+
+    virtual bool isDirect(const Input & input) const
+    { return true; }
 };
 
 void registerInputScheme(std::shared_ptr<InputScheme> && fetcher);

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -41,7 +41,6 @@ struct IndirectInputScheme : InputScheme
         // FIXME: forbid query params?
 
         Input input;
-        input.direct = false;
         input.attrs.insert_or_assign("type", "indirect");
         input.attrs.insert_or_assign("id", id);
         if (rev) input.attrs.insert_or_assign("rev", rev->gitRev());
@@ -63,7 +62,6 @@ struct IndirectInputScheme : InputScheme
             throw BadURL("'%s' is not a valid flake ID", id);
 
         Input input;
-        input.direct = false;
         input.attrs = attrs;
         return input;
     }
@@ -98,6 +96,9 @@ struct IndirectInputScheme : InputScheme
     {
         return Xp::Flakes;
     }
+
+    bool isDirect(const Input & input) const override
+    { return false; }
 };
 
 static auto rIndirectInputScheme = OnStartup([] { registerInputScheme(std::make_unique<IndirectInputScheme>()); });


### PR DESCRIPTION
# Motivation

It's cleaner to have this as a method than as a field that could get out of sync.

Cherry-picked from lazy-trees.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
