### PR TITLE
Implement --raw for nix-instantiate --eval

### DIFF
--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -22,7 +22,7 @@ static Path gcRoot;
 static int rootNr = 0;
 
 
-enum OutputKind { okPlain, okXML, okJSON };
+enum OutputKind { okPlain, okXML, okJSON, okRaw };
 
 
 void processExpr(EvalState & state, const Strings & attrPaths,
@@ -53,6 +53,9 @@ void processExpr(EvalState & state, const Strings & attrPaths,
                 printValueAsXML(state, strict, location, vRes, std::cout, context, noPos);
             else if (output == okJSON) {
                 printValueAsJSON(state, strict, vRes, v.determinePos(noPos), std::cout, context);
+                std::cout << std::endl;
+            } else if (output == okRaw) {
+                std::cout << *state.coerceToString(noPos, vRes, context, "while generating the nix-instantiate output");
                 std::cout << std::endl;
             } else {
                 if (strict) state.forceValueDeep(vRes);
@@ -134,6 +137,8 @@ static int main_nix_instantiate(int argc, char * * argv)
                 outputKind = okXML;
             else if (*arg == "--json")
                 outputKind = okJSON;
+            else if (*arg == "--raw")
+                outputKind = okRaw;
             else if (*arg == "--no-location")
                 xmlOutputSourceLocation = false;
             else if (*arg == "--strict")


### PR DESCRIPTION
# Motivation
For ages now I've been doing hacks like
```
nix-instantiate --eval <something> | tr -d \"
# Or
nix-instantiate --eval <something> | jq -r .
```

to get to the raw string content in the stable CLI.

Today I've had enough and went on to implement `--raw` within like 10 minutes and only a single compilation error.

# Context

`nix eval` already supports `--raw`.

Implements `--raw` for `nix-instantiate`:

```
$ nix-instantiate --eval --raw --expr '"hello"'
hello
```

Not yet documented or tested.

On one hand the Nix team might be inclined to reject this because it changes the old CLI when you're trying to focus on the new one.

On the other hand, this is a 6 line change..

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
