### PR TITLE
nix key: no need for progressBar

### DIFF
--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -1,6 +1,7 @@
 #include "command.hh"
 #include "store-api.hh"
 #include "nar-accessor.hh"
+#include "progress-bar.hh"
 
 using namespace nix;
 
@@ -13,6 +14,7 @@ struct MixCat : virtual Args
         auto st = accessor->lstat(CanonPath(path));
         if (st.type != SourceAccessor::Type::tRegular)
             throw Error("path '%1%' is not a regular file", path);
+        stopProgressBar();
         writeFull(STDOUT_FILENO, accessor->readFile(CanonPath(path)));
     }
 };

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -3,6 +3,7 @@
 #include "shared.hh"
 #include "store-api.hh"
 #include "thread-pool.hh"
+#include "progress-bar.hh"
 
 #include <atomic>
 
@@ -174,6 +175,7 @@ struct CmdKeyGenerateSecret : Command
         if (!keyName)
             throw UsageError("required argument '--key-name' is missing");
 
+        stopProgressBar();
         writeFull(STDOUT_FILENO, SecretKey::generate(*keyName).to_string());
     }
 };
@@ -195,6 +197,7 @@ struct CmdKeyConvertSecretToPublic : Command
     void run() override
     {
         SecretKey secretKey(drainFD(STDIN_FILENO));
+        stopProgressBar();
         writeFull(STDOUT_FILENO, secretKey.toPublicKey().to_string());
     }
 };


### PR DESCRIPTION
otherwise the output will be invisible in common terminal configurations

# Motivation
Alternative to: https://github.com/NixOS/nix/pull/8849

# Context
Intended to make the output visible. Previously there was output, but terminals would often overwrite that output, making it look like the command failed.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

Fixes: https://github.com/NixOS/nix/issues/8844