### PR TITLE
Fetcher cache cleanups

### DIFF
--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -14,7 +14,7 @@ create table if not exists Cache (
     input     text not null,
     info      text not null,
     path      text not null,
-    immutable integer not null,
+    immutable integer not null, /* obsolete */
     timestamp integer not null,
     primary key (input)
 );
@@ -45,7 +45,7 @@ struct CacheImpl : Cache
         state->db.exec(schema);
 
         state->add.create(state->db,
-            "insert or replace into Cache(input, info, path, immutable, timestamp) values (?, ?, ?, ?, ?)");
+            "insert or replace into Cache(input, info, path, immutable, timestamp) values (?, ?, ?, false, ?)");
 
         state->lookup.create(state->db,
             "select info, path, immutable, timestamp from Cache where input = ?");
@@ -59,7 +59,6 @@ struct CacheImpl : Cache
             (attrsToJSON(inAttrs).dump())
             (attrsToJSON(infoAttrs).dump())
             ("") // no path
-            (false)
             (time(0)).exec();
     }
 
@@ -109,14 +108,12 @@ struct CacheImpl : Cache
         Store & store,
         const Attrs & inAttrs,
         const Attrs & infoAttrs,
-        const StorePath & storePath,
-        bool locked) override
+        const StorePath & storePath) override
     {
         _state.lock()->add.use()
             (attrsToJSON(inAttrs).dump())
             (attrsToJSON(infoAttrs).dump())
             (store.printStorePath(storePath))
-            (locked)
             (time(0)).exec();
     }
 

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -11,12 +11,11 @@ namespace nix::fetchers {
 static const char * schema = R"sql(
 
 create table if not exists Cache (
-    input     text not null,
-    info      text not null,
-    path      text not null,
-    immutable integer not null, /* obsolete */
+    domain    text not null,
+    key       text not null,
+    value     text not null,
     timestamp integer not null,
-    primary key (input)
+    primary key (domain, key)
 );
 )sql";
 
@@ -28,7 +27,7 @@ struct CacheImpl : Cache
     struct State
     {
         SQLite db;
-        SQLiteStmt add, lookup;
+        SQLiteStmt upsert, lookup;
     };
 
     Sync<State> _state;
@@ -37,133 +36,134 @@ struct CacheImpl : Cache
     {
         auto state(_state.lock());
 
-        auto dbPath = getCacheDir() + "/nix/fetcher-cache-v1.sqlite";
+        auto dbPath = getCacheDir() + "/nix/fetcher-cache-v2.sqlite";
         createDirs(dirOf(dbPath));
 
         state->db = SQLite(dbPath);
         state->db.isCache();
         state->db.exec(schema);
 
-        state->add.create(state->db,
-            "insert or replace into Cache(input, info, path, immutable, timestamp) values (?, ?, ?, false, ?)");
+        state->upsert.create(state->db,
+            "insert or replace into Cache(domain, key, value, timestamp) values (?, ?, ?, ?)");
 
         state->lookup.create(state->db,
-            "select info, path, immutable, timestamp from Cache where input = ?");
+            "select value, timestamp from Cache where domain = ? and key = ?");
     }
 
     void upsert(
-        const Attrs & inAttrs,
-        const Attrs & infoAttrs) override
+        std::string_view domain,
+        const Attrs & key,
+        const Attrs & value) override
     {
-        _state.lock()->add.use()
-            (attrsToJSON(inAttrs).dump())
-            (attrsToJSON(infoAttrs).dump())
-            ("") // no path
+        _state.lock()->upsert.use()
+            (domain)
+            (attrsToJSON(key).dump())
+            (attrsToJSON(value).dump())
             (time(0)).exec();
     }
 
-    std::optional<Attrs> lookup(const Attrs & inAttrs) override
+    std::optional<Attrs> lookup(
+        std::string_view domain,
+        const Attrs & key) override
     {
-        if (auto res = lookupExpired(inAttrs))
-            return std::move(res->infoAttrs);
+        if (auto res = lookupExpired(domain, key))
+            return std::move(res->value);
         return {};
     }
 
