### PR TITLE
Forbid nested debuggers

### DIFF
--- a/doc/manual/rl-next/forbid-nested-debuggers.md
+++ b/doc/manual/rl-next/forbid-nested-debuggers.md
@@ -1,0 +1,32 @@
+---
+synopsis: Nested debuggers are no longer supported
+prs: 9920
+---
+
+Previously, evaluating an expression that throws an error in the debugger would
+enter a second, nested debugger:
+
+```
+nix-repl> builtins.throw "what"
+error: what
+
+
+Starting REPL to allow you to inspect the current state of the evaluator.
+
+Welcome to Nix 2.18.1. Type :? for help.
+
+nix-repl>
+```
+
+Now, it just prints the error message like `nix repl`:
+
+```
+nix-repl> builtins.throw "what"
+error:
+       … while calling the 'throw' builtin
+         at «string»:1:1:
+            1| builtins.throw "what"
+             | ^
+
+       error: what
+```

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -336,13 +336,7 @@ ReplExitStatus NixRepl::mainLoop()
               printMsg(lvlError, e.msg());
             }
         } catch (EvalError & e) {
-            // in debugger mode, an EvalError should trigger another repl session.
-            // when that session returns the exception will land here.  No need to show it again;
-            // show the error for this repl session instead.
-            if (state->debugRepl && !state->debugTraces.empty())
-                showDebugTrace(std::cout, state->positions, state->debugTraces.front());
-            else
-                printMsg(lvlError, e.msg());
+            printMsg(lvlError, e.msg());
         } catch (Error & e) {
             printMsg(lvlError, e.msg());
         } catch (Interrupted & e) {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -153,6 +153,7 @@ struct DebugTrace {
     bool isError;
 };
 
+
 class EvalState : public std::enable_shared_from_this<EvalState>
 {
 public:
@@ -222,6 +223,7 @@ public:
      */
     ReplExitStatus (* debugRepl)(ref<EvalState> es, const ValMap & extraEnv);
     bool debugStop;
+    bool inDebugger = false;
     int trylevel;
     std::list<DebugTrace> debugTraces;
     std::map<const Expr*, const std::shared_ptr<const StaticEnv>> exprEnvs;

--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -34,7 +34,7 @@ inline void formatHelper(F & f, const T & x, const Args & ... args)
 /**
  * Set the correct exceptions for `fmt`.
  */
-void setExceptions(boost::format & fmt)
+inline void setExceptions(boost::format & fmt)
 {
     fmt.exceptions(
         boost::io::all_error_bits ^

--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -8,7 +8,6 @@
 
 namespace nix {
 
-namespace {
 /**
  * A helper for writing `boost::format` expressions.
  *
@@ -41,7 +40,6 @@ void setExceptions(boost::format & fmt)
         boost::io::all_error_bits ^
         boost::io::too_many_args_bit ^
         boost::io::too_few_args_bit);
-}
 }
 
 /**


### PR DESCRIPTION
# Motivation
The nested debugger behavior is extremely confusing as a user and challenging to maintain invariants for (see the disclaimers about its behavior we get to remove now). The debugger should more-or-less behave like the REPL.

Before:
```
$ nix eval --file test.nix --debugger
info: breakpoint reached

      at «none»:0: (source not available)


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.18.1. Type :? for help.

nix-repl> builtins.throw "what"
error: what


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.18.1. Type :? for help.

nix-repl>
```

After:
```
$ nix eval --file test.nix --debugger
info: breakpoint reached


Starting REPL to allow you to inspect the current state of the evaluator.

Welcome to Nix 2.20.0pre20231222_dirty. Type :? for help.

nix-repl> builtins.throw "what"
error:
       … while calling the 'throw' builtin
         at «string»:1:1:
            1| builtins.throw "what"
             | ^

       error: what

nix-repl>
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
