### PR TITLE
Add some docs on strings with context

### DIFF
--- a/doc/manual/src/language/string-interpolation.md
+++ b/doc/manual/src/language/string-interpolation.md
@@ -196,3 +196,26 @@ If neither is present, an error is thrown.
 >                 3| in
 >                 4| "${a}"
 >                  |  ^
+
+## Strings with context
+
+An interpolated string keeps a reference to the derivations that were interpolated.
+This context is propagated across operators like `+` and string interpolation.  This is useful when you are creating a script string and what to track all the derivation dependencies that such a script would have.
+
+### Example
+
+```
+nix-repl> :lf nixpkgs
+nix-repl> pkgs = legacyPackages.aarch64-darwin
+nix-repl> s1 = "${pkgs.hello}/bin/hello"
+nix-repl> s2 = "${pkgs.coreutils}/bin/yes"
+nix-repl> :p builtins.getContext s1
+{ "/nix/store/qv7ff3f1xjgax460wl62pr8d2z0jcb9l-hello-2.12.1.drv" = { outputs = [ "out" ]; }; }
+nix-repl> :p builtins.getContext s2
+{ "/nix/store/hkpjm293kzap6cnsacdrljgys3ilhm7k-coreutils-9.3.drv" = { outputs = [ "out" ]; }; }
+:p builtins.getContext (s1 + s2)
+{ "/nix/store/hkpjm293kzap6cnsacdrljgys3ilhm7k-coreutils-9.3.drv" = { outputs = [ "out" ]; }; "/nix/store/qv7ff3f1xjgax460wl62pr8d2z0jcb9l-hello-2.12.1.drv" = { outputs = [ "out" ]; }; }
+ :p builtins.getContext ("${s1}  ; ${s2}")
+{ "/nix/store/hkpjm293kzap6cnsacdrljgys3ilhm7k-coreutils-9.3.drv" = { outputs = [ "out" ]; }; "/nix/store/qv7ff3f1xjgax460wl62pr8d2z0jcb9l-hello-2.12.1.drv" = { outputs = [ "out" ]; }; }
+```
+


### PR DESCRIPTION
# Motivation
The concept of strings with context isn't mentioned in the docs whilst being integral to the nix language. Lets add a paragraph in the nix docs


# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
