### PR TITLE
Document builtins.derivation

### DIFF
--- a/src/libexpr/primops/derivation.nix
+++ b/src/libexpr/primops/derivation.nix
@@ -1,6 +1,31 @@
-/* This is the implementation of the ‘derivation’ builtin function.
-   It's actually a wrapper around the ‘derivationStrict’ primop. */
+# This is the implementation of the ‘derivation’ builtin function.
+# It's actually a wrapper around the ‘derivationStrict’ primop.
+# Note that the following comment will be shown in :doc in the repl, but not in the manual.
 
+/**
+  Create a derivation.
+
+  # Inputs
+
+  The single argument is an attribute set that describes what to build and how to build it.
+  See https://nix.dev/manual/nix/2.23/language/derivations
+
+  # Output
+
+  The result is an attribute set that describes the derivation.
+  Notably it contains the outputs, which in the context of the Nix language are special strings that refer to the output paths, which may not yet exist.
+  The realisation of these outputs only occurs when needed; for example
+
+    * When `nix-build` or a similar command is run, it realises the outputs that were requested on its command line.
+      See https://nix.dev/manual/nix/2.23/command-ref/nix-build
+
+    * When `import`, `readFile`, `readDir` or some other functions are called, they have to realise the outputs they depend on.
+      This is referred to as "import from derivation".
+      See https://nix.dev/manual/nix/2.23/language/import-from-derivation
+
+  Note that `derivation` is very bare-bones, and provides almost no commands during the build.
+  Most likely, you'll want to use functions like `stdenv.mkDerivation` in Nixpkgs to set up a basic environment.
+*/
 drvAttrs @ { outputs ? [ "out" ], ... }:
 
 let

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -50,11 +50,22 @@ set +x
 badDiff=0
 badExitCode=0
 
+# Extra post-processing that's specific to each test case
+postprocess() {
+    if [[ -e "lang/$1.postprocess" ]]; then
+        (
+            set -x;
+            "lang/$1.postprocess" "lang/$1"
+        )
+    fi
+}
+
 for i in lang/parse-fail-*.nix; do
     echo "parsing $i (should fail)";
     i=$(basename "$i" .nix)
     if expectStderr 1 nix-instantiate --parse - < "lang/$i.nix" > "lang/$i.err"
     then
+        postprocess "$i"
         diffAndAccept "$i" err err.exp
     else
         echo "FAIL: $i shouldn't parse"
@@ -71,6 +82,7 @@ for i in lang/parse-okay-*.nix; do
             2> "lang/$i.err"
     then
         sed "s!$(pwd)!/pwd!g" "lang/$i.out" "lang/$i.err"
+        postprocess "$i"
         diffAndAccept "$i" out exp
         diffAndAccept "$i" err err.exp
     else
@@ -94,6 +106,7 @@ for i in lang/eval-fail-*.nix; do
         expectStderr 1 nix-instantiate $flags "lang/$i.nix" \
             | sed "s!$(pwd)!/pwd!g" > "lang/$i.err"
     then
+        postprocess "$i"
         diffAndAccept "$i" err err.exp
     else
         echo "FAIL: $i shouldn't evaluate"
@@ -109,6 +122,7 @@ for i in lang/eval-okay-*.nix; do
         if expect 0 nix-instantiate --eval --xml --no-location --strict \
                 "lang/$i.nix" > "lang/$i.out.xml"
         then
+            postprocess "$i"
             diffAndAccept "$i" out.xml exp.xml
         else
             echo "FAIL: $i should evaluate"
@@ -129,6 +143,7 @@ for i in lang/eval-okay-*.nix; do
                 2> "lang/$i.err"
         then
             sed -i "s!$(pwd)!/pwd!g" "lang/$i.out" "lang/$i.err"
+            postprocess "$i"
             diffAndAccept "$i" out exp
             diffAndAccept "$i" err err.exp
         else

--- a/tests/functional/lang.sh
+++ b/tests/functional/lang.sh
@@ -54,8 +54,11 @@ badExitCode=0
 postprocess() {
     if [[ -e "lang/$1.postprocess" ]]; then
         (
+            # We could allow arbitrary interpreters in .postprocess, but that
+            # just exposes us to the complexity of not having /usr/bin/env in
+            # the sandbox. So let's just hardcode bash for now.
             set -x;
-            "lang/$1.postprocess" "lang/$1"
+            bash "lang/$1.postprocess" "lang/$1"
         )
     fi
 }

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -1,24 +1,24 @@
 error:
        … while evaluating the attribute 'outPath'
