### PR TITLE
Use proper struct sockpeercred for SO_PEERCRED for OpenBSD

### DIFF
--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -203,7 +203,11 @@ static PeerInfo getPeerInfo(int remote)
 
 #if defined(SO_PEERCRED)
 
-    ucred cred;
+# if defined(__OpenBSD__)
+   struct sockpeercred cred;
+# else
+   ucred cred;
+# endif
     socklen_t credLen = sizeof(cred);
     if (getsockopt(remote, SOL_SOCKET, SO_PEERCRED, &cred, &credLen) == -1)
         throw SysError("getting peer credentials");

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -211,9 +211,9 @@ static PeerInfo getPeerInfo(int remote)
 
 #elif defined(LOCAL_PEERCRED)
 
-#if !defined(SOL_LOCAL)
-#define SOL_LOCAL 0
-#endif
+# if !defined(SOL_LOCAL)
+# define SOL_LOCAL 0
+# endif
 
     xucred cred;
     socklen_t credLen = sizeof(cred);


### PR DESCRIPTION
# Motivation

getsockopt(2) documents this; ucred is wrong ("cr_" member prefix, no pid).

# Context

I took from https://github.com/openbsd/ports/blob/fcba3be26fa184d22d574b4efb12013760dfaa9e/sysutils/nix/patches/patch-src_nix-daemon_nix-daemon_cc and then made the formatting change myself

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
