### PR TITLE
package: don't set sysconfdir in devShells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -395,7 +395,7 @@
           stdenvs)));
 
       devShells = let
-        makeShell = pkgs: stdenv: (pkgs.nix.override { inherit stdenv; }).overrideAttrs (attrs: {
+        makeShell = pkgs: stdenv: (pkgs.nix.override { inherit stdenv; forDevShell = true; }).overrideAttrs (attrs: {
           installFlags = "sysconfdir=$(out)/etc";
           shellHook = ''
             PATH=$prefix/bin:$PATH

--- a/package.nix
+++ b/package.nix
@@ -87,6 +87,9 @@
 , test-daemon ? null
 , test-client ? null
 
+# Avoid setting things that would interfere with a functioning devShell
+, forDevShell ? false
+
 # Not a real argument, just the only way to approximate let-binding some
 # stuff for argument defaults.
 , __forDefaults ? {
@@ -263,13 +266,14 @@ in {
   );
 
   configureFlags = [
-    "--sysconfdir=/etc"
     (lib.enableFeature doBuild "build")
     (lib.enableFeature buildUnitTests "unit-tests")
     (lib.enableFeature doInstallCheck "functional-tests")
     (lib.enableFeature enableInternalAPIDocs "internal-api-docs")
     (lib.enableFeature enableManual "doc-gen")
     (lib.enableFeature installUnitTests "install-unit-tests")
+  ] ++ lib.optionals (!forDevShell) [
+    "--sysconfdir=/etc"
   ] ++ lib.optionals installUnitTests [
     "--with-check-bin-dir=${builtins.placeholder "check"}/bin"
     "--with-check-lib-dir=${builtins.placeholder "check"}/lib"


### PR DESCRIPTION
# Motivation
Without this, `make install` does not work anymore.

# Context
Introduced in https://github.com/NixOS/nix/pull/9535 (see https://github.com/NixOS/nix/pull/9535#issuecomment-1861566307).

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
