### PR TITLE
Fix compile warning due to unused variable binding.

### DIFF
--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -54,7 +54,7 @@ static json pathInfoToJSON(
 
                 jsonObject["closureSize"] = getStoreObjectsTotalSize(store, closure);
 
-                if (auto * narInfo = dynamic_cast<const NarInfo *>(&*info)) {
+                if (dynamic_cast<const NarInfo *>(&*info)) {
                     uint64_t totalDownloadSize = 0;
                     for (auto & p : closure) {
                         auto depInfo = store.queryPathInfo(p);


### PR DESCRIPTION
# Motivation
We still need the check, since we don't have narinfo for locally built store paths.

# Context


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
