### PR TITLE
Implement `updateWindowSize` for Windows

### DIFF
--- a/src/libutil/terminal.hh
+++ b/src/libutil/terminal.hh
@@ -21,15 +21,11 @@ std::string filterANSIEscapes(std::string_view s,
     bool filterAll = false,
     unsigned int width = std::numeric_limits<unsigned int>::max());
 
-#ifndef _WIN32
-
 /**
  * Recalculate the window size, updating a global variable. Used in the
  * `SIGWINCH` signal handler.
  */
 void updateWindowSize();
-
-#endif
 
 /**
  * @return the number of rows and columns of the terminal.


### PR DESCRIPTION
# Context
Closes #10543. The Windows implementation is based on `uv_tty_get_winsize` in `libuv`, which is the library that Neovim uses for its terminal window size (https://neovim.io/doc/user/term.html#window-size)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
