### PR TITLE
fix: nix copy ssh-ng:// not respecting --substitute-on-destination

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -225,7 +225,7 @@ StorePathSet RemoteStore::queryValidPaths(const StorePathSet & paths, Substitute
         conn->to << WorkerProto::Op::QueryValidPaths;
         WorkerProto::write(*this, *conn, paths);
         if (GET_PROTOCOL_MINOR(conn->daemonVersion) >= 27) {
-            conn->to << (settings.buildersUseSubstitutes ? 1 : 0);
+            conn->to << maybeSubstitute;
         }
         conn.processStderr();
         return WorkerProto::Serialise<StorePathSet>::read(*this, *conn);


### PR DESCRIPTION
# Motivation
When using `nix copy` with a `ssh-ng` destination, the flag `substitute-on-destination` is ignored, instead the `builder-use-substitute` setting is used.

Refer to #9591 for related source code and reproduction steps.

# Context
Closes: #9591, #8744

For legacy ssh destination, `--substitute-on-destination` is used and `builder-use-substitute` setting is ignored. It seems reasonable to keep consistency with this strategy since `builder-use-substitute` looks unrelated to `nix copy`.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
