### PR TITLE
Increase stack size on macOS as well as Linux

### DIFF
--- a/src/libutil/current-process.hh
+++ b/src/libutil/current-process.hh
@@ -16,7 +16,7 @@ unsigned int getMaxCPU();
 /**
  * Change the stack size.
  */
-void setStackSize(size_t stackSize);
+void setStackSize(rlim_t stackSize);
 
 /**
  * Restore the original inherited Unix process context (such as signal


### PR DESCRIPTION
# Motivation
While preparing #9834, I've run into some stack overflow errors that aren't caught by the current recursion depth counter. This patch remedies that error (at least with Nix's current stack usage), and also increases consistency between Linux and macOS.

# Context
The code works fine on macOS, but the default stack size we attempt to set is larger than what my system will allow (Nix attempts to set the stack size to 67108864, but the maximum allowed is 67092480), so I've instead used the requested stack size or the maximum allowed, whichever is smaller.

I've also added an error message if setting the stack size fails. It looks like this:

> Failed to increase stack size from 8372224 to 67108864 (maximum allowed stack size: 67092480): Invalid argument

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
