### PR TITLE
Remove symlink hack from meson packaging

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -10,6 +10,33 @@
   stdenv,
   versionSuffix,
 }:
+let
+  inherit (pkgs) lib;
+
+  localSourceLayer = finalAttrs: prevAttrs:
+    let
+      root = ../.;
+      workDirPath =
+        # Ideally we'd pick finalAttrs.workDir, but for now `mkDerivation` has
+        # the requirement that everything except passthru and meta must be
+        # serialized by mkDerivation, which doesn't work for this.
+        prevAttrs.workDir;
+
+      workDirSubpath = lib.path.removePrefix root workDirPath;
+      sources = assert prevAttrs.fileset._type == "fileset"; prevAttrs.fileset;
+      src = lib.fileset.toSource { fileset = sources; inherit root; };
+
+    in
+    {
+      sourceRoot = "${src.name}/" + workDirSubpath;
+      inherit src;
+
+      # Clear what `derivation` can't/shouldn't serialize; see prevAttrs.workDir.
+      fileset = null;
+      workDir = null;
+    };
+
+in
 scope: {
   inherit stdenv versionSuffix;
 
@@ -55,4 +82,6 @@ scope: {
       CONFIG_ASH_TEST y
     '';
   });
+
+  mkMesonDerivation = f: stdenv.mkDerivation (lib.extends localSourceLayer f);
 }

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -81,9 +81,14 @@ mkMesonDerivation (finalAttrs: {
   disallowedReferences = [ boost ];
 
   preConfigure =
+    # TODO: change release process to add `pre` in `.version`, remove it before tagging, and restore after.
+    ''
+      chmod u+w ./.version
+      echo ${version} > ../../.version
+    ''
     # Copy some boost libraries so we don't get all of Boost in our
     # closure. https://github.com/NixOS/nixpkgs/issues/45462
-    lib.optionalString (!stdenv.hostPlatform.isStatic) (''
+    + lib.optionalString (!stdenv.hostPlatform.isStatic) (''
       mkdir -p $out/lib
       cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
       rm -f $out/lib/*.a


### PR DESCRIPTION
# Motivation

Manipulating the directory structure on the fly makes the packaged build different from the development build, which is bad.
This makes the actual sources just work.

The benefit show here in `libutil` is very minimal, but #10973 currently adds many more files from parent directories, which can all be handled cleanly with this helper.

# Context

- I brought up this idea in https://github.com/NixOS/nix/pull/10973#discussion_r1659807442

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
