### PR TITLE
docs: update uninstall.md to include removal of `bash.bashrc.backup-before-nix` file

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -141,6 +141,10 @@ which you may remove.
 > directory. This is an expected sign of a successful uninstall. The empty
 > `/nix` directory will disappear the next time you reboot.
 >
+> You may still have `bash.bashrc.backup-before-nix` file despite it being empty,
+> preventing the install to work properly. Removing this with `sudo rm -f bash.bashrc.backup-before-nix`
+> may help.
+>
 > You do not have to reboot to finish uninstalling Nix. The uninstall is
 > complete. macOS (Catalina+) directly controls root directories and its
 > read-only root will prevent you from manually deleting the empty `/nix`


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Was following the uninstall docs and still couldn't get the install to work until i realized i needed to remove the actual `bash.bashrc.backup-before-nix` file completely despite it being empty. I've added this in the final note of the docs in the event that others run into this issue also.
# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
