### PR TITLE
Improve error messages for invalid derivation names

### DIFF
--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -2,25 +2,24 @@
 
 namespace nix {
 
-static void checkName(std::string_view path, std::string_view name)
+void checkName(std::string_view name)
 {
     if (name.empty())
-        throw BadStorePath("store path '%s' has an empty name", path);
+        throw BadStorePathName("name must not be empty");
     if (name.size() > StorePath::MaxPathLen)
-        throw BadStorePath("store path '%s' has a name longer than %d characters",
-            path, StorePath::MaxPathLen);
+        throw BadStorePathName("name '%s' must be no longer than %d characters", name, StorePath::MaxPathLen);
     // See nameRegexStr for the definition
     if (name[0] == '.') {
         // check against "." and "..", followed by end or dash
         if (name.size() == 1)
-            throw BadStorePath("store path '%s' has invalid name '%s'", path, name);
+            throw BadStorePathName("name '%s' is not valid", name);
         if (name[1] == '-')
-            throw BadStorePath("store path '%s' has invalid name '%s': first dash-separated component must not be '%s'", path, name, ".");
+            throw BadStorePathName("name '%s' is not valid: first dash-separated component must not be '%s'", name, ".");
         if (name[1] == '.') {
             if (name.size() == 2)
-                throw BadStorePath("store path '%s' has invalid name '%s'", path, name);
+                throw BadStorePathName("name '%s' is not valid", name);
             if (name[2] == '-')
-                throw BadStorePath("store path '%s' has invalid name '%s': first dash-separated component must not be '%s'", path, name, "..");
+                throw BadStorePathName("name '%s' is not valid: first dash-separated component must not be '%s'", name, "..");
         }
     }
     for (auto c : name)
@@ -28,7 +27,16 @@ static void checkName(std::string_view path, std::string_view name)
                 || (c >= 'a' && c <= 'z')
                 || (c >= 'A' && c <= 'Z')
                 || c == '+' || c == '-' || c == '.' || c == '_' || c == '?' || c == '='))
-            throw BadStorePath("store path '%s' contains illegal character '%s'", path, c);
+            throw BadStorePathName("name '%s' contains illegal character '%s'", name, c);
+}
+
+static void checkPathName(std::string_view path, std::string_view name)
+{
+    try {
+        checkName(name);
+    } catch (BadStorePathName & e) {
+        throw BadStorePath("path '%s' is not a valid store path: %s", path, Uncolored(e.message()));
+    }
 }
 
 StorePath::StorePath(std::string_view _baseName)
@@ -40,13 +48,13 @@ StorePath::StorePath(std::string_view _baseName)
         if (c == 'e' || c == 'o' || c == 'u' || c == 't'
             || !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')))
             throw BadStorePath("store path '%s' contains illegal base-32 character '%s'", baseName, c);
-    checkName(baseName, name());
+    checkPathName(baseName, name());
 }
 
 StorePath::StorePath(const Hash & hash, std::string_view _name)
     : baseName((hash.to_string(HashFormat::Nix32, false) + "-").append(std::string(_name)))
 {
-    checkName(baseName, name());
+    checkPathName(baseName, name());
 }
 
 bool StorePath::isDerivation() const noexcept

