### PR TITLE
Add isValid to nix::Value

### DIFF
--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -20,7 +20,7 @@
 #  include "gc_cpp.h"
 #endif
 
-// Helper function to throw an exception if value is null or in an invalid state
+// Internal helper functions to check [in] and [out] `Value *` parameters
 static const nix::Value & check_value_not_null(const Value * value)
 {
     if (!value) {
@@ -37,18 +37,31 @@ static nix::Value & check_value_not_null(Value * value)
     return *((nix::Value *) value);
 }
 
-static void check_value_initialized(const nix::Value & value)
+static const nix::Value & check_value_in(const Value * value)
 {
-    if (!value.isValid()) {
+    auto & v = check_value_not_null(value);
+    if (!v.isValid()) {
         throw std::runtime_error("Uninitialized Value");
     }
+    return v;
 }
 
-static void check_value_uninitialized(const nix::Value & value)
+static nix::Value & check_value_in(Value * value)
 {
-    if (value.isValid()) {
+    auto & v = check_value_not_null(value);
+    if (!v.isValid()) {
+        throw std::runtime_error("Uninitialized Value");
+    }
+    return v;
+}
+
+static nix::Value & check_value_out(Value * value)
+{
+    auto & v = check_value_not_null(value);
+    if (v.isValid()) {
         throw std::runtime_error("Value already initialized. Variables are immutable");
     }
+    return v;
 }
 
 /**
@@ -125,8 +138,7 @@ ValueType nix_get_type(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         using namespace nix;
         switch (v.type()) {
         case nThunk:
@@ -162,8 +174,7 @@ const char * nix_get_typename(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         auto s = nix::showType(v);
         return strdup(s.c_str());
     }
@@ -175,8 +186,7 @@ bool nix_get_bool(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nBool);
         return v.boolean();
     }
@@ -188,8 +198,7 @@ nix_err nix_get_string(nix_c_context * context, const Value * value, nix_get_str
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nString);
         call_nix_get_string_callback(v.c_str(), callback, user_data);
     }
@@ -201,8 +210,7 @@ const char * nix_get_path_string(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nPath);
         // NOTE (from @yorickvP)
         // v._path.path should work but may not be how Eelco intended it.
@@ -221,8 +229,7 @@ unsigned int nix_get_list_size(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nList);
         return v.listSize();
     }
@@ -234,8 +241,7 @@ unsigned int nix_get_attrs_size(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nAttrs);
         return v.attrs()->size();
     }
@@ -247,8 +253,7 @@ double nix_get_float(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nFloat);
         return v.fpoint();
     }
@@ -260,8 +265,7 @@ int64_t nix_get_int(nix_c_context * context, const Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nInt);
         return v.integer();
     }
@@ -273,8 +277,7 @@ ExternalValue * nix_get_external(nix_c_context * context, Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_out(value);
         assert(v.type() == nix::nExternal);
         return (ExternalValue *) v.external();
     }
@@ -286,8 +289,7 @@ Value * nix_get_list_byidx(nix_c_context * context, const Value * value, EvalSta
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nList);
         auto * p = v.listElems()[ix];
         nix_gc_incref(nullptr, p);
@@ -303,8 +305,7 @@ Value * nix_get_attr_byname(nix_c_context * context, const Value * value, EvalSt
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nAttrs);
         nix::Symbol s = state->state.symbols.create(name);
         auto attr = v.attrs()->get(s);
@@ -324,8 +325,7 @@ bool nix_has_attr_byname(nix_c_context * context, const Value * value, EvalState
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         assert(v.type() == nix::nAttrs);
         nix::Symbol s = state->state.symbols.create(name);
         auto attr = v.attrs()->get(s);
@@ -342,8 +342,7 @@ nix_get_attr_byidx(nix_c_context * context, const Value * value, EvalState * sta
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         const nix::Attr & a = (*v.attrs())[i];
         *name = ((const std::string &) (state->state.symbols[a.name])).c_str();
         nix_gc_incref(nullptr, a.value);
@@ -358,8 +357,7 @@ const char * nix_get_attr_name_byidx(nix_c_context * context, const Value * valu
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         const nix::Attr & a = (*v.attrs())[i];
         return ((const std::string &) (state->state.symbols[a.name])).c_str();
     }
@@ -371,8 +369,7 @@ nix_err nix_init_bool(nix_c_context * context, Value * value, bool b)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkBool(b);
     }
     NIXC_CATCH_ERRS
@@ -384,8 +381,7 @@ nix_err nix_init_string(nix_c_context * context, Value * value, const char * str
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkString(std::string_view(str));
     }
     NIXC_CATCH_ERRS
@@ -396,8 +392,7 @@ nix_err nix_init_path_string(nix_c_context * context, EvalState * s, Value * val
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkPath(s->state.rootPath(nix::CanonPath(str)));
     }
     NIXC_CATCH_ERRS
@@ -408,8 +403,7 @@ nix_err nix_init_float(nix_c_context * context, Value * value, double d)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkFloat(d);
     }
     NIXC_CATCH_ERRS
@@ -420,8 +414,7 @@ nix_err nix_init_int(nix_c_context * context, Value * value, int64_t i)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkInt(i);
     }
     NIXC_CATCH_ERRS
@@ -432,8 +425,7 @@ nix_err nix_init_null(nix_c_context * context, Value * value)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkNull();
     }
     NIXC_CATCH_ERRS
@@ -457,8 +449,7 @@ nix_err nix_init_external(nix_c_context * context, Value * value, ExternalValue 
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         auto r = (nix::ExternalValueBase *) val;
         v.mkExternal(r);
     }
@@ -486,7 +477,6 @@ nix_err nix_list_builder_insert(nix_c_context * context, ListBuilder * list_buil
         context->last_err_code = NIX_OK;
     try {
         auto & e = check_value_not_null(value);
-        check_value_initialized(e);
         list_builder->builder[index] = &e;
     }
     NIXC_CATCH_ERRS
@@ -506,8 +496,7 @@ nix_err nix_make_list(nix_c_context * context, ListBuilder * list_builder, Value
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkList(list_builder->builder);
     }
     NIXC_CATCH_ERRS
@@ -518,8 +507,7 @@ nix_err nix_init_primop(nix_c_context * context, Value * value, PrimOp * p)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkPrimOp((nix::PrimOp *) p);
     }
     NIXC_CATCH_ERRS
@@ -530,10 +518,8 @@ nix_err nix_copy_value(nix_c_context * context, Value * value, Value * source)
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
-        auto & s = check_value_not_null(source);
-        check_value_initialized(s);
+        auto & v = check_value_out(value);
+        auto & s = check_value_in(source);
         v = s;
     }
     NIXC_CATCH_ERRS
@@ -544,8 +530,7 @@ nix_err nix_make_attrs(nix_c_context * context, Value * value, BindingsBuilder *
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_uninitialized(v);
+        auto & v = check_value_out(value);
         v.mkAttrs(b->builder);
     }
     NIXC_CATCH_ERRS
@@ -572,7 +557,6 @@ nix_err nix_bindings_builder_insert(nix_c_context * context, BindingsBuilder * b
         context->last_err_code = NIX_OK;
     try {
         auto & v = check_value_not_null(value);
-        check_value_initialized(v);
         nix::Symbol s = bb->builder.state.symbols.create(name);
         bb->builder.insert(s, &v);
     }
@@ -593,8 +577,7 @@ nix_realised_string * nix_string_realise(nix_c_context * context, EvalState * st
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto & v = check_value_not_null(value);
-        check_value_initialized(v);
+        auto & v = check_value_in(value);
         nix::NixStringContext stringContext;
         auto rawStr = state->state.coerceToString(nix::noPos, v, stringContext, "while realising a string").toOwned();
         nix::StorePathSet storePaths;

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -513,7 +513,7 @@ nix_err nix_init_primop(nix_c_context * context, Value * value, PrimOp * p)
     NIXC_CATCH_ERRS
 }
 
-nix_err nix_copy_value(nix_c_context * context, Value * value, Value * source)
+nix_err nix_copy_value(nix_c_context * context, Value * value, const Value * source)
 {
     if (context)
         context->last_err_code = NIX_OK;

--- a/src/libexpr-c/nix_api_value.h
+++ b/src/libexpr-c/nix_api_value.h
@@ -422,7 +422,7 @@ nix_err nix_init_primop(nix_c_context * context, Value * value, PrimOp * op);
  * @param[in] source value to copy from
  * @return error code, NIX_OK on success.
  */
-nix_err nix_copy_value(nix_c_context * context, Value * value, Value * source);
+nix_err nix_copy_value(nix_c_context * context, Value * value, const Value * source);
 /**@}*/
 
 /** @brief Create a bindings builder

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -23,7 +23,7 @@ class BindingsBuilder;
 
 
 typedef enum {
-    tUnset,
+    tUninitialized = 0,
     tInt = 1,
     tBool,
     tString,
@@ -167,7 +167,7 @@ public:
 struct Value
 {
 private:
-    InternalType internalType = tUnset;
+    InternalType internalType = tUninitialized;
 
     friend std::string showType(const Value & v);
 
@@ -271,7 +271,7 @@ public:
     inline ValueType type(bool invalidIsThunk = false) const
     {
         switch (internalType) {
-            case tUnset: break;
+            case tUninitialized: break;
             case tInt: return nInt;
             case tBool: return nBool;
             case tString: return nString;
@@ -296,9 +296,14 @@ public:
         internalType = newType;
     }
 
-    inline bool isInitialized()
+    /**
+     * A value becomes valid when it is initialized. We don't use this
+     * in the evaluator; only in the bindings, where the slight extra
+     * cost is warranted because of inexperienced callers.
+     */
+    inline bool isValid() const
     {
-        return internalType != tUnset;
+        return internalType != tUninitialized;
     }
 
     inline void mkInt(NixInt n)

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -23,6 +23,7 @@ class BindingsBuilder;
 
 
 typedef enum {
+    tUnset,
     tInt = 1,
     tBool,
     tString,
@@ -166,7 +167,7 @@ public:
 struct Value
 {
 private:
-    InternalType internalType;
+    InternalType internalType = tUnset;
 
     friend std::string showType(const Value & v);
 
@@ -270,6 +271,7 @@ public:
     inline ValueType type(bool invalidIsThunk = false) const
     {
         switch (internalType) {
+            case tUnset: break;
             case tInt: return nInt;
             case tBool: return nBool;
             case tString: return nString;
@@ -292,6 +294,11 @@ public:
     {
         payload = newPayload;
         internalType = newType;
+    }
+
+    inline bool isInitialized()
+    {
+        return internalType != tUnset;
     }
 
     inline void mkInt(NixInt n)

--- a/tests/unit/libexpr/nix_api_value.cc
+++ b/tests/unit/libexpr/nix_api_value.cc
@@ -367,4 +367,17 @@ TEST_F(nix_api_expr_test, nix_value_init_apply_lazy_arg)
     nix_gc_decref(ctx, e);
 }
 
+TEST_F(nix_api_expr_test, nix_copy_value)
+{
+    Value * source = nix_alloc_value(ctx, state);
+
+    nix_init_int(ctx, source, 42);
+    nix_copy_value(ctx, value, source);
+
+    ASSERT_EQ(42, nix_get_int(ctx, value));
+
+    // Clean up
+    nix_gc_decref(ctx, source);
+}
+
 }

--- a/tests/unit/libexpr/nix_api_value.cc
+++ b/tests/unit/libexpr/nix_api_value.cc
@@ -139,13 +139,20 @@ TEST_F(nix_api_expr_test, nix_build_and_init_list)
     ListBuilder * builder = nix_make_list_builder(ctx, state, size);
 
     Value * intValue = nix_alloc_value(ctx, state);
+    Value * intValue2 = nix_alloc_value(ctx, state);
+
+    // `init` and `insert` can be called in any order
     nix_init_int(ctx, intValue, 42);
     nix_list_builder_insert(ctx, builder, 0, intValue);
+    nix_list_builder_insert(ctx, builder, 1, intValue2);
+    nix_init_int(ctx, intValue2, 43);
+
     nix_make_list(ctx, builder, value);
     nix_list_builder_free(builder);
 
     ASSERT_EQ(42, nix_get_int(ctx, nix_get_list_byidx(ctx, value, state, 0)));
-    ASSERT_EQ(nullptr, nix_get_list_byidx(ctx, value, state, 1));
+    ASSERT_EQ(43, nix_get_int(ctx, nix_get_list_byidx(ctx, value, state, 1)));
+    ASSERT_EQ(nullptr, nix_get_list_byidx(ctx, value, state, 2));
     ASSERT_EQ(10, nix_get_list_size(ctx, value));
 
     ASSERT_STREQ("a list", nix_get_typename(ctx, value));

--- a/tests/unit/libexpr/nix_api_value.cc
+++ b/tests/unit/libexpr/nix_api_value.cc
@@ -34,18 +34,18 @@ TEST_F(nix_api_expr_test, nix_value_set_get_int)
 
 TEST_F(nix_api_expr_test, nix_value_set_get_float_invalid)
 {
-    ASSERT_FLOAT_EQ(0.0, nix_get_float(ctx, nullptr));
+    ASSERT_DOUBLE_EQ(0.0, nix_get_float(ctx, nullptr));
     assert_ctx_err();
-    ASSERT_FLOAT_EQ(0.0, nix_get_float(ctx, value));
+    ASSERT_DOUBLE_EQ(0.0, nix_get_float(ctx, value));
     assert_ctx_err();
 }
 
 TEST_F(nix_api_expr_test, nix_value_set_get_float)
 {
-    float myDouble = 1.0;
+    double myDouble = 1.0;
     nix_init_float(ctx, value, myDouble);
 
-    ASSERT_FLOAT_EQ(myDouble, nix_get_float(ctx, value));
+    ASSERT_DOUBLE_EQ(myDouble, nix_get_float(ctx, value));
     ASSERT_STREQ("a float", nix_get_typename(ctx, value));
     ASSERT_EQ(NIX_TYPE_FLOAT, nix_get_type(ctx, value));
 }

--- a/tests/unit/libexpr/nix_api_value.cc
+++ b/tests/unit/libexpr/nix_api_value.cc
@@ -14,11 +14,16 @@
 
 namespace nixC {
 
-TEST_F(nix_api_expr_test, nix_value_set_get_int)
+TEST_F(nix_api_expr_test, nix_value_get_int_invalid)
 {
     ASSERT_EQ(0, nix_get_int(ctx, nullptr));
-    ASSERT_DEATH(nix_get_int(ctx, value), "");
+    assert_ctx_err();
+    ASSERT_EQ(0, nix_get_int(ctx, value));
+    assert_ctx_err();
+}
 
+TEST_F(nix_api_expr_test, nix_value_set_get_int)
+{
     int myInt = 1;
     nix_init_int(ctx, value, myInt);
 
@@ -27,11 +32,16 @@ TEST_F(nix_api_expr_test, nix_value_set_get_int)
     ASSERT_EQ(NIX_TYPE_INT, nix_get_type(ctx, value));
 }
 
-TEST_F(nix_api_expr_test, nix_value_set_get_float)
+TEST_F(nix_api_expr_test, nix_value_set_get_float_invalid)
 {
     ASSERT_FLOAT_EQ(0.0, nix_get_float(ctx, nullptr));
-    ASSERT_DEATH(nix_get_float(ctx, value), "");
+    assert_ctx_err();
+    ASSERT_FLOAT_EQ(0.0, nix_get_float(ctx, value));
+    assert_ctx_err();
+}
 
+TEST_F(nix_api_expr_test, nix_value_set_get_float)
+{
     float myDouble = 1.0;
     nix_init_float(ctx, value, myDouble);
 
@@ -40,11 +50,16 @@ TEST_F(nix_api_expr_test, nix_value_set_get_float)
     ASSERT_EQ(NIX_TYPE_FLOAT, nix_get_type(ctx, value));
 }
 
-TEST_F(nix_api_expr_test, nix_value_set_get_bool)
+TEST_F(nix_api_expr_test, nix_value_set_get_bool_invalid)
 {
     ASSERT_EQ(false, nix_get_bool(ctx, nullptr));
-    ASSERT_DEATH(nix_get_bool(ctx, value), "");
+    assert_ctx_err();
+    ASSERT_EQ(false, nix_get_bool(ctx, value));
+    assert_ctx_err();
+}
 
+TEST_F(nix_api_expr_test, nix_value_set_get_bool)
+{
     bool myBool = true;
     nix_init_bool(ctx, value, myBool);
 
@@ -53,12 +68,18 @@ TEST_F(nix_api_expr_test, nix_value_set_get_bool)
     ASSERT_EQ(NIX_TYPE_BOOL, nix_get_type(ctx, value));
 }
 
-TEST_F(nix_api_expr_test, nix_value_set_get_string)
+TEST_F(nix_api_expr_test, nix_value_set_get_string_invalid)
 {
     std::string string_value;
     ASSERT_EQ(NIX_ERR_UNKNOWN, nix_get_string(ctx, nullptr, OBSERVE_STRING(string_value)));
-    ASSERT_DEATH(nix_get_string(ctx, value, OBSERVE_STRING(string_value)), "");
+    assert_ctx_err();
+    ASSERT_EQ(NIX_ERR_UNKNOWN, nix_get_string(ctx, value, OBSERVE_STRING(string_value)));
+    assert_ctx_err();
+}
 
+TEST_F(nix_api_expr_test, nix_value_set_get_string)
+{
+    std::string string_value;
     const char * myString = "some string";
     nix_init_string(ctx, value, myString);
 
@@ -68,21 +89,29 @@ TEST_F(nix_api_expr_test, nix_value_set_get_string)
     ASSERT_EQ(NIX_TYPE_STRING, nix_get_type(ctx, value));
 }
 
+TEST_F(nix_api_expr_test, nix_value_set_get_null_invalid)
+{
+    ASSERT_EQ(NULL, nix_get_typename(ctx, value));
+    assert_ctx_err();
+}
+
 TEST_F(nix_api_expr_test, nix_value_set_get_null)
 {
-    ASSERT_DEATH(nix_get_typename(ctx, value), "");
-
     nix_init_null(ctx, value);
 
     ASSERT_STREQ("null", nix_get_typename(ctx, value));
     ASSERT_EQ(NIX_TYPE_NULL, nix_get_type(ctx, value));
 }
 
-TEST_F(nix_api_expr_test, nix_value_set_get_path)
+TEST_F(nix_api_expr_test, nix_value_set_get_path_invalid)
 {
     ASSERT_EQ(nullptr, nix_get_path_string(ctx, nullptr));
-    ASSERT_DEATH(nix_get_path_string(ctx, value), "");
-
+    assert_ctx_err();
+    ASSERT_EQ(nullptr, nix_get_path_string(ctx, value));
+    assert_ctx_err();
+}
+TEST_F(nix_api_expr_test, nix_value_set_get_path)
+{
     const char * p = "/nix/store/40s0qmrfb45vlh6610rk29ym318dswdr-myname";
     nix_init_path_string(ctx, state, value, p);
 
@@ -91,14 +120,21 @@ TEST_F(nix_api_expr_test, nix_value_set_get_path)
     ASSERT_EQ(NIX_TYPE_PATH, nix_get_type(ctx, value));
 }
 
-TEST_F(nix_api_expr_test, nix_build_and_init_list)
+TEST_F(nix_api_expr_test, nix_build_and_init_list_invalid)
 {
     ASSERT_EQ(nullptr, nix_get_list_byidx(ctx, nullptr, state, 0));
+    assert_ctx_err();
     ASSERT_EQ(0, nix_get_list_size(ctx, nullptr));
+    assert_ctx_err();
 
-    ASSERT_DEATH(nix_get_list_byidx(ctx, value, state, 0), "");
-    ASSERT_DEATH(nix_get_list_size(ctx, value), "");
+    ASSERT_EQ(nullptr, nix_get_list_byidx(ctx, value, state, 0));
+    assert_ctx_err();
+    ASSERT_EQ(0, nix_get_list_size(ctx, value));
+    assert_ctx_err();
+}
 
+TEST_F(nix_api_expr_test, nix_build_and_init_list)
+{
     int size = 10;
     ListBuilder * builder = nix_make_list_builder(ctx, state, size);
 
@@ -119,20 +155,33 @@ TEST_F(nix_api_expr_test, nix_build_and_init_list)
     nix_gc_decref(ctx, intValue);
 }
 
-TEST_F(nix_api_expr_test, nix_build_and_init_attr)
+TEST_F(nix_api_expr_test, nix_build_and_init_attr_invalid)
 {
     ASSERT_EQ(nullptr, nix_get_attr_byname(ctx, nullptr, state, 0));
+    assert_ctx_err();
     ASSERT_EQ(nullptr, nix_get_attr_byidx(ctx, nullptr, state, 0, nullptr));
+    assert_ctx_err();
     ASSERT_EQ(nullptr, nix_get_attr_name_byidx(ctx, nullptr, state, 0));
+    assert_ctx_err();
     ASSERT_EQ(0, nix_get_attrs_size(ctx, nullptr));
+    assert_ctx_err();
     ASSERT_EQ(false, nix_has_attr_byname(ctx, nullptr, state, "no-value"));
+    assert_ctx_err();
 
-    ASSERT_DEATH(nix_get_attr_byname(ctx, value, state, 0), "");
-    ASSERT_DEATH(nix_get_attr_byidx(ctx, value, state, 0, nullptr), "");
-    ASSERT_DEATH(nix_get_attr_name_byidx(ctx, value, state, 0), "");
-    ASSERT_DEATH(nix_get_attrs_size(ctx, value), "");
-    ASSERT_DEATH(nix_has_attr_byname(ctx, value, state, "no-value"), "");
+    ASSERT_EQ(nullptr, nix_get_attr_byname(ctx, value, state, 0));
+    assert_ctx_err();
+    ASSERT_EQ(nullptr, nix_get_attr_byidx(ctx, value, state, 0, nullptr));
+    assert_ctx_err();
+    ASSERT_EQ(nullptr, nix_get_attr_name_byidx(ctx, value, state, 0));
+    assert_ctx_err();
+    ASSERT_EQ(0, nix_get_attrs_size(ctx, value));
+    assert_ctx_err();
+    ASSERT_EQ(false, nix_has_attr_byname(ctx, value, state, "no-value"));
+    assert_ctx_err();
+}
 
+TEST_F(nix_api_expr_test, nix_build_and_init_attr)
+{
     int size = 10;
     const char ** out_name = (const char **) malloc(sizeof(char *));
 

--- a/tests/unit/libexpr/value/value.cc
+++ b/tests/unit/libexpr/value/value.cc
@@ -1,0 +1,25 @@
+#include "value.hh"
+
+#include "tests/libstore.hh"
+
+namespace nix {
+
+class ValueTest : public LibStoreTest
+{};
+
+TEST_F(ValueTest, unsetValue)
+{
+    Value unsetValue;
+    ASSERT_EQ(false, unsetValue.isInitialized());
+    ASSERT_EQ(nThunk, unsetValue.type(true));
+    ASSERT_DEATH(unsetValue.type(), "");
+}
+
+TEST_F(ValueTest, vInt)
+{
+    Value vInt;
+    vInt.mkInt(42);
+    ASSERT_EQ(true, vInt.isInitialized());
+}
+
+} // namespace nix

--- a/tests/unit/libexpr/value/value.cc
+++ b/tests/unit/libexpr/value/value.cc
@@ -10,7 +10,7 @@ class ValueTest : public LibStoreTest
 TEST_F(ValueTest, unsetValue)
 {
     Value unsetValue;
-    ASSERT_EQ(false, unsetValue.isInitialized());
+    ASSERT_EQ(false, unsetValue.isValid());
     ASSERT_EQ(nThunk, unsetValue.type(true));
     ASSERT_DEATH(unsetValue.type(), "");
 }
@@ -19,7 +19,7 @@ TEST_F(ValueTest, vInt)
 {
     Value vInt;
     vInt.mkInt(42);
-    ASSERT_EQ(true, vInt.isInitialized());
+    ASSERT_EQ(true, vInt.isValid());
 }
 
 } // namespace nix

--- a/tests/unit/libutil-support/tests/nix_api_util.hh
+++ b/tests/unit/libutil-support/tests/nix_api_util.hh
@@ -24,7 +24,9 @@ protected:
 
     nix_c_context * ctx;
 
-    inline void assert_ctx_ok() {
+    inline void assert_ctx_ok()
+    {
+
         if (nix_err_code(ctx) == NIX_OK) {
             return;
         }
@@ -33,5 +35,14 @@ protected:
         std::string msg(p, n);
         FAIL() << "nix_err_code(ctx) != NIX_OK, message: " << msg;
     }
+
+    inline void assert_ctx_err()
+    {
+        if (nix_err_code(ctx) != NIX_OK) {
+            return;
+        }
+        FAIL() << "Got NIX_OK, but expected an error!";
+    }
 };
+
 }


### PR DESCRIPTION


# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Add a method to check if a value has been initialized. This helps avoid segfaults when calling `type()`.
Useful in the context of the new C API.

# Context
Closes #10524

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
