### PR TITLE
Add missing `--hash-algo` flag to `nix store add`

### DIFF
--- a/doc/manual/rl-next/nix-store-add.md
+++ b/doc/manual/rl-next/nix-store-add.md
@@ -1,0 +1,7 @@
+---
+synopsis: Give `nix store add` a `--hash-algo` flag
+prs: 9809
+---
+
+Adds a missing feature that was present in the old CLI, and matches our
+plans to have similar flags for `nix hash convert` and `hash hash path`.

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -22,6 +22,7 @@ struct CmdAddToStore : MixDryRun, StoreCommand
     Path path;
     std::optional<std::string> namePart;
     ContentAddressMethod caMethod = FileIngestionMethod::Recursive;
+    HashAlgorithm hashAlgo = HashAlgorithm::SHA256;
 
     CmdAddToStore()
     {
@@ -51,6 +52,8 @@ struct CmdAddToStore : MixDryRun, StoreCommand
                 this->caMethod = parseIngestionMethod(s);
             }},
         });
+
+        addFlag(Flag::mkHashAlgoFlag("hash-algo", &hashAlgo));
     }
 
     void run(ref<Store> store) override
@@ -63,9 +66,9 @@ struct CmdAddToStore : MixDryRun, StoreCommand
 
         auto storePath = dryRun
             ? store->computeStorePath(
-                *namePart, accessor, path2, caMethod, HashAlgorithm::SHA256, {}).first
+                *namePart, accessor, path2, caMethod, hashAlgo, {}).first
             : store->addToStoreSlow(
-                *namePart, accessor, path2, caMethod, HashAlgorithm::SHA256, {}).path;
+                *namePart, accessor, path2, caMethod, hashAlgo, {}).path;
 
         logger->cout("%s", store->printStorePath(storePath));
     }

--- a/tests/functional/add.sh
+++ b/tests/functional/add.sh
@@ -37,9 +37,11 @@ clearStore
     path3=$(nix store add-path ./dummy)
     [[ "$path1" == "$path2" ]]
     [[ "$path1" == "$path3" ]]
+    path4=$(nix store add --mode nar --hash-algo sha1 ./dummy)
 )
 (
     path1=$(nix store add --mode flat ./dummy)
     path2=$(nix store add-file ./dummy)
     [[ "$path1" == "$path2" ]]
+    path4=$(nix store add --mode flat --hash-algo sha1 ./dummy)
 )


### PR DESCRIPTION
# Motivation

This is a paramter to the underlying `addToStore` that we forgot to expose

# Context

Was supposed to have been part of #8915.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
