### PR TITLE
Fix sudo in the darwin installer

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -69,17 +69,17 @@ readonly PROXY_ENVIRONMENT_VARIABLES=(
     NO_PROXY
 )
 
-SUDO_KEPT_ENVIRONMENT_VARIBLES=""
+SUDO_KEPT_ENVIRONMENT_VARIABLES=""
 
 setup_sudo_extra_environment_variables() {
     for variable in "${PROXY_ENVIRONMENT_VARIABLES[@]}"; do
         if [ "x${!variable:-}" != "x" ]; then
-            SUDO_KEPT_ENVIRONMENT_VARIBLES="$SUDO_KEPT_ENVIRONMENT_VARIBLES,$variable"
+            SUDO_KEPT_ENVIRONMENT_VARIABLES="$SUDO_KEPT_ENVIRONMENT_VARIABLES,$variable"
         fi
     done
 
     # Required by the darwin installer
-    export SUDO_KEPT_ENVIRONMENT_VARIBLES
+    export SUDO_KEPT_ENVIRONMENT_VARIABLES
 }
 
 setup_sudo_extra_environment_variables
@@ -387,7 +387,7 @@ _sudo() {
     if is_root; then
         env "$@"
     else
-        sudo --preserve-env="$SUDO_KEPT_ENVIRONMENT_VARIBLES" "$@"
+        sudo --preserve-env="$SUDO_KEPT_ENVIRONMENT_VARIABLES" "$@"
     fi
 }
 

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -69,16 +69,17 @@ readonly PROXY_ENVIRONMENT_VARIABLES=(
     NO_PROXY
 )
 
-SUDO_EXTRA_ENVIRONMENT_VARIABLES=()
+SUDO_KEPT_ENVIRONMENT_VARIBLES=""
 
 setup_sudo_extra_environment_variables() {
-    local i=${#SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}
     for variable in "${PROXY_ENVIRONMENT_VARIABLES[@]}"; do
         if [ "x${!variable:-}" != "x" ]; then
-            SUDO_EXTRA_ENVIRONMENT_VARIABLES[i]="$variable=${!variable}"
-            i=$((i + 1))
+            SUDO_KEPT_ENVIRONMENT_VARIBLES="$SUDO_KEPT_ENVIRONMENT_VARIBLES,$variable"
         fi
     done
+
+    # Required by the darwin installer
+    export SUDO_KEPT_ENVIRONMENT_VARIBLES
 }
 
 setup_sudo_extra_environment_variables
@@ -386,7 +387,7 @@ _sudo() {
     if is_root; then
         env "$@"
     else
-        sudo "${SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}" "$@"
+        sudo --preserve-env="$SUDO_KEPT_ENVIRONMENT_VARIBLES" "$@"
     fi
 }
 


### PR DESCRIPTION
# Motivation

Make sure that every part of the installer has access to the required environment to run our sudo wrapper

# Context

The darwin installer job is broken on master: https://github.com/NixOS/nix/actions/runs/8112489666/job/22176091480
Seems to be due to https://github.com/NixOS/nix/pull/10070

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
