### PR TITLE
Fix SSH invocation when local SHELL misbehaves

### DIFF
--- a/src/libutil/unix/exec.hh
+++ b/src/libutil/unix/exec.hh
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace nix {
+
+/**
+ * `execvpe` is a GNU extension, so we need to implement it for other POSIX
+ * platforms.
+ *
+ * We use our own implementation unconditionally for consistency.
+ */
+int execvpe(const char * file0, char * const argv[], char * const envp[]);
+
+}

--- a/src/libutil/unix/meson.build
+++ b/src/libutil/unix/meson.build
@@ -13,6 +13,7 @@ sources += files(
 include_dirs += include_directories('.')
 
 headers += files(
+  'exec.hh',
   'monitor-fd.hh',
   'signals-impl.hh',
 )

--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -1,5 +1,6 @@
 #include "current-process.hh"
 #include "environment-variables.hh"
+#include "executable-path.hh"
 #include "signals.hh"
 #include "processes.hh"
 #include "finally.hh"
@@ -417,6 +418,12 @@ std::string statusToString(int status)
 bool statusOk(int status)
 {
     return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+int execvpe(const char * file0, char * const argv[], char * const envp[])
+{
+    auto file = ExecutablePath::load().findPath(file0).string();
+    return execve(file.c_str(), argv, envp);
 }
 
 }


### PR DESCRIPTION
# Motivation

Setting it to /bin/sh will make it more predictable when users have their favorite shell in SHELL, which might not behave as expected. For instance, a bad rc file could send something to stdout before our LocalCommand gets to write "started".


# Context

- This may help https://github.com/NixOS/nix/issues/11010


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
