### PR TITLE
Update the release cycle

### DIFF
--- a/doc/manual/src/SUMMARY.md.in
+++ b/doc/manual/src/SUMMARY.md.in
@@ -119,7 +119,7 @@
   - [Experimental Features](contributing/experimental-features.md)
   - [CLI guideline](contributing/cli-guideline.md)
   - [C++ style guide](contributing/cxx.md)
-- [Release Notes](release-notes/index.md)
+- [Releases](release-notes/index.md)
 {{#include ./SUMMARY-rl-next.md}}
   - [Release 2.21 (2024-03-11)](release-notes/rl-2.21.md)
   - [Release 2.20 (2024-01-29)](release-notes/rl-2.20.md)

--- a/doc/manual/src/release-notes/index.md
+++ b/doc/manual/src/release-notes/index.md
@@ -2,14 +2,15 @@
 
 The Nix release cycle is calendar-based as follows:
 
-- A new minor version (`XX.YY+1.0`) is published every month and supported for two months;
-- A new major version (`XX+1.1.0`) is published twice a year, in April and October, and supported for eight months.
+Nix has a release cycle of roughly 6 weeks.
+Notable changes and additions are announced in the release notes for each version.
 
-The rationale behind that cycle is that
-- Minor versions stay close to master and bring early access to new features for the user who need them;
-- Major versions are aligned with the NixOS releases (released one month before NixOS and supported for as long at it).
+The supported Nix versions are:
+- The latest release
+- The version used in the stable NixOS release, which is announced in the [NixOS release notes](https://nixos.org/manual/nixos/stable/release-notes.html#ch-release-notes).
 
 Bugfixes and security issues are backported to every supported version.
 Patch releases are published as needed.
 
 Notable changes and additions are announced in the release notes for each version.
+

--- a/doc/manual/src/release-notes/index.md
+++ b/doc/manual/src/release-notes/index.md
@@ -1,12 +1,15 @@
 # Nix Release Notes
 
-Nix has a release cycle of roughly 6 weeks.
+The Nix release cycle is calendar-based as follows:
+
+- A new minor version (`XX.YY+1.0`) is published every month and supported for two months;
+- A new major version (`XX+1.1.0`) is published twice a year, in April and October, and supported for eight months.
+
+The rationale behind that cycle is that
+- Minor versions stay close to master and bring early access to new features for the user who need them;
+- Major versions are aligned with the NixOS releases (released one month before NixOS and supported for as long at it).
+
+Bugfixes and security issues are backported to every supported version.
+Patch releases are published as needed.
+
 Notable changes and additions are announced in the release notes for each version.
-
-Bugfixes can be backported on request to previous Nix releases.
-We typically backport only as far back as the Nix version used in the latest NixOS release, which is announced in the [NixOS release notes](https://nixos.org/manual/nixos/stable/release-notes.html#ch-release-notes).
-
-Backports never skip releases.
-If a feature is backported to version `x.y`, it must also be available in version `x.(y+1)`.
-This ensures that upgrading from an older version with backports is still safe and no backported functionality will go missing.
-

--- a/doc/manual/src/release-notes/index.md
+++ b/doc/manual/src/release-notes/index.md
@@ -11,6 +11,3 @@ The supported Nix versions are:
 
 Bugfixes and security issues are backported to every supported version.
 Patch releases are published as needed.
-
-Notable changes and additions are announced in the release notes for each version.
-


### PR DESCRIPTION
The [6-weeks release schedule](https://discourse.nixos.org/t/nix-release-schedule-and-roadmap/14204) that we've been using for several years doesn't really work-out that well (the best proof being that the Nixpkgs maintainers decided to sidestep it completely and freeze the stable Nix version in the stable NixOS releases).

Rework it to match more closely the reality and round a few sharp edges:

- Align the “frequent” release cycle with the calendar
  - The 6-weeks release cycle is hard to keep track of. A monthly
    release will make it much easier to remember the release date.
- Officialise the support for a stable version maintained for as long as NixOS stable
  - This is already the case in practice, it just happens that the
    “stable” Nixpkgs version is whichever version was deemed
    stable-enough at the time of the NixOS release.
    Officialise that by cutting a new major release alongside each NixOS one.

Note that this breaks whatever semver compatibility Nix might pretend to
have, but I don't think it makes sense any way.

cc @NixOS/nix-team @NixOS/nix-issue-triage

Also cc @flokli and @raitobezarius as the maintainers of the Nix package in Nixpkgs
