### PR TITLE
reduce the size of Env by one pointer

### DIFF
--- a/doc/manual/rl-next/env-size-reduction.md
+++ b/doc/manual/rl-next/env-size-reduction.md
@@ -1,0 +1,7 @@
+---
+synopsis: Reduce eval memory usage and wall time
+prs: 9658
+---
+
+Reduce the size of the `Env` struct used in the evaluator by a pointer, or 8 bytes on most modern machines.
+This reduces memory usage during eval by around 2% and wall time by around 3%.

--- a/doc/manual/rl-next/with-error-reporting.md
+++ b/doc/manual/rl-next/with-error-reporting.md
@@ -1,0 +1,31 @@
+---
+synopsis: Better error reporting for `with` expressions
+prs: 9658
+---
+
+`with` expressions using non-attrset values to resolve variables are now reported with proper positions.
+
+Previously an incorrect `with` expression would report no position at all, making it hard to determine where the error originated:
+
+```
+nix-repl> with 1; a  
+error:
+       … <borked>
+
+         at «none»:0: (source not available)
+
+       error: value is an integer while a set was expected
+```
+
+Now position information is preserved and reported as with most other errors:
+
+```
+nix-repl> with 1; a
+error:
+       … while evaluating the first subexpression of a with expression
+         at «string»:1:1:
+            1| with 1; a
+             | ^
+
+       error: value is an integer while a set was expected
+```

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -112,7 +112,7 @@ NixRepl::NixRepl(const SearchPath & searchPath, nix::ref<Store> store, ref<EvalS
     : AbstractNixRepl(state)
     , debugTraceIndex(0)
     , getValues(getValues)
-    , staticEnv(new StaticEnv(false, state->staticBaseEnv.get()))
+    , staticEnv(new StaticEnv(nullptr, state->staticBaseEnv.get()))
     , historyFile(getDataDir() + "/nix/repl-history")
 {
 }

--- a/src/libexpr/eval-inline.hh
+++ b/src/libexpr/eval-inline.hh
@@ -73,8 +73,6 @@ Env & EvalState::allocEnv(size_t size)
 #endif
         env = (Env *) allocBytes(sizeof(Env) + size * sizeof(Value *));
 
-    env->type = Env::Plain;
-
     /* We assume that env->values has been cleared by the allocator; maybeThunk() and lookupVar fromWith expect this. */
 
     return *env;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -116,11 +116,6 @@ struct Constant
 struct Env
 {
     Env * up;
-    /**
-     * Number of of levels up to next `with` environment
-     */
-    unsigned short prevWith:14;
-    enum { Plain = 0, HasWithExpr, HasWithAttrs } type:2;
     Value * values[0];
 };
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -214,7 +214,7 @@ static void import(EvalState & state, const PosIdx pos, Value & vPath, Value * v
             Env * env = &state.allocEnv(vScope->attrs->size());
             env->up = &state.baseEnv;
 
-            auto staticEnv = std::make_shared<StaticEnv>(false, state.staticBaseEnv.get(), vScope->attrs->size());
+            auto staticEnv = std::make_shared<StaticEnv>(nullptr, state.staticBaseEnv.get(), vScope->attrs->size());
 
             unsigned int displ = 0;
             for (auto & attr : *vScope->attrs) {


### PR DESCRIPTION
# Motivation

`Env` is too big. this is expensive. 

# Context

we can shave a pointer-sized slot without impeding functionality by relocating `with` linking information to a place that's more representative of how often `with` is actually used, without even introducing too much overhead when it *is* used a lot.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
