### PR TITLE
`fetchers::PublicKey` json impl

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -3,6 +3,7 @@
 #include "input-accessor.hh"
 #include "source-path.hh"
 #include "fetch-to-store.hh"
+#include "json-utils.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -409,6 +410,23 @@ std::optional<ExperimentalFeature> InputScheme::experimentalFeature() const
 std::string publicKeys_to_string(const std::vector<PublicKey>& publicKeys)
 {
     return ((nlohmann::json) publicKeys).dump();
+}
+
+}
+
+namespace nlohmann {
+
+using namespace nix;
+
+fetchers::PublicKey adl_serializer<fetchers::PublicKey>::from_json(const json & json) {
+    auto type = optionalValueAt(json, "type").value_or("ssh-ed25519");
+    auto key = valueAt(json, "key");
+    return fetchers::PublicKey { getString(type), getString(key) };
+}
+
+void adl_serializer<fetchers::PublicKey>::to_json(json & json, fetchers::PublicKey p) {
+    json["type"] = p.type;
+    json["key"] = p.key;
 }
 
 }

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -4,6 +4,7 @@
 #include "types.hh"
 #include "hash.hh"
 #include "canon-path.hh"
+#include "json-impls.hh"
 #include "attrs.hh"
 #include "url.hh"
 
@@ -230,8 +231,9 @@ struct PublicKey
     std::string type = "ssh-ed25519";
     std::string key;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(PublicKey, type, key)
 
 std::string publicKeys_to_string(const std::vector<PublicKey>&);
 
 }
+
+JSON_IMPL(fetchers::PublicKey)

--- a/src/libutil/json-utils.cc
+++ b/src/libutil/json-utils.cc
@@ -30,14 +30,12 @@ const nlohmann::json & valueAt(
     return map.at(key);
 }
 
-std::optional<nlohmann::json> optionalValueAt(const nlohmann::json & value, const std::string & key)
+std::optional<nlohmann::json> optionalValueAt(const nlohmann::json::object_t & map, const std::string & key)
 {
-    try {
-        auto & v = valueAt(value, key);
-        return v.get<nlohmann::json>();
-    } catch (...) {
+    if (!map.contains(key))
         return std::nullopt;
-    }
+
+    return std::optional { map.at(key) };
 }
 
 

--- a/src/libutil/json-utils.hh
+++ b/src/libutil/json-utils.hh
@@ -23,7 +23,7 @@ const nlohmann::json & valueAt(
     const nlohmann::json::object_t & map,
     const std::string & key);
 
-std::optional<nlohmann::json> optionalValueAt(const nlohmann::json & value, const std::string & key);
+std::optional<nlohmann::json> optionalValueAt(const nlohmann::json::object_t & value, const std::string & key);
 
 /**
  * Downcast the json object, failing with a nice error if the conversion fails.

--- a/tests/unit/libutil/json-utils.cc
+++ b/tests/unit/libutil/json-utils.cc
@@ -160,4 +160,16 @@ TEST(getBoolean, wrongAssertions) {
     ASSERT_THROW(getBoolean(valueAt(json, "int")), Error);
 }
 
+TEST(optionalValueAt, existing) {
+    auto json = R"({ "string": "ssh-rsa" })"_json;
+
+    ASSERT_EQ(optionalValueAt(json, "string"), std::optional { "ssh-rsa" });
+}
+
+TEST(optionalValueAt, empty) {
+    auto json = R"({})"_json;
+
+    ASSERT_EQ(optionalValueAt(json, "string2"), std::nullopt);
+}
+
 } /* namespace nix */


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Like originally mentioned in #10087 by @Ericson2314  this small PR implements the json (de)serialization (`JSON_IMPL`) for `fetchers::PublicKey` using the new functions (`getString` etc.) to provide better messages in case of an error.

I also updated the implementation for `optionalValueAt` since the old one seemed to be unnecessarily error prone and added some unit tests for the function.

What I also noticed is that I didn't add any unit tests for `getNullable` in the original PR :/
Should I add some basic ones in this PR?

# Context
<!-- Provide context. Reference open issues if available. -->

> @haenoe That might be a great follow-up task (and you are welcome to submit it as a separate PR!), but it should not be part of this PR, which should be a "pure" refactor --- without any behavioral changes.

_Originally posted by @Ericson2314 in https://github.com/NixOS/nix/pull/10087#discussion_r1547957542_

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
