### PR TITLE
profile install: fail on conflicting name

### DIFF
--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -101,6 +101,15 @@ struct ProfileElement
     }
 };
 
+std::string getNameFromElement(const ProfileElement & element)
+{
+    std::optional<std::string> result = std::nullopt;
+    if (element.source) {
+        result = getNameFromURL(parseURL(element.source->to_string()));
+    }
+    return result.value_or(element.identifier());
+}
+
 struct ProfileManifest
 {
     using ProfileElementName = std::string;
@@ -155,9 +164,7 @@ struct ProfileManifest
                 std::string name =
                     elems.is_object()
                     ? elem.key()
-                    : element.source
-                    ? getNameFromURL(parseURL(element.source->to_string())).value_or(element.identifier())
-                    : element.identifier();
+                    : getNameFromElement(element);
 
                 addElement(name, std::move(element));
             }
@@ -189,12 +196,8 @@ struct ProfileManifest
 
     void addElement(ProfileElement element)
     {
-        auto name =
-            element.source
-            ? getNameFromURL(parseURL(element.source->to_string()))
-            : std::nullopt;
-        auto name2 = name ? *name : element.identifier();
-        addElement(name2, std::move(element));
+        auto name = getNameFromElement(element);
+        addElement(name, std::move(element));
     }
 
     nlohmann::json toJSON(Store & store) const


### PR DESCRIPTION
# Motivation

Currently it is possible to install the same package twice. This installation will only fail on conflicting _files_ and not on conflicting names (profile entry names).

When installing an installable that has the same name as an existing profile entry, it'll be renamed to `{name}-1`. This can be confusing, especially when installing the exact same package, which doesn't have conflicting files. Two entries will be in the profile `{name}` and `{name}-1`.

This change will make package installation conflict based on name. In addition, `--force` is introduced to overwrite existing package entries (with the same name).

I previously also added a `--force` option, so that a user can overwrite conflicting entries. I have removed this to keep the PR small and avoid discussion about adding such an option. Instead, upon conflict Nix now suggests to use `nix profile remove {name}`. An example of the `--force` implementation can be found [here](https://github.com/NixOS/nix/commit/a50b552bc77e257db8238b2779334e99b5b96672). It can be added later if it is considered a good addition.

There is one use-case where this PR can be annoying. I'm hoping it is small enough it doesn't matter:
When installing 2 packages that have the same name (but are actually different packages), it is not possible, at this time, to install them both into the same profile. This is merely because it is not possible to manually define (or force) the name of the entry. (See [`--name` idea](https://github.com/NixOS/nix/issues/7967))
That said, having two entries with seemingly the same name is already confusing, so I'm ~thinking~ hoping this won't be a real issue in practice.

# Context

Fixes https://github.com/NixOS/nix/issues/5587
As suggested in https://github.com/NixOS/nix/issues/7967

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
