### PR TITLE
Cleanup `ContentAddressMethod` to match docs

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2303,7 +2303,7 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
                 path.resolveSymlinks(),
                 settings.readOnlyMode ? FetchMode::DryRun : FetchMode::Copy,
                 path.baseName(),
-                FileIngestionMethod::Recursive,
+                FileIngestionMethod::NixArchive,
                 nullptr,
                 repair);
             allowPath(dstPath);

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2303,7 +2303,7 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
                 path.resolveSymlinks(),
                 settings.readOnlyMode ? FetchMode::DryRun : FetchMode::Copy,
                 path.baseName(),
-                FileIngestionMethod::NixArchive,
+                ContentAddressMethod::Raw::NixArchive,
                 nullptr,
                 repair);
             allowPath(dstPath);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1209,7 +1209,7 @@ static void derivationStrictInternal(
         auto handleHashMode = [&](const std::string_view s) {
             if (s == "recursive") {
                 // back compat, new name is "nar"
-                ingestionMethod = FileIngestionMethod::Recursive;
+                ingestionMethod = FileIngestionMethod::NixArchive;
             } else try {
                 ingestionMethod = ContentAddressMethod::parse(s);
             } catch (UsageError &) {
@@ -1432,7 +1432,7 @@ static void derivationStrictInternal(
                 .atPos(v).debugThrow();
 
         auto ha = outputHashAlgo.value_or(HashAlgorithm::SHA256);
-        auto method = ingestionMethod.value_or(FileIngestionMethod::Recursive);
+        auto method = ingestionMethod.value_or(FileIngestionMethod::NixArchive);
 
         for (auto & i : outputs) {
             drv.env[i] = hashPlaceholder(i);
@@ -2391,7 +2391,7 @@ static void prim_filterSource(EvalState & state, const PosIdx pos, Value * * arg
         "while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'");
     state.forceFunction(*args[0], pos, "while evaluating the first argument passed to builtins.filterSource");
 
-    addPath(state, pos, path.baseName(), path, args[0], FileIngestionMethod::Recursive, std::nullopt, v, context);
+    addPath(state, pos, path.baseName(), path, args[0], FileIngestionMethod::NixArchive, std::nullopt, v, context);
 }
 
 static RegisterPrimOp primop_filterSource({
@@ -2454,7 +2454,7 @@ static void prim_path(EvalState & state, const PosIdx pos, Value * * args, Value
     std::optional<SourcePath> path;
     std::string name;
     Value * filterFun = nullptr;
-    ContentAddressMethod method = FileIngestionMethod::Recursive;
+    ContentAddressMethod method = FileIngestionMethod::NixArchive;
     std::optional<Hash> expectedHash;
     NixStringContext context;
 
@@ -2470,7 +2470,7 @@ static void prim_path(EvalState & state, const PosIdx pos, Value * * args, Value
             state.forceFunction(*(filterFun = attr.value), attr.pos, "while evaluating the `filter` parameter passed to builtins.path");
         else if (n == "recursive")
             method = state.forceBool(*attr.value, attr.pos, "while evaluating the `recursive` attribute passed to builtins.path")
-                ? FileIngestionMethod::Recursive
+                ? FileIngestionMethod::NixArchive
                 : FileIngestionMethod::Flat;
         else if (n == "sha256")
             expectedHash = newHashAllowEmpty(state.forceStringNoCtx(*attr.value, attr.pos, "while evaluating the `sha256` attribute passed to builtins.path"), HashAlgorithm::SHA256);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1209,7 +1209,7 @@ static void derivationStrictInternal(
         auto handleHashMode = [&](const std::string_view s) {
             if (s == "recursive") {
                 // back compat, new name is "nar"
-                ingestionMethod = FileIngestionMethod::NixArchive;
+                ingestionMethod = ContentAddressMethod::Raw::NixArchive;
             } else try {
                 ingestionMethod = ContentAddressMethod::parse(s);
             } catch (UsageError &) {
@@ -1217,9 +1217,9 @@ static void derivationStrictInternal(
                     "invalid value '%s' for 'outputHashMode' attribute", s
                 ).atPos(v).debugThrow();
             }
-            if (ingestionMethod == TextIngestionMethod {})
+            if (ingestionMethod == ContentAddressMethod::Raw::Text)
                 experimentalFeatureSettings.require(Xp::DynamicDerivations);
-            if (ingestionMethod == FileIngestionMethod::Git)
+            if (ingestionMethod == ContentAddressMethod::Raw::Git)
                 experimentalFeatureSettings.require(Xp::GitHashing);
         };
 
@@ -1391,7 +1391,7 @@ static void derivationStrictInternal(
 
     /* Check whether the derivation name is valid. */
     if (isDerivation(drvName) &&
-        !(ingestionMethod == ContentAddressMethod { TextIngestionMethod { } } &&
+        !(ingestionMethod == ContentAddressMethod::Raw::Text &&
           outputs.size() == 1 &&
           *(outputs.begin()) == "out"))
     {
@@ -1413,7 +1413,7 @@ static void derivationStrictInternal(
 
         auto h = newHashAllowEmpty(*outputHash, outputHashAlgo);
 
-        auto method = ingestionMethod.value_or(FileIngestionMethod::Flat);
+        auto method = ingestionMethod.value_or(ContentAddressMethod::Raw::Flat);
 
         DerivationOutput::CAFixed dof {
             .ca = ContentAddress {
@@ -1432,7 +1432,7 @@ static void derivationStrictInternal(
                 .atPos(v).debugThrow();
 
         auto ha = outputHashAlgo.value_or(HashAlgorithm::SHA256);
-        auto method = ingestionMethod.value_or(FileIngestionMethod::NixArchive);
+        auto method = ingestionMethod.value_or(ContentAddressMethod::Raw::NixArchive);
 
         for (auto & i : outputs) {
             drv.env[i] = hashPlaceholder(i);
@@ -2208,7 +2208,7 @@ static void prim_toFile(EvalState & state, const PosIdx pos, Value * * args, Val
         })
         : ({
             StringSource s { contents };
-            state.store->addToStoreFromDump(s, name, FileSerialisationMethod::Flat, TextIngestionMethod {}, HashAlgorithm::SHA256, refs, state.repair);
+            state.store->addToStoreFromDump(s, name, FileSerialisationMethod::Flat, ContentAddressMethod::Raw::Text, HashAlgorithm::SHA256, refs, state.repair);
         });
 
     /* Note: we don't need to add `context' to the context of the
@@ -2391,7 +2391,7 @@ static void prim_filterSource(EvalState & state, const PosIdx pos, Value * * arg
         "while evaluating the second argument (the path to filter) passed to 'builtins.filterSource'");
     state.forceFunction(*args[0], pos, "while evaluating the first argument passed to builtins.filterSource");
 
-    addPath(state, pos, path.baseName(), path, args[0], FileIngestionMethod::NixArchive, std::nullopt, v, context);
+    addPath(state, pos, path.baseName(), path, args[0], ContentAddressMethod::Raw::NixArchive, std::nullopt, v, context);
 }
 
 static RegisterPrimOp primop_filterSource({
@@ -2454,7 +2454,7 @@ static void prim_path(EvalState & state, const PosIdx pos, Value * * args, Value
     std::optional<SourcePath> path;
     std::string name;
     Value * filterFun = nullptr;
-    ContentAddressMethod method = FileIngestionMethod::NixArchive;
+    auto method = ContentAddressMethod::Raw::NixArchive;
     std::optional<Hash> expectedHash;
     NixStringContext context;
 
@@ -2470,8 +2470,8 @@ static void prim_path(EvalState & state, const PosIdx pos, Value * * args, Value
             state.forceFunction(*(filterFun = attr.value), attr.pos, "while evaluating the `filter` parameter passed to builtins.path");
         else if (n == "recursive")
             method = state.forceBool(*attr.value, attr.pos, "while evaluating the `recursive` attribute passed to builtins.path")
-                ? FileIngestionMethod::NixArchive
-                : FileIngestionMethod::Flat;
+                ? ContentAddressMethod::Raw::NixArchive
+                : ContentAddressMethod::Raw::Flat;
         else if (n == "sha256")
             expectedHash = newHashAllowEmpty(state.forceStringNoCtx(*attr.value, attr.pos, "while evaluating the `sha256` attribute passed to builtins.path"), HashAlgorithm::SHA256);
         else

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -468,7 +468,7 @@ static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v
         auto expectedPath = state.store->makeFixedOutputPath(
             name,
             FixedOutputInfo {
-                .method = unpack ? FileIngestionMethod::Recursive : FileIngestionMethod::Flat,
+                .method = unpack ? FileIngestionMethod::NixArchive : FileIngestionMethod::Flat,
                 .hash = *expectedHash,
                 .references = {}
             });

--- a/src/libfetchers/fetch-to-store.hh
+++ b/src/libfetchers/fetch-to-store.hh
@@ -18,7 +18,7 @@ StorePath fetchToStore(
     const SourcePath & path,
     FetchMode mode,
     std::string_view name = "source",
-    ContentAddressMethod method = FileIngestionMethod::NixArchive,
+    ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive,
     PathFilter * filter = nullptr,
     RepairFlag repair = NoRepair);
 

--- a/src/libfetchers/fetch-to-store.hh
+++ b/src/libfetchers/fetch-to-store.hh
@@ -18,7 +18,7 @@ StorePath fetchToStore(
     const SourcePath & path,
     FetchMode mode,
     std::string_view name = "source",
-    ContentAddressMethod method = FileIngestionMethod::Recursive,
+    ContentAddressMethod method = FileIngestionMethod::NixArchive,
     PathFilter * filter = nullptr,
     RepairFlag repair = NoRepair);
 

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -305,7 +305,7 @@ StorePath Input::computeStorePath(Store & store) const
     if (!narHash)
         throw Error("cannot compute store path for unlocked input '%s'", to_string());
     return store.makeFixedOutputPath(getName(), FixedOutputInfo {
-        .method = FileIngestionMethod::Recursive,
+        .method = FileIngestionMethod::NixArchive,
         .hash = *narHash,
         .references = {},
     });

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -213,7 +213,7 @@ struct MercurialInputScheme : InputScheme
                 auto storePath = store->addToStore(
                     input.getName(),
                     {getFSSourceAccessor(), CanonPath(actualPath)},
-                    FileIngestionMethod::Recursive, HashAlgorithm::SHA256, {},
+                    FileIngestionMethod::NixArchive, HashAlgorithm::SHA256, {},
                     filter);
 
                 return storePath;

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -213,7 +213,7 @@ struct MercurialInputScheme : InputScheme
                 auto storePath = store->addToStore(
                     input.getName(),
                     {getFSSourceAccessor(), CanonPath(actualPath)},
-                    FileIngestionMethod::NixArchive, HashAlgorithm::SHA256, {},
+                    ContentAddressMethod::Raw::NixArchive, HashAlgorithm::SHA256, {},
                     filter);
 
                 return storePath;

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -322,7 +322,7 @@ StorePath BinaryCacheStore::addToStoreFromDump(
         if (static_cast<FileIngestionMethod>(dumpMethod) == hashMethod.getFileIngestionMethod())
             caHash = hashString(HashAlgorithm::SHA256, dump2.s);
         switch (dumpMethod) {
-        case FileSerialisationMethod::Recursive:
+        case FileSerialisationMethod::NixArchive:
             // The dump is already NAR in this case, just use it.
             nar = dump2.s;
             break;
@@ -339,7 +339,7 @@ StorePath BinaryCacheStore::addToStoreFromDump(
     } else {
         // Otherwise, we have to do th same hashing as NAR so our single
         // hash will suffice for both purposes.
-        if (dumpMethod != FileSerialisationMethod::Recursive || hashAlgo != HashAlgorithm::SHA256)
+        if (dumpMethod != FileSerialisationMethod::NixArchive || hashAlgo != HashAlgorithm::SHA256)
             unsupported("addToStoreFromDump");
     }
     StringSource narDump { nar };

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -530,7 +530,7 @@ bool Worker::pathContentsGood(const StorePath & path)
     else {
         auto current = hashPath(
             {store.getFSAccessor(), CanonPath(store.printStorePath(path))},
-            FileIngestionMethod::Recursive, info->narHash.algo).first;
+            FileIngestionMethod::NixArchive, info->narHash.algo).first;
         Hash nullHash(HashAlgorithm::SHA256);
         res = info->narHash == nullHash || info->narHash == current;
     }

--- a/src/libstore/content-address.cc
+++ b/src/libstore/content-address.cc
@@ -9,7 +9,7 @@ std::string_view makeFileIngestionPrefix(FileIngestionMethod m)
     switch (m) {
     case FileIngestionMethod::Flat:
         return "";
-    case FileIngestionMethod::Recursive:
+    case FileIngestionMethod::NixArchive:
         return "r:";
     case FileIngestionMethod::Git:
         experimentalFeatureSettings.require(Xp::GitHashing);
@@ -52,7 +52,7 @@ std::string_view ContentAddressMethod::renderPrefix() const
 ContentAddressMethod ContentAddressMethod::parsePrefix(std::string_view & m)
 {
     if (splitPrefix(m, "r:")) {
-        return FileIngestionMethod::Recursive;
+        return FileIngestionMethod::NixArchive;
     }
     else if (splitPrefix(m, "git:")) {
         experimentalFeatureSettings.require(Xp::GitHashing);
@@ -137,7 +137,7 @@ static std::pair<ContentAddressMethod, HashAlgorithm> parseContentAddressMethodP
         // Parse method
         auto method = FileIngestionMethod::Flat;
         if (splitPrefix(rest, "r:"))
-            method = FileIngestionMethod::Recursive;
+            method = FileIngestionMethod::NixArchive;
         else if (splitPrefix(rest, "git:")) {
             experimentalFeatureSettings.require(Xp::GitHashing);
             method = FileIngestionMethod::Git;

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -435,19 +435,21 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         } else {
             HashAlgorithm hashAlgo;
             std::string baseName;
-            FileIngestionMethod method;
+            ContentAddressMethod method;
             {
                 bool fixed;
                 uint8_t recursive;
                 std::string hashAlgoRaw;
                 from >> baseName >> fixed /* obsolete */ >> recursive >> hashAlgoRaw;
-                if (recursive > (uint8_t) FileIngestionMethod::NixArchive)
+                if (recursive > true)
                     throw Error("unsupported FileIngestionMethod with value of %i; you may need to upgrade nix-daemon", recursive);
-                method = FileIngestionMethod { recursive };
+                method = recursive
+                    ? ContentAddressMethod::Raw::NixArchive
+                    : ContentAddressMethod::Raw::Flat;
                 /* Compatibility hack. */
                 if (!fixed) {
                     hashAlgoRaw = "sha256";
-                    method = FileIngestionMethod::NixArchive;
+                    method = ContentAddressMethod::Raw::NixArchive;
                 }
                 hashAlgo = parseHashAlgo(hashAlgoRaw);
             }
@@ -500,7 +502,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         logger->startWork();
         auto path = ({
             StringSource source { s };
-            store->addToStoreFromDump(source, suffix, FileSerialisationMethod::Flat, TextIngestionMethod {}, HashAlgorithm::SHA256, refs, NoRepair);
+            store->addToStoreFromDump(source, suffix, FileSerialisationMethod::Flat, ContentAddressMethod::Raw::Text, HashAlgorithm::SHA256, refs, NoRepair);
         });
         logger->stopWork();
         to << store->printStorePath(path);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -415,12 +415,12 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                 case FileIngestionMethod::Flat:
                     dumpMethod = FileSerialisationMethod::Flat;
                     break;
-                case FileIngestionMethod::Recursive:
-                    dumpMethod = FileSerialisationMethod::Recursive;
+                case FileIngestionMethod::NixArchive:
+                    dumpMethod = FileSerialisationMethod::NixArchive;
                     break;
                 case FileIngestionMethod::Git:
                     // Use NAR; Git is not a serialization method
-                    dumpMethod = FileSerialisationMethod::Recursive;
+                    dumpMethod = FileSerialisationMethod::NixArchive;
                     break;
                 default:
                     assert(false);
@@ -441,13 +441,13 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
                 uint8_t recursive;
                 std::string hashAlgoRaw;
                 from >> baseName >> fixed /* obsolete */ >> recursive >> hashAlgoRaw;
-                if (recursive > (uint8_t) FileIngestionMethod::Recursive)
+                if (recursive > (uint8_t) FileIngestionMethod::NixArchive)
                     throw Error("unsupported FileIngestionMethod with value of %i; you may need to upgrade nix-daemon", recursive);
                 method = FileIngestionMethod { recursive };
                 /* Compatibility hack. */
                 if (!fixed) {
                     hashAlgoRaw = "sha256";
-                    method = FileIngestionMethod::Recursive;
+                    method = FileIngestionMethod::NixArchive;
                 }
                 hashAlgo = parseHashAlgo(hashAlgoRaw);
             }
@@ -468,7 +468,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
             });
             logger->startWork();
             auto path = store->addToStoreFromDump(
-                *dumpSource, baseName, FileSerialisationMethod::Recursive, method, hashAlgo);
+                *dumpSource, baseName, FileSerialisationMethod::NixArchive, method, hashAlgo);
             logger->stopWork();
 
             to << store->printStorePath(path);

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -150,7 +150,7 @@ StorePath writeDerivation(Store & store,
         })
         : ({
             StringSource s { contents };
-            store.addToStoreFromDump(s, suffix, FileSerialisationMethod::Flat, TextIngestionMethod {}, HashAlgorithm::SHA256, references, repair);
+            store.addToStoreFromDump(s, suffix, FileSerialisationMethod::Flat, ContentAddressMethod::Raw::Text, HashAlgorithm::SHA256, references, repair);
         });
 }
 
@@ -274,7 +274,7 @@ static DerivationOutput parseDerivationOutput(
 {
     if (hashAlgoStr != "") {
         ContentAddressMethod method = ContentAddressMethod::parsePrefix(hashAlgoStr);
-        if (method == TextIngestionMethod {})
+        if (method == ContentAddressMethod::Raw::Text)
             xpSettings.require(Xp::DynamicDerivations);
         const auto hashAlgo = parseHashAlgo(hashAlgoStr);
         if (hashS == "impure") {
@@ -1249,7 +1249,7 @@ DerivationOutput DerivationOutput::fromJSON(
     auto methodAlgo = [&]() -> std::pair<ContentAddressMethod, HashAlgorithm> {
         auto & method_ = getString(valueAt(json, "method"));
         ContentAddressMethod method = ContentAddressMethod::parse(method_);
-        if (method == TextIngestionMethod {})
+        if (method == ContentAddressMethod::Raw::Text)
             xpSettings.require(Xp::DynamicDerivations);
 
         auto & hashAlgo_ = getString(valueAt(json, "hashAlgo"));

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -64,8 +64,8 @@ struct DummyStore : public virtual DummyStoreConfig, public virtual Store
     virtual StorePath addToStoreFromDump(
         Source & dump,
         std::string_view name,
-        FileSerialisationMethod dumpMethod = FileSerialisationMethod::Recursive,
-        ContentAddressMethod hashMethod = FileIngestionMethod::Recursive,
+        FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
+        ContentAddressMethod hashMethod = FileIngestionMethod::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         RepairFlag repair = NoRepair) override

--- a/src/libstore/legacy-ssh-store.hh
+++ b/src/libstore/legacy-ssh-store.hh
@@ -76,8 +76,8 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
     virtual StorePath addToStoreFromDump(
         Source & dump,
         std::string_view name,
-        FileSerialisationMethod dumpMethod = FileSerialisationMethod::Recursive,
-        ContentAddressMethod hashMethod = FileIngestionMethod::Recursive,
+        FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
+        ContentAddressMethod hashMethod = FileIngestionMethod::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         RepairFlag repair = NoRepair) override

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1155,7 +1155,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
                     auto fim = specified.method.getFileIngestionMethod();
                     switch (fim) {
                     case FileIngestionMethod::Flat:
-                    case FileIngestionMethod::Recursive:
+                    case FileIngestionMethod::NixArchive:
                     {
                         HashModuloSink caSink {
                             specified.hash.algo,
@@ -1314,7 +1314,7 @@ StorePath LocalStore::addToStoreFromDump(
                 auto fim = hashMethod.getFileIngestionMethod();
                 switch (fim) {
                 case FileIngestionMethod::Flat:
-                case FileIngestionMethod::Recursive:
+                case FileIngestionMethod::NixArchive:
                     restorePath(realPath, dumpSource, (FileSerialisationMethod) fim);
                     break;
                 case FileIngestionMethod::Git:
@@ -1330,7 +1330,7 @@ StorePath LocalStore::addToStoreFromDump(
             /* For computing the nar hash. In recursive SHA-256 mode, this
                is the same as the store hash, so no need to do it again. */
             auto narHash = std::pair { dumpHash, size };
-            if (dumpMethod != FileSerialisationMethod::Recursive || hashAlgo != HashAlgorithm::SHA256) {
+            if (dumpMethod != FileSerialisationMethod::NixArchive || hashAlgo != HashAlgorithm::SHA256) {
                 HashSink narSink { HashAlgorithm::SHA256 };
                 dumpPath(realPath, narSink);
                 narHash = narSink.finish();
@@ -1423,7 +1423,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
             PosixSourceAccessor accessor;
             std::string hash = hashPath(
                 PosixSourceAccessor::createAtRoot(link.path()),
-                FileIngestionMethod::Recursive, HashAlgorithm::SHA256).first.to_string(HashFormat::Nix32, false);
+                FileIngestionMethod::NixArchive, HashAlgorithm::SHA256).first.to_string(HashFormat::Nix32, false);
             if (hash != name.string()) {
                 printError("link '%s' was modified! expected hash '%s', got '%s'",
                     link.path(), name, hash);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1253,7 +1253,7 @@ StorePath LocalStore::addToStoreFromDump(
     std::filesystem::path tempDir;
     AutoCloseFD tempDirFd;
 
-    bool methodsMatch = ContentAddressMethod(FileIngestionMethod(dumpMethod)) == hashMethod;
+    bool methodsMatch = static_cast<FileIngestionMethod>(dumpMethod) == hashMethod.getFileIngestionMethod();
 
     /* If the methods don't match, our streaming hash of the dump is the
        wrong sort, and we need to rehash. */

--- a/src/libstore/make-content-addressed.cc
+++ b/src/libstore/make-content-addressed.cc
@@ -52,7 +52,7 @@ std::map<StorePath, StorePath> makeContentAddressed(
             dstStore,
             path.name(),
             FixedOutputInfo {
-                .method = FileIngestionMethod::Recursive,
+                .method = FileIngestionMethod::NixArchive,
                 .hash = narModuloHash,
                 .references = std::move(refs),
             },

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -151,7 +151,7 @@ void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
     Hash hash = ({
         hashPath(
             {make_ref<PosixSourceAccessor>(), CanonPath(path)},
-            FileSerialisationMethod::Recursive, HashAlgorithm::SHA256).first;
+            FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256).first;
     });
     debug("'%1%' has hash '%2%'", path, hash.to_string(HashFormat::Nix32, true));
 
@@ -165,7 +165,7 @@ void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
             || (repair && hash != ({
                 hashPath(
                     PosixSourceAccessor::createAtRoot(linkPath),
-                    FileSerialisationMethod::Recursive, HashAlgorithm::SHA256).first;
+                    FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256).first;
            })))
         {
             // XXX: Consider overwriting linkPath with our valid version.

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -48,15 +48,21 @@ std::optional<ContentAddressWithReferences> ValidPathInfo::contentAddressWithRef
     if (! ca)
         return std::nullopt;
 
-    return std::visit(overloaded {
-        [&](const TextIngestionMethod &) -> ContentAddressWithReferences {
+    switch (ca->method.raw) {
+        case ContentAddressMethod::Raw::Text:
+        {
             assert(references.count(path) == 0);
             return TextInfo {
                 .hash = ca->hash,
                 .references = references,
             };
-        },
-        [&](const FileIngestionMethod & m2) -> ContentAddressWithReferences {
+        }
+
+        case ContentAddressMethod::Raw::Flat:
+        case ContentAddressMethod::Raw::NixArchive:
+        case ContentAddressMethod::Raw::Git:
+        default:
+        {
             auto refs = references;
             bool hasSelfReference = false;
             if (refs.count(path)) {
@@ -64,15 +70,15 @@ std::optional<ContentAddressWithReferences> ValidPathInfo::contentAddressWithRef
                 refs.erase(path);
             }
             return FixedOutputInfo {
-                .method = m2,
+                .method = ca->method.getFileIngestionMethod(),
                 .hash = ca->hash,
                 .references = {
                     .others = std::move(refs),
                     .self = hasSelfReference,
                 },
             };
-        },
-    }, ca->method.raw);
+        }
+    }
 }
 
 bool ValidPathInfo::isContentAddressed(const Store & store) const
@@ -127,22 +133,18 @@ ValidPathInfo::ValidPathInfo(
       : UnkeyedValidPathInfo(narHash)
       , path(store.makeFixedOutputPathFromCA(name, ca))
 {
+    this->ca = ContentAddress {
+        .method = ca.getMethod(),
+        .hash = ca.getHash(),
+    };
     std::visit(overloaded {
         [this](TextInfo && ti) {
             this->references = std::move(ti.references);
-            this->ca = ContentAddress {
-                .method = TextIngestionMethod {},
-                .hash = std::move(ti.hash),
-            };
         },
         [this](FixedOutputInfo && foi) {
             this->references = std::move(foi.references.others);
             if (foi.references.self)
                 this->references.insert(path);
-            this->ca = ContentAddress {
-                .method = std::move(foi.method),
-                .hash = std::move(foi.hash),
-            };
         },
     }, std::move(ca).raw);
 }

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -392,8 +392,9 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
     else {
         if (repair) throw Error("repairing is not supported when building through the Nix daemon protocol < 1.25");
 
-        std::visit(overloaded {
-            [&](const TextIngestionMethod & thm) -> void {
+        switch (caMethod.raw) {
+            case ContentAddressMethod::Raw::Text:
+            {
                 if (hashAlgo != HashAlgorithm::SHA256)
                     throw UnimplementedError("When adding text-hashed data called '%s', only SHA-256 is supported but '%s' was given",
                         name, printHashAlgo(hashAlgo));
@@ -401,8 +402,14 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
                 conn->to << WorkerProto::Op::AddTextToStore << name << s;
                 WorkerProto::write(*this, *conn, references);
                 conn.processStderr();
-            },
-            [&](const FileIngestionMethod & fim) -> void {
+                break;
+            }
+            case ContentAddressMethod::Raw::Flat:
+            case ContentAddressMethod::Raw::NixArchive:
+            case ContentAddressMethod::Raw::Git:
+            default:
+            {
+                auto fim = caMethod.getFileIngestionMethod();
                 conn->to
                     << WorkerProto::Op::AddToStore
                     << name
@@ -432,9 +439,9 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
                         } catch (EndOfFile & e) { }
                     throw;
                 }
-
+                break;
             }
-        }, caMethod.raw);
+        }
         auto path = parseStorePath(readString(conn->from));
         // Release our connection to prevent a deadlock in queryPathInfo().
         conn_.reset();

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -406,8 +406,8 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
                 conn->to
                     << WorkerProto::Op::AddToStore
                     << name
-                    << ((hashAlgo == HashAlgorithm::SHA256 && fim == FileIngestionMethod::Recursive) ? 0 : 1) /* backwards compatibility hack */
-                    << (fim == FileIngestionMethod::Recursive ? 1 : 0)
+                    << ((hashAlgo == HashAlgorithm::SHA256 && fim == FileIngestionMethod::NixArchive) ? 0 : 1) /* backwards compatibility hack */
+                    << (fim == FileIngestionMethod::NixArchive ? 1 : 0)
                     << printHashAlgo(hashAlgo);
 
                 try {
@@ -415,7 +415,7 @@ ref<const ValidPathInfo> RemoteStore::addCAToStore(
                     connections->incCapacity();
                     {
                         Finally cleanup([&]() { connections->decCapacity(); });
-                        if (fim == FileIngestionMethod::Recursive) {
+                        if (fim == FileIngestionMethod::NixArchive) {
                             dump.drainInto(conn->to);
                         } else {
                             std::string contents = dump.drain();
@@ -457,12 +457,12 @@ StorePath RemoteStore::addToStoreFromDump(
     case FileIngestionMethod::Flat:
         fsm = FileSerialisationMethod::Flat;
         break;
-    case FileIngestionMethod::Recursive:
-        fsm = FileSerialisationMethod::Recursive;
+    case FileIngestionMethod::NixArchive:
+        fsm = FileSerialisationMethod::NixArchive;
         break;
     case FileIngestionMethod::Git:
         // Use NAR; Git is not a serialization method
-        fsm = FileSerialisationMethod::Recursive;
+        fsm = FileSerialisationMethod::NixArchive;
         break;
     default:
         assert(false);

--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -87,8 +87,8 @@ public:
     StorePath addToStoreFromDump(
         Source & dump,
         std::string_view name,
-        FileSerialisationMethod dumpMethod = FileSerialisationMethod::Recursive,
-        ContentAddressMethod hashMethod = FileIngestionMethod::Recursive,
+        FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
+        ContentAddressMethod hashMethod = FileIngestionMethod::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         RepairFlag repair = NoRepair) override;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -356,7 +356,7 @@ ValidPathInfo Store::addToStoreSlow(
     RegularFileSink fileSink { caHashSink };
     TeeSink unusualHashTee { narHashSink, caHashSink };
 
-    auto & narSink = method == FileIngestionMethod::NixArchive && hashAlgo != HashAlgorithm::SHA256
+    auto & narSink = method == ContentAddressMethod::Raw::NixArchive && hashAlgo != HashAlgorithm::SHA256
         ? static_cast<Sink &>(unusualHashTee)
         : narHashSink;
 
@@ -384,9 +384,9 @@ ValidPathInfo Store::addToStoreSlow(
        finish. */
     auto [narHash, narSize] = narHashSink.finish();
 
-    auto hash = method == FileIngestionMethod::NixArchive && hashAlgo == HashAlgorithm::SHA256
+    auto hash = method == ContentAddressMethod::Raw::NixArchive && hashAlgo == HashAlgorithm::SHA256
         ? narHash
-        : method == FileIngestionMethod::Git
+        : method == ContentAddressMethod::Raw::Git
         ? git::dumpHash(hashAlgo, srcPath).hash
         : caHashSink.finish().first;
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -122,7 +122,7 @@ StorePath StoreDirConfig::makeFixedOutputPath(std::string_view name, const Fixed
     if (info.method == FileIngestionMethod::Git && info.hash.algo != HashAlgorithm::SHA1)
         throw Error("Git file ingestion must use SHA-1 hash");
 
-    if (info.hash.algo == HashAlgorithm::SHA256 && info.method == FileIngestionMethod::Recursive) {
+    if (info.hash.algo == HashAlgorithm::SHA256 && info.method == FileIngestionMethod::NixArchive) {
         return makeStorePath(makeType(*this, "source", info.references), info.hash, name);
     } else {
         if (!info.references.empty()) {
@@ -200,12 +200,12 @@ StorePath Store::addToStore(
     case FileIngestionMethod::Flat:
         fsm = FileSerialisationMethod::Flat;
         break;
-    case FileIngestionMethod::Recursive:
-        fsm = FileSerialisationMethod::Recursive;
+    case FileIngestionMethod::NixArchive:
+        fsm = FileSerialisationMethod::NixArchive;
         break;
     case FileIngestionMethod::Git:
         // Use NAR; Git is not a serialization method
-        fsm = FileSerialisationMethod::Recursive;
+        fsm = FileSerialisationMethod::NixArchive;
         break;
     }
     auto source = sinkToSource([&](Sink & sink) {
@@ -356,7 +356,7 @@ ValidPathInfo Store::addToStoreSlow(
     RegularFileSink fileSink { caHashSink };
     TeeSink unusualHashTee { narHashSink, caHashSink };
 
-    auto & narSink = method == FileIngestionMethod::Recursive && hashAlgo != HashAlgorithm::SHA256
+    auto & narSink = method == FileIngestionMethod::NixArchive && hashAlgo != HashAlgorithm::SHA256
         ? static_cast<Sink &>(unusualHashTee)
         : narHashSink;
 
@@ -384,7 +384,7 @@ ValidPathInfo Store::addToStoreSlow(
        finish. */
     auto [narHash, narSize] = narHashSink.finish();
 
-    auto hash = method == FileIngestionMethod::Recursive && hashAlgo == HashAlgorithm::SHA256
+    auto hash = method == FileIngestionMethod::NixArchive && hashAlgo == HashAlgorithm::SHA256
         ? narHash
         : method == FileIngestionMethod::Git
         ? git::dumpHash(hashAlgo, srcPath).hash

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -441,7 +441,7 @@ public:
     virtual StorePath addToStore(
         std::string_view name,
         const SourcePath & path,
-        ContentAddressMethod method = FileIngestionMethod::Recursive,
+        ContentAddressMethod method = FileIngestionMethod::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         PathFilter & filter = defaultPathFilter,
@@ -455,7 +455,7 @@ public:
     ValidPathInfo addToStoreSlow(
         std::string_view name,
         const SourcePath & path,
-        ContentAddressMethod method = FileIngestionMethod::Recursive,
+        ContentAddressMethod method = FileIngestionMethod::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         std::optional<Hash> expectedCAHash = {});
@@ -470,7 +470,7 @@ public:
      *
      * @param dumpMethod What serialisation format is `dump`, i.e. how
      * to deserialize it. Must either match hashMethod or be
-     * `FileSerialisationMethod::Recursive`.
+     * `FileSerialisationMethod::NixArchive`.
      *
      * @param hashMethod How content addressing? Need not match be the
      * same as `dumpMethod`.
@@ -480,8 +480,8 @@ public:
     virtual StorePath addToStoreFromDump(
         Source & dump,
         std::string_view name,
-        FileSerialisationMethod dumpMethod = FileSerialisationMethod::Recursive,
-        ContentAddressMethod hashMethod = FileIngestionMethod::Recursive,
+        FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
+        ContentAddressMethod hashMethod = FileIngestionMethod::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         RepairFlag repair = NoRepair) = 0;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -441,7 +441,7 @@ public:
     virtual StorePath addToStore(
         std::string_view name,
         const SourcePath & path,
-        ContentAddressMethod method = FileIngestionMethod::NixArchive,
+        ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         PathFilter & filter = defaultPathFilter,
@@ -455,7 +455,7 @@ public:
     ValidPathInfo addToStoreSlow(
         std::string_view name,
         const SourcePath & path,
-        ContentAddressMethod method = FileIngestionMethod::NixArchive,
+        ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         std::optional<Hash> expectedCAHash = {});
@@ -481,7 +481,7 @@ public:
         Source & dump,
         std::string_view name,
         FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
-        ContentAddressMethod hashMethod = FileIngestionMethod::NixArchive,
+        ContentAddressMethod hashMethod = ContentAddressMethod::Raw::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = StorePathSet(),
         RepairFlag repair = NoRepair) = 0;

--- a/src/libstore/store-dir-config.hh
+++ b/src/libstore/store-dir-config.hh
@@ -97,7 +97,7 @@ struct StoreDirConfig : public Config
     std::pair<StorePath, Hash> computeStorePath(
         std::string_view name,
         const SourcePath & path,
-        ContentAddressMethod method = FileIngestionMethod::Recursive,
+        ContentAddressMethod method = FileIngestionMethod::NixArchive,
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = {},
         PathFilter & filter = defaultPathFilter) const;

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -2489,7 +2489,7 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
                 auto fim = outputHash.method.getFileIngestionMethod();
                 switch (fim) {
                 case FileIngestionMethod::Flat:
-                case FileIngestionMethod::Recursive:
+                case FileIngestionMethod::NixArchive:
                 {
                     HashModuloSink caSink { outputHash.hashAlgo, oldHashPart };
                     auto fim = outputHash.method.getFileIngestionMethod();
@@ -2531,7 +2531,7 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
             {
                 HashResult narHashAndSize = hashPath(
                     {getFSSourceAccessor(), CanonPath(actualPath)},
-                    FileSerialisationMethod::Recursive, HashAlgorithm::SHA256);
+                    FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256);
                 newInfo0.narHash = narHashAndSize.first;
                 newInfo0.narSize = narHashAndSize.second;
             }
@@ -2554,7 +2554,7 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
                 rewriteOutput(outputRewrites);
                 HashResult narHashAndSize = hashPath(
                     {getFSSourceAccessor(), CanonPath(actualPath)},
-                    FileSerialisationMethod::Recursive, HashAlgorithm::SHA256);
+                    FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256);
                 ValidPathInfo newInfo0 { requiredFinalPath, narHashAndSize.first };
                 newInfo0.narSize = narHashAndSize.second;
                 auto refs = rewriteRefs();

--- a/src/libutil/file-content-address.cc
+++ b/src/libutil/file-content-address.cc
@@ -10,7 +10,7 @@ static std::optional<FileSerialisationMethod> parseFileSerialisationMethodOpt(st
     if (input == "flat") {
         return FileSerialisationMethod::Flat;
     } else if (input == "nar") {
-        return FileSerialisationMethod::Recursive;
+        return FileSerialisationMethod::NixArchive;
     } else {
         return std::nullopt;
     }
@@ -45,7 +45,7 @@ std::string_view renderFileSerialisationMethod(FileSerialisationMethod method)
     switch (method) {
     case FileSerialisationMethod::Flat:
         return "flat";
-    case FileSerialisationMethod::Recursive:
+    case FileSerialisationMethod::NixArchive:
         return "nar";
     default:
         assert(false);
@@ -57,7 +57,7 @@ std::string_view renderFileIngestionMethod(FileIngestionMethod method)
 {
     switch (method) {
     case FileIngestionMethod::Flat:
-    case FileIngestionMethod::Recursive:
+    case FileIngestionMethod::NixArchive:
         return renderFileSerialisationMethod(
             static_cast<FileSerialisationMethod>(method));
     case FileIngestionMethod::Git:
@@ -78,7 +78,7 @@ void dumpPath(
     case FileSerialisationMethod::Flat:
         path.readFile(sink);
         break;
-    case FileSerialisationMethod::Recursive:
+    case FileSerialisationMethod::NixArchive:
         path.dumpPath(sink, filter);
         break;
     }
@@ -94,7 +94,7 @@ void restorePath(
     case FileSerialisationMethod::Flat:
         writeFile(path, source);
         break;
-    case FileSerialisationMethod::Recursive:
+    case FileSerialisationMethod::NixArchive:
         restorePath(path, source);
         break;
     }
@@ -119,7 +119,7 @@ std::pair<Hash, std::optional<uint64_t>> hashPath(
 {
     switch (method) {
     case FileIngestionMethod::Flat:
-    case FileIngestionMethod::Recursive: {
+    case FileIngestionMethod::NixArchive: {
         auto res = hashPath(path, (FileSerialisationMethod) method, ht, filter);
         return {res.first, {res.second}};
     }

--- a/src/libutil/file-content-address.hh
+++ b/src/libutil/file-content-address.hh
@@ -35,14 +35,14 @@ enum struct FileSerialisationMethod : uint8_t {
      * See `file-system-object/content-address.md#serial-nix-archive` in
      * the manual.
      */
-    Recursive,
+    NixArchive,
 };
 
 /**
  * Parse a `FileSerialisationMethod` by name. Choice of:
  *
  *  - `flat`: `FileSerialisationMethod::Flat`
- *  - `nar`: `FileSerialisationMethod::Recursive`
+ *  - `nar`: `FileSerialisationMethod::NixArchive`
  *
  * Opposite of `renderFileSerialisationMethod`.
  */
@@ -107,12 +107,12 @@ enum struct FileIngestionMethod : uint8_t {
     Flat,
 
     /**
-     * Hash `FileSerialisationMethod::Recursive` serialisation.
+     * Hash `FileSerialisationMethod::NixArchive` serialisation.
      *
      * See `file-system-object/content-address.md#serial-flat` in the
      * manual.
      */
-    Recursive,
+    NixArchive,
 
     /**
      * Git hashing.
@@ -127,7 +127,7 @@ enum struct FileIngestionMethod : uint8_t {
  * Parse a `FileIngestionMethod` by name. Choice of:
  *
  *  - `flat`: `FileIngestionMethod::Flat`
- *  - `nar`: `FileIngestionMethod::Recursive`
+ *  - `nar`: `FileIngestionMethod::NixArchive`
  *  - `git`: `FileIngestionMethod::Git`
  *
  * Opposite of `renderFileIngestionMethod`.

--- a/src/libutil/file-content-address.hh
+++ b/src/libutil/file-content-address.hh
@@ -117,6 +117,8 @@ enum struct FileIngestionMethod : uint8_t {
     /**
      * Git hashing.
      *
+     * Part of `ExperimentalFeature::GitHashing`.
+     *
      * See `file-system-object/content-address.md#serial-git` in the
      * manual.
      */

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -115,7 +115,7 @@ bool createUserEnv(EvalState & state, PackageInfos & elems,
         std::string str2 = str.str();
         StringSource source { str2 };
         state.store->addToStoreFromDump(
-            source, "env-manifest.nix", FileSerialisationMethod::Flat, TextIngestionMethod {}, HashAlgorithm::SHA256, references);
+            source, "env-manifest.nix", FileSerialisationMethod::Flat, ContentAddressMethod::Raw::Text, HashAlgorithm::SHA256, references);
     });
 
     /* Get the environment builder expression. */

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -194,10 +194,10 @@ static void opAdd(Strings opFlags, Strings opArgs)
    store. */
 static void opAddFixed(Strings opFlags, Strings opArgs)
 {
-    auto method = FileIngestionMethod::Flat;
+    ContentAddressMethod method = ContentAddressMethod::Raw::Flat;
 
     for (auto & i : opFlags)
-        if (i == "--recursive") method = FileIngestionMethod::NixArchive;
+        if (i == "--recursive") method = ContentAddressMethod::Raw::NixArchive;
         else throw UsageError("unknown flag '%1%'", i);
 
     if (opArgs.empty())

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -197,7 +197,7 @@ static void opAddFixed(Strings opFlags, Strings opArgs)
     auto method = FileIngestionMethod::Flat;
 
     for (auto & i : opFlags)
-        if (i == "--recursive") method = FileIngestionMethod::Recursive;
+        if (i == "--recursive") method = FileIngestionMethod::NixArchive;
         else throw UsageError("unknown flag '%1%'", i);
 
     if (opArgs.empty())
@@ -223,7 +223,7 @@ static void opPrintFixedPath(Strings opFlags, Strings opArgs)
     auto method = FileIngestionMethod::Flat;
 
     for (auto i : opFlags)
-        if (i == "--recursive") method = FileIngestionMethod::Recursive;
+        if (i == "--recursive") method = FileIngestionMethod::NixArchive;
         else throw UsageError("unknown flag '%1%'", i);
 
     if (opArgs.size() != 3)
@@ -563,7 +563,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
             if (!hashGiven) {
                 HashResult hash = hashPath(
                     {store->getFSAccessor(false), CanonPath { store->printStorePath(info->path) }},
-                    FileSerialisationMethod::Recursive, HashAlgorithm::SHA256);
+                    FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256);
                 info->narHash = hash.first;
                 info->narSize = hash.second;
             }

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -12,7 +12,7 @@ struct CmdAddToStore : MixDryRun, StoreCommand
 {
     Path path;
     std::optional<std::string> namePart;
-    ContentAddressMethod caMethod = FileIngestionMethod::Recursive;
+    ContentAddressMethod caMethod = FileIngestionMethod::NixArchive;
     HashAlgorithm hashAlgo = HashAlgorithm::SHA256;
 
     CmdAddToStore()

--- a/src/nix/add-to-store.cc
+++ b/src/nix/add-to-store.cc
@@ -12,7 +12,7 @@ struct CmdAddToStore : MixDryRun, StoreCommand
 {
     Path path;
     std::optional<std::string> namePart;
-    ContentAddressMethod caMethod = FileIngestionMethod::NixArchive;
+    ContentAddressMethod caMethod = ContentAddressMethod::Raw::NixArchive;
     HashAlgorithm hashAlgo = HashAlgorithm::SHA256;
 
     CmdAddToStore()
@@ -68,7 +68,7 @@ struct CmdAddFile : CmdAddToStore
 {
     CmdAddFile()
     {
-        caMethod = FileIngestionMethod::Flat;
+        caMethod = ContentAddressMethod::Raw::Flat;
     }
 
     std::string description() override

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -238,7 +238,7 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
     auto getEnvShPath = ({
         StringSource source { getEnvSh };
         evalStore->addToStoreFromDump(
-            source, "get-env.sh", FileSerialisationMethod::Flat, TextIngestionMethod {}, HashAlgorithm::SHA256, {});
+            source, "get-env.sh", FileSerialisationMethod::Flat, ContentAddressMethod::Raw::Text, HashAlgorithm::SHA256, {});
     });
 
     drv.args = {store->printStorePath(getEnvShPath)};

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -68,7 +68,7 @@ struct CmdHashBase : Command
         switch (mode) {
         case FileIngestionMethod::Flat:
             return "print cryptographic hash of a regular file";
-        case FileIngestionMethod::Recursive:
+        case FileIngestionMethod::NixArchive:
             return "print cryptographic hash of the NAR serialisation of a path";
         case FileIngestionMethod::Git:
             return "print cryptographic hash of the Git serialisation of a path";
@@ -91,7 +91,7 @@ struct CmdHashBase : Command
             Hash h { HashAlgorithm::SHA256 }; // throwaway def to appease C++
             switch (mode) {
             case FileIngestionMethod::Flat:
-            case FileIngestionMethod::Recursive:
+            case FileIngestionMethod::NixArchive:
             {
                 auto hashSink = makeSink();
                 dumpPath(path2, *hashSink, (FileSerialisationMethod) mode);
@@ -126,7 +126,7 @@ struct CmdHashBase : Command
 struct CmdHashPath : CmdHashBase
 {
     CmdHashPath()
-        : CmdHashBase(FileIngestionMethod::Recursive)
+        : CmdHashBase(FileIngestionMethod::NixArchive)
     {
         addFlag(flag::hashAlgo("algo", &hashAlgo));
         addFlag(flag::fileIngestionMethod(&mode));
@@ -311,7 +311,7 @@ static int compatNixHash(int argc, char * * argv)
     });
 
     if (op == opHash) {
-        CmdHashBase cmd(flat ? FileIngestionMethod::Flat : FileIngestionMethod::Recursive);
+        CmdHashBase cmd(flat ? FileIngestionMethod::Flat : FileIngestionMethod::NixArchive);
         if (!hashAlgo.has_value()) hashAlgo = HashAlgorithm::MD5;
         cmd.hashAlgo = hashAlgo.value();
         cmd.hashFormat = hashFormat;

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -57,7 +57,7 @@ std::tuple<StorePath, Hash> prefetchFile(
         bool unpack,
         bool executable)
 {
-    auto ingestionMethod = unpack || executable ? FileIngestionMethod::Recursive : FileIngestionMethod::Flat;
+    auto ingestionMethod = unpack || executable ? FileIngestionMethod::NixArchive : FileIngestionMethod::Flat;
 
     /* Figure out a name in the Nix store. */
     if (!name) {

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -258,7 +258,7 @@ struct ProfileManifest
             *store,
             "profile",
             FixedOutputInfo {
-                .method = FileIngestionMethod::Recursive,
+                .method = FileIngestionMethod::NixArchive,
                 .hash = narHash,
                 .references = {
                     .others = std::move(references),

--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -335,7 +335,7 @@ SV *
 StoreWrapper::addToStore(char * srcPath, int recursive, char * algo)
     PPCODE:
         try {
-            auto method = recursive ? FileIngestionMethod::NixArchive : FileIngestionMethod::Flat;
+            auto method = recursive ? ContentAddressMethod::Raw::NixArchive : ContentAddressMethod::Raw::Flat;
             auto path = THIS->store->addToStore(
                 std::string(baseNameOf(srcPath)),
                 PosixSourceAccessor::createAtRoot(srcPath),

--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -259,7 +259,7 @@ hashPath(char * algo, int base32, char * path)
         try {
             Hash h = hashPath(
                 PosixSourceAccessor::createAtRoot(path),
-                FileIngestionMethod::Recursive, parseHashAlgo(algo)).first;
+                FileIngestionMethod::NixArchive, parseHashAlgo(algo)).first;
             auto s = h.to_string(base32 ? HashFormat::Nix32 : HashFormat::Base16, false);
             XPUSHs(sv_2mortal(newSVpv(s.c_str(), 0)));
         } catch (Error & e) {
@@ -335,7 +335,7 @@ SV *
 StoreWrapper::addToStore(char * srcPath, int recursive, char * algo)
     PPCODE:
         try {
-            auto method = recursive ? FileIngestionMethod::Recursive : FileIngestionMethod::Flat;
+            auto method = recursive ? FileIngestionMethod::NixArchive : FileIngestionMethod::Flat;
             auto path = THIS->store->addToStore(
                 std::string(baseNameOf(srcPath)),
                 PosixSourceAccessor::createAtRoot(srcPath),
@@ -351,7 +351,7 @@ StoreWrapper::makeFixedOutputPath(int recursive, char * algo, char * hash, char 
     PPCODE:
         try {
             auto h = Hash::parseAny(hash, parseHashAlgo(algo));
-            auto method = recursive ? FileIngestionMethod::Recursive : FileIngestionMethod::Flat;
+            auto method = recursive ? FileIngestionMethod::NixArchive : FileIngestionMethod::Flat;
             auto path = THIS->store->makeFixedOutputPath(name, FixedOutputInfo {
                 .method = method,
                 .hash = h,

--- a/tests/unit/libstore/common-protocol.cc
+++ b/tests/unit/libstore/common-protocol.cc
@@ -83,15 +83,15 @@ CHARACTERIZATION_TEST(
     "content-address",
     (std::tuple<ContentAddress, ContentAddress, ContentAddress> {
         ContentAddress {
-            .method = TextIngestionMethod {},
+            .method = ContentAddressMethod::Raw::Text,
             .hash = hashString(HashAlgorithm::SHA256, "Derive(...)"),
         },
         ContentAddress {
-            .method = FileIngestionMethod::Flat,
+            .method = ContentAddressMethod::Raw::Flat,
             .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
         },
         ContentAddress {
-            .method = FileIngestionMethod::NixArchive,
+            .method = ContentAddressMethod::Raw::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
         },
     }))
@@ -178,7 +178,7 @@ CHARACTERIZATION_TEST(
         std::nullopt,
         std::optional {
             ContentAddress {
-                .method = FileIngestionMethod::Flat,
+                .method = ContentAddressMethod::Raw::Flat,
                 .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
             },
         },

--- a/tests/unit/libstore/common-protocol.cc
+++ b/tests/unit/libstore/common-protocol.cc
@@ -91,7 +91,7 @@ CHARACTERIZATION_TEST(
             .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
         },
         ContentAddress {
-            .method = FileIngestionMethod::Recursive,
+            .method = FileIngestionMethod::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
         },
     }))

--- a/tests/unit/libstore/content-address.cc
+++ b/tests/unit/libstore/content-address.cc
@@ -9,11 +9,11 @@ namespace nix {
  * --------------------------------------------------------------------------*/
 
 TEST(ContentAddressMethod, testRoundTripPrintParse_1) {
-    for (const ContentAddressMethod & cam : {
-        ContentAddressMethod { TextIngestionMethod {} },
-        ContentAddressMethod { FileIngestionMethod::Flat },
-        ContentAddressMethod { FileIngestionMethod::NixArchive },
-        ContentAddressMethod { FileIngestionMethod::Git },
+    for (ContentAddressMethod cam : {
+        ContentAddressMethod::Raw::Text,
+        ContentAddressMethod::Raw::Flat,
+        ContentAddressMethod::Raw::NixArchive,
+        ContentAddressMethod::Raw::Git,
     }) {
         EXPECT_EQ(ContentAddressMethod::parse(cam.render()), cam);
     }

--- a/tests/unit/libstore/content-address.cc
+++ b/tests/unit/libstore/content-address.cc
@@ -12,7 +12,7 @@ TEST(ContentAddressMethod, testRoundTripPrintParse_1) {
     for (const ContentAddressMethod & cam : {
         ContentAddressMethod { TextIngestionMethod {} },
         ContentAddressMethod { FileIngestionMethod::Flat },
-        ContentAddressMethod { FileIngestionMethod::Recursive },
+        ContentAddressMethod { FileIngestionMethod::NixArchive },
         ContentAddressMethod { FileIngestionMethod::Git },
     }) {
         EXPECT_EQ(ContentAddressMethod::parse(cam.render()), cam);

--- a/tests/unit/libstore/derivation.cc
+++ b/tests/unit/libstore/derivation.cc
@@ -117,7 +117,7 @@ TEST_JSON(DerivationTest, caFixedFlat,
 TEST_JSON(DerivationTest, caFixedNAR,
     (DerivationOutput::CAFixed {
         .ca = {
-            .method = FileIngestionMethod::Recursive,
+            .method = FileIngestionMethod::NixArchive,
             .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
         },
     }),
@@ -133,7 +133,7 @@ TEST_JSON(DynDerivationTest, caFixedText,
 
 TEST_JSON(CaDerivationTest, caFloating,
     (DerivationOutput::CAFloating {
-        .method = FileIngestionMethod::Recursive,
+        .method = FileIngestionMethod::NixArchive,
         .hashAlgo = HashAlgorithm::SHA256,
     }),
     "drv-name", "output-name")
@@ -144,7 +144,7 @@ TEST_JSON(DerivationTest, deferred,
 
 TEST_JSON(ImpureDerivationTest, impure,
     (DerivationOutput::Impure {
-        .method = FileIngestionMethod::Recursive,
+        .method = FileIngestionMethod::NixArchive,
         .hashAlgo = HashAlgorithm::SHA256,
     }),
     "drv-name", "output-name")

--- a/tests/unit/libstore/derivation.cc
+++ b/tests/unit/libstore/derivation.cc
@@ -108,7 +108,7 @@ TEST_JSON(DerivationTest, inputAddressed,
 TEST_JSON(DerivationTest, caFixedFlat,
     (DerivationOutput::CAFixed {
         .ca = {
-            .method = FileIngestionMethod::Flat,
+            .method = ContentAddressMethod::Raw::Flat,
             .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
         },
     }),
@@ -117,7 +117,7 @@ TEST_JSON(DerivationTest, caFixedFlat,
 TEST_JSON(DerivationTest, caFixedNAR,
     (DerivationOutput::CAFixed {
         .ca = {
-            .method = FileIngestionMethod::NixArchive,
+            .method = ContentAddressMethod::Raw::NixArchive,
             .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
         },
     }),
@@ -126,6 +126,7 @@ TEST_JSON(DerivationTest, caFixedNAR,
 TEST_JSON(DynDerivationTest, caFixedText,
     (DerivationOutput::CAFixed {
         .ca = {
+            .method = ContentAddressMethod::Raw::Text,
             .hash = Hash::parseAnyPrefixed("sha256-iUUXyRY8iW7DGirb0zwGgf1fRbLA7wimTJKgP7l/OQ8="),
         },
     }),
@@ -133,7 +134,7 @@ TEST_JSON(DynDerivationTest, caFixedText,
 
 TEST_JSON(CaDerivationTest, caFloating,
     (DerivationOutput::CAFloating {
-        .method = FileIngestionMethod::NixArchive,
+        .method = ContentAddressMethod::Raw::NixArchive,
         .hashAlgo = HashAlgorithm::SHA256,
     }),
     "drv-name", "output-name")
@@ -144,7 +145,7 @@ TEST_JSON(DerivationTest, deferred,
 
 TEST_JSON(ImpureDerivationTest, impure,
     (DerivationOutput::Impure {
-        .method = FileIngestionMethod::NixArchive,
+        .method = ContentAddressMethod::Raw::NixArchive,
         .hashAlgo = HashAlgorithm::SHA256,
     }),
     "drv-name", "output-name")

--- a/tests/unit/libstore/nar-info.cc
+++ b/tests/unit/libstore/nar-info.cc
@@ -25,7 +25,7 @@ static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo) {
         store,
         "foo",
         FixedOutputInfo {
-            .method = FileIngestionMethod::Recursive,
+            .method = FileIngestionMethod::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
 
             .references = {

--- a/tests/unit/libstore/path-info.cc
+++ b/tests/unit/libstore/path-info.cc
@@ -32,7 +32,7 @@ static UnkeyedValidPathInfo makeFull(const Store & store, bool includeImpureInfo
         store,
         "foo",
         FixedOutputInfo {
-            .method = FileIngestionMethod::Recursive,
+            .method = FileIngestionMethod::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
 
             .references = {

--- a/tests/unit/libstore/serve-protocol.cc
+++ b/tests/unit/libstore/serve-protocol.cc
@@ -55,15 +55,15 @@ VERSIONED_CHARACTERIZATION_TEST(
     defaultVersion,
     (std::tuple<ContentAddress, ContentAddress, ContentAddress> {
         ContentAddress {
-            .method = TextIngestionMethod {},
+            .method = ContentAddressMethod::Raw::Text,
             .hash = hashString(HashAlgorithm::SHA256, "Derive(...)"),
         },
         ContentAddress {
-            .method = FileIngestionMethod::Flat,
+            .method = ContentAddressMethod::Raw::Flat,
             .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
         },
         ContentAddress {
-            .method = FileIngestionMethod::NixArchive,
+            .method = ContentAddressMethod::Raw::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
         },
     }))
@@ -398,7 +398,7 @@ VERSIONED_CHARACTERIZATION_TEST(
         std::nullopt,
         std::optional {
             ContentAddress {
-                .method = FileIngestionMethod::Flat,
+                .method = ContentAddressMethod::Raw::Flat,
                 .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
             },
         },

--- a/tests/unit/libstore/serve-protocol.cc
+++ b/tests/unit/libstore/serve-protocol.cc
@@ -63,7 +63,7 @@ VERSIONED_CHARACTERIZATION_TEST(
             .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
         },
         ContentAddress {
-            .method = FileIngestionMethod::Recursive,
+            .method = FileIngestionMethod::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
         },
     }))
@@ -280,7 +280,7 @@ VERSIONED_CHARACTERIZATION_TEST(
                 *LibStoreTest::store,
                 "foo",
                 FixedOutputInfo {
-                    .method = FileIngestionMethod::Recursive,
+                    .method = FileIngestionMethod::NixArchive,
                     .hash = hashString(HashAlgorithm::SHA256, "(...)"),
                     .references = {
                         .others = {

--- a/tests/unit/libstore/worker-protocol.cc
+++ b/tests/unit/libstore/worker-protocol.cc
@@ -64,7 +64,7 @@ VERSIONED_CHARACTERIZATION_TEST(
             .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
         },
         ContentAddress {
-            .method = FileIngestionMethod::Recursive,
+            .method = FileIngestionMethod::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
         },
     }))
@@ -512,7 +512,7 @@ VERSIONED_CHARACTERIZATION_TEST(
                 *LibStoreTest::store,
                 "foo",
                 FixedOutputInfo {
-                    .method = FileIngestionMethod::Recursive,
+                    .method = FileIngestionMethod::NixArchive,
                     .hash = hashString(HashAlgorithm::SHA256, "(...)"),
                     .references = {
                         .others = {

--- a/tests/unit/libstore/worker-protocol.cc
+++ b/tests/unit/libstore/worker-protocol.cc
@@ -56,15 +56,15 @@ VERSIONED_CHARACTERIZATION_TEST(
     defaultVersion,
     (std::tuple<ContentAddress, ContentAddress, ContentAddress> {
         ContentAddress {
-            .method = TextIngestionMethod {},
+            .method = ContentAddressMethod::Raw::Text,
             .hash = hashString(HashAlgorithm::SHA256, "Derive(...)"),
         },
         ContentAddress {
-            .method = FileIngestionMethod::Flat,
+            .method = ContentAddressMethod::Raw::Flat,
             .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
         },
         ContentAddress {
-            .method = FileIngestionMethod::NixArchive,
+            .method = ContentAddressMethod::Raw::NixArchive,
             .hash = hashString(HashAlgorithm::SHA256, "(...)"),
         },
     }))
@@ -598,7 +598,7 @@ VERSIONED_CHARACTERIZATION_TEST(
         std::nullopt,
         std::optional {
             ContentAddress {
-                .method = FileIngestionMethod::Flat,
+                .method = ContentAddressMethod::Raw::Flat,
                 .hash = hashString(HashAlgorithm::SHA1, "blob blob..."),
             },
         },

--- a/tests/unit/libutil/file-content-address.cc
+++ b/tests/unit/libutil/file-content-address.cc
@@ -11,7 +11,7 @@ namespace nix {
 TEST(FileSerialisationMethod, testRoundTripPrintParse_1) {
     for (const FileSerialisationMethod fim : {
         FileSerialisationMethod::Flat,
-        FileSerialisationMethod::Recursive,
+        FileSerialisationMethod::NixArchive,
     }) {
         EXPECT_EQ(parseFileSerialisationMethod(renderFileSerialisationMethod(fim)), fim);
     }
@@ -37,7 +37,7 @@ TEST(FileSerialisationMethod, testParseFileSerialisationMethodOptException) {
 TEST(FileIngestionMethod, testRoundTripPrintParse_1) {
     for (const FileIngestionMethod fim : {
         FileIngestionMethod::Flat,
-        FileIngestionMethod::Recursive,
+        FileIngestionMethod::NixArchive,
         FileIngestionMethod::Git,
     }) {
         EXPECT_EQ(parseFileIngestionMethod(renderFileIngestionMethod(fim)), fim);


### PR DESCRIPTION
# Motivation
The old `std::variant` is bad because we aren't adding a new case to `FileIngestionMethod` so much as we are defining a separate concept --- store object content addressing rather than file system object content addressing. As such, it is more correct to just create a fresh enumeration.

Note that this includes a mass rename from `::Recursive` -> `::NixArchive`.

# Context

The recent doc changes #10722 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
