### PR TITLE
Fix the error message given in install-multi-user.sh when nix build group already exists

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -530,9 +530,8 @@ It seems the build group $NIX_BUILD_GROUP_NAME already exists, but
 with the UID $primary_group_id. This script can't really handle
 that right now, so I'm going to give up.
 
-You can fix this by editing this script and changing the
-NIX_BUILD_GROUP_ID variable near the top to from $NIX_BUILD_GROUP_ID
-to $primary_group_id and re-run.
+You can fix this by setting NIX_BUILD_GROUP_ID=$primary_group_id in
+your shell environment and re-running the installer.
 EOF
         else
             row "            Exists" "Yes"


### PR DESCRIPTION
Fix the error message given when nix build group already exists.  The existing message gives a misleading solution when the script is typically not downloaded and executed directly.

The solution given in the new message is permitted now by https://github.com/NixOS/nix/pull/4345/files

Fixes: https://github.com/NixOS/nix/issues/4915