### PR TITLE
Restore "checking Hydra job" message in `nix flake check`

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -482,6 +482,8 @@ struct CmdFlakeCheck : FlakeCommand
 
         checkHydraJobs = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
             try {
+                Activity act(*logger, lvlInfo, actUnknown,
+                    fmt("checking Hydra job '%s'", attrPath));
                 state->forceAttrs(v, pos, "");
 
                 if (state->isDerivation(v))


### PR DESCRIPTION
Mistakenly removed in #8893, thanks @lf- for catching this!

https://github.com/NixOS/nix/commit/9404ce36e4edd1df12892089bdab1ceb7d4d7a97#r139485316