### PR TITLE
profile: introduce --regex and --all

### DIFF
--- a/doc/manual/rl-next/profile-regex-all.md
+++ b/doc/manual/rl-next/profile-regex-all.md
@@ -1,0 +1,35 @@
+---
+synopsis: Introduction of `--regex` and `--all` in `nix profile remove` and `nix profile upgrade`
+prs: 10166
+---
+
+Previously the command-line arguments for `nix profile remove` and `nix profile upgrade` matched the package entries using regular expression.
+For instance:
+
+```
+nix profile remove '.*vim.*'
+```
+
+This would remove all packages that contain `vim` in their name.
+
+In most cases, only singular package names were used to remove and upgrade packages. Mixing this with regular expressions sometimes lead to unintended behavior. For instance, `python3.1` could match `python311`.
+
+To avoid unintended behavior, the arguments are now only matching exact names.
+
+Matching using regular expressions is still possible by using the new `--regex` flag:
+
+```
+nix profile remove --regex '.*vim.*'
+```
+
+One of the most useful cases for using regular expressions was to upgrade all packages. This was previously accomplished by:
+
+```
+nix profile upgrade '.*'
+```
+
+With the introduction of the `--all` flag, this now becomes more straightforward:
+
+```
+nix profile upgrade --all
+```

--- a/src/nix/profile-remove.md
+++ b/src/nix/profile-remove.md
@@ -11,8 +11,15 @@ R""(
 * Remove all packages:
 
   ```console
-  # nix profile remove --regex '.*'
+  # nix profile remove --all
   ```
+
+* Remove packages by regular expression:
+
+  ```console
+  # nix profile remove --regex '.*vim.*'
+  ```
+
 
 * Remove a package by store path:
 

--- a/src/nix/profile-remove.md
+++ b/src/nix/profile-remove.md
@@ -11,7 +11,7 @@ R""(
 * Remove all packages:
 
   ```console
-  # nix profile remove '.*'
+  # nix profile remove --regex '.*'
   ```
 
 * Remove a package by store path:

--- a/src/nix/profile-upgrade.md
+++ b/src/nix/profile-upgrade.md
@@ -6,13 +6,19 @@ R""(
   reference:
 
   ```console
-  # nix profile upgrade --regex '.*'
+  # nix profile upgrade --all
   ```
 
 * Upgrade a specific package by name:
 
   ```console
   # nix profile upgrade hello
+  ```
+
+* Upgrade all packages that include 'vim' in their name:
+
+  ```console
+  # nix profile upgrade --regex '.*vim.*'
   ```
 
 # Description

--- a/src/nix/profile-upgrade.md
+++ b/src/nix/profile-upgrade.md
@@ -6,7 +6,7 @@ R""(
   reference:
 
   ```console
-  # nix profile upgrade '.*'
+  # nix profile upgrade --regex '.*'
   ```
 
 * Upgrade a specific package by name:

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -554,6 +554,15 @@ public:
             throw UsageError("No packages specified.");
         }
 
+        if (std::find_if(_matchers.begin(), _matchers.end(), [](const Matcher & m) { return m.type == MatcherType::All; }) != _matchers.end() && _matchers.size() > 1) {
+            throw UsageError("--all cannot be used with package names or regular expressions.");
+        }
+
+        if (manifest.elements.empty()) {
+            warn("There are no packages in the profile.");
+            return {};
+        }
+
         std::set<std::string> result;
         for (auto & matcher : _matchers) {
             bool foundMatch = false;

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -457,6 +457,7 @@ enum MatcherType
 {
     Regex,
     StorePath,
+    Name,
 };
 
 struct Matcher
@@ -489,6 +490,16 @@ Matcher createStorePathMatcher(const nix::StorePath & storePath)
     };
 }
 
+Matcher createNameMatcher(const std::string & name) {
+    return {
+        .type = MatcherType::Name,
+        .title = fmt("Package name '%s'", name),
+        .matches = [name](const std::string &elementName, const ProfileElement & element) {
+            return elementName == name;
+        }
+    };
+}
+
 class MixProfileElementMatchers : virtual Args, virtual StoreCommand
 {
     std::vector<Matcher> _matchers;
@@ -507,7 +518,7 @@ public:
                     } else if (getStore()->isStorePath(arg)) {
                         _matchers.push_back(createStorePathMatcher(getStore()->parseStorePath(arg)));
                     } else {
-                        _matchers.push_back(createRegexMatcher(arg));
+                        _matchers.push_back(createNameMatcher(arg));
                     }
                 }
             }}

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -458,6 +458,7 @@ enum MatcherType
     Regex,
     StorePath,
     Name,
