### PR TITLE
improve note in `nix_value_force` documentation of the c api

### DIFF
--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -129,10 +129,8 @@ nix_err nix_value_call_multi(
  *
  * This function converts these Values into their final type.
  *
- * @note You don't need this function for basic API usage, since all functions
- * that return a value call it for you. The only place you will see a
- * NIX_TYPE_THUNK is in the arguments that are passed to a PrimOp function
- * you supplied to nix_alloc_primop.
+ * @note You don't need this function for basic API usage very often, since all functions that return a `Value` call it
+ * for you. This function is mainly needed before calling @ref getters.
  *
  * @param[out] context Optional, stores error information
  * @param[in] state The state of the evaluation.

--- a/src/libexpr-c/nix_api_value.h
+++ b/src/libexpr-c/nix_api_value.h
@@ -147,7 +147,8 @@ Value * nix_alloc_value(nix_c_context * context, EvalState * state);
  * @brief Functions to inspect and change Nix language values, represented by Value.
  * @{
  */
-/** @name Getters
+/** @anchor getters
+ * @name Getters
  */
 /**@{*/
 /** @brief Get value type


### PR DESCRIPTION
# Motivation
the documentation of `nix_value_force` contains a note that needs fixing.

> You don't need this function for basic API usage

this is wrong because calling a getter on the result of `nix_init_apply`, for example, already needs to be preceded by a call to `nix_value_force` as is exemplified in both examples of the [*Getting started*](https://hydra.nixos.org/build/261758880/download/1/html) page showcasing the very most basic api usage.

> The only place you will see a NIX_TYPE_THUNK is in the arguments that are passed to a PrimOp function you supplied to nix_alloc_primop.

this is wrong because any call to `nix_init_apply`, for example, will result in a value of type `NIX_TYPE_THUNK`.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
