### PR TITLE
doc: fix `directory` definition in nix-archive.md

### DIFF
--- a/doc/manual/src/protocols/nix-archive.md
+++ b/doc/manual/src/protocols/nix-archive.md
@@ -29,7 +29,7 @@ regular = [ str("executable"), str("") ], str("contents"), str(contents);
 symlink = str("target"), str(target);
 
 (* side condition: directory entries must be ordered by their names *)
-directory = str("type"), str("directory") { directory-entry };
+directory = { directory-entry }*;
 
 directory-entry = str("entry"), str("("), str("name"), str(name), str("node"), nar-obj, str(")");
 ```

--- a/doc/manual/src/protocols/nix-archive.md
+++ b/doc/manual/src/protocols/nix-archive.md
@@ -29,7 +29,7 @@ regular = [ str("executable"), str("") ], str("contents"), str(contents);
 symlink = str("target"), str(target);
 
 (* side condition: directory entries must be ordered by their names *)
-directory = { directory-entry }*;
+directory = { directory-entry };
 
 directory-entry = str("entry"), str("("), str("name"), str(name), str("node"), nar-obj, str(")");
 ```


### PR DESCRIPTION
Before the change the document implied that directory of a single entry contained entry:

    "type" "directory" "type" directory" "entry" ...

After the change document should expand into:

    "type" "directory" "entry" ...

While at it added an asterisk to show repetition.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
