### PR TITLE
Use `--with-boost` on macOS to fix local builds

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -284,8 +284,9 @@ in {
   ] ++ lib.optionals installUnitTests [
     "--with-check-bin-dir=${builtins.placeholder "check"}/bin"
     "--with-check-lib-dir=${builtins.placeholder "check"}/lib"
-  ] ++ lib.optionals (doBuild && stdenv.isLinux) [
+  ] ++ lib.optionals (doBuild) [
     "--with-boost=${boost}/lib"
+  ] ++ lib.optionals (doBuild && stdenv.isLinux) [
     "--with-sandbox-shell=${busybox-sandbox-shell}/bin/busybox"
   ] ++ lib.optional (doBuild && stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux"))
        "LDFLAGS=-fuse-ld=gold"


### PR DESCRIPTION
`configureFlags` only included `--with-boost` on Linux, which makes local builds as outlined in `doc/manual/src/contributing/hacking.md` fail when performed on macOS.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
