### PR TITLE
Build system changes for MinGW support

### DIFF
--- a/local.mk
+++ b/local.mk
@@ -7,4 +7,4 @@ $(foreach i, config.h $(wildcard src/lib*/*.hh), \
 
 $(GCH): src/libutil/util.hh config.h
 
-GCH_CXXFLAGS = -I src/libutil
+GCH_CXXFLAGS = $(INCLUDE_libutil)

--- a/package.nix
+++ b/package.nix
@@ -338,6 +338,12 @@ in {
     echo "doc internal-api-docs $out/share/doc/nix/internal-api/html" >> ''${!outputDoc}/nix-support/hydra-build-products
   '';
 
+  # So the check output gets links for DLLs in the out output.
+  preFixup = lib.optionalString (stdenv.hostPlatform.isWindows && builtins.elem "check" finalAttrs.outputs) ''
+    ln -s "$check/lib/"*.dll "$check/bin"
+    ln -s "$out/bin/"*.dll "$check/bin"
+  '';
+
   doInstallCheck = attrs.doInstallCheck;
 
   installCheckFlags = "sysconfdir=$(out)/etc";

--- a/package.nix
+++ b/package.nix
@@ -75,7 +75,10 @@
 # sounds so long as evaluation just takes places within short-lived
 # processes. (When the process exits, the memory is reclaimed; it is
 # only leaked *within* the process.)
-, enableGC ? true
+#
+# Temporarily disabled on Windows because the `GC_throw_bad_alloc`
+# symbol is missing during linking.
+, enableGC ? !stdenv.hostPlatform.isWindows
 
 # Whether to enable Markdown rendering in the Nix binary.
 , enableMarkdown ? !stdenv.hostPlatform.isWindows

--- a/src/libcmd/local.mk
+++ b/src/libcmd/local.mk
@@ -6,7 +6,7 @@ libcmd_DIR := $(d)
 
 libcmd_SOURCES := $(wildcard $(d)/*.cc)
 
-libcmd_CXXFLAGS += -I src/libutil -I src/libstore -I src/libexpr -I src/libmain -I src/libfetchers
+libcmd_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore) $(INCLUDE_libfetchers) $(INCLUDE_libexpr) -I src/libmain
 
 libcmd_LDFLAGS = $(EDITLINE_LIBS) $(LOWDOWN_LIBS) $(THREAD_LDFLAGS)
 

--- a/src/libexpr/local.mk
+++ b/src/libexpr/local.mk
@@ -11,8 +11,11 @@ libexpr_SOURCES := \
   $(wildcard $(d)/flake/*.cc) \
   $(d)/lexer-tab.cc \
   $(d)/parser-tab.cc
+# Not just for this library itself, but also for downstream libraries using this library
 
-libexpr_CXXFLAGS += -I src/libutil -I src/libstore -I src/libfetchers -I src/libmain -I src/libexpr
+INCLUDE_libexpr := -I $(d)
+
+libexpr_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore) $(INCLUDE_libfetchers) -I src/libmain $(INCLUDE_libexpr)
 
 libexpr_LIBS = libutil libstore libfetchers
 

--- a/src/libfetchers/local.mk
+++ b/src/libfetchers/local.mk
@@ -6,7 +6,11 @@ libfetchers_DIR := $(d)
 
 libfetchers_SOURCES := $(wildcard $(d)/*.cc)
 
-libfetchers_CXXFLAGS += -I src/libutil -I src/libstore
+# Not just for this library itself, but also for downstream libraries using this library
+
+INCLUDE_libfetchers := -I $(d)
+
+libfetchers_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore) $(INCLUDE_libfetchers)
 
 libfetchers_LDFLAGS += $(THREAD_LDFLAGS) $(LIBGIT2_LIBS) -larchive
 

--- a/src/libmain/local.mk
+++ b/src/libmain/local.mk
@@ -6,7 +6,7 @@ libmain_DIR := $(d)
 
 libmain_SOURCES := $(wildcard $(d)/*.cc)
 
-libmain_CXXFLAGS += -I src/libutil -I src/libstore
+libmain_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore)
 
 libmain_LDFLAGS += $(OPENSSL_LIBS)
 

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -10,7 +10,7 @@ libstore_LIBS = libutil
 
 libstore_LDFLAGS += $(SQLITE3_LIBS) $(LIBCURL_LIBS) $(THREAD_LDFLAGS)
 ifdef HOST_LINUX
- libstore_LDFLAGS += -ldl
+  libstore_LDFLAGS += -ldl
 endif
 
 $(foreach file,$(libstore_FILES),$(eval $(call install-data-in,$(d)/$(file),$(datadir)/nix/sandbox)))
@@ -27,8 +27,12 @@ ifeq ($(HAVE_SECCOMP), 1)
   libstore_LDFLAGS += $(LIBSECCOMP_LIBS)
 endif
 
+# Not just for this library itself, but also for downstream libraries using this library
+
+INCLUDE_libstore := -I $(d) -I $(d)/build
+
 libstore_CXXFLAGS += \
- -I src/libutil -I src/libstore -I src/libstore/build \
+ $(INCLUDE_libutil) $(INCLUDE_libstore) $(INCLUDE_libstore) \
  -DNIX_PREFIX=\"$(prefix)\" \
  -DNIX_STORE_DIR=\"$(storedir)\" \
  -DNIX_DATA_DIR=\"$(datadir)\" \

--- a/src/libutil/local.mk
+++ b/src/libutil/local.mk
@@ -6,7 +6,10 @@ libutil_DIR := $(d)
 
 libutil_SOURCES := $(wildcard $(d)/*.cc $(d)/signature/*.cc)
 
-libutil_CXXFLAGS += -I src/libutil
+# Not just for this library itself, but also for downstream libraries using this library
+
+INCLUDE_libutil := -I $(d)
+libutil_CXXFLAGS += $(INCLUDE_libutil)
 
 libutil_LDFLAGS += $(THREAD_LDFLAGS) $(LIBCURL_LIBS) $(SODIUM_LIBS) $(OPENSSL_LIBS) $(LIBBROTLI_LIBS) $(LIBARCHIVE_LIBS) $(BOOST_LDFLAGS) -lboost_context
 

--- a/src/nix/local.mk
+++ b/src/nix/local.mk
@@ -14,7 +14,7 @@ nix_SOURCES := \
   $(wildcard src/nix-instantiate/*.cc) \
   $(wildcard src/nix-store/*.cc) \
 
-nix_CXXFLAGS += -I src/libutil -I src/libstore -I src/libfetchers -I src/libexpr -I src/libmain -I src/libcmd -I doc/manual
+nix_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore) $(INCLUDE_libfetchers) $(INCLUDE_libexpr) -I src/libmain -I src/libcmd -I doc/manual
 
 nix_LIBS = libexpr libmain libfetchers libstore libutil libcmd
 

--- a/src/resolve-system-dependencies/local.mk
+++ b/src/resolve-system-dependencies/local.mk
@@ -6,7 +6,7 @@ resolve-system-dependencies_DIR := $(d)
 
 resolve-system-dependencies_INSTALL_DIR := $(libexecdir)/nix
 
-resolve-system-dependencies_CXXFLAGS += -I src/libutil -I src/libstore -I src/libmain
+resolve-system-dependencies_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore) -I src/libmain
 
 resolve-system-dependencies_LIBS := libstore libmain libutil
 

--- a/tests/functional/plugins/local.mk
+++ b/tests/functional/plugins/local.mk
@@ -8,4 +8,4 @@ libplugintest_ALLOW_UNDEFINED := 1
 
 libplugintest_EXCLUDE_FROM_LIBRARY_LIST := 1
 
-libplugintest_CXXFLAGS := -I src/libutil -I src/libstore -I src/libexpr -I src/libfetchers
+libplugintest_CXXFLAGS := $(INCLUDE_libutil) $(INCLUDE_libstore) $(INCLUDE_libexpr) $(INCLUDE_libfetchers)

--- a/tests/functional/test-libstoreconsumer/local.mk
+++ b/tests/functional/test-libstoreconsumer/local.mk
@@ -8,7 +8,7 @@ test-libstoreconsumer_INSTALL_DIR :=
 test-libstoreconsumer_SOURCES := \
   $(wildcard $(d)/*.cc) \
 
-test-libstoreconsumer_CXXFLAGS += -I src/libutil -I src/libstore
+test-libstoreconsumer_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore)
 
 test-libstoreconsumer_LIBS = libstore libutil
 

--- a/tests/unit/libexpr/local.mk
+++ b/tests/unit/libexpr/local.mk
@@ -23,10 +23,10 @@ libexpr-tests_EXTRA_INCLUDES = \
     -I tests/unit/libexpr-support \
     -I tests/unit/libstore-support \
     -I tests/unit/libutil-support \
-    -I src/libexpr \
-    -I src/libfetchers \
-    -I src/libstore \
-    -I src/libutil
+    $(INCLUDE_libexpr) \
+    $(INCLUDE_libfetchers) \
+    $(INCLUDE_libstore) \
+    $(INCLUDE_libutil)
 
 libexpr-tests_CXXFLAGS += $(libexpr-tests_EXTRA_INCLUDES)
 

--- a/tests/unit/libstore/local.mk
+++ b/tests/unit/libstore/local.mk
@@ -19,8 +19,8 @@ libstore-tests_SOURCES := $(wildcard $(d)/*.cc)
 libstore-tests_EXTRA_INCLUDES = \
     -I tests/unit/libstore-support \
     -I tests/unit/libutil-support \
-    -I src/libstore \
-    -I src/libutil
+    $(INCLUDE_libstore) \
+    $(INCLUDE_libutil)
 
 libstore-tests_CXXFLAGS += $(libstore-tests_EXTRA_INCLUDES)
 

--- a/tests/unit/libutil/local.mk
+++ b/tests/unit/libutil/local.mk
@@ -18,7 +18,7 @@ libutil-tests_SOURCES := $(wildcard $(d)/*.cc)
 
 libutil-tests_EXTRA_INCLUDES = \
     -I tests/unit/libutil-support \
-    -I src/libutil
+    $(INCLUDE_libutil)
 
 libutil-tests_CXXFLAGS += $(libutil-tests_EXTRA_INCLUDES)
 


### PR DESCRIPTION
# Motivation

These changes are needed to enable a MinGW build. The most interesting part is support for platform-specific subdirectories to avoid excess CPP. They are not yet used, but will be once we start separating out the larger chunks of platform-specific code.

# Context

First few commits of https://github.com/NixOS/nix/pull/8901

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
