### PR TITLE
develop: Allow shells to declare the minimal bash version they require

### DIFF
--- a/src/nix/get-env.sh
+++ b/src/nix/get-env.sh
@@ -115,6 +115,16 @@ __dumpEnv() {
         printf '\n  }'
     fi
 
+    printf ',\n  "meta": {\n    '
+    # min-bash-version is supposed to be an integer.
+    # If not, just ignore it.
+    if [[ -n "${NIX_ENV_MIN_BASH_VERSION-}" && "$NIX_ENV_MIN_BASH_VERSION" -eq "$NIX_ENV_MIN_BASH_VERSION" ]]; then
+        __escapeString "min-bash-version"
+        printf ': '
+        printf '%d' "${NIX_ENV_MIN_BASH_VERSION}"
+    fi
+    printf '\n  }'
+
     printf '\n}'
 }
 

--- a/tests/functional/flakes/develop.sh
+++ b/tests/functional/flakes/develop.sh
@@ -65,3 +65,20 @@ EOF
 )" -ef "$BASH_INTERACTIVE_EXECUTABLE" ]]
 
 clearStore
+
+# Use a newer bash version than the current one
+cat <<EOF >$TEST_HOME/flake.nix
+{
+    inputs.nixpkgs.url = "$TEST_HOME/nixpkgs";
+    outputs = {self, nixpkgs}: {
+      packages.$system.hello = (import ./config.nix).mkDerivation {
+        name = "hello";
+        outputs = [ "out" "dev" ];
+        meta.outputsToInstall = [ "out" ];
+        buildCommand = "";
+        NIX_ENV_MIN_BASH_VERSION=99;
+      };
+    };
+}
+EOF
+expect 1 nix develop .#hello --command true


### PR DESCRIPTION
Allow derivations to export a `NIX_ENV_MIN_BASH_VERSION` that sets the
minimal (major) bash version that is required to parse their setup
script, and use that to gracefully fail if the current bash is too old.

Fix #10263 (from the Nix side at least, needs https://github.com/NixOS/nixpkgs/pull/299490 from the Nixpkgs side to be useful in practice)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
