### PR TITLE
C API: Make nix_err an enum

### DIFF
--- a/src/libutil-c/nix_api_util.h
+++ b/src/libutil-c/nix_api_util.h
@@ -56,47 +56,51 @@ extern "C" {
  * - NIX_ERR_KEY: A key error occurred (-3)
  * - NIX_ERR_NIX_ERROR: A generic Nix error occurred (-4)
  */
-typedef int nix_err;
+enum nix_err {
 
-/**
- * @brief No error occurred.
- *
- * This error code is returned when no error has occurred during the function
- * execution.
- */
-#define NIX_OK 0
+    /**
+     * @brief No error occurred.
+     *
+     * This error code is returned when no error has occurred during the function
+     * execution.
+     */
+    NIX_OK = 0,
 
-/**
- * @brief An unknown error occurred.
- *
- * This error code is returned when an unknown error occurred during the
- * function execution.
- */
-#define NIX_ERR_UNKNOWN -1
+    /**
+     * @brief An unknown error occurred.
+     *
+     * This error code is returned when an unknown error occurred during the
+     * function execution.
+     */
+    NIX_ERR_UNKNOWN = -1,
 
-/**
- * @brief An overflow error occurred.
- *
- * This error code is returned when an overflow error occurred during the
- * function execution.
- */
-#define NIX_ERR_OVERFLOW -2
+    /**
+     * @brief An overflow error occurred.
+     *
+     * This error code is returned when an overflow error occurred during the
+     * function execution.
+     */
+    NIX_ERR_OVERFLOW = -2,
 
-/**
- * @brief A key error occurred.
- *
- * This error code is returned when a key error occurred during the function
- * execution.
- */
-#define NIX_ERR_KEY -3
+    /**
+     * @brief A key error occurred.
+     *
+     * This error code is returned when a key error occurred during the function
+     * execution.
+     */
+    NIX_ERR_KEY = -3,
 
-/**
- * @brief A generic Nix error occurred.
- *
- * This error code is returned when a generic Nix error occurred during the
- * function execution.
- */
-#define NIX_ERR_NIX_ERROR -4
+    /**
+     * @brief A generic Nix error occurred.
+     *
+     * This error code is returned when a generic Nix error occurred during the
+     * function execution.
+     */
+    NIX_ERR_NIX_ERROR = -4,
+
+};
+
+typedef enum nix_err nix_err;
 
 /**
  * @brief This object stores error state.


### PR DESCRIPTION

# Motivation

Closes #10635

An enum provides more structured information to code generators.

This generally gives a better experience with bindings generators, possibly other tooling.

# Context

I'll request feedback in the bindings matrix channel.

A possible risk is that some generators may not represent unknown codes correctly.
Rust bindgen by default generates suitable code:
  * a type alias `nix_err = c_int`
  * individual constants for the known enum values
 
It does _not_ generate a closed type that can only hold the values that were known at code generation time.

If this change proves to be a problem, we could instead split the type:

`typedef int nix_err;` for return values
`enum nix_known_err` for code generation.

This would complicate the interface, so let's not do it unless it is shown to be needed.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
