### PR TITLE
Systematize lowdown usage with a `lowdown::UniquePtr`

### DIFF
--- a/src/libutil/lowdown-cpp.hh
+++ b/src/libutil/lowdown-cpp.hh
@@ -1,0 +1,45 @@
+#pragma once
+///@file
+
+#include "types.hh"
+
+#include <sys/queue.h>
+#include <lowdown.h>
+
+namespace nix::lowdown {
+
+using Doc = struct lowdown_doc;
+using Node = struct lowdown_node;
+using Buf = struct lowdown_buf;
+
+/**
+ * For type-directed destructor, avoid `void *`
+ *
+ * @todo upstream as `lowdown_term`.
+ */
+struct Term;
+
+struct LowdownDeleter
+{
+    void operator () (Doc * ptr)
+    {
+        lowdown_doc_free(ptr);
+    }
+    void operator () (Node * ptr)
+    {
+        lowdown_node_free(ptr);
+    }
+    void operator () (Term * ptr)
+    {
+        lowdown_term_free(ptr);
+    }
+    void operator () (Buf * ptr)
+    {
+        lowdown_buf_free(ptr);
+    }
+};
+
+template <typename T>
+using UniquePtr = std::unique_ptr<T, LowdownDeleter>;
+
+}


### PR DESCRIPTION
# Motivation

I am not sure this is worth it, because I hope we can use `cmark` instead of `lowdown.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
