### PR TITLE
Fix `boost::bad_format_string` exception in `builtins.addErrorContext`

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -824,7 +824,7 @@ static void prim_addErrorContext(EvalState & state, const PosIdx pos, Value * * 
         auto message = state.coerceToString(pos, *args[0], context,
                 "while evaluating the error message passed to builtins.addErrorContext",
                 false, false).toOwned();
-        e.addTrace(nullptr, message, true);
+        e.addTrace(nullptr, hintfmt(message), true);
         throw;
     }
 }

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -23,6 +23,7 @@ nix-instantiate --trace-verbose --eval -E 'builtins.traceVerbose "Hello" 123' 2>
 nix-instantiate --eval -E 'builtins.traceVerbose "Hello" 123' 2>&1 | grepQuietInverse Hello
 nix-instantiate --show-trace --eval -E 'builtins.addErrorContext "Hello" 123' 2>&1 | grepQuietInverse Hello
 expectStderr 1 nix-instantiate --show-trace --eval -E 'builtins.addErrorContext "Hello" (throw "Foo")' | grepQuiet Hello
+expectStderr 1 nix-instantiate --show-trace --eval -E 'builtins.addErrorContext "Hello %" (throw "Foo")' | grepQuiet 'Hello %'
 
 nix-instantiate --eval -E 'let x = builtins.trace { x = x; } true; in x' \
   2>&1 | grepQuiet -E 'trace: { x = «potential infinite recursion»; }'


### PR DESCRIPTION
# Motivation
The message passed to addTrace was incorrectly being used as a format string and this this would cause an exception when the string contained a '%', which can be hit in places where arbitrary file paths are interpolated.

# Context
You can trigger the bug by running
```bash
nix eval --expr 'builtins.addErrorContext "%" (throw "ack")'
```
which produces
```
error: boost::bad_format_string: format-string is ill-formed
```

The underlying reason that this bug existed is that the two prototypes for for `addTrace` are compatible in a sneaky way
```cpp
void addTrace(std::shared_ptr<AbstractPos> && e, std::string_view fs, const Args & ... args);
void addTrace(std::shared_ptr<AbstractPos> && e, hintformat hint, bool frame = false);
```
A call with `addTrace(pos, string_view, true)`, type checks and works 99% of the time because the the `true` gets stuck in `args` and the formatter is happy to ignore extra arguments.