### PR TITLE
Remove some blank lines from stack traces

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -173,10 +173,9 @@ static bool printUnknownLocations = getEnv("_NIX_EVAL_SHOW_UNKNOWN_LOCATIONS").h
 static bool printPosMaybe(std::ostream & oss, std::string_view indent, const std::shared_ptr<AbstractPos> & pos) {
     bool hasPos = pos && *pos;
     if (hasPos) {
-        oss << "\n" << indent << ANSI_BLUE << "at " ANSI_WARNING << *pos << ANSI_NORMAL << ":";
+        oss << indent << ANSI_BLUE << "at " ANSI_WARNING << *pos << ANSI_NORMAL << ":";
 
         if (auto loc = pos->getCodeLines()) {
-            oss << "\n";
             printCodeLines(oss, "", *pos, *loc);
             oss << "\n";
         }

--- a/tests/functional/lang/eval-fail-abort.err.exp
+++ b/tests/functional/lang/eval-fail-abort.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'abort' builtin
-
          at /pwd/lang/eval-fail-abort.nix:1:14:
-
             1| if true then abort "this should fail" else 1
              |              ^
             2|

--- a/tests/functional/lang/eval-fail-addDrvOutputDependencies-empty-context.err.exp
+++ b/tests/functional/lang/eval-fail-addDrvOutputDependencies-empty-context.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'addDrvOutputDependencies' builtin
-
          at /pwd/lang/eval-fail-addDrvOutputDependencies-empty-context.nix:1:1:
-
             1| builtins.addDrvOutputDependencies ""
              | ^
             2|

--- a/tests/functional/lang/eval-fail-addDrvOutputDependencies-multi-elem-context.err.exp
+++ b/tests/functional/lang/eval-fail-addDrvOutputDependencies-multi-elem-context.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'addDrvOutputDependencies' builtin
-
          at /pwd/lang/eval-fail-addDrvOutputDependencies-multi-elem-context.nix:18:4:
-
            17|
            18| in builtins.addDrvOutputDependencies combo-path
              |    ^

--- a/tests/functional/lang/eval-fail-addDrvOutputDependencies-wrong-element-kind.err.exp
+++ b/tests/functional/lang/eval-fail-addDrvOutputDependencies-wrong-element-kind.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'addDrvOutputDependencies' builtin
-
          at /pwd/lang/eval-fail-addDrvOutputDependencies-wrong-element-kind.nix:9:4:
-
             8|
             9| in builtins.addDrvOutputDependencies drv.outPath
              |    ^

--- a/tests/functional/lang/eval-fail-assert.err.exp
+++ b/tests/functional/lang/eval-fail-assert.err.exp
@@ -1,35 +1,27 @@
 error:
        … while evaluating the attribute 'body'
-
          at /pwd/lang/eval-fail-assert.nix:4:3:
-
             3|
             4|   body = x "x";
              |   ^
             5| }
 
        … from call site
-
          at /pwd/lang/eval-fail-assert.nix:4:10:
-
             3|
             4|   body = x "x";
              |          ^
             5| }
 
        … while calling 'x'
-
          at /pwd/lang/eval-fail-assert.nix:2:7:
