### PR TITLE
system: build for riscv64-unknown-linux-gnu

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -167,7 +167,10 @@ or for Nix with the [`flakes`] and [`nix-command`] experimental features enabled
 $ nix build .#packages.aarch64-linux.default
 ```
 
-Cross-compiled builds are available for ARMv6 (`armv6l-linux`), ARMv7 (`armv7l-linux`) and RISC-V (`riscv64-linux`).
+Cross-compiled builds are available for:
+- `armv6l-linux`
+- `armv7l-linux`
+- `riscv64-linux`
 Add more [system types](#system-type) to `crossSystems` in `flake.nix` to bootstrap Nix on unsupported platforms.
 
 ### Building for multiple platforms at once

--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -144,6 +144,7 @@ Nix can be built for various platforms, as specified in [`flake.nix`]:
 - `aarch64-darwin`
 - `armv6l-linux`
 - `armv7l-linux`
+- `riscv64-linux`
 
 In order to build Nix for a different platform than the one you're currently
 on, you need a way for your current Nix installation to build code for that
@@ -166,7 +167,7 @@ or for Nix with the [`flakes`] and [`nix-command`] experimental features enabled
 $ nix build .#packages.aarch64-linux.default
 ```
 
-Cross-compiled builds are available for ARMv6 (`armv6l-linux`) and ARMv7 (`armv7l-linux`).
+Cross-compiled builds are available for ARMv6 (`armv6l-linux`), ARMv7 (`armv7l-linux`) and RISC-V (`riscv64-linux`).
 Add more [system types](#system-type) to `crossSystems` in `flake.nix` to bootstrap Nix on unsupported platforms.
 
 ### Building for multiple platforms at once

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
       crossSystems = [
         "armv6l-unknown-linux-gnueabihf"
         "armv7l-unknown-linux-gnueabihf"
+        "riscv64-unknown-linux-gnu"
         "x86_64-unknown-netbsd"
       ];
 
@@ -259,6 +260,7 @@
           # Cross
           self.hydraJobs.binaryTarballCross."x86_64-linux"."armv6l-unknown-linux-gnueabihf"
           self.hydraJobs.binaryTarballCross."x86_64-linux"."armv7l-unknown-linux-gnueabihf"
+          self.hydraJobs.binaryTarballCross."x86_64-linux"."riscv64-unknown-linux-gnu"
         ];
         installerScriptForGHA = installScriptFor [
           # Native
@@ -267,6 +269,7 @@
           # Cross
           self.hydraJobs.binaryTarballCross."x86_64-linux"."armv6l-unknown-linux-gnueabihf"
           self.hydraJobs.binaryTarballCross."x86_64-linux"."armv7l-unknown-linux-gnueabihf"
+          self.hydraJobs.binaryTarballCross."x86_64-linux"."riscv64-unknown-linux-gnu"
         ];
 
         # docker image with Nix inside

--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -171,6 +171,10 @@ eval {
     downloadFile("binaryTarballCross.x86_64-linux.armv7l-unknown-linux-gnueabihf", "1");
 };
 warn "$@" if $@;
+eval {
+    downloadFile("binaryTarballCross.x86_64-linux.riscv64-linux-gnu", "1");
+};
+warn "$@" if $@;
 downloadFile("installerScript", "1");
 
 # Upload docker images to dockerhub.


### PR DESCRIPTION
# Motivation

With the advent of increasing RISC-V plaforms, it would be nice to also have a (cross-compiled) nix tarball available to be consumed by our nix installation methods.

# Context

Currently the nix installation instructions both errors out on riscv64-linux systems with following:
```
# curl -sL https://nixos.org/nix/install | sh -s -- --daemon
sh: sorry, there is no binary distribution of Nix for your platform

# curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
nix-installer: unknown CPU type: riscv64
```

With these changes I was able to produce the required output to install nix on a riscv64-linux system (running Debian).
```
nix --extra-experimental-features 'nix-command flakes' build .#hydraJobs.binaryTarballCross.x86_64-linux.riscv64-unknown-linux-gnu
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
