### PR TITLE
Eval cache: fix cache regressions

### DIFF
--- a/src/libcmd/installable-value.hh
+++ b/src/libcmd/installable-value.hh
@@ -66,7 +66,7 @@ struct ExtraPathInfoValue : ExtraPathInfo
 };
 
 /**
- * An Installable which corresponds a Nix langauge value, in addition to
+ * An Installable which corresponds a Nix language value, in addition to
  * a collection of \ref DerivedPath "derived paths".
  */
 struct InstallableValue : Installable

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -95,7 +95,7 @@ struct AttrDb
     {
         try {
             auto state(_state->lock());
-            if (!failed)
+            if (!failed && state->txn->active)
                 state->txn->commit();
             state->txn.reset();
         } catch (...) {

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -697,6 +697,10 @@ struct CmdDevelop : Common, MixEnvironment
             }
         }
 
+        // Release our references to eval caches to ensure they are persisted to disk, because
+        // we are about to exec out of this process without running C++ destructors.
+        getEvalState()->evalCaches.clear();
+
         runProgramInStore(store, UseLookupPath::Use, shell, args, buildEnvironment.getSystem());
 #endif
     }

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -701,7 +701,7 @@ struct CmdDevelop : Common, MixEnvironment
         // we are about to exec out of this process without running C++ destructors.
         getEvalState()->evalCaches.clear();
 
-        runProgramInStore(store, UseLookupPath::Use, shell, args, buildEnvironment.getSystem());
+        execProgramInStore(store, UseLookupPath::Use, shell, args, buildEnvironment.getSystem());
 #endif
     }
 };

--- a/src/nix/env.cc
+++ b/src/nix/env.cc
@@ -1,4 +1,5 @@
 #include "command.hh"
+#include "eval.hh"
 #include "run.hh"
 #include <queue>
 
@@ -99,7 +100,11 @@ struct CmdShell : InstallablesCommand, MixEnvironment
         for (auto & arg : command)
             args.push_back(arg);
 
-        runProgramInStore(store, UseLookupPath::Use, *command.begin(), args);
+        // Release our references to eval caches to ensure they are persisted to disk, because
+        // we are about to exec out of this process without running C++ destructors.
+        getEvalState()->evalCaches.clear();
+
+        execProgramInStore(store, UseLookupPath::Use, *command.begin(), args);
     }
 };
 

--- a/src/nix/fmt.cc
+++ b/src/nix/fmt.cc
@@ -1,5 +1,6 @@
 #include "command.hh"
 #include "installable-value.hh"
+#include "eval.hh"
 #include "run.hh"
 
 using namespace nix;
@@ -49,7 +50,11 @@ struct CmdFmt : SourceExprCommand {
             }
         }
 
-        runProgramInStore(store, UseLookupPath::DontUse, app.program, programArgs);
+        // Release our references to eval caches to ensure they are persisted to disk, because
+        // we are about to exec out of this process without running C++ destructors.
+        evalState->evalCaches.clear();
+
+        execProgramInStore(store, UseLookupPath::DontUse, app.program, programArgs);
     };
 };
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -25,7 +25,7 @@ std::string chrootHelperName = "__run_in_chroot";
 
 namespace nix {
 
-void runProgramInStore(ref<Store> store,
+void execProgramInStore(ref<Store> store,
     UseLookupPath useLookupPath,
     const std::string & program,
     const Strings & args,
@@ -128,7 +128,11 @@ struct CmdRun : InstallableValueCommand
         Strings allArgs{app.program};
         for (auto & i : args) allArgs.push_back(i);
 
-        runProgramInStore(store, UseLookupPath::DontUse, app.program, allArgs);
+        // Release our references to eval caches to ensure they are persisted to disk, because
+        // we are about to exec out of this process without running C++ destructors.
+        state->evalCaches.clear();
+
+        execProgramInStore(store, UseLookupPath::DontUse, app.program, allArgs);
     }
 };
 

--- a/src/nix/run.hh
+++ b/src/nix/run.hh
@@ -10,7 +10,7 @@ enum struct UseLookupPath {
     DontUse
 };
 
-void runProgramInStore(ref<Store> store,
+void execProgramInStore(ref<Store> store,
     UseLookupPath useLookupPath,
     const std::string & program,
     const Strings & args,


### PR DESCRIPTION
# Motivation

Few lines of bugfixes for the eval cache.

# Context

1. Regression in #10570: the eval cache is not being persisted in `nix develop` because `evalCaches` retains references to the caches and is never freed.

2. No longer including in this PR: ~~Regression in #10149 (see also: #10176): the eval cache is not being used at all for commands such as `nix develop path:.` because `getFingerprint` returns null for relative paths. Before the regression, the `/nix/...` path was being included in the hash — I brought this back as a fallback.~~

3. Nix can sometimes try to commit the eval cache sqlite transaction without there being an active transaction, which fails and prints errors that should be non-errors.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
