### PR TITLE
nix shell: Handle output paths that are symlinks

### DIFF
--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -33,6 +33,10 @@ struct LocalStoreAccessor : PosixSourceAccessor
 
     std::optional<Stat> maybeLstat(const CanonPath & path) override
     {
+        /* Handle the case where `path` is (a parent of) the store. */
+        if (isDirOrInDir(store->storeDir, path.abs()))
+            return Stat{ .type = tDirectory };
+
         return PosixSourceAccessor::maybeLstat(toRealPath(path));
     }
 

--- a/src/libutil/source-accessor.hh
+++ b/src/libutil/source-accessor.hh
@@ -10,6 +10,26 @@ namespace nix {
 struct Sink;
 
 /**
+ * Note there is a decent chance this type soon goes away because the problem is solved another way.
+ * See the discussion in https://github.com/NixOS/nix/pull/9985.
+ */
+enum class SymlinkResolution {
+    /**
+     * Resolve symlinks in the ancestors only.
+     *
+     * Only the last component of the result is possibly a symlink.
+     */
+    Ancestors,
+
+    /**
+     * Resolve symlinks fully, realpath(3)-style.
+     *
+     * No component of the result will be a symlink.
+     */
+    Full,
+};
+
+/**
  * A read-only filesystem abstraction. This is used by the Nix
  * evaluator and elsewhere for accessing sources in various
  * filesystem-like entities (such as the real filesystem, tarballs or
@@ -112,9 +132,9 @@ struct SourceAccessor
         PathFilter & filter = defaultPathFilter);
 
     Hash hashPath(
-            const CanonPath & path,
-            PathFilter & filter = defaultPathFilter,
-            HashAlgorithm ha = HashAlgorithm::SHA256);
+        const CanonPath & path,
+        PathFilter & filter = defaultPathFilter,
+        HashAlgorithm ha = HashAlgorithm::SHA256);
 
     /**
      * Return a corresponding path in the root filesystem, if
@@ -137,6 +157,17 @@ struct SourceAccessor
     void setPathDisplay(std::string displayPrefix, std::string displaySuffix = "");
 
     virtual std::string showPath(const CanonPath & path);
+
+    /**
+     * Resolve any symlinks in `path` according to the given
+     * resolution mode.
+     *
+     * @param mode might only be a temporary solution for this.
+     * See the discussion in https://github.com/NixOS/nix/pull/9985.
+     */
+    CanonPath resolveSymlinks(
+        const CanonPath & path,
+        SymlinkResolution mode = SymlinkResolution::Full);
 };
 
 }

--- a/src/libutil/source-path.cc
+++ b/src/libutil/source-path.cc
@@ -62,44 +62,6 @@ bool SourcePath::operator<(const SourcePath & x) const
     return std::tie(*accessor, path) < std::tie(*x.accessor, x.path);
 }
 
-SourcePath SourcePath::resolveSymlinks(SymlinkResolution mode) const
-{
-    auto res = SourcePath(accessor);
-
-    int linksAllowed = 1024;
-
-    std::list<std::string> todo;
-    for (auto & c : path)
-        todo.push_back(std::string(c));
-
-    bool resolve_last = mode == SymlinkResolution::Full;
-
-    while (!todo.empty()) {
-        auto c = *todo.begin();
-        todo.pop_front();
-        if (c == "" || c == ".")
-            ;
-        else if (c == "..")
-            res.path.pop();
-        else {
-            res.path.push(c);
-            if (resolve_last || !todo.empty()) {
-                if (auto st = res.maybeLstat(); st && st->type == InputAccessor::tSymlink) {
-                    if (!linksAllowed--)
-                        throw Error("infinite symlink recursion in path '%s'", path);
-                    auto target = res.readLink();
-                    res.path.pop();
-                    if (hasPrefix(target, "/"))
-                        res.path = CanonPath::root;
-                    todo.splice(todo.begin(), tokenizeString<std::list<std::string>>(target, "/"));
-                }
-            }
-        }
-    }
-
-    return res;
-}
-
 std::ostream & operator<<(std::ostream & str, const SourcePath & path)
 {
     str << path.to_string();

--- a/src/libutil/source-path.hh
+++ b/src/libutil/source-path.hh
@@ -12,26 +12,6 @@
 namespace nix {
 
 /**
- * Note there is a decent chance this type soon goes away because the problem is solved another way.
- * See the discussion in https://github.com/NixOS/nix/pull/9985.
- */
-enum class SymlinkResolution {
-    /**
-     * Resolve symlinks in the ancestors only.
-     *
-     * Only the last component of the result is possibly a symlink.
-     */
-    Ancestors,
-
-    /**
-     * Resolve symlinks fully, realpath(3)-style.
-     *
-     * No component of the result will be a symlink.
-     */
-    Full,
-};
-
-/**
  * An abstraction for accessing source files during
  * evaluation. Currently, it's just a wrapper around `CanonPath` that
  * accesses files in the regular filesystem, but in the future it will
@@ -123,14 +103,13 @@ struct SourcePath
     bool operator<(const SourcePath & x) const;
 
     /**
-     * Resolve any symlinks in this `SourcePath` according to the
-     * given resolution mode.
-     *
-     * @param mode might only be a temporary solution for this. 
-     * See the discussion in https://github.com/NixOS/nix/pull/9985.
+     * Convenience wrapper around `SourceAccessor::resolveSymlinks()`.
      */
     SourcePath resolveSymlinks(
-        SymlinkResolution mode = SymlinkResolution::Full) const;
+        SymlinkResolution mode = SymlinkResolution::Full) const
+    {
+        return {accessor, accessor->resolveSymlinks(path, mode)};
+    }
 };
 
 std::ostream & operator << (std::ostream & str, const SourcePath & path);

