### PR TITLE
Cleanup `fmt.hh`

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -202,7 +202,7 @@ static int main_build_remote(int argc, char * * argv)
                         else
                             drvstr = "<unknown>";
 
-                        auto error = hintfmt(errorText);
+                        auto error = HintFmt(errorText);
                         error
                             % drvstr
                             % neededSystem

--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -202,7 +202,7 @@ static int main_build_remote(int argc, char * * argv)
                         else
                             drvstr = "<unknown>";
 
-                        auto error = hintformat(errorText);
+                        auto error = hintfmt(errorText);
                         error
                             % drvstr
                             % neededSystem

--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -28,7 +28,7 @@ template<class T>
 EvalErrorBuilder<T> & EvalErrorBuilder<T>::withTrace(PosIdx pos, const std::string_view text)
 {
     error.err.traces.push_front(
-        Trace{.pos = error.state.positions[pos], .hint = hintfmt(std::string(text)), .frame = false});
+        Trace{.pos = error.state.positions[pos], .hint = HintFmt(std::string(text)), .frame = false});
     return *this;
 }
 
@@ -36,7 +36,7 @@ template<class T>
 EvalErrorBuilder<T> & EvalErrorBuilder<T>::withFrameTrace(PosIdx pos, const std::string_view text)
 {
     error.err.traces.push_front(
-        Trace{.pos = error.state.positions[pos], .hint = hintformat(std::string(text)), .frame = true});
+        Trace{.pos = error.state.positions[pos], .hint = HintFmt(std::string(text)), .frame = true});
     return *this;
 }
 
@@ -57,13 +57,13 @@ EvalErrorBuilder<T> & EvalErrorBuilder<T>::withFrame(const Env & env, const Expr
         .pos = error.state.positions[expr.getPos()],
         .expr = expr,
         .env = env,
-        .hint = hintformat("Fake frame for debugging purposes"),
+        .hint = HintFmt("Fake frame for debugging purposes"),
         .isError = true});
     return *this;
 }
 
 template<class T>
