### PR TITLE
fix debugger crashing while printing envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ perl/Makefile.config
 /tests/functional/ca/config.nix
 /tests/functional/dyn-drv/config.nix
 /tests/functional/repl-result-out
+/tests/functional/debugger-test-out
 /tests/functional/test-libstoreconsumer/test-libstoreconsumer
 
 # /tests/functional/lang/

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -744,7 +744,8 @@ void printEnvBindings(const SymbolTable & st, const StaticEnv & se, const Env & 
     if (se.up && env.up) {
         std::cout << "static: ";
         printStaticEnvBindings(st, se);
-        printWithBindings(st, env);
+        if (se.isWith)
+            printWithBindings(st, env);
         std::cout << std::endl;
         printEnvBindings(st, *se.up, *env.up, ++lvl);
     } else {
@@ -756,7 +757,8 @@ void printEnvBindings(const SymbolTable & st, const StaticEnv & se, const Env & 
                 std::cout << st[i.first] << " ";
         std::cout << ANSI_NORMAL;
         std::cout << std::endl;
-        printWithBindings(st, env);  // probably nothing there for the top level.
+        if (se.isWith)
+            printWithBindings(st, env);  // probably nothing there for the top level.
         std::cout << std::endl;
 
     }
@@ -778,7 +780,7 @@ void mapStaticEnvBindings(const SymbolTable & st, const StaticEnv & se, const En
     if (env.up && se.up) {
         mapStaticEnvBindings(st, *se.up, *env.up, vm);
 
-        if (!env.values[0]->isThunk()) {
+        if (se.isWith && !env.values[0]->isThunk()) {
             // add 'with' bindings.
             Bindings::iterator j = env.values[0]->attrs->begin();
             while (j != env.values[0]->attrs->end()) {

--- a/tests/functional/debugger.sh
+++ b/tests/functional/debugger.sh
@@ -1,0 +1,13 @@
+source common.sh
+
+clearStore
+
+# regression #9932
+echo ":env" | expect 1 nix eval --debugger --expr '(_: throw "oh snap") 42'
+echo ":env" | expect 1 nix eval --debugger --expr '
+  let x.a = 1; in
+  with x;
+  (_: builtins.seq x.a (throw "oh snap")) x.a
+' >debugger-test-out
+grep -P 'with: .*a' debugger-test-out
+grep -P 'static: .*x' debugger-test-out

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -127,7 +127,8 @@ nix_tests = \
   toString-path.sh \
   read-only-store.sh \
   nested-sandboxing.sh \
-  impure-env.sh
+  impure-env.sh \
+  debugger.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)
   nix_tests += compute-levels.sh


### PR DESCRIPTION
# Motivation
fixes #9932

# Context
ope. sorry, missed a few instances back then. we also added a debugger regression test to hopefully catch this should it happen again, and to act as a bit of a sanity check for future changes that are debugger-adjacent (willingly or not).

cc @Trundle 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
