### PR TITLE
Share evaluation caches across installables

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -443,9 +443,8 @@ ref<eval_cache::EvalCache> openEvalCache(
     EvalState & state,
     std::shared_ptr<flake::LockedFlake> lockedFlake)
 {
-    auto fingerprint = lockedFlake->getFingerprint(state.store);
-    auto hash = evalSettings.useEvalCache && evalSettings.pureEval
-        ? fingerprint
+    auto fingerprint = evalSettings.useEvalCache && evalSettings.pureEval
+        ? lockedFlake->getFingerprint(state.store)
         : std::nullopt;
     auto rootLoader = [&state, lockedFlake]()
         {
@@ -472,7 +471,7 @@ ref<eval_cache::EvalCache> openEvalCache(
         }
         return search->second;
     } else {
-        return make_ref<nix::eval_cache::EvalCache>(hash, state, rootLoader);
+        return make_ref<nix::eval_cache::EvalCache>(std::nullopt, state, rootLoader);
     }
 }
 

--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -464,10 +464,10 @@ ref<eval_cache::EvalCache> openEvalCache(
             return aOutputs->value;
         };
 
-    if (hash) {
-        auto search = state.evalCaches.find(hash.value());
+    if (fingerprint) {
+        auto search = state.evalCaches.find(fingerprint.value());
         if (search == state.evalCaches.end()) {
-            search = state.evalCaches.emplace(hash.value(), make_ref<nix::eval_cache::EvalCache>(hash, state, rootLoader)).first;
+            search = state.evalCaches.emplace(fingerprint.value(), make_ref<nix::eval_cache::EvalCache>(fingerprint, state, rootLoader)).first;
         }
         return search->second;
     } else {

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -34,6 +34,9 @@ class StorePath;
 struct SingleDerivedPath;
 enum RepairFlag : bool;
 struct MemoryInputAccessor;
+namespace eval_cache {
+    class EvalCache;
+}
 
 
 /**
@@ -281,6 +284,11 @@ public:
         // `EvalErrorBuilder::debugThrow` performs the corresponding `delete`.
         return *new EvalErrorBuilder<T>(*this, args...);
     }
+
+    /**
+     * A cache for evaluation caches, so as to reuse the same root value if possible
+     */
+    std::map<const Hash, ref<eval_cache::EvalCache>> evalCaches;
 
 private:
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

I noticed that building multiple installables from the same flake did not share
the same root `Value`. This has significant performance drawbacks that this PR
addresses by reusing said value for all the attribute paths accessed in the
same source.

Nix takes 4 minutes to evaluate (create the .drv files for) 276 packages from
the same flake, which amounts to .9s per installable. With this patch, the
whole evaluation takes 11s. That is twenty times faster. Of course, the overall
speedup is related to the amount of packages and the numbers here are very
specific and imprecise. But still.

This needs a proper review because I have no idea if this is the right approach.
Ideally, I would like the evaluation cache to be shared. Not cached and retrieved.

[edit: moved to #10590]
As this opens the gate to parallel evaluation for even better speedups, I also
discovered that our database transactions span the whole duration of the
evaluation, which became even longer now that the database is kept during the
evaluation of all the installables. I have tried to reduce the scope of the
transactions given that it is a cache. Not sure if it has any impact at all.
[/edit]

This has been extensively tested already, so at least it works as expected.

Note that this has no impact on the racy behavior of `path:` installables.
Since the code fetches them for every occurrence, they still can end up with
a different hash and a different cache. Arguably, a better implementation like
the once outlined above would address this by loading each source only once.

Fixes https://github.com/NixOS/nix/issues/9724

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
