### PR TITLE
Implement `setStackSize` on Windows

### DIFF
--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -60,14 +60,14 @@ unsigned int getMaxCPU()
 
 
 #ifndef _WIN32
-rlim_t savedStackSize = 0;
+size_t savedStackSize = 0;
 
-void setStackSize(rlim_t stackSize)
+void setStackSize(size_t stackSize)
 {
     struct rlimit limit;
     if (getrlimit(RLIMIT_STACK, &limit) == 0 && limit.rlim_cur < stackSize) {
         savedStackSize = limit.rlim_cur;
-        limit.rlim_cur = std::min(stackSize, limit.rlim_max);
+        limit.rlim_cur = std::min(static_cast<rlim_t>(stackSize), limit.rlim_max);
         if (setrlimit(RLIMIT_STACK, &limit) != 0) {
             logger->log(
                 lvlError,

--- a/src/libutil/current-process.hh
+++ b/src/libutil/current-process.hh
@@ -21,7 +21,7 @@ unsigned int getMaxCPU();
 /**
  * Change the stack size.
  */
-void setStackSize(rlim_t stackSize);
+void setStackSize(size_t stackSize);
 #endif
 
 /**

--- a/src/libutil/current-process.hh
+++ b/src/libutil/current-process.hh
@@ -17,12 +17,10 @@ namespace nix {
  */
 unsigned int getMaxCPU();
 
-#ifndef _WIN32 // TODO implement on Windows, if needed.
 /**
  * Change the stack size.
  */
 void setStackSize(size_t stackSize);
-#endif
 
 /**
  * Restore the original inherited Unix process context (such as signal

--- a/src/nix/local.mk
+++ b/src/nix/local.mk
@@ -30,6 +30,11 @@ nix_LIBS = libexpr libmain libfetchers libstore libutil libcmd
 
 nix_LDFLAGS = $(THREAD_LDFLAGS) $(SODIUM_LIBS) $(EDITLINE_LIBS) $(BOOST_LDFLAGS) $(LOWDOWN_LIBS)
 
+ifdef HOST_WINDOWS
+  # Increase the default reserved stack size to 65 MB so Nix doesn't run out of space
+  nix_LDFLAGS += -Wl,--stack,$(shell echo $$((65 * 1024 * 1024)))
+endif
+
 $(foreach name, \
   nix-build nix-channel nix-collect-garbage nix-copy-closure nix-daemon nix-env nix-hash nix-instantiate nix-prefetch-url nix-shell nix-store, \
   $(eval $(call install-symlink, nix, $(bindir)/$(name))))

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -522,14 +522,9 @@ void mainWrapped(int argc, char * * argv)
 
 int main(int argc, char * * argv)
 {
-#ifndef _WIN32
     // Increase the default stack size for the evaluator and for
     // libstdc++'s std::regex.
     nix::setStackSize(64 * 1024 * 1024);
-#else
-    // Windows' default stack reservation is 1 MB, going over will fail
-    nix::setStackSize(1 * 1024 * 1024);
-#endif
 
     return nix::handleExceptions(argv[0], [&]() {
         nix::mainWrapped(argc, argv);

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -522,10 +522,13 @@ void mainWrapped(int argc, char * * argv)
 
 int main(int argc, char * * argv)
 {
-#ifndef _WIN32 // TODO implement on Windows
+#ifndef _WIN32
     // Increase the default stack size for the evaluator and for
     // libstdc++'s std::regex.
     nix::setStackSize(64 * 1024 * 1024);
+#else
+    // Windows' default stack reservation is 1 MB, going over will fail
+    nix::setStackSize(1 * 1024 * 1024);
 #endif
 
     return nix::handleExceptions(argv[0], [&]() {

--- a/tests/unit/libexpr/local.mk
+++ b/tests/unit/libexpr/local.mk
@@ -38,3 +38,8 @@ libexpr-tests_LIBS = \
     libexpr libexprc libfetchers libstore libstorec libutil libutilc
 
 libexpr-tests_LDFLAGS := -lrapidcheck $(GTEST_LIBS) -lgmock
+
+ifdef HOST_WINDOWS
+  # Increase the default reserved stack size to 65 MB so Nix doesn't run out of space
+  libexpr-tests_LDFLAGS += -Wl,--stack,$(shell echo $$((65 * 1024 * 1024)))
+endif

--- a/tests/unit/libfetchers/local.mk
+++ b/tests/unit/libfetchers/local.mk
@@ -30,3 +30,8 @@ libfetchers-tests_LIBS = \
     libfetchers libstore libutil
 
 libfetchers-tests_LDFLAGS := -lrapidcheck $(GTEST_LIBS)
+
+ifdef HOST_WINDOWS
+  # Increase the default reserved stack size to 65 MB so Nix doesn't run out of space
+  libfetchers-tests_LDFLAGS += -Wl,--stack,$(shell echo $$((65 * 1024 * 1024)))
+endif

--- a/tests/unit/libstore/local.mk
+++ b/tests/unit/libstore/local.mk
@@ -31,3 +31,8 @@ libstore-tests_LIBS = \
     libstore libstorec libutil libutilc
 
 libstore-tests_LDFLAGS := -lrapidcheck $(GTEST_LIBS)
+
+ifdef HOST_WINDOWS
+  # Increase the default reserved stack size to 65 MB so Nix doesn't run out of space
+  libstore-tests_LDFLAGS += -Wl,--stack,$(shell echo $$((65 * 1024 * 1024)))
+endif

--- a/tests/unit/libutil/local.mk
+++ b/tests/unit/libutil/local.mk
@@ -27,6 +27,11 @@ libutil-tests_LIBS = libutil-test-support libutil libutilc
 
 libutil-tests_LDFLAGS := -lrapidcheck $(GTEST_LIBS)
 
+ifdef HOST_WINDOWS
+  # Increase the default reserved stack size to 65 MB so Nix doesn't run out of space
+  libutil-tests_LDFLAGS += -Wl,--stack,$(shell echo $$((65 * 1024 * 1024)))
+endif
+
 check: $(d)/data/git/check-data.sh.test
 
 $(eval $(call run-test,$(d)/data/git/check-data.sh))


### PR DESCRIPTION
# Motivation
See #10540.

# Context
This implements setStackSize for Nix using MinGW, with the strategy described in #10540 (SetThreadStackGuarantee). I've tested this on a Windows 10 LTSC VM through NixOS without any issues.

However, I'm not sure if this change is really required. It seems from a bit of skimming that Windows allocates 1 MB of stack space for each thread by default (specified [here](https://learn.microsoft.com/en-us/windows/win32/procthread/thread-stack-size)), and it doesn't seem like that number is modifiable after compilation. As a result, the `setStackSize` call in `main` doesn't work with the 64 MB of stack space requested, as on Unix systems. 

I've opted to request 1 MB of stack space as a result, but I'm unsure if this is even a useful request, considering the default thread's stack size.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
