### PR TITLE
Grep newline safety

### DIFF
--- a/tests/functional/common/vars-and-functions.sh
+++ b/tests/functional/common/vars-and-functions.sh
@@ -351,9 +351,12 @@ checkGrepArgs() {
 #
 # `!` normally doesn't work well with `set -e`, but when we wrap in a
 # function it *does*.
+#
+# `command grep` lets us avoid re-checking the args by going directly to the
+# executable.
 grepInverse() {
     checkGrepArgs "$@" && \
-      ! grep "$@"
+      ! command grep "$@"
 }
 
 # A shorthand, `> /dev/null` is a bit noisy.
@@ -367,15 +370,26 @@ grepInverse() {
 # the closing of the pipe, the buffering of the pipe, and the speed of
 # the producer into the pipe. But rest assured we've seen it happen in
 # CI reliably.
+#
+# `command grep` lets us avoid re-checking the args by going directly to the
+# executable.
 grepQuiet() {
     checkGrepArgs "$@" && \
-      grep "$@" > /dev/null
+      command grep "$@" > /dev/null
 }
 
 # The previous two, combined
 grepQuietInverse() {
     checkGrepArgs "$@" && \
-      ! grep "$@" > /dev/null
+      ! command grep "$@" > /dev/null
+}
+
+# Wrap grep to remove its newline footgun; see checkGrepArgs.
+# Note that we keep the checkGrepArgs calls in the other helpers, because some
+# of them are negated and that would defeat this check.
+grep() {
+    checkGrepArgs "$@" && \
+      command grep "$@"
 }
 
 # Return the number of arguments

--- a/tests/functional/common/vars-and-functions.sh
+++ b/tests/functional/common/vars-and-functions.sh
@@ -306,7 +306,8 @@ onError() {
 # Example (showns as string): 'repl.sh:123: in call to grepQuiet: '
 # This function is inefficient, so it should only be used in error messages.
 callerPrefix() {
-  # Find the closes caller that's not from this file
+  # Find the closest caller that's not from this file
+  # using the bash `caller` builtin.
   local i file line fn savedFn
   # Use `caller`
   for i in $(seq 0 100); do

--- a/tests/functional/common/vars-and-functions.sh
+++ b/tests/functional/common/vars-and-functions.sh
@@ -236,7 +236,8 @@ expect() {
     expected="$1"
     shift
     "$@" && res=0 || res="$?"
-    if [[ $res -ne $expected ]]; then
+    # also match "negative" codes, which wrap around to >127
+    if [[ $res -ne $expected && $res -ne $[256 + expected] ]]; then
         echo "Expected exit code '$expected' but got '$res' from command ${*@Q}" >&2
         return 1
     fi
@@ -250,7 +251,8 @@ expectStderr() {
     expected="$1"
     shift
     "$@" 2>&1 && res=0 || res="$?"
-    if [[ $res -ne $expected ]]; then
+    # also match "negative" codes, which wrap around to >127
+    if [[ $res -ne $expected && $res -ne $[256 + expected] ]]; then
         echo "Expected exit code '$expected' but got '$res' from command ${*@Q}" >&2
         return 1
     fi

--- a/tests/functional/test-infra.sh
+++ b/tests/functional/test-infra.sh
@@ -13,6 +13,25 @@ expect 1 false
 # `expect` will fail when we get it wrong
 expect 1 expect 0 false
 
+function ret() {
+  return $1
+}
+
+# `expect` can call functions, not just executables
+expect 0 ret 0
+expect 1 ret 1
+
+# `expect` supports negative exit codes
+expect -1 ret -1
+
+# or high positive ones, equivalent to negative ones
+expect 255 ret 255
+expect 255 ret -1
+expect -1 ret 255
+
+# but it doesn't confuse negative exit codes with positive ones
+expect 1 expect -10 ret 10
+
 noisyTrue () {
     echo YAY! >&2
     true

--- a/tests/functional/test-infra.sh
+++ b/tests/functional/test-infra.sh
@@ -88,6 +88,10 @@ funBang () {
 expect 1 funBang
 unset funBang
 
+# callerPrefix can be used by the test framework to improve error messages
+# it reports about our call site here
+echo "<[$(callerPrefix)]>" | grepQuiet -F "<[test-infra.sh:$LINENO: ]>"
+
 # `grep -v -q` is not what we want for exit codes, but `grepInverse` is
 # Avoid `grep -v -q`. The following line proves the point, and if it fails,
 # we'll know that `grep` had a breaking change or `-v -q` may not be portable.

--- a/tests/functional/test-infra.sh
+++ b/tests/functional/test-infra.sh
@@ -108,3 +108,8 @@ unset res
 res=$(set -eu -o pipefail; echo foo | expect 1 grepQuietInverse foo | wc -c)
 (( res == 0 ))
 unset res
+
+# `grepQuiet` does not allow newlines in its arguments, because grep quietly
+# treats them as multiple queries.
+( echo foo; echo bar; ) | expectStderr -101 grepQuiet $'foo\nbar' \
+  | grepQuiet -E 'test-infra\.sh:[0-9]+: in call to grepQuiet: newline not allowed in arguments; grep would try each line individually as if connected by an OR operator'

--- a/tests/functional/test-infra.sh
+++ b/tests/functional/test-infra.sh
@@ -111,7 +111,7 @@ unset res
 
 # `grepQuiet` does not allow newlines in its arguments, because grep quietly
 # treats them as multiple queries.
-( echo foo; echo bar; ) | expectStderr -101 grepQuiet $'foo\nbar' \
+{ echo foo; echo bar; } | expectStderr -101 grepQuiet $'foo\nbar' \
   | grepQuiet -E 'test-infra\.sh:[0-9]+: in call to grepQuiet: newline not allowed in arguments; grep would try each line individually as if connected by an OR operator'
 
 # We took the blue pill and woke up in a world where `grep` is moderately safe.

--- a/tests/functional/test-infra.sh
+++ b/tests/functional/test-infra.sh
@@ -113,3 +113,7 @@ unset res
 # treats them as multiple queries.
 ( echo foo; echo bar; ) | expectStderr -101 grepQuiet $'foo\nbar' \
   | grepQuiet -E 'test-infra\.sh:[0-9]+: in call to grepQuiet: newline not allowed in arguments; grep would try each line individually as if connected by an OR operator'
+
+# We took the blue pill and woke up in a world where `grep` is moderately safe.
+expectStderr -101 grep $'foo\nbar' \
+  | grepQuiet -E 'test-infra\.sh:[0-9]+: in call to grep: newline not allowed in arguments; grep would try each line individually as if connected by an OR operator'


### PR DESCRIPTION
# Motivation

Newlines in the query behave like *OR*; not "and then".

- Avoid more #11110

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
