### PR TITLE
libutil: guard Finally against invalid exception throws

### DIFF
--- a/src/libutil/finally.hh
+++ b/src/libutil/finally.hh
@@ -2,6 +2,8 @@
 ///@file
 
 #include <utility>
+#include <cassert>
+#include <exception>
 
 /**
  * A trivial class to run a function at the end of a scope.
@@ -21,5 +23,25 @@ public:
     Finally(Finally &&other) : fun(std::move(other.fun)) {
         other.movedFrom = true;
     }
-    ~Finally() { if (!movedFrom) fun(); }
+    ~Finally() noexcept(false)
+    {
+        try {
+            if (!movedFrom)
+                fun();
+        } catch (...) {
+            // finally may only throw an exception if exception handling is not already
+            // in progress. if handling *is* in progress we have to return cleanly here
+            // but are still prohibited from doing so since eating the exception would,
+            // in almost all cases, mess up error handling even more. the only good way
+            // to handle this is to abort entirely and leave a message, so we'll assert
+            // (and rethrow anyway, just as a defense against possible NASSERT builds.)
+            if (std::uncaught_exceptions()) {
+                assert(false &&
+                    "Finally function threw an exception during exception handling. "
+                    "this is not what you want, please use some other methods (like "
+                    "std::promise or async) instead.");
+            }
+            throw;
+        }
+    }
 };


### PR DESCRIPTION
throwing exceptions is fine, but throwing exceptions during exception handling is hard enough to do correctly that we should just forbid it entirely out of an overabundance of caution. in cases where terminate is the correct answer the users of Finally must call it manually now.

Source: https://git.lix.systems/lix-project/lix/commit/6c777476c9e97abfc5232f0707985caf6df2baea

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
