### PR TITLE
Build IFD in the build store when using eval-store.

### DIFF
--- a/doc/manual/rl-next/ifd-eval-store.md
+++ b/doc/manual/rl-next/ifd-eval-store.md
@@ -1,0 +1,8 @@
+---
+synopsis: import-from-derivation builds the derivation in the build store
+prs: 9661
+---
+
+When using `--eval-store`, `import`ing from a derivation will now result in the derivation being built on the build store, i.e. the store specified in the `store` Nix option.
+
+Because the resulting Nix expression must be copied back to the eval store in order to be imported, this requires the eval store to trust the build store's signatures.

--- a/tests/functional/eval-store.sh
+++ b/tests/functional/eval-store.sh
@@ -40,3 +40,11 @@ if [[ ! -n "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
     (! ls $NIX_STORE_DIR/*.drv)
 fi
 ls $eval_store/nix/store/*.drv
+
+clearStore
+rm -rf "$eval_store"
+
+# Confirm that import-from-derivation builds on the build store
+[[ $(nix eval --eval-store "$eval_store?require-sigs=false" --impure --raw --file ./ifd.nix) = hi ]]
+ls $NIX_STORE_DIR/*dependencies-top/foobar
+(! ls $eval_store/nix/store/*dependencies-top/foobar)

--- a/tests/functional/ifd.nix
+++ b/tests/functional/ifd.nix
@@ -1,0 +1,10 @@
+with import ./config.nix;
+import (
+  mkDerivation {
+    name = "foo";
+    bla = import ./dependencies.nix {};
+    buildCommand = "
+      echo \\\"hi\\\" > $out
+    ";
+  }
+)

--- a/tests/functional/remote-store.sh
+++ b/tests/functional/remote-store.sh
@@ -19,18 +19,7 @@ else
 fi
 
 # Test import-from-derivation through the daemon.
-[[ $(nix eval --impure --raw --expr '
-  with import ./config.nix;
-  import (
-    mkDerivation {
-      name = "foo";
-      bla = import ./dependencies.nix {};
-      buildCommand = "
-        echo \\\"hi\\\" > $out
-      ";
-    }
-  )
-') = hi ]]
+[[ $(nix eval --impure --raw --file ./ifd.nix) = hi ]]
 
 storeCleared=1 NIX_REMOTE_=$NIX_REMOTE $SHELL ./user-envs.sh
 


### PR DESCRIPTION
Previously, IFDs would be built within the eval store, even though one
is typically using `--eval-store` precisely to *avoid* local builds.

Because the resulting Nix expression must be copied back to the eval
store in order to be imported, this requires the eval store to trust
the build store's signatures.