### PR TITLE
flake check: Recognize well known homeModule/homeModules attribute

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -771,6 +771,8 @@ struct CmdFlakeCheck : FlakeCommand
                             || name == "flakeModules"
                             || name == "herculesCI"
                             || name == "homeConfigurations"
+                            || name == "homeModule"
+                            || name == "homeModules"
                             || name == "nixopsConfigurations"
                             )
                             // Known but unchecked community attribute


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
This avoids warning fatigue, making nix flake check more effective.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
See also https://github.com/NixOS/nix/pull/7606 and https://github.com/nix-community/home-manager/issues/1783.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
