### PR TITLE
[Backport 2.13-maintenance] StorePath: reject names starting with '.', Fix typo in error message of too long store path

### DIFF
--- a/src/libstore/path-regex.hh
+++ b/src/libstore/path-regex.hh
@@ -2,6 +2,6 @@
 
 namespace nix {
 
-static constexpr std::string_view nameRegexStr = R"([0-9a-zA-Z\+\-\._\?=]+)";
+static constexpr std::string_view nameRegexStr = R"([0-9a-zA-Z\+\-_\?=][0-9a-zA-Z\+\-\._\?=]*)";
 
 }

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -9,8 +9,8 @@ static void checkName(std::string_view path, std::string_view name)
     if (name.empty())
         throw BadStorePath("store path '%s' has an empty name", path);
     if (name.size() > StorePath::MaxPathLen)
-        throw BadStorePath("store path '%s' has a name longer than '%d characters",
-            StorePath::MaxPathLen, path);
+        throw BadStorePath("store path '%s' has a name longer than %d characters",
+            path, StorePath::MaxPathLen);
     // See nameRegexStr for the definition
     for (auto c : name)
         if (!((c >= '0' && c <= '9')

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -11,6 +11,8 @@ static void checkName(std::string_view path, std::string_view name)
     if (name.size() > StorePath::MaxPathLen)
         throw BadStorePath("store path '%s' has a name longer than %d characters",
             path, StorePath::MaxPathLen);
+    if (name[0] == '.')
+        throw BadStorePath("store path '%s' starts with illegal character '.'", path);
     // See nameRegexStr for the definition
     for (auto c : name)
         if (!((c >= '0' && c <= '9')

--- a/src/libstore/tests/path.cc
+++ b/src/libstore/tests/path.cc
@@ -36,6 +36,7 @@ TEST_DONT_PARSE(double_star, "**")
 TEST_DONT_PARSE(star_first, "*,foo")
 TEST_DONT_PARSE(star_second, "foo,*")
 TEST_DONT_PARSE(bang, "foo!o")
+TEST_DONT_PARSE(dotfile, ".gitignore")
 
 #undef TEST_DONT_PARSE
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

- Backport of #9219
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
