### PR TITLE
docker: Fix command "nix profile install", Don't require --impure

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -241,14 +241,14 @@ let
       mkdir -p $out/nix/var/nix/profiles/per-user/root
 
       ln -s ${profile} $out/nix/var/nix/profiles/default-1-link
-      ln -s $out/nix/var/nix/profiles/default-1-link $out/nix/var/nix/profiles/default
+      ln -s /nix/var/nix/profiles/default-1-link $out/nix/var/nix/profiles/default
       ln -s /nix/var/nix/profiles/default $out/root/.nix-profile
 
       ln -s ${channel} $out/nix/var/nix/profiles/per-user/root/channels-1-link
-      ln -s $out/nix/var/nix/profiles/per-user/root/channels-1-link $out/nix/var/nix/profiles/per-user/root/channels
+      ln -s /nix/var/nix/profiles/per-user/root/channels-1-link $out/nix/var/nix/profiles/per-user/root/channels
 
       mkdir -p $out/root/.nix-defexpr
-      ln -s $out/nix/var/nix/profiles/per-user/root/channels $out/root/.nix-defexpr/channels
+      ln -s /nix/var/nix/profiles/per-user/root/channels $out/root/.nix-defexpr/channels
       echo "${channelURL} ${channelName}" > $out/root/.nix-channels
 
       mkdir -p $out/bin $out/usr/bin


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Since probably nix2.20 or nix2.19, now "nix profile install" checks for "pure evaluation mode".
Example usage throw error:
```console
$ docker run --rm -it nixos/nix
bash-5.2# nix --extra-experimental-features 'nix-command flakes' profile install nixpkgs#hello
error: access to absolute path '/nix/store/32ibcisgls7pp3y759mm00d20fcvx342-user-environment' is forbidden in pure evaluation mode (use '--impure' to override)
```
When I build docker image with nix2.18 it don't throw this error.
Soo my patch fixes symlinks and now nix2.18+ works fine.
