### PR TITLE
Add Store.addTempRoots (batched)

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -237,9 +237,13 @@ void DerivationGoal::haveDerivation()
         return;
     }
 
-    for (auto & i : drv->outputsAndOptPaths(worker.store))
-        if (i.second.second)
-            worker.store.addTempRoot(*i.second.second);
+    {
+        StorePathSet tempRootsRequest;
+        for (auto & i : drv->outputsAndOptPaths(worker.store))
+            if (i.second.second)
+                tempRootsRequest.emplace(*i.second.second);
+        worker.store.addTempRoots(tempRootsRequest);
+    }
 
     auto outputHashes = staticOutputHashes(worker.evalStore, *drv);
     for (auto & [outputName, outputHash] : outputHashes)

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1406,7 +1406,7 @@ struct RestrictedStore : public virtual RestrictedStoreConfig, public virtual In
         BuildMode buildMode = bmNormal) override
     { unsupported("buildDerivation"); }
 
-    void addTempRoot(const StorePath & path) override
+    void addTempRoots(const StorePathSet & path) override
     { }
 
     void addIndirectRoot(const Path & path) override

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -657,6 +657,19 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         break;
     }
 
+    case WorkerProto::Op::AddTempRoots: {
+        Strings pathNames (readStrings<Strings>(from));
+        StorePathSet paths;
+        for (auto & pathName : pathNames) {
+            paths.emplace(pathName);
+        }
+        logger->startWork();
+        store->addTempRoots(paths);
+        logger->stopWork();
+        to << 1;
+        break;
+    }
+
     case WorkerProto::Op::AddPermRoot: {
         if (!trusted)
             throw Error(

--- a/src/libstore/gc-store.hh
+++ b/src/libstore/gc-store.hh
@@ -80,7 +80,7 @@ struct GCResults
  *
  * The notion of GC roots actually not part of this class.
  *
- *  - The base `Store` class has `Store::addTempRoot()` because for a store
+ *  - The base `Store` class has `Store::addTempRoots()` because for a store
  *    that doesn't support garbage collection at all, a temporary GC root is
  *    safely implementable as no-op.
  *

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -186,7 +186,7 @@ public:
         const StorePathSet & references,
         RepairFlag repair) override;
 
-    void addTempRoot(const StorePath & path) override;
+    void addTempRoots(const StorePathSet & path) override;
 
 private:
 

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -124,7 +124,7 @@ public:
 
     void ensurePath(const StorePath & path) override;
 
-    void addTempRoot(const StorePath & path) override;
+    void addTempRoots(const StorePathSet & path) override;
 
     Roots findRoots(bool censor) override;
 

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -562,7 +562,13 @@ public:
      * Add a store path as a temporary root of the garbage collector.
      * The root disappears as soon as we exit.
      */
-    virtual void addTempRoot(const StorePath & path)
+    void addTempRoot(const StorePath & path);
+
+    /**
+     * Add store paths as temporary roots of the garbage collector.
+     * The roots disappear as soon as we exit.
+     */
+    virtual void addTempRoots(const StorePathSet & paths)
     { debug("not creating temporary root, store doesn't support GC"); }
 
     /**

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -9,7 +9,7 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 36)
+#define PROTOCOL_VERSION (1 << 8 | 37)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -162,6 +162,7 @@ enum struct WorkerProto::Op : uint64_t
     AddBuildLog = 45,
     BuildPathsWithResults = 46,
     AddPermRoot = 47,
+    AddTempRoots = 48,
 };
 
 /**

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -874,8 +874,7 @@ static void opServe(Strings opFlags, Strings opArgs)
                 bool substitute = readInt(in);
                 auto paths = ServeProto::Serialise<StorePathSet>::read(*store, rconn);
                 if (lock && writeAllowed)
-                    for (auto & path : paths)
-                        store->addTempRoot(path);
+                    store->addTempRoots(paths);
 
                 if (substitute && writeAllowed) {
                     store->substitutePaths(paths);


### PR DESCRIPTION

# Motivation

By batching the creation of temp roots, we save some roundtrips, in the worker protocol, as well as the gc roots protocol, which would make multiple connections and try to lock multiple times.

TODO:
- [ ] self-review for correctness

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
