### PR TITLE
docs: add inherit to language overview

### DIFF
--- a/doc/manual/src/language/index.md
+++ b/doc/manual/src/language/index.md
@@ -440,7 +440,8 @@ This is an incomplete overview of language features, by example.
   </td>
   <td>
 
-   Adds the variables to the current set (attrset or `let`). Desugars to `pkgs = pkgs; src = src;`
+   Adds the variables to the current scope (attribute set or `let` binding).
+   Desugars to `pkgs = pkgs; src = src;`
 
   </td>
  </tr>
@@ -452,7 +453,8 @@ This is an incomplete overview of language features, by example.
   </td>
   <td>
 
-   Adds the attributes, from the variable in the brackets, to the current set (attrset or `let`). Desugars to `lib = pkgs.lib; stdenv = pkgs.stdenv;`
+   Adds the attributes, from the attribute set in parentheses, to the current scope (attribute set or `let` binding).
+   Desugars to `lib = pkgs.lib; stdenv = pkgs.stdenv;`
 
   </td>
  </tr>

--- a/doc/manual/src/language/index.md
+++ b/doc/manual/src/language/index.md
@@ -435,6 +435,30 @@ This is an incomplete overview of language features, by example.
  <tr>
   <td>
 
+   `inherit pkgs src;`
+
+  </td>
+  <td>
+
+   Adds the variables to the current set (attrset or `let`). Desugars to `pkgs = pkgs; src = src;`
+
+  </td>
+ </tr>
+ <tr>
+  <td>
+
+   `inherit (pkgs) lib stdenv;`
+
+  </td>
+  <td>
+
+   Adds the attributes, from the variable in the brackets, to the current set (attrset or `let`). Desugars to `lib = pkgs.lib; stdenv = pkgs.stdenv;`
+
+  </td>
+ </tr>
+ <tr>
+  <td>
+
    *Functions (lambdas)*
 
   </td>


### PR DESCRIPTION
Adds a short summary about `inherit` to the language index.

# Motivation

When I was first learning Nix I found this incredibly confusing. Even though documentation already exists for [this](https://github.com/NixOS/nix/blob/master/doc/manual/src/language/constructs.md#inheriting-attributes), the summary page where I have made this change ranks first on Google "nixlang syntax" and I (incorrectly) concluded that this was undocumented - mostly because every _other_ language feature was present on this page. I'm making this change in the hope that those who follow won't hit the same stumbling block.

# Context

My own learning experience.