### PR TITLE
make a more relevant example for `nix-store --export`

### DIFF
--- a/doc/manual/src/command-ref/nix-store/export.md
+++ b/doc/manual/src/command-ref/nix-store/export.md
@@ -27,15 +27,21 @@ Nix store, the import will fail.
 
 # Examples
 
-To copy a whole closure, do something
-like:
-
-```console
-$ nix-store --export $(nix-store --query --requisites paths) > out
-```
-
-To import the whole closure again, run:
-
-```console
-$ nix-store --import < out
-```
+> **Example**
+>
+> Deploy GNU Hello to an airgapped machine via USB stick.
+>
+> Write the closure to the block device on a machine with internet connection:
+>
+> ```shell-session
+> [alice@itchy]$ storePath=$(nix-build '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello --no-out-link)
+> [alice@itchy]$ nix-store --export $(nix-store --query --requisites $storePath) | sudo dd of=/dev/usb
+> ```
+>
+> Read the closure from the block device on the machine without internet connection:
+>
+> ```shell-session
+> [bob@scratchy]$ hello=$(sudo dd if=/dev/usb | nix-store --import | tail -1)
+> [bob@scratchy]$ $hello/bin/hello
+> Hello, world!
+> ```


### PR DESCRIPTION
given `nix-copy-closure` exists, it doesn't make much sense to do

    nix-store --export $paths | nix-store --import --store ssh://foo@bar

since that dumps everything rather than granularly transferring store
objects as needed.

therefore, pick an example where dumping the entire closure into a file
actually makes a difference, such as when deploying to airgapped systems.


# Motivation
reworking the use case documentation around `nix-copy-closure`, as discussed with @eflanagan0

# Context
related: https://github.com/NixOS/nix/pull/10708
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).