### PR TITLE
`assert`: Report why values aren't equal

### DIFF
--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -92,6 +92,14 @@ void EvalErrorBuilder<T>::debugThrow()
     throw error;
 }
 
+template<class T>
+void EvalErrorBuilder<T>::panic()
+{
+    logError(error.info());
+    printError("This is a bug! An unexpected condition occurred, causing the Nix evaluator to have to stop. If you could share a reproducible example or a core dump, please open an issue at https://github.com/NixOS/nix/issues");
+    abort();
+}
+
 template class EvalErrorBuilder<EvalBaseError>;
 template class EvalErrorBuilder<EvalError>;
 template class EvalErrorBuilder<AssertionError>;

--- a/src/libexpr/eval-error.hh
+++ b/src/libexpr/eval-error.hh
@@ -112,6 +112,12 @@ public:
      * Delete the `EvalErrorBuilder` and throw the underlying exception.
      */
     [[gnu::noinline, gnu::noreturn]] void debugThrow();
+
+    /**
+     * A programming error or fatal condition occurred. Abort the process for core dump and debugging.
+     * This does not print a proper backtrace, because unwinding the stack is destructive.
+     */
+    [[gnu::noinline, gnu::noreturn]] void panic();
 };
 
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2631,17 +2631,12 @@ void EvalState::assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::st
         return;
 
     case nThunk: // Must not be left by forceValue
-    default:
-        // This should never happen, because eqValues already throws an
-        // error for this, and this function should only be called when
-        // eqValues has found a difference, and it should match
-        // its behavior.
-        // Note that as of writing, we make the compiler require that all enum
-        // values are handled explicitly with `case`s, _despite_ having a
-        // `default:`.
-        error<EvalBaseError>(
-            "BUG: cannot compare %1% with %2%; did forceValue leave a thunk, or might assertEqValues be out of sync with eqValues?", showType(v1), showType(v2))
-            .debugThrow();
+        assert(false);
+    default: // Note that we pass compiler flags that should make `default:` unreachable.
+        // Also note that this probably ran after `eqValues`, which implements
+        // the same logic more efficiently (without having to unwind stacks),
+        // so maybe `assertEqValues` and `eqValues` are out of sync. Check it for solutions.
+        error<EvalError>("assertEqValues: cannot compare %1% with %2%", showType(v1), showType(v2)).withTrace(pos, errorCtx).panic();
     }
 }
 
@@ -2723,8 +2718,9 @@ bool EvalState::eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_v
             return v1.fpoint() == v2.fpoint();
 
         case nThunk: // Must not be left by forceValue
-        default:
-            error<EvalError>("cannot compare %1% with %2%", showType(v1), showType(v2)).withTrace(pos, errorCtx).debugThrow();
+            assert(false);
+        default: // Note that we pass compiler flags that should make `default:` unreachable.
+            error<EvalError>("eqValues: cannot compare %1% with %2%", showType(v1), showType(v2)).withTrace(pos, errorCtx).panic();
     }
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2636,8 +2636,11 @@ void EvalState::assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::st
         // error for this, and this function should only be called when
         // eqValues has found a difference, and it should match
         // its behavior.
+        // Note that as of writing, we make the compiler require that all enum
+        // values are handled explicitly with `case`s, _despite_ having a
+        // `default:`.
         error<EvalBaseError>(
-            "cannot compare %1% with %2%; is assertEqValues out of sync with eqValues?", showType(v1), showType(v2))
+            "BUG: cannot compare %1% with %2%; did forceValue leave a thunk, or might assertEqValues be out of sync with eqValues?", showType(v1), showType(v2))
             .debugThrow();
     }
 }

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -644,6 +644,15 @@ public:
      */
     bool eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_view errorCtx);
 
+    /**
+     * Like `eqValues`, but throws an `AssertionError` if not equal.
+     *
+     * WARNING:
+     * Callers should call `eqValues` first and report if `assertEqValues` behaves
+     * incorrectly. (e.g. if it doesn't throw if eqValues returns false or vice versa)
+     */
+    void assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::string_view errorCtx);
+
     bool isFunctor(Value & fun);
 
     // FIXME: use std::span

--- a/tests/functional/lang/eval-fail-assert-equal-attrs-names-2.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-attrs-names-2.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '({ a = true; } == { a = true; b = true; })'
+         at /pwd/lang/eval-fail-assert-equal-attrs-names-2.nix:1:1:
+            1| assert { a = true; } == { a = true; b = true; };
+             | ^
+            2| throw "unreachable"
+
+       error: attribute names of attribute set '{ a = true; }' differs from attribute set '{ a = true; b = true; }'

