### PR TITLE
small additions to the documentation of `nix_store_open` and `nix_state_create`

### DIFF
--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -140,7 +140,7 @@ nix_err nix_value_force_deep(nix_c_context * context, EvalState * state, Value *
  * @brief Create a new Nix language evaluator state.
  *
  * @param[out] context Optional, stores error information
- * @param[in] lookupPath Array of strings corresponding to entries in NIX_PATH.
+ * @param[in] lookupPath Null-terminated array of strings corresponding to entries in NIX_PATH.
  * @param[in] store The Nix store to use.
  * @return A new Nix state or NULL on failure.
  */

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -57,9 +57,11 @@ nix_err nix_init_plugins(nix_c_context * context);
  * @brief Open a nix store
  * Store instances may share state and resources behind the scenes.
  * @param[out] context Optional, stores error information
- * @param[in] uri URI of the nix store, copied
- * @param[in] params optional, array of key-value pairs, {{"endpoint",
- * "https://s3.local"}}
+ * @param[in] uri URI of the Nix store, copied. See [*Store URL format* in the Nix Reference
+ * Manual](https://nixos.org/manual/nix/stable/store/types/#store-url-format).
+ * @param[in] params optional, null-terminated array of key-value pairs, e.g. {{"endpoint",
+ * "https://s3.local"}}. See [*Store Types* in the Nix Reference
+ * Manual](https://nixos.org/manual/nix/stable/store/types).
  * @return a Store pointer, NULL in case of errors
  * @see nix_store_free
  */


### PR DESCRIPTION
# Motivation
linked to [*Store Types* in the Nix Reference Manual](https://nixos.org/manual/nix/stable/store/types) for the `uri` and `params` arguments of [`nix_store_open`](https://hydra.nixos.org/build/260037898/download/1/html/group__libstore.html#ga843122a2bebf1bdd772becf3a3a81f0d).

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
