### PR TITLE
Show redirected URLs in the progress bar and in error messages

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -351,6 +351,14 @@ public:
             actInfo.lastLine = getS(fields, 0);
             update(*state);
         }
+
+        else if (type == resUpdate) {
+            auto i = state->its.find(act);
+            assert(i != state->its.end());
+            ActInfo & actInfo = *i->second;
+            actInfo.s = getS(fields, 0);
+            update(*state);
+        }
     }
 
     void update(State & state)

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -387,7 +387,7 @@ struct curlFileTransfer : public FileTransfer
             auto httpStatus = getHTTPStatus();
 
             debug("finished %s of '%s'; curl status = %d, HTTP status = %d, body = %d bytes",
-                request.verb(), request.uri, code, httpStatus, result.bodySize);
+                request.verb(), result.urls.back(), code, httpStatus, result.bodySize);
 
             appendCurrentUrl();
 
@@ -479,17 +479,18 @@ struct curlFileTransfer : public FileTransfer
                     response = std::move(errorSink->s);
                 auto exc =
                     code == CURLE_ABORTED_BY_CALLBACK && getInterrupted()
-                    ? FileTransferError(Interrupted, std::move(response), "%s of '%s' was interrupted", request.verb(), request.uri)
+                    ? FileTransferError(Interrupted, std::move(response), "%s of '%s' was interrupted",
+                        request.verb(), result.urls.back())
                     : httpStatus != 0
                     ? FileTransferError(err,
                         std::move(response),
                         "unable to %s '%s': HTTP error %d%s",
-                        request.verb(), request.uri, httpStatus,
+                        request.verb(), result.urls.back(), httpStatus,
                         code == CURLE_OK ? "" : fmt(" (curl error: %s)", curl_easy_strerror(code)))
                     : FileTransferError(err,
                         std::move(response),
                         "unable to %s '%s': %s (%d)",
-                        request.verb(), request.uri, curl_easy_strerror(code), code);
+                        request.verb(), result.urls.back(), curl_easy_strerror(code), code);
 
                 /* If this is a transient error, then maybe retry the
                    download after a while. If we're writing to a

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -35,6 +35,7 @@ typedef enum {
     resSetExpected = 106,
     resPostBuildLogLine = 107,
     resFetchStatus = 108,
+    resUpdate = 109,
 } ResultType;
 
 typedef uint64_t ActivityId;
@@ -167,6 +168,14 @@ struct Activity
     void result(ResultType type, const Logger::Fields & fields) const
     {
         logger.result(id, type, fields);
+    }
+
+    /**
+     * Update the main text of this activity.
+     */
+    void update(std::string s)
+    {
+        result(resUpdate, std::move(s));
     }
 
     friend class Logger;


### PR DESCRIPTION
# Motivation

It's misleading / not helpful to refer to the original URL, especially in error messages. Fixes #9998.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
