### PR TITLE
darwin: allow ipc-sysv* in sandbox

### DIFF
--- a/src/libstore/unix/build/sandbox-defaults.sb
+++ b/src/libstore/unix/build/sandbox-defaults.sb
@@ -17,6 +17,9 @@ R""(
 ; Allow POSIX semaphores and shared memory.
 (allow ipc-posix*)
 
+; Allow SYSV semaphores and shared memory.
+(allow ipc-sysv*)
+
 ; Allow socket creation.
 (allow system-socket)
 


### PR DESCRIPTION
# Motivation

enabling ipc-sysv* in sandbox allows syscalls such as  `shmget` which is needed to be able to run postgres in sandbox

# Context

https://www.postgresql.org/docs/current/kernel-resources.html
# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
