### PR TITLE
Enter debugger on `builtins.trace` with an option

### DIFF
--- a/doc/manual/rl-next/debugger-on-trace.md
+++ b/doc/manual/rl-next/debugger-on-trace.md
@@ -1,0 +1,9 @@
+---
+synopsis: Enter the `--debugger` when `builtins.trace` is called if `builtins-trace-debugger` is set
+prs: 9914
+---
+
+If the `builtins-trace-debugger` option is set and `--debugger` is given,
+`builtins.trace` calls will behave similarly to `builtins.break` and will enter
+the debug REPL. This is useful for determining where warnings are being emitted
+from.

--- a/doc/manual/rl-next/debugger-on-trace.md
+++ b/doc/manual/rl-next/debugger-on-trace.md
@@ -1,9 +1,9 @@
 ---
-synopsis: Enter the `--debugger` when `builtins.trace` is called if `builtins-trace-debugger` is set
+synopsis: Enter the `--debugger` when `builtins.trace` is called if `debugger-on-trace` is set
 prs: 9914
 ---
 
-If the `builtins-trace-debugger` option is set and `--debugger` is given,
+If the `debugger-on-trace` option is set and `--debugger` is given,
 `builtins.trace` calls will behave similarly to `builtins.break` and will enter
 the debug REPL. This is useful for determining where warnings are being emitted
 from.

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -128,8 +128,15 @@ struct EvalSettings : Config
     Setting<unsigned int> maxCallDepth{this, 10000, "max-call-depth",
         "The maximum function call depth to allow before erroring."};
 
-    Setting<bool> builtinsTraceDebugger{this, false, "builtins-trace-debugger",
-        "Whether to enter the debugger on `builtins.trace` calls."};
+    Setting<bool> builtinsTraceDebugger{this, false, "debugger-on-trace",
+        R"(
+          If set to true and the `--debugger` flag is given,
+          [`builtins.trace`](@docroot@/language/builtins.md#builtins-trace) will
+          enter the debugger like
+          [`builtins.break`](@docroot@/language/builtins.md#builtins-break).
+
+          This is useful for debugging warnings in third-party Nix code.
+        )"};
 };
 
 extern EvalSettings evalSettings;

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -127,6 +127,9 @@ struct EvalSettings : Config
 
     Setting<unsigned int> maxCallDepth{this, 10000, "max-call-depth",
         "The maximum function call depth to allow before erroring."};
+
+    Setting<bool> builtinsTraceDebugger{this, false, "builtins-trace-debugger",
+        "Whether to enter the debugger on `builtins.trace` calls."};
 };
 
 extern EvalSettings evalSettings;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -995,6 +995,10 @@ static void prim_trace(EvalState & state, const PosIdx pos, Value * * args, Valu
         printError("trace: %1%", args[0]->string_view());
     else
         printError("trace: %1%", ValuePrinter(state, *args[0]));
+    if (evalSettings.builtinsTraceDebugger && state.debugRepl && !state.debugTraces.empty()) {
+        const DebugTrace & last = state.debugTraces.front();
+        state.runDebugRepl(nullptr, last.env, last.expr);
+    }
     state.forceValue(*args[1], pos);
     v = *args[1];
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1010,6 +1010,12 @@ static RegisterPrimOp primop_trace({
       Evaluate *e1* and print its abstract syntax representation on
       standard error. Then return *e2*. This function is useful for
       debugging.
+
+      If the
+      [`debugger-on-trace`](@docroot@/command-ref/conf-file.md#conf-debugger-on-trace)
+      option is set to `true` and the `--debugger` flag is given, the
+      interactive debugger will be started when `trace` is called (like
+      [`break`](@docroot@/language/builtins.md#builtins-break)).
     )",
     .fun = prim_trace,
 });


### PR DESCRIPTION
# Motivation

With `--debugger --debugger-on-trace`, `builtins.trace` calls will start the interactive debugger, exposing stack trace information.

# Context
Closes #1610.

I recently complained that my Nix project was emitting warnings with no clear provenance:

```
$ nix develop
trace: warning: `pythonForBuild` (from `python*`) has been renamed to `pythonOnBuildForHost`
$ rg pythonForBuild | wc -l
0
```

With this patch, it's easy to print a backtrace:

```
nix develop --debugger --debugger-on-trace
trace: warning: `pythonForBuild` (from `python*`) has been renamed to `pythonOnBuildForHost`
Welcome to Nix 2.21.0pre20240131_dirty. Type :? for help.

nix-repl> :bt

0: while evaluating the attribute 'python311.pythonForBuild.pkgs'
/nix/store/hg65h51xnp74ikahns9hyf3py5mlbbqq-source/overrides/default.nix:132:27

   131|
   132|       bootstrappingBase = pkgs.${self.python.pythonAttr}.pythonForBuild.pkgs;
      |                           ^
   133|     in
```

Then, we can look at the source path to see that it's a checkout of [poetry2nix](https://github.com/nix-community/poetry2nix):

```
$ head /nix/store/hg65h51xnp74ikahns9hyf3py5mlbbqq-source/README.md
[![](https://github.com/nix-community/poetry2nix/workflows/CI/badge.svg)](https://github.com/nix-community/poetry2nix/actions?query=branch%3Amaster+workflow%3ACI)
[![Chat on Matrix](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#poetry2nix:blad.is)

# poetry2nix
```

Nice!

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
