### PR TITLE
Deduplicate our many `package.nix` a bit

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -63,9 +63,16 @@ let
 
   # Work around weird `--as-needed` linker behavior with BSD, see
   # https://github.com/mesonbuild/meson/issues/3593
-  bsdNoLinkAsNeeded = finalAttrs: prevAttrs: lib.optionalAttrs stdenv.hostPlatform.isBSD {
-    mesonFlags = [ (lib.mesonBool "b_asneeded" false) ] ++ prevAttrs.mesonFlags or [];
-  };
+  bsdNoLinkAsNeeded = finalAttrs: prevAttrs:
+    lib.optionalAttrs stdenv.hostPlatform.isBSD {
+      mesonFlags = [ (lib.mesonBool "b_asneeded" false) ] ++ prevAttrs.mesonFlags or [];
+    };
+
+  miscGoodPractice = finalAttrs: prevAttrs:
+    {
+      strictDeps = prevAttrs.strictDeps or true;
+      enableParallelBuilding = true;
+    };
 
 in
 scope: {
@@ -136,8 +143,14 @@ scope: {
 
   inherit resolvePath filesetToSource;
 
-  mkMesonDerivation = f: stdenv.mkDerivation
-    (lib.extends
-      (lib.composeExtensions bsdNoLinkAsNeeded localSourceLayer)
-      f);
+  mkMesonDerivation = f: let
+    exts = [
+      miscGoodPractice
+      bsdNoLinkAsNeeded
+      localSourceLayer
+    ];
+  in stdenv.mkDerivation
+   (lib.extends
+     (lib.foldr lib.composeExtensions (_: _: {}) exts)
+     f);
 }

--- a/src/external-api-docs/package.nix
+++ b/src/external-api-docs/package.nix
@@ -53,10 +53,6 @@ mkMesonDerivation (finalAttrs: {
     echo "doc external-api-docs $out/share/doc/nix/external-api/html" >> ''${!outputDoc}/nix-support/hydra-build-products
   '';
 
-  enableParallelBuilding = true;
-
-  strictDeps = true;
-
   meta = {
     platforms = lib.platforms.all;
   };

--- a/src/internal-api-docs/package.nix
+++ b/src/internal-api-docs/package.nix
@@ -48,10 +48,6 @@ mkMesonDerivation (finalAttrs: {
     echo "doc internal-api-docs $out/share/doc/nix/internal-api/html" >> ''${!outputDoc}/nix-support/hydra-build-products
   '';
 
-  enableParallelBuilding = true;
-
-  strictDeps = true;
-
   meta = {
     platforms = lib.platforms.all;
   };

--- a/src/libcmd/package.nix
+++ b/src/libcmd/package.nix
@@ -93,13 +93,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  # TODO `releaseTools.coverageAnalysis` in Nixpkgs needs to be updated
-  # to work with `strictDeps`.
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libexpr-c/package.nix
+++ b/src/libexpr-c/package.nix
@@ -63,11 +63,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -102,11 +102,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libfetchers/package.nix
+++ b/src/libfetchers/package.nix
@@ -67,13 +67,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  # TODO `releaseTools.coverageAnalysis` in Nixpkgs needs to be updated
-  # to work with `strictDeps`.
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libflake/package.nix
+++ b/src/libflake/package.nix
@@ -67,13 +67,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  # TODO `releaseTools.coverageAnalysis` in Nixpkgs needs to be updated
-  # to work with `strictDeps`.
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libmain-c/package.nix
+++ b/src/libmain-c/package.nix
@@ -68,11 +68,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libmain/package.nix
+++ b/src/libmain/package.nix
@@ -62,13 +62,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  # TODO `releaseTools.coverageAnalysis` in Nixpkgs needs to be updated
-  # to work with `strictDeps`.
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libstore-c/package.nix
+++ b/src/libstore-c/package.nix
@@ -64,11 +64,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -101,11 +101,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libutil-c/package.nix
+++ b/src/libutil-c/package.nix
@@ -62,11 +62,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -88,11 +88,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -84,8 +84,6 @@ mkMesonDerivation (finalAttrs: {
     ]
   );
 
-  outputs = [ "out" "dev" ];
-
   nativeBuildInputs = [
     meson
     ninja
@@ -114,11 +112,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/src/perl/package.nix
+++ b/src/perl/package.nix
@@ -73,5 +73,5 @@ perl.pkgs.toPerlModule (mkMesonDerivation (finalAttrs: {
     "--print-errorlogs"
   ];
 
-  enableParallelBuilding = true;
+  strictDeps = false;
 }))

--- a/tests/unit/libexpr-support/package.nix
+++ b/tests/unit/libexpr-support/package.nix
@@ -66,11 +66,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/tests/unit/libexpr/package.nix
+++ b/tests/unit/libexpr/package.nix
@@ -71,11 +71,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/tests/unit/libfetchers/package.nix
+++ b/tests/unit/libfetchers/package.nix
@@ -69,11 +69,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/tests/unit/libflake/package.nix
+++ b/tests/unit/libflake/package.nix
@@ -69,11 +69,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/tests/unit/libstore-support/package.nix
+++ b/tests/unit/libstore-support/package.nix
@@ -66,11 +66,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/tests/unit/libstore/package.nix
+++ b/tests/unit/libstore/package.nix
@@ -73,11 +73,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/tests/unit/libutil-support/package.nix
+++ b/tests/unit/libutil-support/package.nix
@@ -64,11 +64,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 

--- a/tests/unit/libutil/package.nix
+++ b/tests/unit/libutil/package.nix
@@ -70,11 +70,7 @@ mkMesonDerivation (finalAttrs: {
     LDFLAGS = "-fuse-ld=gold";
   };
 
-  enableParallelBuilding = true;
-
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  strictDeps = true;
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 


### PR DESCRIPTION
# Motivation

- They should all be built in parallel

- They should all use strict deps by default


# Context

#2503

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
