### PR TITLE
mention the actual meaning of FODs in the glossary

### DIFF
--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -73,8 +73,7 @@
 
 - [fixed-output derivation]{#gloss-fixed-output-derivation}
 
-  A derivation which includes the
-  [`outputHash`](./language/advanced-attributes.md#adv-attr-outputHash) attribute.
+  A [derivation] where a cryptographic hash of the [output] is determined in advance using the [`outputHash`](./language/advanced-attributes.md#adv-attr-outputHash) attribute.
 
 - [store]{#gloss-store}
 

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -71,7 +71,7 @@
   [`__contentAddressed`](./language/advanced-attributes.md#adv-attr-__contentAddressed)
   attribute set to `true`.
 
-- [fixed-output derivation]{#gloss-fixed-output-derivation}
+- [fixed-output derivation]{#gloss-fixed-output-derivation} (FOD)
 
   A [derivation] where a cryptographic hash of the [output] is determined in advance using the [`outputHash`](./language/advanced-attributes.md#adv-attr-outputHash) attribute.
 

--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -73,7 +73,7 @@
 
 - [fixed-output derivation]{#gloss-fixed-output-derivation} (FOD)
 
-  A [derivation] where a cryptographic hash of the [output] is determined in advance using the [`outputHash`](./language/advanced-attributes.md#adv-attr-outputHash) attribute.
+  A [derivation] where a cryptographic hash of the [output] is determined in advance using the [`outputHash`](./language/advanced-attributes.md#adv-attr-outputHash) attribute, and where the [`builder`](@docroot@/language/derivations.md#attr-builder) executable has access to the network.
 
 - [store]{#gloss-store}
 

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -122,7 +122,8 @@ Derivations can declare some infrequently used optional attributes.
   - [`outputHash`]{#adv-attr-outputHash}; [`outputHashAlgo`]{#adv-attr-outputHashAlgo}; [`outputHashMode`]{#adv-attr-outputHashMode}\
     These attributes declare that the derivation is a so-called *fixed-output derivation* (FOD), which means that a cryptographic hash of the output is already known in advance.
 
-    When the [`builder`] execution of a fixed-output derivation finishes, Nix computes a cryptographic hash of the output and compares it to the hash declared with these attributes.
+    As opposed to regular derivations, the [`builder`] executable of a fixed-output derivation has access to the network.
+    Nix computes a cryptographic hash of its output and compares that to the hash declared with these attributes.
     If there is a mismatch, the derivation fails.
 
     The rationale for fixed-output derivations is derivations such as

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -120,12 +120,10 @@ Derivations can declare some infrequently used optional attributes.
     configuration setting.
 
   - [`outputHash`]{#adv-attr-outputHash}; [`outputHashAlgo`]{#adv-attr-outputHashAlgo}; [`outputHashMode`]{#adv-attr-outputHashMode}\
-    These attributes declare that the derivation is a so-called
-    *fixed-output derivation*, which means that a cryptographic hash of
-    the output is already known in advance. When the build of a
-    fixed-output derivation finishes, Nix computes the cryptographic
-    hash of the output and compares it to the hash declared with these
-    attributes. If there is a mismatch, the build fails.
+    These attributes declare that the derivation is a so-called *fixed-output derivation*, which means that a cryptographic hash of the output is already known in advance.
+
+    When the [`builder`] execution of a fixed-output derivation finishes, Nix computes a cryptographic hash of the output and compares it to the hash declared with these attributes.
+    If there is a mismatch, the derivation fails.
 
     The rationale for fixed-output derivations is derivations such as
     those produced by the `fetchurl` function. This function downloads a
@@ -279,7 +277,9 @@ Derivations can declare some infrequently used optional attributes.
 
     > **Note**
     >
-    > If set to `false`, the [`builder`](./derivations.md#attr-builder) should be able to run on the system type specified in the [`system` attribute](./derivations.md#attr-system), since the derivation cannot be substituted.
+    > If set to `false`, the [`builder`] should be able to run on the system type specified in the [`system` attribute](./derivations.md#attr-system), since the derivation cannot be substituted.
+
+    [`builder`]: ./derivations.md#attr-builder
 
   - [`__structuredAttrs`]{#adv-attr-structuredAttrs}\
     If the special attribute `__structuredAttrs` is set to `true`, the other derivation

--- a/doc/manual/src/language/advanced-attributes.md
+++ b/doc/manual/src/language/advanced-attributes.md
@@ -120,7 +120,7 @@ Derivations can declare some infrequently used optional attributes.
     configuration setting.
 
   - [`outputHash`]{#adv-attr-outputHash}; [`outputHashAlgo`]{#adv-attr-outputHashAlgo}; [`outputHashMode`]{#adv-attr-outputHashMode}\
-    These attributes declare that the derivation is a so-called *fixed-output derivation*, which means that a cryptographic hash of the output is already known in advance.
+    These attributes declare that the derivation is a so-called *fixed-output derivation* (FOD), which means that a cryptographic hash of the output is already known in advance.
 
     When the [`builder`] execution of a fixed-output derivation finishes, Nix computes a cryptographic hash of the output and compares it to the hash declared with these attributes.
     If there is a mismatch, the derivation fails.


### PR DESCRIPTION
# Motivation
The link from the [Nixpkgs manual's section on fetchers](https://nixos.org/manual/nixpkgs/unstable/#chap-pkgs-fetchers) points to the glossary, which is observably not helpful to readers.


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).