### PR TITLE
nix flake check: Allow modules attribute

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -773,6 +773,7 @@ struct CmdFlakeCheck : FlakeCommand
                             || name == "homeConfigurations"
                             || name == "homeModule"
                             || name == "homeModules"
+                            || name == "modules"
                             || name == "nixopsConfigurations"
                             )
                             // Known but unchecked community attribute


### PR DESCRIPTION
# Motivation

Do not warn about another known community attribute, which solves the problem for potentially all "modules" attributes.

# Contrext

- Implements part of https://github.com/NixOS/nix/issues/6257

This is intended as a module system "library" in the format

    <flake>.modules.<class>.<name>

where class is e.g. "nixos" or "homeManager", and the name is of the author's choice.

Modules that can be loaded in any module system application should use the name "generic".

- Implemented in the module system in https://github.com/NixOS/nixpkgs/pull/197547

- Class parameter for checking: https://nixos.org/manual/nixpkgs/stable/index.html#module-system-lib-evalModules-param-class

<!-- Briefly explain what the change is about and why it is desirable. -->


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
