### PR TITLE
Clean up `print.cc`

### DIFF
--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -44,8 +44,11 @@ bool isReservedKeyword(const std::string_view str)
 }
 
 // Returns 'true' if the character is a symbol that can't be used in a variable name.
-bool isSymbolProhibited(const char& symbol) {
-    bool symbolAllowed = (std::isalnum(symbol) || symbol == '_' || symbol == '-'|| symbol == '\'');
+bool isSymbolProhibited(const char & symbol) {
+    bool symbolAllowed =
+        ((symbol >= 'a' && symbol <= 'z') || (symbol >= 'A' && symbol <= 'Z') ||
+         (symbol >= '0' && symbol <= '9') || symbol == '_' || symbol == '\'' ||
+         symbol == '-');
     return !symbolAllowed;
 }
 
@@ -63,7 +66,8 @@ printIdentifier(std::ostream & str, std::string_view s) {
 
     char firstSymbol = s[0];
     // Name can only begin with a letter or an underscore.
-    if (!(std::isalpha(firstSymbol) || firstSymbol == '_')) {
+    if (!((firstSymbol >= 'a' && firstSymbol <= 'z') ||
+          (firstSymbol >= 'A' && firstSymbol <= 'Z') || firstSymbol == '_')) {
         printLiteralString(str, s);
         return str;
     }
@@ -83,7 +87,9 @@ static bool isVarName(std::string_view s)
     if (isReservedKeyword(s)) return false;
     char firstSymbol = s[0];
     // Name cannot begin with a digit or a special character.
-    if (std::isdigit(firstSymbol) || firstSymbol == '-' || firstSymbol == '\'') return false;
+    if ((firstSymbol >= '0' && firstSymbol <= '9') || firstSymbol == '-' ||
+        firstSymbol == '\'')
+        return false;
 
     return std::none_of(std::begin(s), std::end(s), isSymbolProhibited);
 }

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -43,13 +43,12 @@ bool isReservedKeyword(const std::string_view str)
     return reservedKeywords.contains(str);
 }
 
-// Returns 'true' if the character is a symbol that can't be used in a variable name.
-bool isSymbolProhibited(const char & symbol) {
-    bool symbolAllowed =
-        ((symbol >= 'a' && symbol <= 'z') || (symbol >= 'A' && symbol <= 'Z') ||
-         (symbol >= '0' && symbol <= '9') || symbol == '_' || symbol == '\'' ||
-         symbol == '-');
-    return !symbolAllowed;
+// Returns 'true' if the character is a symbol that can be used in a variable name.
+static bool isValidSymbolChar(const char & symbol) {
+    return ((symbol >= 'a' && symbol <= 'z') ||
+            (symbol >= 'A' && symbol <= 'Z') ||
+            (symbol >= '0' && symbol <= '9') ||
+            (symbol == '_' || symbol == '\'' || symbol == '-'));
 }
 
 std::ostream &
@@ -72,7 +71,8 @@ printIdentifier(std::ostream & str, std::string_view s) {
         return str;
     }
     // Name cannot contain prohibited symbols.
-    if (std::any_of(std::begin(s), std::end(s), isSymbolProhibited)) {
+    // We have already checked the first symbol above, so there's no need to check it again.
+    if (!std::all_of(std::begin(s) + 1, std::end(s), isValidSymbolChar)) {
         printLiteralString(str, s);
         return str;
     }
@@ -90,8 +90,8 @@ static bool isVarName(std::string_view s)
     if ((firstSymbol >= '0' && firstSymbol <= '9') || firstSymbol == '-' ||
         firstSymbol == '\'')
         return false;
-
-    return std::none_of(std::begin(s), std::end(s), isSymbolProhibited);
+    // We have already checked the first symbol above, so there's no need to check it again.
+    return std::all_of(std::begin(s) + 1, std::end(s), isValidSymbolChar);
 }
 
 std::ostream &


### PR DESCRIPTION
- reduce code nesting by using early returns 
- move character prohibition logic into a separate function to remove duplicated code
- use `std::none_of` and `std::all_of` instead of loops for better readability
- use `empty` method instead of checking the size for zero


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
