### PR TITLE
feat: show status bar with 'store copy-sigs'

### DIFF
--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -72,7 +72,7 @@ struct CmdCopySigs : StorePathsCommand
                         if (!info->sigs.count(sig))
                             newSigs.insert(sig);
                 } catch (InvalidPath &) {
-                    printError("path %s was invalid in substituter %s", storePath.to_string(), store2->getUri());
+                    debug("path %s was invalid in substituter %s", storePath.to_string(), store2->getUri());
                 }
             }
 

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -46,7 +46,7 @@ struct CmdCopySigs : StorePathsCommand
         Activity act(*logger, lvlInfo, actCopyPaths, "copying signatures");
         act.setExpected(actCopyPaths, storePaths.size());
 
-        std::atomic_uint64_t counter;
+        std::atomic_uint64_t counter = 0;
 
         auto doPath = [&](const Path & storePathS) {
             checkInterrupt();

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -41,14 +41,14 @@ struct CmdCopySigs : StorePathsCommand
 
         ThreadPool pool;
 
-        std::string doneLabel = "done";
         std::atomic<size_t> added{0};
 
-        //logger->setExpected(doneLabel, storePaths.size());
+        Activity act(*logger, lvlInfo, actCopyPaths, "copying signatures");
+        act.setExpected(actCopyPaths, storePaths.size());
+
+        std::atomic_uint64_t counter;
 
         auto doPath = [&](const Path & storePathS) {
-            //Activity act(*logger, lvlInfo, "getting signatures for '%s'", storePath);
-
             checkInterrupt();
 
             auto storePath = store->parseStorePath(storePathS);
@@ -72,15 +72,17 @@ struct CmdCopySigs : StorePathsCommand
                         if (!info->sigs.count(sig))
                             newSigs.insert(sig);
                 } catch (InvalidPath &) {
+                    printError("path %s was invalid in substituter %s", storePath.to_string(), store2->getUri());
                 }
             }
 
             if (!newSigs.empty()) {
+                debug("adding %d signatures to store for %s", newSigs.size(), storePathS);
                 store->addSignatures(storePath, newSigs);
                 added += newSigs.size();
             }
 
-            //logger->incProgress(doneLabel);
+            act.progress(counter++);
         };
 
         for (auto & storePath : storePaths)


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

`nix store copy-sigs --recursive` can take a while (especially for system closures (as opposed to individual packages) which typically involve a lot (read: potentially thousands) of signatures) since, currently, `copy-sigs` requires blocking when fetching each subsequent signature in order to establish a connection to the remotes. If latency is on the order of 200 ms and there are 1000 outputs' signatures to fetch then that's ~3.5 minutes of an active, but seemingly hanging, process. In practice, though, it's not unusual to see remote store latencies of ~350ms and ~2000 signatures to fetch resulting in ~12m of an active, but seemingly hanging, process.

Note: It seems like it would be much better to open connections to all substituters in the beginning of this flow and then `queryPathInfo` with an already-obtained connection. Something like this would be a performance improvement but it's not clear if something like this would be accepted and/or if there's a clear/preexisting path to do this work.

In order to provide some visibility into this process we propose the following patch which creates a progress bar indicating how many signatures have been already copied and how many remain to be copied.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
