### PR TITLE
Print the value in `error: cannot coerce` messages

### DIFF
--- a/doc/manual/rl-next/print-value-in-coercion-error.md
+++ b/doc/manual/rl-next/print-value-in-coercion-error.md
@@ -1,0 +1,75 @@
+synopsis: Coercion errors include the failing value
+issues: #561
+prs: #9553
+description: {
+
+The `error: cannot coerce a <TYPE> to a string` message now includes the value
+which caused the error. This makes debugging much easier:
+
+```
+$ cat bad.nix
+let
+  pkgs = import <nixpkgs> {};
+  system = pkgs.lib.systems.elaborate "x86_64-linux";
+in
+  import <nixpkgs> {inherit system;}
+```
+
+Previously, attempting to evaluate this expression would produce a confusing error message:
+
+```
+$ nix-instantiate --eval bad.nix
+error:
+       … while evaluating a branch condition
+
+         at /nix/store/m8ah0r1ih2shq35vp3hj1k0m1c4hsfga-nixpkgs/nixpkgs/pkgs/stdenv/booter.nix:64:9:
+
+           63|       go = pred: n:
+           64|         if n == len
+             |         ^
+           65|         then rnul pred
+
+       … while calling the 'length' builtin
+
+         at /nix/store/m8ah0r1ih2shq35vp3hj1k0m1c4hsfga-nixpkgs/nixpkgs/pkgs/stdenv/booter.nix:62:13:
+
+           61|     let
+           62|       len = builtins.length list;
+             |             ^
+           63|       go = pred: n:
+
+       (stack trace truncated; use '--show-trace' to show the full trace)
+
+       error: cannot coerce a set to a string
+```
+
+Now, the error message includes the set itself. This makes debugging much
+simpler, especially when the trace doesn't show the failing expression:
+
+```
+$ nix-instantiate --eval bad.nix
+error:
+       … while evaluating a branch condition
+
+         at /nix/store/m8ah0r1ih2shq35vp3hj1k0m1c4hsfga-nixpkgs/nixpkgs/pkgs/stdenv/booter.nix:64:9:
+
+           63|       go = pred: n:
+           64|         if n == len
+             |         ^
+           65|         then rnul pred
+
+       … while calling the 'length' builtin
+
+         at /nix/store/m8ah0r1ih2shq35vp3hj1k0m1c4hsfga-nixpkgs/nixpkgs/pkgs/stdenv/booter.nix:62:13:
+
+           61|     let
+           62|       len = builtins.length list;
+             |             ^
+           63|       go = pred: n:
+
+       (stack trace truncated; use '--show-trace' to show the full trace)
+
+       error: cannot coerce a set to a string: { system = "x86_64-linux"; ... }
+```
+
+}

