### PR TITLE
darwin-installer: work around zshrc overwrites

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -222,3 +222,32 @@ EOF
         failure "This script needs a /nix volume with global permissions! This may require running sudo /usr/sbin/diskutil enableOwnership /nix."
     fi
 }
+
+# appended to shell init
+poly_extra_init_for_zshenv() {
+    cat <<'EOF'
+
+# wrap path_helper to keep it from pushing nix rightwards
+/usr/libexec/path_helper() {
+    case "$1" in
+        "-c")
+            # don't interfere if this gets invoked with -c
+            command /usr/libexec/path_helper "$@"
+            ;;
+        *)
+            (
+                # subshell to see what path_helper would do to PATH. inject a
+                # separator for splitting (saving previous PATH can duplicate
+                # entries, and people tend to see that as a smell)
+                eval "$(PATH="nixpathsep:$PATH" command /usr/libexec/path_helper "$@")"
+                local prefixed="${PATH%%:nixpathsep:*}" pushed_back="${PATH##*:nixpathsep:}"
+
+                # re-emit what path_helper would; remove function to avoid rerunning
+                echo "PATH=\"${pushed_back}:${prefixed}\"; export PATH; unset -f /usr/libexec/path_helper;"
+            )
+            ;;
+    esac
+}
+
+EOF
+}

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -33,7 +33,7 @@ NIX_BUILD_USER_NAME_TEMPLATE="nixbld%d"
 readonly NIX_ROOT="/nix"
 readonly NIX_EXTRA_CONF=${NIX_EXTRA_CONF:-}
 
-readonly PROFILE_TARGETS=("/etc/bashrc" "/etc/profile.d/nix.sh" "/etc/zshrc" "/etc/bash.bashrc" "/etc/zsh/zshrc")
+readonly PROFILE_TARGETS=("/etc/bashrc" "/etc/profile.d/nix.sh" "/etc/zshenv" "/etc/bash.bashrc" "/etc/zsh/zshrc")
 readonly PROFILE_BACKUP_SUFFIX=".backup-before-nix"
 readonly PROFILE_NIX_FILE="$NIX_ROOT/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
 
@@ -845,6 +845,16 @@ EOF
     )
 }
 
+extra_shell_init() {
+    case "$1" in
+        /etc/zshenv)
+            poly_extra_init_for_zshenv;;
+        *)
+            ;;
+    esac
+}
+
+# $1 == file we're generating for
 shell_source_lines() {
     cat <<EOF
 
@@ -852,6 +862,7 @@ shell_source_lines() {
 if [ -e '$PROFILE_NIX_FILE' ]; then
   . '$PROFILE_NIX_FILE'
 fi
+$(extra_shell_init "$1")
 # End Nix
 
 EOF
@@ -870,26 +881,31 @@ end
 EOF
 }
 
+configure_one_shell_init() {
+    local profile_target="$1"
+    if [ -e "$profile_target" ]; then
+        _sudo "to back up your current $profile_target to $profile_target$PROFILE_BACKUP_SUFFIX" \
+              cp "$profile_target" "$profile_target$PROFILE_BACKUP_SUFFIX"
+    else
+        # try to create the file if its directory exists
+        target_dir="$(dirname "$profile_target")"
+        if [ -d "$target_dir" ]; then
+            _sudo "to create a stub $profile_target which will be updated" \
+                touch "$profile_target"
+        fi
+    fi
+
+    if [ -e "$profile_target" ]; then
+        shell_source_lines "$profile_target" \
+            | _sudo "extend your $profile_target with nix-daemon settings" \
+                    tee -a "$profile_target"
+    fi
+}
+
 configure_shell_profile() {
     task "Setting up shell profiles: ${PROFILE_TARGETS[*]}"
     for profile_target in "${PROFILE_TARGETS[@]}"; do
-        if [ -e "$profile_target" ]; then
-            _sudo "to back up your current $profile_target to $profile_target$PROFILE_BACKUP_SUFFIX" \
-                  cp "$profile_target" "$profile_target$PROFILE_BACKUP_SUFFIX"
-        else
-            # try to create the file if its directory exists
-            target_dir="$(dirname "$profile_target")"
-            if [ -d "$target_dir" ]; then
-                _sudo "to create a stub $profile_target which will be updated" \
-                    touch "$profile_target"
-            fi
-        fi
-
-        if [ -e "$profile_target" ]; then
-            shell_source_lines \
-                | _sudo "extend your $profile_target with nix-daemon settings" \
-                        tee -a "$profile_target"
-        fi
+        configure_one_shell_init "$profile_target"
     done
 
     task "Setting up shell profiles for Fish with ${PROFILE_FISH_SUFFIX} inside ${PROFILE_FISH_PREFIXES[*]}"

--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -216,3 +216,7 @@ poly_create_build_user() {
 poly_prepare_to_install() {
     :
 }
+
+poly_extra_init_for_zshenv() {
+    :
+}

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -1,6 +1,6 @@
 # Only execute this file once per shell.
 if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
-__ETC_PROFILE_NIX_SOURCED=1
+export __ETC_PROFILE_NIX_SOURCED=1
 
 NIX_LINK=$HOME/.nix-profile
 if [ -n "${XDG_STATE_HOME-}" ]; then
@@ -60,5 +60,12 @@ else
   unset -f check_nix_profiles
 fi
 
-export PATH="$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin:$PATH"
+# only append once
+case ":$PATH:" in
+  *:"$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin":*)
+    ;;
+  *)
+    export PATH="$NIX_LINK/bin:@localstatedir@/nix/profiles/default/bin:$PATH"
+    ;;
+esac
 unset NIX_LINK

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,3 +1,7 @@
+# Only execute this file once per shell.
+if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
+export __ETC_PROFILE_NIX_SOURCED=1
+
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     # Set up the per-user profile.
@@ -51,9 +55,24 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     # pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
     # which is in the $PATH. For more info, run `manpath -d`.
     if [ -n "${MANPATH-}" ]; then
-        export MANPATH="$NIX_LINK/share/man:$MANPATH"
+        # only append once
+        case ":$MANPATH:" in
+          *:"$NIX_LINK/share/man":*)
+            ;;
+          *)
+            export MANPATH="$NIX_LINK/share/man:$MANPATH"
+            ;;
+        esac
     fi
 
