### PR TITLE
optimize derivation parsing

### DIFF
--- a/doc/manual/rl-next/drv-string-parse-hang.md
+++ b/doc/manual/rl-next/drv-string-parse-hang.md
@@ -1,0 +1,6 @@
+---
+synopsis: Fix handling of truncated `.drv` files.
+prs: 9673
+---
+
+Previously a `.drv` that was truncated in the middle of a string would case nix to enter an infinite loop, eventually exhausting all memory and crashing.

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -174,6 +174,17 @@ struct StringViewStream {
         return c;
     }
 };
+
+constexpr struct Escapes {
+    char map[256];
+    constexpr Escapes() {
+        for (int i = 0; i < 256; i++) map[i] = (char) (unsigned char) i;
+        map[(int) (unsigned char) 'n'] = '\n';
+        map[(int) (unsigned char) 'r'] = '\r';
+        map[(int) (unsigned char) 't'] = '\t';
+    }
+    char operator[](char c) const { return map[(unsigned char) c]; }
+} escapes;
 }
 
 
@@ -213,10 +224,7 @@ static BackedStringView parseString(StringViewStream & str)
     for (c = content.begin(), end = content.end(); c != end; c++)
         if (*c == '\\') {
             c++;
-            if (*c == 'n') res += '\n';
-            else if (*c == 'r') res += '\r';
-            else if (*c == 't') res += '\t';
-            else res += *c;
+            res += escapes[*c];
         }
         else res += *c;
     return res;

--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -140,7 +140,7 @@ static void parseContents(ParseSink & sink, Source & source, const Path & path)
     sink.preallocateContents(size);
 
     uint64_t left = size;
-    std::vector<char> buf(65536);
+    std::array<char, 65536> buf;
 
     while (left) {
         checkInterrupt();

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -307,7 +307,7 @@ void writeFile(const Path & path, Source & source, mode_t mode, bool sync)
     if (!fd)
         throw SysError("opening file '%1%'", path);
 
-    std::vector<char> buf(64 * 1024);
+    std::array<char, 64 * 1024> buf;
 
     try {
         while (true) {

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -82,7 +82,7 @@ void Source::operator () (std::string_view data)
 void Source::drainInto(Sink & sink)
 {
     std::string s;
-    std::vector<char> buf(8192);
+    std::array<char, 8192> buf;
     while (true) {
         size_t n;
         try {


### PR DESCRIPTION
# Motivation

there's a lot of performance to be had in raw derivation handling. depending on the workload and compile options we see anywhere from 5 to 10% improvement for drv-creation-heavy workloads.

# Context

all benchmarks here are done on an empty store for each run, thus recreating all derivations from scratch each time. tests have been compiled with lto because nixpkgs does the same.

if the drvs already exist we don't see nearly as much benefit, if any at all.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
