### PR TITLE
systemd: Make the daemon properly killable

### DIFF
--- a/misc/systemd/nix-daemon.service.in
+++ b/misc/systemd/nix-daemon.service.in
@@ -8,7 +8,7 @@ ConditionPathIsReadWrite=@localstatedir@/nix/daemon-socket
 
 [Service]
 ExecStart=@@bindir@/nix-daemon nix-daemon --daemon
-KillMode=process
+PrivateTmp=true
 LimitNOFILE=1048576
 TasksMax=1048576
 


### PR DESCRIPTION
This PR accomplishes 2 things in one go: First, it removes KillMode=process. The old behaviour (from which systemd.kill strongly discourages) meant that systemd would not kill leftover processes when the unit was killed. Without this explicit setting, all processes in the cgroup are properly killed, resulting in no leftover processes that might hold locks.
The second change is PrivateTmp=true, which somewhat needs all processes to die to work effectively (hence the first change). The change bind-mounts a directory from /tmp to /tmp of the daemon (for example, my daemon sees
`/tmp/systemd-private-300487753c9143a984fb6202eb0a1a59-nix-daemon.service-YUDZyC/tmp` as `/tmp`). This has the benefit of privacy (the daemon not being able to read everything in /tmp), but also (which is the main reason I implement this) allows systemd to clean up when the daemon is stopped. This is a lot less tedious than removing all nix-build-* directories from /tmp. A simple `systemctl restart nix-daemon` results in a fresh and clean /tmp and helps work around tmpfs spillovers.

# Motivation
My systemd sometimes gets too full and manually removing all nix-build-* directories is annoying.

# Context
See motivation.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
