### PR TITLE
allow arbitrary numbers of / in path tails

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -113,9 +113,10 @@ ID          [a-zA-Z\_][a-zA-Z0-9\_\'\-]*
 INT         [0-9]+
 FLOAT       (([1-9][0-9]*\.[0-9]*)|(0?\.[0-9]+))([Ee][+-]?[0-9]+)?
 PATH_CHAR   [a-zA-Z0-9\.\_\-\+]
-PATH        {PATH_CHAR}*(\/{PATH_CHAR}+)+\/?
-PATH_SEG    {PATH_CHAR}*\/
-HPATH       \~(\/{PATH_CHAR}+)+\/?
+PATH        {PATH_CHAR}*(\/{PATH_CHAR}+)(\/{PATH_CHAR}*)*
+PATH_SEG    {PATH_CHAR}*\/+
+PATH_START  {PATH_CHAR}*\/
+HPATH       \~(\/{PATH_CHAR}+)(\/{PATH_CHAR}*)*
 HPATH_START \~\/
 SPATH       \<{PATH_CHAR}+(\/{PATH_CHAR}+)*\>
 URI         [a-zA-Z][a-zA-Z0-9\+\-\.]*\:[a-zA-Z0-9\%\/\?\:\@\&\=\+\$\,\-\_\.\!\~\*\']+
@@ -224,7 +225,7 @@ or          { return OR_KW; }
                    return IND_STR;
                  }
 
-{PATH_SEG}\$\{ |
+{PATH_START}\$\{ |
 {HPATH_START}\$\{ {
   PUSH_STATE(PATH_START);
   yyless(0);

--- a/tests/functional/lang/eval-okay-path-string-interpolation.exp
+++ b/tests/functional/lang/eval-okay-path-string-interpolation.exp
@@ -1,1 +1,1 @@
-{ absolute = /foo; expr = /pwd/lang/foo/bar; home = /fake-home/foo; notfirst = /pwd/lang/bar/foo; simple = /pwd/lang/foo; slashes = /foo/bar; surrounded = /pwd/lang/a-foo-b; }
+{ absolute = /foo; expr = /pwd/lang/foo/bar; home = /fake-home/foo; more-slashes = [ /pwd/lang/a/foo/foo /pwd/lang/a/foo/foo ]; notfirst = /pwd/lang/bar/foo; simple = /pwd/lang/foo; slashes = /foo/bar; surrounded = /pwd/lang/a-foo-b; }

--- a/tests/functional/lang/eval-okay-path-string-interpolation.nix
+++ b/tests/functional/lang/eval-okay-path-string-interpolation.nix
@@ -9,4 +9,5 @@ in
   home = ~/${foo};
   notfirst = ./bar/${foo};
   slashes = /${foo}/${"bar"};
+  more-slashes = [ ./a//${foo}///${foo} ./a///${foo}///${foo} ];
 }

--- a/tests/functional/lang/eval-okay-path-string-slashes.exp
+++ b/tests/functional/lang/eval-okay-path-string-slashes.exp
@@ -1,0 +1,1 @@
+{ absolute-slashes = /a/b/c; home-slashes = /fake-home/a//b///c; relative-slashes = /pwd/lang/a/b/c; }

--- a/tests/functional/lang/eval-okay-path-string-slashes.nix
+++ b/tests/functional/lang/eval-okay-path-string-slashes.nix
@@ -1,0 +1,5 @@
+{
+  relative-slashes = ./a//b///c;
+  absolute-slashes = /a//b///c;
+  home-slashes = ~/a//b///c;
+}


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

./a/${b} is valid. ./a//${b} is valid. ./a///${b} is invalid. but ./a/${b}///c is valid. this is kind of inconsistent, and considering that we can do path canonicalization outside of the scanner we may as well drop the requirement that slash-runs before the first interpolations be at most 2 long (except for the initial slash of a path which still needs to be restricted, otherwise we'll create ambiguities with the update operator).

this should only accept inputs that were invalid previously. the old behavior of preserving the number of slashes in the final concatenation expression is kept. we do not canonicalize ~ paths because this would break the current ability to create paths that'll traverse out of ~.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
