### PR TITLE
Store::buildPaths(): Fix display of store paths

### DIFF
--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -26,9 +26,9 @@ void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMod
         }
         if (i->exitCode != Goal::ecSuccess) {
             if (auto i2 = dynamic_cast<DerivationGoal *>(i.get()))
-                failed.insert(std::string { i2->drvPath.to_string() });
+                failed.insert(printStorePath(i2->drvPath));
             else if (auto i2 = dynamic_cast<PathSubstitutionGoal *>(i.get()))
-                failed.insert(std::string { i2->storePath.to_string()});
+                failed.insert(printStorePath(i2->storePath));
         }
     }
 


### PR DESCRIPTION
# Motivation

Fixes
```
error: build of 'kph9nxwvydiqx315snx2nhi77vj424fc-bar' failed
```

This was broken in 7ac39ff05c8353c665174e8df61dd76a2b0b93db.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
