### PR TITLE
Update the golden hash of the evalNixpkgs test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -299,8 +299,11 @@
               ''
                 type -p nix-env
                 # Note: we're filtering out nixos-install-tools because https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1020530593.
-                time nix-env --store dummy:// -f ${nixpkgs-regression} -qaP --drv-path | sort | grep -v nixos-install-tools > packages
-                [[ $(sha1sum < packages | cut -c1-40) = ff451c521e61e4fe72bdbe2d0ca5d1809affa733 ]]
+                (
+                  set -x
+                  time nix-env --store dummy:// -f ${nixpkgs-regression} -qaP --drv-path | sort | grep -v nixos-install-tools > packages
+                  [[ $(sha1sum < packages | cut -c1-40) = ff451c521e61e4fe72bdbe2d0ca5d1809affa733 ]]
+                )
                 mkdir $out
               '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -302,7 +302,7 @@
                 (
                   set -x
                   time nix-env --store dummy:// -f ${nixpkgs-regression} -qaP --drv-path | sort | grep -v nixos-install-tools > packages
-                  [[ $(sha1sum < packages | cut -c1-40) = ff451c521e61e4fe72bdbe2d0ca5d1809affa733 ]]
+                  [[ $(sha1sum < packages | cut -c1-40) = e01b031fc9785a572a38be6bc473957e3b6faad7 ]]
                 )
                 mkdir $out
               '';


### PR DESCRIPTION
# Motivation

Fix the hydra failure of <https://hydra.nixos.org/build/251312722> to remove one blocker for the Nix release.

# Context

<https://github.com/NixOS/nix/issues/10132>.
`nix-env` has a bug making it omit derivations that are physically equal (in memory) to another one.
Commit cefd030 made this bug trigger a change in the command's output.

Update the hash to match that change (as this is not a breakage in the evaluator, but just in the output of `nix-env`, it's fine to not require a strict identity).

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
