### PR TITLE
hash: Compare hash algo second for back compat

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -52,11 +52,11 @@ bool Hash::operator == (const Hash & h2) const
 
 std::strong_ordering Hash::operator <=> (const Hash & h) const
 {
-    if (auto cmp = algo <=> h.algo; cmp != 0) return cmp;
     if (auto cmp = hashSize <=> h.hashSize; cmp != 0) return cmp;
     for (unsigned int i = 0; i < hashSize; i++) {
         if (auto cmp = hash[i] <=> h.hash[i]; cmp != 0) return cmp;
     }
+    if (auto cmp = algo <=> h.algo; cmp != 0) return cmp;
     return std::strong_ordering::equivalent;
 }
 


### PR DESCRIPTION
# Motivation

 Previously (in cfc18a77395b5ef49763f77c3cc67a95f762a0eb), we forgot to compare the algo at all. This means we keep the same ordering as before by making the stuff we always have compared take priority.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
