### PR TITLE
`throwExceptionSelfCheck` throw `Error`

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -16,9 +16,10 @@ void BaseError::addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TracePrint pri
     err.traces.push_front(Trace { .pos = std::move(e), .hint = hint, .print = print });
 }
 
-void throwExceptionSelfCheck(){
+void throwExceptionSelfCheck()
+{
     // This is meant to be caught in initLibUtil()
-    throw SysError("C++ exception handling is broken. This would appear to be a problem with the way Nix was compiled and/or linked and/or loaded.");
+    throw Error("C++ exception handling is broken. This would appear to be a problem with the way Nix was compiled and/or linked and/or loaded.");
 }
 
 // c++ std::exception descendants must have a 'const char* what()' function.


### PR DESCRIPTION
# Motivation

`SysError` is not appropriate because there is no (Unix) syscall involved.

# Context

The catch block in `initLibUtil` is already for `Error` and still works.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
