### PR TITLE
nix ping-store: Redirect to 'nix store info'

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -164,7 +164,7 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
         {"ls-store", { AliasStatus::Deprecated, {"store", "ls"}}},
         {"make-content-addressable", { AliasStatus::Deprecated, {"store", "make-content-addressed"}}},
         {"optimise-store", { AliasStatus::Deprecated, {"store", "optimise"}}},
-        {"ping-store", { AliasStatus::Deprecated, {"store", "ping"}}},
+        {"ping-store", { AliasStatus::Deprecated, {"store", "info"}}},
         {"sign-paths", { AliasStatus::Deprecated, {"store", "sign"}}},
         {"shell", { AliasStatus::AcceptedShorthand, {"env", "shell"}}},
         {"show-derivation", { AliasStatus::Deprecated, {"derivation", "show"}}},


### PR DESCRIPTION
# Motivation

This avoids the double warning

```
warning: 'ping-store' is a deprecated alias for 'store ping'
warning: 'nix store ping' is a deprecated alias for 'nix store info'
```

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
