### PR TITLE
fix: valid branch name

### DIFF
--- a/src/libutil/url-parts.hh
+++ b/src/libutil/url-parts.hh
@@ -25,7 +25,7 @@ const static std::string pathRegex = "(?:" + segmentRegex + "(?:/" + segmentRege
 
 /// A Git ref (i.e. branch or tag name).
 /// \todo check that this is correct.
-const static std::string refRegexS = "[a-zA-Z0-9@][a-zA-Z0-9_.\\/@-]*";
+const static std::string refRegexS = "[a-zA-Z0-9@][a-zA-Z0-9_.\\/@-+]*";
 extern std::regex refRegex;
 
 /// Instead of defining what a good Git Ref is, we define what a bad Git Ref is

--- a/src/libutil/url-parts.hh
+++ b/src/libutil/url-parts.hh
@@ -25,6 +25,7 @@ const static std::string pathRegex = "(?:" + segmentRegex + "(?:/" + segmentRege
 
 /// A Git ref (i.e. branch or tag name).
 /// \todo check that this is correct.
+/// This regex incomplete. See https://git-scm.com/docs/git-check-ref-format
 const static std::string refRegexS = "[a-zA-Z0-9@][a-zA-Z0-9_.\\/@-+]*";
 extern std::regex refRegex;
 

--- a/src/libutil/url-parts.hh
+++ b/src/libutil/url-parts.hh
@@ -26,7 +26,7 @@ const static std::string pathRegex = "(?:" + segmentRegex + "(?:/" + segmentRege
 /// A Git ref (i.e. branch or tag name).
 /// \todo check that this is correct.
 /// This regex incomplete. See https://git-scm.com/docs/git-check-ref-format
-const static std::string refRegexS = "[a-zA-Z0-9@][a-zA-Z0-9_.\\/@-+]*";
+const static std::string refRegexS = "[a-zA-Z0-9@][a-zA-Z0-9_.\\/@+-]*";
 extern std::regex refRegex;
 
 /// Instead of defining what a good Git Ref is, we define what a bad Git Ref is


### PR DESCRIPTION
closes #6534

`ref` with a `+` still needs to be encoded `%2B` in `flake.nix` so that the query to gitlab becoms `https://gitlab.com/api/v4/projects/some%2Fowner%2Fmyrepo/repository/commits?ref_name=v0.0.1%2Blocal` (`v0.0.1%2Blocal`).

Please feel free to add a suitable commit to fix that, as well. I unfortunately can't muster the research. https://github.com/NixOS/nix/issues/6534#issuecomment-1129809605 promised a quick fix and this got me unblocked.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
