### PR TITLE
maintainers: refine the mission statement phrasing

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-The team's main responsibility is to set a direction for the development of Nix and ensure that the code is in good shape.
+The team's main responsibility is to guide and direct the development of Nix and ensure that the code is in good shape.
 
 We aim to achieve this by improving the contributor experience and attracting more maintainers – that is, by helping other people contributing to Nix and eventually taking responsibility – in order to scale the development process to match users' needs.
 


### PR DESCRIPTION

# Motivation

setting a direction falls short of what we're already doing: guide contributors.

the direction aspect is still important, as that is the authoritative part. guidance is the supportive part.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
