### PR TITLE
Change skipped test error code from 99 to 77

### DIFF
--- a/mk/run-test.sh
+++ b/mk/run-test.sh
@@ -28,7 +28,7 @@ run_test
 
 if [[ "$status" = 0 ]]; then
   echo "$post_run_msg [${green}PASS$normal]"
-elif [[ "$status" = 99 ]]; then
+elif [[ "$status" = 77 ]]; then
   echo "$post_run_msg [${yellow}SKIP$normal]"
 else
   echo "$post_run_msg [${red}FAIL$normal]"

--- a/tests/functional/common/vars-and-functions.sh
+++ b/tests/functional/common/vars-and-functions.sh
@@ -190,7 +190,7 @@ isDaemonNewer () {
 
 skipTest () {
     echo "$1, skipping this test..." >&2
-    exit 99
+    exit 77
 }
 
 TODO_NixOS() {


### PR DESCRIPTION
# Motivation

Meson uses a venerable GNU convention described in https://www.gnu.org/software/automake/manual/html_node/Scripts_002dbased-Testsuites.html in which:

> When no test protocol is in use, an exit status of 0 from a test
> script will denote a success, an exit status of 77 a skipped test, an
> exit status of 99 a hard error, and any other exit status will denote
> a failure.

77 is thus what we want, not 99.

# Context

#2503 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
