### PR TITLE
Experimentally return `treeHash` on git and github fetchers

### DIFF
--- a/src/libfetchers/git-utils.hh
+++ b/src/libfetchers/git-utils.hh
@@ -16,6 +16,16 @@ struct GitFileSystemObjectSink : FileSystemObjectSink
     virtual Hash sync() = 0;
 };
 
+/**
+ * Git Input Accessor
+ *
+ * Created from `GitRepo`. Support some additional operations.
+ */
+struct GitInputAccessor : InputAccessor
+{
+    virtual Hash getTreeHash() = 0;
+};
+
 struct GitRepo
 {
     virtual ~GitRepo()
@@ -74,6 +84,8 @@ struct GitRepo
         const std::string & base) = 0;
 
     virtual bool hasObject(const Hash & oid) = 0;
+
+    virtual ref<GitInputAccessor> getPlainAccessor(const Hash & rev) = 0;
 
     virtual ref<InputAccessor> getAccessor(const Hash & rev, bool exportIgnore) = 0;
 

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -276,9 +276,8 @@ struct GitArchiveInputScheme : InputScheme
     {
         auto [input, tarballInfo] = downloadArchive(store, _input);
 
-        #if 0
-        input.attrs.insert_or_assign("treeHash", tarballInfo.treeHash.gitRev());
-        #endif
+        if (experimentalFeatureSettings.isEnabled(Xp::GitHashing))
+            input.attrs.insert_or_assign("treeHash", tarballInfo.treeHash.gitRev());
         input.attrs.insert_or_assign("lastModified", uint64_t(tarballInfo.lastModified));
 
         auto accessor = getTarballCache()->getAccessor(tarballInfo.treeHash, false);


### PR DESCRIPTION
# Motivation

We already had some `#if 0` for this, indicating a sort of "TODO" experiment. I would like to make this part of the git-hashing experimental feature.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
