### PR TITLE
[DOCS] Fix deleting Linux users documentation

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -33,7 +33,7 @@ sudo rm -rf /etc/nix /etc/profile.d/nix.sh /etc/tmpfiles.d/nix-daemon.conf /nix 
 Remove build users and their group:
 
 ```console
-for i in $(seq 1 32); do
+for i in $(seq -w 1 32); do
   sudo userdel nixbld$i
 done
 sudo groupdel nixbld


### PR DESCRIPTION
# Motivation

The [uninstall docs](https://nixos.org/manual/nix/stable/installation/uninstall#linux) include a script to remove users on Linux. However, it doesn't work for the users with number less than zero, since it doesn't include a leading zero.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

These are the users that Nix creates:
```
nixbld:x:953:nixbld01,nixbld02,nixbld03,nixbld04,nixbld05,nixbld06,nixbld07,nixbld08,nixbld09
```

But the script runs against the wrong users:
```
userdel: user 'nixbld1' does not exist
userdel: user 'nixbld2' does not exist
userdel: user 'nixbld3' does not exist
...
userdel: user 'nixbld11' does not exist
userdel: user 'nixbld12' does not exist
```
