### PR TITLE
Add missing `#include` for `rlim_t`

### DIFF
--- a/src/libutil/current-process.hh
+++ b/src/libutil/current-process.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include <optional>
+#include <sys/resource.h>
 
 #include "types.hh"
 


### PR DESCRIPTION
# Motivation

My local build in the shell was failing while CI was fine; not sure why that is but having the include here is definitely more correct.

# Context

Per the POSIX spec, this is where it is supposed to be gotten https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/resource.h.html

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
