### PR TITLE
optimize-store.cc: Update macos exclusion comments

### DIFF
--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -98,9 +98,10 @@ void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
 
 #if __APPLE__
     /* HFS/macOS has some undocumented security feature disabling hardlinking for
-       special files within .app dirs. *.app/Contents/PkgInfo and
-       *.app/Contents/Resources/\*.lproj seem to be the only paths affected. See
-       https://github.com/NixOS/nix/issues/1443 for more discussion. */
+       special files within .app dirs. Known affected paths include
+       *.app/Contents/{PkgInfo,Resources/\*.lproj,_CodeSignature} and .DS_Store.
+       See https://github.com/NixOS/nix/issues/1443 and 
+       https://github.com/NixOS/nix/pull/2230 for more discussion. */
 
     if (std::regex_search(path, std::regex("\\.app/Contents/.+$")))
     {


### PR DESCRIPTION
# Motivation
#2230 broadened the scope of macOS hardlink exclusion but did not change the comments. This was a little confusing for me, so I figured the comments should be updated.

# Context
Explained in "motivation". This is a trivial change that only changes comments.

(I meannn, I would love to see the scope broadened somewhat again. Like `GIMP.app/Contents/share` is very unlikely to be watched by macOS. But that's for another day, when/if I get a beefier mac.)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
