### PR TITLE
Print the value in `error: cannot coerce` messages

### DIFF
--- a/doc/manual/rl-next/print-value-in-coercion-error.md
+++ b/doc/manual/rl-next/print-value-in-coercion-error.md
@@ -1,0 +1,24 @@
+---
+synopsis: Coercion errors include the failing value
+issues: #561
+prs: #9754
+---
+
+The `error: cannot coerce a <TYPE> to a string` message now includes the value
+which caused the error.
+
+Before:
+
+```
+       error: cannot coerce a set to a string
+```
+
+After:
+
+```
+       error: cannot coerce a set to a string: { aesSupport = «thunk»;
+       avx2Support = «thunk»; avx512Support = «thunk»; avxSupport = «thunk»;
+       canExecute = «thunk»; config = «thunk»; darwinArch = «thunk»; darwinMinVersion
+       = «thunk»; darwinMinVersionVariable = «thunk»; darwinPlatform = «thunk»; «84
+       attributes elided»}
+```

--- a/doc/manual/src/language/string-interpolation.md
+++ b/doc/manual/src/language/string-interpolation.md
@@ -189,7 +189,7 @@ If neither is present, an error is thrown.
 > "${a}"
 > ```
 >
->     error: cannot coerce a set to a string
+>     error: cannot coerce a set to a string: { }
 >
 >            at «string»:4:2:
 >

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2255,7 +2255,9 @@ BackedStringView EvalState::coerceToString(
             return std::move(*maybeString);
         auto i = v.attrs->find(sOutPath);
         if (i == v.attrs->end()) {
-            error("cannot coerce %1% to a string", showType(v))
+            error("cannot coerce %1% to a string: %2%",
+                  showType(v),
+                  ValuePrinter(*this, v, errorPrintOptions))
                 .withTrace(pos, errorCtx)
                 .debugThrow<TypeError>();
         }
@@ -2301,7 +2303,9 @@ BackedStringView EvalState::coerceToString(
         }
     }
 
-    error("cannot coerce %1% to a string", showType(v))
+    error("cannot coerce %1% to a string: %2%",
+          showType(v),
+          ValuePrinter(*this, v, errorPrintOptions))
         .withTrace(pos, errorCtx)
         .debugThrow<TypeError>();
 }
@@ -2661,7 +2665,7 @@ void EvalState::printStatistics()
 std::string ExternalValueBase::coerceToString(const Pos & pos, NixStringContext & context, bool copyMore, bool copyToStore) const
 {
     throw TypeError({
-        .msg = hintfmt("cannot coerce %1% to a string", showType())
+        .msg = hintfmt("cannot coerce %1% to a string: %2%", showType(), *this)
     });
 }
 

--- a/src/libexpr/print-options.hh
+++ b/src/libexpr/print-options.hh
@@ -36,11 +36,17 @@ struct PrintOptions
      */
     size_t maxDepth = std::numeric_limits<size_t>::max();
     /**
-     * Maximum number of attributes in an attribute set to print.
+     * Maximum number of attributes in attribute sets to print.
+     *
+     * Note that this is a limit for the entire print invocation, not for each
+     * attribute set encountered.
      */
     size_t maxAttrs = std::numeric_limits<size_t>::max();
     /**
      * Maximum number of list items to print.
+     *
+     * Note that this is a limit for the entire print invocation, not for each
+     * list encountered.
      */
     size_t maxListItems = std::numeric_limits<size_t>::max();
     /**

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -20,7 +20,7 @@ void printElided(
 {
     if (ansiColors)
         output << ANSI_FAINT;
-    output << " «";
+    output << "«";
     pluralize(output, value, single, plural);
     output << " elided»";
     if (ansiColors)
@@ -37,7 +37,7 @@ printLiteralString(std::ostream & str, const std::string_view string, size_t max
     str << "\"";
     for (auto i = string.begin(); i != string.end(); ++i) {
         if (charsPrinted >= maxLength) {
-            str << "\"";
+            str << "\" ";
             printElided(str, string.length() - charsPrinted, "byte", "bytes", ansiColors);
             return str;
         }
@@ -161,6 +161,8 @@ private:
     EvalState & state;
     PrintOptions options;
     std::optional<ValuesSeen> seen;
+    size_t attrsPrinted = 0;
+    size_t listItemsPrinted = 0;
 
     void printRepeated()
     {
@@ -279,7 +281,6 @@ private:
             else
                 std::sort(sorted.begin(), sorted.end(), ImportantFirstAttrNameCmp());
 
-            size_t attrsPrinted = 0;
             for (auto & i : sorted) {
                 if (attrsPrinted >= options.maxAttrs) {
                     printElided(sorted.size() - attrsPrinted, "attribute", "attributes");
@@ -307,7 +308,6 @@ private:
 
         output << "[ ";
         if (depth < options.maxDepth) {
-            size_t listItemsPrinted = 0;
             for (auto elem : v.listItems()) {
                 if (listItemsPrinted >= options.maxListItems) {
                     printElided(v.listSize() - listItemsPrinted, "item", "items");
@@ -486,6 +486,9 @@ public:
 
     void print(Value & v)
     {
+        attrsPrinted = 0;
+        listItemsPrinted = 0;
+
         if (options.trackRepeated) {
             seen.emplace();
         } else {

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-1.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-1.err.exp
@@ -5,4 +5,4 @@ error:
              |  ^
             2|
 
-       error: cannot coerce a function to a string
+       error: cannot coerce a function to a string: «lambda @ /pwd/lang/eval-fail-bad-string-interpolation-1.nix:1:4»

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-3.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-3.err.exp
@@ -5,4 +5,4 @@ error:
              |   ^
             2|
 
-       error: cannot coerce a function to a string
+       error: cannot coerce a function to a string: «lambda @ /pwd/lang/eval-fail-bad-string-interpolation-3.nix:1:5»

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-4.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-4.err.exp
@@ -6,4 +6,4 @@ error:
              |   ^
            10|
 
-       error: cannot coerce a set to a string
+       error: cannot coerce a set to a string: { a = { a = { a = { a = "ha"; b = "ha"; c = "ha"; d = "ha"; e = "ha"; f = "ha"; g = "ha"; h = "ha"; j = "ha"; }; «4294967295 attributes elided»}; «4294967294 attributes elided»}; «4294967293 attributes elided»}

--- a/tests/unit/libexpr/error_traces.cc
+++ b/tests/unit/libexpr/error_traces.cc
@@ -295,7 +295,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, toPath) {
         ASSERT_TRACE2("toPath []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while evaluating the first argument passed to builtins.toPath"));
 
         ASSERT_TRACE2("toPath \"foo\"",
@@ -309,7 +309,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, storePath) {
         ASSERT_TRACE2("storePath true",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a Boolean"),
+                      hintfmt("cannot coerce %s to a string: %s", "a Boolean", ANSI_CYAN "true" ANSI_NORMAL),
                       hintfmt("while evaluating the first argument passed to 'builtins.storePath'"));
 
     }
@@ -318,7 +318,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, pathExists) {
         ASSERT_TRACE2("pathExists []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while realising the context of a path"));
 
         ASSERT_TRACE2("pathExists \"zorglub\"",
@@ -332,7 +332,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, baseNameOf) {
         ASSERT_TRACE2("baseNameOf []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while evaluating the first argument passed to builtins.baseNameOf"));
 
     }
@@ -377,7 +377,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, filterSource) {
         ASSERT_TRACE2("filterSource [] []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a list"),
+                      hintfmt("cannot coerce %s to a string: %s", "a list", "[ ]"),
                       hintfmt("while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'"));
 
         ASSERT_TRACE2("filterSource [] \"foo\"",
@@ -1038,7 +1038,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, toString) {
         ASSERT_TRACE2("toString { a = 1; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ a = " ANSI_CYAN "1" ANSI_NORMAL "; }"),
                       hintfmt("while evaluating the first argument passed to builtins.toString"));
 
     }
@@ -1057,7 +1057,7 @@ namespace nix {
 
         ASSERT_TRACE2("substring 0 3 {}",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the third argument (the string) passed to builtins.substring"));
 
         ASSERT_TRACE1("substring (-3) 3 \"sometext\"",
@@ -1070,7 +1070,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, stringLength) {
         ASSERT_TRACE2("stringLength {} # TODO: context is missing ???",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the argument passed to builtins.stringLength"));
 
     }
@@ -1143,7 +1143,7 @@ namespace nix {
 
         ASSERT_TRACE2("concatStringsSep \"foo\" [ 1 2 {} ] # TODO: coerce to string is buggy",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "an integer"),
+                      hintfmt("cannot coerce %s to a string: %s", "an integer", ANSI_CYAN "1" ANSI_NORMAL),
                       hintfmt("while evaluating one element of the list of strings to concat passed to builtins.concatStringsSep"));
 
     }
@@ -1229,12 +1229,12 @@ namespace nix {
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the attribute 'system' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"drv\"; }",
@@ -1279,17 +1279,17 @@ namespace nix {
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; args = [ {} ]; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating an element of the argument list"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; args = [ \"a\" {} ]; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating an element of the argument list"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; FOO = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string", "a set"),
+                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
                       hintfmt("while evaluating the attribute 'FOO' of derivation 'foo'"));
 
     }

--- a/tests/unit/libexpr/value/print.cc
+++ b/tests/unit/libexpr/value/print.cc
@@ -370,7 +370,7 @@ TEST_F(ValuePrintingTests, ansiColorsStringElided)
     v.mkString("puppy");
 
     test(v,
-         ANSI_MAGENTA "\"pup\"" ANSI_FAINT " «2 bytes elided»" ANSI_NORMAL,
+         ANSI_MAGENTA "\"pup\" " ANSI_FAINT "«2 bytes elided»" ANSI_NORMAL,
          PrintOptions {
              .ansiColors = true,
              .maxStringLength = 3
@@ -756,7 +756,7 @@ TEST_F(ValuePrintingTests, ansiColorsAttrsElided)
     vAttrs.mkAttrs(builder.finish());
 
     test(vAttrs,
-         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT " «1 attribute elided»" ANSI_NORMAL "}",
+         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT "«1 attribute elided»" ANSI_NORMAL "}",
          PrintOptions {
              .ansiColors = true,
              .maxAttrs = 1
@@ -769,7 +769,7 @@ TEST_F(ValuePrintingTests, ansiColorsAttrsElided)
     vAttrs.mkAttrs(builder.finish());
 
     test(vAttrs,
-         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT " «2 attributes elided»" ANSI_NORMAL "}",
+         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT "«2 attributes elided»" ANSI_NORMAL "}",
          PrintOptions {
              .ansiColors = true,
              .maxAttrs = 1
@@ -793,7 +793,7 @@ TEST_F(ValuePrintingTests, ansiColorsListElided)
     vList.bigList.size = 2;
 
     test(vList,
-         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT " «1 item elided»" ANSI_NORMAL "]",
+         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT "«1 item elided»" ANSI_NORMAL "]",
          PrintOptions {
              .ansiColors = true,
              .maxListItems = 1
@@ -806,7 +806,7 @@ TEST_F(ValuePrintingTests, ansiColorsListElided)
     vList.bigList.size = 3;
 
     test(vList,
-         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT " «2 items elided»" ANSI_NORMAL "]",
+         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT "«2 items elided»" ANSI_NORMAL "]",
          PrintOptions {
              .ansiColors = true,
              .maxListItems = 1


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
This extends the `error: cannot coerce a <TYPE> to a string` message to print the value that could not be coerced. This helps with debugging by making it easier to track down where the value is being produced from, especially in errors with deep or unhelpful stack traces.

# Context
Take two of #9553 now that https://github.com/NixOS/nix/pull/9606 is merged.
See #561.

Here's an example of a mistake I made that would have been much easier to fix with this patch. I encountered this error while converting a NixOS configuration that relied on `builtins.currentSystem` to work in a flake. There were several overlays which pinned packages to specific versions, like this:

```nix
let
  nixos_master = import (
    builtins.fetchGit {
      url = "https://github.com/NixOS/nixpkgs.git";
      ref = "master";
      rev = "0c0d57d79de06b36286b8c7551dc173e372b86ad";
    }
  ) {};
