### PR TITLE
Inline the usage of `nix::readDirectory` and remove it

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -259,7 +259,7 @@ StringSet NixRepl::completePrefix(const std::string & prefix)
         try {
             auto dir = std::string(cur, 0, slash);
             auto prefix2 = std::string(cur, slash + 1);
-            for (auto & entry : readDirectory(dir == "" ? "/" : dir)) {
+            for (auto & entry : std::filesystem::directory_iterator{dir == "" ? "/" : dir}) {
                 auto name = entry.path().filename().string();
                 if (name[0] != '.' && hasPrefix(name, prefix2))
                     completions.insert(prev + entry.path().string());

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -17,10 +17,10 @@ struct State
 /* For each activated package, create symlinks */
 static void createLinks(State & state, const Path & srcDir, const Path & dstDir, int priority)
 {
-    std::vector<std::filesystem::directory_entry> srcFiles;
+    std::filesystem::directory_iterator srcFiles;
 
     try {
-        srcFiles = readDirectory(srcDir);
+        srcFiles = std::filesystem::directory_iterator{srcDir};
     } catch (std::filesystem::filesystem_error & e) {
         if (e.code() == std::errc::not_a_directory) {
             warn("not including '%s' in the user environment because it's not a directory", srcDir);

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -161,7 +161,7 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
 {
     /* Read the `temproots' directory for per-process temporary root
        files. */
-    for (auto & i : readDirectory(tempRootsDir)) {
+    for (auto & i : std::filesystem::directory_iterator{tempRootsDir}) {
         auto name = i.path().filename().string();
         if (name[0] == '.') {
             // Ignore hidden files. Some package managers (notably portage) create
@@ -228,7 +228,7 @@ void LocalStore::findRoots(const Path & path, std::filesystem::file_type type, R
             type = getFileType(path);
 
         if (type == std::filesystem::file_type::directory) {
-            for (auto & i : readDirectory(path))
+            for (auto & i : std::filesystem::directory_iterator{path})
                 findRoots(i.path().string(), i.symlink_status().type(), roots);
         }
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -345,7 +345,7 @@ void initPlugins()
     for (const auto & pluginFile : settings.pluginFiles.get()) {
         std::vector<std::filesystem::path> pluginFiles;
         try {
-            auto ents = readDirectory(pluginFile);
+            auto ents = std::filesystem::directory_iterator{pluginFile};
             for (const auto & ent : ents)
                 pluginFiles.emplace_back(ent.path());
         } catch (std::filesystem::filesystem_error & e) {

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -83,7 +83,7 @@ protected:
     {
         StorePathSet paths;
 
-        for (auto & entry : readDirectory(binaryCacheDir)) {
+        for (auto & entry : std::filesystem::directory_iterator{binaryCacheDir}) {
             auto name = entry.path().filename().string();
             if (name.size() != 40 ||
                 !hasSuffix(name, ".narinfo"))

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1406,7 +1406,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
 
         printInfo("checking link hashes...");
 
-        for (auto & link : readDirectory(linksDir)) {
+        for (auto & link : std::filesystem::directory_iterator{linksDir}) {
             auto name = link.path().filename();
             printMsg(lvlTalkative, "checking contents of '%s'", name);
             PosixSourceAccessor accessor;
@@ -1498,7 +1498,7 @@ LocalStore::VerificationResult LocalStore::verifyAllValidPaths(RepairFlag repair
        database and the filesystem) in the loop below, in order to catch
        invalid states.
      */
-    for (auto & i : readDirectory(realStoreDir)) {
+    for (auto & i : std::filesystem::directory_iterator{realStoreDir.to_string()}) {
         try {
             storePathsInStoreDir.insert({i.path().filename().string()});
         } catch (BadStorePath &) { }

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -144,8 +144,7 @@ static void canonicalisePathMetaData_(
 #endif
 
     if (S_ISDIR(st.st_mode)) {
-        std::vector<std::filesystem::directory_entry> entries = readDirectory(path);
-        for (auto & i : entries)
+        for (auto & i : std::filesystem::directory_iterator{path})
             canonicalisePathMetaData_(
                 i.path().string(),
 #ifndef _WIN32

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -37,7 +37,7 @@ std::pair<Generations, std::optional<GenerationNumber>> findGenerations(Path pro
     std::filesystem::path profileDir = dirOf(profile);
     auto profileName = std::string(baseNameOf(profile));
 
-    for (auto & i : readDirectory(profileDir.string())) {
+    for (auto & i : std::filesystem::directory_iterator{profileDir}) {
         if (auto n = parseName(profileName, i.path().filename().string())) {
             auto path = i.path().string();
             gens.push_back({

--- a/src/libstore/unix/builtins/unpack-channel.cc
+++ b/src/libstore/unix/builtins/unpack-channel.cc
@@ -21,10 +21,12 @@ void builtinUnpackChannel(
 
     unpackTarfile(src, out);
 
-    auto entries = readDirectory(out);
-    if (entries.size() != 1)
+    auto entries = std::filesystem::directory_iterator{out};
+    auto file_count = std::distance(entries, std::filesystem::directory_iterator{});
+
+    if (file_count != 1)
         throw Error("channel tarball '%s' contains more than one file", src);
-    renameFile(entries[0].path().string(), (out + "/" + channelName));
+    renameFile(entries->path().string(), (out + "/" + channelName));
 }
 
 }

--- a/src/libstore/unix/builtins/unpack-channel.cc
+++ b/src/libstore/unix/builtins/unpack-channel.cc
@@ -22,11 +22,12 @@ void builtinUnpackChannel(
     unpackTarfile(src, out);
 
     auto entries = std::filesystem::directory_iterator{out};
-    auto file_count = std::distance(entries, std::filesystem::directory_iterator{});
+    auto fileName = entries->path().string();
+    auto fileCount = std::distance(std::filesystem::begin(entries), std::filesystem::end(entries));
 
-    if (file_count != 1)
+    if (fileCount != 1)
         throw Error("channel tarball '%s' contains more than one file", src);
-    renameFile(entries->path().string(), (out + "/" + channelName));
+    renameFile(fileName, (out + "/" + channelName));
 }
 
 }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -222,20 +222,6 @@ Path readLink(const Path & path)
 }
 
 
-std::vector<fs::directory_entry> readDirectory(const Path & path)
-{
-    std::vector<fs::directory_entry> entries;
-    entries.reserve(64);
-
-    for (auto & entry : fs::directory_iterator{path}) {
-        checkInterrupt();
-        entries.push_back(std::move(entry));
-    }
-
-    return entries;
-}
-
-
 fs::file_type getFileType(const Path & path)
 {
     return fs::symlink_status(path).type();

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -122,12 +122,6 @@ Path readLink(const Path & path);
  */
 Descriptor openDirectory(const std::filesystem::path & path);
 
-/**
- * Read the contents of a directory.  The entries `.` and `..` are
- * removed.
- */
-std::vector<std::filesystem::directory_entry> readDirectory(const Path & path);
-
 std::filesystem::file_type getFileType(const Path & path);
 
 /**

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -64,7 +64,7 @@ static CgroupStats destroyCgroup(const std::filesystem::path & cgroup, bool retu
 
     /* Otherwise, manually kill every process in the subcgroups and
        this cgroup. */
-    for (auto & entry : readDirectory(cgroup)) {
+    for (auto & entry : std::filesystem::directory_iterator{cgroup}) {
         if (entry.symlink_status().type() != std::filesystem::file_type::directory) continue;
         destroyCgroup(cgroup / entry.path().filename(), false);
     }

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -132,7 +132,7 @@ SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & 
 {
     assertNoSymlinks(path);
     DirEntries res;
-    for (auto & entry : nix::readDirectory(makeAbsPath(path).string())) {
+    for (auto & entry : std::filesystem::directory_iterator{makeAbsPath(path)}) {
         auto type = [&]() -> std::optional<Type> {
             std::filesystem::file_type nativeType;
             try {

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -124,7 +124,7 @@ void closeMostFDs(const std::set<int> & exceptions)
 {
 #if __linux__
     try {
-        for (auto & s : readDirectory("/proc/self/fd")) {
+        for (auto & s : std::filesystem::directory_iterator{"/proc/self/fd"}) {
             auto fd = std::stoi(s.path().filename());
             if (!exceptions.count(fd)) {
                 debug("closing leaked FD %d", fd);

--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -27,7 +27,7 @@ void removeOldGenerations(std::string dir)
 
     bool canWrite = access(dir.c_str(), W_OK) == 0;
 
-    for (auto & i : readDirectory(dir)) {
+    for (auto & i : std::filesystem::directory_iterator{dir}) {
         checkInterrupt();
 
         auto path = i.path().string();

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -866,7 +866,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
         {
             createDirs(to);
 
-            for (auto & entry : readDirectory(from)) {
+            for (auto & entry : std::filesystem::directory_iterator{from}) {
                 auto from2 = entry.path().string();
                 auto to2 = to + "/" + entry.path().filename().string();
                 auto st = lstat(from2);

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -115,9 +115,10 @@ std::tuple<StorePath, Hash> prefetchFile(
 
             /* If the archive unpacks to a single file/directory, then use
                that as the top-level. */
-            auto entries = readDirectory(unpacked);
-            if (entries.size() == 1)
-                tmpFile = entries[0].path();
+            auto entries = std::filesystem::directory_iterator{unpacked};
+            auto file_count = std::distance(entries, std::filesystem::directory_iterator{});
+            if (file_count == 1)
+                tmpFile = entries->path();
             else
                 tmpFile = unpacked;
         }

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -248,7 +248,7 @@ void chrootHelper(int argc, char * * argv)
         if (mount(realStoreDir.c_str(), (tmpDir + storeDir).c_str(), "", MS_BIND, 0) == -1)
             throw SysError("mounting '%s' on '%s'", realStoreDir, storeDir);
 
-        for (auto entry : readDirectory("/")) {
+        for (auto entry : std::filesystem::directory_iterator{"/"}) {
             auto src = entry.path().string();
             Path dst = tmpDir + "/" + entry.path().filename().string();
             if (pathExists(dst)) continue;


### PR DESCRIPTION
`nix::readDirectory` is removed. `std::filesystem::directory_iterator` is used directly in places that used this util.

# Motivation

The `nix::readDirectory` uses `std::filesystem::directory_iterator` and pushes all the entries in a `std::vector` before returning it. This is redundant as we can directly use `std::filesystem::directory_iterator` to iterate through entries and count files (and dirs) in path.

# Context

https://github.com/NixOS/nix/issues/9205
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
