### PR TITLE
Tarball fetcher: Fix fetchToStore() and eval caching

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -260,6 +260,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
     auto [accessor, final] = scheme->getAccessor(store, *this);
 
+    assert(!accessor->fingerprint);
     accessor->fingerprint = scheme->getFingerprint(store, final);
 
     return {accessor, std::move(final)};

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -419,7 +419,7 @@ namespace nlohmann {
 using namespace nix;
 
 fetchers::PublicKey adl_serializer<fetchers::PublicKey>::from_json(const json & json) {
-    fetchers::PublicKey res = {  };
+    fetchers::PublicKey res = { };
     if (auto type = optionalValueAt(json, "type"))
         res.type = getString(*type);
 

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -365,6 +365,16 @@ struct TarballInputScheme : CurlInputScheme
 
         return {result.accessor, input};
     }
+
+    std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const override
+    {
+        if (auto narHash = input.getNarHash())
+            return narHash->to_string(HashFormat::SRI, true);
+        else if (auto rev = input.getRev())
+            return rev->gitRev();
+        else
+            return std::nullopt;
+    }
 };
 
 static auto rTarballInputScheme = OnStartup([] { registerInputScheme(std::make_unique<TarballInputScheme>()); });

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -950,10 +950,20 @@ std::optional<Fingerprint> LockedFlake::getFingerprint(ref<Store> store) const
     auto fingerprint = flake.lockedRef.input.getFingerprint(store);
     if (!fingerprint) return std::nullopt;
 
+    *fingerprint += fmt(";%s;%s", flake.lockedRef.subdir, lockFile);
+
+    /* Include revCount and lastModified because they're not
+       necessarily implied by the content fingerprint (e.g. for
+       tarball flakes) but can influence the evaluation result. */
+    if (auto revCount = flake.lockedRef.input.getRevCount())
+        *fingerprint += fmt(";revCount=%d", *revCount);
+    if (auto lastModified = flake.lockedRef.input.getLastModified())
+        *fingerprint += fmt(";lastModified=%d", *lastModified);
+
     // FIXME: as an optimization, if the flake contains a lock file
     // and we haven't changed it, then it's sufficient to use
     // flake.sourceInfo.storePath for the fingerprint.
-    return hashString(HashAlgorithm::SHA256, fmt("%s;%s;%s", *fingerprint, flake.lockedRef.subdir, lockFile));
+    return hashString(HashAlgorithm::SHA256, *fingerprint);
 }
 
 Flake::~Flake() { }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -233,6 +233,8 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                 j["lastModified"] = *lastModified;
             j["path"] = storePath;
             j["locks"] = lockedFlake.lockFile.toJSON().first;
+            if (auto fingerprint = lockedFlake.getFingerprint(store))
+                j["fingerprint"] = fingerprint->to_string(HashFormat::Base16, false);
             logger->cout("%s", j.dump());
         } else {
             logger->cout(
@@ -265,6 +267,10 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                 logger->cout(
                     ANSI_BOLD "Last modified:" ANSI_NORMAL " %s",
                     std::put_time(std::localtime(&*lastModified), "%F %T"));
+            if (auto fingerprint = lockedFlake.getFingerprint(store))
+                logger->cout(
+                    ANSI_BOLD "Fingerprint:" ANSI_NORMAL "   %s",
+                    fingerprint->to_string(HashFormat::Base16, false));
 
             if (!lockedFlake.lockFile.root->inputs.empty())
                 logger->cout(ANSI_BOLD "Inputs:" ANSI_NORMAL);

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -195,6 +195,7 @@ json=$(nix flake metadata flake1 --json | jq .)
 [[ -d $(echo "$json" | jq -r .path) ]]
 [[ $(echo "$json" | jq -r .lastModified) = $(git -C "$flake1Dir" log -n1 --format=%ct) ]]
 hash1=$(echo "$json" | jq -r .revision)
+[[ -n $(echo "$json" | jq -r .fingerprint) ]]
 
 echo foo > "$flake1Dir/foo"
 git -C "$flake1Dir" add $flake1Dir/foo

--- a/tests/nixos/tarball-flakes.nix
+++ b/tests/nixos/tarball-flakes.nix
@@ -70,6 +70,9 @@ in
     # Check that we got redirected to the immutable URL.
     assert info["locked"]["url"] == "http://localhost/stable/${nixpkgs.rev}.tar.gz"
 
+    # Check that we got a fingerprint for caching.
+    assert info["fingerprint"]
+
     # Check that we got the rev and revCount attributes.
     assert info["revision"] == "${nixpkgs.rev}"
     assert info["revCount"] == 1234


### PR DESCRIPTION
# Motivation

Without this, tarball flakes don't have a fingerprint so `fetchToStore()` has to copy them every time, and eval caching is disabled.

Also added a field to `nix flake metadata` to show the fingerprint of the flake.  This is useful for testing/debugging and maybe for sharing eval caches (since it tells you what file in `~/.cache/nix/eval-cache-v5` to copy).

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
