### PR TITLE
packaging: Set darwinMinVersion to fix x86_64-darwin build

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -12,9 +12,26 @@
 }:
 
 let
+  prevStdenv = stdenv;
+in
+
+let
   inherit (pkgs) lib;
 
   root = ../.;
+
+  stdenv = if prevStdenv.isDarwin && prevStdenv.isx86_64
+    then darwinStdenv
+    else prevStdenv;
+
+  # Fix the following error with the default x86_64-darwin SDK:
+  #
+  #     error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer
+  #
+  # Despite the use of the 10.13 deployment target here, the aligned
+  # allocation function Clang uses with this setting actually works
+  # all the way back to 10.6.
+  darwinStdenv = pkgs.overrideSDK prevStdenv { darwinMinVersion = "10.13"; };
 
   # Nixpkgs implements this by returning a subpath into the fetched Nix sources.
   resolvePath = p: p;


### PR DESCRIPTION
# Motivation

Broken build is no good.

# Context

- Closes #11039
- Ported from https://github.com/NixOS/nixpkgs/pull/326172

TODO: Add x86_64-darwin CI. GitHub switched us to aarch64 some time earlier.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
