### PR TITLE
Rename osStackLow -> osStackLimit

### DIFF
--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -121,7 +121,7 @@ void fixupBoehmStackPointer(void ** sp_ptr, void * _pthread_id)
     osStackBase = (char *) osStackLimit + osStackSize;
     // NOTE: We assume the stack grows down, as it does on all architectures we support.
     //       Architectures that grow the stack up are rare.
-    if (sp >= osStackBase || sp < osStackLimit) { // lo is outside the os stack
+    if (sp >= osStackBase || sp < osStackLimit) { // sp is outside the os stack
         sp = osStackLimit;
     }
 }


### PR DESCRIPTION

# Motivation

This is in accordance with ARM's naming convention. "Low" is confusing, because it could refer to either the cold end of the stack as an abstract data type, or a low address. These are different places, because the stack grows down through the address space.

# Context

As noted by @puckipedia 


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
