### PR TITLE
Move `uriSchemes` to `*StoreConfig`

### DIFF
--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -21,6 +21,10 @@ struct DummyStoreConfig : virtual StoreConfig {
           #include "dummy-store.md"
           ;
     }
+
+    static std::set<std::string> uriSchemes() {
+        return {"dummy"};
+    }
 };
 
 struct DummyStore : public virtual DummyStoreConfig, public virtual Store
@@ -52,10 +56,6 @@ struct DummyStore : public virtual DummyStoreConfig, public virtual Store
     virtual std::optional<TrustedFlag> isTrustedClient() override
     {
         return Trusted;
-    }
-
-    static std::set<std::string> uriSchemes() {
-        return {"dummy"};
     }
 
     std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -83,14 +83,6 @@ public:
         }
     }
 
-    static std::set<std::string> uriSchemes()
-    {
-        static bool forceHttp = getEnv("_NIX_FORCE_HTTP") == "1";
-        auto ret = std::set<std::string>({"http", "https"});
-        if (forceHttp) ret.insert("file");
-        return ret;
-    }
-
 protected:
 
     void maybeDisable()

--- a/src/libstore/http-binary-cache-store.hh
+++ b/src/libstore/http-binary-cache-store.hh
@@ -15,6 +15,15 @@ struct HttpBinaryCacheStoreConfig : virtual BinaryCacheStoreConfig
         return "HTTP Binary Cache Store";
     }
 
+    static std::set<std::string> uriSchemes()
+    {
+        static bool forceHttp = getEnv("_NIX_FORCE_HTTP") == "1";
+        auto ret = std::set<std::string>({"http", "https"});
+        if (forceHttp)
+            ret.insert("file");
+        return ret;
+    }
+
     std::string doc() override;
 };
 

--- a/src/libstore/legacy-ssh-store.hh
+++ b/src/libstore/legacy-ssh-store.hh
@@ -26,6 +26,8 @@ struct LegacySSHStoreConfig : virtual CommonSSHStoreConfig
 
     const std::string name() override { return "SSH Store"; }
 
+    static std::set<std::string> uriSchemes() { return {"ssh"}; }
+
     std::string doc() override;
 };
 
@@ -45,8 +47,6 @@ struct LegacySSHStore : public virtual LegacySSHStoreConfig, public virtual Stor
     ref<Pool<Connection>> connections;
 
     SSHMaster master;
-
-    static std::set<std::string> uriSchemes() { return {"ssh"}; }
 
     LegacySSHStore(
         std::string_view scheme,

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -51,8 +51,6 @@ struct LocalBinaryCacheStore : virtual LocalBinaryCacheStoreConfig, virtual Bina
         return "file://" + binaryCacheDir;
     }
 
-    static std::set<std::string> uriSchemes();
-
 protected:
 
     bool fileExists(const std::string & path) override;
@@ -121,7 +119,7 @@ bool LocalBinaryCacheStore::fileExists(const std::string & path)
     return pathExists(binaryCacheDir + "/" + path);
 }
 
-std::set<std::string> LocalBinaryCacheStore::uriSchemes()
+std::set<std::string> LocalBinaryCacheStoreConfig::uriSchemes()
 {
     if (getEnv("_NIX_FORCE_HTTP") == "1")
         return {};

--- a/src/libstore/local-binary-cache-store.hh
+++ b/src/libstore/local-binary-cache-store.hh
@@ -15,6 +15,8 @@ struct LocalBinaryCacheStoreConfig : virtual BinaryCacheStoreConfig
         return "Local Binary Cache Store";
     }
 
+    static std::set<std::string> uriSchemes();
+
     std::string doc() override;
 };
 

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -63,6 +63,11 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
         return ExperimentalFeature::LocalOverlayStore;
     }
 
+    static std::set<std::string> uriSchemes()
+    {
+        return { "local-overlay" };
+    }
+
     std::string doc() override;
 
 protected:
@@ -101,11 +106,6 @@ public:
     }
 
     LocalOverlayStore(std::string_view scheme, PathView path, const Params & params);
