### PR TITLE
Including `config.h` also needs `$(buildprefix)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ $(eval $(call include-sub-makefile, doc/manual/local.mk))
 $(eval $(call include-sub-makefile, doc/internal-api/local.mk))
 endif
 
-GLOBAL_CXXFLAGS += -g -Wall -include config.h -std=c++2a -I src
+GLOBAL_CXXFLAGS += -g -Wall -include $(buildprefix)config.h -std=c++2a -I src


### PR DESCRIPTION
# Motivation

Per the instruction in the manual, we want to run configure in a different directory so that we can configure + build for multiple platforms. That means `config.h` will be in the build directory. 

# Context

This is just like `Makefile.config`, which already is used with `$(buildprefix)`.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