-EvalErrorBuilder<T> & EvalErrorBuilder<T>::addTrace(PosIdx pos, hintformat hint, bool frame)
+EvalErrorBuilder<T> & EvalErrorBuilder<T>::addTrace(PosIdx pos, HintFmt hint, bool frame)
 {
     error.addTrace(error.state.positions[pos], hint, frame);
     return *this;
@@ -75,7 +75,7 @@ EvalErrorBuilder<T> &
 EvalErrorBuilder<T>::addTrace(PosIdx pos, std::string_view formatString, const Args &... formatArgs)
 {
 
-    addTrace(error.state.positions[pos], hintfmt(std::string(formatString), formatArgs...));
+    addTrace(error.state.positions[pos], HintFmt(std::string(formatString), formatArgs...));
     return *this;
 }
 

--- a/src/libexpr/eval-error.hh
+++ b/src/libexpr/eval-error.hh
@@ -89,7 +89,7 @@ public:
 
     [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> & withFrame(const Env & e, const Expr & ex);
 
-    [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> & addTrace(PosIdx pos, hintformat hint, bool frame = false);
+    [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> & addTrace(PosIdx pos, HintFmt hint, bool frame = false);
 
     template<typename... Args>
     [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> &

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -803,7 +803,7 @@ void EvalState::addErrorTrace(Error & e, const char * s, const std::string & s2)
 
 void EvalState::addErrorTrace(Error & e, const PosIdx pos, const char * s, const std::string & s2, bool frame) const
 {
-    e.addTrace(positions[pos], hintfmt(s, s2), frame);
+    e.addTrace(positions[pos], HintFmt(s, s2), frame);
 }
 
 template<typename... Args>
@@ -819,7 +819,7 @@ static std::unique_ptr<DebugTraceStacker> makeDebugTraceStacker(
             .pos = std::move(pos),
             .expr = expr,
             .env = env,
-            .hint = hintfmt(formatArgs...),
+            .hint = HintFmt(formatArgs...),
             .isError = false
         });
 }
@@ -2792,7 +2792,7 @@ std::optional<std::string> EvalState::resolveSearchPathPath(const SearchPath::Pa
             res = { store->toRealPath(storePath) };
         } catch (FileTransferError & e) {
             logWarning({
-                .msg = hintfmt("Nix search path entry '%1%' cannot be downloaded, ignoring", value)
+                .msg = HintFmt("Nix search path entry '%1%' cannot be downloaded, ignoring", value)
             });
         }
     }
@@ -2825,7 +2825,7 @@ std::optional<std::string> EvalState::resolveSearchPathPath(const SearchPath::Pa
             res = { path };
         else {
             logWarning({
-                .msg = hintfmt("Nix search path entry '%1%' does not exist, ignoring", value)
+                .msg = HintFmt("Nix search path entry '%1%' does not exist, ignoring", value)
             });
             res = std::nullopt;
         }

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -148,7 +148,7 @@ struct DebugTrace {
     std::shared_ptr<Pos> pos;
     const Expr & expr;
     const Env & env;
-    hintfmt hint;
+    HintFmt hint;
     bool isError;
 };
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -148,7 +148,7 @@ struct DebugTrace {
     std::shared_ptr<Pos> pos;
     const Expr & expr;
     const Env & env;
-    hintformat hint;
+    hintfmt hint;
     bool isError;
 };
 

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -155,7 +155,7 @@ static FlakeInput parseFlakeInput(EvalState & state,
         } catch (Error & e) {
             e.addTrace(
                 state.positions[attr.pos],
-                hintfmt("while evaluating flake attribute '%s'", state.symbols[attr.name]));
+                HintFmt("while evaluating flake attribute '%s'", state.symbols[attr.name]));
             throw;
         }
     }
@@ -164,7 +164,7 @@ static FlakeInput parseFlakeInput(EvalState & state,
         try {
             input.ref = FlakeRef::fromAttrs(attrs);
         } catch (Error & e) {
-            e.addTrace(state.positions[pos], hintfmt("while evaluating flake input"));
+            e.addTrace(state.positions[pos], HintFmt("while evaluating flake input"));
             throw;
         }
     else {

--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -147,7 +147,7 @@ or          { return OR_KW; }
                   yylval->n = boost::lexical_cast<int64_t>(yytext);
               } catch (const boost::bad_lexical_cast &) {
                   throw ParseError(ErrorInfo{
-                      .msg = hintfmt("invalid integer '%1%'", yytext),
+                      .msg = HintFmt("invalid integer '%1%'", yytext),
                       .pos = state->positions[CUR_POS],
                   });
               }
@@ -157,7 +157,7 @@ or          { return OR_KW; }
               yylval->nf = strtod(yytext, 0);
               if (errno != 0)
                   throw ParseError(ErrorInfo{
-                      .msg = hintfmt("invalid float '%1%'", yytext),
+                      .msg = HintFmt("invalid float '%1%'", yytext),
                       .pos = state->positions[CUR_POS],
                   });
               return FLOAT_LIT;
@@ -286,7 +286,7 @@ or          { return OR_KW; }
 <INPATH_SLASH>{ANY} |
 <INPATH_SLASH><<EOF>> {
   throw ParseError(ErrorInfo{
-      .msg = hintfmt("path has a trailing slash"),
+      .msg = HintFmt("path has a trailing slash"),
       .pos = state->positions[CUR_POS],
   });
 }

--- a/src/libexpr/parser-state.hh
+++ b/src/libexpr/parser-state.hh
@@ -64,7 +64,7 @@ struct ParserState
 inline void ParserState::dupAttr(const AttrPath & attrPath, const PosIdx pos, const PosIdx prevPos)
 {
     throw ParseError({
-         .msg = hintfmt("attribute '%1%' already defined at %2%",
+         .msg = HintFmt("attribute '%1%' already defined at %2%",
              showAttrPath(symbols, attrPath), positions[prevPos]),
          .pos = positions[pos]
     });
@@ -73,7 +73,7 @@ inline void ParserState::dupAttr(const AttrPath & attrPath, const PosIdx pos, co
 inline void ParserState::dupAttr(Symbol attr, const PosIdx pos, const PosIdx prevPos)
 {
     throw ParseError({
-        .msg = hintfmt("attribute '%1%' already defined at %2%", symbols[attr], positions[prevPos]),
+        .msg = HintFmt("attribute '%1%' already defined at %2%", symbols[attr], positions[prevPos]),
         .pos = positions[pos]
     });
 }
@@ -154,13 +154,13 @@ inline Formals * ParserState::validateFormals(Formals * formals, PosIdx pos, Sym
     }
     if (duplicate)
         throw ParseError({
-            .msg = hintfmt("duplicate formal function argument '%1%'", symbols[duplicate->first]),
+            .msg = HintFmt("duplicate formal function argument '%1%'", symbols[duplicate->first]),
             .pos = positions[duplicate->second]
         });
 
     if (arg && formals->has(arg))
         throw ParseError({
-            .msg = hintfmt("duplicate formal function argument '%1%'", symbols[arg]),
+            .msg = HintFmt("duplicate formal function argument '%1%'", symbols[arg]),
             .pos = positions[pos]
         });
 

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -65,7 +65,7 @@ using namespace nix;
 void yyerror(YYLTYPE * loc, yyscan_t scanner, ParserState * state, const char * error)
 {
     throw ParseError({
-        .msg = hintfmt(error),
+        .msg = HintFmt(error),
         .pos = state->positions[state->at(*loc)]
     });
 }
@@ -154,7 +154,7 @@ expr_function
   | LET binds IN_KW expr_function
     { if (!$2->dynamicAttrs.empty())
         throw ParseError({
-            .msg = hintfmt("dynamic attributes not allowed in let"),
+            .msg = HintFmt("dynamic attributes not allowed in let"),
             .pos = state->positions[CUR_POS]
         });
       $$ = new ExprLet($2, $4);
@@ -244,7 +244,7 @@ expr_simple
       static bool noURLLiterals = experimentalFeatureSettings.isEnabled(Xp::NoUrlLiterals);
       if (noURLLiterals)
           throw ParseError({
-              .msg = hintfmt("URL literals are disabled"),
+              .msg = HintFmt("URL literals are disabled"),
               .pos = state->positions[CUR_POS]
           });
       $$ = new ExprString(std::string($1));
@@ -340,7 +340,7 @@ attrs
           delete str;
       } else
           throw ParseError({
-              .msg = hintfmt("dynamic attributes not allowed in inherit"),
+              .msg = HintFmt("dynamic attributes not allowed in inherit"),
               .pos = state->positions[state->at(@2)]
           });
     }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -754,7 +754,7 @@ static RegisterPrimOp primop_break({
         if (state.debugRepl && !state.debugTraces.empty()) {
             auto error = Error(ErrorInfo {
                 .level = lvlInfo,
-                .msg = hintfmt("breakpoint reached"),
+                .msg = HintFmt("breakpoint reached"),
                 .pos = state.positions[pos],
             });
 
@@ -765,7 +765,7 @@ static RegisterPrimOp primop_break({
                 // If the user elects to quit the repl, throw an exception.
                 throw Error(ErrorInfo{
                     .level = lvlInfo,
-                    .msg = hintfmt("quit the debugger"),
+                    .msg = HintFmt("quit the debugger"),
                     .pos = nullptr,
                 });
             }
@@ -820,7 +820,7 @@ static void prim_addErrorContext(EvalState & state, const PosIdx pos, Value * * 
         auto message = state.coerceToString(pos, *args[0], context,
                 "while evaluating the error message passed to builtins.addErrorContext",
                 false, false).toOwned();
-        e.addTrace(nullptr, hintfmt(message), true);
+        e.addTrace(nullptr, HintFmt(message), true);
         throw;
     }
 }
@@ -1071,7 +1071,7 @@ static void prim_derivationStrict(EvalState & state, const PosIdx pos, Value * *
          * often results from the composition of several functions
          * (derivationStrict, derivation, mkDerivation, mkPythonModule, etc.)
          */
-        e.addTrace(nullptr, hintfmt(
+        e.addTrace(nullptr, HintFmt(
                 "while evaluating derivation '%s'\n"
                 "  whose name attribute is located at %s",
                 drvName, pos), true);
@@ -1232,7 +1232,7 @@ drvName, Bindings * attrs, Value & v)
 
         } catch (Error & e) {
             e.addTrace(state.positions[i->pos],
-                hintfmt("while evaluating attribute '%1%' of derivation '%2%'", key, drvName),
+                HintFmt("while evaluating attribute '%1%' of derivation '%2%'", key, drvName),
                 true);
             throw;
         }

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -23,7 +23,7 @@ static void runFetchClosureWithRewrite(EvalState & state, const PosIdx pos, Stor
         auto rewrittenPath = makeContentAddressed(fromStore, *state.store, fromPath);
         if (toPathMaybe && *toPathMaybe != rewrittenPath)
             throw Error({
-                .msg = hintfmt("rewriting '%s' to content-addressed form yielded '%s', while '%s' was expected",
+                .msg = HintFmt("rewriting '%s' to content-addressed form yielded '%s', while '%s' was expected",
                     state.store->printStorePath(fromPath),
                     state.store->printStorePath(rewrittenPath),
                     state.store->printStorePath(*toPathMaybe)),
@@ -31,7 +31,7 @@ static void runFetchClosureWithRewrite(EvalState & state, const PosIdx pos, Stor
             });
         if (!toPathMaybe)
             throw Error({
-                .msg = hintfmt(
+                .msg = HintFmt(
                     "rewriting '%s' to content-addressed form yielded '%s'\n"
                     "Use this value for the 'toPath' attribute passed to 'fetchClosure'",
                     state.store->printStorePath(fromPath),
@@ -50,7 +50,7 @@ static void runFetchClosureWithRewrite(EvalState & state, const PosIdx pos, Stor
         // We don't perform the rewriting when outPath already exists, as an optimisation.
         // However, we can quickly detect a mistake if the toPath is input addressed.
         throw Error({
-            .msg = hintfmt(
+            .msg = HintFmt(
                 "The 'toPath' value '%s' is input-addressed, so it can't possibly be the result of rewriting to a content-addressed path.\n\n"
                 "Set 'toPath' to an empty string to make Nix report the correct content-addressed path.",
                 state.store->printStorePath(toPath)),
@@ -73,7 +73,7 @@ static void runFetchClosureWithContentAddressedPath(EvalState & state, const Pos
 
     if (!info->isContentAddressed(*state.store)) {
         throw Error({
-            .msg = hintfmt(
+            .msg = HintFmt(
                 "The 'fromPath' value '%s' is input-addressed, but 'inputAddressed' is set to 'false' (default).\n\n"
                 "If you do intend to fetch an input-addressed store path, add\n\n"
                 "    inputAddressed = true;\n\n"
@@ -99,7 +99,7 @@ static void runFetchClosureWithInputAddressedPath(EvalState & state, const PosId
 
     if (info->isContentAddressed(*state.store)) {
         throw Error({
-            .msg = hintfmt(
+            .msg = HintFmt(
                 "The store object referred to by 'fromPath' at '%s' is not input-addressed, but 'inputAddressed' is set to 'true'.\n\n"
                 "Remove the 'inputAddressed' attribute (it defaults to 'false') to expect 'fromPath' to be content-addressed",
                 state.store->printStorePath(fromPath)),
@@ -153,14 +153,14 @@ static void prim_fetchClosure(EvalState & state, const PosIdx pos, Value * * arg
 
         else
             throw Error({
-                .msg = hintfmt("attribute '%s' isn't supported in call to 'fetchClosure'", attrName),
+                .msg = HintFmt("attribute '%s' isn't supported in call to 'fetchClosure'", attrName),
                 .pos = state.positions[pos]
             });
     }
 
     if (!fromPath)
         throw Error({
-            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "fromPath"),
+            .msg = HintFmt("attribute '%s' is missing in call to 'fetchClosure'", "fromPath"),
             .pos = state.positions[pos]
         });
 
@@ -169,7 +169,7 @@ static void prim_fetchClosure(EvalState & state, const PosIdx pos, Value * * arg
     if (inputAddressed) {
         if (toPath)
             throw Error({
-                .msg = hintfmt("attribute '%s' is set to true, but '%s' is also set. Please remove one of them",
+                .msg = HintFmt("attribute '%s' is set to true, but '%s' is also set. Please remove one of them",
                     "inputAddressed",
                     "toPath"),
                 .pos = state.positions[pos]
@@ -178,7 +178,7 @@ static void prim_fetchClosure(EvalState & state, const PosIdx pos, Value * * arg
 
     if (!fromStoreUrl)
         throw Error({
-            .msg = hintfmt("attribute '%s' is missing in call to 'fetchClosure'", "fromStore"),
+            .msg = HintFmt("attribute '%s' is missing in call to 'fetchClosure'", "fromStore"),
             .pos = state.positions[pos]
         });
 
@@ -188,13 +188,13 @@ static void prim_fetchClosure(EvalState & state, const PosIdx pos, Value * * arg
         parsedURL.scheme != "https" &&
         !(getEnv("_NIX_IN_TEST").has_value() && parsedURL.scheme == "file"))
         throw Error({
-            .msg = hintfmt("'fetchClosure' only supports http:// and https:// stores"),
+            .msg = HintFmt("'fetchClosure' only supports http:// and https:// stores"),
             .pos = state.positions[pos]
         });
 
     if (!parsedURL.query.empty())
         throw Error({
-            .msg = hintfmt("'fetchClosure' does not support URL query parameters (in '%s')", *fromStoreUrl),
+            .msg = HintFmt("'fetchClosure' does not support URL query parameters (in '%s')", *fromStoreUrl),
             .pos = state.positions[pos]
         });
 

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -512,7 +512,7 @@ std::ostream & operator<<(std::ostream & output, const ValuePrinter & printer)
 }
 
 template<>
-hintformat & hintformat::operator%(const ValuePrinter & value)
+HintFmt & HintFmt::operator%(const ValuePrinter & value)
 {
         fmt % value;
         return *this;

--- a/src/libexpr/print.hh
+++ b/src/libexpr/print.hh
@@ -86,6 +86,6 @@ std::ostream & operator<<(std::ostream & output, const ValuePrinter & printer);
  * magenta.
  */
 template<>
-hintformat & hintformat::operator%(const ValuePrinter & value);
+HintFmt & HintFmt::operator%(const ValuePrinter & value);
 
 }

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -64,7 +64,7 @@ json printValueAsJSON(EvalState & state, bool strict,
                         out[j] = printValueAsJSON(state, strict, *a.value, a.pos, context, copyToStore);
                     } catch (Error & e) {
                         e.addTrace(state.positions[a.pos],
-                            hintfmt("while evaluating attribute '%1%'", j));
+                            HintFmt("while evaluating attribute '%1%'", j));
                         throw;
                     }
                 }
@@ -81,7 +81,7 @@ json printValueAsJSON(EvalState & state, bool strict,
                     out.push_back(printValueAsJSON(state, strict, *elem, pos, context, copyToStore));
                 } catch (Error & e) {
                     e.addTrace(state.positions[pos],
-                        hintfmt("while evaluating list element at index %1%", i));
+                        HintFmt("while evaluating list element at index %1%", i));
                     throw;
                 }
                 i++;

--- a/src/libexpr/value/context.hh
+++ b/src/libexpr/value/context.hh
@@ -20,7 +20,7 @@ public:
     {
         raw = raw_;
         auto hf = hintfmt(args...);
-        err.msg = hintfmt("Bad String Context element: %1%: %2%", normaltxt(hf.str()), raw);
+        err.msg = hintfmt("Bad String Context element: %1%: %2%", Uncolored(hf.str()), raw);
     }
 };
 

--- a/src/libexpr/value/context.hh
+++ b/src/libexpr/value/context.hh
@@ -19,8 +19,8 @@ public:
         : Error("")
     {
         raw = raw_;
-        auto hf = hintfmt(args...);
-        err.msg = hintfmt("Bad String Context element: %1%: %2%", Uncolored(hf.str()), raw);
+        auto hf = HintFmt(args...);
+        err.msg = HintFmt("Bad String Context element: %1%: %2%", Uncolored(hf.str()), raw);
     }
 };
 

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -708,7 +708,7 @@ void DerivationGoal::tryToBuild()
     if (!outputLocks.lockPaths(lockFiles, "", false)) {
         if (!actLock)
             actLock = std::make_unique<Activity>(*logger, lvlWarn, actBuildWaiting,
-                fmt("waiting for lock on %s", magentatxt(showPaths(lockFiles))));
+                fmt("waiting for lock on %s", Magenta(showPaths(lockFiles))));
         worker.waitForAWhile(shared_from_this());
         return;
     }
@@ -762,7 +762,7 @@ void DerivationGoal::tryToBuild()
                    the wake-up timeout expires. */
                 if (!actLock)
                     actLock = std::make_unique<Activity>(*logger, lvlWarn, actBuildWaiting,
-                        fmt("waiting for a machine to build '%s'", magentatxt(worker.store.printStorePath(drvPath))));
+                        fmt("waiting for a machine to build '%s'", Magenta(worker.store.printStorePath(drvPath))));
                 worker.waitForAWhile(shared_from_this());
                 outputLocks.unlock();
                 return;
@@ -987,7 +987,7 @@ void DerivationGoal::buildDone()
             diskFull |= cleanupDecideWhetherDiskFull();
 
             auto msg = fmt("builder for '%s' %s",
-                magentatxt(worker.store.printStorePath(drvPath)),
+                Magenta(worker.store.printStorePath(drvPath)),
                 statusToString(status));
 
             if (!logger->isVerbose() && !logTail.empty()) {
@@ -1523,7 +1523,7 @@ void DerivationGoal::done(
     outputLocks.unlock();
     buildResult.status = status;
     if (ex)
-        buildResult.errorMsg = fmt("%s", normaltxt(ex->info().msg));
+        buildResult.errorMsg = fmt("%s", Uncolored(ex->info().msg));
     if (buildResult.status == BuildResult::TimedOut)
         worker.timedOut = true;
     if (buildResult.status == BuildResult::PermanentFailure)

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -232,7 +232,7 @@ void LocalDerivationGoal::tryLocalBuild()
         if (!buildUser) {
             if (!actLock)
                 actLock = std::make_unique<Activity>(*logger, lvlWarn, actBuildWaiting,
-                    fmt("waiting for a free build user ID for '%s'", magentatxt(worker.store.printStorePath(drvPath))));
+                    fmt("waiting for a free build user ID for '%s'", Magenta(worker.store.printStorePath(drvPath))));
             worker.waitForAWhile(shared_from_this());
             return;
         }

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -92,7 +92,7 @@ void handleDiffHook(
         } catch (Error & error) {
             ErrorInfo ei = error.info();
             // FIXME: wrap errors.
-            ei.msg = hintfmt("diff hook execution failed: %s", ei.msg.str());
+            ei.msg = HintFmt("diff hook execution failed: %s", ei.msg.str());
             logError(ei);
         }
     }

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -887,7 +887,7 @@ FileTransferError::FileTransferError(FileTransfer::Error error, std::optional<st
     // to print different messages for different verbosity levels. For now
     // we add some heuristics for detecting when we want to show the response.
     if (response && (response->size() < 1024 || response->find("<html>") != std::string::npos))
-        err.msg = hintfmt("%1%\n\nresponse body:\n\n%2%", normaltxt(hf.str()), chomp(*response));
+        err.msg = hintfmt("%1%\n\nresponse body:\n\n%2%", Uncolored(hf.str()), chomp(*response));
     else
         err.msg = hf;
 }

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -882,12 +882,12 @@ template<typename... Args>
 FileTransferError::FileTransferError(FileTransfer::Error error, std::optional<std::string> response, const Args & ... args)
     : Error(args...), error(error), response(response)
 {
-    const auto hf = hintfmt(args...);
+    const auto hf = HintFmt(args...);
     // FIXME: Due to https://github.com/NixOS/nix/issues/3841 we don't know how
     // to print different messages for different verbosity levels. For now
     // we add some heuristics for detecting when we want to show the response.
     if (response && (response->size() < 1024 || response->find("<html>") != std::string::npos))
-        err.msg = hintfmt("%1%\n\nresponse body:\n\n%2%", Uncolored(hf.str()), chomp(*response));
+        err.msg = HintFmt("%1%\n\nresponse body:\n\n%2%", Uncolored(hf.str()), chomp(*response));
     else
         err.msg = hf;
 }

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -10,19 +10,19 @@
 
 namespace nix {
 
-SQLiteError::SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, hintformat && hf)
+SQLiteError::SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, hintfmt && hf)
   : Error(""), path(path), errMsg(errMsg), errNo(errNo), extendedErrNo(extendedErrNo), offset(offset)
 {
     auto offsetStr = (offset == -1) ? "" : "at offset " + std::to_string(offset) + ": ";
     err.msg = hintfmt("%s: %s%s, %s (in '%s')",
-        normaltxt(hf.str()),
+        Uncolored(hf.str()),
         offsetStr,
         sqlite3_errstr(extendedErrNo),
         errMsg,
         path ? path : "(in-memory)");
 }
 
-[[noreturn]] void SQLiteError::throw_(sqlite3 * db, hintformat && hf)
+[[noreturn]] void SQLiteError::throw_(sqlite3 * db, hintfmt && hf)
 {
     int err = sqlite3_errcode(db);
     int exterr = sqlite3_extended_errcode(db);

--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -10,11 +10,11 @@
 
 namespace nix {
 
-SQLiteError::SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, hintfmt && hf)
+SQLiteError::SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, HintFmt && hf)
   : Error(""), path(path), errMsg(errMsg), errNo(errNo), extendedErrNo(extendedErrNo), offset(offset)
 {
     auto offsetStr = (offset == -1) ? "" : "at offset " + std::to_string(offset) + ": ";
-    err.msg = hintfmt("%s: %s%s, %s (in '%s')",
+    err.msg = HintFmt("%s: %s%s, %s (in '%s')",
         Uncolored(hf.str()),
         offsetStr,
         sqlite3_errstr(extendedErrNo),
@@ -22,7 +22,7 @@ SQLiteError::SQLiteError(const char *path, const char *errMsg, int errNo, int ex
         path ? path : "(in-memory)");
 }
 
-[[noreturn]] void SQLiteError::throw_(sqlite3 * db, hintfmt && hf)
+[[noreturn]] void SQLiteError::throw_(sqlite3 * db, HintFmt && hf)
 {
     int err = sqlite3_errcode(db);
     int exterr = sqlite3_extended_errcode(db);
@@ -33,7 +33,7 @@ SQLiteError::SQLiteError(const char *path, const char *errMsg, int errNo, int ex
 
     if (err == SQLITE_BUSY || err == SQLITE_PROTOCOL) {
         auto exp = SQLiteBusy(path, errMsg, err, exterr, offset, std::move(hf));
-        exp.err.msg = hintfmt(
+        exp.err.msg = HintFmt(
             err == SQLITE_PROTOCOL
                 ? "SQLite database '%s' is busy (SQLITE_PROTOCOL)"
                 : "SQLite database '%s' is busy",
@@ -249,7 +249,7 @@ void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning)
     if (now > nextWarning) {
         nextWarning = now + 10;
         logWarning({
-            .msg = hintfmt(e.what())
+            .msg = HintFmt(e.what())
         });
     }
 

--- a/src/libstore/sqlite.hh
+++ b/src/libstore/sqlite.hh
@@ -145,16 +145,16 @@ struct SQLiteError : Error
         throw_(db, hintfmt(fs, args...));
     }
 
-    SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, hintformat && hf);
+    SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, hintfmt && hf);
 
 protected:
 
     template<typename... Args>
     SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, const std::string & fs, const Args & ... args)
-      : SQLiteError(path, errNo, extendedErrNo, offset, hintfmt(fs, args...))
+      : SQLiteError(path, errMsg, errNo, extendedErrNo, offset, hintfmt(fs, args...))
     { }
 
-    [[noreturn]] static void throw_(sqlite3 * db, hintformat && hf);
+    [[noreturn]] static void throw_(sqlite3 * db, hintfmt && hf);
 
 };
 

--- a/src/libstore/sqlite.hh
+++ b/src/libstore/sqlite.hh
@@ -142,19 +142,19 @@ struct SQLiteError : Error
 
     template<typename... Args>
     [[noreturn]] static void throw_(sqlite3 * db, const std::string & fs, const Args & ... args) {
-        throw_(db, hintfmt(fs, args...));
+        throw_(db, HintFmt(fs, args...));
     }
 
-    SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, hintfmt && hf);
+    SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, HintFmt && hf);
 
 protected:
 
     template<typename... Args>
     SQLiteError(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, const std::string & fs, const Args & ... args)
-      : SQLiteError(path, errMsg, errNo, extendedErrNo, offset, hintfmt(fs, args...))
+      : SQLiteError(path, errMsg, errNo, extendedErrNo, offset, HintFmt(fs, args...))
     { }
 
-    [[noreturn]] static void throw_(sqlite3 * db, hintfmt && hf);
+    [[noreturn]] static void throw_(sqlite3 * db, HintFmt && hf);
 
 };
 

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -63,7 +63,7 @@ void setStackSize(rlim_t stackSize)
         if (setrlimit(RLIMIT_STACK, &limit) != 0) {
             logger->log(
                 lvlError,
-                hintfmt(
+                HintFmt(
                     "Failed to increase stack size from %1% to %2% (maximum allowed stack size: %3%): %4%",
                     savedStackSize,
                     stackSize,

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -11,7 +11,7 @@
 
 namespace nix {
 
-void BaseError::addTrace(std::shared_ptr<Pos> && e, hintformat hint, bool frame)
+void BaseError::addTrace(std::shared_ptr<Pos> && e, hintfmt hint, bool frame)
 {
     err.traces.push_front(Trace { .pos = std::move(e), .hint = hint, .frame = frame });
 }
@@ -37,7 +37,7 @@ const std::string & BaseError::calcWhat() const
 
 std::optional<std::string> ErrorInfo::programName = std::nullopt;
 
-std::ostream & operator <<(std::ostream & os, const hintformat & hf)
+std::ostream & operator <<(std::ostream & os, const hintfmt & hf)
 {
     return os << hf.str();
 }

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -11,7 +11,7 @@
 
 namespace nix {
 
-void BaseError::addTrace(std::shared_ptr<Pos> && e, hintfmt hint, bool frame)
+void BaseError::addTrace(std::shared_ptr<Pos> && e, HintFmt hint, bool frame)
 {
     err.traces.push_front(Trace { .pos = std::move(e), .hint = hint, .frame = frame });
 }
@@ -37,7 +37,7 @@ const std::string & BaseError::calcWhat() const
 
 std::optional<std::string> ErrorInfo::programName = std::nullopt;
 
-std::ostream & operator <<(std::ostream & os, const hintfmt & hf)
+std::ostream & operator <<(std::ostream & os, const HintFmt & hf)
 {
     return os << hf.str();
 }

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -63,7 +63,7 @@ void printCodeLines(std::ostream & out,
 
 struct Trace {
     std::shared_ptr<Pos> pos;
-    hintformat hint;
+    hintfmt hint;
     bool frame;
 };
 
@@ -74,7 +74,7 @@ inline bool operator>=(const Trace& lhs, const Trace& rhs);
 
 struct ErrorInfo {
     Verbosity level;
-    hintformat msg;
+    hintfmt msg;
     std::shared_ptr<Pos> pos;
     std::list<Trace> traces;
 
@@ -126,7 +126,7 @@ public:
         : err { .level = lvlError, .msg = hintfmt(args...), .suggestions = sug }
     { }
 
-    BaseError(hintformat hint)
+    BaseError(hintfmt hint)
         : err { .level = lvlError, .msg = hint }
     { }
 
@@ -162,7 +162,7 @@ public:
         addTrace(std::move(e), hintfmt(std::string(fs), args...));
     }
 
-    void addTrace(std::shared_ptr<Pos> && e, hintformat hint, bool frame = false);
+    void addTrace(std::shared_ptr<Pos> && e, hintfmt hint, bool frame = false);
 
     bool hasTrace() const { return !err.traces.empty(); }
 
@@ -215,7 +215,7 @@ public:
         : SystemError(""), errNo(errNo)
     {
         auto hf = hintfmt(args...);
-        err.msg = hintfmt("%1%: %2%", normaltxt(hf.str()), strerror(errNo));
+        err.msg = hintfmt("%1%: %2%", Uncolored(hf.str()), strerror(errNo));
     }
 
     /**

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -63,7 +63,7 @@ void printCodeLines(std::ostream & out,
 
 struct Trace {
     std::shared_ptr<Pos> pos;
-    hintfmt hint;
+    HintFmt hint;
     bool frame;
 };
 
@@ -74,7 +74,7 @@ inline bool operator>=(const Trace& lhs, const Trace& rhs);
 
 struct ErrorInfo {
     Verbosity level;
-    hintfmt msg;
+    HintFmt msg;
     std::shared_ptr<Pos> pos;
     std::list<Trace> traces;
 
@@ -113,20 +113,20 @@ public:
 
     template<typename... Args>
     BaseError(unsigned int status, const Args & ... args)
-        : err { .level = lvlError, .msg = hintfmt(args...), .status = status }
+        : err { .level = lvlError, .msg = HintFmt(args...), .status = status }
     { }
 
     template<typename... Args>
     explicit BaseError(const std::string & fs, const Args & ... args)
-        : err { .level = lvlError, .msg = hintfmt(fs, args...) }
+        : err { .level = lvlError, .msg = HintFmt(fs, args...) }
     { }
 
     template<typename... Args>
     BaseError(const Suggestions & sug, const Args & ... args)
-        : err { .level = lvlError, .msg = hintfmt(args...), .suggestions = sug }
+        : err { .level = lvlError, .msg = HintFmt(args...), .suggestions = sug }
     { }
 
-    BaseError(hintfmt hint)
+    BaseError(HintFmt hint)
         : err { .level = lvlError, .msg = hint }
     { }
 
@@ -159,10 +159,10 @@ public:
     template<typename... Args>
     void addTrace(std::shared_ptr<Pos> && e, std::string_view fs, const Args & ... args)
     {
-        addTrace(std::move(e), hintfmt(std::string(fs), args...));
+        addTrace(std::move(e), HintFmt(std::string(fs), args...));
     }
 
-    void addTrace(std::shared_ptr<Pos> && e, hintfmt hint, bool frame = false);
+    void addTrace(std::shared_ptr<Pos> && e, HintFmt hint, bool frame = false);
 
     bool hasTrace() const { return !err.traces.empty(); }
 
@@ -214,8 +214,8 @@ public:
     SysError(int errNo, const Args & ... args)
         : SystemError(""), errNo(errNo)
     {
-        auto hf = hintfmt(args...);
-        err.msg = hintfmt("%1%: %2%", Uncolored(hf.str()), strerror(errNo));
+        auto hf = HintFmt(args...);
+        err.msg = HintFmt("%1%: %2%", Uncolored(hf.str()), strerror(errNo));
     }
 
     /**

--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -8,37 +8,53 @@
 
 namespace nix {
 
-
+namespace {
 /**
- * Inherit some names from other namespaces for convenience.
- */
-using boost::format;
-
-
-/**
- * A variadic template that does nothing. Useful to call a function
- * for all variadic arguments but ignoring the result.
- */
-struct nop { template<typename... T> nop(T...) {} };
-
-
-/**
- * A helper for formatting strings. ‘fmt(format, a_0, ..., a_n)’ is
- * equivalent to ‘boost::format(format) % a_0 % ... %
- * ... a_n’. However, ‘fmt(s)’ is equivalent to ‘s’ (so no %-expansion
- * takes place).
+ * A helper for writing `boost::format` expressions.
+ *
+ * These are equivalent:
+ *
+ * ```
+ * formatHelper(formatter, a_0, ..., a_n)
+ * formatter % a_0 % ... % a_n
+ * ```
+ *
+ * With a single argument, `formatHelper(s)` is a no-op.
  */
 template<class F>
 inline void formatHelper(F & f)
-{
-}
+{ }
 
 template<class F, typename T, typename... Args>
 inline void formatHelper(F & f, const T & x, const Args & ... args)
 {
+    // Interpolate one argument and then recurse.
     formatHelper(f % x, args...);
 }
+}
 
+/**
+ * A helper for writing a `boost::format` expression to a string.
+ *
+ * These are (roughly) equivalent:
+ *
+ * ```
+ * fmt(formatString, a_0, ..., a_n)
+ * (boost::format(formatString) % a_0 % ... % a_n).str()
+ * ```
+ *
+ * However, when called with a single argument, the string is returned
+ * unchanged.
+ *
+ * If you write code like this:
+ *
+ * ```
+ * std::cout << boost::format(stringFromUserInput) << std::endl;
+ * ```
+ *
+ * And `stringFromUserInput` contains formatting placeholders like `%s`, then
+ * the code will crash at runtime. `fmt` helps you avoid this pitfall.
+ */
 inline std::string fmt(const std::string & s)
 {
     return s;
@@ -63,61 +79,107 @@ inline std::string fmt(const std::string & fs, const Args & ... args)
     return f.str();
 }
 
-// format function for hints in errors.  same as fmt, except templated values
-// are always in magenta.
+/**
+ * Values wrapped in this struct are printed in magenta.
+ *
+ * By default, arguments to `hintfmt` are printed in magenta. To avoid this,
+ * either wrap the argument in `Uncolored` or add a specialization of
+ * `hintfmt::operator%`.
+ */
 template <class T>
-struct magentatxt
+struct Magenta
 {
-    magentatxt(const T &s) : value(s) {}
+    Magenta(const T &s) : value(s) {}
     const T & value;
 };
 
 template <class T>
-std::ostream & operator<<(std::ostream & out, const magentatxt<T> & y)
+std::ostream & operator<<(std::ostream & out, const Magenta<T> & y)
 {
     return out << ANSI_WARNING << y.value << ANSI_NORMAL;
 }
 
+/**
+ * Values wrapped in this class are printed without coloring.
+ *
+ * By default, arguments to `hintfmt` are printed in magenta (see `Magenta`).
+ */
 template <class T>
-struct normaltxt
+struct Uncolored
 {
-    normaltxt(const T & s) : value(s) {}
+    Uncolored(const T & s) : value(s) {}
     const T & value;
 };
 
 template <class T>
-std::ostream & operator<<(std::ostream & out, const normaltxt<T> & y)
+std::ostream & operator<<(std::ostream & out, const Uncolored<T> & y)
 {
     return out << ANSI_NORMAL << y.value;
 }
 
-class hintformat
+/**
+ * A wrapper around `boost::format` which colors interpolated arguments in
+ * magenta by default.
+ */
+class hintfmt
 {
+private:
+    boost::format fmt;
+
 public:
-    hintformat(const std::string & format) : fmt(format)
+    /**
+     * Construct a `hintfmt` from a format string, with values to be
+     * interpolated later with `%`.
+     *
+     * This isn't exposed as a single-argument constructor to avoid
+     * accidentally constructing `hintfmt`s with user-controlled strings. See
+     * the note on `fmt` for more information.
+     */
+    static hintfmt interpolate(const std::string & formatString)
     {
-        fmt.exceptions(boost::io::all_error_bits ^
-                       boost::io::too_many_args_bit ^
-                       boost::io::too_few_args_bit);
+        hintfmt result((boost::format(formatString)));
+        result.fmt.exceptions(
+            boost::io::all_error_bits ^
+            boost::io::too_many_args_bit ^
+            boost::io::too_few_args_bit);
+        return result;
     }
 
-    hintformat(const hintformat & hf)
+    /**
+     * Format the given string literally, without interpolating format
+     * placeholders.
+     */
+    hintfmt(const std::string & literal)
+        : hintfmt("%s", Uncolored(literal))
+    { }
+
+    /**
+     * Interpolate the given arguments into the format string.
+     */
+    template<typename... Args>
+    hintfmt(const std::string & format, const Args & ... args)
+        : fmt(format)
+    {
+        formatHelper(*this, args...);
+    }
+
+    hintfmt(const hintfmt & hf)
         : fmt(hf.fmt)
     { }
 
-    hintformat(format && fmt)
+    hintfmt(boost::format && fmt)
         : fmt(std::move(fmt))
     { }
 
     template<class T>
-    hintformat & operator%(const T & value)
+    hintfmt & operator%(const T & value)
     {
-        fmt % magentatxt(value);
+        fmt % Magenta(value);
         return *this;
     }
 
     template<class T>
-    hintformat & operator%(const normaltxt<T> & value)
+    hintfmt & operator%(const Uncolored<T> & value)
     {
         fmt % value.value;
         return *this;
@@ -127,25 +189,8 @@ public:
     {
         return fmt.str();
     }
-
-private:
-    format fmt;
 };
 
-std::ostream & operator<<(std::ostream & os, const hintformat & hf);
-
-template<typename... Args>
-inline hintformat hintfmt(const std::string & fs, const Args & ... args)
-{
-    hintformat f(fs);
-    formatHelper(f, args...);
-    return f;
-}
-
-inline hintformat hintfmt(const std::string & plain_string)
-{
-    // we won't be receiving any args in this case, so just print the original string
-    return hintfmt("%s", normaltxt(plain_string));
-}
+std::ostream & operator<<(std::ostream & os, const hintfmt & hf);
 
 }

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -120,6 +120,17 @@ public:
     { }
 };
 
+/**
+ * A variadic template that does nothing.
+ *
+ * Useful to call a function with each argument in a parameter pack.
+ */
+struct nop
+{
+    template<typename... T> nop(T...)
+    { }
+};
+
 ActivityId getCurActivity();
 void setCurActivity(const ActivityId activityId);
 

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -448,7 +448,7 @@ Error readError(Source & source)
     auto msg = readString(source);
     ErrorInfo info {
         .level = level,
-        .msg = hintfmt(msg),
+        .msg = HintFmt(msg),
     };
     auto havePos = readNum<size_t>(source);
     assert(havePos == 0);
@@ -457,7 +457,7 @@ Error readError(Source & source)
         havePos = readNum<size_t>(source);
         assert(havePos == 0);
         info.traces.push_back(Trace {
-            .hint = hintfmt(readString(source))
+            .hint = HintFmt(readString(source))
         });
     }
     return Error(std::move(info));

--- a/src/nix/daemon.cc
+++ b/src/nix/daemon.cc
@@ -377,7 +377,7 @@ static void daemonLoop(std::optional<TrustedFlag> forceTrustClientOpt)
         } catch (Error & error) {
             auto ei = error.info();
             // FIXME: add to trace?
-            ei.msg = hintfmt("error processing connection: %1%", ei.msg.str());
+            ei.msg = HintFmt("error processing connection: %1%", ei.msg.str());
             logError(ei);
         }
     }

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -98,7 +98,7 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
                         } catch (Error & e) {
                             e.addTrace(
                                 state->positions[attr.pos],
-                                hintfmt("while evaluating the attribute '%s'", name));
+                                HintFmt("while evaluating the attribute '%s'", name));
                             throw;
                         }
                     }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -411,7 +411,7 @@ struct CmdFlakeCheck : FlakeCommand
                     return storePath;
                 }
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the derivation '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the derivation '%s'", attrPath));
                 reportError(e);
             }
             return std::nullopt;
@@ -430,7 +430,7 @@ struct CmdFlakeCheck : FlakeCommand
                 }
                 #endif
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the app definition '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the app definition '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -454,7 +454,7 @@ struct CmdFlakeCheck : FlakeCommand
                 // FIXME: if we have a 'nixpkgs' input, use it to
                 // evaluate the overlay.
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the overlay '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the overlay '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -465,7 +465,7 @@ struct CmdFlakeCheck : FlakeCommand
                     fmt("checking NixOS module '%s'", attrPath));
                 state->forceValue(v, pos);
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the NixOS module '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the NixOS module '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -491,7 +491,7 @@ struct CmdFlakeCheck : FlakeCommand
                 }
 
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the Hydra jobset '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the Hydra jobset '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -506,7 +506,7 @@ struct CmdFlakeCheck : FlakeCommand
                 if (!state->isDerivation(*vToplevel))
                     throw Error("attribute 'config.system.build.toplevel' is not a derivation");
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the NixOS configuration '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the NixOS configuration '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -540,7 +540,7 @@ struct CmdFlakeCheck : FlakeCommand
                         throw Error("template '%s' has unsupported attribute '%s'", attrPath, name);
                 }
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the template '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the template '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -554,7 +554,7 @@ struct CmdFlakeCheck : FlakeCommand
                     throw Error("bundler must be a function");
                 // TODO: check types of inputs/outputs?
             } catch (Error & e) {
-                e.addTrace(resolve(pos), hintfmt("while checking the template '%s'", attrPath));
+                e.addTrace(resolve(pos), HintFmt("while checking the template '%s'", attrPath));
                 reportError(e);
             }
         };
@@ -774,7 +774,7 @@ struct CmdFlakeCheck : FlakeCommand
                             warn("unknown flake output '%s'", name);
 
                     } catch (Error & e) {
-                        e.addTrace(resolve(pos), hintfmt("while checking flake output '%s'", name));
+                        e.addTrace(resolve(pos), HintFmt("while checking flake output '%s'", name));
                         reportError(e);
                     }
                 });

--- a/tests/unit/libexpr/error_traces.cc
+++ b/tests/unit/libexpr/error_traces.cc
@@ -53,7 +53,6 @@ namespace nix {
                 state.error<EvalError>("beans").debugThrow();
             } catch (Error & e2) {
                 e.addTrace(state.positions[noPos], "beans2", "");
-                //e2.addTrace(state.positions[noPos], "Something", "");
                 ASSERT_TRUE(e.info().traces.size() == 2);
                 ASSERT_TRUE(e2.info().traces.size() == 0);
                 ASSERT_FALSE(&e.info() == &e2.info());

--- a/tests/unit/libexpr/error_traces.cc
+++ b/tests/unit/libexpr/error_traces.cc
@@ -31,14 +31,14 @@ namespace nix {
                 }
             } catch (BaseError & e) {
                 ASSERT_EQ(PrintToString(e.info().msg),
-                          PrintToString(hintfmt("puppy")));
+                          PrintToString(HintFmt("puppy")));
                 auto trace = e.info().traces.rbegin();
                 ASSERT_EQ(e.info().traces.size(), 2);
                 ASSERT_EQ(PrintToString(trace->hint),
-                          PrintToString(hintfmt("doggy")));
+                          PrintToString(HintFmt("doggy")));
                 trace++;
                 ASSERT_EQ(PrintToString(trace->hint),
-                          PrintToString(hintfmt("beans")));
+                          PrintToString(HintFmt("beans")));
                 throw;
             }
             , EvalError
@@ -53,6 +53,7 @@ namespace nix {
                 state.error<EvalError>("beans").debugThrow();
             } catch (Error & e2) {
                 e.addTrace(state.positions[noPos], "beans2", "");
+                //e2.addTrace(state.positions[noPos], "Something", "");
                 ASSERT_TRUE(e.info().traces.size() == 2);
                 ASSERT_TRUE(e2.info().traces.size() == 0);
                 ASSERT_FALSE(&e.info() == &e2.info());
@@ -73,7 +74,7 @@ namespace nix {
                 ASSERT_EQ(e.info().traces.size(), 1) << "while testing " args << std::endl << e.what(); \
                 auto trace = e.info().traces.rbegin();                      \
                 ASSERT_EQ(PrintToString(trace->hint),                       \
-                          PrintToString(hintfmt("while calling the '%s' builtin", name))); \
+                          PrintToString(HintFmt("while calling the '%s' builtin", name))); \
                 throw;                                                      \
             }                                                               \
             , type                                                          \
@@ -95,7 +96,7 @@ namespace nix {
                           PrintToString(context));                          \
                 ++trace;                                                    \
                 ASSERT_EQ(PrintToString(trace->hint),                       \
-                          PrintToString(hintfmt("while calling the '%s' builtin", name))); \
+                          PrintToString(HintFmt("while calling the '%s' builtin", name))); \
                 throw;                                                      \
             }                                                               \
             , type                                                          \
@@ -104,48 +105,48 @@ namespace nix {
     TEST_F(ErrorTraceTest, genericClosure) {
         ASSERT_TRACE2("genericClosure 1",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.genericClosure"));
+                      HintFmt("expected a set but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.genericClosure"));
 
         ASSERT_TRACE2("genericClosure {}",
                       TypeError,
-                      hintfmt("attribute '%s' missing", "startSet"),
-                      hintfmt("in the attrset passed as argument to builtins.genericClosure"));
+                      HintFmt("attribute '%s' missing", "startSet"),
+                      HintFmt("in the attrset passed as argument to builtins.genericClosure"));
 
         ASSERT_TRACE2("genericClosure { startSet = 1; }",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the 'startSet' attribute passed as argument to builtins.genericClosure"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the 'startSet' attribute passed as argument to builtins.genericClosure"));
 
         ASSERT_TRACE2("genericClosure { startSet = [{ key = 1;}]; operator = true; }",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "a Boolean", normaltxt(ANSI_CYAN "true" ANSI_NORMAL)),
-                      hintfmt("while evaluating the 'operator' attribute passed as argument to builtins.genericClosure"));
+                      HintFmt("expected a function but found %s: %s", "a Boolean", Uncolored(ANSI_CYAN "true" ANSI_NORMAL)),
+                      HintFmt("while evaluating the 'operator' attribute passed as argument to builtins.genericClosure"));
 
         ASSERT_TRACE2("genericClosure { startSet = [{ key = 1;}]; operator = item: true; }",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a Boolean", normaltxt(ANSI_CYAN "true" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the `operator` passed to builtins.genericClosure"));
+                      HintFmt("expected a list but found %s: %s", "a Boolean", Uncolored(ANSI_CYAN "true" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the `operator` passed to builtins.genericClosure"));
 
         ASSERT_TRACE2("genericClosure { startSet = [{ key = 1;}]; operator = item: [ true ]; }",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a Boolean", normaltxt(ANSI_CYAN "true" ANSI_NORMAL)),
-                      hintfmt("while evaluating one of the elements generated by (or initially passed to) builtins.genericClosure"));
+                      HintFmt("expected a set but found %s: %s", "a Boolean", Uncolored(ANSI_CYAN "true" ANSI_NORMAL)),
+                      HintFmt("while evaluating one of the elements generated by (or initially passed to) builtins.genericClosure"));
 
         ASSERT_TRACE2("genericClosure { startSet = [{ key = 1;}]; operator = item: [ {} ]; }",
                       TypeError,
-                      hintfmt("attribute '%s' missing", "key"),
-                      hintfmt("in one of the attrsets generated by (or initially passed to) builtins.genericClosure"));
+                      HintFmt("attribute '%s' missing", "key"),
+                      HintFmt("in one of the attrsets generated by (or initially passed to) builtins.genericClosure"));
 
         ASSERT_TRACE2("genericClosure { startSet = [{ key = 1;}]; operator = item: [{ key = ''a''; }]; }",
                       EvalError,
-                      hintfmt("cannot compare %s with %s", "a string", "an integer"),
-                      hintfmt("while comparing the `key` attributes of two genericClosure elements"));
+                      HintFmt("cannot compare %s with %s", "a string", "an integer"),
+                      HintFmt("while comparing the `key` attributes of two genericClosure elements"));
 
         ASSERT_TRACE2("genericClosure { startSet = [ true ]; operator = item: [{ key = ''a''; }]; }",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a Boolean", normaltxt(ANSI_CYAN "true" ANSI_NORMAL)),
-                      hintfmt("while evaluating one of the elements generated by (or initially passed to) builtins.genericClosure"));
+                      HintFmt("expected a set but found %s: %s", "a Boolean", Uncolored(ANSI_CYAN "true" ANSI_NORMAL)),
+                      HintFmt("while evaluating one of the elements generated by (or initially passed to) builtins.genericClosure"));
 
     }
 
@@ -153,32 +154,32 @@ namespace nix {
     TEST_F(ErrorTraceTest, replaceStrings) {
         ASSERT_TRACE2("replaceStrings 0 0 {}",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "0" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.replaceStrings"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "0" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.replaceStrings"));
 
         ASSERT_TRACE2("replaceStrings [] 0 {}",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "0" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.replaceStrings"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "0" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.replaceStrings"));
 
         ASSERT_TRACE1("replaceStrings [ 0 ] [] {}",
                       EvalError,
-                      hintfmt("'from' and 'to' arguments passed to builtins.replaceStrings have different lengths"));
+                      HintFmt("'from' and 'to' arguments passed to builtins.replaceStrings have different lengths"));
 
         ASSERT_TRACE2("replaceStrings [ 1 ] [ \"new\" ] {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating one of the strings to replace passed to builtins.replaceStrings"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating one of the strings to replace passed to builtins.replaceStrings"));
 
         ASSERT_TRACE2("replaceStrings [ \"oo\" ] [ true ] \"foo\"",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a Boolean", normaltxt(ANSI_CYAN "true" ANSI_NORMAL)),
-                      hintfmt("while evaluating one of the replacement strings passed to builtins.replaceStrings"));
+                      HintFmt("expected a string but found %s: %s", "a Boolean", Uncolored(ANSI_CYAN "true" ANSI_NORMAL)),
+                      HintFmt("while evaluating one of the replacement strings passed to builtins.replaceStrings"));
 
         ASSERT_TRACE2("replaceStrings [ \"old\" ] [ \"new\" ] {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the third argument passed to builtins.replaceStrings"));
