### PR TITLE
Fix fetching submodule commits that aren't in the default ref

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -634,6 +634,8 @@ struct GitInputScheme : InputScheme
                 attrs.insert_or_assign("url", resolved);
                 if (submodule.branch != "")
                     attrs.insert_or_assign("ref", submodule.branch);
+                else
+                    attrs.insert_or_assign("allRefs", Explicit<bool> { true });
                 attrs.insert_or_assign("rev", submoduleRev.gitRev());
                 attrs.insert_or_assign("exportIgnore", Explicit<bool>{ exportIgnore });
                 auto submoduleInput = fetchers::Input::fromAttrs(std::move(attrs));


### PR DESCRIPTION
# Motivation

Nix >= 2.20.0 can no longer find rev in submodule of flake or flake input if not in the ref (including just the default HEAD/master ref when unspecified).

In this change, when git submodules are used and the `.gitmodules` file doesn't specify the ref that the submodule commit is contained in, fetch the submodule with allRefs=true.

# Context

Fixes #9979
