### PR TITLE
Rename commit-lockfile-summary to commit-lock-file-summary for consistency

### DIFF
--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -32,7 +32,7 @@ static void writeTrustedList(const TrustedList & trustedList)
 
 void ConfigFile::apply()
 {
-    std::set<std::string> whitelist{"bash-prompt", "bash-prompt-prefix", "bash-prompt-suffix", "flake-registry", "commit-lockfile-summary"};
+    std::set<std::string> whitelist{"bash-prompt", "bash-prompt-prefix", "bash-prompt-suffix", "flake-registry", "commit-lock-file-summary", "commit-lockfile-summary"};
 
     for (auto & [name, value] : settings) {
 

--- a/src/libfetchers/fetch-settings.hh
+++ b/src/libfetchers/fetch-settings.hh
@@ -87,12 +87,12 @@ struct FetchSettings : public Config
         {}, true, Xp::Flakes};
 
     Setting<std::string> commitLockFileSummary{
-        this, "", "commit-lockfile-summary",
+        this, "", "commit-lock-file-summary",
         R"(
           The commit summary to use when committing changed flake lock files. If
           empty, the summary is generated based on the action performed.
         )",
-        {}, true, Xp::Flakes};
+        {"commit-lockfile-summary"}, true, Xp::Flakes};
 
     Setting<bool> trustTarballsFromGitForges{
         this, true, "trust-tarballs-from-git-forges",

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -439,7 +439,7 @@ The following attributes are supported in `flake.nix`:
    - [`bash-prompt-prefix`](@docroot@/command-ref/conf-file.md#conf-bash-prompt-prefix)
    - [`bash-prompt-suffix`](@docroot@/command-ref/conf-file.md#conf-bash-prompt-suffix)
    - [`flake-registry`](@docroot@/command-ref/conf-file.md#conf-flake-registry)
-   - [`commit-lockfile-summary`](@docroot@/command-ref/conf-file.md#conf-commit-lockfile-summary)
+   - [`commit-lock-file-summary`](@docroot@/command-ref/conf-file.md#conf-commit-lock-file-summary)
 
 ## Flake inputs
 


### PR DESCRIPTION

# Motivation

Of the numerous commandline arguments that talk about the lock file, commit-lockfile-summary appears to be the only one without a hyphen. Rename it with a backwards compatibility alias.

# Context

- closes #10687 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
