### PR TITLE
Handle the case where a parent of ~/.nix-defexpr is a symlink

### DIFF
--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -109,7 +109,7 @@ static void getAllExprs(EvalState & state,
     const SourcePath & path, StringSet & seen, BindingsBuilder & attrs)
 {
     StringSet namesSorted;
-    for (auto & [name, _] : path.readDirectory()) namesSorted.insert(name);
+    for (auto & [name, _] : path.resolveSymlinks().readDirectory()) namesSorted.insert(name);
 
     for (auto & i : namesSorted) {
         /* Ignore the manifest.nix used by profiles.  This is

--- a/tests/functional/user-envs.sh
+++ b/tests/functional/user-envs.sh
@@ -189,3 +189,9 @@ nix-env --set $outPath10
 [ "$(nix-store -q --resolve $profiles/test)" = $outPath10 ]
 nix-env --set $drvPath10
 [ "$(nix-store -q --resolve $profiles/test)" = $outPath10 ]
+
+# Test the case where $HOME contains a symlink.
+mkdir -p $TEST_ROOT/real-home/alice/.nix-defexpr/channels
+ln -sfn $TEST_ROOT/real-home $TEST_ROOT/home
+ln -sfn $(pwd)/user-envs.nix $TEST_ROOT/home/alice/.nix-defexpr/channels/foo
+HOME=$TEST_ROOT/home/alice nix-env -i foo-0.1


### PR DESCRIPTION
# Motivation
Fixes https://github.com/DeterminateSystems/nix-installer/issues/912 and probably #10247.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
