### PR TITLE
Tarball fetcher: Fix handling of cached tarballs

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -81,6 +81,7 @@ TarArchive::TarArchive(Source & source, bool raw, std::optional<std::string> com
     if (!raw) {
         archive_read_support_format_tar(archive);
         archive_read_support_format_zip(archive);
+        archive_read_support_format_empty(archive);
     } else {
         archive_read_support_format_raw(archive);
         archive_read_support_format_empty(archive);
@@ -99,6 +100,7 @@ TarArchive::TarArchive(const Path & path)
     archive_read_support_filter_all(archive);
     archive_read_support_format_tar(archive);
     archive_read_support_format_zip(archive);
+    archive_read_support_format_empty(archive);
     archive_read_set_option(archive, NULL, "mac-ext", NULL);
     check(archive_read_open_filename(archive, path.c_str(), 16384), "failed to open archive: %s");
 }

--- a/tests/nixos/tarball-flakes.nix
+++ b/tests/nixos/tarball-flakes.nix
@@ -74,7 +74,7 @@ in
     assert info["revision"] == "${nixpkgs.rev}"
     assert info["revCount"] == 1234
 
-    # Check that a 0-byte cached (304) result works.
+    # Check that a 0-byte HTTP 304 "Not modified" result works.
     machine.succeed("nix flake metadata --refresh --json http://localhost/tags/latest.tar.gz")
 
     # Check that fetching with rev/revCount/narHash succeeds.

--- a/tests/nixos/tarball-flakes.nix
+++ b/tests/nixos/tarball-flakes.nix
@@ -74,8 +74,10 @@ in
     assert info["revision"] == "${nixpkgs.rev}"
     assert info["revCount"] == 1234
 
-    # Check that fetching with rev/revCount/narHash succeeds.
+    # Check that a 0-byte cached (304) result works.
+    machine.succeed("nix flake metadata --refresh --json http://localhost/tags/latest.tar.gz")
 
+    # Check that fetching with rev/revCount/narHash succeeds.
     machine.succeed("nix flake metadata --json http://localhost/tags/latest.tar.gz?rev=" + info["revision"])
     machine.succeed("nix flake metadata --json http://localhost/tags/latest.tar.gz?revCount=" + str(info["revCount"]))
     machine.succeed("nix flake metadata --json http://localhost/tags/latest.tar.gz?narHash=" + info["locked"]["narHash"])


### PR DESCRIPTION
# Motivation

Fixes a regression introduced in 5a9e1c0d20e2332c79fb0fd7570315a5d93041f2 where downloading a cached file causes the error "Failed to open archive (Unrecognized archive format)".
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
