### PR TITLE
eval-fail-infinite-recursion-lambda: Reduce recursion depth

### DIFF
--- a/tests/functional/lang/eval-fail-infinite-recursion-lambda.err.exp
+++ b/tests/functional/lang/eval-fail-infinite-recursion-lambda.err.exp
@@ -29,7 +29,7 @@ error:
              |              ^
             2|
 
-       (19997 duplicate frames omitted)
+       (197 duplicate frames omitted)
 
        error: stack overflow; max-call-depth exceeded
        at /pwd/lang/eval-fail-infinite-recursion-lambda.nix:1:14:

--- a/tests/functional/lang/eval-fail-infinite-recursion-lambda.flags
+++ b/tests/functional/lang/eval-fail-infinite-recursion-lambda.flags
@@ -1,0 +1,1 @@
+--max-call-depth 100


### PR DESCRIPTION
# Motivation

This prevents the test from failing in environments with a smaller configured stack size.

# Context

This was reported on an Amazon Linux instance, maybe they have a smaller `ulimit -s`.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
