### PR TITLE
Add missing `-pthread` for test support libraries

### DIFF
--- a/tests/unit/libexpr-support/local.mk
+++ b/tests/unit/libexpr-support/local.mk
@@ -20,4 +20,4 @@ libexpr-test-support_LIBS = \
     libstore-test-support libutil-test-support \
     libexpr libstore libutil
 
-libexpr-test-support_LDFLAGS := -lrapidcheck
+libexpr-test-support_LDFLAGS := -pthread -lrapidcheck

--- a/tests/unit/libstore-support/local.mk
+++ b/tests/unit/libstore-support/local.mk
@@ -18,4 +18,4 @@ libstore-test-support_LIBS = \
     libutil-test-support \
     libstore libutil
 
-libstore-test-support_LDFLAGS := -lrapidcheck
+libstore-test-support_LDFLAGS := -pthread -lrapidcheck

--- a/tests/unit/libutil-support/local.mk
+++ b/tests/unit/libutil-support/local.mk
@@ -16,4 +16,4 @@ libutil-test-support_CXXFLAGS += $(libutil-tests_EXTRA_INCLUDES)
 
 libutil-test-support_LIBS = libutil
 
-libutil-test-support_LDFLAGS := -lrapidcheck
+libutil-test-support_LDFLAGS := -pthread -lrapidcheck


### PR DESCRIPTION
# Motivation

his is good in general (see how the other libraries also have long had it, since 49fe9592a47e7819179c2de4fd6068e897e944c7) but in particular needed to fix the NetBSD build.

# Context

49fe9592a47e7819179c2de4fd6068e897e944c7, hydra failures

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
