### PR TITLE
[2.3-maintenance] Address removal of pkgconfig alias

### DIFF
--- a/release-common.nix
+++ b/release-common.nix
@@ -50,7 +50,7 @@ rec {
   buildDeps =
     [ curl
       bzip2 xz brotli zstd editline
-      openssl pkgconfig sqlite
+      openssl pkg-config sqlite
       boost
 
       # Tests


### PR DESCRIPTION
nixpkgs ended up removing that alias, this fixes the build with a more recent nixpkgs.

# Motivation / Context
TVL is currently using a set of patches backported to 2.3. WIth the recent activity in 2.3-maintenance, we'd like to upstream these patches.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
