### PR TITLE
Print positions in `--debugger`, instead of pointers

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -232,7 +232,7 @@ static std::ostream & showDebugTrace(std::ostream & out, const PosTable & positi
         : positions[dt.expr.getPos() ? dt.expr.getPos() : noPos];
 
     if (pos) {
-        out << pos;
+        out << *pos;
         if (auto loc = pos->getCodeLines()) {
             out << "\n";
             printCodeLines(out, "", *pos, *loc);


### PR DESCRIPTION
The `--debugger` currently prints the _pointers_ of source code positions, rather than the positions themselves.

Before:

```
0: while evaluating the attribute 'python311.pythonForBuild.pkgs'
0x600001522598
```

After:

```
0: while evaluating the attribute 'python311.pythonForBuild.pkgs'
/nix/store/hg65h51xnp74ikahns9hyf3py5mlbbqq-source/overrides/default.nix:132:27

   131|
   132|       bootstrappingBase = pkgs.${self.python.pythonAttr}.pythonForBuild.pkgs;
      |                           ^
   133|     in
```