### PR TITLE
Add BLAKE3 hashing algorithm (single-threaded C-based implementation)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,26 @@
 
           changelog-d-nix = final.buildPackages.callPackage ./misc/changelog-d.nix { };
 
+          blake3-src-nix = final.stdenv.mkDerivation rec {
+            pname = "blake3-src-nix";
+            version = "1.5.1";
+            src = final.fetchzip {
+              url = "https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/${version}.tar.gz";
+              hash = "sha512-fEdcjMJiqFkeXL91L95kmvl8fTo8LrGnFuT5NLLa+zFkDo4OalpepHTbi/goD1m8aNVzGwhmfnscOzeKv+gMRg==";
+            };
+            phases = [ "unpackPhase" "installPhase" ];
+            installPhase = ''
+              mkdir -p $out
+              cp -a ${src}/* $out
+            '';
+            meta = {
+              description = "The BLAKE3 source code";
+              homepage = "https://github.com/BLAKE3-team/BLAKE3";
+              license = lib.licenses.asl20;
+              platforms = lib.platforms.all;
+            };
+          };
+
           nix =
             let
               officialRelease = false;
@@ -199,6 +219,7 @@
               boehmgc = final.boehmgc-nix;
               libgit2 = final.libgit2-nix;
               busybox-sandbox-shell = final.busybox-sandbox-shell or final.default-busybox-sandbox-shell;
+              blake3-src = final.blake3-src-nix;
             } // {
               # this is a proper separate downstream package, but put
               # here also for back compat reasons.

--- a/package.nix
+++ b/package.nix
@@ -6,6 +6,7 @@
 , autoreconfHook
 , aws-sdk-cpp
 , boehmgc
+, blake3-src
 , buildPackages
 , nlohmann_json
 , bison
@@ -203,6 +204,9 @@ in {
 
   VERSION_SUFFIX = versionSuffix;
 
+  # Export the BLAKE3 source location so we can access it from the make files.
+  NIX_BLAKE3_SRC = blake3-src;
+
   outputs = [ "out" ]
     ++ lib.optional doBuild "dev"
     # If we are doing just build or just docs, the one thing will use
@@ -233,6 +237,7 @@ in {
   ;
 
   buildInputs = lib.optionals doBuild [
+    blake3-src
     boost
     brotli
     bzip2

--- a/src/libcmd/misc-store-flags.cc
+++ b/src/libcmd/misc-store-flags.cc
@@ -50,7 +50,7 @@ Args::Flag hashAlgo(std::string && longName, HashAlgorithm * ha)
 {
     return Args::Flag {
             .longName = std::move(longName),
-            .description = "Hash algorithm (`md5`, `sha1`, `sha256`, or `sha512`).",
+            .description = "Hash algorithm (`blake3`, `md5`, `sha1`, `sha256`, or `sha512`).",
             .labels = {"hash-algo"},
             .handler = {[ha](std::string s) {
                 *ha = parseHashAlgo(s);
@@ -63,7 +63,7 @@ Args::Flag hashAlgoOpt(std::string && longName, std::optional<HashAlgorithm> * o
 {
     return Args::Flag {
             .longName = std::move(longName),
-            .description = "Hash algorithm (`md5`, `sha1`, `sha256`, or `sha512`). Can be omitted for SRI hashes.",
+            .description = "Hash algorithm (`blake3`, `md5`, `sha1`, `sha256`, or `sha512`). Can be omitted for SRI hashes.",
             .labels = {"hash-algo"},
             .handler = {[oha](std::string s) {
                 *oha = std::optional<HashAlgorithm>{parseHashAlgo(s)};

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -11,9 +11,10 @@ namespace nix {
 MakeError(BadHash, Error);
 
 
-enum struct HashAlgorithm : char { MD5 = 42, SHA1, SHA256, SHA512 };
+enum struct HashAlgorithm : char { MD5 = 42, SHA1, SHA256, SHA512, BLAKE3 };
 
 
+const int blake3HashSize = 32;
 const int md5HashSize = 16;
 const int sha1HashSize = 20;
 const int sha256HashSize = 32;

--- a/src/libutil/local.mk
+++ b/src/libutil/local.mk
@@ -40,3 +40,64 @@ $(foreach i, $(wildcard $(d)/signature/*.hh), \
 ifeq ($(HAVE_LIBCPUID), 1)
   libutil_LDFLAGS += -lcpuid
 endif
+
+# BLAKE3 support
+
+# See the comments below for the build rules for the reason we use the `.o` files here.
+
+libutil_SOURCES += \
+  $(d)/blake3.o \
+  $(d)/blake3_dispatch.o \
+  $(d)/blake3_portable.o
+
+ifneq ($(filter aarch64% arm%,$(system)),)
+  libutil_SOURCES += $(d)/blake3_neon.o
+endif
+
+ifneq ($(filter x86_64%,$(system)),)
+  ifneq ($(or $(HOST_UNIX), $(HOST_LINUX)),)
+    libutil_SOURCES += \
+      $(d)/blake3_sse2_x86-64_unix.o \
+      $(d)/blake3_sse41_x86-64_unix.o \
+      $(d)/blake3_avx2_x86-64_unix.o \
+      $(d)/blake3_avx512_x86-64_unix.o
+  endif
+  ifdef HOST_WINDOWS
+    ifneq ($(or $(HOST_CYGWIN), $(HOST_MINGW)),)
+      libutil_SOURCES += \
+        $(d)/blake3_sse2_x86-64_windows_gnu.o \
+        $(d)/blake3_sse41_x86-64_windows_gnu.o \
+        $(d)/blake3_avx2_x86-64_windows_gnu.o \
+        $(d)/blake3_avx512_x86-64_windows_gnu.o
+    else
+      libutil_SOURCES += \
+        $(d)/blake3_sse2_x86-64_windows_mscv.o \
+        $(d)/blake3_sse41_x86-64_windows_mscv.o \
+        $(d)/blake3_avx2_x86-64_windows_mscv.o \
+        $(d)/blake3_avx512_x86-64_windows_mscv.o
+    endif
+  endif
+endif
+
+INCLUDE_libutil += -I $(NIX_BLAKE3_SRC)/c
+
+# We use custom rules for the BLAKE3 source files because they are in a read-only store directory
+# and the default rules will try write build artifacts there and fail with permission errors.
+
+$(d)/blake3%.o: $(NIX_BLAKE3_SRC)/c/blake3%.S
+	$(trace-cc) $(call CC_CMD,$@)
+
+$(d)/blake3%.o: $(NIX_BLAKE3_SRC)/c/blake3%.c
+	$(trace-cc) $(call CC_CMD,$@)
+
+$(d)/blake3.o: $(NIX_BLAKE3_SRC)/c/blake3.c
+	$(trace-cc) $(call CC_CMD,$@)
+
+$(d)/blake3%.compile_commands.json: $(NIX_BLAKE3_SRC)/c/blake3%.S
+	$(trace-jq) $(COMPILE_COMMANDS_JSON_CMD) $(call CC_CMD,$(@:.compile_commands.json=.o)) > $@
+
+$(d)/blake3%.compile_commands.json: $(NIX_BLAKE3_SRC)/c/blake3%.c
+	$(trace-jq) $(COMPILE_COMMANDS_JSON_CMD) $(call CC_CMD,$(@:.compile_commands.json=.o)) > $@
+
+$(d)/blake3.compile_commands.json: $(NIX_BLAKE3_SRC)/c/blake3.c
+	$(trace-jq) $(COMPILE_COMMANDS_JSON_CMD) $(call CC_CMD,$(@:.compile_commands.json=.o)) > $@

--- a/tests/unit/libexpr/error_traces.cc
+++ b/tests/unit/libexpr/error_traces.cc
@@ -1084,7 +1084,7 @@ namespace nix {
 
         ASSERT_TRACE1("hashString \"foo\" \"content\"",
                       UsageError,
-                      HintFmt("unknown hash algorithm '%s', expect 'md5', 'sha1', 'sha256', or 'sha512'", "foo"));
+                      HintFmt("unknown hash algorithm '%s', expect 'blake3', 'md5', 'sha1', 'sha256', or 'sha512'", "foo"));
 
         ASSERT_TRACE2("hashString \"sha256\" {}",
                       TypeError,

--- a/tests/unit/libutil/hash.cc
+++ b/tests/unit/libutil/hash.cc
@@ -10,6 +10,20 @@ namespace nix {
      * hashString
      * --------------------------------------------------------------------------*/
 
+    TEST(hashString, testKnownBLAKE3Hashes1) {
+        auto s = "abc";
+        auto hash = hashString(HashAlgorithm::BLAKE3, s);
+        ASSERT_EQ(hash.to_string(HashFormat::Base16, true),
+                "blake3:6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85");
+    }
+
+    TEST(hashString, testKnownBLAKE3Hashes2) {
+        auto s = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+        auto hash = hashString(HashAlgorithm::BLAKE3, s);
+        ASSERT_EQ(hash.to_string(HashFormat::Base16, true),
+                "blake3:c19012cc2aaf0dc3d8e5c45a1b79114d2df42abb2a410bf54be09e891af06ff8");
+    }
+
     TEST(hashString, testKnownMD5Hashes1) {
         // values taken from: https://tools.ietf.org/html/rfc1321
         auto s1 = "";


### PR DESCRIPTION
# Motivation

This PR adds [BLAKE3](https://github.com/BLAKE3-team/BLAKE3) to the available hashing algorithms.

NOTE: Although this PR is complete (and I would appreciate any feedback) I'm adding it as a draft for now because I would also like to try working on alternative PR based on the multi-threaded Rust implementation (more below).

# Context

- Related issues:
  - https://github.com/NixOS/nix/issues/2166
  - https://github.com/NixOS/nix/issues/8475

The change is relatively small and non-invasive.

I added the BLAKE3 source tarball as a derivation and used this to define a `NIX_BLAKE3_SRC` environment variable which is then referenced in the makefiles.

The [recommended way](https://github.com/BLAKE3-team/BLAKE3/tree/master/c#building) to build the BLAKE3 C implementation is just to add the files directly to the build system rather than trying to compile separately as a library, so that's the reasoning for fetching the tarball.

In order to handle building source files from `NIX_BLAKE3_SRC` (which is read-only) I needed to add some custom build rules specifically for those files.

I also added platform detection for `ARM` and `x86_64` (along with detection for Darwin, Linux, and Windows) and use this to conditionally compile the appropriate SIMD implementations for the given platform.

I use the assembly files directly rather than the C-based intrinsics versions since that is also the [recommended approach](https://github.com/BLAKE3-team/BLAKE3/tree/master/c#x86):

> For each of the x86 SIMD instruction sets, four versions are available: three flavors of assembly (Unix, Windows MSVC, and Windows GNU) and one version using C intrinsics. The assembly versions are generally preferred. They perform better, they perform more consistently across different compilers, and they build more quickly. On the other hand, the assembly versions are x86_64-only, and you need to select the right flavor for your target platform.

The BLAKE3 dispatcher will automatically fall back to the portable implementation if a hardware accelerated implementation is unavailable.

# Performance

I have run benchmarks of the implementation which I detail below.

First, though, some important things to note:

- This is the C implementation, which is single-threaded. Although it is very fast, the Rust version which uses Rayon for multi-threading scales almost linearly up to memory bandwidth limits, so it's obviously significantly faster.

- The NEON implementation is known to not be nearly as performant as the SSE and AVX implementations:
  - https://github.com/BLAKE3-team/BLAKE3/issues/310
  - https://github.com/BLAKE3-team/BLAKE3/issues/315

- Test file was generated with `head -c 5G /dev/urandom > ~/Downloads/largefile.bin`

## Apple M3 Max

- compiled with: `CFLAGS="-O3 -mcpu=apple-m2" configurePhase` (and `OPTIMIZE=1`)

### BLAKE3

```
hyperfine --warmup 3 './outputs/out/bin/nix --extra-experimental-features nix-command hash file --type blake3 ~/Downloads/largefile.bin'
Benchmark 1: ./outputs/out/bin/nix --extra-experimental-features nix-command hash file --type blake3 ~/Downloads/largefile.bin
  Time (mean ± σ):      2.701 s ±  0.006 s    [User: 2.345 s, System: 0.350 s]
  Range (min … max):    2.692 s …  2.714 s    10 runs
```

```
hyperfine --warmup 3 './outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha256 ~/Downloads/largefile.bin'
Benchmark 1: ./outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha256 ~/Downloads/largefile.bin
  Time (mean ± σ):      2.105 s ±  0.005 s    [User: 1.748 s, System: 0.352 s]
  Range (min … max):    2.097 s …  2.110 s    10 runs
```

```
hyperfine --warmup 3 './outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha512 ~/Downloads/largefile.bin'
Benchmark 1: ./outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha512 ~/Downloads/largefile.bin
  Time (mean ± σ):      3.327 s ±  0.006 s    [User: 2.964 s, System: 0.356 s]
  Range (min … max):    3.321 s …  3.338 s    10 runs
```

## AMD Zen 4 Ryzen 9 7950x

- compiled with: `CFLAGS="-O3 -march=znver4" configurePhase` (and `OPTIMIZE=1`)

### BLAKE3

```
hyperfine --warmup 3 './outputs/out/bin/nix --extra-experimental-features nix-command hash file --type blake3 ~/Downloads/largefile.bin'
Benchmark 1: ./outputs/out/bin/nix --extra-experimental-features nix-command hash file --type blake3 ~/Downloads/largefile.bin
  Time (mean ± σ):     915.0 ms ±  11.2 ms    [User: 573.2 ms, System: 339.8 ms]
  Range (min … max):   898.6 ms … 932.4 ms    10 runs
```

### SHA256

```
hyperfine --warmup 3 './outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha256 ~/Downloads/largefile.bin'
Benchmark 1: ./outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha256 ~/Downloads/largefile.bin
  Time (mean ± σ):      2.344 s ±  0.016 s    [User: 1.980 s, System: 0.359 s]
  Range (min … max):    2.320 s …  2.371 s    10 runs
```

### SHA512

```
hyperfine --warmup 3 './outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha512 ~/Downloads/largefile.bin'
Benchmark 1: ./outputs/out/bin/nix --extra-experimental-features nix-command hash file --type sha512 ~/Downloads/largefile.bin
  Time (mean ± σ):      4.529 s ±  0.039 s    [User: 4.156 s, System: 0.363 s]
  Range (min … max):    4.490 s …  4.593 s    10 runs
```