--- a/doc/manual/src/language/string-interpolation.md
+++ b/doc/manual/src/language/string-interpolation.md
@@ -189,7 +189,7 @@ If neither is present, an error is thrown.
 > "${a}"
 > ```
 >
->     error: cannot coerce a set to a string
+>     error: cannot coerce a set to a string: { }
 >
 >            at «string»:4:2:
 >

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -26,9 +26,9 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <iostream>
 #include <fstream>
 #include <functional>
+#include <strstream>
 
 #include <sys/resource.h>
 #include <nlohmann/json.hpp>
@@ -2286,7 +2286,7 @@ BackedStringView EvalState::coerceToString(
             return std::move(*maybeString);
         auto i = v.attrs->find(sOutPath);
         if (i == v.attrs->end()) {
-            error("cannot coerce %1% to a string", showType(v))
+            error("cannot coerce %1% to a string: %2%", showType(v), printValue(*this, v))
                 .withTrace(pos, errorCtx)
                 .debugThrow<TypeError>();
         }
@@ -2332,7 +2332,7 @@ BackedStringView EvalState::coerceToString(
         }
     }
 
-    error("cannot coerce %1% to a string", showType(v))
+    error("cannot coerce %1% to a string: %2%", showType(v), printValue(*this, v))
         .withTrace(pos, errorCtx)
         .debugThrow<TypeError>();
 }
@@ -2691,8 +2691,10 @@ void EvalState::printStatistics()
 
 std::string ExternalValueBase::coerceToString(const Pos & pos, NixStringContext & context, bool copyMore, bool copyToStore) const
 {
+    std::strstream printed;
+    print(printed);
     throw TypeError({
-        .msg = hintfmt("cannot coerce %1% to a string", showType())
+        .msg = hintfmt("cannot coerce %1% to a string: %2%", showType(), printed.str())
     });
 }
 

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-1.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-1.err.exp
@@ -7,4 +7,4 @@ error:
              |  ^
             2|
 
-       error: cannot coerce a function to a string
+       error: cannot coerce a function to a string: <LAMBDA>

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-3.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-3.err.exp
@@ -7,4 +7,4 @@ error:
              |   ^
             2|
 
-       error: cannot coerce a function to a string
+       error: cannot coerce a function to a string: <LAMBDA>

--- a/tests/unit/libexpr/error_traces.cc
+++ b/tests/unit/libexpr/error_traces.cc
@@ -295,7 +295,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, toPath) {
         ASSERT_TRACE2("toPath []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while evaluating the first argument passed to builtins.toPath"));
 
         ASSERT_TRACE2("toPath \"foo\"",
@@ -309,7 +309,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, storePath) {
         ASSERT_TRACE2("storePath true",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a Boolean"),
+                      hintfmt("cannot coerce %s to a string: %s", "a Boolean", "true"),
                       hintfmt("while evaluating the first argument passed to 'builtins.storePath'"));
 
     }
@@ -318,7 +318,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, pathExists) {
         ASSERT_TRACE2("pathExists []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while realising the context of a path"));
 
         ASSERT_TRACE2("pathExists \"zorglub\"",
@@ -332,7 +332,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, baseNameOf) {
         ASSERT_TRACE2("baseNameOf []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while evaluating the first argument passed to builtins.baseNameOf"));
 
     }
@@ -377,7 +377,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, filterSource) {
         ASSERT_TRACE2("filterSource [] []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'"));
 
         ASSERT_TRACE2("filterSource [] \"foo\"",
@@ -1038,7 +1038,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, toString) {
         ASSERT_TRACE2("toString { a = 1; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ a = 1; }"),
                       hintfmt("while evaluating the first argument passed to builtins.toString"));
 
     }
@@ -1057,7 +1057,7 @@ namespace nix {
 
         ASSERT_TRACE2("substring 0 3 {}",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the third argument (the string) passed to builtins.substring"));
 
         ASSERT_TRACE1("substring (-3) 3 \"sometext\"",
@@ -1070,7 +1070,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, stringLength) {
         ASSERT_TRACE2("stringLength {} # TODO: context is missing ???",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the argument passed to builtins.stringLength"));
 
     }
@@ -1143,7 +1143,7 @@ namespace nix {
 
         ASSERT_TRACE2("concatStringsSep \"foo\" [ 1 2 {} ] # TODO: coerce to string is buggy",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "an integer"),
+                      hintfmt("cannot coerce %s to a string: %s", "an integer", "1"),
                       hintfmt("while evaluating one element of the list of strings to concat passed to builtins.concatStringsSep"));
 
     }
@@ -1229,12 +1229,12 @@ namespace nix {
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the attribute 'system' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"drv\"; }",
@@ -1279,17 +1279,17 @@ namespace nix {
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; args = [ {} ]; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating an element of the argument list"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; args = [ \"a\" {} ]; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating an element of the argument list"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; FOO = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the attribute 'FOO' of derivation 'foo'"));
 
     }


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
This extends the `error: cannot coerce a <TYPE> to a string` message to print the value that could not be coerced. This helps with debugging by making it easier to track down where the value is being produced from, especially in errors with deep or unhelpful stack traces.

# Context
See #561.

Here's an example of a mistake I made that would have been much easier to fix with this patch. I encountered this error while converting a NixOS configuration that relied on `builtins.currentSystem` to work in a flake. There were several overlays which pinned packages to specific versions, like this:

```nix
let
  nixos_master = import (
    builtins.fetchGit {
      url = "https://github.com/NixOS/nixpkgs.git";
      ref = "master";
      rev = "0c0d57d79de06b36286b8c7551dc173e372b86ad";
    }
  ) {};
