### PR TITLE
absPath: Explicitly check if path is empty before accessing it

### DIFF
--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -25,7 +25,7 @@ Path absPath(PathView path, std::optional<PathView> dir, bool resolveSymlinks)
 {
     std::string scratch;
 
-    if (path[0] != '/') {
+    if (path.empty() || path[0] != '/') {
         // In this case we need to call `canonPath` on a newly-created
         // string. We set `scratch` to that string first, and then set
         // `path` to `scratch`. This ensures the newly-created string


### PR DESCRIPTION
# Motivation

This test fixes UB in `absPath`.

# Context

It is entirely possible for the path to be an empty string and many unit tests actually pass it as an empty string (e.g. both_roundrip or turnsEmptyPathIntoCWD). In this case, without this patch, absPath will perform a one-byte out-of-bounds access.

This was discovered while enabling the nix test suite on Alpine where we compile all software with `-D_GLIBCXX_ASSERTIONS=1`, thus resulting in a test failure on Alpine.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
