### PR TITLE
Test `nix copy --substitute-on-destination`

### DIFF
--- a/tests/functional/nix-copy-ssh-common.sh
+++ b/tests/functional/nix-copy-ssh-common.sh
@@ -1,0 +1,70 @@
+proto=$1
+shift
+(( $# == 0 ))
+
+clearStore
+clearCache
+
+mkdir -p $TEST_ROOT/stores
+
+# Create path to copy back and forth
+outPath=$(nix-build --no-out-link dependencies.nix)
+
+storeQueryParam="store=${NIX_STORE_DIR}"
+
+realQueryParam () {
+    echo "real=$1$NIX_STORE_DIR"
+}
+
+remoteRoot="$TEST_ROOT/stores/$proto"
+
+clearRemoteStore () {
+    chmod -R u+w "$remoteRoot" || true
+    rm -rf "$remoteRoot"
+}
+
+clearRemoteStore
+
+remoteStore="${proto}://localhost?${storeQueryParam}&remote-store=${remoteRoot}%3f${storeQueryParam}%26$(realQueryParam "$remoteRoot")"
+
+# Copy to store
+
+args=()
+if [[ "$proto" == "ssh-ng" ]]; then
+    # TODO investigate discrepancy
+    args+=(--no-check-sigs)
+fi
+
+[ ! -f ${remoteRoot}${outPath}/foobar ]
+nix copy "${args[@]}" --to "$remoteStore" $outPath
+[ -f ${remoteRoot}${outPath}/foobar ]
+
+# Copy back from store
+
+clearStore
+
+[ ! -f $outPath/foobar ]
+nix copy --no-check-sigs --from "$remoteStore" $outPath
+[ -f $outPath/foobar ]
+
+# Check --substitute-on-destination, avoid corrupted store
+
+clearRemoteStore
+
+corruptedRoot=$TEST_ROOT/stores/corrupted
+corruptedStore="${corruptedRoot}?${storeQueryParam}&$(realQueryParam "$corruptedRoot")"
+
+# Copy it to the corrupted store
+nix copy --no-check-sigs "$outPath" --to "$corruptedStore"
+
+# Corrupt it in there
+corruptPath="${corruptedRoot}${outPath}"
+chmod +w "$corruptPath"
+echo "not supposed to be here" > "$corruptPath/foobarbaz"
+chmod -w "$corruptPath"
+
+# Copy from the corrupted store with the regular store as a
+# substituter. It must use the substituter not the source store in
+# order to avoid errors.
+NIX_CONFIG=$(echo -e "substituters = local\nrequire-sigs = false") \
+    nix copy --no-check-sigs --from "$corruptedStore" --to "$remoteStore" --substitute-on-destination "$outPath"

--- a/tests/functional/nix-copy-ssh-ng.sh
+++ b/tests/functional/nix-copy-ssh-ng.sh
@@ -1,18 +1,14 @@
 source common.sh
 
-clearStore
-clearCache
+source nix-copy-ssh-common.sh "ssh-ng"
 
-remoteRoot=$TEST_ROOT/store2
-chmod -R u+w "$remoteRoot" || true
-rm -rf "$remoteRoot"
+clearStore
+clearRemoteStore
 
 outPath=$(nix-build --no-out-link dependencies.nix)
 
-nix store info --store "ssh-ng://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR"
+nix store info --store "$remoteStore"
 
 # Regression test for https://github.com/NixOS/nix/issues/6253
-nix copy --to "ssh-ng://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR" $outPath --no-check-sigs &
-nix copy --to "ssh-ng://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR" $outPath --no-check-sigs
-
-[ -f $remoteRoot$outPath/foobar ]
+nix copy --to "$remoteStore" $outPath --no-check-sigs &
+nix copy --to "$remoteStore" $outPath --no-check-sigs

--- a/tests/functional/nix-copy-ssh.sh
+++ b/tests/functional/nix-copy-ssh.sh
@@ -1,20 +1,3 @@
 source common.sh
 
-clearStore
-clearCache
-
-remoteRoot=$TEST_ROOT/store2
-chmod -R u+w "$remoteRoot" || true
-rm -rf "$remoteRoot"
-
-outPath=$(nix-build --no-out-link dependencies.nix)
-
-nix copy --to "ssh://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR" $outPath
-
-[ -f $remoteRoot$outPath/foobar ]
-
-clearStore
-
-nix copy --no-check-sigs --from "ssh://localhost?store=$NIX_STORE_DIR&remote-store=$remoteRoot%3fstore=$NIX_STORE_DIR%26real=$remoteRoot$NIX_STORE_DIR" $outPath
-
-[ -f $outPath/foobar ]
+source nix-copy-ssh-common.sh "ssh"


### PR DESCRIPTION
# Motivation

It works with `ssh://` but not `ssh-ng://`.

Also, by making the two tests share code, we nudge ourselves towards making sure there is feature parity.

# Context

Provides the rest needed for https://github.com/NixOS/nix/pull/9600

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
