### PR TITLE
Support unit prefixes in configuration settings

### DIFF
--- a/doc/manual/src/command-ref/conf-file-prefix.md
+++ b/doc/manual/src/command-ref/conf-file-prefix.md
@@ -66,5 +66,12 @@ Configuration options can be set on the command line, overriding the values set 
 
 The `extra-` prefix is supported for settings that take a list of items (e.g. `--extra-trusted users alice` or `--option extra-trusted-users alice`).
 
+## Integer settings
+
+Settings that have an integer type support the suffixes `K`, `M`, `G`
+and `T`. These cause the specified value to be multiplied by 2^10,
+2^20, 2^30 and 2^40, respectively. For instance, `--min-free 1M` is
+equivalent to `--min-free 1048576`.
+
 # Available settings
 

--- a/src/libutil/config-impl.hh
+++ b/src/libutil/config-impl.hh
@@ -116,10 +116,11 @@ T BaseSetting<T>::parse(const std::string & str) const
 {
     static_assert(std::is_integral<T>::value, "Integer required.");
 
-    if (auto n = string2Int<T>(str))
-        return *n;
-    else
+    try {
+        return string2IntWithUnitPrefix<T>(str);
+    } catch (...) {
         throw UsageError("setting '%s' has invalid value '%s'", name, str);
+    }
 }
 
 template<typename T>

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -120,7 +120,7 @@ std::optional<N> string2Int(const std::string_view s)
 template<class N>
 N string2IntWithUnitPrefix(std::string_view s)
 {
-    N multiplier = 1;
+    uint64_t multiplier = 1;
     if (!s.empty()) {
         char u = std::toupper(*s.rbegin());
         if (std::isalpha(u)) {

--- a/tests/functional/config.sh
+++ b/tests/functional/config.sh
@@ -67,3 +67,8 @@ exp_features=$(nix config show | grep '^experimental-features' | cut -d '=' -f 2
 val=$(nix config show | grep '^warn-dirty' | cut -d '=' -f  2 | xargs)
 val2=$(nix config show warn-dirty)
 [[ $val == $val2 ]]
+
+# Test unit prefixes.
+[[ $(nix config show --min-free 64K min-free) = 65536 ]]
+[[ $(nix config show --min-free 1M min-free) = 1048576 ]]
+[[ $(nix config show --min-free 2G min-free) = 2147483648 ]]

--- a/tests/functional/gc-auto.sh
+++ b/tests/functional/gc-auto.sh
@@ -62,11 +62,11 @@ EOF
 )
 
 nix build --impure -v -o $TEST_ROOT/result-A -L --expr "$expr" \
-    --min-free 1000 --max-free 2000 --min-free-check-interval 1 &
+    --min-free 1K --max-free 2K --min-free-check-interval 1 &
 pid1=$!
 
 nix build --impure -v -o $TEST_ROOT/result-B -L --expr "$expr2" \
-    --min-free 1000 --max-free 2000 --min-free-check-interval 1 &
+    --min-free 1K --max-free 2K --min-free-check-interval 1 &
 pid2=$!
 
 # Once the first build is done, unblock the second one.


### PR DESCRIPTION
# Motivation

E.g. you can now say `--min-free 1G`.

This is extracted from #7851. Also useful for #10661.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
