### PR TITLE
Doc comments: use std::unordered_map

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -130,7 +130,7 @@ struct Constant
     typedef std::map<std::string, Value *> ValMap;
 #endif
 
-typedef std::map<PosIdx, DocComment> DocCommentMap;
+typedef std::unordered_map<PosIdx, DocComment> DocCommentMap;
 
 struct Env
 {
@@ -335,7 +335,7 @@ private:
      * Associate source positions of certain AST nodes with their preceding doc comment, if they have one.
      * Grouped by file.
      */
-    std::map<SourcePath, DocCommentMap> positionToDocComment;
+    std::unordered_map<SourcePath, DocCommentMap> positionToDocComment;
 
     LookupPath lookupPath;
 

--- a/src/libexpr/parser-state.hh
+++ b/src/libexpr/parser-state.hh
@@ -64,7 +64,7 @@ struct LexerState
     /**
      * @brief Maps some positions to a DocComment, where the comment is relevant to the location.
      */
-    std::map<PosIdx, DocComment> & positionToDocComment;
+    std::unordered_map<PosIdx, DocComment> & positionToDocComment;
 
     PosTable & positions;
     PosTable::Origin origin;

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -48,7 +48,7 @@
 
 namespace nix {
 
-typedef std::map<PosIdx, DocComment> DocCommentMap;
+typedef std::unordered_map<PosIdx, DocComment> DocCommentMap;
 
 Expr * parseExprFromBuf(
     char * text,

--- a/src/libexpr/pos-idx.hh
+++ b/src/libexpr/pos-idx.hh
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <cinttypes>
-
-#include "std-hash.hh"
+#include <functional>
 
 namespace nix {
 
@@ -43,9 +42,7 @@ public:
 
     size_t hash() const noexcept
     {
-        size_t h = 854125;
-        hash_combine(h, id);
-        return h;
+        return std::hash<uint32_t>{}(id);
     }
 };
 

--- a/src/libexpr/pos-idx.hh
+++ b/src/libexpr/pos-idx.hh
@@ -2,12 +2,15 @@
 
 #include <cinttypes>
 
+#include "util.hh"
+
 namespace nix {
 
 class PosIdx
 {
     friend struct LazyPosAcessors;
     friend class PosTable;
+    friend class std::hash<PosIdx>;
 
 private:
     uint32_t id;
@@ -37,8 +40,28 @@ public:
     {
         return id == other.id;
     }
+
+    size_t hash() const noexcept
+    {
+        size_t h = 854125;
+        hash_combine(h, id);
+        return h;
+    }
 };
 
 inline PosIdx noPos = {};
 
 }
+
+namespace std {
+
+template<>
+struct hash<nix::PosIdx>
+{
+    std::size_t operator()(nix::PosIdx pos) const noexcept
+    {
+        return pos.hash();
+    }
+};
+
+} // namespace std

--- a/src/libexpr/pos-idx.hh
+++ b/src/libexpr/pos-idx.hh
@@ -2,7 +2,7 @@
 
 #include <cinttypes>
 
-#include "util.hh"
+#include "std-hash.hh"
 
 namespace nix {
 

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -216,6 +216,7 @@ headers = [config_h] + files(
   'source-accessor.hh',
   'source-path.hh',
   'split.hh',
+  'std-hash.hh',
   'strings.hh',
   'strings-inline.hh',
   'suggestions.hh',

--- a/src/libutil/source-path.hh
+++ b/src/libutil/source-path.hh
@@ -8,8 +8,7 @@
 #include "ref.hh"
 #include "canon-path.hh"
 #include "source-accessor.hh"
-
-#include <boost/functional/hash.hpp> // for boost::hash_combine
+#include "std-hash.hh"
 
 namespace nix {
 

--- a/src/libutil/std-hash.hh
+++ b/src/libutil/std-hash.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+//!@file Hashing utilities for use with unordered_map, etc. (ie low level implementation logic, not domain logic like
+//! Nix hashing)
+
+#include <functional>
+
+namespace nix {
+
+/**
+ * hash_combine() from Boost. Hash several hashable values together
+ * into a single hash.
+ */
+inline void hash_combine(std::size_t & seed) {}
+
+template<typename T, typename... Rest>
+inline void hash_combine(std::size_t & seed, const T & v, Rest... rest)
+{
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    hash_combine(seed, rest...);
+}
+
+} // namespace nix

--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -375,18 +375,4 @@ inline std::string operator + (std::string_view s1, const char * s2)
     return s;
 }
 
-/**
- * hash_combine() from Boost. Hash several hashable values together
- * into a single hash.
- */
-inline void hash_combine(std::size_t & seed) { }
-
-template <typename T, typename... Rest>
-inline void hash_combine(std::size_t & seed, const T & v, Rest... rest)
-{
-    std::hash<T> hasher;
-    seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-    hash_combine(seed, rest...);
-}
-
 }


### PR DESCRIPTION
# Motivation

As suggested in #11072 and now possible after #11092 

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
