### PR TITLE
`install-multi-user.sh`: `_sudo`: Add proxy variables to sudo (2)

### DIFF
--- a/scripts/binary-tarball.nix
+++ b/scripts/binary-tarball.nix
@@ -23,6 +23,7 @@ in
 runCommand "nix-binary-tarball-${version}" env ''
   cp ${installerClosureInfo}/registration $TMPDIR/reginfo
   cp ${./create-darwin-volume.sh} $TMPDIR/create-darwin-volume.sh
+  cp ${./in-sudo.sh} $TMPDIR/in-sudo
   substitute ${./install-nix-from-closure.sh} $TMPDIR/install \
     --subst-var-by nix ${nix} \
     --subst-var-by cacert ${cacert}
@@ -44,6 +45,7 @@ runCommand "nix-binary-tarball-${version}" env ''
     shellcheck $TMPDIR/create-darwin-volume.sh
     shellcheck $TMPDIR/install-darwin-multi-user.sh
     shellcheck $TMPDIR/install-systemd-multi-user.sh
+    shellcheck $TMPDIR/in-sudo
 
     # SC1091: Don't panic about not being able to source
     #         /etc/profile
@@ -61,6 +63,7 @@ runCommand "nix-binary-tarball-${version}" env ''
   chmod +x $TMPDIR/install-darwin-multi-user.sh
   chmod +x $TMPDIR/install-systemd-multi-user.sh
   chmod +x $TMPDIR/install-multi-user
+  chmod +x $TMPDIR/in-sudo
   dir=nix-${version}-${system}
   fn=$out/$dir.tar.xz
   mkdir -p $out/nix-support
@@ -79,6 +82,7 @@ runCommand "nix-binary-tarball-${version}" env ''
     $TMPDIR/install-darwin-multi-user.sh \
     $TMPDIR/install-systemd-multi-user.sh \
     $TMPDIR/install-multi-user \
+    $TMPDIR/in-sudo \
     $TMPDIR/reginfo \
     $(cat ${installerClosureInfo}/store-paths)
 ''

--- a/scripts/in-sudo.sh
+++ b/scripts/in-sudo.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+export_equal_string() {
+    local equal_string=$1
+
+    local variable_name value
+    IFS='=' read -r -d $'\0' variable_name value <<< "$equal_string"
+    value=${value:0:-1}
+    eval "export $variable_name=$(printf '%q' "$value")"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        *=*) export_equal_string "$1"; shift ;;
+        *) break ;;
+    esac
+done
+
+"$@"

--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -58,6 +58,32 @@ readonly EXTRACTED_NIX_PATH="$(dirname "$0")"
 
 readonly ROOT_HOME=~root
 
+readonly IN_SUDO=$EXTRACTED_NIX_PATH/in-sudo
+readonly PROXY_ENVIRONMENT_VARIABLES=(
+    http_proxy
+    https_proxy
+    ftp_proxy
+    no_proxy
+    HTTP_PROXY
+    HTTPS_PROXY
+    FTP_PROXY
+    NO_PROXY
+)
+
+SUDO_EXTRA_ENVIRONMENT_VARIABLES=()
+
+setup_sudo_extra_environment_variables() {
+    local i=${#SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}
+    for variable in "${PROXY_ENVIRONMENT_VARIABLES[@]}"; do
+        if [ "x${!variable:-}" != "x" ]; then
+            SUDO_EXTRA_ENVIRONMENT_VARIABLES[i]="$variable=${!variable}"
+            i=$((i + 1))
+        fi
+    done
+}
+
+setup_sudo_extra_environment_variables
+
 if [ -t 0 ] && [ -z "${NIX_INSTALLER_YES:-}" ]; then
     readonly IS_HEADLESS='no'
 else
@@ -361,7 +387,7 @@ _sudo() {
     if is_root; then
         env "$@"
     else
-        sudo "$@"
+        sudo "$IN_SUDO" "${SUDO_EXTRA_ENVIRONMENT_VARIABLES[@]}" "$@"
     fi
 }
 


### PR DESCRIPTION
# Motivation
Proxy environment variables are not transferred to sudo. Commands inside sudo cannot access the internet when behind a proxy.

# Context
<!-- Provide context. Reference open issues if available. -->
Fixes: #10016 
Related: #10128 #10173 

<!-- Non-trivial change: Briefly outline the implementation strategy. -->
Passing environment variables to sudo directly breaks the installer for older distros. Passing them to a command made specially to receive environment variables inside sudo might work.

N.B. I just tested on my system. I don't know if this works for older systems.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
