### PR TITLE
`tests/functional/nix-profile.sh`: Add missing `--no-link`

### DIFF
--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -199,6 +199,6 @@ clearProfiles
 mkdir -p $TEST_ROOT/import-profile
 outPath=$(nix build --no-link --print-out-paths $flake1Dir/flake.nix^out)
 printf '{ "version": 2, "elements": [ { "active": true, "attrPath": "legacyPackages.x86_64-linux.hello", "originalUrl": "flake:nixpkgs", "outputs": null, "priority": 5, "storePaths": [ "%s" ], "url": "github:NixOS/nixpkgs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } ] }' "$outPath" > $TEST_ROOT/import-profile/manifest.json
-nix build --profile $TEST_HOME/.nix-profile $(nix store add-path $TEST_ROOT/import-profile)
+nix build --profile $TEST_HOME/.nix-profile $(nix store add-path $TEST_ROOT/import-profile) --no-link
 nix profile list | grep -A4 'Name:.*hello' | grep "Store paths:.*$outPath"
 nix profile remove hello 2>&1 | grep 'removed 1 packages, kept 0 packages'


### PR DESCRIPTION
# Motivation

Otherwise we get a stray `tests/functional/result`, which can cause spurious failures later.

# Context

(I got a failure because the test temp dir effecting the store dir changed. This caused a test later because Nix didn't want to remove the old `result` because it wasn't pointing inside the new Nix store.)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
