### PR TITLE
CODEOWNERS: add fricklerhandwerk for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,16 @@
 .github/CODEOWNERS @edolstra
 
 # Documentation of built-in functions
-src/libexpr/primops.cc @roberth
+src/libexpr/primops.cc @roberth @fricklerhandwerk
+
+# Documentation of settings
+src/libexpr/eval-settings.hh @fricklerhandwerk
+src/libstore/globals.hh @fricklerhandwerk
+
+# Documentation
+doc/manual @fricklerhandwerk
+maintainers/*.md @fricklerhandwerk
+src/**/*.md
 
 # Libstore layer
 /src/libstore @thufschmitt @ericson2314

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ src/libstore/globals.hh @fricklerhandwerk
 # Documentation
 doc/manual @fricklerhandwerk
 maintainers/*.md @fricklerhandwerk
-src/**/*.md
+src/**/*.md @fricklerhandwerk
 
 # Libstore layer
 /src/libstore @thufschmitt @ericson2314


### PR DESCRIPTION
I want to get notified on changes and help with reviewing and merging contributions

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).