### PR TITLE
flakes: bare minimum fix the error message for untracked flake.nix

### DIFF
--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -212,8 +212,16 @@ static Flake getFlake(
     auto [storePath, resolvedRef, lockedRef] = fetchOrSubstituteTree(
         state, originalRef, allowLookup, flakeCache);
 
+    // We need to guard against symlink attacks, but before we start doing
+    // filesystem operations we should make sure there's a flake.nix in the
+    // first place.
+    auto unsafeFlakeDir = state.store->toRealPath(storePath) + "/" + lockedRef.subdir;
+    auto unsafeFlakeFile = unsafeFlakeDir + "/flake.nix";
+    if (!pathExists(unsafeFlakeFile))
+        throw Error("source tree referenced by '%s' does not contain a '%s/flake.nix' file", lockedRef, lockedRef.subdir);
+
     // Guard against symlink attacks.
-    auto flakeDir = canonPath(state.store->toRealPath(storePath) + "/" + lockedRef.subdir, true);
+    auto flakeDir = canonPath(unsafeFlakeDir, true);
     auto flakeFile = canonPath(flakeDir + "/flake.nix", true);
     if (!isInDir(flakeFile, state.store->toRealPath(storePath)))
         throw Error("'flake.nix' file of flake '%s' escapes from '%s'",
@@ -225,9 +233,6 @@ static Flake getFlake(
         .lockedRef = lockedRef,
         .storePath = storePath,
     };
-
-    if (!pathExists(flakeFile))
-        throw Error("source tree referenced by '%s' does not contain a '%s/flake.nix' file", lockedRef, lockedRef.subdir);
 
     Value vInfo;
     state.evalFile(state.rootPath(CanonPath(flakeFile)), vInfo, true); // FIXME: symlink attack


### PR DESCRIPTION
# tl;dr

Before:
```
warning: Git tree '/home/qyriad/code/new-repo' is dirty
error: getting status of '/nix/store/0ccnxa25whszw7mgbgyzdm4nqc0zwnm8-source/flake.nix': No such file or directory
```
After:
```
warning: Git tree '/home/qyriad/code/new-repo' is dirty
error: source tree referenced by 'git+file:///home/qyriad/code/new-repo' does not contain a '/flake.nix' file
```

# Motivation

`error: getting status of /nix/store/path/flake.nix: No such file or directory` is an extremely confusing error message, with multiple related open issues (#6642, #7107), [Discourse](https://discourse.nixos.org/t/nix-flakes-nix-store-source-no-such-file-or-directory/17836) [threads](https://discourse.nixos.org/t/nix-store-no-such-file-or-directory-when-using-flake-from-local-filesystem/24948), [Reddit threads](https://www.reddit.com/r/NixOS/comments/oeeecc/nixos_system_with_nix_flakes_error/), and even [blog posts](https://jvns.ca/blog/2023/11/11/notes-on-nix-flakes/) about it.

This problem warrants *far* more helpful diagnostics than this PR adds, however the current UX is so poor and the fix so trivial I felt it warranted a separate, bare minimum PR before I work on more complex diagnostics.

# Context

Since `canonPath(resolveSymlinks = true)` calls `lstat()` on its argument, I'm *pretty* sure it's impossible for a `pathExists()` check after it to return false. Because of that I moved the check entirely to before the `canonPath()` calls, instead of duplicating them.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
