### PR TITLE
Auto label C API PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,9 @@
+"c api":
+  - changed-files:
+    - any-glob-to-any-file: "src/lib*-c/**/*"
+    - any-glob-to-any-file: "test/unit/**/nix_api_*"
+    - any-glob-to-any-file: "doc/external-api/**/*"
+
 "contributor-experience":
   - changed-files:
     - any-glob-to-any-file: "CONTRIBUTING.md"


### PR DESCRIPTION
# Motivation

This helps find C API PRs. I really liked what @roberth did on #10526, and I think it makes sense to apply the same approach for the C API.

I hope I haven't made any mistakes here. I'm not sure how to test the labeler locally.

Feel free to close this if you don't like the idea.


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