in
self: super: {
  opentelemetry-collector-contrib = nixos_master.opentelemetry-collector-contrib; # version 0.78.0
}
```

My first try added an `inherit (config.nixpkgs) localSystem;` to the `import` arguments, but that gave me an unhelpful error:

```
$ nix repl nixpkgs
nix-repl> nixpkgs = legacyPackages.x86_64-linux.path
nix-repl> system = lib.systems.elaborate "x86_64-linux"
nix-repl> import nixpkgs { inherit system; }
error:
       … while evaluating a branch condition

         at /nix/store/7g8wbm1z6948x0qma4hzkkb9a3xys76w-source/pkgs/stdenv/booter.nix:64:9:

           63|       go = pred: n:
           64|         if n == len
             |         ^
           65|         then rnul pred

       … while calling the 'length' builtin

         at /nix/store/7g8wbm1z6948x0qma4hzkkb9a3xys76w-source/pkgs/stdenv/booter.nix:62:13:

           61|     let
           62|       len = builtins.length list;
             |             ^
           63|       go = pred: n:

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: cannot coerce a set to a string
```

Note that the stack trace and error message don't make it clear _which_ set couldn't be coerced to a string, or where the coercion failed. It's fairly easy to figure out what's gone wrong here, but in a repository with 14kloc it was significantly more difficult.

With this patch, the error message makes it clear what's happened (a system attrset has been used in place of a system string), and how to fix it (select the `system` attribute from `config.nixpkgs.localSystem`):

```
       error: cannot coerce a set to a string: { aesSupport = <CODE>; avx2Support = <CODE>; avx512Support = <CODE>; avxSupport = <CODE>; canExecute = <CODE>; config = <CODE>; darwinArch = <CODE>; darwinMinVersion = <CODE>; darwinMinVersionVariable = <CODE>; darwinPlatform = <CODE>; darwinSdkVersion = <CODE>; efiArch = <CODE>; emulator = <CODE>; emulatorAvailable = <CODE>; extensions = <CODE>; fma4Support = <CODE>; fmaSupport = <CODE>; gcc = <CODE>; hasSharedLibraries = <CODE>; is32bit = <CODE>; is64bit = <CODE>; isAarch = <CODE>; isAarch32 = false; isAarch64 = <CODE>; isAbiElfv2 = <CODE>; isAlpha = <CODE>; isAndroid = <CODE>; isArmv7 = <CODE>; isAvr = <CODE>; isBSD = <CODE>; isBigEndian = <CODE>; isCompatible = <CODE>; isCygwin = <CODE>; isDarwin = <CODE>; isEfi = <CODE>; isFreeBSD = <CODE>; isGenode = <CODE>; isGhcjs = <CODE>; isGnu = <CODE>; isILP32 = <CODE>; isJavaScript = <CODE>; isLinux = <CODE>; isLittleEndian = <CODE>; isLoongArch64 = <CODE>; isM68k = <CODE>; isMacOS = <CODE>; isMicroBlaze = <CODE>; isMinGW = <CODE>; isMips = <CODE>; isMips32 = <CODE>; isMips64 = <CODE>; isMips64n32 = <CODE>; isMips64n64 = <CODE>; isMmix = <CODE>; isMsp430 = <CODE>; isMusl = <CODE>; isNetBSD = <CODE>; isNone = <CODE>; isOpenBSD = <CODE>; isOr1k = <CODE>; isPower = <CODE>; isPower64 = false; isRedox = <CODE>; isRiscV = <CODE>; isRiscV32 = <CODE>; isRiscV64 = <CODE>; isRx = <CODE>; isS390 = <CODE>; isS390x = <CODE>; isSparc = <CODE>; isStatic = <CODE>; isSunOS = <CODE>; isUClibc = <CODE>; isUnix = <CODE>; isVc4 = <CODE>; isWasi = <CODE>; isWasm = <CODE>; isWindows = <CODE>; isi686 = <CODE>; isiOS = <CODE>; isx86 = <CODE>; isx86_32 = <CODE>; isx86_64 = <CODE>; libc = <CODE>; linker = <CODE>; linux-kernel = <CODE>; linuxArch = <CODE>; parsed = { _type = "system"; abi = { _type = "abi"; assertions = [ { assertion = <LAMBDA>; message = "The \"gnu\" ABI is ambiguous on 32-bit ARM. Use \"gnueabi\" or \"gnueabihf\" instead.\n"; } { assertion = <LAMBDA>; message = "The \"gnu\" ABI is ambiguous on big-endian 64-bit PowerPC. Use \"gnuabielfv2\" or \"gnuabielfv1\" instead.\n"; } ]; name = "gnu"; }; cpu = { _type = "cpu-type"; arch = "x86-64"; bits = 64; family = "x86"; name = "x86_64"; significantByte = { _type = "significant-byte"; name = "littleEndian"; }; }; kernel = { _type = "kernel"; execFormat = { _type = "exec-format"; name = "elf"; }; families = { }; name = "linux"; }; vendor = { _type = "vendor"; name = "unknown"; }; }; qemuArch = <CODE>; rust = <CODE>; rustc = <CODE>; sse3Support = <CODE>; sse4_1Support = <CODE>; sse4_2Support = <CODE>; sse4_aSupport = <CODE>; ssse3Support = <CODE>; system = "x86_64-linux"; ubootArch = <CODE>; uname = <CODE>; useAndroidPrebuilt = false; useiOSPrebuilt = false; }
```

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
