### PR TITLE
maintainers: update information on team meetings

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -36,11 +36,13 @@ We aim to achieve this by improving the contributor experience and attracting mo
 - Robert Hensing (@roberth)
 - John Ericson (@Ericson2314)
 
+The team is on Github as [@NixOS/nix-team](https://github.com/orgs/NixOS/teams/nix-team).
+
 ## Meeting protocol
 
-The team meets twice a week:
+The team meets twice a week (times are denoted in the [Europe/Amsterdam](https://en.m.wikipedia.org/wiki/Time_in_the_Netherlands) time zone):
 
-- Discussion meeting: [Fridays 13:00-14:00 CET](https://calendar.google.com/calendar/event?eid=MHNtOGVuNWtrZXNpZHR2bW1sM3QyN2ZjaGNfMjAyMjExMjVUMTIwMDAwWiBiOW81MmZvYnFqYWs4b3E4bGZraGczdDBxZ0Bn)
+- Discussion meeting: [Wednesday 21:00-22:00 Europe/Amsterdam](https://www.google.com/calendar/event?eid=ZG5rZzNyajRjajducGV2NGY5aGkzYWIwdnJfMjAyNDA1MDhUMTkwMDAwWiBiOW81MmZvYnFqYWs4b3E4bGZraGczdDBxZ0Bn)
 
   1. Triage issues and pull requests from the [No Status](#no-status) column (30 min)
   2. Discuss issues and pull requests from the [To discuss](#to-discuss) column (30 min).
@@ -49,14 +51,18 @@ The team meets twice a week:
        - mark it as draft if it is blocked on the contributor
        - escalate it back to the team by moving it to To discuss, and leaving a comment as to why the issue needs to be discussed again.
 
-- Work meeting: [Mondays 13:00-15:00 CET](https://calendar.google.com/calendar/event?eid=NTM1MG1wNGJnOGpmOTZhYms3bTB1bnY5cWxfMjAyMjExMjFUMTIwMDAwWiBiOW81MmZvYnFqYWs4b3E4bGZraGczdDBxZ0Bn)
+- Work meeting: [Mondays 13:00-15:00 Europe/Amsterdam](https://www.google.com/calendar/event?eid=Ym52NDdzYnRic2NzcDcybjZiNDhpNzhpa3NfMjAyNDA1MTNUMTIwMDAwWiBiOW81MmZvYnFqYWs4b3E4bGZraGczdDBxZ0Bn)
 
   1. Code review on pull requests from [In review](#in-review).
   2. Other chores and tasks.
 
 Meeting notes are collected on a [collaborative scratchpad](https://pad.lassul.us/Cv7FpYx-Ri-4VjUykQOLAw).
-Notes on issues and pull requests are posted as comments and linked from the meeting notes, so they are easy to find from both places.
+Notes on issues and pull requests are posted as comments and linked from the meeting notes, so they are can be found from both places.
 [All meeting notes](https://discourse.nixos.org/search?expanded=true&q=Nix%20team%20meeting%20minutes%20%23%20%23dev%3Anix%20in%3Atitle%20order%3Alatest_topic) are published on Discourse under the [Nix category](https://discourse.nixos.org/c/dev/nix/50).
+
+Team meetings are generally open to anyone interested.
+We can make exceptions to discuss sensitive issues, such as security incidents or people matters.
+Contact any team member to get a calendar invite for reminders and updates.
 
 ## Project board protocol
 


### PR DESCRIPTION
- specify meeting times in terms of a time zone rather than standard
  time (the first encompasses standard time changes)
- add information on who can participate and how
- unrelated but still important: add GitHub handle to contact the team


# Motivation
Meeting times got out of sync. Also standard time switching produced some churn in the past.


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).