### PR TITLE
Revert use of boost::container::small_vector in the evaluator

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -31,7 +31,6 @@
 
 #include <sys/resource.h>
 #include <nlohmann/json.hpp>
-#include <boost/container/small_vector.hpp>
 
 #if HAVE_BOEHMGC
 
@@ -1710,7 +1709,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                 /* We have all the arguments, so call the primop with
                    the previous and new arguments. */
 
-                Value * vArgs[maxPrimOpArity];
+                Value * vArgs[arity];
                 auto n = argsDone;
                 for (Value * arg = &vCur; arg->isPrimOpApp(); arg = arg->primOpApp.left)
                     vArgs[--n] = arg->primOpApp.right;
@@ -1773,11 +1772,11 @@ void ExprCall::eval(EvalState & state, Env & env, Value & v)
     // 4: about 60
     // 5: under 10
     // This excluded attrset lambdas (`{...}:`). Contributions of mixed lambdas appears insignificant at ~150 total.
-    boost::container::small_vector<Value *, 4> vArgs(args.size());
+    Value * vArgs[args.size()];
     for (size_t i = 0; i < args.size(); ++i)
         vArgs[i] = args[i]->maybeThunk(state, env);
 
-    state.callFunction(vFun, args.size(), vArgs.data(), v, pos);
+    state.callFunction(vFun, args.size(), vArgs, v, pos);
 }
 
 
@@ -2016,8 +2015,8 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
         return result;
     };
 
-    boost::container::small_vector<Value, conservativeStackReservation> values(es->size());
-    Value * vTmpP = values.data();
+    Value values[es->size()];
+    Value * vTmpP = values;
 
     for (auto & [i_pos, i] : *es) {
         Value & vTmp = *vTmpP++;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2729,7 +2729,7 @@ static void prim_catAttrs(EvalState & state, const PosIdx pos, Value * * args, V
     auto attrName = state.symbols.create(state.forceStringNoCtx(*args[0], pos, "while evaluating the first argument passed to builtins.catAttrs"));
     state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.catAttrs");
 
-    boost::container::small_vector<Value *, nonRecursiveStackReservation> res(args[1]->listSize());
+    Value * res[args[1]->listSize()];
     size_t found = 0;
 
     for (auto v2 : args[1]->listItems()) {
@@ -3064,7 +3064,8 @@ static void prim_filter(EvalState & state, const PosIdx pos, Value * * args, Val
 
     state.forceFunction(*args[0], pos, "while evaluating the first argument passed to builtins.filter");
 
-    boost::container::small_vector<Value *, nonRecursiveStackReservation> vs(args[1]->listSize());
+    // FIXME: putting this on the stack is risky.
+    Value * vs[args[1]->listSize()];
     size_t k = 0;
 
     bool same = true;
@@ -3453,7 +3454,7 @@ static void prim_concatMap(EvalState & state, const PosIdx pos, Value * * args, 
     state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.concatMap");
     auto nrLists = args[1]->listSize();
 
-    boost::container::small_vector<Value, conservativeStackReservation> lists(nrLists);
+    Value lists[nrLists];
     size_t len = 0;
 
     for (unsigned int n = 0; n < nrLists; ++n) {


### PR DESCRIPTION
# Motivation

PR #7348 caused random crashes (https://hydra.nixos.org/build/241514506, https://hydra.nixos.org/build/241443330) because the heap allocation done by small_vector in the not-small case is not scanned for GC roots.

This is probably fixable but let's revisit this after the new release.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
