### PR TITLE
doc: Add comment for fetchurl for name & url

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -529,17 +529,16 @@ static void prim_fetchurl(EvalState & state, const PosIdx pos, Value * * args, V
 
 static RegisterPrimOp primop_fetchurl({
     .name = "__fetchurl",
-    .args = {"args"},
+    .args = {"arg"},
     .doc = R"(
-      If args is a URL, return the path of the downloaded file.
-      Otherwise, it can be an attribute with the following attributes
-      (all except url are optional):
+      Download the specified URL and return the path of the downloaded file.
+      `arg` can be either a string denoting the URL, or an attribute set with the following attributes:
 
       - `url`
 
         The URL of the file to download.
 
-      - `name` (default: `url without the protocol`)
+      - `name` (default: the last path component of the URL)
 
         A name for the file in the store. This can be useful if the URL has any
         characters that are invalid for the store.

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -529,9 +529,20 @@ static void prim_fetchurl(EvalState & state, const PosIdx pos, Value * * args, V
 
 static RegisterPrimOp primop_fetchurl({
     .name = "__fetchurl",
-    .args = {"url"},
+    .args = {"args"},
     .doc = R"(
-      Download the specified URL and return the path of the downloaded file.
+      If args is a URL, return the path of the downloaded file.
+      Otherwise, it can be an attribute with the following attributes
+      (all except url are optional):
+
+      - `url`
+
+        The URL of the file to download.
+
+      - `name` (default: `url without the protocol`)
+
+        A name for the file in the store. This can be useful if the URL has any
+        characters that are invalid for the store.
 
       Not available in [restricted evaluation mode](@docroot@/command-ref/conf-file.md#conf-restrict-eval).
     )",


### PR DESCRIPTION
# Motivation
fetchurl can be given a name and url aside from just the url. Giving a name can be useful if the url has invalid characters such as tilde for the store.

![image](https://github.com/user-attachments/assets/ad968d35-abd2-4bc0-bb49-292a71a77323)

# Context
#10532

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
