### PR TITLE
Remove a nonsensical shorthand flag in `nix store add`

### DIFF
--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -38,7 +38,6 @@ struct CmdAddToStore : MixDryRun, StoreCommand
 
         addFlag({
             .longName  = "mode",
-            .shortName = 'n',
             .description = R"(
     How to compute the hash of the input.
     One of:


### PR DESCRIPTION
`-n` was an alias for `--mode`, but that seems to just be a copy-paste error as it doesn't make sense. `--mode` probably doesn't need a shorthand flag at all, so remove it.

Noticed by @grahamc in https://github.com/NixOS/nix/pull/9809#issuecomment-1899890555

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
