### PR TITLE
improve note in `nix_value_force` documentation again

### DIFF
--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -129,8 +129,8 @@ nix_err nix_value_call_multi(
  *
  * This function converts these Values into their final type.
  *
- * @note You don't need this function for basic API usage very often, since all functions that return a `Value` call it
- * for you. This function is mainly needed before calling @ref getters.
+ * @note You don't need this function for basic API usage as long as you use functions that return a `Value`. This
+ * function is mainly needed before calling @ref getters.
  *
  * @param[out] context Optional, stores error information
  * @param[in] state The state of the evaluation.

--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -129,8 +129,7 @@ nix_err nix_value_call_multi(
  *
  * This function converts these Values into their final type.
  *
- * @note You don't need this function for basic API usage as long as you use functions that return a `Value`. This
- * function is mainly needed before calling @ref getters.
+ * @note This function is mainly needed before calling @ref getters, but not for API calls that return a `Value`. 
  *
  * @param[out] context Optional, stores error information
  * @param[in] state The state of the evaluation.

--- a/src/libexpr-c/nix_api_expr.h
+++ b/src/libexpr-c/nix_api_expr.h
@@ -129,7 +129,7 @@ nix_err nix_value_call_multi(
  *
  * This function converts these Values into their final type.
  *
- * @note This function is mainly needed before calling @ref getters, but not for API calls that return a `Value`. 
+ * @note This function is mainly needed before calling @ref getters, but not for API calls that return a `Value`.
  *
  * @param[out] context Optional, stores error information
  * @param[in] state The state of the evaluation.


### PR DESCRIPTION
# Motivation
the documentation of `nix_value_force` contains a note that needs fixing.

> You don't need this function for basic API usage very often, since all functions that return a `Value` call [`nix_value_force`] for you.

this sounds like "all functions that return a `Value` call [`nix_value_force`] for you" on the `Value` that they return. but this is wrong because `nix_init_apply`, for example, does not call `nix_value_force` on its return value. indeed, it would be silly because no function could ever return a thunk.

i believe the documentation is trying to say here that "all functions that return a `Value` call [`nix_value_force`] for you" on their _arguments_.

some `Value` returning functions do not even need to force their arguments because they return a thunk themselves anyway though. so i think the easiest and most accurate statement is as follows.

> You don't need this function for basic API usage as long as you use functions that return a `Value`.

This work is sponsored by [Antithesis](https://antithesis.com/) ✨

# Context
i just edited the rest of this note in https://github.com/NixOS/nix/pull/10828 but overlooked the misleadingness i am trying to fix here now.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
