### PR TITLE
Disable a slightly annoying clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+# We use pointers to aggregates in a couple of places, intentionally.
+# void * would look weird.
+Checks: '-bugprone-sizeof-expression'

--- a/src/libstore/build/worker.hh
+++ b/src/libstore/build/worker.hh
@@ -116,7 +116,7 @@ private:
     WeakGoals waitingForAWhile;
 
     /**
-     * Last time the goals in `waitingForAWhile` where woken up.
+     * Last time the goals in `waitingForAWhile` were woken up.
      */
     steady_time_point lastWokenUp;
 


### PR DESCRIPTION
# Motivation

Prevent warning fatigue when using clangd, by stopping clang-tidy from warning about things that aren't problems.

We have expressions such as `sizeof(Value *)` and that's perfectly fine. I don't think we want to change that to `sizeof(void *)` because that'd be harder to understand.

I've checked that the other rules are still active, using the misleading indentation rule on something like:

```c++
if (foo)
    bar()
    baz()
```

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
