### PR TITLE
Turn `Descriptor` into a struct, hiding the CPP

### DIFF
--- a/src/libstore/remote-fs-accessor.cc
+++ b/src/libstore/remote-fs-accessor.cc
@@ -71,7 +71,7 @@ std::pair<ref<SourceAccessor>, CanonPath> RemoteFSAccessor::fetch(const CanonPat
             auto narAccessor = makeLazyNarAccessor(listing,
                 [cacheFile](uint64_t offset, uint64_t length) {
 
-                    AutoCloseFD fd = toDescriptor(open(cacheFile.c_str(), O_RDONLY
+                    AutoCloseFD fd = Descriptor::fromFileDescriptor(open(cacheFile.c_str(), O_RDONLY
                     #ifndef _WIN32
                         | O_CLOEXEC
                     #endif
@@ -79,7 +79,7 @@ std::pair<ref<SourceAccessor>, CanonPath> RemoteFSAccessor::fetch(const CanonPat
                     if (!fd)
                         throw SysError("opening NAR cache file '%s'", cacheFile);
 
-                    if (lseek(fromDescriptorReadOnly(fd.get()), offset, SEEK_SET) != (off_t) offset)
+                    if (lseek(toFileDescriptorReadOnly(fd.get()), offset, SEEK_SET) != (off_t) offset)
                         throw SysError("seeking in '%s'", cacheFile);
 
                     std::string buf(length, 0);

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -108,8 +108,8 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(
     }, options);
 
 
-    in.readSide = INVALID_DESCRIPTOR;
-    out.writeSide = INVALID_DESCRIPTOR;
+    in.readSide = Descriptor::invalid;
+    out.writeSide = Descriptor::invalid;
 
     // Wait for the SSH connection to be established,
     // So that we don't overwrite the password prompt with our progress bar.
@@ -140,7 +140,7 @@ Path SSHMaster::startMaster()
 
     auto state(state_.lock());
 
-    if (state->sshMaster != INVALID_DESCRIPTOR) return state->socketPath;
+    if (state->sshMaster != Descriptor::invalid) return state->socketPath;
 
     state->socketPath = (Path) *state->tmpDir + "/ssh.sock";
 
@@ -173,7 +173,7 @@ Path SSHMaster::startMaster()
         throw SysError("unable to execute '%s'", args.front());
     }, options);
 
-    out.writeSide = INVALID_DESCRIPTOR;
+    out.writeSide = Descriptor::invalid;
 
     std::string reply;
     try {

--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -121,7 +121,7 @@ bool PathLocks::lockPaths(const PathSet & paths, const std::string & waitMsg, bo
             debug("lock aquired on '%1%'", lockPath);
 
             struct _stat st;
-            if (_fstat(fromDescriptorReadOnly(fd.get()), &st) == -1)
+            if (_fstat(toFileDescriptorReadOnly(fd.get()), &st) == -1)
                 throw SysError("statting lock file '%1%'", lockPath);
             if (st.st_size != 0)
                 debug("open lock file '%1%' has become stale", lockPath);

--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -39,7 +39,7 @@ std::string drainFD(Descriptor fd, bool block, const size_t reserveSize)
 //////////////////////////////////////////////////////////////////////
 
 
-AutoCloseFD::AutoCloseFD() : fd{INVALID_DESCRIPTOR} {}
+AutoCloseFD::AutoCloseFD() : fd{Descriptor::invalid} {}
 
 
 AutoCloseFD::AutoCloseFD(Descriptor fd) : fd{fd} {}
@@ -47,7 +47,7 @@ AutoCloseFD::AutoCloseFD(Descriptor fd) : fd{fd} {}
 
 AutoCloseFD::AutoCloseFD(AutoCloseFD && that) : fd{that.fd}
 {
-    that.fd = INVALID_DESCRIPTOR;
+    that.fd = Descriptor::invalid;
 }
 
 
@@ -55,7 +55,7 @@ AutoCloseFD & AutoCloseFD::operator =(AutoCloseFD && that)
 {
     close();
     fd = that.fd;
-    that.fd = INVALID_DESCRIPTOR;
+    that.fd = Descriptor::invalid;
     return *this;
 }
 
@@ -78,7 +78,7 @@ Descriptor AutoCloseFD::get() const
 
 void AutoCloseFD::close()
 {
-    if (fd != INVALID_DESCRIPTOR) {
+    if (fd != Descriptor::invalid) {
         if(
 #ifdef _WIN32
            ::CloseHandle(fd)
@@ -88,13 +88,13 @@ void AutoCloseFD::close()
            == -1)
             /* This should never happen. */
             throw NativeSysError("closing file descriptor %1%", fd);
-        fd = INVALID_DESCRIPTOR;
+        fd = Descriptor::invalid;
     }
 }
 
 void AutoCloseFD::fsync()
 {
-    if (fd != INVALID_DESCRIPTOR) {
+    if (fd != Descriptor::invalid) {
         int result;
         result =
 #ifdef _WIN32
@@ -113,14 +113,14 @@ void AutoCloseFD::fsync()
 
 AutoCloseFD::operator bool() const
 {
-    return fd != INVALID_DESCRIPTOR;
+    return fd != Descriptor::invalid;
 }
 
 
 Descriptor AutoCloseFD::release()
 {
     Descriptor oldFD = fd;
-    fd = INVALID_DESCRIPTOR;
+    fd = Descriptor::invalid;
     return oldFD;
 }
 

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -288,7 +288,7 @@ unsigned char getFileType(const Path & path)
 
 std::string readFile(const Path & path)
 {
-    AutoCloseFD fd = toDescriptor(open(path.c_str(), O_RDONLY
+    AutoCloseFD fd = Descriptor::fromFileDescriptor(open(path.c_str(), O_RDONLY
 // TODO
 #ifndef _WIN32
        | O_CLOEXEC
@@ -302,7 +302,7 @@ std::string readFile(const Path & path)
 
 void readFile(const Path & path, Sink & sink)
 {
-    AutoCloseFD fd = toDescriptor(open(path.c_str(), O_RDONLY
+    AutoCloseFD fd = Descriptor::fromFileDescriptor(open(path.c_str(), O_RDONLY
 // TODO
 #ifndef _WIN32
        | O_CLOEXEC
@@ -316,7 +316,7 @@ void readFile(const Path & path, Sink & sink)
 
 void writeFile(const Path & path, std::string_view s, mode_t mode, bool sync)
 {
-    AutoCloseFD fd = toDescriptor(open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT
+    AutoCloseFD fd = Descriptor::fromFileDescriptor(open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT
 // TODO
 #ifndef _WIN32
        | O_CLOEXEC
@@ -341,7 +341,7 @@ void writeFile(const Path & path, std::string_view s, mode_t mode, bool sync)
 
 void writeFile(const Path & path, Source & source, mode_t mode, bool sync)
 {
-    AutoCloseFD fd = toDescriptor(open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT
+    AutoCloseFD fd = Descriptor::fromFileDescriptor(open(path.c_str(), O_WRONLY | O_TRUNC | O_CREAT
 // TODO
 #ifndef _WIN32
        | O_CLOEXEC
@@ -373,7 +373,7 @@ void writeFile(const Path & path, Source & source, mode_t mode, bool sync)
 
 void syncParent(const Path & path)
 {
-    AutoCloseFD fd = toDescriptor(open(dirOf(path).c_str(), O_RDONLY, 0));
+    AutoCloseFD fd = Descriptor::fromFileDescriptor(open(dirOf(path).c_str(), O_RDONLY, 0));
     if (!fd)
         throw SysError("opening file '%1%'", path);
     fd.fsync();
@@ -453,7 +453,7 @@ static void _deletePath(const Path & path, uint64_t & bytesFreed)
     if (dir == "")
         dir = "/";
 
-    AutoCloseFD dirfd = toDescriptor(open(dir.c_str(), O_RDONLY));
+    AutoCloseFD dirfd = Descriptor::fromFileDescriptor(open(dir.c_str(), O_RDONLY));
     if (!dirfd) {
         if (errno == ENOENT) return;
         throw SysError("opening directory '%1%'", path);
@@ -600,7 +600,7 @@ std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix)
     Path tmpl(defaultTempDir() + "/" + prefix + ".XXXXXX");
     // Strictly speaking, this is UB, but who cares...
     // FIXME: use O_TMPFILE.
-    AutoCloseFD fd = toDescriptor(mkstemp((char *) tmpl.c_str()));
+    AutoCloseFD fd = Descriptor::fromFileDescriptor(mkstemp((char *) tmpl.c_str()));
     if (!fd)
         throw SysError("creating temporary file '%s'", tmpl);
 #ifndef _WIN32

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -47,7 +47,7 @@ void PosixSourceAccessor::readFile(
 
     auto ap = makeAbsPath(path);
 
-    AutoCloseFD fd = toDescriptor(open(ap.string().c_str(), O_RDONLY
+    AutoCloseFD fd = Descriptor::fromFileDescriptor(open(ap.string().c_str(), O_RDONLY
     #ifndef _WIN32
         | O_NOFOLLOW | O_CLOEXEC
     #endif
@@ -56,7 +56,7 @@ void PosixSourceAccessor::readFile(
         throw SysError("opening file '%1%'", ap.string());
 
     struct stat st;
-    if (fstat(fromDescriptorReadOnly(fd.get()), &st) == -1)
+    if (fstat(toFileDescriptorReadOnly(fd.get()), &st) == -1)
         throw SysError("statting file");
 
     sizeCallback(st.st_size);
@@ -66,7 +66,7 @@ void PosixSourceAccessor::readFile(
     std::array<unsigned char, 64 * 1024> buf;
     while (left) {
         checkInterrupt();
-        ssize_t rd = read(fromDescriptorReadOnly(fd.get()), buf.data(), (size_t) std::min(left, (off_t) buf.size()));
+        ssize_t rd = read(toFileDescriptorReadOnly(fd.get()), buf.data(), (size_t) std::min(left, (off_t) buf.size()));
         if (rd == -1) {
             if (errno != EINTR)
                 throw SysError("reading from file '%s'", showPath(path));

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -122,7 +122,7 @@ struct FdSink : BufferedSink
     Descriptor fd;
     size_t written = 0;
 
-    FdSink() : fd(INVALID_DESCRIPTOR) { }
+    FdSink() : fd(Descriptor::invalid) { }
     FdSink(Descriptor fd) : fd(fd) { }
     FdSink(FdSink&&) = default;
 
@@ -130,7 +130,7 @@ struct FdSink : BufferedSink
     {
         flush();
         fd = s.fd;
-        s.fd = INVALID_DESCRIPTOR;
+        s.fd = Descriptor::invalid;
         written = s.written;
         return *this;
     }
@@ -155,14 +155,14 @@ struct FdSource : BufferedSource
     size_t read = 0;
     BackedStringView endOfFileError{"unexpected end-of-file"};
 
-    FdSource() : fd(INVALID_DESCRIPTOR) { }
+    FdSource() : fd(Descriptor::invalid) { }
     FdSource(Descriptor fd) : fd(fd) { }
     FdSource(FdSource &&) = default;
 
     FdSource & operator=(FdSource && s)
     {
         fd = s.fd;
-        s.fd = INVALID_DESCRIPTOR;
+        s.fd = Descriptor::invalid;
         read = s.read;
         return *this;
     }

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -95,7 +95,7 @@ std::tuple<StorePath, Hash> prefetchFile(
             if (executable)
                 mode = 0700;
 
-            AutoCloseFD fd = toDescriptor(open(tmpFile.c_str(), O_WRONLY | O_CREAT | O_EXCL, mode));
+            AutoCloseFD fd = Descriptor::fromFileDescriptor(open(tmpFile.c_str(), O_WRONLY | O_CREAT | O_EXCL, mode));
             if (!fd) throw SysError("creating temporary file '%s'", tmpFile);
 
             FdSink sink(fd.get());


### PR DESCRIPTION
# Motivation

This doesn't build because lots of conversions are needed. In code that is already Unix-only that is especially annoying.

I wish there was a way to have a namespace-specific implicit coercion, so I could have `Descriptor <-> int` implicit coercsions in `namespace nix::unix` but not `namespace nix`.

# Context

Requested by @roberth in #10556, approved by rest of the team.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
