### PR TITLE
Add `SharedSync` class

### DIFF
--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -90,14 +90,14 @@ bool PosixSourceAccessor::pathExists(const CanonPath & path)
 
 std::optional<struct stat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
 {
-    static Sync<std::unordered_map<Path, std::optional<struct stat>>> _cache;
+    static SharedSync<std::unordered_map<Path, std::optional<struct stat>>> _cache;
 
     // Note: we convert std::filesystem::path to Path because the
     // former is not hashable on libc++.
     Path absPath = makeAbsPath(path).string();
 
     {
-        auto cache(_cache.lock());
+        auto cache(_cache.read());
         auto i = cache->find(absPath);
         if (i != cache->end()) return i->second;
     }

--- a/src/libutil/sync.hh
+++ b/src/libutil/sync.hh
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <mutex>
+#include <shared_mutex>
 #include <condition_variable>
 #include <cassert>
 
@@ -24,8 +25,8 @@ namespace nix {
  * Here, "data" is automatically unlocked when "data_" goes out of
  * scope.
  */
-template<class T, class M = std::mutex>
-class Sync
+template<class T, class M, class WL, class RL>
+class SyncBase
 {
 private:
     M mutex;
@@ -33,23 +34,22 @@ private:
 
 public:
 
-    Sync() { }
-    Sync(const T & data) : data(data) { }
-    Sync(T && data) noexcept : data(std::move(data)) { }
+    SyncBase() { }
+    SyncBase(const T & data) : data(data) { }
+    SyncBase(T && data) noexcept : data(std::move(data)) { }
 
+    template<class L>
     class Lock
     {
-    private:
-        Sync * s;
-        std::unique_lock<M> lk;
-        friend Sync;
-        Lock(Sync * s) : s(s), lk(s->mutex) { }
+    protected:
+        SyncBase * s;
+        L lk;
+        friend SyncBase;
+        Lock(SyncBase * s) : s(s), lk(s->mutex) { }
     public:
         Lock(Lock && l) : s(l.s) { abort(); }
         Lock(const Lock & l) = delete;
         ~Lock() { }
-        T * operator -> () { return &s->data; }
-        T & operator * () { return s->data; }
 
         void wait(std::condition_variable & cv)
         {
@@ -83,7 +83,34 @@ public:
         }
     };
 
-    Lock lock() { return Lock(this); }
+    struct WriteLock : Lock<WL>
+    {
+        T * operator -> () { return &WriteLock::s->data; }
+        T & operator * () { return WriteLock::s->data; }
+    };
+
+    /**
+     * Acquire write (exclusive) access to the inner value.
+     */
+    WriteLock lock() { return WriteLock(this); }
+
+    struct ReadLock : Lock<RL>
+    {
+        const T * operator -> () { return &ReadLock::s->data; }
+        const T & operator * () { return ReadLock::s->data; }
+    };
+
+    /**
+     * Acquire read access to the inner value. When using
+     * `std::shared_mutex`, this will use a shared lock.
+     */
+    ReadLock read() const { return ReadLock(const_cast<SyncBase *>(this)); }
 };
+
+template<class T>
+using Sync = SyncBase<T, std::mutex, std::unique_lock<std::mutex>, std::unique_lock<std::mutex>>;
+
+template<class T>
+using SharedSync = SyncBase<T, std::shared_mutex, std::unique_lock<std::shared_mutex>, std::shared_lock<std::shared_mutex>>;
 
 }


### PR DESCRIPTION
# Motivation

`SharedSync` is like `Sync`, but it uses `std::shared_mutex` instead of `std::mutex`. This allows you to get shared (non-exclusive) const access to the data by calling `foo.read()`, and exclusive write access by calling `foo.lock()`.

The goal is to reduce lock contention for read access to shared data structures in the multi-threaded evaluator. (See the `PosixSourceAccessor` stat cache for an example.)

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
