### PR TITLE
Print top-level errors normally in `nix repl`

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -123,7 +123,8 @@ struct NixRepl
             .force = true,
             .derivationPaths = true,
             .maxDepth = maxDepth,
-            .prettyIndent = 2
+            .prettyIndent = 2,
+            .errors = ErrorPrintBehavior::ThrowTopLevel,
         });
     }
 };

--- a/src/libexpr/print-options.hh
+++ b/src/libexpr/print-options.hh
@@ -9,6 +9,29 @@
 namespace nix {
 
 /**
+ * How errors should be handled when printing values.
+ */
+enum class ErrorPrintBehavior {
+    /**
+     * Print the first line of the error in brackets: `«error: oh no!»`
+     */
+    Print,
+    /**
+     * Throw the error to the code that attempted to print the value, instead
+     * of suppressing it it.
+     */
+    Throw,
+    /**
+     * Only throw the error if encountered at the top level of the expression.
+     *
+     * This will cause expressions like `builtins.throw "uh oh!"` to throw
+     * errors, but will print attribute sets and other nested structures
+     * containing values that error (like `nixpkgs`) normally.
+     */
+    ThrowTopLevel,
+};
+
+/**
  * Options for printing Nix values.
  */
 struct PrintOptions
@@ -69,6 +92,11 @@ struct PrintOptions
     size_t prettyIndent = 0;
 
     /**
+     * How to handle errors encountered while printing values.
+     */
+    ErrorPrintBehavior errors = ErrorPrintBehavior::Print;
+
+    /**
      * True if pretty-printing is enabled.
      */
     inline bool shouldPrettyPrint()
@@ -86,7 +114,7 @@ static PrintOptions errorPrintOptions = PrintOptions {
     .maxDepth = 10,
     .maxAttrs = 10,
     .maxListItems = 10,
-    .maxStringLength = 1024
+    .maxStringLength = 1024,
 };
 
 }

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -271,25 +271,21 @@ private:
 
     void printDerivation(Value & v)
     {
-        try {
-            Bindings::iterator i = v.attrs->find(state.sDrvPath);
-            NixStringContext context;
-            std::string storePath;
-            if (i != v.attrs->end())
-                storePath = state.store->printStorePath(state.coerceToStorePath(i->pos, *i->value, context, "while evaluating the drvPath of a derivation"));
+        Bindings::iterator i = v.attrs->find(state.sDrvPath);
+        NixStringContext context;
+        std::string storePath;
+        if (i != v.attrs->end())
+            storePath = state.store->printStorePath(state.coerceToStorePath(i->pos, *i->value, context, "while evaluating the drvPath of a derivation"));
 
-            if (options.ansiColors)
-                output << ANSI_GREEN;
-            output << "«derivation";
-            if (!storePath.empty()) {
-                output << " " << storePath;
-            }
-            output << "»";
-            if (options.ansiColors)
-                output << ANSI_NORMAL;
-        } catch (Error & e) {
-            printError_(e);
+        if (options.ansiColors)
+            output << ANSI_GREEN;
+        output << "«derivation";
+        if (!storePath.empty()) {
+            output << " " << storePath;
         }
+        output << "»";
+        if (options.ansiColors)
+            output << ANSI_NORMAL;
     }
 
     bool shouldPrettyPrintAttrs(AttrVec & v)
@@ -510,64 +506,68 @@ private:
         output.flush();
         checkInterrupt();
 
-        if (options.force) {
-            try {
+        try {
+            if (options.force) {
                 state.forceValue(v, v.determinePos(noPos));
-            } catch (Error & e) {
-                printError_(e);
-                return;
             }
-        }
 
-        switch (v.type()) {
+            switch (v.type()) {
 
-        case nInt:
-            printInt(v);
-            break;
+            case nInt:
+                printInt(v);
+                break;
 
-        case nFloat:
-            printFloat(v);
-            break;
+            case nFloat:
+                printFloat(v);
+                break;
 
-        case nBool:
-            printBool(v);
-            break;
+            case nBool:
+                printBool(v);
+                break;
 
-        case nString:
-            printString(v);
-            break;
+            case nString:
+                printString(v);
+                break;
 
-        case nPath:
-            printPath(v);
-            break;
+            case nPath:
+                printPath(v);
+                break;
 
-        case nNull:
-            printNull();
-            break;
+            case nNull:
+                printNull();
+                break;
 
-        case nAttrs:
-            printAttrs(v, depth);
-            break;
+            case nAttrs:
+                printAttrs(v, depth);
+                break;
 
-        case nList:
-            printList(v, depth);
-            break;
+            case nList:
+                printList(v, depth);
+                break;
 
-        case nFunction:
-            printFunction(v);
-            break;
+            case nFunction:
+                printFunction(v);
+                break;
 
-        case nThunk:
-            printThunk(v);
-            break;
+            case nThunk:
+                printThunk(v);
+                break;
 
-        case nExternal:
-            printExternal(v);
-            break;
+            case nExternal:
+                printExternal(v);
+                break;
 
-        default:
-            printUnknown();
-            break;
+            default:
+                printUnknown();
+                break;
+            }
+        } catch (Error & e) {
+            if (options.errors == ErrorPrintBehavior::Throw
+                || (options.errors == ErrorPrintBehavior::ThrowTopLevel
+                    && depth == 0)) {
+                throw;
+            }
+            printError_(e);
         }
     }
 


### PR DESCRIPTION
Previously, errors while printing values in `nix repl` would be printed in `«error: ...»` brackets rather than displayed normally:

```
nix-repl> legacyPackages.aarch64-darwin.pythonPackages.APScheduler
«error: Package ‘python-2.7.18.7’ in /nix/store/6s0m1qc31zw3l3kq0q4wd5cp3lqpkq0q-source/pkgs/development/interpreters/python/cpython/2.7/default.nix:335 is marked as insecure, refusing to evaluate.»
```

Now, errors will be displayed normally if they're emitted at the top-level of an expression:

```
nix-repl> legacyPackages.aarch64-darwin.pythonPackages.APScheduler
error:
       … in the condition of the assert statement
         at /nix/store/6s0m1qc31zw3l3kq0q4wd5cp3lqpkq0q-source/lib/customisation.nix:268:17:
          267|     in commonAttrs // {
          268|       drvPath = assert condition; drv.drvPath;
             |                 ^
          269|       outPath = assert condition; drv.outPath;

       … in the left operand of the OR (||) operator
         at /nix/store/6s0m1qc31zw3l3kq0q4wd5cp3lqpkq0q-source/pkgs/development/interpreters/python/passthrufun.nix:28:45:
           27|         if lib.isDerivation value then
           28|           lib.extendDerivation (valid value || throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.") {} value
             |                                             ^
           29|         else

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Package ‘python-2.7.18.7’ in /nix/store/6s0m1qc31zw3l3kq0q4wd5cp3lqpkq0q-source/pkgs/development/interpreters/python/cpython/2.7/default.nix:335 is marked as insecure, refusing to evaluate.
```

Errors emitted in nested structures (like e.g. when printing `nixpkgs`) will still be printed in brackets.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
