### PR TITLE
Mark `fetchTree` as unstable again

### DIFF
--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -17,7 +17,8 @@
 
 - `nix-shell` shebang lines now support single-quoted arguments.
 
-- `builtins.fetchTree` is now marked as stable.
+- `builtins.fetchTree` is now unstable under its own experimental feature, [`fetch-tree`](@docroot@/contributing/experimental-features.md#xp-fetch-tree).
+  As described in the document for that feature, this is because we anticipate polishing it and then stabilizing it before the rest of Flakes.
 
 - The interface for creating and updating lock files has been overhauled:
 

--- a/doc/manual/src/release-notes/rl-next.md
+++ b/doc/manual/src/release-notes/rl-next.md
@@ -17,7 +17,7 @@
 
 - `nix-shell` shebang lines now support single-quoted arguments.
 
-- `builtins.fetchTree` is now unstable under its own experimental feature, [`fetch-tree`](@docroot@/contributing/experimental-features.md#xp-fetch-tree).
+- `builtins.fetchTree` is now its own experimental feature, [`fetch-tree`](@docroot@/contributing/experimental-features.md#xp-fetch-tree).
   As described in the document for that feature, this is because we anticipate polishing it and then stabilizing it before the rest of Flakes.
 
 - The interface for creating and updating lock files has been overhauled:

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -228,6 +228,7 @@ static RegisterPrimOp primop_fetchTree({
           ```
     )",
     .fun = prim_fetchTree,
+    .experimentalFeature = Xp::FetchTree,
 });
 
 static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v,

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -332,8 +332,6 @@ template<> std::set<ExperimentalFeature> BaseSetting<std::set<ExperimentalFeatur
     for (auto & s : tokenizeString<StringSet>(str)) {
         if (auto thisXpFeature = parseExperimentalFeature(s); thisXpFeature) {
             res.insert(thisXpFeature.value());
-            // FIXME: Replace this hack with a proper notion of
-            // experimental feature implications/dependencies.
             if (thisXpFeature.value() == Xp::Flakes)
                 res.insert(Xp::FetchTree);
         } else

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -330,9 +330,13 @@ template<> std::set<ExperimentalFeature> BaseSetting<std::set<ExperimentalFeatur
 {
     std::set<ExperimentalFeature> res;
     for (auto & s : tokenizeString<StringSet>(str)) {
-        if (auto thisXpFeature = parseExperimentalFeature(s); thisXpFeature)
+        if (auto thisXpFeature = parseExperimentalFeature(s); thisXpFeature) {
             res.insert(thisXpFeature.value());
-        else
+            // FIXME: Replace this hack with a proper notion of
+            // experimental feature implications/dependencies.
+            if (thisXpFeature.value() == Xp::Flakes)
+                res.insert(Xp::FetchTree);
+        } else
             warn("unknown experimental feature '%s'", s);
     }
     return res;

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -80,9 +80,8 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .description = R"(
             Enable the use of the [`fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree) built-in function in the Nix language.
 
-            `fetchTree` exposes a larger suite of fetching functionality in a more systematic way.
-            The same fetching functionality is always used for for
-            [`flakes`](#xp-feature-flakes).
+            `fetchTree` exposes a large suite of fetching functionality in a more systematic way.
+            The [`flakes`](#xp-feature-flakes) feature flag always enables `fetch-tree`.
 
             This built-in was previously guarded by the `flakes` experimental feature because of that overlap,
             but since the plan is to work on stabilizing this first (due 2024 Q1), we are putting it underneath a separate feature.

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -12,7 +12,19 @@ struct ExperimentalFeatureDetails
     std::string_view description;
 };
 
-constexpr std::array<ExperimentalFeatureDetails, 16> xpFeatureDetails = {{
+/**
+ * If two different PRs both add an experimental feature, and we just
+ * used a number for this, we *woudln't* get merge conflict and the
+ * counter will be incremented once instead of twice, causing a build
+ * failure.
+ *
+ * By instead defining this instead as 1 + the bottom experimental
+ * feature, we either have no issue at all if few features are not added
+ * at the end of the list, or a proper merge conflict if they are.
+ */
+constexpr size_t numXpFeatures = 1 + static_cast<size_t>(Xp::VerifiedFetches);
+
+constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails = {{
     {
         .tag = Xp::CaDerivations,
         .name = "ca-derivations",

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -75,6 +75,21 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         )",
     },
     {
+        .tag = Xp::FetchTree,
+        .name = "fetch-tree",
+        .description = R"(
+            Enable the use of the [`fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree) built-in function in the Nix language.
+
+            `fetchTree` exposes a larger suite of fetching functionality in a more systematic way.
+            The same fetching functionality is always used for for
+            [`flakes`](#xp-feature-flakes).
+
+            This built-in was previously guarded by the `flakes` experimental feature because of that overlap,
+            but since the plan is to work on stabilizing this first (due 2024 Q1), we are putting it underneath a separate feature.
+            Once we've made the changes we want to make, enabling just this feature will serve as a "release candidate" --- allowing users to try out the functionality we want to stabilize and not any other functionality we don't yet want to, in isolation.
+        )",
+    },
+    {
         .tag = Xp::NixCommand,
         .name = "nix-command",
         .description = R"(

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -20,6 +20,7 @@ enum struct ExperimentalFeature
     CaDerivations,
     ImpureDerivations,
     Flakes,
+    FetchTree,
     NixCommand,
     RecursiveNix,
     NoUrlLiterals,

--- a/tests/functional/config.sh
+++ b/tests/functional/config.sh
@@ -50,7 +50,8 @@ exp_cores=$(nix show-config | grep '^cores' | cut -d '=' -f 2 | xargs)
 exp_features=$(nix show-config | grep '^experimental-features' | cut -d '=' -f 2 | xargs)
 [[ $prev != $exp_cores ]]
 [[ $exp_cores == "4242" ]]
-[[ $exp_features == "flakes nix-command" ]]
+# flakes implies fetch-tree
+[[ $exp_features == "fetch-tree flakes nix-command" ]]
 
 # Test that it's possible to retrieve a single setting's value
 val=$(nix show-config | grep '^warn-dirty' | cut -d '=' -f  2 | xargs)


### PR DESCRIPTION
# Motivation

As discussed in our last meeting, we need a bit more time, but we are "time boxing" the work left to do to ensure there is not unbounded delay.

Rather than putting it back underneath `flakes`, though, put it underneath its own `fetch-tree` experimental feature (which `flakes` includes/implies). This signals our commitment to the plan to stabilize it first without waiting to go through the rest of Flakes, and also will give users a "release candidate" when we get closer to stabilization.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
