### PR TITLE
Fix the docker push job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,4 +157,5 @@ jobs:
         docker push $IMAGE_ID:$NIX_VERSION
         docker push $IMAGE_ID:latest
         # deprecated 2024-02-24
+        docker tag nix:$NIX_VERSION $IMAGE_ID:master
         docker push $IMAGE_ID:master


### PR DESCRIPTION
# Motivation

After https://github.com/NixOS/nix/pull/10071, the CI was trying to push ghcr.io/nixos/nix:master for backwards-compatibility, but the image was not tagged as such, causing the job to fail.

Fix this.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).