--- a/src/nix/unix/run.cc
+++ b/src/nix/unix/run.cc
@@ -124,7 +124,8 @@ struct CmdShell : InstallablesCommand, MixEnvironment
             if (true)
                 pathAdditions.push_back(store->printStorePath(path) + "/bin");
 
-            auto propPath = CanonPath(store->printStorePath(path)) / "nix-support" / "propagated-user-env-packages";
+            auto propPath = accessor->resolveSymlinks(
+                CanonPath(store->printStorePath(path)) / "nix-support" / "propagated-user-env-packages");
             if (auto st = accessor->maybeLstat(propPath); st && st->type == SourceAccessor::tRegular) {
                 for (auto & p : tokenizeString<Paths>(accessor->readFile(propPath)))
                     todo.push(store->parseStorePath(p));

--- a/tests/functional/shell-hello.nix
+++ b/tests/functional/shell-hello.nix
@@ -32,6 +32,14 @@ rec {
       '';
   };
 
+  forbidden-symlink = mkDerivation {
+    name = "forbidden-symlink";
+    buildCommand =
+      ''
+        ln -s /tmp/foo/bar $out
+      '';
+  };
+
   salve-mundi = mkDerivation {
     name = "salve-mundi";
     outputs = [ "out" ];

--- a/tests/functional/shell-hello.nix
+++ b/tests/functional/shell-hello.nix
@@ -1,6 +1,6 @@
 with import ./config.nix;
 
-{
+rec {
   hello = mkDerivation {
     name = "hello";
     outputs = [ "out" "dev" ];
@@ -21,6 +21,14 @@ with import ./config.nix;
         echo "Hello2"
         EOF
         chmod +x $dev/bin/hello2
+      '';
+  };
+
+  hello-symlink = mkDerivation {
+    name = "hello-symlink";
+    buildCommand =
+      ''
+        ln -s ${hello} $out
       '';
   };
 

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -10,6 +10,8 @@ nix shell -f shell-hello.nix hello -c hello NixOS | grep 'Hello NixOS'
 nix shell -f shell-hello.nix hello^dev -c hello2 | grep 'Hello2'
 nix shell -f shell-hello.nix 'hello^*' -c hello2 | grep 'Hello2'
 
+# Test output paths that are a symlink.
+#nix shell -f shell-hello.nix hello-symlink -c hello | grep 'Hello World'
 
 if isDaemonNewer "2.20.0pre20231220"; then
     # Test that command line attribute ordering is reflected in the PATH

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -13,6 +13,9 @@ nix shell -f shell-hello.nix 'hello^*' -c hello2 | grep 'Hello2'
 # Test output paths that are a symlink.
 nix shell -f shell-hello.nix hello-symlink -c hello | grep 'Hello World'
 
+# Test that symlinks outside of the store don't work.
+expect 1 nix shell -f shell-hello.nix forbidden-symlink -c hello 2>&1 | grepQuiet "is not in the Nix store"
+
 if isDaemonNewer "2.20.0pre20231220"; then
     # Test that command line attribute ordering is reflected in the PATH
     # https://github.com/NixOS/nix/issues/7905

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -11,7 +11,7 @@ nix shell -f shell-hello.nix hello^dev -c hello2 | grep 'Hello2'
 nix shell -f shell-hello.nix 'hello^*' -c hello2 | grep 'Hello2'
 
 # Test output paths that are a symlink.
-#nix shell -f shell-hello.nix hello-symlink -c hello | grep 'Hello World'
+nix shell -f shell-hello.nix hello-symlink -c hello | grep 'Hello World'
 
 if isDaemonNewer "2.20.0pre20231220"; then
     # Test that command line attribute ordering is reflected in the PATH


### PR DESCRIPTION
# Motivation

This requires moving resolveSymlinks() into SourceAccessor. Also, it requires LocalStoreAccessor::maybeLstat() to work on parents of the store (to avoid an error like "/nix is not in the store").

Fixes #10375.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
