### PR TITLE
scripts/upload-release: fix riscv64 call

### DIFF
--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -172,7 +172,7 @@ eval {
 };
 warn "$@" if $@;
 eval {
-    downloadFile("binaryTarballCross.x86_64-linux.riscv64-linux-gnu", "1");
+    downloadFile("binaryTarballCross.x86_64-linux.riscv64-unknown-linux-gnu", "1");
 };
 warn "$@" if $@;
 downloadFile("installerScript", "1");


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Fix call in upload-release.pl script for `riscv64-unknown-linux-gnu`

# Context
<!-- Provide context. Reference open issues if available. -->
Folowup for https://github.com/NixOS/nix/pull/10228#discussion_r1570831972

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
