### PR TITLE
Installer tests

### DIFF
--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -105,7 +105,7 @@ in
   installerScriptForGHA = installScriptFor [
     # Native
     self.hydraJobs.binaryTarball."x86_64-linux"
-    self.hydraJobs.binaryTarball."x86_64-darwin"
+    self.hydraJobs.binaryTarball."aarch64-darwin"
     # Cross
     self.hydraJobs.binaryTarballCross."x86_64-linux"."armv6l-unknown-linux-gnueabihf"
     self.hydraJobs.binaryTarballCross."x86_64-linux"."armv7l-unknown-linux-gnueabihf"


### PR DESCRIPTION
GitHub Actions seems to have magically switched architectures
without changing their identifiers.
See https://github.com/actions/runner-images/blob/2813ee66cbe85b31a8322ff8967148548b1a5db9/README.md#available-images
Maybe they have more complete documentation elsewhere, but it
seems to be incapable of selecting a runner based on architecture.

TODO:
- [ ] remove `TMP` commit

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
