### PR TITLE
Fix empty outputsToInstall for InstallableAttrPath

### DIFF
--- a/src/libcmd/installable-attr-path.cc
+++ b/src/libcmd/installable-attr-path.cc
@@ -75,6 +75,8 @@ DerivedPathsWithInfo InstallableAttrPath::toDerivedPaths()
                 std::set<std::string> outputsToInstall;
                 for (auto & output : packageInfo.queryOutputs(false, true))
                     outputsToInstall.insert(output.first);
+                if (outputsToInstall.empty())
+                    outputsToInstall.insert("out");
                 return OutputsSpec::Names { std::move(outputsToInstall) };
             },
             [&](const ExtendedOutputsSpec::Explicit & e) -> OutputsSpec {

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -45,6 +45,14 @@ nix build -f multiple-outputs.nix --json e --no-link | jq --exit-status '
     (.outputs | keys == ["a_a", "b"]))
 '
 
+# Tests that we can handle empty 'outputsToInstall' (assuming that default
+# output "out" exists).
+nix build -f multiple-outputs.nix --json nothing-to-install --no-link | jq --exit-status '
+  (.[0] |
+    (.drvPath | match(".*nothing-to-install.drv")) and
+    (.outputs | keys == ["out"]))
+'
+
 # But not when it's overriden.
 nix build -f multiple-outputs.nix --json e^a_a --no-link
 nix build -f multiple-outputs.nix --json e^a_a --no-link | jq --exit-status '

--- a/tests/functional/multiple-outputs.nix
+++ b/tests/functional/multiple-outputs.nix
@@ -96,6 +96,12 @@ rec {
     buildCommand = "mkdir $a_a $b $c";
   };
 
+  nothing-to-install = mkDerivation {
+    name = "nothing-to-install";
+    meta.outputsToInstall = [ ];
+    buildCommand = "mkdir $out";
+  };
+
   independent = mkDerivation {
     name = "multiple-outputs-independent";
     outputs = [ "first" "second" ];


### PR DESCRIPTION
# Motivation

`OutputsSpec::Names` constructor requires a non-empty set of output names.

https://github.com/NixOS/nix/blob/802b4e403bb5ad34b26e36fbbe89dab91126d215/src/libstore/outputs-spec.hh#L37-L46

# Context

Fixes assertion failure if outputsToInstall is empty by defaulting to the "out" output. That is, behavior between the following commands should be consistent:

	$ nix build --no-link --json .#nothing-to-install-no-out
	error: derivation '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-nothing-to-install-no-out.drv' does not have wanted outputs 'out'

	$ nix build --no-link --file default.nix --json nothing-to-install-no-out
	error: derivation '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-nothing-to-install-no-out.drv' does not have wanted outputs 'out'

Real-world example of this issue:

	$ nix build --json .#.legacyPackages.aarch64-linux.texlive.pkgs.iwona
	error: derivation '/nix/store/dj0h6b0pnlnan5nidnhqa0bmzq4rv6sx-iwona-0.995b.drv' does not have wanted outputs 'out'

	$ git rev-parse HEAD
	eee33247cf6941daea8398c976bd2dda7962b125
	$ nix build --json --file . texlive.pkgs.iwona
	nix: src/libstore/outputs-spec.hh:46: nix::OutputsSpec::Names::Names(std::set<std::__cxx11::basic_string<char> >&&): Assertion `!empty()' failed.
	Aborted (core dumped)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
