### PR TITLE
Fix clang devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -395,7 +395,7 @@
           stdenvs)));
 
       devShells = let
-        makeShell = pkgs: stdenv: (pkgs.nix.override { inherit stdenv; }).overrideAttrs (_: {
+        makeShell = pkgs: stdenv: (pkgs.nix.override { inherit stdenv; }).overrideAttrs (attrs: {
           installFlags = "sysconfdir=$(out)/etc";
           shellHook = ''
             PATH=$prefix/bin:$PATH
@@ -405,6 +405,9 @@
             # Make bash completion work.
             XDG_DATA_DIRS+=:$out/share
           '';
+          nativeBuildInputs = attrs.nativeBuildInputs or []
+            ++ lib.optional stdenv.cc.isClang pkgs.buildPackages.bear
+            ++ lib.optional (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) pkgs.buildPackages.clang-tools;
         });
         in
         forAllSystems (system:

--- a/package.nix
+++ b/package.nix
@@ -5,6 +5,7 @@
 , autoreconfHook
 , aws-sdk-cpp
 , boehmgc
+, buildPackages
 , nlohmann_json
 , bison
 , boost
@@ -207,6 +208,9 @@ in {
     # changelog
     ++ lib.optional (!officialRelease && buildUnreleasedNotes) changelog-d
     ++ lib.optional enableInternalAPIDocs doxygen
+
+    ++ lib.optional stdenv.cc.isClang buildPackages.bear
+    ++ lib.optional (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) buildPackages.clang-tools
   ;
 
   buildInputs = lib.optionals doBuild [

--- a/package.nix
+++ b/package.nix
@@ -5,7 +5,6 @@
 , autoreconfHook
 , aws-sdk-cpp
 , boehmgc
-, buildPackages
 , nlohmann_json
 , bison
 , boost
@@ -208,9 +207,6 @@ in {
     # changelog
     ++ lib.optional (!officialRelease && buildUnreleasedNotes) changelog-d
     ++ lib.optional enableInternalAPIDocs doxygen
-
-    ++ lib.optional stdenv.cc.isClang buildPackages.bear
-    ++ lib.optional (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) buildPackages.clang-tools
   ;
 
   buildInputs = lib.optionals doBuild [


### PR DESCRIPTION
Issue introduced in https://github.com/NixOS/nix/pull/9535

# Motivation

`native-clang11StdenvPackages` dev shell is missing some tooling. 

Following the steps from  https://nixos.org/manual/nix/stable/contributing/hacking.html#editor-integration : 
```bash
make clean && bear -- make -j$NIX_BUILD_CORES default check install
```
 returns an error


# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
