### PR TITLE
`absPath`: just take a `std::string_view`

### DIFF
--- a/src/libutil/canon-path.cc
+++ b/src/libutil/canon-path.cc
@@ -6,11 +6,11 @@ namespace nix {
 CanonPath CanonPath::root = CanonPath("/");
 
 CanonPath::CanonPath(std::string_view raw)
-    : path(absPath((Path) raw, "/"))
+    : path(absPath(raw, "/"))
 { }
 
 CanonPath::CanonPath(std::string_view raw, const CanonPath & root)
-    : path(absPath((Path) raw, root.abs()))
+    : path(absPath(raw, root.abs()))
 { }
 
 CanonPath::CanonPath(const std::vector<std::string> & elems)
@@ -22,7 +22,7 @@ CanonPath::CanonPath(const std::vector<std::string> & elems)
 
 CanonPath CanonPath::fromCwd(std::string_view path)
 {
-    return CanonPath(unchecked_t(), absPath((Path) path));
+    return CanonPath(unchecked_t(), absPath(path));
 }
 
 std::optional<CanonPath> CanonPath::parent() const

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -41,7 +41,7 @@ struct Source;
  * specified directory, or the current directory otherwise.  The path
  * is also canonicalised.
  */
-Path absPath(Path path,
+Path absPath(PathView path,
     std::optional<PathView> dir = {},
     bool resolveSymlinks = false);
 


### PR DESCRIPTION
# Motivation

1. Slightly more efficient

2. Easier to call

# Context

(Noticed this while cleaning up path things for Windows.)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
