### PR TITLE
parser: Remove empty multiline string parts earlier

### DIFF
--- a/tests/functional/lang/parse-okay-ind-string.exp
+++ b/tests/functional/lang/parse-okay-ind-string.exp
@@ -1,0 +1,1 @@
+(let string = "str"; in [ (/some/path) ((/some/path)) (("" + /some/path)) ((/some/path + "\n    end")) (string) ((string)) (("" + string)) ((string + "\n    end")) ("") ("") ("end") ])

--- a/tests/functional/lang/parse-okay-ind-string.exp
+++ b/tests/functional/lang/parse-okay-ind-string.exp
@@ -1,1 +1,1 @@
-(let string = "str"; in [ (/some/path) ((/some/path)) (("" + /some/path)) ((/some/path + "\n    end")) (string) ((string)) (("" + string)) ((string + "\n    end")) ("") ("") ("end") ])
+(let string = "str"; in [ (/some/path) ((/some/path)) ((/some/path)) ((/some/path + "\n    end")) (string) ((string)) ((string)) ((string + "\n    end")) ("") ("") ("end") ])

--- a/tests/functional/lang/parse-okay-ind-string.nix
+++ b/tests/functional/lang/parse-okay-ind-string.nix
@@ -1,0 +1,31 @@
+let
+  string = "str";
+in [
+  /some/path
+
+  ''${/some/path}''
+
+  ''
+    ${/some/path}''
+
+  ''${/some/path}
+    end''
+
+  string
+
+  ''${string}''
+
+  ''
+    ${string}''
+
+  ''${string}
+    end''
+
+  ''''
+
+  ''
+  ''
+
+  ''
+    end''
+]


### PR DESCRIPTION
# Motivation

Consider these two expressions:
```nix
# a.nix
[
  ''
    ${"string"}''
]
```

```nix
# b.nix
[
  ''${"string"}''
]
```

They parse differently:
```shell
$ nix-instantiate --parse a.nix
[ (("" + "string")) ]
$ nix-instantiate --parse b.nix
[ ("string") ]
```

The first one also ends up allocating an extra thunk to be evaluated, but they evaluate to the same:
```shell
$ NIX_SHOW_STATS=1 NIX_SHOW_STATS_PATH=stats.json nix-instantiate --eval --strict a.nix
[ "string" ]
$ jq .nrThunks stats.json
1

$ NIX_SHOW_STATS=1 NIX_SHOW_STATS_PATH=stats.json nix-instantiate --eval --strict b.nix
[ "string" ]
$ jq .nrThunks stats.json
0
```

There is no need for this inconsistency, so this PR changes it to treat both the same (`a.nix` now acts the same as `b.nix`). This is done by preventing the propagation of empty strings to be concatenated in the parser already.

# Context

I've found this when I tried to verify that `nix-instantiate --parse` doesn't change upon [applying a formatter on Nixpkgs](https://github.com/NixOS/nixpkgs/pull/322537). Turns out it does change at least because of this.

# Priorities and Process

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
