### PR TITLE
Use `std::filesystem` functions in more places

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,6 @@ AC_SYS_LARGEFILE
 
 
 # Solaris-specific stuff.
-AC_STRUCT_DIRENT_D_TYPE
 case "$host_os" in
   solaris*)
     # Solaris requires -lsocket -lnsl for network functions

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -264,6 +264,7 @@ StringSet NixRepl::completePrefix(const std::string & prefix)
                     completions.insert(prev + dir + "/" + entry.name);
             }
         } catch (Error &) {
+        } catch (std::filesystem::filesystem_error &) {
         }
     } else if ((dot = cur.rfind('.')) == std::string::npos) {
         /* This is a variable name; look it up in the current scope. */

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -260,8 +260,9 @@ StringSet NixRepl::completePrefix(const std::string & prefix)
             auto dir = std::string(cur, 0, slash);
             auto prefix2 = std::string(cur, slash + 1);
             for (auto & entry : readDirectory(dir == "" ? "/" : dir)) {
-                if (entry.name[0] != '.' && hasPrefix(entry.name, prefix2))
-                    completions.insert(prev + dir + "/" + entry.name);
+                auto name = entry.path().filename().string();
+                if (name[0] != '.' && hasPrefix(name, prefix2))
+                    completions.insert(prev + entry.path().string());
             }
         } catch (Error &) {
         } catch (std::filesystem::filesystem_error &) {

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -17,7 +17,7 @@ struct State
 /* For each activated package, create symlinks */
 static void createLinks(State & state, const Path & srcDir, const Path & dstDir, int priority)
 {
-    DirEntries srcFiles;
+    std::vector<std::filesystem::directory_entry> srcFiles;
 
     try {
         srcFiles = readDirectory(srcDir);
@@ -30,11 +30,12 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
     }
 
     for (const auto & ent : srcFiles) {
-        if (ent.name[0] == '.')
+        auto name = ent.path().filename();
+        if (name.string()[0] == '.')
             /* not matched by glob */
             continue;
-        auto srcFile = srcDir + "/" + ent.name;
-        auto dstFile = dstDir + "/" + ent.name;
+        auto srcFile = (std::filesystem::path{srcDir} / name).string();
+        auto dstFile = (std::filesystem::path{dstDir} / name).string();
 
         struct stat srcSt;
         try {

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -21,8 +21,8 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
 
     try {
         srcFiles = readDirectory(srcDir);
-    } catch (SysError & e) {
-        if (e.errNo == ENOTDIR) {
+    } catch (std::filesystem::filesystem_error & e) {
+        if (e.code() == std::errc::not_a_directory) {
             warn("not including '%s' in the user environment because it's not a directory", srcDir);
             return;
         }

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -343,11 +343,11 @@ void initPlugins()
 {
     assert(!settings.pluginFiles.pluginsLoaded);
     for (const auto & pluginFile : settings.pluginFiles.get()) {
-        Paths pluginFiles;
+        std::vector<std::filesystem::path> pluginFiles;
         try {
             auto ents = readDirectory(pluginFile);
             for (const auto & ent : ents)
-                pluginFiles.emplace_back(pluginFile + "/" + ent.name);
+                pluginFiles.emplace_back(ent.path());
         } catch (std::filesystem::filesystem_error & e) {
             if (e.code() != std::errc::not_a_directory)
                 throw;

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -348,8 +348,8 @@ void initPlugins()
             auto ents = readDirectory(pluginFile);
             for (const auto & ent : ents)
                 pluginFiles.emplace_back(pluginFile + "/" + ent.name);
-        } catch (SysError & e) {
-            if (e.errNo != ENOTDIR)
+        } catch (std::filesystem::filesystem_error & e) {
+            if (e.code() != std::errc::not_a_directory)
                 throw;
             pluginFiles.emplace_back(pluginFile);
         }

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -84,11 +84,12 @@ protected:
         StorePathSet paths;
 
         for (auto & entry : readDirectory(binaryCacheDir)) {
-            if (entry.name.size() != 40 ||
-                !hasSuffix(entry.name, ".narinfo"))
+            auto name = entry.path().filename().string();
+            if (name.size() != 40 ||
+                !hasSuffix(name, ".narinfo"))
                 continue;
             paths.insert(parseStorePath(
-                    storeDir + "/" + entry.name.substr(0, entry.name.size() - 8)
+                    storeDir + "/" + name.substr(0, name.size() - 8)
                     + "-" + MissingName));
         }
 

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -338,6 +338,8 @@ Path getDefaultProfile()
         return absPath(readLink(profileLink), dirOf(profileLink));
     } catch (Error &) {
         return profileLink;
+    } catch (std::filesystem::filesystem_error &) {
+        return profileLink;
     }
 }
 

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -34,12 +34,12 @@ std::pair<Generations, std::optional<GenerationNumber>> findGenerations(Path pro
 {
     Generations gens;
 
-    Path profileDir = dirOf(profile);
+    std::filesystem::path profileDir = dirOf(profile);
     auto profileName = std::string(baseNameOf(profile));
 
-    for (auto & i : readDirectory(profileDir)) {
-        if (auto n = parseName(profileName, i.name)) {
-            auto path = profileDir + "/" + i.name;
+    for (auto & i : readDirectory(profileDir.string())) {
+        if (auto n = parseName(profileName, i.path().filename().string())) {
+            auto path = i.path().string();
             gens.push_back({
                 .number = *n,
                 .path = path,

--- a/src/libstore/unix/builtins/unpack-channel.cc
+++ b/src/libstore/unix/builtins/unpack-channel.cc
@@ -24,7 +24,7 @@ void builtinUnpackChannel(
     auto entries = readDirectory(out);
     if (entries.size() != 1)
         throw Error("channel tarball '%s' contains more than one file", src);
-    renameFile((out + "/" + entries[0].name), (out + "/" + channelName));
+    renameFile(entries[0].path().string(), (out + "/" + channelName));
 }
 
 }

--- a/src/libstore/unix/gc.cc
+++ b/src/libstore/unix/gc.cc
@@ -256,6 +256,14 @@ void LocalStore::findRoots(const Path & path, std::filesystem::file_type type, R
 
     }
 
+    catch (std::filesystem::filesystem_error & e) {
+        /* We only ignore permanent failures. */
+        if (e.code() == std::errc::permission_denied || e.code() == std::errc::no_such_file_or_directory || e.code() == std::errc::not_a_directory)
+            printInfo("cannot read potential root '%1%'", path);
+        else
+            throw;
+    }
+
     catch (SysError & e) {
         /* We only ignore permanent failures. */
         if (e.errNo == EACCES || e.errNo == ENOENT || e.errNo == ENOTDIR)

--- a/src/libstore/unix/gc.cc
+++ b/src/libstore/unix/gc.cc
@@ -160,14 +160,15 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
     /* Read the `temproots' directory for per-process temporary root
        files. */
     for (auto & i : readDirectory(tempRootsDir)) {
-        if (i.name[0] == '.') {
+        auto name = i.path().filename().string();
+        if (name[0] == '.') {
             // Ignore hidden files. Some package managers (notably portage) create
             // those to keep the directory alive.
             continue;
         }
-        Path path = tempRootsDir + "/" + i.name;
+        Path path = i.path();
 
-        pid_t pid = std::stoi(i.name);
+        pid_t pid = std::stoi(name);
 
         debug("reading temporary root file '%1%'", path);
         AutoCloseFD fd(open(path.c_str(), O_CLOEXEC | O_RDWR, 0666));
@@ -222,7 +223,7 @@ void LocalStore::findRoots(const Path & path, std::filesystem::file_type type, R
 
         if (type == std::filesystem::file_type::directory) {
             for (auto & i : readDirectory(path))
-                findRoots(path + "/" + i.name, i.type, roots);
+                findRoots(i.path().string(), i.symlink_status().type(), roots);
         }
 
         else if (type == std::filesystem::file_type::symlink) {

--- a/src/libstore/unix/local-store.cc
+++ b/src/libstore/unix/local-store.cc
@@ -1388,15 +1388,16 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
         printInfo("checking link hashes...");
 
         for (auto & link : readDirectory(linksDir)) {
-            printMsg(lvlTalkative, "checking contents of '%s'", link.name);
-            Path linkPath = linksDir + "/" + link.name;
+            auto name = link.path().filename();
+            printMsg(lvlTalkative, "checking contents of '%s'", name);
+            Path linkPath = linksDir / name;
             PosixSourceAccessor accessor;
             std::string hash = hashPath(
                 {getFSSourceAccessor(), CanonPath(linkPath)},
                 FileIngestionMethod::Recursive, HashAlgorithm::SHA256).to_string(HashFormat::Nix32, false);
-            if (hash != link.name) {
+            if (hash != name.string()) {
                 printError("link '%s' was modified! expected hash '%s', got '%s'",
-                    linkPath, link.name, hash);
+                    linkPath, name, hash);
                 if (repair) {
                     if (unlink(linkPath.c_str()) == 0)
                         printInfo("removed link '%s'", linkPath);
@@ -1483,7 +1484,7 @@ LocalStore::VerificationResult LocalStore::verifyAllValidPaths(RepairFlag repair
      */
     for (auto & i : readDirectory(realStoreDir)) {
         try {
-            storePathsInStoreDir.insert({i.name});
+            storePathsInStoreDir.insert({i.path().filename().string()});
         } catch (BadStorePath &) { }
     }
 

--- a/src/libstore/unix/local-store.hh
+++ b/src/libstore/unix/local-store.hh
@@ -371,7 +371,7 @@ private:
     PathSet queryValidPathsOld();
     ValidPathInfo queryPathInfoOld(const Path & path);
 
-    void findRoots(const Path & path, unsigned char type, Roots & roots);
+    void findRoots(const Path & path, std::filesystem::file_type type, Roots & roots);
 
     void findRootsNoTemp(Roots & roots, bool censor);
 

--- a/src/libstore/unix/posix-fs-canonicalise.cc
+++ b/src/libstore/unix/posix-fs-canonicalise.cc
@@ -136,9 +136,9 @@ static void canonicalisePathMetaData_(
     }
 
     if (S_ISDIR(st.st_mode)) {
-        DirEntries entries = readDirectory(path);
+        std::vector<std::filesystem::directory_entry> entries = readDirectory(path);
         for (auto & i : entries)
-            canonicalisePathMetaData_(path + "/" + i.name, uidRange, inodesSeen);
+            canonicalisePathMetaData_(i.path().string(), uidRange, inodesSeen);
     }
 }
 

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -120,10 +120,10 @@ Path canonPath(PathView path, bool resolveSymlinks)
 
 Path dirOf(const PathView path)
 {
-    Path::size_type pos = path.rfind('/');
+    Path::size_type pos = NativePathTrait::rfindPathSep(path);
     if (pos == path.npos)
         return ".";
-    return pos == 0 ? "/" : Path(path, 0, pos);
+    return fs::path{path}.parent_path().string();
 }
 
 
@@ -217,72 +217,36 @@ bool pathAccessible(const Path & path)
 
 Path readLink(const Path & path)
 {
-#ifndef _WIN32
     checkInterrupt();
-    std::vector<char> buf;
-    for (ssize_t bufSize = PATH_MAX/4; true; bufSize += bufSize/2) {
-        buf.resize(bufSize);
-        ssize_t rlSize = readlink(path.c_str(), buf.data(), bufSize);
-        if (rlSize == -1)
-            if (errno == EINVAL)
-                throw Error("'%1%' is not a symlink", path);
-            else
-                throw SysError("reading symbolic link '%1%'", path);
-        else if (rlSize < bufSize)
-            return std::string(buf.data(), rlSize);
-    }
-#else
-    // TODO modern Windows does in fact support symlinks
-    throw UnimplementedError("reading symbolic link '%1%'", path);
-#endif
+    return fs::read_symlink(path).string();
 }
 
 
 bool isLink(const Path & path)
 {
-    return getFileType(path) == DT_LNK;
+    return getFileType(path) == fs::file_type::symlink;
 }
 
 
-DirEntries readDirectory(DIR *dir, const Path & path)
+DirEntries readDirectory(const Path & path)
 {
     DirEntries entries;
     entries.reserve(64);
 
-    struct dirent * dirent;
-    while (errno = 0, dirent = readdir(dir)) { /* sic */
+    for (auto & entry : fs::directory_iterator{path}) {
         checkInterrupt();
-        std::string name = dirent->d_name;
-        if (name == "." || name == "..") continue;
-        entries.emplace_back(name, dirent->d_ino,
-#ifdef HAVE_STRUCT_DIRENT_D_TYPE
-            dirent->d_type
-#else
-            DT_UNKNOWN
-#endif
-        );
+        entries.emplace_back(
+            entry.path().filename().string(),
+            entry.symlink_status().type());
     }
-    if (errno) throw SysError("reading directory '%1%'", path);
 
     return entries;
 }
 
-DirEntries readDirectory(const Path & path)
+
+fs::file_type getFileType(const Path & path)
 {
-    AutoCloseDir dir(opendir(path.c_str()));
-    if (!dir) throw SysError("opening directory '%1%'", path);
-
-    return readDirectory(dir.get(), path);
-}
-
-
-unsigned char getFileType(const Path & path)
-{
-    struct stat st = lstat(path);
-    if (S_ISDIR(st.st_mode)) return DT_DIR;
-    if (S_ISLNK(st.st_mode)) return DT_LNK;
-    if (S_ISREG(st.st_mode)) return DT_REG;
-    return DT_UNKNOWN;
+    return fs::symlink_status(path).type();
 }
 
 
@@ -432,8 +396,15 @@ static void _deletePath(Descriptor parentfd, const Path & path, uint64_t & bytes
         AutoCloseDir dir(fdopendir(fd));
         if (!dir)
             throw SysError("opening directory '%1%'", path);
-        for (auto & i : readDirectory(dir.get(), path))
-            _deletePath(dirfd(dir.get()), path + "/" + i.name, bytesFreed);
+
+        struct dirent * dirent;
+        while (errno = 0, dirent = readdir(dir.get())) { /* sic */
+            checkInterrupt();
+            std::string childName = dirent->d_name;
+            if (childName == "." || childName == "..") continue;
+            _deletePath(dirfd(dir.get()), path + "/" + childName, bytesFreed);
+        }
+        if (errno) throw SysError("reading directory '%1%'", path);
     }
 
     int flags = S_ISDIR(st.st_mode) ? AT_REMOVEDIR : 0;
@@ -611,13 +582,7 @@ std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix)
 
 void createSymlink(const Path & target, const Path & link)
 {
-#ifndef _WIN32
-    if (symlink(target.c_str(), link.c_str()))
-        throw SysError("creating symlink from '%1%' to '%2%'", link, target);
-#else
-    // TODO modern Windows does in fact support symlinks
-    throw UnimplementedError("createSymlink");
-#endif
+    fs::create_symlink(target, link);
 }
 
 void replaceSymlink(const Path & target, const Path & link)
@@ -627,8 +592,8 @@ void replaceSymlink(const Path & target, const Path & link)
 
         try {
             createSymlink(target, tmp);
-        } catch (SysError & e) {
-            if (e.errNo == EEXIST) continue;
+        } catch (fs::filesystem_error & e) {
+            if (e.code() == std::errc::file_exists) continue;
             throw;
         }
 

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -228,16 +228,14 @@ bool isLink(const Path & path)
 }
 
 
-DirEntries readDirectory(const Path & path)
+std::vector<std::filesystem::directory_entry> readDirectory(const Path & path)
 {
-    DirEntries entries;
+    std::vector<std::filesystem::directory_entry> entries;
     entries.reserve(64);
 
     for (auto & entry : fs::directory_iterator{path}) {
         checkInterrupt();
-        entries.emplace_back(
-            entry.path().filename().string(),
-            entry.symlink_status().type());
+        entries.push_back(std::move(entry));
     }
 
     return entries;

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -122,17 +122,7 @@ bool isLink(const Path & path);
  * Read the contents of a directory.  The entries `.` and `..` are
  * removed.
  */
-struct DirEntry
-{
-    std::string name;
-    std::filesystem::file_type type;
-    DirEntry(std::string name, std::filesystem::file_type type)
-        : name(std::move(name)), type(type) { }
-};
-
-typedef std::vector<DirEntry> DirEntries;
-
-DirEntries readDirectory(const Path & path);
+std::vector<std::filesystem::directory_entry> readDirectory(const Path & path);
 
 std::filesystem::file_type getFileType(const Path & path);
 

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -27,13 +27,6 @@
 #include <sstream>
 #include <optional>
 
-#ifndef HAVE_STRUCT_DIRENT_D_TYPE
-#define DT_UNKNOWN 0
-#define DT_REG 1
-#define DT_LNK 2
-#define DT_DIR 3
-#endif
-
 /**
  * Polyfill for MinGW
  *
@@ -132,20 +125,16 @@ bool isLink(const Path & path);
 struct DirEntry
 {
     std::string name;
-    ino_t ino;
-    /**
-     * one of DT_*
-     */
-    unsigned char type;
-    DirEntry(std::string name, ino_t ino, unsigned char type)
-        : name(std::move(name)), ino(ino), type(type) { }
+    std::filesystem::file_type type;
+    DirEntry(std::string name, std::filesystem::file_type type)
+        : name(std::move(name)), type(type) { }
 };
 
 typedef std::vector<DirEntry> DirEntries;
 
 DirEntries readDirectory(const Path & path);
 
-unsigned char getFileType(const Path & path);
+std::filesystem::file_type getFileType(const Path & path);
 
 /**
  * Read the contents of a file into a string.

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -47,26 +47,26 @@ std::map<std::string, std::string> getCgroups(const Path & cgroupFile)
     return cgroups;
 }
 
-static CgroupStats destroyCgroup(const Path & cgroup, bool returnStats)
+static CgroupStats destroyCgroup(const std::filesystem::path & cgroup, bool returnStats)
 {
     if (!pathExists(cgroup)) return {};
 
-    auto procsFile = cgroup + "/cgroup.procs";
+    auto procsFile = cgroup / "cgroup.procs";
 
     if (!pathExists(procsFile))
         throw Error("'%s' is not a cgroup", cgroup);
 
     /* Use the fast way to kill every process in a cgroup, if
        available. */
-    auto killFile = cgroup + "/cgroup.kill";
+    auto killFile = cgroup / "cgroup.kill";
     if (pathExists(killFile))
         writeFile(killFile, "1");
 
     /* Otherwise, manually kill every process in the subcgroups and
        this cgroup. */
     for (auto & entry : readDirectory(cgroup)) {
-        if (entry.type != std::filesystem::file_type::directory) continue;
-        destroyCgroup(cgroup + "/" + entry.name, false);
+        if (entry.symlink_status().type() != std::filesystem::file_type::directory) continue;
+        destroyCgroup(cgroup / entry.path().filename(), false);
     }
 
     int round = 1;
@@ -111,7 +111,7 @@ static CgroupStats destroyCgroup(const Path & cgroup, bool returnStats)
     CgroupStats stats;
 
     if (returnStats) {
-        auto cpustatPath = cgroup + "/cpu.stat";
+        auto cpustatPath = cgroup / "cpu.stat";
 
         if (pathExists(cpustatPath)) {
             for (auto & line : tokenizeString<std::vector<std::string>>(readFile(cpustatPath), "\n")) {

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -65,7 +65,7 @@ static CgroupStats destroyCgroup(const Path & cgroup, bool returnStats)
     /* Otherwise, manually kill every process in the subcgroups and
        this cgroup. */
     for (auto & entry : readDirectory(cgroup)) {
-        if (entry.type != DT_DIR) continue;
+        if (entry.type != std::filesystem::file_type::directory) continue;
         destroyCgroup(cgroup + "/" + entry.name, false);
     }
 

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -138,14 +138,14 @@ SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & 
         // additional file types are allowed.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-enum"
-        switch (entry.type) {
+        switch (entry.symlink_status().type()) {
         case std::filesystem::file_type::regular: type = Type::tRegular; break;
         case std::filesystem::file_type::symlink: type = Type::tSymlink; break;
         case std::filesystem::file_type::directory: type = Type::tDirectory; break;
         default: type = tMisc;
         }
 #pragma GCC diagnostic pop
-        res.emplace(entry.name, type);
+        res.emplace(entry.path().filename().string(), type);
     }
     return res;
 }

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -133,6 +133,7 @@ void closeMostFDs(const std::set<int> & exceptions)
         }
         return;
     } catch (SysError &) {
+    } catch (std::filesystem::filesystem_error &) {
     }
 #endif
 

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -125,7 +125,7 @@ void closeMostFDs(const std::set<int> & exceptions)
 #if __linux__
     try {
         for (auto & s : readDirectory("/proc/self/fd")) {
-            auto fd = std::stoi(s.name);
+            auto fd = std::stoi(s.path().filename());
             if (!exceptions.count(fd)) {
                 debug("closing leaked FD %d", fd);
                 close(fd);

--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -31,14 +31,14 @@ void removeOldGenerations(std::string dir)
         checkInterrupt();
 
         auto path = dir + "/" + i.name;
-        auto type = i.type == DT_UNKNOWN ? getFileType(path) : i.type;
+        auto type = i.type == std::filesystem::file_type::unknown ? getFileType(path) : i.type;
 
-        if (type == DT_LNK && canWrite) {
+        if (type == std::filesystem::file_type::symlink && canWrite) {
             std::string link;
             try {
                 link = readLink(path);
-            } catch (SysError & e) {
-                if (e.errNo == ENOENT) continue;
+            } catch (std::filesystem::filesystem_error & e) {
+                if (e.code() == std::errc::no_such_file_or_directory) continue;
                 throw;
             }
             if (link.find("link") != std::string::npos) {
@@ -49,7 +49,7 @@ void removeOldGenerations(std::string dir)
                 } else
                     deleteOldGenerations(path, dryRun);
             }
-        } else if (type == DT_DIR) {
+        } else if (type == std::filesystem::file_type::directory) {
             removeOldGenerations(path);
         }
     }

--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -30,8 +30,8 @@ void removeOldGenerations(std::string dir)
     for (auto & i : readDirectory(dir)) {
         checkInterrupt();
 
-        auto path = dir + "/" + i.name;
-        auto type = i.type == std::filesystem::file_type::unknown ? getFileType(path) : i.type;
+        auto path = i.path().string();
+        auto type = i.symlink_status().type();
 
         if (type == std::filesystem::file_type::symlink && canWrite) {
             std::string link;

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -107,7 +107,8 @@ struct CmdConfigCheck : StoreCommand
                     if (profileDir.find("/profiles/") == std::string::npos)
                         dirs.insert(dir);
                 }
-            } catch (SystemError &) {}
+            } catch (SystemError &) {
+            } catch (std::filesystem::filesystem_error &) {}
         }
 
         if (!dirs.empty()) {

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -867,8 +867,8 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
             createDirs(to);
 
             for (auto & entry : readDirectory(from)) {
-                auto from2 = from + "/" + entry.name;
-                auto to2 = to + "/" + entry.name;
+                auto from2 = entry.path().string();
+                auto to2 = to + "/" + entry.path().filename().string();
                 auto st = lstat(from2);
                 if (S_ISDIR(st.st_mode))
                     copyDir(from2, to2);

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -117,7 +117,7 @@ std::tuple<StorePath, Hash> prefetchFile(
                that as the top-level. */
             auto entries = readDirectory(unpacked);
             if (entries.size() == 1)
-                tmpFile = unpacked + "/" + entries[0].name;
+                tmpFile = entries[0].path().string();
             else
                 tmpFile = unpacked;
         }

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -249,8 +249,8 @@ void chrootHelper(int argc, char * * argv)
             throw SysError("mounting '%s' on '%s'", realStoreDir, storeDir);
 
         for (auto entry : readDirectory("/")) {
-            auto src = "/" + entry.name;
-            Path dst = tmpDir + "/" + entry.name;
+            auto src = entry.path().string();
+            Path dst = tmpDir + "/" + entry.path().filename().string();
             if (pathExists(dst)) continue;
             auto st = lstat(src);
             if (S_ISDIR(st.st_mode)) {


### PR DESCRIPTION
# Motivation

This makes for shorter and more portable code.

The only tricky part is catching exceptions: I just searched for near by `catch (Error &)` or `catch (SysError &)` and adjusted them to `catch (std::filesystem::filesystem_error &)` according to my human judgement.

# Context

Good for windows portability; will help @siddhantk232 with his GSOC project.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
