### PR TITLE
Make parser LALR, conflict-free

### DIFF
--- a/src/libexpr/parser-state.hh
+++ b/src/libexpr/parser-state.hh
@@ -20,6 +20,7 @@ struct StringToken
     operator std::string_view() const { return {p, l}; }
 };
 
+// This type must be trivially copyable; see YYLTYPE_IS_TRIVIAL in parser.y.
 struct ParserLocation
 {
     int beginOffset;

--- a/src/libexpr/parser-state.hh
+++ b/src/libexpr/parser-state.hh
@@ -86,7 +86,7 @@ struct ParserState
 
     void dupAttr(const AttrPath & attrPath, const PosIdx pos, const PosIdx prevPos);
     void dupAttr(Symbol attr, const PosIdx pos, const PosIdx prevPos);
-    void addAttr(ExprAttrs * attrs, AttrPath && attrPath, Expr * e, const PosIdx pos);
+    void addAttr(ExprAttrs * attrs, AttrPath && attrPath, const ParserLocation & loc, Expr * e, const ParserLocation & exprLoc);
     Formals * validateFormals(Formals * formals, PosIdx pos = noPos, Symbol arg = {});
     Expr * stripIndentation(const PosIdx pos,
         std::vector<std::pair<PosIdx, std::variant<Expr *, StringToken>>> && es);
@@ -110,11 +110,12 @@ inline void ParserState::dupAttr(Symbol attr, const PosIdx pos, const PosIdx pre
     });
 }
 
-inline void ParserState::addAttr(ExprAttrs * attrs, AttrPath && attrPath, Expr * e, const PosIdx pos)
+inline void ParserState::addAttr(ExprAttrs * attrs, AttrPath && attrPath, const ParserLocation & loc, Expr * e, const ParserLocation & exprLoc)
 {
     AttrPath::iterator i;
     // All attrpaths have at least one attr
     assert(!attrPath.empty());
+    auto pos = at(loc);
     // Checking attrPath validity.
     // ===========================
     for (i = attrPath.begin(); i + 1 < attrPath.end(); i++) {
@@ -178,6 +179,12 @@ inline void ParserState::addAttr(ExprAttrs * attrs, AttrPath && attrPath, Expr *
         }
     } else {
         attrs->dynamicAttrs.push_back(ExprAttrs::DynamicAttrDef(i->expr, e, pos));
+    }
+
+    auto it = lexerState.positionToDocComment.find(pos);
+    if (it != lexerState.positionToDocComment.end()) {
+        e->setDocComment(it->second);
+        lexerState.positionToDocComment.emplace(at(exprLoc), it->second);
     }
 }
 

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -366,18 +366,7 @@ ind_string_parts
 binds
   : binds[accum] attrpath '=' expr ';' {
       $$ = $accum;
-
-      auto pos = state->at(@attrpath);
-      auto exprPos = state->at(@expr);
-      {
-        auto it = state->lexerState.positionToDocComment.find(pos);
-        if (it != state->lexerState.positionToDocComment.end()) {
-          $expr->setDocComment(it->second);
-          state->lexerState.positionToDocComment.emplace(exprPos, it->second);
-        }
-      }
-
-      state->addAttr($$, std::move(*$attrpath), $expr, pos);
+      state->addAttr($$, std::move(*$attrpath), @attrpath, $expr, @expr);
       delete $attrpath;
     }
   | binds[accum] INHERIT attrs ';'

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -180,22 +180,22 @@ expr_function
       $$ = me;
       SET_DOC_POS(me, @1);
     }
