### PR TITLE
repl: do not crash when tab-completing import errors

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -304,6 +304,8 @@ StringSet NixRepl::completePrefix(const std::string & prefix)
             // Quietly ignore evaluation errors.
         } catch (BadURL & e) {
             // Quietly ignore BadURL flake-related errors.
+        } catch (FileNotFound & e) {
+            // Quietly ignore non-existent file beeing `import`-ed.
         }
     }
 

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -53,7 +53,7 @@ SourceAccessor::Stat SourceAccessor::lstat(const CanonPath & path)
     if (auto st = maybeLstat(path))
         return *st;
     else
-        throw Error("path '%s' does not exist", showPath(path));
+        throw FileNotFound("path '%s' does not exist", showPath(path));
 }
 
 void SourceAccessor::setPathDisplay(std::string displayPrefix, std::string displaySuffix)

--- a/src/libutil/source-accessor.hh
+++ b/src/libutil/source-accessor.hh
@@ -29,6 +29,8 @@ enum class SymlinkResolution {
     Full,
 };
 
+MakeError(FileNotFound, Error);
+
 /**
  * A read-only filesystem abstraction. This is used by the Nix
  * evaluator and elsewhere for accessing sources in various


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

```
$ cat /tmp/foo.nix
{
  someImport = import ./this_file_does_not_exist;
}
$ ./src/nix/nix repl --file /tmp/foo.nix
warning: unknown experimental feature 'repl-flake'
Nix 2.23.0pre20240517_dirty
Type :? for help.
Loading installable ''...
Added 1 variables.
nix-repl> someImport.<TAB>
```

# Context

Original bug report: https://git.lix.systems/lix-project/lix/issues/340
Fix has been adapted from https://gerrit.lix.systems/c/lix/+/1189

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
