### PR TITLE
Two Build system fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -340,13 +340,6 @@ AC_CHECK_HEADERS([aws/s3/S3Client.h],
 AC_SUBST(ENABLE_S3, [$enable_s3])
 AC_LANG_POP(C++)
 
-if test -n "$enable_s3"; then
-  declare -a aws_version_tokens=($(printf '#include <aws/core/VersionConfig.h>\nAWS_SDK_VERSION_STRING' | $CPP $CPPFLAGS - | grep -v '^#.*' | sed 's/"//g' | tr '.' ' '))
-  AC_DEFINE_UNQUOTED([AWS_VERSION_MAJOR], ${aws_version_tokens@<:@0@:>@}, [Major version of aws-sdk-cpp.])
-  AC_DEFINE_UNQUOTED([AWS_VERSION_MINOR], ${aws_version_tokens@<:@1@:>@}, [Minor version of aws-sdk-cpp.])
-  AC_DEFINE_UNQUOTED([AWS_VERSION_PATCH], ${aws_version_tokens@<:@2@:>@}, [Patch version of aws-sdk-cpp.])
-fi
-
 
 # Whether to use the Boehm garbage collector.
 AC_ARG_ENABLE(gc, AS_HELP_STRING([--enable-gc],[enable garbage collection in the Nix expression evaluator (requires Boehm GC) [default=yes]]),

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -55,6 +55,7 @@ configdata.set('CAN_LINK_SYMLINK', can_link_symlink.to_int())
 check_funcs = [
   # Optionally used for canonicalising files from the build
   'lchown',
+  'statvfs',
 ]
 foreach funcspec : check_funcs
   define_name = 'HAVE_' + funcspec.underscorify().to_upper()

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -100,6 +100,23 @@ deps_public += nlohmann_json
 sqlite = dependency('sqlite3', 'sqlite', version : '>=3.6.19')
 deps_private += sqlite
 
+# AWS C++ SDK has bad pkg-config
+aws_s3 = dependency('aws-cpp-sdk-s3', required : false)
+configdata.set('ENABLE_S3', aws_s3.found().to_int())
+if aws_s3.found()
+  aws_s3 = declare_dependency(
+    include_directories: include_directories(aws_s3.get_variable('includedir')),
+    link_args: [
+      '-L' + aws_s3.get_variable('libdir'),
+      '-laws-cpp-sdk-transfer',
+      '-laws-cpp-sdk-s3',
+      '-laws-cpp-sdk-core',
+      '-laws-crt-cpp',
+    ],
+  )
+endif
+deps_other += aws_s3
+
 subdir('build-utils-meson/generate-header')
 
 generated_headers = []

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -60,7 +60,7 @@ class AwsLogger : public Aws::Utils::Logging::FormattedLogSystem
         debug("AWS: %s", chomp(statement));
     }
 
-#if !(AWS_VERSION_MAJOR <= 1 && AWS_VERSION_MINOR <= 7 && AWS_VERSION_PATCH <= 115)
+#if !(AWS_SDK_VERSION_MAJOR <= 1 && AWS_SDK_VERSION_MINOR <= 7 && AWS_SDK_VERSION_PATCH <= 115)
     void Flush() override {}
 #endif
 };
@@ -103,7 +103,7 @@ S3Helper::S3Helper(
                 std::make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>(profile.c_str())),
             *config,
             // FIXME: https://github.com/aws/aws-sdk-cpp/issues/759
-#if AWS_VERSION_MAJOR == 1 && AWS_VERSION_MINOR < 3
+#if AWS_SDK_VERSION_MAJOR == 1 && AWS_SDK_VERSION_MINOR < 3
             false,
 #else
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,


### PR DESCRIPTION
# Motivation

1. Add S3 opt dep to Meson, and simplify build
2. Meson build: libstore check for `statvfs`

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
