### PR TITLE
Doc: explicitly specify which shell to use to get clangd

### DIFF
--- a/doc/manual/src/contributing/hacking.md
+++ b/doc/manual/src/contributing/hacking.md
@@ -261,7 +261,7 @@ To use the LSP with your editor, you first need to [set up `clangd`](https://cla
 make compile_commands.json
 ```
 
-Configure your editor to use the `clangd` from the shell, either by running it inside the development shell, or by using [nix-direnv](https://github.com/nix-community/nix-direnv) and [the appropriate editor plugin](https://github.com/direnv/direnv/wiki#editor-integration).
+Configure your editor to use the `clangd` from the `.#native-clangStdenvPackages` shell. You can do that either by running it inside the development shell, or by using [nix-direnv](https://github.com/nix-community/nix-direnv) and [the appropriate editor plugin](https://github.com/direnv/direnv/wiki#editor-integration).
 
 > **Note**
 >


### PR DESCRIPTION
I was using by mistake the .#nix-clangStdenv shell to retrieve clangd. This clangd is unusable with the project and constantly segfaults. Let's explicitly state which shell the user should use in the docs.

I don't really understand the source of this segfault. I assume it's related to a clang version incompatibility. (16.0.6 for .#nix-clangStdenv 14.0.6 for .#native-clangStdenvPackages)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
