### PR TITLE
DerivationInfo -> PackageInfo

### DIFF
--- a/src/libcmd/installable-attr-path.cc
+++ b/src/libcmd/installable-attr-path.cc
@@ -58,22 +58,22 @@ DerivedPathsWithInfo InstallableAttrPath::toDerivedPaths()
 
     Bindings & autoArgs = *cmd.getAutoArgs(*state);
 
-    DrvInfos drvInfos;
-    getDerivations(*state, *v, "", autoArgs, drvInfos, false);
+    PackageInfos packageInfos;
+    getDerivations(*state, *v, "", autoArgs, packageInfos, false);
 
     // Backward compatibility hack: group results by drvPath. This
     // helps keep .all output together.
     std::map<StorePath, OutputsSpec> byDrvPath;
 
-    for (auto & drvInfo : drvInfos) {
-        auto drvPath = drvInfo.queryDrvPath();
+    for (auto & packageInfo : packageInfos) {
+        auto drvPath = packageInfo.queryDrvPath();
         if (!drvPath)
             throw Error("'%s' is not a derivation", what());
 
         auto newOutputs = std::visit(overloaded {
             [&](const ExtendedOutputsSpec::Default & d) -> OutputsSpec {
                 std::set<std::string> outputsToInstall;
-                for (auto & output : drvInfo.queryOutputs(false, true))
+                for (auto & output : packageInfo.queryOutputs(false, true))
                     outputsToInstall.insert(output.first);
                 return OutputsSpec::Names { std::move(outputsToInstall) };
             },

--- a/src/libcmd/installable-value.hh
+++ b/src/libcmd/installable-value.hh
@@ -6,7 +6,7 @@
 
 namespace nix {
 
-struct DrvInfo;
+struct PackageInfo;
 struct SourceExprCommand;
 
 namespace eval_cache { class EvalCache; class AttrCursor; }

--- a/src/libcmd/installables.hh
+++ b/src/libcmd/installables.hh
@@ -12,7 +12,7 @@
 
 namespace nix {
 
-struct DrvInfo;
+struct PackageInfo;
 
 enum class Realise {
     /**

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -450,10 +450,10 @@ static bool isVarName(std::string_view s)
 
 
 StorePath NixRepl::getDerivationPath(Value & v) {
-    auto drvInfo = getDerivation(*state, v, false);
-    if (!drvInfo)
+    auto packageInfo = getDerivation(*state, v, false);
+    if (!packageInfo)
         throw Error("expression does not evaluate to a derivation, so I can't build it");
-    auto drvPath = drvInfo->queryDrvPath();
+    auto drvPath = packageInfo->queryDrvPath();
     if (!drvPath)
         throw Error("expression did not evaluate to a valid derivation (no 'drvPath' attribute)");
     if (!state->store->isValidPath(*drvPath))

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -11,13 +11,13 @@
 namespace nix {
 
 
-DrvInfo::DrvInfo(EvalState & state, std::string attrPath, Bindings * attrs)
+PackageInfo::PackageInfo(EvalState & state, std::string attrPath, Bindings * attrs)
     : state(&state), attrs(attrs), attrPath(std::move(attrPath))
 {
 }
 
 
-DrvInfo::DrvInfo(EvalState & state, ref<Store> store, const std::string & drvPathWithOutputs)
+PackageInfo::PackageInfo(EvalState & state, ref<Store> store, const std::string & drvPathWithOutputs)
     : state(&state), attrs(nullptr), attrPath("")
 {
     auto [drvPath, selectedOutputs] = parsePathWithOutputs(*store, drvPathWithOutputs);
@@ -45,7 +45,7 @@ DrvInfo::DrvInfo(EvalState & state, ref<Store> store, const std::string & drvPat
 }
 
 
-std::string DrvInfo::queryName() const
+std::string PackageInfo::queryName() const
 {
     if (name == "" && attrs) {
         auto i = attrs->find(state->sName);
@@ -56,7 +56,7 @@ std::string DrvInfo::queryName() const
 }
 
 
-std::string DrvInfo::querySystem() const
+std::string PackageInfo::querySystem() const
 {
     if (system == "" && attrs) {
         auto i = attrs->find(state->sSystem);
@@ -66,7 +66,7 @@ std::string DrvInfo::querySystem() const
 }
 
 
-std::optional<StorePath> DrvInfo::queryDrvPath() const
+std::optional<StorePath> PackageInfo::queryDrvPath() const
 {
     if (!drvPath && attrs) {
         Bindings::iterator i = attrs->find(state->sDrvPath);
@@ -80,7 +80,7 @@ std::optional<StorePath> DrvInfo::queryDrvPath() const
 }
 
 
-StorePath DrvInfo::requireDrvPath() const
+StorePath PackageInfo::requireDrvPath() const
 {
     if (auto drvPath = queryDrvPath())
         return *drvPath;
@@ -88,7 +88,7 @@ StorePath DrvInfo::requireDrvPath() const
 }
 
 
-StorePath DrvInfo::queryOutPath() const
+StorePath PackageInfo::queryOutPath() const
 {
     if (!outPath && attrs) {
         Bindings::iterator i = attrs->find(state->sOutPath);
@@ -102,7 +102,7 @@ StorePath DrvInfo::queryOutPath() const
 }
 
 
-DrvInfo::Outputs DrvInfo::queryOutputs(bool withPaths, bool onlyOutputsToInstall)
+PackageInfo::Outputs PackageInfo::queryOutputs(bool withPaths, bool onlyOutputsToInstall)
 {
     if (outputs.empty()) {
         /* Get the ‘outputs’ list. */
@@ -164,7 +164,7 @@ DrvInfo::Outputs DrvInfo::queryOutputs(bool withPaths, bool onlyOutputsToInstall
 }
 
 
-std::string DrvInfo::queryOutputName() const
+std::string PackageInfo::queryOutputName() const
 {
     if (outputName == "" && attrs) {
         Bindings::iterator i = attrs->find(state->sOutputName);
@@ -174,7 +174,7 @@ std::string DrvInfo::queryOutputName() const
 }
 
 
-Bindings * DrvInfo::getMeta()
+Bindings * PackageInfo::getMeta()
 {
     if (meta) return meta;
     if (!attrs) return 0;
@@ -186,7 +186,7 @@ Bindings * DrvInfo::getMeta()
 }
 
 
-StringSet DrvInfo::queryMetaNames()
+StringSet PackageInfo::queryMetaNames()
 {
     StringSet res;
     if (!getMeta()) return res;
@@ -196,7 +196,7 @@ StringSet DrvInfo::queryMetaNames()
 }
 
 
-bool DrvInfo::checkMeta(Value & v)
+bool PackageInfo::checkMeta(Value & v)
 {
     state->forceValue(v, v.determinePos(noPos));
     if (v.type() == nList) {
@@ -216,7 +216,7 @@ bool DrvInfo::checkMeta(Value & v)
 }
 
 
-Value * DrvInfo::queryMeta(const std::string & name)
+Value * PackageInfo::queryMeta(const std::string & name)
 {
     if (!getMeta()) return 0;
     Bindings::iterator a = meta->find(state->symbols.create(name));
@@ -225,7 +225,7 @@ Value * DrvInfo::queryMeta(const std::string & name)
 }
 
 
-std::string DrvInfo::queryMetaString(const std::string & name)
+std::string PackageInfo::queryMetaString(const std::string & name)
 {
     Value * v = queryMeta(name);
     if (!v || v->type() != nString) return "";
@@ -233,7 +233,7 @@ std::string DrvInfo::queryMetaString(const std::string & name)
 }
 
 
-NixInt DrvInfo::queryMetaInt(const std::string & name, NixInt def)
+NixInt PackageInfo::queryMetaInt(const std::string & name, NixInt def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
@@ -247,7 +247,7 @@ NixInt DrvInfo::queryMetaInt(const std::string & name, NixInt def)
     return def;
 }
 
-NixFloat DrvInfo::queryMetaFloat(const std::string & name, NixFloat def)
+NixFloat PackageInfo::queryMetaFloat(const std::string & name, NixFloat def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
@@ -262,7 +262,7 @@ NixFloat DrvInfo::queryMetaFloat(const std::string & name, NixFloat def)
 }
 
 
-bool DrvInfo::queryMetaBool(const std::string & name, bool def)
+bool PackageInfo::queryMetaBool(const std::string & name, bool def)
 {
     Value * v = queryMeta(name);
     if (!v) return def;
@@ -277,7 +277,7 @@ bool DrvInfo::queryMetaBool(const std::string & name, bool def)
 }
 
 
-void DrvInfo::setMeta(const std::string & name, Value * v)
+void PackageInfo::setMeta(const std::string & name, Value * v)
 {
     getMeta();
     auto attrs = state->buildBindings(1 + (meta ? meta->size() : 0));
@@ -300,7 +300,7 @@ typedef std::set<Bindings *> Done;
    The result boolean indicates whether it makes sense
    for the caller to recursively search for derivations in `v'. */
 static bool getDerivation(EvalState & state, Value & v,
-    const std::string & attrPath, DrvInfos & drvs, Done & done,
+    const std::string & attrPath, PackageInfos & drvs, Done & done,
     bool ignoreAssertionFailures)
 {
     try {
@@ -311,7 +311,7 @@ static bool getDerivation(EvalState & state, Value & v,
            derivation {...}; y = x;}'. */
         if (!done.insert(v.attrs).second) return false;
 
-        DrvInfo drv(state, attrPath, v.attrs);
+        PackageInfo drv(state, attrPath, v.attrs);
 
         drv.queryName();
 
@@ -326,11 +326,11 @@ static bool getDerivation(EvalState & state, Value & v,
 }
 
 
-std::optional<DrvInfo> getDerivation(EvalState & state, Value & v,
+std::optional<PackageInfo> getDerivation(EvalState & state, Value & v,
     bool ignoreAssertionFailures)
 {
     Done done;
-    DrvInfos drvs;
+    PackageInfos drvs;
     getDerivation(state, v, "", drvs, done, ignoreAssertionFailures);
     if (drvs.size() != 1) return {};
     return std::move(drvs.front());
@@ -348,7 +348,7 @@ static std::regex attrRegex("[A-Za-z_][A-Za-z0-9-_+]*");
 
 static void getDerivations(EvalState & state, Value & vIn,
     const std::string & pathPrefix, Bindings & autoArgs,
-    DrvInfos & drvs, Done & done,
+    PackageInfos & drvs, Done & done,
     bool ignoreAssertionFailures)
 {
     Value v;
@@ -401,7 +401,7 @@ static void getDerivations(EvalState & state, Value & vIn,
 
 
 void getDerivations(EvalState & state, Value & v, const std::string & pathPrefix,
-    Bindings & autoArgs, DrvInfos & drvs, bool ignoreAssertionFailures)
+    Bindings & autoArgs, PackageInfos & drvs, bool ignoreAssertionFailures)
 {
     Done done;
     getDerivations(state, v, pathPrefix, autoArgs, drvs, done, ignoreAssertionFailures);

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -11,7 +11,7 @@
 namespace nix {
 
 
-struct DrvInfo
+struct PackageInfo
 {
 public:
     typedef std::map<std::string, std::optional<StorePath>> Outputs;
@@ -43,9 +43,9 @@ public:
      */
     std::string attrPath;
 
-    DrvInfo(EvalState & state) : state(&state) { };
-    DrvInfo(EvalState & state, std::string attrPath, Bindings * attrs);
-    DrvInfo(EvalState & state, ref<Store> store, const std::string & drvPathWithOutputs);
+    PackageInfo(EvalState & state) : state(&state) { };
+    PackageInfo(EvalState & state, std::string attrPath, Bindings * attrs);
+    PackageInfo(EvalState & state, ref<Store> store, const std::string & drvPathWithOutputs);
 
     std::string queryName() const;
     std::string querySystem() const;
@@ -82,21 +82,21 @@ public:
 
 
 #if HAVE_BOEHMGC
-typedef std::list<DrvInfo, traceable_allocator<DrvInfo>> DrvInfos;
+typedef std::list<PackageInfo, traceable_allocator<PackageInfo>> PackageInfos;
 #else
-typedef std::list<DrvInfo> DrvInfos;
+typedef std::list<PackageInfo> PackageInfos;
 #endif
 
 
 /**
- * If value `v` denotes a derivation, return a DrvInfo object
+ * If value `v` denotes a derivation, return a PackageInfo object
  * describing it. Otherwise return nothing.
  */
-std::optional<DrvInfo> getDerivation(EvalState & state,
+std::optional<PackageInfo> getDerivation(EvalState & state,
     Value & v, bool ignoreAssertionFailures);
 
 void getDerivations(EvalState & state, Value & v, const std::string & pathPrefix,
-    Bindings & autoArgs, DrvInfos & drvs,
+    Bindings & autoArgs, PackageInfos & drvs,
     bool ignoreAssertionFailures);
 
 

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -10,7 +10,9 @@
 
 namespace nix {
 
-
+/**
+ * A "parsed" package attribute set.
+ */
 struct PackageInfo
 {
 public:

--- a/src/libstore/builtins/buildenv.hh
+++ b/src/libstore/builtins/buildenv.hh
@@ -5,6 +5,9 @@
 
 namespace nix {
 
+/**
+ * Think of this as a "store level package attrset", but stripped down to no more than the needs of buildenv.
+ */
 struct Package {
     Path path;
     bool active;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -289,7 +289,7 @@ static void main_nix_build(int argc, char * * argv)
     if (runEnv)
         setenv("IN_NIX_SHELL", pure ? "pure" : "impure", 1);
 
-    DrvInfos drvs;
+    PackageInfos drvs;
 
     /* Parse the expressions. */
     std::vector<Expr *> exprs;
@@ -307,7 +307,7 @@ static void main_nix_build(int argc, char * * argv)
                 } catch (Error & e) {};
                 auto [path, outputNames] = parsePathWithOutputs(absolute);
                 if (evalStore->isStorePath(path) && hasSuffix(path, ".drv"))
-                    drvs.push_back(DrvInfo(*state, evalStore, absolute));
+                    drvs.push_back(PackageInfo(*state, evalStore, absolute));
                 else
                     /* If we're in a #! script, interpret filenames
                        relative to the script. */
@@ -383,8 +383,8 @@ static void main_nix_build(int argc, char * * argv)
         if (drvs.size() != 1)
             throw UsageError("nix-shell requires a single derivation");
 
-        auto & drvInfo = drvs.front();
-        auto drv = evalStore->derivationFromPath(drvInfo.requireDrvPath());
+        auto & packageInfo = drvs.front();
+        auto drv = evalStore->derivationFromPath(packageInfo.requireDrvPath());
 
         std::vector<DerivedPath> pathsToBuild;
         RealisedPath::Set pathsToCopy;
@@ -527,7 +527,7 @@ static void main_nix_build(int argc, char * * argv)
             for (const auto & [inputDrv, inputNode] : drv.inputDrvs.map)
                 accumInputClosure(inputDrv, inputNode);
 
-            ParsedDerivation parsedDrv(drvInfo.requireDrvPath(), drv);
+            ParsedDerivation parsedDrv(packageInfo.requireDrvPath(), drv);
 
             if (auto structAttrs = parsedDrv.prepareStructuredAttrs(*store, inputs)) {
                 auto json = structAttrs.value();
@@ -620,10 +620,10 @@ static void main_nix_build(int argc, char * * argv)
 
         std::map<StorePath, std::pair<size_t, StringSet>> drvMap;
 
-        for (auto & drvInfo : drvs) {
-            auto drvPath = drvInfo.requireDrvPath();
+        for (auto & packageInfo : drvs) {
+            auto drvPath = packageInfo.requireDrvPath();
 
-            auto outputName = drvInfo.queryOutputName();
+            auto outputName = packageInfo.queryOutputName();
             if (outputName == "")
                 throw Error("derivation '%s' lacks an 'outputName' attribute", store->printStorePath(drvPath));
 

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -184,7 +184,7 @@ static void loadSourceExpr(EvalState & state, const SourcePath & path, Value & v
 
 static void loadDerivations(EvalState & state, const SourcePath & nixExprPath,
     std::string systemFilter, Bindings & autoArgs,
-    const std::string & pathPrefix, DrvInfos & elems)
+    const std::string & pathPrefix, PackageInfos & elems)
 {
     Value vRoot;
     loadSourceExpr(state, nixExprPath, vRoot);
@@ -195,7 +195,7 @@ static void loadDerivations(EvalState & state, const SourcePath & nixExprPath,
 
     /* Filter out all derivations not applicable to the current
        system. */
-    for (DrvInfos::iterator i = elems.begin(), j; i != elems.end(); i = j) {
+    for (PackageInfos::iterator i = elems.begin(), j; i != elems.end(); i = j) {
         j = i; j++;
         if (systemFilter != "*" && i->querySystem() != systemFilter)
             elems.erase(i);
@@ -203,13 +203,13 @@ static void loadDerivations(EvalState & state, const SourcePath & nixExprPath,
 }
 
 
-static long getPriority(EvalState & state, DrvInfo & drv)
+static long getPriority(EvalState & state, PackageInfo & drv)
 {
     return drv.queryMetaInt("priority", 0);
 }
 
 
-static long comparePriorities(EvalState & state, DrvInfo & drv1, DrvInfo & drv2)
+static long comparePriorities(EvalState & state, PackageInfo & drv1, PackageInfo & drv2)
 {
     return getPriority(state, drv2) - getPriority(state, drv1);
 }
@@ -217,7 +217,7 @@ static long comparePriorities(EvalState & state, DrvInfo & drv1, DrvInfo & drv2)
 
 // FIXME: this function is rather slow since it checks a single path
 // at a time.
-static bool isPrebuilt(EvalState & state, DrvInfo & elem)
+static bool isPrebuilt(EvalState & state, PackageInfo & elem)
 {
     auto path = elem.queryOutPath();
     if (state.store->isValidPath(path)) return true;
@@ -236,11 +236,11 @@ static void checkSelectorUse(DrvNames & selectors)
 
 namespace {
 
-std::set<std::string> searchByPrefix(const DrvInfos & allElems, std::string_view prefix) {
+std::set<std::string> searchByPrefix(const PackageInfos & allElems, std::string_view prefix) {
     constexpr std::size_t maxResults = 3;
     std::set<std::string> result;
-    for (const auto & drvInfo : allElems) {
-        const auto drvName = DrvName { drvInfo.queryName() };
+    for (const auto & packageInfo : allElems) {
+        const auto drvName = DrvName { packageInfo.queryName() };
         if (hasPrefix(drvName.name, prefix)) {
             result.emplace(drvName.name);
 
@@ -254,11 +254,11 @@ std::set<std::string> searchByPrefix(const DrvInfos & allElems, std::string_view
 
 struct Match
 {
-    DrvInfo drvInfo;
+    PackageInfo packageInfo;
     std::size_t index;
 
-    Match(DrvInfo drvInfo_, std::size_t index_)
-    : drvInfo{std::move(drvInfo_)}
+    Match(PackageInfo packageInfo_, std::size_t index_)
+    : packageInfo{std::move(packageInfo_)}
     , index{index_}
     {}
 };
@@ -276,7 +276,7 @@ std::vector<Match> pickNewestOnly(EvalState & state, std::vector<Match> matches)
     StringSet multiple;
 
     for (auto & match : matches) {
-        auto & oneDrv = match.drvInfo;
+        auto & oneDrv = match.packageInfo;
 
         const auto drvName = DrvName { oneDrv.queryName() };
         long comparison = 1;
@@ -284,7 +284,7 @@ std::vector<Match> pickNewestOnly(EvalState & state, std::vector<Match> matches)
         const auto itOther = newest.find(drvName.name);
 
         if (itOther != newest.end()) {
-            auto & newestDrv = itOther->second.drvInfo;
+            auto & newestDrv = itOther->second.packageInfo;
 
             comparison =
                 oneDrv.querySystem() == newestDrv.querySystem() ? 0 :
@@ -319,23 +319,23 @@ std::vector<Match> pickNewestOnly(EvalState & state, std::vector<Match> matches)
 
 } // end namespace
 
-static DrvInfos filterBySelector(EvalState & state, const DrvInfos & allElems,
+static PackageInfos filterBySelector(EvalState & state, const PackageInfos & allElems,
     const Strings & args, bool newestOnly)
 {
     DrvNames selectors = drvNamesFromArgs(args);
     if (selectors.empty())
         selectors.emplace_back("*");
 
-    DrvInfos elems;
+    PackageInfos elems;
     std::set<std::size_t> done;
 
     for (auto & selector : selectors) {
         std::vector<Match> matches;
-        for (const auto & [index, drvInfo] : enumerate(allElems)) {
-            const auto drvName = DrvName { drvInfo.queryName() };
+        for (const auto & [index, packageInfo] : enumerate(allElems)) {
+            const auto drvName = DrvName { packageInfo.queryName() };
             if (selector.matches(drvName)) {
                 ++selector.hits;
-                matches.emplace_back(drvInfo, index);
+                matches.emplace_back(packageInfo, index);
             }
         }
 
@@ -347,7 +347,7 @@ static DrvInfos filterBySelector(EvalState & state, const DrvInfos & allElems,
            haven't inserted before. */
         for (auto & match : matches)
             if (done.insert(match.index).second)
-                elems.push_back(match.drvInfo);
+                elems.push_back(match.packageInfo);
 
         if (selector.hits == 0 && selector.fullName != "*") {
             const auto prefixHits = searchByPrefix(allElems, selector.name);
@@ -376,7 +376,7 @@ static bool isPath(std::string_view s)
 
 static void queryInstSources(EvalState & state,
     InstallSourceInfo & instSource, const Strings & args,
-    DrvInfos & elems, bool newestOnly)
+    PackageInfos & elems, bool newestOnly)
 {
     InstallSourceType type = instSource.type;
     if (type == srcUnknown && args.size() > 0 && isPath(args.front()))
@@ -392,7 +392,7 @@ static void queryInstSources(EvalState & state,
 
             /* Load the derivations from the (default or specified)
                Nix expression. */
-            DrvInfos allElems;
+            PackageInfos allElems;
             loadDerivations(state, *instSource.nixExprPath,
                 instSource.systemFilter, *instSource.autoArgs, "", allElems);
 
@@ -433,7 +433,7 @@ static void queryInstSources(EvalState & state,
 
                 std::string name(path.name());
 
-                DrvInfo elem(state, "", nullptr);
+                PackageInfo elem(state, "", nullptr);
                 elem.setName(name);
 
                 if (path.isDerivation()) {
@@ -476,7 +476,7 @@ static void queryInstSources(EvalState & state,
 }
 
 
-static void printMissing(EvalState & state, DrvInfos & elems)
+static void printMissing(EvalState & state, PackageInfos & elems)
 {
     std::vector<DerivedPath> targets;
     for (auto & i : elems)
@@ -494,7 +494,7 @@ static void printMissing(EvalState & state, DrvInfos & elems)
 }
 
 
-static bool keep(DrvInfo & drv)
+static bool keep(PackageInfo & drv)
 {
     return drv.queryMetaBool("keep", false);
 }
@@ -506,7 +506,7 @@ static void installDerivations(Globals & globals,
     debug("installing derivations");
 
     /* Get the set of user environment elements to be installed. */
-    DrvInfos newElems, newElemsTmp;
+    PackageInfos newElems, newElemsTmp;
     queryInstSources(*globals.state, globals.instSource, args, newElemsTmp, true);
 
     /* If --prebuilt-only is given, filter out source-only packages. */
@@ -529,12 +529,12 @@ static void installDerivations(Globals & globals,
     while (true) {
         auto lockToken = optimisticLockProfile(profile);
 
-        DrvInfos allElems(newElems);
+        PackageInfos allElems(newElems);
 
         /* Add in the already installed derivations, unless they have
            the same name as a to-be-installed element. */
         if (!globals.removeAll) {
-            DrvInfos installedElems = queryInstalled(*globals.state, profile);
+            PackageInfos installedElems = queryInstalled(*globals.state, profile);
 
             for (auto & i : installedElems) {
                 DrvName drvName(i.queryName());
@@ -592,14 +592,14 @@ static void upgradeDerivations(Globals & globals,
     while (true) {
         auto lockToken = optimisticLockProfile(globals.profile);
 
-        DrvInfos installedElems = queryInstalled(*globals.state, globals.profile);
+        PackageInfos installedElems = queryInstalled(*globals.state, globals.profile);
 
         /* Fetch all derivations from the input file. */
-        DrvInfos availElems;
+        PackageInfos availElems;
         queryInstSources(*globals.state, globals.instSource, args, availElems, false);
 
         /* Go through all installed derivations. */
-        DrvInfos newElems;
+        PackageInfos newElems;
         for (auto & i : installedElems) {
             DrvName drvName(i.queryName());
 
@@ -617,7 +617,7 @@ static void upgradeDerivations(Globals & globals,
                    priority.  If there are still multiple matches,
                    take the one with the highest version.
                    Do not upgrade if it would decrease the priority. */
-                DrvInfos::iterator bestElem = availElems.end();
+                PackageInfos::iterator bestElem = availElems.end();
                 std::string bestVersion;
                 for (auto j = availElems.begin(); j != availElems.end(); ++j) {
                     if (comparePriorities(*globals.state, i, *j) > 0)
@@ -687,7 +687,7 @@ static void opUpgrade(Globals & globals, Strings opFlags, Strings opArgs)
 }
 
 
-static void setMetaFlag(EvalState & state, DrvInfo & drv,
+static void setMetaFlag(EvalState & state, PackageInfo & drv,
     const std::string & name, const std::string & value)
 {
     auto v = state.allocValue();
@@ -711,7 +711,7 @@ static void opSetFlag(Globals & globals, Strings opFlags, Strings opArgs)
     while (true) {
         std::string lockToken = optimisticLockProfile(globals.profile);
 
-        DrvInfos installedElems = queryInstalled(*globals.state, globals.profile);
+        PackageInfos installedElems = queryInstalled(*globals.state, globals.profile);
 
         /* Update all matching derivations. */
         for (auto & i : installedElems) {
@@ -745,13 +745,13 @@ static void opSet(Globals & globals, Strings opFlags, Strings opArgs)
         else throw UsageError("unknown flag '%1%'", arg);
     }
 
-    DrvInfos elems;
+    PackageInfos elems;
     queryInstSources(*globals.state, globals.instSource, opArgs, elems, true);
 
     if (elems.size() != 1)
         throw Error("--set requires exactly one derivation");
 
-    DrvInfo & drv(elems.front());
+    PackageInfo & drv(elems.front());
 
     if (globals.forceName != "")
         drv.setName(globals.forceName);
@@ -786,10 +786,10 @@ static void uninstallDerivations(Globals & globals, Strings & selectors,
     while (true) {
         auto lockToken = optimisticLockProfile(profile);
 
-        DrvInfos workingElems = queryInstalled(*globals.state, profile);
+        PackageInfos workingElems = queryInstalled(*globals.state, profile);
 
         for (auto & selector : selectors) {
-            DrvInfos::iterator split = workingElems.begin();
+            PackageInfos::iterator split = workingElems.begin();
             if (isPath(selector)) {
                 StorePath selectorStorePath = globals.state->store->followLinksToStorePath(selector);
                 split = std::partition(
@@ -838,7 +838,7 @@ static bool cmpChars(char a, char b)
 }
 
 
-static bool cmpElemByName(const DrvInfo & a, const DrvInfo & b)
+static bool cmpElemByName(const PackageInfo & a, const PackageInfo & b)
 {
     auto a_name = a.queryName();
     auto b_name = b.queryName();
@@ -891,7 +891,7 @@ void printTable(Table & table)
 typedef enum { cvLess, cvEqual, cvGreater, cvUnavail } VersionDiff;
 
 static VersionDiff compareVersionAgainstSet(
-    const DrvInfo & elem, const DrvInfos & elems, std::string & version)
+    const PackageInfo & elem, const PackageInfos & elems, std::string & version)
 {
     DrvName name(elem.queryName());
 
@@ -922,7 +922,7 @@ static VersionDiff compareVersionAgainstSet(
 }
 
 
-static void queryJSON(Globals & globals, std::vector<DrvInfo> & elems, bool printOutPath, bool printDrvPath, bool printMeta)
+static void queryJSON(Globals & globals, std::vector<PackageInfo> & elems, bool printOutPath, bool printDrvPath, bool printMeta)
 {
     using nlohmann::json;
     json topObj = json::object();
@@ -942,7 +942,7 @@ static void queryJSON(Globals & globals, std::vector<DrvInfo> & elems, bool prin
             };
 
             {
-                DrvInfo::Outputs outputs = i.queryOutputs(printOutPath);
+                PackageInfo::Outputs outputs = i.queryOutputs(printOutPath);
                 json &outputObj = pkgObj["outputs"];
                 outputObj = json::object();
                 for (auto & j : outputs) {
@@ -1032,7 +1032,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
         throw UsageError("--attr-path(-P) only works with --available");
 
     /* Obtain derivation information from the specified source. */
-    DrvInfos availElems, installedElems;
+    PackageInfos availElems, installedElems;
 
     if (source == sInstalled || compareVersions || printStatus)
         installedElems = queryInstalled(*globals.state, globals.profile);
@@ -1042,16 +1042,16 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
             globals.instSource.systemFilter, *globals.instSource.autoArgs,
             attrPath, availElems);
 
-    DrvInfos elems_ = filterBySelector(*globals.state,
+    PackageInfos elems_ = filterBySelector(*globals.state,
         source == sInstalled ? installedElems : availElems,
         opArgs, false);
 
-    DrvInfos & otherElems(source == sInstalled ? availElems : installedElems);
+    PackageInfos & otherElems(source == sInstalled ? availElems : installedElems);
 
 
     /* Sort them by name. */
     /* !!! */
-    std::vector<DrvInfo> elems;
+    std::vector<PackageInfo> elems;
     for (auto & i : elems_) elems.push_back(i);
     sort(elems.begin(), elems.end(), cmpElemByName);
 
@@ -1192,7 +1192,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                 attrs["outputName"] = i.queryOutputName();
 
             if (printOutPath && !xmlOutput) {
-                DrvInfo::Outputs outputs = i.queryOutputs();
+                PackageInfo::Outputs outputs = i.queryOutputs();
                 std::string s;
                 for (auto & j : outputs) {
                     if (!s.empty()) s += ';';
@@ -1212,7 +1212,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
 
             if (xmlOutput) {
                 XMLOpenElement item(xml, "item", attrs);
-                DrvInfo::Outputs outputs = i.queryOutputs(printOutPath);
+                PackageInfo::Outputs outputs = i.queryOutputs(printOutPath);
                 for (auto & j : outputs) {
                     XMLAttrs attrs2;
                     attrs2["name"] = j.first;

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -15,9 +15,9 @@
 namespace nix {
 
 
-DrvInfos queryInstalled(EvalState & state, const Path & userEnv)
+PackageInfos queryInstalled(EvalState & state, const Path & userEnv)
 {
-    DrvInfos elems;
+    PackageInfos elems;
     if (pathExists(userEnv + "/manifest.json"))
         throw Error("profile '%s' is incompatible with 'nix-env'; please use 'nix profile' instead", userEnv);
     auto manifestFile = userEnv + "/manifest.nix";
@@ -31,7 +31,7 @@ DrvInfos queryInstalled(EvalState & state, const Path & userEnv)
 }
 
 
-bool createUserEnv(EvalState & state, DrvInfos & elems,
+bool createUserEnv(EvalState & state, PackageInfos & elems,
     const Path & profile, bool keepDerivations,
     const std::string & lockToken)
 {
@@ -57,7 +57,7 @@ bool createUserEnv(EvalState & state, DrvInfos & elems,
            output paths, and optionally the derivation path, as well
            as the meta attributes. */
         std::optional<StorePath> drvPath = keepDerivations ? i.queryDrvPath() : std::nullopt;
-        DrvInfo::Outputs outputs = i.queryOutputs(true, true);
+        PackageInfo::Outputs outputs = i.queryOutputs(true, true);
         StringSet metaNames = i.queryMetaNames();
 
         auto attrs = state.buildBindings(7 + outputs.size());

--- a/src/nix-env/user-env.hh
+++ b/src/nix-env/user-env.hh
@@ -5,9 +5,9 @@
 
 namespace nix {
 
-DrvInfos queryInstalled(EvalState & state, const Path & userEnv);
+PackageInfos queryInstalled(EvalState & state, const Path & userEnv);
 
-bool createUserEnv(EvalState & state, DrvInfos & elems,
+bool createUserEnv(EvalState & state, PackageInfos & elems,
     const Path & profile, bool keepDerivations,
     const std::string & lockToken);
 

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -62,7 +62,7 @@ void processExpr(EvalState & state, const Strings & attrPaths,
                 std::cout << std::endl;
             }
         } else {
-            DrvInfos drvs;
+            PackageInfos drvs;
             getDerivations(state, v, "", autoArgs, drvs, false);
             for (auto & i : drvs) {
                 auto drvPath = i.requireDrvPath();

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -395,11 +395,11 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkDerivation = [&](const std::string & attrPath, Value & v, const PosIdx pos) -> std::optional<StorePath> {
             try {
-                auto drvInfo = getDerivation(*state, v, false);
-                if (!drvInfo)
+                auto packageInfo = getDerivation(*state, v, false);
+                if (!packageInfo)
                     throw Error("flake attribute '%s' is not a derivation", attrPath);
                 // FIXME: check meta attributes
-                return drvInfo->queryDrvPath();
+                return packageInfo->queryDrvPath();
             } catch (Error & e) {
                 e.addTrace(resolve(pos), hintfmt("while checking the derivation '%s'", attrPath));
                 reportError(e);

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -168,11 +168,11 @@ struct ProfileManifest
             state.allowPath(state.store->followLinksToStore(profile));
             state.allowPath(state.store->followLinksToStore(profile + "/manifest.nix"));
 
-            auto drvInfos = queryInstalled(state, state.store->followLinksToStore(profile));
+            auto packageInfos = queryInstalled(state, state.store->followLinksToStore(profile));
 
-            for (auto & drvInfo : drvInfos) {
+            for (auto & packageInfo : packageInfos) {
                 ProfileElement element;
-                element.storePaths = {drvInfo.queryOutPath()};
+                element.storePaths = {packageInfo.queryOutPath()};
                 addElement(std::move(element));
             }
         }


### PR DESCRIPTION
This does not yet resolve the coupling between packages and derivations, but it makes the code more consistent with the terminology, and it accentuates places where the coupling is obvious, such as

```c++
         auto drvPath = packageInfo.queryDrvPath();
         if (!drvPath)
             throw Error("'%s' is not a derivation", what());
```

... which isn't wrong, and in my opinion, doesn't even look wrong, because it just reflects the current logic. However, I do like that we can now start to see in the code that this coupling is perhaps a bit arbitrary.
After this rename, we can bring the DerivingPath concept into type and start to lift this limitation.

# Motivation

- RFC 92 dynamic derivations
- Multi-derivation packages (ie simplify bootstrapping with separate doc derivation, without changing the in-language package interface) (we love you, staging team)
- Chip away at the derivation - package confusion.

# Context

- Applies to the code #9762 

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
