### PR TITLE
Do not rely on $stdenv/setup to set output variables

### DIFF
--- a/tests/functional/shell.nix
+++ b/tests/functional/shell.nix
@@ -21,14 +21,6 @@ let pkgs = rec {
       export PATH=$PATH:$pkg/bin
     done
 
-    # mimic behavior of stdenv for `$out` etc. for structured attrs.
-    if [ -n "''${NIX_ATTRS_SH_FILE}" ]; then
-      for o in "''${!outputs[@]}"; do
-        eval "''${o}=''${outputs[$o]}"
-        export "''${o}"
-      done
-    fi
-
     declare -a arr1=(1 2 "3 4" 5)
     declare -a arr2=(x $'\n' $'x\ny')
     fun() {

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -32,4 +32,4 @@ jsonOut="$(nix print-dev-env -f structured-attrs-shell.nix --json)"
 
 test "$(<<<"$jsonOut" jq '.structuredAttrs|keys|.[]' -r)" = "$(printf ".attrs.json\n.attrs.sh")"
 
-test "$(<<<"$jsonOut" jq '.variables.out.value' -r)" = "$(<<<"$jsonOut" jq '.structuredAttrs.".attrs.json"' -r | jq -r '.outputs.out')"
+test "$(<<<"$jsonOut" jq '.variables.outputs.value.out' -r)" = "$(<<<"$jsonOut" jq '.structuredAttrs.".attrs.json"' -r | jq -r '.outputs.out')"


### PR DESCRIPTION
# Motivation

Instead of relying on setup script to set output variables when structured attributes are enabled, iterate over the values of an outputs associative array.

# Context

- https://github.com/NixOS/nixpkgs/blob/374fa3532ee7d7496165d3b5a6652a3dcad1ebc2/pkgs/stdenv/generic/setup.sh#L23-L26
- https://github.com/NixOS/nix/blob/65d711351e2718596dadc291ce0fecf072585ae9/tests/functional/shell.nix#L24-L30

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
