### PR TITLE
Revert the sudo installer changes

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -58,31 +58,6 @@ readonly EXTRACTED_NIX_PATH="$(dirname "$0")"
 
 readonly ROOT_HOME=~root
 
-readonly PROXY_ENVIRONMENT_VARIABLES=(
-    http_proxy
-    https_proxy
-    ftp_proxy
-    no_proxy
-    HTTP_PROXY
-    HTTPS_PROXY
-    FTP_PROXY
-    NO_PROXY
-)
-
-SUDO_EXTRA_ENVIRONMENT_VARIABLES=()
-
-setup_sudo_extra_environment_variables() {
-    local i=${#SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}
-    for variable in "${PROXY_ENVIRONMENT_VARIABLES[@]}"; do
-        if [ "x${!variable:-}" != "x" ]; then
-            SUDO_EXTRA_ENVIRONMENT_VARIABLES[i]="$variable=${!variable}"
-            i=$((i + 1))
-        fi
-    done
-}
-
-setup_sudo_extra_environment_variables
-
 if [ -t 0 ] && [ -z "${NIX_INSTALLER_YES:-}" ]; then
     readonly IS_HEADLESS='no'
 else
@@ -386,7 +361,7 @@ _sudo() {
     if is_root; then
         env "$@"
     else
-        sudo "${SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}" "$@"
+        sudo "$@"
     fi
 }
 

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -69,17 +69,16 @@ readonly PROXY_ENVIRONMENT_VARIABLES=(
     NO_PROXY
 )
 
-SUDO_KEPT_ENVIRONMENT_VARIABLES=""
+SUDO_EXTRA_ENVIRONMENT_VARIABLES=()
 
 setup_sudo_extra_environment_variables() {
+    local i=${#SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}
     for variable in "${PROXY_ENVIRONMENT_VARIABLES[@]}"; do
         if [ "x${!variable:-}" != "x" ]; then
-            SUDO_KEPT_ENVIRONMENT_VARIABLES="$SUDO_KEPT_ENVIRONMENT_VARIABLES,$variable"
+            SUDO_EXTRA_ENVIRONMENT_VARIABLES[i]="$variable=${!variable}"
+            i=$((i + 1))
         fi
     done
-
-    # Required by the darwin installer
-    export SUDO_KEPT_ENVIRONMENT_VARIABLES
 }
 
 setup_sudo_extra_environment_variables
@@ -387,7 +386,7 @@ _sudo() {
     if is_root; then
         env "$@"
     else
-        sudo --preserve-env="$SUDO_KEPT_ENVIRONMENT_VARIABLES" "$@"
+        sudo "${SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}" "$@"
     fi
 }
 


### PR DESCRIPTION
Revert https://github.com/NixOS/nix/pull/10070 and https://github.com/NixOS/nix/pull/10128 because they cause breakages when installing on old machines:

- #10070 broke the installation on rhel7 and Ubuntu 16.04, probably because of an old `bash` version
- #10128 broke the installation on Ubuntu 16.04 because of an old `sudo` version.

There's probably a way to get that properly, but since we're due to release next week, the priority is to keep things working for now.

- Revert "Fix sudo in the darwin installer (#10128)"
- Revert "`install-multi-user.sh`: `_sudo`: add proxy variables to sudo"
