### PR TITLE
Add 'poison' context

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -606,7 +606,7 @@ string_t AttrCursor::getStringWithContext()
                             return o.path;
                         },
                         [&](const NixStringContextElem::Poison & p) -> const StorePath & {
-                            root->state.error<PoisonContextError>().debugThrow();
+                            root->state.error<PoisonContextError>(p).debugThrow();
                         },
                     }, c.raw);
                     if (!root->state.store->isValidPath(path)) {

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -605,6 +605,9 @@ string_t AttrCursor::getStringWithContext()
                         [&](const NixStringContextElem::Opaque & o) -> const StorePath & {
                             return o.path;
                         },
+                        [&](const NixStringContextElem::Poison & p) -> const StorePath & {
+                            root->state.error<PoisonContextError>().debugThrow();
+                        },
                     }, c.raw);
                     if (!root->state.store->isValidPath(path)) {
                         valid = false;

--- a/src/libexpr/eval-cache.hh
+++ b/src/libexpr/eval-cache.hh
@@ -82,8 +82,6 @@ class AttrCursor : public std::enable_shared_from_this<AttrCursor>
 
     AttrKey getKey();
 
-    Value & getValue();
-
 public:
 
     AttrCursor(
@@ -129,6 +127,8 @@ public:
     std::vector<Symbol> getAttrs();
 
     bool isDerivation();
+
+    Value & getValue();
 
     Value & forceValue();
 

--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -1,5 +1,6 @@
 #include "eval-error.hh"
 #include "eval.hh"
+#include "print.hh"
 #include "value.hh"
 
 namespace nix {
@@ -101,5 +102,12 @@ template class EvalErrorBuilder<MissingArgumentError>;
 template class EvalErrorBuilder<InfiniteRecursionError>;
 template class EvalErrorBuilder<CachedEvalError>;
 template class EvalErrorBuilder<InvalidPathError>;
+template class EvalErrorBuilder<PoisonContextError>;
+
+PoisonContextError::PoisonContextError(EvalState & state)
+    : EvalError(state, "Found 'poison' context that may not be built or included in derivations")
+    , value(*state.allocValue())
+{
+}
 
 }

--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -104,10 +104,4 @@ template class EvalErrorBuilder<CachedEvalError>;
 template class EvalErrorBuilder<InvalidPathError>;
 template class EvalErrorBuilder<PoisonContextError>;
 
-PoisonContextError::PoisonContextError(EvalState & state)
-    : EvalError(state, "Found 'poison' context that may not be built or included in derivations")
-    , value(*state.allocValue())
-{
-}
-
 }

--- a/src/libexpr/eval-error.hh
+++ b/src/libexpr/eval-error.hh
@@ -6,6 +6,7 @@
 #include "pos-idx.hh"
 #include "print-options.hh"
 #include "print.hh"
+#include "value/context.hh"
 
 namespace nix {
 
@@ -61,14 +62,22 @@ public:
 struct PoisonContextError : public EvalError
 {
 public:
-    Value & value;
-    PoisonContextError(EvalState & state, Value & value)
-        : EvalError(state, "Value contains 'poison' context that may not be built or included in derivations: %1%", ValuePrinter(state, value, errorPrintOptions))
-        , value(value)
+    std::shared_ptr<Value> value;
+    const Poison & poison;
+
+    PoisonContextError(EvalState & state, const Poison & poison)
+        : EvalError(state, "Value is poisoned from %1% and may not be built or included in derivations", poison)
+        , value(nullptr)
+        , poison(poison)
     {
     }
 
-    PoisonContextError(EvalState & state);
+    PoisonContextError(EvalState & state, const Poison & poison, Value * value)
+        : EvalError(state, "Value is poisoned from %1% and may not be built or included in derivations: %2%", poison, ValuePrinter(state, *value, errorPrintOptions))
+        , value(value)
+        , poison(poison)
+    {
+    }
 };
 
 /**

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2473,6 +2473,9 @@ std::pair<SingleDerivedPath, std::string_view> EvalState::coerceToSingleDerivedP
         [&](NixStringContextElem::Built && b) -> SingleDerivedPath {
             return std::move(b);
         },
+        [&](NixStringContextElem::Poison && p) -> SingleDerivedPath {
+            error<PoisonContextError>(v).debugThrow();
+        },
     }, ((NixStringContextElem &&) *context.begin()).raw);
     return {
         std::move(derivedPath),

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2474,7 +2474,7 @@ std::pair<SingleDerivedPath, std::string_view> EvalState::coerceToSingleDerivedP
             return std::move(b);
         },
         [&](NixStringContextElem::Poison && p) -> SingleDerivedPath {
-            error<PoisonContextError>(v).debugThrow();
+            error<PoisonContextError>(p, &v).debugThrow();
         },
     }, ((NixStringContextElem &&) *context.begin()).raw);
     return {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -240,7 +240,7 @@ public:
 
     template<class T, typename... Args>
     [[nodiscard, gnu::noinline]]
-    EvalErrorBuilder<T> & error(const Args & ... args) {
+    EvalErrorBuilder<T> & error(Args && ... args) {
         // `EvalErrorBuilder::debugThrow` performs the corresponding `delete`.
         return *new EvalErrorBuilder<T>(*this, args...);
     }
@@ -689,7 +689,7 @@ public:
      * Realise the given context, and return a mapping from the placeholders
      * used to construct the associated value to their final store path
      */
-    [[nodiscard]] StringMap realiseContext(const NixStringContext & context);
+    [[nodiscard]] StringMap realiseContext(Value & v, const NixStringContext & context);
 
     /* Call the binary path filter predicate used builtins.path etc. */
     bool callPathFilter(

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -69,7 +69,7 @@ StringMap EvalState::realiseContext(Value & v, const NixStringContext & context)
                 ensureValid(d.drvPath);
             },
             [&](const NixStringContextElem::Poison & p) {
-                error<PoisonContextError>(v).debugThrow();
+                error<PoisonContextError>(p, &v).debugThrow();
             },
         }, c.raw);
     }
