### PR TITLE
Change an `allowPath` call to take a store path again

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -112,7 +112,7 @@ StringMap EvalState::realiseContext(const NixStringContext & context)
     for (auto & outputPath : outputsToCopyAndAllow) {
         /* Add the output of this derivations to the allowed
            paths. */
-        allowPath(store->toRealPath(outputPath));
+        allowPath(outputPath);
     }
 
     return res;


### PR DESCRIPTION
# Context

This looks like a revert of #5844, but is not.

That one was needed because
https://github.com/NixOS/nix/commit/d90f9d4b9994dc1f15b9d664ae313f06261d6058#diff-0f59bb6f197822ef9f19ceae9624989499d170c84dfdc1f486a8959bb4588cafR85 changed the type of the argument to `allowPath` from a `StorePath` to a `Path`. But since
https://github.com/NixOS/nix/commit/caabc4f64889d5a4c47d6102b3aa1d3c80bbc107#diff-0f59bb6f197822ef9f19ceae9624989499d170c84dfdc1f486a8959bb4588cafL100-R92, it is a `StorePath` again.

# Motivation

I think this is worth changing because we want to be very careful about `toRealPath` and the evaluator --- ideally the choice of real path does not affect evaluation at all. So using it fewer times is better.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
