### PR TITLE
Use CFLAGS for libseccomp from pkg-config also for the CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,7 @@ case "$host_os" in
                                 ]))
     if test "x$enable_seccomp_sandboxing" != "xno"; then
       PKG_CHECK_MODULES([LIBSECCOMP], [libseccomp],
-                        [CXXFLAGS="$LIBSECCOMP_CFLAGS $CXXFLAGS"])
+                        [CXXFLAGS="$LIBSECCOMP_CFLAGS $CXXFLAGS" CFLAGS="$LIBSECCOMP_CFLAGS $CFLAGS"])
       have_seccomp=1
       AC_DEFINE([HAVE_SECCOMP], [1], [Whether seccomp is available and should be used for sandboxing.])
       AC_COMPILE_IFELSE([


### PR DESCRIPTION
# Motivation

Otherwise the configure check for fchmodat2 afterwards fails because it can not find the header files.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

#10744

# Priorities and Process

Minor build fix found while packaging nix for openSUSE Tumbleweed.