### PR TITLE
nix repl: Remove unnecessary call to evalString

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -644,9 +644,6 @@ ProcessLineResult NixRepl::processLine(std::string line)
                 fallbackPos = attr->pos;
                 fallbackDoc = state->getDocCommentForPos(fallbackPos);
             }
-
-        } else {
-            evalString(arg, v);
         }
 
         evalString(arg, v);


### PR DESCRIPTION
# Motivation

This crashes with the multithreaded evaluator, which checks against attempts to finish an already finished value. Cherry-picked from #10938.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