--- a/tests/functional/lang/eval-fail-assert-equal-attrs-names-2.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-attrs-names-2.nix
@@ -1,0 +1,2 @@
+assert { a = true; } == { a = true; b = true; };
+throw "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-attrs-names.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-attrs-names.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '({ a = true; b = true; } == { a = true; })'
+         at /pwd/lang/eval-fail-assert-equal-attrs-names.nix:1:1:
+            1| assert { a = true; b = true; } == { a = true; };
+             | ^
+            2| throw "unreachable"
+
+       error: attribute names of attribute set '{ a = true; b = true; }' differs from attribute set '{ a = true; }'

--- a/tests/functional/lang/eval-fail-assert-equal-attrs-names.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-attrs-names.nix
@@ -1,0 +1,2 @@
+assert { a = true; b = true; } == { a = true; };
+throw "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-derivations-extra.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations-extra.err.exp
@@ -1,0 +1,26 @@
+error:
+       … while evaluating the condition of the assertion '({ foo = { outPath = "/nix/store/0"; type = "derivation"; }; } == { foo = { devious = true; outPath = "/nix/store/1"; type = "derivation"; }; })'
+         at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:1:1:
+            1| assert
+             | ^
+            2|   { foo = { type = "derivation"; outPath = "/nix/store/0"; }; }
+
+       … while comparing attribute 'foo'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:2:5:
+            1| assert
+            2|   { foo = { type = "derivation"; outPath = "/nix/store/0"; }; }
+             |     ^
+            3|   ==
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-equal-derivations-extra.nix:4:5:
+            3|   ==
+            4|   { foo = { type = "derivation"; outPath = "/nix/store/1"; devious = true; }; };
+             |     ^
+            5| throw "unreachable"
+
+       … while comparing a derivation by its 'outPath' attribute
+
+       error: string '"/nix/store/0"' is not equal to string '"/nix/store/1"'

--- a/tests/functional/lang/eval-fail-assert-equal-derivations-extra.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations-extra.nix
@@ -1,0 +1,5 @@
+assert
+  { foo = { type = "derivation"; outPath = "/nix/store/0"; }; }
+  ==
+  { foo = { type = "derivation"; outPath = "/nix/store/1"; devious = true; }; };
+throw "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-derivations.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations.err.exp
@@ -1,0 +1,26 @@
+error:
+       … while evaluating the condition of the assertion '({ foo = { ignored = (abort "not ignored"); outPath = "/nix/store/0"; type = "derivation"; }; } == { foo = { ignored = (abort "not ignored"); outPath = "/nix/store/1"; type = "derivation"; }; })'
+         at /pwd/lang/eval-fail-assert-equal-derivations.nix:1:1:
+            1| assert
+             | ^
+            2|   { foo = { type = "derivation"; outPath = "/nix/store/0"; ignored = abort "not ignored"; }; }
+
+       … while comparing attribute 'foo'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-equal-derivations.nix:2:5:
+            1| assert
+            2|   { foo = { type = "derivation"; outPath = "/nix/store/0"; ignored = abort "not ignored"; }; }
+             |     ^
+            3|   ==
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-equal-derivations.nix:4:5:
+            3|   ==
+            4|   { foo = { type = "derivation"; outPath = "/nix/store/1"; ignored = abort "not ignored"; }; };
+             |     ^
+            5| throw "unreachable"
+
+       … while comparing a derivation by its 'outPath' attribute
+
+       error: string '"/nix/store/0"' is not equal to string '"/nix/store/1"'

--- a/tests/functional/lang/eval-fail-assert-equal-derivations.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-derivations.nix
@@ -1,0 +1,5 @@
+assert
+  { foo = { type = "derivation"; outPath = "/nix/store/0"; ignored = abort "not ignored"; }; }
+  ==
+  { foo = { type = "derivation"; outPath = "/nix/store/1"; ignored = abort "not ignored"; }; };
+throw "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-floats.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-floats.err.exp
@@ -1,0 +1,22 @@
+error:
+       … while evaluating the condition of the assertion '({ b = 1; } == { b = 1.01; })'
+         at /pwd/lang/eval-fail-assert-equal-floats.nix:1:1:
+            1| assert { b = 1.0; } == { b = 1.01; };
+             | ^
+            2| abort "unreachable"
+
+       … while comparing attribute 'b'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-equal-floats.nix:1:10:
+            1| assert { b = 1.0; } == { b = 1.01; };
+             |          ^
+            2| abort "unreachable"
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-equal-floats.nix:1:26:
+            1| assert { b = 1.0; } == { b = 1.01; };
+             |                          ^
+            2| abort "unreachable"
+
+       error: a float with value '1' is not equal to a float with value '1.01'

