### PR TITLE
Document builtins.substring negative length behavior

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3720,10 +3720,11 @@ static RegisterPrimOp primop_substring({
     .doc = R"(
       Return the substring of *s* from character position *start*
       (zero-based) up to but not including *start + len*. If *start* is
-      greater than the length of the string, an empty string is returned,
-      and if *start + len* lies beyond the end of the string, only the
-      substring up to the end of the string is returned. *start* must be
-      non-negative. For example,
+      greater than the length of the string, an empty string is returned.
+      If *start + len* lies beyond the end of the string or *len* is `-1`,
+      only the substring up to the end of the string is returned.
+      *start* must be non-negative.
+      For example,
 
       ```nix
       builtins.substring 0 3 "nixos"


### PR DESCRIPTION
# Motivation
Was not documented, but is guaranteed by the underlying [`std::string::substr`](https://cplusplus.com/reference/string/string/substr/). Notably while other negative values have the same behavior, it's not documented in the C++ manual, so we shouldn't rely on that and also not document it.

# Context
```nix
builtins.substring 1 (-1) "hello"
-> "ello"
```

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