+                      HintFmt("expected a string but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the third argument passed to builtins.replaceStrings"));
 
     }
 
@@ -242,8 +243,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, ceil) {
         ASSERT_TRACE2("ceil \"foo\"",
                       TypeError,
-                      hintfmt("expected a float but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.ceil"));
+                      HintFmt("expected a float but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.ceil"));
 
     }
 
@@ -251,8 +252,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, floor) {
         ASSERT_TRACE2("floor \"foo\"",
                       TypeError,
-                      hintfmt("expected a float but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.floor"));
+                      HintFmt("expected a float but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.floor"));
 
     }
 
@@ -264,8 +265,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, getEnv) {
         ASSERT_TRACE2("getEnv [ ]",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.getEnv"));
+                      HintFmt("expected a string but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.getEnv"));
 
     }
 
@@ -285,8 +286,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, placeholder) {
         ASSERT_TRACE2("placeholder []",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.placeholder"));
+                      HintFmt("expected a string but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.placeholder"));
 
     }
 
@@ -294,13 +295,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, toPath) {
         ASSERT_TRACE2("toPath []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.toPath"));
+                      HintFmt("cannot coerce %s to a string: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.toPath"));
 
         ASSERT_TRACE2("toPath \"foo\"",
                       EvalError,
-                      hintfmt("string '%s' doesn't represent an absolute path", "foo"),
-                      hintfmt("while evaluating the first argument passed to builtins.toPath"));
+                      HintFmt("string '%s' doesn't represent an absolute path", "foo"),
+                      HintFmt("while evaluating the first argument passed to builtins.toPath"));
 
     }
 
