### PR TITLE
Document `Makefile` variables in `hacking.md`

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -64,6 +64,16 @@ $ nix build
 
 You can also build Nix for one of the [supported platforms](#platforms).
 
+## Makefile variables
+
+- `ENABLE_BUILD=yes` to enable building the C++ code.
+- `ENABLE_TESTS=yes` to enable building the tests.
+- `OPTIMIZE=1` to enable optimizations.
+- `doc_generate=yes` to enable building the documentation (manual, man pages, etc.).
+
+  The docs can take a while to build, so you may want to disable this for local
+  development.
+
 ## Building Nix
 
 To build all dependencies and start a shell in which all environment variables are set up so that those dependencies can be found:

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -71,8 +71,7 @@ You can also build Nix for one of the [supported platforms](#platforms).
 - `OPTIMIZE=1` to enable optimizations.
 - `doc_generate=yes` to enable building the documentation (manual, man pages, etc.).
 
-  The docs can take a while to build, so you may want to disable this for local
-  development.
+  The docs can take a while to build, so you may want to disable this for local development.
 
 ## Building Nix
 


### PR DESCRIPTION
I couldn't find these variables (especially `doc_generate=no`) documented anywhere, and `hacking.md` is where I _expected_ them to be documented. Maybe it's some autoconf thing I'm not familiar with?