### PR TITLE
PackageInfo::queryDrvPath(): Don't dereference an empty optional

### DIFF
--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -82,8 +82,7 @@ std::optional<StorePath> PackageInfo::queryDrvPath() const
         } else
             drvPath = {std::nullopt};
     }
-    drvPath.value_or(std::nullopt);
-    return *drvPath;
+    return drvPath.value_or(std::nullopt);
 }
 
 

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -278,7 +278,7 @@ private:
             storePath = state.coerceToStorePath(i->pos, *i->value, context, "while evaluating the drvPath of a derivation");
         }
 
-        /* This unforutately breaks printing nested values because of
+        /* This unfortunately breaks printing nested values because of
            how the pretty printer is used (when pretting printing and warning
            to same terminal / std stream). */
 #if 0


### PR DESCRIPTION
# Motivation

Fixes a regression introduced in f923ed6b6a7318e8fc77e8d3aeda6796671f67cb.

https://hydra.nixos.org/build/262267313

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
