### PR TITLE
Add `builtins.warn`

### DIFF
--- a/doc/manual/rl-next/builtins-warn.md
+++ b/doc/manual/rl-next/builtins-warn.md
@@ -1,0 +1,10 @@
+---
+synopsis: "New builtin: `builtins.warn`"
+issues: 306026
+prs: 10592
+---
+
+`builtins.warn` behaves like `builtins.trace "warning: ${msg}`, has an accurate log level, and is controlled by the options
+[`debugger-on-trace`](@docroot@/command-ref/conf-file.md#conf-debugger-on-trace),
+[`debugger-on-warn`](@docroot@/command-ref/conf-file.md#conf-debugger-on-warn) and
+[`abort-on-warn`](@docroot@/command-ref/conf-file.md#conf-abort-on-warn).

--- a/doc/manual/rl-next/builtins-warn.md
+++ b/doc/manual/rl-next/builtins-warn.md
@@ -4,7 +4,7 @@ issues: 306026
 prs: 10592
 ---
 
-`builtins.warn` behaves like `builtins.trace "warning: ${msg}`, has an accurate log level, and is controlled by the options
+`builtins.warn` behaves like `builtins.trace "warning: ${msg}"`, has an accurate log level, and is controlled by the options
 [`debugger-on-trace`](@docroot@/command-ref/conf-file.md#conf-debugger-on-trace),
 [`debugger-on-warn`](@docroot@/command-ref/conf-file.md#conf-debugger-on-warn) and
 [`abort-on-warn`](@docroot@/command-ref/conf-file.md#conf-abort-on-warn).

--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -73,12 +73,7 @@ EvalErrorBuilder<T>::addTrace(PosIdx pos, std::string_view formatString, const A
 template<class T>
 void EvalErrorBuilder<T>::debugThrow()
 {
-    if (error.state.debugRepl && !error.state.debugTraces.empty()) {
-        const DebugTrace & last = error.state.debugTraces.front();
-        const Env * env = &last.env;
-        const Expr * expr = &last.expr;
-        error.state.runDebugRepl(&error, *env, *expr);
-    }
+    error.state.runDebugRepl(&error);
 
     // `EvalState` is the only class that can construct an `EvalErrorBuilder`,
     // and it does so in dynamic storage. This is the final method called on

--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -71,6 +71,13 @@ EvalErrorBuilder<T>::addTrace(PosIdx pos, std::string_view formatString, const A
 }
 
 template<class T>
+EvalErrorBuilder<T> & EvalErrorBuilder<T>::setIsFromExpr()
+{
+    error.err.isFromExpr = true;
+    return *this;
+}
+
+template<class T>
 void EvalErrorBuilder<T>::debugThrow()
 {
     error.state.runDebugRepl(&error);
@@ -85,6 +92,7 @@ void EvalErrorBuilder<T>::debugThrow()
     throw error;
 }
 
+template class EvalErrorBuilder<EvalBaseError>;
 template class EvalErrorBuilder<EvalError>;
 template class EvalErrorBuilder<AssertionError>;
 template class EvalErrorBuilder<ThrownError>;

--- a/src/libexpr/eval-error.hh
+++ b/src/libexpr/eval-error.hh
@@ -15,27 +15,39 @@ class EvalState;
 template<class T>
 class EvalErrorBuilder;
 
-class EvalError : public Error
+/**
+ * Base class for all errors that occur during evaluation.
+ *
+ * Most subclasses should inherit from `EvalError` instead of this class.
+ */
+class EvalBaseError : public Error
 {
     template<class T>
     friend class EvalErrorBuilder;
 public:
     EvalState & state;
 
-    EvalError(EvalState & state, ErrorInfo && errorInfo)
+    EvalBaseError(EvalState & state, ErrorInfo && errorInfo)
         : Error(errorInfo)
         , state(state)
     {
     }
 
     template<typename... Args>
-    explicit EvalError(EvalState & state, const std::string & formatString, const Args &... formatArgs)
+    explicit EvalBaseError(EvalState & state, const std::string & formatString, const Args &... formatArgs)
         : Error(formatString, formatArgs...)
         , state(state)
     {
     }
 };
 
+/**
+ * `EvalError` is the base class for almost all errors that occur during evaluation.
+ *
+ * All instances of `EvalError` should show a degree of purity that allows them to be
+ * cached in pure mode. This means that they should not depend on the configuration or the overall environment.
+ */
+MakeError(EvalError, EvalBaseError);
 MakeError(ParseError, Error);
 MakeError(AssertionError, EvalError);
 MakeError(ThrownError, AssertionError);
@@ -89,6 +101,8 @@ public:
     [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> & withFrame(const Env & e, const Expr & ex);
 
     [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> & addTrace(PosIdx pos, HintFmt hint);
+
+    [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> & setIsFromExpr();
 
     template<typename... Args>
     [[nodiscard, gnu::noinline]] EvalErrorBuilder<T> &

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -48,6 +48,10 @@ EvalSettings::EvalSettings()
 {
     auto var = getEnv("NIX_PATH");
     if (var) nixPath = parseNixPath(*var);
+
+    var = getEnv("NIX_ABORT_ON_WARN");
+    if (var && (var == "1" || var == "yes" || var == "true"))
+        builtinsAbortOnWarn = true;
 }
 
 Strings EvalSettings::getDefaultNixPath()

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -158,12 +158,38 @@ struct EvalSettings : Config
 
     Setting<bool> builtinsTraceDebugger{this, false, "debugger-on-trace",
         R"(
-          If set to true and the `--debugger` flag is given,
-          [`builtins.trace`](@docroot@/language/builtins.md#builtins-trace) will
-          enter the debugger like
-          [`builtins.break`](@docroot@/language/builtins.md#builtins-break).
+          If set to true and the `--debugger` flag is given, the following functions
+          will enter the debugger like [`builtins.break`](@docroot@/language/builtins.md#builtins-break).
+
+          * [`builtins.trace`](@docroot@/language/builtins.md#builtins-trace)
+          * [`builtins.traceVerbose`](@docroot@/language/builtins.md#builtins-traceVerbose)
+            if [`trace-verbose`](#conf-trace-verbose) is set to true.
+          * [`builtins.warn`](@docroot@/language/builtins.md#builtins-warn)
 
           This is useful for debugging warnings in third-party Nix code.
+        )"};
+
+    Setting<bool> builtinsDebuggerOnWarn{this, false, "debugger-on-warn",
+        R"(
+          If set to true and the `--debugger` flag is given, [`builtins.warn`](@docroot@/language/builtins.md#builtins-warn)
+          will enter the debugger like [`builtins.break`](@docroot@/language/builtins.md#builtins-break).
+
+          This is useful for debugging warnings in third-party Nix code.
+
+          Use [`debugger-on-trace`](#conf-debugger-on-trace) to also enter the debugger on legacy warnings that are logged with [`builtins.trace`](@docroot@/language/builtins.md#builtins-trace).
+        )"};
+
+    Setting<bool> builtinsAbortOnWarn{this, false, "abort-on-warn",
+        R"(
+          If set to true, [`builtins.warn`](@docroot@/language/builtins.md#builtins-warn) will throw an error when logging a warning.
+
+          This will give you a stack trace that leads to the location of the warning.
+
+          This is useful for finding information about warnings in third-party Nix code when you can not start the interactive debugger, such as when Nix is called from a non-interactive script. See [`debugger-on-warn`](#conf-debugger-on-warn).
+
+          Currently, a stack trace can only be produced when the debugger is enabled, or when evaluation is aborted.
+
+          This option can be enabled by setting `NIX_ABORT_ON_WARN=1` in the environment.
         )"};
 };
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -785,6 +785,24 @@ public:
     }
 };
 
+bool EvalState::canDebug()
+{
+    return debugRepl && !debugTraces.empty();
+}
+
+void EvalState::runDebugRepl(const Error * error)
+{
+    if (!canDebug())
+        return;
+
+    assert(!debugTraces.empty());
+    const DebugTrace & last = debugTraces.front();
+    const Env & env = last.env;
+    const Expr & expr = last.expr;
+
+    runDebugRepl(error, env, expr);
+}
+
 void EvalState::runDebugRepl(const Error * error, const Env & env, const Expr & expr)
 {
     // Make sure we have a debugger to run and we're not already in a debugger.

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -276,6 +276,18 @@ public:
             return std::shared_ptr<const StaticEnv>();;
     }
 
+    /** Whether a debug repl can be started. If `false`, `runDebugRepl(error)` will return without starting a repl. */
+    bool canDebug();
+
+    /** Use front of `debugTraces`; see `runDebugRepl(error,env,expr)` */
+    void runDebugRepl(const Error * error);
+
+    /**
+     * Run a debug repl with the given error, environment and expression.
+     * @param error The error to debug, may be nullptr.
+     * @param env The environment to debug, matching the expression.
+     * @param expr The expression to debug, matching the environment.
+     */
     void runDebugRepl(const Error * error, const Env & env, const Expr & expr);
 
     template<class T, typename... Args>

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1045,16 +1045,12 @@ static RegisterPrimOp primop_trace({
 
 static void prim_warn(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    state.forceValue(*args[0], pos);
+    // We only accept a string argument for now. The use case for pretty printing a value is covered by `trace`.
+    // By rejecting non-strings we allow future versions to add more features without breaking existing code.
+    auto msgStr = state.forceString(*args[0], pos, "while evaluating the first argument; the message passed to builtins.warn");
 
     {
-        BaseError msg(args[0]->type() == nString
-                ? std::string(args[0]->string_view())
-                : ({
-                    std::stringstream s;
-                    s << ValuePrinter(state, *args[0]);
-                    s.str();
-                }));
+        BaseError msg(std::string{msgStr});
         msg.atPos(state.positions[pos]);
         auto info = msg.info();
         info.level = lvlWarn;

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1056,7 +1056,8 @@ static void prim_warn(EvalState & state, const PosIdx pos, Value * * args, Value
     }
 
     if (evalSettings.builtinsAbortOnWarn) {
-        state.error<Abort>("aborting to reveal stack trace of warning, as abort-on-warn is set").debugThrow();
+        // Not an EvalError or subclass, which would cause the error to be stored in the eval cache.
+        state.error<Error>("aborting to reveal stack trace of warning, as abort-on-warn is set").debugThrow();
     }
     if (evalSettings.builtinsTraceDebugger || evalSettings.builtinsDebuggerOnWarn) {
         state.runDebugRepl(nullptr);

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -240,7 +240,10 @@ std::ostream & showErrorInfo(std::ostream & out, const ErrorInfo & einfo, bool s
             break;
         }
         case Verbosity::lvlWarn: {
-            prefix = ANSI_WARNING "warning";
+            if (einfo.isFromExpr)
+                prefix = ANSI_WARNING "evaluation warning";
+            else
+                prefix = ANSI_WARNING "warning";
             break;
         }
         case Verbosity::lvlInfo: {

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -89,6 +89,11 @@ struct ErrorInfo {
     HintFmt msg;
     std::shared_ptr<Pos> pos;
     std::list<Trace> traces;
+    /**
+     * Some messages are generated directly by expressions; notably `builtins.warn`, `abort`, `throw`.
+     * These may be rendered differently, so that users can distinguish them.
+     */
+    bool isFromExpr = false;
 
     /**
      * Exit status.

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -38,8 +38,10 @@ nix-instantiate --eval -E 'let x = { repeating = x; tracing = builtins.trace x t
 
 nix-instantiate --eval -E 'builtins.warn "Hello" 123' 2>&1 | grepQuiet 'warning: Hello'
 nix-instantiate --eval -E 'builtins.addErrorContext "while doing ${"something"} interesting" (builtins.warn "Hello" 123)' 2>/dev/null | grepQuiet 123
-nix-instantiate --eval -E 'let x = builtins.warn { x = x; } true; in x' \
-  2>&1 | grepQuiet -E 'warning: { x = «potential infinite recursion»; }'
+
+# warn does not accept non-strings for now
+expectStderr 1 nix-instantiate --eval -E 'let x = builtins.warn { x = x; } true; in x' \
+  | grepQuiet "expected a string but found a set"
 expectStderr 1 nix-instantiate --eval --abort-on-warn -E 'builtins.warn "Hello" 123' | grepQuiet Hello
 NIX_ABORT_ON_WARN=1 expectStderr 1 nix-instantiate --eval -E 'builtins.addErrorContext "while doing ${"something"} interesting" (builtins.warn "Hello" 123)' | grepQuiet "while doing something interesting"
 


### PR DESCRIPTION
# Motivation

A variation of `trace`, but
- with the correct log level
- no ANSI codes in expressions
- can be debugged without stopping for actual `trace` calls (ie intentional "info level" or trace logging).
- logs warnings without `trace:` in front of it
- follows the Nix color scheme.

# Context

I'd planned to add this a long time ago but forgot to eventually follow up on it.
This Nixpkgs PR reminded me to complete it, and I would like to avoid an unnecessary deprecation.
It proposes to rename the environment variable, which would make the current `lib.warn` not an (anachronistic) polyfill of the Nix feature anymore. That'd be unfortunate.
- https://github.com/NixOS/nixpkgs/pull/306026



# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
