### PR TITLE
docs: add link to project board to PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,8 @@
 
 <!-- Large change: Provide instructions to reviewers how to read the diff. -->
 
-# Priorities
+# Priorities and Process
 
 Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
+
+The Nix Team uses [this project board](https://github.com/orgs/NixOS/projects/19) to help track and schedule work. This should provide visibility into the initial discussion, assignments, as well as postponments.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@
 
 Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
 
-The Nix Team uses [this project board](https://github.com/orgs/NixOS/projects/19) to track and schedule reviews.
+The Nix maintainer team uses [this project board](https://github.com/orgs/NixOS/projects/19) to track and schedule reviews.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@
 
 Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
 
-The Nix Team uses [this project board](https://github.com/orgs/NixOS/projects/19) to help track and schedule work. This should provide visibility into the initial discussion, assignments, as well as postponments.
+The Nix Team uses [this project board](https://github.com/orgs/NixOS/projects/19) to track and schedule reviews.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@
 
 Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
 
-The Nix maintainer team uses [this project board](https://github.com/orgs/NixOS/projects/19) to track and schedule reviews.
+The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 


### PR DESCRIPTION
# Motivation
Make the Project Board more visible in order to expose more of the process to contributors.

(expecting a squash)

# Context
Reduce uncertainty about the status of a PR.

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
