### PR TITLE
fix `nix help-stores` for 2.19

### DIFF
--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -3,7 +3,7 @@ let
     attrNames attrValues fromJSON listToAttrs mapAttrs groupBy
     concatStringsSep concatMap length lessThan replaceStrings sort;
   inherit (import <nix/utils.nix>) attrsToList concatStrings optionalString filterAttrs trim squash unique;
-  showStoreDocs = import ./generate-store-info.nix;
+  showStoreDocs = import <nix/generate-store-info.nix>;
 in
 
 inlineHTML: commandDump:

--- a/doc/manual/generate-settings.nix
+++ b/doc/manual/generate-settings.nix
@@ -1,6 +1,6 @@
 let
   inherit (builtins) attrValues concatStringsSep isAttrs isBool mapAttrs;
-  inherit (import ./utils.nix) concatStrings indent optionalString squash;
+  inherit (import <nix/utils.nix>) concatStrings indent optionalString squash;
 in
 
 # `inlineHTML` is a hack to accommodate inconsistent output from `lowdown`

--- a/doc/manual/generate-store-info.nix
+++ b/doc/manual/generate-store-info.nix
@@ -1,7 +1,7 @@
 let
   inherit (builtins) attrValues mapAttrs;
-  inherit (import ./utils.nix) concatStrings optionalString;
-  showSettings = import ./generate-settings.nix;
+  inherit (import <nix/utils.nix>) concatStrings optionalString;
+  showSettings = import <nix/generate-settings.nix>;
 in
 
 inlineHTML: storesInfo:

--- a/flake.nix
+++ b/flake.nix
@@ -188,6 +188,7 @@
             buildPackages.mercurial # FIXME: remove? only needed for tests
             buildPackages.jq # Also for custom mdBook preprocessor.
             buildPackages.openssh # only needed for tests (ssh-keygen)
+            buildPackages.man # needed for testing `nix-* --help`
           ]
           ++ lib.optionals stdenv.hostPlatform.isLinux [(buildPackages.util-linuxMinimal or buildPackages.utillinuxMinimal)];
 

--- a/tests/functional/help.sh
+++ b/tests/functional/help.sh
@@ -1,0 +1,69 @@
+source common.sh
+
+clearStore
+
+# test help output
+
+nix-build --help
+nix-shell --help
+
+nix-env --help
+nix-env --install --help
+nix-env --upgrade --help
+nix-env --uninstall --help
+nix-env --set --help
+nix-env --set-flag --help
+nix-env --query --help
+nix-env --switch-profile --help
+nix-env --list-generations --help
+nix-env --delete-generations --help
+nix-env --switch-generation --help
+nix-env --rollback --help
+
+nix-store --help
+nix-store --realise --help
+nix-store --serve --help
+nix-store --gc --help
+nix-store --delete --help
+nix-store --query --help
+nix-store --add --help
+nix-store --add-fixed --help
+nix-store --verify --help
+nix-store --verify-path --help
+nix-store --repair-path --help
+nix-store --dump --help
+nix-store --restore --help
+nix-store --export --help
+nix-store --import --help
+nix-store --optimise --help
+nix-store --read-log --help
+nix-store --dump-db --help
+nix-store --load-db --help
+nix-store --print-env --help
+nix-store --generate-binary-cache-key --help
+
+nix-channel --help
+nix-collect-garbage --help
+nix-copy-closure --help
+nix-daemon --help
+nix-hash --help
+nix-instantiate --help
+nix-prefetch-url --help
+
+function subcommands() {
+  jq -r '
+def recurse($prefix):
+    to_entries[] |
+    ($prefix + [.key]) as $newPrefix |
+    (if .value | has("commands") then
+      ($newPrefix, (.value.commands | recurse($newPrefix)))
+    else
+      $newPrefix
+    end);
+.args.commands | recurse([]) | join(" ")
+'
+}
+
+nix __dump-cli | subcommands | while IFS= read -r cmd; do
+    nix $cmd --help
+done

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -124,7 +124,8 @@ nix_tests = \
   toString-path.sh \
   read-only-store.sh \
   nested-sandboxing.sh \
-  impure-env.sh
+  impure-env.sh \
+  help.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)
 	nix_tests += compute-levels.sh


### PR DESCRIPTION
# Motivation
fixes #10037

# Context
the crash when calling `nix help-stores` was probably introduced an artifact from a prior untangling of merge conflicts. that said, `nix help-stores` should eventually cease to exist in favor of dedicated `--help` outputs and `man` pages for the various store types.


# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).