### PR TITLE
docs: mention importNative/exec in allow-unsafe-native-code-during-evaluation

### DIFF
--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -15,8 +15,11 @@ struct EvalSettings : Config
 
     static std::string resolvePseudoUrl(std::string_view url);
 
-    Setting<bool> enableNativeCode{this, false, "allow-unsafe-native-code-during-evaluation",
-        "Whether builtin functions that allow executing native code should be enabled."};
+    Setting<bool> enableNativeCode{this, false, "allow-unsafe-native-code-during-evaluation", R"(
+        Whether builtin functions that allow executing native code should be enabled.
+
+        In particular, this adds the `importNative` and `exec` builtins.
+    )"};
 
     Setting<Strings> nixPath{
         this, getDefaultNixPath(), "nix-path",


### PR DESCRIPTION
Cherry-picked from https://git.lix.systems/lix-project/lix/commit/5ff076d8adeec81654abbab47b2c871d4b3fdaa2