### PR TITLE
Fix nix edit

### DIFF
--- a/src/libfetchers/filtering-source-accessor.cc
+++ b/src/libfetchers/filtering-source-accessor.cc
@@ -2,6 +2,12 @@
 
 namespace nix {
 
+std::optional<std::filesystem::path> FilteringSourceAccessor::getPhysicalPath(const CanonPath & path)
+{
+    checkAccess(path);
+    return next->getPhysicalPath(prefix / path);
+}
+
 std::string FilteringSourceAccessor::readFile(const CanonPath & path)
 {
     checkAccess(path);

--- a/src/libfetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/filtering-source-accessor.hh
@@ -30,6 +30,8 @@ struct FilteringSourceAccessor : SourceAccessor
         displayPrefix.clear();
     }
 
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override;
+
     std::string readFile(const CanonPath & path) override;
 
     bool pathExists(const CanonPath & path) override;

--- a/tests/functional/flakes/edit.sh
+++ b/tests/functional/flakes/edit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+requireGit
+
+flake1Dir=$TEST_ROOT/flake1
+
+createGitRepo "$flake1Dir"
+createSimpleGitFlake "$flake1Dir"
+
+export EDITOR=cat
+nix edit "$flake1Dir#" | grepQuiet simple.builder.sh

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -2,6 +2,7 @@ nix_tests = \
   test-infra.sh \
   flakes/flakes.sh \
   flakes/develop.sh \
+  flakes/edit.sh \
   flakes/run.sh \
   flakes/mercurial.sh \
   flakes/circular.sh \

--- a/tests/functional/simple.nix
+++ b/tests/functional/simple.nix
@@ -5,4 +5,5 @@ mkDerivation {
   builder = ./simple.builder.sh;
   PATH = "";
   goodPath = path;
+  meta.position = "${__curPos.file}:${toString __curPos.line}";
 }


### PR DESCRIPTION
# Motivation

Since we introduced SourceAccessor, nix edit no longer works as described in https://github.com/NixOS/nix/issues/9652

This pull requests fixes the issue and adds regression test so that we no longer have this issue in future.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
