### PR TITLE
libmain: add missing header include

### DIFF
--- a/src/libmain/plugin.cc
+++ b/src/libmain/plugin.cc
@@ -2,6 +2,8 @@
 #  include <dlfcn.h>
 #endif
 
+#include <filesystem>
+
 #include "config-global.hh"
 #include "signals.hh"
 


### PR DESCRIPTION
# Motivation

Fixes the build for me on `x86_64-darwin`. I have no idea how this passed CI (SDK version header differences?). If `x86_64-darwin` is meant to be a viable Nix platform I’d strongly recommend ensuring that CI continues to build it, as this is the second recent incident of a broken build only on `x86_64-darwin`. (Of course, using an Apple Silicon runner to build the `x86_64-darwin` version through Rosetta is fine.)

cc @Ericson2314 who might have introduced this by moving the plugin code around

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