-    std::optional<Attrs> lookupWithTTL(const Attrs & inAttrs) override
+    std::optional<Attrs> lookupWithTTL(
+        std::string_view domain,
+        const Attrs & key) override
     {
-        if (auto res = lookupExpired(inAttrs)) {
+        if (auto res = lookupExpired(domain, key)) {
             if (!res->expired)
-                return std::move(res->infoAttrs);
-            debug("ignoring expired cache entry '%s'",
-                attrsToJSON(inAttrs).dump());
-        }
-        return {};
-    }
-
-    std::optional<Result2> lookupExpired(const Attrs & inAttrs) override
-    {
-        auto state(_state.lock());
-
-        auto inAttrsJSON = attrsToJSON(inAttrs).dump();
-
-        auto stmt(state->lookup.use()(inAttrsJSON));
-        if (!stmt.next()) {
-            debug("did not find cache entry for '%s'", inAttrsJSON);
-            return {};
-        }
-
-        auto infoJSON = stmt.getStr(0);
-        auto locked = stmt.getInt(2) != 0;
-        auto timestamp = stmt.getInt(3);
-
-        debug("using cache entry '%s' -> '%s'", inAttrsJSON, infoJSON);
-
-        return Result2 {
-            .expired = !locked && (settings.tarballTtl.get() == 0 || timestamp + settings.tarballTtl < time(0)),
-            .infoAttrs = jsonToAttrs(nlohmann::json::parse(infoJSON)),
-        };
-    }
-
-    void add(
-        Store & store,
-        const Attrs & inAttrs,
-        const Attrs & infoAttrs,
-        const StorePath & storePath) override
-    {
-        _state.lock()->add.use()
-            (attrsToJSON(inAttrs).dump())
-            (attrsToJSON(infoAttrs).dump())
-            (store.printStorePath(storePath))
-            (time(0)).exec();
-    }
-
-    std::optional<std::pair<Attrs, StorePath>> lookup(
-        Store & store,
-        const Attrs & inAttrs) override
-    {
-        if (auto res = lookupExpired(store, inAttrs)) {
-            if (!res->expired)
-                return std::make_pair(std::move(res->infoAttrs), std::move(res->storePath));
-            debug("ignoring expired cache entry '%s'",
-                attrsToJSON(inAttrs).dump());
+                return std::move(res->value);
+            debug("ignoring expired cache entry '%s:%s'",
+                domain, attrsToJSON(key).dump());
         }
         return {};
     }
 
     std::optional<Result> lookupExpired(
-        Store & store,
-        const Attrs & inAttrs) override
+        std::string_view domain,
+        const Attrs & key) override
     {
         auto state(_state.lock());
 
-        auto inAttrsJSON = attrsToJSON(inAttrs).dump();
+        auto keyJSON = attrsToJSON(key).dump();
 
-        auto stmt(state->lookup.use()(inAttrsJSON));
+        auto stmt(state->lookup.use()(domain)(keyJSON));
         if (!stmt.next()) {
-            debug("did not find cache entry for '%s'", inAttrsJSON);
+            debug("did not find cache entry for '%s:%s'", domain, keyJSON);
             return {};
         }
 
-        auto infoJSON = stmt.getStr(0);
-        auto storePath = store.parseStorePath(stmt.getStr(1));
-        auto locked = stmt.getInt(2) != 0;
-        auto timestamp = stmt.getInt(3);
+        auto valueJSON = stmt.getStr(0);
+        auto timestamp = stmt.getInt(1);
 
-        store.addTempRoot(storePath);
-        if (!store.isValidPath(storePath)) {
+        debug("using cache entry '%s:%s' -> '%s'", domain, keyJSON, valueJSON);
+
+        return Result {
+            .expired = settings.tarballTtl.get() == 0 || timestamp + settings.tarballTtl < time(0),
+            .value = jsonToAttrs(nlohmann::json::parse(valueJSON)),
+        };
+    }
+
+    void upsert(
+        std::string_view domain,
+        Attrs key,
+        Store & store,
+        Attrs value,
+        const StorePath & storePath)
+    {
+        /* Add the store prefix to the cache key to handle multiple
+           store prefixes. */
+        key.insert_or_assign("store", store.storeDir);
+
+        value.insert_or_assign("storePath", (std::string) storePath.to_string());
+
+        upsert(domain, key, value);
+    }
+
+    std::optional<ResultWithStorePath> lookupStorePath(
+        std::string_view domain,
+        Attrs key,
+        Store & store) override
+    {
+        key.insert_or_assign("store", store.storeDir);
+
+        auto res = lookupExpired(domain, key);
+        if (!res) return std::nullopt;
+
+        auto storePathS = getStrAttr(res->value, "storePath");
+        res->value.erase("storePath");
+
+        ResultWithStorePath res2(*res, StorePath(storePathS));
+
+        store.addTempRoot(res2.storePath);
+        if (!store.isValidPath(res2.storePath)) {
             // FIXME: we could try to substitute 'storePath'.
-            debug("ignoring disappeared cache entry '%s'", inAttrsJSON);
-            return {};
+            debug("ignoring disappeared cache entry '%s' -> '%s'",
+                attrsToJSON(key).dump(),
+                store.printStorePath(res2.storePath));
+            return std::nullopt;
         }
 
         debug("using cache entry '%s' -> '%s', '%s'",
-            inAttrsJSON, infoJSON, store.printStorePath(storePath));
+            attrsToJSON(key).dump(),
+            attrsToJSON(res2.value).dump(),
+            store.printStorePath(res2.storePath));
 
-        return Result {
-            .expired = !locked && (settings.tarballTtl.get() == 0 || timestamp + settings.tarballTtl < time(0)),
-            .infoAttrs = jsonToAttrs(nlohmann::json::parse(infoJSON)),
-            .storePath = std::move(storePath)
-        };
+        return res2;
+    }
+
+    std::optional<ResultWithStorePath> lookupStorePathWithTTL(
+        std::string_view domain,
+        Attrs key,
+        Store & store) override
+    {
+        auto res = lookupStorePath(domain, std::move(key), store);
+        return res && !res->expired ? res : std::nullopt;
     }
 };
 

