### PR TITLE
Add missing `-lrapidcheck` fixing build with shared lib

### DIFF
--- a/src/libexpr/tests/local.mk
+++ b/src/libexpr/tests/local.mk
@@ -20,4 +20,4 @@ libexpr-tests_CXXFLAGS += -I src/libexpr -I src/libutil -I src/libstore -I src/l
 
 libexpr-tests_LIBS = libstore-tests libutils-tests libexpr libutil libstore libfetchers
 
-libexpr-tests_LDFLAGS := $(GTEST_LIBS) -lgmock
+libexpr-tests_LDFLAGS := -lrapidcheck $(GTEST_LIBS) -lgmock


### PR DESCRIPTION
# Motivation

https://github.com/NixOS/nixpkgs/pull/269064 makes rapidcheck be build as a shared lib, but that broke Nix because the `-lrapidcheck` was missing. This fixes that (and doesn't break Nix what the library is a static archive as today).

# Context

https://github.com/NixOS/nixpkgs/pull/269064 found the issue; it now applies this as a patch.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
