### PR TITLE
Allow flag aliases

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -304,18 +304,21 @@ template<> void BaseSetting<SandboxMode>::convertToArg(Args & args, const std::s
 {
     args.addFlag({
         .longName = name,
+        .aliases = aliases,
         .description = "Enable sandboxing.",
         .category = category,
         .handler = {[this]() { override(smEnabled); }}
     });
     args.addFlag({
         .longName = "no-" + name,
+        .aliases = aliases,
         .description = "Disable sandboxing.",
         .category = category,
         .handler = {[this]() { override(smDisabled); }}
     });
     args.addFlag({
         .longName = "relaxed-" + name,
+        .aliases = aliases,
         .description = "Enable sandboxing, but allow builds to disable it.",
         .category = category,
         .handler = {[this]() { override(smRelaxed); }}

--- a/src/libutil/config-impl.hh
+++ b/src/libutil/config-impl.hh
@@ -81,6 +81,7 @@ void BaseSetting<T>::convertToArg(Args & args, const std::string & category)
 {
     args.addFlag({
         .longName = name,
+        .aliases = aliases,
         .description = fmt("Set the `%s` setting.", name),
         .category = category,
         .labels = {"value"},
@@ -91,6 +92,7 @@ void BaseSetting<T>::convertToArg(Args & args, const std::string & category)
     if (isAppendable())
         args.addFlag({
             .longName = "extra-" + name,
+            .aliases = aliases,
             .description = fmt("Append to the `%s` setting.", name),
             .category = category,
             .labels = {"value"},

--- a/src/libutil/config.cc
+++ b/src/libutil/config.cc
@@ -292,6 +292,7 @@ template<> void BaseSetting<bool>::convertToArg(Args & args, const std::string &
 {
     args.addFlag({
         .longName = name,
+        .aliases = aliases,
         .description = fmt("Enable the `%s` setting.", name),
         .category = category,
         .handler = {[this] { override(true); }},
@@ -299,6 +300,7 @@ template<> void BaseSetting<bool>::convertToArg(Args & args, const std::string &
     });
     args.addFlag({
         .longName = "no-" + name,
+        .aliases = aliases,
         .description = fmt("Disable the `%s` setting.", name),
         .category = category,
         .handler = {[this] { override(false); }},

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -140,6 +140,18 @@ nix build --impure -f multiple-outputs.nix --json e --no-link | jq --exit-status
     (.outputs | keys == ["a_a", "b"]))
 '
 
+# Make sure that the 3 types of aliases work
+# BaseSettings<T>, BaseSettings<bool>, and BaseSettings<SandboxMode>.
+nix build --impure -f multiple-outputs.nix --json e --no-link \
+    --build-max-jobs 3 \
+    --gc-keep-outputs \
+    --build-use-sandbox | \
+    jq --exit-status '
+  (.[0] |
+    (.drvPath | match(".*multiple-outputs-e.drv")) and
+    (.outputs | keys == ["a_a", "b"]))
+'
+
 # Make sure that `--stdin` works and does not apply any defaults
 printf "" | nix build --no-link --stdin --json | jq --exit-status '. == []'
 printf "%s\n" "$drv^*" | nix build --no-link --stdin --json | jq --exit-status '.[0]|has("drvPath")'

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -58,3 +58,7 @@ fi
 # Test that unknown settings are warned about
 out="$(expectStderr 0 nix eval --option foobar baz --expr '""' --raw)"
 [[ "$(echo "$out" | grep foobar | wc -l)" = 1 ]]
+
+# Test flag alias
+out="$(nix eval --expr '{}' --build-cores 1)"
+[[ "$(echo "$out" | wc -l)" = 1 ]]


### PR DESCRIPTION
# Motivation

The nix cli should allow aliases to be used as flags. Examples:

* `--max-jobs` has an alias `--build-max-jobs`
* `--keep-derivations` has an alias `--gc-keep-derivations`
* `--sandbox` has an alias `--build-use-sandbox`

# Context
Fixes https://github.com/NixOS/nix/issues/10989

Per the issue, the nix CLI should allow aliases to be used as flags. Currently, the cli prevents this and throws an unrecognized error. [Looks like this behavior was implemented](https://github.com/NixOS/nix/blob/8ce4287409319e04f46ed1352deb956c30e35fc6/src/libutil/args.cc#L25-L26) but not enabled so I've added some very small changes to `BaseSettings<T>`, `BaseSettings<bool>`, and `BaseSettings<SandboxMode>` to fix this.

Also added 2 tests to make sure all 3 types work.

Example from the issue works now:
```
nix eval --extra-experimental-features nix-command --expr '{}' --cores 1
nix eval --extra-experimental-features nix-command --expr '{}' --build-cores 1
```

Also returns the same error:
```bash
nix build --extra-experimental-features nix-command --extra-experimental-features flakes --build-max-jobs -1 nixpkgs#hello
nix build --extra-experimental-features nix-command --extra-experimental-features flakes --max-jobs -1 nixpkgs#hello

> error: configuration setting 'max-jobs' should be 'auto' or an integer
```

Feel free to close if this behavior isn't desired.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
