### PR TITLE
No global eval settings in `libnixexpr`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,20 +4,20 @@
 # Top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file, utf-8 charset
+# Unix-style newlines with a newline ending every file, UTF-8 charset
 [*]
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
-# Match nix files, set indent to spaces with width of two
+# Match Nix files, set indent to spaces with width of two
 [*.nix]
 indent_style = space
 indent_size = 2
 
-# Match c++/shell/perl, set indent to spaces with width of four
-[*.{hpp,cc,hh,sh,pl,xs}]
+# Match C++/C/shell/Perl, set indent to spaces with width of four
+[*.{hpp,cc,hh,c,h,sh,pl,xs}]
 indent_style = space
 indent_size = 4
 

--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -126,13 +126,11 @@ ref<EvalState> EvalCommand::getEvalState()
 {
     if (!evalState) {
         evalState =
+            std::allocate_shared<EvalState>(
             #if HAVE_BOEHMGC
-            std::allocate_shared<EvalState>(traceable_allocator<EvalState>(),
-                lookupPath, getEvalStore(), getStore())
-            #else
-            std::make_shared<EvalState>(
-                lookupPath, getEvalStore(), getStore())
+                traceable_allocator<EvalState>(),
             #endif
+                lookupPath, getEvalStore(), evalSettings, getStore())
             ;
 
         evalState->repair = repair;

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -1,6 +1,7 @@
 #include "eval-settings.hh"
 #include "common-eval-args.hh"
 #include "shared.hh"
+#include "config-global.hh"
 #include "filetransfer.hh"
 #include "eval.hh"
 #include "fetchers.hh"
@@ -12,6 +13,12 @@
 #include "fetch-to-store.hh"
 
 namespace nix {
+
+EvalSettings evalSettings {
+    settings.readOnlyMode
+};
+
+static GlobalConfig::Register rEvalSettings(&evalSettings);
 
 MixEvalArgs::MixEvalArgs()
 {

--- a/src/libcmd/common-eval-args.hh
+++ b/src/libcmd/common-eval-args.hh
@@ -12,8 +12,14 @@ namespace nix {
 
 class Store;
 class EvalState;
+struct EvalSettings;
 class Bindings;
 struct SourcePath;
+
+/**
+ * @todo Get rid of global setttings variables
+ */
+extern EvalSettings evalSettings;
 
 struct MixEvalArgs : virtual Args, virtual MixRepair
 {

--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -7,6 +7,7 @@
 #include "eval.hh"
 #include "globals.hh"
 #include "util.hh"
+#include "eval-settings.hh"
 
 #include "nix_api_expr.h"
 #include "nix_api_expr_internal.h"
@@ -106,7 +107,21 @@ EvalState * nix_state_create(nix_c_context * context, const char ** lookupPath_c
             for (size_t i = 0; lookupPath_c[i] != nullptr; i++)
                 lookupPath.push_back(lookupPath_c[i]);
 
-        return new EvalState{nix::EvalState(nix::LookupPath::parse(lookupPath), store->ptr)};
+        void * p = ::operator new(
+            sizeof(EvalState),
+            static_cast<std::align_val_t>(alignof(EvalState)));
+        auto * p2 = static_cast<EvalState *>(p);
+        new (p) EvalState {
+            .settings = nix::EvalSettings{
+                nix::settings.readOnlyMode,
+            },
+            .state = nix::EvalState(
+                nix::LookupPath::parse(lookupPath),
+                store->ptr,
+                p2->settings),
+        };
+        loadConfFile(p2->settings);
+        return p2;
     }
     NIXC_CATCH_ERRS_NULL
 }

--- a/src/libexpr-c/nix_api_expr_internal.h
+++ b/src/libexpr-c/nix_api_expr_internal.h
@@ -2,11 +2,13 @@
 #define NIX_API_EXPR_INTERNAL_H
 
 #include "eval.hh"
+#include "eval-settings.hh"
 #include "attr-set.hh"
 #include "nix_api_value.h"
 
 struct EvalState
 {
+    nix::EvalSettings settings;
     nix::EvalState state;
 };
 

--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -45,7 +45,8 @@ static Strings parseNixPath(const std::string & s)
     return res;
 }
 
-EvalSettings::EvalSettings()
+EvalSettings::EvalSettings(bool & readOnlyMode)
+    : readOnlyMode{readOnlyMode}
 {
     auto var = getEnv("NIX_PATH");
     if (var) nixPath = parseNixPath(*var);
@@ -55,7 +56,7 @@ EvalSettings::EvalSettings()
         builtinsAbortOnWarn = true;
 }
 
-Strings EvalSettings::getDefaultNixPath()
+Strings EvalSettings::getDefaultNixPath() const
 {
     Strings res;
     auto add = [&](const Path & p, const std::string & s = std::string()) {
@@ -68,7 +69,7 @@ Strings EvalSettings::getDefaultNixPath()
         }
     };
 
-    if (!evalSettings.restrictEval && !evalSettings.pureEval) {
+    if (!restrictEval && !pureEval) {
         add(getNixDefExpr() + "/channels");
         add(rootChannelsDir() + "/nixpkgs", "nixpkgs");
         add(rootChannelsDir());
@@ -94,15 +95,11 @@ std::string EvalSettings::resolvePseudoUrl(std::string_view url)
         return std::string(url);
 }
 
-const std::string & EvalSettings::getCurrentSystem()
+const std::string & EvalSettings::getCurrentSystem() const
 {
     const auto & evalSystem = currentSystem.get();
     return evalSystem != "" ? evalSystem : settings.thisSystem.get();
 }
-
-EvalSettings evalSettings;
-
-static GlobalConfig::Register rEvalSettings(&evalSettings);
 
 Path getNixDefExpr()
 {

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -7,9 +7,11 @@ namespace nix {
 
 struct EvalSettings : Config
 {
-    EvalSettings();
+    EvalSettings(bool & readOnlyMode);
 
-    static Strings getDefaultNixPath();
+    bool & readOnlyMode;
+
+    Strings getDefaultNixPath() const;
 
     static bool isPseudoUrl(std::string_view s);
 
@@ -74,7 +76,7 @@ struct EvalSettings : Config
      * Implements the `eval-system` vs `system` defaulting logic
      * described for `eval-system`.
      */
-    const std::string & getCurrentSystem();
+    const std::string & getCurrentSystem() const;
 
     Setting<bool> restrictEval{
         this, false, "restrict-eval",
@@ -192,8 +194,6 @@ struct EvalSettings : Config
           This option can be enabled by setting `NIX_ABORT_ON_WARN=1` in the environment.
         )"};
 };
-
-extern EvalSettings evalSettings;
 
 /**
  * Conventionally part of the default nix path in impure mode.

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -30,6 +30,7 @@ namespace nix {
 constexpr size_t maxPrimOpArity = 8;
 
 class Store;
+struct EvalSettings;
 class EvalState;
 class StorePath;
 struct SingleDerivedPath;
@@ -38,7 +39,6 @@ struct MemorySourceAccessor;
 namespace eval_cache {
     class EvalCache;
 }
-
 
 /**
  * Function that implements a primop.
@@ -162,6 +162,7 @@ struct DebugTrace {
 class EvalState : public std::enable_shared_from_this<EvalState>
 {
 public:
+    const EvalSettings & settings;
     SymbolTable symbols;
     PosTable positions;
 
@@ -352,6 +353,7 @@ public:
     EvalState(
         const LookupPath & _lookupPath,
         ref<Store> store,
+        const EvalSettings & settings,
         std::shared_ptr<Store> buildStore = nullptr);
     ~EvalState();
 

--- a/src/libexpr/flake/config.cc
+++ b/src/libexpr/flake/config.cc
@@ -1,6 +1,5 @@
 #include "users.hh"
 #include "config-global.hh"
-#include "globals.hh"
 #include "fetch-settings.hh"
 #include "flake.hh"
 

--- a/src/libexpr/flake/flake.cc
+++ b/src/libexpr/flake/flake.cc
@@ -803,7 +803,7 @@ static void prim_getFlake(EvalState & state, const PosIdx pos, Value * * args, V
 {
     std::string flakeRefS(state.forceStringNoCtx(*args[0], pos, "while evaluating the argument passed to builtins.getFlake"));
     auto flakeRef = parseFlakeRef(flakeRefS, {}, true);
-    if (evalSettings.pureEval && !flakeRef.input.isLocked())
+    if (state.settings.pureEval && !flakeRef.input.isLocked())
         throw Error("cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)", flakeRefS, state.positions[pos]);
 
     callFlake(state,
@@ -811,8 +811,8 @@ static void prim_getFlake(EvalState & state, const PosIdx pos, Value * * args, V
             LockFlags {
                 .updateLockFile = false,
                 .writeLockFile = false,
-                .useRegistries = !evalSettings.pureEval && fetchSettings.useRegistries,
-                .allowUnlocked = !evalSettings.pureEval,
+                .useRegistries = !state.settings.pureEval && fetchSettings.useRegistries,
+                .allowUnlocked = !state.settings.pureEval,
             }),
         v);
 }

--- a/src/libexpr/parser-state.hh
+++ b/src/libexpr/parser-state.hh
@@ -46,6 +46,7 @@ struct ParserState
     PosTable::Origin origin;
     const ref<SourceAccessor> rootFS;
     const Expr::AstSymbols & s;
+    const EvalSettings & settings;
 
     void dupAttr(const AttrPath & attrPath, const PosIdx pos, const PosIdx prevPos);
     void dupAttr(Symbol attr, const PosIdx pos, const PosIdx prevPos);

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -25,7 +25,6 @@
 #include "nixexpr.hh"
 #include "eval.hh"
 #include "eval-settings.hh"
-#include "globals.hh"
 #include "parser-state.hh"
 
 #define YYLTYPE ::nix::ParserLocation
@@ -40,6 +39,7 @@ Expr * parseExprFromBuf(
     Pos::Origin origin,
     const SourcePath & basePath,
     SymbolTable & symbols,
+    const EvalSettings & settings,
     PosTable & positions,
     const ref<SourceAccessor> rootFS,
     const Expr::AstSymbols & astSymbols);
@@ -294,7 +294,7 @@ path_start
     $$ = new ExprPath(ref<SourceAccessor>(state->rootFS), std::move(path));
   }
   | HPATH {
-    if (evalSettings.pureEval) {
+    if (state->settings.pureEval) {
         throw Error(
             "the path '%s' can not be resolved in pure mode",
             std::string_view($1.p, $1.l)
@@ -429,6 +429,7 @@ Expr * parseExprFromBuf(
     Pos::Origin origin,
     const SourcePath & basePath,
     SymbolTable & symbols,
+    const EvalSettings & settings,
     PosTable & positions,
     const ref<SourceAccessor> rootFS,
     const Expr::AstSymbols & astSymbols)
@@ -441,6 +442,7 @@ Expr * parseExprFromBuf(
         .origin = positions.addOrigin(origin, length),
         .rootFS = rootFS,
         .s = astSymbols,
+        .settings = settings,
     };
 
     yylex_init(&scanner);

--- a/src/libexpr/primops/fetchMercurial.cc
+++ b/src/libexpr/primops/fetchMercurial.cc
@@ -53,7 +53,7 @@ static void prim_fetchMercurial(EvalState & state, const PosIdx pos, Value * * a
     // whitelist. Ah well.
     state.checkURI(url);
 
-    if (evalSettings.pureEval && !rev)
+    if (state.settings.pureEval && !rev)
         throw Error("in pure evaluation mode, 'fetchMercurial' requires a Mercurial revision");
 
     fetchers::Attrs attrs;

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -171,10 +171,10 @@ static void fetchTree(
         }
     }
 
-    if (!evalSettings.pureEval && !input.isDirect() && experimentalFeatureSettings.isEnabled(Xp::Flakes))
+    if (!state.settings.pureEval && !input.isDirect() && experimentalFeatureSettings.isEnabled(Xp::Flakes))
         input = lookupInRegistries(state.store, input).first;
 
-    if (evalSettings.pureEval && !input.isLocked()) {
+    if (state.settings.pureEval && !input.isLocked()) {
         auto fetcher = "fetchTree";
         if (params.isFetchGit)
             fetcher = "fetchGit";
@@ -453,14 +453,14 @@ static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v
         url = state.forceStringNoCtx(*args[0], pos, "while evaluating the url we should fetch");
 
     if (who == "fetchTarball")
-        url = evalSettings.resolvePseudoUrl(*url);
+        url = state.settings.resolvePseudoUrl(*url);
 
     state.checkURI(*url);
 
     if (name == "")
         name = baseNameOf(*url);
 
-    if (evalSettings.pureEval && !expectedHash)
+    if (state.settings.pureEval && !expectedHash)
         state.error<EvalError>("in pure evaluation mode, '%s' requires a 'sha256' argument", who).atPos(pos).debugThrow();
 
     // early exit if pinned and already in the store

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -259,7 +259,7 @@ static void main_nix_build(int argc, char * * argv)
     auto store = openStore();
     auto evalStore = myArgs.evalStoreUrl ? openStore(*myArgs.evalStoreUrl) : store;
 
-    auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, store);
+    auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, evalSettings, store);
     state->repair = myArgs.repair;
     if (myArgs.repair) buildMode = bmRepair;
 

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1525,7 +1525,7 @@ static int main_nix_env(int argc, char * * argv)
 
         auto store = openStore();
 
-        globals.state = std::shared_ptr<EvalState>(new EvalState(myArgs.lookupPath, store));
+        globals.state = std::shared_ptr<EvalState>(new EvalState(myArgs.lookupPath, store, evalSettings));
         globals.state->repair = myArgs.repair;
 
         globals.instSource.nixExprPath = std::make_shared<SourcePath>(

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -157,7 +157,7 @@ static int main_nix_instantiate(int argc, char * * argv)
         auto store = openStore();
         auto evalStore = myArgs.evalStoreUrl ? openStore(*myArgs.evalStoreUrl) : store;
 
-        auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, store);
+        auto state = std::make_unique<EvalState>(myArgs.lookupPath, evalStore, evalSettings, store);
         state->repair = myArgs.repair;
 
         Bindings & autoArgs = *myArgs.getAutoArgs(*state);

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -242,7 +242,7 @@ static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
 
     evalSettings.restrictEval = false;
     evalSettings.pureEval = false;
-    EvalState state({}, openStore("dummy://"));
+    EvalState state({}, openStore("dummy://"), evalSettings);
 
     auto vGenerateManpage = state.allocValue();
     state.eval(state.parseExprFromString(
@@ -418,7 +418,7 @@ void mainWrapped(int argc, char * * argv)
             Xp::FetchTree,
         };
         evalSettings.pureEval = false;
-        EvalState state({}, openStore("dummy://"));
+        EvalState state({}, openStore("dummy://"), evalSettings);
         auto res = nlohmann::json::object();
         res["builtins"] = ({
             auto builtinsJson = nlohmann::json::object();

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -193,7 +193,7 @@ static int main_nix_prefetch_url(int argc, char * * argv)
           startProgressBar();
 
         auto store = openStore();
-        auto state = std::make_unique<EvalState>(myArgs.lookupPath, store);
+        auto state = std::make_unique<EvalState>(myArgs.lookupPath, store, evalSettings);
 
         Bindings & autoArgs = *myArgs.getAutoArgs(*state);
 

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -147,7 +147,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         auto req = FileTransferRequest((std::string&) settings.upgradeNixStorePathUrl);
         auto res = getFileTransfer()->download(req);
 
-        auto state = std::make_unique<EvalState>(LookupPath{}, store);
+        auto state = std::make_unique<EvalState>(LookupPath{}, store, evalSettings);
         auto v = state->allocValue();
         state->eval(state->parseExprFromString(res.data, state->rootPath(CanonPath("/no-such-path"))), *v);
         Bindings & bindings(*state->allocBindings(0));

--- a/tests/unit/libexpr-support/tests/libexpr.hh
+++ b/tests/unit/libexpr-support/tests/libexpr.hh
@@ -19,14 +19,14 @@ namespace nix {
             static void SetUpTestSuite() {
                 LibStoreTest::SetUpTestSuite();
                 initGC();
-                evalSettings.nixPath = {};
             }
 
         protected:
             LibExprTest()
                 : LibStoreTest()
-                , state({}, store)
+                , state({}, store, evalSettings, nullptr)
             {
+                evalSettings.nixPath = {};
             }
             Value eval(std::string input, bool forceValue = true) {
                 Value v;
@@ -42,6 +42,8 @@ namespace nix {
                 return state.symbols.create(value);
             }
 
+            bool readOnlyMode = true;
+            EvalSettings evalSettings{readOnlyMode};
             EvalState state;
     };
 


### PR DESCRIPTION
# Motivation

Progress on #5638

# Context

There is still a global eval settings, but it pushed down into `libnixcmd`, which is a lot less bad a place for this sort of thing.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
