### PR TITLE
Indirections for packaging meson-based granular build for Nixpkgs

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -40,6 +40,7 @@ let
 in
 scope: {
   inherit stdenv versionSuffix;
+  version = lib.fileContents ../.version + versionSuffix;
 
   libseccomp = pkgs.libseccomp.overrideAttrs (_: rec {
     version = "2.5.5";

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -14,9 +14,16 @@
 let
   inherit (pkgs) lib;
 
+  root = ../.;
+
+  # Nixpkgs implements this by returning a subpath into the fetched Nix sources.
+  resolvePath = p: p;
+
+  # Indirection for Nixpkgs to override when package.nix files are vendored
+  filesetToSource = lib.fileset.toSource;
+
   localSourceLayer = finalAttrs: prevAttrs:
     let
-      root = ../.;
       workDirPath =
         # Ideally we'd pick finalAttrs.workDir, but for now `mkDerivation` has
         # the requirement that everything except passthru and meta must be
@@ -103,6 +110,8 @@ scope: {
   toml11 = pkgs.toml11.overrideAttrs (old: {
     meta.platforms = lib.platforms.all;
   });
+
+  inherit resolvePath filesetToSource;
 
   mkMesonDerivation = f: stdenv.mkDerivation (lib.extends localSourceLayer f);
 }

--- a/src/external-api-docs/package.nix
+++ b/src/external-api-docs/package.nix
@@ -7,7 +7,7 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
@@ -16,7 +16,7 @@ in
 
 mkMesonDerivation (finalAttrs: {
   pname = "nix-external-api-docs";
-  version = lib.fileContents ./.version + versionSuffix;
+  inherit version;
 
   workDir = ./.;
   fileset =

--- a/src/internal-api-docs/package.nix
+++ b/src/internal-api-docs/package.nix
@@ -7,7 +7,7 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
@@ -16,7 +16,7 @@ in
 
 mkMesonDerivation (finalAttrs: {
   pname = "nix-internal-api-docs";
-  version = lib.fileContents ./.version + versionSuffix;
+  inherit version;
 
   workDir = ./.;
   fileset = let

--- a/src/libcmd/package.nix
+++ b/src/libcmd/package.nix
@@ -20,7 +20,7 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 
 # Whether to enable Markdown rendering in the Nix binary.
 , enableMarkdown ? !stdenv.hostPlatform.isWindows
@@ -36,8 +36,6 @@
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libexpr-c/package.nix
+++ b/src/libexpr-c/package.nix
@@ -11,13 +11,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -20,7 +20,7 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 
 # Whether to use garbage collection for the Nix language evaluator.
 #
@@ -36,8 +36,6 @@
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libfetchers/package.nix
+++ b/src/libfetchers/package.nix
@@ -15,13 +15,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libflake/package.nix
+++ b/src/libflake/package.nix
@@ -17,13 +17,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libmain/package.nix
+++ b/src/libmain/package.nix
@@ -14,13 +14,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libstore-c/package.nix
+++ b/src/libstore-c/package.nix
@@ -12,13 +12,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -20,15 +20,13 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 
 , embeddedSandboxShell ? stdenv.hostPlatform.isStatic
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libutil-c/package.nix
+++ b/src/libutil-c/package.nix
@@ -11,13 +11,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -17,13 +17,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/perl/package.nix
+++ b/src/perl/package.nix
@@ -8,7 +8,7 @@
 , pkg-config
 , nix-store
 , darwin
-, versionSuffix ? ""
+, version
 , curl
 , bzip2
 , libsodium
@@ -20,7 +20,7 @@ in
 
 perl.pkgs.toPerlModule (mkMesonDerivation (finalAttrs: {
   pname = "nix-perl";
-  version = lib.fileContents ./.version + versionSuffix;
+  inherit version;
 
   workDir = ./.;
   fileset = fileset.unions ([

--- a/tests/unit/libexpr-support/package.nix
+++ b/tests/unit/libexpr-support/package.nix
@@ -14,13 +14,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/tests/unit/libexpr/package.nix
+++ b/tests/unit/libexpr/package.nix
@@ -18,6 +18,7 @@
 # Configuration Options
 
 , version
+, resolvePath
 }:
 
 let
@@ -84,7 +85,7 @@ mkMesonDerivation (finalAttrs: {
       run = runCommand "${finalAttrs.pname}-run" {
       } ''
         PATH="${lib.makeBinPath [ finalAttrs.finalPackage ]}:$PATH"
-        export _NIX_TEST_UNIT_DATA=${./data}
+        export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
         nix-expr-tests
         touch $out
       '';

--- a/tests/unit/libexpr/package.nix
+++ b/tests/unit/libexpr/package.nix
@@ -17,13 +17,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/tests/unit/libfetchers/package.nix
+++ b/tests/unit/libfetchers/package.nix
@@ -16,13 +16,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/tests/unit/libfetchers/package.nix
+++ b/tests/unit/libfetchers/package.nix
@@ -17,6 +17,7 @@
 # Configuration Options
 
 , version
+, resolvePath
 }:
 
 let
@@ -82,7 +83,7 @@ mkMesonDerivation (finalAttrs: {
       run = runCommand "${finalAttrs.pname}-run" {
       } ''
         PATH="${lib.makeBinPath [ finalAttrs.finalPackage ]}:$PATH"
-        export _NIX_TEST_UNIT_DATA=${./data}
+        export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
         nix-fetchers-tests
         touch $out
       '';

--- a/tests/unit/libflake/package.nix
+++ b/tests/unit/libflake/package.nix
@@ -16,13 +16,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/tests/unit/libflake/package.nix
+++ b/tests/unit/libflake/package.nix
@@ -17,6 +17,7 @@
 # Configuration Options
 
 , version
+, resolvePath
 }:
 
 let
@@ -82,7 +83,7 @@ mkMesonDerivation (finalAttrs: {
       run = runCommand "${finalAttrs.pname}-run" {
       } ''
         PATH="${lib.makeBinPath [ finalAttrs.finalPackage ]}:$PATH"
-        export _NIX_TEST_UNIT_DATA=${./data}
+        export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
         nix-flake-tests
         touch $out
       '';

--- a/tests/unit/libstore-support/package.nix
+++ b/tests/unit/libstore-support/package.nix
@@ -14,13 +14,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/tests/unit/libstore/package.nix
+++ b/tests/unit/libstore/package.nix
@@ -19,6 +19,7 @@
 # Configuration Options
 
 , version
+, filesetToSource
 }:
 
 let
@@ -86,7 +87,7 @@ mkMesonDerivation (finalAttrs: {
       run = let
         # Some data is shared with the functional tests: they create it,
         # we consume it.
-        data = lib.fileset.toSource {
+        data = filesetToSource {
           root = ../..;
           fileset = lib.fileset.unions [
             ./data

--- a/tests/unit/libstore/package.nix
+++ b/tests/unit/libstore/package.nix
@@ -18,13 +18,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/tests/unit/libutil-support/package.nix
+++ b/tests/unit/libutil-support/package.nix
@@ -13,13 +13,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/tests/unit/libutil/package.nix
+++ b/tests/unit/libutil/package.nix
@@ -17,13 +17,11 @@
 
 # Configuration Options
 
-, versionSuffix ? ""
+, version
 }:
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 in
 
 mkMesonDerivation (finalAttrs: {


### PR DESCRIPTION
# Motivation

Make it so that we don't have provide monolithic build in addition to the component-wise expressions.

This PR makes it possible to vendor the `package.nix` expressions and build them with an unfiltered fixed-output derivation source.

See [prototype](https://github.com/NixOS/nixpkgs/compare/master...roberth:nixpkgs:nix-meson)
- `pkgs/tools/package-management/nix/granular/README.md`
- `pkgs/tools/package-management/nix/default.nix`
- `pkgs/tools/package-management/nix/granular/default.nix` (adapted from `flake.nix`)
- `pkgs/tools/package-management/nix/granular/dependencies.nix` (adapted from `packaging/dependencies.nix`)
- the rest is vendored verbatim

# Context

- Currently set to merge into #11054 

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
