### PR TITLE
Update uninstall.md: mention .profile

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -7,6 +7,7 @@ If you have a [single-user installation](./installing-binary.md#single-user-inst
 ```console
 $ rm -rf /nix
 ```
+You might also want to manually remove reference to Nix from your `~/.profile`.
 
 ## Multi User
 

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -7,7 +7,7 @@ If you have a [single-user installation](./installing-binary.md#single-user-inst
 ```console
 $ rm -rf /nix ~/.nix-channels ~/.nix-defexpr ~/.nix-profile
 ```
-You might also want to manually remove reference to Nix from your `~/.profile`.
+You might also want to manually remove references to Nix from your `~/.profile`.
 
 ## Multi User
 

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -5,7 +5,7 @@
 If you have a [single-user installation](./installing-binary.md#single-user-installation) of Nix, uninstall it by running:
 
 ```console
-$ rm -rf /nix
+$ rm -rf /nix ~/.nix-channels ~/.nix-defexpr ~/.nix-profile
 ```
 You might also want to manually remove reference to Nix from your `~/.profile`.
 


### PR DESCRIPTION
`~/.profile` is auto-edited by the single-mode installer so we should mention it in the uninstall instructions