### PR TITLE
Add support for clearing ACLs on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -283,7 +283,7 @@ esac
 AC_SUBST(HAVE_SECCOMP, [$have_seccomp])
 
 # Optional dependencies for better normalizing file system data
-AC_CHECK_HEADERS[sys/xattr.h]
+AC_CHECK_HEADERS[sys/xattr.h sys/extattr.h]
 
 # Look for aws-cpp-sdk-s3.
 AC_LANG_PUSH(C++)

--- a/configure.ac
+++ b/configure.ac
@@ -282,6 +282,8 @@ case "$host_os" in
 esac
 AC_SUBST(HAVE_SECCOMP, [$have_seccomp])
 
+# Optional dependencies for better normalizing file system data
+AC_CHECK_HEADERS[sys/xattr.h]
 
 # Look for aws-cpp-sdk-s3.
 AC_LANG_PUSH(C++)

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -34,7 +34,6 @@
 #include <sys/statvfs.h>
 #include <sys/mount.h>
 #include <sys/ioctl.h>
-#include <sys/xattr.h>
 #endif
 
 #ifdef __CYGWIN__

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -1,4 +1,6 @@
-#include <sys/xattr.h>
+#if HAVE_SYS_XATTR_H
+# include <sys/xattr.h>
+#endif
 
 #include "posix-fs-canonicalise.hh"
 #include "file-system.hh"
@@ -76,7 +78,7 @@ static void canonicalisePathMetaData_(
     if (!(S_ISREG(st.st_mode) || S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)))
         throw Error("file '%1%' has an unsupported type", path);
 
-#if __linux__
+#ifdef HAVE_SYS_XATTR_H
     /* Remove extended attributes / ACLs. */
     ssize_t eaSize = llistxattr(path.c_str(), nullptr, 0);
 


### PR DESCRIPTION
# Motivation

FreeBSD uses a slightly different interface than NetBSD, Linux, and Darwin.

# Context

I got too excited working on #9491 :).

This needs to be tested, by someone (and ideally we would write tests for this). I'll leave it draft until a FreeBSD person chimes in here.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
