### PR TITLE
Fix exportReferencesGraph when given store subpath

### DIFF
--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -186,7 +186,7 @@ std::optional<nlohmann::json> ParsedDerivation::prepareStructuredAttrs(Store & s
         for (auto i = e->begin(); i != e->end(); ++i) {
             StorePathSet storePaths;
             for (auto & p : *i)
-                storePaths.insert(store.parseStorePath(p.get<std::string>()));
+                storePaths.insert(store.toStorePath(p.get<std::string>()).first);
             json[i.key()] = pathInfoToJSON(store,
                 store.exportReferences(storePaths, inputPaths));
         }


### PR DESCRIPTION
# Motivation

Regression.

# Context

With Nix 2.3, it was possible to pass a subpath of a store path to exportReferencesGraph:

	with import <nixpkgs> {};

	let
	  hello = writeShellScriptBin "hello" ''
	    echo ${toString builtins.currentTime}
	  '';
	in

	writeClosure [ "${hello}/bin/hello" ]

This regressed with Nix 2.4, with a very confusing error message, that presumably indicates it was unintentional:

	error: path '/nix/store/3gl7kgjr4pwf03f0x70dgx9ln3bhl7zc-hello/bin/hello' is not in the Nix store

I tried to write a test, but failed to replicate the broken behaviour in the test suite.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
