### PR TITLE
Link to shebang interpreter docs from release notes

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -1,7 +1,8 @@
 # Release X.Y (202?-??-??)
 
-- The experimental nix command is now a `#!-interpreter` by appending the
-  contents of any `#! nix` lines and the script's location to a single call.
+- The experimental nix command can now act as a [shebang interpreter](@docroot@/command-ref/new-cli/nix.md#shebang-interpreter)
+  by appending the contents of any `#! nix` lines and the script's location to a single call.
+
 - [URL flake references](@docroot@/command-ref/new-cli/nix3-flake.md#flake-references) now support [percent-encoded](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) characters.
 
 - [Path-like flake references](@docroot@/command-ref/new-cli/nix3-flake.md#path-like-syntax) now accept arbitrary unicode characters (except `#` and `?`).


### PR DESCRIPTION
# Motivation
From reading the release notes, it was not clear where to look for documentation of the feature.

# Context
I built the docs locally and confirmed the link does indeed lead to the "Shebang interpreter" section.

Follow-up to #8327.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
