### PR TITLE
Json infra tests misc

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -419,9 +419,13 @@ namespace nlohmann {
 using namespace nix;
 
 fetchers::PublicKey adl_serializer<fetchers::PublicKey>::from_json(const json & json) {
-    auto type = optionalValueAt(json, "type").value_or("ssh-ed25519");
-    auto key = valueAt(json, "key");
-    return fetchers::PublicKey { getString(type), getString(key) };
+    fetchers::PublicKey res = {  };
+    if (auto type = optionalValueAt(json, "type"))
+        res.type = getString(*type);
+
+    res.key = getString(valueAt(json, "key"));
+
+    return res;
 }
 
 void adl_serializer<fetchers::PublicKey>::to_json(json & json, fetchers::PublicKey p) {

--- a/tests/unit/libfetchers/data/public-key/defaultType.json
+++ b/tests/unit/libfetchers/data/public-key/defaultType.json
@@ -1,0 +1,4 @@
+{
+  "key": "ABCDE",
+  "type": "ssh-ed25519"
+}

--- a/tests/unit/libfetchers/data/public-key/simple.json
+++ b/tests/unit/libfetchers/data/public-key/simple.json
@@ -1,0 +1,4 @@
+{
+  "key": "ABCDE",
+  "type": "ssh-rsa"
+}

--- a/tests/unit/libutil/json-utils.cc
+++ b/tests/unit/libutil/json-utils.cc
@@ -169,7 +169,19 @@ TEST(optionalValueAt, existing) {
 TEST(optionalValueAt, empty) {
     auto json = R"({})"_json;
 
-    ASSERT_EQ(optionalValueAt(json, "string2"), std::nullopt);
+    ASSERT_EQ(optionalValueAt(json, "string"), std::nullopt);
+}
+
+TEST(getNullable, null) {
+    auto json = R"(null)"_json;
+
+    ASSERT_EQ(getNullable(json), std::nullopt);
+}
+
+TEST(getNullable, empty) {
+    auto json = R"({})"_json;
+
+    ASSERT_EQ(getNullable(json), std::optional { R"({})"_json });
 }
 
 } /* namespace nix */


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This PR does the rest of things as described in #10503

1. `tests/unit/libfetchers/public-key.cc` now follows the characterization test pattern

> Also if you could imitate `tests/unit/libstore/derivation.cc` to make the JSON for the `fetchers::PublicKey` an external file and fit our [characterisation unit testing](https://nixos.org/manual/nix/unstable/contributing/testing#characaterisation-testing-unit) pattern, that would be great too!

_Originally posted by @Ericson2314 in https://github.com/NixOS/nix/issues/10503#issuecomment-2054199144_

2. The serializer for `fetchers::PublicKey` now doesn't repeat the default value for member `type`

> Also we should not repeat the default value.

_Originally posted by @Ericson2314 in https://github.com/NixOS/nix/pull/10503#discussion_r1564952017_

3. I've added some basic unit tests for `getNullable`

# Context
<!-- Provide context. Reference open issues if available. -->

See #10503

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
