### PR TITLE
Pretty-print values in the REPL

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -101,7 +101,8 @@ struct NixRepl
             .ansiColors = true,
             .force = true,
             .derivationPaths = true,
-            .maxDepth = maxDepth
+            .maxDepth = maxDepth,
+            .prettyIndent = 2
         });
     }
 };

--- a/src/libexpr/print-options.hh
+++ b/src/libexpr/print-options.hh
@@ -17,24 +17,29 @@ struct PrintOptions
      * If true, output ANSI color sequences.
      */
     bool ansiColors = false;
+
     /**
      * If true, force values.
      */
     bool force = false;
+
     /**
      * If true and `force` is set, print derivations as
      * `«derivation /nix/store/...»` instead of as attribute sets.
      */
     bool derivationPaths = false;
+
     /**
      * If true, track which values have been printed and skip them on
      * subsequent encounters. Useful for self-referential values.
      */
     bool trackRepeated = true;
+
     /**
      * Maximum depth to evaluate to.
      */
     size_t maxDepth = std::numeric_limits<size_t>::max();
+
     /**
      * Maximum number of attributes in attribute sets to print.
      *
@@ -42,6 +47,7 @@ struct PrintOptions
      * attribute set encountered.
      */
     size_t maxAttrs = std::numeric_limits<size_t>::max();
+
     /**
      * Maximum number of list items to print.
      *
@@ -49,10 +55,26 @@ struct PrintOptions
      * list encountered.
      */
     size_t maxListItems = std::numeric_limits<size_t>::max();
+
     /**
      * Maximum string length to print.
      */
     size_t maxStringLength = std::numeric_limits<size_t>::max();
+
+    /**
+     * Indentation width for pretty-printing.
+     *
+     * If set to 0 (the default), values are not pretty-printed.
+     */
+    size_t prettyIndent = 0;
+
+    /**
+     * True if pretty-printing is enabled.
+     */
+    inline bool prettyPrint()
+    {
+        return prettyIndent > 0;
+    }
 };
 
 /**

--- a/src/libexpr/print-options.hh
+++ b/src/libexpr/print-options.hh
@@ -71,7 +71,7 @@ struct PrintOptions
     /**
      * True if pretty-printing is enabled.
      */
-    inline bool prettyPrint()
+    inline bool shouldPrettyPrint()
     {
         return prettyIndent > 0;
     }

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -176,6 +176,7 @@ private:
     void decreaseIndent()
     {
         if (options.prettyPrint()) {
+            assert(indent.size() >= options.prettyIndent);
             indent.resize(indent.size() - options.prettyIndent);
         }
     }

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -181,6 +181,21 @@ private:
         }
     }
 
