### PR TITLE
build-remote: fix format string shenanigans

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -202,7 +202,7 @@ static int main_build_remote(int argc, char * * argv)
                         else
                             drvstr = "<unknown>";
 
-                        auto error = HintFmt(errorText);
+                        auto error = HintFmt::fromFormatString(errorText);
                         error
                             % drvstr
                             % neededSystem

--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -144,6 +144,10 @@ public:
         : HintFmt("%s", Uncolored(literal))
     { }
 
+    static HintFmt fromFormatString(const std::string & format) {
+        return HintFmt(boost::format(format));
+    }
+
     /**
      * Interpolate the given arguments into the format string.
      */


### PR DESCRIPTION
HintFmt(string) invokes the HintFmt("%s", literal) constructor, which is not what we want here. Add a constructor with a proper name and call that.

Next step: rename all the other ones to HintFmt::literal(string).

Fixes https://github.com/NixOS/nix/issues/10238

Shoutout @lf- and @puckipedia for helping debug this.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
