### PR TITLE
doc/rl-2.20: clarify builders-use-substitutes vs. substitute-on-destion

### DIFF
--- a/doc/manual/src/release-notes/rl-2.20.md
+++ b/doc/manual/src/release-notes/rl-2.20.md
@@ -204,4 +204,5 @@
 - `nix copy` to a `ssh-ng` store now needs `--substitute-on-destination` (a.k.a. `-s`)
   in order to substitute paths on the remote store instead of copying them.
   The behavior is consistent with `nix copy` to a different kind of remote store.
-  Previously this behavior was controlled by `--builders-use-substitutes`.
+  Previously this behavior was controlled by the
+  `builders-use-substitutes` setting and `--substitute-on-destination` was ignored.


### PR DESCRIPTION
# Motivation
...as this lead to confusion before.

# Context
https://github.com/NixOS/nix/pull/10449/files#r1559123949
https://matrix.to/#/%23nix-dev%3Anixos.org/%24sUwisiR7TnpdJYVJI-pRMSJoYBj0SExl9QXj5TTv1I8?via=nicht-so.sexy&via=matrix.org&via=flipdot.org&via=envs.net

cc @NixOS/nix-team 
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
