### PR TITLE
Expose locals from `let` expressions to the debugger

### DIFF
--- a/doc/manual/rl-next/debugger-locals-for-let-expressions.md
+++ b/doc/manual/rl-next/debugger-locals-for-let-expressions.md
@@ -1,0 +1,9 @@
+---
+synopsis: "`--debugger` can now access bindings from `let` expressions"
+prs: 9918
+issues: 8827.
+---
+
+Breakpoints and errors in the bindings of a `let` expression can now access
+those bindings in the debugger. Previously, only the body of `let` expressions
+could access those bindings.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1322,6 +1322,19 @@ void ExprLet::eval(EvalState & state, Env & env, Value & v)
     for (auto & i : attrs->attrs)
         env2.values[displ++] = i.second.e->maybeThunk(state, i.second.inherited ? env : env2);
 
+    auto dts = state.debugRepl
+        ? makeDebugTraceStacker(
+            state,
+            *this,
+            env2,
+            getPos()
+                ? std::make_shared<Pos>(state.positions[getPos()])
+                : nullptr,
+            "while evaluating a '%1%' expression",
+            "let"
+        )
+        : nullptr;
+
     body->eval(state, env2, v);
 }
 

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -409,9 +409,6 @@ void ExprCall::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> &
 
 void ExprLet::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env)
 {
-    if (es.debugRepl)
-        es.exprEnvs.insert(std::make_pair(this, env));
-
     auto newEnv = std::make_shared<StaticEnv>(nullptr, env.get(), attrs->attrs.size());
 
     Displacement displ = 0;
@@ -422,6 +419,9 @@ void ExprLet::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & 
 
     for (auto & i : attrs->attrs)
         i.second.e->bindVars(es, i.second.inherited ? env : newEnv);
+
+    if (es.debugRepl)
+        es.exprEnvs.insert(std::make_pair(this, newEnv));
 
     body->bindVars(es, newEnv);
 }
@@ -446,9 +446,6 @@ void ExprWith::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> &
             prevWith = level;
             break;
         }
-
-    if (es.debugRepl)
-        es.exprEnvs.insert(std::make_pair(this, env));
 
     attrs->bindVars(es, env);
     auto newEnv = std::make_shared<StaticEnv>(this, env.get());


### PR DESCRIPTION
# Motivation
Closes #8827.

With this file:

```nix
let
  r = [];
  x = builtins.throw r;
in
  x
```

Before:

```
$ nix eval --file test.nix --debugger
error: cannot coerce a list to a string

nix-repl> :env
Env level 0
builtins true false ...
```

After:

```
$ nix eval --file test.nix --debugger
error: cannot coerce a list to a string: [ ]

nix-repl> :env
Env level 0
static: x r

Env level 1
builtins true false ...

nix-repl> r
[ ]
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
