### PR TITLE
Don’t use `execvp` when we know the path

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -662,7 +662,7 @@ struct CmdDevelop : Common, MixEnvironment
             }
         }
 
-        runProgramInStore(store, true, shell, args, buildEnvironment.getSystem());
+        runProgramInStore(store, UseSearchPath::Use, shell, args, buildEnvironment.getSystem());
     }
 };
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -662,7 +662,7 @@ struct CmdDevelop : Common, MixEnvironment
             }
         }
 
-        runProgramInStore(store, shell, args, buildEnvironment.getSystem());
+        runProgramInStore(store, true, shell, args, buildEnvironment.getSystem());
     }
 };
 

--- a/src/nix/fmt.cc
+++ b/src/nix/fmt.cc
@@ -49,7 +49,7 @@ struct CmdFmt : SourceExprCommand {
             }
         }
 
-        runProgramInStore(store, app.program, programArgs);
+        runProgramInStore(store, false, app.program, programArgs);
     };
 };
 

--- a/src/nix/fmt.cc
+++ b/src/nix/fmt.cc
@@ -49,7 +49,7 @@ struct CmdFmt : SourceExprCommand {
             }
         }
 
-        runProgramInStore(store, false, app.program, programArgs);
+        runProgramInStore(store, UseSearchPath::DontUse, app.program, programArgs);
     };
 };
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -25,6 +25,7 @@ std::string chrootHelperName = "__run_in_chroot";
 namespace nix {
 
 void runProgramInStore(ref<Store> store,
+    bool search,
     const std::string & program,
     const Strings & args,
     std::optional<std::string_view> system)
@@ -58,7 +59,10 @@ void runProgramInStore(ref<Store> store,
     if (system)
         setPersonality(*system);
 
-    execvp(program.c_str(), stringsToCharPtrs(args).data());
+    if (search)
+        execvp(program.c_str(), stringsToCharPtrs(args).data());
+    else
+        execv(program.c_str(), stringsToCharPtrs(args).data());
 
     throw SysError("unable to execute '%s'", program);
 }
@@ -132,7 +136,7 @@ struct CmdShell : InstallablesCommand, MixEnvironment
         Strings args;
         for (auto & arg : command) args.push_back(arg);
 
-        runProgramInStore(store, *command.begin(), args);
+        runProgramInStore(store, true, *command.begin(), args);
     }
 };
 
@@ -194,7 +198,7 @@ struct CmdRun : InstallableValueCommand
         Strings allArgs{app.program};
         for (auto & i : args) allArgs.push_back(i);
 
-        runProgramInStore(store, app.program, allArgs);
+        runProgramInStore(store, false, app.program, allArgs);
     }
 };
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -25,7 +25,7 @@ std::string chrootHelperName = "__run_in_chroot";
 namespace nix {
 
 void runProgramInStore(ref<Store> store,
-    bool search,
+    UseSearchPath useSearchPath,
     const std::string & program,
     const Strings & args,
     std::optional<std::string_view> system)
@@ -59,7 +59,7 @@ void runProgramInStore(ref<Store> store,
     if (system)
         setPersonality(*system);
 
-    if (search)
+    if (useSearchPath == UseSearchPath::Use)
         execvp(program.c_str(), stringsToCharPtrs(args).data());
     else
         execv(program.c_str(), stringsToCharPtrs(args).data());
@@ -136,7 +136,7 @@ struct CmdShell : InstallablesCommand, MixEnvironment
         Strings args;
         for (auto & arg : command) args.push_back(arg);
 
-        runProgramInStore(store, true, *command.begin(), args);
+        runProgramInStore(store, UseSearchPath::Use, *command.begin(), args);
     }
 };
 
@@ -198,7 +198,7 @@ struct CmdRun : InstallableValueCommand
         Strings allArgs{app.program};
         for (auto & i : args) allArgs.push_back(i);
 
-        runProgramInStore(store, false, app.program, allArgs);
+        runProgramInStore(store, UseSearchPath::DontUse, app.program, allArgs);
     }
 };
 

--- a/src/nix/run.hh
+++ b/src/nix/run.hh
@@ -5,8 +5,13 @@
 
 namespace nix {
 
+enum struct UseSearchPath {
+    Use,
+    DontUse
+};
+
 void runProgramInStore(ref<Store> store,
-    bool search,
+    UseSearchPath useSearchPath,
     const std::string & program,
     const Strings & args,
     std::optional<std::string_view> system = std::nullopt);

--- a/src/nix/run.hh
+++ b/src/nix/run.hh
@@ -6,6 +6,7 @@
 namespace nix {
 
 void runProgramInStore(ref<Store> store,
+    bool search,
     const std::string & program,
     const Strings & args,
     std::optional<std::string_view> system = std::nullopt);


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
`execvp` (and other `exec*p*` functions) have an odd behavior when provided program can't be executed – they try to pass the program to `/bin/sh` to treat it as a POSIX shell script.

This is hard to avoid when you need to search `PATH`, but when the program is a path (like in `nix run`) we don’t need to search, which also avoids the `/bin/sh` fallback and instead reports a reasonable error.

Specifically, this crops up on MacOS when the program is a script with a shebang command interpreter – BSDs don’t support that. The previous behavior fell back to Bash 3.2 which is just reasonable enough to convince the user (like me) that they have done something wrong. This removes the fallback behavior, letting `nix` return a not-too-terrible error message instead.

There’s an example of the old & new behavior in https://github.com/NixOS/nix/issues/9488#issuecomment-1833239816.

# Context
<!-- Provide context. Reference open issues if available. -->
Fixes #9488.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->
Conditionalize on whether or not the program can be a bare filename. This should probably be changed to avoid the `bool`, but first I’d like some confirmation that this is reasonable.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
