### PR TITLE
[2.3] Add flake for testing purposes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705133751,
+        "narHash": "sha256-rCIsyE80jgiOU78gCWN3A0wE0tR2GI5nH6MlS+HaaSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  # A very basic flake to conveniently `nix run nix/2.3` for testing.
+  # Note that this release has no built-in support for flakes,
+  # and this flake declaration is provided on a best-effort basis.
+  outputs = { self, nixpkgs, ... }:
+    let
+      inherit (nixpkgs) lib;
+      inherit (lib) flip genAttrs mapAttrs substring;
+      rev = self.sourceInfo.rev or self.sourceInfo.dirtyRev or "";
+      revCount = self.sourceInfo.revCount or 0;
+      shortRev = self.sourceInfo.shortRev or (substring 0 7 rev);
+      release = import ./release.nix {
+        nix = {
+          outPath = ./.;
+          inherit rev revCount shortRev;
+        };
+        nixpkgs = nixpkgs.outPath;
+        officialRelease = false;
+      };
+    in
+  {
+    # inherit release;
+    packages =
+      mapAttrs
+        (system: nix: {
+          default = nix;
+          nix = nix;
+        })
+        release.build;
+    apps =
+      mapAttrs
+        (system: packages:
+          let
+            appFor = mainProgram: {
+              type = "app";
+              program = lib.getExe' packages.nix mainProgram;
+            };
+          in flip genAttrs appFor [
+            "nix"
+            "nix-build"
+            "nix-channel"
+            "nix-collect-garbage"
+            "nix-copy-closure"
+            "nix-daemon"
+            "nix-env"
+            "nix-hash"
+            "nix-instantiate"
+            "nix-prefetch-url"
+            "nix-shell"
+            "nix-store"
+          ])
+        self.packages;
+  };
+}
+

--- a/tests/add.sh
+++ b/tests/add.sh
@@ -9,7 +9,7 @@ echo $path2
 if test "$path1" != "$path2"; then
     echo "nix-store --add and --add-fixed mismatch"
     exit 1
-fi    
+fi
 
 path3=$(nix-store --add-fixed sha256 ./dummy)
 echo $path3

--- a/tests/check.nix
+++ b/tests/check.nix
@@ -11,7 +11,7 @@ with import ./config.nix;
   };
 
   hashmismatch = import <nix/fetchurl.nix> {
-    url = "file://" + toString ./dummy;
+    url = "file://" + builtins.getEnv "TMPDIR" + "/dummy";
     sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
   };
 

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -34,9 +34,9 @@ nix-build check.nix -A fetchurl --no-out-link --repair --hashed-mirrors ''
 nix-build check.nix -A hashmismatch --no-out-link --hashed-mirrors '' || status=$?
 [ "$status" = "102" ]
 
-echo -n > ./dummy
+echo -n > $TMPDIR/dummy
 nix-build check.nix -A hashmismatch --no-out-link --hashed-mirrors ''
-echo 'Hello World' > ./dummy
+echo 'Hello World' > $TMPDIR/dummy
 
 nix-build check.nix -A hashmismatch --no-out-link --check --hashed-mirrors '' || status=$?
 [ "$status" = "102" ]


### PR DESCRIPTION
# Motivation

Makes it easier to answer questions about this old release.

E.g.

```
nix run nix/2.3-maintenance#nix-daemon -- --help
```

or to try this PR's branch:

```
nix run github:hercules-ci/nix/2.3-flake#nix-daemon -- --help
```

We may consider forward porting the `apps`.

# Context


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
