### PR TITLE
Make lowdown optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -374,7 +374,21 @@ PKG_CHECK_MODULES([NLOHMANN_JSON], [nlohmann_json >= 3.9])
 
 
 # Look for lowdown library.
-PKG_CHECK_MODULES([LOWDOWN], [lowdown >= 0.9.0], [CXXFLAGS="$LOWDOWN_CFLAGS $CXXFLAGS"])
+AC_ARG_ENABLE([markdown], AS_HELP_STRING([--enable-markdown], [Enable Markdown rendering in the Nix binary (requires lowdown) [default=auto]]),
+  enable_markdown=$enableval, enable_markdown=auto)
+AS_CASE(["$enable_markdown"],
+  [yes | auto], [
+    PKG_CHECK_MODULES([LOWDOWN], [lowdown >= 0.9.0], [
+      CXXFLAGS="$LOWDOWN_CFLAGS $CXXFLAGS"
+      have_lowdown=1
+      AC_DEFINE(HAVE_LOWDOWN, 1, [Whether lowdown is available and should be used for Markdown rendering.])
+    ], [
+      AS_IF([test "x$enable_markdown" == "xyes"], [AC_MSG_ERROR([--enable-markdown was specified, but lowdown was not found.])])
+    ])
+  ],
+  [no], [have_lowdown=],
+  [AC_MSG_ERROR([--enable-markdown must be one of: yes, no, auto])])
+AC_SUBST(HAVE_LOWDOWN, [$have_lowdown])
 
 
 # Look for libgit2.

--- a/package.nix
+++ b/package.nix
@@ -68,6 +68,9 @@
 # Whether to build the regular manual
 , enableManual ? __forDefaults.canRunInstalled
 
+# Whether to enable Markdown rendering in the Nix binary.
+, enableMarkdown ? !stdenv.hostPlatform.isWindows
+
 # Whether to compile `rl-next.md`, the release notes for the next
 # not-yet-released version of Nix in the manul, from the individual
 # change log entries in the directory.
@@ -213,6 +216,7 @@ in {
     xz
   ] ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
     editline
+  ] ++ lib.optionals enableMarkdown [
     lowdown
   ] ++ lib.optionals buildUnitTests [
     gtest
@@ -269,6 +273,7 @@ in {
     (lib.enableFeature doInstallCheck "functional-tests")
     (lib.enableFeature enableInternalAPIDocs "internal-api-docs")
     (lib.enableFeature enableManual "doc-gen")
+    (lib.enableFeature enableMarkdown "markdown")
     (lib.enableFeature installUnitTests "install-unit-tests")
   ] ++ lib.optionals (!forDevShell) [
     "--sysconfdir=/etc"

--- a/src/libcmd/markdown.cc
+++ b/src/libcmd/markdown.cc
@@ -4,12 +4,15 @@
 #include "terminal.hh"
 
 #include <sys/queue.h>
+#if HAVE_LOWDOWN
 #include <lowdown.h>
+#endif
 
 namespace nix {
 
 std::string renderMarkdownToTerminal(std::string_view markdown)
 {
+#if HAVE_LOWDOWN
     int windowWidth = getWindowSize().second;
 
     struct lowdown_opts opts {
@@ -48,6 +51,9 @@ std::string renderMarkdownToTerminal(std::string_view markdown)
         throw Error("allocation error while rendering Markdown");
 
     return filterANSIEscapes(std::string(buf->data, buf->size), !shouldANSI());
+#else
+    return std::string(markdown);
+#endif
 }
 
 }


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This PR makes the lowdown library optional. Specifically, when `--disable-markdown` is passed, `renderMarkdownToTerminal` becomes trivial, i.e. Markdown is not rendered:

```bash
$ nix help

> **Warning** \
> This program is
> [**experimental**](@docroot@/contributing/experimental-features.md#xp-feature-nix-command)
> and its interface is subject to change.

# Name

`nix` - a tool for reproducible and declarative configuration management
...
```

# Context
<!-- Provide context. Reference open issues if available. -->

lowdown currently has no MinGW support (kristapsdz/lowdown#130). While this PR is inspired by the commit with the same name in #4953, the latter hasn't been updated for two years. I think it's good to have a PR with an atomic commit to drive the changes forward, one by one.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
