### PR TITLE
Clean up `args.hh`

### DIFF
--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -84,29 +84,29 @@ protected:
         { }
 
         Handler(std::vector<std::string> * dest)
-            : fun([=](std::vector<std::string> ss) { *dest = ss; })
+            : fun([dest](std::vector<std::string> ss) { *dest = ss; })
             , arity(ArityAny)
         { }
 
         Handler(std::string * dest)
-            : fun([=](std::vector<std::string> ss) { *dest = ss[0]; })
+            : fun([dest](std::vector<std::string> ss) { *dest = ss[0]; })
             , arity(1)
         { }
 
         Handler(std::optional<std::string> * dest)
-            : fun([=](std::vector<std::string> ss) { *dest = ss[0]; })
+            : fun([dest](std::vector<std::string> ss) { *dest = ss[0]; })
             , arity(1)
         { }
 
         template<class T>
         Handler(T * dest, const T & val)
-            : fun([=](std::vector<std::string> ss) { *dest = val; })
+            : fun([dest, val](std::vector<std::string> ss) { *dest = val; })
             , arity(0)
         { }
 
         template<class I>
         Handler(I * dest)
-            : fun([=](std::vector<std::string> ss) {
+            : fun([dest](std::vector<std::string> ss) {
                 *dest = string2IntWithUnitPrefix<I>(ss[0]);
               })
             , arity(1)
@@ -114,7 +114,7 @@ protected:
 
         template<class I>
         Handler(std::optional<I> * dest)
-            : fun([=](std::vector<std::string> ss) {
+            : fun([dest](std::vector<std::string> ss) {
                 *dest = string2IntWithUnitPrefix<I>(ss[0]);
             })
             , arity(1)

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -57,7 +57,7 @@ protected:
         std::function<void(std::vector<std::string>)> fun;
         size_t arity;
 
-        Handler() {}
+        Handler() = default;
 
         Handler(std::function<void(std::vector<std::string>)> && fun)
             : fun(std::move(fun))

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -296,7 +296,7 @@ struct Command : virtual public Args
 {
     friend class MultiCommand;
 
-    virtual ~Command() { }
+    virtual ~Command() = default;
 
     /**
      * Entry point to the command

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -130,7 +130,7 @@ protected:
      * The `AddCompletions` that is passed is an interface to the state
      * stored as part of the root command
      */
-    typedef void CompleterFun(AddCompletions &, size_t, std::string_view);
+    using CompleterFun = void(AddCompletions &, size_t, std::string_view);
 
     /**
      * The closure type of the completion callback.
@@ -138,7 +138,7 @@ protected:
      * This is what is actually stored as part of each Flag / Expected
      * Arg.
      */
-    typedef std::function<CompleterFun> CompleterClosure;
+    using CompleterClosure = std::function<CompleterFun>;
 
     /**
      * Description of flags / options
@@ -148,7 +148,7 @@ protected:
      */
     struct Flag
     {
-        typedef std::shared_ptr<Flag> ptr;
+        using ptr = std::shared_ptr<Flag>;
 
         std::string longName;
         std::set<std::string> aliases;
@@ -303,7 +303,7 @@ struct Command : virtual public Args
      */
     virtual void run() = 0;
 
-    typedef int Category;
+    using Category = int;
 
     static constexpr Category catDefault = 0;
 
@@ -312,7 +312,7 @@ struct Command : virtual public Args
     virtual Category category() { return catDefault; }
 };
 
-typedef std::map<std::string, std::function<ref<Command>()>> Commands;
+using Commands = std::map<std::string, std::function<ref<Command>()>>;
 
 /**
  * An argument parser that supports multiple subcommands,


### PR DESCRIPTION
# Context
- use `default` keywords for empty constructors and destructors
- replace `typedef` with `using`
- explicitly pass lambda scope variables instead of `[=]`

I also tried to make all single-argument constructors explicit, but it caused a lot of errors since there are many places where the initializer list is used. :(
# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
