### PR TITLE
nix-copy: document --all --from local binary cache example

### DIFF
--- a/src/nix/copy.md
+++ b/src/nix/copy.md
@@ -11,6 +11,12 @@ R""(
   Note the `file://` - without this, the destination is a chroot
   store, not a binary cache.
 
+* Copy all store paths from a local binary cache in `/tmp/cache` to the local store:
+
+  ```console
+  # nix copy --all --from file:///tmp/cache
+  ```
+
 * Copy the entire current NixOS system closure to another machine via
   SSH:
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

`nix copy --help` does not clearly display how to import everything from a local binary cache, which is useful for offline system interactions. The `--all` flag is used for this purpose, but it is not easy to find and interpret in the current documentation.

# Context
<!-- Provide context. Reference open issues if available. -->

https://github.com/NixOS/nix/issues/10217

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
