### PR TITLE
Cure option

### DIFF
--- a/scripts/install-nix-from-closure.sh
+++ b/scripts/install-nix-from-closure.sh
@@ -71,6 +71,10 @@ while [ $# -gt 0 ]; do
         #     # intentional tail space
         #     ACTIONS="${ACTIONS}uninstall "
         #     ;;
+        --cure)
+            # intentional tail space
+            ACTIONS="${ACTIONS}cure "
+            ;;
         --yes)
             export NIX_INSTALLER_YES=1;;
         --no-channel-add)
@@ -105,6 +109,8 @@ while [ $# -gt 0 ]; do
                 echo " --no-daemon: Simple, single-user installation that does not require root and is"
                 echo "              trivial to uninstall."
                 echo "              (default)"
+                echo " --cure:      Tries to fix an already existing installation."
+                echo "              It does not fix installed packages."
                 echo ""
                 echo " --yes:               Run the script non-interactively, accepting all prompts."
                 echo ""


### PR DESCRIPTION
# Motivation

Currently, if nix installation is broken for some reason (e.g. macos tends to overwrite /etc/zshrc on updates), there is no way to "reinstall" nix, you have to uninstall (which is manual process) and then install one more time (which is super easy thanks to the super friendly installer). This PR hopefully adds an ability to cure (or fix) an already existing installation.

Background:
We maintain development env (using nix) for more than 100 users, who are not very tech-savvy, since they do data-science.
Running `sh <(curl -L https://nixos.org/nix/install) --daemon --cure --yes` should be enough to fix problems.

# Context

Updated installer (on "cure" option) would perform these steps :

- disable validation of prerequisites
- disable backup up shell rc files, cause we want to preserve initial files
- write Nix entries to rc files only if there are no traces of Nix in the files.

I believe this functionality could be extended and the current approach might seem to be quite naive, but it does the job.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
