### PR TITLE
Add tests/functional/lang/eval-fail-readDir-storeDir-pure

### DIFF
--- a/tests/functional/lang/eval-fail-readDir-storeDir-pure.err.exp
+++ b/tests/functional/lang/eval-fail-readDir-storeDir-pure.err.exp
@@ -1,0 +1,1 @@
+error: access to absolute path '/home' is forbidden in pure evaluation mode (use '--impure' to override)

--- a/tests/functional/lang/eval-fail-readDir-storeDir-pure.flags
+++ b/tests/functional/lang/eval-fail-readDir-storeDir-pure.flags
@@ -1,0 +1,1 @@
+--pure-eval

--- a/tests/functional/lang/eval-fail-readDir-storeDir-pure.nix
+++ b/tests/functional/lang/eval-fail-readDir-storeDir-pure.nix
@@ -1,0 +1,1 @@
+builtins.readDir builtins.storeDir


### PR DESCRIPTION
# Motivation

Add missing test case.

- [ ] It's the wrong error. Make `--pure-eval --expr` without flakes work. Reproducable outside the test framework. Not sensitive to `NIX_PATH` environment variable or `--nix-path ""`.

```
$ nix-instantiate --pure-eval tests/functional/lang/eval-fail-readDir-storeDir-pure.nix
error: access to absolute path '/home' is forbidden in pure evaluation mode (use '--impure' to override)
```

# Context

- #10505 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
