### PR TITLE
Pretty print idempotently

### DIFF
--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -377,6 +377,9 @@ private:
         }
     }
 
+    /**
+     * @note This may force items.
+     */
     bool shouldPrettyPrintList(std::span<Value * const> list)
     {
         if (!options.shouldPrettyPrint() || list.empty()) {
@@ -392,6 +395,9 @@ private:
         if (!item) {
             return true;
         }
+
+        // It is ok to force the item(s) here, because they will be printed anyway.
+        state.forceValue(*item, item->determinePos(noPos));
 
         // Pretty-print single-item lists only if they contain nested
         // structures.

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -299,6 +299,9 @@ private:
             output << ANSI_NORMAL;
     }
 
+    /**
+     * @note This may force items.
+     */
     bool shouldPrettyPrintAttrs(AttrVec & v)
     {
         if (!options.shouldPrettyPrint() || v.empty()) {
@@ -314,6 +317,9 @@ private:
         if (!item) {
             return true;
         }
+
+        // It is ok to force the item(s) here, because they will be printed anyway.
+        state.forceValue(*item, item->determinePos(noPos));
 
         // Pretty-print single-item attrsets only if they contain nested
         // structures.

--- a/tests/functional/repl/pretty-print-idempotent.expected
+++ b/tests/functional/repl/pretty-print-idempotent.expected
@@ -1,0 +1,33 @@
+Nix <nix version>
+Type :? for help.
+Added <number omitted> variables.
+
+{
+  homepage = "https://example.com";
+}
+
+{ homepage = "https://example.com"; }
+
+{
+  layerOne = { ... };
+}
+
+{
+  layerOne = { ... };
+}
+
+[
+  "https://example.com"
+]
+
+[ "https://example.com" ]
+
+[
+  [ ... ]
+]
+
+[
+  [ ... ]
+]
+
+

--- a/tests/functional/repl/pretty-print-idempotent.expected
+++ b/tests/functional/repl/pretty-print-idempotent.expected
@@ -14,9 +14,7 @@ Added <number omitted> variables.
   layerOne = { ... };
 }
 
-[
-  "https://example.com"
-]
+[ "https://example.com" ]
 
 [ "https://example.com" ]
 

--- a/tests/functional/repl/pretty-print-idempotent.expected
+++ b/tests/functional/repl/pretty-print-idempotent.expected
@@ -2,9 +2,7 @@ Nix <nix version>
 Type :? for help.
 Added <number omitted> variables.
 
-{
-  homepage = "https://example.com";
-}
+{ homepage = "https://example.com"; }
 
 { homepage = "https://example.com"; }
 

--- a/tests/functional/repl/pretty-print-idempotent.in
+++ b/tests/functional/repl/pretty-print-idempotent.in
@@ -1,0 +1,9 @@
+:l pretty-print-idempotent.nix
+oneDeep
+oneDeep
+twoDeep
+twoDeep
+oneDeepList
+oneDeepList
+twoDeepList
+twoDeepList

--- a/tests/functional/repl/pretty-print-idempotent.nix
+++ b/tests/functional/repl/pretty-print-idempotent.nix
@@ -1,0 +1,19 @@
+{
+  oneDeep = {
+    homepage = "https://" + "example.com";
+  };
+  twoDeep = {
+    layerOne = {
+      homepage = "https://" + "example.com";
+    };
+  };
+
+  oneDeepList = [
+    ("https://" + "example.com")
+  ];
+  twoDeepList = [
+    [
+      ("https://" + "example.com")
+    ]
+  ];
+}


### PR DESCRIPTION
# Motivation

Make printing idempotent, as users reasonably expect.

From the commit:

> Reported on matrix by aleksana:
> https://matrix.to/#/!VRULIdgoKmKPzJZzjj:nixos.org/$7wZp5lUDTd-_u6MYo8kWWcysjtqTiQqP8dLI0RDNVVM?via=nixos.org&via=matrix.org&via=nixos.dev

# Context



<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
