### PR TITLE
Fix `sys/xattr.h` check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,7 +289,8 @@ esac
 AC_SUBST(HAVE_SECCOMP, [$have_seccomp])
 
 # Optional dependencies for better normalizing file system data
-AC_CHECK_HEADERS[sys/xattr.h]
+AC_CHECK_HEADERS([sys/xattr.h])
+AC_CHECK_FUNCS([llistxattr lremovexattr])
 
 # Look for aws-cpp-sdk-s3.
 AC_LANG_PUSH(C++)

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -78,7 +78,7 @@ static void canonicalisePathMetaData_(
     if (!(S_ISREG(st.st_mode) || S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)))
         throw Error("file '%1%' has an unsupported type", path);
 
-#ifdef HAVE_SYS_XATTR_H
+#if HAVE_SYS_XATTR_H && HAVE_LLISTXATTR && HAVE_LREMOVEXATTR
     /* Remove extended attributes / ACLs. */
     ssize_t eaSize = llistxattr(path.c_str(), nullptr, 0);
 


### PR DESCRIPTION
# Motivation

I wrote the `configure.ac` wrong, and so we just got no builds supporting ACLs.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
