### PR TITLE
libexpr: Track and show GC time and cycle number

### DIFF
--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -155,6 +155,10 @@ static inline void initGCReal()
        there. */
     GC_set_no_dls(1);
 
+    /* Enable perf measurements. This is just a setting; not much of a
+       start of something. */
+    GC_start_performance_measurement();
+
     GC_INIT();
 
     GC_set_oom_fn(oomHandler);
@@ -205,6 +209,7 @@ static inline void initGCReal()
 #endif
 
 static bool gcInitialised = false;
+static GC_word gcCyclesAfterInit = 0;
 
 void initGC()
 {
@@ -216,6 +221,7 @@ void initGC()
 #endif
 
     gcInitialised = true;
+    gcCyclesAfterInit = GC_get_gc_no();
 }
 
 void assertGCInitialized()
@@ -223,4 +229,10 @@ void assertGCInitialized()
     assert(gcInitialised);
 }
 
+size_t getGCCycles()
+{
+    assertGCInitialized();
+    return GC_get_gc_no() - gcCyclesAfterInit;
 }
+
+} // namespace nix

--- a/src/libexpr/eval-gc.hh
+++ b/src/libexpr/eval-gc.hh
@@ -1,6 +1,8 @@
 #pragma once
 ///@file
 
+#include <cstddef>
+
 namespace nix {
 
 /**
@@ -12,5 +14,10 @@ void initGC();
  * Make sure `initGC` has already been called.
  */
 void assertGCInitialized();
+
+/**
+ * The number of GC cycles since initGC().
+ */
+size_t getGCCycles();
 
 }


### PR DESCRIPTION
# Motivation

Let us see what's going on.

Example

```diff
{
  "cpuTime": 0.6123340129852295,
  "envs": {
    "bytes": 119111360,
    "elements": 7444462,
    "number": 7444458
  },
  "gc": {
+   "cycles": 35,
    "heapSize": 76148736,
    "totalBytes": 266679568
  },
  "list": {
    "bytes": 16888888,
    "concats": 0,
    "elements": 2111111
  },
  "nrAvoided": 9666691,
  "nrExprs": 168,
  "nrFunctionCalls": 7444456,
  "nrLookups": 2,
  "nrOpUpdateValuesCopied": 0,
  "nrOpUpdates": 0,
  "nrPrimOpCalls": 4333344,
  "nrThunks": 3333349,
  "sets": {
    "bytes": 2112,
    "elements": 130,
    "number": 2
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 8,
    "Value": 24
  },
  "symbols": {
    "bytes": 2523,
    "number": 271
  },
+ "time": {
+   "cpu": 0.6123340129852295,
+   "gc": 0.17,
+   "gcFraction": 0.2776262569038455
+ },
  "values": {
    "bytes": 104003256,
    "number": 4333469
  }
}
```

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
