### PR TITLE
Improve nix-store --delete failure message

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -781,7 +781,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 throw Error(
                     "Cannot delete path '%1%' since it is still alive. "
                     "To find out why, use: "
-                    "nix-store --query --roots",
+                    "nix-store --query --roots and nix-store --query --referrers",
                     printStorePath(i));
         }
 


### PR DESCRIPTION
# Motivation

On several occasions I've found myself confused when trying to delete a store path, because I am told it's still alive, but nix-store --query --roots doesn't show anything.  Let's save future users this confusion by mentioning that a path might be alive due to having referrers, not just roots.

# Context

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
