### PR TITLE
add call to `checkInterrupt` in a bunch of places

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -260,6 +260,7 @@ StringSet NixRepl::completePrefix(const std::string & prefix)
             auto dir = std::string(cur, 0, slash);
             auto prefix2 = std::string(cur, slash + 1);
             for (auto & entry : std::filesystem::directory_iterator{dir == "" ? "/" : dir}) {
+                checkInterrupt();
                 auto name = entry.path().filename().string();
                 if (name[0] != '.' && hasPrefix(name, prefix2))
                     completions.insert(prev + entry.path().string());

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -1,5 +1,6 @@
 #include "buildenv.hh"
 #include "derivations.hh"
+#include "signals.hh"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -30,6 +31,7 @@ static void createLinks(State & state, const Path & srcDir, const Path & dstDir,
     }
 
     for (const auto & ent : srcFiles) {
+        checkInterrupt();
         auto name = ent.path().filename();
         if (name.string()[0] == '.')
             /* not matched by glob */

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -162,6 +162,7 @@ void LocalStore::findTempRoots(Roots & tempRoots, bool censor)
     /* Read the `temproots' directory for per-process temporary root
        files. */
     for (auto & i : std::filesystem::directory_iterator{tempRootsDir}) {
+        checkInterrupt();
         auto name = i.path().filename().string();
         if (name[0] == '.') {
             // Ignore hidden files. Some package managers (notably portage) create
@@ -228,8 +229,10 @@ void LocalStore::findRoots(const Path & path, std::filesystem::file_type type, R
             type = std::filesystem::symlink_status(path).type();
 
         if (type == std::filesystem::file_type::directory) {
-            for (auto & i : std::filesystem::directory_iterator{path})
+            for (auto & i : std::filesystem::directory_iterator{path}) {
+                checkInterrupt();
                 findRoots(i.path().string(), i.symlink_status().type(), roots);
+            }
         }
 
         else if (type == std::filesystem::file_type::symlink) {

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -4,6 +4,7 @@
 #include "args.hh"
 #include "abstract-setting-to-json.hh"
 #include "compute-levels.hh"
+#include "signals.hh"
 
 #include <algorithm>
 #include <map>
@@ -346,14 +347,17 @@ void initPlugins()
         std::vector<std::filesystem::path> pluginFiles;
         try {
             auto ents = std::filesystem::directory_iterator{pluginFile};
-            for (const auto & ent : ents)
+            for (const auto & ent : ents) {
+                checkInterrupt();
                 pluginFiles.emplace_back(ent.path());
+            }
         } catch (std::filesystem::filesystem_error & e) {
             if (e.code() != std::errc::not_a_directory)
                 throw;
             pluginFiles.emplace_back(pluginFile);
         }
         for (const auto & file : pluginFiles) {
+            checkInterrupt();
             /* handle is purposefully leaked as there may be state in the
                DSO needed by the action of the plugin. */
 #ifndef _WIN32 // TODO implement via DLL loading on Windows

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -1,6 +1,7 @@
 #include "binary-cache-store.hh"
 #include "globals.hh"
 #include "nar-info-disk-cache.hh"
+#include "signals.hh"
 
 #include <atomic>
 
@@ -84,6 +85,7 @@ protected:
         StorePathSet paths;
 
         for (auto & entry : std::filesystem::directory_iterator{binaryCacheDir}) {
+            checkInterrupt();
             auto name = entry.path().filename().string();
             if (name.size() != 40 ||
                 !hasSuffix(name, ".narinfo"))

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1407,6 +1407,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
         printInfo("checking link hashes...");
 
         for (auto & link : std::filesystem::directory_iterator{linksDir}) {
+            checkInterrupt();
             auto name = link.path().filename();
             printMsg(lvlTalkative, "checking contents of '%s'", name);
             PosixSourceAccessor accessor;
@@ -1499,6 +1500,7 @@ LocalStore::VerificationResult LocalStore::verifyAllValidPaths(RepairFlag repair
        invalid states.
      */
     for (auto & i : std::filesystem::directory_iterator{realStoreDir.to_string()}) {
+        checkInterrupt();
         try {
             storePathsInStoreDir.insert({i.path().filename().string()});
         } catch (BadStorePath &) { }

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -144,13 +144,15 @@ static void canonicalisePathMetaData_(
 #endif
 
     if (S_ISDIR(st.st_mode)) {
-        for (auto & i : std::filesystem::directory_iterator{path})
+        for (auto & i : std::filesystem::directory_iterator{path}) {
+            checkInterrupt();
             canonicalisePathMetaData_(
                 i.path().string(),
 #ifndef _WIN32
                 uidRange,
 #endif
                 inodesSeen);
+        }
     }
 }
 

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -1,4 +1,5 @@
 #include "profiles.hh"
+#include "signals.hh"
 #include "store-api.hh"
 #include "local-fs-store.hh"
 #include "users.hh"
@@ -38,6 +39,7 @@ std::pair<Generations, std::optional<GenerationNumber>> findGenerations(Path pro
     auto profileName = std::string(baseNameOf(profile));
 
     for (auto & i : std::filesystem::directory_iterator{profileDir}) {
+        checkInterrupt();
         if (auto n = parseName(profileName, i.path().filename().string())) {
             auto path = i.path().string();
             gens.push_back({

--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -1,4 +1,5 @@
 #include "cgroup.hh"
+#include "signals.hh"
 #include "util.hh"
 #include "file-system.hh"
 #include "finally.hh"
@@ -65,6 +66,7 @@ static CgroupStats destroyCgroup(const std::filesystem::path & cgroup, bool retu
     /* Otherwise, manually kill every process in the subcgroups and
        this cgroup. */
     for (auto & entry : std::filesystem::directory_iterator{cgroup}) {
+        checkInterrupt();
         if (entry.symlink_status().type() != std::filesystem::file_type::directory) continue;
         destroyCgroup(cgroup / entry.path().filename(), false);
     }

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -133,6 +133,7 @@ SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & 
     assertNoSymlinks(path);
     DirEntries res;
     for (auto & entry : std::filesystem::directory_iterator{makeAbsPath(path)}) {
+        checkInterrupt();
         auto type = [&]() -> std::optional<Type> {
             std::filesystem::file_type nativeType;
             try {

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -125,6 +125,7 @@ void closeMostFDs(const std::set<int> & exceptions)
 #if __linux__
     try {
         for (auto & s : std::filesystem::directory_iterator{"/proc/self/fd"}) {
+            checkInterrupt();
             auto fd = std::stoi(s.path().filename());
             if (!exceptions.count(fd)) {
                 debug("closing leaked FD %d", fd);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -7,6 +7,7 @@
 #include "eval-settings.hh"
 #include "flake/flake.hh"
 #include "get-drvs.hh"
+#include "signals.hh"
 #include "store-api.hh"
 #include "derivations.hh"
 #include "outputs-spec.hh"
@@ -867,6 +868,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
             createDirs(to);
 
             for (auto & entry : std::filesystem::directory_iterator{from}) {
+                checkInterrupt();
                 auto from2 = entry.path().string();
                 auto to2 = to + "/" + entry.path().filename().string();
                 auto st = lstat(from2);

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -3,6 +3,7 @@
 #include "command-installable-value.hh"
 #include "common-args.hh"
 #include "shared.hh"
+#include "signals.hh"
 #include "store-api.hh"
 #include "derivations.hh"
 #include "local-fs-store.hh"
@@ -249,6 +250,7 @@ void chrootHelper(int argc, char * * argv)
             throw SysError("mounting '%s' on '%s'", realStoreDir, storeDir);
 
         for (auto entry : std::filesystem::directory_iterator{"/"}) {
+            checkInterrupt();
             auto src = entry.path().string();
             Path dst = tmpDir + "/" + entry.path().filename().string();
             if (pathExists(dst)) continue;


### PR DESCRIPTION
# Motivation

This brings back the old behavior which was lost in #10684. We check for interrupts in places that may iterate over wide directories.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->
https://github.com/NixOS/nix/pull/10684#issuecomment-2107679555

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
