### PR TITLE
Add memoise primop

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1683,6 +1683,8 @@ void EvalState::printStats()
     printMsg(v, format("  number of primop calls: %1%") % nrPrimOpCalls);
     printMsg(v, format("  number of function calls: %1%") % nrFunctionCalls);
     printMsg(v, format("  total allocations: %1% bytes") % (bEnvs + bLists + bValues + bAttrsets));
+    printMsg(v, format("  memoisation hits: %d") % nrMemoiseHits);
+    printMsg(v, format("  memoisation misses: %d") % nrMemoiseMisses);
 
 #if HAVE_BOEHMGC
     GC_word heapSize, totalBytes;

--- a/src/libexpr/primops/memoise.cc
+++ b/src/libexpr/primops/memoise.cc
@@ -1,0 +1,95 @@
+#include "primops.hh"
+#include "eval-inline.hh"
+
+#include <cstring>
+
+namespace nix {
+
+bool EvalState::MemoArgComparator::operator()(Value * v1, Value * v2)
+{
+    if (v1 == v2) return false;
+
+    state.forceValue(*v1);
+    state.forceValue(*v2);
+
+    if (v1->type == v2->type) {
+        switch (v1->type) {
+
+        case tInt:
+            return v1->integer < v2->integer;
+
+        case tBool:
+            return v1->boolean < v2->boolean;
+
+        case tString:
+            return strcmp(v1->string.s, v2->string.s);
+
+        case tPath:
+            return strcmp(v1->path, v2->path);
+
+        case tNull:
+            return false;
+
+        case tList1:
+        case tList2:
+        case tListN:
+            unsigned int n;
+            for (n = 0; n < v1->listSize() && n < v2->listSize(); ++n) {
+                if ((*this)(v1->listElems()[n], v2->listElems()[n])) return true;
+                if ((*this)(v2->listElems()[n], v1->listElems()[n])) return false;
+            }
+
+            return n == v1->listSize() && n < v2->listSize();
+
+        case tAttrs:
+            Bindings::iterator i, j;
+            for (i = v1->attrs->begin(), j = v2->attrs->begin(); i != v1->attrs->end() && j != v2->attrs->end(); ++i, ++j) {
+                if (i->name < j->name) return true;
+                if (j->name < i->name) return false;
+                if ((*this)(i->value, j->value)) return true;
+                if ((*this)(j->value, i->value)) return false;
+            }
+            return i == v1->attrs->end() && j != v2->attrs->end();
+
+        case tLambda:
+            return std::make_pair(v1->lambda.env, v1->lambda.fun) < std::make_pair(v2->lambda.env, v2->lambda.fun);
+
+        case tFloat:
+            return v1->fpoint < v2->fpoint;
+
+        default:
+            break;
+        }
+    }
+
+    // As a fallback, use pointer equality.
+    return v1 < v2;
+}
+
+void prim_memoise(EvalState & state, const Pos & pos, Value * * args, Value & v)
+{
+    state.forceFunction(*args[0], pos);
+
+    EvalState::PerLambdaMemo foo(state);
+
+    auto & memo = state.memos.emplace(std::make_pair(args[0]->lambda.env, args[0]->lambda.fun), state).first->second;
+
+    auto result = memo.find(args[1]);
+
+    if (result != memo.end()) {
+        state.nrMemoiseHits++;
+        v = result->second;
+        return;
+    }
+
+    state.nrMemoiseMisses++;
+
+    state.callFunction(*args[0], *args[1], v, pos);
+
+    memo[args[1]] = v;
+
+}
+
+static RegisterPrimOp r("memoise", 2, prim_memoise);
+
+}


### PR DESCRIPTION
# Motivation

Written by @edolstra, but PR opened by @roberth: This change comes up every now and then. I'm opening a draft PR for it, to increase visibility and so that a discussion can be had.

-------



'builtins.memoise f x' is equal to 'f x', but uses a cache to speed up repeated invocations of 'f' with the same 'x'. A typical application is memoising evaluations of Nixpkgs in NixOps network specifications. For example, with the patch below, the time to evaluate a 10-machine NixOps network is reduced from 17.1s to 9.6s, while memory consumption goes from 4486 MiB to 3089 MiB. (This is with GC_INITIAL_HEAP_SIZE=16G.)

Nixpkgs patch:

```diff
diff --git a/pkgs/top-level/impure.nix b/pkgs/top-level/impure.nix index a9f21e45aed..f641067e022 100644
--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -79,7 +79,7 @@ in
 # not be passed.
 assert args ? localSystem -> !(args ? system || args ? platform);

-import ./. (builtins.removeAttrs args [ "system" "platform" ] // { 
+builtins.memoise or (x: x) (import ./.) (builtins.removeAttrs args [ "system" "platform" ] // {
   inherit config overlays crossSystem;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.
```


# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