@@ -308,8 +309,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, storePath) {
         ASSERT_TRACE2("storePath true",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a Boolean", normaltxt(ANSI_CYAN "true" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to 'builtins.storePath'"));
+                      HintFmt("cannot coerce %s to a string: %s", "a Boolean", Uncolored(ANSI_CYAN "true" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to 'builtins.storePath'"));
 
     }
 
@@ -317,13 +318,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, pathExists) {
         ASSERT_TRACE2("pathExists []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while realising the context of a path"));
+                      HintFmt("cannot coerce %s to a string: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while realising the context of a path"));
 
         ASSERT_TRACE2("pathExists \"zorglub\"",
                       EvalError,
-                      hintfmt("string '%s' doesn't represent an absolute path", "zorglub"),
-                      hintfmt("while realising the context of a path"));
+                      HintFmt("string '%s' doesn't represent an absolute path", "zorglub"),
+                      HintFmt("while realising the context of a path"));
 
     }
 
@@ -331,8 +332,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, baseNameOf) {
         ASSERT_TRACE2("baseNameOf []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.baseNameOf"));
+                      HintFmt("cannot coerce %s to a string: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.baseNameOf"));
 
     }
 
@@ -376,30 +377,30 @@ namespace nix {
     TEST_F(ErrorTraceTest, filterSource) {
         ASSERT_TRACE2("filterSource [] []",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'"));
+                      HintFmt("cannot coerce %s to a string: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'"));
 
         ASSERT_TRACE2("filterSource [] \"foo\"",
                       EvalError,
-                      hintfmt("string '%s' doesn't represent an absolute path", "foo"),
-                      hintfmt("while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'"));
+                      HintFmt("string '%s' doesn't represent an absolute path", "foo"),
+                      HintFmt("while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'"));
 
         ASSERT_TRACE2("filterSource [] ./.",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.filterSource"));
+                      HintFmt("expected a function but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.filterSource"));
 
         // Usupported by store "dummy"
 
         // ASSERT_TRACE2("filterSource (_: 1) ./.",
         //               TypeError,
-        //               hintfmt("attempt to call something which is not a function but %s", "an integer"),
-        //               hintfmt("while adding path '/home/layus/projects/nix'"));
+        //               HintFmt("attempt to call something which is not a function but %s", "an integer"),
+        //               HintFmt("while adding path '/home/layus/projects/nix'"));
 
         // ASSERT_TRACE2("filterSource (_: _: 1) ./.",
         //               TypeError,
-        //               hintfmt("expected a Boolean but found %s: %s", "an integer", "1"),
-        //               hintfmt("while evaluating the return value of the path filter function"));
+        //               HintFmt("expected a Boolean but found %s: %s", "an integer", "1"),
+        //               HintFmt("while evaluating the return value of the path filter function"));
 
     }
 
