### PR TITLE
tests/nixos: Test remote build against older versions

### DIFF
--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -28,6 +28,13 @@ let
       };
     };
 
+  # Checks that a NixOS configuration does not contain any references to our
+  # locally defined Nix version.
+  checkOverrideNixVersion = { pkgs, lib, ... }: {
+    # pkgs.nix: The new Nix in this repo
+    # We disallow it, to make sure we don't accidentally use it.
+    system.forbiddenDependenciesRegex = lib.strings.escapeRegex "nix-${pkgs.nix.version}";
+  };
 in
 
 {
@@ -35,7 +42,100 @@ in
 
   remoteBuilds = runNixOSTestFor "x86_64-linux" ./remote-builds.nix;
 
+  # Test our Nix as a client against remotes that are older
+
+  remoteBuilds_remote_2_3 = runNixOSTestFor "x86_64-linux" {
+    name = "remoteBuilds_remote_2_3";
+    imports = [ ./remote-builds.nix ];
+    builders.config = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_3;
+    };
+  };
+
+  remoteBuilds_remote_2_13 = runNixOSTestFor "x86_64-linux" ({ lib, pkgs, ... }: {
+    name = "remoteBuilds_remote_2_13";
+    imports = [ ./remote-builds.nix ];
+    builders.config = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_3;
+    };
+  });
+
+  # TODO: (nixpkgs update) remoteBuilds_remote_2_18 = ...
+
+  # Test our Nix as a builder for clients that are older
+
+  remoteBuilds_local_2_3 = runNixOSTestFor "x86_64-linux" ({ lib, pkgs, ... }: {
+    name = "remoteBuilds_local_2_3";
+    imports = [ ./remote-builds.nix ];
+    nodes.client = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_3;
+    };
+  });
+
+  remoteBuilds_local_2_13 = runNixOSTestFor "x86_64-linux" ({ lib, pkgs, ... }: {
+    name = "remoteBuilds_local_2_13";
+    imports = [ ./remote-builds.nix ];
+    nodes.client = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_13;
+    };
+  });
+
+  # TODO: (nixpkgs update) remoteBuilds_local_2_18 = ...
+
+  # End remoteBuilds tests
+
   remoteBuildsSshNg = runNixOSTestFor "x86_64-linux" ./remote-builds-ssh-ng.nix;
+
+  # Test our Nix as a client against remotes that are older
+
+  remoteBuildsSshNg_remote_2_3 = runNixOSTestFor "x86_64-linux" {
+    name = "remoteBuildsSshNg_remote_2_3";
+    imports = [ ./remote-builds-ssh-ng.nix ];
+    builders.config = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_3;
+    };
+  };
+
+  remoteBuildsSshNg_remote_2_13 = runNixOSTestFor "x86_64-linux" {
+    name = "remoteBuildsSshNg_remote_2_13";
+    imports = [ ./remote-builds-ssh-ng.nix ];
+    builders.config = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_13;
+    };
+  };
+  
+  # TODO: (nixpkgs update) remoteBuildsSshNg_remote_2_18 = ...
+
+  # Test our Nix as a builder for clients that are older
+
+  # FIXME: these tests don't work yet
+  /*
+  remoteBuildsSshNg_local_2_3 = runNixOSTestFor "x86_64-linux" ({ lib, pkgs, ... }: {
+    name = "remoteBuildsSshNg_local_2_3";
+    imports = [ ./remote-builds-ssh-ng.nix ];
+    nodes.client = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_3;
+    };
+  });
+
+  remoteBuildsSshNg_local_2_13 = runNixOSTestFor "x86_64-linux" ({ lib, pkgs, ... }: {
+    name = "remoteBuildsSshNg_local_2_13";
+    imports = [ ./remote-builds-ssh-ng.nix ];
+    nodes.client = { lib, pkgs, ... }: {
+      imports = [ checkOverrideNixVersion ];
+      nix.package = lib.mkForce pkgs.nixVersions.nix_2_13;
+    };
+  });
+
+  # TODO: (nixpkgs update) remoteBuildsSshNg_local_2_18 = ...
+  */
 
   nix-copy-closure = runNixOSTestFor "x86_64-linux" ./nix-copy-closure.nix;
 

