### PR TITLE
Restrict supported tarball formats to actual Tarballs

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -79,7 +79,8 @@ TarArchive::TarArchive(Source & source, bool raw, std::optional<std::string> com
     }
 
     if (!raw) {
-        archive_read_support_format_all(archive);
+        archive_read_support_format_tar(archive);
+        archive_read_support_format_zip(archive);
     } else {
         archive_read_support_format_raw(archive);
         archive_read_support_format_empty(archive);
@@ -96,7 +97,8 @@ TarArchive::TarArchive(const Path & path)
     , buffer(defaultBufferSize)
 {
     archive_read_support_filter_all(archive);
-    archive_read_support_format_all(archive);
+    archive_read_support_format_tar(archive);
+    archive_read_support_format_zip(archive);
     archive_read_set_option(archive, NULL, "mac-ext", NULL);
     check(archive_read_open_filename(archive, path.c_str(), 16384), "failed to open archive: %s");
 }


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

The documentation is clear about the supported formats (with at least `builtins.fetchTarball`). The way the code was written previously it supported all the formats that libarchive supported. That is a surprisingly large amount of formats that are likely not on the radar of the Nix developers and users. Before people end up relying on this (or if they do) it is better to break it now before it becomes a widespread "feature".

Zip file support has been retained as (at least to my knowledge)
historically that has been used to fetch nixpkgs in some shell
expressions *many* years back.

Fixes https://github.com/NixOS/nix/issues/10917

# Context
See https://github.com/NixOS/nix/issues/10917

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
