### PR TITLE
Factor out `nix::maybeLstat`

### DIFF
--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -64,9 +64,9 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
             continue;
 
         else if (S_ISDIR(srcSt.st_mode)) {
-            struct stat dstSt;
-            auto res = lstat(dstFile.c_str(), &dstSt);
-            if (res == 0) {
+            auto dstStOpt = maybeLstat(dstFile.c_str());
+            if (dstStOpt) {
+                auto & dstSt = *dstStOpt;
                 if (S_ISDIR(dstSt.st_mode)) {
                     createLinks(state, srcFile, dstFile, priority);
                     continue;
@@ -82,14 +82,13 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
                     createLinks(state, srcFile, dstFile, priority);
                     continue;
                 }
-            } else if (errno != ENOENT)
-                throw SysError("getting status of '%1%'", dstFile);
+            }
         }
 
         else {
-            struct stat dstSt;
-            auto res = lstat(dstFile.c_str(), &dstSt);
-            if (res == 0) {
+            auto dstStOpt = maybeLstat(dstFile.c_str());
+            if (dstStOpt) {
+                auto & dstSt = *dstStOpt;
                 if (S_ISLNK(dstSt.st_mode)) {
                     auto prevPriority = state.priorities[dstFile];
                     if (prevPriority == priority)
@@ -104,8 +103,7 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
                         throw SysError("unlinking '%1%'", dstFile);
                 } else if (S_ISDIR(dstSt.st_mode))
                     throw Error("collision between non-directory '%1%' and directory '%2%'", srcFile, dstFile);
-            } else if (errno != ENOENT)
-                throw SysError("getting status of '%1%'", dstFile);
+            }
         }
 
         createSymlink(srcFile, dstFile);

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -174,15 +174,23 @@ struct stat lstat(const Path & path)
 }
 
 
+std::optional<struct stat> maybeLstat(const Path & path)
+{
+    std::optional<struct stat> st{std::in_place};
+    if (lstat(path.c_str(), &*st))
+    {
+        if (errno == ENOENT || errno == ENOTDIR)
+            st.reset();
+        else
+            throw SysError("getting status of '%s'", path);
+    }
+    return st;
+}
+
+
 bool pathExists(const Path & path)
 {
-    int res;
-    struct stat st;
-    res = lstat(path.c_str(), &st);
-    if (!res) return true;
-    if (errno != ENOENT && errno != ENOTDIR)
-        throw SysError("getting status of %1%", path);
-    return false;
+    return maybeLstat(path).has_value();
 }
 
 bool pathAccessible(const Path & path)

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -84,6 +84,10 @@ bool isDirOrInDir(std::string_view path, std::string_view dir);
  */
 struct stat stat(const Path & path);
 struct stat lstat(const Path & path);
+/**
+ * `lstat` the given path if it exists.
+ * @return std::nullopt if the path doesn't exist, or an optional containing the result of `lstat` otherwise
+ */
 std::optional<struct stat> maybeLstat(const Path & path);
 
 /**

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -84,6 +84,7 @@ bool isDirOrInDir(std::string_view path, std::string_view dir);
  */
 struct stat stat(const Path & path);
 struct stat lstat(const Path & path);
+std::optional<struct stat> maybeLstat(const Path & path);
 
 /**
  * @return true iff the given path exists.

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -97,13 +97,7 @@ std::optional<struct stat> PosixSourceAccessor::cachedLstat(const CanonPath & pa
         if (i != cache->end()) return i->second;
     }
 
-    std::optional<struct stat> st{std::in_place};
-    if (::lstat(absPath.c_str(), &*st)) {
-        if (errno == ENOENT || errno == ENOTDIR)
-            st.reset();
-        else
-            throw SysError("getting status of '%s'", showPath(path));
-    }
+    auto st = nix::maybeLstat(absPath.c_str());
 
     auto cache(_cache.lock());
     if (cache->size() >= 16384) cache->clear();


### PR DESCRIPTION
# Motivation

This function is nice for more than `PosixSourceAccessor`. We can make a few things simpler with it.

# Context

Note that the error logic slightly changes in some of the call sites, in that we also count `ENOTDIR` and not just `ENOENT` as not having the file, but that should be fine.

Helps out with windows porting.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
