### PR TITLE
Signer infrastructure: Prep for #9076

### DIFF
--- a/perl/lib/Nix/Store.xs
+++ b/perl/lib/Nix/Store.xs
@@ -12,7 +12,6 @@
 #include "realisation.hh"
 #include "globals.hh"
 #include "store-api.hh"
-#include "crypto.hh"
 #include "posix-source-accessor.hh"
 
 #include <sodium.h>

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -28,7 +28,8 @@ BinaryCacheStore::BinaryCacheStore(const Params & params)
     , Store(params)
 {
     if (secretKeyFile != "")
-        secretKey = std::unique_ptr<SecretKey>(new SecretKey(readFile(secretKeyFile)));
+        signer = std::make_unique<LocalSigner>(
+            SecretKey { readFile(secretKeyFile) });
 
     StringSink sink;
     sink << narVersionMagic1;
@@ -274,7 +275,7 @@ ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
     stats.narWriteCompressionTimeMs += duration;
 
     /* Atomically write the NAR info file.*/
-    if (secretKey) narInfo->sign(*this, *secretKey);
+    if (signer) narInfo->sign(*this, *signer);
 
     writeNarInfo(narInfo);
 

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -1,7 +1,7 @@
 #pragma once
 ///@file
 
-#include "crypto.hh"
+#include "signature/local-keys.hh"
 #include "store-api.hh"
 #include "log-store.hh"
 
@@ -57,8 +57,7 @@ class BinaryCacheStore : public virtual BinaryCacheStoreConfig,
 {
 
 private:
-
-    std::unique_ptr<SecretKey> secretKey;
+    std::unique_ptr<Signer> signer;
 
 protected:
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -15,8 +15,6 @@
 
 #include <nlohmann/json.hpp>
 
-#include <sodium/core.h>
-
 #ifdef __GLIBC__
 # include <gnu/lib-names.h>
 # include <nss.h>
@@ -408,9 +406,6 @@ void assertLibStoreInitialized() {
 void initLibStore() {
 
     initLibUtil();
-
-    if (sodium_init() == -1)
-        throw Error("could not initialise libsodium");
 
     loadConfFile();
 

--- a/src/libstore/keys.cc
+++ b/src/libstore/keys.cc
@@ -1,0 +1,31 @@
+#include "file-system.hh"
+#include "globals.hh"
+#include "keys.hh"
+
+namespace nix {
+
+PublicKeys getDefaultPublicKeys()
+{
+    PublicKeys publicKeys;
+
+    // FIXME: filter duplicates
+
+    for (auto s : settings.trustedPublicKeys.get()) {
+        PublicKey key(s);
+        publicKeys.emplace(key.name, key);
+    }
+
+    for (auto secretKeyFile : settings.secretKeyFiles.get()) {
+        try {
+            SecretKey secretKey(readFile(secretKeyFile));
+            publicKeys.emplace(secretKey.name, secretKey.toPublicKey());
+        } catch (SysError & e) {
+            /* Ignore unreadable key files. That's normal in a
+               multi-user installation. */
+        }
+    }
+
+    return publicKeys;
+}
+
+}

--- a/src/libstore/keys.hh
+++ b/src/libstore/keys.hh
@@ -1,0 +1,10 @@
+#pragma once
+///@file
+
+#include "signature/local-keys.hh"
+
+namespace nix {
+
+PublicKeys getDefaultPublicKeys();
+
+}

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -14,6 +14,7 @@
 #include "signals.hh"
 #include "posix-fs-canonicalise.hh"
 #include "posix-source-accessor.hh"
+#include "keys.hh"
 
 #include <iostream>
 #include <algorithm>
@@ -1578,7 +1579,8 @@ void LocalStore::signRealisation(Realisation & realisation)
 
     for (auto & secretKeyFile : secretKeyFiles.get()) {
         SecretKey secretKey(readFile(secretKeyFile));
-        realisation.sign(secretKey);
+        LocalSigner signer(std::move(secretKey));
+        realisation.sign(signer);
     }
 }
 
@@ -1590,7 +1592,8 @@ void LocalStore::signPathInfo(ValidPathInfo & info)
 
     for (auto & secretKeyFile : secretKeyFiles.get()) {
         SecretKey secretKey(readFile(secretKeyFile));
-        info.sign(*this, secretKey);
+        LocalSigner signer(std::move(secretKey));
+        info.sign(*this, signer);
     }
 }
 

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -8,7 +8,7 @@ libstore_SOURCES := $(wildcard $(d)/*.cc $(d)/builtins/*.cc $(d)/build/*.cc)
 
 libstore_LIBS = libutil
 
-libstore_LDFLAGS += $(SQLITE3_LIBS) $(LIBCURL_LIBS) $(SODIUM_LIBS) -pthread
+libstore_LDFLAGS += $(SQLITE3_LIBS) $(LIBCURL_LIBS) -pthread
 ifdef HOST_LINUX
  libstore_LDFLAGS += -ldl
 endif

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -38,9 +38,9 @@ std::string ValidPathInfo::fingerprint(const Store & store) const
 }
 
 
-void ValidPathInfo::sign(const Store & store, const SecretKey & secretKey)
+void ValidPathInfo::sign(const Store & store, const Signer & signer)
 {
-    sigs.insert(secretKey.signDetached(fingerprint(store)));
+    sigs.insert(signer.signDetached(fingerprint(store)));
 }
 
 std::optional<ContentAddressWithReferences> ValidPathInfo::contentAddressWithReferences() const

--- a/src/libstore/path-info.hh
+++ b/src/libstore/path-info.hh
@@ -1,7 +1,7 @@
 #pragma once
 ///@file
 
-#include "crypto.hh"
+#include "signature/signer.hh"
 #include "path.hh"
 #include "hash.hh"
 #include "content-address.hh"
@@ -107,7 +107,7 @@ struct ValidPathInfo : UnkeyedValidPathInfo {
      */
     std::string fingerprint(const Store & store) const;
 
-    void sign(const Store & store, const SecretKey & secretKey);
+    void sign(const Store & store, const Signer & signer);
 
     /**
      * @return The `ContentAddressWithReferences` that determines the

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -1,7 +1,5 @@
 #include "store-dir-config.hh"
 
-#include <sodium.h>
-
 namespace nix {
 
 static void checkName(std::string_view path, std::string_view name)
@@ -49,9 +47,7 @@ StorePath StorePath::dummy("ffffffffffffffffffffffffffffffff-x");
 
 StorePath StorePath::random(std::string_view name)
 {
-    Hash hash(HashAlgorithm::SHA1);
-    randombytes_buf(hash.hash, hash.hashSize);
-    return StorePath(hash, name);
+    return StorePath(Hash::random(HashAlgorithm::SHA1), name);
 }
 
 StorePath StoreDirConfig::parseStorePath(std::string_view path) const

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -1,6 +1,7 @@
 #include "realisation.hh"
 #include "store-api.hh"
 #include "closure.hh"
+#include "signature/local-keys.hh"
 #include <nlohmann/json.hpp>
 
 namespace nix {
@@ -113,9 +114,9 @@ std::string Realisation::fingerprint() const
     return serialized.dump();
 }
 
-void Realisation::sign(const SecretKey & secretKey)
+void Realisation::sign(const Signer &signer)
 {
-    signatures.insert(secretKey.signDetached(fingerprint()));
+    signatures.insert(signer.signDetached(fingerprint()));
 }
 
 bool Realisation::checkSignature(const PublicKeys & publicKeys, const std::string & sig) const

--- a/src/libstore/realisation.hh
+++ b/src/libstore/realisation.hh
@@ -8,7 +8,7 @@
 #include "derived-path.hh"
 #include <nlohmann/json_fwd.hpp>
 #include "comparator.hh"
-#include "crypto.hh"
+#include "signature/signer.hh"
 
 namespace nix {
 
@@ -64,7 +64,7 @@ struct Realisation {
     static Realisation fromJSON(const nlohmann::json& json, const std::string& whence);
 
     std::string fingerprint() const;
-    void sign(const SecretKey &);
+    void sign(const Signer &);
     bool checkSignature(const PublicKeys & publicKeys, const std::string & sig) const;
     size_t checkSignatures(const PublicKeys & publicKeys) const;
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1,4 +1,4 @@
-#include "crypto.hh"
+#include "signature/local-keys.hh"
 #include "source-accessor.hh"
 #include "globals.hh"
 #include "derived-path.hh"

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -14,6 +14,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include <sodium.h>
+
 namespace nix {
 
 static size_t regularHashSize(HashAlgorithm type) {
@@ -259,6 +261,13 @@ Hash::Hash(std::string_view rest, HashAlgorithm algo, bool isSRI)
 
     else
         throw BadHash("hash '%s' has wrong length for hash algorithm '%s'", rest, printHashAlgo(this->algo));
+}
+
+Hash Hash::random(HashAlgorithm algo)
+{
+    Hash hash(algo);
+    randombytes_buf(hash.hash, hash.hashSize);
+    return hash;
 }
 
 Hash newHashAllowEmpty(std::string_view hashStr, std::optional<HashAlgorithm> ha)

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -5,7 +5,6 @@
 #include "serialise.hh"
 #include "file-system.hh"
 
-
 namespace nix {
 
 
@@ -143,6 +142,11 @@ public:
     }
 
     static Hash dummy;
+
+    /**
+     * @return a random hash with hash algorithm `algo`
+     */
+    static Hash random(HashAlgorithm algo);
 };
 
 /**

--- a/src/libutil/local.mk
+++ b/src/libutil/local.mk
@@ -4,14 +4,17 @@ libutil_NAME = libnixutil
 
 libutil_DIR := $(d)
 
-libutil_SOURCES := $(wildcard $(d)/*.cc)
+libutil_SOURCES := $(wildcard $(d)/*.cc $(d)/signature/*.cc)
 
 libutil_CXXFLAGS += -I src/libutil
 
-libutil_LDFLAGS += -pthread $(OPENSSL_LIBS) $(LIBBROTLI_LIBS) $(LIBARCHIVE_LIBS) $(BOOST_LDFLAGS) -lboost_context
+libutil_LDFLAGS += -pthread $(LIBCURL_LIBS) $(SODIUM_LIBS) $(OPENSSL_LIBS) $(LIBBROTLI_LIBS) $(LIBARCHIVE_LIBS) $(BOOST_LDFLAGS) -lboost_context
 
 $(foreach i, $(wildcard $(d)/args/*.hh), \
   $(eval $(call install-file-in, $(i), $(includedir)/nix/args, 0644)))
+$(foreach i, $(wildcard $(d)/signature/*.hh), \
+  $(eval $(call install-file-in, $(i), $(includedir)/nix/signature, 0644)))
+
 
 ifeq ($(HAVE_LIBCPUID), 1)
 	libutil_LDFLAGS += -lcpuid

--- a/src/libutil/signature/local-keys.hh
+++ b/src/libutil/signature/local-keys.hh
@@ -7,6 +7,25 @@
 
 namespace nix {
 
+/**
+ * Except where otherwise noted, Nix serializes keys and signatures in
+ * the form:
+ *
+ * ```
+ * <name>:<key/signature-in-Base64>
+ * ```
+ */
+struct BorrowedCryptoValue {
+    std::string_view name;
+    std::string_view payload;
+
+    /**
+     * This splits on the colon, the user can then separated decode the
+     * Base64 payload separately.
+     */
+    static BorrowedCryptoValue parse(std::string_view);
+};
+
 struct Key
 {
     std::string name;
@@ -49,21 +68,36 @@ struct PublicKey : Key
 {
     PublicKey(std::string_view data);
 
+    /**
+     * @return true iff `sig` and this key's names match, and `sig` is a
+     * correct signature over `data` using the given public key.
+     */
+    bool verifyDetached(std::string_view data, std::string_view sigs) const;
+
+    /**
+     * @return true iff `sig` is a correct signature over `data` using the
+     * given public key.
+     *
+     * @param just the Base64 signature itself, not a colon-separated pair of a
+     * public key name and signature.
+     */
+    bool verifyDetachedAnon(std::string_view data, std::string_view sigs) const;
+
 private:
     PublicKey(std::string_view name, std::string && key)
         : Key(name, std::move(key)) { }
     friend struct SecretKey;
 };
 
+/**
+ * Map from key names to public keys
+ */
 typedef std::map<std::string, PublicKey> PublicKeys;
 
 /**
  * @return true iff ‘sig’ is a correct signature over ‘data’ using one
  * of the given public keys.
  */
-bool verifyDetached(const std::string & data, const std::string & sig,
-    const PublicKeys & publicKeys);
-
-PublicKeys getDefaultPublicKeys();
+bool verifyDetached(std::string_view data, std::string_view sig, const PublicKeys & publicKeys);
 
 }

--- a/src/libutil/signature/signer.cc
+++ b/src/libutil/signature/signer.cc
@@ -1,0 +1,23 @@
+#include "signature/signer.hh"
+#include "error.hh"
+
+#include <sodium.h>
+
+namespace nix {
+
+LocalSigner::LocalSigner(SecretKey && privateKey)
+    : privateKey(privateKey)
+    , publicKey(privateKey.toPublicKey())
+{ }
+
+std::string LocalSigner::signDetached(std::string_view s) const
+{
+    return privateKey.signDetached(s);
+}
+
+const PublicKey & LocalSigner::getPublicKey()
+{
+    return publicKey;
+}
+
+}

--- a/src/libutil/signature/signer.hh
+++ b/src/libutil/signature/signer.hh
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "types.hh"
+#include "signature/local-keys.hh"
+
+#include <map>
+#include <optional>
+
+namespace nix {
+
+/**
+ * An abstract signer
+ *
+ * Derive from this class to implement a custom signature scheme.
+ *
+ * It is only necessary to implement signature of bytes and provide a
+ * public key.
+ */
+struct Signer
+{
+    virtual ~Signer() = default;
+
+    /**
+     * Sign the given data, creating a (detached) signature.
+     *
+     * @param data data to be signed.
+     *
+     * @return the [detached
+     * signature](https://en.wikipedia.org/wiki/Detached_signature),
+     * i.e. just the signature itself without a copy of the signed data.
+     */
+    virtual std::string signDetached(std::string_view data) const = 0;
+
+    /**
+     * View the public key associated with this `Signer`.
+     */
+    virtual const PublicKey & getPublicKey() = 0;
+};
+
+using Signers = std::map<std::string, Signer*>;
+
+/**
+ * Local signer
+ *
+ * The private key is held in this machine's RAM
+ */
+struct LocalSigner : Signer
+{
+    LocalSigner(SecretKey && privateKey);
+
+    std::string signDetached(std::string_view s) const override;
+
+    const PublicKey & getPublicKey() override;
+
+private:
+
+    SecretKey privateKey;
+    PublicKey publicKey;
+};
+
+}

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -7,6 +7,7 @@
 #include <grp.h>
 #include <regex>
 
+#include <sodium.h>
 
 namespace nix {
 
@@ -28,6 +29,9 @@ void initLibUtil() {
     }
     // This is not actually the main point of this check, but let's make sure anyway:
     assert(caught);
+
+    if (sodium_init() == -1)
+        throw Error("could not initialise libsodium");
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -112,7 +112,7 @@ struct CmdSign : StorePathsCommand
 
     std::string description() override
     {
-        return "sign store paths";
+        return "sign store paths with a local key";
     }
 
     void run(ref<Store> store, StorePaths && storePaths) override
@@ -121,6 +121,7 @@ struct CmdSign : StorePathsCommand
             throw UsageError("you must specify a secret key file using '-k'");
 
         SecretKey secretKey(readFile(secretKeyFile));
+        LocalSigner signer(std::move(secretKey));
 
         size_t added{0};
 
@@ -129,7 +130,7 @@ struct CmdSign : StorePathsCommand
 
             auto info2(*info);
             info2.sigs.clear();
-            info2.sign(*store, secretKey);
+            info2.sign(*store, signer);
             assert(!info2.sigs.empty());
 
             if (!info->sigs.count(*info2.sigs.begin())) {

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -5,6 +5,7 @@
 #include "thread-pool.hh"
 #include "references.hh"
 #include "signals.hh"
+#include "keys.hh"
 
 #include <atomic>
 


### PR DESCRIPTION
# Motivation

This sets up infrastructure in libutil to allow for signing other than by a secret key in memory. 

# Context

#9076 uses this to implement remote signing.

(Split from that PR to allow reviewing in smaller chunks.)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
