### PR TITLE
Allow access to /dev/stderr in Darwin sandbox

### DIFF
--- a/src/libstore/build/sandbox-defaults.sb
+++ b/src/libstore/build/sandbox-defaults.sb
@@ -68,6 +68,7 @@ R""(
 (allow file*
        (literal "/dev/null")
        (literal "/dev/random")
+       (literal "/dev/stderr")
        (literal "/dev/stdin")
        (literal "/dev/stdout")
        (literal "/dev/tty")


### PR DESCRIPTION
# Motivation

Impetus is trying to build nixpkgs’ diffoscope on Darwin with sandbox enabled, but it fails due to trying to read from `/dev/stderr` ([src](https://salsa.debian.org/reproducible-builds/diffoscope/-/blob/647b4f6bd79c7637439af153e1775410fc27eb76/tests/comparators/test_utils.py#L118)].

# Context

We allow /dev/stdout, so why not this? Since it is process-local, anyway, should not be possible to escape sandbox using it.

Tested and building (on Darwin with sandbox) nixpkgs’ diffoscopeMinimal fails without this, succeeds with

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
