### PR TITLE
Accept response from gitlab api with more than one entry in json

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -433,7 +433,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
                 store->toRealPath(
                     downloadFile(store, url, "source", headers).storePath)));
 
-        if (json.is_array() && json.size() == 1 && json[0]["id"] != nullptr) {
+        if (json.is_array() && json.size() >= 1 && json[0]["id"] != nullptr) {
           return RefInfo {
               .rev = Hash::parseAny(std::string(json[0]["id"]), HashAlgorithm::SHA1)
           };


### PR DESCRIPTION
# Motivation
In #10811 it is assumed that the json response from Gitlab API is a single item, but I found that it may contain more than one entry and was causing `nix flake update` to fail after version `2.23.0`.
This should fix the issue with flake updates.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