-    export PATH="$NIX_LINK/bin:$PATH"
+    # only append once
+    case ":$PATH:" in
+      *:"$NIX_LINK/bin":*)
+        ;;
+      *)
+        export PATH="$NIX_LINK/bin:$PATH"
+        ;;
+    esac
+
     unset NIX_LINK NIX_LINK_NEW
 fi


### PR DESCRIPTION
# Motivation
- Reduce support load.
- Fix #3616 and #5950 (and many more duplicate issues, probably)

# Context
We know of 2 ~workarounds to the problem that doesn't entail compromising on the general purpose of a multi-user install. I'll save thoughts on pros/cons for a later post and focus on nuts and bolts:
1. Set up a ~persistence-daemon that will attempt to restore the shell hooks on boot if they go missing. This has recently been implemented in the detsys installer: https://github.com/DeterminateSystems/nix-installer/pull/672 
2. Move our shell hook to /etc/zshenv on macOS (which macOS doesn't ship, and updates presumably don't touch). This doesn't work _by itself_ (indeed, a previous PR trying this was reverted) because the /etc/zprofile that ships with macOS will run `path_helper` later in the zsh init process. Evaling the output from `path_helper` resets PATH with items from `/etc/paths`, `/etc/paths.d/*`, and the default system PATH all to the left of anything we've added before that point in init (which includes anything we add in `/etc/zshenv`).

    We need one of two potential fixes to make zshenv work:
    1. add the Nix paths to `/etc/paths`. This would put them in the right position, but it's just a static list of hardcoded paths (and macOS does ship the file, so we'd have to worry about them overwriting it on update as well).
    2. shadow/wrap `/usr/libexec/path_helper` in order to keep it from pushing our PATH additions to the rear of the PATH.

This PR implements 2.ii by declaring a shell function that shadows `/usr/libexec/path_helper` and adding it only to `/etc/zshenv`. (The shell function currently removes itself when it runs. I'm not quite sure if that's the right call or not.)

---

While not strictly related, this PR also tries to address the PATH-appending issue because of a fundamental difference between `zshrc` and `zshenv`--zsh runs the latter for all shells, and the former for interactive ones. IIUC, this means a hook in `zshenv` can run when `zsh` is used as a shebang.

I'm not certain this PR makes the right set of choices here (I'm not very familiar with zsh; I'm just tired of watching people run into this particular sharp corner...), but I'm implementing two approaches mentioned in #5950: exporting `__ETC_PROFILE_NIX_SOURCED` to minimize reruns, and trying to make the actual append step idempotent.

I think this will mitigate one known issue with moving the hook to zshenv which was pointed out by the detsys folks (see the 2nd bullet under https://github.com/DeterminateSystems/nix-installer#using-macos-remote-ssh-builders-nix-binaries-are-not-on-path), but I'm less certain that it's the right fix in all circumstances.

# Testing notes
1. I've run installer tests in my fork: https://github.com/abathur/nix/actions/runs/66490502622. 
2. I've manually tested a fresh install of this on a spare pre-catalina mac I have laying around. I don't use zsh and don't have it set up for day-to-day use, so this is just a basic check.
3. @iFreilicht has been helping with some manual testing (not clean install; just spot-applying equivalent changes) and should be able to weigh in on how this is going. 
4. I have also set up a gist with instructions for zsh users willing to help test this (but please only do this if you know you're comfortable enough with shell init/environment issues to recognize if this causes any subtle problems and work around trouble). It describes how to do a fresh install on x86_64 macs (the test installer won't support Apple Silicon macs, unfortunately) and how to ~patch an existing install to try it: https://gist.github.com/abathur/877a4fa25ec7047baeb3033a9153b269

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
