### PR TITLE
notify whole team of PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,10 +5,7 @@
 # For documentation on this mechanism, see https://help.github.com/articles/about-codeowners/
 
 # Default reviewers if nothing else matches
-* @edolstra
-
-# This file
-.github/CODEOWNERS @edolstra
+* @NixOS/nix-team
 
 # Public documentation
 /doc @fricklerhandwerk


### PR DESCRIPTION
this is only a suggestion!

# Motivation

There are still lots of PRs that stall around for a long time.
We may be simply missing a lot of stuff that's going on and people have to ping us directly.

There's a potential downside to this: currently @edolstra is the only one being spammed with notifications, with this change the whole team will be spammed. The potential upside is that we can use the round-robin notification feature of GitHub to distribute the load, but also simply being aware of what's going on could already help synchronise our minds. One can always unsubscribe from any PR or issue (which I often do if its not actionable for me, for instance).

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).