### PR TITLE
Run unit tests with clean config

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -113,7 +113,7 @@ static void sigHandler(int signo) { }
 #endif
 
 
-void initNix()
+void initNix(bool loadConfig)
 {
     /* Turn on buffering for cerr. */
 #if HAVE_PUBSETBUF
@@ -121,7 +121,7 @@ void initNix()
     std::cerr.rdbuf()->pubsetbuf(buf, sizeof(buf));
 #endif
 
-    initLibStore();
+    initLibStore(loadConfig);
 
 #ifndef _WIN32
     unix::startSignalHandlerThread();

--- a/src/libmain/shared.hh
+++ b/src/libmain/shared.hh
@@ -21,8 +21,9 @@ int handleExceptions(const std::string & programName, std::function<void()> fun)
 
 /**
  * Don't forget to call initPlugins() after settings are initialized!
+ * @param loadConfig Whether to load configuration from `nix.conf`, `NIX_CONFIG`, etc. May be disabled for unit tests.
  */
-void initNix();
+void initNix(bool loadConfig = true);
 
 void parseCmdLine(int argc, char * * argv,
     std::function<bool(Strings::iterator & arg, const Strings::iterator & end)> parseArg);

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -19,6 +19,16 @@ nix_err nix_libstore_init(nix_c_context * context)
     NIXC_CATCH_ERRS
 }
 
+nix_err nix_libstore_init_no_load_config(nix_c_context * context)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        nix::initLibStore(false);
+    }
+    NIXC_CATCH_ERRS
+}
+
 nix_err nix_init_plugins(nix_c_context * context)
 {
     if (context)

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -36,6 +36,13 @@ typedef struct StorePath StorePath;
 nix_err nix_libstore_init(nix_c_context * context);
 
 /**
+ * @brief Like nix_libstore_init, but does not load the Nix configuration.
+ *
+ * This is useful when external configuration is not desired, such as when running unit tests.
+ */
+nix_err nix_libstore_init_no_load_config(nix_c_context * context);
+
+/**
  * @brief Loads the plugins specified in Nix's plugin-files setting.
  *
  * Call this once, after calling your desired init functions and setting

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -427,12 +427,13 @@ void assertLibStoreInitialized() {
     };
 }
 
-void initLibStore() {
+void initLibStore(bool loadConfig) {
     if (initLibStoreDone) return;
 
     initLibUtil();
 
-    loadConfFile();
+    if (loadConfig)
+        loadConfFile();
 
     preloadNSS();
 

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -1279,9 +1279,10 @@ std::vector<Path> getUserConfigFiles();
 extern const std::string nixVersion;
 
 /**
- * NB: This is not sufficient. You need to call initNix()
+ * @param loadConfig Whether to load configuration from `nix.conf`, `NIX_CONFIG`, etc. May be disabled for unit tests.
+ * @note When using libexpr, and/or libmain, This is not sufficient. See initNix().
  */
-void initLibStore();
+void initLibStore(bool loadConfig = true);
 
 /**
  * It's important to initialize before doing _anything_, which is why we

--- a/tests/functional/test-libstoreconsumer/main.cc
+++ b/tests/functional/test-libstoreconsumer/main.cc
@@ -15,7 +15,8 @@ int main (int argc, char **argv)
 
         std::string drvPath = argv[1];
 
-        initLibStore();
+        // This small program is a test, so we do not want user config to interfere.
+        initLibStore(false);
 
         auto store = nix::openStore();
 

--- a/tests/functional/test-libstoreconsumer/main.cc
+++ b/tests/functional/test-libstoreconsumer/main.cc
@@ -15,8 +15,7 @@ int main (int argc, char **argv)
 
         std::string drvPath = argv[1];
 
-        // This small program is a test, so we do not want user config to interfere.
-        initLibStore(false);
+        initLibStore();
 
         auto store = nix::openStore();
 

--- a/tests/unit/libstore-support/tests/libstore.hh
+++ b/tests/unit/libstore-support/tests/libstore.hh
@@ -11,7 +11,7 @@ namespace nix {
 class LibStoreTest : public virtual ::testing::Test {
     public:
         static void SetUpTestSuite() {
-            initLibStore();
+            initLibStore(false);
         }
 
     protected:


### PR DESCRIPTION
# Motivation

@edolstra found an error running the tests in the dev shell.

It turns out the normal initialization still ran, and loaded configuration that caused the error.

This PR disables the loading of external configuration during unit test execution, and makes it possible for test suites for C API based bindings to do the same.

# Context

The error was:

```
tests/unit/libutil-support/tests/nix_api_util.hh:34: Failure
Failed
nix_err_code(ctx) != NIX_OK, message: error: creating cgroup '/sys/fs/cgroup/user.slice/user-1000.slice/session-7.scope/nix-build-pid-2087076-2': Permission denied
tests/unit/libexpr/nix_api_expr.cc:162: Failure
```

This error was only recently possible, as https://github.com/NixOS/nix/pull/10412 was the first PR to run small builds as part of the unit tests.
Building in unit tests should perhaps be kept to a minimum, but I have to note:
- single derivations are pretty fast to build
- we need to be able to build in various environment for the functional tests anyway
- this was the only way to test that part of the C API
- mocking only works if you have exceptionally good interfaces and the mocking code is reviewed over and over, if it works at all

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
