### PR TITLE
Add missing setPathDisplay() calls

### DIFF
--- a/src/libfetchers/filtering-input-accessor.cc
+++ b/src/libfetchers/filtering-input-accessor.cc
@@ -38,7 +38,7 @@ std::string FilteringInputAccessor::readLink(const CanonPath & path)
 
 std::string FilteringInputAccessor::showPath(const CanonPath & path)
 {
-    return next->showPath(prefix / path);
+    return displayPrefix + next->showPath(prefix / path) + displaySuffix;
 }
 
 void FilteringInputAccessor::checkAccess(const CanonPath & path)

--- a/src/libfetchers/filtering-input-accessor.hh
+++ b/src/libfetchers/filtering-input-accessor.hh
@@ -27,7 +27,9 @@ struct FilteringInputAccessor : InputAccessor
         : next(src.accessor)
         , prefix(src.path)
         , makeNotAllowedError(std::move(makeNotAllowedError))
-    { }
+    {
+        displayPrefix.clear();
+    }
 
     std::string readFile(const CanonPath & path) override;
 

--- a/src/libfetchers/fs-input-accessor.cc
+++ b/src/libfetchers/fs-input-accessor.cc
@@ -24,7 +24,10 @@ ref<InputAccessor> makeStorePathAccessor(
     const StorePath & storePath)
 {
     // FIXME: should use `store->getFSAccessor()`
-    return makeFSInputAccessor(std::filesystem::path { store->toRealPath(storePath) });
+    auto root = std::filesystem::path { store->toRealPath(storePath) };
+    auto accessor = makeFSInputAccessor(root);
+    accessor->setPathDisplay(root);
+    return accessor;
 }
 
 SourcePath getUnfilteredRootPath(CanonPath path)

--- a/src/libfetchers/mounted-input-accessor.cc
+++ b/src/libfetchers/mounted-input-accessor.cc
@@ -9,6 +9,8 @@ struct MountedInputAccessor : InputAccessor
     MountedInputAccessor(std::map<CanonPath, ref<InputAccessor>> _mounts)
         : mounts(std::move(_mounts))
     {
+        displayPrefix.clear();
+
         // Currently we require a root filesystem. This could be relaxed.
         assert(mounts.contains(CanonPath::root));
 
@@ -48,7 +50,7 @@ struct MountedInputAccessor : InputAccessor
     std::string showPath(const CanonPath & path) override
     {
         auto [accessor, subpath] = resolve(path);
-        return accessor->showPath(subpath);
+        return displayPrefix + accessor->showPath(subpath) + displaySuffix;
     }
 
     std::pair<ref<InputAccessor>, CanonPath> resolve(CanonPath path)

--- a/src/libfetchers/unix/git.cc
+++ b/src/libfetchers/unix/git.cc
@@ -645,6 +645,7 @@ struct GitInputScheme : InputScheme
                 auto submoduleInput = fetchers::Input::fromAttrs(std::move(attrs));
                 auto [submoduleAccessor, submoduleInput2] =
                     submoduleInput.getAccessor(store);
+                submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
                 mounts.insert_or_assign(submodule.path, submoduleAccessor);
             }
 
@@ -681,6 +682,8 @@ struct GitInputScheme : InputScheme
                 exportIgnore,
                 makeNotAllowedError(repoInfo.url));
 
+        accessor->setPathDisplay(repoInfo.url);
+
         /* If the repo has submodules, return a mounted input accessor
            consisting of the accessor for the top-level repo and the
            accessors for the submodule workdirs. */
@@ -697,6 +700,7 @@ struct GitInputScheme : InputScheme
                 auto submoduleInput = fetchers::Input::fromAttrs(std::move(attrs));
                 auto [submoduleAccessor, submoduleInput2] =
                     submoduleInput.getAccessor(store);
+                submoduleAccessor->setPathDisplay("«" + submoduleInput.to_string() + "»");
 
                 /* If the submodule is dirty, mark this repo dirty as
                    well. */

--- a/src/libfetchers/unix/mercurial.cc
+++ b/src/libfetchers/unix/mercurial.cc
@@ -352,7 +352,11 @@ struct MercurialInputScheme : InputScheme
 
         auto storePath = fetchToStore(store, input);
 
-        return {makeStorePathAccessor(store, storePath), input};
+        auto accessor = makeStorePathAccessor(store, storePath);
+
+        accessor->setPathDisplay("«" + input.to_string() + "»");
+
+        return {accessor, input};
     }
 
     bool isLocked(const Input & input) const override


### PR DESCRIPTION
# Motivation

This improves path display for various input types (including Git workdirs), so instead of `copying '/' to the store` you now get `copying '/path/to/git/repo' to the store`.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
