### PR TITLE
Allow overlay arguments to be called previous as well as prev

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -457,8 +457,8 @@ struct CmdFlakeCheck : FlakeCommand
                 auto body = dynamic_cast<ExprLambda *>(v.payload.lambda.fun->body);
                 if (!body
                     || body->hasFormals()
-                    || !argHasName(body->arg, "prev"))
-                    throw Error("overlay does not take an argument named 'prev'");
+                    || !(argHasName(body->arg, "prev")) || argHasName(body->arg, "previous"))
+                    throw Error("overlay does not take an argument named 'prev' or 'previous'");
                 // FIXME: if we have a 'nixpkgs' input, use it to
                 // evaluate the overlay.
             } catch (Error & e) {


### PR DESCRIPTION
# Motivation

See #10516 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
