### PR TITLE
Fix `__darwinAllowLocalNetworking` sandbox

### DIFF
--- a/src/libstore/build/sandbox-defaults.sb
+++ b/src/libstore/build/sandbox-defaults.sb
@@ -45,7 +45,7 @@ R""(
 ; allow it if the package explicitly asks for it.
 (if (param "_ALLOW_LOCAL_NETWORKING")
     (begin
-      (allow network* (local ip) (local tcp) (local udp))
+      (allow network* (remote ip "localhost:*"))
 
       ; Allow access to /etc/resolv.conf (which is a symlink to
       ; /private/var/run/resolv.conf).


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

The sandbox rule `(allow network* (local ip))` doesn't do what it implies. Using this rule permits all network traffic. We should be matching on `(remote ip "localhost:*")` instead.

# Context
<!-- Provide context. Reference open issues if available. -->

This is a first step towards fixing https://github.com/NixOS/nix/issues/6049

Similar issue experienced in Bazel https://github.com/bazelbuild/bazel/issues/10068.

It's hard to tell because the sandbox is notoriously poorly documented by Apple, but it seems likely that this was working at some point and Apple made a breaking change. Either way, this has been a reported issue since at least 2019 (by other build systems), so I think it's safe to say that MacOS versions where this might still work are obsolete by now.

I tested the following scenarios with `netcat` on MacOS 14.3.1 (23D60) using `sandbox-exec -f sandbox-defaults.sb ...`:
- tcp/udp
- local/remote IPs
- with and without `_ALLOW_LOCAL_NETWORKING=1`



<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
