### PR TITLE
libstore: Enable kerberos negotiation for http binary caches

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -316,7 +316,7 @@ struct curlFileTransfer : public FileTransfer
             curl_easy_setopt(req, CURLOPT_PIPEWAIT, 1);
             #endif
             #if LIBCURL_VERSION_NUM >= 0x072f00
-            if (fileTransferSettings.enableHttp2)
+            if (fileTransferSettings.enableHttp2 && !request.negotiate)
                 curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
             else
                 curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
@@ -351,6 +351,12 @@ struct curlFileTransfer : public FileTransfer
             } else {
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 0);
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0);
+            }
+
+            if (request.negotiate) {
+                curl_easy_setopt(req, CURLOPT_HTTPAUTH, CURLAUTH_NEGOTIATE);
+                curl_easy_setopt(req, CURLOPT_USERNAME, "");
+                curl_easy_setopt(req, CURLOPT_PASSWORD, "");
             }
 
             curl_easy_setopt(req, CURLOPT_CONNECTTIMEOUT, fileTransferSettings.connectTimeout.get());

--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -56,6 +56,7 @@ struct FileTransferRequest
     std::string expectedETag;
     bool verifyTLS = true;
     bool head = false;
+    bool negotiate = false;
     size_t tries = fileTransferSettings.tries;
     unsigned int baseRetryTimeMs = 250;
     ActivityId parentAct;

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -14,6 +14,9 @@ struct HttpBinaryCacheStoreConfig : virtual BinaryCacheStoreConfig
 
     const std::string name() override { return "HTTP Binary Cache Store"; }
 
+    const Setting<bool> negotiate{this, false, "negotiate",
+        "Whether to do kerberos negotiate when talking to the http binary cache."};
+
     std::string doc() override
     {
         return
@@ -144,10 +147,12 @@ protected:
 
     FileTransferRequest makeRequest(const std::string & path)
     {
-        return FileTransferRequest(
+        auto request = FileTransferRequest(
             hasPrefix(path, "https://") || hasPrefix(path, "http://") || hasPrefix(path, "file://")
             ? path
             : cacheUri + "/" + path);
+        request.negotiate = negotiate;
+        return request;
 
     }
 


### PR DESCRIPTION
# Motivation
It would be nice to be able to do kerberos negotiation when fetching or pushing stuff to an HTTP binary store. This PR makes it possible to add `?negotiate=true` to have libcurl do krb negotiation.  

I debated on just adding `CURLAUTH_ANY` unconditionally here, which would automatically do krb negotiation if the server supports it, but figured that might be a too dramatic change as that could change existing behavior. 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
