### PR TITLE
gitignore: Also ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ result
 
 # clangd and possibly more
 .cache/
+
+# Mac OS
+.DS_Store


### PR DESCRIPTION
This is a file that Finder on Mac OS loves to add into various folders.

# Motivation

Make live nicer for devs on Mac OS.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