@@ -1292,7 +1292,7 @@ drvName, Bindings * attrs, Value & input, Value & v)
                 drv.inputSrcs.insert(o.path);
             },
             [&](const NixStringContextElem::Poison & p) {
-                state.error<PoisonContextError>(input)
+                state.error<PoisonContextError>(p, &input)
                     .debugThrow();
             },
         }, c.raw);

--- a/src/libexpr/value/context.cc
+++ b/src/libexpr/value/context.cc
@@ -57,6 +57,9 @@ NixStringContextElem NixStringContextElem::parse(
             .drvPath = StorePath { s.substr(1) },
         };
     }
+    case '%': {
+        return Poison();
+    }
     default: {
         // Ensure no '!'
         if (s.find("!") != std::string_view::npos) {
@@ -99,6 +102,9 @@ std::string NixStringContextElem::to_string() const
         [&](const NixStringContextElem::DrvDeep & d) {
             res += '=';
             res += d.drvPath.to_string();
+        },
+        [&](const Poison & p) {
+            res += "%poison";
         },
     }, raw);
 

--- a/src/libexpr/value/context.hh
+++ b/src/libexpr/value/context.hh
@@ -54,10 +54,25 @@ struct NixStringContextElem {
      */
     using Built = SingleDerivedPath::Built;
 
+    /**
+     * "Poison pill" output that is rejected by `builtins.derivation`.
+     *
+     * Used to ensure the implementation of functions like
+     * `builtins.toStringDebug` do not get hashed into derivations.
+     *
+     * Encoded as ‘%poison’.
+     */
+    struct Poison {
+        bool operator ==(const Poison & other) const { return true; }
+        bool operator <(const Poison & other) const { return false; }
+        bool operator >(const Poison & other) const { return false; }
+    };
+
     using Raw = std::variant<
         Opaque,
         DrvDeep,
-        Built
+        Built,
+        Poison
     >;
 
     Raw raw;
@@ -71,6 +86,7 @@ struct NixStringContextElem {
      * - ‘<path>’
      * - ‘=<path>’
      * - ‘!<name>!<path>’
+     * - ‘%poison’
      *
      * @param xpSettings Stop-gap to avoid globals during unit tests.
      */

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -68,6 +68,7 @@ template<class C> C tokenizeString(std::string_view s, std::string_view separato
 template Strings tokenizeString(std::string_view s, std::string_view separators);
 template StringSet tokenizeString(std::string_view s, std::string_view separators);
 template std::vector<std::string> tokenizeString(std::string_view s, std::string_view separators);
+template std::vector<std::string_view> tokenizeString(std::string_view s, std::string_view separators);
 
 
 std::string chomp(std::string_view s)

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -94,7 +94,7 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
                     };
                 },
                 [&](const NixStringContextElem::Poison & p) -> DerivedPath {
-                    state.error<PoisonContextError>(attr->getValue()).debugThrow();
+                    state.error<PoisonContextError>(p, &attr->getValue()).debugThrow();
                 },
             }, c.raw));
         }

--- a/src/nix/app.cc
+++ b/src/nix/app.cc
@@ -69,7 +69,8 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
         throw Error("attribute '%s' should have type '%s'", cursor->getAttrPathStr(), expectedType);
 
     if (type == "app") {
-        auto [program, context] = cursor->getAttr("program")->getStringWithContext();
+        auto attr = cursor->getAttr("program");
+        auto [program, context] = attr->getStringWithContext();
 
         std::vector<DerivedPath> context2;
         for (auto & c : context) {
@@ -91,6 +92,9 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
                     return DerivedPath::Opaque {
                         .path = o.path,
                     };
+                },
+                [&](const NixStringContextElem::Poison & p) -> DerivedPath {
+                    state.error<PoisonContextError>(attr->getValue()).debugThrow();
                 },
             }, c.raw));
         }


### PR DESCRIPTION
This can be added to strings to prevent them from being used in derivations. This lets us implement "unstable" functions without fear!

Motivated by #10206.

- Closes https://github.com/NixOS/nix/issues/8388

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
