### PR TITLE
docs: fix description of how NIX_PATH / nix-path interact

### DIFF
--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -84,7 +84,8 @@ struct EvalSettings : Config
           $NIX_STATE_DIR/profiles/per-user/root/channels
           ```
 
-          It can be overridden with the [`NIX_PATH` environment variable](@docroot@/command-ref/env-common.md#env-NIX_PATH) or the [`-I` command line option](@docroot@/command-ref/opt-common.md#opt-I).
+          If set, it overrides the [`NIX_PATH` environment variable](@docroot@/command-ref/env-common.md#env-NIX_PATH),
+          and can be overridden with the [`-I` command line option](@docroot@/command-ref/opt-common.md#opt-I).
 
           > **Note**
           >


### PR DESCRIPTION
If nix-path is set in nix.conf, the environment variable is always ignored.

# Motivation
I was confused by this incorrect fact in the documentation, and I'm submitting a correction.

# Context
<!-- Provide context. Reference open issues if available. -->
I was trying to set up NixOS without channels. Setting `nix.channel.enable = false;` causes `nix.settings.nix-path` to be set to `""`, which I thought wouldn't change much, but it actually effectively globally configures Nix to always ignore `NIX_PATH` in the environment.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
