### PR TITLE
Fix the parsing of the query of path-like flakerefs

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -55,7 +55,7 @@ FlakeRef parseFlakeRef(
 {
     auto [flakeRef, fragment] = parseFlakeRefWithFragment(url, baseDir, allowMissing, isFlake);
     if (fragment != "")
-        throw Error("unexpected fragment '%s' in flake reference '%s'", fragment, url);
+        throw FlakeRefError("unexpected fragment '%s' in flake reference '%s'", fragment, url);
     return flakeRef;
 }
 
@@ -113,10 +113,10 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
                         found = true;
                         break;
                     } else if (pathExists(path + "/.git"))
-                        throw Error("path '%s' is not part of a flake (neither it nor its parent directories contain a 'flake.nix' file)", path);
+                        throw FlakeRefError("path '%s' is not part of a flake (neither it nor its parent directories contain a 'flake.nix' file)", path);
                     else {
                         if (lstat(path).st_dev != device)
-                            throw Error("unable to find a flake before encountering filesystem boundary at '%s'", path);
+                            throw FlakeRefError("unable to find a flake before encountering filesystem boundary at '%s'", path);
                     }
                     path = dirOf(path);
                 }
@@ -148,7 +148,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
 
                     if (subdir != "") {
                         if (parsedURL.query.count("dir"))
-                            throw Error("flake URL '%s' has an inconsistent 'dir' parameter", url);
+                            throw FlakeRefError("flake URL '%s' has an inconsistent 'dir' parameter", url);
                         parsedURL.query.insert_or_assign("dir", subdir);
                     }
 

--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -171,11 +171,16 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
         path = canonPath(path + "/" + getOr(query, "dir", ""));
     }
 
-    fetchers::Attrs attrs;
-    attrs.insert_or_assign("type", "path");
-    attrs.insert_or_assign("path", path);
+    auto parsedURL = ParsedURL{
+        .url = url,
+        .base = url,
+        .scheme = "path",
+        .authority = "",
+        .path = path,
+        .query = query,
+    };
 
-    return std::make_pair(FlakeRef(fetchers::Input::fromAttrs(std::move(attrs)), ""), fragment);
+    return std::make_pair(FlakeRef(fetchers::Input::fromURL(parsedURL), getOr(parsedURL.query, "dir", "")), fragment);
 };
 
 

--- a/src/libexpr/flake/flakeref.hh
+++ b/src/libexpr/flake/flakeref.hh
@@ -15,6 +15,8 @@ class Store;
 
 typedef std::string FlakeId;
 
+MakeError(FlakeRefError, Error);
+
 /**
  * A flake reference specifies how to fetch a flake or raw source
  * (e.g. from a Git repository).  It is created from a URL-like syntax

--- a/tests/functional/flakes/inputs.sh
+++ b/tests/functional/flakes/inputs.sh
@@ -24,7 +24,7 @@ test_subdir_self_path() {
 }
 EOF
     (
-        nix build $baseDir?dir=b-low --no-link
+        nix build $baseDir/b-low --no-link
     )
 }
 test_subdir_self_path


### PR DESCRIPTION
# Motivation

On current master, a flake-like pathref with a query but no fragment will quietly drop the query.
For instance, `nix build .?rev=c43c75ea7983f84270cfdcca18169c03987287a4` will quietly ignore the `rev` parameter and behave like `nix build .`.

Fix that, and add some tests.

# Context

Spotted as part of <https://github.com/NixOS/nix/issues/6633>.
Probably introduced by <https://github.com/NixOS/nix/pull/6614>.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
