### PR TITLE
Document <drvPath>^<outputName> syntax for installables

### DIFF
--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -29,7 +29,7 @@
   - The character `^`
   - Either:
     - one of the store derivation's [output names](#gloss-output-name) or
-    - the character `*`
+    - the character `*` denoting all outputs of the derivation
 
   > **Examples**
   >

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -21,6 +21,24 @@
 
   [store derivation]: #gloss-store-derivation
 
+- [store derivation output reference]{#gloss-store-derivation-output-reference}
+
+  The string resulting from concatenating three things:
+
+  - The path to a [store derivation](#gloss-store-derivation)
+  - The character `^`
+  - Either:
+    - one of the store derivation's [output names](#gloss-output-name) or
+    - the character `*`
+
+  > **Examples**
+  >
+  > `/nix/store/xvni94ndxy75v1wdpshk8k0l75nwyc54-stdenv-linux.drv^*`
+  >
+  > `/nix/store/llil5bng8p7203l25mqb5lwdhlaya4d9-bash-5.2-p15.drv^man`
+
+  [store derivation output reference]: #gloss-store-derivation-output-reference
+
 - [instantiate]{#gloss-instantiate}, instantiation
 
   Translate a [derivation] into a [store derivation].
@@ -211,6 +229,11 @@
   See [the `outputs` argument to the `derivation` function](@docroot@/language/derivations.md#attr-outputs) for details.
 
   [output]: #gloss-output
+
+- [output name]{#gloss-output-name}
+
+  A string identifier, such as `out` or `man`, given to each output of a derivation.
+  See [the `outputs` argument to the `derivation` function](@docroot@/language/derivations.md#attr-outputs) for details; the `outputs` argument is a list and each element of this list is an output name.
 
 - [output path]{#gloss-output-path}
 

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -31,9 +31,15 @@
     - one of the store derivation's [output names](#gloss-output-name) or
     - the character `*` denoting all outputs of the derivation
 
-  > **Examples**
+  > **Example**
+  >
+  > Reference to all outputs of a given `stdenv-linux` derivation:
   >
   > `/nix/store/xvni94ndxy75v1wdpshk8k0l75nwyc54-stdenv-linux.drv^*`
+
+  > **Example**
+  >
+  > Reference to the `man` output of a given `bash-5.2-p15` derivation:
   >
   > `/nix/store/llil5bng8p7203l25mqb5lwdhlaya4d9-bash-5.2-p15.drv^man`
 

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -23,7 +23,7 @@
 
 - [store derivation output reference]{#gloss-store-derivation-output-reference}
 
-  The string resulting from concatenating three things:
+  The string resulting from the concatenation of:
 
   - The path to a [store derivation](#gloss-store-derivation)
   - The character `^`

--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -59,6 +59,7 @@ These are command line arguments that represent something that can be realised i
 The following types of installable are supported by most commands:
 
 - [Flake output attribute](#flake-output-attribute) (experimental)
+- [Store derivation output reference](../../glossary.md#gloss-store-derivation-output-reference)
 - [Store path](#store-path)
 - [Nix file](#nix-file), optionally qualified by an attribute path
 - [Nix expression](#nix-expression), optionally qualified by an attribute path

--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -59,7 +59,7 @@ These are command line arguments that represent something that can be realised i
 The following types of installable are supported by most commands:
 
 - [Flake output attribute](#flake-output-attribute) (experimental)
-- [Store derivation output reference](../../glossary.md#gloss-store-derivation-output-reference)
+- [Store derivation output reference](@docroot@/glossary.md#gloss-store-derivation-output-reference)
 - [Store path](#store-path)
 - [Nix file](#nix-file), optionally qualified by an attribute path
 - [Nix expression](#nix-expression), optionally qualified by an attribute path


### PR DESCRIPTION
The `^` syntax for installables was added in these three PRs:
- https://github.com/NixOS/nix/pull/6426
- https://github.com/NixOS/nix/pull/4543
- https://github.com/NixOS/nix/pull/7600

... but was not added to the manual.  This commit documents the syntax for this fifth type of installable.

My earlier complaints about vagueness in #4543 are solved if `/nix/store/xyz.drv^outname` counts as an installable, since this syntax gives us a way to use installable-accepting commands (like `nix copy`) on a derivation without using the command on its outputs (or vice versa).

At the time of that discussion the `^` syntax had not yet reached the then-stable version of Nix, and I didn't find out about it until a few months ago.  I think it is awesome.  The `--derivation` flag always seemed like an ugly hack.

Anyways, I assume that the intent is that `/nix/store/xyz.drv^outname` counts as an installable.  If so, this is my attempt at documenting that fact.