### PR TITLE
tests/functional/common/init.sh: Make $TEST_ROOT writable before removing it

### DIFF
--- a/tests/functional/common/init.sh
+++ b/tests/functional/common/init.sh
@@ -2,7 +2,10 @@ test -n "$TEST_ROOT"
 # We would delete any daemon socket, so let's stop the daemon first.
 killDaemon
 # Destroy the test directory that may have persisted from previous runs
-rm -rf "$TEST_ROOT"
+if [[ -e "$TEST_ROOT" ]]; then
+    chmod -R u+w "$TEST_ROOT"
+    rm -rf "$TEST_ROOT"
+fi
 mkdir -p "$TEST_ROOT"
 mkdir "$TEST_HOME"
 


### PR DESCRIPTION
# Motivation
$TEST_ROOT typically contains read-only files/directories (e.g. the Nix store). So we have to make it writable first.

This was lost in 7822ecbadff47fe350a483969e1e307c1c3a3ebe.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
