### PR TITLE
fix: don’t expand aliases in develop stdenv setup

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -610,7 +610,7 @@ struct CmdDevelop : Common, MixEnvironment
         }
 
         else {
-            script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\n" + script;
+            script = "[ -n \"$PS1\" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\nshopt -u expand_aliases\n" + script + "\nshopt -s expand_aliases\n";
             if (developSettings.bashPrompt != "")
                 script += fmt("[ -n \"$PS1\" ] && PS1=%s;\n",
                     shellEscape(developSettings.bashPrompt.get()));


### PR DESCRIPTION
N.B.: I don't know anything about C++ so I'm ill equipped to judge the quality of this PR or write any tests for it. I don't even know how to cleanly reflow this now very long line. It's more of a POC to open the floor for discussion, than anything else, really.

# Motivation
This fixes https://github.com/NixOS/nixpkgs/pull/290775 by not expanding aliases when sourcing the stdenv setup script.

# Context

The way bash handles aliases is to expand them when a function is defined, not when it is used. I.e.:

    $ alias echo="echo bar "
    $ echo foo
    bar foo
    $ xyzzy() { echo foo; }
    $ shopt -u expand_aliases
    $ xyzzy
    bar foo
    $ xyzzy2() { echo foo; }
    $ xyzzy2
    foo

The problem is that ~/.bashrc is sourced before the stdenv setup, and bashrc commonly sets aliases for ‘cp’, ‘mv’ and ‘rm’ which you don’t want to take effect in the stdenv derivation builders. The original commit introducing this feature (5fd8cf76676a280ae2b7a86ddabc6b14b41ebfe5) even mentioned this very alias.

The only way to avoid this is to disable aliases entirely while sourcing the stdenv setup, and reenable them afterwards.

Example of this bug occurring in this very repo:

```
mbp23:nix user$ nix develop
 ↳ mbp23:nix user$ dontUnpack=1
 ↳ mbp23:nix user$ genericBuild
Running phase: patchPhase
Running phase: autoreconfPhase
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: /nix/store/mn7d82dx9xfini8fv5c6f8b7xy9g4sjc-autoconf-2.71/bin/autoconf --force
configure.ac:1: warning: AC_INIT: not a literal: "m4_esyscmd(bash -c "echo -n $(cat ./.version)$VERSION_SUFFIX")"
autoreconf: running: /nix/store/mn7d82dx9xfini8fv5c6f8b7xy9g4sjc-autoconf-2.71/bin/autoheader --force
autoreconf: configure.ac: not using Automake
autoreconf: Leaving directory '.'
Running phase: updateAutotoolsGnuConfigScriptsPhase
Updating Autotools / GNU config script to a newer upstream version: ./config/config.sub
cp: overwrite './config/config.sub'?
```

And now I have to confirm `cp` many many times to actually get anywhere.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
