### PR TITLE
Improve GitHub actions doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,8 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix --experimental-features 'nix-command flakes' build .#dockerImage -L
     - run: docker load -i ./result/image.tar.gz
-    - run: docker tag nix:$NIX_VERSION nixos/nix:$NIX_VERSION
-    - run: docker tag nix:$NIX_VERSION nixos/nix:master
+    - run: docker tag nix:$NIX_VERSION ${{ secrets.DOCKERHUB_USERNAME }}/nix:$NIX_VERSION
+    - run: docker tag nix:$NIX_VERSION ${{ secrets.DOCKERHUB_USERNAME }}/nix:master
     # We'll deploy the newly built image to both Docker Hub and Github Container Registry.
     #
     # Push to Docker Hub first
@@ -137,8 +137,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - run: docker push nixos/nix:$NIX_VERSION
-    - run: docker push nixos/nix:master
+    - run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/nix:$NIX_VERSION
+    - run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/nix:master
     # Push to GitHub Container Registry as well
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix --experimental-features 'nix-command flakes' flake check -L
 
+  # Steps to test CI automation in your own fork.
+  # Cachix:
+  # 1. Sign-up with cachix and create a cache for $githubuser-nix-install-tests
+  # 2. Create a cachix auth token and save it in https://github.com/$githubuser/nix/settings/secrets/actions in "Repository variables" as CACHIX_AUTH_TOKEN
+  # Dockerhub:
+  # 1. Sign-up with dockerhub
+  # 2. Than store your dockerhub username as DOCKERHUB_USERNAME in "Repository variables" of your fork
+  # 3. Create an access token in https://hub.docker.com/settings/security and store it as DOCKERHUB_TOKEN in "Repository variables" of your fork
   check_secrets:
     permissions:
       contents: none


### PR DESCRIPTION
When debugging failing tests, I found this useful to reproduce ci errors in forks: https://github.com/NixOS/nix/actions/runs/9392197873/job/25867113360