### PR TITLE
`nix flake update` add deprecation warnings.

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -48,6 +48,16 @@ MixFlakeOptions::MixFlakeOptions()
     auto category = "Common flake-related options";
 
     addFlag({
+        .longName = "recreate-lock-file",
+        .description = "Recreate the flake's lock file from scratch.",
+        .category = category,
+        .handler = {[&]() {
+            lockFlags.recreateLockFile = true;
+            warn("'--recreate-lock-file' is deprecated and will be removed in a future version; use 'nix flake update' instead.");
+        }}
+    });
+
+    addFlag({
         .longName = "no-update-lock-file",
         .description = "Do not allow any updates to the flake's lock file.",
         .category = category,
@@ -77,6 +87,20 @@ MixFlakeOptions::MixFlakeOptions()
         .description = "Commit changes to the flake's lock file.",
         .category = category,
         .handler = {&lockFlags.commitLockFile, true}
+    });
+
+    addFlag({
+        .longName = "update-input",
+        .description = "Update a specific flake input (ignoring its previous entry in the lock file).",
+        .category = category,
+        .labels = {"input-path"},
+        .handler = {[&](std::string s) {
+            warn("'--update-input' is a deprecated alias for 'flake update' and will be removed in a future version.");
+            lockFlags.inputUpdates.insert(flake::parseInputPath(s));
+        }},
+        .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
+            completeFlakeInputPath(completions, getEvalState(), getFlakeRefsForCompletion(), prefix);
+        }}
     });
 
     addFlag({

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -89,7 +89,13 @@ public:
             .label="inputs",
             .optional=true,
             .handler={[&](std::string inputToUpdate){
-                auto inputPath = flake::parseInputPath(inputToUpdate);
+                InputPath inputPath;
+                try {
+                    inputPath = flake::parseInputPath(inputToUpdate);
+                } catch (Error & e) {
+                    warn("Invalid flake input '%s'. To update a specific flake, use 'nix flake update --flake %s' instead.", inputToUpdate, inputToUpdate);
+                    throw e;
+                }
                 if (lockFlags.inputUpdates.contains(inputPath))
                     warn("Input '%s' was specified multiple times. You may have done this by accident.");
                 lockFlags.inputUpdates.insert(inputPath);


### PR DESCRIPTION
This builds on #8817, to add additional UX help for people with existing muscle memory (or shell history) with --update-input and tries to gently guide them towards the newly evolved CLI UI.

# Motivation
This change introduces a deprecation warning for the `nix flake lock --update-input INPUT` command, guiding users towards the newer `nix flake update INPUT` syntax. The motivation is to enhance user experience by providing clear and helpful guidance when encountering deprecated commands. This change aligns with our ongoing efforts to streamline Nix commands and improve their intuitiveness and ease of use.

# Context
Many users familiar with the older `nix flake lock --update-input` syntax may not be aware of its deprecation and the transition to the new `nix flake update` command. The current behavior, which results in an unrecognised flag error, can be confusing and does not guide users towards the correct command. By introducing a deprecation warning, we provide a more user-friendly approach, aiding in a smoother transition to the updated syntax.

# Example
Before:
```
bash-5.2$ outputs/out/bin/nix flake lock --update-input libgit2
error: unrecognised flag '--update-input'
```
After:
```
bash-5.2$ outputs/out/bin/nix flake lock --recreate-lock-file
warning: '--recreate-lock-file' is deprecated; use 'nix flake update' instead.
warning: Git tree 'nix' is dirty
warning: updating lock file 'nix/flake.lock':
```
# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
