### PR TITLE
Test that the root of a tree produces /nix/store/<hash1>-<hash2>-source

### DIFF
--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -25,6 +25,8 @@ writeSimpleFlake() {
     parent = builtins.dirOf ./.;
 
     baseName = builtins.baseNameOf ./.;
+
+    root = ./.;
   };
 }
 EOF

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -237,7 +237,9 @@ nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1
 # Regression test for baseNameOf on the root of the flake.
 [[ $(nix eval --raw flake1#baseName) =~ ^[a-z0-9]+-source$ ]]
 
-# Test that the root of a tree returns a path named /nix/store/<hash1>-<hash2>-source (#10627).
+# Test that the root of a tree returns a path named /nix/store/<hash1>-<hash2>-source.
+# This behavior is *not* desired, but has existed for a while.
+# Issue #10627 what to do about it.
 [[ $(nix eval --raw flake1#root) =~ ^.*/[a-z0-9]+-[a-z0-9]+-source$ ]]
 
 # Building a flake with an unlocked dependency should fail in pure mode.

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -235,7 +235,10 @@ nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1
 [[ $(nix eval --json flake1#parent) = \""$NIX_STORE_DIR"\" ]]
 
 # Regression test for baseNameOf on the root of the flake.
-[[ $(nix eval --raw flake1#baseName) =~ ^[a-z0-9]*-source$ ]]
+[[ $(nix eval --raw flake1#baseName) =~ ^[a-z0-9]+-source$ ]]
+
+# Test that the root of a tree returns a path named /nix/store/<hash1>-<hash2>-source (#10627).
+[[ $(nix eval --raw flake1#root) =~ ^.*/[a-z0-9]+-[a-z0-9]+-source$ ]]
 
 # Building a flake with an unlocked dependency should fail in pure mode.
 (! nix build -o "$TEST_ROOT/result" flake2#bar --no-registries)


### PR DESCRIPTION
# Motivation

This is really a bug, but unless we decide to make a breaking change, we should test it. (See https://github.com/NixOS/nix/pull/6530/commits/c5ae41d8be6eb391ae39de9cce58b5e6b9e8085b for the backwards compatibility hack needed on lazy-trees to maintain this behavior.)

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
