### PR TITLE
Always print addErrorContext

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1665,7 +1665,8 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                 try {
                     fn->fun(*this, vCur.determinePos(noPos), args, vCur);
                 } catch (Error & e) {
-                    addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
+                    if (fn->addTrace)
+                        addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
                     throw;
                 }
 
@@ -1713,7 +1714,8 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                     //    so the debugger allows to inspect the wrong parameters passed to the builtin.
                     fn->fun(*this, vCur.determinePos(noPos), vArgs, vCur);
                 } catch (Error & e) {
-                    addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
+                    if (fn->addTrace)
+                        addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
                     throw;
                 }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -70,6 +70,13 @@ struct PrimOp
     const char * doc = nullptr;
 
     /**
+     * Add a trace item, `while calling the '<name>' builtin`
+     *
+     * This is used to remove the redundant item for `builtins.addErrorContext`.
+     */
+    bool addTrace = true;
+
+    /**
      * Implementation of the primop.
      */
     PrimOpFun fun;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -826,7 +826,7 @@ static void prim_addErrorContext(EvalState & state, const PosIdx pos, Value * * 
         auto message = state.coerceToString(pos, *args[0], context,
                 "while evaluating the error message passed to builtins.addErrorContext",
                 false, false).toOwned();
-        e.addTrace(nullptr, HintFmt(message), TraceKind::Custom);
+        e.addTrace(nullptr, HintFmt(message), TracePrint::Always);
         throw;
     }
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -826,7 +826,7 @@ static void prim_addErrorContext(EvalState & state, const PosIdx pos, Value * * 
         auto message = state.coerceToString(pos, *args[0], context,
                 "while evaluating the error message passed to builtins.addErrorContext",
                 false, false).toOwned();
-        e.addTrace(nullptr, HintFmt(message));
+        e.addTrace(nullptr, HintFmt(message), TraceKind::Custom);
         throw;
     }
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -834,6 +834,8 @@ static void prim_addErrorContext(EvalState & state, const PosIdx pos, Value * * 
 static RegisterPrimOp primop_addErrorContext(PrimOp {
     .name = "__addErrorContext",
     .arity = 2,
+    // The normal trace item is redundant
+    .addTrace = false,
     .fun = prim_addErrorContext,
 });
 

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -163,7 +163,7 @@ static bool printPosMaybe(std::ostream & oss, std::string_view indent, const std
     return hasPos;
 }
 
-void printTrace(
+static void printTrace(
     std::ostream & output,
     const std::string_view & indent,
     size_t & count,

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -11,9 +11,9 @@
 
 namespace nix {
 
-void BaseError::addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TraceKind kind)
+void BaseError::addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TracePrint print)
 {
-    err.traces.push_front(Trace { .pos = std::move(e), .hint = hint, .kind = kind });
+    err.traces.push_front(Trace { .pos = std::move(e), .hint = hint, .print = print });
 }
 
 void throwExceptionSelfCheck(){
@@ -388,7 +388,7 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
                 truncate = true;
             }
 
-            if (!truncate || trace.kind == TraceKind::Custom) {
+            if (!truncate || trace.print == TracePrint::Always) {
 
                 if (tracesSeen.count(trace)) {
                     skippedTraces.push_back(trace);

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -61,16 +61,22 @@ void printCodeLines(std::ostream & out,
     const Pos & errPos,
     const LinesOfCode & loc);
 
-enum struct TraceKind {
-    Other,
-    /** Produced by builtins.addErrorContext. Always printed. */
-    Custom,
+/**
+ * When a stack frame is printed.
+ */
+enum struct TracePrint {
+    /**
+     * The default behavior; always printed when `--show-trace` is set.
+     */
+    Default,
+    /** Always printed. Produced by `builtins.addErrorContext`. */
+    Always,
 };
 
 struct Trace {
     std::shared_ptr<Pos> pos;
     HintFmt hint;
-    TraceKind kind = TraceKind::Other;
+    TracePrint print = TracePrint::Default;
 };
 
 inline bool operator<(const Trace& lhs, const Trace& rhs);
@@ -168,7 +174,7 @@ public:
         addTrace(std::move(e), HintFmt(std::string(fs), args...));
     }
 
-    void addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TraceKind kind = TraceKind::Other);
+    void addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TracePrint print = TracePrint::Default);
 
     bool hasTrace() const { return !err.traces.empty(); }
 

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -61,9 +61,16 @@ void printCodeLines(std::ostream & out,
     const Pos & errPos,
     const LinesOfCode & loc);
 
+enum struct TraceKind {
+    Other,
+    /** Produced by builtins.addErrorContext. Always printed. */
+    Custom,
+};
+
 struct Trace {
     std::shared_ptr<Pos> pos;
     HintFmt hint;
+    TraceKind kind = TraceKind::Other;
 };
 
 inline bool operator<(const Trace& lhs, const Trace& rhs);
@@ -161,7 +168,7 @@ public:
         addTrace(std::move(e), HintFmt(std::string(fs), args...));
     }
 
-    void addTrace(std::shared_ptr<Pos> && e, HintFmt hint);
+    void addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TraceKind kind = TraceKind::Other);
 
     bool hasTrace() const { return !err.traces.empty(); }
 

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -68,8 +68,16 @@ done
 for i in lang/eval-fail-*.nix; do
     echo "evaluating $i (should fail)";
     i=$(basename "$i" .nix)
+    flags="$(
+        if [[ -e "lang/$i.flags" ]]; then
+            sed -e 's/#.*//' < "lang/$i.flags"
+        else
+            # note that show-trace is also set by init.sh
+            echo "--eval --strict --show-trace"
+        fi
+    )"
     if
