### PR TITLE
Make `Machine::systemTypes` a set not vector

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -139,9 +139,7 @@ static int main_build_remote(int argc, char * * argv)
 
                     if (m.enabled
                         && (neededSystem == "builtin"
-                            || std::find(m.systemTypes.begin(),
-                                m.systemTypes.end(),
-                                neededSystem) != m.systemTypes.end()) &&
+                            || m.systemTypes.count(neededSystem) > 0) &&
                         m.allSupported(requiredFeatures) &&
                         m.mandatoryMet(requiredFeatures))
                     {
@@ -214,7 +212,7 @@ static int main_build_remote(int argc, char * * argv)
 
                         for (auto & m : machines)
                             error
-                                % concatStringsSep<std::vector<std::string>>(", ", m.systemTypes)
+                                % concatStringsSep<StringSet>(", ", m.systemTypes)
                                 % m.maxJobs
                                 % concatStringsSep<StringSet>(", ", m.supportedFeatures)
                                 % concatStringsSep<StringSet>(", ", m.mandatoryFeatures);

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -145,7 +145,7 @@ static Machine parseBuilderLine(const std::string & line)
 
     return {
         tokens[0],
-        isSet(1) ? tokenizeString<std::vector<std::string>>(tokens[1], ",") : std::vector<std::string>{settings.thisSystem},
+        isSet(1) ? tokenizeString<std::set<std::string>>(tokens[1], ",") : std::set<std::string>{settings.thisSystem},
         isSet(2) ? tokens[2] : "",
         isSet(3) ? parseUnsignedIntField(3) : 1U,
         isSet(4) ? parseUnsignedIntField(4) : 1U,

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -10,7 +10,7 @@ class Store;
 struct Machine {
 
     const std::string storeUri;
-    const std::vector<std::string> systemTypes;
+    const std::set<std::string> systemTypes;
     const std::string sshKey;
     const unsigned int maxJobs;
     const unsigned int speedFactor;


### PR DESCRIPTION
# Motivation

This is more conceptually correct (the order does not matter), and also matches what Hydra already does.

# Context

Nix and Hydra matching is needed for dedup
https://github.com/NixOS/hydra/issues/1164
# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
