### PR TITLE
InstallableFlake::getCursors(): Force re-evaluation in case of cached failure

### DIFF
--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -181,7 +181,7 @@ InstallableFlake::getCursors(EvalState & state)
     for (auto & attrPath : attrPaths) {
         debug("trying flake output attribute '%s'", attrPath);
 
-        auto attr = root->findAlongAttrPath(parseAttrPath(state, attrPath));
+        auto attr = root->findAlongAttrPath(parseAttrPath(state, attrPath), true);
         if (attr) {
             res.push_back(ref(*attr));
         } else {

--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -1,0 +1,22 @@
+source ./common.sh
+
+requireGit
+
+flake1Dir="$TEST_ROOT/eval-cache-flake"
+
+createGitRepo "$flake1Dir" ""
+
+cat >"$flake1Dir/flake.nix" <<EOF
+{
+  description = "Fnord";
+  outputs = { self }: {
+    foo.bar = throw "breaks";
+  };
+}
+EOF
+
+git -C "$flake1Dir" add flake.nix
+git -C "$flake1Dir" commit -m "Init"
+
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -16,6 +16,7 @@ nix_tests = \
   flakes/absolute-attr-paths.sh \
   flakes/build-paths.sh \
   flakes/flake-in-submodule.sh \
+  flakes/eval-cache.sh \
   gc.sh \
   nix-collect-garbage-d.sh \
   remote-store.sh \


### PR DESCRIPTION
# Motivation

This fixes the "cached failure of attribute ..." message in case the flake output fails at top-level (i.e. in `getCursors()`).

Issue #3872.

Test case borrowed from #10368.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
