### PR TITLE
nix-profile: fix both profile links detection

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -9,11 +9,9 @@ else
     NIX_LINK_NEW=$HOME/.local/state/nix/profile
 fi
 if [ -e "$NIX_LINK_NEW" ]; then
-    NIX_LINK="$NIX_LINK_NEW"
-else
-    if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then
+    if [ -t 2 ] && [ -e "$NIX_LINK" ]; then
         warning="\033[1;35mwarning:\033[0m"
-        printf "$warning Both %s and legacy %s exist; using the latter.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
+        printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
         if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
             printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
         else
@@ -26,6 +24,7 @@ else
             printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
         fi
     fi
+    NIX_LINK="$NIX_LINK_NEW"
 fi
 
 export NIX_PROFILES="@localstatedir@/nix/profiles/default $NIX_LINK"

--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -1,4 +1,5 @@
 # Only execute this file once per shell.
+# This file is tested by tests/installer/default.nix.
 if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
 __ETC_PROFILE_NIX_SOURCED=1
 

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -9,11 +9,9 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
         NIX_LINK_NEW="$HOME/.local/state/nix/profile"
     fi
     if [ -e "$NIX_LINK_NEW" ]; then
-        NIX_LINK="$NIX_LINK_NEW"
-    else
-        if [ -t 2 ] && [ -e "$NIX_LINK_NEW" ]; then
+        if [ -t 2 ] && [ -e "$NIX_LINK" ]; then
             warning="\033[1;35mwarning:\033[0m"
-            printf "$warning Both %s and legacy %s exist; using the latter.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
+            printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
             if [ "$(realpath "$NIX_LINK")" = "$(realpath "$NIX_LINK_NEW")" ]; then
                 printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
             else
@@ -26,6 +24,7 @@ if [ -n "$HOME" ] && [ -n "$USER" ]; then
                 printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
             fi
         fi
+        NIX_LINK="$NIX_LINK_NEW"
     fi
 
     # Set up environment.

--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,3 +1,4 @@
+# This file is tested by tests/installer/default.nix.
 if [ -n "$HOME" ] && [ -n "$USER" ]; then
 
     # Set up the per-user profile.

--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -13,6 +13,17 @@ let
       '';
     };
 
+    install-both-profile-links = {
+      script = ''
+        tar -xf ./nix.tar.xz
+        mv ./nix-* nix
+        ln -s $HOME/.local/state/nix/profiles/a-profile $HOME/.nix-profile
+        mkdir -p $HOME/.local/state/nix
+        ln -s $HOME/.local/state/nix/profiles/b-profile $HOME/.local/state/nix/profile
+        ./nix/install --no-channel-add
+      '';
+    };
+
     install-force-no-daemon = {
       script = ''
         tar -xf ./nix.tar.xz


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
In #7925, using "new nix link exists" instead of "old nix link doesn't exist" mistakenly made it impossible to trigger the "oh no, both links exist" logic. This restores that.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
What I gathered from the discussion in March, pushing harder to use the new link is not a priority. But the logic is here, so I want to let it work.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
