### PR TITLE
Avoid accessing uninitialized settings in own init

### DIFF
--- a/src/libexpr/eval-settings.cc
+++ b/src/libexpr/eval-settings.cc
@@ -56,7 +56,7 @@ EvalSettings::EvalSettings(bool & readOnlyMode, EvalSettings::LookupPathHooks lo
         builtinsAbortOnWarn = true;
 }
 
-Strings EvalSettings::getDefaultNixPath() const
+Strings EvalSettings::getDefaultNixPath()
 {
     Strings res;
     auto add = [&](const Path & p, const std::string & s = std::string()) {
@@ -69,11 +69,9 @@ Strings EvalSettings::getDefaultNixPath() const
         }
     };
 
-    if (!restrictEval && !pureEval) {
-        add(getNixDefExpr() + "/channels");
-        add(rootChannelsDir() + "/nixpkgs", "nixpkgs");
-        add(rootChannelsDir());
-    }
+    add(getNixDefExpr() + "/channels");
+    add(rootChannelsDir() + "/nixpkgs", "nixpkgs");
+    add(rootChannelsDir());
 
     return res;
 }

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -43,7 +43,7 @@ struct EvalSettings : Config
 
     bool & readOnlyMode;
 
-    Strings getDefaultNixPath() const;
+    static Strings getDefaultNixPath();
 
     static bool isPseudoUrl(std::string_view s);
 


### PR DESCRIPTION
The default value for the setting was evaluated by calling a method on the object _being currently constructed_, so we were using it before all fields were initialized.

This has been fixed by making the called method static, and not using the previously used fields at all.

But functionality hasn't changed!
The fields were usually always zero (by chance?) anyway, meaning the conditional path was always taken.

Thus the current logic has been kept, the code simplified, and UB removed.

This was found with the helper of UBSan.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
