### PR TITLE
`file-descriptor.hh`: Avoid some C-isms for better C++-isms

### DIFF
--- a/src/libutil/file-descriptor.hh
+++ b/src/libutil/file-descriptor.hh
@@ -17,13 +17,13 @@ struct Source;
 /**
  * Operating System capability
  */
-typedef
+using Descriptor =
 #if _WIN32
     HANDLE
 #else
     int
 #endif
-    Descriptor;
+    ;
 
 const Descriptor INVALID_DESCRIPTOR =
 #if _WIN32
@@ -41,7 +41,7 @@ const Descriptor INVALID_DESCRIPTOR =
 static inline Descriptor toDescriptor(int fd)
 {
 #ifdef _WIN32
-    return (HANDLE) _get_osfhandle(fd);
+    return reinterpret_cast<HANDLE>(_get_osfhandle(fd));
 #else
     return fd;
 #endif
@@ -56,7 +56,7 @@ static inline Descriptor toDescriptor(int fd)
 static inline int fromDescriptorReadOnly(Descriptor fd)
 {
 #ifdef _WIN32
-    return _open_osfhandle((intptr_t) fd, _O_RDONLY);
+    return _open_osfhandle(reinterpret_cast<intptr_t>(fd), _O_RDONLY);
 #else
     return fd;
 #endif


### PR DESCRIPTION
# Motivation

- `reinterpret_cast` not C-style cast
- `using` not `typedef`


# Context

CC @tfc 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
