### PR TITLE
PathInputScheme::getFingerprint(): Don't barf on relative paths

### DIFF
--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -89,6 +89,15 @@ struct PathInputScheme : InputScheme
         writeFile((CanonPath(getAbsPath(input)) / path).abs(), contents);
     }
 
+    std::optional<std::string> isRelative(const Input & input) const
+    {
+        auto path = getStrAttr(input.attrs, "path");
+        if (hasPrefix(path, "/"))
+            return std::nullopt;
+        else
+            return path;
+    }
+
     bool isLocked(const Input & input) const override
     {
         return (bool) input.getNarHash();
@@ -151,6 +160,9 @@ struct PathInputScheme : InputScheme
 
     std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const override
     {
+        if (isRelative(input))
+            return std::nullopt;
+
         /* If this path is in the Nix store, use the hash of the
            store object and the subpath. */
         auto path = getAbsPath(input);


### PR DESCRIPTION
# Motivation

This wasn't caught by CI because #10149 and #10152 pass individually... It doesn't happen on lazy-trees either because we never try to fetch relative path flakes (#10089).

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
