### PR TITLE
Fix the access of symlinks to host files in the sandbox

### DIFF
--- a/tests/functional/linux-sandbox.sh
+++ b/tests/functional/linux-sandbox.sh
@@ -61,9 +61,11 @@ testCert () {
 nocert=$TEST_ROOT/no-cert-file.pem
 cert=$TEST_ROOT/some-cert-file.pem
 symlinkcert=$TEST_ROOT/symlink-cert-file.pem
+transitivesymlinkcert=$TEST_ROOT/transitive-symlink-cert-file.pem
 symlinkDir=$TEST_ROOT/symlink-dir
 echo -n "CERT_CONTENT" > $cert
 ln -s $cert $symlinkcert
+ln -s $symlinkcert $transitivesymlinkcert
 ln -s $TEST_ROOT $symlinkDir
 
 # No cert in sandbox when not a fixed-output derivation
@@ -78,8 +80,9 @@ testCert missing fixed-output "$nocert"
 # Cert in sandbox when ssl-cert-file is set to an existing file
 testCert present fixed-output "$cert"
 
-# Cert in sandbox when ssl-cert-file is set to a symlink to an existing file
+# Cert in sandbox when ssl-cert-file is set to a (potentially transitive) symlink to an existing file
 testCert present fixed-output "$symlinkcert"
+testCert present fixed-output "$transitivesymlinkcert"
 
 # Symlinks should be added in the sandbox directly and not followed
 nix-sandbox-build symlink-derivation.nix -A depends_on_symlink

--- a/tests/functional/symlink-derivation.nix
+++ b/tests/functional/symlink-derivation.nix
@@ -15,22 +15,45 @@ let
     '';
   };
 in
-mkDerivation {
-  name = "depends-on-symlink";
-  buildCommand = ''
-    (
-      set -x
+{
+  depends_on_symlink = mkDerivation {
+    name = "depends-on-symlink";
+    buildCommand = ''
+      (
+        set -x
 
-      # `foo_symlink` should be a symlink pointing to `foo_in_store`
-      [[ -L ${foo_symlink} ]]
-      [[ $(readlink ${foo_symlink}) == ${foo_in_store} ]]
+        # `foo_symlink` should be a symlink pointing to `foo_in_store`
+        [[ -L ${foo_symlink} ]]
+        [[ $(readlink ${foo_symlink}) == ${foo_in_store} ]]
 
-      # `symlink_to_not_in_store` should be a symlink pointing to `./.`, which
-      # is not available in the sandbox
-      [[ -L ${symlink_to_not_in_store} ]]
-      [[ $(readlink ${symlink_to_not_in_store}) == ${builtins.toString ./.} ]]
-      (! ls ${symlink_to_not_in_store}/)
-    )
-    echo "Success!" > $out
-  '';
+        # `symlink_to_not_in_store` should be a symlink pointing to `./.`, which
+        # is not available in the sandbox
+        [[ -L ${symlink_to_not_in_store} ]]
+        [[ $(readlink ${symlink_to_not_in_store}) == ${builtins.toString ./.} ]]
+        (! ls ${symlink_to_not_in_store}/)
+
+        # Native paths
+      )
+      echo "Success!" > $out
+    '';
+  };
+
+  test_sandbox_paths = mkDerivation {
+    # Depends on the caller to set a bunch of `--sandbox-path` arguments
+    name = "test-sandbox-paths";
+    buildCommand = ''
+      (
+        set -x
+        [[ -f /file ]]
+        [[ -d /dir ]]
+
+        # /symlink and /symlinkDir should be available as raw symlinks
+        # (pointing to files outside of the sandbox)
+        [[ -L /symlink ]] && [[ ! -e $(readlink /symlink) ]]
+        [[ -L /symlinkDir ]] && [[ ! -e $(readlink /symlinkDir) ]]
+      )
+
+      touch $out
+    '';
+  };
 }


### PR DESCRIPTION
https://github.com/NixOS/nix/pull/10456 fixed the addition of symlink
store paths to the sandbox, but also made it so that the hardcoded
sandbox paths (like `/etc/hosts`) were now bind-mounted without
following the possible symlinks. This made these files unreadable if
there were symlinks (because the sandbox would now contain a symlink to
an unreachable file rather than the underlying file).
In particular, this broke FOD derivations on NixOS as `/etc/hosts` is a
symlink there.

Fix that by canonicalizing all these hardcoded sandbox paths before
adding them to the sandbox.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
