### PR TITLE
Fix makefile bug confusing `libnixutil-test` exe vs lib

### DIFF
--- a/src/libutil/tests/local.mk
+++ b/src/libutil/tests/local.mk
@@ -1,6 +1,6 @@
 check: libutil-tests_RUN
 
-programs += libutil-tests
+programs += libutil-tests-exe
 
 libutil-tests-exe_NAME = libnixutil-tests
 


### PR DESCRIPTION
# Motivation

The `-exe` variant is the program, the unsuffixed variant is the library.

# Context

The corrected usage matches `libnixstore-test`.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