-
-    static std::set<std::string> uriSchemes()
-    {
-        return { "local-overlay" };
-    }
 
     std::string getUri() override
     {

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -67,6 +67,9 @@ struct LocalStoreConfig : virtual LocalFSStoreConfig
 
     const std::string name() override { return "Local Store"; }
 
+    static std::set<std::string> uriSchemes()
+    { return {"local"}; }
+
     std::string doc() override;
 };
 
@@ -148,9 +151,6 @@ public:
         const Params & params);
 
     ~LocalStore();
-
-    static std::set<std::string> uriSchemes()
-    { return {"local"}; }
 
     /**
      * Implementations of abstract store API methods.

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -475,9 +475,6 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStoreConfig, public virtual
     {
         return std::nullopt;
     }
-
-    static std::set<std::string> uriSchemes() { return {"s3"}; }
-
 };
 
 static RegisterStoreImplementation<S3BinaryCacheStoreImpl, S3BinaryCacheStoreConfig> regS3BinaryCacheStore;

--- a/src/libstore/s3-binary-cache-store.hh
+++ b/src/libstore/s3-binary-cache-store.hh
@@ -94,6 +94,11 @@ public:
         return "S3 Binary Cache Store";
     }
 
+    static std::set<std::string> uriSchemes()
+    {
+        return {"s3"};
+    }
+
     std::string doc() override;
 };
 

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -47,8 +47,6 @@ public:
     {
     }
 
-    static std::set<std::string> uriSchemes() { return {"ssh-ng"}; }
-
     std::string getUri() override
     {
         return *uriSchemes().begin() + "://" + host;
@@ -152,11 +150,6 @@ public:
         extraRemoteProgramArgs = {
             "--process-ops",
         };
-    }
-
-    static std::set<std::string> uriSchemes()
-    {
-        return {"mounted-ssh-ng"};
     }
 
     std::string getUri() override

--- a/src/libstore/ssh-store.hh
+++ b/src/libstore/ssh-store.hh
@@ -23,6 +23,11 @@ struct SSHStoreConfig : virtual RemoteStoreConfig, virtual CommonSSHStoreConfig
         return "Experimental SSH Store";
     }
 
+    static std::set<std::string> uriSchemes()
+    {
+        return {"ssh-ng"};
+    }
+
     std::string doc() override;
 };
 
@@ -38,6 +43,11 @@ struct MountedSSHStoreConfig : virtual SSHStoreConfig, virtual LocalFSStoreConfi
     const std::string name() override
     {
         return "Experimental SSH Store with filesystem mounted";
+    }
+
+    static std::set<std::string> uriSchemes()
+    {
+        return {"mounted-ssh-ng"};
     }
 
     std::string doc() override;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -216,6 +216,10 @@ public:
 
     virtual ~Store() { }
 
+    /**
+     * @todo move to `StoreConfig` one we store enough information in
+     * those to recover the scheme and authority in all cases.
+     */
     virtual std::string getUri() = 0;
 
     /**
@@ -897,7 +901,7 @@ struct Implementations
     {
         if (!registered) registered = new std::vector<StoreFactory>();
         StoreFactory factory{
-            .uriSchemes = T::uriSchemes(),
+            .uriSchemes = TConfig::uriSchemes(),
             .create =
                 ([](auto scheme, auto uri, auto & params)
                  -> std::shared_ptr<Store>

--- a/src/libstore/uds-remote-store.hh
+++ b/src/libstore/uds-remote-store.hh
@@ -36,6 +36,10 @@ struct UDSRemoteStoreConfig : virtual LocalFSStoreConfig, virtual RemoteStoreCon
 
 protected:
     static constexpr char const * scheme = "unix";
+
+public:
+    static std::set<std::string> uriSchemes()
+    { return {scheme}; }
 };
 
 class UDSRemoteStore : public virtual UDSRemoteStoreConfig
@@ -58,9 +62,6 @@ public:
         const Params & params);
 
     std::string getUri() override;
-
-    static std::set<std::string> uriSchemes()
-    { return {scheme}; }
 
     ref<SourceAccessor> getFSAccessor(bool requireValidPath = true) override
     { return LocalFSStore::getFSAccessor(requireValidPath); }


### PR DESCRIPTION
# Motivation

It is a property of the configuration of a store --- how a store URL is parsed into a store config, not a store itself.

# Context

Progress towards #10766

Depends on #11109

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
