### PR TITLE
chore: PhD thesis as reference in `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,3 @@
-# This CITATION.cff file was generated with cffinit.
-# Visit https://bit.ly/cffinit to generate yours today!
-
 cff-version: 1.2.0
 title: Nix
 message: >-
@@ -13,10 +10,24 @@ authors:
     email: edolstra@gmail.com
   - name: The Nix contributors
     website: 'https://github.com/NixOS/nix'
-identifiers:
-  - type: url
-    value: 'https://edolstra.github.io/pubs/phd-thesis.pdf'
-    description: PHD Thesis
+references:
+  - title: The Purely Functional Software Deployment Model
+    authors:
+    - family-names: Dolstra
+      given-names: Eelco
+    year: 2006
+    type: thesis
+    thesis-type: PhD thesis
+    isbn: 90-393-4130-3
+    url: https://dspace.library.uu.nl/handle/1874/7540
+    database-provider: Utrecht University Repository
+    institution:
+      name: Utrecht University
+    keywords:
+    - configuration management
+    - software deployment
+    - purely functional
+    - component-based software engineering
 repository-code: 'https://github.com/NixOS/nix'
 url: 'https://nixos.org/'
 abstract: >-


### PR DESCRIPTION
I saw #10732 by @drupol and merged by @Ericson2314 and would like to propose the following improvements:

 1. Move the thesis from `identifiers` to `references`. Justification: The [`identifiers`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#identifiers) key is intended to list identifiers for versions or rather close derivations/packages of *the software itself*. Eelco's PhD thesis, while its connection to Nix is very obvious, in the CFF model still is a [`reference`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#references) because it is not *Nix itself*. You'll see that [`definitions.identifier`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsidentifier) is limited to `type` being one of `"doi"`, `"url"`, `"swh"`, and `"other"` (focused on software and datasets) while [`definitions.reference`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreference) has keys [`doi`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreference), [`isbn`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreference), [`url`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreference), [`collection-doi`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreferencecollection-doi), [`pmcid`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreferencepmcid) that are suited to identify written works and helpful further keys like [`thesis-type`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreferencethesis-type).
 2. Instead of referring to the thesis via the URL that points at GitHub, use the handle provided by Utrecht University. Justification: University libraries usually aim to preserve theses for an indefinite time and are very conscious about preservation. I would have provided the GitHub URL in addition, but it seems that CFF only supports one URL per reference.
 3. Copy metadata such as keywords from Utrecht University.

Note that CFF also supports [credit redirection](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#credit-redirection). That is, one can specify a [`definitions.reference`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsreference) object (like the thesis is with the changes in this PR), under the [`preferred-citation`](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#preferred-citation) key. In the case at hand, it would signal "please cite the thesis directly when you want to reference Nix". I opted to *not* do this, since if I were a long time contributor on the Nix team, I would probably object, as the thesis is only in Eelco's name, but I wanted to mention it here in case the Nix team wants to consider it.