### PR TITLE
Remove `comparator.hh` and switch to `<=>` in a bunch of places

### DIFF
--- a/src/libcmd/built-path.hh
+++ b/src/libcmd/built-path.hh
@@ -18,7 +18,8 @@ struct SingleBuiltPathBuilt {
     static SingleBuiltPathBuilt parse(const StoreDirConfig & store, std::string_view, std::string_view);
     nlohmann::json toJSON(const StoreDirConfig & store) const;
 
-    DECLARE_CMP(SingleBuiltPathBuilt);
+    bool operator ==(const SingleBuiltPathBuilt &) const noexcept;
+    std::strong_ordering operator <=>(const SingleBuiltPathBuilt &) const noexcept;
 };
 
 using _SingleBuiltPathRaw = std::variant<
@@ -32,6 +33,9 @@ struct SingleBuiltPath : _SingleBuiltPathRaw {
 
     using Opaque = DerivedPathOpaque;
     using Built = SingleBuiltPathBuilt;
+
+    bool operator == (const SingleBuiltPath &) const = default;
+    auto operator <=> (const SingleBuiltPath &) const = default;
 
     inline const Raw & raw() const {
         return static_cast<const Raw &>(*this);
@@ -59,11 +63,13 @@ struct BuiltPathBuilt {
     ref<SingleBuiltPath> drvPath;
     std::map<std::string, StorePath> outputs;
 
+    bool operator == (const BuiltPathBuilt &) const noexcept;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //std::strong_ordering operator <=> (const BuiltPathBuilt &) const noexcept;
+
     std::string to_string(const StoreDirConfig & store) const;
     static BuiltPathBuilt parse(const StoreDirConfig & store, std::string_view, std::string_view);
     nlohmann::json toJSON(const StoreDirConfig & store) const;
-
-    DECLARE_CMP(BuiltPathBuilt);
 };
 
 using _BuiltPathRaw = std::variant<
@@ -81,6 +87,10 @@ struct BuiltPath : _BuiltPathRaw {
 
     using Opaque = DerivedPathOpaque;
     using Built = BuiltPathBuilt;
+
+    bool operator == (const BuiltPath &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //auto operator <=> (const BuiltPath &) const = default;
 
     inline const Raw & raw() const {
         return static_cast<const Raw &>(*this);

--- a/src/libexpr-c/nix_api_external.cc
+++ b/src/libexpr-c/nix_api_external.cc
@@ -115,7 +115,7 @@ public:
     /**
      * Compare to another value of the same type.
      */
-    virtual bool operator==(const ExternalValueBase & b) const override
+    virtual bool operator==(const ExternalValueBase & b) const noexcept override
     {
         if (!desc.equal) {
             return false;

--- a/src/libexpr/attr-set.hh
+++ b/src/libexpr/attr-set.hh
@@ -27,9 +27,9 @@ struct Attr
     Attr(Symbol name, Value * value, PosIdx pos = noPos)
         : name(name), pos(pos), value(value) { };
     Attr() { };
-    bool operator < (const Attr & a) const
+    auto operator <=> (const Attr & a) const
     {
-        return name < a.name;
+        return name <=> a.name;
     }
 };
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2842,7 +2842,7 @@ std::string ExternalValueBase::coerceToString(EvalState & state, const PosIdx & 
 }
 
 
-bool ExternalValueBase::operator==(const ExternalValueBase & b) const
+bool ExternalValueBase::operator==(const ExternalValueBase & b) const noexcept
 {
     return false;
 }

--- a/src/libexpr/pos-idx.hh
+++ b/src/libexpr/pos-idx.hh
@@ -28,19 +28,14 @@ public:
         return id > 0;
     }
 
-    bool operator<(const PosIdx other) const
+    auto operator<=>(const PosIdx other) const
     {
-        return id < other.id;
+        return id <=> other.id;
     }
 
     bool operator==(const PosIdx other) const
     {
         return id == other.id;
-    }
-
-    bool operator!=(const PosIdx other) const
-    {
-        return id != other.id;
     }
 };
 

--- a/src/libexpr/symbol-table.hh
+++ b/src/libexpr/symbol-table.hh
@@ -62,9 +62,8 @@ public:
 
     explicit operator bool() const { return id > 0; }
 
-    bool operator<(const Symbol other) const { return id < other.id; }
+    auto operator<=>(const Symbol other) const { return id <=> other.id; }
     bool operator==(const Symbol other) const { return id == other.id; }
-    bool operator!=(const Symbol other) const { return id != other.id; }
 };
 
 /**

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -111,7 +111,7 @@ class ExternalValueBase
      * Compare to another value of the same type. Defaults to uncomparable,
      * i.e. always false.
      */
-    virtual bool operator ==(const ExternalValueBase & b) const;
+    virtual bool operator ==(const ExternalValueBase & b) const noexcept;
 
     /**
      * Print the value as JSON. Defaults to unconvertable, i.e. throws an error

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -150,7 +150,7 @@ Attrs Input::toAttrs() const
     return attrs;
 }
 
-bool Input::operator ==(const Input & other) const
+bool Input::operator ==(const Input & other) const noexcept
 {
     return attrs == other.attrs;
 }

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -89,7 +89,7 @@ public:
      */
     bool isLocked() const;
 
-    bool operator ==(const Input & other) const;
+    bool operator ==(const Input & other) const noexcept;
 
     bool contains(const Input & other) const;
 

--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -36,11 +36,6 @@ std::ostream & operator << (std::ostream & str, const FlakeRef & flakeRef)
     return str;
 }
 
-bool FlakeRef::operator ==(const FlakeRef & other) const
-{
-    return input == other.input && subdir == other.subdir;
-}
-
 FlakeRef FlakeRef::resolve(ref<Store> store) const
 {
     auto [input2, extraAttrs] = lookupInRegistries(store, input);

--- a/src/libflake/flake/flakeref.hh
+++ b/src/libflake/flake/flakeref.hh
@@ -46,7 +46,7 @@ struct FlakeRef
      */
     Path subdir;
 
-    bool operator==(const FlakeRef & other) const;
+    bool operator ==(const FlakeRef & other) const = default;
 
     FlakeRef(fetchers::Input && input, const Path & subdir)
         : input(std::move(input)), subdir(subdir)

--- a/src/libflake/flake/lockfile.cc
+++ b/src/libflake/flake/lockfile.cc
@@ -249,11 +249,6 @@ bool LockFile::operator ==(const LockFile & other) const
     return toJSON().first == other.toJSON().first;
 }
 
-bool LockFile::operator !=(const LockFile & other) const
-{
-    return !(*this == other);
-}
-
 InputPath parseInputPath(std::string_view s)
 {
     InputPath path;

--- a/src/libflake/flake/lockfile.hh
+++ b/src/libflake/flake/lockfile.hh
@@ -74,9 +74,6 @@ struct LockFile
     std::optional<FlakeRef> isUnlocked() const;
 
     bool operator ==(const LockFile & other) const;
-    // Needed for old gcc versions that don't synthesize it (like gcc 8.2.2
-    // that is still the default on aarch64-linux)
-    bool operator !=(const LockFile & other) const;
 
     std::shared_ptr<Node> findInput(const InputPath & path);
 

--- a/src/libstore/build-result.cc
+++ b/src/libstore/build-result.cc
@@ -2,17 +2,7 @@
 
 namespace nix {
 
-GENERATE_CMP_EXT(
-    ,
-    BuildResult,
-    me->status,
-    me->errorMsg,
-    me->timesBuilt,
-    me->isNonDeterministic,
-    me->builtOutputs,
-    me->startTime,
-    me->stopTime,
-    me->cpuUser,
-    me->cpuSystem);
+bool BuildResult::operator==(const BuildResult &) const noexcept = default;
+std::strong_ordering BuildResult::operator<=>(const BuildResult &) const noexcept = default;
 
 }

--- a/src/libstore/build-result.hh
+++ b/src/libstore/build-result.hh
@@ -3,7 +3,6 @@
 
 #include "realisation.hh"
 #include "derived-path.hh"
-#include "comparator.hh"
 
 #include <string>
 #include <chrono>
@@ -101,7 +100,8 @@ struct BuildResult
      */
     std::optional<std::chrono::microseconds> cpuUser, cpuSystem;
 
-    DECLARE_CMP(BuildResult);
+    bool operator ==(const BuildResult &) const noexcept;
+    std::strong_ordering operator <=>(const BuildResult &) const noexcept;
 
     bool success()
     {

--- a/src/libstore/content-address.hh
+++ b/src/libstore/content-address.hh
@@ -73,6 +73,7 @@ struct ContentAddressMethod
 
     Raw raw;
 
+    bool operator ==(const ContentAddressMethod &) const = default;
     auto operator <=>(const ContentAddressMethod &) const = default;
 
     MAKE_WRAPPER_CONSTRUCTOR(ContentAddressMethod);
@@ -159,6 +160,7 @@ struct ContentAddress
      */
     Hash hash;
 
+    bool operator ==(const ContentAddress &) const = default;
     auto operator <=>(const ContentAddress &) const = default;
 
     /**
@@ -217,6 +219,10 @@ struct StoreReferences
      * iff self is true.
      */
     size_t size() const;
+
+    bool operator ==(const StoreReferences &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //auto operator <=>(const StoreReferences &) const = default;
 };
 
 // This matches the additional info that we need for makeTextPath
@@ -232,6 +238,10 @@ struct TextInfo
      * disallowed
      */
     StorePathSet references;
+
+    bool operator ==(const TextInfo &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //auto operator <=>(const TextInfo &) const = default;
 };
 
 struct FixedOutputInfo
@@ -250,6 +260,10 @@ struct FixedOutputInfo
      * References to other store objects or this one.
      */
     StoreReferences references;
+
+    bool operator ==(const FixedOutputInfo &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //auto operator <=>(const FixedOutputInfo &) const = default;
 };
 
 /**
@@ -265,6 +279,10 @@ struct ContentAddressWithReferences
     > Raw;
 
     Raw raw;
+
+    bool operator ==(const ContentAddressWithReferences &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //auto operator <=>(const ContentAddressWithReferences &) const = default;
 
     MAKE_WRAPPER_CONSTRUCTOR(ContentAddressWithReferences);
 

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -8,7 +8,6 @@
 #include "repair-flag.hh"
 #include "derived-path-map.hh"
 #include "sync.hh"
-#include "comparator.hh"
 #include "variant-wrapper.hh"
 
 #include <map>
@@ -32,7 +31,8 @@ struct DerivationOutput
     {
         StorePath path;
 
-        GENERATE_CMP(InputAddressed, me->path);
+        bool operator == (const InputAddressed &) const = default;
+        auto operator <=> (const InputAddressed &) const = default;
     };
 
     /**
@@ -56,7 +56,8 @@ struct DerivationOutput
          */
         StorePath path(const StoreDirConfig & store, std::string_view drvName, OutputNameView outputName) const;
 
-        GENERATE_CMP(CAFixed, me->ca);
+        bool operator == (const CAFixed &) const = default;
+        auto operator <=> (const CAFixed &) const = default;
     };
 
     /**
@@ -76,7 +77,8 @@ struct DerivationOutput
          */
         HashAlgorithm hashAlgo;
 
-        GENERATE_CMP(CAFloating, me->method, me->hashAlgo);
+        bool operator == (const CAFloating &) const = default;
+        auto operator <=> (const CAFloating &) const = default;
     };
 
     /**
@@ -84,7 +86,8 @@ struct DerivationOutput
      * isn't known yet.
      */
     struct Deferred {
-        GENERATE_CMP(Deferred);
+        bool operator == (const Deferred &) const = default;
+        auto operator <=> (const Deferred &) const = default;
     };
 
     /**
@@ -103,7 +106,8 @@ struct DerivationOutput
          */
         HashAlgorithm hashAlgo;
 
-        GENERATE_CMP(Impure, me->method, me->hashAlgo);
+        bool operator == (const Impure &) const = default;
+        auto operator <=> (const Impure &) const = default;
     };
 
     typedef std::variant<
@@ -116,7 +120,8 @@ struct DerivationOutput
 
     Raw raw;
 
-    GENERATE_CMP(DerivationOutput, me->raw);
+    bool operator == (const DerivationOutput &) const = default;
+    auto operator <=> (const DerivationOutput &) const = default;
 
     MAKE_WRAPPER_CONSTRUCTOR(DerivationOutput);
 
@@ -177,7 +182,8 @@ struct DerivationType {
         */
         bool deferred;
 
-        GENERATE_CMP(InputAddressed, me->deferred);
+        bool operator == (const InputAddressed &) const = default;
+        auto operator <=> (const InputAddressed &) const = default;
     };
 
     /**
@@ -201,7 +207,8 @@ struct DerivationType {
          */
         bool fixed;
 
-        GENERATE_CMP(ContentAddressed, me->sandboxed, me->fixed);
+        bool operator == (const ContentAddressed &) const = default;
+        auto operator <=> (const ContentAddressed &) const = default;
     };
 
     /**
@@ -211,7 +218,8 @@ struct DerivationType {
      * type, but has some restrictions on its usage.
      */
     struct Impure {
-        GENERATE_CMP(Impure);
+        bool operator == (const Impure &) const = default;
+        auto operator <=> (const Impure &) const = default;
     };
 
     typedef std::variant<
