### PR TITLE
Put flake functional tests in their own group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ ifeq ($(ENABLE_FUNCTIONAL_TESTS), yes)
 ifdef HOST_UNIX
 makefiles += \
   tests/functional/local.mk \
+  tests/functional/flakes/local.mk \
   tests/functional/ca/local.mk \
   tests/functional/git-hashing/local.mk \
   tests/functional/dyn-drv/local.mk \

--- a/tests/functional/flakes/local.mk
+++ b/tests/functional/flakes/local.mk
@@ -1,0 +1,24 @@
+flake-tests := \
+  $(d)/flakes.sh \
+  $(d)/develop.sh \
+  $(d)/edit.sh \
+  $(d)/run.sh \
+  $(d)/mercurial.sh \
+  $(d)/circular.sh \
+  $(d)/init.sh \
+  $(d)/inputs.sh \
+  $(d)/follow-paths.sh \
+  $(d)/bundle.sh \
+  $(d)/check.sh \
+  $(d)/unlocked-override.sh \
+  $(d)/absolute-paths.sh \
+  $(d)/absolute-attr-paths.sh \
+  $(d)/build-paths.sh \
+  $(d)/flake-in-submodule.sh \
+  $(d)/prefetch.sh \
+  $(d)/eval-cache.sh \
+  $(d)/search-root.sh \
+  $(d)/config.sh \
+  $(d)/show.sh
+
+install-tests-groups += flake

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -1,23 +1,5 @@
 nix_tests = \
   test-infra.sh \
-  flakes/flakes.sh \
-  flakes/develop.sh \
-  flakes/edit.sh \
-  flakes/run.sh \
-  flakes/mercurial.sh \
-  flakes/circular.sh \
-  flakes/init.sh \
-  flakes/inputs.sh \
-  flakes/follow-paths.sh \
-  flakes/bundle.sh \
-  flakes/check.sh \
-  flakes/unlocked-override.sh \
-  flakes/absolute-paths.sh \
-  flakes/absolute-attr-paths.sh \
-  flakes/build-paths.sh \
-  flakes/flake-in-submodule.sh \
-  flakes/prefetch.sh \
-  flakes/eval-cache.sh \
   gc.sh \
   nix-collect-garbage-d.sh \
   remote-store.sh \
@@ -61,7 +43,6 @@ nix_tests = \
   restricted.sh \
   fetchGitSubmodules.sh \
   fetchGitVerification.sh \
-  flakes/search-root.sh \
   readfile-context.sh \
   nix-channel.sh \
   recursive.sh \
@@ -102,7 +83,6 @@ nix_tests = \
   nix-copy-ssh-ng.sh \
   post-hook.sh \
   function-trace.sh \
-  flakes/config.sh \
   fmt.sh \
   eval-store.sh \
   why-depends.sh \
@@ -125,7 +105,6 @@ nix_tests = \
   store-info.sh \
   fetchClosure.sh \
   completions.sh \
-  flakes/show.sh \
   impure-derivations.sh \
   path-from-hash-part.sh \
   path-info.sh \


### PR DESCRIPTION
# Motivation

This is a nice thing to have, and it made it easier to work on the Meson-ifcation of these functional tests too.

# Context

#2503

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
