### PR TITLE
Forbid drvPath in strictDerivation outputs attribute

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1184,11 +1184,11 @@ static void derivationStrictInternal(
                         .debugThrow();
                 /* !!! Check whether j is a valid attribute
                    name. */
-                /* Derivations cannot be named ‘drv’, because
-                   then we'd have an attribute ‘drvPath’ in
-                   the resulting set. */
-                if (j == "drv")
-                    state.error<EvalError>("invalid derivation output name 'drv'")
+                /* Derivations cannot be named ‘drvPath’, because
+                   we already have an attribute ‘drvPath’ in
+                   the resulting set (see state.sDrvPath). */
+                if (j == "drvPath")
+                    state.error<EvalError>("invalid derivation output name 'drvPath'")
                         .atPos(v)
                         .debugThrow();
                 outputs.insert(j);


### PR DESCRIPTION
# Motivation

builtins.strictDerivation returns an attribute set with drvPath and output paths. For some reason, current implementation forbids drv instead of drvPath.

# Context

n/a

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
