### PR TITLE
Create `StoreURI` and use it in `Machine`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -351,7 +351,7 @@ fi
 AS_IF([test "$ENABLE_UNIT_TESTS" == "yes"],[
 
 # Look for gtest.
-PKG_CHECK_MODULES([GTEST], [gtest_main])
+PKG_CHECK_MODULES([GTEST], [gtest_main gmock_main])
 
 # Look for rapidcheck.
 PKG_CHECK_MODULES([RAPIDCHECK], [rapidcheck rapidcheck_gtest])

--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -37,7 +37,7 @@ static std::string currentLoad;
 
 static AutoCloseFD openSlotLock(const Machine & m, uint64_t slot)
 {
-    return openLockFile(fmt("%s/%s-%d", currentLoad, escapeUri(m.storeUri), slot), true);
+    return openLockFile(fmt("%s/%s-%d", currentLoad, escapeUri(m.storeUri.render()), slot), true);
 }
 
 static bool allSupportedLocally(Store & store, const std::set<std::string>& requiredFeatures) {
@@ -99,7 +99,7 @@ static int main_build_remote(int argc, char * * argv)
         }
 
         std::optional<StorePath> drvPath;
-        std::string storeUri;
+        StoreURI storeUri;
 
         while (true) {
 
@@ -135,7 +135,7 @@ static int main_build_remote(int argc, char * * argv)
                 Machine * bestMachine = nullptr;
                 uint64_t bestLoad = 0;
                 for (auto & m : machines) {
-                    debug("considering building on remote machine '%s'", m.storeUri);
+                    debug("considering building on remote machine '%s'", m.storeUri.render());
 
                     if (m.enabled &&
                         m.systemSupported(neededSystem) &&
@@ -233,7 +233,7 @@ static int main_build_remote(int argc, char * * argv)
 
                 try {
 
-                    Activity act(*logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", bestMachine->storeUri));
+                    Activity act(*logger, lvlTalkative, actUnknown, fmt("connecting to '%s'", bestMachine->storeUri.render()));
 
                     sshStore = bestMachine->openStore();
                     sshStore->connect();
@@ -242,7 +242,7 @@ static int main_build_remote(int argc, char * * argv)
                 } catch (std::exception & e) {
                     auto msg = chomp(drainFD(5, false));
                     printError("cannot build on '%s': %s%s",
-                        bestMachine->storeUri, e.what(),
+                        bestMachine->storeUri.render(), e.what(),
                         msg.empty() ? "" : ": " + msg);
                     bestMachine->enabled = false;
                     continue;
@@ -257,15 +257,15 @@ connected:
 
         assert(sshStore);
 
-        std::cerr << "# accept\n" << storeUri << "\n";
+        std::cerr << "# accept\n" << storeUri.render() << "\n";
 
         auto inputs = readStrings<PathSet>(source);
         auto wantedOutputs = readStrings<StringSet>(source);
 
-        AutoCloseFD uploadLock = openLockFile(currentLoad + "/" + escapeUri(storeUri) + ".upload-lock", true);
+        AutoCloseFD uploadLock = openLockFile(currentLoad + "/" + escapeUri(storeUri.render()) + ".upload-lock", true);
 
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("waiting for the upload lock to '%s'", storeUri));
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("waiting for the upload lock to '%s'", storeUri.render()));
 
             auto old = signal(SIGALRM, handleAlarm);
             alarm(15 * 60);
@@ -278,7 +278,7 @@ connected:
         auto substitute = settings.buildersUseSubstitutes ? Substitute : NoSubstitute;
 
         {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri));
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying dependencies to '%s'", storeUri.render()));
             copyPaths(*store, *sshStore, store->parseStorePathSet(inputs), NoRepair, NoCheckSigs, substitute);
         }
 
@@ -316,7 +316,7 @@ connected:
             optResult = sshStore->buildDerivation(*drvPath, (const BasicDerivation &) drv);
             auto & result = *optResult;
             if (!result.success())
-                throw Error("build of '%s' on '%s' failed: %s", store->printStorePath(*drvPath), storeUri, result.errorMsg);
+                throw Error("build of '%s' on '%s' failed: %s", store->printStorePath(*drvPath), storeUri.render(), result.errorMsg);
         } else {
             copyClosure(*store, *sshStore, StorePathSet {*drvPath}, NoRepair, NoCheckSigs, substitute);
             auto res = sshStore->buildPathsWithResults({
@@ -359,7 +359,7 @@ connected:
         }
 
         if (!missingPaths.empty()) {
-            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying outputs from '%s'", storeUri));
+            Activity act(*logger, lvlTalkative, actUnknown, fmt("copying outputs from '%s'", storeUri.render()));
             if (auto localStore = store.dynamic_pointer_cast<LocalStore>())
                 for (auto & path : missingPaths)
                     localStore->locksHeld.insert(store->printStorePath(path)); /* FIXME: ugly */

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -6,7 +6,8 @@
 
 namespace nix {
 
-Machine::Machine(decltype(storeUri) storeUri,
+Machine::Machine(
+    const std::string & storeUri,
     decltype(systemTypes) systemTypes,
     decltype(sshKey) sshKey,
     decltype(maxJobs) maxJobs,
@@ -14,21 +15,15 @@ Machine::Machine(decltype(storeUri) storeUri,
     decltype(supportedFeatures) supportedFeatures,
     decltype(mandatoryFeatures) mandatoryFeatures,
     decltype(sshPublicHostKey) sshPublicHostKey) :
-    storeUri(
-        // Backwards compatibility: if the URI is schemeless, is not a path,
-        // and is not one of the special store connection words, prepend
-        // ssh://.
-        storeUri.find("://") != std::string::npos
-        || storeUri.find("/") != std::string::npos
-        || storeUri == "auto"
-        || storeUri == "daemon"
-        || storeUri == "local"
-        || hasPrefix(storeUri, "auto?")
-        || hasPrefix(storeUri, "daemon?")
-        || hasPrefix(storeUri, "local?")
-        || hasPrefix(storeUri, "?")
-        ? storeUri
-        : "ssh://" + storeUri),
+    storeUri([&storeUri]{
+        try {
+            return StoreURI::parse(storeUri);
+        } catch (UsageError &) {
+            // Backwards compatibility: if the URI is invalid, it might
+            // be bare host name.
+            return StoreURI::parse("ssh://" + storeUri);
+        }
+    }()),
     systemTypes(systemTypes),
     sshKey(sshKey),
     maxJobs(maxJobs),
@@ -62,21 +57,24 @@ bool Machine::mandatoryMet(const std::set<std::string> & features) const
 
 ref<Store> Machine::openStore() const
 {
-    Store::Params storeParams;
-    if (hasPrefix(storeUri, "ssh://")) {
-        storeParams["max-connections"] = "1";
-        storeParams["log-fd"] = "4";
+    auto storeUri = this->storeUri;
+
+    auto * generic = std::get_if<StoreURI::Generic>(&storeUri.variant);
+
+    if (generic && generic->scheme == "ssh") {
+        storeUri.params["max-connections"] = "1";
+        storeUri.params["log-fd"] = "4";
     }
 
-    if (hasPrefix(storeUri, "ssh://") || hasPrefix(storeUri, "ssh-ng://")) {
+    if (generic && generic->scheme == "ssh-ng") {
         if (sshKey != "")
-            storeParams["ssh-key"] = sshKey;
+            storeUri.params["ssh-key"] = sshKey;
         if (sshPublicHostKey != "")
-            storeParams["base64-ssh-public-host-key"] = sshPublicHostKey;
+            storeUri.params["base64-ssh-public-host-key"] = sshPublicHostKey;
     }
 
     {
-        auto & fs = storeParams["system-features"];
+        auto & fs = storeUri.params["system-features"];
         auto append = [&](auto feats) {
             for (auto & f : feats) {
                 if (fs.size() > 0) fs += ' ';
@@ -87,7 +85,7 @@ ref<Store> Machine::openStore() const
         append(mandatoryFeatures);
     }
 
-    return nix::openStore(storeUri, storeParams);
+    return nix::openStore(std::move(storeUri));
 }
 
 static std::vector<std::string> expandBuilderLines(const std::string & builders)

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include "types.hh"
+#include "store-uri.hh"
 
 namespace nix {
 
@@ -9,7 +10,7 @@ class Store;
 
 struct Machine {
 
-    const std::string storeUri;
+    const StoreURI storeUri;
     const std::set<std::string> systemTypes;
     const std::string sshKey;
     const unsigned int maxJobs;
@@ -36,7 +37,8 @@ struct Machine {
      */
     bool mandatoryMet(const std::set<std::string> & features) const;
 
-    Machine(decltype(storeUri) storeUri,
+    Machine(
+        const std::string & storeUri,
         decltype(systemTypes) systemTypes,
         decltype(sshKey) sshKey,
         decltype(maxJobs) maxJobs,

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -8,7 +8,6 @@
 #include "util.hh"
 #include "nar-info-disk-cache.hh"
 #include "thread-pool.hh"
-#include "url.hh"
 #include "references.hh"
 #include "archive.hh"
 #include "callback.hh"
@@ -20,7 +19,6 @@
 #include "users.hh"
 
 #include <nlohmann/json.hpp>
-#include <regex>
 
 using json = nlohmann::json;
 
@@ -1327,141 +1325,70 @@ Derivation Store::readInvalidDerivation(const StorePath & drvPath)
 
 namespace nix {
 
-/* Split URI into protocol+hierarchy part and its parameter set. */
-std::pair<std::string, Store::Params> splitUriAndParams(const std::string & uri_)
-{
-    auto uri(uri_);
-    Store::Params params;
-    auto q = uri.find('?');
-    if (q != std::string::npos) {
-        params = decodeQuery(uri.substr(q + 1));
-        uri = uri_.substr(0, q);
-    }
-    return {uri, params};
-}
-
-static bool isNonUriPath(const std::string & spec)
-{
-    return
-        // is not a URL
-        spec.find("://") == std::string::npos
-        // Has at least one path separator, and so isn't a single word that
-        // might be special like "auto"
-        && spec.find("/") != std::string::npos;
-}
-
-std::shared_ptr<Store> openFromNonUri(const std::string & uri, const Store::Params & params)
-{
-    if (uri == "" || uri == "auto") {
-        auto stateDir = getOr(params, "state", settings.nixStateDir);
-        if (access(stateDir.c_str(), R_OK | W_OK) == 0)
-            return std::make_shared<LocalStore>(params);
-        else if (pathExists(settings.nixDaemonSocketFile))
-            return std::make_shared<UDSRemoteStore>(params);
-        #if __linux__
-        else if (!pathExists(stateDir)
-            && params.empty()
-            && getuid() != 0
-            && !getEnv("NIX_STORE_DIR").has_value()
-            && !getEnv("NIX_STATE_DIR").has_value())
-        {
-            /* If /nix doesn't exist, there is no daemon socket, and
-               we're not root, then automatically set up a chroot
-               store in ~/.local/share/nix/root. */
-            auto chrootStore = getDataDir() + "/nix/root";
-            if (!pathExists(chrootStore)) {
-                try {
-                    createDirs(chrootStore);
-                } catch (Error & e) {
-                    return std::make_shared<LocalStore>(params);
-                }
-                warn("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
-            } else
-                debug("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
-            Store::Params params2;
-            params2["root"] = chrootStore;
-            return std::make_shared<LocalStore>(params2);
-        }
-        #endif
-        else
-            return std::make_shared<LocalStore>(params);
-    } else if (uri == "daemon") {
-        return std::make_shared<UDSRemoteStore>(params);
-    } else if (uri == "local") {
-        return std::make_shared<LocalStore>(params);
-    } else if (isNonUriPath(uri)) {
-        Store::Params params2 = params;
-        params2["root"] = absPath(uri);
-        return std::make_shared<LocalStore>(params2);
-    } else {
-        return nullptr;
-    }
-}
-
-// The `parseURL` function supports both IPv6 URIs as defined in
-// RFC2732, but also pure addresses. The latter one is needed here to
-// connect to a remote store via SSH (it's possible to do e.g. `ssh root@::1`).
-//
-// This function now ensures that a usable connection string is available:
-// * If the store to be opened is not an SSH store, nothing will be done.
-// * If the URL looks like `root@[::1]` (which is allowed by the URL parser and probably
-//   needed to pass further flags), it
-//   will be transformed into `root@::1` for SSH (same for `[::1]` -> `::1`).
-// * If the URL looks like `root@::1` it will be left as-is.
-// * In any other case, the string will be left as-is.
-static std::string extractConnStr(const std::string &proto, const std::string &connStr)
-{
-    if (proto.rfind("ssh") != std::string::npos) {
-        std::smatch result;
-        std::regex v6AddrRegex("^((.*)@)?\\[(.*)\\]$");
-
-        if (std::regex_match(connStr, result, v6AddrRegex)) {
-            if (result[1].matched) {
-                return result.str(1) + result.str(3);
-            }
-            return result.str(3);
-        }
-    }
-
-    return connStr;
-}
-
-ref<Store> openStore(const std::string & uri_,
+ref<Store> openStore(const std::string & uri,
     const Store::Params & extraParams)
 {
-    auto params = extraParams;
-    try {
-        auto parsedUri = parseURL(uri_);
-        params.insert(parsedUri.query.begin(), parsedUri.query.end());
+    return openStore(StoreURI::parse(uri, extraParams));
+}
 
-        auto baseURI = extractConnStr(
-            parsedUri.scheme,
-            parsedUri.authority.value_or("") + parsedUri.path
-        );
+ref<Store> openStore(StoreURI && storeURI)
+{
+    auto & params = storeURI.params;
 
-        for (auto implem : *Implementations::registered) {
-            if (implem.uriSchemes.count(parsedUri.scheme)) {
-                auto store = implem.create(parsedUri.scheme, baseURI, params);
-                if (store) {
-                    experimentalFeatureSettings.require(store->experimentalFeature());
-                    store->init();
-                    store->warnUnknownSettings();
-                    return ref<Store>(store);
-                }
+    auto store = std::visit(overloaded {
+        [&](const StoreURI::Auto &) -> std::shared_ptr<Store> {
+            auto stateDir = getOr(params, "state", settings.nixStateDir);
+            if (access(stateDir.c_str(), R_OK | W_OK) == 0)
+                return std::make_shared<LocalStore>(params);
+            else if (pathExists(settings.nixDaemonSocketFile))
+                return std::make_shared<UDSRemoteStore>(params);
+            #if __linux__
+            else if (!pathExists(stateDir)
+                && params.empty()
+                && getuid() != 0
+                && !getEnv("NIX_STORE_DIR").has_value()
+                && !getEnv("NIX_STATE_DIR").has_value())
+            {
+                /* If /nix doesn't exist, there is no daemon socket, and
+                   we're not root, then automatically set up a chroot
+                   store in ~/.local/share/nix/root. */
+                auto chrootStore = getDataDir() + "/nix/root";
+                if (!pathExists(chrootStore)) {
+                    try {
+                        createDirs(chrootStore);
+                    } catch (Error & e) {
+                        return std::make_shared<LocalStore>(params);
+                    }
+                    warn("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
+                } else
+                    debug("'%s' does not exist, so Nix will use '%s' as a chroot store", stateDir, chrootStore);
+                params["root"] = chrootStore;
+                return std::make_shared<LocalStore>(params);
             }
-        }
-    }
-    catch (BadURL &) {
-        auto [uri, uriParams] = splitUriAndParams(uri_);
-        params.insert(uriParams.begin(), uriParams.end());
+            #endif
+            else
+                return std::make_shared<LocalStore>(params);
+        },
+        [&](const StoreURI::Daemon &) -> std::shared_ptr<Store> {
+            return std::make_shared<UDSRemoteStore>(params);
+        },
+        [&](const StoreURI::Local &) -> std::shared_ptr<Store> {
+            return std::make_shared<LocalStore>(params);
+        },
+        [&](const StoreURI::Generic & g) {
+            for (auto implem : *Implementations::registered)
+                if (implem.uriSchemes.count(g.scheme))
+                    return implem.create(g.scheme, g.authority, params);
 
-        if (auto store = openFromNonUri(uri, params)) {
-            store->warnUnknownSettings();
-            return ref<Store>(store);
-        }
-    }
+            throw Error("don't know how to open Nix store with scheme '%s'", g.scheme);
+        },
+    }, storeURI.variant);
 
-    throw Error("don't know how to open Nix store '%s'", uri_);
+    experimentalFeatureSettings.require(store->experimentalFeature());
+    store->warnUnknownSettings();
+    store->init();
+
+    return ref<Store> { store };
 }
 
 std::list<ref<Store>> getDefaultSubstituters()

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -13,6 +13,7 @@
 #include "path-info.hh"
 #include "repair-flag.hh"
 #include "store-dir-config.hh"
+#include "store-uri.hh"
 #include "source-path.hh"
 
 #include <nlohmann/json_fwd.hpp>
@@ -102,7 +103,7 @@ typedef std::map<StorePath, std::optional<ContentAddress>> StorePathCAMap;
 
 struct StoreConfig : public StoreDirConfig
 {
-    typedef std::map<std::string, std::string> Params;
+    using Params = StoreURI::Params;
 
     using StoreDirConfig::StoreDirConfig;
 
@@ -852,34 +853,13 @@ OutputPathMap resolveDerivedPath(Store &, const DerivedPath::Built &, Store * ev
 /**
  * @return a Store object to access the Nix store denoted by
  * ‘uri’ (slight misnomer...).
- *
- * @param uri Supported values are:
- *
- * - ‘local’: The Nix store in /nix/store and database in
- *   /nix/var/nix/db, accessed directly.
- *
- * - ‘daemon’: The Nix store accessed via a Unix domain socket
- *   connection to nix-daemon.
- *
- * - ‘unix://<path>’: The Nix store accessed via a Unix domain socket
- *   connection to nix-daemon, with the socket located at <path>.
- *
- * - ‘auto’ or ‘’: Equivalent to ‘local’ or ‘daemon’ depending on
- *   whether the user has write access to the local Nix
- *   store/database.
- *
- * - ‘file://<path>’: A binary cache stored in <path>.
- *
- * - ‘https://<path>’: A binary cache accessed via HTTP.
- *
- * - ‘s3://<path>’: A writable binary cache stored on Amazon's Simple
- *   Storage Service.
- *
- * - ‘ssh://[user@]<host>’: A remote Nix store accessed by running
- *   ‘nix-store --serve’ via SSH.
- *
- * You can pass parameters to the store type by appending
- * ‘?key=value&key=value&...’ to the URI.
+ */
+ref<Store> openStore(StoreURI && storeURI);
+
+
+/**
+ * Convenient function to `StoreURI::parse` a raw unparsed store URI and
+ * `openStore` it.
  */
 ref<Store> openStore(const std::string & uri = settings.storeUri.get(),
     const Store::Params & extraParams = Store::Params());
@@ -942,11 +922,6 @@ std::optional<ValidPathInfo> decodeValidPathInfo(
     const Store & store,
     std::istream & str,
     std::optional<HashResult> hashGiven = std::nullopt);
-
-/**
- * Split URI into protocol+hierarchy part and its parameter set.
- */
-std::pair<std::string, Store::Params> splitUriAndParams(const std::string & uri);
 
 const ContentAddress * getDerivationCA(const BasicDerivation & drv);
 

--- a/src/libstore/store-uri.cc
+++ b/src/libstore/store-uri.cc
@@ -4,6 +4,7 @@
 #include "url.hh"
 #include "store-uri.hh"
 #include "file-system.hh"
+#include "util.hh"
 
 namespace nix {
 
@@ -44,6 +45,33 @@ static bool isNonUriPath(const std::string & spec)
         // Has at least one path separator, and so isn't a single word that
         // might be special like "auto"
         && spec.find("/") != std::string::npos;
+}
+
+
+std::string StoreURI::render() const
+{
+    std::string res;
+
+    std::visit(overloaded {
+        [&](const StoreURI::Auto &) {
+            res = "auto";
+        },
+        [&](const StoreURI::Daemon &) {
+            res = "daemon";
+        },
+        [&](const StoreURI::Local &) {
+            res = "local";
+        },
+        [&](const StoreURI::Generic & g) {
+            res = g.scheme;
+            res += "://";
+            res += g.authority;
+        },
+    }, variant);
+
+    res += encodeQuery(params);
+
+    return res;
 }
 
 

--- a/src/libstore/store-uri.cc
+++ b/src/libstore/store-uri.cc
@@ -1,0 +1,115 @@
+#include <regex>
+
+#include "error.hh"
+#include "url.hh"
+#include "store-uri.hh"
+#include "file-system.hh"
+
+namespace nix {
+
+// The `parseURL` function supports both IPv6 URIs as defined in
+// RFC2732, but also pure addresses. The latter one is needed here to
+// connect to a remote store via SSH (it's possible to do e.g. `ssh root@::1`).
+//
+// This function now ensures that a usable connection string is available:
+// * If the store to be opened is not an SSH store, nothing will be done.
+// * If the URL looks like `root@[::1]` (which is allowed by the URL parser and probably
+//   needed to pass further flags), it
+//   will be transformed into `root@::1` for SSH (same for `[::1]` -> `::1`).
+// * If the URL looks like `root@::1` it will be left as-is.
+// * In any other case, the string will be left as-is.
+static std::string extractConnStr(const std::string &proto, const std::string &connStr)
+{
+    if (proto.rfind("ssh") != std::string::npos) {
+        std::smatch result;
+        std::regex v6AddrRegex("^((.*)@)?\\[(.*)\\]$");
+
+        if (std::regex_match(connStr, result, v6AddrRegex)) {
+            if (result[1].matched) {
+                return result.str(1) + result.str(3);
+            }
+            return result.str(3);
+        }
+    }
+
+    return connStr;
+}
+
+
+static bool isNonUriPath(const std::string & spec)
+{
+    return
+        // is not a URL
+        spec.find("://") == std::string::npos
+        // Has at least one path separator, and so isn't a single word that
+        // might be special like "auto"
+        && spec.find("/") != std::string::npos;
+}
+
+
+StoreURI StoreURI::parse(const std::string & uri, const StoreURI::Params & extraParams)
+{
+    auto params = extraParams;
+    try {
+        auto parsedUri = parseURL(uri);
+        params.insert(parsedUri.query.begin(), parsedUri.query.end());
+
+        auto baseURI = extractConnStr(
+            parsedUri.scheme,
+            parsedUri.authority.value_or("") + parsedUri.path
+        );
+
+        return {
+            .variant = Generic {
+                .scheme = std::move(parsedUri.scheme),
+                .authority = std::move(baseURI),
+            },
+            .params = std::move(params),
+        };
+    }
+    catch (BadURL &) {
+        auto [baseURI, uriParams] = splitUriAndParams(uri);
+        params.insert(uriParams.begin(), uriParams.end());
+
+        if (baseURI == "" || baseURI == "auto") {
+            return {
+                .variant = Auto {},
+                .params = std::move(params),
+            };
+        } else if (baseURI == "daemon") {
+            return {
+                .variant = Daemon {},
+                .params = std::move(params),
+            };
+        } else if (baseURI == "local") {
+            return {
+                .variant = Local {},
+                .params = std::move(params),
+            };
+        } else if (isNonUriPath(baseURI)) {
+            params["root"] = absPath(baseURI);
+            return {
+                .variant = Local {},
+                .params = std::move(params),
+            };
+        }
+    }
+
+    throw UsageError("Cannot parse Nix store '%s'", uri);
+}
+
+
+/* Split URI into protocol+hierarchy part and its parameter set. */
+std::pair<std::string, StoreURI::Params> splitUriAndParams(const std::string & uri_)
+{
+    auto uri(uri_);
+    StoreURI::Params params;
+    auto q = uri.find('?');
+    if (q != std::string::npos) {
+        params = decodeQuery(uri.substr(q + 1));
+        uri = uri_.substr(0, q);
+    }
+    return {uri, params};
+}
+
+}

--- a/src/libstore/store-uri.hh
+++ b/src/libstore/store-uri.hh
@@ -86,7 +86,10 @@ struct StoreURI {
 
     auto operator <=> (const StoreURI & rhs) const = default;
 
+    std::string render() const;
+
     static StoreURI parse(const std::string & uri, const Params & extraParams = Params {});
+
 };
 
 /**

--- a/src/libstore/store-uri.hh
+++ b/src/libstore/store-uri.hh
@@ -1,0 +1,97 @@
+#pragma once
+///@file
+
+#include <variant>
+
+#include "types.hh"
+
+namespace nix {
+
+/**
+ * A parsed Store URI (URI is a slight misnomer...), parsed but not yet
+ * resolved to a specific instance and query parms validated.
+ *
+ * Supported values are:
+ *
+ * - ‘local’: The Nix store in /nix/store and database in
+ *   /nix/var/nix/db, accessed directly.
+ *
+ * - ‘daemon’: The Nix store accessed via a Unix domain socket
+ *   connection to nix-daemon.
+ *
+ * - ‘unix://<path>’: The Nix store accessed via a Unix domain socket
+ *   connection to nix-daemon, with the socket located at <path>.
+ *
+ * - ‘auto’ or ‘’: Equivalent to ‘local’ or ‘daemon’ depending on
+ *   whether the user has write access to the local Nix
+ *   store/database.
+ *
+ * - ‘file://<path>’: A binary cache stored in <path>.
+ *
+ * - ‘https://<path>’: A binary cache accessed via HTTP.
+ *
+ * - ‘s3://<path>’: A writable binary cache stored on Amazon's Simple
+ *   Storage Service.
+ *
+ * - ‘ssh://[user@]<host>’: A remote Nix store accessed by running
+ *   ‘nix-store --serve’ via SSH.
+ *
+ * You can pass parameters to the store type by appending
+ * ‘?key=value&key=value&...’ to the URI.
+ */
+struct StoreURI {
+    using Params = std::map<std::string, std::string>;
+
+    /**
+     * Special keyword `` or `auto`
+     */
+    struct Auto {
+        inline auto operator <=> (const Auto & rhs) const = default;
+    };
+
+    /**
+     * Special keyword `local`
+     */
+    struct Local {
+        inline auto operator <=> (const Local & rhs) const = default;
+    };
+
+    /**
+     * Special keyword `daemon`
+     */
+    struct Daemon {
+        inline auto operator <=> (const Daemon & rhs) const = default;
+    };
+
+    /**
+     * General case, a regular `scheme://authority` URL.
+     */
+    struct Generic {
+        std::string scheme;
+        std::string authority;
+
+        auto operator <=> (const Generic & rhs) const = default;
+    };
+
+    typedef std::variant<
+        Auto,
+        Local,
+        Daemon,
+        Generic
+    > Variant;
+
+    Variant variant;
+
+    Params params;
+
+    auto operator <=> (const StoreURI & rhs) const = default;
+
+    static StoreURI parse(const std::string & uri, const Params & extraParams = Params {});
+};
+
+/**
+ * Split URI into protocol+hierarchy part and its parameter set.
+ */
+std::pair<std::string, StoreURI::Params> splitUriAndParams(const std::string & uri);
+
+}

--- a/src/libutil/url.hh
+++ b/src/libutil/url.hh
@@ -33,6 +33,8 @@ std::string percentEncode(std::string_view s, std::string_view keep="");
 
 std::map<std::string, std::string> decodeQuery(const std::string & query);
 
+std::string encodeQuery(const std::map<std::string, std::string> & query);
+
 ParsedURL parseURL(const std::string & url);
 
 /**

--- a/tests/unit/libstore/machines.cc
+++ b/tests/unit/libstore/machines.cc
@@ -3,23 +3,16 @@
 #include "file-system.hh"
 #include "util.hh"
 
+#include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
 
 using testing::Contains;
 using testing::ElementsAre;
-using testing::EndsWith;
 using testing::Eq;
 using testing::Field;
 using testing::SizeIs;
 
-using nix::absPath;
-using nix::FormatError;
-using nix::getMachines;
-using nix::Machine;
-using nix::Machines;
-using nix::pathExists;
-using nix::Settings;
-using nix::settings;
+using namespace nix;
 
 class Environment : public ::testing::Environment {
   public:
@@ -39,7 +32,7 @@ TEST(machines, getMachinesUriOnly) {
     settings.builders = "nix@scratchy.labs.cs.uu.nl";
     Machines actual = getMachines();
     ASSERT_THAT(actual, SizeIs(1));
-    EXPECT_THAT(actual[0], Field(&Machine::storeUri, Eq("ssh://nix@scratchy.labs.cs.uu.nl")));
+    EXPECT_THAT(actual[0], Field(&Machine::storeUri, Eq(StoreURI::parse("ssh://nix@scratchy.labs.cs.uu.nl"))));
     EXPECT_THAT(actual[0], Field(&Machine::systemTypes, ElementsAre("TEST_ARCH-TEST_OS")));
     EXPECT_THAT(actual[0], Field(&Machine::sshKey, SizeIs(0)));
     EXPECT_THAT(actual[0], Field(&Machine::maxJobs, Eq(1)));
@@ -53,7 +46,7 @@ TEST(machines, getMachinesDefaults) {
     settings.builders = "nix@scratchy.labs.cs.uu.nl - - - - - - -";
     Machines actual = getMachines();
     ASSERT_THAT(actual, SizeIs(1));
-    EXPECT_THAT(actual[0], Field(&Machine::storeUri, Eq("ssh://nix@scratchy.labs.cs.uu.nl")));
+    EXPECT_THAT(actual[0], Field(&Machine::storeUri, Eq(StoreURI::parse("ssh://nix@scratchy.labs.cs.uu.nl"))));
     EXPECT_THAT(actual[0], Field(&Machine::systemTypes, ElementsAre("TEST_ARCH-TEST_OS")));
     EXPECT_THAT(actual[0], Field(&Machine::sshKey, SizeIs(0)));
     EXPECT_THAT(actual[0], Field(&Machine::maxJobs, Eq(1)));
@@ -63,20 +56,31 @@ TEST(machines, getMachinesDefaults) {
     EXPECT_THAT(actual[0], Field(&Machine::sshPublicHostKey, SizeIs(0)));
 }
 
+MATCHER_P(AuthorityMatches, authority, "") {
+    *result_listener
+        << "where the authority of "
+        << arg.render()
+        << " is "
+        << authority;
+    auto * generic = std::get_if<StoreURI::Generic>(&arg.variant);
+    if (!generic) return false;
+    return generic->authority == authority;
+}
+
 TEST(machines, getMachinesWithNewLineSeparator) {
     settings.builders = "nix@scratchy.labs.cs.uu.nl\nnix@itchy.labs.cs.uu.nl";
     Machines actual = getMachines();
     ASSERT_THAT(actual, SizeIs(2));
-    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, EndsWith("nix@scratchy.labs.cs.uu.nl"))));
-    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, EndsWith("nix@itchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@scratchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@itchy.labs.cs.uu.nl"))));
 }
 
 TEST(machines, getMachinesWithSemicolonSeparator) {
     settings.builders = "nix@scratchy.labs.cs.uu.nl ; nix@itchy.labs.cs.uu.nl";
     Machines actual = getMachines();
     EXPECT_THAT(actual, SizeIs(2));
-    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, EndsWith("nix@scratchy.labs.cs.uu.nl"))));
-    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, EndsWith("nix@itchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@scratchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@itchy.labs.cs.uu.nl"))));
 }
 
 TEST(machines, getMachinesWithCorrectCompleteSingleBuilder) {
@@ -85,7 +89,7 @@ TEST(machines, getMachinesWithCorrectCompleteSingleBuilder) {
                         "benchmark SSH+HOST+PUBLIC+KEY+BASE64+ENCODED==";
     Machines actual = getMachines();
     ASSERT_THAT(actual, SizeIs(1));
-    EXPECT_THAT(actual[0], Field(&Machine::storeUri, EndsWith("nix@scratchy.labs.cs.uu.nl")));
+    EXPECT_THAT(actual[0], Field(&Machine::storeUri, AuthorityMatches("nix@scratchy.labs.cs.uu.nl")));
     EXPECT_THAT(actual[0], Field(&Machine::systemTypes, ElementsAre("i686-linux")));
     EXPECT_THAT(actual[0], Field(&Machine::sshKey, Eq("/home/nix/.ssh/id_scratchy_auto")));
     EXPECT_THAT(actual[0], Field(&Machine::maxJobs, Eq(8)));
@@ -103,7 +107,7 @@ TEST(machines,
         "KEY+BASE64+ENCODED==";
     Machines actual = getMachines();
     ASSERT_THAT(actual, SizeIs(1));
-    EXPECT_THAT(actual[0], Field(&Machine::storeUri, EndsWith("nix@scratchy.labs.cs.uu.nl")));
+    EXPECT_THAT(actual[0], Field(&Machine::storeUri, AuthorityMatches("nix@scratchy.labs.cs.uu.nl")));
     EXPECT_THAT(actual[0], Field(&Machine::systemTypes, ElementsAre("i686-linux")));
     EXPECT_THAT(actual[0], Field(&Machine::sshKey, Eq("/home/nix/.ssh/id_scratchy_auto")));
     EXPECT_THAT(actual[0], Field(&Machine::maxJobs, Eq(8)));
@@ -119,7 +123,7 @@ TEST(machines, getMachinesWithMultiOptions) {
                         "MandatoryFeature1,MandatoryFeature2";
     Machines actual = getMachines();
     ASSERT_THAT(actual, SizeIs(1));
-    EXPECT_THAT(actual[0], Field(&Machine::storeUri, EndsWith("nix@scratchy.labs.cs.uu.nl")));
+    EXPECT_THAT(actual[0], Field(&Machine::storeUri, AuthorityMatches("nix@scratchy.labs.cs.uu.nl")));
     EXPECT_THAT(actual[0], Field(&Machine::systemTypes, ElementsAre("Arch1", "Arch2")));
     EXPECT_THAT(actual[0], Field(&Machine::supportedFeatures, ElementsAre("SupportedFeature1", "SupportedFeature2")));
     EXPECT_THAT(actual[0], Field(&Machine::mandatoryFeatures, ElementsAre("MandatoryFeature1", "MandatoryFeature2")));
@@ -145,9 +149,9 @@ TEST(machines, getMachinesWithCorrectFileReference) {
     settings.builders = std::string("@") + path;
     Machines actual = getMachines();
     ASSERT_THAT(actual, SizeIs(3));
-    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, EndsWith("nix@scratchy.labs.cs.uu.nl"))));
-    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, EndsWith("nix@itchy.labs.cs.uu.nl"))));
-    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, EndsWith("nix@poochie.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@scratchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@itchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@poochie.labs.cs.uu.nl"))));
 }
 
 TEST(machines, getMachinesWithCorrectFileReferenceToEmptyFile) {


### PR DESCRIPTION
# Motivation

Separating parsing the URI from opening the store allows for a more robust `Machine` data type that is easier to use.

# Context

Helps with Hydra dedup too https://github.com/NixOS/hydra/issues/1164

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
