### PR TITLE
Keep generated documentation for `--help` in a separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ perl/Makefile.config
 
 /src/nix/nix
 
-/src/nix/doc
+/src/nix/generated-doc
 
 # /src/nix-env/
 /src/nix-env/nix-env

--- a/doc/manual/src/store/types/index.md.in
+++ b/doc/manual/src/store/types/index.md.in
@@ -1,5 +1,3 @@
-R"(
-
 Nix supports different types of stores. These are described below.
 
 ## Store URL format
@@ -42,5 +40,3 @@ store as follows:
 * Otherwise, use the [local store](#local-store) `/nix/store`.
 
 @stores@
-
-)"

--- a/src/nix/local.mk
+++ b/src/nix/local.mk
@@ -31,10 +31,23 @@ src/nix/develop.cc: src/nix/get-env.sh.gen.hh
 
 src/nix-channel/nix-channel.cc: src/nix-channel/unpack-channel.nix.gen.hh
 
-src/nix/main.cc: doc/manual/generate-manpage.nix.gen.hh doc/manual/utils.nix.gen.hh doc/manual/generate-settings.nix.gen.hh doc/manual/generate-store-info.nix.gen.hh
+src/nix/main.cc: \
+  doc/manual/generate-manpage.nix.gen.hh \
+  doc/manual/utils.nix.gen.hh doc/manual/generate-settings.nix.gen.hh \
+  doc/manual/generate-store-info.nix.gen.hh \
+  src/nix/generated-doc/help-stores.md
 
-src/nix/doc/files/%.md: doc/manual/src/command-ref/files/%.md
+src/nix/generated-doc/files/%.md: doc/manual/src/command-ref/files/%.md
 	@mkdir -p $$(dirname $@)
 	@cp $< $@
 
-src/nix/profile.cc: src/nix/profile.md src/nix/doc/files/profiles.md.gen.hh
+src/nix/profile.cc: src/nix/profile.md src/nix/generated-doc/files/profiles.md.gen.hh
+
+src/nix/generated-doc/help-stores.md: doc/manual/src/store/types/index.md.in
+	@mkdir -p $$(dirname $@)
+	@echo 'R"(' >> $@.tmp
+	@echo >> $@.tmp
+	@cat $^ >> $@.tmp
+	@echo >> $@.tmp
+	@echo ')"' >> $@.tmp
+	@mv $@.tmp $@

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -297,7 +297,7 @@ struct CmdHelpStores : Command
     std::string doc() override
     {
         return
-          #include "help-stores.md"
+          #include "generated-doc/help-stores.md"
           ;
     }
 

--- a/src/nix/profile.md
+++ b/src/nix/profile.md
@@ -11,7 +11,7 @@ them to be rolled back easily.
 
 )""
 
-#include "doc/files/profiles.md.gen.hh"
+#include "generated-doc/files/profiles.md.gen.hh"
 
 R""(
 


### PR DESCRIPTION
# Motivation

- helps navigating the code as it highlights which files are generated
- makes it less error prone when working incrementally
  (although this should be just fixed by building out of tree)

# Context

picking apart https://github.com/NixOS/nix/pull/8781

@Ericson2314

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).