### PR TITLE
backport `src` definition from 2.16

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -320,12 +320,18 @@
           };
           let
             canRunInstalled = currentStdenv.buildPlatform.canExecute currentStdenv.hostPlatform;
+
+            sourceByRegexInverted = rxs: origSrc: final.lib.cleanSourceWith {
+              filter = (path: type:
+                let relPath = final.lib.removePrefix (toString origSrc + "/") (toString path);
+                in ! lib.any (re: builtins.match re relPath != null) rxs);
+              src = origSrc;
+            };
           in currentStdenv.mkDerivation (finalAttrs: {
             name = "nix-${version}";
             inherit version;
 
-            src = self;
-
+            src = sourceByRegexInverted [ "tests/nixos/.*" "tests/installer/.*" ] self;
             VERSION_SUFFIX = versionSuffix;
 
             outputs = [ "out" "dev" "doc" ];


### PR DESCRIPTION
# Motivation

I just want to finish hosting versioned manuals and updating them automatically, without having to re-build multiple versions of Nix: https://github.com/NixOS/nix.dev/pull/863

# Context

This fixes a weirdness when consuming `default.nix` from the 2.15 release branch archive, where the Nix derivation's `src` store path gets wrapped for some reason:

    "src": "/nix/store/mfa0j89j4f42nrxwxfwqrz0b6m32ih99-fcyq2x0wld440n9jc756vnh93kvjz9ac-source",

This is the only difference to instantiating the Nix derivation from the repository itself, and prevents a build cache hit.

It doesn't happen on 2.14 (adds `flake-compat`) and 2.16 (uses `cleanSource`). I suppose this is somehow caused by `flake-compat` doing something funky,

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).