### PR TITLE
Add -P shortName for --print-out-paths

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -90,6 +90,7 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
 
         addFlag({
             .longName = "print-out-paths",
+            .shortName = 'P',
             .description = "Print the resulting output paths",
             .handler = {&printOutputPaths, true},
         });


### PR DESCRIPTION
# Motivation
Provide something similar `-L` for `--print-build-logs`.

Chose `P` for 'paths' or `print'.
`O` might be also relevant for `outpaths`, but felt that was more of a stretch

# Context
```
$ nix build .#openssl^* -P
/nix/store/gvad6v0cmq1qccmc4wphsazqbj0xzjsl-openssl-3.0.13-bin
/nix/store/a07jqdrc8afnk8r6f3lnhh4gvab7chk4-openssl-3.0.13-debug
/nix/store/yg75achq89wgqn2fi3gglgsd77kjpi03-openssl-3.0.13-dev
/nix/store/bvdcihi8c88fw31cg6gzzmpnwglpn1jv-openssl-3.0.13-doc
/nix/store/gjqcvq47cmxazxga0cirspm3jywkmvfv-openssl-3.0.13-man
/nix/store/7nmrrad8skxr47f9hfl3xc0pfqmwq51b-openssl-3.0.13
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
