### PR TITLE
C API: `nix_clear_err`

### DIFF
--- a/src/libutil-c/nix_api_util.cc
+++ b/src/libutil-c/nix_api_util.cc
@@ -112,7 +112,7 @@ const char * nix_err_msg(nix_c_context * context, const nix_c_context * read_con
 {
     if (context)
         context->last_err_code = NIX_OK;
-    if (read_context->last_err) {
+    if (read_context->last_err && read_context->last_err_code != NIX_OK) {
         if (n)
             *n = read_context->last_err->size();
         return read_context->last_err->c_str();

--- a/src/libutil-c/nix_api_util.cc
+++ b/src/libutil-c/nix_api_util.cc
@@ -57,6 +57,12 @@ nix_err nix_set_err_msg(nix_c_context * context, nix_err err, const char * msg)
     return err;
 }
 
+void nix_clear_err(nix_c_context * context)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+}
+
 const char * nix_version_get()
 {
     return PACKAGE_VERSION;

--- a/src/libutil-c/nix_api_util_internal.h
+++ b/src/libutil-c/nix_api_util_internal.h
@@ -10,6 +10,7 @@
 struct nix_c_context
 {
     nix_err last_err_code = NIX_OK;
+    /** The last error message. Always check last_err_code. This may not have been cleared, so that clearing is fast. */
     std::optional<std::string> last_err = {};
     std::optional<nix::ErrorInfo> info = {};
     std::string name = "";

--- a/tests/unit/libutil/nix_api_util.cc
+++ b/tests/unit/libutil/nix_api_util.cc
@@ -31,6 +31,9 @@ TEST_F(nix_api_util_context, nix_context_error)
     }
     ASSERT_EQ(ctx->last_err_code, NIX_ERR_UNKNOWN);
     ASSERT_EQ(*ctx->last_err, err_msg_ref);
+
+    nix_clear_err(ctx);
+    ASSERT_EQ(ctx->last_err_code, NIX_OK);
 }
 
 TEST_F(nix_api_util_context, nix_set_err_msg)


### PR DESCRIPTION
# Motivation

- By providing a `nix_context` error resetting function, the context can be reused more safely.
- Make `nix_err_msg` more robust

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
