### PR TITLE
Fix typo in primops.cc (and therefore Nix docs)

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1878,7 +1878,7 @@ static RegisterPrimOp primop_outputOf({
       For instance,
       ```nix
       builtins.outputOf
-        (builtins.outputOf myDrv "out)
+        (builtins.outputOf myDrv "out")
         "out"
       ```
       will return a placeholder for the output of the output of `myDrv`.


### PR DESCRIPTION
This also fixes the typo in the Nix docs at https://nixos.org/manual/nix/unstable/language/builtins#builtins-outputOf.

# Motivation
Removes the typo.

# Context

There is a typo. Also breaks syntax highlighting in the docs :(

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
