### PR TITLE
Make fetchTree locked input error message clearer

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -167,7 +167,7 @@ static void fetchTree(
         input = lookupInRegistries(state.store, input).first;
 
     if (evalSettings.pureEval && !input.isLocked())
-        if (type == "git")
+        if (params.isFetchGit)
             state.debugThrowLastTrace(EvalError("in pure evaluation mode, 'fetchGit' requires a locked input, at %s", state.positions[pos]));
         else
             state.debugThrowLastTrace(EvalError("in pure evaluation mode, 'fetchTree' requires a locked input, at %s", state.positions[pos]));

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -167,7 +167,10 @@ static void fetchTree(
         input = lookupInRegistries(state.store, input).first;
 
     if (evalSettings.pureEval && !input.isLocked())
-        state.debugThrowLastTrace(EvalError("in pure evaluation mode, 'fetchTree' requires a locked input, at %s", state.positions[pos]));
+        if (type == "git")
+            state.debugThrowLastTrace(EvalError("in pure evaluation mode, 'fetchGit' requires a locked input, at %s", state.positions[pos]));
+        else
+            state.debugThrowLastTrace(EvalError("in pure evaluation mode, 'fetchTree' requires a locked input, at %s", state.positions[pos]));
 
     state.checkURI(input.toURLString());
 


### PR DESCRIPTION
# Motivation

Today I was trying to use Nix and I got the error message

```
       error: in pure evaluation mode, 'fetchTree' requires a locked input, at «none»:0
```

This was completely baffling to me -- what's "pure evaluation mode"? What's `fetchTree`? What's a locked input? It didn't mention any line number in my code, so I couldn't figure out which part of my code it even related to.

Someone on the Discord helped me understand that the problem was in my call to `fetchGit` (I'd forgotten to set `rev = ...`, because the `fetchGit` builtin calls `fetchTree`. 

So here's an idea for how to improve the error message, to mention `fetchGit` so that users can figure out which function the error message is coming from. It's a little messy but seems potentially worth it to help people out.

Hopefully it compiles, I don't have a toolchain set up.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
