### PR TITLE
Make `nix flake check` show the actual type on type mismatch errors

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -764,4 +764,32 @@ StorePath AttrCursor::forceDerivation()
     return drvPath;
 }
 
+std::string showAttrValueType(const AttrValue & attrValue)
+{
+    return std::visit(overloaded{
+        [&](const string_t & s) { return "a string"; },
+        [&](bool) { return "a boolean"; },
+        [&](int_t) { return "an integer"; },
+        [&](const std::vector<std::string> &) { return "a list of strings"; },
+        [&](const std::vector<Symbol> &) { return "an attribute set"; },
+        [&](const placeholder_t &) { return "a placeholder"; },
+        [&](const missing_t &) { return "nothing"; },
+        [&](const misc_t &) { return "an unknown value"; },
+        [&](const failed_t &) { return "an error"; },
+    }, attrValue);
+}
+
+std::string AttrCursor::showType()
+{
+    if (root->db) {
+        if (!cachedValue)
+            cachedValue = root->db->getAttr(getKey());
+        if (cachedValue) {
+            return showAttrValueType(cachedValue->second);
+        }
+    }
+    auto & v = forceValue();
+    return nix::showType(v);
+}
+
 }

--- a/src/libexpr/eval-cache.hh
+++ b/src/libexpr/eval-cache.hh
@@ -136,6 +136,8 @@ public:
      * Force creation of the .drv file in the Nix store.
      */
     StorePath forceDerivation();
+
+    std::string showType();
 };
 
 }

--- a/tests/functional/flakes/check.sh
+++ b/tests/functional/flakes/check.sh
@@ -35,7 +35,8 @@ cat > $flakeDir/flake.nix <<EOF
 EOF
 
 checkRes=$(nix flake check $flakeDir 2>&1 && fail "nix flake check --all-systems should have failed" || true)
-echo "$checkRes" | grepQuiet "error: overlay is not a function, but a set instead"
+echo "$checkRes" | grepQuiet "error: expected a function, but got a set"
+echo "$checkRes" | grepQuiet "while checking the overlay"
 
 cat > $flakeDir/flake.nix <<EOF
 {


### PR DESCRIPTION
Fix #5610

This isn't a perfect solution – ideally we should use the eval machinery for throwing eval errors to get some proper position reporting and so on. But given that part of the code uses the evaluator directly, and part uses the eval-cache, doing so would be significantly more involved, so this is a good-enough stop-gap.

Also makes the error messages more consistent by using the same exception type everywhere (which will print the same template message).

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
