### PR TITLE
maintainers: Fix work meeting information

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -49,8 +49,7 @@ The team meets twice a week:
        - mark it as draft if it is blocked on the contributor
        - escalate it back to the team by moving it to To discuss, and leaving a comment as to why the issue needs to be discussed again.
 
-- Work meeting: [Mondays 13:00-15:00 CET](https://calendar.google.com/calendar/event?eid=NTM1MG1wNGJnOGpmOTZhYms3bTB1bnY5cWxfMjAyMjExMjFUMTIwMDAwWiBiOW81MmZvYnFqYWs4b3E4bGZraGczdDBxZ0Bn)
-
+- Work meeting: [Mondays 12:00-14:00 UTC](https://jitsi.lassul.us/nix-maintainers)
   1. Code review on pull requests from [In review](#in-review).
   2. Other chores and tasks.
 


### PR DESCRIPTION
The Google Calendar event included an incorrect link, and the time was also wrong.
Currently, it happens at 12:00 UTC.

There is the issue of DST, and perhaps you have already decided how to handle that,
but given that it said `13:00 CET` before, it should have been `13:00 UTC+2` in the summer, which it wasn't.
It was UTC+1 yesterday.

If DST isn't observed, then you can just write the time as UTC.