### PR TITLE
fix: path-info can return 1 when used with json

### DIFF
--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -3,6 +3,7 @@
 #include "store-api.hh"
 #include "common-args.hh"
 #include "nar-info.hh"
+#include "exit.hh"
 
 #include <algorithm>
 #include <array>
@@ -34,12 +35,13 @@ static uint64_t getStoreObjectsTotalSize(Store & store, const StorePathSet & clo
  * @param showClosureSize If true, the closure size of each path is
  * included.
  */
-static json pathInfoToJSON(
+static std::pair<json, int> pathInfoToJSON(
     Store & store,
     const StorePathSet & storePaths,
     bool showClosureSize)
 {
     json::object_t jsonAllObjects = json::object();
+    int resultCode = 0;
 
     for (auto & storePath : storePaths) {
         json jsonObject;
@@ -78,11 +80,12 @@ static json pathInfoToJSON(
 
         } catch (InvalidPath &) {
             jsonObject = nullptr;
+            resultCode = 1;
         }
 
         jsonAllObjects[printedStorePath] = std::move(jsonObject);
     }
-    return jsonAllObjects;
+    return std::make_pair(jsonAllObjects, resultCode);
 }
 
 
@@ -152,11 +155,15 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
             pathLen = std::max(pathLen, store->printStorePath(storePath).size());
 
         if (json) {
-            std::cout << pathInfoToJSON(
+            auto pair = pathInfoToJSON(
                 *store,
                 // FIXME: preserve order?
                 StorePathSet(storePaths.begin(), storePaths.end()),
-                showClosureSize).dump();
+                showClosureSize);
+            auto json = pair.first;
+            auto resultCode = pair.second;
+            std::cout << json.dump();
+            throw Exit(resultCode);
         }
 
         else {


### PR DESCRIPTION
# Motivation
`nix path-info` would always return 0 previously even in the case of invalid paths.

This change makes `nix path-info` return 1 when atore paths do not exist and need to be built which when used with `--json`.

This matches the non-json equivalent.

fixes #10886

# Context
Please see #10886 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
