### PR TITLE
tests/nixos: make the tarball-flakes test better reflect real use cases

### DIFF
--- a/tests/nixos/tarball-flakes.nix
+++ b/tests/nixos/tarball-flakes.nix
@@ -5,7 +5,7 @@ let
 
   root = pkgs.runCommand "nixpkgs-flake" {}
     ''
-      mkdir -p $out/stable
+      mkdir -p $out/{stable,tags}
 
       set -x
       dir=nixpkgs-${nixpkgs.shortRev}
@@ -14,9 +14,13 @@ let
       find $dir -print0 | xargs -0 touch -h -t ${builtins.substring 0 12 nixpkgs.lastModifiedDate}.${builtins.substring 12 2 nixpkgs.lastModifiedDate} --
       tar cfz $out/stable/${nixpkgs.rev}.tar.gz $dir --hard-dereference
 
-      echo 'Redirect "/latest.tar.gz" "/stable/${nixpkgs.rev}.tar.gz"' > $out/.htaccess
-
-      echo 'Header set Link "<http://localhost/stable/${nixpkgs.rev}.tar.gz?rev=${nixpkgs.rev}&revCount=1234>; rel=\"immutable\""' > $out/stable/.htaccess
+      # Set the "Link" header on the redirect but not the final response to
+      # simulate an S3-like serving environment where the final host cannot set
+      # arbitrary headers.
+      cat >$out/tags/.htaccess <<EOF
+      Redirect "/tags/latest.tar.gz" "/stable/${nixpkgs.rev}.tar.gz"
+      Header always set Link "<http://localhost/stable/${nixpkgs.rev}.tar.gz?rev=${nixpkgs.rev}&revCount=1234>; rel=\"immutable\""
+      EOF
     '';
 in
 
@@ -59,7 +63,7 @@ in
 
     machine.wait_for_unit("httpd.service")
 
-    out = machine.succeed("nix flake metadata --json http://localhost/latest.tar.gz")
+    out = machine.succeed("nix flake metadata --json http://localhost/tags/latest.tar.gz")
     print(out)
     info = json.loads(out)
 
@@ -71,14 +75,15 @@ in
     assert info["revCount"] == 1234
 
     # Check that fetching with rev/revCount/narHash succeeds.
-    machine.succeed("nix flake metadata --json http://localhost/latest.tar.gz?rev=" + info["revision"])
-    machine.succeed("nix flake metadata --json http://localhost/latest.tar.gz?revCount=" + str(info["revCount"]))
-    machine.succeed("nix flake metadata --json http://localhost/latest.tar.gz?narHash=" + info["locked"]["narHash"])
+
+    machine.succeed("nix flake metadata --json http://localhost/tags/latest.tar.gz?rev=" + info["revision"])
+    machine.succeed("nix flake metadata --json http://localhost/tags/latest.tar.gz?revCount=" + str(info["revCount"]))
+    machine.succeed("nix flake metadata --json http://localhost/tags/latest.tar.gz?narHash=" + info["locked"]["narHash"])
 
     # Check that fetching fails if we provide incorrect attributes.
-    machine.fail("nix flake metadata --json http://localhost/latest.tar.gz?rev=493300eb13ae6fb387fbd47bf54a85915acc31c0")
-    machine.fail("nix flake metadata --json http://localhost/latest.tar.gz?revCount=789")
-    machine.fail("nix flake metadata --json http://localhost/latest.tar.gz?narHash=sha256-tbudgBSg+bHWHiHnlteNzN8TUvI80ygS9IULh4rklEw=")
+    machine.fail("nix flake metadata --json http://localhost/tags/latest.tar.gz?rev=493300eb13ae6fb387fbd47bf54a85915acc31c0")
+    machine.fail("nix flake metadata --json http://localhost/tags/latest.tar.gz?revCount=789")
+    machine.fail("nix flake metadata --json http://localhost/tags/latest.tar.gz?narHash=sha256-tbudgBSg+bHWHiHnlteNzN8TUvI80ygS9IULh4rklEw=")
   '';
 
 }


### PR DESCRIPTION
In most real world cases, the Link header is set on the redirect, not on the final file. This regressed in Lix earlier and while new unit tests were added to cover it, this integration test should probably have also caught it.

Source: https://git.lix.systems/lix-project/lix/commit/a3256a93759206dc64e597e2ad790ce582e84cf3

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
