### PR TITLE
[WIP] Add call position to primops

### DIFF
--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -48,6 +48,10 @@ EvalSettings::EvalSettings()
 {
     auto var = getEnv("NIX_PATH");
     if (var) nixPath = parseNixPath(*var);
+
+    var = getEnv("NIX_ABORT_ON_WARN");
+    if (var && (var == "1" || var == "yes" || var == "true"))
+        builtinsAbortOnWarn = true;
 }
 
 Strings EvalSettings::getDefaultNixPath()

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -142,12 +142,38 @@ struct EvalSettings : Config
 
     Setting<bool> builtinsTraceDebugger{this, false, "debugger-on-trace",
         R"(
-          If set to true and the `--debugger` flag is given,
-          [`builtins.trace`](@docroot@/language/builtins.md#builtins-trace) will
-          enter the debugger like
-          [`builtins.break`](@docroot@/language/builtins.md#builtins-break).
+          If set to true and the `--debugger` flag is given, the following functions
+          will enter the debugger like [`builtins.break`](@docroot@/language/builtins.md#builtins-break).
+
+          * [`builtins.trace`](@docroot@/language/builtins.md#builtins-trace)
+          * [`builtins.traceVerbose`](@docroot@/language/builtins.md#builtins-traceVerbose)
+            if [`trace-verbose`](#conf-trace-verbose) is set to true.
+          * [`builtins.warn`](@docroot@/language/builtins.md#builtins-warn)
 
           This is useful for debugging warnings in third-party Nix code.
+        )"};
+
+    Setting<bool> builtinsDebuggerOnWarn{this, false, "debugger-on-warn",
+        R"(
+          If set to true and the `--debugger` flag is given, [`builtins.warn`](@docroot@/language/builtins.md#builtins-warn)
+          will enter the debugger like [`builtins.break`](@docroot@/language/builtins.md#builtins-break).
+
+          This is useful for debugging warnings in third-party Nix code.
+
+          Use [`debugger-on-trace`](#conf-debugger-on-trace) to also enter the debugger on legacy warnings that are logged with [`builtins.trace`](@docroot@/language/builtins.md#builtins-trace).
+        )"};
+
+    Setting<bool> builtinsAbortOnWarn{this, false, "abort-on-warn",
+        R"(
+          If set to true, [`builtins.warn`](@docroot@/language/builtins.md#builtins-warn) will throw an error when logging a warning.
+
+          This will give you a stack trace that leads to the location of the warning.
+
+          This is useful for finding information about warnings in third-party Nix code when you can not start the interactive debugger, such as when Nix is called from a non-interactive script. See [`debugger-on-warn`](#conf-debugger-on-warn).
+
+          Currently, a stack trace can only be produced when the debugger is enabled, or when evaluation is aborted.
+
+          This option can be enabled by setting `NIX_ABORT_ON_WARN=1` in the environment.
         )"};
 };
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1659,7 +1659,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                 if (countCalls) primOpCalls[fn->name]++;
 
                 try {
-                    fn->fun(*this, vCur.determinePos(noPos), args, vCur);
+                    fn->fun(*this, vCur.determinePos(pos), args, vCur);
                 } catch (Error & e) {
                     if (fn->addTrace)
                         addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
@@ -1708,7 +1708,7 @@ void EvalState::callFunction(Value & fun, size_t nrArgs, Value * * args, Value &
                     // 1. Unify this and above code. Heavily redundant.
                     // 2. Create a fake env (arg1, arg2, etc.) and a fake expr (arg1: arg2: etc: builtins.name arg1 arg2 etc)
                     //    so the debugger allows to inspect the wrong parameters passed to the builtin.
-                    fn->fun(*this, vCur.determinePos(noPos), vArgs, vCur);
+                    fn->fun(*this, vCur.determinePos(pos), vArgs, vCur);
                 } catch (Error & e) {
                     if (fn->addTrace)
                         addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1043,6 +1043,43 @@ static RegisterPrimOp primop_trace({
     .fun = prim_trace,
 });
 
+static void prim_warn(EvalState & state, const PosIdx pos, Value * * args, Value & v)
+{
+    state.forceValue(*args[0], pos);
+    if (args[0]->type() == nString)
+        printMsg(lvlWarn, ANSI_WARNING "warning:" ANSI_NORMAL " %1%", args[0]->string_view());
+    else
+        printMsg(lvlWarn, ANSI_WARNING "warning:" ANSI_NORMAL " %1%", ValuePrinter(state, *args[0]));
+
+    if (evalSettings.builtinsAbortOnWarn) {
+        state.error<Abort>("aborting to reveal stack trace of warning, as abort-on-warn is set").debugThrow();
+    }
+    if (evalSettings.builtinsTraceDebugger && state.debugRepl && !state.debugTraces.empty()) {
+        const DebugTrace & last = state.debugTraces.front();
+        state.runDebugRepl(nullptr, last.env, last.expr);
+    }
+    state.forceValue(*args[1], pos);
+    v = *args[1];
+}
+
+static RegisterPrimOp primop_warn({
+    .name = "__warn",
+    .args = {"e1", "e2"},
+    .doc = R"(
+      Evaluate *e1* and print its abstract syntax representation on
+      standard error as a warning. Then return *e2*. This function is
+      useful for non-critical situations where attention is advisable.
+
+      If the
+      [`debugger-on-trace`](@docroot@/command-ref/conf-file.md#conf-debugger-on-trace)
+      or [`debugger-on-warn`](@docroot@/command-ref/conf-file.md#conf-debugger-on-warn)
+      option is set to `true` and the `--debugger` flag is given, the
+      interactive debugger will be started when `warn` is called (like
+      [`break`](@docroot@/language/builtins.md#builtins-break)).
+    )",
+    .fun = prim_warn,
+});
+
 
 /* Takes two arguments and evaluates to the second one. Used as the
  * builtins.traceVerbose implementation when --trace-verbose is not enabled

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -31,6 +31,13 @@ nix-instantiate --eval -E 'let x = builtins.trace { x = x; } true; in x' \
 nix-instantiate --eval -E 'let x = { repeating = x; tracing = builtins.trace x true; }; in x.tracing'\
   2>&1 | grepQuiet -F 'trace: { repeating = «repeated»; tracing = «potential infinite recursion»; }'
 
+nix-instantiate --eval -E 'builtins.warn "Hello" 123' 2>&1 | grepQuiet 'warning: Hello'
+nix-instantiate --eval -E 'builtins.addErrorContext "while doing ${"something"} interesting" (builtins.warn "Hello" 123)' 2>/dev/null | grepQuiet 123
+nix-instantiate --eval -E 'let x = builtins.warn { x = x; } true; in x' \
+  2>&1 | grepQuiet -E 'warning: { x = «potential infinite recursion»; }'
+expectStderr 1 nix-instantiate --eval --abort-on-warn -E 'builtins.warn "Hello" 123' | grepQuiet Hello
+NIX_ABORT_ON_WARN=1 expectStderr 1 nix-instantiate --eval -E 'builtins.addErrorContext "while doing ${"something"} interesting" (builtins.warn "Hello" 123)' | grepQuiet "while doing something interesting"
+
 set +x
 
 badDiff=0

--- a/tests/functional/lang/eval-fail-attr-name-type.err.exp
+++ b/tests/functional/lang/eval-fail-attr-name-type.err.exp
@@ -14,8 +14,3 @@ error:
             8|
 
        error: expected a string but found an integer: 1
-       at /pwd/lang/eval-fail-attr-name-type.nix:7:17:
-            6| in
-            7|   attrs.puppy.${key}
-             |                 ^
-            8|

--- a/tests/functional/lang/eval-fail-foldlStrict-strict-op-application.err.exp
+++ b/tests/functional/lang/eval-fail-foldlStrict-strict-op-application.err.exp
@@ -6,6 +6,8 @@ error:
              | ^
             3|   (_: f: f null)
 
+       … from call site
+
        … while calling anonymous lambda
          at /pwd/lang/eval-fail-foldlStrict-strict-op-application.nix:3:7:
             2| builtins.foldl'

--- a/tests/functional/lang/eval-fail-infinite-recursion-lambda.err.exp
+++ b/tests/functional/lang/eval-fail-infinite-recursion-lambda.err.exp
@@ -32,7 +32,3 @@ error:
        (19997 duplicate frames omitted)
 
        error: stack overflow; max-call-depth exceeded
-       at /pwd/lang/eval-fail-infinite-recursion-lambda.nix:1:14:
-            1| (x: x x) (x: x x)
-             |              ^
-            2|

--- a/tests/functional/lang/eval-fail-not-throws.err.exp
+++ b/tests/functional/lang/eval-fail-not-throws.err.exp
@@ -6,9 +6,5 @@ error:
             2|
 
        … while calling the 'throw' builtin
-         at /pwd/lang/eval-fail-not-throws.nix:1:4:
-            1| ! (throw "uh oh!")
-             |    ^
-            2|
 
        error: uh oh!

--- a/tests/functional/lang/eval-fail-toJSON.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON.err.exp
@@ -13,18 +13,8 @@ error:
             3|     true
 
        … while evaluating attribute 'b'
-         at /pwd/lang/eval-fail-toJSON.nix:2:3:
-            1| builtins.toJSON {
-            2|   a.b = [
-             |   ^
-            3|     true
 
        … while evaluating list element at index 3
-         at /pwd/lang/eval-fail-toJSON.nix:2:3:
-            1| builtins.toJSON {
-            2|   a.b = [
-             |   ^
-            3|     true
 
        … while evaluating attribute 'c'
          at /pwd/lang/eval-fail-toJSON.nix:7:7:
@@ -34,11 +24,6 @@ error:
             8|     }
 
        … while evaluating attribute 'd'
-         at /pwd/lang/eval-fail-toJSON.nix:7:7:
-            6|     {
-            7|       c.d = throw "hah no";
-             |       ^
-            8|     }
 
        … while calling the 'throw' builtin
          at /pwd/lang/eval-fail-toJSON.nix:7:13:

--- a/tests/functional/lang/eval-fail-using-set-as-attr-name.err.exp
+++ b/tests/functional/lang/eval-fail-using-set-as-attr-name.err.exp
@@ -7,8 +7,3 @@ error:
             6|
 
        error: expected a string but found a set: { }
-       at /pwd/lang/eval-fail-using-set-as-attr-name.nix:5:10:
-            4| in
-            5|   attr.${key}
-             |          ^
-            6|


### PR DESCRIPTION
# Motivation

Pass a `Pos` to primops, so that [warn](https://github.com/NixOS/nix/pull/10592) can print a position.

Notably, the position works well with partial application, such as here:
```nix
let
  warnIf = c: s: if c then builtins.warn s else null;
in
  builtins.warn "hI"
  (warnIf true "ok" 1213)
```

Both warning calls print their most relevant position.

TODO:
 - [ ] The simple change of forwarding `pos` caused a number of duplicate positions to be printed. The deduplication isn't quite done.

# Context

- Is relevant to, and currently includes commits from #10592

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
