### PR TITLE
nix3-build: show all FOD errors with `--keep-going`

### DIFF
--- a/doc/manual/rl-next/consistent-nix-build.md
+++ b/doc/manual/rl-next/consistent-nix-build.md
@@ -1,0 +1,6 @@
+---
+synopsis: Show all FOD errors with `nix build --keep-going`
+---
+
+`nix build --keep-going` now behaves consistently with `nix-build --keep-going`. This means
+that if e.g. multiple FODs fail to build, all hash mismatches are displayed.

--- a/tests/functional/fod-failing.nix
+++ b/tests/functional/fod-failing.nix
@@ -1,0 +1,39 @@
+with import ./config.nix;
+rec {
+  x1 = mkDerivation {
+    name = "x1";
+    builder = builtins.toFile "builder.sh"
+      ''
+        echo $name > $out
+      '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+  x2 = mkDerivation {
+    name = "x2";
+    builder = builtins.toFile "builder.sh"
+      ''
+        echo $name > $out
+      '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+  x3 = mkDerivation {
+    name = "x3";
+    builder = builtins.toFile "builder.sh"
+      ''
+        echo $name > $out
+      '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+  x4 = mkDerivation {
+    name = "x4";
+    inherit x2 x3;
+    builder = builtins.toFile "builder.sh"
+      ''
+        echo $x2 $x3
+        exit 1
+      '';
+  };
+}


### PR DESCRIPTION
This was cherry-picked from lix.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Basically I'd expect the same behavior as with `nix-build`, i.e. with `--keep-going` the hash-mismatch error of each failing fixed-output derivation is shown.

The approach is derived from `Store::buildPaths` (`entry-point.cc`): instead of throwing the first build-result, check if there are any build errors and if so, display all of them and throw after that.

Unfortunately, the BuildResult struct doesn't have an `ErrorInfo` (there's a FIXME for that at least), so I have to construct my own here. This is a rather cheap bugfix and I decided against touching too many parts of libstore for that (also I don't know if that's in line with the ongoing refactoring work).

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
