### PR TITLE
Make `cgroup.{cc,hh}` linux-only files

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -14,7 +14,6 @@
 #include "topo-sort.hh"
 #include "callback.hh"
 #include "json-utils.hh"
-#include "cgroup.hh"
 #include "personality.hh"
 #include "current-process.hh"
 #include "child.hh"
@@ -52,6 +51,7 @@
 #   include <seccomp.h>
 # endif
 # define pivot_root(new_root, put_old) (syscall(SYS_pivot_root, new_root, put_old))
+# include "cgroup.hh"
 #endif
 
 #if __APPLE__

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -1,5 +1,3 @@
-#if __linux__
-
 #include "cgroup.hh"
 #include "util.hh"
 #include "file-system.hh"
@@ -145,5 +143,3 @@ CgroupStats destroyCgroup(const Path & cgroup)
 }
 
 }
-
-#endif

--- a/src/libutil/linux/cgroup.hh
+++ b/src/libutil/linux/cgroup.hh
@@ -1,8 +1,6 @@
 #pragma once
 ///@file
 
-#if __linux__
-
 #include <chrono>
 #include <optional>
 
@@ -28,5 +26,3 @@ struct CgroupStats
 CgroupStats destroyCgroup(const Path & cgroup);
 
 }
-
-#endif


### PR DESCRIPTION
# Motivation

Forcing a conditional include, vs making the headers content conditional, I think is more maintainable.

# Context

It is also how the other platform-specific headers (like `namespaces.hh`) have been adapted.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