-
             1| let {
             2|   x = arg: assert arg == "y"; 123;
              |       ^
             3|
 
        error: assertion '(arg == "y")' failed
-
        at /pwd/lang/eval-fail-assert.nix:2:12:
-
             1| let {
             2|   x = arg: assert arg == "y"; 123;
              |            ^

--- a/tests/functional/lang/eval-fail-attr-name-type.err.exp
+++ b/tests/functional/lang/eval-fail-attr-name-type.err.exp
@@ -1,17 +1,13 @@
 error:
        … while evaluating the attribute 'puppy."${key}"'
-
          at /pwd/lang/eval-fail-attr-name-type.nix:3:5:
-
             2|   attrs = {
             3|     puppy.doggy = {};
              |     ^
             4|   };
 
        … while evaluating an attribute name
-
          at /pwd/lang/eval-fail-attr-name-type.nix:7:17:
-
             6| in
             7|   attrs.puppy.${key}
              |                 ^

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-1.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-1.err.exp
@@ -1,8 +1,6 @@
 error:
        … while evaluating a path segment
-
          at /pwd/lang/eval-fail-bad-string-interpolation-1.nix:1:2:
-
             1| "${x: x}"
              |  ^
             2|

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-3.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-3.err.exp
@@ -1,8 +1,6 @@
 error:
        … while evaluating a path segment
-
          at /pwd/lang/eval-fail-bad-string-interpolation-3.nix:1:3:
-
             1| ''${x: x}''
              |   ^
             2|

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-4.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-4.err.exp
@@ -1,8 +1,6 @@
 error:
        … while evaluating a path segment
-
          at /pwd/lang/eval-fail-bad-string-interpolation-4.nix:9:3:
-
             8| # The error message should not be too long.
             9| ''${pkgs}''
              |   ^

--- a/tests/functional/lang/eval-fail-blackhole.err.exp
+++ b/tests/functional/lang/eval-fail-blackhole.err.exp
@@ -1,17 +1,13 @@
 error:
        … while evaluating the attribute 'body'
-
          at /pwd/lang/eval-fail-blackhole.nix:2:3:
-
             1| let {
             2|   body = x;
              |   ^
             3|   x = y;
 
        error: infinite recursion encountered
-
        at /pwd/lang/eval-fail-blackhole.nix:3:7:
-
             2|   body = x;
             3|   x = y;
              |       ^

--- a/tests/functional/lang/eval-fail-call-primop.err.exp
+++ b/tests/functional/lang/eval-fail-call-primop.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'length' builtin
-
          at /pwd/lang/eval-fail-call-primop.nix:1:1:
-
             1| builtins.length 1
              | ^
             2|

--- a/tests/functional/lang/eval-fail-deepseq.err.exp
+++ b/tests/functional/lang/eval-fail-deepseq.err.exp
@@ -1,24 +1,18 @@
 error:
        … while calling the 'deepSeq' builtin
-
          at /pwd/lang/eval-fail-deepseq.nix:1:1:
-
             1| builtins.deepSeq { x = abort "foo"; } 456
              | ^
             2|
 
        … while evaluating the attribute 'x'
-
          at /pwd/lang/eval-fail-deepseq.nix:1:20:
-
             1| builtins.deepSeq { x = abort "foo"; } 456
              |                    ^
             2|
 
        … while calling the 'abort' builtin
-
          at /pwd/lang/eval-fail-deepseq.nix:1:24:
-
             1| builtins.deepSeq { x = abort "foo"; } 456
              |                        ^
             2|

--- a/tests/functional/lang/eval-fail-dup-dynamic-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-dup-dynamic-attrs.err.exp
@@ -1,17 +1,13 @@
 error:
        … while evaluating the attribute 'set'
-
          at /pwd/lang/eval-fail-dup-dynamic-attrs.nix:2:3:
-
             1| {
             2|   set = { "${"" + "b"}" = 1; };
              |   ^
             3|   set = { "${"b" + ""}" = 2; };
 
        error: dynamic attribute 'b' already defined at /pwd/lang/eval-fail-dup-dynamic-attrs.nix:2:11
-
        at /pwd/lang/eval-fail-dup-dynamic-attrs.nix:3:11:
-
             2|   set = { "${"" + "b"}" = 1; };
             3|   set = { "${"b" + ""}" = 2; };
              |           ^

--- a/tests/functional/lang/eval-fail-foldlStrict-strict-op-application.err.exp
+++ b/tests/functional/lang/eval-fail-foldlStrict-strict-op-application.err.exp
@@ -1,35 +1,27 @@
 error:
        … while calling the 'foldl'' builtin
-
          at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:2:1:
-
             1| # Tests that the result of applying op is forced even if the value is never used
             2| builtins.foldl'
              | ^
             3|   (_: f: f null)
 
        … while calling anonymous lambda
-
          at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:3:7:
-
             2| builtins.foldl'
             3|   (_: f: f null)
              |       ^
             4|   null
 
        … from call site
-
          at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:3:10:
-
             2| builtins.foldl'
             3|   (_: f: f null)
              |          ^
             4|   null
 
        … while calling anonymous lambda
-
          at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:5:6:
-
             4|   null
             5|   [ (_: throw "Not the final value, but is still forced!") (_: 23) ]
              |      ^

--- a/tests/functional/lang/eval-fail-fromTOML-timestamps.err.exp
+++ b/tests/functional/lang/eval-fail-fromTOML-timestamps.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'fromTOML' builtin
-
          at /pwd/lang/eval-fail-fromTOML-timestamps.nix:1:1:
-
             1| builtins.fromTOML ''
              | ^
             2|   key = "value"

--- a/tests/functional/lang/eval-fail-hashfile-missing.err.exp
+++ b/tests/functional/lang/eval-fail-hashfile-missing.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'toString' builtin
-
          at /pwd/lang/eval-fail-hashfile-missing.nix:4:3:
-
             3| in
             4|   toString (builtins.concatLists (map (hash: map (builtins.hashFile hash) paths) ["md5" "sha1" "sha256" "sha512"]))
              |   ^

--- a/tests/functional/lang/eval-fail-list.err.exp
+++ b/tests/functional/lang/eval-fail-list.err.exp
@@ -1,8 +1,6 @@
 error:
        … while evaluating one of the elements to concatenate
-
          at /pwd/lang/eval-fail-list.nix:1:2:
-
             1| 8++1
              |  ^
             2|

--- a/tests/functional/lang/eval-fail-missing-arg.err.exp
+++ b/tests/functional/lang/eval-fail-missing-arg.err.exp
@@ -1,16 +1,12 @@
 error:
        … from call site
-
          at /pwd/lang/eval-fail-missing-arg.nix:1:1:
-
             1| ({x, y, z}: x + y + z) {x = "foo"; z = "bar";}
              | ^
             2|
 
        error: function 'anonymous lambda' called without required argument 'y'
-
        at /pwd/lang/eval-fail-missing-arg.nix:1:2:
-
             1| ({x, y, z}: x + y + z) {x = "foo"; z = "bar";}
              |  ^
             2|

--- a/tests/functional/lang/eval-fail-not-throws.err.exp
+++ b/tests/functional/lang/eval-fail-not-throws.err.exp
@@ -1,16 +1,12 @@
 error:
        … in the argument of the not operator
-
          at /pwd/lang/eval-fail-not-throws.nix:1:4:
-
             1| ! (throw "uh oh!")
              |    ^
             2|
 
        … while calling the 'throw' builtin
-
          at /pwd/lang/eval-fail-not-throws.nix:1:4:
-
             1| ! (throw "uh oh!")
              |    ^
             2|

--- a/tests/functional/lang/eval-fail-path-slash.err.exp
+++ b/tests/functional/lang/eval-fail-path-slash.err.exp
@@ -1,7 +1,5 @@
 error: path has a trailing slash
-
        at /pwd/lang/eval-fail-path-slash.nix:6:12:
-
             5| # and https://nixos.org/nix-dev/2016-June/020829.html
             6| /nix/store/
              |            ^

--- a/tests/functional/lang/eval-fail-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-recursion.err.exp
@@ -1,16 +1,12 @@
 error:
        … in the right operand of the update (//) operator
-
          at /pwd/lang/eval-fail-recursion.nix:1:12:
-
             1| let a = {} // a; in a.foo
              |            ^
             2|
 
        error: infinite recursion encountered
-
        at /pwd/lang/eval-fail-recursion.nix:1:15:
-
             1| let a = {} // a; in a.foo
              |               ^
             2|

--- a/tests/functional/lang/eval-fail-remove.err.exp
+++ b/tests/functional/lang/eval-fail-remove.err.exp
@@ -1,17 +1,13 @@
 error:
        … while evaluating the attribute 'body'
-
          at /pwd/lang/eval-fail-remove.nix:4:3:
-
             3|
             4|   body = (removeAttrs attrs ["x"]).x;
              |   ^
             5| }
 
        error: attribute 'x' missing
-
        at /pwd/lang/eval-fail-remove.nix:4:10:
-
             3|
             4|   body = (removeAttrs attrs ["x"]).x;
              |          ^

--- a/tests/functional/lang/eval-fail-scope-5.err.exp
+++ b/tests/functional/lang/eval-fail-scope-5.err.exp
@@ -1,35 +1,27 @@
 error:
        … while evaluating the attribute 'body'
-
          at /pwd/lang/eval-fail-scope-5.nix:8:3:
-
             7|
             8|   body = f {};
              |   ^
             9|
 
        … from call site
-
          at /pwd/lang/eval-fail-scope-5.nix:8:10:
-
             7|
             8|   body = f {};
              |          ^
             9|
 
        … while calling 'f'
-
          at /pwd/lang/eval-fail-scope-5.nix:6:7:
-
             5|
             6|   f = {x ? y, y ? x}: x + y;
              |       ^
             7|
 
        error: infinite recursion encountered
-
        at /pwd/lang/eval-fail-scope-5.nix:6:12:
-
             5|
             6|   f = {x ? y, y ? x}: x + y;
              |            ^

--- a/tests/functional/lang/eval-fail-seq.err.exp
+++ b/tests/functional/lang/eval-fail-seq.err.exp
@@ -1,16 +1,12 @@
 error:
        … while calling the 'seq' builtin
-
          at /pwd/lang/eval-fail-seq.nix:1:1:
-
             1| builtins.seq (abort "foo") 2
              | ^
             2|
 
        … while calling the 'abort' builtin
-
          at /pwd/lang/eval-fail-seq.nix:1:15:
-
             1| builtins.seq (abort "foo") 2
              |               ^
             2|

--- a/tests/functional/lang/eval-fail-set.err.exp
+++ b/tests/functional/lang/eval-fail-set.err.exp
@@ -1,7 +1,5 @@
 error: undefined variable 'x'
-
        at /pwd/lang/eval-fail-set.nix:1:3:
-
             1| 8.x
              |   ^
             2|

--- a/tests/functional/lang/eval-fail-substring.err.exp
+++ b/tests/functional/lang/eval-fail-substring.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'substring' builtin
-
          at /pwd/lang/eval-fail-substring.nix:1:1:
-
             1| builtins.substring (builtins.sub 0 1) 1 "x"
              | ^
             2|

--- a/tests/functional/lang/eval-fail-to-path.err.exp
+++ b/tests/functional/lang/eval-fail-to-path.err.exp
@@ -1,8 +1,6 @@
 error:
        … while calling the 'toPath' builtin
-
          at /pwd/lang/eval-fail-to-path.nix:1:1:
-
             1| builtins.toPath "foo/bar"
              | ^
             2|

--- a/tests/functional/lang/eval-fail-toJSON.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON.err.exp
@@ -1,25 +1,19 @@
 error:
        … while calling the 'toJSON' builtin
-
          at /pwd/lang/eval-fail-toJSON.nix:1:1:
-
             1| builtins.toJSON {
              | ^
             2|   a.b = [
 
        … while evaluating attribute 'a'
-
          at /pwd/lang/eval-fail-toJSON.nix:2:3:
-
             1| builtins.toJSON {
             2|   a.b = [
              |   ^
             3|     true
 
        … while evaluating attribute 'b'
-
          at /pwd/lang/eval-fail-toJSON.nix:2:3:
-
             1| builtins.toJSON {
             2|   a.b = [
              |   ^
@@ -28,27 +22,21 @@ error:
        … while evaluating list element at index 3
 
        … while evaluating attribute 'c'
-
          at /pwd/lang/eval-fail-toJSON.nix:7:7:
-
             6|     {
             7|       c.d = throw "hah no";
              |       ^
             8|     }
 
        … while evaluating attribute 'd'
-
          at /pwd/lang/eval-fail-toJSON.nix:7:7:
-
             6|     {
             7|       c.d = throw "hah no";
              |       ^
             8|     }
 
        … while calling the 'throw' builtin
-
          at /pwd/lang/eval-fail-toJSON.nix:7:13:
-
             6|     {
             7|       c.d = throw "hah no";
              |             ^

--- a/tests/functional/lang/eval-fail-undeclared-arg.err.exp
+++ b/tests/functional/lang/eval-fail-undeclared-arg.err.exp
@@ -1,16 +1,12 @@
 error:
        … from call site
-
          at /pwd/lang/eval-fail-undeclared-arg.nix:1:1:
-
             1| ({x, z}: x + z) {x = "foo"; y = "bla"; z = "bar";}
              | ^
             2|
 
        error: function 'anonymous lambda' called with unexpected argument 'y'
-
        at /pwd/lang/eval-fail-undeclared-arg.nix:1:2:
-
             1| ({x, z}: x + z) {x = "foo"; y = "bla"; z = "bar";}
              |  ^
             2|

--- a/tests/functional/lang/eval-fail-using-set-as-attr-name.err.exp
+++ b/tests/functional/lang/eval-fail-using-set-as-attr-name.err.exp
@@ -1,8 +1,6 @@
 error:
        … while evaluating an attribute name
-
          at /pwd/lang/eval-fail-using-set-as-attr-name.nix:5:10:
-
             4| in
             5|   attr.${key}
              |          ^

--- a/tests/functional/lang/parse-fail-dup-attrs-1.err.exp
+++ b/tests/functional/lang/parse-fail-dup-attrs-1.err.exp
@@ -1,7 +1,5 @@
 error: attribute 'x' already defined at «stdin»:1:3
-
        at «stdin»:3:3:
-
             2|   y = 456;
             3|   x = 789;
              |   ^

--- a/tests/functional/lang/parse-fail-dup-attrs-2.err.exp
+++ b/tests/functional/lang/parse-fail-dup-attrs-2.err.exp
@@ -1,7 +1,5 @@
 error: attribute 'x' already defined at «stdin»:9:5
-
        at «stdin»:10:17:
-
             9|     x = 789;
            10|     inherit (as) x;
              |                 ^

--- a/tests/functional/lang/parse-fail-dup-attrs-3.err.exp
+++ b/tests/functional/lang/parse-fail-dup-attrs-3.err.exp
@@ -1,7 +1,5 @@
 error: attribute 'x' already defined at «stdin»:9:5
-
        at «stdin»:10:17:
-
             9|     x = 789;
            10|     inherit (as) x;
              |                 ^

--- a/tests/functional/lang/parse-fail-dup-attrs-4.err.exp
+++ b/tests/functional/lang/parse-fail-dup-attrs-4.err.exp
@@ -1,7 +1,5 @@
 error: attribute 'services.ssh.port' already defined at «stdin»:2:3
-
        at «stdin»:3:3:
-
             2|   services.ssh.port = 22;
             3|   services.ssh.port = 23;
              |   ^

--- a/tests/functional/lang/parse-fail-dup-attrs-7.err.exp
+++ b/tests/functional/lang/parse-fail-dup-attrs-7.err.exp
@@ -1,7 +1,5 @@
 error: attribute 'x' already defined at «stdin»:6:12
-
        at «stdin»:7:12:
-
             6|     inherit x;
             7|     inherit x;
              |            ^

--- a/tests/functional/lang/parse-fail-dup-formals.err.exp
+++ b/tests/functional/lang/parse-fail-dup-formals.err.exp
@@ -1,6 +1,4 @@
 error: duplicate formal function argument 'x'
-
        at «stdin»:1:8:
-
             1| {x, y, x}: x
              |        ^

--- a/tests/functional/lang/parse-fail-eof-in-string.err.exp
+++ b/tests/functional/lang/parse-fail-eof-in-string.err.exp
@@ -1,7 +1,5 @@
 error: syntax error, unexpected end of file, expecting '"'
-
        at «stdin»:3:5:
-
             2| # Note that this file must not end with a newline.
             3| a 1"$
              |     ^

--- a/tests/functional/lang/parse-fail-mixed-nested-attrs1.err.exp
+++ b/tests/functional/lang/parse-fail-mixed-nested-attrs1.err.exp
@@ -1,7 +1,5 @@
 error: attribute 'z' already defined at «stdin»:3:16
-
        at «stdin»:2:3:
-
             1| {
             2|   x.z = 3;
              |   ^

--- a/tests/functional/lang/parse-fail-mixed-nested-attrs2.err.exp
+++ b/tests/functional/lang/parse-fail-mixed-nested-attrs2.err.exp
@@ -1,7 +1,5 @@
 error: attribute 'y' already defined at «stdin»:3:9
-
        at «stdin»:2:3:
-
             1| {
             2|   x.y.y = 3;
              |   ^

--- a/tests/functional/lang/parse-fail-patterns-1.err.exp
+++ b/tests/functional/lang/parse-fail-patterns-1.err.exp
@@ -1,7 +1,5 @@
 error: duplicate formal function argument 'args'
-
        at «stdin»:1:1:
-
             1| args@{args, x, y, z}: x
              | ^
             2|

--- a/tests/functional/lang/parse-fail-regression-20060610.err.exp
+++ b/tests/functional/lang/parse-fail-regression-20060610.err.exp
@@ -1,7 +1,5 @@
 error: undefined variable 'gcc'
-
        at «stdin»:8:12:
-
             7|
             8|   body = ({
              |            ^

--- a/tests/functional/lang/parse-fail-undef-var-2.err.exp
+++ b/tests/functional/lang/parse-fail-undef-var-2.err.exp
@@ -1,7 +1,5 @@
 error: syntax error, unexpected ':', expecting '}'
-
        at «stdin»:3:13:
-
             2|
             3|   f = {x, y :
              |             ^

--- a/tests/functional/lang/parse-fail-undef-var.err.exp
+++ b/tests/functional/lang/parse-fail-undef-var.err.exp
@@ -1,7 +1,5 @@
 error: undefined variable 'y'
-
        at «stdin»:1:4:
-
             1| x: y
              |    ^
             2|

--- a/tests/functional/lang/parse-fail-utf8.err.exp
+++ b/tests/functional/lang/parse-fail-utf8.err.exp
@@ -1,6 +1,4 @@
 error: syntax error, unexpected invalid token, expecting end of file
-
        at «stdin»:1:5:
-
             1| 123 �
              |     ^


### PR DESCRIPTION
# Context

This keeps hint messages, source location information, and source code snippets grouped together, while making stack traces shorter (so that more stack frames can be viewed on the same terminal).

Before:

    error:
           … while evaluating the attribute 'body'

             at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:4:3:

                3|
                4|   body = x "x";
                 |   ^
                5| }

           … from call site

             at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:4:10:

                3|
                4|   body = x "x";
                 |          ^
                5| }

           … while calling 'x'

             at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:2:7:

                1| let {
                2|   x = arg: assert arg == "y"; 123;
                 |       ^
                3|

           error: assertion '(arg == "y")' failed

           at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:2:12:

                1| let {
                2|   x = arg: assert arg == "y"; 123;
                 |            ^
                3|

After:

    error:
           … while evaluating the attribute 'body'
             at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:4:3:
                3|
                4|   body = x "x";
                 |   ^
                5| }

           … from call site
             at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:4:10:
                3|
                4|   body = x "x";
                 |          ^
                5| }

           … while calling 'x'
             at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:2:7:
                1| let {
                2|   x = arg: assert arg == "y"; 123;
                 |       ^
                3|

           error: assertion '(arg == "y")' failed
           at /Users/wiggles/nix/tests/functional/lang/eval-fail-assert.nix:2:12:
                1| let {
                2|   x = arg: assert arg == "y"; 123;
                 |            ^
                3|

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