-  | '{' formals '}' ':' expr_function
-    { auto me = new ExprLambda(CUR_POS, state->validateFormals($2), $5);
+  | '{' formals '}' ':' expr_function[body]
+    { auto me = new ExprLambda(CUR_POS, state->validateFormals($formals), $body);
       $$ = me;
       SET_DOC_POS(me, @1);
     }
-  | '{' formals '}' '@' ID ':' expr_function
+  | '{' formals '}' '@' ID ':' expr_function[body]
     {
-      auto arg = state->symbols.create($5);
-      auto me = new ExprLambda(CUR_POS, arg, state->validateFormals($2, CUR_POS, arg), $7);
+      auto arg = state->symbols.create($ID);
+      auto me = new ExprLambda(CUR_POS, arg, state->validateFormals($formals, CUR_POS, arg), $body);
       $$ = me;
       SET_DOC_POS(me, @1);
     }
-  | ID '@' '{' formals '}' ':' expr_function
+  | ID '@' '{' formals '}' ':' expr_function[body]
     {
-      auto arg = state->symbols.create($1);
-      auto me = new ExprLambda(CUR_POS, arg, state->validateFormals($4, CUR_POS, arg), $7);
+      auto arg = state->symbols.create($ID);
+      auto me = new ExprLambda(CUR_POS, arg, state->validateFormals($formals, CUR_POS, arg), $body);
       $$ = me;
       SET_DOC_POS(me, @1);
     }
@@ -364,50 +364,50 @@ ind_string_parts
   ;
 
 binds
-  : binds attrpath '=' expr ';' {
-      $$ = $1;
+  : binds[accum] attrpath '=' expr ';' {
+      $$ = $accum;
 
-      auto pos = state->at(@2);
-      auto exprPos = state->at(@4);
+      auto pos = state->at(@attrpath);
+      auto exprPos = state->at(@expr);
       {
         auto it = state->lexerState.positionToDocComment.find(pos);
         if (it != state->lexerState.positionToDocComment.end()) {
-          $4->setDocComment(it->second);
+          $expr->setDocComment(it->second);
           state->lexerState.positionToDocComment.emplace(exprPos, it->second);
         }
       }
 
-      state->addAttr($$, std::move(*$2), $4, pos);
-      delete $2;
+      state->addAttr($$, std::move(*$attrpath), $expr, pos);
+      delete $attrpath;
     }
-  | binds INHERIT attrs ';'
-    { $$ = $1;
-      for (auto & [i, iPos] : *$3) {
-          if ($$->attrs.find(i.symbol) != $$->attrs.end())
-              state->dupAttr(i.symbol, iPos, $$->attrs[i.symbol].pos);
-          $$->attrs.emplace(
+  | binds[accum] INHERIT attrs ';'
+    { $$ = $accum;
+      for (auto & [i, iPos] : *$attrs) {
+          if ($accum->attrs.find(i.symbol) != $accum->attrs.end())
+              state->dupAttr(i.symbol, iPos, $accum->attrs[i.symbol].pos);
+          $accum->attrs.emplace(
               i.symbol,
               ExprAttrs::AttrDef(new ExprVar(iPos, i.symbol), iPos, ExprAttrs::AttrDef::Kind::Inherited));
       }
-      delete $3;
+      delete $attrs;
     }
-  | binds INHERIT '(' expr ')' attrs ';'
-    { $$ = $1;
-      if (!$$->inheritFromExprs)
-          $$->inheritFromExprs = std::make_unique<std::vector<Expr *>>();
-      $$->inheritFromExprs->push_back($4);
-      auto from = new nix::ExprInheritFrom(state->at(@4), $$->inheritFromExprs->size() - 1);
-      for (auto & [i, iPos] : *$6) {
-          if ($$->attrs.find(i.symbol) != $$->attrs.end())
-              state->dupAttr(i.symbol, iPos, $$->attrs[i.symbol].pos);
-          $$->attrs.emplace(
+  | binds[accum] INHERIT '(' expr ')' attrs ';'
+    { $$ = $accum;
+      if (!$accum->inheritFromExprs)
+          $accum->inheritFromExprs = std::make_unique<std::vector<Expr *>>();
+      $accum->inheritFromExprs->push_back($expr);
+      auto from = new nix::ExprInheritFrom(state->at(@expr), $accum->inheritFromExprs->size() - 1);
+      for (auto & [i, iPos] : *$attrs) {
+          if ($accum->attrs.find(i.symbol) != $accum->attrs.end())
+              state->dupAttr(i.symbol, iPos, $accum->attrs[i.symbol].pos);
+          $accum->attrs.emplace(
               i.symbol,
               ExprAttrs::AttrDef(
                   new ExprSelect(iPos, from, i.symbol),
                   iPos,
                   ExprAttrs::AttrDef::Kind::InheritedFrom));
       }
-      delete $6;
+      delete $attrs;
     }
   | { $$ = new ExprAttrs(state->at(@0)); }
   ;
@@ -468,10 +468,10 @@ expr_list
   ;
 
 formals
-  : formal ',' formals
-    { $$ = $3; $$->formals.emplace_back(*$1); delete $1; }
+  : formal ',' formals[accum]
+    { $$ = $accum; $$->formals.emplace_back(*$formal); delete $formal; }
   | formal
-    { $$ = new Formals; $$->formals.emplace_back(*$1); $$->ellipsis = false; delete $1; }
+    { $$ = new Formals; $$->formals.emplace_back(*$formal); $$->ellipsis = false; delete $formal; }
   |
     { $$ = new Formals; $$->ellipsis = false; }
   | ELLIPSIS

--- a/tests/functional/lang/parse-fail-undef-var-2.err.exp
+++ b/tests/functional/lang/parse-fail-undef-var-2.err.exp
@@ -1,4 +1,4 @@
-error: syntax error, unexpected ':', expecting '}'
+error: syntax error, unexpected ':', expecting '}' or ','
        at «stdin»:3:13:
             2|
             3|   f = {x, y : ["baz" "bar" z "bat"]}: x + y;


### PR DESCRIPTION
# Motivation

This improves parsing performance by ~6%, maybe more.

The only reason GLR parsing was needed was to resolve a reduce-reduce conflict that I've factored away (along with the one shift-reduce conflict).

# Context

Below is a plot of the time required to parse every Nix file in Nixpkgs, at each commit in this PR (100 runs each, median times are marked):

![Violin plot showing benchmark results](https://github.com/user-attachments/assets/74d5c358-8114-4d76-8791-b1845307466a)

Note that benchmarks are based on `nix-instantiate --parse`, which includes the cost of showing expressions and sending them to /dev/null, so improvement may be more significant than presented.

I recommend reading this PR commit-by-commit. Each commit is hopefully self-explanatory, but the first three are only there so that the final GLR -> LALR refactoring goes smoothly. As you can see, they have no impact on parsing time.

In the first commit, I took the liberty of using Bison's [named references](https://www.gnu.org/software/bison/manual/bison.html#Named-References) feature for the rules I refactored, because it makes the refactoring less accident-prone and easier to read. I can back that out if it isn't house style, but I highly recommend it for anything but the simplest Bison grammars.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
