### PR TITLE
Daemon: warn when an untrusted user cannot override a setting

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -254,7 +254,7 @@ struct ClientSettings
                 else if (setSubstituters(settings.substituters))
                     ;
                 else
-                    debug("ignoring the client-specified setting '%s', because it is a restricted setting and you are not a trusted user", name);
+                    warn("ignoring the client-specified setting '%s', because it is a restricted setting and you are not a trusted user", name);
             } catch (UsageError & e) {
                 warn(e.what());
             }


### PR DESCRIPTION
In a daemon-based Nix setup, some options cannot be overridden by a client unless the client's user is considered trusted.

Currently, if an untrusted user tries to override one of those options, we are silently ignoring it.

This can be pretty confusing in certain situations, e.g. a user thinks he disabled the sandbox when in reality he did not.
We are now sending a warning message letting know the user some options have been ignored.

Related to #1761.

This is a cherry-pick of 9e0f5f803f6cbfe9925cef69a0e58cbf5375bfaf. The above commit has been reverted by
a59e77d9e54e8e7bf0f3c3f40c22cd34b7a81225 to prevent spamming warnings with experimental features, but these are now totally ignored on the daemon side, so there's no reason for the revert any more.

Credit to @picnoir who authored the original commit.

Fix #10272 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
