### PR TITLE
Evaluator GC: unmap more memory

### DIFF
--- a/maintainers/manual-tests/nixos-mem/default.nix
+++ b/maintainers/manual-tests/nixos-mem/default.nix
@@ -1,0 +1,38 @@
+
+{ pkgs ? import ../../../../nixpkgs { system = "x86_64-linux"; } }:
+
+pkgs.runCommand "slow-with-dep-on-nixos" {
+  nixos = (pkgs.nixos {
+    # make it pass
+    boot.loader.grub.enable = false;
+    fileSystems."/".device = "x";
+
+    # add some stuff to eval
+
+    services.postgresql.enable = true;
+
+    services.xserver.enable = true;
+    services.xserver.displayManager.gdm.enable = true;
+    services.xserver.desktopManager.gnome.enable = true;
+
+    programs.git.enable = true;
+
+    system.stateVersion = "24.11"; # shut it up
+
+  }).toplevel;
+  note = ''
+    sleeping 1h, so you can measure the CLI's resident memory size
+    on linux:
+        ^Z
+        # make sure ps only lists one nix-build process
+        grep VmRSS /proc/$(ps | grep nix-build | awk '{print $1}')/status
+        fg
+        ^C
+
+    sleeping...
+  '';
+} ''
+  echo "$note"
+
+  sleep 1h
+''

--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -145,6 +145,17 @@ public:
 
 static inline void initGCReal()
 {
+    /* Make sure we're the first to initialize the GC. If we're not, GC_init()
+       will exit early, and therefore fail to assign values from environment
+       variables we're about to modify.
+       Some setters should also be called before GC_init(). */
+    if (GC_is_init_called()) {
+        /* This can be a problem in the nix command, or perhaps a problem for someone
+           who's linked against libnixexpr. */
+        warn(
+            "to developers: GC_init() has already been called. Some parameters may not be set optimally or correctly. Make sure to always call nix::initGC() before using the GC.");
+    }
+
     /* Initialise the Boehm garbage collector. */
 
     /* Don't look for interior pointers. This reduces the odds of

--- a/src/libutil/environment-variables.cc
+++ b/src/libutil/environment-variables.cc
@@ -45,4 +45,12 @@ void replaceEnv(const std::map<std::string, std::string> & newEnv)
         setEnv(newEnvVar.first.c_str(), newEnvVar.second.c_str());
 }
 
+void setMaybeEnv(const char * key, std::optional<std::string> value)
+{
+    if (value)
+        setEnv(key, value->c_str());
+    else
+        unsetenv(key);
 }
+
+} // namespace nix

--- a/src/libutil/environment-variables.hh
+++ b/src/libutil/environment-variables.hh
@@ -44,6 +44,11 @@ int unsetenv(const char * name);
 int setEnv(const char * name, const char * value);
 
 /**
+ * `unsetenv` when `value` is `nullopt`, `setEnv` otherwise.
+ */
+void setMaybeEnv(const char * key, std::optional<std::string> value);
+
+/**
  * Clear the environment.
  */
 void clearEnv();

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -1,5 +1,5 @@
 #include <cstring>
-#include <fstream>
+#include <gc/gc.h>
 #include <iostream>
 #include <filesystem>
 #include <regex>
@@ -19,7 +19,6 @@
 #include "shared.hh"
 #include "path-with-outputs.hh"
 #include "eval.hh"
-#include "eval-inline.hh"
 #include "get-drvs.hh"
 #include "common-eval-args.hh"
 #include "attr-path.hh"

--- a/tests/functional/shell-hello.nix
+++ b/tests/functional/shell-hello.nix
@@ -55,4 +55,26 @@ rec {
         chmod +x $out/bin/hello
       '';
   };
+
+  # execs env from PATH, so that we can probe the environment
+  # does not allow arguments, because we don't need them
+  env = mkDerivation {
+    name = "env";
+    outputs = [ "out" ];
+    buildCommand =
+      ''
+        mkdir -p $out/bin
+
+        cat > $out/bin/env <<EOF
+        #! ${shell}
+        if [ $# -ne 0 ]; then
+          echo "env: Unexpected arguments ($#): $@" 1>&2
+          exit 1
+        fi
+        exec env
+        EOF
+        chmod +x $out/bin/env
+      '';
+  };
+
 }


### PR DESCRIPTION
# Motivation

Make the GC unmap sooner, so that it gets a chance to actually do it. Does not unmap too soon, but see code comment in `initGC` for all subtleties.

If it has a similar effect, it is better alternative to `GC_FORCE_UNMAP_ON_GCOLLECT=1`, but without the slight overhead (of ~10-100ms, tested unscientifically).
- https://github.com/NixOS/nix/issues/10862#issuecomment-2152979006

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
