### PR TITLE
patched fromTOML to fix MacOS testing

### DIFF
--- a/src/libexpr/primops/fromTOML.cc
+++ b/src/libexpr/primops/fromTOML.cc
@@ -1,6 +1,20 @@
 #include "primops.hh"
 #include "eval-inline.hh"
 
+
+/*
+FIXME: currently, toml11 requires us to set
+the C++ version to differentiate between
+invoke_result and result_of. Fixes compilation
+on MacOS.
+
+https://stackoverflow.com/questions/75121130
+
+*/
+#ifndef __cplusplus
+    #define __cplusplus 202000L
+#endif
+
 #include "../../toml11/toml.hpp"
 
 #include <sstream>


### PR DESCRIPTION
# Motivation
currently, compilation on MacOS is broken due to a known issue relating to `std::result_of` being removed from c++20. This PR fixes this issue by instructing TOML11 to use `std::invoke_result` 

More information can be found via: https://stackoverflow.com/questions/75121130
