### PR TITLE
Reduce visual clutter in the debugger

### DIFF
--- a/doc/manual/rl-next/reduce-debugger-clutter.md
+++ b/doc/manual/rl-next/reduce-debugger-clutter.md
@@ -1,0 +1,37 @@
+---
+synopsis: "Visual clutter in `--debugger` is reduced"
+prs: 9919
+---
+
+Before:
+```
+info: breakpoint reached
+
+
+Starting REPL to allow you to inspect the current state of the evaluator.
+
+Welcome to Nix 2.20.0pre20231222_dirty. Type :? for help.
+
+nix-repl> :continue
+error: uh oh
+
+
+Starting REPL to allow you to inspect the current state of the evaluator.
+
+Welcome to Nix 2.20.0pre20231222_dirty. Type :? for help.
+
+nix-repl>
+```
+
+After:
+
+```
+info: breakpoint reached
+
+Nix 2.20.0pre20231222_dirty debugger
+Type :? for help.
+nix-repl> :continue
+error: uh oh
+
+nix-repl>
+```

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -255,9 +255,7 @@ void NixRepl::mainLoop()
         notice("Nix %1%%2%\nType :? for help.", nixVersion, debuggerNotice);
     }
 
-    if (isFirstRepl) {
-        isFirstRepl = false;
-    }
+    isFirstRepl = false;
 
     loadFiles();
 

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -243,10 +243,21 @@ static std::ostream & showDebugTrace(std::ostream & out, const PosTable & positi
     return out;
 }
 
+static bool isFirstRepl = true;
+
 void NixRepl::mainLoop()
 {
-    std::string error = ANSI_RED "error:" ANSI_NORMAL " ";
-    notice("Welcome to Nix " + nixVersion + ". Type :? for help.\n");
+    if (isFirstRepl) {
+        std::string_view debuggerNotice = "";
+        if (state->debugRepl) {
+            debuggerNotice = " debugger";
+        }
+        notice("Nix %1%%2%\nType :? for help.", nixVersion, debuggerNotice);
+    }
+
+    if (isFirstRepl) {
+        isFirstRepl = false;
+    }
 
     loadFiles();
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -821,12 +821,10 @@ void EvalState::runDebugRepl(const Error * error, const Env & env, const Expr & 
 
     if (error)
     {
-        printError("%s\n\n", error->what());
+        printError("%s\n", error->what());
 
         if (trylevel > 0 && error->info().level != lvlInfo)
             printError("This exception occurred in a 'tryEval' call. Use " ANSI_GREEN "--ignore-try" ANSI_NORMAL " to skip these.\n");
-
-        printError(ANSI_BOLD "Starting REPL to allow you to inspect the current state of the evaluator.\n" ANSI_NORMAL);
     }
 
     auto se = getStaticEnv(expr);


### PR DESCRIPTION
# Motivation

When you enter the debugger, there's a bunch of visual clutter. This PR reduces it.

Before:
```
info: breakpoint reached


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.20.0pre20231222_dirty. Type :? for help.

nix-repl> :continue
error: uh oh


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.20.0pre20231222_dirty. Type :? for help.

nix-repl>
```

After:
```
info: breakpoint reached

Nix 2.20.0pre20231222_dirty debugger
Type :? for help.
nix-repl> :continue
error: uh oh

nix-repl>
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
