### PR TITLE
Test the `run` and `shell` envs for stray variables

### DIFF
--- a/tests/functional/flakes/run.sh
+++ b/tests/functional/flakes/run.sh
@@ -27,5 +27,26 @@ nix run --no-write-lock-file .#pkgAsPkg
 ! nix run --no-write-lock-file .#pkgAsApp || fail "'nix run' shouldn’t accept an 'app' defined under 'packages'"
 ! nix run --no-write-lock-file .#appAsPkg || fail "elements of 'apps' should be of type 'app'"
 
+# Test that we're not setting any more environment variables than necessary.
+# For instance, we might set an environment variable temporarily to affect some
+# initialization or whatnot, but this must not leak into the environment of the
+# command being run.
+env > $TEST_ROOT/expected-env
+nix run -f shell-hello.nix env > $TEST_ROOT/actual-env
+# Remove/reset variables we expect to be different.
+# - PATH is modified by nix shell
+# - _ is set by bash and is expected to differ because it contains the original command
+# - __CF_USER_TEXT_ENCODING is set by macOS and is beyond our control
+sed -i \
+  -e 's/PATH=.*/PATH=.../' \
+  -e 's/_=.*/_=.../' \
+  -e '/^__CF_USER_TEXT_ENCODING=.*$/d' \
+  $TEST_ROOT/expected-env $TEST_ROOT/actual-env
+sort $TEST_ROOT/expected-env | uniq > $TEST_ROOT/expected-env.sorted
+# nix run appears to clear _. I don't understand why. Is this ok?
+echo "_=..." >> $TEST_ROOT/actual-env
+sort $TEST_ROOT/actual-env | uniq > $TEST_ROOT/actual-env.sorted
+diff $TEST_ROOT/expected-env.sorted $TEST_ROOT/actual-env.sorted
+
 clearStore
 

--- a/tests/functional/shell-hello.nix
+++ b/tests/functional/shell-hello.nix
@@ -55,4 +55,26 @@ rec {
         chmod +x $out/bin/hello
       '';
   };
+
+  # execs env from PATH, so that we can probe the environment
+  # does not allow arguments, because we don't need them
+  env = mkDerivation {
+    name = "env";
+    outputs = [ "out" ];
+    buildCommand =
+      ''
+        mkdir -p $out/bin
+
+        cat > $out/bin/env <<EOF
+        #! ${shell}
+        if [ $# -ne 0 ]; then
+          echo "env: Unexpected arguments ($#): $@" 1>&2
+          exit 1
+        fi
+        exec env
+        EOF
+        chmod +x $out/bin/env
+      '';
+  };
+
 }

--- a/tests/functional/shell.sh
+++ b/tests/functional/shell.sh
@@ -21,6 +21,25 @@ nix shell -f shell-hello.nix hello-symlink -c hello | grep 'Hello World'
 # Test that symlinks outside of the store don't work.
 expect 1 nix shell -f shell-hello.nix forbidden-symlink -c hello 2>&1 | grepQuiet "is not in the Nix store"
 
+# Test that we're not setting any more environment variables than necessary.
+# For instance, we might set an environment variable temporarily to affect some
+# initialization or whatnot, but this must not leak into the environment of the
+# command being run.
+env > $TEST_ROOT/expected-env
+nix shell -f shell-hello.nix hello -c env > $TEST_ROOT/actual-env
+# Remove/reset variables we expect to be different.
+# - PATH is modified by nix shell
+# - _ is set by bash and is expectedf to differ because it contains the original command
+# - __CF_USER_TEXT_ENCODING is set by macOS and is beyond our control
+sed -i \
+  -e 's/PATH=.*/PATH=.../' \
+  -e 's/_=.*/_=.../' \
+  -e '/^__CF_USER_TEXT_ENCODING=.*$/d' \
+  $TEST_ROOT/expected-env $TEST_ROOT/actual-env
+sort $TEST_ROOT/expected-env > $TEST_ROOT/expected-env.sorted
+sort $TEST_ROOT/actual-env > $TEST_ROOT/actual-env.sorted
+diff $TEST_ROOT/expected-env.sorted $TEST_ROOT/actual-env.sorted
+
 if isDaemonNewer "2.20.0pre20231220"; then
     # Test that command line attribute ordering is reflected in the PATH
     # https://github.com/NixOS/nix/issues/7905


### PR DESCRIPTION
# Motivation

Test an important property of the `nix run` and `nix shell` commands.

# Context

Originally written for #10879, which needed to set a variable temporarily.
The need to check this may arise from a different change in the future.


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
