### PR TITLE
doc(xp-feature): add issue url in experimental feature details

### DIFF
--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -1,4 +1,5 @@
 #include "experimental-features.hh"
+#include "fmt.hh"
 #include "util.hh"
 
 #include "nlohmann/json.hpp"
@@ -10,6 +11,7 @@ struct ExperimentalFeatureDetails
     ExperimentalFeature tag;
     std::string_view name;
     std::string_view description;
+    std::string_view trackingUrl;
 };
 
 /**
@@ -35,6 +37,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             [__contentAddressed](@docroot@/language/advanced-attributes.md#adv-attr-__contentAddressed)
             for details.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/35",
     },
     {
         .tag = Xp::ImpureDerivations,
@@ -65,6 +68,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
 
             This is a more explicit alternative to using [`builtins.currentTime`](@docroot@/language/builtin-constants.md#builtins-currentTime).
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/42",
     },
     {
         .tag = Xp::Flakes,
@@ -73,6 +77,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             Enable flakes. See the manual entry for [`nix
             flake`](@docroot@/command-ref/new-cli/nix3-flake.md) for details.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/27",
     },
     {
         .tag = Xp::FetchTree,
@@ -86,6 +91,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
 
             Enabling just this feature serves as a "release candidate", allowing users to try it out in isolation.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/31",
     },
     {
         .tag = Xp::NixCommand,
@@ -94,6 +100,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             Enable the new `nix` subcommands. See the manual on
             [`nix`](@docroot@/command-ref/new-cli/nix.md) for details.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/28",
     },
     {
         .tag = Xp::GitHashing,
@@ -102,6 +109,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             Allow creating (content-addressed) store objects which are hashed via Git's hashing algorithm.
             These store objects will not be understandable by older versions of Nix.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/41",
     },
     {
         .tag = Xp::RecursiveNix,
@@ -143,6 +151,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             already in the build inputs or built by a previous recursive Nix
             call.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/47",
     },
     {
         .tag = Xp::NoUrlLiterals,
@@ -184,6 +193,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             containing parameters have to be quoted anyway, and unquoted URLs
             may confuse external tooling.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/44",
     },
     {
         .tag = Xp::FetchClosure,
@@ -191,6 +201,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .description = R"(
             Enable the use of the [`fetchClosure`](@docroot@/language/builtins.md#builtins-fetchClosure) built-in function in the Nix language.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/40",
     },
     {
         .tag = Xp::ReplFlake,
@@ -200,6 +211,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
 
             Allow passing [installables](@docroot@/command-ref/new-cli/nix.md#installables) to `nix repl`, making its interface consistent with the other experimental commands.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/32",
     },
     {
         .tag = Xp::AutoAllocateUids,
@@ -208,6 +220,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             Allows Nix to automatically pick UIDs for builds, rather than creating
             `nixbld*` user accounts. See the [`auto-allocate-uids`](@docroot@/command-ref/conf-file.md#conf-auto-allocate-uids) setting for details.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/34",
     },
     {
         .tag = Xp::Cgroups,
@@ -216,6 +229,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             Allows Nix to execute builds inside cgroups. See
             the [`use-cgroups`](@docroot@/command-ref/conf-file.md#conf-use-cgroups) setting for details.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/36",
     },
     {
         .tag = Xp::DaemonTrustOverride,
@@ -226,6 +240,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
             useful for various experiments with `nix-daemon --stdio`
             networking.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/38",
     },
     {
         .tag = Xp::DynamicDerivations,
@@ -239,6 +254,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
               - dependencies in derivations on the outputs of
                 derivations that are themselves derivations outputs.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/39",
     },
     {
         .tag = Xp::ParseTomlTimestamps,
@@ -246,6 +262,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .description = R"(
             Allow parsing of timestamps in builtins.fromTOML.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/45",
     },
     {
         .tag = Xp::ReadOnlyLocalStore,
@@ -253,6 +270,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .description = R"(
             Allow the use of the `read-only` parameter in [local store](@docroot@/store/types/local-store.md) URIs.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/46",
     },
     {
         .tag = Xp::ConfigurableImpureEnv,
@@ -260,6 +278,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .description = R"(
             Allow the use of the [impure-env](@docroot@/command-ref/conf-file.md#conf-impure-env) setting.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/37",
     },
     {
         .tag = Xp::MountedSSHStore,
@@ -267,6 +286,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .description = R"(
             Allow the use of the [`mounted SSH store`](@docroot@/command-ref/new-cli/nix3-help-stores.html#experimental-ssh-store-with-filesytem-mounted).
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/43",
     },
     {
         .tag = Xp::VerifiedFetches,
@@ -274,6 +294,7 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .description = R"(
             Enables verification of git commit signatures through the [`fetchGit`](@docroot@/language/builtins.md#builtins-fetchGit) built-in.
         )",
+        .trackingUrl = "https://github.com/NixOS/nix/milestone/48",
     },
 }};
 
@@ -312,9 +333,12 @@ std::string_view showExperimentalFeature(const ExperimentalFeature tag)
 nlohmann::json documentExperimentalFeatures()
 {
     StringMap res;
-    for (auto & xpFeature : xpFeatureDetails)
-        res[std::string { xpFeature.name }] =
-            trim(stripIndentation(xpFeature.description));
+    for (auto & xpFeature : xpFeatureDetails) {
+        std::stringstream docOss;
+        docOss << stripIndentation(xpFeature.description);
+        docOss << fmt("\nRefer to [%1% tracking issue](%2%) for feature tracking.", xpFeature.name, xpFeature.trackingUrl);
+        res[std::string{xpFeature.name}] = trim(docOss.str());
+    }
     return (nlohmann::json) res;
 }
 


### PR DESCRIPTION
# Motivation

Include tracking issue in experimental feature documentation. So users/developers can follow the progress of the feature and easily vote for or against it.

# Context

Fixes #9345

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
