### PR TITLE
shorten the quick start chapter

### DIFF
--- a/doc/manual/src/quick-start.md
+++ b/doc/manual/src/quick-start.md
@@ -1,10 +1,9 @@
 # Quick Start
 
-This chapter is for impatient people who don't like reading
-documentation.  For more in-depth information you are kindly referred
-to subsequent chapters.
+This chapter is for impatient people who don't like reading documentation.
+For more in-depth information you are kindly referred to subsequent chapters.
 
-1. Install Nix by running the following:
+1. Install Nix:
 
    ```console
    $ curl -L https://nixos.org/nix/install | sh
@@ -13,87 +12,33 @@ to subsequent chapters.
    The install script will use `sudo`, so make sure you have sufficient rights.
    On Linux, `--daemon` can be omitted for a single-user install.
 
-   For other installation methods, see [here](installation/index.md).
+   For other installation methods, see the detailed [installation instructions](installation/index.md).
 
-1. See what installable packages are currently available in the
-   channel:
+1. Run software without installing it permanently:
 
    ```console
-   $ nix-env --query --available --attr-path
-   nixpkgs.docbook_xml_dtd_43                    docbook-xml-4.3
-   nixpkgs.docbook_xml_dtd_45                    docbook-xml-4.5
-   nixpkgs.firefox                               firefox-33.0.2
-   nixpkgs.hello                                 hello-2.9
-   nixpkgs.libxslt                               libxslt-1.1.28
-   …
+   $ nix-shell --packages cowsay lolcat
    ```
 
-1. Install some packages from the channel:
+   This downloads the specified packages with all their dependencies, and drops you into a Bash shell where the commands provided by those packages are present.
+   This will not affect your normal environment:
 
    ```console
-   $ nix-env --install --attr nixpkgs.hello
+   [nix-shell:~]$ cowsay Hello, Nix! | lolcat
    ```
 
-   This should download pre-built packages; it should not build them
-   locally (if it does, something went wrong).
-
-1. Test that they work:
+   Exiting the shell will make the programs disappear again:
 
    ```console
-   $ which hello
-   /home/eelco/.nix-profile/bin/hello
-   $ hello
-   Hello, world!
-   ```
-
-1. Uninstall a package:
-
-   ```console
-   $ nix-env --uninstall hello
-   ```
-
-1. You can also test a package without installing it:
-
-   ```console
-   $ nix-shell --packages hello
-   ```
-
-   This builds or downloads GNU Hello and its dependencies, then drops
-   you into a Bash shell where the `hello` command is present, all
-   without affecting your normal environment:
-
-   ```console
-   [nix-shell:~]$ hello
-   Hello, world!
-
    [nix-shell:~]$ exit
-
-   $ hello
-   hello: command not found
+   $ lolcat
+   lolcat: command not found
    ```
 
-1. To keep up-to-date with the channel, do:
+1. Search for more packages on <search.nixos.org> to try them out.
+
+1. Free up storage space:
 
    ```console
-   $ nix-channel --update nixpkgs
-   $ nix-env --upgrade '*'
-   ```
-
-   The latter command will upgrade each installed package for which
-   there is a “newer” version (as determined by comparing the version
-   numbers).
-
-1. If you're unhappy with the result of a `nix-env` action (e.g., an
-   upgraded package turned out not to work properly), you can go back:
-
-   ```console
-   $ nix-env --rollback
-   ```
-
-1. You should periodically run the Nix garbage collector to get rid of
-   unused packages, since uninstalls or upgrades don't actually delete
-   them:
-
-   ```console
-   $ nix-collect-garbage --delete-old
+   $ nix-collect-garbage
    ```


### PR DESCRIPTION
this focuses on `nix-shell -p` and refers to search.nixos.org for
package search, which is currently the easiest and most effective way to
find program names.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).