### PR TITLE
nix flake show: add the description if it exists

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1263,8 +1263,11 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             attrPath.size() >= 1 && attrPathS[0] == "hydraJobs" ? "derivation" :
                             "package";
                         if (description && !description->empty()) {
+                            // Maximum length to print
+                            size_t maxLength = getWindowSize().second;
+                            if (maxLength == 0)
+                                maxLength = 77;
                             // Trim the string and only display the first line of the description.
-                            const size_t maxLength = 77;
                             auto trimmed = nix::trim(*description);
                             auto newLinePos = trimmed.find('\n');
                             auto length = newLinePos != std::string::npos ? newLinePos : trimmed.length();

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1261,12 +1261,23 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             attrPath.size() == 3 && attrPathS[0] == "checks" ? "derivation" :
                             attrPath.size() >= 1 && attrPathS[0] == "hydraJobs" ? "derivation" :
                             "package";
-                        if (description) {
-                            // Handle new lines in descriptions.
-                            auto index = description->find('\n');
-                            std::string_view sanitized_description(description->data(), index != std::string::npos ? index : description->size());
+                        if (description && !description->empty()) {
+                            // Trim the string and only display the first line of the description.
+                            auto trimmed = nix::trim(*description);
+                            auto newLinePos = trimmed.find('\n');
+                            auto length = newLinePos != std::string::npos ? newLinePos : trimmed.size();
 
-                            logger->cout("%s: %s '%s' - '%s'", headerPrefix, type, name, sanitized_description);
+                            // If the string is too long then resize add ellipses
+                            std::string desc;
+                            if (length > 80) {
+                                trimmed.resize(80);
+                                desc = trimmed.append("...");
+                            }
+                            else {
+                                desc = trimmed.substr(0, length);
+                            }
+
+                            logger->cout("%s: %s '%s' - '%s'", headerPrefix, type, name, desc);
                         }
                         else {
                             logger->cout("%s: %s '%s'", headerPrefix, type, name);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1262,7 +1262,11 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             attrPath.size() >= 1 && attrPathS[0] == "hydraJobs" ? "derivation" :
                             "package";
                         if (description) {
-                            logger->cout("%s: %s '%s' - '%s'", headerPrefix, type, name, *description);
+                            // Handle new lines in descriptions.
+                            auto index = description->find('\n');
+                            std::string_view sanitized_description(description->data(), index != std::string::npos ? index : description->size());
+
+                            logger->cout("%s: %s '%s' - '%s'", headerPrefix, type, name, sanitized_description);
                         }
                         else {
                             logger->cout("%s: %s '%s'", headerPrefix, type, name);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1269,8 +1269,8 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
                             // If the string is too long then resize add ellipses
                             std::string desc;
-                            if (length > 80) {
-                                trimmed.resize(80);
+                            if (length > 77) {
+                                trimmed.resize(77);
                                 desc = trimmed.append("...");
                             }
                             else {

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1243,25 +1243,30 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                 auto showDerivation = [&]()
                 {
                     auto name = visitor.getAttr(state->sName)->getString();
+                    std::optional<std::string> description;
+                    if (auto aMeta = visitor.maybeGetAttr(state->sMeta)) {
+                        if (auto aDescription = aMeta->maybeGetAttr(state->sDescription))
+                            description = aDescription->getString();
+                    }
+                    
                     if (json) {
-                        std::optional<std::string> description;
-                        if (auto aMeta = visitor.maybeGetAttr(state->sMeta)) {
-                            if (auto aDescription = aMeta->maybeGetAttr(state->sDescription))
-                                description = aDescription->getString();
-                        }
                         j.emplace("type", "derivation");
                         j.emplace("name", name);
                         if (description)
                             j.emplace("description", *description);
                     } else {
-                        logger->cout("%s: %s '%s'",
-                            headerPrefix,
+                        auto type =
                             attrPath.size() == 2 && attrPathS[0] == "devShell" ? "development environment" :
                             attrPath.size() >= 2 && attrPathS[0] == "devShells" ? "development environment" :
                             attrPath.size() == 3 && attrPathS[0] == "checks" ? "derivation" :
                             attrPath.size() >= 1 && attrPathS[0] == "hydraJobs" ? "derivation" :
-                            "package",
-                            name);
+                            "package";
+                        if (description) {
+                            logger->cout("%s: %s '%s' - '%s'", headerPrefix, type, name, *description);
+                        }
+                        else {
+                            logger->cout("%s: %s '%s'", headerPrefix, type, name);
+                        }
                     }
                 };
 

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -110,5 +110,5 @@ nix flake show > ./show-output.txt
 test "$(awk -F '[:] ' '/aNoDescription/{print $NF}' ./show-output.txt)" = "package 'simple'"
 test "$(awk -F '[:] ' '/bOneLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'one line'"
 test "$(awk -F '[:] ' '/cMultiLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'line one'"
-test "$(awk -F '[:] ' '/dLongDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - '01234567890123456789012345678901234567890123456789012345678901234567890123456...'"
+test "$(awk -F '[:] ' '/dLongDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - '012345678901234567890123456..."
 test "$(awk -F '[:] ' '/eEmptyDescription/{print $NF}' ./show-output.txt)" = "package 'simple'"

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -87,3 +87,22 @@ assert show_output.legacyPackages.${builtins.currentSystem}.AAAAAASomeThingsFail
 assert show_output.legacyPackages.${builtins.currentSystem}.simple.name == "simple";
 true
 '
+
+cat >flake.nix<<EOF
+{
+  outputs = inputs: {
+    packages.$system = {
+      aNoDescription = import ./simple.nix;
+      bOneLineDescription = import ./simple.nix // { meta.description = "one line"; };
+      cMultiLineDescription = import ./simple.nix // { meta.description = ''
+        line one
+        line two
+      ''; };
+    };
+  };
+}
+EOF
+nix flake show > ./show-output.txt
+test "$(awk -F '[:] ' '/aNoDescription/{print $NF}' ./show-output.txt)" = "package 'simple'"
+test "$(awk -F '[:] ' '/bOneLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'one line'"
+test "$(awk -F '[:] ' '/cMultiLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'line one'"

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -110,5 +110,5 @@ nix flake show > ./show-output.txt
 test "$(awk -F '[:] ' '/aNoDescription/{print $NF}' ./show-output.txt)" = "package 'simple'"
 test "$(awk -F '[:] ' '/bOneLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'one line'"
 test "$(awk -F '[:] ' '/cMultiLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'line one'"
-test "$(awk -F '[:] ' '/dLongDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - '01234567890123456789012345678901234567890123456789012345678901234567890123456789...'"
+test "$(awk -F '[:] ' '/dLongDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - '01234567890123456789012345678901234567890123456789012345678901234567890123456...'"
 test "$(awk -F '[:] ' '/eEmptyDescription/{print $NF}' ./show-output.txt)" = "package 'simple'"

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -95,9 +95,13 @@ cat >flake.nix<<EOF
       aNoDescription = import ./simple.nix;
       bOneLineDescription = import ./simple.nix // { meta.description = "one line"; };
       cMultiLineDescription = import ./simple.nix // { meta.description = ''
-        line one
+         line one
         line two
       ''; };
+      dLongDescription = import ./simple.nix // { meta.description = ''
+        01234567890123456789012345678901234567890123456789012345678901234567890123456789abcdefg
+      ''; };
+      eEmptyDescription = import ./simple.nix // { meta.description = ""; };
     };
   };
 }
@@ -106,3 +110,5 @@ nix flake show > ./show-output.txt
 test "$(awk -F '[:] ' '/aNoDescription/{print $NF}' ./show-output.txt)" = "package 'simple'"
 test "$(awk -F '[:] ' '/bOneLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'one line'"
 test "$(awk -F '[:] ' '/cMultiLineDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - 'line one'"
+test "$(awk -F '[:] ' '/dLongDescription/{print $NF}' ./show-output.txt)" = "package 'simple' - '01234567890123456789012345678901234567890123456789012345678901234567890123456789...'"
+test "$(awk -F '[:] ' '/eEmptyDescription/{print $NF}' ./show-output.txt)" = "package 'simple'"


### PR DESCRIPTION
# Motivation
Displays the description of the package if it exists. This information is already present in the json output.

I have a flake with many packages and dev shells and this helps discoverability.

# Context
<!-- Provide context. Reference open issues if available. -->
#10977 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
