### PR TITLE
Fix `make check`

### DIFF
--- a/src/libutil/tests/local.mk
+++ b/src/libutil/tests/local.mk
@@ -1,4 +1,4 @@
-check: libutil-tests_RUN
+check: libutil-tests-exe_RUN
 
 programs += libutil-tests-exe
 


### PR DESCRIPTION
After 9c7749e13508996eb9df83b1692664cc8cdbf952, `libutil-tests_RUN` doesn't exist. It needs to become `libutil-tests-exe_RUN`.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
