### PR TITLE
libfetchers/git: Support export-ignore

### DIFF
--- a/doc/manual/rl-next/git-fetcher.md
+++ b/doc/manual/rl-next/git-fetcher.md
@@ -1,0 +1,18 @@
+---
+synopsis: "Nix now uses `libgit2` for Git fetching"
+prs:
+  - 9240
+  - 9241
+  - 9258
+  - 9480
+issues:
+  - 5313
+---
+
+Nix has built-in support for fetching sources from Git, during evaluation and locking; outside the sandbox.
+The existing implementation based on the Git CLI had issues regarding reproducibility and performance.
+
+Most of the original `fetchGit` behavior has been implemented using the `libgit2` library, which gives the fetcher fine-grained control.
+
+Known issues:
+- The `export-subst` behavior has not been reimplemented. [Partial](https://github.com/NixOS/nix/pull/9391#issuecomment-1872503447) support for this Git feature is feasible, but it did not make the release window.

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -607,6 +607,8 @@ static RegisterPrimOp primop_fetchGit({
         A Boolean parameter that specifies whether `export-ignore` from `.gitattributes` should be applied.
         This approximates part of the `git archive` behavior.
 
+        Enabling this option is not recommended because it is unknown whether the Git developers commit to the reproducibility of `export-ignore` in newer Git versions.
+
       - `shallow` (default: `false`)
 
         A Boolean parameter that specifies whether fetching from a shallow remote repository is allowed.

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -161,6 +161,7 @@ static void fetchTree(
             fetchers::Attrs attrs;
             attrs.emplace("type", "git");
             attrs.emplace("url", fixGitURL(url));
+            attrs.emplace("exportIgnore", Explicit<bool>{true});
             input = fetchers::Input::fromAttrs(std::move(attrs));
         } else {
             if (!experimentalFeatureSettings.isEnabled(Xp::Flakes))

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -39,6 +39,10 @@ void emitTreeAttrs(
         attrs.alloc("submodules").mkBool(
             fetchers::maybeGetBoolAttr(input.attrs, "submodules").value_or(false));
 
+    if (input.getType() == "git")
+        attrs.alloc("exportIgnore").mkBool(
+            fetchers::maybeGetBoolAttr(input.attrs, "exportIgnore").value_or(false));
+
     if (!forceDirty) {
 
         if (auto rev = input.getRev()) {
@@ -111,6 +115,11 @@ static void fetchTree(
             }));
 
         attrs.emplace("type", type.value());
+
+        if (params.isFetchGit) {
+            // Default value; user attrs are assigned later.
+            attrs.emplace("exportIgnore", Explicit<bool>{true});
+        }
 
         for (auto & attr : *args[0]->attrs) {
             if (attr.name == state.sType) continue;
@@ -592,6 +601,11 @@ static RegisterPrimOp primop_fetchGit({
       - `submodules` (default: `false`)
 
         A Boolean parameter that specifies whether submodules should be checked out.
+
+      - `exportIgnore` (default: `true`)
+
+        A Boolean parameter that specifies whether `export-ignore` from `.gitattributes` should be applied.
+        This approximates part of the `git archive` behavior.
 
       - `shallow` (default: `false`)
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -25,7 +25,7 @@ void emitTreeAttrs(
 {
     assert(input.isLocked());
 
-    auto attrs = state.buildBindings(10);
+    auto attrs = state.buildBindings(100);
 
     state.mkStorePathString(storePath, attrs.alloc(state.sOutPath));
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -1,3 +1,4 @@
+#include "libfetchers/attrs.hh"
 #include "primops.hh"
 #include "eval-inline.hh"
 #include "eval-settings.hh"
@@ -139,9 +140,7 @@ static void fetchTree(
                     state.symbols[attr.name], showType(*attr.value)));
         }
 
-        if (params.isFetchGit && !attrs.contains("exportIgnore")) {
-            // Default value; user attrs are assigned later.
-            // FIXME: exportIgnore := !submodules
+        if (params.isFetchGit && !attrs.contains("exportIgnore") && (!attrs.contains("submodules") || !*fetchers::maybeGetBoolAttr(attrs, "submodules"))) {
             attrs.emplace("exportIgnore", Explicit<bool>{true});
         }
 
@@ -162,8 +161,7 @@ static void fetchTree(
             fetchers::Attrs attrs;
             attrs.emplace("type", "git");
             attrs.emplace("url", fixGitURL(url));
-            if (!attrs.contains("exportIgnore")) {
-                // FIXME: exportIgnore := !submodules
+            if (!attrs.contains("exportIgnore") && (!attrs.contains("submodules") || !*fetchers::maybeGetBoolAttr(attrs, "submodules"))) {
                 attrs.emplace("exportIgnore", Explicit<bool>{true});
             }
             input = fetchers::Input::fromAttrs(std::move(attrs));

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -40,10 +40,6 @@ void emitTreeAttrs(
         attrs.alloc("submodules").mkBool(
             fetchers::maybeGetBoolAttr(input.attrs, "submodules").value_or(false));
 
-    if (input.getType() == "git")
-        attrs.alloc("exportIgnore").mkBool(
-            fetchers::maybeGetBoolAttr(input.attrs, "exportIgnore").value_or(false));
-
     if (!forceDirty) {
 
         if (auto rev = input.getRev()) {

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -187,6 +187,13 @@ struct InputScheme
     virtual bool isDirect(const Input & input) const
     { return true; }
 
+    /**
+     * A sufficiently unique string that can be used as a cache key to identify the `input`.
+     *
+     * Only known-equivalent inputs should return the same fingerprint.
+     *
+     * This is not a stable identifier between Nix versions, but not guaranteed to change either.
+     */
     virtual std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const
     { return std::nullopt; }
 };

--- a/src/libfetchers/filtering-input-accessor.cc
+++ b/src/libfetchers/filtering-input-accessor.cc
@@ -80,4 +80,13 @@ ref<AllowListInputAccessor> AllowListInputAccessor::create(
     return make_ref<AllowListInputAccessorImpl>(next, std::move(allowedPaths), std::move(makeNotAllowedError));
 }
 
+bool CachingFilteringInputAccessor::isAllowed(const CanonPath & path)
+{
+    auto i = cache.find(path);
+    if (i != cache.end()) return i->second;
+    auto res = isAllowedUncached(path);
+    cache.emplace(path, res);
+    return res;
+}
+
 }

--- a/src/libfetchers/filtering-input-accessor.hh
+++ b/src/libfetchers/filtering-input-accessor.hh
@@ -71,4 +71,18 @@ struct AllowListInputAccessor : public FilteringInputAccessor
     using FilteringInputAccessor::FilteringInputAccessor;
 };
 
+/**
+ * A wrapping `InputAccessor` mix-in where `isAllowed()` caches the result of virtual `isAllowedUncached()`.
+ */
+struct CachingFilteringInputAccessor : FilteringInputAccessor
+{
+    std::map<CanonPath, bool> cache;
+
+    using FilteringInputAccessor::FilteringInputAccessor;
+
+    bool isAllowed(const CanonPath & path) override;
+
+    virtual bool isAllowedUncached(const CanonPath & path) = 0;
+};
+
 }

--- a/src/libfetchers/filtering-input-accessor.hh
+++ b/src/libfetchers/filtering-input-accessor.hh
@@ -6,7 +6,7 @@
 namespace nix {
 
 /**
- * A function that should throw an exception of type
+ * A function that returns an exception of type
  * `RestrictedPathError` explaining that access to `path` is
  * forbidden.
  */

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -674,8 +674,7 @@ struct GitExportIgnoreInputAccessor : CachingFilteringInputAccessor {
 
     bool gitAttrGet(const CanonPath & path, const char * attrName, const char * & valueOut)
     {
-        std::string pathStr {path.rel()};
-        const char * pathCStr = pathStr.c_str();
+        const char * pathCStr = path.rel_c_str();
 
         if (rev) {
             git_attr_options opts = GIT_ATTR_OPTIONS_INIT;

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -701,7 +701,8 @@ struct GitExportIgnoreInputAccessor : FilteringInputAccessor {
         }
     }
 
-    bool isExportIgnored(const CanonPath & path) {
+    bool isExportIgnored(const CanonPath & path)
+    {
         const char *exportIgnoreEntry = nullptr;
 
         // GIT_ATTR_CHECK_INDEX_ONLY:
@@ -721,7 +722,8 @@ struct GitExportIgnoreInputAccessor : FilteringInputAccessor {
         }
     }
 
-    bool isAllowed(const CanonPath & path) override {
+    bool isAllowed(const CanonPath & path) override
+    {
         return !isExportIgnored(path);
     }
 

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -660,12 +660,12 @@ struct GitInputAccessor : InputAccessor
     }
 };
 
-struct GitExportIgnoreInputAccessor : FilteringInputAccessor {
+struct GitExportIgnoreInputAccessor : CachingFilteringInputAccessor {
     ref<GitRepoImpl> repo;
     std::optional<Hash> rev;
 
     GitExportIgnoreInputAccessor(ref<GitRepoImpl> repo, ref<InputAccessor> next, std::optional<Hash> rev)
-        : FilteringInputAccessor(next, [&](const CanonPath & path) {
+        : CachingFilteringInputAccessor(next, [&](const CanonPath & path) {
             return RestrictedPathError(fmt("'%s' does not exist because it was fetched with exportIgnore enabled", path));
         })
         , repo(repo)
@@ -722,7 +722,7 @@ struct GitExportIgnoreInputAccessor : FilteringInputAccessor {
         }
     }
 
-    bool isAllowed(const CanonPath & path) override
+    bool isAllowedUncached(const CanonPath & path) override
     {
         return !isExportIgnored(path);
     }

--- a/src/libfetchers/git-utils.hh
+++ b/src/libfetchers/git-utils.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "filtering-input-accessor.hh"
 #include "input-accessor.hh"
 
 namespace nix {
@@ -72,6 +73,8 @@ struct GitRepo
     virtual bool hasObject(const Hash & oid) = 0;
 
     virtual ref<InputAccessor> getAccessor(const Hash & rev, bool exportIgnore) = 0;
+
+    virtual ref<InputAccessor> getAccessor(const WorkdirInfo & wd, bool exportIgnore, MakeNotAllowedError makeNotAllowedError) = 0;
 
     virtual void fetch(
         const std::string & url,

--- a/src/libfetchers/git-utils.hh
+++ b/src/libfetchers/git-utils.hh
@@ -57,7 +57,7 @@ struct GitRepo
      * Return the submodules of this repo at the indicated revision,
      * along with the revision of each submodule.
      */
-    virtual std::vector<std::tuple<Submodule, Hash>> getSubmodules(const Hash & rev) = 0;
+    virtual std::vector<std::tuple<Submodule, Hash>> getSubmodules(const Hash & rev, bool exportIgnore) = 0;
 
     virtual std::string resolveSubmoduleUrl(
         const std::string & url,
@@ -71,7 +71,7 @@ struct GitRepo
 
     virtual bool hasObject(const Hash & oid) = 0;
 
-    virtual ref<InputAccessor> getAccessor(const Hash & rev) = 0;
+    virtual ref<InputAccessor> getAccessor(const Hash & rev, bool exportIgnore) = 0;
 
     virtual void fetch(
         const std::string & url,

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -9,7 +9,6 @@
 #include "processes.hh"
 #include "git.hh"
 #include "fs-input-accessor.hh"
-#include "filtering-input-accessor.hh"
 #include "mounted-input-accessor.hh"
 #include "git-utils.hh"
 #include "logging.hh"
@@ -659,10 +658,11 @@ struct GitInputScheme : InputScheme
             for (auto & submodule : repoInfo.workdirInfo.submodules)
                 repoInfo.workdirInfo.files.insert(submodule.path);
 
+        auto repo = GitRepo::openRepo(CanonPath(repoInfo.url), false, false);
+
         ref<InputAccessor> accessor =
-            AllowListInputAccessor::create(
-                makeFSInputAccessor(CanonPath(repoInfo.url)),
-                std::move(repoInfo.workdirInfo.files),
+            repo->getAccessor(repoInfo.workdirInfo,
+                getExportIgnoreAttr(input),
                 makeNotAllowedError(repoInfo.url));
 
         /* If the repo has submodules, return a mounted input accessor

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -1,3 +1,4 @@
+#include "error.hh"
 #include "fetchers.hh"
 #include "users.hh"
 #include "cache.hh"
@@ -738,6 +739,16 @@ struct GitInputScheme : InputScheme
         Input input(_input);
 
         auto repoInfo = getRepoInfo(input);
+
+        if (getExportIgnoreAttr(input)
+            && getSubmodulesAttr(input)) {
+            /* In this situation, we don't have a git CLI behavior that we can copy.
+               `git archive` does not support submodules, so it is unclear whether
+               rules from the parent should affect the submodule or not.
+               When git may eventually implement this, we need Nix to match its
+               behavior. */
+            throw UnimplementedError("exportIgnore and submodules are not supported together yet");
+        }
 
         auto [accessor, final] =
             input.getRef() || input.getRev() || !repoInfo.isLocal

--- a/src/libutil/canon-path.hh
+++ b/src/libutil/canon-path.hh
@@ -88,6 +88,13 @@ public:
     std::string_view rel() const
     { return ((std::string_view) path).substr(1); }
 
+    const char * rel_c_str() const
+    {
+        auto cs = path.c_str();
+        assert(cs[0]); // for safety if invariant is broken
+        return &cs[1];
+    }
+
     struct Iterator
     {
         std::string_view remaining;

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -231,12 +231,15 @@ unset _NIX_FORCE_HTTP
 
 # Ensure .gitattributes is respected
 touch $repo/not-exported-file
+touch $repo/exported-wonky
 echo "/not-exported-file export-ignore" >> $repo/.gitattributes
-git -C $repo add not-exported-file .gitattributes
+echo "/exported-wonky export-ignore=wonk" >> $repo/.gitattributes
+git -C $repo add not-exported-file exported-wonky .gitattributes
 git -C $repo commit -m 'Bla6'
 rev5=$(git -C $repo rev-parse HEAD)
 path12=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev5\"; }).outPath")
 [[ ! -e $path12/not-exported-file ]]
+[[ -e $path12/exported-wonky ]]
 
 # should fail if there is no repo
 rm -rf $repo/.git

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -229,6 +229,15 @@ rev_tag2=$(git -C $repo rev-parse refs/tags/tag2)
 [[ $rev_tag2_nix = $rev_tag2 ]]
 unset _NIX_FORCE_HTTP
 
+# Ensure .gitattributes is respected
+touch $repo/not-exported-file
+echo "/not-exported-file export-ignore" >> $repo/.gitattributes
+git -C $repo add not-exported-file .gitattributes
+git -C $repo commit -m 'Bla6'
+rev5=$(git -C $repo rev-parse HEAD)
+path12=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev5\"; }).outPath")
+[[ ! -e $path12/not-exported-file ]]
+
 # should fail if there is no repo
 rm -rf $repo/.git
 (! nix eval --impure --raw --expr "(builtins.fetchGit \"file://$repo\").outPath")

--- a/tests/functional/fetchGitSubmodules.sh
+++ b/tests/functional/fetchGitSubmodules.sh
@@ -124,12 +124,16 @@ git -C $rootRepo/sub config user.email "foobar@example.com"
 git -C $rootRepo/sub config user.name "Foobar"
 
 echo "/exclude-from-root export-ignore" >> $rootRepo/.gitattributes
+# TBD possible semantics for submodules + exportIgnore
+# echo "/sub/exclude-deep export-ignore" >> $rootRepo/.gitattributes
 echo nope > $rootRepo/exclude-from-root
 git -C $rootRepo add .gitattributes exclude-from-root
 git -C $rootRepo commit -m "Add export-ignore"
 
 echo "/exclude-from-sub export-ignore" >> $rootRepo/sub/.gitattributes
 echo nope > $rootRepo/sub/exclude-from-sub
+# TBD possible semantics for submodules + exportIgnore
+# echo aye > $rootRepo/sub/exclude-from-root
 git -C $rootRepo/sub add .gitattributes exclude-from-sub
 git -C $rootRepo/sub commit -m "Add export-ignore (sub)"
 
@@ -138,15 +142,21 @@ git -C $rootRepo commit -m "Update submodule"
 
 git -C $rootRepo status
 
-# exportIgnore can be used with submodules
-pathWithExportIgnore=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$rootRepo; submodules = true; exportIgnore = true; }).outPath")
-# find $pathWithExportIgnore
-# git -C $rootRepo archive --format=tar HEAD | tar -t
-# cp -a $rootRepo /tmp/rootRepo
+# # TBD: not supported yet, because semantics are undecided and current implementation leaks rules from the root to submodules
+# # exportIgnore can be used with submodules
+# pathWithExportIgnore=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$rootRepo; submodules = true; exportIgnore = true; }).outPath")
+# # find $pathWithExportIgnore
+# # git -C $rootRepo archive --format=tar HEAD | tar -t
+# # cp -a $rootRepo /tmp/rootRepo
 
-[[ -e $pathWithExportIgnore/sub/content ]]
-[[ ! -e $pathWithExportIgnore/exclude-from-root ]]
-[[ ! -e $pathWithExportIgnore/sub/exclude-from-sub ]]
+# [[ -e $pathWithExportIgnore/sub/content ]]
+# [[ ! -e $pathWithExportIgnore/exclude-from-root ]]
+# [[ ! -e $pathWithExportIgnore/sub/exclude-from-sub ]]
+# TBD possible semantics for submodules + exportIgnore
+# # root .gitattribute has no power across submodule boundary
+# [[ -e $pathWithExportIgnore/sub/exclude-from-root ]]
+# [[ -e $pathWithExportIgnore/sub/exclude-deep ]]
+
 
 # exportIgnore can be explicitly disabled with submodules
 pathWithoutExportIgnore=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$rootRepo; submodules = true; exportIgnore = false; }).outPath")


### PR DESCRIPTION
# Motivation

Reintroduce export-ignore processing for fetchGit, which historically had this behavior, among other behaviors that I believe we do not want in fetchGit.

- Resolves this issue raised in PR https://github.com/NixOS/nix/pull/9391


# Change

- Add `exportIgnore` parameter to the git fetcher
- `fetchTree` disables this parameter by default. It can choose the
simpler behavior, as it is still experimental.
   - (relevant to `fetchTree` too!) #7195 
- `fetchGit` enables this parameter by default, to approximate legacy behavior.

# TODO

- [x] I ~am~ was not confident that the filtering implementation is future proof. It should reuse a source filtering wrapper, such as `FilteringInputAccessor` from #6530. Not a straightforward backport because we don't have `virtual bool isAllowed(const CanonPath & path) = 0;` (yet?)
- [x] POSTPONED Test export-ignore in submodule (`exportIgnore` (Nix) parameter should be inherited)
  - [x] basic tests
  - [ ] somewhat decent coverage (perhaps via DRY item below?)
- [x] Release note
- [x] Use `_ext` git attributes functions, ~or reimplement~ (no, half of semantics already hardcoded; not worth it). Need to pass `rev`
- [ ] DRY workdir vs rev more
- [x] Discourage use, because this assumes that the feature is as stable as the tree data model and interpretation. I don't expect the git developer to apply the same level of rigor to it, although it's probably still pretty good.
- [x] POSTPONED Decide how the interaction works between submodules and export-ignore. Currently root ignores affect the submodule, and I'm *not* happy about that. Maybe just forbid it for now. `fetchGit` does not export-ignore when it submodules.

# Context

- Uses reproducer from https://github.com/NixOS/nix/pull/9391
- Either
   - depends on #9497
   - or  factor out the filtering class ahead of time
 
# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
