### PR TITLE
Store: Use SharedSync

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -920,7 +920,7 @@ StorePathSet Store::exportReferences(const StorePathSet & storePaths, const Stor
 const Store::Stats & Store::getStats()
 {
     {
-        auto state_(state.lock());
+        auto state_(state.read());
         stats.pathInfoCacheSize = state_->pathInfoCache.size();
     }
     return stats;

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -201,7 +201,7 @@ protected:
         LRUCache<std::string, PathInfoCacheValue> pathInfoCache;
     };
 
-    Sync<State> state;
+    SharedSync<State> state;
 
     std::shared_ptr<NarInfoDiskCache> diskCache;
 

--- a/src/libutil/lru-cache.hh
+++ b/src/libutil/lru-cache.hh
@@ -89,7 +89,7 @@ public:
         return i->second.second;
     }
 
-    size_t size()
+    size_t size() const
     {
         return data.size();
     }


### PR DESCRIPTION
# Motivation

Not super useful in itself, but it reduces the #10938 diff a bit.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
