### PR TITLE
[don't merge] Add test for the evaluation cache

### DIFF
--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+source ./common.sh
+
+requireGit
+
+flake1Dir="$TEST_ROOT/eval-cache-flake"
+
+createGitRepo "$flake1Dir" ""
+
+cat >"$flake1Dir/flake.nix" <<EOF
+{
+  description = "Fnord";
+  outputs = { self }: {
+    foo.bar = throw "breaks";
+  };
+}
+EOF
+
+git -C "$flake1Dir" add flake.nix
+git -C "$flake1Dir" commit -m "Init"
+
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'
+expect 1 nix build "$flake1Dir#foo.bar" 2>&1 | grepQuiet 'error: breaks'

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -16,6 +16,7 @@ nix_tests = \
   flakes/build-paths.sh \
   flakes/flake-in-submodule.sh \
   flakes/prefetch.sh \
+  flakes/eval-cache.sh \
   gc.sh \
   nix-collect-garbage-d.sh \
   remote-store.sh \


### PR DESCRIPTION
# Motivation

This is just to validate if the test from https://github.com/NixOS/nix/pull/10564 fails

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
