### PR TITLE
bdw-gc 8.2.6 has sp corrector

### DIFF
--- a/src/libexpr/eval-cache.hh
+++ b/src/libexpr/eval-cache.hh
@@ -31,7 +31,7 @@ struct CachedEvalError : EvalError
 class EvalCache : public std::enable_shared_from_this<EvalCache>
 {
     friend class AttrCursor;
-    friend class CachedEvalError;
+    friend struct CachedEvalError;
 
     std::shared_ptr<AttrDb> db;
     EvalState & state;
@@ -87,7 +87,7 @@ typedef std::variant<
 class AttrCursor : public std::enable_shared_from_this<AttrCursor>
 {
     friend class EvalCache;
-    friend class CachedEvalError;
+    friend struct CachedEvalError;
 
     ref<EvalCache> root;
     typedef std::optional<std::pair<std::shared_ptr<AttrCursor>, Symbol>> Parent;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -365,7 +365,7 @@ void initGC()
         };
     }
     #else
-    #warning "BoehmGC version does not support GC while coroutine exists. GC will be disabled inside coroutines. Consider updating bwd-gc to 8.4 or later."
+    #warning "BoehmGC version does not support GC while coroutine exists. GC will be disabled inside coroutines. Consider updating bdw-gc to 8.4 or later."
     #endif
 
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -354,7 +354,7 @@ void initGC()
     // TODO: Remove __APPLE__ condition.
     //       Comment suggests an implementation that works on darwin and windows
     //       https://github.com/ivmai/bdwgc/issues/362#issuecomment-1936672196
-    #if GC_VERSION_MAJOR >= 8 && GC_VERSION_MINOR >= 4 && !defined(__APPLE__)
+    #if GC_VERSION_MAJOR >= 8 && GC_VERSION_MINOR >= 2 && GC_VERSION_MICRO >= 4 && !defined(__APPLE__)
     GC_set_sp_corrector(&fixupBoehmStackPointer);
 
     if (!GC_get_sp_corrector()) {
@@ -365,7 +365,7 @@ void initGC()
         };
     }
     #else
-    #warning "BoehmGC version does not support GC while coroutine exists. GC will be disabled inside coroutines. Consider updating bdw-gc to 8.4 or later."
+    #warning "BoehmGC version does not support GC while coroutine exists. GC will be disabled inside coroutines. Consider updating bdw-gc to 8.2.4 or later."
     #endif
 
 


### PR DESCRIPTION
# Motivation

This fixes an inaccuracy in https://github.com/NixOS/nix/commit/cc6f31525253b73e4776b5f733e0950e1706d546,
in the update to Nixpkgs 24.05 https://github.com/NixOS/nix/pull/10835

After this fixup, the build log won't ask for an upgrade, and we'll be
able to collect when a coroutine exists, e.g. during filterSource.

Also fixes a clang compiler warning.

# Context

- Inaccuracy introduced in #10835

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
