### PR TITLE
remove redundant and outdated example from `libexpr-c` documentation

### DIFF
--- a/doc/external-api/README.md
+++ b/doc/external-api/README.md
@@ -27,7 +27,7 @@ appreciated.
 The following examples, for simplicity, don't include error handling. See the
 [Handling errors](@ref errors) section for more information.
 
-# Embedding the Nix Evaluator
+# Embedding the Nix Evaluator{#nix_evaluator_example}
 
 In this example we programmatically start the Nix language evaluator with a
 dummy store (that has no store paths and cannot be written to), and evaluate the

--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -3,25 +3,7 @@
 /** @defgroup libexpr libexpr
  * @brief Bindings to the Nix language evaluator
  *
- * Example (without error handling):
- * @code{.c}
- * int main() {
- *    nix_libexpr_init(NULL);
- *
- *    Store* store = nix_store_open(NULL, "dummy", NULL);
- *    EvalState* state = nix_state_create(NULL, NULL, store); // empty nix path
- *    Value *value = nix_alloc_value(NULL, state);
- *
- *    nix_expr_eval_from_string(NULL, state, "builtins.nixVersion", ".", value);
- *    nix_value_force(NULL, state, value);
- *    printf("nix version: %s\n", nix_get_string(NULL, value));
- *
- *    nix_gc_decref(NULL, value);
- *    nix_state_free(state);
- *    nix_store_free(store);
- *    return 0;
- *    }
- * @endcode
+ * See *[Embedding the Nix Evaluator](@ref nix_evaluator_example)* for an example.
  * @{
  */
 /** @file


### PR DESCRIPTION
# Motivation
[the example in the `libexpr-c` documenation](https://hydra.nixos.org/build/259630051/download/1/html/group__libexpr.html#details) is outdated, does not compile anymore, and is redundant with [the _Embedding the Nix Evaluator_ example](https://hydra.nixos.org/build/259630051/download/1/html/index.html#autotoc_md1), which _has_ been kept up to date. so this pull request just replaces the outdated redundant example with a link to the other example.

it is rendered as follows.

![image](https://github.com/NixOS/nix/assets/30812734/4cbb0a8a-52c2-4e33-91b2-a59de51c2053)

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
