### PR TITLE
add empty line to documentation comments after `@brief` field

### DIFF
--- a/src/libexpr-c/nix_api_value.h
+++ b/src/libexpr-c/nix_api_value.h
@@ -79,6 +79,7 @@ typedef struct nix_realised_string nix_realised_string;
  * @{
  */
 /** @brief Function pointer for primops
+ *
  * When you want to return an error, call nix_set_err_msg(context, NIX_ERR_UNKNOWN, "your error message here").
  *
  * @param[in] user_data Arbitrary data that was initially supplied to nix_alloc_primop

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -54,8 +54,10 @@ nix_err nix_libstore_init_no_load_config(nix_c_context * context);
 nix_err nix_init_plugins(nix_c_context * context);
 
 /**
- * @brief Open a nix store
+ * @brief Open a nix store.
+ *
  * Store instances may share state and resources behind the scenes.
+ *
  * @param[out] context Optional, stores error information
  * @param[in] uri URI of the Nix store, copied. See [*Store URL format* in the Nix Reference
  * Manual](https://nixos.org/manual/nix/stable/store/types/#store-url-format).
@@ -157,6 +159,7 @@ nix_err nix_store_realise(
 
 /**
  * @brief get the version of a nix store.
+ *
  * If the store doesn't have a version (like the dummy store), returns an empty string.
  * @param[out] context Optional, stores error information
  * @param[in] store nix store reference

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -161,6 +161,7 @@ nix_err nix_store_realise(
  * @brief get the version of a nix store.
  *
  * If the store doesn't have a version (like the dummy store), returns an empty string.
+ *
  * @param[out] context Optional, stores error information
  * @param[in] store nix store reference
  * @param[in] callback Called with the version.


### PR DESCRIPTION
# Motivation
the documentation of some definitions like [`nix_store_open`](https://hydra.nixos.org/build/261507418/download/1/html/group__libstore.html#ga843122a2bebf1bdd772becf3a3a81f0d) and [`PrimOpFun`](https://hydra.nixos.org/build/261507418/download/1/html/group__primops.html#ga17365c66df7f598a3c606aa4aec7c1e5) is rendered incorrectly because the `@brief` field was not terminated by an empty line.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
