### PR TITLE
refactor: Extract `Store::queryPathInfoFromClientCache`

### DIFF
--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -285,14 +285,14 @@ public:
     /**
      * NOTE: this is not the final interface - to be modified in next commit.
      *
-     * Asynchronous version that only queries the local narinfo cache and not
+     * Version of queryPathInfo() that only queries the local narinfo cache and not
      * the actual store.
      *
-     * @return true if the path was known and the callback invoked
-     * @return false if the path was not known and the callback not invoked
+     * @return `std::make_optional(vpi)` if the path is known
+     * @return `std::null_opt` if the path was not known to be valid or invalid
      * @throw InvalidPathError if the path is known to be invalid
      */
-    bool queryPathInfoFromClientCache(const StorePath & path, Callback<ref<const ValidPathInfo>> & callback);
+    std::optional<ref<const ValidPathInfo>> queryPathInfoFromClientCache(const StorePath & path);
 
     /**
      * Query the information about a realisation.

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -283,16 +283,14 @@ public:
         Callback<ref<const ValidPathInfo>> callback) noexcept;
 
     /**
-     * NOTE: this is not the final interface - to be modified in next commit.
-     *
      * Version of queryPathInfo() that only queries the local narinfo cache and not
      * the actual store.
      *
-     * @return `std::make_optional(vpi)` if the path is known
-     * @return `std::null_opt` if the path was not known to be valid or invalid
-     * @throw InvalidPathError if the path is known to be invalid
+     * @return `std::nullopt` if nothing is known about the path in the local narinfo cache.
+     * @return `std::make_optional(nullptr)` if the path is known to not exist.
+     * @return `std::make_optional(validPathInfo)` if the path is known to exist.
      */
-    std::optional<ref<const ValidPathInfo>> queryPathInfoFromClientCache(const StorePath & path);
+    std::optional<std::shared_ptr<const ValidPathInfo>> queryPathInfoFromClientCache(const StorePath & path);
 
     /**
      * Query the information about a realisation.

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -283,6 +283,18 @@ public:
         Callback<ref<const ValidPathInfo>> callback) noexcept;
 
     /**
+     * NOTE: this is not the final interface - to be modified in next commit.
+     *
+     * Asynchronous version that only queries the local narinfo cache and not
+     * the actual store.
+     *
+     * @return true if the path was known and the callback invoked
+     * @return false if the path was not known and the callback not invoked
+     * @throw InvalidPathError if the path is known to be invalid
+     */
+    bool queryPathInfoFromClientCache(const StorePath & path, Callback<ref<const ValidPathInfo>> & callback);
+
+    /**
      * Query the information about a realisation.
      */
     std::shared_ptr<const Realisation> queryRealisation(const DrvOutput &);


### PR DESCRIPTION
# Motivation

This "new" method is useful for quickly figuring out whether a store is known to have a path. This will be useful to me as a C++ library consumer. This does not add new call sites - it is just a refactor that exposes a "new" method.

> [!TIP]
> This refactor is split into three small steps with separate commits, if that helps you see the equivalence.
> Disable whitespace in the diff.


# Context

An alternative would be for users to invoke the narinfo cache db directly,
so why should we make this change?

 - This way, the narinfo cache db remains an implementation detail.
 - Callers get to use the in-memory cache as well.
 - It is easier to use.



# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
