### PR TITLE
labeler: capture all docs files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,7 @@
 
 "documentation":
   - changed-files:
-    - any-glob-to-any-file: "doc/manual/*"
+    - any-glob-to-any-file: "doc/manual/**/*"
     - any-glob-to-any-file: "src/nix/**/*.md"
 
 "store":
@@ -40,4 +40,4 @@
     - any-glob-to-any-file: "src/*/tests/**/*"
     # Functional and integration tests
     - any-glob-to-any-file: "tests/functional/**/*"
-    
+


### PR DESCRIPTION
# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).