### PR TITLE
Properly fail on flakerefs that don't point to a directory

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -102,6 +102,9 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
 
         if (isFlake) {
 
+            if (!S_ISDIR(lstat(path).st_mode))
+                throw BadURL("path '%s' is not a flake (because it's not a directory)", path);
+
             if (!allowMissing && !pathExists(path + "/flake.nix")){
                 notice("path '%s' does not contain a 'flake.nix', searching up",path);
 
@@ -123,9 +126,6 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
                 if (!found)
                     throw BadURL("could not find a flake.nix file");
             }
-
-            if (!S_ISDIR(lstat(path).st_mode))
-                throw BadURL("path '%s' is not a flake (because it's not a directory)", path);
 
             if (!allowMissing && !pathExists(path + "/flake.nix"))
                 throw BadURL("path '%s' is not a flake (because it doesn't contain a 'flake.nix' file)", path);

--- a/tests/functional/flakes/search-root.sh
+++ b/tests/functional/flakes/search-root.sh
@@ -22,7 +22,7 @@ mkdir subdir
 pushd subdir
 
 success=("" . .# .#test ../subdir ../subdir#test "$PWD")
-failure=("path:$PWD")
+failure=("path:$PWD" "../simple.nix")
 
 for i in "${success[@]}"; do
     nix build $i || fail "flake should be found by searching up directories"


### PR DESCRIPTION
Directly fail if a flakeref points to something that isn't a directory instead of falling back to the logic of trying to look up the hierarchy to find a valid flake root.

Said otherwise, `nix build ./default.nix` shouldn't fallback to loading the current directory as a flake (which it does right now).

Fix https://github.com/NixOS/nix/issues/9868

cc @roberth

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
