### PR TITLE
profile: suggest removal using profile entry name

### DIFF
--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -166,7 +166,7 @@ error: An existing package already provides the following file:
 
        To remove the existing package:
 
-         nix profile remove path:${flake1Dir}#packages.${system}.default
+         nix profile remove flake1
 
        The new package can also be installed next to the existing one by assigning a different priority.
        The conflicting packages have a priority of 5.


### PR DESCRIPTION
# Motivation

When a file conflict arises during a package install a suggestion is made to remove the old entry. This was previously done using the installable URLs of the old entry. These (resolved) URLs are quite verbose and often do not match the source URL of the existing entry (see https://github.com/NixOS/nix/issues/8728).

This change uses the recently introduced profile entry name for the suggestion (see https://github.com/NixOS/nix/pull/9656), resulting in a simpler output.

The improvement is easily seen in the change to the functional test.

# Context

Fixes #8728
As mentioned: https://github.com/NixOS/nix/issues/7967#issuecomment-1866968575
Follow up from #9656

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