--- a/tests/functional/lang/eval-fail-assert-equal-floats.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-floats.nix
@@ -1,0 +1,2 @@
+assert { b = 1.0; } == { b = 1.01; };
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-function-direct.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-function-direct.err.exp
@@ -1,0 +1,9 @@
+error:
+       … while evaluating the condition of the assertion '((x: x) == (x: x))'
+         at /pwd/lang/eval-fail-assert-equal-function-direct.nix:3:1:
+            2| # This only compares a direct comparison and makes no claims about functions in nested structures.
+            3| assert
+             | ^
+            4|   (x: x)
+
+       error: distinct functions and immediate comparisons of identical functions compare as unequal

--- a/tests/functional/lang/eval-fail-assert-equal-function-direct.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-function-direct.nix
@@ -1,0 +1,7 @@
+# Note: functions in nested structures, e.g. attributes, may be optimized away by pointer identity optimization.
+# This only compares a direct comparison and makes no claims about functions in nested structures.
+assert
+  (x: x)
+  ==
+  (x: x);
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-int-float.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-int-float.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '(1 == 1.1)'
+         at /pwd/lang/eval-fail-assert-equal-int-float.nix:1:1:
+            1| assert 1 == 1.1;
+             | ^
+            2| throw "unreachable"
+
+       error: an integer with value '1' is not equal to a float with value '1.1'

--- a/tests/functional/lang/eval-fail-assert-equal-int-float.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-int-float.nix
@@ -1,0 +1,2 @@
+assert 1 == 1.1;
+throw "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-ints.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-ints.err.exp
@@ -1,0 +1,22 @@
+error:
+       … while evaluating the condition of the assertion '({ b = 1; } == { b = 2; })'
+         at /pwd/lang/eval-fail-assert-equal-ints.nix:1:1:
+            1| assert { b = 1; } == { b = 2; };
+             | ^
+            2| abort "unreachable"
+
+       … while comparing attribute 'b'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-equal-ints.nix:1:10:
+            1| assert { b = 1; } == { b = 2; };
+             |          ^
+            2| abort "unreachable"
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-equal-ints.nix:1:24:
+            1| assert { b = 1; } == { b = 2; };
+             |                        ^
+            2| abort "unreachable"
+
+       error: an integer with value '1' is not equal to an integer with value '2'

--- a/tests/functional/lang/eval-fail-assert-equal-ints.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-ints.nix
@@ -1,0 +1,2 @@
+assert { b = 1; } == { b = 2; };
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-list-length.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-list-length.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '([ (1) (0) ] == [ (10) ])'
+         at /pwd/lang/eval-fail-assert-equal-list-length.nix:1:1:
+            1| assert [ 1 0 ] == [ 10 ];
+             | ^
+            2| throw "unreachable"
+
+       error: list of size '2' is not equal to list of size '1', left hand side is '[ 1 0 ]', right hand side is '[ 10 ]'

--- a/tests/functional/lang/eval-fail-assert-equal-list-length.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-list-length.nix
@@ -1,0 +1,2 @@
+assert [ 1 0 ] == [ 10 ];
+throw "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-paths.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-paths.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '(/pwd/lang/foo == /pwd/lang/bar)'
+         at /pwd/lang/eval-fail-assert-equal-paths.nix:1:1:
+            1| assert ./foo == ./bar;
+             | ^
+            2| throw "unreachable"
+
+       error: path '/pwd/lang/foo' is not equal to path '/pwd/lang/bar'

--- a/tests/functional/lang/eval-fail-assert-equal-paths.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-paths.nix
@@ -1,0 +1,2 @@
+assert ./foo == ./bar;
+throw "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-type-nested.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-type-nested.err.exp
@@ -1,0 +1,22 @@
+error:
+       … while evaluating the condition of the assertion '({ ding = false; } == { ding = null; })'
+         at /pwd/lang/eval-fail-assert-equal-type-nested.nix:1:1:
+            1| assert { ding = false; } == { ding = null; };
+             | ^
+            2| abort "unreachable"
+
+       … while comparing attribute 'ding'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-equal-type-nested.nix:1:10:
+            1| assert { ding = false; } == { ding = null; };
+             |          ^
+            2| abort "unreachable"
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-equal-type-nested.nix:1:31:
+            1| assert { ding = false; } == { ding = null; };
+             |                               ^
+            2| abort "unreachable"
+
+       error: a Boolean of value 'false' is not equal to null of value 'null'

