### PR TITLE
document store url `trusted=true` option behavior

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -782,6 +782,7 @@ public:
 
           - the store object has been signed using a key in the trusted keys list
           - the [`require-sigs`](#conf-require-sigs) option has been set to `false`
+          - the store URL is configured with `trusted=true`
           - the store object is [content-addressed](@docroot@/glossary.md#gloss-content-addressed-store-object)
         )",
         {"binary-cache-public-keys"}};


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

I believe this section of the documentation is incomplete. It is missing an additional condition under which Nix accepts unsigned store objects.

# Context

The S3 Binary Cache Store has the following [`trusted`](https://nixos.org/manual/nix/stable/store/types/s3-binary-cache-store#store-s3-binary-cache-store-trusted) option.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
