### PR TITLE
Query path infos (plural) and handshake version minimum for hydra

### DIFF
--- a/src/libstore/serve-protocol-impl.hh
+++ b/src/libstore/serve-protocol-impl.hh
@@ -122,6 +122,10 @@ struct ServeProto::BasicClientConnection
         bool lock, const StorePathSet & paths,
         SubstituteFlag maybeSubstitute);
 
+    std::map<StorePath, UnkeyedValidPathInfo> queryPathInfos(
+        const Store & store,
+        const StorePathSet & paths);
+
     /**
      * Just the request half, because Hydra may do other things between
      * issuing the request and reading the `BuildResult` response.

--- a/tests/unit/libstore/serve-protocol.cc
+++ b/tests/unit/libstore/serve-protocol.cc
@@ -505,7 +505,8 @@ TEST_F(ServeProtoTest, handshake_client_corrupted_throws)
             } else {
                 auto ver = ServeProto::BasicClientConnection::handshake(
                     nullSink, in, defaultVersion, "blah");
-                EXPECT_NE(ver, defaultVersion);
+                // `std::min` of this and the other version saves us
+                EXPECT_EQ(ver, defaultVersion);
             }
         }
     });


### PR DESCRIPTION
# Motivation

1. Hydra currently queries for multiple path infos at once, so let us make a connection item for that.

2. The minimum of the two versions should always be used, see #9584. (The issue remains open because the daemon protocol needs to be likewise updated.)


<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
