### PR TITLE
nix upgrade-nix: make the source URL an option

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -1084,6 +1084,16 @@ public:
         true, // document default
         Xp::ConfigurableImpureEnv
     };
+
+    Setting<std::string> upgradeNixStorePathUrl{
+        this,
+        "https://github.com/NixOS/nixpkgs/raw/master/nixos/modules/installer/tools/nix-fallback-paths.nix",
+        "upgrade-nix-store-path-url",
+        R"(
+          Used by `nix upgrade-nix`, the URL of the file that contains the
+          store paths of the latest Nix release.
+        )"
+    };
 };
 
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -14,7 +14,6 @@ using namespace nix;
 struct CmdUpgradeNix : MixDryRun, StoreCommand
 {
     Path profileDir;
-    std::string storePathsUrl = "https://github.com/NixOS/nixpkgs/raw/master/nixos/modules/installer/tools/nix-fallback-paths.nix";
 
     CmdUpgradeNix()
     {
@@ -30,7 +29,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
             .longName = "nix-store-paths-url",
             .description = "The URL of the file that contains the store paths of the latest Nix release.",
             .labels = {"url"},
-            .handler = {&storePathsUrl}
+            .handler = {&(std::string&) settings.upgradeNixStorePathUrl}
         });
     }
 
@@ -44,7 +43,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
     std::string description() override
     {
-        return "upgrade Nix to the stable version declared in Nixpkgs";
+        return "upgrade Nix to the latest stable version";
     }
 
     std::string doc() override
@@ -145,7 +144,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         Activity act(*logger, lvlInfo, actUnknown, "querying latest Nix version");
 
         // FIXME: use nixos.org?
-        auto req = FileTransferRequest(storePathsUrl);
+        auto req = FileTransferRequest((std::string&) settings.upgradeNixStorePathUrl);
         auto res = getFileTransfer()->download(req);
 
         auto state = std::make_unique<EvalState>(SearchPath{}, store);

--- a/src/nix/upgrade-nix.md
+++ b/src/nix/upgrade-nix.md
@@ -16,8 +16,10 @@ R""(
 
 # Description
 
-This command upgrades Nix to the stable version declared in Nixpkgs.
-This stable version is defined in [nix-fallback-paths.nix](https://github.com/NixOS/nixpkgs/raw/master/nixos/modules/installer/tools/nix-fallback-paths.nix)
+This command upgrades Nix to the stable version.
+
+By default, the latest stable version is defined by Nixpkgs, in
+[nix-fallback-paths.nix](https://github.com/NixOS/nixpkgs/raw/master/nixos/modules/installer/tools/nix-fallback-paths.nix)
 and updated manually. It may not always be the latest tagged release.
 
 By default, it locates the directory containing the `nix` binary in the `$PATH`


### PR DESCRIPTION
# Motivation

This new option enables organizations to more easily manage their Nix fleet's deployment, and ensure a consistent and planned rollout of Nix upgrades.

# Context

The current implementation requires remembering to specify an option every time `nix upgrade-nix` is called. However, that is error prone and causes issues for users and coordinated deployments.

Additionally, users may want to pin their upgrade source to a non-master version of Nixpkgs.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
