### PR TITLE
Add tests for dirOf/baseNameOf on the root of a flake

### DIFF
--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -54,6 +54,7 @@ struct PathInputScheme : InputScheme
             "narHash",
         };
     }
+
     std::optional<Input> inputFromAttrs(const Attrs & attrs) const override
     {
         getStrAttr(attrs, "path");

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -23,6 +23,8 @@ writeSimpleFlake() {
     legacyPackages.$system.hello = import ./simple.nix;
 
     parent = builtins.dirOf ./.;
+
+    baseName = builtins.baseNameOf ./.;
   };
 }
 EOF

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -21,6 +21,8 @@ writeSimpleFlake() {
 
     # To test "nix flake init".
     legacyPackages.$system.hello = import ./simple.nix;
+
+    parent = builtins.dirOf ./.;
   };
 }
 EOF

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -234,6 +234,9 @@ nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1
 # Regression test for dirOf on the root of the flake.
 [[ $(nix eval --json flake1#parent) = \""$NIX_STORE_DIR"\" ]]
 
+# Regression test for baseNameOf on the root of the flake.
+[[ $(nix eval --raw flake1#baseName) =~ ^[a-z0-9]*-source$ ]]
+
 # Building a flake with an unlocked dependency should fail in pure mode.
 (! nix build -o "$TEST_ROOT/result" flake2#bar --no-registries)
 (! nix build -o "$TEST_ROOT/result" flake2#bar --no-use-registries)

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -231,6 +231,9 @@ nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"$flake1Dir\").pack
 # 'getFlake' on a locked flakeref should succeed even in pure mode.
 nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1Dir?rev=$hash2\").packages.$system.default"
 
+# Regression test for dirOf on the root of the flake.
+[[ $(nix eval --json flake1#parent) = \""$NIX_STORE_DIR"\" ]]
+
 # Building a flake with an unlocked dependency should fail in pure mode.
 (! nix build -o "$TEST_ROOT/result" flake2#bar --no-registries)
 (! nix build -o "$TEST_ROOT/result" flake2#bar --no-use-registries)


### PR DESCRIPTION
# Motivation

Extracted from lazy-trees.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