+    /**
+     * Print a space (for separating items or attributes).
+     *
+     * If pretty-printing is enabled, a newline and the current `indent` is
+     * printed instead.
+     */
+    void printSpace(bool prettyPrint)
+    {
+        if (prettyPrint) {
+            output << "\n" << indent;
+        } else {
+            output << " ";
+        }
+    }
+
     void printRepeated()
     {
         if (options.ansiColors)
@@ -324,11 +339,7 @@ private:
             auto prettyPrint = shouldPrettyPrintAttrs(sorted);
 
             for (auto & i : sorted) {
-                if (prettyPrint) {
-                    output << "\n" << indent;
-                } else {
-                    output << " ";
-                }
+                printSpace(prettyPrint);
 
                 if (attrsPrinted >= options.maxAttrs) {
                     printElided(sorted.size() - attrsPrinted, "attribute", "attributes");
@@ -343,11 +354,7 @@ private:
             }
 
             decreaseIndent();
-            if (prettyPrint) {
-                output << "\n" << indent;
-            } else {
-                output << " ";
-            }
+            printSpace(prettyPrint);
             output << "}";
         } else {
             output << "{ ... }";
@@ -389,11 +396,7 @@ private:
             auto listItems = v.listItems();
             auto prettyPrint = shouldPrettyPrintList(listItems);
             for (auto elem : listItems) {
-                if (prettyPrint) {
-                    output << "\n" << indent;
-                } else {
-                    output << " ";
-                }
+                printSpace(prettyPrint);
 
                 if (listItemsPrinted >= options.maxListItems) {
                     printElided(listItems.size() - listItemsPrinted, "item", "items");
@@ -409,11 +412,7 @@ private:
             }
 
             decreaseIndent();
-            if (prettyPrint) {
-                output << "\n" << indent;
-            } else {
-                output << " ";
-            }
+            printSpace(prettyPrint);
             output << "]";
         } else {
             output << "[ ... ]";

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -153,6 +153,7 @@ struct ImportantFirstAttrNameCmp
 };
 
 typedef std::set<const void *> ValuesSeen;
+typedef std::vector<std::pair<std::string, Value *>> AttrVec;
 
 class Printer
 {
@@ -163,6 +164,21 @@ private:
     std::optional<ValuesSeen> seen;
     size_t attrsPrinted = 0;
     size_t listItemsPrinted = 0;
+    std::string indent;
+
+    void increaseIndent()
+    {
+        if (options.prettyPrint()) {
+            indent.append(options.prettyIndent, ' ');
+        }
+    }
+
+    void decreaseIndent()
+    {
+        if (options.prettyPrint()) {
+            indent.resize(indent.size() - options.prettyIndent);
+        }
+    }
 
     void printRepeated()
     {
@@ -260,6 +276,28 @@ private:
         }
     }
 
+    bool shouldPrettyPrintAttrs(AttrVec & v)
+    {
+        if (!options.prettyPrint() || v.empty()) {
+            return false;
+        }
+
+        // Pretty-print attrsets with more than one item.
+        if (v.size() > 1) {
+            return true;
+        }
+
+        auto item = v[0].second;
+        if (!item) {
+            return true;
+        }
+
+        // Pretty-print single-item attrsets only if they contain nested
+        // structures.
+        auto itemType = item->type();
+        return itemType == nList || itemType == nAttrs || itemType == nThunk;
+    }
+
     void printAttrs(Value & v, size_t depth)
     {
         if (seen && !seen->insert(v.attrs).second) {
@@ -270,9 +308,10 @@ private:
         if (options.force && options.derivationPaths && state.isDerivation(v)) {
             printDerivation(v);
         } else if (depth < options.maxDepth) {
-            output << "{ ";
+            increaseIndent();
+            output << "{";
 
-            std::vector<std::pair<std::string, Value *>> sorted;
+            AttrVec sorted;
             for (auto & i : *v.attrs)
                 sorted.emplace_back(std::pair(state.symbols[i.name], i.value));
 
@@ -281,7 +320,15 @@ private:
             else
                 std::sort(sorted.begin(), sorted.end(), ImportantFirstAttrNameCmp());
 
+            auto prettyPrint = shouldPrettyPrintAttrs(sorted);
+
             for (auto & i : sorted) {
+                if (prettyPrint) {
+                    output << "\n" << indent;
+                } else {
+                    output << " ";
+                }
+
                 if (attrsPrinted >= options.maxAttrs) {
                     printElided(sorted.size() - attrsPrinted, "attribute", "attributes");
                     break;
@@ -290,13 +337,42 @@ private:
                 printAttributeName(output, i.first);
                 output << " = ";
                 print(*i.second, depth + 1);
-                output << "; ";
+                output << ";";
                 attrsPrinted++;
             }
 
+            decreaseIndent();
+            if (prettyPrint) {
+                output << "\n" << indent;
+            } else {
+                output << " ";
+            }
             output << "}";
-        } else
+        } else {
             output << "{ ... }";
+        }
+    }
+
+    bool shouldPrettyPrintList(std::span<Value * const> list)
+    {
+        if (!options.prettyPrint() || list.empty()) {
+            return false;
+        }
+
+        // Pretty-print lists with more than one item.
+        if (list.size() > 1) {
+            return true;
+        }
+
+        auto item = list[0];
+        if (!item) {
+            return true;
+        }
+
+        // Pretty-print single-item lists only if they contain nested
+        // structures.
+        auto itemType = item->type();
+        return itemType == nList || itemType == nAttrs || itemType == nThunk;
     }
 
     void printList(Value & v, size_t depth)
@@ -306,11 +382,20 @@ private:
             return;
         }
 
-        output << "[ ";
         if (depth < options.maxDepth) {
-            for (auto elem : v.listItems()) {
+            increaseIndent();
+            output << "[";
+            auto listItems = v.listItems();
+            auto prettyPrint = shouldPrettyPrintList(listItems);
+            for (auto elem : listItems) {
+                if (prettyPrint) {
+                    output << "\n" << indent;
+                } else {
+                    output << " ";
+                }
+
                 if (listItemsPrinted >= options.maxListItems) {
-                    printElided(v.listSize() - listItemsPrinted, "item", "items");
+                    printElided(listItems.size() - listItemsPrinted, "item", "items");
                     break;
                 }
 
@@ -319,13 +404,19 @@ private:
                 } else {
                     printNullptr();
                 }
-                output << " ";
                 listItemsPrinted++;
             }
+
+            decreaseIndent();
+            if (prettyPrint) {
+                output << "\n" << indent;
+            } else {
+                output << " ";
+            }
+            output << "]";
+        } else {
+            output << "[ ... ]";
         }
-        else
-            output << "... ";
-        output << "]";
     }
 
     void printFunction(Value & v)
@@ -488,6 +579,7 @@ public:
     {
         attrsPrinted = 0;
         listItemsPrinted = 0;
+        indent.clear();
 
         if (options.trackRepeated) {
             seen.emplace();

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -168,14 +168,14 @@ private:
 
     void increaseIndent()
     {
-        if (options.prettyPrint()) {
+        if (options.shouldPrettyPrint()) {
             indent.append(options.prettyIndent, ' ');
         }
     }
 
     void decreaseIndent()
     {
-        if (options.prettyPrint()) {
+        if (options.shouldPrettyPrint()) {
             assert(indent.size() >= options.prettyIndent);
             indent.resize(indent.size() - options.prettyIndent);
         }
@@ -279,7 +279,7 @@ private:
 
     bool shouldPrettyPrintAttrs(AttrVec & v)
     {
-        if (!options.prettyPrint() || v.empty()) {
+        if (!options.shouldPrettyPrint() || v.empty()) {
             return false;
         }
 
@@ -356,7 +356,7 @@ private:
 
     bool shouldPrettyPrintList(std::span<Value * const> list)
     {
-        if (!options.prettyPrint() || list.empty()) {
+        if (!options.shouldPrettyPrint() || list.empty()) {
             return false;
         }
 

--- a/tests/functional/lang/eval-fail-bad-string-interpolation-4.err.exp
+++ b/tests/functional/lang/eval-fail-bad-string-interpolation-4.err.exp
@@ -6,4 +6,4 @@ error:
              |   ^
            10|
 
-       error: cannot coerce a set to a string: { a = { a = { a = { a = "ha"; b = "ha"; c = "ha"; d = "ha"; e = "ha"; f = "ha"; g = "ha"; h = "ha"; j = "ha"; }; «4294967295 attributes elided»}; «4294967294 attributes elided»}; «4294967293 attributes elided»}
+       error: cannot coerce a set to a string: { a = { a = { a = { a = "ha"; b = "ha"; c = "ha"; d = "ha"; e = "ha"; f = "ha"; g = "ha"; h = "ha"; j = "ha"; }; «4294967295 attributes elided» }; «4294967294 attributes elided» }; «4294967293 attributes elided» }

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -146,29 +146,86 @@ echo "$replResult" | grepQuiet -s afterChange
 # Normal output should print attributes in lexicographical order non-recursively
 testReplResponseNoRegex '
 { a = { b = 2; }; l = [ 1 2 3 ]; s = "string"; n = 1234; x = rec { y = { z = { inherit y; }; }; }; }
-' '{ a = { ... }; l = [ ... ]; n = 1234; s = "string"; x = { ... }; }'
+' \
+'{
+  a = { ... };
+  l = [ ... ];
+  n = 1234;
+  s = "string";
+  x = { ... };
+}
+'
 
 # Same for lists, but order is preserved
 testReplResponseNoRegex '
 [ 42 1 "thingy" ({ a = 1; }) ([ 1 2 3 ]) ]
-' '[ 42 1 "thingy" { ... } [ ... ] ]'
+' \
+'[
+  42
+  1
+  "thingy"
+  { ... }
+  [ ... ]
+]
+'
 
 # Same for let expressions
 testReplResponseNoRegex '
 let x = { y = { a = 1; }; inherit x; }; in x
-' '{ x = «repeated»; y = { ... }; }'
+' \
+'{
+  x = { ... };
+  y = { ... };
+}
+'
 
 # The :p command should recursively print sets, but prevent infinite recursion
 testReplResponseNoRegex '
 :p { a = { b = 2; }; s = "string"; n = 1234; x = rec { y = { z = { inherit y; }; }; }; }
-' '{ a = { b = 2; }; n = 1234; s = "string"; x = { y = { z = { y = «repeated»; }; }; }; }'
+' \
+'{
+  a = { b = 2; };
+  n = 1234;
+  s = "string";
+  x = {
+    y = {
+      z = {
+        y = «repeated»;
+      };
+    };
+  };
+}
+'
 
 # Same for lists
 testReplResponseNoRegex '
 :p [ 42 1 "thingy" (rec { a = 1; b = { inherit a; inherit b; }; }) ([ 1 2 3 ]) ]
-' '[ 42 1 "thingy" { a = 1; b = { a = 1; b = «repeated»; }; } [ 1 2 3 ] ]'
+' \
+'[
+  42
+  1
+  "thingy"
+  {
+    a = 1;
+    b = {
+      a = 1;
+      b = «repeated»;
+    };
+  }
+  [
+    1
+    2
+    3
+  ]
+]
+'
 
 # Same for let expressions
 testReplResponseNoRegex '
 :p let x = { y = { a = 1; }; inherit x; }; in x
-' '{ x = «repeated»; y = { a = 1; }; }'
+' \
+'{
+  x = «repeated»;
+  y = { a = 1 };
+}
+'

--- a/tests/unit/libexpr/value/print.cc
+++ b/tests/unit/libexpr/value/print.cc
@@ -756,7 +756,7 @@ TEST_F(ValuePrintingTests, ansiColorsAttrsElided)
     vAttrs.mkAttrs(builder.finish());
 
     test(vAttrs,
-         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT "«1 attribute elided»" ANSI_NORMAL "}",
+         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT "«1 attribute elided»" ANSI_NORMAL " }",
          PrintOptions {
              .ansiColors = true,
              .maxAttrs = 1
@@ -769,7 +769,7 @@ TEST_F(ValuePrintingTests, ansiColorsAttrsElided)
     vAttrs.mkAttrs(builder.finish());
 
     test(vAttrs,
-         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT "«2 attributes elided»" ANSI_NORMAL "}",
+         "{ one = " ANSI_CYAN "1" ANSI_NORMAL "; " ANSI_FAINT "«2 attributes elided»" ANSI_NORMAL " }",
          PrintOptions {
              .ansiColors = true,
              .maxAttrs = 1
@@ -793,7 +793,7 @@ TEST_F(ValuePrintingTests, ansiColorsListElided)
     vList.bigList.size = 2;
 
     test(vList,
-         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT "«1 item elided»" ANSI_NORMAL "]",
+         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT "«1 item elided»" ANSI_NORMAL " ]",
          PrintOptions {
              .ansiColors = true,
              .maxListItems = 1
@@ -806,7 +806,7 @@ TEST_F(ValuePrintingTests, ansiColorsListElided)
     vList.bigList.size = 3;
 
     test(vList,
-         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT "«2 items elided»" ANSI_NORMAL "]",
+         "[ " ANSI_CYAN "1" ANSI_NORMAL " " ANSI_FAINT "«2 items elided»" ANSI_NORMAL " ]",
          PrintOptions {
              .ansiColors = true,
              .maxListItems = 1


### PR DESCRIPTION
# Motivation

Pretty-print values in the REPL by printing each item in a list or attrset on a separate line. When possible, single-item lists and attrsets are printed on one line, as long as they don't contain a nested list, attrset, or thunk.

Before:
```
{ attrs = { a = { b = { c = { }; }; }; }; list = [ 1 ]; list' = [ 1 2 3 ]; }
```

After:
```
{
  attrs = {
    a = {
      b = {
        c = { };
      };
    };
  };
  list = [ 1 ];
  list' = [
    1
    2
    3
  ];
}
```

Here's how the output looks (with #9928 and #9926 applied as well):
![image](https://github.com/NixOS/nix/assets/15312184/a5419164-5bdc-4318-b2c1-a21d9db18e21)


# Context

@Qyriad's prototype pretty-printer in Xil gave me the inspiration to do this. It turns out the patch is pretty small, so here it is!

In the future, users should be able to customize how much is printed for large values. See #9942.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
