### PR TITLE
Fix `logging.sh` test on macOS

### DIFF
--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -15,7 +15,7 @@ nix-build dependencies.nix --no-out-link --compress-build-log
 [ "$(nix-store -l $path)" = FOO ]
 
 # test whether empty logs work fine with `nix log`.
-builder="$(mktemp)"
+builder="$(realpath "$(mktemp)")"
 echo -e "#!/bin/sh\nmkdir \$out" > "$builder"
 outp="$(nix-build -E \
     'with import ./config.nix; mkDerivation { name = "fnord"; builder = '"$builder"'; }' \


### PR DESCRIPTION
On macOS in the `nix develop` shell, `make tests/functional/logging.sh.test` errors:

    ++(logging.sh:18) mktemp
    +(logging.sh:18) builder=/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/tmp.StuabKUhMh
    +(logging.sh:19) echo -e '#!/bin/sh\nmkdir $out'
    +++(logging.sh:22) mktemp -d
    ++(logging.sh:22) nix-build -E 'with import ./config.nix; mkDerivation { name = "fnord"; builder = /var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/tmp.StuabKUhMh; }' --out-link /var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/tmp.oaKcy0NXqC/result
    error:
           … while calling the 'derivationStrict' builtin
             at <nix/derivation-internal.nix>:9:12:
                8|
                9|   strict = derivationStrict drvAttrs;
                 |            ^
               10|

           … while evaluating derivation 'fnord'
             whose name attribute is located at «string»:1:42

           … while evaluating attribute 'args' of derivation 'fnord'
             at /Users/wiggles/nix/tests/functional/config.nix:23:7:
               22|       builder = shell;
               23|       args = ["-e" args.builder or (builtins.toFile "builder-${args.name}.sh" ''
                 |       ^
               24|         if [ -e "$NIX_ATTRS_SH_FILE" ]; then source $NIX_ATTRS_SH_FILE; fi;

           error: path '/var' is a symlink
    +(logging.sh:22) outp=
    ++(logging.sh:22) onError
    ++(/Users/wiggles/nix/tests/functional/common/vars-and-functions.sh:237) set +x
    logging.sh: test failed at:
      main in logging.sh:22

This is because `mktemp` returns a path like `/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/tmp.qDY24l6bIM`, where `/var` is a symlink to `/private/var`.

Then, we attempt to use that path as a `builder`, which errors because symlinks are impure or whatever.

Anyways, we can fix this by using `realpath "$(mktemp)"` instead of `mktemp` directly.

NB: This error doesn't seem to happen when I run the tests through `nix flake check`. I'm not sure if Nix does something to `$TMP` in that case. I did check that `which -a mktemp` is pulling the correct `mktemp` in my `nix develop` shell though.