+    All,
 };
 
 struct Matcher
@@ -500,6 +501,14 @@ Matcher createNameMatcher(const std::string & name) {
     };
 }
 
+Matcher all = {
+    .type = MatcherType::All,
+    .title = "--all",
+    .matches = [](const std::string &name, const ProfileElement & element) {
+        return true;
+    }
+};
+
 class MixProfileElementMatchers : virtual Args, virtual StoreCommand
 {
     std::vector<Matcher> _matchers;
@@ -508,6 +517,13 @@ public:
 
     MixProfileElementMatchers()
     {
+        addFlag({
+            .longName = "all",
+            .description = "Match all packages in the profile.",
+            .handler = {[this]() {
+                _matchers.push_back(all);
+            }},
+        });
         addFlag({
             .longName = "regex",
             .description = "A regular expression to match one or more packages in the profile.",

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -508,7 +508,15 @@ public:
 
     MixProfileElementMatchers()
     {
-        expectArgs(ExpectedArg {
+        addFlag({
+            .longName = "regex",
+            .description = "A regular expression to match one or more packages in the profile.",
+            .labels = {"pattern"},
+            .handler = {[this](std::string arg) {
+                _matchers.push_back(createRegexMatcher(arg));
+            }},
+        });
+        expectArgs({
             .label = "elements",
             .optional = true,
             .handler = {[this](std::vector<std::string> args) {

--- a/tests/functional/common/vars-and-functions.sh.in
+++ b/tests/functional/common/vars-and-functions.sh.in
@@ -216,6 +216,17 @@ expectStderr() {
     return 0
 }
 
+# Run a command and check whether the stderr matches stdin.
+# Show a diff when output does not match.
+# Usage:
+#
+#   assertStderr nix profile remove nothing << EOF
+#   error: This error is expected
+#   EOF
+assertStderr() {
+    diff -u /dev/stdin <($@ 2>/dev/null 2>&1)
+}
+
 needLocalStore() {
   if [[ "$NIX_REMOTE" == "daemon" ]]; then
     skipTest "Can’t run through the daemon ($1)"

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -77,6 +77,18 @@ nix profile upgrade --regex '.*'
 [[ $(readlink $TEST_HOME/.nix-profile/bin/hello) =~ .*-profile-test-2\.1/bin/hello ]]
 nix profile rollback
 
+# Test matching no packages using literal package name.
+assertStderr nix --offline profile upgrade this_package_is_not_installed << EOF
+warning: Package name 'this_package_is_not_installed' does not match any packages in the profile.
+warning: No packages to upgrade. Use 'nix profile list' to see the current profile.
+EOF
+
+# Test matching no packages using regular expression.
+assertStderr nix --offline profile upgrade --regex '.*unknown_package.*' << EOF
+warning: Regex '.*unknown_package.*' does not match any packages in the profile.
+warning: No packages to upgrade. Use 'nix profile list' to see the current profile.
+EOF
+
 # Test removing all packages using regular expression.
 nix profile remove --regex '.*' 2>&1 | grep "removed 2 packages, kept 0 packages"
 nix profile rollback
@@ -85,6 +97,10 @@ nix profile rollback
 nix profile diff-closures
 
 # Test rollback.
+printf World > $flake1Dir/who
+nix profile upgrade flake1
+printf NixOS > $flake1Dir/who
+nix profile upgrade flake1
 nix profile rollback
 [[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello World" ]]
 

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -77,6 +77,13 @@ nix profile upgrade --regex '.*'
 [[ $(readlink $TEST_HOME/.nix-profile/bin/hello) =~ .*-profile-test-2\.1/bin/hello ]]
 nix profile rollback
 
+# Test upgrading all packages
+printf 2.2 > $flake1Dir/version
+nix profile upgrade --all
+[[ $(readlink $TEST_HOME/.nix-profile/bin/hello) =~ .*-profile-test-2\.2/bin/hello ]]
+nix profile rollback
+printf 1.0 > $flake1Dir/version
+
 # Test matching no packages using literal package name.
 assertStderr nix --offline profile upgrade this_package_is_not_installed << EOF
 warning: Package name 'this_package_is_not_installed' does not match any packages in the profile.

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -84,6 +84,12 @@ nix profile upgrade --all
 nix profile rollback
 printf 1.0 > $flake1Dir/version
 
+# Test --all exclusivity.
+assertStderr nix --offline profile upgrade --all foo << EOF
+error: --all cannot be used with package names or regular expressions.
+Try 'nix --help' for more information.
+EOF
+
 # Test matching no packages using literal package name.
 assertStderr nix --offline profile upgrade this_package_is_not_installed << EOF
 warning: Package name 'this_package_is_not_installed' does not match any packages in the profile.

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -71,6 +71,16 @@ nix profile upgrade flake1
 [[ $($TEST_HOME/.nix-profile/bin/hello) = "Hello NixOS" ]]
 nix profile history | grep "packages.$system.default: 1.0, 1.0-man -> 2.0, 2.0-man"
 
+# Test upgrading package using regular expression.
+printf 2.1 > $flake1Dir/version
+nix profile upgrade --regex '.*'
+[[ $(readlink $TEST_HOME/.nix-profile/bin/hello) =~ .*-profile-test-2\.1/bin/hello ]]
+nix profile rollback
+
+# Test removing all packages using regular expression.
+nix profile remove --regex '.*' 2>&1 | grep "removed 2 packages, kept 0 packages"
+nix profile rollback
+
 # Test 'history', 'diff-closures'.
 nix profile diff-closures
 


### PR DESCRIPTION
# Motivation

Currently `nix profile upgrade` and `nix profile remove` both implicitly allow using regex by default. This usually works like matching normal package names, but sometimes works slightly different.

Related, the documentation mentions using `nix profile upgrade '.*'` to upgrade all packages. However, as #7487 shows, this doesn't work for store-path installed packages. Question is: should we also regex-match on store paths? I think this can lead to unintended matching of hashes. So, probably not.

Since most people will likely use the arguments as full names of packages, instead of regex, I thought I'd make this explicit:

* `nix profile upgrade vim`
* `nix profile upgrade --regex '.*vim.*'`
* `nix profile upgrade --all`
* `nix profile upgrade /nix/store/...-vim-2.0`

Same goes for remove:

* `nix profile remove vim`
* `nix profile remove --regex '.*vim.*'`
* `nix profile remove --all`
* `nix profile remove /nix/store/...-vim-2.0`

Although minor, this also avoids issues like `python3.1` matching `python311` and `python310`. Also minor: it avoids running into reserved regex characters, as https://github.com/NixOS/nix/issues/3530 describes.

## Implementation

I've restructured the matching of packages a bit, so that it uses a generic matcher type with variants `Name`, `StorePath`, `Regex` and `All` matchers.

I've also introduced `assertStderr` in the functional test functions, so that it is easier to compare stderr output against expected output.

# Context

Fixes https://github.com/NixOS/nix/issues/7487
Fixes https://github.com/NixOS/nix/issues/10162
Related: https://github.com/NixOS/nix/issues/7962
Fixes regex issue, but for `nix profile`: https://github.com/NixOS/nix/issues/3530

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
