### PR TITLE
Use `--keep-going` to make the garbage collector continue upon error

### DIFF
--- a/doc/manual/src/command-ref/nix-collect-garbage.md
+++ b/doc/manual/src/command-ref/nix-collect-garbage.md
@@ -4,7 +4,7 @@
 
 # Synopsis
 
-`nix-collect-garbage` [`--delete-old`] [`-d`] [`--delete-older-than` *period*] [`--max-freed` *bytes*] [`--dry-run`]
+`nix-collect-garbage` [`--delete-old`] [`-d`] [`--delete-older-than` *period*] [`--max-freed` *bytes*] [`--dry-run`] [`--keep-going`]
 
 # Description
 

--- a/doc/manual/src/command-ref/nix-store/gc.md
+++ b/doc/manual/src/command-ref/nix-store/gc.md
@@ -4,7 +4,7 @@
 
 # Synopsis
 
-`nix-store` `--gc` [`--print-roots` | `--print-live` | `--print-dead`] [`--max-freed` *bytes*]
+`nix-store` `--gc` [`--print-roots` | `--print-live` | `--print-dead`] [`--max-freed` *bytes*] [`--keep-going`]
 
 # Description
 

--- a/doc/manual/src/command-ref/opt-common.md
+++ b/doc/manual/src/command-ref/opt-common.md
@@ -118,6 +118,7 @@ Most Nix commands accept the following command-line options:
   Keep going in case of failed builds, to the greatest extent possible.
   That is, if building an input of some derivation fails, Nix will still build the other inputs, but not the derivation itself.
   Without this option, Nix stops if any build fails (except for builds of substitutes), possibly killing builds in progress (in case of parallel or distributed builds).
+  In the context of garbage collection, this option indicates that the garbage collector should continue deleting garbage even if an error occurs while deleting a path.
 
 - <span id="opt-keep-failed">[`--keep-failed`](#opt-keep-failed)</span> / `-K`
 

--- a/src/nix/store-gc.md
+++ b/src/nix/store-gc.md
@@ -14,6 +14,12 @@ R""(
   # nix store gc --max 1G
   ```
 
+* Keep deleting garbage even if an error occurs while deleting a path:
+
+  ```console
+  # nix store gc --keep-going
+  ```
+
 # Description
 
 This command deletes unreachable paths in the Nix store.


### PR DESCRIPTION
Currently, when an error occurs during garbage collection, the process is aborted and the error is reported. This is not ideal, as it means that the garbage collection is not completed and garbage will continue to be accumulated.

Example:

```
error: cannot delete path '/nix/store/4haq90hy2jz3i9n359zpw3bfan9jm0ss-glib-networking-2.78.0' because it is in use by '/nix/store/94nz5lnlsi4ss53izwg1ikifk4bxrs6g-seahorse-43.0', '/nix/store/mfw6k5a1712zqd6q2h4h3ipmx3q0lb1n-geoclue-2.7.0'
```

In this commit, we reuse the existing option `--keep-going` to allow the garbage collection to continue when an error occurs.

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
