### PR TITLE
Add position information to `while evaluating the attribute` errors in the debugger

### DIFF
--- a/doc/manual/rl-next/source-location-in-while-evaluating-attribute.md
+++ b/doc/manual/rl-next/source-location-in-while-evaluating-attribute.md
@@ -1,0 +1,23 @@
+---
+synopsis: "In the debugger, `while evaluating the attribute` errors now include position information"
+prs: 9915
+---
+
+Before:
+
+```
+0: while evaluating the attribute 'python311.pythonForBuild.pkgs'
+0x600001522598
+```
+
+After:
+
+```
+0: while evaluating the attribute 'python311.pythonForBuild.pkgs'
+/nix/store/hg65h51xnp74ikahns9hyf3py5mlbbqq-source/overrides/default.nix:132:27
+
+   131|
+   132|       bootstrappingBase = pkgs.${self.python.pythonAttr}.pythonForBuild.pkgs;
+      |                           ^
+   133|     in
+```

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1384,7 +1384,7 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
                 state,
                 *this,
                 env,
-                state.positions[pos2],
+                state.positions[getPos()],
                 "while evaluating the attribute '%1%'",
                 showAttrPath(state, env, attrPath))
             : nullptr;


### PR DESCRIPTION
Before:

```
0: while evaluating the attribute 'python311.pythonForBuild.pkgs'
0x600001522598
```

After:

```
0: while evaluating the attribute 'python311.pythonForBuild.pkgs'
/nix/store/hg65h51xnp74ikahns9hyf3py5mlbbqq-source/overrides/default.nix:132:27

   131|
   132|       bootstrappingBase = pkgs.${self.python.pythonAttr}.pythonForBuild.pkgs;
      |                           ^
   133|     in
```