### PR TITLE
Revert "Merge pull request #9902 from NixOS/require-fixed-output-fetchurl"

### DIFF
--- a/tests/functional/fetchurl.sh
+++ b/tests/functional/fetchurl.sh
@@ -78,9 +78,3 @@ outPath=$(nix-build -vvvvv --expr 'import <nix/fetchurl.nix>' --argstr url file:
 
 test -x $outPath/fetchurl.sh
 test -L $outPath/symlink
-
-# Make sure that *not* passing a outputHash fails.
-requireDaemonNewerThan "2.20"
-expected=100
-if [[ -v NIX_DAEMON_PACKAGE ]]; then expected=1; fi # work around the daemon not returning a 100 status correctly
-expectStderr $expected nix-build --expr '{ url }: builtins.derivation { name = "nix-cache-info"; system = "x86_64-linux"; builder = "builtin:fetchurl"; inherit url; outputHashMode = "flat"; }' --argstr url file://$narxz 2>&1 | grep 'must be a fixed-output derivation'


### PR DESCRIPTION
This reverts commit 081dc5daa1e9047e693d496a5cdf77c0a4d717ba, reversing changes made to ef6d055ace0c3ccc1955ddf2150024ff9d58f2bd.

# Motivation

This is not actually a bug on Nix (2.18, at least), and breaks code I've written (with no other way to write that code.)
```nix
nix-repl> :b builtins.derivation { name = "nix-cache-info"; system = "x86_64-linux"; builder = "builtin:fetchurl"; url = https://cache.nixos.org/nix-cache-info; outputHashMode = "flat"; }
warning: error: unable to download 'https://cache.nixos.org/nix-cache-info': Couldn't resolve host name (6); retrying in 309 ms
warning: error: unable to download 'https://cache.nixos.org/nix-cache-info': Couldn't resolve host name (6); retrying in 607 ms
warning: error: unable to download 'https://cache.nixos.org/nix-cache-info': Couldn't resolve host name (6); retrying in 1002 ms
warning: error: unable to download 'https://cache.nixos.org/nix-cache-info': Couldn't resolve host name (6); retrying in 2554 ms
error: builder for '/nix/store/z89j6fdfm6k9k1qir99449wyvldpm2ma-nix-cache-info.drv' failed with exit code 1;
       last 4 log lines:
       > error:
       >        … writing file '/nix/store/l9ax62fdagg4cvw9wd4h84cf4pxqcmlg-nix-cache-info'
       >
       >        error: unable to download 'https://cache.nixos.org/nix-cache-info': Couldn't resolve host name (6)
       For full logs, run 'nix-store -l /nix/store/z89j6fdfm6k9k1qir99449wyvldpm2ma-nix-cache-info.drv'.
```
# Context
Reverts #9902.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
