### PR TITLE
install-darwin: fix symbolic perms for install cmd

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -102,7 +102,7 @@ poly_extra_try_me_commands() {
 poly_configure_nix_daemon_service() {
     task "Setting up the nix-daemon LaunchDaemon"
     _sudo "to set up the nix-daemon as a LaunchDaemon" \
-          /usr/bin/install -m -rw-r--r-- "/nix/var/nix/profiles/default$NIX_DAEMON_DEST" "$NIX_DAEMON_DEST"
+          /usr/bin/install -m "u=rw,go=r" "/nix/var/nix/profiles/default$NIX_DAEMON_DEST" "$NIX_DAEMON_DEST"
 
     _sudo "to load the LaunchDaemon plist for nix-daemon" \
           launchctl load /Library/LaunchDaemons/org.nixos.nix-daemon.plist


### PR DESCRIPTION
# Motivation
The symbolic form in use here doesn't seem to have an effect in either the BSD or coreutils install commands, leaving the daemon plist with empty permissions. This seems to cause its own problems.

I think I've got the right symbolic syntax now :)

I suspect this is the underlying cause in: 
- https://github.com/NixOS/nix/issues/9702#issuecomment-1918117677
- #9969
- #9978

(But I'll reserve confidence until after I've used the generated installer, uninstalled, and reinstalled...)

# Context

```
$ touch inst1
$ /usr/bin/install -m -rw-r--r-- inst1 inst2
$ ls -la inst*
-rw-r--r-- 1 abathur _lpoperator      0 Feb 12 12:19 inst1
---------- 1 abathur _lpoperator      0 Feb 12 12:21 inst2

 $ rm inst2

$ /usr/bin/install -m "u=rw,go=r" inst1 inst2

$ ls -la inst*
-rw-r--r-- 1 abathur _lpoperator      0 Feb 12 12:19 inst1
-rw-r--r-- 1 abathur _lpoperator      0 Feb 13 01:17 inst2
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
