### PR TITLE
Print a more helpful message if the daemon crashes

### DIFF
--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -67,6 +67,7 @@ void RemoteStore::initConnection(Connection & conn)
 {
     /* Send the magic greeting, check for the reply. */
     try {
+        conn.from.endOfFileError = "Nix daemon disconnected unexpectedly (maybe it crashed?)";
         conn.to << WORKER_MAGIC_1;
         conn.to.flush();
         StringSink saved;

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -132,7 +132,7 @@ size_t FdSource::readUnbuffered(char * data, size_t len)
         n = ::read(fd, data, len);
     } while (n == -1 && errno == EINTR);
     if (n == -1) { _good = false; throw SysError("reading from file"); }
-    if (n == 0) { _good = false; throw EndOfFile(endOfFileError); }
+    if (n == 0) { _good = false; throw EndOfFile(std::string(*endOfFileError)); }
     read += n;
     return n;
 }

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -132,7 +132,7 @@ size_t FdSource::readUnbuffered(char * data, size_t len)
         n = ::read(fd, data, len);
     } while (n == -1 && errno == EINTR);
     if (n == -1) { _good = false; throw SysError("reading from file"); }
-    if (n == 0) { _good = false; throw EndOfFile("unexpected end-of-file"); }
+    if (n == 0) { _good = false; throw EndOfFile(endOfFileError); }
     read += n;
     return n;
 }

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -153,12 +153,13 @@ struct FdSource : BufferedSource
 {
     int fd;
     size_t read = 0;
+    std::string endOfFileError{"unexpected end-of-file"};
 
     FdSource() : fd(-1) { }
     FdSource(int fd) : fd(fd) { }
-    FdSource(FdSource&&) = default;
+    FdSource(FdSource &&) = default;
 
-    FdSource& operator=(FdSource && s)
+    FdSource & operator=(FdSource && s)
     {
         fd = s.fd;
         s.fd = -1;

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -153,7 +153,7 @@ struct FdSource : BufferedSource
 {
     int fd;
     size_t read = 0;
-    std::string endOfFileError{"unexpected end-of-file"};
+    BackedStringView endOfFileError{"unexpected end-of-file"};
 
     FdSource() : fd(-1) { }
     FdSource(int fd) : fd(fd) { }


### PR DESCRIPTION
# Motivation

Instead of

```
error: unexpected end-of-file
```

you now get

```
error: Nix daemon disconnected unexpectedly (maybe it crashed?)
```

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
