### PR TITLE
Add `builtins.toStringDebug`

### DIFF
--- a/doc/manual/rl-next/to-string-debug.md
+++ b/doc/manual/rl-next/to-string-debug.md
@@ -8,3 +8,6 @@ purposes. Unlike `builtins.toString`, `builtins.toStringDebug` will never error
 and will always produce human-readable, pretty-printed output (including for
 expressions that error). This makes it ideal for interpolation into
 `builtins.trace` calls and `assert` messages.
+
+A variant, `builtins.toStringDebugOptions`, accepts as its first argument a set
+of options for additional control over the output.

--- a/doc/manual/rl-next/to-string-debug.md
+++ b/doc/manual/rl-next/to-string-debug.md
@@ -1,0 +1,10 @@
+---
+synopsis: Add `builtins.toStringDebug`
+prs:
+---
+
+Added `builtins.toStringDebug`, which formats a value as a string for debugging
+purposes. Unlike `builtins.toString`, `builtins.toStringDebug` will never error
+and will always produce human-readable, pretty-printed output (including for
+expressions that error). This makes it ideal for interpolation into
+`builtins.trace` calls and `assert` messages.

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -9,6 +9,7 @@
 #include "json-to-value.hh"
 #include "names.hh"
 #include "path-references.hh"
+#include "print-options.hh"
 #include "store-api.hh"
 #include "util.hh"
 #include "processes.hh"
