### PR TITLE
tests: avoid a chroot store without sandbox support

### DIFF
--- a/tests/functional/build-remote-trustless-should-fail-0.sh
+++ b/tests/functional/build-remote-trustless-should-fail-0.sh
@@ -4,6 +4,7 @@ enableFeatures "daemon-trust-override"
 
 restartDaemon
 
+requireSandboxSupport
 [[ $busybox =~ busybox ]] || skipTest "no busybox"
 
 unset NIX_STORE_DIR


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
This test, functional/build-remote-trustless-should-fail-0.sh, requires sandbox support. It's checked in the build-remote-trustless.sh file that it calls. But a `nix --store ...` before it tries to use a chroot store before the check. In systems that don't support sandbox, this also would fail, instead of skipping the test.

This PR adds an earlier `requireSandboxSupport` call so that we skip the test instead of failing on the `nix --store ...` command.

# Context
<!-- Provide context. Reference open issues if available. -->
I had tried building on a host where `unshare` is not allowed, where the `nix-build build-hook.nix -A passthru.input2 ...` command fails.
 
<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
