### PR TITLE
PosixSourceAccessor::cachedLstat(): Use absolute path

### DIFF
--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -85,9 +85,11 @@ bool PosixSourceAccessor::pathExists(const CanonPath & path)
 
 std::optional<struct stat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
 {
-    static Sync<std::unordered_map<std::filesystem::path, std::optional<struct stat>>> _cache;
+    static Sync<std::unordered_map<Path, std::optional<struct stat>>> _cache;
 
-    auto absPath = makeAbsPath(path);
+    // Note: we convert std::filesystem::path to Path because the
+    // former is not hashable on libc++.
+    Path absPath = makeAbsPath(path);
 
     {
         auto cache(_cache.lock());


### PR DESCRIPTION
# Motivation

Using the relative path can cause collisions between cache entries for `PosixSourceAccessor`s with different roots.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
