### PR TITLE
Use std::unordered_map for the EvalState caches

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1011,7 +1011,7 @@ void EvalState::evalFile(const SourcePath & path, Value & v, bool mustBeTrivial)
     if (!e)
         e = parseExprFromFile(resolvedPath);
 
-    fileParseCache[resolvedPath] = e;
+    fileParseCache.emplace(resolvedPath, e);
 
     try {
         auto dts = debugRepl
@@ -1034,8 +1034,8 @@ void EvalState::evalFile(const SourcePath & path, Value & v, bool mustBeTrivial)
         throw;
     }
 
-    fileEvalCache[resolvedPath] = v;
-    if (path != resolvedPath) fileEvalCache[path] = v;
+    fileEvalCache.emplace(resolvedPath, v);
+    if (path != resolvedPath) fileEvalCache.emplace(path, v);
 }
 
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -307,15 +307,15 @@ private:
 
     /* Cache for calls to addToStore(); maps source paths to the store
        paths. */
-    Sync<std::map<SourcePath, StorePath>> srcToStore;
+    Sync<std::unordered_map<SourcePath, StorePath>> srcToStore;
 
     /**
      * A cache from path names to parse trees.
      */
 #if HAVE_BOEHMGC
-    typedef std::map<SourcePath, Expr *, std::less<SourcePath>, traceable_allocator<std::pair<const SourcePath, Expr *>>> FileParseCache;
+    typedef std::unordered_map<SourcePath, Expr *, std::hash<SourcePath>, std::equal_to<SourcePath>, traceable_allocator<std::pair<const SourcePath, Expr *>>> FileParseCache;
 #else
-    typedef std::map<SourcePath, Expr *> FileParseCache;
+    typedef std::unordered_map<SourcePath, Expr *> FileParseCache;
 #endif
     FileParseCache fileParseCache;
 
@@ -323,9 +323,9 @@ private:
      * A cache from path names to values.
      */
 #if HAVE_BOEHMGC
-    typedef std::map<SourcePath, Value, std::less<SourcePath>, traceable_allocator<std::pair<const SourcePath, Value>>> FileEvalCache;
+    typedef std::unordered_map<SourcePath, Value, std::hash<SourcePath>, std::equal_to<SourcePath>, traceable_allocator<std::pair<const SourcePath, Value>>> FileEvalCache;
 #else
-    typedef std::map<SourcePath, Value> FileEvalCache;
+    typedef std::unordered_map<SourcePath, Value> FileEvalCache;
 #endif
     FileEvalCache fileEvalCache;
 

--- a/src/libutil/source-path.hh
+++ b/src/libutil/source-path.hh
@@ -115,8 +115,19 @@ struct SourcePath
     {
         return {accessor, accessor->resolveSymlinks(path, mode)};
     }
+
+    friend class std::hash<nix::SourcePath>;
 };
 
 std::ostream & operator << (std::ostream & str, const SourcePath & path);
 
 }
+
+template<>
+struct std::hash<nix::SourcePath>
+{
+    std::size_t operator()(const nix::SourcePath & s) const noexcept
+    {
+        return std::hash<decltype(s.path)>{}(s.path);
+    }
+};

--- a/src/libutil/source-path.hh
+++ b/src/libutil/source-path.hh
@@ -9,6 +9,8 @@
 #include "canon-path.hh"
 #include "source-accessor.hh"
 
+#include <boost/functional/hash.hpp> // for boost::hash_combine
+
 namespace nix {
 
 /**
@@ -128,6 +130,8 @@ struct std::hash<nix::SourcePath>
 {
     std::size_t operator()(const nix::SourcePath & s) const noexcept
     {
-        return std::hash<decltype(s.path)>{}(s.path);
+        std::size_t hash = 0;
+        hash_combine(hash, s.accessor->number, s.path);
+        return hash;
     }
 };

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -360,4 +360,18 @@ inline std::string operator + (std::string_view s1, const char * s2)
     return s;
 }
 
+/**
+ * hash_combine() from Boost. Hash several hashable values together
+ * into a single hash.
+ */
+inline void hash_combine(std::size_t & seed) { }
+
+template <typename T, typename... Rest>
+inline void hash_combine(std::size_t & seed, const T & v, Rest... rest)
+{
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+    hash_combine(seed, rest...);
+}
+
 }


### PR DESCRIPTION
# Motivation

This is slightly faster and does fewer allocations. Cherry-picked from #10938.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
