### PR TITLE
flake.nix: Cache shell inputs through hydra

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -540,6 +540,8 @@
         # Binary package for various platforms.
         build = forAllSystems (system: self.packages.${system}.nix);
 
+        shellInputs = forAllSystems (system: self.devShells.${system}.default.inputDerivation);
+
         buildStatic = lib.genAttrs linux64BitSystems (system: self.packages.${system}.nix-static);
 
         buildCross = forAllCrossSystems (crossSystem:


### PR DESCRIPTION
# Motivation

Make sure all shell dependencies are cached, even if they're custom.

# Context

#9573 may need this, and this is good to have in general.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
