### PR TITLE
print-dev-env: Avoid using unbound shellHook variable

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -354,7 +354,7 @@ struct Common : InstallableCommand, MixProfile
         for (auto & i : {"TMP", "TMPDIR", "TEMP", "TEMPDIR"})
             out << fmt("export %s=\"$NIX_BUILD_TOP\"\n", i);
 
-        out << "eval \"$shellHook\"\n";
+        out << "eval \"${shellHook:-}\"\n";
 
         auto script = out.str();
 

--- a/tests/functional/nix-shell.sh
+++ b/tests/functional/nix-shell.sh
@@ -118,10 +118,10 @@ diff $TEST_ROOT/dev-env{,2}.json
 # Ensure `nix print-dev-env --json` contains variable assignments.
 [[ $(jq -r .variables.arr1.value[2] $TEST_ROOT/dev-env.json) = '3 4' ]]
 
-# Run tests involving `source <(nix print-dev-inv)` in subshells to avoid modifying the current
+# Run tests involving `source <(nix print-dev-env)` in subshells to avoid modifying the current
 # environment.
 
-set +u # FIXME: Make print-dev-env `set -u` compliant (issue #7951)
+set -u
 
 # Ensure `source <(nix print-dev-env)` modifies the environment.
 (


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Some tools which consume the `nix print-dev-env` rc script (such as [nix-direnv](https://github.com/nix-community/nix-direnv)) are sensitive to the use of unbound variables. They use `set -u`.

The `nix print-dev-env` rc script initially unsets `shellHook`, then loads variables from the derivation, and then evaluates `shellHook`. However, most derivations don't have a `shellHook` attribute.

So users get the error "shellHook: unbound variable". This can be demonstrated with the command:

    nix print-dev-env nixpkgs#hello | bash -u

This commit changes the rc script to provide an empty fallback value for the `shellHook` variable.

# Context

<!-- Provide context. Reference open issues if available. -->
Closes: #7951 #8253

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
