### PR TITLE
BasicClientConnection::handshake(): Don't send our version twice

### DIFF
--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -152,7 +152,6 @@ WorkerProto::BasicClientConnection::handshake(BufferedSink & to, Source & from, 
         throw Error("Nix daemon protocol version not supported");
     if (GET_PROTOCOL_MINOR(daemonVersion) < 10)
         throw Error("the Nix daemon version is too old");
-    to << localVersion;
 
     return std::min(daemonVersion, localVersion);
 }


### PR DESCRIPTION

# Motivation

This was accidentally introduced in f71b4da0b3ed994f2bfc3764df6f524ebe72c4da.  We didn't notice this because the version got interpreted by the daemon as the obsolete "CPU affinity will follow" field, and being non-zero, it would then read another integer for the ignored CPU affinity.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
