### PR TITLE
Fix `nix eval nixpkgs#bash` segfault

### DIFF
--- a/doc/manual/rl-next/nix-eval-derivations.md
+++ b/doc/manual/rl-next/nix-eval-derivations.md
@@ -1,0 +1,13 @@
+---
+synopsis: "`nix eval` prints derivations as `.drv` paths"
+prs: 10200
+---
+
+`nix eval` will now print derivations as their `.drv` paths, rather than as
+attribute sets. This makes commands like `nix eval nixpkgs#bash` terminate
+instead of infinitely looping into recursive self-referential attributes:
+
+```ShellSession
+$ nix eval nixpkgs#bash
+«derivation /nix/store/m32cbgbd598f4w299g0hwyv7gbw6rqcg-bash-5.2p26.drv»
+```

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -120,8 +120,17 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
         }
 
         else {
-            state->forceValueDeep(*v);
-            logger->cout("%s", ValuePrinter(*state, *v, PrintOptions { .force = true }));
+            logger->cout(
+                "%s",
+                ValuePrinter(
+                    *state,
+                    *v,
+                    PrintOptions {
+                        .force = true,
+                        .derivationPaths = true
+                    }
+                )
+            );
         }
     }
 };


### PR DESCRIPTION
`nix eval` forces values and prints derivations as attribute sets, so commands that print derivations (e.g. `nix eval nixpkgs#bash`) will infinitely loop and segfault.

Printing derivations as `.drv` paths makes `nix eval` complete as expected. Further work is needed, but this is better than a segfault.