### PR TITLE
flakes: remove experimental repl-flake

### DIFF
--- a/doc/manual/rl-next/remove-repl-flake.md
+++ b/doc/manual/rl-next/remove-repl-flake.md
@@ -1,0 +1,12 @@
+---
+synopsis: Remove experimental repl-flake
+significant: significant
+issues: 10103
+prs: 10299
+---
+
+This PR removes the repl-flake feature that was adopted to provide a migration path when changing the behavior of `nix repl`. Moving forward this command will behave more like the rest of the modern cli.
+
+- Removes any repl-flake references.
+- Removes the parts of `applyDefaultInstallables` that are no longer needed in repl.cc.
+- Fix/Add any tests.

--- a/doc/manual/rl-next/remove-repl-flake.md
+++ b/doc/manual/rl-next/remove-repl-flake.md
@@ -5,8 +5,4 @@ issues: 10103
 prs: 10299
 ---
 
-This PR removes the repl-flake feature that was adopted to provide a migration path when changing the behavior of `nix repl`. Moving forward this command will behave more like the rest of the modern cli.
-
-- Removes any repl-flake references.
-- Removes the parts of `applyDefaultInstallables` that are no longer needed in repl.cc.
-- Fix/Add any tests.
+The `repl-flake` experimental feature has been removed. The `nix repl` command now works like the rest of the new CLI in that `nix repl {path}` now tries to load a flake at `{path}` (or fails if the `flakes` experimental feature isn't enabled).*

--- a/doc/manual/rl-next/remove-repl-flake.md
+++ b/doc/manual/rl-next/remove-repl-flake.md
@@ -1,6 +1,6 @@
 ---
 synopsis: Remove experimental repl-flake
-significant: significant
+significance: significant
 issues: 10103
 prs: 10299
 ---

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -204,16 +204,6 @@ constexpr std::array<ExperimentalFeatureDetails, numXpFeatures> xpFeatureDetails
         .trackingUrl = "https://github.com/NixOS/nix/milestone/40",
     },
     {
-        .tag = Xp::ReplFlake,
-        .name = "repl-flake",
-        .description = R"(
-            *Enabled with [`flakes`](#xp-feature-flakes) since 2.19*
-
-            Allow passing [installables](@docroot@/command-ref/new-cli/nix.md#installables) to `nix repl`, making its interface consistent with the other experimental commands.
-        )",
-        .trackingUrl = "https://github.com/NixOS/nix/milestone/32",
-    },
-    {
         .tag = Xp::AutoAllocateUids,
         .name = "auto-allocate-uids",
         .description = R"(

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -26,7 +26,6 @@ enum struct ExperimentalFeature
     RecursiveNix,
     NoUrlLiterals,
     FetchClosure,
-    ReplFlake,
     AutoAllocateUids,
     Cgroups,
     DaemonTrustOverride,

--- a/src/nix/repl.cc
+++ b/src/nix/repl.cc
@@ -47,15 +47,6 @@ struct CmdRepl : RawInstallablesCommand
 
     void applyDefaultInstallables(std::vector<std::string> & rawInstallables) override
     {
-        if (!experimentalFeatureSettings.isEnabled(Xp::Flakes) && !(file) && rawInstallables.size() >= 1) {
-            warn("future versions of Nix will require using `--file` to load a file");
-            if (rawInstallables.size() > 1)
-                warn("more than one input file is not currently supported");
-            auto filePath = rawInstallables[0].data();
-            file = std::optional(filePath);
-            rawInstallables.front() = rawInstallables.back();
-            rawInstallables.pop_back();
-        }
         if (rawInstallables.empty() && (file.has_value() || expr.has_value())) {
             rawInstallables.push_back(".");
         }

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -47,6 +47,9 @@ testRepl () {
       | grep "attribute 'currentSystem' missing"
     nix repl "${nixArgs[@]}" 2>&1 <<< "builtins.currentSystem" \
       | grep "$(nix-instantiate --eval -E 'builtins.currentSystem')"
+
+    expectStderr 1 nix repl ${testDir}/simple.nix \
+      | grepQuiet -s "error: path '$testDir/simple.nix' is not a flake"
 }
 
 # Simple test, try building a drv


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
This PR removes the repl-flake feature that was adopted to provide a migration path when changing the behavior of `nix repl`.  Moving forward this command will behave more like the rest of the modern cli.

```
# No longer evaluates and returns the same error as nix run
nix repl default.nix

>>> error: path 'default.nix' is not a flake (because it's not a directory)

# Works as before
nix repl --file default.nix
```

# Context
<!-- Provide context. Reference open issues if available. -->

Fixes https://github.com/NixOS/nix/issues/10103

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

No major changes from a code perspective. I only removed a small amount. `applyDefaultInstallables` still plays a part in allowing `nix repl` to run without any arguments so it's not removed entirely. 

Tests all pass but it would probably be good to add a test that expects `nix repl default.nix` to fail? One question I might have: should there still be a warning or clarification if the --file flag is not used or was deprecation warning from previous version enough?

If anyone has suggestions or edits, let me know.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
