### PR TITLE
Fix readfile from special files

### DIFF
--- a/src/libutil/posix-source-accessor.hh
+++ b/src/libutil/posix-source-accessor.hh
@@ -25,8 +25,6 @@ struct PosixSourceAccessor : virtual SourceAccessor
      */
     time_t mtime = 0;
 
-    std::string readFile(const CanonPath & path) override;
-
     void readFile(
         const CanonPath & path,
         Sink & sink,

--- a/src/libutil/posix-source-accessor.hh
+++ b/src/libutil/posix-source-accessor.hh
@@ -25,6 +25,8 @@ struct PosixSourceAccessor : virtual SourceAccessor
      */
     time_t mtime = 0;
 
+    std::string readFile(const CanonPath & path) override;
+
     void readFile(
         const CanonPath & path,
         Sink & sink,

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -60,6 +60,7 @@ nix_tests = \
   fetchGitVerification.sh \
   flakes/search-root.sh \
   readfile-context.sh \
+  readfile-stdin.sh \
   nix-channel.sh \
   recursive.sh \
   dependencies.sh \

--- a/tests/functional/readfile-stdin.sh
+++ b/tests/functional/readfile-stdin.sh
@@ -1,0 +1,3 @@
+source common.sh
+
+[[ $(echo yay | nix eval --raw --impure --expr 'builtins.readFile "/dev/stdin"') = yay ]]


### PR DESCRIPTION
Allow `builtins.readFile` to work on non-standard files (like `/dev/stdin`, pipes, etc..).

Fix #9330

Thanks @ThinkChaos for the bisect and the implementation

Keeping as draft for now because

1. It doesn't fully work (`builtins.readFile "/dev/stdin"` from a tty works, but `echo "foo" | nix eval --impure --expr 'builtins.readFile "/dev/stdin"'` fails with `error: opening file '/proc/3978327/fd/pipe:[15074562]': No such file or directory`)
2. I'm not sure about all the implications – I imagine that this allows reading from a pipe in pure eval mode, which isn't exactly pure, so we might need further restrictions
3. ~~The change introducing the breakage (https://github.com/NixOS/nix/commit/57db3be9e448042814d386def2d8af16a2a4c4b9) made the read more streaming, and this undoes that. We might want to only fallback to a non-streaming read when we can't avoid it~~ EDIT: Fixed now