### PR TITLE
nix repl: hide progress bar during :edit

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -506,6 +506,10 @@ ProcessLineResult NixRepl::processLine(std::string line)
         auto editor = args.front();
         args.pop_front();
 
+        // avoid garbling the editor with the progress bar
+        logger->pause();
+        Finally resume([&]() { logger->resume(); });
+
         // runProgram redirects stdout to a StringSink,
         // using runProgram2 to allow editors to display their UI
         runProgram2(RunOptions { .program = editor, .lookupPath = true, .args = args });


### PR DESCRIPTION
# Motivation

Attempt to fix #10617 

# Context

I have no idea what I'm doing, so someone familiar with, like, C++, or how the progress bar usually works, should probably see if this is sensible. It just looked vaguely-like-the-right-spot to do the thing. :smile_cat: 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
