### PR TITLE
doc: builtins.addDrvOutputDependencies: fix link target

### DIFF
--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -144,7 +144,7 @@ static RegisterPrimOp primop_addDrvOutputDependencies({
       The original string context element must not be empty or have multiple elements, and it must not have any other type of element other than a constant or derivation deep element.
       The latter is supported so this function is idempotent.
 
-      This is the opposite of [`builtins.unsafeDiscardOutputDependency`](#builtins-addDrvOutputDependencies).
+      This is the opposite of [`builtins.unsafeDiscardOutputDependency`](#builtins-unsafeDiscardOutputDependency).
     )",
     .fun = prim_addDrvOutputDependencies
 });

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -246,7 +246,7 @@ static RegisterPrimOp primop_getContext({
 
 /* Append the given context to a given string.
 
-   See the commentary above unsafeGetContext for details of the
+   See the commentary above getContext for details of the
    context representation.
 */
 static void prim_appendContext(EvalState & state, const PosIdx pos, Value * * args, Value & v)


### PR DESCRIPTION
# Motivation

In the documentation of `builtins.addDrvOutputDependencies`, a hyperlink of text `builtins.unsafeDiscardOutputDependency` turns out to link to `#builtins-addDrvOutputDependencies`. This PR directs the link to the right anchor and fixes such inconsistency.

# Context

The issue has started from 765436e300b855922d5793092cc2a533c81d521d and affect Nix 2.19, 2.20, and 2.21, including the [stable Nix Manual](https://nixos.org/manual/nix/stable/language/builtins.html?highlight=unsafeDisca#builtins-addDrvOutputDependencies). It needs to be backported to the corresponding maintenance branches.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
