### PR TITLE
Avoid building too many jobs at once

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -270,8 +270,11 @@
           (lib.genAttrs stdenvs (_: { })))
         {
           "nix" = { };
-          "nix-util" = { };
-          "nix-store" = { };
+          # Temporarily disabled because GitHub Actions OOM issues. Once
+          # the old build system is gone and we are back to one build
+          # system, we should reenable these.
+          #"nix-util" = { };
+          #"nix-store" = { };
         }
         // lib.optionalAttrs (builtins.elem system linux64BitSystems) {
         dockerImage =

--- a/maintainers/hydra.nix
+++ b/maintainers/hydra.nix
@@ -42,7 +42,7 @@ in
 {
   # Binary package for various platforms.
   build = forAllPackages (pkgName:
-    forAllSystems (system: self.packages.${system}.${pkgName}));
+    forAllSystems (system: nixpkgsFor.${system}.native.${pkgName}));
 
   shellInputs = forAllSystems (system: self.devShells.${system}.default.inputDerivation);
 

--- a/maintainers/hydra.nix
+++ b/maintainers/hydra.nix
@@ -41,7 +41,8 @@ let
 in
 {
   # Binary package for various platforms.
-  build = forAllSystems (system: self.packages.${system}.nix);
+  build = forAllPackages (pkgName:
+    forAllSystems (system: self.packages.${system}.${pkgName}));
 
   shellInputs = forAllSystems (system: self.devShells.${system}.default.inputDerivation);
 


### PR DESCRIPTION
# Motivation

This will avoid some out-of-memory issues in GitHub actions that result
from num jobs > 1 and num cores = 4. Once we only have the Meson build
system, this problem should go away, and we can reenable these jobs.

# Context

(First commit is a separate fix and should be kept, is not temporary.) 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
