### PR TITLE
Convert `Machine::speedFactor` from a non-neg int to a non-neg float

### DIFF
--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -32,11 +32,14 @@ Machine::Machine(decltype(storeUri) storeUri,
     systemTypes(systemTypes),
     sshKey(sshKey),
     maxJobs(maxJobs),
-    speedFactor(std::max(1U, speedFactor)),
+    speedFactor(speedFactor == 0.0f ? 1.0f : std::move(speedFactor)),
     supportedFeatures(supportedFeatures),
     mandatoryFeatures(mandatoryFeatures),
     sshPublicHostKey(sshPublicHostKey)
-{}
+{
+    if (speedFactor < 0.0)
+        throw UsageError("speed factor must be >= 0");
+}
 
 bool Machine::systemSupported(const std::string & system) const
 {
@@ -135,6 +138,14 @@ static Machine parseBuilderLine(const std::string & line)
         return result.value();
     };
 
+    auto parseFloatField = [&](size_t fieldIndex) {
+        const auto result = string2Int<float>(tokens[fieldIndex]);
+        if (!result) {
+            throw FormatError("bad machine specification: failed to convert column #%lu in a row: '%s' to 'float'", fieldIndex, line);
+        }
+        return result.value();
+    };
+
     auto ensureBase64 = [&](size_t fieldIndex) {
         const auto & str = tokens[fieldIndex];
         try {
@@ -153,7 +164,7 @@ static Machine parseBuilderLine(const std::string & line)
         isSet(1) ? tokenizeString<std::set<std::string>>(tokens[1], ",") : std::set<std::string>{settings.thisSystem},
         isSet(2) ? tokens[2] : "",
         isSet(3) ? parseUnsignedIntField(3) : 1U,
-        isSet(4) ? parseUnsignedIntField(4) : 1U,
+        isSet(4) ? parseFloatField(4) : 1.0f,
         isSet(5) ? tokenizeString<std::set<std::string>>(tokens[5], ",") : std::set<std::string>{},
         isSet(6) ? tokenizeString<std::set<std::string>>(tokens[6], ",") : std::set<std::string>{},
         isSet(7) ? ensureBase64(7) : ""

--- a/src/libstore/machines.hh
+++ b/src/libstore/machines.hh
@@ -13,7 +13,7 @@ struct Machine {
     const std::set<std::string> systemTypes;
     const std::string sshKey;
     const unsigned int maxJobs;
-    const unsigned int speedFactor;
+    const float speedFactor;
     const std::set<std::string> supportedFeatures;
     const std::set<std::string> mandatoryFeatures;
     const std::string sshPublicHostKey;

--- a/tests/unit/libstore/machines.cc
+++ b/tests/unit/libstore/machines.cc
@@ -14,6 +14,7 @@ using testing::SizeIs;
 
 using nix::absPath;
 using nix::FormatError;
+using nix::UsageError;
 using nix::getMachines;
 using nix::Machine;
 using nix::Machines;
@@ -133,7 +134,7 @@ TEST(machines, getMachinesWithIncorrectFormat) {
     settings.builders = "nix@scratchy.labs.cs.uu.nl - - 8 three";
     EXPECT_THROW(getMachines(), FormatError);
     settings.builders = "nix@scratchy.labs.cs.uu.nl - - 8 -3";
-    EXPECT_THROW(getMachines(), FormatError);
+    EXPECT_THROW(getMachines(), UsageError);
     settings.builders = "nix@scratchy.labs.cs.uu.nl - - 8 3 - - BAD_BASE64";
     EXPECT_THROW(getMachines(), FormatError);
 }


### PR DESCRIPTION
# Motivation

The short motivation is to match Hydra, so we can de-dup.

# Context

The long version is layed out in
https://github.com/NixOS/nix/issues/9840.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
