### PR TITLE
test: for derivation output selection with `.`

### DIFF
--- a/tests/functional/flakes/build-paths.sh
+++ b/tests/functional/flakes/build-paths.sh
@@ -56,6 +56,18 @@ cat > $flake1Dir/flake.nix <<EOF
     a12 = self.drvCall.outPath;
 
     a13 = "\${self.drvCall.drvPath}\${self.drvCall.outPath}";
+
+    a14 = with import ./config.nix; mkDerivation {
+      name = "dot-installable";
+      outputs = [ "foo" "out" ];
+      meta.outputsToInstall = [ "out" ];
+      buildCommand = ''
+          mkdir \$foo \$out
+          echo "foo" > \$foo/file
+          echo "out" > \$out/file
+      '';
+      outputSpecified = true;
+    };
   };
 }
 EOF
@@ -94,3 +106,10 @@ nix build --json --out-link $TEST_ROOT/result $flake1Dir#a12
 
 expectStderr 1 nix build --impure --json --out-link $TEST_ROOT/result $flake1Dir#a13 \
   | grepQuiet "has 2 entries in its context. It should only have exactly one entry"
+
+# Test accessing output in installables with `.` (foobarbaz.<output>)
+nix build --json --no-link $flake1Dir#a14.foo | jq --exit-status '
+  (.[0] |
+    (.drvPath | match(".*dot-installable.drv")) and
+    (.outputs | keys == ["foo"]))
+'

--- a/tests/functional/flakes/build-paths.sh
+++ b/tests/functional/flakes/build-paths.sh
@@ -57,16 +57,21 @@ cat > $flake1Dir/flake.nix <<EOF
 
     a13 = "\${self.drvCall.drvPath}\${self.drvCall.outPath}";
 
-    a14 = with import ./config.nix; mkDerivation {
-      name = "dot-installable";
-      outputs = [ "foo" "out" ];
-      meta.outputsToInstall = [ "out" ];
-      buildCommand = ''
-          mkdir \$foo \$out
-          echo "foo" > \$foo/file
-          echo "out" > \$out/file
-      '';
-      outputSpecified = true;
+    a14 = with import ./config.nix; let
+      top = mkDerivation {
+        name = "dot-installable";
+        outputs = [ "foo" "out" ];
+        meta.outputsToInstall = [ "out" ];
+        buildCommand = ''
+            mkdir \$foo \$out
+            echo "foo" > \$foo/file
+            echo "out" > \$out/file
+        '';
+      };
+    in top // {
+      foo = top.foo // {
+        outputSpecified = true;
+      };
     };
   };
 }

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -285,35 +285,6 @@ git -C "$flake3Dir" add flake.lock
 
 git -C "$flake3Dir" commit -m 'Add lockfile'
 
-# Test accessing output in installables with `.` (foobarbaz.<output>)
-cat > "$flake3Dir/flake.nix" <<EOF
-{
-    outputs = {self}: {
-      packages.$system.hello = (import ./config.nix).mkDerivation {
-        name = "hello";
-        outputs = [ "foo" "out" ];
-        meta.outputsToInstall = [ "out" ];
-        buildCommand = ''
-            mkdir \$foo \$out
-            echo "foo" > \$foo/file
-            echo "out" > \$out/file
-        '';
-        outputSpecified = true;
-      };
-    };
-}
-EOF
-
-cp ../config.nix "$flake3Dir"
-git -C "$flake3Dir" add flake.nix config.nix
-git -C "$flake3Dir" commit -m 'multi outputs flake'
-
-nix build "$flake3Dir#hello.foo" --json --no-link | jq --exit-status '
-  (.[0] |
-    (.drvPath | match(".*hello.drv")) and
-    (.outputs | keys == ["foo"]))
-'
-
 # Test whether registry caching works.
 nix registry list --flake-registry "file://$registry" | grepQuiet flake3
 mv "$registry" "$registry.tmp"


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
added test and fixes #7236 

As discussed in #7236, after #6589 the command `nix build nixpkgs#libxml2.dev` correctly builds the `dev` output
  - and this pr adds test for this behavior

Also as pointed out by @Ericson2314 [Here](https://github.com/NixOS/nix/issues/7236#issuecomment-1295943559)
  - #6589 uses `outputSpecified` attribute in derivations (Nixpkgs convention) to enable this behavior

![image](https://github.com/NixOS/nix/assets/80959679/d4456d3a-997a-48da-a2ae-f562f95f15d7)

# Context
<!-- Provide context. Reference open issues if available. -->
- The test uses [nix build](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-build) command with [--json](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-build#opt-json) and [--no-link](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-build#opt-no-link) flags
- which are then passed to [jq](https://jqlang.github.io/jq/manual/) with [match](https://jqlang.github.io/jq/manual/#match), [keys](https://jqlang.github.io/jq/manual/#keys-keys_unsorted) filters for checking the output names and derivations
- `outputSpecified` attribute in Nixpkgs [Here](https://github.com/NixOS/nixpkgs/blob/57e6b3a9e4ebec5aa121188301f04a6b8c354c9b/lib/customisation.nix#L350)
- `meta.outputsToInstall` attribute is used in the test because originally with #6426 `outputsToInstall` is given more priority that command-line argument, thats why we are testing that behaviour too
- this pr marks my first contribution to the nix code-base except documentation capturing all my learnings

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
