### PR TITLE
C API: Add nix_init_apply

### DIFF
--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -93,6 +93,8 @@ nix_err nix_expr_eval_from_string(
  * @param[in] arg The argument to pass to the function.
  * @param[out] value The result of the function call.
  * @return NIX_OK if the function call was successful, an error code otherwise.
+ * @see nix_init_apply() for a similar function that does not performs the call immediately, but stores it as a thunk.
+ *      Note the different argument order.
  */
 nix_err nix_value_call(nix_c_context * context, EvalState * state, Value * fn, Value * arg, Value * value);
 

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -404,6 +404,19 @@ nix_err nix_init_null(nix_c_context * context, Value * value)
     NIXC_CATCH_ERRS
 }
 
+nix_err nix_init_apply(nix_c_context * context, Value * value, Value * fn, Value * arg)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        auto & v = check_value_not_null(value);
+        auto & f = check_value_not_null(fn);
+        auto & a = check_value_not_null(arg);
+        v.mkApp(&f, &a);
+    }
+    NIXC_CATCH_ERRS
+}
+
 nix_err nix_init_external(nix_c_context * context, Value * value, ExternalValue * val)
 {
     if (context)

--- a/src/libexpr-c/nix_api_value.h
+++ b/src/libexpr-c/nix_api_value.h
@@ -342,8 +342,24 @@ nix_err nix_init_int(nix_c_context * context, Value * value, int64_t i);
  * @param[out] value Nix value to modify
  * @return error code, NIX_OK on success.
  */
-
 nix_err nix_init_null(nix_c_context * context, Value * value);
+
+/** @brief Set the value to a thunk that will perform a function application when needed.
+ *
+ * Thunks may be put into attribute sets and lists to perform some computation lazily; on demand.
+ * However, note that in some places, a thunk must not be returned, such as in the return value of a PrimOp.
+ * In such cases, you may use nix_value_call() instead (but note the different argument order).
+ *
+ * @param[out] context Optional, stores error information
+ * @param[out] value Nix value to modify
+ * @param[in] fn function to call
+ * @param[in] arg argument to pass
+ * @return error code, NIX_OK on successful initialization.
+ * @see nix_value_call() for a similar function that performs the call immediately and only stores the return value.
+ *      Note the different argument order.
+ */
+nix_err nix_init_apply(nix_c_context * context, Value * value, Value * fn, Value * arg);
+
 /** @brief Set an external value
  * @param[out] context Optional, stores error information
  * @param[out] value Nix value to modify
@@ -421,7 +437,7 @@ BindingsBuilder * nix_make_bindings_builder(nix_c_context * context, EvalState *
 /** @brief Insert bindings into a builder
  * @param[out] context Optional, stores error information
  * @param[in] builder BindingsBuilder to insert into
- * @param[in] name attribute name, copied into the symbol store
+ * @param[in] name attribute name, only used for the duration of the call.
  * @param[in] value value to give the binding
  * @return error code, NIX_OK on success.
  */


### PR DESCRIPTION
# Motivation

Thunks are relevant when initializing attrsets and lists, or passing arguments to functions that are lazy in those arguments. This is an important way to produce them.


# Context

- #8699 
- Lazy functionality needs attention; #10499
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

cc @jlesquembre 

Also, the labeler worked :)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
