### PR TITLE
No `scratch` for `absPath`?

### DIFF
--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -9,6 +9,7 @@
 #include "error.hh"
 #include "logging.hh"
 #include "file-descriptor.hh"
+#include "util.hh"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -35,6 +36,13 @@ namespace nix {
 
 struct Sink;
 struct Source;
+
+#ifdef __GNUC__
+/**
+ * GNU libc can malloc the path for you with the right length.
+ */
+std::unique_ptr<char, FreeDeleter> getCwd();
+#endif
 
 /**
  * @return An absolutized path, resolving paths relative to the

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -345,6 +345,16 @@ std::string showBytes(uint64_t bytes);
 
 
 /**
+ * For using `std::unique` with C functions.
+ */
+struct FreeDeleter
+{
+    template <typename T>
+    void operator()(T *p) const { std::free(p); }
+};
+
+
+/**
  * Provide an addition operator between strings and string_views
  * inexplicably omitted from the standard library.
  */

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -259,14 +259,13 @@ void chrootHelper(int argc, char * * argv)
                 createSymlink(readLink(src), dst);
         }
 
-        char * cwd = getcwd(0, 0);
+        auto cwd = getCwd();
         if (!cwd) throw SysError("getting current directory");
-        Finally freeCwd([&]() { free(cwd); });
 
         if (chroot(tmpDir.c_str()) == -1)
             throw SysError("chrooting into '%s'", tmpDir);
 
-        if (chdir(cwd) == -1)
+        if (chdir(&*cwd) == -1)
             throw SysError("chdir to '%s' in chroot", cwd);
     } else
         if (mount(realStoreDir.c_str(), storeDir.c_str(), "", MS_BIND, 0) == -1)


### PR DESCRIPTION
# Motivation

I found a way to avoid the `scratch` variable I just introduced in #9759, but I am not sure whether this makes this code easier or harder to read 😅.

# Context

See conversation in #9759

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
