### PR TITLE
Catch `Error`, not `BaseError` in `ValuePrinter`

### DIFF
--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -255,7 +255,7 @@ private:
             output << "»";
             if (options.ansiColors)
                 output << ANSI_NORMAL;
-        } catch (BaseError & e) {
+        } catch (Error & e) {
             printError_(e);
         }
     }
@@ -405,7 +405,7 @@ private:
             output << ANSI_NORMAL;
     }
 
-    void printError_(BaseError & e)
+    void printError_(Error & e)
     {
         if (options.ansiColors)
             output << ANSI_RED;
@@ -422,7 +422,7 @@ private:
         if (options.force) {
             try {
                 state.forceValue(v, v.determinePos(noPos));
-            } catch (BaseError & e) {
+            } catch (Error & e) {
                 printError_(e);
                 return;
             }


### PR DESCRIPTION
`BaseError` includes `Interrupt`. We probably don't want the value printer to tell you Ctrl-C was pressed while it was printing.