### PR TITLE
Faster flake.lock parsing

### DIFF
--- a/src/libexpr/flake/lockfile.cc
+++ b/src/libexpr/flake/lockfile.cc
@@ -107,7 +107,7 @@ LockFile::LockFile(const nlohmann::json & json, const Path & path)
                 std::string inputKey = i.value();
                 auto k = nodeMap.find(inputKey);
                 if (k == nodeMap.end()) {
-                    auto nodes = json["nodes"];
+                    auto & nodes = json["nodes"];
                     auto jsonNode2 = nodes.find(inputKey);
                     if (jsonNode2 == nodes.end())
                         throw Error("lock file references missing node '%s'", inputKey);


### PR DESCRIPTION
# Motivation
I have some Nix flake repositories with large flake.lock files (~1.5MB) and I was observing ~60s being spent on trivial nix build operations, and discovered that this was largely being spent inside `LockFile::LockFile`. Further investigation with `perf` indicated that a large number of short-lived `basic_json` objects from the nlohmann JSON library were being created and destroyed. It turns out in `LockFile::LockFile` a copy of a basic_json object was being made where a reference was probably intended. Making this small change has reduced these trivial nix build operations from ~60s to ~1.6s.

# Context

This change will likely resolve çhttps://github.com/NixOS/nix/issues/6626

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
