### PR TITLE
Replace call to `stat`, `lstat`, and `maybeLstat` with appropriate functions from `std::filesystem`

### DIFF
--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -4,6 +4,7 @@
 #include "url-parts.hh"
 #include "fetchers.hh"
 #include "registry.hh"
+#include <filesystem>
 
 namespace nix {
 
@@ -101,8 +102,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
         path = absPath(path, baseDir);
 
         if (isFlake) {
-
-            if (!S_ISDIR(lstat(path).st_mode)) {
+            if (!std::filesystem::is_directory(std::filesystem::symlink_status(path))) {
                 if (baseNameOf(path) == "flake.nix") {
                     // Be gentle with people who accidentally write `/foo/bar/flake.nix` instead of `/foo/bar`
                     warn(
@@ -119,6 +119,8 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
                 notice("path '%s' does not contain a 'flake.nix', searching up",path);
 
                 // Save device to detect filesystem boundary
+                // TODO: this needs platform specific implementations
+                // TODO: Can I depend on the root path (C:/ or D:/)?
                 dev_t device = lstat(path).st_dev;
                 bool found = false;
                 while (path != "/") {

--- a/src/libexpr/flake/flakeref.cc
+++ b/src/libexpr/flake/flakeref.cc
@@ -119,9 +119,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
                 notice("path '%s' does not contain a 'flake.nix', searching up",path);
 
                 // Save device to detect filesystem boundary
-                // TODO: this needs platform specific implementations
-                // TODO: Can I depend on the root path (C:/ or D:/)?
-                dev_t device = lstat(path).st_dev;
+                dev_t device = unix::lstat(path).st_dev;
                 bool found = false;
                 while (path != "/") {
                     if (pathExists(path + "/flake.nix")) {
@@ -130,7 +128,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
                     } else if (pathExists(path + "/.git"))
                         throw Error("path '%s' is not part of a flake (neither it nor its parent directories contain a 'flake.nix' file)", path);
                     else {
-                        if (lstat(path).st_dev != device)
+                        if (unix::lstat(path).st_dev != device)
                             throw Error("unable to find a flake before encountering filesystem boundary at '%s'", path);
                     }
                     path = dirOf(path);

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -9,6 +9,7 @@
 #include "store-path-accessor.hh"
 #include "fetch-settings.hh"
 
+#include <filesystem>
 #include <sys/time.h>
 
 using namespace std::string_literals;
@@ -199,9 +200,9 @@ struct MercurialInputScheme : InputScheme
                     assert(hasPrefix(p, actualPath));
                     std::string file(p, actualPath.size() + 1);
 
-                    auto st = lstat(p);
+                    auto st = std::filesystem::symlink_status(p);
 
-                    if (S_ISDIR(st.st_mode)) {
+                    if (std::filesystem::is_directory(st)) {
                         auto prefix = file + "/";
                         auto i = files.lower_bound(prefix);
                         return i != files.end() && hasPrefix(*i, prefix);

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -852,7 +852,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
             if (name == "." || name == "..") continue;
             Path path = linksDir + "/" + name;
 
-            auto st = lstat(path);
+            auto st = unix::lstat(path);
 
             if (st.st_nlink != 1) {
                 actualSize += st.st_size;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -251,10 +251,8 @@ LocalStore::LocalStore(const Params & params)
     /* Ensure that the store and its parents are not symlinks. */
     if (!settings.allowSymlinkedStore) {
         Path path = realStoreDir;
-        struct stat st;
         while (path != "/") {
-            st = lstat(path);
-            if (S_ISLNK(st.st_mode))
+            if (std::filesystem::is_symlink(path))
                 throw Error(
                         "the path '%1%' is a symlink; "
                         "this is not allowed for the Nix store and its parent directories",

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -53,7 +53,7 @@ static void canonicaliseTimestampAndPermissions(const Path & path, const struct 
 
 void canonicaliseTimestampAndPermissions(const Path & path)
 {
-    canonicaliseTimestampAndPermissions(path, lstat(path));
+    canonicaliseTimestampAndPermissions(path, unix::lstat(path));
 }
 
 
@@ -76,7 +76,7 @@ static void canonicalisePathMetaData_(
     }
 #endif
 
-    auto st = lstat(path);
+    auto st = unix::lstat(path);
 
     /* Really make sure that the path is of a supported type. */
     if (!(S_ISREG(st.st_mode) || S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)))
@@ -174,7 +174,7 @@ void canonicalisePathMetaData(
 #ifndef _WIN32
     /* On platforms that don't have lchown(), the top-level path can't
        be a symlink, since we can't change its ownership. */
-    auto st = lstat(path);
+    auto st = unix::lstat(path);
 
     if (st.st_uid != geteuid()) {
         assert(S_ISLNK(st.st_mode));

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -45,7 +45,7 @@ std::pair<Generations, std::optional<GenerationNumber>> findGenerations(Path pro
             gens.push_back({
                 .number = *n,
                 .path = path,
-                .creationTime = lstat(path).st_mtime
+                .creationTime = unix::lstat(path).st_mtime
             });
         }
     }

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -1,4 +1,5 @@
 #include "local-derivation-goal.hh"
+#include "file-system.hh"
 #include "indirect-root-store.hh"
 #include "hook-instance.hh"
 #include "worker.hh"
@@ -20,6 +21,7 @@
 #include "posix-fs-canonicalise.hh"
 #include "posix-source-accessor.hh"
 
+#include <filesystem>
 #include <regex>
 #include <queue>
 
@@ -278,7 +280,7 @@ static void chmod_(const Path & path, mode_t mode)
    directory's parent link ".."). */
 static void movePath(const Path & src, const Path & dst)
 {
-    auto st = lstat(src);
+    auto st = unix::lstat(src);
 
     bool changePerm = (geteuid() && S_ISDIR(st.st_mode) && !(st.st_mode & S_IWUSR));
 
@@ -406,7 +408,7 @@ static void doBind(const Path & source, const Path & target, bool optional = fal
             throw SysError("bind mount from '%1%' to '%2%' failed", source, target);
     };
 
-    auto maybeSt = maybeLstat(source);
+    auto maybeSt = maybeSymlinkStat(source);
     if (!maybeSt) {
         if (optional)
             return;
@@ -415,10 +417,10 @@ static void doBind(const Path & source, const Path & target, bool optional = fal
     }
     auto st = *maybeSt;
 
-    if (S_ISDIR(st.st_mode)) {
+    if (std::filesystem::is_directory(st)) {
         createDirs(target);
         bindMount();
-    } else if (S_ISLNK(st.st_mode)) {
+    } else if (std::filesystem::is_symlink(st)) {
         // Symlinks can (apparently) not be bind-mounted, so just copy it
         createDirs(dirOf(target));
         copyFile(
@@ -2298,12 +2300,12 @@ SingleDrvOutputs LocalDerivationGoal::registerOutputs()
             continue;
         }
 
-        auto optSt = maybeLstat(actualPath.c_str());
+        auto optSt = unix::maybeLstat(actualPath);
         if (!optSt)
             throw BuildError(
                 "builder for '%s' failed to produce output path for output '%s' at '%s'",
                 worker.store.printStorePath(drvPath), outputName, actualPath);
-        struct stat & st = *optSt;
+        auto & st = *optSt;
 
 #ifndef __CYGWIN__
         /* Check that the output is not group or world writable, as

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -6,6 +6,7 @@
 #include "users.hh"
 #include "json-utils.hh"
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <regex>
@@ -553,8 +554,8 @@ static void _completePath(AddCompletions & completions, std::string_view prefix,
     if (glob((expandTilde(prefix) + "*").c_str(), flags, nullptr, &globbuf) == 0) {
         for (size_t i = 0; i < globbuf.gl_pathc; ++i) {
             if (onlyDirs) {
-                auto st = stat(globbuf.gl_pathv[i]);
-                if (!S_ISDIR(st.st_mode)) continue;
+                if (!std::filesystem::is_directory(globbuf.gl_pathv[i]))
+                    continue;
             }
             completions.add(globbuf.gl_pathv[i]);
         }

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -88,8 +88,10 @@ bool isDirOrInDir(std::string_view path, std::string_view dir);
 /**
  * Get status of `path`.
  */
-struct stat stat(const Path & path);
+namespace unix {
+std::optional<struct stat> maybeLstat(const Path & path);
 struct stat lstat(const Path & path);
+}
 
 /**
  * call `std::filesystem::symlink_status` on the given path if it exists.

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -90,11 +90,12 @@ bool isDirOrInDir(std::string_view path, std::string_view dir);
  */
 struct stat stat(const Path & path);
 struct stat lstat(const Path & path);
+
 /**
- * `lstat` the given path if it exists.
- * @return std::nullopt if the path doesn't exist, or an optional containing the result of `lstat` otherwise
+ * call `std::filesystem::symlink_status` on the given path if it exists.
+ * @return std::nullopt if the path doesn't exist, or an optional containing the result of `std::filesystem::symlink_status` otherwise
  */
-std::optional<struct stat> maybeLstat(const Path & path);
+std::optional<std::filesystem::file_status> maybeSymlinkStat(const Path & path);
 
 /**
  * @return true iff the given path exists.

--- a/src/libutil/posix-source-accessor.hh
+++ b/src/libutil/posix-source-accessor.hh
@@ -64,7 +64,7 @@ private:
      */
     void assertNoSymlinks(CanonPath path);
 
-    std::optional<struct stat> cachedLstat(const CanonPath & path);
+    std::optional<std::filesystem::file_status> cachedLstat(const CanonPath & path);
 
     std::filesystem::path makeAbsPath(const CanonPath & path);
 };

--- a/src/libutil/posix-source-accessor.hh
+++ b/src/libutil/posix-source-accessor.hh
@@ -64,7 +64,7 @@ private:
      */
     void assertNoSymlinks(CanonPath path);
 
-    std::optional<std::filesystem::file_status> cachedLstat(const CanonPath & path);
+    std::optional<struct stat> cachedLstat(const CanonPath & path);
 
     std::filesystem::path makeAbsPath(const CanonPath & path);
 };

--- a/src/libutil/unix/users.cc
+++ b/src/libutil/unix/users.cc
@@ -1,7 +1,5 @@
-#include "util.hh"
-#include "users.hh"
 #include "environment-variables.hh"
-#include "file-system.hh"
+#include "logging.hh"
 
 #include <pwd.h>
 #include <sys/types.h>


### PR DESCRIPTION
# Motivation

The cpp `std::filesystem` [has functions](https://en.cppreference.com/w/cpp/filesystem/status) that we can use in place of `stat` and `lstat`. This makes the code more portable between windows and unix.

Some places where it required windows native implementation are still using `unix::lstat` (the old `lstat` just moved inside the new `unix` namespace). Alternative windows implementation needs to be written to tackle these situations.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
