### PR TITLE
Improve error message for fixed-outputs with references.

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -194,7 +194,10 @@ StorePath StoreDirConfig::makeFixedOutputPath(std::string_view name, const Fixed
     if (info.hash.algo == HashAlgorithm::SHA256 && info.method == FileIngestionMethod::Recursive) {
         return makeStorePath(makeType(*this, "source", info.references), info.hash, name);
     } else {
-        assert(info.references.size() == 0);
+        if (!info.references.empty()) {
+            throw Error("fixed output derivation '%s' is not allowed to refer to other store paths.\nYou may need to use the 'unsafeDiscardReferences' derivation attribute, see the manual for more details.",
+                name);
+        }
         return makeStorePath("output:out",
             hashString(HashAlgorithm::SHA256,
                 "fixed:out:"

--- a/tests/functional/fixed.nix
+++ b/tests/functional/fixed.nix
@@ -48,6 +48,15 @@ rec {
     (f ./fixed.builder1.sh "flat" "md5" "ddd8be4b179a529afa5f2ffae4b9858")
   ];
 
+  badReferences = mkDerivation rec {
+    name = "bad-hash";
+    builder = script;
+    script = builtins.toFile "installer.sh" "echo $script >$out";
+    outputHash = "1ixr6yd3297ciyp9im522dfxpqbkhcw0pylkb2aab915278fqaik";
+    outputHashAlgo = "sha256";
+    outputHashMode = "flat";
+  };
+
   # Test for building two derivations in parallel that produce the
   # same output path because they're fixed-output derivations.
   parallelSame = [

--- a/tests/functional/fixed.sh
+++ b/tests/functional/fixed.sh
@@ -26,6 +26,9 @@ nix-build fixed.nix -A good2 --no-out-link
 echo 'testing reallyBad...'
 nix-instantiate fixed.nix -A reallyBad && fail "should fail"
 
+echo 'testing fixed with references...'
+expectStderr 1 nix-build fixed.nix -A badReferences | grepQuiet "not allowed to refer to other store paths"
+
 # While we're at it, check attribute selection a bit more.
 echo 'testing attribute selection...'
 test $(nix-instantiate fixed.nix -A good.1 | wc -l) = 1

--- a/tests/functional/fixed.sh
+++ b/tests/functional/fixed.sh
@@ -26,8 +26,10 @@ nix-build fixed.nix -A good2 --no-out-link
 echo 'testing reallyBad...'
 nix-instantiate fixed.nix -A reallyBad && fail "should fail"
 
-echo 'testing fixed with references...'
-expectStderr 1 nix-build fixed.nix -A badReferences | grepQuiet "not allowed to refer to other store paths"
+if isDaemonNewer "2.20pre20240108"; then
+    echo 'testing fixed with references...'
+    expectStderr 1 nix-build fixed.nix -A badReferences | grepQuiet "not allowed to refer to other store paths"
+fi
 
 # While we're at it, check attribute selection a bit more.
 echo 'testing attribute selection...'


### PR DESCRIPTION
This codepath is possible, e.g. with a dockerTools.pullImage of an image with a Nix store.