in
self: super: {
  opentelemetry-collector-contrib = nixos_master.opentelemetry-collector-contrib; # version 0.78.0
}
```

My first try added an `inherit (config.nixpkgs) localSystem;` to the `import` arguments, but that gave me an unhelpful error:

```
$ nix repl nixpkgs
nix-repl> nixpkgs = legacyPackages.x86_64-linux.path
nix-repl> system = lib.systems.elaborate "x86_64-linux"
nix-repl> import nixpkgs { inherit system; }
error:
       … while evaluating a branch condition

         at /nix/store/7g8wbm1z6948x0qma4hzkkb9a3xys76w-source/pkgs/stdenv/booter.nix:64:9:

           63|       go = pred: n:
           64|         if n == len
             |         ^
           65|         then rnul pred

       … while calling the 'length' builtin

         at /nix/store/7g8wbm1z6948x0qma4hzkkb9a3xys76w-source/pkgs/stdenv/booter.nix:62:13:

           61|     let
           62|       len = builtins.length list;
             |             ^
           63|       go = pred: n:

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: cannot coerce a set to a string
```

Note that the stack trace and error message don't make it clear _which_ set couldn't be coerced to a string, or where the coercion failed. It's fairly easy to figure out what's gone wrong here, but in a repository with 14kloc it was significantly more difficult.

With this patch, the error message makes it clear what's happened (a system attrset has been used in place of a system string):

```
error: cannot coerce a set to a string: { aesSupport = «thunk»; avx2Support = «thunk»; avx512Support = «thunk»; avxSupport = «thunk»; canExecute = «thunk»; config = «thunk»; darwinArch = «thunk»; darwinMinVersion = «thunk»; darwinMinVersionVariable = «thunk»; darwinPlatform = «thunk»; «94 attributes elided»}
```

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
