### PR TITLE
[2.20] Backport changes to release notes

### DIFF
--- a/doc/manual/src/release-notes/rl-2.20.md
+++ b/doc/manual/src/release-notes/rl-2.20.md
@@ -167,3 +167,7 @@
 
          error: expected a set but found an integer
   ```
+- Flake operations like `nix develop` will no longer fail when run in a Git
+  repository where the `flake.lock` file is `.gitignore`d
+  [#8854](https://github.com/NixOS/nix/issues/8854)
+  [#9324](https://github.com/NixOS/nix/pull/9324)

--- a/doc/manual/src/release-notes/rl-2.20.md
+++ b/doc/manual/src/release-notes/rl-2.20.md
@@ -194,4 +194,5 @@
 - `nix copy` to a `ssh-ng` store now needs `--substitute-on-destination` (a.k.a. `-s`)
   in order to substitute paths on the remote store instead of copying them.
   The behavior is consistent with `nix copy` to a different kind of remote store.
-  Previously this behavior was controlled by `--builders-use-substitutes`.
+  Previously this behavior was controlled by the
+  `builders-use-substitutes` setting and `--substitute-on-destination` was ignored.

--- a/doc/manual/src/release-notes/rl-2.20.md
+++ b/doc/manual/src/release-notes/rl-2.20.md
@@ -167,6 +167,25 @@
 
          error: expected a set but found an integer
   ```
+
+- Functions are printed with more detail [#7145](https://github.com/NixOS/nix/issues/7145) [#9606](https://github.com/NixOS/nix/pull/9606)
+
+  `nix repl`, `nix eval`, `builtins.trace`, and most other places values are
+  printed will now include function names and source location information:
+
+  ```
+  $ nix repl nixpkgs
+  nix-repl> builtins.map
+  «primop map»
+
+  nix-repl> builtins.map lib.id
+  «partially applied primop map»
+
+  nix-repl> builtins.trace lib.id "my-value"
+  trace: «lambda id @ /nix/store/8rrzq23h2zq7sv5l2vhw44kls5w0f654-source/lib/trivial.nix:26:5»
+  "my-value"
+  ```
+
 - Flake operations like `nix develop` will no longer fail when run in a Git
   repository where the `flake.lock` file is `.gitignore`d
   [#8854](https://github.com/NixOS/nix/issues/8854)

--- a/doc/manual/src/release-notes/rl-2.20.md
+++ b/doc/manual/src/release-notes/rl-2.20.md
@@ -190,3 +190,8 @@
   repository where the `flake.lock` file is `.gitignore`d
   [#8854](https://github.com/NixOS/nix/issues/8854)
   [#9324](https://github.com/NixOS/nix/pull/9324)
+
+- `nix copy` to a `ssh-ng` store now needs `--substitute-on-destination` (a.k.a. `-s`)
+  in order to substitute paths on the remote store instead of copying them.
+  The behavior is consistent with `nix copy` to a different kind of remote store.
+  Previously this behavior was controlled by `--builders-use-substitutes`.


### PR DESCRIPTION
# Motivation
Effectively backports the relevant portions of #9943, #10458, #10449.

Not sure why some of the previous changes were part of rl-next & rl-2.20, but I figured it's correct to only backport the stuff affecting rl-2.20.md.

# Context

cc @NixOS/nix-team 
cc @9999years 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
