### PR TITLE
builtin:fetchurl: Revert impureEnvVars attribute

### DIFF
--- a/src/libexpr/fetchurl.nix
+++ b/src/libexpr/fetchurl.nix
@@ -28,13 +28,9 @@ derivation ({
   # No need to double the amount of network traffic
   preferLocalBuild = true;
 
+  # This attribute does nothing; it's here to avoid changing evaluation results.
   impureEnvVars = [
-    # We borrow these environment variables from the caller to allow
-    # easy proxy configuration.  This is impure, but a fixed-output
-    # derivation like fetchurl is allowed to do so since its result is
-    # by definition pure.
     "http_proxy" "https_proxy" "ftp_proxy" "all_proxy" "no_proxy"
-    "HTTP_PROXY" "HTTPS_PROXY" "FTP_PROXY" "ALL_PROXY" "NO_PROXY"
   ];
 
   # To make "nix-prefetch-url" work.


### PR DESCRIPTION
# Motivation

This was changed in #10611, which caused the derivation paths of anything using `builtin:fetchurl` to change (i.e. all of Nixpkgs). However, `impureEnvVars` doesn't actually do anything for `builtin:fetchurl`, so we can just set it to its historical value.

This was caught by the flake-regressions test suite (https://github.com/NixOS/nix/actions/runs/8975397312/job/24650530065?pr=6530).

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
