### PR TITLE
Update nix-build.cc: don't add gcc automatically

### DIFF
--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -273,7 +273,7 @@ static void main_nix_build(int argc, char * * argv)
 
     if (packages) {
         std::ostringstream joined;
-        joined << "{...}@args: with import <nixpkgs> args; (pkgs.runCommandCC or pkgs.runCommand) \"shell\" { buildInputs = [ ";
+        joined << "{...}@args: with import <nixpkgs> args; (pkgs.runCommand or pkgs.runCommandCC) \"shell\" { buildInputs = [ ";
         for (const auto & i : left)
             joined << '(' << i << ") ";
         joined << "]; } \"\"";


### PR DESCRIPTION


# Motivation
`nix-shell -p gcc13 --run "gcc --version"` always prints the version of gcc12, the current default gcc. This doesn't work as expected. In a flake shell however, it works as expected.

With this change, this doesn't happen anymore. 

# Context
This changes arises from this upstream discussion:

https://github.com/NixOS/nixpkgs/issues/283248#event-11573017053

I didn't test this but it looks as it would work.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