--- a/src/libfetchers/cache.hh
+++ b/src/libfetchers/cache.hh
@@ -15,28 +15,35 @@ struct Cache
     virtual ~Cache() { }
 
     /**
-     * Add a value to the cache. The cache is an arbitrary mapping of
-     * Attrs to Attrs.
+     * A domain is a partition of the key/value cache for a particular
+     * purpose, e.g. "Git revision to revcount".
+     */
+    using Domain = std::string_view;
+
+    /**
+     * A cache key is a domain and an arbitrary set of attributes.
+     */
+    using Key = std::pair<Domain, Attrs>;
+
+    /**
+     * Add a key/value pair to the cache.
      */
     virtual void upsert(
-        std::string_view domain,
-        const Attrs & key,
+        const Key & key,
         const Attrs & value) = 0;
 
     /**
      * Look up a key with infinite TTL.
      */
     virtual std::optional<Attrs> lookup(
-        std::string_view domain,
-        const Attrs & key) = 0;
+        const Key & key) = 0;
 
     /**
      * Look up a key. Return nothing if its TTL has exceeded
      * `settings.tarballTTL`.
      */
     virtual std::optional<Attrs> lookupWithTTL(
-        std::string_view domain,
-        const Attrs & key) = 0;
+        const Key & key) = 0;
 
     struct Result
     {
@@ -49,8 +56,7 @@ struct Cache
      * exceeded `settings.tarballTTL`.
      */
     virtual std::optional<Result> lookupExpired(
-        std::string_view domain,
-        const Attrs & key) = 0;
+        const Key & key) = 0;
 
     /**
      * Insert a cache entry that has a store path associated with
@@ -58,8 +64,7 @@ struct Cache
      * associated store path is invalid.
      */
     virtual void upsert(
-        std::string_view domain,
-        Attrs key,
+        Key key,
         Store & store,
         Attrs value,
         const StorePath & storePath) = 0;
