### PR TITLE
Fix shellcheck issue

### DIFF
--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 source ./common.sh
 
 requireGit


### PR DESCRIPTION
# Motivation

8b86f415c1a8565085e70475933e459a29d67283 was merged from a CI run that predated the new linting.

# Context

#10795

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