-         at <nix/derivation-internal.nix>:19:9:
-           18|       value = commonAttrs // {
-           19|         outPath = builtins.getAttr outputName strict;
+         at <nix/derivation-internal.nix>:44:9:
+           43|       value = commonAttrs // {
+           44|         outPath = builtins.getAttr outputName strict;
              |         ^
-           20|         drvPath = strict.drvPath;
+           45|         drvPath = strict.drvPath;
 
        … while calling the 'getAttr' builtin
-         at <nix/derivation-internal.nix>:19:19:
-           18|       value = commonAttrs // {
-           19|         outPath = builtins.getAttr outputName strict;
+         at <nix/derivation-internal.nix>:44:19:
+           43|       value = commonAttrs // {
+           44|         outPath = builtins.getAttr outputName strict;
              |                   ^
-           20|         drvPath = strict.drvPath;
+           45|         drvPath = strict.drvPath;
 
        … while calling the 'derivationStrict' builtin
-         at <nix/derivation-internal.nix>:9:12:
-            8|
-            9|   strict = derivationStrict drvAttrs;
+         at <nix/derivation-internal.nix>:34:12:
+           33|
+           34|   strict = derivationStrict drvAttrs;
              |            ^
-           10|
+           35|
 
        … while evaluating derivation '~jiggle~'
          whose name attribute is located at /pwd/lang/eval-fail-derivation-name.nix:2:3

--- a/tests/functional/lang/eval-fail-derivation-name.err.exp
+++ b/tests/functional/lang/eval-fail-derivation-name.err.exp
@@ -1,26 +1,26 @@
 error:
        … while evaluating the attribute 'outPath'
-         at <nix/derivation-internal.nix>:44:9:
-           43|       value = commonAttrs // {
-           44|         outPath = builtins.getAttr outputName strict;
+         at <nix/derivation-internal.nix>:<number>:<number>:
+     <number>|       value = commonAttrs // {
+     <number>|         outPath = builtins.getAttr outputName strict;
              |         ^
-           45|         drvPath = strict.drvPath;
+     <number>|         drvPath = strict.drvPath;
 
        … while calling the 'getAttr' builtin
-         at <nix/derivation-internal.nix>:44:19:
-           43|       value = commonAttrs // {
-           44|         outPath = builtins.getAttr outputName strict;
+         at <nix/derivation-internal.nix>:<number>:<number>:
+     <number>|       value = commonAttrs // {
+     <number>|         outPath = builtins.getAttr outputName strict;
              |                   ^
-           45|         drvPath = strict.drvPath;
+     <number>|         drvPath = strict.drvPath;
 
        … while calling the 'derivationStrict' builtin
-         at <nix/derivation-internal.nix>:34:12:
-           33|
-           34|   strict = derivationStrict drvAttrs;
+         at <nix/derivation-internal.nix>:<number>:<number>:
+     <number>|
+     <number>|   strict = derivationStrict drvAttrs;
              |            ^
-           35|
+     <number>|
 
        … while evaluating derivation '~jiggle~'
-         whose name attribute is located at /pwd/lang/eval-fail-derivation-name.nix:2:3
+         whose name attribute is located at /pwd/lang/eval-fail-derivation-name.nix:<number>:<number>
 
        error: invalid derivation name: name '~jiggle~' contains illegal character '~'. Please pass a different 'name'.

--- a/tests/functional/lang/eval-fail-derivation-name.postprocess
+++ b/tests/functional/lang/eval-fail-derivation-name.postprocess
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+testcaseBasename=$1
+
+# Line numbers change when derivation.nix docs are updated.
+sed -i "$testcaseBasename.err" \
+  -e 's/[0-9 ][0-9 ][0-9 ][0-9 ][0-9 ][0-9 ][0-9 ][0-9]\([^0-9]\)/<number>\1/g' \
+  -e 's/[0-9][0-9]*/<number>/g' \
+  ;

--- a/tests/functional/lang/eval-fail-derivation-name.postprocess
+++ b/tests/functional/lang/eval-fail-derivation-name.postprocess
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 set -euo pipefail
 testcaseBasename=$1
 


### PR DESCRIPTION
# Motivation

For use with `:doc` in the repl.

We didn't have much of a function-oriented documentation for this, and this should really also be part of the manual somehow, but the format is different and I don't think we have tooling to automate this, but at least this could be a half-decent start that fills a significant gap.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
