### PR TITLE
git-lfs support

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -318,6 +318,8 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
 
     std::vector<std::tuple<Submodule, Hash>> getSubmodules(const Hash & rev, bool exportIgnore) override;
 
+    void smudgeLfs() override;
+
     std::string resolveSubmoduleUrl(
         const std::string & url,
         const std::string & base) override
@@ -1005,6 +1007,15 @@ std::vector<std::tuple<GitRepoImpl::Submodule, Hash>> GitRepoImpl::getSubmodules
     }
 
     return result;
+}
+
+void GitRepoImpl::smudgeLfs() {
+    runProgram(RunOptions{
+            .program = "git",
+            .searchPath = true,
+            .args = { "lfs", "pull" },
+            .chdir = std::make_optional(this->path)
+            });
 }
 
 ref<GitRepo> getTarballCache()

--- a/src/libfetchers/git-utils.hh
+++ b/src/libfetchers/git-utils.hh
@@ -69,6 +69,8 @@ struct GitRepo
      */
     virtual std::vector<std::tuple<Submodule, Hash>> getSubmodules(const Hash & rev, bool exportIgnore) = 0;
 
+    virtual void smudgeLfs() = 0;
+
     virtual std::string resolveSubmoduleUrl(
         const std::string & url,
         const std::string & base) = 0;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -381,6 +381,11 @@ struct GitInputScheme : InputScheme
         return maybeGetBoolAttr(input.attrs, "submodules").value_or(false);
     }
 
+    bool getLfsAttr(const Input & input) const
+    {
+        return maybeGetBoolAttr(input.attrs, "lfs").value_or(false);
+    }
+
     bool getExportIgnoreAttr(const Input & input) const
     {
         return maybeGetBoolAttr(input.attrs, "exportIgnore").value_or(false);
@@ -646,6 +651,11 @@ struct GitInputScheme : InputScheme
                 mounts.insert_or_assign(CanonPath::root, accessor);
                 accessor = makeMountedInputAccessor(std::move(mounts));
             }
+        }
+
+        if (getLfsAttr(input)) {
+            // urlencoded `?lfs=1` param is set,
+            repo->smudgeLfs();
         }
 
         assert(!origRev || origRev == rev);


### PR DESCRIPTION
Hi! This PR works, but there's definitely a better way to support LFS. Looking for maintainer feedback.

# Motivation
`nix` fetches git repos using `libgit2`, which does not run filters by default. This means LFS-enabled repos can be fetched, but LFS pointer files are not smudged. 

This change adds a `lfs` attribute to fetcher URLs. With `lfs=1`, when fetching LFS-enabled repos, nix will smudge all the files.

# Context
See https://github.com/NixOS/nix/issues/10079.
Git Large File Storage lets you track large files directly in git, using [git filters](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes). A `clean` filter runs on your LFS-enrolled files before push, replacing large files with small "pointer files". Upon checkout, a "smudge" filter replaces pointer files with full file contents. When this works correctly, it is not visible to users, which is nice.

# Limitations
Right now, for repos with `lfs=1`, the LFS-tracked files are materialized during `nix flake lock` - this is bad, I'm looking for a way to avoid this.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
