### PR TITLE
fetchGit/fetchTree: add support for shallow cloning

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -423,9 +423,16 @@ static RegisterPrimOp primop_fetchGit({
 
         A Boolean parameter that specifies whether submodules should be checked out.
 
+      - `shallowRev` (default: `false`)
+
+        A Boolean parameter that specifies whether to perform a shallow clone.
+        This reduces the amount of data transmitted while fetching.
+
       - `shallow` (default: `false`)
 
-        A Boolean parameter that specifies whether fetching a shallow clone is allowed.
+        A Boolean parameter that specifies whether fetching from a shallow remote repository is allowed.
+        This still performs a full clone of what is available on the remote.
+        For most cases 'shallowRev = true' should be used instead.
 
       - `allRefs`
 

--- a/tests/functional/fetchGit-shallowRev.sh
+++ b/tests/functional/fetchGit-shallowRev.sh
@@ -1,0 +1,50 @@
+source common.sh
+
+requireGit
+
+clearStore
+
+# Intentionally not in a canonical form
+# See https://github.com/NixOS/nix/issues/6195
+repo=$TEST_ROOT/./git
+
+export _NIX_FORCE_HTTP=1
+
+rm -rf $TEST_HOME/.cache/nix $TEST_ROOT/shallow
+
+git init $repo
+git -C $repo config user.email "foobar@example.com"
+git -C $repo config user.name "Foobar"
+
+echo utrecht > $repo/hello
+touch $repo/.gitignore
+touch $repo/not-exported-file
+echo "/not-exported-file export-ignore" >> $repo/.gitattributes
+git -C $repo add hello not-exported-file .gitignore .gitattributes
+git -C $repo commit -m 'Bla1'
+rev1=$(git -C $repo rev-parse HEAD)
+
+echo world > $repo/hello
+git -C $repo commit -m 'Bla2' -a
+rev2=$(git -C $repo rev-parse HEAD)
+
+
+# Fetch local repo using shallowRev
+path0=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev1\"; shallowRev = true; name = \"test1\"; }).outPath")
+[[ $(cat $path0/hello) = utrecht ]]
+[[ $(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev1\"; shallowRev = true; name = \"test1\"; }).rev") = $rev1 ]]
+
+# Ensure .gitattributes is respected
+[[ ! -e $path0/not-exported-file ]]
+
+# Fetch local shallow repo using shallowRev
+git clone --depth 1 file://$repo $TEST_ROOT/shallow
+path1=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$TEST_ROOT/shallow; rev = \"$rev2\"; shallowRev = true; name = \"test2\"; }).outPath")
+[[ $(cat $path1/hello) = world ]]
+
+# Ensure that fetching a non-existing revision fails
+# (since /shallow is a truncated repo, it does not contain $rev1)
+out=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$TEST_ROOT/shallow; rev = \"$rev1\"; shallowRev = true; name = \"test3\"; }).outPath" 2>&1) || status=$?
+[[ $status == 1 ]]
+# The error message is not very spcific in this case, but what matters is that it fails properly
+[[ $out =~ 'Could not fetch single revision of Git repository' ]]

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -235,6 +235,15 @@ rev_tag2=$(git -C $repo rev-parse refs/tags/tag2)
 [[ $rev_tag2_nix = $rev_tag2 ]]
 unset _NIX_FORCE_HTTP
 
+# Ensure .gitattributes is respected
+touch $repo/not-exported-file
+echo "/not-exported-file export-ignore" >> $repo/.gitattributes
+git -C $repo add not-exported-file .gitattributes
+git -C $repo commit -m 'Bla6'
+rev5=$(git -C $repo rev-parse HEAD)
+path12=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev5\"; }).outPath")
+[[ ! -e $path12/not-exported-file ]]
+
 # should fail if there is no repo
 rm -rf $repo/.git
 (! nix eval --impure --raw --expr "(builtins.fetchGit \"file://$repo\").outPath")

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -38,6 +38,7 @@ nix_tests = \
   gc-runtime.sh \
   tarball.sh \
   fetchGit.sh \
+  fetchGit-shallowRev.sh \
   fetchurl.sh \
   fetchPath.sh \
   fetchTree-file.sh \


### PR DESCRIPTION
This PR should mainly serve as a POC and a basis for discussions.

It implements a significantly more efficient way of fetching git sources (100x in many cases), hidden behind a flag. But rather than implementing this as an optional feature it would be much better if this became the default as part of the stabilization work on fetchTree. If I get green light by the nix team I'm happy to adapt these changes and make it the default for fetchTree.

fixes https://github.com/NixOS/nix/issues/5119
fixes https://github.com/NixOS/nix/issues/4455 (This was closed, but not fixed, probably due to a misunderstanding, see the `'shallow = true' option confusion` paragraph below)

## Motivation

TL;DR;

- Reduce the required download size of some git sources by more than 99.7%.
- Make fetchGit achieve similar performance as the github tarball feature but without depending on github for it

In lang2nix scenarios it is common to have lock files with entries pointing to git repos. Usually git revisions sha1 hashes are used to pin down such sources and verify their integrity. Fetching these lock file closures via nix is currently rather expensive, because the fetchGit/fetchTree builtins do not support shallow fetching for most git repos.

For example fetching a single revision of the php static analyzer `phpstan` currently requires fetching 4.17 GiB from the network, while with this PR, it only requires fetching 13.40 MiB, which is a reduction by ~99.7%.

## The 'shallow = true' option confusion

The current fetchGit/fetchTree builtin already offers a `shallow` flag, but this only allows fetching remote shallow repos. It does not support shallow fetching from non-shallow remote repos. This has been confusing to a number of users, because they expected the `shallow` flag to behave similar to a `nix clone https://example.com --branch $ref --depth 1`. It's not obvious at first glance, but this behavior wouldn't make much sense. It would not be reproducible, because the selected `$ref` is not static and might progress over time on the remote. The number for `--depth {number}` would have to be increased over time in order to still reach the same desired revision.

## Fixing the problem

In order to really do a shallow fetch on a non-shallow remote, we have to fetch shallowly by revision ignoring any `ref`. Git supports this since version 2.5, but the nix builtin doesn't support it yet, as it always enforces fetching via `ref` (nix will automatically select a `ref` if the user didn't specify one). This PR fixes that by introducing a new option `shallowRev = true`, which enforces `ref` being unset and makes git fetch only the specified revision using `fetch --depth 1` on the specific revision sha1 hash.

## The way forward

Shallow cloning results in the exact same output in the nix store compared to full cloning. The contents can still be verified either via the revision sha1 hash, or a narHash. The only problem why shallow fetching can not become the default right now is because it cannot reliably return a `revCount`. As a result, it would break the API.

Therefore, my question to the nix team: What was the original motivation behind having a `revCount`? It doesn't seem to provide any guarantees. It is not needed for verifying the file contents either. The simplest fix seems to deprecate `revCount` in  `fetchTree`, or make it optional. Is this change feasible? This way, shallow cloning can be made the default.

## Considerations

There is no guarantee if a remote supports or allows shallow cloning by revision. Therefore if shallow cloning became the default, a fallback to full cloning should be implemented which triggers whenever shallow cloning fails.

Also, the current POC implementation of this PR does not cache the git repos, which doesn't hurt mach, as the amount of data transmitted is already much lower than before. But caching could be added here as well. Even if all fetching is done shallowly, caching can still be beneficial, because two different revisions can still contain identical files, in which case re-downloading these git blobs could be omitted. Though, I'm not sure how smart the git protocol really is in omitting unnecessary objects during transfer. Maybe it's not worth it. I can look into this more.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
