### PR TITLE
Create `CommonSSHStoreConfig::createSSHMaster`

### DIFF
--- a/src/libstore/legacy-ssh-store.hh
+++ b/src/libstore/legacy-ssh-store.hh
@@ -33,8 +33,6 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
 
     struct Connection;
 
-    std::string host;
-
     ref<Pool<Connection>> connections;
 
     SSHMaster master;
@@ -45,13 +43,6 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
         std::string_view scheme,
         std::string_view host,
         const Params & params);
-
-private:
-    LegacySSHStore(
-        std::string_view scheme,
-        std::string host,
-        const Params & params);
-public:
 
     ref<Connection> openConnection();
 

--- a/src/libstore/ssh-store-config.cc
+++ b/src/libstore/ssh-store-config.cc
@@ -1,10 +1,11 @@
 #include <regex>
 
 #include "ssh-store-config.hh"
+#include "ssh.hh"
 
 namespace nix {
 
-std::string CommonSSHStoreConfig::extractConnStr(std::string_view scheme, std::string_view _connStr)
+static std::string extractConnStr(std::string_view scheme, std::string_view _connStr)
 {
     if (_connStr.empty())
         throw UsageError("`%s` store requires a valid SSH host as the authority part in Store URI", scheme);
@@ -19,6 +20,24 @@ std::string CommonSSHStoreConfig::extractConnStr(std::string_view scheme, std::s
     }
 
     return connStr;
+}
+
+CommonSSHStoreConfig::CommonSSHStoreConfig(std::string_view scheme, std::string_view host, const Params & params)
+    : StoreConfig(params)
+    , host(extractConnStr(scheme, host))
+{
+}
+
+SSHMaster CommonSSHStoreConfig::createSSHMaster(bool useMaster, Descriptor logFD)
+{
+    return {
+        host,
+        sshKey.get(),
+        sshPublicHostKey.get(),
+        useMaster,
+        compress,
+        logFD,
+    };
 }
 
 }

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -10,7 +10,7 @@ SSHMaster::SSHMaster(
     std::string_view host,
     std::string_view keyFile,
     std::string_view sshPublicHostKey,
-    bool useMaster, bool compress, int logFD)
+    bool useMaster, bool compress, Descriptor logFD)
     : host(host)
     , fakeSSH(host == "localhost")
     , keyFile(keyFile)

--- a/src/libstore/ssh.hh
+++ b/src/libstore/ssh.hh
@@ -17,7 +17,7 @@ private:
     const std::string sshPublicHostKey;
     const bool useMaster;
     const bool compress;
-    const int logFD;
+    const Descriptor logFD;
 
     struct State
     {
@@ -43,7 +43,7 @@ public:
         std::string_view host,
         std::string_view keyFile,
         std::string_view sshPublicHostKey,
-        bool useMaster, bool compress, int logFD = -1);
+        bool useMaster, bool compress, Descriptor logFD = INVALID_DESCRIPTOR);
 
     struct Connection
     {


### PR DESCRIPTION
# Motivation

By moving `host` to the config, we can do a lot further cleanups and dedups. This anticipates a world where we always go `StoreReference` -> `*StoreConfig` -> `Store*` rather than skipping the middle step too.

The new function is also useful for Hydra, not just deduplicating code in Nix.

# Context

Progress on #10766

Progress on https://github.com/NixOS/hydra/issues/1164

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
