### PR TITLE
Ban building Nix with NDEBUG

### DIFF
--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -9,6 +9,10 @@
 
 #include <sodium.h>
 
+#ifdef NDEBUG
+#error "Nix may not be built with assertions disabled (i.e. with -DNDEBUG)."
+#endif
+
 namespace nix {
 
 void initLibUtil() {

--- a/tests/unit/libstore/outputs-spec.cc
+++ b/tests/unit/libstore/outputs-spec.cc
@@ -6,11 +6,9 @@
 
 namespace nix {
 
-#ifndef NDEBUG
 TEST(OutputsSpec, no_empty_names) {
     ASSERT_DEATH(OutputsSpec::Names { std::set<std::string> { } }, "");
 }
-#endif
 
 #define TEST_DONT_PARSE(NAME, STR)           \
     TEST(OutputsSpec, bad_ ## NAME) {        \


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

When reviewing old PRs, I found that #9997 adds some code to ensure one particular assert is always present. But, removing asserts isn't something we do in our own release builds either in the flake here or in nixpkgs, and is plainly a bad idea that increases support burden, especially if other distros make bad choices of build flags in their Nix packaging.

For context, the assert macro in the C standard is defined to do nothing if NDEBUG is set.

There is no way in our build system to set -DNDEBUG without manually adding it to CFLAGS, so this is simply a configuration we do not use. Let's ban it at compile time.

I put this preprocessor directive in main.cc because it is not obvious where else to put it, and it seems like the most logical file since you are not getting an executable nix without it.


# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
