### PR TITLE
eval cache: fix and make re-evaluation of cached errors configurable

### DIFF
--- a/src/libexpr/eval-cache.hh
+++ b/src/libexpr/eval-cache.hh
@@ -102,11 +102,11 @@ public:
 
     Suggestions getSuggestionsForAttr(Symbol name);
 
-    std::shared_ptr<AttrCursor> maybeGetAttr(Symbol name, bool forceErrors = false);
+    std::shared_ptr<AttrCursor> maybeGetAttr(Symbol name);
 
     std::shared_ptr<AttrCursor> maybeGetAttr(std::string_view name);
 
-    ref<AttrCursor> getAttr(Symbol name, bool forceErrors = false);
+    ref<AttrCursor> getAttr(Symbol name);
 
     ref<AttrCursor> getAttr(std::string_view name);
 
@@ -114,7 +114,7 @@ public:
      * Get an attribute along a chain of attrsets. Note that this does
      * not auto-call functors or functions.
      */
-    OrSuggestions<ref<AttrCursor>> findAlongAttrPath(const std::vector<Symbol> & attrPath, bool force = false);
+    OrSuggestions<ref<AttrCursor>> findAlongAttrPath(const std::vector<Symbol> & attrPath);
 
     std::string getString();
 

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -128,6 +128,9 @@ struct EvalSettings : Config
     Setting<bool> useEvalCache{this, true, "eval-cache",
         "Whether to use the flake evaluation cache."};
 
+    Setting<bool> forceErrorsInEvalCache{this, true, "force-errors-in-eval-cache",
+        "Whether to force reevaluation of cached failures."};
+
     Setting<bool> ignoreExceptionsDuringTry{this, false, "ignore-try",
         R"(
           If set to true, ignore exceptions inside 'tryEval' calls when evaluating nix expressions in

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -930,7 +930,15 @@ std::optional<Fingerprint> LockedFlake::getFingerprint(ref<Store> store) const
     if (lockFile.isUnlocked()) return std::nullopt;
 
     auto fingerprint = flake.lockedRef.input.getFingerprint(store);
-    if (!fingerprint) return std::nullopt;
+    if (!fingerprint) {
+        return hashString(HashAlgorithm::SHA256,
+            fmt("%s;%s;%d;%d;%s",
+                flake.path.to_string(),
+                flake.lockedRef.subdir,
+                flake.lockedRef.input.getRevCount().value_or(0),
+                flake.lockedRef.input.getLastModified().value_or(0),
+                lockFile));
+    }
 
     // FIXME: as an optimization, if the flake contains a lock file
     // and we haven't changed it, then it's sufficient to use

--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -30,11 +30,15 @@ nix flake lock "$flake1Dir"
 # FIXME `packages.$system.foo` requires three invocations of `nix build`,
 # for `foo = throw` only it'll never be cached.
 expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'
-expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: cached failure of attribute '"'foo.bar'"
+expect 1 nix build "$flake1Dir#foo.bar" --no-force-errors-in-eval-cache 2>&1 | \
+    grepQuiet 'error: cached failure of attribute '"'foo.bar'"
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'
 
 git -C "$flake1Dir" add flake.lock
 git -C "$flake1Dir" commit -m "Init"
 
 # Cache is invalidated with a new git revision
 expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'
-expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: cached failure of attribute '"'foo.bar'"
+expect 1 nix build "$flake1Dir#foo.bar" --no-force-errors-in-eval-cache 2>&1 | \
+    grepQuiet 'error: cached failure of attribute '"'foo.bar'"
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'

--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -1,0 +1,40 @@
+source ./common.sh
+
+requireGit
+
+clearStore
+rm -rf $TEST_HOME/.cache $TEST_HOME/.config
+
+flake1Dir="$TEST_ROOT/eval-cache-flake"
+flake2Dir="$TEST_ROOT/flake2"
+createGitRepo "$flake1Dir" ""
+createGitRepo "$flake2Dir" ""
+
+createSimpleGitFlake "$flake2Dir"
+
+nix registry add --registry "$registry" flake2 "git+file://$flake2Dir"
+
+cat >"$flake1Dir/flake.nix" <<EOF
+{
+  description = "Fnord";
+  outputs = { self, flake2 }: {
+    foo.bar = throw "breaks";
+  };
+}
+EOF
+
+git -C "$flake1Dir" add flake.nix
+nix flake lock "$flake2Dir"
+nix flake lock "$flake1Dir"
+
+# FIXME `packages.$system.foo` requires three invocations of `nix build`,
+# for `foo = throw` only it'll never be cached.
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: cached failure of attribute '"'foo.bar'"
+
+git -C "$flake1Dir" add flake.lock
+git -C "$flake1Dir" commit -m "Init"
+
+# Cache is invalidated with a new git revision
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: cached failure of attribute '"'foo.bar'"

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -14,6 +14,7 @@ nix_tests = \
   flakes/unlocked-override.sh \
   flakes/absolute-paths.sh \
   flakes/absolute-attr-paths.sh \
+  flakes/eval-cache.sh \
   flakes/build-paths.sh \
   flakes/flake-in-submodule.sh \
   gc.sh \


### PR DESCRIPTION
# Motivation



I'm on Nix 2.19 and I wanted to fix the dreaded `cached failure of attribute` thing (again).
I realized that it's gone on 2.20+, but it turns out the eval cache just regressed and doesn't seem to cache anything. Fix for that is in the first commit.
The second commit adds an eval setting to configure whether or not to force re-evaluation of cached failures.

Future work:
* set this to `false` by default for a few commands such as `nix search`.
* cache error messages (and traces?) as well.

# Context
I'd recommend to review commit-wise.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
