### PR TITLE
Rebuild doxygen docs when headers change

### DIFF
--- a/doc/external-api/local.mk
+++ b/doc/external-api/local.mk
@@ -1,4 +1,4 @@
-$(docdir)/external-api/html/index.html $(docdir)/external-api/latex: $(d)/doxygen.cfg
+$(docdir)/external-api/html/index.html $(docdir)/external-api/latex: $(d)/doxygen.cfg src/lib*-c/*.h
 	mkdir -p $(docdir)/external-api
 	{ cat $< ; echo "OUTPUT_DIRECTORY=$(docdir)/external-api" ; } | doxygen -
 

--- a/doc/internal-api/local.mk
+++ b/doc/internal-api/local.mk
@@ -1,4 +1,4 @@
-$(docdir)/internal-api/html/index.html $(docdir)/internal-api/latex: $(d)/doxygen.cfg
+$(docdir)/internal-api/html/index.html $(docdir)/internal-api/latex: $(d)/doxygen.cfg src/**/*.hh
 	mkdir -p $(docdir)/internal-api
 	{ cat $< ; echo "OUTPUT_DIRECTORY=$(docdir)/internal-api" ; } | doxygen -
 


### PR DESCRIPTION
# Motivation

Make it easy to review rendered docs.


# Context


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
