### PR TITLE
nix search: Disallow empty regex

### DIFF
--- a/doc/manual/rl-next/empty-search-regex.md
+++ b/doc/manual/rl-next/empty-search-regex.md
@@ -1,0 +1,8 @@
+synopsis: Disallow empty search regex in `nix search`
+prs: #9481
+description: {
+
+[`nix search`](@docroot@/command-ref/new-cli/nix3-search.md) now requires a search regex to be passed. To show all packages, use `^`.
+
+}
+

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -67,11 +67,9 @@ struct CmdSearch : InstallableValueCommand, MixJSON
         settings.readOnlyMode = true;
         evalSettings.enableImportFromDerivation.setDefault(false);
 
-        // Empty search string should match all packages
-        // Use "^" here instead of ".*" due to differences in resulting highlighting
-        // (see #1893 -- libc++ claims empty search string is not in POSIX grammar)
+        // Recommend "^" here instead of ".*" due to differences in resulting highlighting
         if (res.empty())
-            res.push_back("^");
+            throw UsageError("Must provide at least one regex! To match all packages, use '%s'.", "nix search <installable> ^");
 
         std::vector<std::regex> regexes;
         std::vector<std::regex> excludeRegexes;

--- a/src/nix/search.md
+++ b/src/nix/search.md
@@ -5,7 +5,7 @@ R""(
 * Show all packages in the `nixpkgs` flake:
 
   ```console
-  # nix search nixpkgs
+  # nix search nixpkgs ^
   * legacyPackages.x86_64-linux.AMB-plugins (0.8.1)
     A set of ambisonics ladspa plugins
 
@@ -34,7 +34,7 @@ R""(
 * Show all packages in the flake in the current directory:
 
   ```console
-  # nix search
+  # nix search . ^
   ```
 
 * Search for Firefox or Chromium:
@@ -64,11 +64,16 @@ R""(
 
 `nix search` searches [*installable*](./nix.md#installables) (which can be evaluated, that is, a
 flake or Nix expression, but not a store path or store derivation path) for packages whose name or description matches all of the
-regular expressions *regex*.  For each matching package, It prints the
+regular expressions *regex*. For each matching package, It prints the
 full attribute name (from the root of the [installable](./nix.md#installables)), the version
 and the `meta.description` field, highlighting the substrings that
-were matched by the regular expressions. If no regular expressions are
-specified, all packages are shown.
+were matched by the regular expressions.
+
+To show all packages, use the regular expression `^`. In contrast to `.*`,
+it avoids highlighting the entire name and description of every package.
+
+> Note that in this context, `^` is the regex character to match the beginning of a string, *not* the delimiter for
+> [selecting a derivation output](@docroot@/command-ref/new-cli/nix.md#derivation-output-selection).
 
 # Flake output attributes
 

--- a/tests/functional/search.sh
+++ b/tests/functional/search.sh
@@ -17,12 +17,15 @@ clearCache
 # Multiple arguments will not exist
 (( $(nix search -f search.nix '' hello broken | wc -l) == 0 ))
 
+# No regex should return an error
+(( $(nix search -f search.nix '' | wc -l) == 0 ))
+
 ## Search expressions
 
 # Check that empty search string matches all
-nix search -f search.nix '' |grepQuiet foo
-nix search -f search.nix '' |grepQuiet bar
-nix search -f search.nix '' |grepQuiet hello
+nix search -f search.nix '' ^ | grepQuiet foo
+nix search -f search.nix '' ^ | grepQuiet bar
+nix search -f search.nix '' ^ | grepQuiet hello
 
 ## Tests for multiple regex/match highlighting
 
@@ -39,8 +42,8 @@ e=$'\x1b' # grep doesn't support \e, \033 or even \x1b
 (( $(nix search -f search.nix '' 'b' | grep -Eo "$e\[32;1mb$e\[(0|0;1)m" | wc -l) == 3 ))
 
 ## Tests for --exclude
-(( $(nix search -f search.nix -e hello | grep -c hello) == 0 ))
+(( $(nix search -f search.nix ^ -e hello | grep -c hello) == 0 ))
 
-(( $(nix search -f search.nix foo --exclude 'foo|bar' | grep -Ec 'foo|bar') == 0 ))
-(( $(nix search -f search.nix foo -e foo --exclude bar | grep -Ec 'foo|bar') == 0 ))
-[[ $(nix search -f search.nix -e bar --json | jq -c 'keys') == '["foo","hello"]' ]]
+(( $(nix search -f search.nix foo ^ --exclude 'foo|bar' | grep -Ec 'foo|bar') == 0 ))
+(( $(nix search -f search.nix foo ^ -e foo --exclude bar | grep -Ec 'foo|bar') == 0 ))
+[[ $(nix search -f search.nix '' ^ -e bar --json | jq -c 'keys') == '["foo","hello"]' ]]


### PR DESCRIPTION
# Motivation
This will make invocations of `nix search` without a regex fail with the following error message:

```
nix search .
error: Must provide at least one regex! To match all packages, use '^'.
Try '/Users/feuh/repos/nix/outputs/out/bin/nix --help' for more information.
```

This protects users from accidentally printing every package in nixpkgs. If someone still wanted to do that, they can by explicitly passing `^`. Why we recommend this over `^` is explained in the docs.

# Context

Fixes #4739.

Also fixes #3553 in spirit IMO. That issue calls for outputting the entire output of `nix search --help` when no regex is passed, but that would be a more substantial change, as all new CLI commands have no short help and `--help` opens the manpage. *If* we wanted to change that, we should change it for all `UsageError` invocations.

I considered adding an `--all` flag, but this seemed redundant. I briefly looked into other ways of enforcing at least one argument with `expectArgs`, but adding `optional = false` didn't change the rest of the implementation or the docs, so I opted not to touch that part.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
