### PR TITLE
[2.18] prohibit creating setuid/setgid binaries with fchmodat2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,6 +252,17 @@ case "$host_os" in
                         [CXXFLAGS="$LIBSECCOMP_CFLAGS $CXXFLAGS"])
       have_seccomp=1
       AC_DEFINE([HAVE_SECCOMP], [1], [Whether seccomp is available and should be used for sandboxing.])
+      AC_COMPILE_IFELSE([
+        AC_LANG_SOURCE([[
+          #include <seccomp.h>
+          #ifndef __SNR_fchmodat2
+          # error "Missing support for fchmodat2"
+          #endif
+        ]])
+      ], [], [
+        echo "libseccomp is missing __SNR_fchmodat2. Please provide libseccomp 2.5.5 or later"
+        exit 1
+      ])
     else
       have_seccomp=
     fi

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,13 @@
             boost
             lowdown-nix
           ]
-          ++ lib.optionals stdenv.isLinux [libseccomp]
+          ++ lib.optionals stdenv.isLinux [(libseccomp.overrideAttrs (_: rec {
+            version = "2.5.5";
+            src = fetchurl {
+              url = "https://github.com/seccomp/libseccomp/releases/download/v${version}/libseccomp-${version}.tar.gz";
+              hash = "sha256-JIosik2bmFiqa69ScSw0r+/PnJ6Ut23OAsHJqiX7M3U=";
+            };
+          }))]
           ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
           ++ lib.optional stdenv.hostPlatform.isx86_64 libcpuid;
 

--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -35,6 +35,7 @@
 /* Includes required for chroot support. */
 #if __linux__
 #include <sys/ioctl.h>
+#include "linux/fchmodat2-compat.hh"
 #include <net/if.h>
 #include <netinet/ip.h>
 #include <sys/mman.h>
@@ -1660,6 +1661,10 @@ void setupSeccomp()
             throw SysError("unable to add seccomp rule");
 
         if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(fchmodat), 1,
+                SCMP_A2(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
+            throw SysError("unable to add seccomp rule");
+
+        if (seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), NIX_SYSCALL_FCHMODAT2, 1,
                 SCMP_A2(SCMP_CMP_MASKED_EQ, (scmp_datum_t) perm, (scmp_datum_t) perm)) != 0)
             throw SysError("unable to add seccomp rule");
     }

--- a/src/libstore/linux/fchmodat2-compat.hh
+++ b/src/libstore/linux/fchmodat2-compat.hh
@@ -1,0 +1,34 @@
+/*
+ * Determine the syscall number for `fchmodat2`.
+ *
+ * On most platforms this is 452. Exceptions can be found on
+ * a glibc git checkout via `rg --pcre2 'define __NR_fchmodat2 (?!452)'`.
+ *
+ * The problem is that glibc 2.39 and libseccomp 2.5.5 are needed to
+ * get the syscall number. However, a Nix built against nixpkgs 23.11
+ * (glibc 2.38) should still have the issue fixed without depending
+ * on the build environment.
+ *
+ * To achieve that, the macros below try to determine the platform and
+ * set the syscall number which is platform-specific, but
+ * in most cases 452.
+ *
+ * TODO: remove this when 23.11 is EOL and the entire (supported) ecosystem
+ * is on glibc 2.39.
+ */
+
+#if HAVE_SECCOMP
+#  if defined(__alpha__)
+#    define NIX_SYSCALL_FCHMODAT2 562
+#  elif defined(__x86_64__) && SIZE_MAX == 0xFFFFFFFF // x32
+#    define NIX_SYSCALL_FCHMODAT2 1073742276
+#  elif defined(__mips__) && defined(__mips64) && defined(_ABIN64) // mips64/n64
+#    define NIX_SYSCALL_FCHMODAT2 5452
+#  elif defined(__mips__) && defined(__mips64) && defined(_ABIN32) // mips64/n32
+#    define NIX_SYSCALL_FCHMODAT2 6452
+#  elif defined(__mips__) && defined(_ABIO32) // mips32
+#    define NIX_SYSCALL_FCHMODAT2 4452
+#  else
+#    define NIX_SYSCALL_FCHMODAT2 452
+#  endif
+#endif // HAVE_SECCOMP


### PR DESCRIPTION
# Motivation
Backport the fixes from #10501 & #10591 to 2.18.

cc @NixOS/nix-team 

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
