### PR TITLE
Make goals use C++20 coroutines 

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -681,6 +681,7 @@ Goal::Co DerivationGoal::tryToBuild()
             actLock = std::make_unique<Activity>(*logger, lvlWarn, actBuildWaiting,
                 fmt("waiting for lock on %s", Magenta(showPaths(lockFiles))));
         worker.waitForAWhile(shared_from_this());
+        co_await SuspendGoal{};
         co_return tryToBuild();
     }
 

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -1520,7 +1520,7 @@ SingleDrvOutputs DerivationGoal::assertPathValidity()
 }
 
 
-Goal::Done DerivationGoal::done(
+Goal::Co DerivationGoal::done(
     BuildResult::Status status,
     SingleDrvOutputs builtOutputs,
     std::optional<Error> ex)

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -329,7 +329,7 @@ struct DerivationGoal : public Goal
 
     void started();
 
-    Co done(
+    Done done(
         BuildResult::Status status,
         SingleDrvOutputs builtOutputs = {},
         std::optional<Error> ex = {});

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -194,9 +194,6 @@ struct DerivationGoal : public Goal
      */
     std::optional<DerivationType> derivationType;
 
-    typedef void (DerivationGoal::*GoalState)();
-    GoalState state;
-
     BuildMode buildMode;
 
     std::unique_ptr<MaintainCount<uint64_t>> mcExpectedBuilds, mcRunningBuilds;
@@ -227,8 +224,6 @@ struct DerivationGoal : public Goal
 
     std::string key() override;
 
-    void work() override;
-
     /**
      * Add wanted outputs to an already existing derivation goal.
      */
@@ -237,18 +232,19 @@ struct DerivationGoal : public Goal
     /**
      * The states.
      */
-    void getDerivation();
-    void loadDerivation();
-    void haveDerivation();
-    void outputsSubstitutionTried();
-    void gaveUpOnSubstitution();
-    void closureRepaired();
-    void inputsRealised();
-    void tryToBuild();
-    virtual void tryLocalBuild();
-    void buildDone();
+    Co init() override;
+    Co getDerivation();
+    Co loadDerivation();
+    Co haveDerivation();
+    Co outputsSubstitutionTried();
+    Co gaveUpOnSubstitution();
+    Co closureRepaired();
+    Co inputsRealised();
+    Co tryToBuild();
+    virtual Co tryLocalBuild();
+    Co buildDone();
 
-    void resolvedFinished();
+    Co resolvedFinished();
 
     /**
      * Is the build hook willing to perform the build?
@@ -329,11 +325,11 @@ struct DerivationGoal : public Goal
      */
     virtual void killChild();
 
-    void repairClosure();
+    Co repairClosure();
 
     void started();
 
-    void done(
+    Done done(
         BuildResult::Status status,
         SingleDrvOutputs builtOutputs = {},
         std::optional<Error> ex = {});

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -329,7 +329,7 @@ struct DerivationGoal : public Goal
 
     void started();
 
-    Done done(
+    Co done(
         BuildResult::Status status,
         SingleDrvOutputs builtOutputs = {},
         std::optional<Error> ex = {});

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -30,6 +30,8 @@ Goal::Co DrvOutputSubstitutionGoal::init()
 
     auto subs = settings.useSubstitutes ? getDefaultSubstituters() : std::list<ref<Store>>();
 
+    bool substituterFailed = false;
+
     for (auto sub : subs) {
         trace("trying next substituter");
 

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -36,14 +36,14 @@ Goal::Co DrvOutputSubstitutionGoal::init()
         /* The callback of the curl download below can outlive `this` (if
            some other error occurs), so it must not touch `this`. So put
            the shared state in a separate refcounted object. */
-        std::shared_ptr<MuxablePipe> outPipe;
+        auto outPipe = std::make_shared<MuxablePipe>();
     #ifndef _WIN32
         outPipe->create();
     #else
         outPipe->createAsyncPipe(worker.ioport.get());
     #endif
 
-        std::shared_ptr<std::promise<std::shared_ptr<const Realisation>>> promise;
+        auto promise = std::make_shared<std::promise<std::shared_ptr<const Realisation>>>();
 
         sub->queryRealisation(
             id,

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -66,7 +66,7 @@ Goal::Co DrvOutputSubstitutionGoal::init()
     #endif
         }, true, false);
 
-        co_await SuspendGoal{};
+        co_await Suspend{};
 
         worker.childTerminated(this);
 
@@ -130,7 +130,7 @@ Goal::Co DrvOutputSubstitutionGoal::init()
 Goal::Co DrvOutputSubstitutionGoal::realisationFetched(std::shared_ptr<const Realisation> outputInfo, nix::ref<nix::Store> sub) {
     addWaitee(worker.makePathSubstitutionGoal(outputInfo->outPath));
 
-    if (!waitees.empty()) co_await SuspendGoal{};
+    if (!waitees.empty()) co_await Suspend{};
 
     trace("output path substituted");
 

--- a/src/libstore/build/drv-output-substitution-goal.hh
+++ b/src/libstore/build/drv-output-substitution-goal.hh
@@ -27,11 +27,6 @@ class DrvOutputSubstitutionGoal : public Goal {
      */
     DrvOutput id;
 
-    /**
-     * Whether a substituter failed.
-     */
-    bool substituterFailed = false;
-
 public:
     DrvOutputSubstitutionGoal(const DrvOutput& id, Worker & worker, RepairFlag repair = NoRepair, std::optional<ContentAddress> ca = std::nullopt);
 

--- a/src/libstore/build/drv-output-substitution-goal.hh
+++ b/src/libstore/build/drv-output-substitution-goal.hh
@@ -28,30 +28,6 @@ class DrvOutputSubstitutionGoal : public Goal {
     DrvOutput id;
 
     /**
-     * The realisation corresponding to the given output id.
-     * Will be filled once we can get it.
-     */
-    std::shared_ptr<const Realisation> outputInfo;
-
-    /**
-     * The remaining substituters.
-     */
-    std::list<ref<Store>> subs;
-
-    /**
-     * The current substituter.
-     */
-    std::shared_ptr<Store> sub;
-
-    struct DownloadState
-    {
-        MuxablePipe outPipe;
-        std::promise<std::shared_ptr<const Realisation>> promise;
-    };
-
-    std::shared_ptr<DownloadState> downloadState;
-
-    /**
      * Whether a substituter failed.
      */
     bool substituterFailed = false;
@@ -63,10 +39,7 @@ public:
     GoalState state;
 
     Co init() override;
-    Co tryNext();
-    Co realisationFetched();
-    Co outPathValid();
-    Co finished();
+    Co realisationFetched(std::shared_ptr<const Realisation> outputInfo, nix::ref<nix::Store> sub);
 
     void timedOut(Error && ex) override { abort(); };
 

--- a/src/libstore/build/drv-output-substitution-goal.hh
+++ b/src/libstore/build/drv-output-substitution-goal.hh
@@ -62,17 +62,16 @@ public:
     typedef void (DrvOutputSubstitutionGoal::*GoalState)();
     GoalState state;
 
-    void init();
-    void tryNext();
-    void realisationFetched();
-    void outPathValid();
-    void finished();
+    Co init() override;
+    Co tryNext();
+    Co realisationFetched();
+    Co outPathValid();
+    Co finished();
 
     void timedOut(Error && ex) override { abort(); };
 
     std::string key() override;
 
-    void work() override;
     void handleEOF(Descriptor fd) override;
 
     JobCategory jobCategory() const override {

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -173,8 +173,7 @@ void Goal::waiteeDone(GoalPtr waitee, ExitCode result)
     }
 }
 
-
-Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
+Co Goal::amDone(ExitCode result, std::optional<Error> ex)
 {
     trace("done");
     assert(exitCode == ecBusy);
@@ -196,6 +195,9 @@ Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
     worker.removeGoal(shared_from_this());
 
     cleanup();
+
+    // won't return to caller because of logic in final_awaiter
+    co_return Return{};
 }
 
 

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -17,14 +17,9 @@ void Co::operator=(Co&& rhs) {
     rhs.handle = nullptr;
 }
 Co::~Co() {
-    std::clog << "destroying coroutine" << std::endl;
     if (handle) {
-        assert(handle);
         handle.promise().alive = false;
-        // assert(handle.done());
         handle.destroy();
-    } else {
-        std::clog << "empty coroutine destroyed" << std::endl;
     }
 }
 

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -3,6 +3,106 @@
 
 namespace nix {
 
+using Co = nix::Goal::Co;
+using promise_type = nix::Goal::promise_type;
+using handle_type = nix::Goal::handle_type;
+using SuspendGoal = nix::Goal::SuspendGoal;
+
+Co::Co(Co&& rhs) {
+    this->handle = rhs.handle;
+    rhs.handle = nullptr;
+}
+void Co::operator=(Co&& rhs) {
+    this->handle = rhs.handle;
+    rhs.handle = nullptr;
+}
+Co::~Co() {
+    std::clog << "destroying coroutine" << std::endl;
+    if (handle) {
+        assert(handle);
+        std::clog << "destroying coroutine for " << handle.promise().loc.function_name() << std::endl;
+        handle.promise().alive = false;
+        // assert(handle.done());
+        handle.destroy();
+    } else {
+        std::clog << "empty coroutine destroyed" << std::endl;
+    }
+}
+
+Co promise_type::get_return_object() {
+    auto handle = handle_type::from_promise(*this);
+    return Co{handle};
+};
+// Here we execute our continuation, by passing it back to the caller.
+// C++ compiler will create code that takes that and executes it promptly.
+// `h` is the handle for the coroutine that is finishing execution,
+// thus it must be destroyed.
+std::coroutine_handle<> promise_type::final_awaiter::await_suspend(handle_type h) noexcept {
+    auto& p = h.promise();
+    p.goal.trace("in final_awaiter");
+    // we are still on-going
+    if (p.goal.exitCode == ecBusy) {
+        p.goal.trace("we're busy");
+        assert(p.alive); // sanity check to make sure it's not been destructed prematurely
+        assert(p.goal.top_co);
+        assert(p.goal.top_co->handle == h);
+        // we move continuation to the top,
+        // note: previous top_co is actually h, so by moving into it,
+        // we're calling the destructor on h, DON'T use h and p after this!
+        auto c = std::move(p.continuation);
+        assert(c);
+        auto& goal = p.goal;
+        goal.top_co = std::move(c);
+        goal.trace(fmt("jumping to %s", goal.top_co->handle.promise().loc.function_name()));
+        return goal.top_co->handle;
+    // we are done, give control back to caller of top_co.resume()
+    } else {
+        p.goal.top_co = {};
+        return std::noop_coroutine();
+    }
+}
+
+// When "returning" another coroutine, what happens is that
+// we set it as our own continuation, thus once the final suspend
+// happens, we transfer control to it.
+// The original continuation we had is set as the continuation
+// of the coroutine passed in.
+// `final_suspend` is called after this, and `final_awaiter` will pass control off to `continuation`.
+// However, we also have to transfer the ownership of `next`, since it's an rvalue,
+// the handle to which is on our stack.
+// We thus give it to our previous continuation.
+void promise_type::return_value(Co&& next) {
+    goal.trace("return_value(Co&&)");
+    // we save our old continuation
+    auto old_continuation = std::move(continuation);
+    // we set our continuation to next
+    continuation = std::move(next);
+    // next must be continuation-less
+    assert(!continuation->handle.promise().continuation);
+    // next's continuation is set to the old continuation
+    continuation->handle.promise().continuation = std::move(old_continuation);
+}
+
+// When we `co_await` another `Co`-returning coroutine,
+// we tell the caller of `caller.resume()` to switch to our coroutine (`handle`).
+// To make sure we return to the original coroutine, we set it as the continuation of our
+// coroutine. In `final_awaiter` we check if it's set and if so we return to it.
+//
+// To explain in more understandable terms:
+// When we `co_await Co_returning_function()`, this function is called on the resultant Co of
+// the _called_ function, and C++ automatically passes the caller in.
+// We don't use this caller, because we make use of the invariant that top_co == caller.
+std::coroutine_handle<> Co::await_suspend(handle_type caller) {
+    assert(handle); // we must be a valid coroutine
+    auto& p = handle.promise();
+    assert(!p.continuation); // we must have no continuation
+    assert(p.goal.top_co); // top_co invariant must be maintained
+    assert(p.goal.top_co->handle == caller); // top_co invariant must be maintained
+    p.continuation = std::move(p.goal.top_co); // we set our continuation to be top_co (i.e. caller)
+    p.goal.top_co = std::move(*this); // we set top_co to ourselves
+    return handle; // we execute ourselves
+}
+
 
 bool CompareGoalPtrs::operator() (const GoalPtr & a, const GoalPtr & b) const {
     std::string s1 = a->key();
@@ -76,7 +176,7 @@ void Goal::waiteeDone(GoalPtr waitee, ExitCode result)
 }
 
 
-void Goal::amDone(ExitCode result, std::optional<Error> ex)
+Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
 {
     trace("done");
     assert(exitCode == ecBusy);
@@ -105,5 +205,17 @@ void Goal::trace(std::string_view s)
 {
     debug("%1%: %2%", name, s);
 }
+
+void Goal::work()
+{
+    assert(top_co);
+    assert(top_co->handle);
+    assert(top_co->handle.promise().alive);
+    top_co->handle.resume();
+    // We either should be in a state where we can be work()-ed again,
+    // or we should be done.
+    assert(top_co || exitCode != ecBusy);
+}
+
 
 }

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -20,7 +20,6 @@ Co::~Co() {
     std::clog << "destroying coroutine" << std::endl;
     if (handle) {
         assert(handle);
-        std::clog << "destroying coroutine for " << handle.promise().loc.function_name() << std::endl;
         handle.promise().alive = false;
         // assert(handle.done());
         handle.destroy();
@@ -53,7 +52,6 @@ std::coroutine_handle<> promise_type::final_awaiter::await_suspend(handle_type h
         assert(c);
         auto& goal = p.goal;
         goal.top_co = std::move(c);
-        goal.trace(fmt("jumping to %s", goal.top_co->handle.promise().loc.function_name()));
         return goal.top_co->handle;
     // we are done, give control back to caller of top_co.resume()
     } else {

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -153,7 +153,7 @@ public:
         // Either this is who called us, or it is who we will tail-call.
         // It is what we "jump" to once we are done.
         std::optional<Co> continuation;
-        Goal* goal;
+        Goal* goal = nullptr;
         bool alive = true;
 
         promise_type() {}
@@ -213,7 +213,7 @@ public:
     Goal(Worker & worker, DerivedPath path)
         : worker(worker), top_co(init_wrapper())
     {
-        assert(!top_co->handle.promise().goal);
+        // assert(!top_co->handle.promise().goal);
         top_co->handle.promise().goal = this;
     }
 

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -143,7 +143,7 @@ public:
      * children you're waiting for.
      * Coroutines allow you to resume the work cleanly.
      *
-     * @note Below follows a brief explanation of C++20 coroutines.
+     * @note Brief explanation of C++20 coroutines:
      *       When you `Co f()`, a `std::coroutine_handle<promise_type>` is created,
      *       alongside its @ref promise_type.
      *       There are suspension points at the beginning of the coroutine,
@@ -165,6 +165,8 @@ public:
      * @todo Allocate explicitly on stack since HALO thing doesn't really work,
      *       specifically, there's no way to uphold the requirements when trying to do
      *       tail-calls without using a trampoline AFAICT.
+     *
+     * @todo Support returning data natively
      */
     struct [[nodiscard]] Co {
         /**

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -24,7 +24,7 @@ PathSubstitutionGoal::~PathSubstitutionGoal()
 }
 
 
-PathSubstitutionGoal::Done PathSubstitutionGoal::done(
+Goal::Co PathSubstitutionGoal::done(
     ExitCode result,
     BuildResult::Status status,
     std::optional<std::string> errorMsg)

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -7,115 +7,10 @@
 
 namespace nix {
 
-using Co = nix::PathSubstitutionGoal::Co;
-using promise_type = nix::PathSubstitutionGoal::promise_type;
-using handle_type = nix::PathSubstitutionGoal::handle_type;
-using SuspendGoalAwaiter = nix::PathSubstitutionGoal::SuspendGoalAwaiter;
-using SuspendGoal = nix::PathSubstitutionGoal::SuspendGoal;
-
-Co::Co(Co&& rhs) {
-    this->handle = rhs.handle;
-    rhs.handle = nullptr;
-}
-void Co::operator=(Co&& rhs) {
-    this->handle = rhs.handle;
-    rhs.handle = nullptr;
-}
-Co::~Co() {
-    std::clog << "destroying coroutine" << std::endl;
-    if (handle) {
-        assert(handle);
-        std::clog << "destroying coroutine for " << handle.promise().loc.function_name() << std::endl;
-        handle.promise().alive = false;
-        // assert(handle.done());
-        handle.destroy();
-    } else {
-        std::clog << "empty coroutine destroyed" << std::endl;
-    }
-}
-
-Co promise_type::get_return_object() {
-    auto handle = handle_type::from_promise(*this);
-    return Co{handle};
-};
-// Here we execute our continuation, by passing it back to the caller.
-// C++ compiler will create code that takes that and executes it promptly.
-// `h` is the handle for the coroutine that is finishing execution,
-// thus it must be destroyed.
-std::coroutine_handle<> promise_type::final_awaiter::await_suspend(handle_type h) noexcept {
-    auto& p = h.promise();
-    p.goal.trace("in final_awaiter");
-    // we are still on-going
-    if (p.goal.exitCode == ecBusy) {
-        p.goal.trace("we're busy");
-        assert(p.alive); // sanity check to make sure it's not been destructed prematurely
-        assert(p.goal.top_co);
-        assert(p.goal.top_co->handle == h);
-        // we move continuation to the top,
-        // note: previous top_co is actually h, so by moving into it,
-        // we're calling the destructor on h, DON'T use h and p after this!
-        auto c = std::move(p.continuation);
-        assert(c);
-        auto& goal = p.goal;
-        goal.top_co = std::move(c);
-        goal.trace(fmt("jumping to %s", goal.top_co->handle.promise().loc.function_name()));
-        return goal.top_co->handle;
-    // we are done, give control back to caller of top_co.resume()
-    } else {
-        p.goal.top_co = {};
-        return std::noop_coroutine();
-    }
-}
-
-// When "returning" another coroutine, what happens is that
-// we set it as our own continuation, thus once the final suspend
-// happens, we transfer control to it.
-// The original continuation we had is set as the continuation
-// of the coroutine passed in.
-// `final_suspend` is called after this, and `final_awaiter` will pass control off to `continuation`.
-// However, we also have to transfer the ownership of `next`, since it's an rvalue,
-// the handle to which is on our stack.
-// We thus give it to our previous continuation.
-void promise_type::return_value(Co&& next) {
-    goal.trace("return_value(Co&&)");
-    // we save our old continuation
-    auto old_continuation = std::move(continuation);
-    // we set our continuation to next
-    continuation = std::move(next);
-    // next must be continuation-less
-    assert(!continuation->handle.promise().continuation);
-    // next's continuation is set to the old continuation
-    continuation->handle.promise().continuation = std::move(old_continuation);
-}
-
-// When we `co_await` another `Co`-returning coroutine,
-// we tell the caller of `caller.resume()` to switch to our coroutine (`handle`).
-// To make sure we return to the original coroutine, we set it as the continuation of our
-// coroutine. In `final_awaiter` we check if it's set and if so we return to it.
-//
-// To explain in more understandable terms:
-// When we `co_await Co_returning_function()`, this function is called on the resultant Co of
-// the _called_ function, and C++ automatically passes the caller in.
-// We don't use this caller, because we make use of the invariant that top_co == caller.
-std::coroutine_handle<> Co::await_suspend(handle_type caller) {
-    assert(handle); // we must be a valid coroutine
-    auto& p = handle.promise();
-    assert(!p.continuation); // we must have no continuation
-    assert(p.goal.top_co); // top_co invariant must be maintained
-    assert(p.goal.top_co->handle == caller); // top_co invariant must be maintained
-    p.continuation = std::move(p.goal.top_co); // we set our continuation to be top_co (i.e. caller)
-    p.goal.top_co = std::move(*this); // we set top_co to ourselves
-    return handle; // we execute ourselves
-}
-
-void SuspendGoalAwaiter::await_suspend(std::coroutine_handle<> handle) noexcept {
-}
-
 PathSubstitutionGoal::PathSubstitutionGoal(const StorePath & storePath, Worker & worker, RepairFlag repair, std::optional<ContentAddress> ca)
     : Goal(worker, DerivedPath::Opaque { storePath })
     , storePath(storePath)
     , repair(repair)
-    , top_co(init())
     , ca(ca)
 {
     name = fmt("substitution of '%s'", worker.store.printStorePath(this->storePath));
@@ -139,24 +34,11 @@ PathSubstitutionGoal::Done PathSubstitutionGoal::done(
         debug(*errorMsg);
         buildResult.errorMsg = *errorMsg;
     }
-    amDone(result);
-    return {};
+    return amDone(result);
 }
 
 
-void PathSubstitutionGoal::work()
-{
-    assert(top_co);
-    assert(top_co->handle);
-    assert(top_co->handle.promise().alive);
-    top_co->handle.resume();
-    // We either should be in a state where we can be work()-ed again,
-    // or we should be done.
-    assert(top_co || exitCode != ecBusy);
-}
-
-
-Co PathSubstitutionGoal::init()
+Goal::Co PathSubstitutionGoal::init()
 {
     trace("init");
 
@@ -178,7 +60,7 @@ Co PathSubstitutionGoal::init()
 }
 
 
-Co PathSubstitutionGoal::tryNext()
+Goal::Co PathSubstitutionGoal::tryNext()
 {
     trace("trying next substituter");
 
@@ -295,7 +177,7 @@ Co PathSubstitutionGoal::tryNext()
 }
 
 
-Co PathSubstitutionGoal::referencesValid()
+Goal::Co PathSubstitutionGoal::referencesValid()
 {
     trace("all references realised");
 
@@ -316,7 +198,7 @@ Co PathSubstitutionGoal::referencesValid()
 }
 
 
-Co PathSubstitutionGoal::tryToRun()
+Goal::Co PathSubstitutionGoal::tryToRun()
 {
     trace("trying to run");
 
@@ -371,7 +253,7 @@ Co PathSubstitutionGoal::tryToRun()
 }
 
 
-Co PathSubstitutionGoal::finished()
+Goal::Co PathSubstitutionGoal::finished()
 {
     trace("substitute finished");
 

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -275,9 +275,6 @@ Goal::Co PathSubstitutionGoal::tryToRun(StorePath subPath, nix::ref<Store> sub, 
 }
 
 
-void PathSubstitutionGoal::handleChildOutput(Descriptor fd, std::string_view data) {}
-
-
 void PathSubstitutionGoal::handleEOF(Descriptor fd)
 {
     worker.wakeUp(shared_from_this());

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -240,7 +240,7 @@ Co PathSubstitutionGoal::tryNext()
         if (i != storePath) /* ignore self-references */
             addWaitee(worker.makePathSubstitutionGoal(i));
 
-    co_await SuspendGoal{};
+    if (!waitees.empty()) co_await SuspendGoal{};
     co_return referencesValid();
 }
 
@@ -260,6 +260,8 @@ Co PathSubstitutionGoal::referencesValid()
         if (i != storePath) /* ignore self-references */
             assert(worker.store.isValidPath(i));
 
+    worker.wakeUp(shared_from_this());
+    co_await SuspendGoal{};
     co_return tryToRun();
 }
 

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -18,6 +18,7 @@ PathSubstitutionGoal::PathSubstitutionGoal(const StorePath & storePath, Worker &
     maintainExpectedSubstitutions = std::make_unique<MaintainCount<uint64_t>>(worker.expectedSubstitutions);
 }
 
+
 PathSubstitutionGoal::~PathSubstitutionGoal()
 {
     cleanup();

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -41,7 +41,7 @@ struct PathSubstitutionGoal : public Goal
      */
     std::optional<ContentAddress> ca;
 
-    Co done(
+    Done done(
         ExitCode result,
         BuildResult::Status status,
         std::optional<std::string> errorMsg = {});

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -19,30 +19,9 @@ struct PathSubstitutionGoal : public Goal
     StorePath storePath;
 
     /**
-     * The path the substituter refers to the path as. This will be
-     * different when the stores have different names.
+     * Whether to try to repair a valid path.
      */
-    std::optional<StorePath> subPath;
-
-    /**
-     * The remaining substituters.
-     */
-    std::list<ref<Store>> subs;
-
-    /**
-     * The current substituter.
-     */
-    std::shared_ptr<Store> sub;
-
-    /**
-     * Whether a substituter failed.
-     */
-    bool substituterFailed = false;
-
-    /**
-     * Path info returned by the substituter's query info operation.
-     */
-    std::shared_ptr<const ValidPathInfo> info;
+    RepairFlag repair;
 
     /**
      * Pipe for the substituter's standard output.
@@ -54,22 +33,8 @@ struct PathSubstitutionGoal : public Goal
      */
     std::thread thr;
 
-    std::promise<void> promise;
-
-    /**
-     * Whether to try to repair a valid path.
-     */
-    RepairFlag repair;
-
-    /**
-     * Location where we're downloading the substitute.  Differs from
-     * storePath when doing a repair.
-     */
-    Path destPath;
-
     std::unique_ptr<MaintainCount<uint64_t>> maintainExpectedSubstitutions,
         maintainRunningSubstitutions, maintainExpectedNar, maintainExpectedDownload;
-
 
     /**
      * Content address for recomputing store path
@@ -100,10 +65,8 @@ public:
      * The states.
      */
     Co init() override;
-    Co tryNext();
     Co gotInfo();
-    Co referencesValid();
-    Co tryToRun();
+    Co tryToRun(StorePath subPath, nix::ref<Store> sub, std::shared_ptr<const ValidPathInfo> info, bool& substituterFailed);
     Co finished();
 
     /**

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -72,7 +72,7 @@ public:
     /**
      * Callback used by the worker to write to the log.
      */
-    void handleChildOutput(Descriptor fd, std::string_view data) override;
+    void handleChildOutput(Descriptor fd, std::string_view data) override {};
     void handleEOF(Descriptor fd) override;
 
     /* Called by destructor, can't be overridden */

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -81,8 +81,8 @@ struct PathSubstitutionGoal : public Goal
         void await_suspend(std::coroutine_handle<>) noexcept;
         void await_resume() noexcept {};
     };
-    struct Done {};
-    struct Co {
+    struct [[nodiscard]] Done {};
+    struct [[nodiscard]] Co {
         struct promise_type;
         using handle_type = std::coroutine_handle<promise_type>;
         handle_type handle;

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -76,7 +76,7 @@ struct PathSubstitutionGoal : public Goal
      */
     std::optional<ContentAddress> ca;
 
-    Done done(
+    Co done(
         ExitCode result,
         BuildResult::Status status,
         std::optional<std::string> errorMsg = {});

--- a/src/libstore/build/substitution-goal.hh
+++ b/src/libstore/build/substitution-goal.hh
@@ -7,6 +7,7 @@
 #include "muxable-pipe.hh"
 #include <coroutine>
 #include <future>
+#include <source_location>
 
 namespace nix {
 
@@ -76,60 +77,87 @@ struct PathSubstitutionGoal : public Goal
     struct SuspendGoal {};
     struct SuspendGoalAwaiter {
         PathSubstitutionGoal& goal;
-        explicit SuspendGoalAwaiter(PathSubstitutionGoal& goal) : goal(goal) {}
+        std::source_location& loc;
+        explicit SuspendGoalAwaiter(PathSubstitutionGoal& goal, std::source_location& loc) : goal(goal), loc(loc) {}
         bool await_ready() noexcept { return false; };
         void await_suspend(std::coroutine_handle<>) noexcept;
         void await_resume() noexcept {};
     };
     struct [[nodiscard]] Done {};
+    struct promise_type;
+    using handle_type = std::coroutine_handle<promise_type>;
+    // FIXME: Allocate explicitly on stack since HALO thing doesn't really work,
+    // specifically, there's no way to uphold the requirements when trying to do
+    // tail-calls without using a trampoline AFAICT.
+    // NOTES:
+    // These are good resources for understanding how coroutines work:
+    // https://lewissbaker.github.io/
+    // https://www.chiark.greenend.org.uk/~sgtatham/quasiblog/coroutines-c++20/
+    // https://www.scs.stanford.edu/~dm/blog/c++-coroutines.html
     struct [[nodiscard]] Co {
-        struct promise_type;
-        using handle_type = std::coroutine_handle<promise_type>;
         handle_type handle;
-        explicit Co(handle_type handle) : handle(handle) {
-            assert(handle);
-        };
+        explicit Co(handle_type handle) : handle(handle) {};
         Co(const Co&) = delete;
         Co &operator=(const Co&) = delete;
-        Co &operator=(Co&&) = delete;
+        void operator=(Co&&);
         Co(Co&& rhs);
         ~Co();
 
-        struct promise_type {
-            std::coroutine_handle<> continuation;
-            PathSubstitutionGoal& goal;
+        bool await_ready() { return false; };
+        std::coroutine_handle<> await_suspend(handle_type handle);
+        void await_resume() {};
 
-            promise_type(PathSubstitutionGoal& goal) : goal(goal) {};
+    };
+    struct promise_type {
+        ~promise_type() {
+            goal.trace(fmt("destroying promise %p for %s", this, loc.function_name()));
+        }
+        // Either this is who called us, or it is who we will tail-call.
+        // It is what we "jump" to once we are done.
+        std::optional<Co> continuation;
+        PathSubstitutionGoal& goal;
+        std::source_location loc;
+        bool alive = true;
 
-            struct final_awaiter {
-                bool await_ready() noexcept { return false; };;
-                std::coroutine_handle<> await_suspend(std::coroutine_handle<promise_type>) noexcept;
-                void await_resume() noexcept { assert(false); };
-            };
-            Co get_return_object();
-            std::suspend_always initial_suspend() { return {}; };
-            final_awaiter final_suspend() noexcept { return {}; };
-            // Same as returning void, but makes it clear that we're done.
-            // Should ideally call `done` rather than `done` giving you a `Done`.
-            // `final_suspend` will be called after this (since we're returning),
-            // and that will give us a `final_awaiter`, which will stop the coroutine
-            // from executing since `exitCode != ecBusy`.
-            void return_value(Done) {
-                assert(goal.exitCode != ecBusy);
-            }
-            void return_value(Co&&);
-            void unhandled_exception() { throw; };
-
-            inline Co&& await_transform(Co&& co) { return static_cast<Co&&>(co); }
-            inline SuspendGoalAwaiter await_transform(SuspendGoal) { return SuspendGoalAwaiter(goal); };
+        promise_type(PathSubstitutionGoal& goal, std::source_location loc = std::source_location::current()) : goal(goal), loc(loc) {
+            goal.trace(fmt("creating promise %p for %s", this, loc.function_name()));
         };
 
-        bool await_ready() { return false; };
-        std::coroutine_handle<> await_suspend(std::coroutine_handle<Co::promise_type> handle);
-        void await_resume() {};
+        struct final_awaiter {
+            bool await_ready() noexcept { return false; };;
+            std::coroutine_handle<> await_suspend(handle_type) noexcept;
+            void await_resume() noexcept { assert(false); };
+        };
+        Co get_return_object();
+        std::suspend_always initial_suspend() { 
+            // top_co isn't set to us yet,
+            // we've merely constructed the frame and now the
+            // caller is free to do whatever they wish to us.
+            goal.trace(fmt("suspend promise %p for %s", this, loc.function_name()));
+            return {};
+        };
+        final_awaiter final_suspend() noexcept { return {}; };
+        // Same as returning void, but makes it clear that we're done.
+        // Should ideally call `done` rather than `done` giving you a `Done`.
+        // `final_suspend` will be called after this (since we're returning),
+        // and that will give us a `final_awaiter`, which will stop the coroutine
+        // from executing since `exitCode != ecBusy`.
+        void return_value(Done) {
+            assert(goal.exitCode != ecBusy);
+        }
+        void return_value(Co&&);
+        void unhandled_exception() { throw; };
+
+        inline Co&& await_transform(Co&& co) { return static_cast<Co&&>(co); }
+        inline SuspendGoalAwaiter await_transform(SuspendGoal) { return SuspendGoalAwaiter(goal, loc); };
     };
-    Co top_co;
-    std::coroutine_handle<> cur_co;
+    /**
+     * The coroutine being currently executed.
+     * You MUST update this when switching the coroutine being executed!
+     * This is used both for memory management and to resume the last
+     * coroutine executed.
+     */
+    std::optional<Co> top_co;
 
     /**
      * Content address for recomputing store path
@@ -183,3 +211,9 @@ public:
 };
 
 }
+
+template<typename... ArgTypes>
+struct std::coroutine_traits<nix::PathSubstitutionGoal::Co, ArgTypes...> {
+  using promise_type = nix::PathSubstitutionGoal::promise_type;
+};
+

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -337,31 +337,27 @@ void Worker::run(const Goals & _topGoals)
         /* Wait for input. */
         if (!children.empty() || !waitingForAWhile.empty())
             waitForInput();
-        else {
-            if (awake.empty() && 0U == settings.maxBuildJobs)
-            {
-                if (getMachines().empty())
-                   throw Error(
-                        R"(
-                        Unable to start any build;
-                        either increase '--max-jobs' or enable remote builds.
+        else if (awake.empty() && 0U == settings.maxBuildJobs) {
+            if (getMachines().empty())
+               throw Error(
+                    R"(
+                    Unable to start any build;
+                    either increase '--max-jobs' or enable remote builds.
 
-                        For more information run 'man nix.conf' and search for '/machines'.
-                        )"
-                    );
-                else
-                   throw Error(
-                        R"(
-                        Unable to start any build;
-                        remote machines may not have all required system features.
+                    For more information run 'man nix.conf' and search for '/machines'.
+                    )"
+                );
+            else
+               throw Error(
+                    R"(
+                    Unable to start any build;
+                    remote machines may not have all required system features.
 
-                        For more information run 'man nix.conf' and search for '/machines'.
-                        )"
-                    );
+                    For more information run 'man nix.conf' and search for '/machines'.
+                    )"
+                );
 
-            }
-            assert(!awake.empty());
-        }
+        } else assert(!awake.empty());
     }
 
     /* If --keep-going is not set, it's possible that the main goal

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -187,7 +187,7 @@ Goal::Co LocalDerivationGoal::tryLocalBuild()
     if (curBuilds >= settings.maxBuildJobs) {
         worker.waitForBuildSlot(shared_from_this());
         outputLocks.unlock();
-        co_await SuspendGoal{};
+        co_await Suspend{};
         co_return tryToBuild();
     }
 
@@ -242,7 +242,7 @@ Goal::Co LocalDerivationGoal::tryLocalBuild()
                 actLock = std::make_unique<Activity>(*logger, lvlWarn, actBuildWaiting,
                     fmt("waiting for a free build user ID for '%s'", Magenta(worker.store.printStorePath(drvPath))));
             worker.waitForAWhile(shared_from_this());
-            co_await SuspendGoal{};
+            co_await Suspend{};
             co_return tryLocalBuild();
         }
     }
@@ -262,7 +262,7 @@ Goal::Co LocalDerivationGoal::tryLocalBuild()
     }
 
     started();
-    co_await SuspendGoal{};
+    co_await Suspend{};
     // after EOF on child
     co_return buildDone();
 }

--- a/src/libstore/unix/build/local-derivation-goal.hh
+++ b/src/libstore/unix/build/local-derivation-goal.hh
@@ -198,7 +198,7 @@ struct LocalDerivationGoal : public DerivationGoal
     /**
      * The additional states.
      */
-    void tryLocalBuild() override;
+    Goal::Co tryLocalBuild() override;
 
     /**
      * Start building a derivation.


### PR DESCRIPTION
Part of building refactor WG work. I don't necessarily expect to merge the code in the current state, but it's not really a draft since I think it works. There might be bugs hiding somewhere though. OTOH bugs we haven't discovered yet might have been removed by this PR.

# Motivation

Goals before this PR do coroutine-like things explicitly
using `state` and setting function pointers.
Everytime `work()` is called, the `state` function pointer is called.
The control flow resulting from this design is not very obvious (for me personally at least).
One consequence of this design is that any state that has to be maintained between
different `state`s has to be in the goal class, such that all variables that could
ever be used are all fields of the class.

It is because of this not clear what fields are used when,
and more importantly, which are initialized in which states.

It is further complicated by the fact that if you do not set the `state`,
it implicitly loops.

It is not a "nice" way of writing the goal logic.

C++20 however has coroutines, which can do much of what we do manually, automatically.

This PR is an experiment in that direction, seeing how goal logic would look
using coroutines.

# Context

Reference for learning about coroutines:
- https://lewissbaker.github.io/
- https://www.chiark.greenend.org.uk/~sgtatham/quasiblog/coroutines-c++20/
- https://www.scs.stanford.edu/~dm/blog/c++-coroutines.html

My own as short as possible explanation:
Coroutines are functions that use co_await/co_return.
When you run the coroutine function, a coroutine handle is created,
alongside its user-defined promise type.
There are suspension points at the beginning, at every `co_await`,
and at the final (possibly implicit) `co_return`.
Once suspended, you can resume the coroutine by doing `coroutine_handle.resume()`.
Suspension points are implemented by passing a struct to the compiler
that implements `await_suspend`.
`await_suspend` can either say "cancel suspension", in which case execution resumes,
"suspend", in which case control is passed back to the caller of `coroutine_handle.resume()`
or the place where the coroutine function is initially executed in the case of the initial
suspension, or `await_suspend` can specify _another_ coroutine to jump to, which is
how tail calls are implemented.

---

I've tried to roughly make every state into a coroutine.
Where before you'd do `state = &f; return`, you now do `co_await SuspendGoal{}; co_return f()`.
However, you can also do `co_await f()`, i.e. a "coroutine" call!

Places where a suspension would happen implicitly (i.e. `return`-ing from the function),
are now explicit by doing `co_await SuspendGoal{}`.

Each goal at all times keeps track of the `top_co`, i.e. the coroutine last (possibly now) executed.
When we `co_return` another coroutine, i.e. do a "coroutine" tail call, we set the `top_co`,
and switch to it. Our current coroutine is destroyed.

When we `co_await` another coroutine, we _swap_ `top_co`, and set the previous `top_co`,
i.e. the coroutine being currently executed, as the _continuation_ of the coroutine to be called.

Once a coroutine has finished executing (at `co_return`), we check whether the goal is still busy
(is status `ecBusy`?), and if so, we jump to the continuation at the final suspension point.
If not, we suspend the coroutine and ignore the continuation, since the goal has finished.
The goal should be destroyed by someone else after this point.

Coroutines are wrapped in `Co` to ensure automatic destruction.

Currently, there is the limitation that our coroutines (`Co`) can not return a value,
but this should be trivial to implement using templates, or you could just pass in a pointer
to the coroutine and "return" the value that way.
It has however not been necessary yet.

I've rewritten most of the code mechanically.
`DrvOutputSubstitionGoal` I've used the most effort on, and it's an example
of how the logic can be heavily simplified.
The intermediate variables no longer have to be fields of the class and aren't in the
header anymore.

### Alternatives

You could have heavily simplified the code without coroutines too.
You could have made `state` into a function pointer with state,
i.e. a class, to improve the legibility of the control flow,
and also prevent implicit looping by making the state _return_ the
next state rather than setting a field that already has a value.

You could also have reimplemented the code in another language entirely.

I deemed both of these suboptimal. We're already using C++, so why not use
all of the features. Coroutines are mostly well supported by all major compilers
AFAICT, albeit GCC didn't support a feature that would reduce complexity by a small
amount (getting the `this` of coroutine methods in `promise_type` constructor).

There are _obviously_ better languages than C++, but deciding on a new language
is a social problem as well as a technical one. There also isn't a language
that is better than C++(20) on all fronts (e.g. bootstrappability, multiple implementations,
has a specification).

I feel that we can heavily improve the quality of the Nix codebase without switching from C++.

We are probably better off having multiple implementations of Nix anyway in my own humble opinion.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 