### PR TITLE
doc: primops: add more info for foldl

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3180,9 +3180,14 @@ static RegisterPrimOp primop_foldlStrict({
     .doc = R"(
       Reduce a list by applying a binary operator, from left to right,
       e.g. `foldl' op nul [x0 x1 x2 ...] = op (op (op nul x0) x1) x2)
-      ...`. For example, `foldl' (x: y: x + y) 0 [1 2 3]` evaluates to 6.
-      The return value of each application of `op` is evaluated immediately,
-      even for intermediate values.
+      ...`.
+      For example, `foldl' (acc: elem: acc + elem) 0 [1 2 3]` evaluates
+      to `6` and `foldl' (acc: elem: { "${elem}" = elem; } // acc) {}
+      ["a" "b"]` evaluates to `{ a = "a"; b = "b"; }`.
+      The first argument of `op` is the accumulator wheres the second
+      argument is the current element being processed. The return value
+      of each application of `op` is evaluated immediately, even for
+      intermediate values.
     )",
     .fun = prim_foldlStrict,
 });

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3181,9 +3181,11 @@ static RegisterPrimOp primop_foldlStrict({
       Reduce a list by applying a binary operator, from left to right,
       e.g. `foldl' op nul [x0 x1 x2 ...] = op (op (op nul x0) x1) x2)
       ...`.
+
       For example, `foldl' (acc: elem: acc + elem) 0 [1 2 3]` evaluates
       to `6` and `foldl' (acc: elem: { "${elem}" = elem; } // acc) {}
       ["a" "b"]` evaluates to `{ a = "a"; b = "b"; }`.
+
       The first argument of `op` is the accumulator wheres the second
       argument is the current element being processed. The return value
       of each application of `op` is evaluated immediately, even for


### PR DESCRIPTION

# Motivation
Improving documentation of `builtins.foldl`.

From the existing doc it is not obvious whether the first or the second argument of `builtins.foldl'` is the accumulator. This is however relevant to know, as for certain scenarios, this might change the behavior.

We can solve this by either adding more info (as I did) or by changing the example from `foldl' (x: y: x + y) 0 [1 2 3]` to `foldl' (accumulator: next: accumulator + next) 0 [1 2 3]`. **Which do you prefer?**

# Context

For reference:

![image](https://github.com/NixOS/nix/assets/5737016/00671968-b6e7-46a3-8b65-9c97a68497a3)


# Priorities

Not very important.