-        expectStderr 1 nix-instantiate --eval --strict --show-trace "lang/$i.nix" \
+        expectStderr 1 nix-instantiate $flags "lang/$i.nix" \
             | sed "s!$(pwd)!/pwd!g" > "lang/$i.err"
     then
         diffAndAccept "$i" err err.exp

--- a/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
+++ b/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
@@ -1,19 +1,5 @@
 error:
-       … while calling the 'addErrorContext' builtin
-         at /pwd/lang/eval-fail-addErrorContext-example.nix:6:7:
-            5|     else
-            6|       builtins.addErrorContext
-             |       ^
-            7|         "while counting down; n = ${toString n}"
-
        … while counting down; n = 10
-
-       … while calling the 'addErrorContext' builtin
-         at /pwd/lang/eval-fail-addErrorContext-example.nix:6:7:
-            5|     else
-            6|       builtins.addErrorContext
-             |       ^
-            7|         "while counting down; n = ${toString n}"
 
        … while counting down; n = 9
 

--- a/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
+++ b/tests/functional/lang/eval-fail-addErrorContext-example.err.exp
@@ -1,0 +1,38 @@
+error:
+       … while calling the 'addErrorContext' builtin
+         at /pwd/lang/eval-fail-addErrorContext-example.nix:6:7:
+            5|     else
+            6|       builtins.addErrorContext
+             |       ^
+            7|         "while counting down; n = ${toString n}"
+
+       … while counting down; n = 10
+
+       … while calling the 'addErrorContext' builtin
+         at /pwd/lang/eval-fail-addErrorContext-example.nix:6:7:
+            5|     else
+            6|       builtins.addErrorContext
+             |       ^
+            7|         "while counting down; n = ${toString n}"
+
+       … while counting down; n = 9
+
+       … while counting down; n = 8
+
+       … while counting down; n = 7
+
+       … while counting down; n = 6
+
+       … while counting down; n = 5
+
+       … while counting down; n = 4
+
+       … while counting down; n = 3
+
+       … while counting down; n = 2
+
+       … while counting down; n = 1
+
+       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
+
+       error: kaboom

--- a/tests/functional/lang/eval-fail-addErrorContext-example.flags
+++ b/tests/functional/lang/eval-fail-addErrorContext-example.flags
@@ -1,0 +1,1 @@
+--eval --strict --no-show-trace

--- a/tests/functional/lang/eval-fail-addErrorContext-example.nix
+++ b/tests/functional/lang/eval-fail-addErrorContext-example.nix
@@ -1,0 +1,9 @@
+let
+  countDown = n:
+    if n == 0
+    then throw "kaboom"
+    else
+      builtins.addErrorContext
+        "while counting down; n = ${toString n}"
+        ("x" + countDown (n - 1));
+in countDown 10


### PR DESCRIPTION
# Motivation

`addErrorContext` traces are sufficiently valuable and usually terse, so they should always be shown.

# Context

- Closes https://github.com/NixOS/nix/issues/7553
  - no `--no-trace`, which might actually be confusing, because of `--no-show-trace`, which is a simple negation of `--show-trace`.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
