### PR TITLE
Persistently cache `InputAccessor::fetchToStore()`

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -108,6 +108,11 @@ Input Input::fromAttrs(Attrs && attrs)
     return std::move(*res);
 }
 
+std::optional<std::string> Input::getFingerprint(ref<Store> store) const
+{
+    return scheme ? scheme->getFingerprint(store, *this) : std::nullopt;
+}
+
 ParsedURL Input::toURL() const
 {
     if (!scheme)

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -113,6 +113,12 @@ public:
     std::optional<Hash> getRev() const;
     std::optional<uint64_t> getRevCount() const;
     std::optional<time_t> getLastModified() const;
+
+    /**
+     * For locked inputs, return a string that uniquely specifies the
+     * content of the input (typically a commit hash or content hash).
+     */
+    std::optional<std::string> getFingerprint(ref<Store> store) const;
 };
 
 
@@ -180,6 +186,9 @@ struct InputScheme
 
     virtual bool isDirect(const Input & input) const
     { return true; }
+
+    virtual std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const
+    { return std::nullopt; }
 };
 
 void registerInputScheme(std::shared_ptr<InputScheme> && fetcher);

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -700,10 +700,22 @@ struct GitInputScheme : InputScheme
 
         auto repoInfo = getRepoInfo(input);
 
-        return
+        auto [accessor, final] =
             input.getRef() || input.getRev() || !repoInfo.isLocal
             ? getAccessorFromCommit(store, repoInfo, std::move(input))
             : getAccessorFromWorkdir(store, repoInfo, std::move(input));
+
+        accessor->fingerprint = final.getFingerprint(store);
+
+        return {accessor, std::move(final)};
+    }
+
+    std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const override
+    {
+        if (auto rev = input.getRev())
+            return rev->gitRev() + (getSubmodulesAttr(input) ? ";s" : "");
+        else
+            return std::nullopt;
     }
 };
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -229,6 +229,14 @@ struct GitArchiveInputScheme : InputScheme
     {
         return Xp::Flakes;
     }
+
+    std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const override
+    {
+        if (auto rev = input.getRev())
+            return rev->gitRev();
+        else
+            return std::nullopt;
+    }
 };
 
 struct GitHubInputScheme : GitArchiveInputScheme

--- a/src/libfetchers/input-accessor.cc
+++ b/src/libfetchers/input-accessor.cc
@@ -26,12 +26,9 @@ StorePath InputAccessor::fetchToStore(
             {"method", (uint8_t) method},
             {"path", path.abs()}
         };
-        if (auto res = fetchers::getCache()->lookup(*cacheKey)) {
-            StorePath storePath{fetchers::getStrAttr(*res, "storePath")};
-            if (store->isValidPath(storePath)) {
-                debug("store path cache hit for '%s'", showPath(path));
-                return storePath;
-            }
+        if (auto res = fetchers::getCache()->lookup(store, *cacheKey)) {
+            debug("store path cache hit for '%s'", showPath(path));
+            return res->second;
         }
     } else
         debug("source path '%s' is uncacheable", showPath(path));
@@ -51,9 +48,7 @@ StorePath InputAccessor::fetchToStore(
         : store->addToStoreFromDump(*source, name, method, htSHA256, repair);
 
     if (cacheKey)
-        fetchers::getCache()->upsert(
-            *cacheKey,
-            fetchers::Attrs{{"storePath", std::string(storePath.to_string())}});
+        fetchers::getCache()->add(store, *cacheKey, {}, storePath, true);
 
     return storePath;
 }

--- a/src/libfetchers/input-accessor.cc
+++ b/src/libfetchers/input-accessor.cc
@@ -27,7 +27,7 @@ StorePath InputAccessor::fetchToStore(
             {"path", path.abs()}
         };
         if (auto res = fetchers::getCache()->lookup(*cacheKey)) {
-            StorePath storePath(fetchers::getStrAttr(*res, "storePath"));
+            StorePath storePath{fetchers::getStrAttr(*res, "storePath")};
             if (store->isValidPath(storePath)) {
                 debug("store path cache hit for '%s'", showPath(path));
                 return storePath;

--- a/src/libfetchers/input-accessor.hh
+++ b/src/libfetchers/input-accessor.hh
@@ -18,6 +18,8 @@ class Store;
 
 struct InputAccessor : virtual SourceAccessor, std::enable_shared_from_this<InputAccessor>
 {
+    std::optional<std::string> fingerprint;
+
     /**
      * Return the maximum last-modified time of the files in this
      * tree, if available.

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -339,6 +339,14 @@ struct MercurialInputScheme : InputScheme
 
         return makeResult(infoAttrs, std::move(storePath));
     }
+
+    std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const override
+    {
+        if (auto rev = input.getRev())
+            return rev->gitRev();
+        else
+            return std::nullopt;
+    }
 };
 
 static auto rMercurialInputScheme = OnStartup([] { registerInputScheme(std::make_unique<MercurialInputScheme>()); });

--- a/src/libstore/content-address.hh
+++ b/src/libstore/content-address.hh
@@ -39,12 +39,12 @@ enum struct FileIngestionMethod : uint8_t {
     /**
      * Flat-file hashing. Directly ingest the contents of a single file
      */
-    Flat = false,
+    Flat = 0,
     /**
      * Recursive (or NAR) hashing. Serializes the file-system object in Nix
      * Archive format and ingest that
      */
-    Recursive = true
+    Recursive = 1
 };
 
 /**


### PR DESCRIPTION
# Motivation

This avoids repeated copying of the same source tree between Nix invocations. It requires the accessor to have a "fingerprint" (e.g. a Git revision) that uniquely determines its contents.

Backported from lazy-trees, where it is also replaces the flake fingerprint used by the evaluation cache.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
