### PR TITLE
`testresults` output

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -208,7 +208,9 @@ in {
     # If we are doing just build or just docs, the one thing will use
     # "out". We only need additional outputs if we are doing both.
     ++ lib.optional (doBuild && (enableManual || enableInternalAPIDocs || enableExternalAPIDocs)) "doc"
-    ++ lib.optional installUnitTests "check";
+    ++ lib.optional installUnitTests "check"
+    ++ lib.optional doCheck "testresults"
+    ;
 
   nativeBuildInputs = [
     autoconf-archive
@@ -316,6 +318,10 @@ in {
   enableParallelBuilding = true;
 
   makeFlags = "profiledir=$(out)/etc/profile.d PRECOMPILE_HEADERS=1";
+
+  preCheck = ''
+    mkdir $testresults
+  '';
 
   installTargets = lib.optional doBuild "install"
     ++ lib.optional enableInternalAPIDocs "internal-api-html"

--- a/tests/unit/libexpr/local.mk
+++ b/tests/unit/libexpr/local.mk
@@ -4,7 +4,7 @@ programs += libexpr-tests
 
 libexpr-tests_NAME := libnixexpr-tests
 
-libexpr-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data
+libexpr-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data GTEST_OUTPUT=xml:$$testresults/libexpr-tests.xml
 
 libexpr-tests_DIR := $(d)
 

--- a/tests/unit/libfetchers/local.mk
+++ b/tests/unit/libfetchers/local.mk
@@ -4,7 +4,7 @@ programs += libfetchers-tests
 
 libfetchers-tests_NAME = libnixfetchers-tests
 
-libfetchers-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data
+libfetchers-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data GTEST_OUTPUT=xml:$$testresults/libfetchers-tests.xml
 
 libfetchers-tests_DIR := $(d)
 

--- a/tests/unit/libstore/local.mk
+++ b/tests/unit/libstore/local.mk
@@ -4,7 +4,7 @@ programs += libstore-tests
 
 libstore-tests_NAME = libnixstore-tests
 
-libstore-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data
+libstore-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data GTEST_OUTPUT=xml:$$testresults/libstore-tests.xml
 
 libstore-tests_DIR := $(d)
 

--- a/tests/unit/libutil/local.mk
+++ b/tests/unit/libutil/local.mk
@@ -4,7 +4,7 @@ programs += libutil-tests
 
 libutil-tests_NAME = libnixutil-tests
 
-libutil-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data
+libutil-tests_ENV := _NIX_TEST_UNIT_DATA=$(d)/data GTEST_OUTPUT=xml:$$testresults/libutil-tests.xml
 
 libutil-tests_DIR := $(d)
 


### PR DESCRIPTION
# Motivation

A step towards better test reporting, to keep a good grasp on what runs where; see
 - https://github.com/NixOS/nix/issues/10569
 
The generated data can be viewed as HTML with e.g. `xunit-viewer` (https://github.com/NixOS/nixpkgs/pull/319020), which is moderately helpful, and only a step towards aforementioned end goal.
 
 
# Context

Draft because actually doing this during the meson port is bad timing. This isn't urgent and can be finished when meson is done.


<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
