### PR TITLE
doc: add example usage for gitea in tarball fetcher

### DIFF
--- a/doc/manual/src/protocols/tarball-fetcher.md
+++ b/doc/manual/src/protocols/tarball-fetcher.md
@@ -43,21 +43,28 @@ defined as the timestamp of the newest file inside the tarball.
 
 ## Gitea and Forgejo support
 
-Since Gitea v1.22.1 and Forgejo v7.0.4/v8.0.0, this protocol is supported in both, which can be used like this:
+This protocol is supported by Gitea since v1.22.1 and by Forgejo since v7.0.4/v8.0.0 and can be used with the following flake URL schema:
 
-```nix
-{
-    inputs = {
-        gitea-repo-schema.url = "https://<instance hostname>/<owner>/<repo>/archive/<ref>.tar.gz";
+```
+https://<domain name>/<owner>/<repo>/archive/<reference or revison>.tar.gz
+```
 
-        main-branch.url = "https://gitea.example/johndoe/some-nix-flake/archive/main.tar.gz";
-        other-branch.url = "https://gitea2.example/someotherperson/other-flake/archive/other.tar.gz";
-        non-flake = {
-            url = "https://forgejo.example/random-person/random-non-flake-repo/archive/main.tar.gz";
-            flake = false;
-        };
-    };
-}
+> **Example**
+>
+>
+> ```nix
+> # flake.nix
+> {
+>    inputs = {
+>      foo.url = "https://gitea.example.org/some-person/some-flake/archive/main.tar.gz";
+>      bar.url = "https://gitea.example.org/some-other-person/other-flake/archive/442793d9ec0584f6a6e82fa253850c8085bb150a.tar.gz";
+>      qux = {
+>        url = "https://forgejo.example.org/another-person/some-non-flake-repo/archive/development.tar.gz";
+>        flake = false;
+>      };
+>    };
+>    outputs = { foo, bar, qux }: { /* ... */ };
+> }
 ```
 
 [Nix Archive]: @docroot@/store/file-system-object/content-address.md#serial-nix-archive

--- a/doc/manual/src/protocols/tarball-fetcher.md
+++ b/doc/manual/src/protocols/tarball-fetcher.md
@@ -41,4 +41,23 @@ Link: <https://example.org/hello/442793d9ec0584f6a6e82fa253850c8085bb150a.tar.gz
 For tarball flakes, the value of the `lastModified` flake attribute is
 defined as the timestamp of the newest file inside the tarball.
 
+## Gitea and Forgejo support
+
+Since Gitea v1.22.1 and Forgejo v7.0.4/v8.0.0, this protocol is supported in both, which can be used like this:
+
+```nix
+{
+    inputs = {
+        gitea-repo-schema.url = "https://<instance hostname>/<owner>/<repo>/archive/<ref>.tar.gz";
+
+        main-branch.url = "https://gitea.example/johndoe/some-nix-flake/archive/main.tar.gz";
+        other-branch.url = "https://gitea2.example/someotherperson/other-flake/archive/other.tar.gz";
+        non-flake = {
+            url = "https://forgejo.example/random-person/random-non-flake-repo/archive/main.tar.gz";
+            flake = false;
+        };
+    };
+}
+```
+
 [Nix Archive]: @docroot@/store/file-system-object/content-address.md#serial-nix-archive

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -259,6 +259,8 @@ Currently the `type` attribute can be one of the following:
   `.tgz`, `.tar.gz`, `.tar.xz`, `.tar.bz2` or `.tar.zst`), then the `tarball+`
   can be dropped.
 
+  This can also be used to set the location of gitea/forgejo branches. [See here](@docroot@/protocols/tarball-fetcher.md#gitea-and-forgejo-support)
+
 * `file`: Plain files or directory tarballs, either over http(s) or from the local
   disk.
 


### PR DESCRIPTION
# Motivation
Since both Gitea and Forgejo now support the `rel="immutable"` Link headers, it should be documented how one would use it in a flake.

# Context
Forgejo PR: https://codeberg.org/forgejo/forgejo/pulls/3615
Gitea PR: https://github.com/go-gitea/gitea/pull/31139

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
