### PR TITLE
`nix-shell`: look up `shell.nix` when argument is a directory

### DIFF
--- a/doc/manual/rl-next/nix-shell-looks-for-shell-nix.md
+++ b/doc/manual/rl-next/nix-shell-looks-for-shell-nix.md
@@ -1,0 +1,28 @@
+---
+synopsis: "`nix-shell <directory>` looks for `shell.nix`"
+significance: significant
+issues:
+- 496
+- 2279
+- 4529
+- 5431
+- 11053
+prs:
+- 11057
+---
+
+`nix-shell $x` now looks for `$x/shell.nix` when `$x` resolves to a directory.
+
+Although this might be seen as a breaking change, its primarily interactive usage makes it a minor issue.
+This adjustment addresses a commonly reported problem.
+
+This also applies to `nix-shell` shebang scripts. Consider the following example:
+
+```shell
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash
+```
+
+This will now load `shell.nix` from the script's directory, if it exists; `default.nix` otherwise.
+
+The old behavior can be opted into by setting the option [`nix-shell-always-looks-for-shell-nix`](@docroot@/command-ref/conf-file.md#conf-nix-shell-always-looks-for-shell-nix) to `false`.

--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -11,6 +11,8 @@
 #include "command.hh"
 #include "tarball.hh"
 #include "fetch-to-store.hh"
+#include "compatibility-settings.hh"
+#include "eval-settings.hh"
 
 namespace nix {
 
@@ -32,6 +34,11 @@ EvalSettings evalSettings {
 };
 
 static GlobalConfig::Register rEvalSettings(&evalSettings);
+
+CompatibilitySettings compatibilitySettings {};
+
+static GlobalConfig::Register rCompatibilitySettings(&compatibilitySettings);
+
 
 MixEvalArgs::MixEvalArgs()
 {

--- a/src/libcmd/common-eval-args.hh
+++ b/src/libcmd/common-eval-args.hh
@@ -13,6 +13,7 @@ namespace nix {
 class Store;
 class EvalState;
 struct EvalSettings;
+struct CompatibilitySettings;
 class Bindings;
 struct SourcePath;
 
@@ -20,6 +21,11 @@ struct SourcePath;
  * @todo Get rid of global setttings variables
  */
 extern EvalSettings evalSettings;
+
+/**
+ * Settings that control behaviors that have changed since Nix 2.3.
+ */
+extern CompatibilitySettings compatibilitySettings;
 
 struct MixEvalArgs : virtual Args, virtual MixRepair
 {

--- a/src/libcmd/compatibility-settings.hh
+++ b/src/libcmd/compatibility-settings.hh
@@ -1,0 +1,19 @@
+#pragma once
+#include "config.hh"
+
+namespace nix {
+struct CompatibilitySettings : public Config
+{
+
+    CompatibilitySettings() = default;
+
+    Setting<bool> nixShellAlwaysLooksForShellNix{this, true, "nix-shell-always-looks-for-shell-nix", R"(
+        Before Nix 2.24, [`nix-shell`](@docroot@/command-ref/nix-shell.md) would only look at `shell.nix` if it was in the working directory - when no file was specified.
+
+        Since Nix 2.24, `nix-shell` always looks for a `shell.nix`, whether that's in the working directory, or in a directory that was passed as an argument.
+
+        You may set this to `false` to revert to the Nix 2.3 behavior.
+    )"};
+};
+
+};

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -97,6 +97,7 @@ headers = [config_h] + files(
   'command-installable-value.hh',
   'command.hh',
   'common-eval-args.hh',
+  'compatibility-settings.hh',
   'editor-for.hh',
   'installable-attr-path.hh',
   'installable-derived-path.hh',

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2650,7 +2650,7 @@ void EvalState::printStatistics()
 }
 
 
-SourcePath resolveExprPath(SourcePath path)
+SourcePath resolveExprPath(SourcePath path, bool addDefaultNix)
 {
     unsigned int followCount = 0, maxFollow = 1024;
 
@@ -2666,7 +2666,7 @@ SourcePath resolveExprPath(SourcePath path)
     }
 
     /* If `path' refers to a directory, append `/default.nix'. */
-    if (path.resolveSymlinks().lstat().type == SourceAccessor::tDirectory)
+    if (addDefaultNix && path.resolveSymlinks().lstat().type == SourceAccessor::tDirectory)
         return path / "default.nix";
 
     return path;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -850,8 +850,10 @@ std::string showType(const Value & v);
 
 /**
  * If `path` refers to a directory, then append "/default.nix".
+ *
+ * @param addDefaultNix Whether to append "/default.nix" after resolving symlinks.
  */
-SourcePath resolveExprPath(SourcePath path);
+SourcePath resolveExprPath(SourcePath path, bool addDefaultNix = true);
 
 /**
  * Whether a URI is allowed, assuming restrictEval is enabled

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -310,14 +310,17 @@ static void main_nix_build(int argc, char * * argv)
                 auto [path, outputNames] = parsePathWithOutputs(absolute);
                 if (evalStore->isStorePath(path) && hasSuffix(path, ".drv"))
                     drvs.push_back(PackageInfo(*state, evalStore, absolute));
-                else
+                else {
                     /* If we're in a #! script, interpret filenames
                        relative to the script. */
+                    auto baseDir = inShebang && !packages ? absPath(i, absPath(dirOf(script))) : i;
+
                     exprs.push_back(
                         state->parseExprFromFile(
                             resolveExprPath(
                                 lookupFileArg(*state,
-                                    inShebang && !packages ? absPath(i, absPath(dirOf(script))) : i))));
+                                    baseDir))));
+                }
             }
         }
 

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -315,11 +315,11 @@ static void main_nix_build(int argc, char * * argv)
                        relative to the script. */
                     auto baseDir = inShebang && !packages ? absPath(i, absPath(dirOf(script))) : i;
 
