### PR TITLE
Fix ub

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -1569,7 +1569,7 @@ void DerivationGoal::waiteeDone(GoalPtr waitee, ExitCode result)
 {
     Goal::waiteeDone(waitee, result);
 
-    if (!useDerivation) return;
+    if (!useDerivation || !drv) return;
     auto & fullDrv = *dynamic_cast<Derivation *>(drv.get());
 
     auto * dg = dynamic_cast<DerivationGoal *>(&*waitee);

--- a/tests/unit/libutil-support/tests/string_callback.cc
+++ b/tests/unit/libutil-support/tests/string_callback.cc
@@ -2,9 +2,10 @@
 
 namespace nix::testing {
 
-void observe_string_cb(const char * start, unsigned int n, std::string * user_data)
+void observe_string_cb(const char * start, unsigned int n, void * user_data)
 {
-    *user_data = std::string(start);
+    auto user_data_casted = reinterpret_cast<std::string *>(user_data);
+    *user_data_casted = std::string(start);
 }
 
 }

--- a/tests/unit/libutil-support/tests/string_callback.hh
+++ b/tests/unit/libutil-support/tests/string_callback.hh
@@ -3,14 +3,13 @@
 
 namespace nix::testing {
 
-void observe_string_cb(const char * start, unsigned int n, std::string * user_data);
+void observe_string_cb(const char * start, unsigned int n, void * user_data);
 
 inline void * observe_string_cb_data(std::string & out)
 {
     return (void *) &out;
 };
 
-#define OBSERVE_STRING(str) \
-    (nix_get_string_callback) nix::testing::observe_string_cb, nix::testing::observe_string_cb_data(str)
+#define OBSERVE_STRING(str) nix::testing::observe_string_cb, nix::testing::observe_string_cb_data(str)
 
 }


### PR DESCRIPTION
Follow-up PR to #11117, but independent.
Merging without squashing is probably best, since the two commits are also independent.

The goal is to eventually have zero UBSan failures. There still is one left after this  and #11117 where
activity code complains about there being a `Verbosity` of value 8 (which is one more than the max, `lvlVerbosity`).
I'm not sure where that comes from so I haven't fixed it.

Commit messages:

> Avoid casting function pointer in libutil test support 
> 
> Casting function pointers seems to be almost always UB.
> See https://stackoverflow.com/questions/559581/casting-a-function-pointer-to-another-type
> 
> Fixed by doing the casting of `void*` to `std::string*` inside the function instead.
>
> Caught by UBSan.

> Check if drv is initialized in DerivationGoal::waiteeDone 
> 
> It might not be set, in which case we shouldn't do anything.
> Surprisingly, this somehow did not cause segfaults before?
> 
> Caught by UBSan.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
