### PR TITLE
Fix issue #11141 broken stack pointer corrector

### DIFF
--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -121,7 +121,7 @@ void fixupBoehmStackPointer(void ** sp_ptr, void * _pthread_id)
     // NOTE: We assume the stack grows down, as it does on all architectures we support.
     //       Architectures that grow the stack up are rare.
     if (sp >= osStackBase || sp < osStackLow) { // lo is outside the os stack
-        sp = osStackBase;
+        sp = osStackLow;
     }
 }
 

--- a/tests/functional/lang-gc.sh
+++ b/tests/functional/lang-gc.sh
@@ -9,6 +9,8 @@ source common.sh
 
 set -o pipefail
 
+skipTest "Too memory instensive for CI. Attempt to reduce memory usage was unsuccessful, because it made detection of the bug unreliable."
+
 # Regression test for #11141. The stack pointer corrector assigned the base
 # instead of the top (which resides at the low end of the stack). Sounds confusing?
 # Stacks grow downwards, so that's why this mistake happened.

--- a/tests/functional/lang-gc.sh
+++ b/tests/functional/lang-gc.sh
@@ -1,0 +1,34 @@
+# shellcheck shell=bash
+
+# Regression tests for the evaluator
+# These are not in lang.sh because they generally only need to run in CI,
+# whereas lang.sh is often run locally during development
+
+
+source common.sh
+
+set -o pipefail
+
+# Regression test for #11141. The stack pointer corrector assigned the base
+# instead of the top (which resides at the low end of the stack). Sounds confusing?
+# Stacks grow downwards, so that's why this mistake happened.
+# My manual testing did not uncover this, because it didn't rely on the stack enough.
+# https://github.com/NixOS/nix/issues/11141
+test_issue_11141() {
+  mkdir -p "$TEST_ROOT/issue-11141/src"
+  cp lang-gc/issue-11141-gc-coroutine-test.nix "$TEST_ROOT/issue-11141/"
+  (
+    set +x;
+    n=10
+    echo "populating $TEST_ROOT/issue-11141/src with $((n*100)) files..."
+    for i in $(seq 0 $n); do
+      touch "$TEST_ROOT/issue-11141/src/file-$i"{0,1,2,3,4,5,6,7,8,9}{0,1,2,3,4,5,6,7,8,9}
+    done
+  )
+
+  GC_INITIAL_HEAP_SIZE=$((1024 * 1024)) \
+  NIX_SHOW_STATS=1 \
+  nix eval -vvv\
+    -f "$TEST_ROOT/issue-11141/issue-11141-gc-coroutine-test.nix"
+}
+test_issue_11141

--- a/tests/functional/lang-gc/issue-11141-gc-coroutine-test.nix
+++ b/tests/functional/lang-gc/issue-11141-gc-coroutine-test.nix
@@ -1,0 +1,65 @@
+
+# Run:
+# GC_INITIAL_HEAP_SIZE=$[1024 * 1024] NIX_SHOW_STATS=1 nix eval -f gc-coroutine-test.nix  -vvvv
+
+let
+  inherit (builtins)
+    foldl'
+    isList
+    ;
+
+  # Generate a tree of numbers, n deep, such that the numbers add up to (1 + salt) * 10^n.
+  # The salting makes the numbers all different, increasing the likelihood of catching
+  # any memory corruptions that might be caused by the GC or otherwise.
+  garbage = salt: n:
+    if n == 0
+    then [(1 + salt)]
+    else [
+      (garbage (10 * salt + 1) (n - 1))
+      (garbage (10 * salt - 1) (n - 1))
+      (garbage (10 * salt + 2) (n - 1))
+      (garbage (10 * salt - 2) (n - 1))
+      (garbage (10 * salt + 3) (n - 1))
+      (garbage (10 * salt - 3) (n - 1))
+      (garbage (10 * salt + 4) (n - 1))
+      (garbage (10 * salt - 4) (n - 1))
+      (garbage (10 * salt + 5) (n - 1))
+      (garbage (10 * salt - 5) (n - 1))
+    ];
+
+  pow = base: n:
+    if n == 0
+    then 1
+    else base * (pow base (n - 1));
+
+  sumNestedLists = l:
+    if isList l
+    then foldl' (a: b: a + sumNestedLists b) 0 l
+    else l;
+
+in
+  assert sumNestedLists (garbage 0 3) == pow 10 3;
+  assert sumNestedLists (garbage 0 6) == pow 10 6;
+  builtins.foldl'
+    (a: b:
+      assert
+        "${
+          builtins.path {
+            path = ./src;
+            filter = path: type:
+              # We're not doing common subexpression elimination, so this reallocates
+              # the fairly big tree over and over, producing a lot of garbage during
+              # source filtering, whose filter runs in a coroutine.
+              assert sumNestedLists (garbage 0 3) == pow 10 3;
+              true;
+          }
+        }"
+          == "${./src}";
+
+      # These asserts don't seem necessary, as the lambda value get corrupted first
+      assert a.okay;
+      assert b.okay;
+      { okay = true; }
+    )
+    { okay = true; }
+    [ { okay = true; } { okay = true; } { okay = true; } ]

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -23,6 +23,7 @@ nix_tests = \
   remote-store.sh \
   legacy-ssh-store.sh \
   lang.sh \
+  lang-gc.sh \
   characterisation-test-infra.sh \
   experimental-features.sh \
   fetchMercurial.sh \


### PR DESCRIPTION
# Motivation

Fixes #11141

The stack pointer corrector assigned the base instead of the top (which resides at the low end of the stack).
Sounds confusing?
Stacks grow downwards, so that's why this mistake happened.
My manual testing did not uncover this in #10835, because it didn't rely on the stack enough.

# Context

- Fixes #11141
- Bug introduced in #10835

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
