### PR TITLE
libstore/daemon.cc: note trust model difference in readDerivation()s

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -574,6 +574,15 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
     case WorkerProto::Op::BuildDerivation: {
         auto drvPath = store->parseStorePath(readString(from));
         BasicDerivation drv;
+        /*
+         * Note: unlike wopEnsurePath, this operation reads a
+         * derivation-to-be-realized from the client with
+         * readDerivation(Source,Store) rather than reading it from
+         * the local store with Store::readDerivation().  Since the
+         * derivation-to-be-realized is not registered in the store
+         * it cannot be trusted that its outPath was calculated
+         * correctly.
+         */
         readDerivation(from, *store, drv, Derivation::nameFromPath(drvPath));
         BuildMode buildMode = (BuildMode) readInt(from);
         logger->startWork();


### PR DESCRIPTION
Below the comment added by this commit is a much longer comment followed by a trust check, both of which have confused me on at least two occasions.  I figured it out once, forgot it, then had to ask @Ericson2314 to explain it, at which point I understood it again.  I think this might confuse other people too, or maybe I will just forget it a third time.  So let's add a comment.

Farther down in the function is the following check:

```
if (!(drvType.isCA() || trusted))
  throw Error("you are not privileged to build input-addressed derivations");
```

This seems really strange at first.  A key property of Nix is that you can compute the outpath of a derivation using the derivation (and its references-closure) without trusting anybody!

The missing insight is that at this point in the code the builder doesn't necessarily have the references-closure of the derivation being built, and therefore needs to trust that the derivation's outPath is honest.  It's incredibly easy to overlook this, because the only difference between these two cases is which of these identically-named functions we used:

- `readDerivation(Source,Store)`
- `Store::readDerivation()`

Since these two functions with the same name have totally different trust models we should call the reader's attention to this fact.