### PR TITLE
Fix logic for default XDG_DATA_DIRS value

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -20,7 +20,7 @@ set __ETC_PROFILE_NIX_SOURCED 1
 set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
 # Populate bash completions, .desktop files, etc
-if test -n "$XDG_DATA_DIRS"
+if test -z "$XDG_DATA_DIRS"
     # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
     set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:/nix/var/nix/profiles/default/share"
 else

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -31,7 +31,7 @@ fi
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
 
 # Populate bash completions, .desktop files, etc
-if [ -n "${XDG_DATA_DIRS-}" ]; then
+if [ -z "$XDG_DATA_DIRS" ]; then
     # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
     export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
 else

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -21,7 +21,7 @@ if test -n "$HOME" && test -n "$USER"
     set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
     # Populate bash completions, .desktop files, etc
-    if test -n "$XDG_DATA_DIRS"
+    if test -z "$XDG_DATA_DIRS"
         # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
         set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
     else

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -33,7 +33,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
 
     # Populate bash completions, .desktop files, etc
-    if [ -n "${XDG_DATA_DIRS-}" ]; then
+    if [ -z "$XDG_DATA_DIRS" ]; then
         # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
         export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
     else


### PR DESCRIPTION
# Motivation
Fixes an oversight in #8985.

# Context
The [POSIX test manpage](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html) as well as the [fish test manpage](https://fishshell.com/docs/current/cmds/test.html#operators-for-text-strings) specify that `-z` will be "True if the length of string string is zero; otherwise, false."

The `-n` was likely a mixup and not caught during testing of https://github.com/NixOS/nix/pull/8985 due to a lack of missing conflicting entries in `XDG_DATA_DIRS`.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
