### PR TITLE
Document field being initialized in `Machine` constructor

### DIFF
--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -168,14 +168,24 @@ static Machine parseBuilderLine(const std::set<std::string> & defaultSystems, co
     if (!isSet(0))
         throw FormatError("bad machine specification: store URL was not found at the first column of a row: '%s'", line);
 
+    // TODO use designated initializers, once C++ supports those with
+    // custom constructors.
     return {
+        // `storeUri`
         tokens[0],
+        // `systemTypes`
         isSet(1) ? tokenizeString<std::set<std::string>>(tokens[1], ",") : defaultSystems,
+        // `sshKey`
         isSet(2) ? tokens[2] : "",
+        // `maxJobs`
         isSet(3) ? parseUnsignedIntField(3) : 1U,
+        // `speedFactor`
         isSet(4) ? parseFloatField(4) : 1.0f,
+        // `supportedFeatures`
         isSet(5) ? tokenizeString<std::set<std::string>>(tokens[5], ",") : std::set<std::string>{},
+        // `mandatoryFeatures`
         isSet(6) ? tokenizeString<std::set<std::string>>(tokens[6], ",") : std::set<std::string>{},
+        // `sshPublicHostKey`
         isSet(7) ? ensureBase64(7) : ""
     };
 }


### PR DESCRIPTION
# Context

As requested by @haenoe in https://github.com/NixOS/nix/pull/10763#discussion_r1611266158

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
