### PR TITLE
flake: Remove the cross-compilation to freebsd13

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
       crossSystems = [
         "armv6l-unknown-linux-gnueabihf"
         "armv7l-unknown-linux-gnueabihf"
-        "x86_64-unknown-freebsd13"
         "x86_64-unknown-netbsd"
       ];
 


### PR DESCRIPTION
`libc` is broken there: https://hydra.nixos.org/build/252347598.

We can reintroduce it once the base system is working

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
