### PR TITLE
Do not warn on unknown flake inputs

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -771,7 +771,7 @@ struct CmdFlakeCheck : FlakeCommand
                             ;
 
                         else
-                            warn("unknown flake output '%s'", name);
+                            debug("unknown flake output '%s'", name);
 
                     } catch (Error & e) {
                         e.addTrace(resolve(pos), HintFmt("while checking flake output '%s'", name));


### PR DESCRIPTION
# Motivation

I want my users to be worried when they see warnings, and right now every time they run nix flake check, they get warnings.

# Context

It's common for flake library authors to have one use different, custom nix flake outputs. deploy-rs uses deploy, nixops uses nixops, home-manager modules sometimes use homeModules or hmModules. There's a nix-darwin thing, too. All of these lead to Nix printing warnings.

There seemed to be some consensus on #6381 that it's reasonable to reduce the current warn level below warning, so I've replaced it with a 'debug' log.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
