### PR TITLE
Fix non-deterministic inherit printing

### DIFF
--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -82,7 +82,9 @@ void ExprAttrs::showBindings(const SymbolTable & symbols, std::ostream & str) co
         return sa < sb;
     });
     std::vector<Symbol> inherits;
-    std::map<ExprInheritFrom *, std::vector<Symbol>> inheritsFrom;
+    // We can use the displacement as a proxy for the order in which the symbols were parsed.
+    // The assignment of displacements should be deterministic, so that showBindings is deterministic.
+    std::map<Displacement, std::vector<Symbol>> inheritsFrom;
     for (auto & i : sorted) {
         switch (i->second.kind) {
         case AttrDef::Kind::Plain:
@@ -93,7 +95,7 @@ void ExprAttrs::showBindings(const SymbolTable & symbols, std::ostream & str) co
         case AttrDef::Kind::InheritedFrom: {
             auto & select = dynamic_cast<ExprSelect &>(*i->second.e);
             auto & from = dynamic_cast<ExprInheritFrom &>(*select.e);
-            inheritsFrom[&from].push_back(i->first);
+            inheritsFrom[from.displ].push_back(i->first);
             break;
         }
         }
@@ -105,7 +107,7 @@ void ExprAttrs::showBindings(const SymbolTable & symbols, std::ostream & str) co
     }
     for (const auto & [from, syms] : inheritsFrom) {
         str << "inherit (";
-        (*inheritFromExprs)[from->displ]->show(symbols, str);
+        (*inheritFromExprs)[from]->show(symbols, str);
         str << ")";
         for (auto sym : syms) str << " " << symbols[sym];
         str << "; ";


### PR DESCRIPTION
# Motivation
In _very_ rare cases (I had about 7 cases out of 32200 files!), the order of how inherit-from bindings are printed when using `nix-instantiate --parse` gets messed up.

The cause of this seems to be because the [std::map](https://en.cppreference.com/w/cpp/container/map) the bindings are placed in is keyed on a _pointer_, which then uses an [implementation-defined strict total order](https://en.cppreference.com/w/cpp/language/operator_comparison#Pointer_total_order).

The fix here is to key the bindings on their displacement instead, which maintains the same order as they appear in the file.

Unfortunately I wasn't able to make a reproducible test for this in the source, there's something about the local environment that makes it unreproducible for me.

However I was able to make a reproducible test in a Nix build on a Nix version from a very recent master:

```bash
nix build github:infinisil/non-det-nix-parsing-repro
```

which shows the difference (prettified for easy viewing):
```diff
diff --git a/a.nix b/b.nix
index 6f0637998..a5fd9ebfa 100644
--- a/a.nix
+++ b/b.nix
@@ -1,6 +1,6 @@
 ({ crun, emptyDirectory, haskell, haskellPackages, lib, makeWrapper, stdenv }: (
-  let inherit (lib) makeBinPath;
-  inherit ((haskell).lib.compose) addBuildTools appendConfigureFlags justStaticExecutables overrideCabal;
+  let inherit ((haskell).lib.compose) addBuildTools appendConfigureFlags justStaticExecutables overrideCabal;
+  inherit (lib) makeBinPath;
   bundledBins = ((lib).optional (stdenv).isLinux crun);
   overrides = (old: {
     hercules-ci-agent = (overrideCabal (o: { buildTarget = "lib:hercules-ci-agent hercules-ci-agent-unit-tests"; configureFlags = ((o).configureFlags or ([ ]) ++ [ (("--bindir=" + emptyDirectory + "/hercules-ci-built-without-binaries/no-bin")) ]); enableSharedExecutables = false; isExecutable = false; isLibrary = true; postInstall = ""; }) (old).hercules-ci-agent);
```

# Context

I've found this when I tried to verify that `nix-instantiate --parse` doesn't change upon [applying a formatter on Nixpkgs](https://github.com/NixOS/nixpkgs/pull/322537). Turns out it does change at least because of this.

Another unrelated instance of this is https://github.com/NixOS/nix/pull/11120

# Priorities and Process

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 