### PR TITLE
src/nix/prefetch: fix prefetch containing current directory instead o…

### DIFF
--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -114,14 +114,15 @@ std::tuple<StorePath, Hash> prefetchFile(
             createDirs(unpacked);
             unpackTarfile(tmpFile.string(), unpacked);
 
+            auto entries = std::filesystem::directory_iterator{unpacked};
             /* If the archive unpacks to a single file/directory, then use
                that as the top-level. */
-            auto entries = std::filesystem::directory_iterator{unpacked};
-            auto file_count = std::distance(entries, std::filesystem::directory_iterator{});
-            if (file_count == 1)
-                tmpFile = entries->path();
-            else
+            tmpFile = entries->path();
+            unsigned fileCount = std::distance(entries, std::filesystem::directory_iterator{});
+            if (fileCount != 1) {
+                /* otherwise, use the directory itself */
                 tmpFile = unpacked;
+            }
         }
 
         Activity act(*logger, lvlChatty, actUnknown,

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -118,7 +118,7 @@ std::tuple<StorePath, Hash> prefetchFile(
             /* If the archive unpacks to a single file/directory, then use
                that as the top-level. */
             tmpFile = entries->path();
-            unsigned fileCount = std::distance(entries, std::filesystem::directory_iterator{});
+            auto fileCount = std::distance(entries, std::filesystem::directory_iterator{});
             if (fileCount != 1) {
                 /* otherwise, use the directory itself */
                 tmpFile = unpacked;

--- a/tests/functional/tarball.sh
+++ b/tests/functional/tarball.sh
@@ -54,6 +54,18 @@ test_tarball() {
     # with the content-addressing
     (! nix-instantiate --eval -E "fetchTree { type = \"tarball\"; url = file://$tarball; narHash = \"$hash\"; name = \"foo\"; }")
 
+    store_path=$(nix store prefetch-file --json "file://$tarball" | jq -r .storePath)
+    if ! cmp -s "$store_path" "$tarball"; then
+        echo "prefetched tarball differs from original: $store_path vs $tarball" >&2
+        exit 1
+    fi
+    store_path2=$(nix store prefetch-file --json --unpack "file://$tarball" | jq -r .storePath)
+    diff_output=$(diff -r "$store_path2" "$tarroot")
+    if [ -n "$diff_output" ]; then
+        echo "prefetched tarball differs from original: $store_path2 vs $tarroot" >&2
+        echo "$diff_output"
+        exit 1
+    fi
 }
 
 test_tarball '' cat


### PR DESCRIPTION
…f tarball

When --unpack was used the nix would add the current directory to the nix store instead of the content of unpacked.
The reason for this is that std::distance already consumes the iterator. To fix this we re-instantiate the directory iterator in case the directory only contains a single entry.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
