### PR TITLE
docker: Allow building for non-root user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     - run: exec bash -c "nix-channel --update && nix-env -iA nixpkgs.hello && hello"
 
   docker_push_image:
-    needs: [check_secrets, tests]
+    needs: [check_secrets, tests, vm_tests]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix build -L .#hydraJobs.tests.githubFlakes .#hydraJobs.tests.tarballFlakes .#hydraJobs.tests.functional_user
+      - run: |
+          nix build -L \
+            .#hydraJobs.tests.functional_user \
+            .#hydraJobs.tests.githubFlakes \
+            .#hydraJobs.tests.nix-docker \
+            .#hydraJobs.tests.tarballFlakes \
+            ;
 
   flake_regressions:
     needs: vm_tests

--- a/doc/manual/source/installation/installing-docker.md
+++ b/doc/manual/source/installation/installing-docker.md
@@ -57,3 +57,21 @@ $ nix build ./\#hydraJobs.dockerImage.x86_64-linux
 $ docker load -i ./result/image.tar.gz
 $ docker run -ti nix:2.5pre20211105
 ```
+
+# Docker image with non-root Nix
+
+If you would like to run Nix in a container under a user other than `root`,
+you can build an image with a non-root single-user installation of Nix
+by specifying the `uid`, `gid`, `uname`, and `gname` arguments to `docker.nix`:
+
+```console
+$ nix build --file docker.nix \
+    --arg uid 1000 \
+    --arg gid 1000 \
+    --argstr uname user \
+    --argstr gname user \
+    --argstr name nix-user \
+    --out-link nix-user.tar.gz
+$ docker load -i nix-user.tar.gz
+$ docker run -ti nix-user
+```

--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -124,6 +124,8 @@ in
 
   nix-copy = runNixOSTestFor "x86_64-linux" ./nix-copy.nix;
 
+  nix-docker = runNixOSTestFor "x86_64-linux" ./nix-docker.nix;
+
   nssPreload = runNixOSTestFor "x86_64-linux" ./nss-preload.nix;
 
   githubFlakes = runNixOSTestFor "x86_64-linux" ./github-flakes.nix;

--- a/tests/nixos/nix-docker-test.sh
+++ b/tests/nixos/nix-docker-test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# docker.nix test script. Runs inside a built docker.nix container.
+
+set -eEuo pipefail
+
+export NIX_CONFIG='substituters = http://cache:5000?trusted=1'
+
+cd /tmp
+
+# Test getting a fetched derivation
+test "$("$(nix-build -E '(import <nixpkgs> {}).hello')"/bin/hello)" = "Hello, world!"
+
+# Test building a simple derivation
+# shellcheck disable=SC2016
+nix-build -E '
+let
+  pkgs = import <nixpkgs> {};
+in
+builtins.derivation {
+  name = "test";
+  system = builtins.currentSystem;
+  builder = "${pkgs.bash}/bin/bash";
+  args = ["-c" "echo OK > $out"];
+}'
+test "$(cat result)" = OK
+
+# Ensure #!/bin/sh shebang works
+echo '#!/bin/sh' > ./shebang-test
+echo 'echo OK' >> ./shebang-test
+chmod +x ./shebang-test
+test "$(./shebang-test)" = OK
+
+# Ensure #!/usr/bin/env shebang works
+echo '#!/usr/bin/env bash' > ./shebang-test
+echo 'echo OK' >> ./shebang-test
+chmod +x ./shebang-test
+test "$(./shebang-test)" = OK
+
+# Test nix-shell
+{
+    echo '#!/usr/bin/env nix-shell'
+    echo '#! nix-shell -i bash'
+    echo '#! nix-shell -p hello'
+    echo 'hello'
+} > ./nix-shell-test
+chmod +x ./nix-shell-test
+test "$(./nix-shell-test)" = "Hello, world!"

--- a/tests/nixos/nix-docker.nix
+++ b/tests/nixos/nix-docker.nix
@@ -1,0 +1,39 @@
+# Test the container built by ../../docker.nix.
+
+{ lib, config, nixpkgs, hostPkgs, ... }:
+
+let
+  pkgs = config.nodes.machine.nixpkgs.pkgs;
+
+  nixImage = import ../../docker.nix {
+    inherit (config.nodes.machine.nixpkgs) pkgs;
+  };
+  nixUserImage = import ../../docker.nix {
+    inherit (config.nodes.machine.nixpkgs) pkgs;
+    name = "nix-user";
+    uid = 1000;
+    gid = 1000;
+    uname = "user";
+    gname = "user";
+  };
+
+in {
+  name = "nix-docker";
+
+  nodes.machine =
+    { config, lib, pkgs, ... }:
+    { virtualisation.diskSize = 4096;
+    };
+
+  testScript = { nodes }: ''
+    machine.succeed("mkdir -p /etc/containers")
+    machine.succeed("""echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json""")
+
+    machine.succeed("${pkgs.podman}/bin/podman load -i ${nixImage}")
+    machine.succeed("${pkgs.podman}/bin/podman run --rm nix nix --version")
+
+    machine.succeed("${pkgs.podman}/bin/podman load -i ${nixUserImage}")
+    machine.succeed("${pkgs.podman}/bin/podman run --rm nix-user nix --version")
+    machine.succeed("[[ $(${pkgs.podman}/bin/podman run --rm nix-user stat -c %u /nix/store) = 1000 ]]")
+  '';
+}

--- a/tests/nixos/nix-docker.nix
+++ b/tests/nixos/nix-docker.nix
@@ -17,23 +17,37 @@ let
     gname = "user";
   };
 
+  containerTestScript = ./nix-docker-test.sh;
+
 in {
   name = "nix-docker";
 
-  nodes.machine =
-    { config, lib, pkgs, ... }:
-    { virtualisation.diskSize = 4096;
+  nodes =
+    { machine =
+        { config, lib, pkgs, ... }:
+        { virtualisation.diskSize = 4096;
+        };
+      cache =
+        { config, lib, pkgs, ... }:
+        { virtualisation.additionalPaths = [ pkgs.stdenv pkgs.hello ];
+          services.harmonia.enable = true;
+          networking.firewall.allowedTCPPorts = [ 5000 ];
+        };
     };
 
   testScript = { nodes }: ''
+    cache.wait_for_unit("harmonia.service")
+
     machine.succeed("mkdir -p /etc/containers")
     machine.succeed("""echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json""")
 
     machine.succeed("${pkgs.podman}/bin/podman load -i ${nixImage}")
     machine.succeed("${pkgs.podman}/bin/podman run --rm nix nix --version")
+    machine.succeed("${pkgs.podman}/bin/podman run --rm -i nix < ${containerTestScript}")
 
     machine.succeed("${pkgs.podman}/bin/podman load -i ${nixUserImage}")
     machine.succeed("${pkgs.podman}/bin/podman run --rm nix-user nix --version")
+    machine.succeed("${pkgs.podman}/bin/podman run --rm -i nix-user < ${containerTestScript}")
     machine.succeed("[[ $(${pkgs.podman}/bin/podman run --rm nix-user stat -c %u /nix/store) = 1000 ]]")
   '';
 }


### PR DESCRIPTION
# Motivation

Add options uid, gid, uname, and gname to docker.nix.

Setting these to e.g. 1000, 1000, "user", "user" will build an image which runs and allows using Nix as that user.

# Context

- Fixes https://github.com/nix-community/docker-nixpkgs/issues/62

- Dependencies:
  - [x] https://github.com/NixOS/nixpkgs/pull/271976
  - [x] https://github.com/NixOS/nixpkgs/pull/281520
  - [x] https://github.com/NixOS/nixpkgs/pull/282886

Although (with https://github.com/NixOS/nixpkgs/pull/281520) it's possible to simply do a `chown ... /nix` in `fakeRootCommands`, this is quite inefficient. A change *only* in ownership is not representable as a Docker layer, so the contents of the entire Nix store will end up being copied in the final layer. This is what https://github.com/NixOS/nixpkgs/pull/282886 fixes and this PR builds on.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