--- a/src/libstore/path.hh
+++ b/src/libstore/path.hh
@@ -10,6 +10,13 @@ namespace nix {
 struct Hash;
 
 /**
+ * Check whether a name is a valid store path name.
+ *
+ * @throws BadStorePathName if the name is invalid. The message is of the format "name %s is not valid, for this specific reason".
+ */
+void checkName(std::string_view name);
+
+/**
  * \ref StorePath "Store path" is the fundamental reference type of Nix.
  * A store paths refers to a Store object.
  *
@@ -31,8 +38,10 @@ public:
 
     StorePath() = delete;
 
+    /** @throws BadStorePath */
     StorePath(std::string_view baseName);
 
+    /** @throws BadStorePath */
     StorePath(const Hash & hash, std::string_view name);
 
     std::string_view to_string() const noexcept

--- a/src/libstore/store-dir-config.hh
+++ b/src/libstore/store-dir-config.hh
@@ -16,6 +16,7 @@ namespace nix {
 struct SourcePath;
 
 MakeError(BadStorePath, Error);
+MakeError(BadStorePathName, BadStorePath);
 
 struct StoreDirConfig : public Config
 {

--- a/src/libutil/error.hh
+++ b/src/libutil/error.hh
@@ -155,6 +155,7 @@ public:
         : err(e)
     { }
 
+    /** The error message without "error: " prefixed to it. */
     std::string message() {
         return err.msg.str();
     }

--- a/src/libutil/fmt.hh
+++ b/src/libutil/fmt.hh
@@ -111,6 +111,8 @@ std::ostream & operator<<(std::ostream & out, const Magenta<T> & y)
 /**
  * Values wrapped in this class are printed without coloring.
  *
+ * Specifically, the color is reset to normal before printing the value.
+ *
  * By default, arguments to `HintFmt` are printed in magenta (see `Magenta`).
  */
 template <class T>

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -1,0 +1,26 @@
+error:
+       … while evaluating the attribute 'outPath'
+         at <nix/derivation-internal.nix>:19:9:
+           18|       value = commonAttrs // {
+           19|         outPath = builtins.getAttr outputName strict;
+             |         ^
+           20|         drvPath = strict.drvPath;
+
+       … while calling the 'getAttr' builtin
+         at <nix/derivation-internal.nix>:19:19:
+           18|       value = commonAttrs // {
+           19|         outPath = builtins.getAttr outputName strict;
+             |                   ^
+           20|         drvPath = strict.drvPath;
+
+       … while calling the 'derivationStrict' builtin
+         at <nix/derivation-internal.nix>:9:12:
+            8|
+            9|   strict = derivationStrict drvAttrs;
+             |            ^
+           10|
+
+       … while evaluating derivation '~jiggle~'
+         whose name attribute is located at /pwd/lang/eval-fail-derivation-name.nix:2:3
+
+       error: invalid derivation name: name '~jiggle~' contains illegal character '~'. Please pass a different 'name'.

--- a/tests/functional/lang/eval-fail-derivation-name.nix
+++ b/tests/functional/lang/eval-fail-derivation-name.nix
@@ -1,0 +1,5 @@
+derivation {
+  name = "~jiggle~";
+  system = "some-system";
+  builder = "/dontcare";
+}

--- a/tests/functional/lang/eval-fail-fetchurl-baseName-attrs-name.err.exp
+++ b/tests/functional/lang/eval-fail-fetchurl-baseName-attrs-name.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fetchurl' builtin
+         at /pwd/lang/eval-fail-fetchurl-baseName-attrs-name.nix:1:1:
+            1| builtins.fetchurl { url = "https://example.com/foo.tar.gz"; name = "~wobble~"; }
+             | ^
+            2|
+
+       error: invalid store path name when fetching URL 'https://example.com/foo.tar.gz': name '~wobble~' contains illegal character '~'. Please change the value for the 'name' attribute passed to 'fetchurl', so that it can create a valid store path.

--- a/tests/functional/lang/eval-fail-fetchurl-baseName-attrs-name.nix
+++ b/tests/functional/lang/eval-fail-fetchurl-baseName-attrs-name.nix
@@ -1,0 +1,1 @@
+builtins.fetchurl { url = "https://example.com/foo.tar.gz"; name = "~wobble~"; }

--- a/tests/functional/lang/eval-fail-fetchurl-baseName-attrs.err.exp
+++ b/tests/functional/lang/eval-fail-fetchurl-baseName-attrs.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fetchurl' builtin
+         at /pwd/lang/eval-fail-fetchurl-baseName-attrs.nix:1:1:
+            1| builtins.fetchurl { url = "https://example.com/~wiggle~"; }
+             | ^
+            2|
+
+       error: invalid store path name when fetching URL 'https://example.com/~wiggle~': name '~wiggle~' contains illegal character '~'. Please add a valid 'name' attribute to the argument for 'fetchurl', so that it can create a valid store path.

--- a/tests/functional/lang/eval-fail-fetchurl-baseName-attrs.nix
+++ b/tests/functional/lang/eval-fail-fetchurl-baseName-attrs.nix
@@ -1,0 +1,1 @@
+builtins.fetchurl { url = "https://example.com/~wiggle~"; }

--- a/tests/functional/lang/eval-fail-fetchurl-baseName.err.exp
+++ b/tests/functional/lang/eval-fail-fetchurl-baseName.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fetchurl' builtin
+         at /pwd/lang/eval-fail-fetchurl-baseName.nix:1:1:
+            1| builtins.fetchurl "https://example.com/~wiggle~"
+             | ^
+            2|
+
+       error: invalid store path name when fetching URL 'https://example.com/~wiggle~': name '~wiggle~' contains illegal character '~'. Please pass an attribute set with 'url' and 'name' attributes to 'fetchurl',  so that it can create a valid store path.

--- a/tests/functional/lang/eval-fail-fetchurl-baseName.nix
+++ b/tests/functional/lang/eval-fail-fetchurl-baseName.nix
@@ -1,0 +1,1 @@
+builtins.fetchurl "https://example.com/~wiggle~"


### PR DESCRIPTION
# Motivation

Make the error messages more informative and actionable so that users - especially newcomers - don't get stuck.

# Context

- #7742

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
