### PR TITLE
Fix stackoverflow during doc generation

### DIFF
--- a/doc/manual/generate-manpage.nix
+++ b/doc/manual/generate-manpage.nix
@@ -116,9 +116,12 @@ let
             storeInfo = commandInfo.stores;
             inherit inlineHTML;
           };
+          hasInfix = infix: content:
+            builtins.stringLength content != builtins.stringLength (replaceStrings [ infix ] [ "" ] content);
         in
         optionalString (details ? doc) (
-          if match ".*@store-types@.*" details.doc != null
+          # An alternate implementation with builtins.match stack overflowed on some systems.
+          if hasInfix "@store-types@" details.doc
           then help-stores
           else details.doc
         );


### PR DESCRIPTION
# Motivation

On some systems, previous usage of `match` may cause a stackoverflow (presumably due to the large size of the match result) on some systems (notably Amazon Linux). Avoid this by (ab)using `replaceStrings` to test for containment without using regexes, thereby avoiding the issue.

Match the fn name to similar fn in nixpkgs.lib, but different implementation that does not use `match`. This impl gives perhaps unexpected results when the needle is `""`, but the scope of this is narrow and that case is a bit odd anyway.

This makes for some duplication-of-work as we do a different `replaceStrings` if this one is true, but this only runs during doc generation at build time so has no runtime impact.

I verified that `nix help-stores` output is identical with and without this change.

# Context

See https://github.com/NixOS/nix/issues/11085 for details.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
