### PR TITLE
path-info: print correct path when using `nix path-info --store file://... --all --json`

### DIFF
--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -43,9 +43,15 @@ static json pathInfoToJSON(
 
     for (auto & storePath : storePaths) {
         json jsonObject;
+        auto printedStorePath = store.printStorePath(storePath);
 
         try {
             auto info = store.queryPathInfo(storePath);
+
+            // `storePath` has the representation `<hash>-x` rather than
+            // `<hash>-<name>` in case of binary-cache stores & `--all` because we don't
+            // know the name yet until we've read the NAR info.
+            printedStorePath = store.printStorePath(info->path);
 
             jsonObject = info->toJSON(store, true, HashFormat::SRI);
 
@@ -74,7 +80,7 @@ static json pathInfoToJSON(
             jsonObject = nullptr;
         }
 
-        jsonAllObjects[store.printStorePath(storePath)] = std::move(jsonObject);
+        jsonAllObjects[printedStorePath] = std::move(jsonObject);
     }
     return jsonAllObjects;
 }

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -14,6 +14,14 @@ outPath=$(nix-build dependencies.nix --no-out-link)
 
 nix copy --to file://$cacheDir $outPath
 
+readarray -t paths < <(nix path-info --all --json --store file://$cacheDir | jq 'keys|sort|.[]' -r)
+[[ "${#paths[@]}" -eq 3 ]]
+for path in "${paths[@]}"; do
+    [[ "$path" =~ -dependencies-input-0$ ]] \
+        || [[ "$path" =~ -dependencies-input-2$ ]] \
+        || [[ "$path" =~ -dependencies-top$ ]]
+done
+
 # Test copying build logs to the binary cache.
 expect 1 nix log --store file://$cacheDir $outPath 2>&1 | grep 'is not available'
 nix store copy-log --to file://$cacheDir $outPath


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

When querying all paths in a binary cache store, the path's representation is `<hash>-x` (where `x` is the value of `MissingName`) because the narinfo files only contain the store-path hash.

When querying all paths in a binary cache store, the path's representation is `<hash>-x` (where `x` is the value of `MissingName`) because the .narinfo filenames only contain the hash.

# Context
<!-- Provide context. Reference open issues if available. -->

Before cc46ea163024254d0b74646e1b38b19896d40040 this worked correctly, because the entire path info was read and the path from this representation was printed, i.e. in the form `<hash>-<name>`. Since then however, the direct result from `queryAllValidPaths()` was used as `path`.

Added a regression test to make sure the behavior remains correct.

cc @Ericson2314 

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
