### PR TITLE
Fix some BSD builds missing pthread functions

### DIFF
--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -30,6 +30,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -29,6 +29,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -26,6 +26,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -26,6 +26,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -29,6 +29,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -26,6 +26,7 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
 
 pubsetbuf_test = '''
 #include <iostream>

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -27,6 +27,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -25,6 +25,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -28,6 +28,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 subdir('build-utils-meson/export-all-symbols')
 
 add_project_arguments(

--- a/tests/unit/libexpr-support/meson.build
+++ b/tests/unit/libexpr-support/meson.build
@@ -27,6 +27,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 

--- a/tests/unit/libexpr/meson.build
+++ b/tests/unit/libexpr/meson.build
@@ -25,6 +25,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 subdir('build-utils-meson/export-all-symbols')
 
 rapidcheck = dependency('rapidcheck')

--- a/tests/unit/libfetchers/meson.build
+++ b/tests/unit/libfetchers/meson.build
@@ -24,6 +24,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 subdir('build-utils-meson/export-all-symbols')
 
 rapidcheck = dependency('rapidcheck')

--- a/tests/unit/libflake/meson.build
+++ b/tests/unit/libflake/meson.build
@@ -24,6 +24,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 subdir('build-utils-meson/export-all-symbols')
 
 rapidcheck = dependency('rapidcheck')

--- a/tests/unit/libstore-support/meson.build
+++ b/tests/unit/libstore-support/meson.build
@@ -25,6 +25,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 

--- a/tests/unit/libstore/meson.build
+++ b/tests/unit/libstore/meson.build
@@ -25,6 +25,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 subdir('build-utils-meson/export-all-symbols')
 
 sqlite = dependency('sqlite3', 'sqlite', version : '>=3.6.19')

--- a/tests/unit/libutil-support/meson.build
+++ b/tests/unit/libutil-support/meson.build
@@ -23,6 +23,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 

--- a/tests/unit/libutil/meson.build
+++ b/tests/unit/libutil/meson.build
@@ -25,6 +25,8 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
+subdir('build-utils-meson/threads')
+
 subdir('build-utils-meson/export-all-symbols')
 
 rapidcheck = dependency('rapidcheck')


### PR DESCRIPTION
# Motivation

In addition to adding the missing thread deps in the last commit, we also appear to need to skip `-Wl,--as-needed` flags that Meson wants to use, but doesn't work with our *BSD toolchains.

Also, add missing thread deps.

# Context

See https://github.com/mesonbuild/meson/issues/3593

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
