### PR TITLE
Improve ACL clearing support (fixing FreeBSD build)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -282,6 +282,8 @@ case "$host_os" in
 esac
 AC_SUBST(HAVE_SECCOMP, [$have_seccomp])
 
+# Optional dependencies for better normalizing file system data
+AC_CHECK_HEADERS[sys/xattr.h]
 
 # Look for aws-cpp-sdk-s3.
 AC_LANG_PUSH(C++)

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -34,7 +34,6 @@
 #include <sys/statvfs.h>
 #include <sys/mount.h>
 #include <sys/ioctl.h>
-#include <sys/xattr.h>
 #endif
 
 #ifdef __CYGWIN__

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -1,4 +1,6 @@
-#include <sys/xattr.h>
+#if HAVE_SYS_XATTR_H
+# include <sys/xattr.h>
+#endif
 
 #include "posix-fs-canonicalise.hh"
 #include "file-system.hh"
@@ -76,7 +78,7 @@ static void canonicalisePathMetaData_(
     if (!(S_ISREG(st.st_mode) || S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)))
         throw Error("file '%1%' has an unsupported type", path);
 
-#if __linux__
+#ifdef HAVE_SYS_XATTR_H
     /* Remove extended attributes / ACLs. */
     ssize_t eaSize = llistxattr(path.c_str(), nullptr, 0);
 


### PR DESCRIPTION
# Motivation

The problem was that f880469173061a07f0b2a24734932c5a9ad633c6 forgot that the `#include <sys/xattr.h>` was guarded by an `#ifdef __linux__`.

However, the build failure was only on FreeBSD --- turns out other platforms have this header too!

# Context

f880469173061a07f0b2a24734932c5a9ad633c6 is from #9394

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
