### PR TITLE
Add uninstallation hint for MacOS regarding key chain entries

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -135,6 +135,14 @@ which you may remove.
 
    If you _do_ find a "Nix Store" volume, delete it by running `diskutil deleteVolume` with the store volume's `diskXsY` identifier.
 
+8. Remove the password to the encrypted Nix Store volume:
+
+   ```console
+   sudo security delete-generic-password  -a "Nix Store" -s "Nix Store" -l "disk3 encryption password" -D "Encrypted volume password"`
+   ```
+
+   If you had multiple Nix Store volumes, you need to run the command multiple times until it mentions, that no further passwords matching the criteria were found.
+
 > **Note**
 >
 > After you complete the steps here, you will still have an empty `/nix` directory.


### PR DESCRIPTION
# Motivation

To upgrade my devenv 0.6 setup I got the suggestion to completely wipe my nix installation before. Therefore I went for this and the experimental installer and apparently this is an issue during installation. This should be mentioned to be removed on a cleanup as well.

# Context

see above

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
