### PR TITLE
Fix crash when NAR is missing from binary cache

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -251,7 +251,7 @@ void Worker::childTerminated(Goal * goal, bool wakeSleepers)
 
 void Worker::waitForBuildSlot(GoalPtr goal)
 {
-    debug("wait for build slot");
+    goal->trace("wait for build slot");
     bool isSubstitutionGoal = goal->jobCategory() == JobCategory::Substitution;
     if ((!isSubstitutionGoal && getNrLocalBuilds() < settings.maxBuildJobs) ||
         (isSubstitutionGoal && getNrSubstitutions() < settings.maxSubstitutionJobs))

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1049,7 +1049,11 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
     Finally cleanup = [&]() {
         if (!narRead) {
             NullParseSink sink;
-            parseDump(sink, source);
+            try {
+                parseDump(sink, source);
+            } catch (...) {
+                ignoreException();
+            }
         }
     };
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -981,6 +981,11 @@ void copyStorePath(
     RepairFlag repair,
     CheckSigsFlag checkSigs)
 {
+    /* Bail out early (before starting a download from srcStore) if
+       dstStore already has this path. */
+    if (!repair && dstStore.isValidPath(storePath))
+        return;
+
     auto srcUri = srcStore.getUri();
     auto dstUri = dstStore.getUri();
     auto storePathS = srcStore.printStorePath(storePath);


### PR DESCRIPTION
# Motivation

This fixes random crashes like 
```
terminate called after throwing an instance of 'nix::SubstituteGone'
  what():  error: file 'nar/06br3254rx4gz4cvjzxlv028jrx80zg5i4jr62vjmn416dqihgr7.nar.xz' does not exist in binary cache 'http://localhost'
Aborted (core dumped)
```
and
```
terminate called recursively
Aborted (core dumped)
```
observed with `magic-nix-cache` when NARs (but not the corresponding .narinfos) had been pruned from the GHA cache.

Nix already handles missing NARs via the `SubstituteGone` exception. However, when using `allowSubstitutes = false`, it is possible to end up in a situation where Nix simultaneously has a `DerivationGoal` and a `SubstitutionGoal` for the same path. If the path is built first, Nix will then substitute it, causing `LocalStore::addToStore()` to discard the incoming NAR from a `Finally` handler because the path is already valid. This causes the `SubstituteGone` exception to be thrown from a destructor, which crashes Nix.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
