### PR TITLE
saner default for log-lines: change to 25

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -144,7 +144,7 @@ public:
      */
     bool verboseBuild = true;
 
-    Setting<size_t> logLines{this, 10, "log-lines",
+    Setting<size_t> logLines{this, 25, "log-lines",
         "The number of lines of the tail of "
         "the log to show if a build fails."};
 


### PR DESCRIPTION
This seems to be a much saner default. 10 lines are just not enough in so many cases.
