### PR TITLE
Fix the labeler.yml config file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,30 @@
 "documentation":
-  - doc/manual/*
-  - src/nix/**/*.md
+  - changed-files:
+    - any-glob-to-any-file: "doc/manual/*"
+    - any-glob-to-any-file: "src/nix/**/*.md"
 
 "store":
-  - src/libstore/store-api.*
-  - src/libstore/*-store.*
+  - changed-files:
+    - any-glob-to-any-file: "src/libstore/store-api.*"
+    - any-glob-to-any-file: "src/libstore/*-store.*"
 
 "fetching":
-  - src/libfetchers/**/*
+  - changed-files:
+    - any-glob-to-any-file: "src/libfetchers/**/*"
 
 "repl":
-  - src/libcmd/repl.*
-  - src/nix/repl.*
+  - changed-files:
+    - any-glob-to-any-file: "src/libcmd/repl.*"
+    - any-glob-to-any-file: "src/nix/repl.*"
 
 "new-cli":
-  - src/nix/**/*
+  - changed-files:
+    - any-glob-to-any-file: "src/nix/**/*"
 
 "with-tests":
-  # Unit tests
-  - src/*/tests/**/*
-  # Functional and integration tests
-  - tests/functional/**/*
+  - changed-files:
+    # Unit tests
+    - any-glob-to-any-file: "src/*/tests/**/*"
+    # Functional and integration tests
+    - any-glob-to-any-file: "tests/functional/**/*"
+    


### PR DESCRIPTION

# Motivation

labeler 5.0 changed the configuration file in a non-backwards-compatible way (https://github.com/actions/labeler/tree/main#breaking-changes-in-v5), so update our config file to match that (because all the CIs are red otherwise :grimacing: ).

# Context

The world broke after https://github.com/NixOS/nix/pull/9539 got merged

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
