### PR TITLE
"but doctor, I AM the untrusted store": nix doctor had wrong trustedness

### DIFF
--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -145,10 +145,9 @@ struct CmdConfigCheck : StoreCommand
 
     void checkTrustedUser(ref<Store> store)
     {
-        std::string_view trusted = store->isTrustedClient()
-            ? "trusted"
-            : "not trusted";
-        checkInfo(fmt("You are %s by store uri: %s", trusted, store->getUri()));
+        auto trustedMay = store->isTrustedClient();
+        std::string_view trustedness = trustedMay ? (*trustedMay ? "trusted" : "not trusted") : "unknown trust";
+        checkInfo(fmt("You are %s by store uri: %s", trustedness, store->getUri()));
     }
 };
 

--- a/tests/functional/legacy-ssh-store.sh
+++ b/tests/functional/legacy-ssh-store.sh
@@ -1,4 +1,9 @@
 source common.sh
 
+store_uri="ssh://localhost?remote-store=$TEST_ROOT/other-store"
+
 # Check that store info trusted doesn't yet work with ssh://
-nix --store ssh://localhost?remote-store=$TEST_ROOT/other-store store info --json | jq -e 'has("trusted") | not'
+nix --store "$store_uri" store info --json | jq -e 'has("trusted") | not'
+
+# Suppress grumpiness about multiple nixes on PATH
+(nix --store "$store_uri" doctor || true) 2>&1 | grep 'You are unknown trust'

--- a/tests/functional/remote-store.sh
+++ b/tests/functional/remote-store.sh
@@ -13,6 +13,8 @@ startDaemon
 if isDaemonNewer "2.15pre0"; then
     # Ensure that ping works trusted with new daemon
     nix store info --json | jq -e '.trusted'
+    # Suppress grumpiness about multiple nixes on PATH
+    (nix doctor || true) 2>&1 | grep 'You are trusted by'
 else
     # And the the field is absent with the old daemon
     nix store info --json | jq -e 'has("trusted") | not'


### PR DESCRIPTION
This probably snuck in in a refactor using truthiness or so. The trustedness flag was having the optional fullness checked, rather than the actual contained trust level.

Also adds some tests.

```
m1@6876551b-255d-4cb0-af02-8a4f17b27e2e ~ % nix store ping
warning: 'nix store ping' is a deprecated alias for 'nix store info'
Store URL: daemon
Version: 2.20.4
Trusted: 0
m1@6876551b-255d-4cb0-af02-8a4f17b27e2e ~ % nix doctor
warning: 'doctor' is a deprecated alias for 'config check'
[PASS] PATH contains only one nix version.
[PASS] All profiles are gcroots.
[PASS] Client protocol matches store protocol.
[INFO] You are trusted by store uri: daemon
```

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
