### PR TITLE
Warn on unknown settings when the first positional is an argument

### DIFF
--- a/doc/manual/rl-next/fix-silent-unknown-options
+++ b/doc/manual/rl-next/fix-silent-unknown-options
@@ -1,0 +1,28 @@
+---
+synopsis: Warn on unknown settings anywhere in the command line
+prs: 10701
+---
+
+All `nix` commands will now properly warn when an unknown option is specified anywhere in the command line.
+
+Before:
+
+```console
+$ nix-instantiate --option foobar baz --expr '{}'
+warning: unknown setting 'foobar'
+$ nix-instantiate '{}' --option foobar baz --expr
+$ nix eval --expr '{}' --option foobar baz
+{ }
+```
+
+After:
+
+```console
+$ nix-instantiate --option foobar baz --expr '{}'
+warning: unknown setting 'foobar'
+$ nix-instantiate '{}' --option foobar baz --expr
+warning: unknown setting 'foobar'
+$ nix eval --expr '{}' --option foobar baz
+warning: unknown setting 'foobar'
+{ }
+```

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -268,8 +268,6 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
         verbosity = lvlError;
     }
 
-    bool argsSeen = false;
-
     // Heuristic to see if we're invoked as a shebang script, namely,
     // if we have at least one argument, it's the name of an
     // executable file, and it starts with "#!".
@@ -336,10 +334,6 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
                 throw UsageError("unrecognised flag '%1%'", arg);
         }
         else {
-            if (!argsSeen) {
-                argsSeen = true;
-                initialFlagsProcessed();
-            }
             pos = rewriteArgs(cmdline, pos);
             pendingArgs.push_back(*pos++);
             if (processArgs(pendingArgs, false))
@@ -349,8 +343,7 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
 
     processArgs(pendingArgs, true);
 
-    if (!argsSeen)
-        initialFlagsProcessed();
+    initialFlagsProcessed();
 
     /* Now that we are done parsing, make sure that any experimental
      * feature required by the flags is enabled */

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -52,3 +52,7 @@ fi
 
 # Test --arg-from-stdin.
 [[ "$(echo bla | nix eval --raw --arg-from-stdin foo --expr '{ foo }: { inherit foo; }' foo)" = bla ]]
+
+# Test that unknown settings are warned about
+out="$(expectStderr 0 nix eval --option foobar baz --expr '""' --raw)"
+[[ "$(echo "$out" | grep foobar | wc -l)" = 1 ]]

--- a/tests/functional/misc.sh
+++ b/tests/functional/misc.sh
@@ -30,3 +30,12 @@ expectStderr 1 nix-instantiate --eval -E '[]' -A 'x' | grepQuiet "should be a se
 expectStderr 1 nix-instantiate --eval -E '{}' -A '1' | grepQuiet "should be a list"
 expectStderr 1 nix-instantiate --eval -E '{}' -A '.' | grepQuiet "empty attribute name"
 expectStderr 1 nix-instantiate --eval -E '[]' -A '1' | grepQuiet "out of range"
+
+# Unknown setting warning
+# NOTE(cole-h): behavior is different depending on the order, which is why we test an unknown option
+# before and after the `'{}'`!
+out="$(expectStderr 0 nix-instantiate --option foobar baz --expr '{}')"
+[[ "$(echo "$out" | grep foobar | wc -l)" = 1 ]]
+
+out="$(expectStderr 0 nix-instantiate '{}' --option foobar baz --expr )"
+[[ "$(echo "$out" | grep foobar | wc -l)" = 1 ]]


### PR DESCRIPTION
# Motivation
We should warn when unknown settings are passed on the command line.

# Context
While debugging an unrelated issue, I noticed that one of the flags I was passing wasn't valid for that version, but Nix never warned me of this fact. When I tested a similar invocation with the legacy interface, I was immediately warned about this unknown setting.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
