### PR TITLE
doc: primops: fix typo

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3185,7 +3185,7 @@ static RegisterPrimOp primop_foldlStrict({
       to `6` and `foldl' (acc: elem: { "${elem}" = elem; } // acc) {}
       ["a" "b"]` evaluates to `{ a = "a"; b = "b"; }`.
 
-      The first argument of `op` is the accumulator wheres the second
+      The first argument of `op` is the accumulator whereas the second
       argument is the current element being processed. The return value
       of each application of `op` is evaluated immediately, even for
       intermediate values.


### PR DESCRIPTION
# Motivation

Fixing a typo that I accidentally introduced in https://github.com/NixOS/nix/pull/9254.


# Context

See changes of https://github.com/NixOS/nix/pull/9254

I know that this repo doesn't use [typos](https://github.com/crate-ci/typos), but I made that in future, typos will catch this error: https://github.com/crate-ci/typos/issues/865#issuecomment-1825395022

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
