### PR TITLE
refactor: Add `Value` types, use `std::span` for list iteration

### DIFF
--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <climits>
+#include <span>
 
 #include "symbol-table.hh"
 #include "value/context.hh"
@@ -395,7 +396,13 @@ public:
         return internalType == tList1 || internalType == tList2 ? smallList : bigList.elems;
     }
 
-    const Value * const * listElems() const
+    std::span<Value * const> listItems() const
+    {
+        assert(isList());
+        return std::span<Value * const>(listElems(), listSize());
+    }
+
+    Value * const * listElems() const
     {
         return internalType == tList1 || internalType == tList2 ? smallList : bigList.elems;
     }
@@ -413,34 +420,6 @@ public:
      * non-trivial.
      */
     bool isTrivial() const;
-
-    auto listItems()
-    {
-        struct ListIterable
-        {
-            typedef Value * const * iterator;
-            iterator _begin, _end;
-            iterator begin() const { return _begin; }
-            iterator end() const { return _end; }
-        };
-        assert(isList());
-        auto begin = listElems();
-        return ListIterable { begin, begin + listSize() };
-    }
-
-    auto listItems() const
-    {
-        struct ConstListIterable
-        {
-            typedef const Value * const * iterator;
-            iterator _begin, _end;
-            iterator begin() const { return _begin; }
-            iterator end() const { return _end; }
-        };
-        assert(isList());
-        auto begin = listElems();
-        return ConstListIterable { begin, begin + listSize() };
-    }
 
     SourcePath path() const
     {

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -190,6 +190,11 @@ public:
         const char * path;
     };
 
+    struct ClosureThunk {
+        Env * env;
+        Expr * expr;
+    };
+
     union
     {
         NixInt integer;
@@ -205,10 +210,7 @@ public:
             Value * * elems;
         } bigList;
         Value * smallList[2];
-        struct {
-            Env * env;
-            Expr * expr;
-        } thunk;
+        ClosureThunk thunk;
         struct {
             Value * left, * right;
         } app;

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -158,37 +158,39 @@ public:
     inline bool isPrimOp() const { return internalType == tPrimOp; };
     inline bool isPrimOpApp() const { return internalType == tPrimOpApp; };
 
+    /**
+     * Strings in the evaluator carry a so-called `context` which
+     * is a list of strings representing store paths.  This is to
+     * allow users to write things like
+     *
+     *   "--with-freetype2-library=" + freetype + "/lib"
+     *
+     * where `freetype` is a derivation (or a source to be copied
+     * to the store).  If we just concatenated the strings without
+     * keeping track of the referenced store paths, then if the
+     * string is used as a derivation attribute, the derivation
+     * will not have the correct dependencies in its inputDrvs and
+     * inputSrcs.
+
+     * The semantics of the context is as follows: when a string
+     * with context C is used as a derivation attribute, then the
+     * derivations in C will be added to the inputDrvs of the
+     * derivation, and the other store paths in C will be added to
+     * the inputSrcs of the derivations.
+
+     * For canonicity, the store paths should be in sorted order.
+     */
+    struct StringWithContext {
+        const char * c_str;
+        const char * * context; // must be in sorted order
+    };
+
     union
     {
         NixInt integer;
         bool boolean;
 
-        /**
-         * Strings in the evaluator carry a so-called `context` which
-         * is a list of strings representing store paths.  This is to
-         * allow users to write things like
-
-         *   "--with-freetype2-library=" + freetype + "/lib"
-
-         * where `freetype` is a derivation (or a source to be copied
-         * to the store).  If we just concatenated the strings without
-         * keeping track of the referenced store paths, then if the
-         * string is used as a derivation attribute, the derivation
-         * will not have the correct dependencies in its inputDrvs and
-         * inputSrcs.
-
-         * The semantics of the context is as follows: when a string
-         * with context C is used as a derivation attribute, then the
-         * derivations in C will be added to the inputDrvs of the
-         * derivation, and the other store paths in C will be added to
-         * the inputSrcs of the derivations.
-
-         * For canonicity, the store paths should be in sorted order.
-         */
-        struct {
-            const char * c_str;
-            const char * * context; // must be in sorted order
-        } string;
+        StringWithContext string;
 
         struct {
             InputAccessor * accessor;

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -185,6 +185,11 @@ public:
         const char * * context; // must be in sorted order
     };
 
+    struct Path {
+        InputAccessor * accessor;
+        const char * path;
+    };
+
     union
     {
         NixInt integer;
@@ -192,10 +197,7 @@ public:
 
         StringWithContext string;
 
-        struct {
-            InputAccessor * accessor;
-            const char * path;
-        } _path;
+        Path _path;
 
         Bindings * attrs;
         struct {

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -195,6 +195,10 @@ public:
         Expr * expr;
     };
 
+    struct FunctionApplicationThunk {
+        Value * left, * right;
+    };
+
     union
     {
         NixInt integer;
@@ -211,17 +215,13 @@ public:
         } bigList;
         Value * smallList[2];
         ClosureThunk thunk;
-        struct {
-            Value * left, * right;
-        } app;
+        FunctionApplicationThunk app;
         struct {
             Env * env;
             ExprLambda * fun;
         } lambda;
         PrimOp * primOp;
-        struct {
-            Value * left, * right;
-        } primOpApp;
+        FunctionApplicationThunk primOpApp;
         ExternalValueBase * external;
         NixFloat fpoint;
     };

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -199,6 +199,11 @@ public:
         Value * left, * right;
     };
 
+    struct Lambda {
+        Env * env;
+        ExprLambda * fun;
+    };
+
     union
     {
         NixInt integer;
@@ -216,10 +221,7 @@ public:
         Value * smallList[2];
         ClosureThunk thunk;
         FunctionApplicationThunk app;
-        struct {
-            Env * env;
-            ExprLambda * fun;
-        } lambda;
+        Lambda lambda;
         PrimOp * primOp;
         FunctionApplicationThunk primOpApp;
         ExternalValueBase * external;

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -172,7 +172,7 @@ static void loadSourceExpr(EvalState & state, const SourcePath & path, Value & v
        directory). */
     else if (st.type == InputAccessor::tDirectory) {
         auto attrs = state.buildBindings(maxAttrs);
-        attrs.alloc("_combineChannels").mkList(0);
+        state.mkList(attrs.alloc("_combineChannels"), 0);
         StringSet seen;
         getAllExprs(state, path, seen, attrs);
         v.mkAttrs(attrs);


### PR DESCRIPTION
# Motivation

I've done some work on exception safety in the evaluator that's resulting in some refactoring. I'm not done with it yet, but I believe these commits should be uncontroversial and I figured `StringWithContext` might be semi-useful for @tomberek's work on string performance.

Changes:

- Add explicit type names for the items of the `Value` `union`. They aren't used yet, but can be used to write more type safe helper functions.
- Use `std::span` for accessing list values. That's a view of a contiguous memory region a dynamic number of instances of a certain type. `string_view` is like a `span<char>`.
  - This changes how `const` is used. I've explained it in the second to last commit message.
- The change in `nix-env` is also basically a no-op, but makes it so that all list initialization happens through EvalState, which will be useful later.

# Context

Reasons why I'm looking into exception safety:

- #8530
- #8585

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
