### PR TITLE
Add --unpack to nix store prefetch-file

### DIFF
--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -262,6 +262,7 @@ struct CmdStorePrefetchFile : StoreCommand, MixJSON
 {
     std::string url;
     bool executable = false;
+    bool unpack = false;
     std::optional<std::string> name;
     HashAlgorithm hashAlgo = HashAlgorithm::SHA256;
     std::optional<Hash> expectedHash;
@@ -294,6 +295,14 @@ struct CmdStorePrefetchFile : StoreCommand, MixJSON
             .handler = {&executable, true},
         });
 
+        addFlag({
+            .longName = "unpack",
+            .description =
+                "Unpack the archive (which must be a tarball or zip file) and add "
+                "the result to the Nix store.",
+            .handler = {&unpack, true},
+        });
+
         expectArg("url", &url);
     }
 
@@ -310,7 +319,7 @@ struct CmdStorePrefetchFile : StoreCommand, MixJSON
     }
     void run(ref<Store> store) override
     {
-        auto [storePath, hash] = prefetchFile(store, url, name, hashAlgo, expectedHash, false, executable);
+        auto [storePath, hash] = prefetchFile(store, url, name, hashAlgo, expectedHash, unpack, executable);
 
         if (json) {
             auto res = nlohmann::json::object();


### PR DESCRIPTION
# Motivation

`nix-prefetch-url` has an unpack option, but it has no real equivalent in the new nix command

# Context
#4429 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
