### PR TITLE
Fix a compile error on windows

### DIFF
--- a/src/libutil/file-descriptor.hh
+++ b/src/libutil/file-descriptor.hh
@@ -157,7 +157,7 @@ void closeOnExec(Descriptor fd);
 #endif
 
 #if defined(_WIN32) && _WIN32_WINNT >= 0x0600
-namespace windows (
+namespace windows {
 
 Path handleToPath(Descriptor handle);
 std::wstring handleToFileName(Descriptor handle);


### PR DESCRIPTION
# Context
There's a compile error on windows in the most current commit due to typing a parenthesis rather than a curly bracket.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
