### PR TITLE
Set `NIX_FIRST_BUILD_UID` to 30001 on macOS

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # System specific settings
-export NIX_FIRST_BUILD_UID="${NIX_FIRST_BUILD_UID:-301}"
+export NIX_FIRST_BUILD_UID="${NIX_FIRST_BUILD_UID:-701}"
 export NIX_BUILD_USER_NAME_TEMPLATE="_nixbld%d"
 
 readonly NIX_DAEMON_DEST=/Library/LaunchDaemons/org.nixos.nix-daemon.plist

--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -4,7 +4,11 @@ set -eu
 set -o pipefail
 
 # System specific settings
-export NIX_FIRST_BUILD_UID="${NIX_FIRST_BUILD_UID:-30001}"
+if [[ $(sw_vers -productVersion | cut -d '.' -f 1) -ge 15 ]]; then
+    export NIX_FIRST_BUILD_UID=${NIX_FIRST_BUILD_UID:-30001}
+else
+    export NIX_FIRST_BUILD_UID=${NIX_FIRST_BUILD_UID:-301}
+fi
 export NIX_BUILD_USER_NAME_TEMPLATE="_nixbld%d"
 
 readonly NIX_DAEMON_DEST=/Library/LaunchDaemons/org.nixos.nix-daemon.plist

--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # System specific settings
-export NIX_FIRST_BUILD_UID="${NIX_FIRST_BUILD_UID:-701}"
+export NIX_FIRST_BUILD_UID="${NIX_FIRST_BUILD_UID:-30001}"
 export NIX_BUILD_USER_NAME_TEMPLATE="_nixbld%d"
 
 readonly NIX_DAEMON_DEST=/Library/LaunchDaemons/org.nixos.nix-daemon.plist


### PR DESCRIPTION
# Motivation

Currently, the installer creates users starting with `uid` 301. This fails on recent macOS releases, because 301 is now used by the system:

```
% dscl . -search /Users UniqueID "301" 
_modelmanagerd		UniqueID = (
    301
)
```

# Context

- https://github.com/NixOS/nix/issues/2242,
- https://github.com/NixOS/nix/issues/2179,
- https://github.com/NixOS/nix/issues/5928,
- https://github.com/NixOS/nix/issues/6153,
- https://github.com/NixOS/nix/issues/9682
- #11075 

# Workaround

```sh
NIX_FIRST_BUILD_UID=30001 sh <(curl -L https://nixos.org/nix/install)
```

# Notes

Starting at `30001` is currently done in `install-systemd-multi-user.sh` https://github.com/NixOS/nix/blob/b1effc9649e2c9103aa4b9f42fabb02b601bf80e/scripts/install-systemd-multi-user.sh#L7C51-L7C52.

# Other PRs

Similar to https://github.com/NixOS/nix/pull/10919 except that this is (a) more minimal in scope (while still working) (b) obviates issues with future releases of macOS that could easily well use other uids in the 300-400 range