### PR TITLE
C API: nix_get_string now accepts a callback to return the value

### DIFF
--- a/doc/external-api/README.md
+++ b/doc/external-api/README.md
@@ -40,24 +40,37 @@ Nix expression `builtins.nixVersion`.
 #include <nix_api_expr.h>
 #include <nix_api_value.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 // NOTE: This example lacks all error handling. Production code must check for
 // errors, as some return values will be undefined.
-int main() {
-   nix_libexpr_init(NULL);
 
-   Store* store = nix_store_open(NULL, "dummy://", NULL);
-   EvalState* state = nix_state_create(NULL, NULL, store); // empty search path (NIX_PATH)
-   Value *value = nix_alloc_value(NULL, state);
+void my_get_string_cb(const char * start, unsigned int n, char ** user_data)
+{
+    *user_data = strdup(start);
+}
 
-   nix_expr_eval_from_string(NULL, state, "builtins.nixVersion", ".", value);
-   nix_value_force(NULL, state, value);
-   printf("Nix version: %s\n", nix_get_string(NULL, value));
+int main()
+{
+    nix_libexpr_init(NULL);
 
-   nix_gc_decref(NULL, value);
-   nix_state_free(state);
-   nix_store_free(store);
-   return 0;
+    Store * store = nix_store_open(NULL, "dummy://", NULL);
+    EvalState * state = nix_state_create(NULL, NULL, store); // empty search path (NIX_PATH)
+    Value * value = nix_alloc_value(NULL, state);
+
+    nix_expr_eval_from_string(NULL, state, "builtins.nixVersion", ".", value);
+    nix_value_force(NULL, state, value);
+
+    char * version;
+    nix_get_string(NULL, value, my_get_string_cb, version);
+    printf("Nix version: %s\n", version);
+
+    free(version);
+    nix_gc_decref(NULL, value);
+    nix_state_free(state);
+    nix_store_free(store);
+    return 0;
 }
 ```
 

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -15,9 +15,9 @@
 #include "value/context.hh"
 
 #ifdef HAVE_BOEHMGC
-# include "gc/gc.h"
-# define GC_INCLUDE_NEW 1
-# include "gc_cpp.h"
+#  include "gc/gc.h"
+#  define GC_INCLUDE_NEW 1
+#  include "gc_cpp.h"
 #endif
 
 // Helper function to throw an exception if value is null
@@ -166,16 +166,16 @@ bool nix_get_bool(nix_c_context * context, const Value * value)
     NIXC_CATCH_ERRS_RES(false);
 }
 
-const char * nix_get_string(nix_c_context * context, const Value * value)
+nix_err nix_get_string(nix_c_context * context, const Value * value, nix_get_string_callback callback, void * user_data)
 {
     if (context)
         context->last_err_code = NIX_OK;
     try {
         auto & v = check_value_not_null(value);
         assert(v.type() == nix::nString);
-        return v.c_str();
+        call_nix_get_string_callback(v.c_str(), callback, user_data);
     }
-    NIXC_CATCH_ERRS_NULL
+    NIXC_CATCH_ERRS
 }
 
 const char * nix_get_path_string(nix_c_context * context, const Value * value)

--- a/src/libexpr-c/nix_api_value.h
+++ b/src/libexpr-c/nix_api_value.h
@@ -178,10 +178,13 @@ bool nix_get_bool(nix_c_context * context, const Value * value);
  *
  * @param[out] context Optional, stores error information
  * @param[in] value Nix value to inspect
+ * @param[in] callback Called with the string value.
+ * @param[in] user_data optional, arbitrary data, passed to the callback when it's called.
  * @return string
- * @return NULL in case of error.
+ * @return error code, NIX_OK on success.
  */
-const char * nix_get_string(nix_c_context * context, const Value * value);
+nix_err
+nix_get_string(nix_c_context * context, const Value * value, nix_get_string_callback callback, void * user_data);
 
 /** @brief Get path as string
  * @param[out] context Optional, stores error information
@@ -481,7 +484,6 @@ const StorePath * nix_realised_string_get_store_path(nix_realised_string * reali
  * @param[in] realised_string
  */
 void nix_realised_string_free(nix_realised_string * realised_string);
-
 
 // cffi end
 #ifdef __cplusplus

--- a/tests/unit/libexpr/nix_api_external.cc
+++ b/tests/unit/libexpr/nix_api_external.cc
@@ -6,7 +6,9 @@
 #include "nix_api_expr_internal.h"
 #include "nix_api_value.h"
 #include "nix_api_external.h"
+
 #include "tests/nix_api_expr.hh"
+#include "tests/string_callback.hh"
 
 #include <gtest/gtest.h>
 
@@ -58,6 +60,9 @@ TEST_F(nix_api_expr_test, nix_expr_eval_external)
 
     nix_value_call(ctx, state, valueFn, value, valueResult);
 
-    ASSERT_STREQ("nix-external<MyExternalValueDesc( 42 )>", nix_get_string(nullptr, valueResult));
+    std::string string_value;
+    nix_get_string(nullptr, valueResult, OBSERVE_STRING(string_value));
+    ASSERT_STREQ("nix-external<MyExternalValueDesc( 42 )>", string_value.c_str());
 }
+
 }


### PR DESCRIPTION
# Motivation
As suggested by @roberth in https://github.com/NixOS/nix/pull/8699#discussion_r1551998276,
use the callback approach to simplify GC and avoid breaking changes  if we change the internal representation of strings.
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
Stabilize the C interface introduced in https://github.com/NixOS/nix/pull/8699

Milestone: https://github.com/NixOS/nix/milestone/52
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
