### PR TITLE
Undeprecate isNull

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -438,9 +438,7 @@ static RegisterPrimOp primop_isNull({
     .doc = R"(
       Return `true` if *e* evaluates to `null`, and `false` otherwise.
 
-      > **Warning**
-      >
-      > This function is *deprecated*; just write `e == null` instead.
+      This is equivalent to `e == null`.
     )",
     .fun = prim_isNull,
 });


### PR DESCRIPTION
There's no good reason to deprecate it:
- For consistency reasons it should continue to exist, such that all primitive types have a corresponding `builtins.is*` primop.
- There's no implementation cost to continuing to have this function
- It costs users time to try to migrate away from it, e.g. https://github.com/NixOS/nixpkgs/pull/219747 and https://github.com/NixOS/nixpkgs/pull/275548
- Using it can give easier-to-read code like `all isNull list`

This closes https://github.com/NixOS/nix/issues/8264

Fyi this deprecation notice has been there [for 17 years now](https://github.com/NixOS/nix/commit/3837fb233cccc8f65629749f07820afba04952a0#diff-8b61e6791a80e8f345a28fbf2b65fe2e640f735867cfcaae70f63ec7277a3525R1512-R1513)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
