### PR TITLE
doc: document SRI hash format for `outputHash`

### DIFF
--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -188,8 +188,9 @@ Derivations can declare some infrequently used optional attributes.
     }
     ```
 
-    The `outputHash` attribute must be a string containing the hash in either hexadecimal or base-32 notation, or following the format for integrity metadata as defined by [SRI](https://www.w3.org/TR/SRI/).
-    (See the [`nix-hash` command](../command-ref/nix-hash.md) for information about converting to and from base-32 notation.)
+    The `outputHash` attribute must be a string containing the hash in either hexadecimal or "nix32" notation, or following the format for integrity metadata as defined by [SRI](https://www.w3.org/TR/SRI/).
+    The "nix32" notation is an adaptation of a base-32 notation.
+    The [`convertHash`](@docroot@/language/builtins.md#builtins-convertHash) function shows how to convert between different notations, and the [`nix-hash` command](../command-ref/nix-hash.md) has information about obtaining the hash for some contents, as well as converting to and from notations.
 
     The `outputHashAlgo` attribute specifies the hash algorithm used to compute the hash.
     It can currently be `"sha1"`, `"sha256"`, `"sha512"`, or `null`.

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -188,9 +188,12 @@ Derivations can declare some infrequently used optional attributes.
     }
     ```
 
-    The `outputHashAlgo` attribute specifies the hash algorithm used to
-    compute the hash. It can currently be `"sha1"`, `"sha256"` or
-    `"sha512"`.
+    The `outputHash` attribute must be a string containing the hash in either hexadecimal or base-32 notation, or following the format for integrity metadata as defined by [SRI](https://www.w3.org/TR/SRI/).
+    (See the [`nix-hash` command](../command-ref/nix-hash.md) for information about converting to and from base-32 notation.)
+
+    The `outputHashAlgo` attribute specifies the hash algorithm used to compute the hash.
+    It can currently be `"sha1"`, `"sha256"`, `"sha512"`, or `null`.
+    `outputHashAlgo` can only be `null` when `outputHash` follows the SRI format.
 
     The `outputHashMode` attribute determines how the hash is computed.
     It must be one of the following two values:
@@ -208,11 +211,6 @@ Derivations can declare some infrequently used optional attributes.
         (i.e., the result of [`nix-store --dump`](@docroot@/command-ref/nix-store/dump.md)). In
         this case, the output can be anything, including a directory
         tree.
-
-    The `outputHash` attribute, finally, must be a string containing
-    the hash in either hexadecimal or base-32 notation. (See the
-    [`nix-hash` command](../command-ref/nix-hash.md) for information
-    about converting to and from base-32 notation.)
 
   - [`__contentAddressed`]{#adv-attr-__contentAddressed}
     > **Warning**

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -188,9 +188,9 @@ Derivations can declare some infrequently used optional attributes.
     }
     ```
 
-    The `outputHash` attribute must be a string containing the hash in either hexadecimal or "nix32" notation, or following the format for integrity metadata as defined by [SRI](https://www.w3.org/TR/SRI/).
-    The "nix32" notation is an adaptation of a base-32 notation.
-    The [`convertHash`](@docroot@/language/builtins.md#builtins-convertHash) function shows how to convert between different notations, and the [`nix-hash` command](../command-ref/nix-hash.md) has information about obtaining the hash for some contents, as well as converting to and from notations.
+    The `outputHash` attribute must be a string containing the hash in either hexadecimal or "nix32" encoding, or following the format for integrity metadata as defined by [SRI](https://www.w3.org/TR/SRI/).
+    The "nix32" encoding is an adaptation of base-32 encoding.
+    The [`convertHash`](@docroot@/language/builtins.md#builtins-convertHash) function shows how to convert between different encodings, and the [`nix-hash` command](../command-ref/nix-hash.md) has information about obtaining the hash for some contents, as well as converting to and from encodings.
 
     The `outputHashAlgo` attribute specifies the hash algorithm used to compute the hash.
     It can currently be `"sha1"`, `"sha256"`, `"sha512"`, or `null`.


### PR DESCRIPTION
# Motivation

Nix supports SRI hashes when using `outputHash` and `outputHashAlgo` [since 2.2](https://nixos.org/manual/nix/stable/release-notes/rl-2.2). However, this hasn't been documented in the manual yet.

This PR documents that `outputHash` can follow the SRI format, and in that case `outputHashAlgo` can be `null`.

# Context
[Nix 2.2 release notes](https://nixos.org/manual/nix/stable/release-notes/rl-2.2).

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
