### PR TITLE
Don't include store docs in every manpage

### DIFF
--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -93,9 +93,6 @@ let
 
       maybeProse =
         # FIXME: this is a horrible hack to keep `nix help-stores` working.
-        # the correct answer to this is to remove that command and replace it
-        # by statically generated manpages or the output of something like `nix
-        # store info <store type>`.
         let
           help-stores = ''
             ${index}
@@ -121,7 +118,7 @@ let
           };
         in
         optionalString (details ? doc) (
-          if match "@store-types@" details.doc != [ ]
+          if match ".*@store-types@.*" details.doc != null
           then help-stores
           else details.doc
         );

--- a/tests/unit/libstore/serve-protocol.cc
+++ b/tests/unit/libstore/serve-protocol.cc
@@ -412,7 +412,7 @@ TEST_F(ServeProtoTest, handshake_log)
         toClient.create();
         toServer.create();
 
-        ServeProto::Version clientResult, serverResult;
+        ServeProto::Version clientResult;
 
         auto thread = std::thread([&]() {
             FdSink out { toServer.writeSide.get() };
@@ -425,7 +425,7 @@ TEST_F(ServeProtoTest, handshake_log)
         {
             FdSink out { toClient.writeSide.get() };
             FdSource in { toServer.readSide.get() };
-            serverResult = ServeProto::BasicServerConnection::handshake(
+            ServeProto::BasicServerConnection::handshake(
                 out, in, defaultVersion);
         };
 


### PR DESCRIPTION
# Motivation

And also shut up a gcc warning.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
