### PR TITLE
Remove `isLink` in favor of `std::filesystem::is_link`

### DIFF
--- a/src/libstore/indirect-root-store.cc
+++ b/src/libstore/indirect-root-store.cc
@@ -33,8 +33,9 @@ Path IndirectRootStore::addPermRoot(const StorePath & storePath, const Path & _g
 
     /* Don't clobber the link if it already exists and doesn't
        point to the Nix store. */
-    if (pathExists(gcRoot) && (!isLink(gcRoot) || !isInStore(readLink(gcRoot))))
+    if (pathExists(gcRoot) && (!std::filesystem::is_symlink(gcRoot) || !isInStore(readLink(gcRoot))))
         throw Error("cannot create symlink '%1%'; already exists", gcRoot);
+
     makeSymlink(gcRoot, printStorePath(storePath));
     addIndirectRoot(gcRoot);
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -54,7 +54,7 @@ Path Store::followLinksToStore(std::string_view _path) const
 {
     Path path = absPath(std::string(_path));
     while (!isInStore(path)) {
-        if (!isLink(path)) break;
+        if (!std::filesystem::is_symlink(path)) break;
         auto target = readLink(path);
         path = absPath(target, dirOf(path));
     }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -94,7 +94,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
         path,
         [&followCount, &temp, maxFollow, resolveSymlinks]
         (std::string & result, std::string_view & remaining) {
-            if (resolveSymlinks && isLink(result)) {
+            if (resolveSymlinks && std::filesystem::is_symlink(result)) {
                 if (++followCount >= maxFollow)
                     throw Error("infinite symlink recursion in path '%0%'", remaining);
                 remaining = (temp = concatStrings(readLink(result), remaining));
@@ -219,12 +219,6 @@ Path readLink(const Path & path)
 {
     checkInterrupt();
     return fs::read_symlink(path).string();
-}
-
-
-bool isLink(const Path & path)
-{
-    return getFileType(path) == fs::file_type::symlink;
 }
 
 

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -117,8 +117,6 @@ bool pathAccessible(const Path & path);
  */
 Path readLink(const Path & path);
 
-bool isLink(const Path & path);
-
 /**
  * Read the contents of a directory.  The entries `.` and `..` are
  * removed.

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -101,7 +101,7 @@ struct CmdConfigCheck : StoreCommand
                 Path userEnv = canonPath(profileDir, true);
 
                 if (store->isStorePath(userEnv) && hasSuffix(userEnv, "user-environment")) {
-                    while (profileDir.find("/profiles/") == std::string::npos && isLink(profileDir))
+                    while (profileDir.find("/profiles/") == std::string::npos && std::filesystem::is_symlink(profileDir))
                         profileDir = absPath(readLink(profileDir), dirOf(profileDir));
 
                     if (profileDir.find("/profiles/") == std::string::npos)

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -121,7 +121,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         Path profileDir = dirOf(where);
 
         // Resolve profile to /nix/var/nix/profiles/<name> link.
-        while (canonPath(profileDir).find("/profiles/") == std::string::npos && isLink(profileDir))
+        while (canonPath(profileDir).find("/profiles/") == std::string::npos && std::filesystem::is_symlink(profileDir))
             profileDir = readLink(profileDir);
 
         printInfo("found profile '%s'", profileDir);


### PR DESCRIPTION
# Motivation

`isLink` util is removed in favour of `std::filesystem::is_symlink`

# Context

This is one step closer to eventually getting rid of most of our file system utils (in `file-system.cc`) in favor of the `std::filesystem`.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
