### PR TITLE
Try to fix boost configuring

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -304,7 +304,8 @@ in {
     "--with-check-bin-dir=${builtins.placeholder "check"}/bin"
     "--with-check-lib-dir=${builtins.placeholder "check"}/lib"
   ] ++ lib.optionals (doBuild) [
-    "--with-boost=${boost}/lib"
+    "--with-boost=${boost.dev}"
+    "--with-boost-libdir=${boost}/lib"
   ] ++ lib.optionals (doBuild && stdenv.isLinux) [
     "--with-sandbox-shell=${busybox-sandbox-shell}/bin/busybox"
   ] ++ lib.optional (doBuild && stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux"))


### PR DESCRIPTION
# Motivation

This code dates back to ec9c1286ad5caf2e77907dc2548085f02cce5237, but in https://hydra.nixos.org/build/245937181/nixlog/1 it seemed to stop working. The `--with-boost-libdir` doesn't show up in the logs sadly, but should be taking an effect.

# Context

ec9c1286ad5caf2e77907dc2548085f02cce5237 / https://github.com/NixOS/nix/pull/5421

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