@@ -1000,7 +1001,7 @@ static void prim_trace(EvalState & state, const PosIdx pos, Value * * args, Valu
     if (args[0]->type() == nString)
         printError("trace: %1%", args[0]->string_view());
     else
-        printError("trace: %1%", ValuePrinter(state, *args[0]));
+        printError("trace: %1%", ValuePrinter(state, *args[0], debugPrintOptions));
     if (evalSettings.builtinsTraceDebugger && state.debugRepl && !state.debugTraces.empty()) {
         const DebugTrace & last = state.debugTraces.front();
         state.runDebugRepl(nullptr, last.env, last.expr);

--- a/src/libexpr/primops/toStringDebug.cc
+++ b/src/libexpr/primops/toStringDebug.cc
@@ -1,0 +1,32 @@
+#include "primops.hh"
+#include "print-options.hh"
+
+namespace nix {
+
+static void prim_toStringDebug(EvalState & state, const PosIdx pos, Value * * args, Value & v)
+{
+    v.mkString(printValue(state, *args[0], debugPrintOptions));
+}
+
+static RegisterPrimOp primop_toStringDebug({
+    .name = "toStringDebug",
+    .args = {"value"},
+    .doc = R"(
+      Format a value as a string for debugging purposes.
+
+      Unlike [`toString`](@docroot@/language/builtins.md#builtins-toString),
+      `toStringDebug` will never error and will always produce human-readable
+      output (including for values that throw errors). For this reason,
+      `toStringDebug` is ideal for interpolation into messages in
+      [`trace`](@docroot@/language/builtins.md#builtins-trace)
+      calls and [`assert`](@docroot@/language/constructs.html#assertions)
+      statements.
+
+      Output will be pretty-printed and include ANSI escape sequences.
+      If the value contains too many values (for instance, more than 32
+      attributes or list items), some values will be elided.
+    )",
+    .fun = prim_toStringDebug,
+});
+
+}

--- a/src/libexpr/primops/toStringDebug.cc
+++ b/src/libexpr/primops/toStringDebug.cc
@@ -1,5 +1,6 @@
 #include "primops.hh"
 #include "print-options.hh"
+#include "value.hh"
 
 namespace nix {
 
@@ -22,11 +23,67 @@ static RegisterPrimOp primop_toStringDebug({
       calls and [`assert`](@docroot@/language/constructs.html#assertions)
       statements.
 
-      Output will be pretty-printed and include ANSI escape sequences.
-      If the value contains too many values (for instance, more than 32
-      attributes or list items), some values will be elided.
+      Output may change in future Nix versions. Currently, output is
+      pretty-printed and include ANSI escape sequences. If the value contains
+      too many values (for instance, more than 32 attributes or list items),
+      some values will be elided.
     )",
     .fun = prim_toStringDebug,
+});
+
+static void prim_toStringDebugOptions(EvalState & state, const PosIdx pos, Value * * args, Value & v)
+{
+    auto options = PrintOptions::fromValue(state, *args[0]);
+    v.mkString(printValue(state, *args[1], options));
+}
+
+static RegisterPrimOp primop_toStringDebugOptions({
+    .name = "toStringDebugOptions",
+    .args = {"options", "value"},
+    .doc = R"(
+      Format a value as a string for debugging purposes.
+
+      Like
+      [`toStringDebug`](@docroot@/language/builtins.md#builtins-toStringDebug)
+      but accepts an additional attribute set of arguments as its first value:
+
+      - `ansiColors` (boolean, default `true`): Whether or not to include ANSI
+        escapes for coloring in the output.
+      - `force` (boolean, default `true`): Whether or not to force values while
+        printing output.
+      - `derivationPaths` (boolean, default `true`): If `force` is set, print
+        derivations as `.drv` paths instead of as attribute sets.
+      - `trackRepeated` (boolean, default `true`): Whether or not to track
+        repeated values while printing output. This will help avoid excessive
+        output while printing self-referential structures. The specific cycle
+        detection algorithm may not detect all repeated values and may change
+        between releases.
+      - `maxDepth` (integer, default 15): The maximum depth to print values to.
+        Depth is increased when printing nested lists and attribute sets. If
+        `maxDepth` is -1, values will be printed to unlimited depth (or until
+        Nix crashes).
+      - `maxAttrs` (integer, default 32): The maximum number of attributes to
+        print in attribute sets. Further attributes will be replaced with a
+        `«234 attributes elided»` message. Note that this is the maximum number
+        of attributes to print for the entire `toStringDebugOptions` call (if
+        it were per-attribute set, it would be possible for
+        `toStringDebugOptions` to produce essentially unbounded output). If
+        `maxAttrs` is -1, all attributes will be printed.
+      - `maxListItems` (integer, default 32): The maximum number of list items to
+        print. Further items will be replaced with a `«234 items elided»`
+        message. If `maxListItems` is -1, all items will be printed.
+      - `maxStringLength` (integer, default 1024): The maximum number of bytes
+        to print of strings. Further data will be replaced with a `«234 bytes
+        elided»` message. If `maxStringLength` is -1, full strings will be
+        printed.
+      - `prettyIndent` (integer, default 2): The number of spaces of indent to
+        use when pretty-printing values. If `prettyIndent` is 0, values will be
+        printed on a single line.
+
+      Missing attributes will be substituted with a default value. Default
+      values may change between releases.
+    )",
+    .fun = prim_toStringDebugOptions,
 });
 
 }

--- a/src/libexpr/print-options.cc
+++ b/src/libexpr/print-options.cc
@@ -1,0 +1,85 @@
+#include <boost/numeric/conversion/cast.hpp>
+
+#include "print-options.hh"
+#include "value.hh"
+#include "eval.hh"
+
+namespace nix {
+
+namespace {
+static std::string_view ERROR_CONTEXT = "while constructing printing options";
+}
+
+size_t nixIntToSizeT(EvalState & state, Value & v, NixInt i, bool minusOneIsMax)
+{
+    if (minusOneIsMax && i == -1) {
+        return std::numeric_limits<size_t>::max();
+    }
+
+    try {
+        return boost::numeric_cast<size_t>(i);
+    } catch (boost::numeric::bad_numeric_cast & e) {
+        state.error<EvalError>(
+            "Failed to convert integer to `size_t`: %1%", e.what()
+        )
+            .atPos(v)
+            .debugThrow();
+    }
+}
+
+bool boolAttr(EvalState & state, Value & v, std::string_view attrName, bool defaultValue)
+{
+    auto attr = v.attrs->find(state.symbols.create(attrName));
+    if (attr != v.attrs->end()) {
+        return state.forceBool(*attr->value, attr->pos, ERROR_CONTEXT);
+    } else {
+        return defaultValue;
+    }
+}
+
+size_t intAttr(EvalState & state, Value & v, std::string_view attrName, size_t defaultValue, bool minusOneIsMax)
+{
+    auto attr = v.attrs->find(state.symbols.create(attrName));
+    if (attr != v.attrs->end()) {
+        return nixIntToSizeT(
+            state,
+            v,
+            state.forceInt(*attr->value, attr->pos, ERROR_CONTEXT),
+            minusOneIsMax
+        );
+    } else {
+        return defaultValue;
+    }
+}
+
+PrintOptions PrintOptions::fromValue(EvalState & state, Value & v)
+{
+    state.forceAttrs(
+        v, [v]() { return v.determinePos(noPos); }, ERROR_CONTEXT);
+
+    auto ansiColors = boolAttr(state, v, "ansiColors", true);
+    auto force = boolAttr(state, v, "force", true);
+    auto derivationPaths = boolAttr(state, v, "derivationPaths", true);
+    auto trackRepeated = boolAttr(state, v, "trackRepeated", true);
+
+    auto maxDepth = intAttr(state, v, "trackRepeated", 15, true);
+    auto maxAttrs = intAttr(state, v, "maxAttrs", 32, true);
+    auto maxListItems = intAttr(state, v, "maxListItems", 32, true);
+    auto maxStringLength = intAttr(state, v, "maxStringLength", 1024, true);
+
+    auto prettyIndent = intAttr(state, v, "prettyIndent", 2, false);
+
+    return PrintOptions {
+        .ansiColors = ansiColors,
+        .force = force,
+        .derivationPaths = derivationPaths,
+        .trackRepeated = trackRepeated,
+        .maxDepth = maxDepth,
+        .maxAttrs = maxAttrs,
+        .maxListItems = maxListItems,
+        .maxStringLength = maxStringLength,
+        .prettyIndent = prettyIndent,
+    };
+}
+
+}

--- a/src/libexpr/print-options.hh
+++ b/src/libexpr/print-options.hh
@@ -89,4 +89,21 @@ static PrintOptions errorPrintOptions = PrintOptions {
     .maxStringLength = 1024
 };
 
+/**
+ * `PrintOptions` for unknown and therefore potentially large values in
+ * debugging contexts, to avoid printing "too much" output.
+ *
+ * This is like `errorPrintOptions`, but prints more values.
+ */
+static PrintOptions debugPrintOptions = PrintOptions {
+    .ansiColors = true,
+    .force = true,
+    .derivationPaths = true,
+    .maxDepth = 15,
+    .maxAttrs = 32,
+    .maxListItems = 32,
+    .maxStringLength = 1024,
+    .prettyIndent = 2
+};
+
 }

--- a/src/libexpr/print-options.hh
+++ b/src/libexpr/print-options.hh
@@ -8,11 +8,21 @@
 
 namespace nix {
 
+struct Value;
+class EvalState;
+
 /**
  * Options for printing Nix values.
  */
 struct PrintOptions
 {
+    /**
+     * Construct `PrintOptions` from a Nix `Value`.
+     *
+     * See `builtins.toStringDebugOptions` for details on the format.
+     */
+    static PrintOptions fromValue(EvalState & state, Value & v);
+
     /**
      * If true, output ANSI color sequences.
      */

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -592,9 +592,22 @@ public:
     }
 };
 
+/**
+ * Print the given value to `output`.
+ */
 void printValue(EvalState & state, std::ostream & output, Value & v, PrintOptions options)
 {
     Printer(output, state, options).print(v);
+}
+
+/**
+ * Print the given value to a new string.
+ */
+std::string printValue(EvalState & state, Value & v, PrintOptions options)
+{
+    std::ostringstream output;
+    printValue(state, output, v, options);
+    return output.str();
 }
 
 std::ostream & operator<<(std::ostream & output, const ValuePrinter & printer)

--- a/src/libexpr/print.hh
+++ b/src/libexpr/print.hh
@@ -62,6 +62,8 @@ std::ostream & printIdentifier(std::ostream & o, std::string_view s);
 
 void printValue(EvalState & state, std::ostream & str, Value & v, PrintOptions options = PrintOptions {});
 
+std::string printValue(EvalState & state, Value & v, PrintOptions options = PrintOptions {});
+
 /**
  * A partially-applied form of `printValue` which can be formatted using `<<`
  * without allocating an intermediate string.

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -26,10 +26,15 @@ expectStderr 1 nix-instantiate --show-trace --eval -E 'builtins.addErrorContext 
 expectStderr 1 nix-instantiate --show-trace --eval -E 'builtins.addErrorContext "Hello %" (throw "Foo")' | grepQuiet 'Hello %'
 
 nix-instantiate --eval -E 'let x = builtins.trace { x = x; } true; in x' \
-  2>&1 | grepQuiet -E 'trace: { x = «potential infinite recursion»; }'
+  2>&1 | grepQuiet -F "trace: {
+  x = «potential infinite recursion»;
+}"
 
 nix-instantiate --eval -E 'let x = { repeating = x; tracing = builtins.trace x true; }; in x.tracing'\
-  2>&1 | grepQuiet -F 'trace: { repeating = «repeated»; tracing = «potential infinite recursion»; }'
+  2>&1 | grepQuiet -F "trace: {
+  repeating = «repeated»;
+  tracing = «potential infinite recursion»;
+}"
 
 set +x
 

--- a/tests/functional/lang/eval-okay-print.err.exp
+++ b/tests/functional/lang/eval-okay-print.err.exp
@@ -1,1 +1,3 @@
-trace: [ «thunk» ]
+trace: [
+  2
+]


### PR DESCRIPTION
# Motivation

Added `builtins.toStringDebug`, which formats a value as a string for debugging purposes. Unlike `builtins.toString`, `builtins.toStringDebug` will never error and will always produce human-readable, pretty-printed output (including for expressions that error). This makes it ideal for interpolation into `builtins.trace` calls and `assert` messages.

A variant, `builtins.toStringDebugOptions`, accepts as its first argument an attribute set of options for additional control over output formatting.

To prevent strings returned from `builtins.toStringDebug` from being included in derivations, a new `%poison` context element is added in #10212 which produces an error if accessed in `builtins.derivation`.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
