### PR TITLE
Fix format

### DIFF
--- a/src/libutil/windows/windows-async-pipe.cc
+++ b/src/libutil/windows/windows-async-pipe.cc
@@ -13,8 +13,14 @@ void AsyncPipe::createAsyncPipe(HANDLE iocp)
     std::string pipeName = fmt("\\\\.\\pipe\\nix-%d-%p", GetCurrentProcessId(), (void *) this);
 
     readSide = CreateNamedPipeA(
-        pipeName.c_str(), PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED, PIPE_TYPE_BYTE, PIPE_UNLIMITED_INSTANCES, 0, 0,
-        INFINITE, NULL);
+        pipeName.c_str(),
+        PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
+        PIPE_TYPE_BYTE,
+        PIPE_UNLIMITED_INSTANCES,
+        0,
+        0,
+        INFINITE,
+        NULL);
     if (!readSide)
         throw WinError("CreateNamedPipeA(%s)", pipeName);
 


### PR DESCRIPTION
# Context

39b2a399ad94f061eea0e0fc639cf1466587959e passed CI but was landed after the formatting change in 1d6c2316a988a97b2c4d214f582580f70c7d9586.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
