### PR TITLE
Use `git add --force` to add `flake.lock`.

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -395,7 +395,7 @@ struct GitInputScheme : InputScheme
         auto gitDir = ".git";
 
         runProgram("git", true,
-            { "-C", *root, "--git-dir", gitDir, "add", "--intent-to-add", "--", std::string(path.rel()) });
+            { "-C", *root, "--git-dir", gitDir, "add", "--intent-to-add", "--force", "--", std::string(path.rel()) });
 
         if (commitMsg)
             runProgram("git", true,


### PR DESCRIPTION
This prevents flake operations which create a lockfile (like `nix flake metadata`, `nix flake develop`) from failing if `flake.lock` is `.gitignore`d.

Closes #8854.