### PR TITLE
doc: Fix fetchGit default name

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -392,7 +392,7 @@ static RegisterPrimOp primop_fetchGit({
 
         The URL of the repo.
 
-      - `name` (default: *basename of the URL*)
+      - `name` (default: `source`)
 
         The name of the directory the repo should be exported to in the store.
 


### PR DESCRIPTION
fetchGit never used the basename of the URL as the name by default. The mistake was introduced when docs were written in https://github.com/NixOS/nix/pull/2005.

```
nix-repl> (builtins.fetchGit ~/src/github-test).outPath
"/nix/store/hl61hkwpvx0g3miix3ybns5795fipz8d-source"
```

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
