### PR TITLE
Start standardizing hash algo flags

### DIFF
--- a/doc/manual/rl-next/nix-hash-convert.md
+++ b/doc/manual/rl-next/nix-hash-convert.md
@@ -9,7 +9,7 @@ to stabilization! Examples:
 - Convert the hash to `nix32`.
 
   ```bash
-  $ nix hash convert --algo "sha1" --to nix32 "800d59cfcd3c05e900cb4e214be48f6b886a08df"
+  $ nix hash convert --hash-algo "sha1" --to nix32 "800d59cfcd3c05e900cb4e214be48f6b886a08df"
   vw46m23bizj4n8afrc0fj19wrp7mj3c0
   ```
   `nix32` is a base32 encoding with a nix-specific character set.
@@ -17,23 +17,23 @@ to stabilization! Examples:
   hash.
 - Convert the hash to the `sri` format that includes an algorithm specification:
   ```bash
-  nix hash convert --algo "sha1" "800d59cfcd3c05e900cb4e214be48f6b886a08df"
+  nix hash convert --hash-algo "sha1" "800d59cfcd3c05e900cb4e214be48f6b886a08df"
   sha1-gA1Zz808BekAy04hS+SPa4hqCN8=
   ```
   or with an explicit `-to` format:
   ```bash
-  nix hash convert --algo "sha1" --to sri "800d59cfcd3c05e900cb4e214be48f6b886a08df"
+  nix hash convert --hash-algo "sha1" --to sri "800d59cfcd3c05e900cb4e214be48f6b886a08df"
   sha1-gA1Zz808BekAy04hS+SPa4hqCN8=
   ```
 - Assert the input format of the hash:
   ```bash
-  nix hash convert --algo "sha256" --from nix32 "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+  nix hash convert --hash-algo "sha256" --from nix32 "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
   error: input hash 'ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=' does not have the expected format '--from nix32'
-  nix hash convert --algo "sha256" --from nix32 "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
+  nix hash convert --hash-algo "sha256" --from nix32 "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s"
   sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=
   ```
 
-The `--to`/`--from`/`--algo` parameters have context-sensitive auto-completion.
+The `--to`/`--from`/`--hash-algo` parameters have context-sensitive auto-completion.
 
 ## Related Deprecations
 

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -177,7 +177,13 @@ protected:
         std::optional<ExperimentalFeature> experimentalFeature;
 
         static Flag mkHashAlgoFlag(std::string && longName, HashAlgorithm * ha);
+        static Flag mkHashAlgoFlag(HashAlgorithm * ha) {
+            return mkHashAlgoFlag("hash-algo", ha);
+        }
         static Flag mkHashAlgoOptFlag(std::string && longName, std::optional<HashAlgorithm> * oha);
+        static Flag mkHashAlgoOptFlag(std::optional<HashAlgorithm> * oha) {
+            return mkHashAlgoOptFlag("hash-algo", oha);
+        }
         static Flag mkHashFormatFlagWithDefault(std::string && longName, HashFormat * hf);
         static Flag mkHashFormatOptFlag(std::string && longName, std::optional<HashFormat> * ohf);
     };

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -53,7 +53,7 @@ struct CmdAddToStore : MixDryRun, StoreCommand
             }},
         });
 
