### PR TITLE
Put some file descriptor functions in unix and windows namespaces

### DIFF
--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -1500,7 +1500,7 @@ void LocalDerivationGoal::startDaemon()
                 throw SysError("accepting connection");
             }
 
-            closeOnExec(remote.get());
+            unix::closeOnExec(remote.get());
 
             debug("received daemon connection");
 
@@ -1961,7 +1961,7 @@ void LocalDerivationGoal::runChild()
             throw SysError("changing into '%1%'", tmpDir);
 
         /* Close all other file descriptors. */
-        closeMostFDs({STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO});
+        unix::closeMostFDs({STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO});
 
 #if __linux__
         linux::setPersonality(drv->platform);

--- a/src/libutil/file-descriptor.hh
+++ b/src/libutil/file-descriptor.hh
@@ -140,6 +140,7 @@ public:
 };
 
 #ifndef _WIN32 // Not needed on Windows, where we don't fork
+namespace unix {
 
 /**
  * Close all file descriptors except those listed in the given set.
@@ -152,13 +153,16 @@ void closeMostFDs(const std::set<Descriptor> & exceptions);
  */
 void closeOnExec(Descriptor fd);
 
+} // namespace unix
 #endif
 
-#ifdef _WIN32
-# if _WIN32_WINNT >= 0x0600
+#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
+namespace windows (
+
 Path handleToPath(Descriptor handle);
 std::wstring handleToFileName(Descriptor handle);
-# endif
+
+} // namespace windows
 #endif
 
 MakeError(EndOfFile, Error);

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -546,7 +546,7 @@ std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix)
     if (!fd)
         throw SysError("creating temporary file '%s'", tmpl);
 #ifndef _WIN32
-    closeOnExec(fd.get());
+    unix::closeOnExec(fd.get());
 #endif
     return {std::move(fd), tmpl};
 }

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -24,7 +24,7 @@ AutoCloseFD createUnixDomainSocket()
     if (!fdSocket)
         throw SysError("cannot create Unix domain socket");
 #ifndef _WIN32
-    closeOnExec(fdSocket.get());
+    unix::closeOnExec(fdSocket.get());
 #endif
     return fdSocket;
 }

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -110,8 +110,8 @@ void Pipe::create()
     if (pipe2(fds, O_CLOEXEC) != 0) throw SysError("creating pipe");
 #else
     if (pipe(fds) != 0) throw SysError("creating pipe");
-    closeOnExec(fds[0]);
-    closeOnExec(fds[1]);
+    unix::closeOnExec(fds[0]);
+    unix::closeOnExec(fds[1]);
 #endif
     readSide = fds[0];
     writeSide = fds[1];
@@ -120,7 +120,7 @@ void Pipe::create()
 
 //////////////////////////////////////////////////////////////////////
 
-void closeMostFDs(const std::set<int> & exceptions)
+void unix::closeMostFDs(const std::set<int> & exceptions)
 {
 #if __linux__
     try {
@@ -146,7 +146,7 @@ void closeMostFDs(const std::set<int> & exceptions)
 }
 
 
-void closeOnExec(int fd)
+void unix::closeOnExec(int fd)
 {
     int prev;
     if ((prev = fcntl(fd, F_GETFD, 0)) == -1 ||

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -122,7 +122,7 @@ void Pipe::create()
 
 #if _WIN32_WINNT >= 0x0600
 
-std::wstring handleToFileName(HANDLE handle) {
+std::wstring windows::handleToFileName(HANDLE handle) {
     std::vector<wchar_t> buf(0x100);
     DWORD dw = GetFinalPathNameByHandleW(handle, buf.data(), buf.size(), FILE_NAME_OPENED);
     if (dw == 0) {
@@ -141,7 +141,7 @@ std::wstring handleToFileName(HANDLE handle) {
 }
 
 
-Path handleToPath(HANDLE handle) {
+Path windows::handleToPath(HANDLE handle) {
     return os_string_to_string(handleToFileName(handle));
 }
 

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -295,7 +295,7 @@ static void daemonLoop(std::optional<TrustedFlag> forceTrustClientOpt)
         if (getEnv("LISTEN_PID") != std::to_string(getpid()) || listenFds != "1")
             throw Error("unexpected systemd environment variables");
         fdSocket = SD_LISTEN_FDS_START;
-        closeOnExec(fdSocket.get());
+        unix::closeOnExec(fdSocket.get());
     }
 
     //  Otherwise, create and bind to a Unix domain socket.
@@ -323,7 +323,7 @@ static void daemonLoop(std::optional<TrustedFlag> forceTrustClientOpt)
                 throw SysError("accepting connection");
             }
 
-            closeOnExec(remote.get());
+            unix::closeOnExec(remote.get());
 
             PeerInfo peer { .pidKnown = false };
             TrustedFlag trusted;


### PR DESCRIPTION
# Motivation

It is misleading when platform-specific functions are in the overall `nix` namespace. More namespaces also makes for nicer doxygen.


# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
