### PR TITLE
nix shell: reflect command line order in PATH order

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -715,7 +715,7 @@ BuiltPaths Installable::toBuiltPaths(
     }
 }
 
-StorePathSet Installable::toStorePaths(
+StorePathSet Installable::toStorePathSet(
     ref<Store> evalStore,
     ref<Store> store,
     Realise mode, OperateOn operateOn,
@@ -735,7 +735,7 @@ StorePath Installable::toStorePath(
     Realise mode, OperateOn operateOn,
     ref<Installable> installable)
 {
-    auto paths = toStorePaths(evalStore, store, mode, operateOn, {installable});
+    auto paths = toStorePathSet(evalStore, store, mode, operateOn, {installable});
 
     if (paths.size() != 1)
         throw Error("argument '%s' should evaluate to one store path", installable->what());

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -729,6 +729,20 @@ StorePathSet Installable::toStorePathSet(
     return outPaths;
 }
 
+StorePaths Installable::toStorePaths(
+    ref<Store> evalStore,
+    ref<Store> store,
+    Realise mode, OperateOn operateOn,
+    const Installables & installables)
+{
+    StorePaths outPaths;
+    for (auto & path : toBuiltPaths(evalStore, store, mode, operateOn, installables)) {
+        auto thisOutPaths = path.outPaths();
+        outPaths.insert(outPaths.end(), thisOutPaths.begin(), thisOutPaths.end());
+    }
+    return outPaths;
+}
+
 StorePath Installable::toStorePath(
     ref<Store> evalStore,
     ref<Store> store,

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -165,7 +165,7 @@ struct Installable
         const Installables & installables,
         BuildMode bMode = bmNormal);
 
-    static std::set<StorePath> toStorePaths(
+    static std::set<StorePath> toStorePathSet(
         ref<Store> evalStore,
         ref<Store> store,
         Realise mode,

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -172,6 +172,13 @@ struct Installable
         OperateOn operateOn,
         const Installables & installables);
 
+    static std::vector<StorePath> toStorePaths(
+        ref<Store> evalStore,
+        ref<Store> store,
+        Realise mode,
+        OperateOn operateOn,
+        const Installables & installables);
+
     static StorePath toStorePath(
         ref<Store> evalStore,
         ref<Store> store,

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -376,7 +376,7 @@ struct Common : InstallableCommand, MixProfile
         for (auto & [installable_, dir_] : redirects) {
             auto dir = absPath(dir_);
             auto installable = parseInstallable(store, installable_);
-            auto builtPaths = Installable::toStorePaths(
+            auto builtPaths = Installable::toStorePathSet(
                 getEvalStore(), store, Realise::Nothing, OperateOn::Output, {installable});
             for (auto & path: builtPaths) {
                 auto from = store->printStorePath(path);
@@ -631,7 +631,7 @@ struct CmdDevelop : Common, MixEnvironment
 
             bool found = false;
 
-            for (auto & path : Installable::toStorePaths(getEvalStore(), store, Realise::Outputs, OperateOn::Output, {bashInstallable})) {
+            for (auto & path : Installable::toStorePathSet(getEvalStore(), store, Realise::Outputs, OperateOn::Output, {bashInstallable})) {
                 auto s = store->printStorePath(path) + "/bin/bash";
                 if (pathExists(s)) {
                     shell = s;

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -114,7 +114,7 @@ struct CmdShell : InstallablesCommand, MixEnvironment
 
         setEnviron();
 
-        auto unixPath = tokenizeString<Strings>(getEnv("PATH").value_or(""), ":");
+        std::vector<std::string> pathAdditions;
 
         while (!todo.empty()) {
             auto path = todo.front();
@@ -122,7 +122,7 @@ struct CmdShell : InstallablesCommand, MixEnvironment
             if (!done.insert(path).second) continue;
 
             if (true)
-                unixPath.push_front(store->printStorePath(path) + "/bin");
+                pathAdditions.push_back(store->printStorePath(path) + "/bin");
 
             auto propPath = CanonPath(store->printStorePath(path)) + "nix-support" + "propagated-user-env-packages";
             if (auto st = accessor->maybeLstat(propPath); st && st->type == SourceAccessor::tRegular) {
@@ -131,7 +131,10 @@ struct CmdShell : InstallablesCommand, MixEnvironment
             }
         }
 
-        setenv("PATH", concatStringsSep(":", unixPath).c_str(), 1);
+        auto unixPath = tokenizeString<Strings>(getEnv("PATH").value_or(""), ":");
+        unixPath.insert(unixPath.begin(), pathAdditions.begin(), pathAdditions.end());
+        auto unixPathString = concatStringsSep(":", unixPath);
+        setenv("PATH", unixPathString.c_str(), 1);
 
         Strings args;
         for (auto & arg : command) args.push_back(arg);

--- a/tests/functional/shell-hello.nix
+++ b/tests/functional/shell-hello.nix
@@ -23,4 +23,20 @@ with import ./config.nix;
         chmod +x $dev/bin/hello2
       '';
   };
+
+  salve-mundi = mkDerivation {
+    name = "salve-mundi";
+    outputs = [ "out" ];
+    meta.outputsToInstall = [ "out" ];
+    buildCommand =
+      ''
+        mkdir -p $out/bin
+
+        cat > $out/bin/hello <<EOF
+        #! ${shell}
+        echo "Salve Mundi from $out/bin/hello"
+        EOF
+        chmod +x $out/bin/hello
+      '';
+  };
 }

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -10,6 +10,14 @@ nix shell -f shell-hello.nix hello -c hello NixOS | grep 'Hello NixOS'
 nix shell -f shell-hello.nix hello^dev -c hello2 | grep 'Hello2'
 nix shell -f shell-hello.nix 'hello^*' -c hello2 | grep 'Hello2'
 
+
+if isDaemonNewer "2.20.0pre20231220"; then
+    # Test that command line attribute ordering is reflected in the PATH
+    # https://github.com/NixOS/nix/issues/7905
+    nix shell -f shell-hello.nix hello salve-mundi -c hello | grep 'Hello World'
+    nix shell -f shell-hello.nix salve-mundi hello -c hello | grep 'Salve Mundi'
+fi
+
 requireSandboxSupport
 
 chmod -R u+w $TEST_ROOT/store0 || true


### PR DESCRIPTION
# Motivation
I wanted to help with the CLI stabilization project, and this was a relatively easy problem to pick from the project board.

# Context
Fixes https://github.com/NixOS/nix/issues/7905.

The first commit is a test that will fail without the second commit (to demonstrate the problem and ensure we don't regress).

The second switches `CmdShell` to use an `Installable::toStorePaths` alternative that returns an unsorted collection.

I'm under no illusions that my `outPaths2` and `toStorePaths2` functions will be accepted as-is. However, a solution just like them will be necessary: `std::set` is sorted (according to https://en.cppreference.com/w/cpp/container/set), which is what causes this problem in the first place and means that anything that returns a `std::set` needs to be replaced with an unordered alternative. I went with `StorePaths` (`std::vector<StorePath>`) because it already existed.

I'm open to any suggestions on how to improve this.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