@@ -411,8 +412,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, attrNames) {
         ASSERT_TRACE2("attrNames []",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the argument passed to builtins.attrNames"));
+                      HintFmt("expected a set but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the argument passed to builtins.attrNames"));
 
     }
 
@@ -420,8 +421,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, attrValues) {
         ASSERT_TRACE2("attrValues []",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the argument passed to builtins.attrValues"));
+                      HintFmt("expected a set but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the argument passed to builtins.attrValues"));
 
     }
 
@@ -429,18 +430,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, getAttr) {
         ASSERT_TRACE2("getAttr [] []",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.getAttr"));
+                      HintFmt("expected a string but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.getAttr"));
 
         ASSERT_TRACE2("getAttr \"foo\" []",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the second argument passed to builtins.getAttr"));
+                      HintFmt("expected a set but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the second argument passed to builtins.getAttr"));
 
         ASSERT_TRACE2("getAttr \"foo\" {}",
                       TypeError,
-                      hintfmt("attribute '%s' missing", "foo"),
-                      hintfmt("in the attribute set under consideration"));
+                      HintFmt("attribute '%s' missing", "foo"),
+                      HintFmt("in the attribute set under consideration"));
 
     }
 
@@ -452,13 +453,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, hasAttr) {
         ASSERT_TRACE2("hasAttr [] []",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.hasAttr"));
+                      HintFmt("expected a string but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.hasAttr"));
 
         ASSERT_TRACE2("hasAttr \"foo\" []",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the second argument passed to builtins.hasAttr"));
+                      HintFmt("expected a set but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the second argument passed to builtins.hasAttr"));
 
     }
 
@@ -470,18 +471,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, removeAttrs) {
         ASSERT_TRACE2("removeAttrs \"\" \"\"",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.removeAttrs"));
+                      HintFmt("expected a set but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.removeAttrs"));
 
         ASSERT_TRACE2("removeAttrs \"\" [ 1 ]",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.removeAttrs"));
+                      HintFmt("expected a set but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.removeAttrs"));
 
         ASSERT_TRACE2("removeAttrs \"\" [ \"1\" ]",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.removeAttrs"));
+                      HintFmt("expected a set but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.removeAttrs"));
 
     }
 
@@ -489,28 +490,28 @@ namespace nix {
     TEST_F(ErrorTraceTest, listToAttrs) {
         ASSERT_TRACE2("listToAttrs 1",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the argument passed to builtins.listToAttrs"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the argument passed to builtins.listToAttrs"));
 
         ASSERT_TRACE2("listToAttrs [ 1 ]",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating an element of the list passed to builtins.listToAttrs"));
+                      HintFmt("expected a set but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating an element of the list passed to builtins.listToAttrs"));
 
         ASSERT_TRACE2("listToAttrs [ {} ]",
                       TypeError,
-                      hintfmt("attribute '%s' missing", "name"),
-                      hintfmt("in a {name=...; value=...;} pair"));
+                      HintFmt("attribute '%s' missing", "name"),
+                      HintFmt("in a {name=...; value=...;} pair"));
 
         ASSERT_TRACE2("listToAttrs [ { name = 1; } ]",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the `name` attribute of an element of the list passed to builtins.listToAttrs"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the `name` attribute of an element of the list passed to builtins.listToAttrs"));
 
         ASSERT_TRACE2("listToAttrs [ { name = \"foo\"; } ]",
                       TypeError,
-                      hintfmt("attribute '%s' missing", "value"),
-                      hintfmt("in a {name=...; value=...;} pair"));
+                      HintFmt("attribute '%s' missing", "value"),
+                      HintFmt("in a {name=...; value=...;} pair"));
 
     }
 
@@ -518,13 +519,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, intersectAttrs) {
         ASSERT_TRACE2("intersectAttrs [] []",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.intersectAttrs"));
+                      HintFmt("expected a set but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.intersectAttrs"));
 
         ASSERT_TRACE2("intersectAttrs {} []",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the second argument passed to builtins.intersectAttrs"));
+                      HintFmt("expected a set but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the second argument passed to builtins.intersectAttrs"));
 
     }
 
@@ -532,23 +533,23 @@ namespace nix {
     TEST_F(ErrorTraceTest, catAttrs) {
         ASSERT_TRACE2("catAttrs [] {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.catAttrs"));
+                      HintFmt("expected a string but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.catAttrs"));
 
         ASSERT_TRACE2("catAttrs \"foo\" {}",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the second argument passed to builtins.catAttrs"));
+                      HintFmt("expected a list but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the second argument passed to builtins.catAttrs"));
 
         ASSERT_TRACE2("catAttrs \"foo\" [ 1 ]",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating an element in the list passed as second argument to builtins.catAttrs"));
+                      HintFmt("expected a set but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating an element in the list passed as second argument to builtins.catAttrs"));
 
         ASSERT_TRACE2("catAttrs \"foo\" [ { foo = 1; } 1 { bar = 5;} ]",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating an element in the list passed as second argument to builtins.catAttrs"));
+                      HintFmt("expected a set but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating an element in the list passed as second argument to builtins.catAttrs"));
 
     }
 
