### PR TITLE
Meson fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,4 +205,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix build -L .#hydraJobs.build.{nix-fetchers,nix-store,nix-util}.$(nix-instantiate --eval --expr builtins.currentSystem | sed -e 's/"//g')
+      # Only meson packages that don't have a tests.run derivation.
+      # Those that have it are already built and tested as part of nix flake check.
+      - run: nix build -L .#hydraJobs.build.{nix-cmd,nix-main}.$(nix-instantiate --eval --expr builtins.currentSystem | sed -e 's/"//g')

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,6 @@
 
     let
       inherit (nixpkgs) lib;
-      inherit (lib) fileset;
 
       officialRelease = false;
 

--- a/src/external-api-docs/package.nix
+++ b/src/external-api-docs/package.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, mkMesonDerivation
 
 , meson
 , ninja
@@ -14,27 +14,27 @@ let
   inherit (lib) fileset;
 in
 
-stdenv.mkDerivation (finalAttrs: {
+mkMesonDerivation (finalAttrs: {
   pname = "nix-external-api-docs";
   version = lib.fileContents ./.version + versionSuffix;
 
-  src = fileset.toSource {
-    root = ../..;
-    fileset =
-      let
-        cpp = fileset.fileFilter (file: file.hasExt "cc" || file.hasExt "h");
-      in
-      fileset.unions [
-        ./meson.build
-        ./doxygen.cfg.in
-        ./README.md
-        # Source is not compiled, but still must be available for Doxygen
-        # to gather comments.
-        (cpp ../libexpr-c)
-        (cpp ../libstore-c)
-        (cpp ../libutil-c)
-      ];
-  };
+  workDir = ./.;
+  fileset =
+    let
+      cpp = fileset.fileFilter (file: file.hasExt "cc" || file.hasExt "h");
+    in
+    fileset.unions [
+      ./.version
+      ../../.version
+      ./meson.build
+      ./doxygen.cfg.in
+      ./README.md
+      # Source is not compiled, but still must be available for Doxygen
+      # to gather comments.
+      (cpp ../libexpr-c)
+      (cpp ../libstore-c)
+      (cpp ../libutil-c)
+    ];
 
   nativeBuildInputs = [
     meson
@@ -42,14 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
   ];
 
-  postUnpack = ''
-    sourceRoot=$sourceRoot/src/external-api-docs
-  '';
-
   preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix
     ''
-      echo ${finalAttrs.version} > .version
+      chmod u+w ./.version
+      echo ${finalAttrs.version} > ./.version
     '';
 
   postInstall = ''

--- a/src/internal-api-docs/package.nix
+++ b/src/internal-api-docs/package.nix
@@ -1,5 +1,5 @@
 { lib
-, stdenv
+, mkMesonDerivation
 
 , meson
 , ninja
@@ -14,22 +14,22 @@ let
   inherit (lib) fileset;
 in
 
-stdenv.mkDerivation (finalAttrs: {
+mkMesonDerivation (finalAttrs: {
   pname = "nix-internal-api-docs";
   version = lib.fileContents ./.version + versionSuffix;
 
-  src = fileset.toSource {
-    root = ../..;
-    fileset = let
-      cpp = fileset.fileFilter (file: file.hasExt "cc" || file.hasExt "hh");
-    in fileset.unions [
-      ./meson.build
-      ./doxygen.cfg.in
-      # Source is not compiled, but still must be available for Doxygen
-      # to gather comments.
-      (cpp ../.)
-    ];
-  };
+  workDir = ./.;
+  fileset = let
+    cpp = fileset.fileFilter (file: file.hasExt "cc" || file.hasExt "hh");
+  in fileset.unions [
+    ./.version
+    ../../.version
+    ./meson.build
+    ./doxygen.cfg.in
+    # Source is not compiled, but still must be available for Doxygen
+    # to gather comments.
+    (cpp ../.)
+  ];
 
   nativeBuildInputs = [
     meson
@@ -37,14 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
   ];
 
-  postUnpack = ''
-    sourceRoot=$sourceRoot/src/internal-api-docs
-  '';
-
   preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix
     ''
-      echo ${finalAttrs.version} > .version
+      chmod u+w ./.version
+      echo ${finalAttrs.version} > ./.version
     '';
 
   postInstall = ''

--- a/src/libmain/package.nix
+++ b/src/libmain/package.nix
@@ -7,6 +7,8 @@
 , ninja
 , pkg-config
 
+, openssl
+
 , nix-util
 , nix-store
 
@@ -47,6 +49,7 @@ mkMesonDerivation (finalAttrs: {
   propagatedBuildInputs = [
     nix-util
     nix-store
+    openssl
   ];
 
   preConfigure =


### PR DESCRIPTION
# Motivation

`nix-cmd` and `nix-main` didn't actually build, but it wasn't caught by
- `nix flake check`, because they don't have a `.tests.run` derivation
- `ci.yml`/`meson_build`, because that wasn't updated to include the new components
  - this problem goes away when we finish the meson packaging
  - could have been prevented by having `nix build` build nested attrs, in which case CI would have built the whole components attrset (can't find related issue rn)



# Context

- #2503

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
