### PR TITLE
Avoid unnecessary copy of goal log

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -449,7 +449,7 @@ void Worker::waitForInput()
                 } else {
                     printMsg(lvlVomit, "%1%: read %2% bytes",
                         goal->getName(), rd);
-                    std::string data((char *) buffer.data(), rd);
+                    std::string_view data((char *) buffer.data(), rd);
                     j->lastOutput = after;
                     goal->handleChildOutput(k, data);
                 }


### PR DESCRIPTION
# Motivation
The data was (accidentally?) copied into a std::string, even though the string is immediately converted into a std::string_view. The code has been changed to construct a std::string_view directly, such that one copy less happens.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
