### PR TITLE
Fix #10747

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -580,7 +580,12 @@ struct curlFileTransfer : public FileTransfer
         #endif
 
         #if __linux__
-        unshareFilesystem();
+        try {
+            unshareFilesystem();
+        } catch (nix::Error & e) {
+            e.addTrace({}, "in download thread");
+            throw;
+        }
         #endif
 
         std::map<CURL *, std::shared_ptr<TransferItem>> items;

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -581,7 +581,7 @@ struct curlFileTransfer : public FileTransfer
 
         #if __linux__
         try {
-            unshareFilesystem();
+            tryUnshareFilesystem();
         } catch (nix::Error & e) {
             e.addTrace({}, "in download thread");
             throw;

--- a/src/libutil/linux/namespaces.cc
+++ b/src/libutil/linux/namespaces.cc
@@ -140,7 +140,7 @@ void restoreMountNamespace()
 void unshareFilesystem()
 {
     if (unshare(CLONE_FS) != 0 && errno != EPERM)
-        throw SysError("unsharing filesystem state in download thread");
+        throw SysError("unsharing filesystem state");
 }
 
 }

--- a/src/libutil/linux/namespaces.cc
+++ b/src/libutil/linux/namespaces.cc
@@ -137,9 +137,9 @@ void restoreMountNamespace()
     }
 }
 
-void unshareFilesystem()
+void tryUnshareFilesystem()
 {
-    if (unshare(CLONE_FS) != 0 && errno != EPERM)
+    if (unshare(CLONE_FS) != 0 && errno != EPERM && errno != ENOSYS)
         throw SysError("unsharing filesystem state");
 }
 

--- a/src/libutil/linux/namespaces.hh
+++ b/src/libutil/linux/namespaces.hh
@@ -20,11 +20,13 @@ void saveMountNamespace();
 void restoreMountNamespace();
 
 /**
- * Cause this thread to not share any FS attributes with the main
+ * Cause this thread to try to not share any FS attributes with the main
  * thread, because this causes setns() in restoreMountNamespace() to
  * fail.
+ *
+ * This is best effort -- EPERM and ENOSYS failures are just ignored.
  */
-void unshareFilesystem();
+void tryUnshareFilesystem();
 
 bool userNamespacesSupported();
 


### PR DESCRIPTION
# Motivation

- Fix error reporting to separate caller and callee
- Rename function to indicate it's best effort
- Ignore `ENOSYS` too which looks like it would solve #10747

# Context

Fix #10747

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
