### PR TITLE
Fix "unbound variable" errors in bash

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -31,7 +31,7 @@ fi
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
 
 # Populate bash completions, .desktop files, etc
-if [ -z "$XDG_DATA_DIRS" ]; then
+if [ -z "${XDG_DATA_DIRS-}" ]; then
     # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
     export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
 else

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -33,7 +33,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
     export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"
 
     # Populate bash completions, .desktop files, etc
-    if [ -z "$XDG_DATA_DIRS" ]; then
+    if [ -z "${XDG_DATA_DIRS-}" ]; then
         # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
         export XDG_DATA_DIRS="/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
     else


### PR DESCRIPTION
Fixes #9414

# Motivation
Dumb mistake from my side, should be fixed ASAP, see linked issue.

# Context
This was caused by https://github.com/NixOS/nix/pull/9312, which was meant to be a quick fix for #8985.

As #9414 is present in the current 2.19.0 release, this change should probably be backported to 2.19.1 to reduce the risk of people installing broken profile scripts.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
