### PR TITLE
fix(doc/manual/src/command-ref/nix-env/install): fix typo

### DIFF
--- a/doc/manual/src/command-ref/nix-env/install.md
+++ b/doc/manual/src/command-ref/nix-env/install.md
@@ -50,7 +50,7 @@ The arguments *args* map to store paths in a number of possible ways:
     Show the attribute paths of available packages with [`nix-env --query`](./query.md):
 
     ```console
-    nix-env --query --available --attr-path`
+    nix-env --query --available --attr-path
     ```
 
   - If `--from-profile` *path* is given, *args* is a set of names


### PR DESCRIPTION
# Motivation
Fix a typo in `doc/manual/src/command-ref/nix-env/install.md`.

# Context
<!-- Provide context. Reference open issues if available. -->
The typo was introduced by https://github.com/NixOS/nix/commit/369b076986531f3fbf6933539a0379b5d3fb1970 while converting a code span into a fenced code block.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
