### PR TITLE
doc: add note about trusted users

### DIFF
--- a/doc/manual/src/advanced-topics/distributed-builds.md
+++ b/doc/manual/src/advanced-topics/distributed-builds.md
@@ -149,6 +149,11 @@ file included in `builders` via the syntax `@file`. For example,
 causes the list of machines in `/etc/nix/machines` to be included. (This
 is the default.)
 
+> **Note**
+>
+> If you are just specifying machine files and are not using the NixOS module
+> then you have to add your self to [`trusted-users`](#conf-trusted-users) on your local machine.
+
 If you want the builders to use caches, you likely want to set the
 option `builders-use-substitutes` in your local `nix.conf`.
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
it took me way too long to figure out why remote builds with just a machine file don't work, esp. since the error message isn't that great and I want to make it easier for other people. 