@@ -556,7 +557,7 @@ namespace nix {
     TEST_F(ErrorTraceTest, functionArgs) {
         ASSERT_TRACE1("functionArgs {}",
                       TypeError,
-                      hintfmt("'functionArgs' requires a function"));
+                      HintFmt("'functionArgs' requires a function"));
 
     }
 
@@ -564,24 +565,24 @@ namespace nix {
     TEST_F(ErrorTraceTest, mapAttrs) {
         ASSERT_TRACE2("mapAttrs [] []",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the second argument passed to builtins.mapAttrs"));
+                      HintFmt("expected a set but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the second argument passed to builtins.mapAttrs"));
 
         // XXX: defered
         // ASSERT_TRACE2("mapAttrs \"\" { foo.bar = 1; }",
         //               TypeError,
-        //               hintfmt("attempt to call something which is not a function but %s", "a string"),
-        //               hintfmt("while evaluating the attribute 'foo'"));
+        //               HintFmt("attempt to call something which is not a function but %s", "a string"),
+        //               HintFmt("while evaluating the attribute 'foo'"));
 
         // ASSERT_TRACE2("mapAttrs (x: x + \"1\") { foo.bar = 1; }",
         //               TypeError,
-        //               hintfmt("attempt to call something which is not a function but %s", "a string"),
-        //               hintfmt("while evaluating the attribute 'foo'"));
+        //               HintFmt("attempt to call something which is not a function but %s", "a string"),
+        //               HintFmt("while evaluating the attribute 'foo'"));
 
         // ASSERT_TRACE2("mapAttrs (x: y: x + 1) { foo.bar = 1; }",
         //               TypeError,
-        //               hintfmt("cannot coerce %s to a string", "an integer"),
-        //               hintfmt("while evaluating a path segment"));
+        //               HintFmt("cannot coerce %s to a string", "an integer"),
+        //               HintFmt("while evaluating a path segment"));
 
     }
 
@@ -589,27 +590,27 @@ namespace nix {
     TEST_F(ErrorTraceTest, zipAttrsWith) {
         ASSERT_TRACE2("zipAttrsWith [] [ 1 ]",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "a list", normaltxt("[ ]")),
-                      hintfmt("while evaluating the first argument passed to builtins.zipAttrsWith"));
+                      HintFmt("expected a function but found %s: %s", "a list", Uncolored("[ ]")),
+                      HintFmt("while evaluating the first argument passed to builtins.zipAttrsWith"));
 
         ASSERT_TRACE2("zipAttrsWith (_: 1) [ 1 ]",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating a value of the list passed as second argument to builtins.zipAttrsWith"));
+                      HintFmt("expected a set but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating a value of the list passed as second argument to builtins.zipAttrsWith"));
 
         // XXX: How to properly tell that the fucntion takes two arguments ?
         // The same question also applies to sort, and maybe others.
         // Due to lazyness, we only create a thunk, and it fails later on.
         // ASSERT_TRACE2("zipAttrsWith (_: 1) [ { foo = 1; } ]",
         //               TypeError,
-        //               hintfmt("attempt to call something which is not a function but %s", "an integer"),
-        //               hintfmt("while evaluating the attribute 'foo'"));
+        //               HintFmt("attempt to call something which is not a function but %s", "an integer"),
+        //               HintFmt("while evaluating the attribute 'foo'"));
 
         // XXX: Also deferred deeply
         // ASSERT_TRACE2("zipAttrsWith (a: b: a + b) [ { foo = 1; } { foo = 2; } ]",
         //               TypeError,
-        //               hintfmt("cannot coerce %s to a string", "a list"),
-        //               hintfmt("while evaluating a path segment"));
+        //               HintFmt("cannot coerce %s to a string", "a list"),
+        //               HintFmt("while evaluating a path segment"));
 
     }
 
@@ -621,16 +622,16 @@ namespace nix {
     TEST_F(ErrorTraceTest, elemAt) {
         ASSERT_TRACE2("elemAt \"foo\" (-1)",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.elemAt"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.elemAt"));
 
         ASSERT_TRACE1("elemAt [] (-1)",
                       Error,
-                      hintfmt("list index %d is out of bounds", -1));
+                      HintFmt("list index %d is out of bounds", -1));
 
         ASSERT_TRACE1("elemAt [\"foo\"] 3",
                       Error,
-                      hintfmt("list index %d is out of bounds", 3));
+                      HintFmt("list index %d is out of bounds", 3));
 
     }
 
@@ -638,12 +639,12 @@ namespace nix {
     TEST_F(ErrorTraceTest, head) {
         ASSERT_TRACE2("head 1",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.elemAt"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.elemAt"));
 
         ASSERT_TRACE1("head []",
                       Error,
-                      hintfmt("list index %d is out of bounds", 0));
+                      HintFmt("list index %d is out of bounds", 0));
 
     }
 
@@ -651,12 +652,12 @@ namespace nix {
     TEST_F(ErrorTraceTest, tail) {
         ASSERT_TRACE2("tail 1",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.tail"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.tail"));
 
         ASSERT_TRACE1("tail []",
                       Error,
-                      hintfmt("'tail' called on an empty list"));
+                      HintFmt("'tail' called on an empty list"));
 
     }
 
@@ -664,13 +665,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, map) {
         ASSERT_TRACE2("map 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.map"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.map"));
 
         ASSERT_TRACE2("map 1 [ 1 ]",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.map"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.map"));
 
     }
 
@@ -678,18 +679,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, filter) {
         ASSERT_TRACE2("filter 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.filter"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.filter"));
 
         ASSERT_TRACE2("filter 1 [ \"foo\" ]",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.filter"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.filter"));
 
         ASSERT_TRACE2("filter (_: 5) [ \"foo\" ]",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "an integer", normaltxt(ANSI_CYAN "5" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the filtering function passed to builtins.filter"));
+                      HintFmt("expected a Boolean but found %s: %s", "an integer", Uncolored(ANSI_CYAN "5" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the filtering function passed to builtins.filter"));
 
     }
 
@@ -697,8 +698,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, elem) {
         ASSERT_TRACE2("elem 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.elem"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.elem"));
 
     }
 
@@ -706,18 +707,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, concatLists) {
         ASSERT_TRACE2("concatLists 1",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.concatLists"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.concatLists"));
 
         ASSERT_TRACE2("concatLists [ 1 ]",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating a value of the list passed to builtins.concatLists"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating a value of the list passed to builtins.concatLists"));
 
         ASSERT_TRACE2("concatLists [ [1] \"foo\" ]",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating a value of the list passed to builtins.concatLists"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating a value of the list passed to builtins.concatLists"));
 
     }
 
@@ -725,13 +726,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, length) {
         ASSERT_TRACE2("length 1",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.length"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.length"));
 
         ASSERT_TRACE2("length \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.length"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.length"));
 
     }
 
