### PR TITLE
Fix 0. in lexer

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -106,7 +106,7 @@ static StringToken unescapeStr(SymbolTable & symbols, char * s, size_t length)
 ANY         .|\n
 ID          [a-zA-Z\_][a-zA-Z0-9\_\'\-]*
 INT         [0-9]+
-FLOAT       (([1-9][0-9]*\.[0-9]*)|(0?\.[0-9]+))([Ee][+-]?[0-9]+)?
+FLOAT       (([0-9]+\.[0-9]*)|(\.[0-9]+))([Ee][+-]?[0-9]+)?
 PATH_CHAR   [a-zA-Z0-9\.\_\-\+]
 PATH        {PATH_CHAR}*(\/{PATH_CHAR}+)+\/?
 PATH_SEG    {PATH_CHAR}*\/


### PR DESCRIPTION
# Motivation

`0.` is not parsed correctly as a float.

# Context
<!-- Provide context. Reference open issues if available. -->

Currently, it is tokenized as `INT '.'`.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