@@ -222,7 +230,8 @@ struct DerivationType {
 
     Raw raw;
 
-    GENERATE_CMP(DerivationType, me->raw);
+    bool operator == (const DerivationType &) const = default;
+    auto operator <=> (const DerivationType &) const = default;
 
     MAKE_WRAPPER_CONSTRUCTOR(DerivationType);
 
@@ -312,14 +321,9 @@ struct BasicDerivation
 
     static std::string_view nameFromPath(const StorePath & storePath);
 
-    GENERATE_CMP(BasicDerivation,
-        me->outputs,
-        me->inputSrcs,
-        me->platform,
-        me->builder,
-        me->args,
-        me->env,
-        me->name);
+    bool operator == (const BasicDerivation &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //auto operator <=> (const BasicDerivation &) const = default;
 };
 
 class Store;
@@ -377,9 +381,9 @@ struct Derivation : BasicDerivation
         const nlohmann::json & json,
         const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
 
-    GENERATE_CMP(Derivation,
-        static_cast<const BasicDerivation &>(*me),
-        me->inputDrvs);
+    bool operator == (const Derivation &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    //auto operator <=> (const Derivation &) const = default;
 };
 
 

--- a/src/libstore/derived-path-map.cc
+++ b/src/libstore/derived-path-map.cc
@@ -54,17 +54,18 @@ typename DerivedPathMap<V>::ChildNode * DerivedPathMap<V>::findSlot(const Single
 
 namespace nix {
 
-GENERATE_CMP_EXT(
-    template<>,
-    DerivedPathMap<std::set<std::string>>::ChildNode,
-    me->value,
-    me->childMap);
+template<>
+bool DerivedPathMap<std::set<std::string>>::ChildNode::operator == (
+    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept = default;
 
-GENERATE_CMP_EXT(
-    template<>,
-    DerivedPathMap<std::set<std::string>>,
-    me->map);
+// TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+#if 0
+template<>
+std::strong_ordering DerivedPathMap<std::set<std::string>>::ChildNode::operator <=> (
+    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept = default;
+#endif
 
+template struct DerivedPathMap<std::set<std::string>>::ChildNode;
 template struct DerivedPathMap<std::set<std::string>>;
 
 };

--- a/src/libstore/derived-path-map.hh
+++ b/src/libstore/derived-path-map.hh
@@ -47,7 +47,11 @@ struct DerivedPathMap {
          */
         Map childMap;
 
-        DECLARE_CMP(ChildNode);
+        bool operator == (const ChildNode &) const noexcept;
+
+        // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+        // decltype(std::declval<V>() <=> std::declval<V>())
+        // operator <=> (const ChildNode &) const noexcept;
     };
 
     /**
@@ -60,7 +64,10 @@ struct DerivedPathMap {
      */
     Map map;
 
-    DECLARE_CMP(DerivedPathMap);
+    bool operator == (const DerivedPathMap &) const = default;
+
+    // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+    // auto operator <=> (const DerivedPathMap &) const noexcept;
 
     /**
      * Find the node for `k`, creating it if needed.
@@ -83,14 +90,21 @@ struct DerivedPathMap {
     ChildNode * findSlot(const SingleDerivedPath & k);
 };
 
+template<>
+bool DerivedPathMap<std::set<std::string>>::ChildNode::operator == (
+    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept;
 
-DECLARE_CMP_EXT(
-    template<>,
-    DerivedPathMap<std::set<std::string>>::,
-    DerivedPathMap<std::set<std::string>>);
-DECLARE_CMP_EXT(
-    template<>,
-    DerivedPathMap<std::set<std::string>>::ChildNode::,
-    DerivedPathMap<std::set<std::string>>::ChildNode);
+// TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
+#if 0
+template<>
+std::strong_ordering DerivedPathMap<std::set<std::string>>::ChildNode::operator <=> (
+    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept;
+
+template<>
+inline auto DerivedPathMap<std::set<std::string>>::operator <=> (const DerivedPathMap<std::set<std::string>> &) const noexcept = default;
+#endif
+
+extern template struct DerivedPathMap<std::set<std::string>>::ChildNode;
+extern template struct DerivedPathMap<std::set<std::string>>;
 
 }

--- a/src/libstore/derived-path.hh
+++ b/src/libstore/derived-path.hh
@@ -3,7 +3,6 @@
 
 #include "path.hh"
 #include "outputs-spec.hh"
-#include "comparator.hh"
 #include "config.hh"
 #include "ref.hh"
 
@@ -32,7 +31,8 @@ struct DerivedPathOpaque {
     static DerivedPathOpaque parse(const StoreDirConfig & store, std::string_view);
     nlohmann::json toJSON(const StoreDirConfig & store) const;
 
-    GENERATE_CMP(DerivedPathOpaque, me->path);
+    bool operator == (const DerivedPathOpaque &) const = default;
+    auto operator <=> (const DerivedPathOpaque &) const = default;
 };
 
 struct SingleDerivedPath;
@@ -79,7 +79,8 @@ struct SingleDerivedPathBuilt {
         const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
     nlohmann::json toJSON(Store & store) const;
 
-    DECLARE_CMP(SingleDerivedPathBuilt);
+    bool operator == (const SingleDerivedPathBuilt &) const noexcept;
+    std::strong_ordering operator <=> (const SingleDerivedPathBuilt &) const noexcept;
 };
 
 using _SingleDerivedPathRaw = std::variant<
@@ -108,6 +109,9 @@ struct SingleDerivedPath : _SingleDerivedPathRaw {
     inline const Raw & raw() const {
         return static_cast<const Raw &>(*this);
     }
+
+    bool operator == (const SingleDerivedPath &) const = default;
+    auto operator <=> (const SingleDerivedPath &) const = default;
 
     /**
      * Get the store path this is ultimately derived from (by realising
@@ -202,7 +206,9 @@ struct DerivedPathBuilt {
         const ExperimentalFeatureSettings & xpSettings = experimentalFeatureSettings);
     nlohmann::json toJSON(Store & store) const;
 
-    DECLARE_CMP(DerivedPathBuilt);
+    bool operator == (const DerivedPathBuilt &) const noexcept;
+    // TODO libc++ 16 (used by darwin) missing `std::set::operator <=>`, can't do yet.
+    bool operator < (const DerivedPathBuilt &) const noexcept;
 };
 
 using _DerivedPathRaw = std::variant<
@@ -230,6 +236,10 @@ struct DerivedPath : _DerivedPathRaw {
     inline const Raw & raw() const {
         return static_cast<const Raw &>(*this);
     }
+
+    bool operator == (const DerivedPath &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::set::operator <=>`, can't do yet.
+    //auto operator <=> (const DerivedPath &) const = default;
 
     /**
      * Get the store path this is ultimately derived from (by realising

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -4,15 +4,6 @@
 
 namespace nix {
 
-GENERATE_CMP_EXT(
-    ,
-    NarInfo,
-    me->url,
-    me->compression,
-    me->fileHash,
-    me->fileSize,
-    static_cast<const ValidPathInfo &>(*me));
-
 NarInfo::NarInfo(const Store & store, const std::string & s, const std::string & whence)
     : ValidPathInfo(StorePath(StorePath::dummy), Hash(Hash::dummy)) // FIXME: hack
 {

--- a/src/libstore/nar-info.hh
+++ b/src/libstore/nar-info.hh
@@ -24,7 +24,9 @@ struct NarInfo : ValidPathInfo
     NarInfo(const ValidPathInfo & info) : ValidPathInfo(info) { }
     NarInfo(const Store & store, const std::string & s, const std::string & whence);
 
-    DECLARE_CMP(NarInfo);
+    bool operator ==(const NarInfo &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::optional::operator <=>`, can't do yet
+    //auto operator <=>(const NarInfo &) const = default;
 
     std::string to_string(const Store & store) const;
 

--- a/src/libstore/outputs-spec.hh
+++ b/src/libstore/outputs-spec.hh
@@ -6,9 +6,7 @@
 #include <set>
 #include <variant>
 
-#include "comparator.hh"
 #include "json-impls.hh"
-#include "comparator.hh"
 #include "variant-wrapper.hh"
 
 namespace nix {
@@ -60,7 +58,11 @@ struct OutputsSpec {
 
     Raw raw;
 
-    GENERATE_CMP(OutputsSpec, me->raw);
+    bool operator == (const OutputsSpec &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::set::operator <=>`, can't do yet.
+    bool operator < (const OutputsSpec & other) const {
+        return raw < other.raw;
+    }
 
     MAKE_WRAPPER_CONSTRUCTOR(OutputsSpec);
 
@@ -99,7 +101,9 @@ struct ExtendedOutputsSpec {
 
     Raw raw;
 
-    GENERATE_CMP(ExtendedOutputsSpec, me->raw);
+    bool operator == (const ExtendedOutputsSpec &) const = default;
+    // TODO libc++ 16 (used by darwin) missing `std::set::operator <=>`, can't do yet.
+    bool operator < (const ExtendedOutputsSpec &) const;
 
     MAKE_WRAPPER_CONSTRUCTOR(ExtendedOutputsSpec);
 

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -3,11 +3,13 @@
 #include "path-info.hh"
 #include "store-api.hh"
 #include "json-utils.hh"
+#include "comparator.hh"
 
 namespace nix {
 
 GENERATE_CMP_EXT(
     ,
+    std::weak_ordering,
     UnkeyedValidPathInfo,
     me->deriver,
     me->narHash,
@@ -18,12 +20,6 @@ GENERATE_CMP_EXT(
     me->ultimate,
     me->sigs,
     me->ca);
-
-GENERATE_CMP_EXT(
-    ,
-    ValidPathInfo,
-    me->path,
-    static_cast<const UnkeyedValidPathInfo &>(*me));
 
 std::string ValidPathInfo::fingerprint(const Store & store) const
 {

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -57,8 +57,7 @@ void Completions::add(std::string completion, std::string description)
     });
 }
 
-bool Completion::operator<(const Completion & other) const
-{ return completion < other.completion || (completion == other.completion && description < other.description); }
+auto Completion::operator<=>(const Completion & other) const noexcept = default;
 
 std::string completionMarker = "___COMPLETE___";
 

--- a/src/libutil/args.hh
+++ b/src/libutil/args.hh
@@ -380,7 +380,7 @@ struct Completion {
     std::string completion;
     std::string description;
 
-    bool operator<(const Completion & other) const;
+    auto operator<=>(const Completion & other) const noexcept;
 };
 
 /**

--- a/src/libutil/canon-path.hh
+++ b/src/libutil/canon-path.hh
@@ -169,7 +169,7 @@ public:
      * a directory is always followed directly by its children. For
      * instance, 'foo' < 'foo/bar' < 'foo!'.
      */
-    bool operator < (const CanonPath & x) const
+    auto operator <=> (const CanonPath & x) const
     {
         auto i = path.begin();
         auto j = x.path.begin();
@@ -178,10 +178,9 @@ public:
             if (c_i == '/') c_i = 0;
             auto c_j = *j;
             if (c_j == '/') c_j = 0;
-            if (c_i < c_j) return true;
-            if (c_i > c_j) return false;
+            if (auto cmp = c_i <=> c_j; cmp != 0) return cmp;
         }
-        return i == path.end() && j != x.path.end();
+        return (i != path.end()) <=> (j != x.path.end());
     }
 
     /**

--- a/src/libutil/comparator.hh
+++ b/src/libutil/comparator.hh
@@ -1,17 +1,8 @@
 #pragma once
 ///@file
 
-#define DECLARE_ONE_CMP(PRE, QUAL, COMPARATOR, MY_TYPE) \
-    PRE bool QUAL operator COMPARATOR(const MY_TYPE & other) const;
-#define DECLARE_EQUAL(prefix, qualification, my_type) \
-    DECLARE_ONE_CMP(prefix, qualification, ==, my_type)
-#define DECLARE_LEQ(prefix, qualification, my_type) \
-    DECLARE_ONE_CMP(prefix, qualification, <, my_type)
-#define DECLARE_NEQ(prefix, qualification, my_type) \
-    DECLARE_ONE_CMP(prefix, qualification, !=, my_type)
-
-#define GENERATE_ONE_CMP(PRE, QUAL, COMPARATOR, MY_TYPE, ...) \
-    PRE bool QUAL operator COMPARATOR(const MY_TYPE & other) const { \
+#define GENERATE_ONE_CMP(PRE, RET, QUAL, COMPARATOR, MY_TYPE, ...) \
+    PRE RET QUAL operator COMPARATOR(const MY_TYPE & other) const noexcept { \
       __VA_OPT__(const MY_TYPE * me = this;) \
       auto fields1 = std::tie( __VA_ARGS__ ); \
       __VA_OPT__(me = &other;) \
@@ -19,30 +10,9 @@
       return fields1 COMPARATOR fields2; \
     }
 #define GENERATE_EQUAL(prefix, qualification, my_type, args...) \
-    GENERATE_ONE_CMP(prefix, qualification, ==, my_type, args)
-#define GENERATE_LEQ(prefix, qualification, my_type, args...) \
-    GENERATE_ONE_CMP(prefix, qualification, <, my_type, args)
-#define GENERATE_NEQ(prefix, qualification, my_type, args...) \
-    GENERATE_ONE_CMP(prefix, qualification, !=, my_type, args)
-
-/**
- * Declare comparison methods without defining them.
- */
-#define DECLARE_CMP(my_type) \
-    DECLARE_EQUAL(,,my_type) \
-    DECLARE_LEQ(,,my_type) \
-    DECLARE_NEQ(,,my_type)
-
-/**
- * @param prefix This is for something before each declaration like
- * `template<classname Foo>`.
- *
- * @param my_type the type are defining operators for.
- */
-#define DECLARE_CMP_EXT(prefix, qualification, my_type) \
-    DECLARE_EQUAL(prefix, qualification, my_type) \
-    DECLARE_LEQ(prefix, qualification, my_type) \
-    DECLARE_NEQ(prefix, qualification, my_type)
+    GENERATE_ONE_CMP(prefix, bool, qualification, ==, my_type, args)
+#define GENERATE_SPACESHIP(prefix, ret, qualification, my_type, args...) \
+    GENERATE_ONE_CMP(prefix, ret, qualification, <=>, my_type, args)
 
 /**
  * Awful hacky generation of the comparison operators by doing a lexicographic
@@ -55,15 +25,19 @@
  * will generate comparison operators semantically equivalent to:
  *
  * ```
- * bool operator<(const ClassName& other) {
- *   return field1 < other.field1 && field2 < other.field2 && ...;
+ * auto operator<=>(const ClassName& other) const noexcept {
+ *   if (auto cmp = field1 <=> other.field1; cmp != 0)
+ *      return cmp;
+ *   if (auto cmp = field2 <=> other.field2; cmp != 0)
+ *      return cmp;
+ *   ...
+ *   return 0;
  * }
  * ```
  */
 #define GENERATE_CMP(args...) \
     GENERATE_EQUAL(,,args) \
-    GENERATE_LEQ(,,args) \
-    GENERATE_NEQ(,,args)
+    GENERATE_SPACESHIP(,auto,,args)
 
 /**
  * @param prefix This is for something before each declaration like
@@ -71,7 +45,6 @@
  *
  * @param my_type the type are defining operators for.
  */
-#define GENERATE_CMP_EXT(prefix, my_type, args...) \
+#define GENERATE_CMP_EXT(prefix, ret, my_type, args...) \
     GENERATE_EQUAL(prefix, my_type ::, my_type, args) \
-    GENERATE_LEQ(prefix, my_type ::, my_type, args) \
-    GENERATE_NEQ(prefix, my_type ::, my_type, args)
+    GENERATE_SPACESHIP(prefix, ret, my_type ::, my_type, args)

--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -46,27 +46,22 @@ std::ostream & operator <<(std::ostream & os, const HintFmt & hf)
 /**
  * An arbitrarily defined value comparison for the purpose of using traces in the key of a sorted container.
  */
-inline bool operator<(const Trace& lhs, const Trace& rhs)
+inline std::strong_ordering operator<=>(const Trace& lhs, const Trace& rhs)
 {
     // `std::shared_ptr` does not have value semantics for its comparison
     // functions, so we need to check for nulls and compare the dereferenced
     // values here.
     if (lhs.pos != rhs.pos) {
-        if (!lhs.pos)
-            return true;
-        if (!rhs.pos)
-            return false;
-        if (*lhs.pos != *rhs.pos)
-            return *lhs.pos < *rhs.pos;
+        if (auto cmp = bool{lhs.pos} <=> bool{rhs.pos}; cmp != 0)
+            return cmp;
+        if (auto cmp = *lhs.pos <=> *rhs.pos; cmp != 0)
+            return cmp;
     }
     // This formats a freshly formatted hint string and then throws it away, which
     // shouldn't be much of a problem because it only runs when pos is equal, and this function is
     // used for trace printing, which is infrequent.
-    return lhs.hint.str() < rhs.hint.str();
+    return lhs.hint.str() <=> rhs.hint.str();
 }
-inline bool operator> (const Trace& lhs, const Trace& rhs) { return rhs < lhs; }
-inline bool operator<=(const Trace& lhs, const Trace& rhs) { return !(lhs > rhs); }
-inline bool operator>=(const Trace& lhs, const Trace& rhs) { return !(lhs < rhs); }
 
 // print lines of code to the ostream, indicating the error column.
 void printCodeLines(std::ostream & out,

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -75,10 +75,7 @@ struct Trace {
     TracePrint print = TracePrint::Default;
 };
 
-inline bool operator<(const Trace& lhs, const Trace& rhs);
-inline bool operator> (const Trace& lhs, const Trace& rhs);
-inline bool operator<=(const Trace& lhs, const Trace& rhs);
-inline bool operator>=(const Trace& lhs, const Trace& rhs);
+inline std::strong_ordering operator<=>(const Trace& lhs, const Trace& rhs);
 
 struct ErrorInfo {
     Verbosity level;

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -1,7 +1,6 @@
 #pragma once
 ///@file
 
-#include "comparator.hh"
 #include "error.hh"
 #include "json-utils.hh"
 #include "types.hh"

--- a/src/libutil/git.hh
+++ b/src/libutil/git.hh
@@ -39,7 +39,8 @@ struct TreeEntry
     Mode mode;
     Hash hash;
 
-    GENERATE_CMP(TreeEntry, me->mode, me->hash);
+    bool operator ==(const TreeEntry &) const = default;
+    auto operator <=>(const TreeEntry &) const = default;
 };
 
 /**

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -41,7 +41,7 @@ Hash::Hash(HashAlgorithm algo) : algo(algo)
 }
 
 
-bool Hash::operator == (const Hash & h2) const
+bool Hash::operator == (const Hash & h2) const noexcept
 {
     if (hashSize != h2.hashSize) return false;
     for (unsigned int i = 0; i < hashSize; i++)
@@ -50,7 +50,7 @@ bool Hash::operator == (const Hash & h2) const
 }
 
 
-std::strong_ordering Hash::operator <=> (const Hash & h) const
+std::strong_ordering Hash::operator <=> (const Hash & h) const noexcept
 {
     if (auto cmp = hashSize <=> h.hashSize; cmp != 0) return cmp;
     for (unsigned int i = 0; i < hashSize; i++) {

--- a/src/libutil/hash.hh
+++ b/src/libutil/hash.hh
@@ -88,12 +88,12 @@ public:
     /**
      * Check whether two hashes are equal.
      */
-    bool operator == (const Hash & h2) const;
+    bool operator == (const Hash & h2) const noexcept;
 
     /**
      * Compare how two hashes are ordered.
      */
-    std::strong_ordering operator <=> (const Hash & h2) const;
+    std::strong_ordering operator <=> (const Hash & h2) const noexcept;
 
     /**
      * Returns the length of a base-16 representation of this hash.

--- a/src/libutil/position.cc
+++ b/src/libutil/position.cc
@@ -17,12 +17,6 @@ Pos::operator std::shared_ptr<Pos>() const
     return std::make_shared<Pos>(&*this);
 }
 
-bool Pos::operator<(const Pos &rhs) const
-{
-    return std::forward_as_tuple(line, column, origin)
-        < std::forward_as_tuple(rhs.line, rhs.column, rhs.origin);
-}
-
 std::optional<LinesOfCode> Pos::getCodeLines() const
 {
     if (line == 0)

--- a/src/libutil/position.hh
+++ b/src/libutil/position.hh
@@ -22,21 +22,17 @@ struct Pos
 
     struct Stdin {
         ref<std::string> source;
-        bool operator==(const Stdin & rhs) const
+        bool operator==(const Stdin & rhs) const noexcept
         { return *source == *rhs.source; }
-        bool operator!=(const Stdin & rhs) const
-        { return *source != *rhs.source; }
-        bool operator<(const Stdin & rhs) const
-        { return *source < *rhs.source; }
+        std::strong_ordering operator<=>(const Stdin & rhs) const noexcept
+        { return *source <=> *rhs.source; }
     };
     struct String {
         ref<std::string> source;
-        bool operator==(const String & rhs) const
+        bool operator==(const String & rhs) const noexcept
         { return *source == *rhs.source; }
-        bool operator!=(const String & rhs) const
-        { return *source != *rhs.source; }
-        bool operator<(const String & rhs) const
-        { return *source < *rhs.source; }
+        std::strong_ordering operator<=>(const String & rhs) const noexcept
+        { return *source <=> *rhs.source; }
     };
 
     typedef std::variant<std::monostate, Stdin, String, SourcePath> Origin;
@@ -65,8 +61,7 @@ struct Pos
     std::optional<LinesOfCode> getCodeLines() const;
 
     bool operator==(const Pos & rhs) const = default;
-    bool operator!=(const Pos & rhs) const = default;
-    bool operator<(const Pos & rhs) const;
+    auto operator<=>(const Pos & rhs) const = default;
 
     struct LinesIterator {
         using difference_type = size_t;

--- a/src/libutil/ref.hh
+++ b/src/libutil/ref.hh
@@ -87,9 +87,9 @@ public:
         return p != other.p;
     }
 
-    bool operator < (const ref<T> & other) const
+    auto operator <=> (const ref<T> & other) const
     {
-        return p < other.p;
+        return p <=> other.p;
     }
 
 private:

--- a/src/libutil/source-accessor.hh
+++ b/src/libutil/source-accessor.hh
@@ -152,9 +152,9 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
         return number == x.number;
     }
 
-    bool operator < (const SourceAccessor & x) const
+    auto operator <=> (const SourceAccessor & x) const
     {
-        return number < x.number;
+        return number <=> x.number;
     }
 
     void setPathDisplay(std::string displayPrefix, std::string displaySuffix = "");

--- a/src/libutil/source-path.cc
+++ b/src/libutil/source-path.cc
@@ -47,19 +47,14 @@ SourcePath SourcePath::operator / (const CanonPath & x) const
 SourcePath SourcePath::operator / (std::string_view c) const
 { return {accessor, path / c}; }
 
-bool SourcePath::operator==(const SourcePath & x) const
+bool SourcePath::operator==(const SourcePath & x) const noexcept
 {
     return std::tie(*accessor, path) == std::tie(*x.accessor, x.path);
 }
 
-bool SourcePath::operator!=(const SourcePath & x) const
+std::strong_ordering SourcePath::operator<=>(const SourcePath & x) const noexcept
 {
-    return std::tie(*accessor, path) != std::tie(*x.accessor, x.path);
-}
-
-bool SourcePath::operator<(const SourcePath & x) const
-{
-    return std::tie(*accessor, path) < std::tie(*x.accessor, x.path);
+    return std::tie(*accessor, path) <=> std::tie(*x.accessor, x.path);
 }
 
 std::ostream & operator<<(std::ostream & str, const SourcePath & path)

--- a/src/libutil/source-path.hh
+++ b/src/libutil/source-path.hh
@@ -103,9 +103,8 @@ struct SourcePath
      */
     SourcePath operator / (std::string_view c) const;
 
-    bool operator==(const SourcePath & x) const;
-    bool operator!=(const SourcePath & x) const;
-    bool operator<(const SourcePath & x) const;
+    bool operator==(const SourcePath & x) const noexcept;
+    std::strong_ordering operator<=>(const SourcePath & x) const noexcept;
 
     /**
      * Convenience wrapper around `SourceAccessor::resolveSymlinks()`.

--- a/src/libutil/suggestions.hh
+++ b/src/libutil/suggestions.hh
@@ -1,7 +1,6 @@
 #pragma once
 ///@file
 
-#include "comparator.hh"
 #include "types.hh"
 #include <set>
 
@@ -20,7 +19,8 @@ public:
 
     std::string to_string() const;
 
-    GENERATE_CMP(Suggestion, me->distance, me->suggestion)
+    bool operator ==(const Suggestion &) const = default;
+    auto operator <=>(const Suggestion &) const = default;
 };
 
 class Suggestions {

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -132,7 +132,7 @@ std::string ParsedURL::to_string() const
         + (fragment.empty() ? "" : "#" + percentEncode(fragment));
 }
 
-bool ParsedURL::operator ==(const ParsedURL & other) const
+bool ParsedURL::operator ==(const ParsedURL & other) const noexcept
 {
     return
         scheme == other.scheme

--- a/src/libutil/url.hh
+++ b/src/libutil/url.hh
@@ -18,7 +18,7 @@ struct ParsedURL
 
     std::string to_string() const;
 
-    bool operator ==(const ParsedURL & other) const;
+    bool operator ==(const ParsedURL & other) const noexcept;
 
     /**
      * Remove `.` and `..` path elements.

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -27,7 +27,9 @@ struct ProfileElementSource
     std::string attrPath;
     ExtendedOutputsSpec outputs;
 
-    bool operator < (const ProfileElementSource & other) const
+    // TODO libc++ 16 (used by darwin) missing `std::set::operator <=>`, can't do yet.
+    //auto operator <=> (const ProfileElementSource & other) const
+    auto operator < (const ProfileElementSource & other) const
     {
         return
             std::tuple(originalRef.to_string(), attrPath, outputs) <

--- a/tests/unit/libutil/git.cc
+++ b/tests/unit/libutil/git.cc
@@ -229,7 +229,7 @@ TEST_F(GitTest, both_roundrip) {
 
     mkSinkHook(CanonPath::root, root.hash, BlobMode::Regular);
 
-    ASSERT_EQ(*files, *files2);
+    ASSERT_EQ(files->root, files2->root);
 }
 
 TEST(GitLsRemote, parseSymrefLineWithReference) {


### PR DESCRIPTION
# Motivation
Progress on #10832

What remains for that issue is hopefully much easier!\

# Context

Known behavior changes:

- `MemorySourceAccessor`'s comparison operators no longer forget to compare the `SourceAccessor` base class.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
