### PR TITLE
Add functional tests for include directives in nix config file

### DIFF
--- a/tests/functional/config.sh
+++ b/tests/functional/config.sh
@@ -43,6 +43,16 @@ export NIX_USER_CONF_FILES=$here/config/nix-with-substituters.conf
 var=$(nix config show | grep '^substituters =' | cut -d '=' -f 2 | xargs)
 [[ $var == https://example.com ]]
 
+# Test that we can include a file.
+export NIX_USER_CONF_FILES=$here/config/nix-with-include.conf
+var=$(nix config show | grep '^allowed-uris =' | cut -d '=' -f 2 | xargs)
+[[ $var == https://github.com/NixOS/nix ]]
+
+# Test that we can !include a file.
+export NIX_USER_CONF_FILES=$here/config/nix-with-bang-include.conf
+var=$(nix config show | grep '^experimental-features =' | cut -d '=' -f 2 | xargs)
+[[ $var == nix-command ]]
+
 # Test that it's possible to load config from the environment
 prev=$(nix config show | grep '^cores' | cut -d '=' -f 2 | xargs)
 export NIX_CONFIG="cores = 4242"$'\n'"experimental-features = nix-command flakes"

--- a/tests/functional/config/extra-config.conf
+++ b/tests/functional/config/extra-config.conf
@@ -1,0 +1,1 @@
+allowed-uris = https://github.com/NixOS/nix

--- a/tests/functional/config/nix-with-bang-include.conf
+++ b/tests/functional/config/nix-with-bang-include.conf
@@ -1,0 +1,2 @@
+experimental-features = nix-command
+!include ./missing-extra-config.conf

--- a/tests/functional/config/nix-with-include.conf
+++ b/tests/functional/config/nix-with-include.conf
@@ -1,0 +1,2 @@
+experimental-features = nix-command
+include ./extra-config.conf


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Add two tests for the `!include` and `include` directives used in nix.conf 

https://github.com/NixOS/nix/pull/10358/files
# Context
<!-- Provide context. Reference open issues if available. -->
Resolves #10383

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
