### PR TITLE
Run the Nixpkgs tests on Hydra

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -313,6 +313,8 @@
                   nixVersions = [ self.packages.${system}.nix ];
                 }
             );
+
+            nixosTests = lib.genAttrs linuxSystems (system: nixpkgsFor.${system}.native.nixosTests);
         };
 
         metrics.nixpkgs = import "${nixpkgs-regression}/pkgs/top-level/metrics.nix" {


### PR DESCRIPTION
Add `nixosTests` to the hydra jobset to ensure that we're not breaking them as it has been reported as frequently catching Nix bugs on the Nixpkgs-side.

Fix #9743 

Note that this doesn't run them on the GitHub CI atm (this would be too expensive).
I also don't think it can be merged as-it-is because there's a (un)-healthy amount of [broken tests](https://hydra.nixos.org/eval/1805136?filter=nixos.tests&full=1&compare=1805101#tabs-still-fail) from the NixOS side, so this would be completely meaningless if we don't find a good way of filtering things out.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
