### PR TITLE
Docs: Documentation manual build output path correction

### DIFF
--- a/doc/manual/src/contributing/documentation.md
+++ b/doc/manual/src/contributing/documentation.md
@@ -30,7 +30,7 @@ To build the manual incrementally, [enter the development shell](./hacking.md) a
 make manual-html -j $NIX_BUILD_CORES
 ```
 
-and open `./outputs/out/share/doc/nix/manual/language/index.html`.
+and open `./outputs/doc/share/doc/nix/manual/language/index.html`.
 
 In order to reflect changes to the [Makefile for the manual], clear all generated files before re-building:
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

[Here](https://nixos.org/manual/nix/unstable/contributing/documentation#building-the-manual) in incremental building of the manual part,
the current documentation says output is in the `./outputs/out/` sub-directory, 
but the build command actually produces output at `./outputs/doc/` sub-directory

![image](https://github.com/NixOS/nix/assets/80959679/4472657a-0915-44d0-b712-bd266698f89c)



# Context
<!-- Provide context. Reference open issues if available. -->
- The `--docdir` flag used to build the output seems to be a [standard directory variable](https://www.gnu.org/software/automake/manual/automake.html#Standard-Directory-Variables) of automake tools
- current build process of man-pages [Here](https://github.com/dottharun/nix/blob/4e2f11b6927cb0e4171b2758196f2310760617d2/doc/manual/local.mk#L177)
- This PR captures my learning of the Nix code and marks my first contribution to the codebase
<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
