### PR TITLE
Don't assume uid/gid 0 is invalid

### DIFF
--- a/src/libstore/lock.cc
+++ b/src/libstore/lock.cc
@@ -39,9 +39,9 @@ struct SimpleUserLock : UserLock
     gid_t gid;
     std::vector<gid_t> supplementaryGIDs;
 
-    uid_t getUID() override { assert(uid); return uid; }
+    uid_t getUID() override { return uid; }
     uid_t getUIDCount() override { return 1; }
-    gid_t getGID() override { assert(gid); return gid; }
+    gid_t getGID() override { return gid; }
 
     std::vector<gid_t> getSupplementaryGIDs() override { return supplementaryGIDs; }
 


### PR DESCRIPTION
uid and gid 0 are the uid and gid of the root user so remove the asserts that trigger when running as root since both are valid uids, gids.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

We managed to trigger this when setting build-users-group to "root".

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
