### PR TITLE
libexpr: Add missing GC root for `baseEnv`

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -547,6 +547,11 @@ public:
      */
     SingleDerivedPath coerceToSingleDerivedPath(const PosIdx pos, Value & v, std::string_view errorCtx);
 
+#if HAVE_BOEHMGC
+    /** A GC root for the baseEnv reference. */
+    std::shared_ptr<Env *> baseEnvP;
+#endif
+
 public:
 
     /**


### PR DESCRIPTION
This missing GC root wasn't much of a problem before, because the heap would end up with a reference to the `baseEnv` pretty soon, but when unit testing, the construction of `EvalState` doesn't necessarily happen well before GC runs for the first time.

Found while unit testing the Rust bindings that currently reside at https://github.com/nixops4/nixops4/tree/main/rust

# Motivation

Robustness.
Fix flaky unit tests in language bindings.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
