### PR TITLE
Remove unused `operator<=>`'s that darwin can't generate

### DIFF
--- a/src/libstore/content-address.hh
+++ b/src/libstore/content-address.hh
@@ -217,8 +217,6 @@ struct StoreReferences
      * iff self is true.
      */
     size_t size() const;
-
-    auto operator <=>(const StoreReferences &) const = default;
 };
 
 // This matches the additional info that we need for makeTextPath
@@ -234,8 +232,6 @@ struct TextInfo
      * disallowed
      */
     StorePathSet references;
-
-    auto operator <=>(const TextInfo &) const = default;
 };
 
 struct FixedOutputInfo
@@ -254,8 +250,6 @@ struct FixedOutputInfo
      * References to other store objects or this one.
      */
     StoreReferences references;
-
-    auto operator <=>(const FixedOutputInfo &) const = default;
 };
 
 /**
@@ -271,8 +265,6 @@ struct ContentAddressWithReferences
     > Raw;
 
     Raw raw;
-
-    auto operator <=>(const ContentAddressWithReferences &) const = default;
 
     MAKE_WRAPPER_CONSTRUCTOR(ContentAddressWithReferences);
 

--- a/src/libstore/store-reference.hh
+++ b/src/libstore/store-reference.hh
@@ -71,7 +71,6 @@ struct StoreReference
     Params params;
 
     bool operator==(const StoreReference & rhs) const = default;
-    auto operator<=>(const StoreReference & rhs) const = default;
 
     /**
      * Render the whole store reference as a URI, including parameters.


### PR DESCRIPTION

# Motivation

It was complaining *a lot*, with dozens of MB of logs.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
