### PR TITLE
Fix reference to experimental features docs

### DIFF
--- a/doc/manual/src/language/operators.md
+++ b/doc/manual/src/language/operators.md
@@ -198,11 +198,11 @@ Equivalent to `!`*b1* `||` *b2*.
 > **Warning**
 >
 > This syntax is part of an
-> [experimental feature](@docroot@/contributing/experimental-features.md)
+> [experimental feature](@docroot@/development/experimental-features.md)
 > and may change in future releases.
 >
 > To use this syntax, make sure the
-> [`pipe-operators` experimental feature](@docroot@/contributing/experimental-features.md#xp-feature-pipe-operators)
+> [`pipe-operators` experimental feature](@docroot@/development/experimental-features.md#xp-feature-pipe-operators)
 > is enabled.
 > For example, include the following in [`nix.conf`](@docroot@/command-ref/conf-file.md):
 >


### PR DESCRIPTION
Arose because https://github.com/NixOS/nix/pull/9014 merged before https://github.com/NixOS/nix/pull/11131, but the latter did not rebase / merge against the latest master.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
