### PR TITLE
feat: show activity progress as a pipe

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -437,15 +437,15 @@ public:
             if (running || done || expected || failed) {
                 if (running)
                     if (expected != 0)
-                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" ANSI_GREEN + numberFmt + ANSI_NORMAL "/" + numberFmt,
-                            running / unit, done / unit, expected / unit);
+                        s = fmt(numberFmt + "→" ANSI_BLUE + numberFmt + ANSI_NORMAL "→" ANSI_GREEN + numberFmt + ANSI_NORMAL,
+                            expected / unit, running / unit, done / unit);
                     else
-                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "/" ANSI_GREEN + numberFmt + ANSI_NORMAL,
+                        s = fmt(ANSI_BLUE + numberFmt + ANSI_NORMAL "→" ANSI_GREEN + numberFmt + ANSI_NORMAL,
                             running / unit, done / unit);
                 else if (expected != done)
                     if (expected != 0)
-                        s = fmt(ANSI_GREEN + numberFmt + ANSI_NORMAL "/" + numberFmt,
-                            done / unit, expected / unit);
+                        s = fmt(numberFmt + "→" ANSI_GREEN + numberFmt + ANSI_NORMAL,
+                            expected / unit, done / unit);
                     else
                         s = fmt(ANSI_GREEN + numberFmt + ANSI_NORMAL, done / unit);
                 else


### PR DESCRIPTION
# Motivation
This changes activity display from:

    building/built/expected

To:

    expected→building→built

This makes the count “flow” from left to right, reminiscent of a pipeline.

It took me over a year to understand the meaning of the individual numbers. I realized the order was unintuitive to me, and I never bothered to look it up or "think hard".

I now mentally parse the numbers in the order `2/3/1`, so this PR changes it to `1→2→3`. I think this looks more intuitive to newbies, as the numbers "flow" from left to right.

Very curious to hear your thoughts! I know this can seem like a meaningless, and the status quo is obvious to those familiar with it, but I believe this could help improve the UI for those who are least likely to know how to improve it.

(**Update:** See [below](https://github.com/NixOS/nix/pull/9906#issuecomment-1924265378) for another option: `todo→in progress→done`)

# Example

## From

![image](https://github.com/NixOS/nix/assets/137852/07ce4ddc-87ff-4ef6-b5d2-42c842d25601)

## To

![image](https://github.com/NixOS/nix/assets/137852/4cc4cc04-ceb6-4fa4-a300-8cc9cf24fbd9)

I highly recommend trying it yourself to see the effect in action: the flow of numbers is what makes this intuitive (IMO):

```
nix run github:nixos/nix/pull/9906/head -- build --no-link github:nixos/nixpkgs/staging#hello
```

# Context

I just put a UTF-8 string directly in the source but I'm sure that will break in all sorts of ways in edge cases. See this PR as a RFC.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
