### PR TITLE
libutil/url: fix git+file:./ parse error

### DIFF
--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -171,16 +171,16 @@ std::string fixGitURL(const std::string & url)
     std::regex scpRegex("([^/]*)@(.*):(.*)");
     if (!hasPrefix(url, "/") && std::regex_match(url, scpRegex))
         return std::regex_replace(url, scpRegex, "ssh://$1@$2/$3");
-    else {
-        if (url.find("://") == std::string::npos) {
-            return (ParsedURL {
-                .scheme = "file",
-                .authority = "",
-                .path = url
-            }).to_string();
-        } else
-            return url;
+    if (hasPrefix(url, "file:"))
+        return url;
+    if (url.find("://") == std::string::npos) {
+        return (ParsedURL {
+            .scheme = "file",
+            .authority = "",
+            .path = url
+        }).to_string();
     }
+    return url;
 }
 
 // https://www.rfc-editor.org/rfc/rfc3986#section-3.1


### PR DESCRIPTION
# Motivation

Partially fixes regression #9708: parse error of `git+file:./`
- This is a fully working fix before libgit2 (i.e. it fixes the 2.19 series),
- ... but is still inadequate after libgit2, although it does improve the correctness.

I am hoping that this could be backported to 2.19-maintenance.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

Previously, the "file:./" prefix was not recognized in `fixGitURL`; instead, it was parsed as a file path, which resulted in a url of the form "file://file:./" (#9708).

This commit fixes the issue by properly detecting the "file:" prefix. Note, however, that unlike "file://", the "file:./" URI is _not_ standardized, but has been widely used to referred to relative file paths. In particular, the "git+file:./" did work for nix<=2.18, and was broken since nix 2.19.0. These are the usages found in github: https://github.com/search?q=git%2Bfile%3A.&type=code

Finally, this commit fixes the issue completely for the 2.19 series, but is still inadequate for the 2.20 series due to new behaviors from the switch to libgit2 (consequently, we do _not_ add a test because it is not yet working on master). However, it does improve the correctness of parsing, even though it is not yet a complete solution.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Pinging @roberth as they might be interested :wink: if not, sorry for the noise...

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
