### PR TITLE
chore: add `CITATION.cff` file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Nix
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Eelco
+    family-names: Dolstra
+    email: edolstra@gmail.com
+  - name: The Nix contributors
+    website: 'https://github.com/NixOS/nix'
+identifiers:
+  - type: url
+    value: 'https://edolstra.github.io/pubs/phd-thesis.pdf'
+    description: PHD Thesis
+repository-code: 'https://github.com/NixOS/nix'
+url: 'https://nixos.org/'
+abstract: >-
+  Nix, a purely functional package manager, is a powerful
+  package manager for Linux and other Unix systems that
+  makes package management reliable and reproducible.
+keywords:
+  - reproducibility
+  - open-source
+  - c++
+  - functional
+license: LGPL-2.1


### PR DESCRIPTION
Hello,

I frequently need to cite Nix in the documents I write, and noticed that GitHub supports a specific citation file format (`CITATION.cff`). Having this file would enhance the visibility and proper citation of Nix directly from the GitHub repository page.

GitHub's support for the `CITATION.cff` files enables easy access to citation information, which can be automatically parsed and displayed on the project page. More details can be found in the [GitHub documentation on citation files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files).

When Github detect such a file in a repo, a new link is displayed on the right side:

![image](https://github.com/NixOS/nix/assets/252042/3995069e-cd58-4820-9688-e3615e7a15a0)

See it lively at https://github.com/drupol/nix/tree/add-citation-cff
