### PR TITLE
Make `Matcher` subclasses `final`

### DIFF
--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -481,6 +481,7 @@ struct CmdProfileInstall : InstallablesCommand, MixDefaultProfile
 
 struct Matcher
 {
+    virtual ~Matcher() { }
     virtual std::string getTitle() = 0;
     virtual bool matches(const std::string & name, const ProfileElement & element) = 0;
 };

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -485,7 +485,7 @@ struct Matcher
     virtual bool matches(const std::string & name, const ProfileElement & element) = 0;
 };
 
-struct RegexMatcher : public Matcher
+struct RegexMatcher final : public Matcher
 {
     std::regex regex;
     std::string pattern;
@@ -504,7 +504,7 @@ struct RegexMatcher : public Matcher
     }
 };
 
-struct StorePathMatcher : public Matcher
+struct StorePathMatcher final : public Matcher
 {
     nix::StorePath storePath;
 
@@ -522,7 +522,7 @@ struct StorePathMatcher : public Matcher
     }
 };
 
-struct NameMatcher : public Matcher
+struct NameMatcher final : public Matcher
 {
     std::string name;
 
@@ -540,7 +540,7 @@ struct NameMatcher : public Matcher
     }
 };
 
-struct AllMatcher : public Matcher
+struct AllMatcher final : public Matcher
 {
     std::string getTitle() override
     {


### PR DESCRIPTION
Fixes this very long warning, which I'll only include the first line of:

```
/nix/store/8wrjhrycpshhc3b41xmjwvgqr2m3yajq-libcxx-16.0.6-dev/include/c++/v1/__memory/construct_at.h:66:5: warning: destructor called on non-final 'RegexMatcher' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
    __loc->~_Tp();
```