### PR TITLE
WorkerProto: Support fine-grained protocol feature negotiation

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -1025,19 +1025,20 @@ void processConnection(
 #endif
 
     /* Exchange the greeting. */
-    WorkerProto::Version clientVersion =
+    auto [protoVersion, features] =
         WorkerProto::BasicServerConnection::handshake(
-            to, from, PROTOCOL_VERSION);
+            to, from, PROTOCOL_VERSION, WorkerProto::allFeatures);
 
-    if (clientVersion < 0x10a)
+    if (protoVersion < 0x10a)
         throw Error("the Nix client version is too old");
 
     WorkerProto::BasicServerConnection conn;
     conn.to = std::move(to);
     conn.from = std::move(from);
-    conn.protoVersion = clientVersion;
+    conn.protoVersion = protoVersion;
+    conn.features = features;
 
-    auto tunnelLogger = new TunnelLogger(conn.to, clientVersion);
+    auto tunnelLogger = new TunnelLogger(conn.to, protoVersion);
     auto prevLogger = nix::logger;
     // FIXME
     if (!recursive)

--- a/src/libstore/worker-protocol-connection.hh
+++ b/src/libstore/worker-protocol-connection.hh
@@ -24,6 +24,11 @@ struct WorkerProto::BasicConnection
     WorkerProto::Version protoVersion;
 
     /**
+     * The set of features that both sides support.
+     */
+    std::set<Feature> features;
+
+    /**
      * Coercion to `WorkerProto::ReadConn`. This makes it easy to use the
      * factored out serve protocol serializers with a
      * `LegacySSHStore::Connection`.
@@ -72,8 +77,8 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
     /**
      * Establishes connection, negotiating version.
      *
-     * @return the version provided by the other side of the
-     * connection.
+     * @return the minimum version supported by both sides and the set
+     * of protocol features supported by both sides.
      *
      * @param to Taken by reference to allow for various error handling
      * mechanisms.
@@ -82,8 +87,15 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
      * handling mechanisms.
      *
      * @param localVersion Our version which is sent over
+     *
+     * @param features The protocol features that we support
      */
-    static Version handshake(BufferedSink & to, Source & from, WorkerProto::Version localVersion);
+    // FIXME: this should probably be a constructor.
+    static std::tuple<Version, std::set<Feature>> handshake(
+        BufferedSink & to,
+        Source & from,
+        WorkerProto::Version localVersion,
+        const std::set<Feature> & supportedFeatures);
 
     /**
      * After calling handshake, must call this to exchange some basic
@@ -138,8 +150,15 @@ struct WorkerProto::BasicServerConnection : WorkerProto::BasicConnection
      * handling mechanisms.
      *
      * @param localVersion Our version which is sent over
+     *
+     * @param features The protocol features that we support
      */
-    static WorkerProto::Version handshake(BufferedSink & to, Source & from, WorkerProto::Version localVersion);
+    // FIXME: this should probably be a constructor.
+    static std::tuple<Version, std::set<Feature>> handshake(
+        BufferedSink & to,
+        Source & from,
+        WorkerProto::Version localVersion,
+        const std::set<Feature> & supportedFeatures);
 
     /**
      * After calling handshake, must call this to exchange some basic

--- a/src/libstore/worker-protocol.hh
+++ b/src/libstore/worker-protocol.hh
@@ -11,7 +11,9 @@ namespace nix {
 #define WORKER_MAGIC_1 0x6e697863
 #define WORKER_MAGIC_2 0x6478696f
 
-#define PROTOCOL_VERSION (1 << 8 | 37)
+/* Note: you generally shouldn't change the protocol version. Define a
+   new `WorkerProto::Feature` instead. */
+#define PROTOCOL_VERSION (1 << 8 | 38)
 #define GET_PROTOCOL_MAJOR(x) ((x) & 0xff00)
 #define GET_PROTOCOL_MINOR(x) ((x) & 0x00ff)
 
@@ -131,6 +133,10 @@ struct WorkerProto
     {
         WorkerProto::Serialise<T>::write(store, conn, t);
     }
+
+    using Feature = std::string;
+
+    static const std::set<Feature> allFeatures;
 };
 
 enum struct WorkerProto::Op : uint64_t


### PR DESCRIPTION
# Motivation

Currently, the worker protocol has a version number that we increment whenever we change something in the protocol. However, this can cause a collision between Nix PRs / forks that make protocol changes (e.g. PR #9857 increments the version, which could collide with another PR). So instead, the client and daemon now exchange a set of protocol features (such as `auth-forwarding`). They will use the intersection of the sets of features, i.e. the features they both support.

Note that protocol features are completely distinct from `ExperimentalFeature`s.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