-        addFlag(Flag::mkHashAlgoFlag("hash-algo", &hashAlgo));
+        addFlag(Flag::mkHashAlgoFlag(&hashAlgo));
     }
 
     void run(ref<Store> store) override

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -141,7 +141,7 @@ struct CmdHashConvert : Command
     CmdHashConvert(): to(HashFormat::SRI) {
         addFlag(Args::Flag::mkHashFormatOptFlag("from", &from));
         addFlag(Args::Flag::mkHashFormatFlagWithDefault("to", &to));
-        addFlag(Args::Flag::mkHashAlgoOptFlag("algo", &algo));
+        addFlag(Args::Flag::mkHashAlgoOptFlag(&algo));
         expectArgs({
            .label = "hashes",
            .handler = {&hashStrings},

--- a/tests/functional/hash.sh
+++ b/tests/functional/hash.sh
@@ -87,7 +87,7 @@ try3() {
     # $2 = expected hash in base16
     # $3 = expected hash in base32
     # $4 = expected hash in base64
-    h64=$(nix hash convert --algo "$1" --to base64 "$2")
+    h64=$(nix hash convert --hash-algo "$1" --to base64 "$2")
     [ "$h64" = "$4" ]
     h64=$(nix-hash --type "$1" --to-base64 "$2")
     [ "$h64" = "$4" ]
@@ -95,13 +95,13 @@ try3() {
     h64=$(nix hash to-base64 --type "$1" "$2")
     [ "$h64" = "$4" ]
 
-    sri=$(nix hash convert --algo "$1" --to sri "$2")
+    sri=$(nix hash convert --hash-algo "$1" --to sri "$2")
     [ "$sri" = "$1-$4" ]
     sri=$(nix-hash --type "$1" --to-sri "$2")
     [ "$sri" = "$1-$4" ]
     sri=$(nix hash to-sri --type "$1" "$2")
     [ "$sri" = "$1-$4" ]
-    h32=$(nix hash convert --algo "$1" --to base32 "$2")
+    h32=$(nix hash convert --hash-algo "$1" --to base32 "$2")
     [ "$h32" = "$3" ]
     h32=$(nix-hash --type "$1" --to-base32 "$2")
     [ "$h32" = "$3" ]
@@ -110,7 +110,7 @@ try3() {
     h16=$(nix-hash --type "$1" --to-base16 "$h32")
     [ "$h16" = "$2" ]
 
-    h16=$(nix hash convert --algo "$1" --to base16 "$h64")
+    h16=$(nix hash convert --hash-algo "$1" --to base16 "$h64")
     [ "$h16" = "$2" ]
     h16=$(nix hash to-base16 --type "$1" "$h64")
     [ "$h16" = "$2" ]
@@ -143,40 +143,40 @@ try3() {
     # Auto-detecting the input from algo and length.
     #
 
-    sri=$(nix hash convert --algo "$1" "$2")
+    sri=$(nix hash convert --hash-algo "$1" "$2")
     [ "$sri" = "$1-$4" ]
-    sri=$(nix hash convert --algo "$1" "$3")
+    sri=$(nix hash convert --hash-algo "$1" "$3")
     [ "$sri" = "$1-$4" ]
-    sri=$(nix hash convert --algo "$1" "$4")
+    sri=$(nix hash convert --hash-algo "$1" "$4")
     [ "$sri" = "$1-$4" ]
 
-    sri=$(nix hash convert --algo "$1" "$2")
+    sri=$(nix hash convert --hash-algo "$1" "$2")
     [ "$sri" = "$1-$4" ]
-    sri=$(nix hash convert --algo "$1" "$3")
+    sri=$(nix hash convert --hash-algo "$1" "$3")
     [ "$sri" = "$1-$4" ]
-    sri=$(nix hash convert --algo "$1" "$4")
+    sri=$(nix hash convert --hash-algo "$1" "$4")
     [ "$sri" = "$1-$4" ]
 
     #
     # Asserting input format succeeds.
     #
 
-    sri=$(nix hash convert --algo "$1" --from base16 "$2")
+    sri=$(nix hash convert --hash-algo "$1" --from base16 "$2")
     [ "$sri" = "$1-$4" ]
-    sri=$(nix hash convert --algo "$1" --from nix32 "$3")
+    sri=$(nix hash convert --hash-algo "$1" --from nix32 "$3")
     [ "$sri" = "$1-$4" ]
-    sri=$(nix hash convert --algo "$1" --from base64 "$4")
+    sri=$(nix hash convert --hash-algo "$1" --from base64 "$4")
     [ "$sri" = "$1-$4" ]
 
     #
     # Asserting input format fails.
     #
 
-    fail=$(nix hash convert --algo "$1" --from nix32 "$2" 2>&1 || echo "exit: $?")
+    fail=$(nix hash convert --hash-algo "$1" --from nix32 "$2" 2>&1 || echo "exit: $?")
     [[ "$fail" == *"error: input hash"*"exit: 1" ]]
-    fail=$(nix hash convert --algo "$1" --from base16 "$3" 2>&1 || echo "exit: $?")
+    fail=$(nix hash convert --hash-algo "$1" --from base16 "$3" 2>&1 || echo "exit: $?")
     [[ "$fail" == *"error: input hash"*"exit: 1" ]]
-    fail=$(nix hash convert --algo "$1" --from nix32 "$4" 2>&1 || echo "exit: $?")
+    fail=$(nix hash convert --hash-algo "$1" --from nix32 "$4" 2>&1 || echo "exit: $?")
     [[ "$fail" == *"error: input hash"*"exit: 1" ]]
 
 }


### PR DESCRIPTION
# Motivation

Do this if we want to do `--hash-algo` everywhere, and not `--algo` for hash commands.

The new `nix hash convert` is updated. Deprecated new CLI commands are left as-is (`nix hash path` needs to be redone and is also left as-is).

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
