### PR TITLE
Fix gcc 12 warnings

### DIFF
--- a/src/libstore/build-result.hh
+++ b/src/libstore/build-result.hh
@@ -123,6 +123,11 @@ struct KeyedBuildResult : BuildResult
      * The derivation we built or the store path we substituted.
      */
     DerivedPath path;
+
+    // Hack to work around a gcc "may be used uninitialized" warning.
+    KeyedBuildResult(BuildResult res, DerivedPath path)
+        : BuildResult(std::move(res)), path(std::move(path))
+    { }
 };
 
 }

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -2480,6 +2480,7 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
                         CanonPath { tmpDir + "/tmp" }).hash;
                 }
                 }
+                assert(false);
             }();
 
             ValidPathInfo newInfo0 {

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -415,6 +415,8 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                     // Use NAR; Git is not a serialization method
                     dumpMethod = FileSerialisationMethod::Recursive;
                     break;
+                default:
+                    assert(false);
                 }
                 // TODO these two steps are essentially RemoteStore::addCAToStore. Move it up to Store.
                 auto path = store->addToStoreFromDump(source, name, dumpMethod, contentAddressMethod, hashAlgo, refs, repair);

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -527,6 +527,8 @@ StorePath RemoteStore::addToStoreFromDump(
         // Use NAR; Git is not a serialization method
         fsm = FileSerialisationMethod::Recursive;
         break;
+    default:
+        assert(false);
     }
     if (fsm != dumpMethod)
         unsupported("RemoteStore::addToStoreFromDump doesn't support this `dumpMethod` `hashMethod` combination");

--- a/src/libutil/file-content-address.cc
+++ b/src/libutil/file-content-address.cc
@@ -123,7 +123,7 @@ Hash hashPath(
     case FileIngestionMethod::Git:
         return git::dumpHash(ht, accessor, path, filter).hash;
     }
-
+    assert(false);
 }
 
 }


### PR DESCRIPTION
# Motivation

Unfortunately gcc 12 isn't smart enough to see that switch statements over `FileSerialisationMethod` etc. are exhaustive, so it complains about uninitialized variables.

Note: we could switch to `-std=c++23` and use `std::unreachable()` instead of `assert(false)`.

# Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
