### PR TITLE
Increase download buffer size and improve tarball import logging

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -254,9 +254,14 @@ struct GitArchiveInputScheme : InputScheme
             getFileTransfer()->download(std::move(req), sink);
         });
 
+        auto act = std::make_unique<Activity>(*logger, lvlInfo, actUnknown,
+            fmt("unpacking '%s' into the Git cache", input.to_string()));
+
         TarArchive archive { *source };
         auto parseSink = getTarballCache()->getFileSystemObjectSink();
         auto lastModified = unpackTarfileToSink(archive, *parseSink);
+
+        act.reset();
 
         TarballInfo tarballInfo {
             .treeHash = parseSink->sync(),

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -143,6 +143,9 @@ DownloadTarballResult downloadTarball(
 
     // TODO: fall back to cached value if download fails.
 
+    auto act = std::make_unique<Activity>(*logger, lvlInfo, actUnknown,
+        fmt("unpacking '%s' into the Git cache", url));
+
     AutoDelete cleanupTemp;
 
     /* Note: if the download is cached, `importTarball()` will receive
@@ -166,6 +169,8 @@ DownloadTarballResult downloadTarball(
         : TarArchive{*source};
     auto parseSink = getTarballCache()->getFileSystemObjectSink();
     auto lastModified = unpackTarfileToSink(archive, *parseSink);
+
+    act.reset();
 
     auto res(_res->lock());
 

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -858,7 +858,7 @@ void FileTransfer::download(
            buffer). We don't wait forever to prevent stalling the
            download thread. (Hopefully sleeping will throttle the
            sender.) */
-        if (state->data.size() > 1024 * 1024) {
+        if (state->data.size() > fileTransferSettings.downloadBufferSize) {
             debug("download buffer is full; going to sleep");
             state.wait_for(state->request, std::chrono::seconds(10));
         }

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -71,7 +71,10 @@ struct curlFileTransfer : public FileTransfer
 
         curl_off_t writtenToSink = 0;
 
+        std::chrono::steady_clock::time_point startTime = std::chrono::steady_clock::now();
+
         inline static const std::set<long> successfulStatuses {200, 201, 204, 206, 304, 0 /* other protocol */};
+
         /* Get the HTTP status code, or 0 for other protocols. */
         long getHTTPStatus()
         {
@@ -373,10 +376,14 @@ struct curlFileTransfer : public FileTransfer
 
         void finish(CURLcode code)
         {
+            auto finishTime = std::chrono::steady_clock::now();
+
             auto httpStatus = getHTTPStatus();
 
-            debug("finished %s of '%s'; curl status = %d, HTTP status = %d, body = %d bytes",
-                request.verb(), request.uri, code, httpStatus, result.bodySize);
+            debug("finished %s of '%s'; curl status = %d, HTTP status = %d, body = %d bytes, duration = %.2f s",
+                request.verb(), request.uri, code, httpStatus, result.bodySize,
+                std::chrono::duration_cast<std::chrono::milliseconds>(finishTime - startTime).count() / 1000.0f
+                );
 
             appendCurrentUrl();
 

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -860,6 +860,8 @@ void FileTransfer::download(
            sender.) */
         if (state->data.size() > fileTransferSettings.downloadBufferSize) {
             debug("download buffer is full; going to sleep");
+            static bool haveWarned = false;
+            warnOnce(haveWarned, "download buffer is full; consider increasing the 'download-buffer-size' setting");
             state.wait_for(state->request, std::chrono::seconds(10));
         }
 

--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -47,6 +47,12 @@ struct FileTransferSettings : Config
 
     Setting<unsigned int> tries{this, 5, "download-attempts",
         "How often Nix will attempt to download a file before giving up."};
+
+    Setting<size_t> downloadBufferSize{this, 64 * 1024 * 1024, "download-buffer-size",
+        R"(
+          The size of Nix's internal download buffer during `curl` transfers. If data is
+          not processed quickly enough to exceed the size of this buffer, downloads may stall.
+        )"};
 };
 
 extern FileTransferSettings fileTransferSettings;


### PR DESCRIPTION
# Motivation

Downloads of `tarball` and `github` flakes could appear quite slow. This was because we are piping curl downloads into `unpackTarfileToSink()`, but the latter is typically slower than the former if you're on a fast connection. This would cause the curl download to be put to sleep. (There is even a risk that if the Git import is *really* slow for whatever reason, the TCP connection could time out.)

So let's make the download buffer bigger by default - 64 MiB is big enough for the Nixpkgs tarball. Perhaps in the future, we could have an unlimited buffer that spills data to disk beyond a certain threshold, but that's probably overkill.

This also adds a warning if the download buffer is full, and shows when we are unpacking an archive into the Git cache.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
