### PR TITLE
profile install: warn on installing package twice

### DIFF
--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -395,7 +395,26 @@ struct CmdProfileInstall : InstallablesCommand, MixDefaultProfile
 
             element.updateStorePaths(getEvalStore(), store, res);
 
-            manifest.addElement(std::move(element));
+            auto elementName = getNameFromElement(element);
+
+            // Check if the element already exists.
+            auto existingPair = manifest.elements.find(elementName);
+            if (existingPair != manifest.elements.end()) {
+                auto existingElement = existingPair->second;
+                auto existingSource = existingElement.source;
+                auto elementSource = element.source;
+                if (existingSource
+                    && elementSource
+                    && existingElement.priority == element.priority
+                    && existingSource->originalRef == elementSource->originalRef
+                    && existingSource->attrPath == elementSource->attrPath
+                    ) {
+                    warn("'%s' is already installed", elementName);
+                    continue;
+                }
+            }
+
+            manifest.addElement(elementName, std::move(element));
         }
 
         try {

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -101,6 +101,15 @@ struct ProfileElement
     }
 };
 
+std::string getNameFromElement(const ProfileElement & element)
+{
+    std::optional<std::string> result = std::nullopt;
+    if (element.source) {
+        result = getNameFromURL(parseURL(element.source->to_string()));
+    }
+    return result.value_or(element.identifier());
+}
+
 struct ProfileManifest
 {
     using ProfileElementName = std::string;
@@ -189,12 +198,8 @@ struct ProfileManifest
 
     void addElement(ProfileElement element)
     {
-        auto name =
-            element.source
-            ? getNameFromURL(parseURL(element.source->to_string()))
-            : std::nullopt;
-        auto name2 = name ? *name : element.identifier();
-        addElement(name2, std::move(element));
+        auto name = getNameFromElement(element);
+        addElement(name, std::move(element));
     }
 
     nlohmann::json toJSON(Store & store) const

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -64,6 +64,9 @@ nix profile install $flake1Dir
 [[ $($TEST_HOME/.local/state/nix/profile/bin/hello) = "Hello World" ]]
 unset NIX_CONFIG
 
+# Test conflicting package install.
+nix profile install $flake1Dir 2>&1 | grep "warning: 'flake1' is already installed"
+
 # Test upgrading a package.
 printf NixOS > $flake1Dir/who
 printf 2.0 > $flake1Dir/version


### PR DESCRIPTION
# Motivation

Currently it is possible to install a package twice.

```console
$ nix profile install nixpkgs#firefox
$ nix profile install nixpkgs#firefox
$ nix profile list
...
Name: firefox
...
Name: firefox-1
```

This change explicitly checks for duplicate entries when installing packages. It'll look like:

```console
$ nix profile install nixpkgs#firefox
$ nix profile install nixpkgs#firefox
error: 'firefox' is already installed
```

To decide a duplicate, the name, `attrPath` and `originalRef` (`flake:nixpkgs`) should be the same.

`lockedRef` (`github:NixOS/nixpkgs/2a34566b67bef34c551f204063faeecc444ae9da`) is ignored. This is to make sure installing the package twice at any time in the future will still be a conflict.

# Context

Fixes https://github.com/NixOS/nix/issues/5587
As suggested in https://github.com/NixOS/nix/pull/10065#issuecomment-1961285593

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
