### PR TITLE
Improve error printing in `nix repl`

### DIFF
--- a/doc/manual/rl-next/better-errors-in-nix-repl.md
+++ b/doc/manual/rl-next/better-errors-in-nix-repl.md
@@ -1,0 +1,40 @@
+---
+synopsis: Concise error printing in `nix repl`
+prs: 9928
+---
+
+Previously, if an element of a list or attribute set threw an error while
+evaluating, `nix repl` would print the entire error (including source location
+information) inline. This output was clumsy and difficult to parse:
+
+```
+nix-repl> { err = builtins.throw "uh oh!"; }
+{ err = «error:
+       … while calling the 'throw' builtin
+         at «string»:1:9:
+            1| { err = builtins.throw "uh oh!"; }
+             |         ^
+
+       error: uh oh!»; }
+```
+
+Now, only the error message is displayed, making the output much more readable.
+```
+nix-repl> { err = builtins.throw "uh oh!"; }
+{ err = «error: uh oh!»; }
+```
+
+However, if the whole expression being evaluated throws an error, source
+locations and (if applicable) a stack trace are printed, just like you'd expect:
+
+```
+nix-repl> builtins.throw "uh oh!"
+error:
+       … while calling the 'throw' builtin
+         at «string»:1:1:
+            1| builtins.throw "uh oh!"
+             | ^
+
+       error: uh oh!
+```
+

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -409,7 +409,7 @@ private:
     {
         if (options.ansiColors)
             output << ANSI_RED;
-        output << "«" << e.msg() << "»";
+        output << "«error: " << filterANSIEscapes(e.info().msg.str(), true) << "»";
         if (options.ansiColors)
             output << ANSI_NORMAL;
     }

--- a/tests/unit/libexpr/value/print.cc
+++ b/tests/unit/libexpr/value/print.cc
@@ -460,19 +460,7 @@ TEST_F(ValuePrintingTests, ansiColorsError)
 
     test(vError,
          ANSI_RED
-         "«"
-         ANSI_RED
-         "error:"
-         ANSI_NORMAL
-         "\n       … while calling the '"
-         ANSI_MAGENTA
-         "throw"
-         ANSI_NORMAL
-         "' builtin\n\n       "
-         ANSI_RED
-         "error:"
-         ANSI_NORMAL
-         " uh oh!»"
+         "«error: uh oh!»"
          ANSI_NORMAL,
          PrintOptions {
              .ansiColors = true,
@@ -501,19 +489,7 @@ TEST_F(ValuePrintingTests, ansiColorsDerivationError)
     test(vAttrs,
          "{ drvPath = "
          ANSI_RED
-         "«"
-         ANSI_RED
-         "error:"
-         ANSI_NORMAL
-         "\n       … while calling the '"
-         ANSI_MAGENTA
-         "throw"
-         ANSI_NORMAL
-         "' builtin\n\n       "
-         ANSI_RED
-         "error:"
-         ANSI_NORMAL
-         " uh oh!»"
+         "«error: uh oh!»"
          ANSI_NORMAL
          "; type = "
          ANSI_MAGENTA
@@ -527,19 +503,7 @@ TEST_F(ValuePrintingTests, ansiColorsDerivationError)
 
     test(vAttrs,
          ANSI_RED
-         "«"
-         ANSI_RED
-         "error:"
-         ANSI_NORMAL
-         "\n       … while calling the '"
-         ANSI_MAGENTA
-         "throw"
-         ANSI_NORMAL
-         "' builtin\n\n       "
-         ANSI_RED
-         "error:"
-         ANSI_NORMAL
-         " uh oh!»"
+         "«error: uh oh!»"
          ANSI_NORMAL,
          PrintOptions {
              .ansiColors = true,
@@ -560,7 +524,7 @@ TEST_F(ValuePrintingTests, ansiColorsAssert)
     state.mkThunk_(v, &expr);
 
     test(v,
-         ANSI_RED "«" ANSI_RED "error:" ANSI_NORMAL " assertion '" ANSI_MAGENTA "false" ANSI_NORMAL "' failed»" ANSI_NORMAL,
+         ANSI_RED "«error: assertion 'false' failed»" ANSI_NORMAL,
          PrintOptions {
              .ansiColors = true,
              .force = true


### PR DESCRIPTION
This makes the output of values that include errors much cleaner.

Before:
```
nix-repl> { err = builtins.throw "uh oh!"; }
{ err = «error:
       … while calling the 'throw' builtin
         at «string»:1:9:
            1| { err = builtins.throw "uh oh!"; }
             |         ^

       error: uh oh!»; }
```

After:
```
nix-repl> { err = builtins.throw "uh oh!"; }
{ err = «error: uh oh!»; }
```

But if the whole expression throws an error, source locations and (if applicable) a stack trace are printed, like you'd expect:

```
nix-repl> builtins.throw "uh oh!"
error:
       … while calling the 'throw' builtin
         at «string»:1:1:
            1| builtins.throw "uh oh!"
             | ^

       error: uh oh!
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