@@ -739,22 +740,22 @@ namespace nix {
     TEST_F(ErrorTraceTest, foldlPrime) {
         ASSERT_TRACE2("foldl' 1 \"foo\" true",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.foldlStrict"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.foldlStrict"));
 
         ASSERT_TRACE2("foldl' (_: 1) \"foo\" true",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a Boolean", normaltxt(ANSI_CYAN "true" ANSI_NORMAL)),
-                      hintfmt("while evaluating the third argument passed to builtins.foldlStrict"));
+                      HintFmt("expected a list but found %s: %s", "a Boolean", Uncolored(ANSI_CYAN "true" ANSI_NORMAL)),
+                      HintFmt("while evaluating the third argument passed to builtins.foldlStrict"));
 
         ASSERT_TRACE1("foldl' (_: 1) \"foo\" [ true ]",
                       TypeError,
-                      hintfmt("attempt to call something which is not a function but %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)));
+                      HintFmt("attempt to call something which is not a function but %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)));
 
         ASSERT_TRACE2("foldl' (a: b: a && b) \"foo\" [ true ]",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("in the left operand of the AND (&&) operator"));
+                      HintFmt("expected a Boolean but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("in the left operand of the AND (&&) operator"));
 
     }
 
@@ -762,18 +763,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, any) {
         ASSERT_TRACE2("any 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.any"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.any"));
 
         ASSERT_TRACE2("any (_: 1) \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.any"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.any"));
 
         ASSERT_TRACE2("any (_: 1) [ \"foo\" ]",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the function passed to builtins.any"));
+                      HintFmt("expected a Boolean but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the function passed to builtins.any"));
 
     }
 
@@ -781,18 +782,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, all) {
         ASSERT_TRACE2("all 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.all"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.all"));
 
         ASSERT_TRACE2("all (_: 1) \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.all"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.all"));
 
         ASSERT_TRACE2("all (_: 1) [ \"foo\" ]",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the function passed to builtins.all"));
+                      HintFmt("expected a Boolean but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the function passed to builtins.all"));
 
     }
 
@@ -800,23 +801,23 @@ namespace nix {
     TEST_F(ErrorTraceTest, genList) {
         ASSERT_TRACE2("genList 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.genList"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.genList"));
 
         ASSERT_TRACE2("genList 1 2",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.genList", "an integer"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.genList", "an integer"));
 
         // XXX: defered
         // ASSERT_TRACE2("genList (x: x + \"foo\") 2 #TODO",
         //               TypeError,
-        //               hintfmt("cannot add %s to an integer", "a string"),
-        //               hintfmt("while evaluating anonymous lambda"));
+        //               HintFmt("cannot add %s to an integer", "a string"),
+        //               HintFmt("while evaluating anonymous lambda"));
 
         ASSERT_TRACE1("genList false (-3)",
                       EvalError,
-                      hintfmt("cannot create list of size %d", -3));
+                      HintFmt("cannot create list of size %d", -3));
 
     }
 
@@ -824,31 +825,31 @@ namespace nix {
     TEST_F(ErrorTraceTest, sort) {
         ASSERT_TRACE2("sort 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.sort"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.sort"));
 
         ASSERT_TRACE2("sort 1 [ \"foo\" ]",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.sort"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.sort"));
 
         ASSERT_TRACE1("sort (_: 1) [ \"foo\" \"bar\" ]",
                       TypeError,
-                      hintfmt("attempt to call something which is not a function but %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)));
+                      HintFmt("attempt to call something which is not a function but %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)));
 
         ASSERT_TRACE2("sort (_: _: 1) [ \"foo\" \"bar\" ]",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the sorting function passed to builtins.sort"));
+                      HintFmt("expected a Boolean but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the sorting function passed to builtins.sort"));
 
         // XXX: Trace too deep, need better asserts
         // ASSERT_TRACE1("sort (a: b: a <= b) [ \"foo\" {} ] # TODO",
         //               TypeError,
-        //               hintfmt("cannot compare %s with %s", "a string", "a set"));
+        //               HintFmt("cannot compare %s with %s", "a string", "a set"));
 
         // ASSERT_TRACE1("sort (a: b: a <= b) [ {} {} ] # TODO",
         //               TypeError,
-        //               hintfmt("cannot compare %s with %s; values of that type are incomparable", "a set", "a set"));
+        //               HintFmt("cannot compare %s with %s; values of that type are incomparable", "a set", "a set"));
 
     }
 
@@ -856,18 +857,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, partition) {
         ASSERT_TRACE2("partition 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.partition"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.partition"));
 
         ASSERT_TRACE2("partition (_: 1) \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.partition"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.partition"));
 
         ASSERT_TRACE2("partition (_: 1) [ \"foo\" ]",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the partition function passed to builtins.partition"));
+                      HintFmt("expected a Boolean but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the partition function passed to builtins.partition"));
 
     }
 
@@ -875,18 +876,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, groupBy) {
         ASSERT_TRACE2("groupBy 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.groupBy"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.groupBy"));
 
         ASSERT_TRACE2("groupBy (_: 1) \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.groupBy"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.groupBy"));
 
         ASSERT_TRACE2("groupBy (x: x) [ \"foo\" \"bar\" 1 ]",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the grouping function passed to builtins.groupBy"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the grouping function passed to builtins.groupBy"));
 
     }
 
@@ -894,23 +895,23 @@ namespace nix {
     TEST_F(ErrorTraceTest, concatMap) {
         ASSERT_TRACE2("concatMap 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a function but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.concatMap"));
+                      HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.concatMap"));
 
         ASSERT_TRACE2("concatMap (x: 1) \"foo\"",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.concatMap"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.concatMap"));
 
         ASSERT_TRACE2("concatMap (x: 1) [ \"foo\" ] # TODO",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the function passed to builtins.concatMap"));
+                      HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the function passed to builtins.concatMap"));
 
         ASSERT_TRACE2("concatMap (x: \"foo\") [ 1 2 ] # TODO",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the return value of the function passed to builtins.concatMap"));
+                      HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the return value of the function passed to builtins.concatMap"));
 
     }
 
@@ -918,13 +919,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, add) {
         ASSERT_TRACE2("add \"foo\" 1",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument of the addition"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument of the addition"));
 
         ASSERT_TRACE2("add 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument of the addition"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument of the addition"));
 
     }
 
@@ -932,13 +933,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, sub) {
         ASSERT_TRACE2("sub \"foo\" 1",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument of the subtraction"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument of the subtraction"));
 
         ASSERT_TRACE2("sub 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument of the subtraction"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument of the subtraction"));
 
     }
 
@@ -946,13 +947,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, mul) {
         ASSERT_TRACE2("mul \"foo\" 1",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument of the multiplication"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument of the multiplication"));
 
         ASSERT_TRACE2("mul 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument of the multiplication"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument of the multiplication"));
 
     }
 
@@ -960,17 +961,17 @@ namespace nix {
     TEST_F(ErrorTraceTest, div) {
         ASSERT_TRACE2("div \"foo\" 1 # TODO: an integer was expected -> a number",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first operand of the division"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first operand of the division"));
 
         ASSERT_TRACE2("div 1 \"foo\"",
                       TypeError,
-                      hintfmt("expected a float but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second operand of the division"));
+                      HintFmt("expected a float but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second operand of the division"));
 
         ASSERT_TRACE1("div \"foo\" 0",
                       EvalError,
-                      hintfmt("division by zero"));
+                      HintFmt("division by zero"));
 
     }
 
@@ -978,13 +979,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, bitAnd) {
         ASSERT_TRACE2("bitAnd 1.1 2",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a float", normaltxt(ANSI_CYAN "1.1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.bitAnd"));
+                      HintFmt("expected an integer but found %s: %s", "a float", Uncolored(ANSI_CYAN "1.1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.bitAnd"));
 
         ASSERT_TRACE2("bitAnd 1 2.2",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a float", normaltxt(ANSI_CYAN "2.2" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.bitAnd"));
+                      HintFmt("expected an integer but found %s: %s", "a float", Uncolored(ANSI_CYAN "2.2" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.bitAnd"));
 
     }
 
@@ -992,13 +993,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, bitOr) {
         ASSERT_TRACE2("bitOr 1.1 2",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a float", normaltxt(ANSI_CYAN "1.1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.bitOr"));
+                      HintFmt("expected an integer but found %s: %s", "a float", Uncolored(ANSI_CYAN "1.1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.bitOr"));
 
         ASSERT_TRACE2("bitOr 1 2.2",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a float", normaltxt(ANSI_CYAN "2.2" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.bitOr"));
+                      HintFmt("expected an integer but found %s: %s", "a float", Uncolored(ANSI_CYAN "2.2" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.bitOr"));
 
     }
 
@@ -1006,13 +1007,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, bitXor) {
         ASSERT_TRACE2("bitXor 1.1 2",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a float", normaltxt(ANSI_CYAN "1.1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.bitXor"));
+                      HintFmt("expected an integer but found %s: %s", "a float", Uncolored(ANSI_CYAN "1.1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.bitXor"));
 
         ASSERT_TRACE2("bitXor 1 2.2",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a float", normaltxt(ANSI_CYAN "2.2" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument passed to builtins.bitXor"));
+                      HintFmt("expected an integer but found %s: %s", "a float", Uncolored(ANSI_CYAN "2.2" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument passed to builtins.bitXor"));
 
     }
 
@@ -1020,16 +1021,16 @@ namespace nix {
     TEST_F(ErrorTraceTest, lessThan) {
         ASSERT_TRACE1("lessThan 1 \"foo\"",
                       EvalError,
-                      hintfmt("cannot compare %s with %s", "an integer", "a string"));
+                      HintFmt("cannot compare %s with %s", "an integer", "a string"));
 
         ASSERT_TRACE1("lessThan {} {}",
                       EvalError,
-                      hintfmt("cannot compare %s with %s; values of that type are incomparable", "a set", "a set"));
+                      HintFmt("cannot compare %s with %s; values of that type are incomparable", "a set", "a set"));
 
         ASSERT_TRACE2("lessThan [ 1 2 ] [ \"foo\" ]",
                       EvalError,
-                      hintfmt("cannot compare %s with %s", "an integer", "a string"),
-                      hintfmt("while comparing two list elements"));
+                      HintFmt("cannot compare %s with %s", "an integer", "a string"),
+                      HintFmt("while comparing two list elements"));
 
     }
 
@@ -1037,8 +1038,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, toString) {
         ASSERT_TRACE2("toString { a = 1; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", normaltxt("{ a = " ANSI_CYAN "1" ANSI_NORMAL "; }")),
-                      hintfmt("while evaluating the first argument passed to builtins.toString"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", Uncolored("{ a = " ANSI_CYAN "1" ANSI_NORMAL "; }")),
+                      HintFmt("while evaluating the first argument passed to builtins.toString"));
 
     }
 
@@ -1046,22 +1047,22 @@ namespace nix {
     TEST_F(ErrorTraceTest, substring) {
         ASSERT_TRACE2("substring {} \"foo\" true",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the first argument (the start offset) passed to builtins.substring"));
+                      HintFmt("expected an integer but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the first argument (the start offset) passed to builtins.substring"));
 
         ASSERT_TRACE2("substring 3 \"foo\" true",
                       TypeError,
-                      hintfmt("expected an integer but found %s: %s", "a string", normaltxt(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      hintfmt("while evaluating the second argument (the substring length) passed to builtins.substring"));
+                      HintFmt("expected an integer but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
+                      HintFmt("while evaluating the second argument (the substring length) passed to builtins.substring"));
 
         ASSERT_TRACE2("substring 0 3 {}",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the third argument (the string) passed to builtins.substring"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the third argument (the string) passed to builtins.substring"));
 
         ASSERT_TRACE1("substring (-3) 3 \"sometext\"",
                       EvalError,
-                      hintfmt("negative start position in 'substring'"));
+                      HintFmt("negative start position in 'substring'"));
 
     }
 
@@ -1069,8 +1070,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, stringLength) {
         ASSERT_TRACE2("stringLength {} # TODO: context is missing ???",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the argument passed to builtins.stringLength"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the argument passed to builtins.stringLength"));
 
     }
 
@@ -1078,17 +1079,17 @@ namespace nix {
     TEST_F(ErrorTraceTest, hashString) {
         ASSERT_TRACE2("hashString 1 {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.hashString"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.hashString"));
 
         ASSERT_TRACE1("hashString \"foo\" \"content\"",
                       UsageError,
-                      hintfmt("unknown hash algorithm '%s', expect 'md5', 'sha1', 'sha256', or 'sha512'", "foo"));
+                      HintFmt("unknown hash algorithm '%s', expect 'md5', 'sha1', 'sha256', or 'sha512'", "foo"));
 
         ASSERT_TRACE2("hashString \"sha256\" {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the second argument passed to builtins.hashString"));
+                      HintFmt("expected a string but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the second argument passed to builtins.hashString"));
 
     }
 
@@ -1096,17 +1097,17 @@ namespace nix {
     TEST_F(ErrorTraceTest, match) {
         ASSERT_TRACE2("match 1 {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.match"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.match"));
 
         ASSERT_TRACE2("match \"foo\" {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the second argument passed to builtins.match"));
+                      HintFmt("expected a string but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the second argument passed to builtins.match"));
 
         ASSERT_TRACE1("match \"(.*\" \"\"",
                       EvalError,
-                      hintfmt("invalid regular expression '%s'", "(.*"));
+                      HintFmt("invalid regular expression '%s'", "(.*"));
 
     }
 
@@ -1114,17 +1115,17 @@ namespace nix {
     TEST_F(ErrorTraceTest, split) {
         ASSERT_TRACE2("split 1 {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.split"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.split"));
 
         ASSERT_TRACE2("split \"foo\" {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the second argument passed to builtins.split"));
+                      HintFmt("expected a string but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the second argument passed to builtins.split"));
 
         ASSERT_TRACE1("split \"f(o*o\" \"1foo2\"",
                       EvalError,
-                      hintfmt("invalid regular expression '%s'", "f(o*o"));
+                      HintFmt("invalid regular expression '%s'", "f(o*o"));
 
     }
 
@@ -1132,18 +1133,18 @@ namespace nix {
     TEST_F(ErrorTraceTest, concatStringsSep) {
         ASSERT_TRACE2("concatStringsSep 1 {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument (the separator string) passed to builtins.concatStringsSep"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument (the separator string) passed to builtins.concatStringsSep"));
 
         ASSERT_TRACE2("concatStringsSep \"foo\" {}",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the second argument (the list of strings to concat) passed to builtins.concatStringsSep"));
+                      HintFmt("expected a list but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the second argument (the list of strings to concat) passed to builtins.concatStringsSep"));
 
         ASSERT_TRACE2("concatStringsSep \"foo\" [ 1 2 {} ] # TODO: coerce to string is buggy",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating one element of the list of strings to concat passed to builtins.concatStringsSep"));
+                      HintFmt("cannot coerce %s to a string: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating one element of the list of strings to concat passed to builtins.concatStringsSep"));
 
     }
 
@@ -1151,8 +1152,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, parseDrvName) {
         ASSERT_TRACE2("parseDrvName 1",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.parseDrvName"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.parseDrvName"));
 
     }
 
@@ -1160,13 +1161,13 @@ namespace nix {
     TEST_F(ErrorTraceTest, compareVersions) {
         ASSERT_TRACE2("compareVersions 1 {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.compareVersions"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.compareVersions"));
 
         ASSERT_TRACE2("compareVersions \"abd\" {}",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "a set", normaltxt("{ }")),
-                      hintfmt("while evaluating the second argument passed to builtins.compareVersions"));
+                      HintFmt("expected a string but found %s: %s", "a set", Uncolored("{ }")),
+                      HintFmt("while evaluating the second argument passed to builtins.compareVersions"));
 
     }
 
@@ -1174,8 +1175,8 @@ namespace nix {
     TEST_F(ErrorTraceTest, splitVersion) {
         ASSERT_TRACE2("splitVersion 1",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", normaltxt(ANSI_CYAN "1" ANSI_NORMAL)),
-                      hintfmt("while evaluating the first argument passed to builtins.splitVersion"));
+                      HintFmt("expected a string but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
+                      HintFmt("while evaluating the first argument passed to builtins.splitVersion"));
 
     }
 
@@ -1188,108 +1189,108 @@ namespace nix {
     TEST_F(ErrorTraceTest, derivationStrict) {
         ASSERT_TRACE2("derivationStrict \"\"",
                       TypeError,
-                      hintfmt("expected a set but found %s: %s", "a string", "\"\""),
-                      hintfmt("while evaluating the argument passed to builtins.derivationStrict"));
+                      HintFmt("expected a set but found %s: %s", "a string", "\"\""),
+                      HintFmt("while evaluating the argument passed to builtins.derivationStrict"));
 
         ASSERT_TRACE2("derivationStrict {}",
                       TypeError,
-                      hintfmt("attribute '%s' missing", "name"),
-                      hintfmt("in the attrset passed as argument to builtins.derivationStrict"));
+                      HintFmt("attribute '%s' missing", "name"),
+                      HintFmt("in the attrset passed as argument to builtins.derivationStrict"));
 
         ASSERT_TRACE2("derivationStrict { name = 1; }",
                       TypeError,
-                      hintfmt("expected a string but found %s: %s", "an integer", "1"),
-                      hintfmt("while evaluating the `name` attribute passed to builtins.derivationStrict"));
+                      HintFmt("expected a string but found %s: %s", "an integer", "1"),
+                      HintFmt("while evaluating the `name` attribute passed to builtins.derivationStrict"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; }",
                       TypeError,
-                      hintfmt("required attribute 'builder' missing"),
-                      hintfmt("while evaluating derivation 'foo'"));
+                      HintFmt("required attribute 'builder' missing"),
+                      HintFmt("while evaluating derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; __structuredAttrs = 15; }",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "an integer", "15"),
-                      hintfmt("while evaluating the `__structuredAttrs` attribute passed to builtins.derivationStrict"));
+                      HintFmt("expected a Boolean but found %s: %s", "an integer", "15"),
+                      HintFmt("while evaluating the `__structuredAttrs` attribute passed to builtins.derivationStrict"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; __ignoreNulls = 15; }",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "an integer", "15"),
-                      hintfmt("while evaluating the `__ignoreNulls` attribute passed to builtins.derivationStrict"));
+                      HintFmt("expected a Boolean but found %s: %s", "an integer", "15"),
+                      HintFmt("while evaluating the `__ignoreNulls` attribute passed to builtins.derivationStrict"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; outputHashMode = 15; }",
                       TypeError,
