### PR TITLE
nix repl: make runNix() isInteractive is true by default

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -137,12 +137,13 @@ void runNix(Path program, const Strings & args,
 {
     auto subprocessEnv = getEnv();
     subprocessEnv["NIX_CONFIG"] = globalConfig.toKeyValue();
-
+    //isInteractive avoid grabling interactive commands
     runProgram2(RunOptions {
         .program = settings.nixBinDir+ "/" + program,
         .args = args,
         .environment = subprocessEnv,
         .input = input,
+        .isInteractive = true,
     });
 
     return;
@@ -508,13 +509,9 @@ ProcessLineResult NixRepl::processLine(std::string line)
         auto editor = args.front();
         args.pop_front();
 
-        // avoid garbling the editor with the progress bar
-        logger->pause();
-        Finally resume([&]() { logger->resume(); });
-
         // runProgram redirects stdout to a StringSink,
         // using runProgram2 to allow editors to display their UI
-        runProgram2(RunOptions { .program = editor, .lookupPath = true, .args = args });
+        runProgram2(RunOptions { .program = editor, .lookupPath = true, .args = args , .isInteractive = true });
 
         // Reload right after exiting the editor
         state->resetFileCache();


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Duplicate PR https://github.com/NixOS/nix/pull/10693
Same Issue https://github.com/NixOS/nix/issues/10617
Attempt to fix nix-repl interactive commands like :e :sh :u 
# Context
(Because of my stupidity, I force-pushed the previous PR and closed by mistake.)
nixcmd/repl.cc: Make repl runNix() isInteractive is true by defaut.
[isInteractive](https://github.com/NixOS/nix/blob/7822ecbadff47fe350a483969e1e307c1c3a3ebe/src/libutil/unix/processes.cc#L302) would pause progress bar like https://github.com/NixOS/nix/pull/10618
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
