### PR TITLE
`TERM=dumb` fixes

### DIFF
--- a/src/libcmd/markdown.cc
+++ b/src/libcmd/markdown.cc
@@ -50,7 +50,7 @@ std::string renderMarkdownToTerminal(std::string_view markdown)
     if (!rndr_res)
         throw Error("allocation error while rendering Markdown");
 
-    return filterANSIEscapes(std::string(buf->data, buf->size), !shouldANSI());
+    return filterANSIEscapes(std::string(buf->data, buf->size), !isTTY());
 #else
     return std::string(markdown);
 #endif

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -537,7 +537,7 @@ public:
 
 Logger * makeProgressBar()
 {
-    return new ProgressBar(shouldANSI());
+    return new ProgressBar(isTTY());
 }
 
 void startProgressBar()

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -123,14 +123,18 @@ public:
     }
 
     void pause() override {
-        state_.lock()->paused = true;
-        writeToStderr("\r\e[K");
+        auto state (state_.lock());
+        state->paused = true;
+        if (state->active)
+            writeToStderr("\r\e[K");
     }
 
     void resume() override {
-        state_.lock()->paused = false;
-        writeToStderr("\r\e[K");
-        state_.lock()->haveUpdate = true;
+        auto state (state_.lock());
+        state->paused = false;
+        if (state->active)
+            writeToStderr("\r\e[K");
+        state->haveUpdate = true;
         updateCV.notify_one();
     }
 
@@ -162,9 +166,7 @@ public:
             writeToStderr("\r\e[K" + filterANSIEscapes(s, !isTTY) + ANSI_NORMAL "\n");
             draw(state);
         } else {
-            auto s2 = s + ANSI_NORMAL "\n";
-            if (!isTTY) s2 = filterANSIEscapes(s2, true);
-            writeToStderr(s2);
+            writeToStderr(filterANSIEscapes(s, !isTTY) + "\n");
         }
     }
 
@@ -519,7 +521,7 @@ public:
     std::optional<char> ask(std::string_view msg) override
     {
         auto state(state_.lock());
-        if (!state->active || !isatty(STDIN_FILENO)) return {};
+        if (!state->active) return {};
         std::cerr << fmt("\r\e[K%s ", msg);
         auto s = trim(readLine(STDIN_FILENO));
         if (s.size() != 1) return {};

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -52,7 +52,7 @@ public:
         : printBuildLogs(printBuildLogs)
     {
         systemd = getEnv("IN_SYSTEMD") == "1";
-        tty = shouldANSI();
+        tty = isTTY();
     }
 
     bool isVerbose() override {

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -7,7 +7,7 @@
 
 namespace nix {
 
-bool shouldANSI()
+bool isTTY()
 {
     return isatty(STDERR_FILENO)
         && getEnv("TERM").value_or("dumb") != "dumb"

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -9,9 +9,12 @@ namespace nix {
 
 bool isTTY()
 {
-    return isatty(STDERR_FILENO)
+    static const bool tty =
+        isatty(STDERR_FILENO)
         && getEnv("TERM").value_or("dumb") != "dumb"
         && !(getEnv("NO_COLOR").has_value() || getEnv("NOCOLOR").has_value());
+
+    return tty;
 }
 
 std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int width)

--- a/src/libutil/terminal.hh
+++ b/src/libutil/terminal.hh
@@ -8,7 +8,7 @@ namespace nix {
  * Determine whether ANSI escape sequences are appropriate for the
  * present output.
  */
-bool shouldANSI();
+bool isTTY();
 
 /**
  * Truncate a string to 'width' printable characters. If 'filterAll'

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1090,7 +1090,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
         return;
     }
 
-    bool tty = shouldANSI();
+    bool tty = isTTY();
     RunPager pager;
 
     Table table;

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -16,6 +16,7 @@
 #include "xml-writer.hh"
 #include "legacy.hh"
 #include "eval-settings.hh" // for defexpr
+#include "terminal.hh"
 
 #include <cerrno>
 #include <ctime>
@@ -1089,7 +1090,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
         return;
     }
 
-    bool tty = isatty(STDOUT_FILENO);
+    bool tty = shouldANSI();
     RunPager pager;
 
     Table table;

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -378,7 +378,7 @@ void mainWrapped(int argc, char * * argv)
     settings.verboseBuild = false;
 
     // If on a terminal, progress will be displayed via progress bars etc. (thus verbosity=notice)
-    if (nix::shouldANSI()) {
+    if (nix::isTTY()) {
         verbosity = lvlNotice;
     } else {
         verbosity = lvlInfo;

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -16,6 +16,7 @@
 #include "loggers.hh"
 #include "markdown.hh"
 #include "memory-input-accessor.hh"
+#include "terminal.hh"
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -375,7 +376,9 @@ void mainWrapped(int argc, char * * argv)
 
     setLogFormat("bar");
     settings.verboseBuild = false;
-    if (isatty(STDERR_FILENO)) {
+
+    // If on a terminal, progress will be displayed via progress bars etc. (thus verbosity=notice)
+    if (nix::shouldANSI()) {
         verbosity = lvlNotice;
     } else {
         verbosity = lvlInfo;

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -11,6 +11,7 @@
 #include "legacy.hh"
 #include "posix-source-accessor.hh"
 #include "misc-store-flags.hh"
+#include "terminal.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -188,7 +189,7 @@ static int main_nix_prefetch_url(int argc, char * * argv)
 
         Finally f([]() { stopProgressBar(); });
 
-        if (isatty(STDERR_FILENO))
+        if (shouldANSI())
           startProgressBar();
 
         auto store = openStore();

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -189,7 +189,7 @@ static int main_nix_prefetch_url(int argc, char * * argv)
 
         Finally f([]() { stopProgressBar(); });
 
-        if (shouldANSI())
+        if (isTTY())
           startProgressBar();
 
         auto store = openStore();


### PR DESCRIPTION
- **libmain/progress-bar: try harder to avoid escape sequences if !isTTY**
- **treewide: replace usages of isatty(STDERR_FILENO) with shouldANSI()**
- **treewide: shouldANSI() -> isTTY()**
- **libutil/terminal: cache isTTY()**

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Currently, progress bar code emits control sequences (at least `\r` and CSI K)
regardless of whether nix allows other escape sequences in its output (as
determined by `nix::shouldANSI()` function.

Rework progress bar code such that !isTTY disables emission of _all_ control
sequences, including `\r`.

Additionally, rename `nix::shouldANSI()` into `nix::isTTY()` to better reflect
the semantics of this function.

# Context

Running `nix copy` with `TERM=dumb` and/or standard streams redirected into
a pipe still causes nix to emit several control sequences, interfering with
programmatic parsing of its output:

```
    "msg": [
        "",
        "\u001b[KWarning: Permanently added '<redacted>' (ED25519) to the list of known hosts.",
        "",
        "\u001b[Kcopying path '/nix/store/xdrsf841kdlf95rxd3qy6yhi57s25krr-dns-root-data-2023-11-27' from 'https://cache.nixos.org'...",
        "copying path '/nix/store/l3lhzwrfgzncjj1z4wyq6kkrp6czx5qp-gcc-12.3.0-libgcc' from 'https://cache.nixos.org'...",
        <...>
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
