### PR TITLE
reword documentation on `nix-store --import`

### DIFF
--- a/doc/manual/src/command-ref/nix-store/import.md
+++ b/doc/manual/src/command-ref/nix-store/import.md
@@ -8,11 +8,13 @@
 
 # Description
 
-The operation `--import` reads a serialisation of a set of store paths
-produced by `nix-store --export` from standard input and adds those
-store paths to the Nix store. Paths that already exist in the Nix store
-are ignored. If a path refers to another path that doesn’t exist in the
-Nix store, the import fails.
+The operation `--import` reads a serialisation of a set of [store objects](@docroot@/glossary.md#gloss-store-object) produced by [`nix-store --export`](./export.md) from standard input, and adds those store objects to the specified [Nix store](@docroot@/store/index.md).
+Paths that already exist in the target Nix store are ignored.
+If a path [refers](@docroot@/glossary.md#gloss-reference) to another path that doesn’t exist in the target Nix store, the import fails.
+
+> **Note**
+>
+> For efficient transfer of closures to remote machines over SSH, use [`nix-copy-closure`](@docroot@/command-ref/nix-copy-closure.md).
 
 {{#include ./opt-common.md}}
 


### PR DESCRIPTION
- add links to definitions of terms
- one sentence per line
- be more specific about which store is used for the import
- clearly distinguish store paths and store objects
- make a recommendation to use `nix-copy-closure` for efficient SSH transfers


# Motivation
reworking documentation around use cases related to `nix-copy-closure`, as discussed with @eflanagan0

# Context
related: https://github.com/NixOS/nix/pull/10708
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).