### PR TITLE
[2.3-maintenance] Wait for build users when none are available

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -4475,7 +4475,7 @@ void Worker::waitForInput()
     if (!waitingForAWhile.empty()) {
         useTimeout = true;
         if (lastWokenUp == steady_time_point::min())
-            printError("waiting for locks or build slots...");
+            printError("waiting for locks, build slots or build users...");
         if (lastWokenUp == steady_time_point::min() || lastWokenUp > before) lastWokenUp = before;
         timeout.tv_sec = std::max(1L,
             (long) std::chrono::duration_cast<std::chrono::seconds>(

--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -508,9 +508,6 @@ private:
     Path fnUserLock;
     AutoCloseFD fdUserLock;
 
-    bool findFreeUser();
-
-
     string user;
     uid_t uid;
     gid_t gid;
@@ -527,6 +524,8 @@ public:
     uid_t getGID() { assert(gid); return gid; }
     std::vector<gid_t> getSupplementaryGIDs() { return supplementaryGIDs; }
 
+    bool findFreeUser();
+
     bool enabled() { return uid != 0; }
 
 };
@@ -538,12 +537,8 @@ UserLock::UserLock()
 {
     assert(settings.buildUsersGroup != "");
     createDirs(settings.nixStateDir + "/userpool");
-
-    if (findFreeUser()) return;
-
-    printError("waiting for build users");
-
-    do std::this_thread::sleep_for(std::chrono::seconds(2)); while (! findFreeUser());
+    /* Mark that user is not enabled by default */
+    uid = 0;
 }
 
 bool UserLock::findFreeUser() {
@@ -1422,6 +1417,30 @@ void DerivationGoal::tryToBuild()
 {
     trace("trying to build");
 
+    /* If `build-users-group' is not empty, then we have to build as
+       one of the members of that group. */
+    if (settings.buildUsersGroup != "" && getuid() == 0) {
+#if defined(__linux__) || defined(__APPLE__)
+        if (!buildUser) buildUser = std::make_unique<UserLock>();
+
+        if (!buildUser->enabled()) {
+            if (!buildUser->findFreeUser()) {
+                debug("waiting for build users");
+                worker.waitForAWhile(shared_from_this());
+                return;
+            }
+
+            /* Make sure that no other processes are executing under this
+               uid. */
+            buildUser->kill();
+        }
+#else
+        /* Don't know how to block the creation of setuid/setgid
+           binaries on this platform. */
+        throw Error("build users are not supported on this platform for security reasons");
+#endif
+    }
+
     /* Obtain locks on all output paths.  The locks are automatically
        released when we exit this function or Nix crashes.  If we
        can't acquire the lock, then continue; hopefully some other
@@ -1936,22 +1955,6 @@ void DerivationGoal::startBuilder()
         #else
             throw Error("building using a diverted store is not supported on this platform");
         #endif
-    }
-
-    /* If `build-users-group' is not empty, then we have to build as
-       one of the members of that group. */
-    if (settings.buildUsersGroup != "" && getuid() == 0) {
-#if defined(__linux__) || defined(__APPLE__)
-        buildUser = std::make_unique<UserLock>();
-
-        /* Make sure that no other processes are executing under this
-           uid. */
-        buildUser->kill();
-#else
-        /* Don't know how to block the creation of setuid/setgid
-           binaries on this platform. */
-        throw Error("build users are not supported on this platform for security reasons");
-#endif
     }
 
     /* Create a temporary directory where the build will take


### PR DESCRIPTION
Backport of #3564 to `2.3-maintenance`. One commit in the series (183dd28266e0292116da6cfbc3e2643577adbfbe) was skipped due too many conflicts.

# Motivation / Context
TVL is currently using a set of patches backported to 2.3. WIth the recent activity in 2.3-maintenance, we'd like to upstream these patches.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
