### PR TITLE
Allocate a bit less

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -437,6 +437,8 @@ EvalState::EvalState(
 
     vEmptyList.mkList(buildList(0));
     vNull.mkNull();
+    vTrue.mkBool(true);
+    vFalse.mkBool(false);
     vStringRegular.mkString("regular");
     vStringDirectory.mkString("directory");
     vStringSymlink.mkString("symlink");

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -937,6 +937,9 @@ ListBuilder::ListBuilder(EvalState & state, size_t size)
     state.nrListElems += size;
 }
 
+Value * EvalState::getBool(bool b) {
+    return b ? &vTrue : &vFalse;
+}
 
 unsigned long nrThunks = 0;
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -437,6 +437,10 @@ EvalState::EvalState(
 
     vEmptyList.mkList(buildList(0));
     vNull.mkNull();
+    vStringRegular.mkString("regular");
+    vStringDirectory.mkString("directory");
+    vStringSymlink.mkString("symlink");
+    vStringUnknown.mkString("unknown");
 
     /* Initialise the Nix expression search path. */
     if (!evalSettings.pureEval) {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -650,6 +650,11 @@ public:
         return ListBuilder(*this, size);
     }
 
+    /**
+     * Return a boolean `Value *` without allocating.
+     */
+    Value *getBool(bool b);
+
     void mkThunk_(Value & v, Expr * expr);
     void mkPos(Value & v, PosIdx pos);
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -191,6 +191,15 @@ public:
      */
     Value vNull;
 
+    /** `"regular"` */
+    Value vStringRegular;
+    /** `"directory"` */
+    Value vStringDirectory;
+    /** `"symlink"` */
+    Value vStringSymlink;
+    /** `"unknown"` */
+    Value vStringUnknown;
+
     /**
      * The accessor for the root filesystem.
      */

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -187,9 +187,25 @@ public:
     Value vEmptyList;
 
     /**
-     * Null constant.
+     * `null` constant.
+     *
+     * This is _not_ a singleton. Pointer equality is _not_ sufficient.
      */
     Value vNull;
+
+    /**
+     * `true` constant.
+     *
+     * This is _not_ a singleton. Pointer equality is _not_ sufficient.
+     */
+    Value vTrue;
+
+    /**
+     * `true` constant.
+     *
+     * This is _not_ a singleton. Pointer equality is _not_ sufficient.
+     */
+    Value vFalse;
 
     /** `"regular"` */
     Value vStringRegular;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2845,8 +2845,7 @@ static void prim_functionArgs(EvalState & state, const PosIdx pos, Value * * arg
 
     auto attrs = state.buildBindings(args[0]->lambda.fun->formals->formals.size());
     for (auto & i : args[0]->lambda.fun->formals->formals)
-        // !!! should optimise booleans (allocate only once)
-        attrs.alloc(i.name, i.pos).mkBool(i.def);
+        attrs.insert(i.name, state.getBool(i.def), i.pos);
     v.mkAttrs(attrs);
 }
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -896,10 +896,11 @@ static void prim_tryEval(EvalState & state, const PosIdx pos, Value * * args, Va
     try {
         state.forceValue(*args[0], pos);
         attrs.insert(state.sValue, args[0]);
-        attrs.alloc("success").mkBool(true);
+        attrs.insert(state.symbols.create("success"), &state.vTrue);
     } catch (AssertionError & e) {
-        attrs.alloc(state.sValue).mkBool(false);
-        attrs.alloc("success").mkBool(false);
+        // `value = false;` is unfortunate but removing it is a breaking change.
+        attrs.insert(state.sValue, &state.vFalse);
+        attrs.insert(state.symbols.create("success"), &state.vFalse);
     }
 
     // restore the debugRepl pointer if we saved it earlier.

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -159,7 +159,7 @@ public:
     iterator begin() { return &elems[0]; }
     iterator end() { return &elems[size]; }
 
-    friend class Value;
+    friend struct Value;
 };
 
 


### PR DESCRIPTION
# Motivation

Check off a few dumb optimizations and a `!!!`, so that we allocate a little less in
- `readDir`
- `functionArgs`
- similarly, the `Bindings::alloc` call sites that are invoked more than a couple of times.

Also fixes a trivial warning emitted by clang.

# Context

Like `vNull` which snuck into #10251.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
