### PR TITLE
Remove "error:" prefix to SQLite warning message

### DIFF
--- a/src/libstore/sqlite.hh
+++ b/src/libstore/sqlite.hh
@@ -158,7 +158,12 @@ protected:
 
 };
 
-MakeError(SQLiteBusy, SQLiteError);
+struct SQLiteBusy : SQLiteError
+{
+    SQLiteBusy(const char *path, const char *errMsg, int errNo, int extendedErrNo, int offset, HintFmt && hf)
+      : SQLiteError(path, errMsg, errNo, extendedErrNo, offset, std::move(hf))
+    { err.level = lvlWarn; }
+};
 
 void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning);
 

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -25,8 +25,12 @@ void throwExceptionSelfCheck(){
 // This stringifies the error and caches it for use by what(), or similarly by msg().
 const std::string & BaseError::calcWhat() const
 {
-    if (what_.has_value())
+    if (what_.has_value()) {
+        if (err.level == Verbosity::lvlWarn) {
+            removeErrorPrefix(*what_);
+        }
         return *what_;
+    }
     else {
         std::ostringstream oss;
         showErrorInfo(oss, err, loggerSettings.showTrace);

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -324,6 +324,12 @@ bool handleJSONLogMessage(const std::string & msg,
     return handleJSONLogMessage(*json, act, activities, trusted);
 }
 
+void removeErrorPrefix(std::string & msg)
+{
+    if (hasPrefix(msg, "error: "))
+        msg.erase(0, 7);
+}
+
 Activity::~Activity()
 {
     try {

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -257,4 +257,6 @@ inline void warn(const std::string & fs, const Args & ... args)
 
 void writeToStderr(std::string_view s);
 
+void removeErrorPrefix(std::string & msg);
+
 }


### PR DESCRIPTION
Avoid the confusing error message "warning: error: SQLite database '/nix/var/nix/db/db.sqlite' is busy".  Instead, just print "warning: ..." as the message.

Fixes #6656 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
