### PR TITLE
feat: small-string optimization

### DIFF
--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -25,6 +25,7 @@ typedef enum {
     tInt = 1,
     tBool,
     tString,
+    tStringSmall,
     tPath,
     tNull,
     tAttrs,
@@ -185,6 +186,10 @@ public:
         const char * c_str;
         const char * * context; // must be in sorted order
     };
+    struct SmallStringWithoutContext {
+        char * c_str;
+        char * c_str_2;
+    };
 
     struct Path {
         InputAccessor * accessor;
@@ -211,6 +216,7 @@ public:
         bool boolean;
 
         StringWithContext string;
+        SmallStringWithoutContext smallString;
 
         Path _path;
 
@@ -242,6 +248,7 @@ public:
             case tInt: return nInt;
             case tBool: return nBool;
             case tString: return nString;
+            case tStringSmall: return nString;
             case tPath: return nPath;
             case tNull: return nNull;
             case tAttrs: return nAttrs;
@@ -280,6 +287,18 @@ public:
         boolean = b;
     }
 
+    // Assumption that the string s is null-terminated
+    // assert(s[len] == '\0');
+    inline void mkString(const char * s, size_t len, const char * * context = 0, bool forceLarge = false){
+        if (!forceLarge && len < (sizeof(char *) *2) && context == 0){
+            internalType = tStringSmall;
+            char * t = (char *) &(smallString.c_str);
+            memcpy(t, s, len);
+            t[len] = '\0';
+            return;
+        }
+        mkString(s, context);
+    }
     inline void mkString(const char * s, const char * * context = 0)
     {
         internalType = tString;
@@ -291,11 +310,11 @@ public:
 
     void mkString(std::string_view s, const NixStringContext & context);
 
-    void mkStringMove(const char * s, const NixStringContext & context);
+    void mkStringMove(std::string_view s, const NixStringContext & context);
 
     inline void mkString(const Symbol & s)
     {
-        mkString(((const std::string &) s).c_str());
+        mkString((const std::string &) s);
     }
 
     void mkPath(const SourcePath & path);
@@ -432,19 +451,28 @@ public:
 
     std::string_view string_view() const
     {
-        assert(internalType == tString);
-        return std::string_view(string.c_str);
+        assert(internalType == tString || internalType == tStringSmall);
+        if (internalType == tStringSmall)
+            return std::string_view((const char * const) &(smallString.c_str));
+        else
+            return std::string_view(string.c_str);
     }
 
     const char * const c_str() const
     {
-        assert(internalType == tString);
-        return string.c_str;
+        assert(internalType == tString || internalType == tStringSmall);
+        if (internalType == tStringSmall)
+            return (const char * const) &(smallString.c_str);
+        else
+            return string.c_str;
     }
 
     const char * * context() const
     {
-        return string.context;
+        if (internalType == tString)
+            return string.context;
+        else
+            return 0;
     }
 };
 


### PR DESCRIPTION
If a string can fit into a Value, without a context, then pack it in. This avoids extra allocation and clean up for common strings.

# Motivation
Speed up Nix's string performance, reduce memory usage.
- memory: 98%
- cpu: ~same
    - I expected a bigger improvement as this avoids nearly 1M allocations. Very likely my C++-fu could be better.

# Context
Looking at various approaches: small-strings, symbol table usage, storing strings as a list of pointers for efficient concat without allocation.

It is easy to violate GC assumptions when doing things like this, so I expect to go through a few iterations and plenty of testing.

ping: @pennae 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
