### PR TITLE
styleguide: add note on highlighting examples and syntax definitions

### DIFF
--- a/doc/manual/src/contributing/documentation.md
+++ b/doc/manual/src/contributing/documentation.md
@@ -151,6 +151,24 @@ Please observe these guidelines to ease reviews:
   > This is a note.
   ```
 
+  Highlight examples as such:
+
+  ````
+  > **Example**
+  >
+  > ```console
+  > $ nix --version
+  > ```
+  ````
+
+  Highlight syntax definiions as such, using [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form) notation:
+
+  ````
+  > **Syntax**
+  >
+  > *attribute-set* = `{` [ *attribute-name* `=` *expression* `;` ... ] `}`
+  ````
+
 ### The `@docroot@` variable
 
 `@docroot@` provides a base path for links that occur in reusable snippets or other documentation that doesn't have a base path of its own.


### PR DESCRIPTION
# Motivation


Currently examples are largely buried in the code, making them hard to discern from actual reference documentation. Nix language syntax is, except for a few instances I added recently, only documented by example, which is not great given how many people rely on it.

#
# Context
These are two conventions I would like to establish in the manual, as that will help scanning and searching for these to particular classes of documentation.

I'm not sure about the EBNF notation, and so far used an improvised one. Glad to agree on an existing convention that's visually more less noisy than the one linked.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).