-                      hintfmt("invalid value '15' for 'outputHashMode' attribute"),
-                      hintfmt("while evaluating the attribute 'outputHashMode' of derivation 'foo'"));
+                      HintFmt("invalid value '15' for 'outputHashMode' attribute"),
+                      HintFmt("while evaluating the attribute 'outputHashMode' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; outputHashMode = \"custom\"; }",
                       TypeError,
-                      hintfmt("invalid value 'custom' for 'outputHashMode' attribute"),
-                      hintfmt("while evaluating the attribute 'outputHashMode' of derivation 'foo'"));
+                      HintFmt("invalid value 'custom' for 'outputHashMode' attribute"),
+                      HintFmt("while evaluating the attribute 'outputHashMode' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
-                      hintfmt("while evaluating the attribute 'system' of derivation 'foo'"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", "{ }"),
+                      HintFmt("while evaluating the attribute 'system' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
-                      hintfmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", "{ }"),
+                      HintFmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"drv\"; }",
                       TypeError,
-                      hintfmt("invalid derivation output name 'drv'"),
-                      hintfmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
+                      HintFmt("invalid derivation output name 'drv'"),
+                      HintFmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = []; }",
                       TypeError,
-                      hintfmt("derivation cannot have an empty set of outputs"),
-                      hintfmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
+                      HintFmt("derivation cannot have an empty set of outputs"),
+                      HintFmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = [ \"drv\" ]; }",
                       TypeError,
-                      hintfmt("invalid derivation output name 'drv'"),
-                      hintfmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
+                      HintFmt("invalid derivation output name 'drv'"),
+                      HintFmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = [ \"out\" \"out\" ]; }",
                       TypeError,
-                      hintfmt("duplicate derivation output 'out'"),
-                      hintfmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
+                      HintFmt("duplicate derivation output 'out'"),
+                      HintFmt("while evaluating the attribute 'outputs' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; __contentAddressed = \"true\"; }",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "a string", "\"true\""),
-                      hintfmt("while evaluating the attribute '__contentAddressed' of derivation 'foo'"));
+                      HintFmt("expected a Boolean but found %s: %s", "a string", "\"true\""),
+                      HintFmt("while evaluating the attribute '__contentAddressed' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; __impure = \"true\"; }",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "a string", "\"true\""),
-                      hintfmt("while evaluating the attribute '__impure' of derivation 'foo'"));
+                      HintFmt("expected a Boolean but found %s: %s", "a string", "\"true\""),
+                      HintFmt("while evaluating the attribute '__impure' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; __impure = \"true\"; }",
                       TypeError,
-                      hintfmt("expected a Boolean but found %s: %s", "a string", "\"true\""),
-                      hintfmt("while evaluating the attribute '__impure' of derivation 'foo'"));
+                      HintFmt("expected a Boolean but found %s: %s", "a string", "\"true\""),
+                      HintFmt("while evaluating the attribute '__impure' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; args = \"foo\"; }",
                       TypeError,
-                      hintfmt("expected a list but found %s: %s", "a string", "\"foo\""),
-                      hintfmt("while evaluating the attribute 'args' of derivation 'foo'"));
+                      HintFmt("expected a list but found %s: %s", "a string", "\"foo\""),
+                      HintFmt("while evaluating the attribute 'args' of derivation 'foo'"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; args = [ {} ]; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
-                      hintfmt("while evaluating an element of the argument list"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", "{ }"),
+                      HintFmt("while evaluating an element of the argument list"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; args = [ \"a\" {} ]; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
-                      hintfmt("while evaluating an element of the argument list"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", "{ }"),
+                      HintFmt("while evaluating an element of the argument list"));
 
         ASSERT_TRACE2("derivationStrict { name = \"foo\"; builder = 1; system = 1; outputs = \"out\"; FOO = {}; }",
                       TypeError,
-                      hintfmt("cannot coerce %s to a string: %s", "a set", "{ }"),
-                      hintfmt("while evaluating the attribute 'FOO' of derivation 'foo'"));
+                      HintFmt("cannot coerce %s to a string: %s", "a set", "{ }"),
+                      HintFmt("while evaluating the attribute 'FOO' of derivation 'foo'"));
 
     }
     */

--- a/tests/unit/libexpr/error_traces.cc
+++ b/tests/unit/libexpr/error_traces.cc
@@ -26,7 +26,7 @@ namespace nix {
                 try {
                     state.error<EvalError>("puppy").withTrace(noPos, "doggy").debugThrow();
                 } catch (Error & e) {
-                    e.addTrace(state.positions[noPos], "beans", "");
+                    e.addTrace(state.positions[noPos], "beans");
                     throw;
                 }
             } catch (BaseError & e) {
@@ -52,7 +52,7 @@ namespace nix {
             try {
                 state.error<EvalError>("beans").debugThrow();
             } catch (Error & e2) {
-                e.addTrace(state.positions[noPos], "beans2", "");
+                e.addTrace(state.positions[noPos], "beans2");
                 //e2.addTrace(state.positions[noPos], "Something", "");
                 ASSERT_TRUE(e.info().traces.size() == 2);
                 ASSERT_TRUE(e2.info().traces.size() == 0);
@@ -807,7 +807,7 @@ namespace nix {
         ASSERT_TRACE2("genList 1 2",
                       TypeError,
                       HintFmt("expected a function but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
-                      HintFmt("while evaluating the first argument passed to builtins.genList", "an integer"));
+                      HintFmt("while evaluating the first argument passed to builtins.genList"));
 
         // XXX: defered
         // ASSERT_TRACE2("genList (x: x + \"foo\") 2 #TODO",

--- a/tests/unit/libutil/logging.cc
+++ b/tests/unit/libutil/logging.cc
@@ -62,7 +62,7 @@ namespace nix {
             throw TestError(e.info());
         } catch (Error &e) {
             ErrorInfo ei = e.info();
-            ei.msg = hintfmt("%s; subsequent error message.", normaltxt(e.info().msg.str()));
+            ei.msg = hintfmt("%s; subsequent error message.", Uncolored(e.info().msg.str()));
 
             testing::internal::CaptureStderr();
             logger->logEI(ei);

--- a/tests/unit/libutil/logging.cc
+++ b/tests/unit/libutil/logging.cc
@@ -42,7 +42,7 @@ namespace nix {
 
         makeJSONLogger(*logger)->logEI({
                 .name = "error name",
-                .msg = hintfmt("this hint has %1% templated %2%!!",
+                .msg = HintFmt("this hint has %1% templated %2%!!",
                     "yellow",
                     "values"),
                 .errPos = Pos(foFile, problem_file, 02, 13)
@@ -62,7 +62,7 @@ namespace nix {
             throw TestError(e.info());
         } catch (Error &e) {
             ErrorInfo ei = e.info();
-            ei.msg = hintfmt("%s; subsequent error message.", Uncolored(e.info().msg.str()));
+            ei.msg = HintFmt("%s; subsequent error message.", Uncolored(e.info().msg.str()));
 
             testing::internal::CaptureStderr();
             logger->logEI(ei);
@@ -176,7 +176,7 @@ namespace nix {
 
         logError({
                 .name = "error name",
-                .msg = hintfmt("this hint has %1% templated %2%!!",
+                .msg = HintFmt("this hint has %1% templated %2%!!",
                     "yellow",
                     "values"),
                 .errPos = Pos(foString, problem_file, 02, 13),
@@ -193,7 +193,7 @@ namespace nix {
 
         logError({
                 .name = "error name",
-                .msg = hintfmt("this hint has %1% templated %2%!!",
+                .msg = HintFmt("this hint has %1% templated %2%!!",
                     "yellow",
                     "values"),
                 .errPos = Pos(foFile, problem_file, 02, 13)
@@ -208,7 +208,7 @@ namespace nix {
 
         logError({
                 .name = "error name",
-                .msg = hintfmt("hint %1%", "only"),
+                .msg = HintFmt("hint %1%", "only"),
             });
 
         auto str = testing::internal::GetCapturedStderr();
@@ -225,7 +225,7 @@ namespace nix {
 
         logWarning({
                 .name = "name",
-                .msg = hintfmt("there was a %1%", "warning"),
+                .msg = HintFmt("there was a %1%", "warning"),
             });
 
         auto str = testing::internal::GetCapturedStderr();
@@ -241,7 +241,7 @@ namespace nix {
 
         logWarning({
                 .name = "warning name",
-                .msg = hintfmt("this hint has %1% templated %2%!!",
+                .msg = HintFmt("this hint has %1% templated %2%!!",
                     "yellow",
                     "values"),
                 .errPos = Pos(foStdin, problem_file, 2, 13),
@@ -264,7 +264,7 @@ namespace nix {
 
         auto e = AssertionError(ErrorInfo {
                 .name = "wat",
-                .msg = hintfmt("it has been %1% days since our last error", "zero"),
+                .msg = HintFmt("it has been %1% days since our last error", "zero"),
                 .errPos = Pos(foString, problem_file, 2, 13),
             });
 
@@ -290,7 +290,7 @@ namespace nix {
 
         auto e = AssertionError(ErrorInfo {
                 .name = "wat",
-                .msg = hintfmt("it has been %1% days since our last error", "zero"),
+                .msg = HintFmt("it has been %1% days since our last error", "zero"),
                 .errPos = Pos(foString, problem_file, 2, 13),
             });
 
@@ -310,39 +310,39 @@ namespace nix {
 
 
     /* ----------------------------------------------------------------------------
-     * hintfmt
+     * HintFmt
      * --------------------------------------------------------------------------*/
 
-    TEST(hintfmt, percentStringWithoutArgs) {
+    TEST(HintFmt, percentStringWithoutArgs) {
 
         const char *teststr = "this is 100%s correct!";
 
         ASSERT_STREQ(
-            hintfmt(teststr).str().c_str(),
+            HintFmt(teststr).str().c_str(),
             teststr);
 
     }
 
-    TEST(hintfmt, fmtToHintfmt) {
+    TEST(HintFmt, fmtToHintfmt) {
 
         ASSERT_STREQ(
-            hintfmt(fmt("the color of this this text is %1%", "not yellow")).str().c_str(),
+            HintFmt(fmt("the color of this this text is %1%", "not yellow")).str().c_str(),
             "the color of this this text is not yellow");
 
     }
 
-    TEST(hintfmt, tooFewArguments) {
+    TEST(HintFmt, tooFewArguments) {
 
         ASSERT_STREQ(
-            hintfmt("only one arg %1% %2%", "fulfilled").str().c_str(),
+            HintFmt("only one arg %1% %2%", "fulfilled").str().c_str(),
             "only one arg " ANSI_WARNING "fulfilled" ANSI_NORMAL " ");
 
     }
 
-    TEST(hintfmt, tooManyArguments) {
+    TEST(HintFmt, tooManyArguments) {
 
         ASSERT_STREQ(
-            hintfmt("what about this %1% %2%", "%3%", "one", "two").str().c_str(),
+            HintFmt("what about this %1% %2%", "%3%", "one", "two").str().c_str(),
             "what about this " ANSI_WARNING "%3%" ANSI_NORMAL " " ANSI_YELLOW "one" ANSI_NORMAL);
 
     }


### PR DESCRIPTION
# Motivation

When I started contributing to Nix, I found the mix of definitions and names in `fmt.hh` to be rather confusing, especially the small difference between `hintfmt` and `hintformat`. To alleviate this, I've renamed many classes and added documentation to most definitions.

- Type names are now `TitleCased` rather than lowercased, to match most other type names in the Nix codebase.
- `formatHelper` is no longer exported.
- `fmt`'s documentation is now with `fmt` rather than (misleadingly) above `formatHelper`.
- `yellowtxt` is renamed to `Magenta`. See #9924.
- `normaltxt` is renamed to `Uncolored`.
- `hintfmt` has been merged into `hintformat` as extra constructor functions.
- `hintformat` has been renamed to `HintFmt`.
- The single-argument `hintformat(std::string)` constructor has been renamed to a static member `hintformat::interpolate` to avoid pitfalls with using user-generated strings as format strings.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
