### PR TITLE
Renamed nix nar dump-path to nix nar pack

### DIFF
--- a/src/nix/dump-path.cc
+++ b/src/nix/dump-path.cc
@@ -61,4 +61,12 @@ struct CmdDumpPath2 : Command
     }
 };
 
-static auto rDumpPath2 = registerCommand2<CmdDumpPath2>({"nar", "dump-path"});
+struct CmdNarDumpPath : CmdDumpPath2 {
+    void run() override {
+        warn("'nix nar dump-path' is a deprecated alias for 'nix nar pack'");
+        CmdDumpPath2::run();
+    }
+};
+
+static auto rCmdNarPack = registerCommand2<CmdDumpPath2>({"nar", "pack"});
+static auto rCmdNarDumpPath = registerCommand2<CmdNarDumpPath>({"nar", "dump-path"});

--- a/src/nix/nar-dump-path.md
+++ b/src/nix/nar-dump-path.md
@@ -5,7 +5,7 @@ R""(
 * To serialise directory `foo` as a NAR:
 
   ```console
-  # nix nar dump-path ./foo > foo.nar
+  # nix nar pack ./foo > foo.nar
   ```
 
 # Description
@@ -15,3 +15,4 @@ This command generates a NAR file containing the serialisation of
 symbolic links. The NAR is written to standard output.
 
 )""
+

--- a/src/nix/nar-dump-path.md
+++ b/src/nix/nar-dump-path.md
@@ -15,4 +15,3 @@ This command generates a NAR file containing the serialisation of
 symbolic links. The NAR is written to standard output.
 
 )""
-


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Fixes: #8875 
`nix nar dump-path` command is renamed to `nix nar pack`

# Context
<!-- Provide context. Reference open issues if available. -->
* Used alias method to implement the pack command
* dump-path command is now made as an alias of pack

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Screenshot:
![image](https://github.com/NixOS/nix/assets/24916780/da8eaec8-ab87-4685-a59f-30bc5d2c8f5c)


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
