### PR TITLE
Fix warnings when running checks

### DIFF
--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -144,7 +144,7 @@ in
           virtualisation.memorySize = 4096;
           nix.settings.substituters = lib.mkForce [ ];
           nix.extraOptions = "experimental-features = nix-command flakes";
-          networking.hosts.${(builtins.head nodes.github.config.networking.interfaces.eth1.ipv4.addresses).address} =
+          networking.hosts.${(builtins.head nodes.github.networking.interfaces.eth1.ipv4.addresses).address} =
             [ "channels.nixos.org" "api.github.com" "github.com" ];
           security.pki.certificateFiles = [ "${cert}/ca.crt" ];
         };

--- a/tests/nixos/nix-copy.nix
+++ b/tests/nixos/nix-copy.nix
@@ -36,7 +36,7 @@ in {
       server =
         { config, pkgs, ... }:
         { services.openssh.enable = true;
-          services.openssh.permitRootLogin = "yes";
+          services.openssh.settings.PermitRootLogin = "yes";
 					users.users.root.password = "foobar";
           virtualisation.writableStore = true;
           virtualisation.additionalPaths = [ pkgB pkgC ];

--- a/tests/nixos/nss-preload.nix
+++ b/tests/nixos/nss-preload.nix
@@ -84,8 +84,8 @@ in
     client = { lib, nodes, pkgs, ... }: {
       networking.useDHCP = false;
       networking.nameservers = [
-        (lib.head nodes.http_dns.config.networking.interfaces.eth1.ipv6.addresses).address
-        (lib.head nodes.http_dns.config.networking.interfaces.eth1.ipv4.addresses).address
+        (lib.head nodes.http_dns.networking.interfaces.eth1.ipv6.addresses).address
+        (lib.head nodes.http_dns.networking.interfaces.eth1.ipv4.addresses).address
       ];
       networking.interfaces.eth1.ipv6.addresses = [
         { address = "fd21::10"; prefixLength = 64; }

--- a/tests/nixos/remote-builds-ssh-ng.nix
+++ b/tests/nixos/remote-builds-ssh-ng.nix
@@ -81,7 +81,7 @@ in
     client.succeed(f"ssh -o StrictHostKeyChecking=no {builder.name} 'echo hello world'")
 
     # Perform a build
-    out = client.succeed("nix-build ${expr nodes.client.config 1} 2> build-output")
+    out = client.succeed("nix-build ${expr nodes.client 1} 2> build-output")
 
     # Verify that the build was done on the builder
     builder.succeed(f"test -e {out.strip()}")

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -90,22 +90,22 @@ in
 
     # Perform a build and check that it was performed on the builder.
     out = client.succeed(
-      "nix-build ${expr nodes.client.config 1} 2> build-output",
+      "nix-build ${expr nodes.client 1} 2> build-output",
       "grep -q Hello build-output"
     )
     builder1.succeed(f"test -e {out}")
 
     # And a parallel build.
-    paths = client.succeed(r'nix-store -r $(nix-instantiate ${expr nodes.client.config 2})\!out $(nix-instantiate ${expr nodes.client.config 3})\!out')
+    paths = client.succeed(r'nix-store -r $(nix-instantiate ${expr nodes.client 2})\!out $(nix-instantiate ${expr nodes.client 3})\!out')
     out1, out2 = paths.split()
     builder1.succeed(f"test -e {out1} -o -e {out2}")
     builder2.succeed(f"test -e {out1} -o -e {out2}")
 
     # And a failing build.
-    client.fail("nix-build ${expr nodes.client.config 5}")
+    client.fail("nix-build ${expr nodes.client 5}")
 
     # Test whether the build hook automatically skips unavailable builders.
     builder1.block()
-    client.succeed("nix-build ${expr nodes.client.config 4}")
+    client.succeed("nix-build ${expr nodes.client 4}")
   '';
 }

--- a/tests/nixos/sourcehut-flakes.nix
+++ b/tests/nixos/sourcehut-flakes.nix
@@ -108,7 +108,7 @@ in
               flake-registry = https://git.sr.ht/~NixOS/flake-registry/blob/master/flake-registry.json
             '';
             environment.systemPackages = [ pkgs.jq ];
-            networking.hosts.${(builtins.head nodes.sourcehut.config.networking.interfaces.eth1.ipv4.addresses).address} =
+            networking.hosts.${(builtins.head nodes.sourcehut.networking.interfaces.eth1.ipv4.addresses).address} =
               [ "git.sr.ht" ];
             security.pki.certificateFiles = [ "${cert}/ca.crt" ];
           };


### PR DESCRIPTION

# Motivation
`nix flake check` had these warnings:

    trace: warning: Module argument `nodes.client.config` is deprecated. Use `nodes.client` instead.
    trace: warning: Module argument `nodes.client.config` is deprecated. Use `nodes.client` instead.
    trace: warning: The option `services.openssh.permitRootLogin' defined in `/nix/store/3m3hfpmbjdf4w39qfjami7ljhvhczay1-source/tests/nixos/nix-copy.nix' has been renamed to `services.openssh.settings.PermitRootLogin'.
    trace: warning: Module argument `nodes.http_dns.config` is deprecated. Use `nodes.http_dns` instead.
    trace: warning: Module argument `nodes.github.config` is deprecated. Use `nodes.github` instead.
    trace: warning: Module argument `nodes.sourcehut.config` is deprecated. Use `nodes.sourcehut` instead.


# Context
I was running `nix flake check` and noticed these warnings, and it was trivial to fix them, so I did!

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
