### PR TITLE
add UID migration script for macOS Sequoia 15

### DIFF
--- a/scripts/bigsur-nixbld-user-migration.sh
+++ b/scripts/bigsur-nixbld-user-migration.sh
@@ -2,7 +2,7 @@
 
 ((NEW_NIX_FIRST_BUILD_UID=301))
 
-id_available(){
+id_unavailable(){
 	dscl . list /Users UniqueID | grep -E '\b'"$1"'\b' >/dev/null
 }
 
@@ -15,7 +15,7 @@ change_nixbld_names_and_ids(){
 	while read -r name uid; do
 		echo "   Checking $name (uid: $uid)"
 		# iterate for a clean ID
-		while id_available "$next_id"; do
+		while id_unavailable "$next_id"; do
 			((next_id++))
 			if ((next_id >= 400)); then
 				echo "We've hit UID 400 without placing all of your users :("

--- a/scripts/sequoia-nixbld-user-migration.sh
+++ b/scripts/sequoia-nixbld-user-migration.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+((NEW_NIX_FIRST_BUILD_UID=331))
+
+id_available(){
+	dscl . list /Users UniqueID | grep -E '\b'"$1"'\b' >/dev/null
+}
+
+change_nixbld_names_and_ids(){
+	local name uid next_id
+	((next_id=NEW_NIX_FIRST_BUILD_UID))
+	echo "Attempting to migrate _nixbld users."
+	echo "Each _nixbld# user should have its UID moved to $next_id+"
+	while read -r name uid; do
+		echo "   Checking $name (uid: $uid)"
+		# iterate for a clean ID
+		while id_available "$next_id"; do
+			((next_id++))
+			if ((next_id >= 400)); then
+				echo "We've hit UID 400 without placing all of your users :("
+				echo "You should use the commands in this script as a starting"
+				echo "point to review your UID-space and manually move the"
+				echo "remaining users (or delete them, if you don't need them)."
+				exit 1
+			fi
+		done
+
+		# first 2 are cleanup, it's OK if they aren't here
+		sudo dscl . delete "/Users/$name" dsAttrTypeNative:_writers_passwd &>/dev/null || true
+		sudo dscl . change "/Users/$name" NFSHomeDirectory "/private/var/empty 1" "/var/empty" &>/dev/null || true
+		sudo dscl . change "/Users/$name" UniqueID "$uid" "$next_id"
+		echo "      $name migrated to uid: $next_id"
+	done < <(dscl . list /Users UniqueID | grep _nixbld | sort -n -k2)
+}
+
+change_nixbld_names_and_ids

--- a/scripts/sequoia-nixbld-user-migration.sh
+++ b/scripts/sequoia-nixbld-user-migration.sh
@@ -1,36 +1,163 @@
 #!/usr/bin/env bash
 
-((NEW_NIX_FIRST_BUILD_UID=331))
+set -x
 
-id_available(){
+((NEW_NIX_FIRST_BUILD_UID=350))
+((TEMP_NIX_FIRST_BUILD_UID=31000))
+
+nix_user_n() {
+	printf "_nixbld%d" "$1"
+}
+
+id_unavailable(){
 	dscl . list /Users UniqueID | grep -E '\b'"$1"'\b' >/dev/null
 }
 
-change_nixbld_names_and_ids(){
-	local name uid next_id
-	((next_id=NEW_NIX_FIRST_BUILD_UID))
-	echo "Attempting to migrate _nixbld users."
-	echo "Each _nixbld# user should have its UID moved to $next_id+"
+any_nixbld(){
+	dscl . list /Users UniqueID | grep -E '\b_nixbld' >/dev/null
+}
+
+re_create_nixbld_user(){
+	local name uid
+
+	name="$1"
+	uid="$2"
+
+	sudo /usr/bin/dscl . -create "/Users/$name" "UniqueID" "$uid"
+	sudo /usr/bin/dscl . -create "/Users/$name" "IsHidden" "1"
+	sudo /usr/bin/dscl . -create "/Users/$name" "NFSHomeDirectory" "/var/empty"
+	sudo /usr/bin/dscl . -create "/Users/$name" "RealName" "Nix build user $name"
+	sudo /usr/bin/dscl . -create "/Users/$name" "UserShell" "/sbin/nologin"
+	sudo /usr/bin/dscl . -create "/Users/$name" "PrimaryGroupID" "30001"
+}
+
+hit_id_cap(){
+	echo "We've hit UID 400 without placing all of your users :("
+	echo "You should use the commands in this script as a starting"
+	echo "point to review your UID-space and manually move the"
+	echo "remaining users (or delete them, if you don't need them)."
+}
+
+# evacuate the role-uid space to simplify final placement logic
+temporarily_move_existing_nixbld_uids(){
+	local name uid next_id user_n
+
+	((next_id=TEMP_NIX_FIRST_BUILD_UID))
+
+	echo ""
+	echo "Step 1: move existing _nixbld users out of the destination UID range."
+
 	while read -r name uid; do
-		echo "   Checking $name (uid: $uid)"
 		# iterate for a clean ID
-		while id_available "$next_id"; do
+		while id_unavailable "$next_id"; do
 			((next_id++))
-			if ((next_id >= 400)); then
-				echo "We've hit UID 400 without placing all of your users :("
+			# We really want to get these all placed, but I guess there's
+			# some risk we iterate forever--so we'll give up after 9k uids.
+			if ((next_id >= 40000)); then
+				echo "We've hit UID 40000 without temporarily placing all of your users :("
 				echo "You should use the commands in this script as a starting"
 				echo "point to review your UID-space and manually move the"
-				echo "remaining users (or delete them, if you don't need them)."
+				echo "remaining users to any open UID over 1000."
+				exit 1
+			fi
+		done
+		sudo dscl . -create "/Users/$name" UniqueID "$next_id"
+		echo "   Temporarily moved $name from uid $uid -> $next_id"
+
+	done < <(dscl . list /Users UniqueID | grep _nixbld | sort -n -k2)
+}
+
+change_nixbld_uids(){
+	local name next_id user_n
+
+	((next_id=NEW_NIX_FIRST_BUILD_UID))
+	((user_n=1))
+	name="$(nix_user_n "$user_n")"
+
+	# we know that we have *some* nixbld users, but macOS may have
+	# already clobbered the first few users if this system has been
+	# upgraded
+
+	echo ""
+	echo "Step 2: re-create missing early _nixbld# users."
+
+	until dscl . read "/Users/$name" &>/dev/null; do
+		# iterate for a clean ID
+		while id_unavailable "$next_id"; do
+			((next_id++))
+			if ((next_id >= 400)); then
+				hit_id_cap
 				exit 1
 			fi
 		done
 
-		# first 2 are cleanup, it's OK if they aren't here
-		sudo dscl . delete "/Users/$name" dsAttrTypeNative:_writers_passwd &>/dev/null || true
-		sudo dscl . change "/Users/$name" NFSHomeDirectory "/private/var/empty 1" "/var/empty" &>/dev/null || true
-		sudo dscl . change "/Users/$name" UniqueID "$uid" "$next_id"
+		re_create_nixbld_user "$name" "$next_id"
+		echo "      $name was missing; created with uid: $next_id"
+
+		((user_n++))
+		name="$(nix_user_n "$user_n")"
+	done
+
+	echo ""
+	echo "Step 3: relocate remaining _nixbld# UIDs to $next_id+"
+
+	# start at first _nixbld# not re-created above and increment
+	# until _nixbld<n> doesn't exist
+	while dscl . read "/Users/$name" &>/dev/null; do
+		# iterate for a clean ID
+		while id_unavailable "$next_id"; do
+			((next_id++))
+			if ((next_id >= 400)); then
+				hit_id_cap
+				exit 1
+			fi
+		done
+
+		sudo dscl . -create "/Users/$name" UniqueID "$next_id"
 		echo "      $name migrated to uid: $next_id"
+
+		((user_n++))
+		name="$(nix_user_n "$user_n")"
+	done
+
+	if ((user_n == 1)); then
+		echo "Didn't find _nixbld1. Perhaps you have single-user Nix?"
+		exit 1
+	else
+		echo "Migrated $((user_n - 1)) users. If you want to double-check, try:"
+		echo "dscl . list /Users UniqueID | grep _nixbld | sort -n -k2"
+	fi
+}
+needs_migration(){
+	local name uid next_id user_n
+
+	((next_id=NEW_NIX_FIRST_BUILD_UID))
+	((user_n=1))
+
+	while read -r name uid; do
+		expected_name="$(nix_user_n "$user_n")"
+		if [[ "$expected_name" != "$name" ]]; then
+			return 0
+		fi
+		if [[ "$next_id" != "$uid" ]]; then
+			return 0
+		fi
+		((next_id++))
+		((user_n++))
 	done < <(dscl . list /Users UniqueID | grep _nixbld | sort -n -k2)
+	return 1
 }
 
-change_nixbld_names_and_ids
+
+if any_nixbld; then
+	if needs_migration; then
+		echo "Attempting to migrate _nixbld users."
+		temporarily_move_existing_nixbld_uids
+		change_nixbld_uids
+	else
+		echo "_nixbld users already appear to be migrated."
+	fi
+else
+	echo "Didn't find any _nixbld users. Perhaps you have single-user Nix?"
+	exit 1
+fi


### PR DESCRIPTION
# Motivation
Unless Apple fixes the current behavior of the macOS Sequoia 15 beta updaters (which is ~taking UIDs 301-304 from our _nixbld1-4 users) before public beta, we'll likely get a lot of support requests from users with broken installs.

Unless it's feasible for Nix itself to automatically migrate them, it's probably worth having a migration script that people can manually run before or after their update.

Early iterations of this migrated to 331+, but I've more recently relocated to 350+ on suggestion from an Apple devrel.

# Context
- #10892
- I split this out of #10919 on request so that one can potentially go a little faster once we settle on a UID range.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
