### PR TITLE
[2.18] Fix the build

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -693,7 +693,7 @@ SourcePath resolveExprPath(SourcePath path)
         if (++followCount >= maxFollow)
             throw Error("too many symbolic links encountered while traversing the path '%s'", path);
         if (path.lstat().type != InputAccessor::tSymlink) break;
-        path = {path.accessor, CanonPath(path.readLink(), path.path.parent().value_or(CanonPath::root))};
+        path = {CanonPath(path.readLink(), path.path.parent().value_or(CanonPath::root))};
     }
 
     /* If `path' refers to a directory, append `/default.nix'. */


### PR DESCRIPTION
# Motivation

bef68e53b9d08c99873a5bc60568b7351934ad51 (backport of 31ebc6028b3682969d86a7b39ae87131c41cc604) accidentally broke the build because of a change in the constructor of `SourcePath` between 2.18 and master.
Fix that.

# Context

https://hydra.nixos.org/build/248912484/nixlog/1

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).