### PR TITLE
Add repl completion test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -393,6 +393,7 @@
           in pkgs.buildPackages.runCommand "test-rl-next-release-notes" { } ''
           LANG=C.UTF-8 ${pkgs.changelog-d-nix}/bin/changelog-d ${./doc/manual/rl-next} >$out
         '';
+        repl-completion = nixpkgsFor.${system}.native.callPackage ./tests/repl-completion.nix { };
       } // (lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
         dockerImage = self.hydraJobs.dockerImage.${system};
       } // (lib.optionalAttrs (!(builtins.elem system linux32BitSystems))) {

--- a/tests/repl-completion.nix
+++ b/tests/repl-completion.nix
@@ -1,0 +1,40 @@
+{ runCommand, nix, expect }:
+
+# We only use expect when necessary, e.g. for testing tab completion in nix repl.
+# See also tests/functional/repl.sh
+
+runCommand "repl-completion" {
+  nativeBuildInputs = [
+    expect
+    nix
+  ];
+  expectScript = ''
+    # Regression https://github.com/NixOS/nix/pull/10778
+    spawn nix repl --offline --extra-experimental-features nix-command
+    expect "nix-repl>"
+    send "foo = import ./does-not-exist.nix\n"
+    expect "nix-repl>"
+    send "foo.\t"
+    expect {
+      "nix-repl>" {
+        puts "Got another prompt. Good."
+      }
+      eof {
+        puts "Got EOF. Bad."
+        exit 1
+      }
+    }
+    exit 0
+  '';
+  passAsFile = [ "expectScript" ];
+}
+''
+  export NIX_STORE=$TMPDIR/store
+  export NIX_STATE_DIR=$TMPDIR/state
+  export HOME=$TMPDIR/home
+  mkdir $HOME
+
+  nix-store --init
+  expect $expectScriptPath
+  touch $out
+''


### PR DESCRIPTION
# Motivation

Closes #10784 

This uses `expect`, which I don't like, but it gets the job done, and doesn't require that we add dependencies to existing derivations.

Most repl tests should be done in a DX friendly way in the functional test suite, e.g.
- #10075

Tab completion would be out of scope for such a test runner.

# Context

- Tests https://github.com/NixOS/nix/pull/10778
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
