### PR TITLE
Modernize `Hash` ordering with C++20 `<=>`

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -50,21 +50,14 @@ bool Hash::operator == (const Hash & h2) const
 }
 
 
-bool Hash::operator != (const Hash & h2) const
+std::strong_ordering Hash::operator <=> (const Hash & h) const
 {
-    return !(*this == h2);
-}
-
-
-bool Hash::operator < (const Hash & h) const
-{
-    if (hashSize < h.hashSize) return true;
-    if (hashSize > h.hashSize) return false;
+    if (auto cmp = algo <=> h.algo; cmp != 0) return cmp;
+    if (auto cmp = hashSize <=> h.hashSize; cmp != 0) return cmp;
     for (unsigned int i = 0; i < hashSize; i++) {
-        if (hash[i] < h.hash[i]) return true;
-        if (hash[i] > h.hash[i]) return false;
+        if (auto cmp = hash[i] <=> h.hash[i]; cmp != 0) return cmp;
     }
-    return false;
+    return std::strong_ordering::equivalent;
 }
 
 

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -86,19 +86,14 @@ private:
 
 public:
     /**
-     * Check whether two hash are equal.
+     * Check whether two hashes are equal.
      */
     bool operator == (const Hash & h2) const;
 
     /**
-     * Check whether two hash are not equal.
+     * Compare how two hashes are ordered.
      */
-    bool operator != (const Hash & h2) const;
-
-    /**
-     * For sorting.
-     */
-    bool operator < (const Hash & h) const;
+    std::strong_ordering operator <=> (const Hash & h2) const;
 
     /**
      * Returns the length of a base-16 representation of this hash.


### PR DESCRIPTION
# Context

Progress on #10832

# Motivation

This doesn't switch to auto-deriving the fields, but by defining `<=>` we allow deriving `<=>` in downstream types where `Hash` is used.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
