### PR TITLE
Create and install a `nix-util.pc`

### DIFF
--- a/src/libutil/local.mk
+++ b/src/libutil/local.mk
@@ -40,3 +40,5 @@ $(foreach i, $(wildcard $(d)/signature/*.hh), \
 ifeq ($(HAVE_LIBCPUID), 1)
   libutil_LDFLAGS += -lcpuid
 endif
+
+$(eval $(call install-file-in, $(buildprefix)$(d)/nix-util.pc, $(libdir)/pkgconfig, 0644))

--- a/src/libutil/nix-util.pc.in
+++ b/src/libutil/nix-util.pc.in
@@ -5,6 +5,5 @@ includedir=@includedir@
 Name: Nix
 Description: Nix Package Manager
 Version: @PACKAGE_VERSION@
-Requires: nix-util
-Libs: -L${libdir} -lnixstore
+Libs: -L${libdir} -lnixutil
 Cflags: -I${includedir}/nix -std=c++2a


### PR DESCRIPTION

# Motivation

Before, `-lnixutil` was just stuck in `nix-store.pc`, but that doesn't seem so nice.

This prepares us to distribute `libnixutil` in a separate package if we want, but it should be a good change either way. I suspect it wasn't done before because libutil was an extra unstable interface, but I don't think we need worry about that. *All* the C++ is less stable than the C (or that's the goal at least).

# Context

For what it's worth, Lix also created this pkg-config file *en passant* during their rename:
https://git.lix.systems/lix-project/lix/commit/c97e17144e0d0b666d7b79d8b4b0d581bfdf373b#diff-3c4f60cc44a0e35444c7f45331cfa50f76637118

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
