### PR TITLE
Make SQLite busy back-off logic portable

### DIFF
--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -7,6 +7,7 @@
 #include <sqlite3.h>
 
 #include <atomic>
+#include <thread>
 
 namespace nix {
 
@@ -256,10 +257,8 @@ void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning)
     /* Sleep for a while since retrying the transaction right away
        is likely to fail again. */
     checkInterrupt();
-    struct timespec t;
-    t.tv_sec = 0;
-    t.tv_nsec = (random() % 100) * 1000 * 1000; /* <= 0.1s */
-    nanosleep(&t, 0);
+    /* <= 0.1s */
+    std::this_thread::sleep_for(std::chrono::milliseconds { rand() % 100 });
 }
 
 }


### PR DESCRIPTION
# Motivation

Use C++ standard library not Unix functions for sleeping and randomness.

# Context

Suggested by @edolstra in https://github.com/NixOS/nix/pull/8901#discussion_r1550416615


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
