### PR TITLE
Don't download source tarball if not needed.

### DIFF
--- a/src/libfetchers/cache.hh
+++ b/src/libfetchers/cache.hh
@@ -63,6 +63,7 @@ struct Cache
     struct Result
     {
         bool expired = false;
+        bool storePathValid;
         Attrs infoAttrs;
         StorePath storePath;
     };

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -17,7 +17,8 @@ DownloadFileResult downloadFile(
     const std::string & url,
     const std::string & name,
     bool locked,
-    const Headers & headers)
+    const Headers & headers,
+    bool onlyIfChanged)
 {
     // FIXME: check store
 
@@ -32,6 +33,7 @@ DownloadFileResult downloadFile(
     auto useCached = [&]() -> DownloadFileResult
     {
         return {
+            .storePathValid = cached->storePathValid,
             .storePath = std::move(cached->storePath),
             .etag = getStrAttr(cached->infoAttrs, "etag"),
             .effectiveUrl = getStrAttr(cached->infoAttrs, "url"),
@@ -39,18 +41,19 @@ DownloadFileResult downloadFile(
         };
     };
 
-    if (cached && !cached->expired && cached->storePathValid)
+    bool storePathUseable = cached && (cached->storePathValid || onlyIfChanged);
+    if (storePathUseable && !cached->expired)
         return useCached();
 
     FileTransferRequest request(url);
     request.headers = headers;
-    if (cached && cached->storePathValid)
+    if (storePathUseable)
         request.expectedETag = getStrAttr(cached->infoAttrs, "etag");
     FileTransferResult res;
     try {
         res = getFileTransfer()->download(request);
     } catch (FileTransferError & e) {
-        if (cached && cached->storePathValid) {
+        if (storePathUseable) {
             warn("%s; using cached version", e.msg());
             return useCached();
         } else
@@ -69,7 +72,7 @@ DownloadFileResult downloadFile(
     std::optional<StorePath> storePath;
 
     if (res.cached) {
-        assert(cached && cached->storePathValid);
+        assert(storePathUseable);
         storePath = std::move(cached->storePath);
     } else {
         StringSink sink;
@@ -111,6 +114,7 @@ DownloadFileResult downloadFile(
             locked);
 
     return {
+        .storePathValid = true,
         .storePath = std::move(*storePath),
         .etag = res.etag,
         .effectiveUrl = res.effectiveUri,
@@ -143,6 +147,7 @@ DownloadTarballResult downloadTarball(
         };
 
     auto res = downloadFile(store, url, name, locked, headers);
+    assert(res.storePathValid);
 
     std::optional<StorePath> unpackedStorePath;
     time_t lastModified;
@@ -280,6 +285,7 @@ struct FileInputScheme : CurlInputScheme
     std::pair<StorePath, Input> fetch(ref<Store> store, const Input & input) override
     {
         auto file = downloadFile(store, getStrAttr(input.attrs, "url"), input.getName(), false);
+        assert(file.storePathValid);
         return {std::move(file.storePath), input};
     }
 };

--- a/src/libfetchers/tarball.hh
+++ b/src/libfetchers/tarball.hh
@@ -13,6 +13,7 @@ namespace nix::fetchers {
 
 struct DownloadFileResult
 {
+    bool storePathValid;
     StorePath storePath;
     std::string etag;
     std::string effectiveUrl;
@@ -24,7 +25,8 @@ DownloadFileResult downloadFile(
     const std::string & url,
     const std::string & name,
     bool locked,
-    const Headers & headers = {});
+    const Headers & headers = {},
+    bool onlyIfChanged = false);
 
 struct DownloadTarballResult
 {


### PR DESCRIPTION
# Motivation

flake tarball inputs generate two store paths, it first downloads the source file into the store, then unpacks it into another store path.

assuming the file at the source URL hasn't changed, when I run `nix flake update`, if both paths exist, all is good. `nix` will fetch the source URL with an `etag`, and get a `304` response, and do nothing. but if the source file has been deleted from the store, then `nix` will redownload the source file, regardless if the unpacked store path is still valid.

this commit makes sure if the unpacked source exists in the store, the source file will only be downloaded if it has changed.

# Context

* I changed `cache->lookupExpired(store, attrs)` so it returns the cache entry along with if the store path is still valid, instead of just throwing it away when the path is invalid.
* I added a parameter `onlyIfChanged` to `downloadFile`. when `true`, `downloadFile` will only download the source file if it's different from the cache, even when the source file doesn't exist in store.
* Finally I changed `downloadTarball` to utilize this parameter to achieve what I described in the motivation section

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
