### PR TITLE
add example to `nix-store --import`

### DIFF
--- a/doc/manual/src/command-ref/nix-store/import.md
+++ b/doc/manual/src/command-ref/nix-store/import.md
@@ -19,3 +19,21 @@ Nix store, the import fails.
 {{#include ../opt-common.md}}
 
 {{#include ../env-common.md}}
+
+# Examples
+
+> **Example**
+>
+> Given a closure of GNU Hello as a file:
+>
+> ```shell-session
+> $ storePath="$(nix-build '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello --no-out-link)"
+> $ nix-store --export $(nix-store --query --requisites $storePath) > hello.closure
+> ```
+>
+> Import the closure into a [remote SSH store](@docroot@/store/types/ssh-store.md) using the [`--store`](@docroot@/command-ref/conf-file.md#conf-store) option:
+>
+> ```console
+> $ nix-store --import --store ssh://alice@itchy.example.org < hello.closure
+> ```
+


### PR DESCRIPTION
this also features specifying `--store` to give more pointers for
discoverability


# Motivation
rework the documentation around the use cases related to copying closures, as discussed with @eflanagan0

# Context
related: https://github.com/NixOS/nix/pull/10708
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).