### PR TITLE
Color `diff` output in `tests/functional/lang` tests

### DIFF
--- a/tests/functional/lang/framework.sh
+++ b/tests/functional/lang/framework.sh
@@ -16,7 +16,7 @@ function diffAndAcceptInner() {
     fi
 
     # Diff so we get a nice message
-    if ! diff --unified "$got" "$expectedOrEmpty"; then
+    if ! diff --color=always --unified "$expectedOrEmpty" "$got"; then
         echo "FAIL: evaluation result of $testName not as expected"
         badDiff=1
     fi


### PR DESCRIPTION
# Motivation

Use `diff --color=always` to print colored output for language test failures. I've also flipped the arguments so that expected lines missing from the actual output will be marked with a red `-` and additional lines found in the actual output will be marked with a green `+`. Previously it was the other way around, which was very confusing.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