--- a/tests/functional/lang/eval-fail-assert-equal-type-nested.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-type-nested.nix
@@ -1,0 +1,2 @@
+assert { ding = false; } == { ding = null; };
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-equal-type.err.exp
+++ b/tests/functional/lang/eval-fail-assert-equal-type.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while evaluating the condition of the assertion '(false == null)'
+         at /pwd/lang/eval-fail-assert-equal-type.nix:1:1:
+            1| assert false == null;
+             | ^
+            2| abort "unreachable"
+
+       error: a Boolean of value 'false' is not equal to null of value 'null'

--- a/tests/functional/lang/eval-fail-assert-equal-type.nix
+++ b/tests/functional/lang/eval-fail-assert-equal-type.nix
@@ -1,0 +1,2 @@
+assert false == null;
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert-nested-bool.err.exp
+++ b/tests/functional/lang/eval-fail-assert-nested-bool.err.exp
@@ -1,0 +1,74 @@
+error:
+       … while evaluating the condition of the assertion '({ a = { b = [ ({ c = { d = true; }; }) ]; }; } == { a = { b = [ ({ c = { d = false; }; }) ]; }; })'
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:1:1:
+            1| assert
+             | ^
+            2|   { a.b = [ { c.d = true; } ]; }
+
+       … while comparing attribute 'a'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:2:5:
+            1| assert
+            2|   { a.b = [ { c.d = true; } ]; }
+             |     ^
+            3|   ==
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:4:5:
+            3|   ==
+            4|   { a.b = [ { c.d = false; } ]; };
+             |     ^
+            5|
+
+       … while comparing attribute 'b'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:2:5:
+            1| assert
+            2|   { a.b = [ { c.d = true; } ]; }
+             |     ^
+            3|   ==
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:4:5:
+            3|   ==
+            4|   { a.b = [ { c.d = false; } ]; };
+             |     ^
+            5|
+
+       … while comparing list element 0
+
+       … while comparing attribute 'c'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:2:15:
+            1| assert
+            2|   { a.b = [ { c.d = true; } ]; }
+             |               ^
+            3|   ==
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:4:15:
+            3|   ==
+            4|   { a.b = [ { c.d = false; } ]; };
+             |               ^
+            5|
+
+       … while comparing attribute 'd'
+
+       … where left hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:2:15:
+            1| assert
+            2|   { a.b = [ { c.d = true; } ]; }
+             |               ^
+            3|   ==
+
+       … where right hand side is
+         at /pwd/lang/eval-fail-assert-nested-bool.nix:4:15:
+            3|   ==
+            4|   { a.b = [ { c.d = false; } ]; };
+             |               ^
+            5|
+
+       error: boolean 'true' is not equal to boolean 'false'

--- a/tests/functional/lang/eval-fail-assert-nested-bool.nix
+++ b/tests/functional/lang/eval-fail-assert-nested-bool.nix
@@ -1,0 +1,6 @@
+assert
+  { a.b = [ { c.d = true; } ]; }
+  ==
+  { a.b = [ { c.d = false; } ]; };
+
+abort "unreachable"

--- a/tests/functional/lang/eval-fail-assert.err.exp
+++ b/tests/functional/lang/eval-fail-assert.err.exp
@@ -20,9 +20,11 @@ error:
              |       ^
             3|
 
-       error: assertion '(arg == "y")' failed
-       at /pwd/lang/eval-fail-assert.nix:2:12:
+       … while evaluating the condition of the assertion '(arg == "y")'
+         at /pwd/lang/eval-fail-assert.nix:2:12:
             1| let {
             2|   x = arg: assert arg == "y"; 123;
              |            ^
             3|
+
+       error: string '"x"' is not equal to string '"y"'


### PR DESCRIPTION
# Motivation

`assert a == b; x` should report why `a` isn't equal to `b`.

With this change it does so rather well, I would say, especially when `a` and `b` are nested structures. See for example `eval-fail-assert-nested-bool.err.exp`.

# Context

This adds code that duplicates existing behavior. I've done so to keep normal equality fast and simple.
While this approach does add a risk of the code paths diverging in the future, I believe this risk is well worth the benefit.
It makes the difference between knowing immediately why something fails, or a debugging session, changing code in a dependency, etc.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
