### PR TITLE
profile: add installable matcher

### DIFF
--- a/doc/manual/rl-next/profile-flake-url.md
+++ b/doc/manual/rl-next/profile-flake-url.md
@@ -1,0 +1,12 @@
+---
+synopsis: Removing and upgrading packages using flake URLs
+prs: 10198
+---
+
+It is now possible to remove and upgrade packages in `nix profile` using flake URLs.
+
+```console
+$ nix profile install nixpkgs#firefox
+$ nix profile upgrade nixpkgs#firefox
+$ nix profile remove nixpkgs#firefox
+```

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -106,8 +106,27 @@ warning: No packages to upgrade. Use 'nix profile list' to see the current profi
 EOF
 
 # Test removing all packages using regular expression.
-nix profile remove --regex '.*' 2>&1 | grep "removed 2 packages, kept 0 packages"
+assertStderr nix --offline profile remove --regex '.*' << EOF
+removing 'path:$flake1Dir#packages.$system.default'
+removing 'foo'
+removed 2 packages, kept 0 packages
+EOF
 nix profile rollback
+
+# Test removing package using full url.
+nix profile remove "path:$flake1Dir#packages.$system.default"
+[[ ! -f $TEST_HOME/.nix-profile/bin/hello ]]
+nix profile install $flake1Dir
+
+# Test removing package using shorthand flake url.
+nix profile remove path:$flake1Dir
+[[ ! -f $TEST_HOME/.nix-profile/bin/hello ]]
+nix profile install $flake1Dir
+
+# Test removing package using shorthand package name.
+nix profile remove path:$flake1Dir#default
+[[ ! -f $TEST_HOME/.nix-profile/bin/hello ]]
+nix profile install $flake1Dir
 
 # Test 'history', 'diff-closures'.
 nix profile diff-closures


### PR DESCRIPTION
This allows removing and upgrading packages using flake urls.

# Motivation

Currently it can be surprising that using the same argument for installing a package will not work for removing them:

```console
$ nix profile install nixpkgs#firefox
$ nix profile remove nixpkgs#firefox
```

To make this work this PR adds another matcher (like in #10166), but now for 'installables': `flake#package` or any of the variants thereof.

# Context

Fixes https://github.com/NixOS/nix/issues/10064

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
