### PR TITLE
Fix bad_format_string error when builder stdout contains %

### DIFF
--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -448,7 +448,7 @@ Error readError(Source & source)
     auto msg = readString(source);
     ErrorInfo info {
         .level = level,
-        .msg = hintformat(fmt("%s", msg)),
+        .msg = hintfmt(msg),
     };
     auto havePos = readNum<size_t>(source);
     assert(havePos == 0);
@@ -457,7 +457,7 @@ Error readError(Source & source)
         havePos = readNum<size_t>(source);
         assert(havePos == 0);
         info.traces.push_back(Trace {
-            .hint = hintformat(fmt("%s", readString(source)))
+            .hint = hintfmt(readString(source))
         });
     }
     return Error(std::move(info));


### PR DESCRIPTION
# Motivation
Had nix crashing with `error: boost::bad_format_string: format-string is ill-formed`. After debugging with lldb, it turned out to be caused by treating the output of the builder as a format string. It doesn't look like this was intentional. I switched it over to using the `hintfmt()` helper.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
