### PR TITLE
Configure aws s3 lib to use system defined proxy, if existent

### DIFF
--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -132,6 +132,7 @@ ref<Aws::Client::ClientConfiguration> S3Helper::makeConfig(
 {
     initAWS();
     auto res = make_ref<Aws::Client::ClientConfiguration>();
+    res->allowSystemProxy = true;
     res->region = region;
     if (!scheme.empty()) {
         res->scheme = Aws::Http::SchemeMapper::FromString(scheme.c_str());


### PR DESCRIPTION
# Motivation
This PR aim to close the ticket #4883 as it only tell the AWS S3 SDK' to use system defined proxy configuration if any.

# Context
See the linked ticket for more context.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