@@ -74,8 +79,7 @@ struct Cache
      * be valid, but it may be expired.
      */
     virtual std::optional<ResultWithStorePath> lookupStorePath(
-        std::string_view domain,
-        Attrs key,
+        Key key,
         Store & store) = 0;
 
     /**
@@ -83,8 +87,7 @@ struct Cache
      * has exceeded `settings.tarballTTL`.
      */
     virtual std::optional<ResultWithStorePath> lookupStorePathWithTTL(
-        std::string_view domain,
-        Attrs key,
+        Key key,
         Store & store) = 0;
 };
 

--- a/src/libfetchers/cache.hh
+++ b/src/libfetchers/cache.hh
@@ -16,7 +16,7 @@ struct Cache
 
     /**
      * A domain is a partition of the key/value cache for a particular
-     * purpose, e.g. "Git revision to revcount".
+     * purpose, e.g. git revision to revcount.
      */
     using Domain = std::string_view;
 

--- a/src/libfetchers/cache.hh
+++ b/src/libfetchers/cache.hh
@@ -53,8 +53,7 @@ struct Cache
         Store & store,
         const Attrs & inAttrs,
         const Attrs & infoAttrs,
-        const StorePath & storePath,
-        bool locked) = 0;
+        const StorePath & storePath) = 0;
 
     virtual std::optional<std::pair<Attrs, StorePath>> lookup(
         Store & store,

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -16,17 +16,16 @@ StorePath fetchToStore(
     // FIXME: add an optimisation for the case where the accessor is
     // an FSInputAccessor pointing to a store path.
 
-    auto domain = "fetchToStore";
-    std::optional<fetchers::Attrs> cacheKey;
+    std::optional<fetchers::Cache::Key> cacheKey;
 
     if (!filter && path.accessor->fingerprint) {
-        cacheKey = fetchers::Attrs{
+        cacheKey = fetchers::Cache::Key{"fetchToStore", {
             {"name", std::string{name}},
             {"fingerprint", *path.accessor->fingerprint},
             {"method", std::string{method.render()}},
             {"path", path.path.abs()}
-        };
-        if (auto res = fetchers::getCache()->lookupStorePath(domain, *cacheKey, store)) {
+        }};
+        if (auto res = fetchers::getCache()->lookupStorePath(*cacheKey, store)) {
             debug("store path cache hit for '%s'", path);
             return res->storePath;
         }
@@ -46,7 +45,7 @@ StorePath fetchToStore(
             name, *path.accessor, path.path, method, HashAlgorithm::SHA256, {}, filter2, repair);
 
     if (cacheKey && mode == FetchMode::Copy)
-        fetchers::getCache()->upsert(domain, *cacheKey, store, {}, storePath);
+        fetchers::getCache()->upsert(*cacheKey, store, {}, storePath);
 
     return storePath;
 }

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -16,20 +16,19 @@ StorePath fetchToStore(
     // FIXME: add an optimisation for the case where the accessor is
     // an FSInputAccessor pointing to a store path.
 
+    auto domain = "fetchToStore";
     std::optional<fetchers::Attrs> cacheKey;
 
     if (!filter && path.accessor->fingerprint) {
         cacheKey = fetchers::Attrs{
-            {"_what", "fetchToStore"},
-            {"store", store.storeDir},
             {"name", std::string{name}},
             {"fingerprint", *path.accessor->fingerprint},
             {"method", std::string{method.render()}},
             {"path", path.path.abs()}
         };
-        if (auto res = fetchers::getCache()->lookup(store, *cacheKey)) {
+        if (auto res = fetchers::getCache()->lookupStorePath(domain, *cacheKey, store)) {
             debug("store path cache hit for '%s'", path);
-            return res->second;
+            return res->storePath;
         }
     } else
         debug("source path '%s' is uncacheable", path);
@@ -47,7 +46,7 @@ StorePath fetchToStore(
             name, *path.accessor, path.path, method, HashAlgorithm::SHA256, {}, filter2, repair);
 
     if (cacheKey && mode == FetchMode::Copy)
-        fetchers::getCache()->add(store, *cacheKey, {}, storePath);
+        fetchers::getCache()->upsert(domain, *cacheKey, store, {}, storePath);
 
     return storePath;
 }

--- a/src/libfetchers/fetch-to-store.cc
+++ b/src/libfetchers/fetch-to-store.cc
@@ -47,10 +47,9 @@ StorePath fetchToStore(
             name, *path.accessor, path.path, method, HashAlgorithm::SHA256, {}, filter2, repair);
 
     if (cacheKey && mode == FetchMode::Copy)
-        fetchers::getCache()->add(store, *cacheKey, {}, storePath, true);
+        fetchers::getCache()->add(store, *cacheKey, {}, storePath);
 
     return storePath;
 }
-
 
 }

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -456,15 +456,14 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
     {
         auto accessor = getAccessor(treeHash, false);
 
-        auto domain = "treeHashToNarHash";
-        fetchers::Attrs cacheKey({{"treeHash", treeHash.gitRev()}});
+        fetchers::Cache::Key cacheKey{"treeHashToNarHash", {{"treeHash", treeHash.gitRev()}}};
 
-        if (auto res = fetchers::getCache()->lookup(domain, cacheKey))
+        if (auto res = fetchers::getCache()->lookup(cacheKey))
             return Hash::parseAny(fetchers::getStrAttr(*res, "narHash"), HashAlgorithm::SHA256);
 
         auto narHash = accessor->hashPath(CanonPath::root);
 
-        fetchers::getCache()->upsert(domain, cacheKey, fetchers::Attrs({{"narHash", narHash.to_string(HashFormat::SRI, true)}}));
+        fetchers::getCache()->upsert(cacheKey, fetchers::Attrs({{"narHash", narHash.to_string(HashFormat::SRI, true)}}));
 
         return narHash;
     }

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -456,14 +456,15 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
     {
         auto accessor = getAccessor(treeHash, false);
 
-        fetchers::Attrs cacheKey({{"_what", "treeHashToNarHash"}, {"treeHash", treeHash.gitRev()}});
+        auto domain = "treeHashToNarHash";
+        fetchers::Attrs cacheKey({{"treeHash", treeHash.gitRev()}});
 
-        if (auto res = fetchers::getCache()->lookup(cacheKey))
+        if (auto res = fetchers::getCache()->lookup(domain, cacheKey))
             return Hash::parseAny(fetchers::getStrAttr(*res, "narHash"), HashAlgorithm::SHA256);
 
         auto narHash = accessor->hashPath(CanonPath::root);
 
-        fetchers::getCache()->upsert(cacheKey, fetchers::Attrs({{"narHash", narHash.to_string(HashFormat::SRI, true)}}));
+        fetchers::getCache()->upsert(domain, cacheKey, fetchers::Attrs({{"narHash", narHash.to_string(HashFormat::SRI, true)}}));
 
         return narHash;
     }

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -225,11 +225,13 @@ struct GitArchiveInputScheme : InputScheme
 
         auto cache = getCache();
 
-        Attrs treeHashKey{{"_what", "gitRevToTreeHash"}, {"rev", rev->gitRev()}};
-        Attrs lastModifiedKey{{"_what", "gitRevToLastModified"}, {"rev", rev->gitRev()}};
+        auto treeHashDomain = "gitRevToTreeHash";
+        Attrs treeHashKey{{"rev", rev->gitRev()}};
+        auto lastModifiedDomain = "gitRevToLastModified";
+        Attrs lastModifiedKey{{"rev", rev->gitRev()}};
 
-        if (auto treeHashAttrs = cache->lookup(treeHashKey)) {
-            if (auto lastModifiedAttrs = cache->lookup(lastModifiedKey)) {
+        if (auto treeHashAttrs = cache->lookup(treeHashDomain, treeHashKey)) {
+            if (auto lastModifiedAttrs = cache->lookup(lastModifiedDomain, lastModifiedKey)) {
                 auto treeHash = getRevAttr(*treeHashAttrs, "treeHash");
                 auto lastModified = getIntAttr(*lastModifiedAttrs, "lastModified");
                 if (getTarballCache()->hasObject(treeHash))
@@ -257,8 +259,8 @@ struct GitArchiveInputScheme : InputScheme
             .lastModified = lastModified
         };
 
-        cache->upsert(treeHashKey, Attrs{{"treeHash", tarballInfo.treeHash.gitRev()}});
-        cache->upsert(lastModifiedKey, Attrs{{"lastModified", (uint64_t) tarballInfo.lastModified}});
+        cache->upsert(treeHashDomain, treeHashKey, Attrs{{"treeHash", tarballInfo.treeHash.gitRev()}});
+        cache->upsert(lastModifiedDomain, lastModifiedKey, Attrs{{"lastModified", (uint64_t) tarballInfo.lastModified}});
 
         #if 0
         if (upstreamTreeHash != tarballInfo.treeHash)

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -225,13 +225,11 @@ struct GitArchiveInputScheme : InputScheme
 
         auto cache = getCache();
 
-        auto treeHashDomain = "gitRevToTreeHash";
-        Attrs treeHashKey{{"rev", rev->gitRev()}};
-        auto lastModifiedDomain = "gitRevToLastModified";
-        Attrs lastModifiedKey{{"rev", rev->gitRev()}};
+        Cache::Key treeHashKey{"gitRevToTreeHash", {{"rev", rev->gitRev()}}};
+        Cache::Key lastModifiedKey{"gitRevToLastModified", {{"rev", rev->gitRev()}}};
 
-        if (auto treeHashAttrs = cache->lookup(treeHashDomain, treeHashKey)) {
-            if (auto lastModifiedAttrs = cache->lookup(lastModifiedDomain, lastModifiedKey)) {
+        if (auto treeHashAttrs = cache->lookup(treeHashKey)) {
+            if (auto lastModifiedAttrs = cache->lookup(lastModifiedKey)) {
                 auto treeHash = getRevAttr(*treeHashAttrs, "treeHash");
                 auto lastModified = getIntAttr(*lastModifiedAttrs, "lastModified");
                 if (getTarballCache()->hasObject(treeHash))
@@ -259,8 +257,8 @@ struct GitArchiveInputScheme : InputScheme
             .lastModified = lastModified
         };
 
-        cache->upsert(treeHashDomain, treeHashKey, Attrs{{"treeHash", tarballInfo.treeHash.gitRev()}});
-        cache->upsert(lastModifiedDomain, lastModifiedKey, Attrs{{"lastModified", (uint64_t) tarballInfo.lastModified}});
+        cache->upsert(treeHashKey, Attrs{{"treeHash", tarballInfo.treeHash.gitRev()}});
+        cache->upsert(lastModifiedKey, Attrs{{"lastModified", (uint64_t) tarballInfo.lastModified}});
 
         #if 0
         if (upstreamTreeHash != tarballInfo.treeHash)

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -99,8 +99,7 @@ DownloadFileResult downloadFile(
             *store,
             inAttrs,
             infoAttrs,
-            *storePath,
-            false);
+            *storePath);
     }
 
     return {

--- a/src/libfetchers/unix/git.cc
+++ b/src/libfetchers/unix/git.cc
@@ -427,36 +427,34 @@ struct GitInputScheme : InputScheme
 
     uint64_t getLastModified(const RepoInfo & repoInfo, const std::string & repoDir, const Hash & rev) const
     {
-        auto domain = "gitLastModified";
-        Attrs key{{"rev", rev.gitRev()}};
+        Cache::Key key{"gitLastModified", {{"rev", rev.gitRev()}}};
 
         auto cache = getCache();
 
-        if (auto res = cache->lookup(domain, key))
+        if (auto res = cache->lookup(key))
             return getIntAttr(*res, "lastModified");
 
         auto lastModified = GitRepo::openRepo(repoDir)->getLastModified(rev);
 
-        cache->upsert(domain, key, {{"lastModified", lastModified}});
+        cache->upsert(key, {{"lastModified", lastModified}});
 
         return lastModified;
     }
 
     uint64_t getRevCount(const RepoInfo & repoInfo, const std::string & repoDir, const Hash & rev) const
     {
-        auto domain = "gitRevCount";
-        Attrs key{{"rev", rev.gitRev()}};
+        Cache::Key key{"gitRevCount", {{"rev", rev.gitRev()}}};
 
         auto cache = getCache();
 
-        if (auto revCountAttrs = cache->lookup(domain, key))
+        if (auto revCountAttrs = cache->lookup(key))
             return getIntAttr(*revCountAttrs, "revCount");
 
         Activity act(*logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.url));
 
         auto revCount = GitRepo::openRepo(repoDir)->getRevCount(rev);
 
-        cache->upsert(domain, key, Attrs{{"revCount", revCount}});
+        cache->upsert(key, Attrs{{"revCount", revCount}});
 
         return revCount;
     }

--- a/src/libfetchers/unix/git.cc
+++ b/src/libfetchers/unix/git.cc
@@ -427,34 +427,36 @@ struct GitInputScheme : InputScheme
 
     uint64_t getLastModified(const RepoInfo & repoInfo, const std::string & repoDir, const Hash & rev) const
     {
-        Attrs key{{"_what", "gitLastModified"}, {"rev", rev.gitRev()}};
+        auto domain = "gitLastModified";
+        Attrs key{{"rev", rev.gitRev()}};
 
         auto cache = getCache();
 
-        if (auto res = cache->lookup(key))
+        if (auto res = cache->lookup(domain, key))
             return getIntAttr(*res, "lastModified");
 
         auto lastModified = GitRepo::openRepo(repoDir)->getLastModified(rev);
 
-        cache->upsert(key, Attrs{{"lastModified", lastModified}});
+        cache->upsert(domain, key, {{"lastModified", lastModified}});
 
         return lastModified;
     }
 
     uint64_t getRevCount(const RepoInfo & repoInfo, const std::string & repoDir, const Hash & rev) const
     {
-        Attrs key{{"_what", "gitRevCount"}, {"rev", rev.gitRev()}};
+        auto domain = "gitRevCount";
+        Attrs key{{"rev", rev.gitRev()}};
 
         auto cache = getCache();
 
-        if (auto revCountAttrs = cache->lookup(key))
+        if (auto revCountAttrs = cache->lookup(domain, key))
             return getIntAttr(*revCountAttrs, "revCount");
 
         Activity act(*logger, lvlChatty, actUnknown, fmt("getting Git revision count of '%s'", repoInfo.url));
 
         auto revCount = GitRepo::openRepo(repoDir)->getRevCount(rev);
 
-        cache->upsert(key, Attrs{{"revCount", revCount}});
+        cache->upsert(domain, key, Attrs{{"revCount", revCount}});
 
         return revCount;
     }

--- a/tests/functional/fetchMercurial.sh
+++ b/tests/functional/fetchMercurial.sh
@@ -101,6 +101,7 @@ path4=$(nix eval --impure --refresh --raw --expr "(builtins.fetchMercurial file:
 [[ $path2 = $path4 ]]
 
 echo paris > $repo/hello
+
 # Passing a `name` argument should be reflected in the output path
 path5=$(nix eval -vvvvv --impure --refresh --raw --expr "(builtins.fetchMercurial { url = \"file://$repo\"; name = \"foo\"; } ).outPath")
 [[ $path5 =~ -foo$ ]]


### PR DESCRIPTION
# Motivation

This PR:

* Removes the "locked" / "immutable" flag from the cache. (It was already mostly unused.)
* Ensures that all cache entries that contain a store path also contain the store prefix, so that different store prefixes don't collide. This removes the explicit `store` field in `fetchToStore()`'s cache key.
* Removes the `_what` and `type` fields, turning them into a mandatory part of the cache key.

Since this is a schema change, the fetcher cache is renamed to `fetcher-cache-v2.sqlite`.

Depends on #10414.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
