### PR TITLE
`nix`: Fix `haveInternet` to check for proxy

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -23,7 +23,6 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <regex>
-#include <cstdlib>
 
 #include <nlohmann/json.hpp>
 
@@ -35,7 +34,7 @@ namespace nix {
 
 static bool haveProxyEnvironmentVariables()
 {
-    static const char * const proxyVariables[] = {
+    static const std::vector<std::string> proxyVariables = {
         "http_proxy",
         "https_proxy",
         "ftp_proxy",
@@ -44,7 +43,7 @@ static bool haveProxyEnvironmentVariables()
         "FTP_PROXY"
     };
     for (auto & proxyVariable: proxyVariables) {
-        if (std::getenv(proxyVariable)) {
+        if (getEnv(proxyVariable).has_value()) {
             return true;
         }
     }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -23,6 +23,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <regex>
+#include <cstdlib>
 
 #include <nlohmann/json.hpp>
 
@@ -31,6 +32,24 @@ extern std::string chrootHelperName;
 void chrootHelper(int argc, char * * argv);
 
 namespace nix {
+
+static bool haveProxyEnvironmentVariables()
+{
+    static const char * const proxyVariables[] = {
+        "http_proxy",
+        "https_proxy",
+        "ftp_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "FTP_PROXY"
+    };
+    for (auto & proxyVariable: proxyVariables) {
+        if (std::getenv(proxyVariable)) {
+            return true;
+        }
+    }
+    return false;
+}
 
 /* Check if we have a non-loopback/link-local network interface. */
 static bool haveInternet()
@@ -54,6 +73,8 @@ static bool haveInternet()
                 return true;
         }
     }
+
+    if (haveProxyEnvironmentVariables()) return true;
 
     return false;
 }


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
`haveInternet` should check if a proxy is available. If it is, it must return true so `nix` could function properly. See #10017 for more details.

# Context
<!-- Provide context. Reference open issues if available. -->
Fixes: #10017
<!-- Non-trivial change: Briefly outline the implementation strategy. -->
`/etc/systemd/system/nix-daemon.service.d/override.conf` is used by `nix-daemon` and not necessarily by `nix`. If `nix` needs to download something without going through the daemon, it can only be done if proxy environment variables are defined. `haveProxyEnvironmentVariables` check for these variables.
 
<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
