### PR TITLE
Stabilise fetchTree

### DIFF
--- a/doc/manual/rl-next/stabilize-fetchtree.md
+++ b/doc/manual/rl-next/stabilize-fetchtree.md
@@ -1,0 +1,9 @@
+---
+synopsis: Stabilize fetchTree
+prs: 10068
+---
+
+The core of `fetchTree` is now stable.
+This includes
+- the `fetchTree` function itself
+- all the existing fetchers, except `git` (still unstable because of some reproducibility concerns)

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -159,9 +159,9 @@ static void fetchTree(
             }
             input = fetchers::Input::fromAttrs(std::move(attrs));
         } else {
-            if (!experimentalFeatureSettings.isEnabled(Xp::Flakes))
+            if (!experimentalFeatureSettings.isEnabled(Xp::FetchTreeUrls))
                 state.error<EvalError>(
-                    "passing a string argument to 'fetchTree' requires the 'flakes' experimental feature"
+                    "passing a string argument to 'fetchTree' requires the 'fetch-tree-urls' experimental feature"
                 ).atPos(pos).debugThrow();
             input = fetchers::Input::fromURL(url);
         }

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -410,7 +410,6 @@ static RegisterPrimOp primop_fetchTree({
       >   ```
     )",
     .fun = prim_fetchTree,
-    .experimentalFeature = Xp::FetchTree,
 });
 
 static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v,

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -282,6 +282,11 @@ struct GitInputScheme : InputScheme
         return res;
     }
 
+    std::optional<ExperimentalFeature> experimentalFeature() const override
+    {
+        return Xp::FetchTreeGit;
+    }
+
     void clone(const Input & input, const Path & destDir) const override
     {
         auto repoInfo = getRepoInfo(input);

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -334,8 +334,14 @@ template<> std::set<ExperimentalFeature> BaseSetting<std::set<ExperimentalFeatur
     for (auto & s : tokenizeString<StringSet>(str)) {
         if (auto thisXpFeature = parseExperimentalFeature(s); thisXpFeature) {
             res.insert(thisXpFeature.value());
-            if (thisXpFeature.value() == Xp::Flakes)
+            if (thisXpFeature.value() == Xp::Flakes) {
                 res.insert(Xp::FetchTree);
+                res.insert(Xp::FetchTreeGit);
+                res.insert(Xp::FetchTreeUrls);
+            } else if (thisXpFeature.value() == Xp::FetchTree) {
+                res.insert(Xp::FetchTreeGit);
+                res.insert(Xp::FetchTreeUrls);
+            }
         } else
             warn("unknown experimental feature '%s'", s);
     }

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -78,13 +78,23 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .tag = Xp::FetchTree,
         .name = "fetch-tree",
         .description = R"(
-            Enable the use of the [`fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree) built-in function in the Nix language.
-
-            `fetchTree` exposes a generic interface for fetching remote file system trees from different types of remote sources.
-            The [`flakes`](#xp-feature-flakes) feature flag always enables `fetch-tree`.
-            This built-in was previously guarded by the `flakes` experimental feature because of that overlap.
-
-            Enabling just this feature serves as a "release candidate", allowing users to try it out in isolation.
+            Backwards-compatibility alias for
+            [fetch-tree-git](#xp-feature-fetch-tree-git) and
+            [fetch-tree-urls](#xp-feature-fetch-tree-urls).
+        )",
+    },
+    {
+        .tag = Xp::FetchTreeGit,
+        .name = "fetch-tree-git",
+        .description = R"(
+            Enable the use of the `git` [`fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree) fetcher.
+        )",
+    },
+    {
+        .tag = Xp::FetchTreeUrls,
+        .name = "fetch-tree-urls",
+        .description = R"(
+            Enable the use of the [URL-like syntax](@docroot@/command-ref/new-cli/nix3-flake.html#url-like-syntax) in [`fetchTree`](@docroot@/language/builtins.md#builtins-fetchTree).
         )",
     },
     {

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -21,6 +21,8 @@ enum struct ExperimentalFeature
     ImpureDerivations,
     Flakes,
     FetchTree,
+    FetchTreeGit,
+    FetchTreeUrls,
     NixCommand,
     GitHashing,
     RecursiveNix,

--- a/tests/functional/common/vars-and-functions.sh.in
+++ b/tests/functional/common/vars-and-functions.sh.in
@@ -232,6 +232,12 @@ enableFeatures() {
     sed -i 's/experimental-features .*/& '"$features"'/' "$NIX_CONF_DIR"/nix.conf
 }
 
+disableFeature() {
+  local feature="$1"
+  sed -i '/^\(extra-\)\?experimental-features/s/\b'"$feature"'\b//g' "$NIX_CONF_DIR"/nix.conf
+  sed -i '/^\(extra-\)\?experimental-features/s/\b'"$feature"'\b//g' "$NIX_CONF_DIR"/nix.conf.extra
+}
+
 set -x
 
 onError() {

--- a/tests/functional/fetchTree-file.sh
+++ b/tests/functional/fetchTree-file.sh
@@ -2,6 +2,8 @@ source common.sh
 
 clearStore
 
+disableFeature "flakes"
+
 cd "$TEST_ROOT"
 
 test_fetch_file () {
@@ -21,6 +23,7 @@ EOF
 # Make sure that `http(s)` and `file` flake inputs are properly extracted when
 # they should be, and treated as opaque files when they should be
 test_file_flake_input () {
+    enableFeatures "flakes"
     rm -fr "$TEST_ROOT/testFlake";
     mkdir "$TEST_ROOT/testFlake";
     pushd testFlake


### PR DESCRIPTION
# Motivation

Stabilise the core of `fetchTree`.

This includes:
- the `fetchTree` function itself
- all the existing fetchers, except `git` (still unstable because of some reproducibility concerns)

# Context

Agreed-upon to be stabilised after the 2.20. About time we do it now :)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
