### PR TITLE
Die rather than warn if a Docker image is missing

### DIFF
--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -189,10 +189,7 @@ for my $platforms (["x86_64-linux", "amd64"], ["aarch64-linux", "arm64"]) {
     eval {
         downloadFile("dockerImage.$system", "1", $fn);
     };
-    if ($@) {
-        warn "$@" if $@;
-        next;
-    }
+    die "$@" if $@;
     $haveDocker = 1;
 
     print STDERR "loading docker image for $dockerPlatform...\n";


### PR DESCRIPTION
# Motivation
The warning was done to handle older Nix releases that didn't have Docker images (091f2328962fccfd71602b0b7c072c8d08291c86), but this was a bad idea because it causes us to silently skip uploading Docker images if e.g. Hydra hasn't finished building them yet.

Issue #10648.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
