### PR TITLE
tests/functional/lang: Test substring with negative length

### DIFF
--- a/tests/functional/lang/eval-okay-substring.exp
+++ b/tests/functional/lang/eval-okay-substring.exp
@@ -1,1 +1,1 @@
-"ooxfoobarybarzobaabbc"
+"ooxfoobarybarzobaabbc_bad"

--- a/tests/functional/lang/eval-okay-substring.nix
+++ b/tests/functional/lang/eval-okay-substring.nix
@@ -19,3 +19,5 @@ substring 1 2 s
 + substring 3 1 s
 + "c"
 + substring 5 10 "perl"
++ "_"
++ substring 3 (-1) "tebbad"


### PR DESCRIPTION
# Motivation

I made a mistake reviewing #9747. It might not have been caught by the test suite.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
