### PR TITLE
Enter debugger more reliably in `let` expressions and function calls

### DIFF
--- a/doc/manual/rl-next/enter-debugger-more-reliably-in-let-and-calls.md
+++ b/doc/manual/rl-next/enter-debugger-more-reliably-in-let-and-calls.md
@@ -1,0 +1,25 @@
+---
+synopsis: The `--debugger` will start more reliably in `let` expressions and function calls
+prs: 9917
+issues: 6649
+---
+
+Previously, if you attempted to evaluate this file with the debugger:
+
+```nix
+let
+  a = builtins.trace "before inner break" (
+    builtins.break "hello"
+  );
+  b = builtins.trace "before outer break" (
+    builtins.break a
+  );
+in
+  b
+```
+
+Nix would correctly enter the debugger at `builtins.break a`, but if you asked
+it to `:continue`, it would skip over the `builtins.break "hello"` expression
+entirely.
+
+Now, Nix will correctly enter the debugger at both breakpoints.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -846,20 +846,20 @@ void EvalState::addErrorTrace(Error & e, const PosIdx pos, const char * s, const
     e.addTrace(positions[pos], hintfmt(s, s2), frame);
 }
 
+template<typename... Args>
 static std::unique_ptr<DebugTraceStacker> makeDebugTraceStacker(
     EvalState & state,
     Expr & expr,
     Env & env,
     std::shared_ptr<Pos> && pos,
-    const char * s,
-    const std::string & s2)
+    const Args & ... formatArgs)
 {
     return std::make_unique<DebugTraceStacker>(state,
         DebugTrace {
             .pos = std::move(pos),
             .expr = expr,
             .env = env,
-            .hint = hintfmt(s, s2),
+            .hint = hintfmt(formatArgs...),
             .isError = false
         });
 }
@@ -1322,6 +1322,19 @@ void ExprLet::eval(EvalState & state, Env & env, Value & v)
     for (auto & i : attrs->attrs)
         env2.values[displ++] = i.second.e->maybeThunk(state, i.second.inherited ? env : env2);
 
+    auto dts = state.debugRepl
+        ? makeDebugTraceStacker(
+            state,
+            *this,
+            env2,
+            getPos()
+                ? std::make_shared<Pos>(state.positions[getPos()])
+                : nullptr,
+            "while evaluating a '%1%' expression",
+            "let"
+        )
+        : nullptr;
+
     body->eval(state, env2, v);
 }
 
@@ -1718,6 +1731,18 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
 
 void ExprCall::eval(EvalState & state, Env & env, Value & v)
 {
+    auto dts = state.debugRepl
+        ? makeDebugTraceStacker(
+            state,
+            *this,
+            env,
+            getPos()
+                ? std::make_shared<Pos>(state.positions[getPos()])
+                : nullptr,
+            "while calling a function"
+        )
+        : nullptr;
+
     Value vFun;
     fun->eval(state, env, vFun);
 


### PR DESCRIPTION
# Motivation

Currently, if you attempt to evaluate this file with the debugger:

```nix
let
  a = builtins.trace "before inner break" (
    builtins.break "hello"
  );
  b = builtins.trace "before outer break" (
    builtins.break a
  );
in
  b
```

Nix will correctly enter the debugger at `builtins.break a`, but if you ask it to `:continue`, it'll skip over the `builtins.break "hello"` expression entirely:

```
$ nix eval --file xxx-test.nix --debugger
trace: before outer break
info: breakpoint reached

      at «none»:0: (source not available)


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.18.1. Type :? for help.

nix-repl> :c
trace: before inner break
"hello"
```

This is because the set of debug traces is empty by the time Nix gets to the second call:

https://github.com/NixOS/nix/blob/0127d54d5e86db9039e6322d482d26e66af8bd8a/src/libexpr/primops.cc#L757

With this patch, Nix will correctly enter the debugger both times:

```
$ nix eval --file xxx-test.nix --debugger
trace: before outer break
info: breakpoint reached


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.20.0pre20231222_dirty. Type :? for help.

nix-repl> :c
trace: before inner break
info: breakpoint reached


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.20.0pre20231222_dirty. Type :? for help.

nix-repl> :c
"hello"
```

# Context

Fixes #6649.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
