### PR TITLE
Move `libseccomp` source override outside `package.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -179,6 +179,14 @@
             ];
           });
 
+          libseccomp-nix = final.libseccomp.overrideAttrs (_: rec {
+            version = "2.5.5";
+            src = final.fetchurl {
+              url = "https://github.com/seccomp/libseccomp/releases/download/v${version}/libseccomp-${version}.tar.gz";
+              hash = "sha256-JIosik2bmFiqa69ScSw0r+/PnJ6Ut23OAsHJqiX7M3U=";
+            };
+          });
+
           changelog-d-nix = final.buildPackages.callPackage ./misc/changelog-d.nix { };
 
           nix =
@@ -198,6 +206,7 @@
               officialRelease = false;
               boehmgc = final.boehmgc-nix;
               libgit2 = final.libgit2-nix;
+              libseccomp = final.libseccomp-nix;
               busybox-sandbox-shell = final.busybox-sandbox-shell or final.default-busybox-sandbox-shell;
             } // {
               # this is a proper separate downstream package, but put

--- a/package.nix
+++ b/package.nix
@@ -249,13 +249,7 @@ in {
   ] ++ lib.optionals buildUnitTests [
     gtest
     rapidcheck
-  ] ++ lib.optional stdenv.isLinux (libseccomp.overrideAttrs (_: rec {
-    version = "2.5.5";
-    src = fetchurl {
-      url = "https://github.com/seccomp/libseccomp/releases/download/v${version}/libseccomp-${version}.tar.gz";
-      hash = "sha256-JIosik2bmFiqa69ScSw0r+/PnJ6Ut23OAsHJqiX7M3U=";
-    };
-  }))
+  ] ++ lib.optional stdenv.isLinux libseccomp
     ++ lib.optional stdenv.hostPlatform.isx86_64 libcpuid
     # There have been issues building these dependencies
     ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin))


### PR DESCRIPTION
# Motivation

This makes it match the current pattern:

- `package.nix` assumes deps are right version

- Overlay in `flake.nix` creates `*-nix` package variations

- Overlay manually passes in those packages to `package.nix`

# Context

https://github.com/NixOS/nix/pull/10591 original PR

CC @Ma27 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
