### PR TITLE
Make `outputHashAlgo` accept `"nar"`, stay in sync

### DIFF
--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -207,11 +207,16 @@ Derivations can declare some infrequently used optional attributes.
 
         This is the default.
 
-      - `"recursive"`\
-        The hash is computed over the NAR archive dump of the output
+      - `"recursive"` or `"nar"`\
+        The hash is computed over the [NAR archive](@docroot@/glossary.md#gloss-nar) dump of the output
         (i.e., the result of [`nix-store --dump`](@docroot@/command-ref/nix-store/dump.md)). In
         this case, the output can be anything, including a directory
         tree.
+
+    `"recursive"` is the traditional way of indicating this,
+    and is supported since 2005 (virtually the entire history of Nix).
+    `"nar"` is more clear, and consistent with other parts of Nix (such as the CLI),
+    however support for it is only added in Nix version 2.21.
 
   - [`__contentAddressed`]{#adv-attr-__contentAddressed}
     > **Warning**

--- a/tests/functional/fixed.nix
+++ b/tests/functional/fixed.nix
@@ -64,4 +64,6 @@ rec {
     (f2 "bar" ./fixed.builder2.sh "recursive" "md5" "3670af73070fa14077ad74e0f5ea4e42")
   ];
 
+  # Can use "nar" instead of "recursive" now.
+  nar-not-recursive = f2 "foo" ./fixed.builder2.sh "nar" "md5" "3670af73070fa14077ad74e0f5ea4e42";
 }

--- a/tests/functional/fixed.sh
+++ b/tests/functional/fixed.sh
@@ -61,3 +61,7 @@ out3=$(nix-store --add-fixed --recursive sha256 $TEST_ROOT/fixed)
 
 out4=$(nix-store --print-fixed-path --recursive sha256 "1ixr6yd3297ciyp9im522dfxpqbkhcw0pylkb2aab915278fqaik" fixed)
 [ "$out" = "$out4" ]
+
+# Can use `outputHashMode = "nar";` instead of `"recursive"` now.
+clearStore
+nix-build fixed.nix -A nar-not-recursive --no-out-link


### PR DESCRIPTION
# Motivation

Now that we have a few things identifying content address methods by name, we should be consistent about it.

Move up the `parseHashAlgoOpt` for tidiness too.

# Context

Discussed this change for consistency's sake as part of #8876

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