--- a/tests/nixos/remote-builds-ssh-ng.nix
+++ b/tests/nixos/remote-builds-ssh-ng.nix
@@ -1,4 +1,4 @@
-{ config, lib, hostPkgs, ... }:
+test@{ config, lib, hostPkgs, ... }:
 
 let
   pkgs = config.nodes.client.nixpkgs.pkgs;
@@ -28,12 +28,27 @@ let
 in
 
 {
-  name = "remote-builds-ssh-ng";
+  name = lib.mkDefault "remote-builds-ssh-ng";
+
+  # TODO expand module shorthand syntax instead of use imports
+  imports = [{
+    options = {
+      builders.config = lib.mkOption {
+        type = lib.types.deferredModule;
+        description = ''
+          Configuration to add to the builder nodes.
+        '';
+        default = { };
+      };
+    };
+  }];
 
   nodes =
     { builder =
       { config, pkgs, ... }:
-      { services.openssh.enable = true;
+      {
+        imports = [ test.config.builders.config ];
+        services.openssh.enable = true;
         virtualisation.writableStore = true;
         nix.settings.sandbox = true;
         nix.settings.substituters = lib.mkForce [ ];

--- a/tests/nixos/remote-builds-ssh-ng.nix
+++ b/tests/nixos/remote-builds-ssh-ng.nix
@@ -42,29 +42,31 @@ in
     name = lib.mkDefault "remote-builds-ssh-ng";
 
     nodes =
-      { builder =
-        { config, pkgs, ... }:
-        {
-          imports = [ test.config.builders.config ];
-          services.openssh.enable = true;
-          virtualisation.writableStore = true;
-          nix.settings.sandbox = true;
-          nix.settings.substituters = lib.mkForce [ ];
-        };
+      {
+        builder =
+          { config, pkgs, ... }:
+          {
+            imports = [ test.config.builders.config ];
+            services.openssh.enable = true;
+            virtualisation.writableStore = true;
+            nix.settings.sandbox = true;
+            nix.settings.substituters = lib.mkForce [ ];
+          };
 
         client =
           { config, lib, pkgs, ... }:
-          { nix.settings.max-jobs = 0; # force remote building
+          {
+            nix.settings.max-jobs = 0; # force remote building
             nix.distributedBuilds = true;
             nix.buildMachines =
-              [ { hostName = "builder";
-                  sshUser = "root";
-                  sshKey = "/root/.ssh/id_ed25519";
-                  system = "i686-linux";
-                  maxJobs = 1;
-                  protocol = "ssh-ng";
-                }
-              ];
+              [{
+                hostName = "builder";
+                sshUser = "root";
+                sshKey = "/root/.ssh/id_ed25519";
+                system = "i686-linux";
+                maxJobs = 1;
+                protocol = "ssh-ng";
+              }];
             virtualisation.writableStore = true;
             virtualisation.additionalPaths = [ config.system.build.extraUtils ];
             nix.settings.substituters = lib.mkForce [ ];

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -1,6 +1,6 @@
 # Test Nix's remote build feature.
 
-{ config, lib, hostPkgs, ... }:
+test@{ config, lib, hostPkgs, ... }:
 
 let
   pkgs = config.nodes.client.nixpkgs.pkgs;
@@ -8,7 +8,9 @@ let
   # The configuration of the remote builders.
   builder =
     { config, pkgs, ... }:
-    { services.openssh.enable = true;
+    {
+      imports = [ test.config.builders.config ];
+      services.openssh.enable = true;
       virtualisation.writableStore = true;
       nix.settings.sandbox = true;
 
@@ -35,7 +37,20 @@ let
 in
 
 {
-  name = "remote-builds";
+  name = lib.mkDefault "remote-builds";
+
+  # TODO expand module shorthand syntax instead of use imports
+  imports = [{
+    options = {
+      builders.config = lib.mkOption {
+        type = lib.types.deferredModule;
+        description = ''
+          Configuration to add to the builder nodes.
+        '';
+        default = { };
+      };
+    };
+  }];
 
   nodes =
     { builder1 = builder;

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -51,21 +51,26 @@ in
     name = lib.mkDefault "remote-builds";
 
     nodes =
-      { builder1 = builder;
+      {
+        builder1 = builder;
         builder2 = builder;
 
         client =
           { config, lib, pkgs, ... }:
-          { nix.settings.max-jobs = 0; # force remote building
+          {
+            nix.settings.max-jobs = 0; # force remote building
             nix.distributedBuilds = true;
             nix.buildMachines =
-              [ { hostName = "builder1";
+              [
+                {
+                  hostName = "builder1";
                   sshUser = "root";
                   sshKey = "/root/.ssh/id_ed25519";
                   system = "i686-linux";
                   maxJobs = 1;
                 }
-                { hostName = "builder2";
+                {
+                  hostName = "builder2";
                   sshUser = "root";
                   sshKey = "/root/.ssh/id_ed25519";
                   system = "i686-linux";

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -37,90 +37,89 @@ let
 in
 
 {
-  name = lib.mkDefault "remote-builds";
+  options = {
+    builders.config = lib.mkOption {
+      type = lib.types.deferredModule;
+      description = ''
+        Configuration to add to the builder nodes.
+      '';
+      default = { };
+    };
+  };
 
-  # TODO expand module shorthand syntax instead of use imports
-  imports = [{
-    options = {
-      builders.config = lib.mkOption {
-        type = lib.types.deferredModule;
-        description = ''
-          Configuration to add to the builder nodes.
-        '';
-        default = { };
+  config = {
+    name = lib.mkDefault "remote-builds";
+
+    nodes =
+      { builder1 = builder;
+        builder2 = builder;
+
+        client =
+          { config, lib, pkgs, ... }:
+          { nix.settings.max-jobs = 0; # force remote building
+            nix.distributedBuilds = true;
+            nix.buildMachines =
+              [ { hostName = "builder1";
+                  sshUser = "root";
+                  sshKey = "/root/.ssh/id_ed25519";
+                  system = "i686-linux";
+                  maxJobs = 1;
+                }
+                { hostName = "builder2";
+                  sshUser = "root";
+                  sshKey = "/root/.ssh/id_ed25519";
+                  system = "i686-linux";
+                  maxJobs = 1;
+                }
+              ];
+            virtualisation.writableStore = true;
+            virtualisation.additionalPaths = [ config.system.build.extraUtils ];
+            nix.settings.substituters = lib.mkForce [ ];
+            programs.ssh.extraConfig = "ConnectTimeout 30";
+          };
       };
-    };
-  }];
 
-  nodes =
-    { builder1 = builder;
-      builder2 = builder;
+    testScript = { nodes }: ''
+      # fmt: off
+      import subprocess
 
-      client =
-        { config, lib, pkgs, ... }:
-        { nix.settings.max-jobs = 0; # force remote building
-          nix.distributedBuilds = true;
-          nix.buildMachines =
-            [ { hostName = "builder1";
-                sshUser = "root";
-                sshKey = "/root/.ssh/id_ed25519";
-                system = "i686-linux";
-                maxJobs = 1;
-              }
-              { hostName = "builder2";
-                sshUser = "root";
-                sshKey = "/root/.ssh/id_ed25519";
-                system = "i686-linux";
-                maxJobs = 1;
-              }
-            ];
-          virtualisation.writableStore = true;
-          virtualisation.additionalPaths = [ config.system.build.extraUtils ];
-          nix.settings.substituters = lib.mkForce [ ];
-          programs.ssh.extraConfig = "ConnectTimeout 30";
-        };
-    };
+      start_all()
 
-  testScript = { nodes }: ''
-    # fmt: off
-    import subprocess
+      # Create an SSH key on the client.
+      subprocess.run([
+        "${hostPkgs.openssh}/bin/ssh-keygen", "-t", "ed25519", "-f", "key", "-N", ""
+      ], capture_output=True, check=True)
+      client.succeed("mkdir -p -m 700 /root/.ssh")
+      client.copy_from_host("key", "/root/.ssh/id_ed25519")
+      client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
-    start_all()
+      # Install the SSH key on the builders.
+      client.wait_for_unit("network.target")
+      for builder in [builder1, builder2]:
+        builder.succeed("mkdir -p -m 700 /root/.ssh")
+        builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
+        builder.wait_for_unit("sshd")
+        client.succeed(f"ssh -o StrictHostKeyChecking=no {builder.name} 'echo hello world'")
 
-    # Create an SSH key on the client.
-    subprocess.run([
-      "${hostPkgs.openssh}/bin/ssh-keygen", "-t", "ed25519", "-f", "key", "-N", ""
-    ], capture_output=True, check=True)
-    client.succeed("mkdir -p -m 700 /root/.ssh")
-    client.copy_from_host("key", "/root/.ssh/id_ed25519")
-    client.succeed("chmod 600 /root/.ssh/id_ed25519")
+      # Perform a build and check that it was performed on the builder.
+      out = client.succeed(
+        "nix-build ${expr nodes.client 1} 2> build-output",
+        "grep -q Hello build-output"
+      )
+      builder1.succeed(f"test -e {out}")
 
-    # Install the SSH key on the builders.
-    client.wait_for_unit("network.target")
-    for builder in [builder1, builder2]:
-      builder.succeed("mkdir -p -m 700 /root/.ssh")
-      builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
-      builder.wait_for_unit("sshd")
-      client.succeed(f"ssh -o StrictHostKeyChecking=no {builder.name} 'echo hello world'")
+      # And a parallel build.
+      paths = client.succeed(r'nix-store -r $(nix-instantiate ${expr nodes.client 2})\!out $(nix-instantiate ${expr nodes.client 3})\!out')
+      out1, out2 = paths.split()
+      builder1.succeed(f"test -e {out1} -o -e {out2}")
+      builder2.succeed(f"test -e {out1} -o -e {out2}")
 
-    # Perform a build and check that it was performed on the builder.
-    out = client.succeed(
-      "nix-build ${expr nodes.client 1} 2> build-output",
-      "grep -q Hello build-output"
-    )
-    builder1.succeed(f"test -e {out}")
+      # And a failing build.
+      client.fail("nix-build ${expr nodes.client 5}")
 
-    # And a parallel build.
-    paths = client.succeed(r'nix-store -r $(nix-instantiate ${expr nodes.client 2})\!out $(nix-instantiate ${expr nodes.client 3})\!out')
-    out1, out2 = paths.split()
-    builder1.succeed(f"test -e {out1} -o -e {out2}")
-    builder2.succeed(f"test -e {out1} -o -e {out2}")
-
-    # And a failing build.
-    client.fail("nix-build ${expr nodes.client 5}")
-
-    # Test whether the build hook automatically skips unavailable builders.
-    builder1.block()
-    client.succeed("nix-build ${expr nodes.client 4}")
-  '';
+      # Test whether the build hook automatically skips unavailable builders.
+      builder1.block()
+      client.succeed("nix-build ${expr nodes.client 4}")
+    '';
+  };
 }


### PR DESCRIPTION
# Motivation

We want to know that
- remote builds work when the remote builder runs a different version.
- remote builds work in older versions when we're the remote builder.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
