### PR TITLE
Improve SourceAccessor path display

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -532,6 +532,9 @@ EvalState::EvalState(
     , baseEnv(allocEnv(128))
     , staticBaseEnv{std::make_shared<StaticEnv>(false, nullptr)}
 {
+    corepkgsFS->setPathDisplay("<nix", ">");
+    internalFS->setPathDisplay("«nix-internal»", "");
+
     countCalls = getEnv("NIX_COUNT_CALLS").value_or("0") != "0";
 
     assert(gcInitialised);

--- a/src/libfetchers/fs-input-accessor.cc
+++ b/src/libfetchers/fs-input-accessor.cc
@@ -18,6 +18,7 @@ struct FSInputAccessorImpl : FSInputAccessor, PosixSourceAccessor
         , allowedPaths(std::move(allowedPaths))
         , makeNotAllowedError(std::move(makeNotAllowedError))
     {
+        displayPrefix = root.isRoot() ? "" : root.abs();
     }
 
     void readFile(

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -582,6 +582,8 @@ struct GitInputScheme : InputScheme
 
         auto accessor = repo->getAccessor(rev);
 
+        accessor->setPathDisplay("«" + input.to_string() + "»");
+
         /* If the repo has submodules, fetch them and return a mounted
            input accessor consisting of the accessor for the top-level
            repo and the accessors for the submodules. */

--- a/src/libutil/posix-source-accessor.hh
+++ b/src/libutil/posix-source-accessor.hh
@@ -7,7 +7,7 @@ namespace nix {
 /**
  * A source accessor that uses the Unix filesystem.
  */
-struct PosixSourceAccessor : SourceAccessor
+struct PosixSourceAccessor : virtual SourceAccessor
 {
     /**
      * The most recent mtime seen by lstat(). This is a hack to

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -7,6 +7,7 @@ static std::atomic<size_t> nextNumber{0};
 
 SourceAccessor::SourceAccessor()
     : number(++nextNumber)
+    , displayPrefix{"«unknown»"}
 {
 }
 
@@ -55,9 +56,15 @@ SourceAccessor::Stat SourceAccessor::lstat(const CanonPath & path)
         throw Error("path '%s' does not exist", showPath(path));
 }
 
+void SourceAccessor::setPathDisplay(std::string displayPrefix, std::string displaySuffix)
+{
+    this->displayPrefix = std::move(displayPrefix);
+    this->displaySuffix = std::move(displaySuffix);
+}
+
 std::string SourceAccessor::showPath(const CanonPath & path)
 {
-    return path.abs();
+    return displayPrefix + path.abs() + displaySuffix;
 }
 
 }

--- a/src/libutil/source-accessor.hh
+++ b/src/libutil/source-accessor.hh
@@ -17,6 +17,8 @@ struct SourceAccessor
 {
     const size_t number;
 
+    std::string displayPrefix, displaySuffix;
+
     SourceAccessor();
 
     virtual ~SourceAccessor()
@@ -116,6 +118,8 @@ struct SourceAccessor
     {
         return number < x.number;
     }
+
+    void setPathDisplay(std::string displayPrefix, std::string displaySuffix = "");
 
     virtual std::string showPath(const CanonPath & path);
 };


### PR DESCRIPTION
# Motivation

Backported from lazy-trees. This allows SourceAccessors to show the origin of the accessor. E.g. we now get

```
copying '«git+https://github.com/blender/blender.git?ref=refs/heads/main&rev=4edc1389337dd3679ff66969c332d2aff52e1992»/' to the store
```

instead of

```
copying '/' to the store
```

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
