### PR TITLE
Util improvements

### DIFF
--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -114,7 +114,7 @@ void drainFD(int fd, Sink & sink, bool block)
                 throw SysError("reading from file");
         }
         else if (rd == 0) break;
-        else sink({(char *) buf.data(), (size_t) rd});
+        else sink({reinterpret_cast<char *>(buf.data()), size_t(rd)});
     }
 }
 

--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -96,7 +96,7 @@ void drainFD(int fd, Sink & sink, bool block)
             throw SysError("making file descriptor non-blocking");
     }
 
-    Finally finally([&]() {
+    Finally finally([&] {
         if (!block) {
             if (fcntl(fd, F_SETFL, saved) == -1)
                 throw SysError("making file descriptor blocking");

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -116,7 +116,11 @@ Path canonPath(PathView path, bool resolveSymlinks)
         }
     }
 
-    return s.empty() ? "/" : std::move(s);
+    if (s.empty()) {
+        s = "/";
+    }
+
+    return s;
 }
 
 

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -90,7 +90,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
         /* Normal component; copy it. */
         else {
             s += '/';
-            if (const auto slash = path.find('/'); slash == std::string::npos) {
+            if (const auto slash = path.find('/'); slash == path.npos) {
                 s += path;
                 path = {};
             } else {
@@ -123,7 +123,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
 Path dirOf(const PathView path)
 {
     Path::size_type pos = path.rfind('/');
-    if (pos == std::string::npos)
+    if (pos == path.npos)
         return ".";
     return pos == 0 ? "/" : Path(path, 0, pos);
 }
@@ -139,7 +139,7 @@ std::string_view baseNameOf(std::string_view path)
         last -= 1;
 
     auto pos = path.rfind('/', last);
-    if (pos == std::string::npos)
+    if (pos == path.npos)
         pos = 0;
     else
         pos += 1;

--- a/src/libutil/processes.cc
+++ b/src/libutil/processes.cc
@@ -226,8 +226,8 @@ pid_t startProcess(std::function<void()> fun, const ProcessOptions & options)
         assert(!(options.cloneFlags & CLONE_VM));
 
         size_t stackSize = 1 * 1024 * 1024;
-        auto stack = (char *) mmap(0, stackSize,
-            PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+        auto stack = static_cast<char *>(mmap(0, stackSize,
+            PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0));
         if (stack == MAP_FAILED) throw SysError("allocating stack");
 
         Finally freeStack([&] { munmap(stack, stackSize); });

--- a/src/libutil/signals.cc
+++ b/src/libutil/signals.cc
@@ -179,7 +179,7 @@ std::unique_ptr<InterruptCallback> createInterruptCallback(std::function<void()>
     auto token = interruptCallbacks->nextToken++;
     interruptCallbacks->callbacks.emplace(token, callback);
 
-    auto res = std::make_unique<InterruptCallbackImpl>();
+    std::unique_ptr<InterruptCallbackImpl> res {new InterruptCallbackImpl{}};
     res->token = token;
 
     return std::unique_ptr<InterruptCallback>(res.release());

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -47,7 +47,7 @@ void bind(int fd, const std::string & path)
     addr.sun_family = AF_UNIX;
 
     if (path.size() + 1 >= sizeof(addr.sun_path)) {
-        Pid pid = startProcess([&]() {
+        Pid pid = startProcess([&] {
             Path dir = dirOf(path);
             if (chdir(dir.c_str()) == -1)
                 throw SysError("chdir to '%s' failed", dir);
@@ -78,7 +78,7 @@ void connect(int fd, const std::string & path)
     if (path.size() + 1 >= sizeof(addr.sun_path)) {
         Pipe pipe;
         pipe.create();
-        Pid pid = startProcess([&]() {
+        Pid pid = startProcess([&] {
             try {
                 pipe.readSide.close();
                 Path dir = dirOf(path);

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -183,7 +183,7 @@ std::string base64Encode(std::string_view s)
 std::string base64Decode(std::string_view s)
 {
     constexpr char npos = -1;
-    constexpr std::array<char, 256> base64DecodeChars = [&]() {
+    constexpr std::array<char, 256> base64DecodeChars = [&] {
         std::array<char, 256>  result{};
         for (auto& c : result)
             c = npos;

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -52,9 +52,9 @@ template<class C> C tokenizeString(std::string_view s, std::string_view separato
 {
     C result;
     auto pos = s.find_first_not_of(separators, 0);
-    while (pos != std::string_view::npos) {
+    while (pos != s.npos) {
         auto end = s.find_first_of(separators, pos + 1);
-        if (end == std::string_view::npos) end = s.size();
+        if (end == s.npos) end = s.size();
         result.insert(result.end(), std::string(s, pos, end - pos));
         pos = s.find_first_not_of(separators, end);
     }
@@ -69,7 +69,7 @@ template std::vector<std::string> tokenizeString(std::string_view s, std::string
 std::string chomp(std::string_view s)
 {
     size_t i = s.find_last_not_of(" \n\r\t");
-    return i == std::string_view::npos ? "" : std::string(s, 0, i + 1);
+    return i == s.npos ? "" : std::string(s, 0, i + 1);
 }
 
 
@@ -89,7 +89,7 @@ std::string replaceStrings(
 {
     if (from.empty()) return res;
     size_t pos = 0;
-    while ((pos = res.find(from, pos)) != std::string::npos) {
+    while ((pos = res.find(from, pos)) != res.npos) {
         res.replace(pos, from.size(), to);
         pos += to.size();
     }
@@ -102,7 +102,7 @@ std::string rewriteStrings(std::string s, const StringMap & rewrites)
     for (auto & i : rewrites) {
         if (i.first == i.second) continue;
         size_t j = 0;
-        while ((j = s.find(i.first, j)) != std::string::npos)
+        while ((j = s.find(i.first, j)) != s.npos)
             s.replace(j, i.first.size(), i.second);
     }
     return s;

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -122,12 +122,11 @@ bool hasSuffix(std::string_view s, std::string_view suffix)
 }
 
 
-std::string toLower(const std::string & s)
+std::string toLower(std::string s)
 {
-    std::string r(s);
-    for (auto & c : r)
+    for (auto & c : s)
         c = std::tolower(c);
-    return r;
+    return s;
 }
 
 
@@ -135,7 +134,7 @@ std::string shellEscape(const std::string_view s)
 {
     std::string r;
     r.reserve(s.size() + 2);
-    r += "'";
+    r += '\'';
     for (auto & i : s)
         if (i == '\'') r += "'\\''"; else r += i;
     r += '\'';

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -180,7 +180,7 @@ bool hasSuffix(std::string_view s, std::string_view suffix);
 /**
  * Convert a string to lower case.
  */
-std::string toLower(const std::string & s);
+std::string toLower(std::string s);
 
 
 /**


### PR DESCRIPTION
# Motivation

This PR contains additional random enhancements of the code:

- using the `npos` member variable instead of the static variable within the type, which makes the code more generic
- the `stringsToCharPtrs` does some really unsafe const casting. I changed its signature to be safe and then added const_casts at the caller side where C-style functions are used that make the const casts necessary. This makes the `stringsToCharPtrs` function safer to use.
- Generelly removed some C-style casts
- dropped parentheses from lambda expressions that accept no parameters
- slightly improved some string-handling functions
- removed a `std::make_unique` call. the reason is that make_unique tries to allocate the unique pointer and the managed object in one chunk of heap memory. in this special case this is not advantageous because we're dropping the pointer just to transfer the management into a new unique pointer.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
