### PR TITLE
flakeref: follow symlinks

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -98,7 +98,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
             to 'baseDir'). If so, search upward to the root of the
             repo (i.e. the directory containing .git). */
 
-        path = absPath(path, baseDir);
+        path = readLink( absPath(path, baseDir) );
 
         if (isFlake) {
 

--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -98,7 +98,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
             to 'baseDir'). If so, search upward to the root of the
             repo (i.e. the directory containing .git). */
 
-        path = readLink( absPath(path, baseDir) );
+        path = canonPath(absPath(path, baseDir), true);
 
         if (isFlake) {
 


### PR DESCRIPTION
fixes #9463

# Motivation

Given `/tmp/flakelink` is a symlink to an actual flake directory, currently this happens:

```shell
$ nix build '/tmp/flakelink/#hello'
error: path '/tmp/flakelink' is not a flake (because it's not a directory)
```

This PR attempts to fix that.

Warning: I have no prior knowledge of the nix-codebase or much of a background in C++. Please review carefully. In particular, I do not know if there's any ramification, regarding the use of `flakeref` in the `inputs` definitions of `flake.nix` files or other edge-cases. @infinisil and @YorikSar pressured me into this 😉

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
