### PR TITLE
scripts/install.in: add riscv64 support to installer

### DIFF
--- a/maintainers/upload-release.pl
+++ b/maintainers/upload-release.pl
@@ -243,6 +243,7 @@ write_file("$tmpDir/fallback-paths.nix",
     "  x86_64-linux = \"" . getStorePath("build.x86_64-linux") . "\";\n" .
     "  i686-linux = \"" . getStorePath("build.i686-linux") . "\";\n" .
     "  aarch64-linux = \"" . getStorePath("build.aarch64-linux") . "\";\n" .
+    "  riscv64-linux = \"" . getStorePath("buildCross.riscv64-unknown-linux-gnu.x86_64-linux") . "\";\n" .
     "  x86_64-darwin = \"" . getStorePath("build.x86_64-darwin") . "\";\n" .
     "  aarch64-darwin = \"" . getStorePath("build.aarch64-darwin") . "\";\n" .
     "}\n");

--- a/scripts/install.in
+++ b/scripts/install.in
@@ -50,6 +50,11 @@ case "$(uname -s).$(uname -m)" in
         path=@tarballPath_armv7l-linux@
         system=armv7l-linux
         ;;
+    Linux.riscv64)
+        hash=@tarballHash_riscv64-linux@
+        path=@tarballPath_riscv64-linux@
+        system=riscv64-linux
+        ;;
     Darwin.x86_64)
         hash=@tarballHash_x86_64-darwin@
         path=@tarballPath_x86_64-darwin@


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

The artifacts are already built and hosted, the install script just needs to be taught about riscv64.

# Context
<!-- Provide context. Reference open issues if available. -->

Making this change manually to the install script the Nix installation was able to succeed. 

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
