### PR TITLE
small c api documentation fixes

### DIFF
--- a/src/libexpr-c/nix_api_external.h
+++ b/src/libexpr-c/nix_api_external.h
@@ -136,7 +136,7 @@ typedef struct NixCExternalValueDesc
      * or setting it to the empty string, will make the conversion throw an error.
      */
     void (*printValueAsJSON)(
-        void * self, EvalState *, bool strict, nix_string_context * c, bool copyToStore, nix_string_return * res);
+        void * self, EvalState * state, bool strict, nix_string_context * c, bool copyToStore, nix_string_return * res);
     /**
      * @brief Convert the external value to XML
      *
@@ -155,7 +155,7 @@ typedef struct NixCExternalValueDesc
      */
     void (*printValueAsXML)(
         void * self,
-        EvalState *,
+        EvalState * state,
         int strict,
         int location,
         void * doc,

--- a/src/libexpr-c/nix_api_external.h
+++ b/src/libexpr-c/nix_api_external.h
@@ -48,7 +48,7 @@ void nix_set_string_return(nix_string_return * str, const char * c);
  * Print to the nix_printer
  *
  * @param[out] context Optional, stores error information
- * @param printer The nix_printer to print to
+ * @param[out] printer The nix_printer to print to
  * @param[in] str The string to print
  * @returns NIX_OK if everything worked
  */

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -63,7 +63,7 @@ nix_err nix_init_plugins(nix_c_context * context);
  * @return a Store pointer, NULL in case of errors
  * @see nix_store_free
  */
-Store * nix_store_open(nix_c_context *, const char * uri, const char *** params);
+Store * nix_store_open(nix_c_context * context, const char * uri, const char *** params);
 
 /**
  * @brief Deallocate a nix store and free any resources if not also held by other Store instances.


### PR DESCRIPTION
# Motivation
- [`nix_store_open`](https://hydra.nixos.org/build/259630051/download/1/html/group__libstore.html#gac805d1efb72516568c0a23343beecb72), [`printValueAsJSON`](https://hydra.nixos.org/build/259630051/download/1/html/structNixCExternalValueDesc.html#a0d031c0bceb64544a35fc0bfa9389381), and [`printValueAsXML`](https://hydra.nixos.org/build/259630051/download/1/html/structNixCExternalValueDesc.html#aeeea25776b7bba5ca0113b9919d86c53) show up in the documentation with some parameter names missing.
- document [`nix_external_print`](https://hydra.nixos.org/build/259630051/download/1/html/group__Externals.html#ga9757fd9087e8d9a7a86c8ffb0c759916)'s `printer` parameter to be an out parameter.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
this pull request was split off from my draft pull request https://github.com/NixOS/nix/pull/10629.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
