### PR TITLE
libfetchers/git: fix UB due to invalid usage of unique_ptr

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -590,7 +590,7 @@ struct GitInputAccessor : InputAccessor
             i = lookupCache.emplace(path, std::move(entry)).first;
         }
 
-        return &*i->second;
+        return i->second.get();
     }
 
     git_tree_entry * need(const CanonPath & path)


### PR DESCRIPTION
# Motivation

According to [N4950 20.3.1.3.5 [unique.ptr.single.observers]/1](https://timsong-cpp.github.io/cppwp/n4950/unique.ptr.single.observers#1), the behavior is undefined if `get()` == `nullptr`. Use `get()` instead of `operator*()` on a possibly-null unique_ptr.

# Context

Fixes #10123.

(Note that master does not seem to have this issue due to relevant code being rewritten.)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
