### PR TITLE
fix "Embedding the Nix Evaluator" c api example

### DIFF
--- a/doc/external-api/README.md
+++ b/doc/external-api/README.md
@@ -46,9 +46,9 @@ Nix expression `builtins.nixVersion`.
 // NOTE: This example lacks all error handling. Production code must check for
 // errors, as some return values will be undefined.
 
-void my_get_string_cb(const char * start, unsigned int n, char ** user_data)
+void my_get_string_cb(const char * start, unsigned int n, void * user_data)
 {
-    *user_data = strdup(start);
+    *((char **) user_data) = strdup(start);
 }
 
 int main()
@@ -63,7 +63,7 @@ int main()
     nix_value_force(NULL, state, value);
 
     char * version;
-    nix_get_string(NULL, value, my_get_string_cb, version);
+    nix_get_string(NULL, value, my_get_string_cb, &version);
     printf("Nix version: %s\n", version);
 
     free(version);


### PR DESCRIPTION
# Motivation
- the [_Embedding the Nix Evaluator_ example](https://hydra.nixos.org/build/259630051/download/1/html/index.html#autotoc_md1) fails with `error: incompatible function pointer types` with clang.
- the [_Embedding the Nix Evaluator_ example](https://hydra.nixos.org/build/259630051/download/1/html/index.html#autotoc_md1) segmentation faults.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
this pull request was split off from my draft pull request https://github.com/NixOS/nix/pull/10629.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