-                    exprs.push_back(
-                        state->parseExprFromFile(
-                            resolveExprPath(
-                                lookupFileArg(*state,
-                                    baseDir))));
+                    auto sourcePath = lookupFileArg(*state,
+                                    baseDir);
+                    auto resolvedPath = resolveExprPath(sourcePath);
+
+                    exprs.push_back(state->parseExprFromFile(resolvedPath));
                 }
             }
         }

--- a/tests/functional/shell.nix
+++ b/tests/functional/shell.nix
@@ -56,6 +56,7 @@ let pkgs = rec {
   # See nix-shell.sh
   polo = mkDerivation {
     name = "polo";
+    inherit stdenv;
     shellHook = ''
       echo Polo
     '';

--- a/tests/functional/shell.nix
+++ b/tests/functional/shell.nix
@@ -26,6 +26,9 @@ let pkgs = rec {
     fun() {
       echo blabla
     }
+    runHook() {
+      eval "''${!1}"
+    }
   '';
 
   stdenv = mkDerivation {

--- a/tests/functional/shell.nix
+++ b/tests/functional/shell.nix
@@ -45,6 +45,17 @@ let pkgs = rec {
     TEST_inNixShell = if inNixShell then "true" else "false";
     inherit stdenv;
     outputs = ["dev" "out"];
+  } // {
+    shellHook = abort "Ignore non-drv shellHook attr";
+  };
+
+  # https://github.com/NixOS/nix/issues/5431
+  # See nix-shell.sh
+  polo = mkDerivation {
+    name = "polo";
+    shellHook = ''
+      echo Polo
+    '';
   };
 
   # Used by nix-shell -p


### PR DESCRIPTION
# Motivation

Solve a **long standing** bug **responsibly**; see release note.

Users who have complicated `shell.nix`/`default.nix` setups can **opt out** by setting `nix-shell-always-looks-for-shell-nix` to `false`.
If they do, they'll be warned when the new behavior would be triggered.

> ```
>   expectStderr 1 nix-shell $TEST_ROOT/lookup-test -A shellDrv --run 'echo "it works"' --option nix-shell-always-looks-for-shell-nix false \
>     | grepQuiet "Skipping .*lookup-test/shell\.nix.*, because the setting .*nix-shell-always-looks-for-shell-nix.* is disabled. This is a deprecated behavior\. Consider enabling .*nix-shell-always-looks-for-shell-nix.*"
> ```

# Context

- Closes #496
- Closes #2279
- Closes #4529
- Closes #5431
- Closes #11053

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
