### PR TITLE
Avoid `std::strstream`, fix the clang build

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -28,7 +28,7 @@
 #include <sys/resource.h>
 #include <fstream>
 #include <functional>
-#include <strstream>
+#include <sstream>
 
 #include <sys/resource.h>
 #include <nlohmann/json.hpp>
@@ -2691,7 +2691,7 @@ void EvalState::printStatistics()
 
 std::string ExternalValueBase::coerceToString(const Pos & pos, NixStringContext & context, bool copyMore, bool copyToStore) const
 {
-    std::strstream printed;
+    std::stringstream printed;
     print(printed);
     throw TypeError({
         .msg = hintfmt("cannot coerce %1% to a string: %2%", showType(), printed.str())


### PR DESCRIPTION
# Motivation

According https://en.cppreference.com/w/cpp/io/strstream, it has been deprecated since C++98! The Clang + Linux build systems to not have it at all, or at least be hiding it.

We can just use `std::stringstream` instead, I think.

# Context

https://github.com/NixOS/nix/pull/9553 added this I think.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
