### PR TITLE
Add --arg-from-file and --arg-from-stdin

### DIFF
--- a/doc/manual/rl-next/arg-from-file.md
+++ b/doc/manual/rl-next/arg-from-file.md
@@ -1,0 +1,9 @@
+---
+synopsis: "CLI options `--arg-from-file` and `--arg-from-stdin`"
+prs: 10122
+---
+
+The new CLI option `--arg-from-file` *name* *path* passes the contents
+of file *path* as a string value via the function argument *name* to a
+Nix expression. Similarly, the new option `--arg-from-stdin` *name*
+reads the contents of the string from standard input.

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -41,6 +41,14 @@ MixEvalArgs::MixEvalArgs()
     });
 
     addFlag({
+        .longName = "arg-from-stdin",
+        .description = "Pass the contents of stdin as the argument *name* to Nix functions.",
+        .category = category,
+        .labels = {"name"},
+        .handler = {[&](std::string name) { autoArgs.insert_or_assign(name, AutoArg{AutoArgStdin{}}); }},
+    });
+
+    addFlag({
         .longName = "include",
         .shortName = 'I',
         .description = R"(
@@ -174,6 +182,9 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
             },
             [&](const AutoArgFile & arg) {
                 v->mkString(readFile(arg.path));
+            },
+            [&](const AutoArgStdin & arg) {
+                v->mkString(readFile(STDIN_FILENO));
             }
         }, arg);
         res.insert(state.symbols.create(name), v);

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -32,6 +32,15 @@ MixEvalArgs::MixEvalArgs()
     });
 
     addFlag({
+        .longName = "arg-from-file",
+        .description = "Pass the contents of file *path* as the argument *name* to Nix functions.",
+        .category = category,
+        .labels = {"name", "path"},
+        .handler = {[&](std::string name, std::string path) { autoArgs.insert_or_assign(name, AutoArg{AutoArgFile(path)}); }},
+        .completer = completePath
+    });
+
+    addFlag({
         .longName = "include",
         .shortName = 'I',
         .description = R"(
@@ -162,6 +171,9 @@ Bindings * MixEvalArgs::getAutoArgs(EvalState & state)
             },
             [&](const AutoArgString & arg) {
                 v->mkString(arg.s);
+            },
+            [&](const AutoArgFile & arg) {
+                v->mkString(readFile(arg.path));
             }
         }, arg);
         res.insert(state.symbols.create(name), v);

--- a/src/libcmd/common-eval-args.hh
+++ b/src/libcmd/common-eval-args.hh
@@ -28,8 +28,9 @@ struct MixEvalArgs : virtual Args, virtual MixRepair
 private:
     struct AutoArgExpr { std::string expr; };
     struct AutoArgString { std::string s; };
+    struct AutoArgFile { std::filesystem::path path; };
 
-    using AutoArg = std::variant<AutoArgExpr, AutoArgString>;
+    using AutoArg = std::variant<AutoArgExpr, AutoArgString, AutoArgFile>;
 
     std::map<std::string, AutoArg> autoArgs;
 };

--- a/src/libcmd/common-eval-args.hh
+++ b/src/libcmd/common-eval-args.hh
@@ -29,8 +29,9 @@ private:
     struct AutoArgExpr { std::string expr; };
     struct AutoArgString { std::string s; };
     struct AutoArgFile { std::filesystem::path path; };
+    struct AutoArgStdin { };
 
-    using AutoArg = std::variant<AutoArgExpr, AutoArgString, AutoArgFile>;
+    using AutoArg = std::variant<AutoArgExpr, AutoArgString, AutoArgFile, AutoArgStdin>;
 
     std::map<std::string, AutoArg> autoArgs;
 };

--- a/src/libcmd/common-eval-args.hh
+++ b/src/libcmd/common-eval-args.hh
@@ -6,6 +6,8 @@
 #include "common-args.hh"
 #include "search-path.hh"
 
+#include <filesystem>
+
 namespace nix {
 
 class Store;

--- a/src/libcmd/common-eval-args.hh
+++ b/src/libcmd/common-eval-args.hh
@@ -26,7 +26,12 @@ struct MixEvalArgs : virtual Args, virtual MixRepair
     std::optional<std::string> evalStoreUrl;
 
 private:
-    std::map<std::string, std::string> autoArgs;
+    struct AutoArgExpr { std::string expr; };
+    struct AutoArgString { std::string s; };
+
+    using AutoArg = std::variant<AutoArgExpr, AutoArgString>;
+
+    std::map<std::string, AutoArg> autoArgs;
 };
 
 SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * baseDir = nullptr);

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -41,3 +41,11 @@ mkdir -p $TEST_ROOT/xyzzy $TEST_ROOT/foo
 ln -sfn ../xyzzy $TEST_ROOT/foo/bar
 printf 123 > $TEST_ROOT/xyzzy/default.nix
 [[ $(nix eval --impure --expr "import $TEST_ROOT/foo/bar") = 123 ]]
+
+# Test --arg-from-file.
+[[ "$(nix eval --raw --arg-from-file foo config.nix --expr '{ foo }: { inherit foo; }' foo)" = "$(cat config.nix)" ]]
+
+# Check that special(-ish) files are drained.
+if [[ -e /proc/version ]]; then
+    [[ "$(nix eval --raw --arg-from-file foo /proc/version --expr '{ foo }: { inherit foo; }' foo)" = "$(cat /proc/version)" ]]
+fi

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -49,3 +49,6 @@ printf 123 > $TEST_ROOT/xyzzy/default.nix
 if [[ -e /proc/version ]]; then
     [[ "$(nix eval --raw --arg-from-file foo /proc/version --expr '{ foo }: { inherit foo; }' foo)" = "$(cat /proc/version)" ]]
 fi
+
+# Test --arg-from-stdin.
+[[ "$(echo bla | nix eval --raw --arg-from-stdin foo --expr '{ foo }: { inherit foo; }' foo)" = bla ]]


### PR DESCRIPTION
# Motivation

These read arguments from a file or from stdin, respectively. This is a cleaner alternative to `builtins.readFile "/dev/stdin"` (see #9330, #10019).

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
