### PR TITLE
[2.3-maintenance] Convert stringly-typed configureFlags to lists of strings

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -25,7 +25,7 @@ let
 
         buildInputs = tarballDeps ++ buildDeps ++ propagatedDeps;
 
-        configureFlags = "--enable-gc";
+        configureFlags = [ "--enable-gc" ];
 
         postUnpack = ''
           (cd $sourceRoot && find . -type f) | cut -c3- > $sourceRoot/.dist-files
@@ -111,10 +111,10 @@ let
           ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
           ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
-        configureFlags = ''
-          --with-dbi=${perlPackages.DBI}/${pkgs.perl.libPrefix}
-          --with-dbd-sqlite=${perlPackages.DBDSQLite}/${pkgs.perl.libPrefix}
-        '';
+        configureFlags = [
+          "--with-dbi=${perlPackages.DBI}/${pkgs.perl.libPrefix}"
+          "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${pkgs.perl.libPrefix}"
+        ];
 
         enableParallelBuilding = true;
 


### PR DESCRIPTION
This has been deprecated in nixpkgs and the warning resulting from that is driving me crazy.

# Motivation / Context
TVL is currently using a set of patches backported to 2.3. WIth the recent activity in 2.3-maintenance, we'd like to upstream these patches.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
