### PR TITLE
libexpr: print value of what is attempted to be called as function

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1692,7 +1692,11 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
         }
 
         else
-            error("attempt to call something which is not a function but %1%", showType(vCur)).atPos(pos).debugThrow<TypeError>();
+            error("attempt to call something which is not a function but %1%: %2%",
+                    showType(vCur),
+                    ValuePrinter(*this, vCur, errorPrintOptions))
+                .atPos(pos)
+                .debugThrow<TypeError>();
     }
 
     vRes = vCur;

--- a/tests/unit/libexpr/error_traces.cc
+++ b/tests/unit/libexpr/error_traces.cc
@@ -750,7 +750,7 @@ namespace nix {
 
         ASSERT_TRACE1("foldl' (_: 1) \"foo\" [ true ]",
                       TypeError,
-                      hintfmt("attempt to call something which is not a function but %s", "an integer"));
+                      hintfmt("attempt to call something which is not a function but %s: %s", "an integer", ANSI_CYAN "1" ANSI_NORMAL));
 
         ASSERT_TRACE2("foldl' (a: b: a && b) \"foo\" [ true ]",
                       TypeError,
@@ -835,7 +835,7 @@ namespace nix {
 
         ASSERT_TRACE1("sort (_: 1) [ \"foo\" \"bar\" ]",
                       TypeError,
-                      hintfmt("attempt to call something which is not a function but %s", "an integer"));
+                      hintfmt("attempt to call something which is not a function but %s: %s", "an integer", ANSI_CYAN "1" ANSI_NORMAL));
 
         ASSERT_TRACE2("sort (_: _: 1) [ \"foo\" \"bar\" ]",
                       TypeError,


### PR DESCRIPTION
# Motivation

Depends on #9753

This basically prints out what was attempted to be called as function,
i.e.

  map (import <nixpkgs> {}) [ 1 2 3 ]

now gives the following error message:

    error:
           … while calling the 'map' builtin
             at «string»:1:1:
                1| map (import <nixpkgs> {}) [ 1 2 3 ]
                 | ^

           … while evaluating the first argument passed to builtins.map

           error: expected a function but found a set: { _type = "pkgs"; AAAAAASomeThingsFailToEvaluate = «thunk»; AMB-plugins = «thunk»; ArchiSteamFarm = «thunk»; BeatSaberModManager = «thunk»; CHOWTapeModel = «thunk»; ChowCentaur = «thunk»; ChowKick = «thunk»; ChowPhaser = «thunk»; CoinMP = «thunk»;  «18783 attributes elided»}

Remains a draft until #9753 (the parent of this PR) is merged.

# Context

Low-hanging fruit in the spirit of #9753 and #9754 (means 9999years did
all the hard work already), but for

> attempt to call something which is not a function but ...

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
