### PR TITLE
Rename SyncBase::read() -> readLock()

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -920,7 +920,7 @@ StorePathSet Store::exportReferences(const StorePathSet & storePaths, const Stor
 const Store::Stats & Store::getStats()
 {
     {
-        auto state_(state.read());
+        auto state_(state.readLock());
         stats.pathInfoCacheSize = state_->pathInfoCache.size();
     }
     return stats;

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -97,7 +97,7 @@ std::optional<struct stat> PosixSourceAccessor::cachedLstat(const CanonPath & pa
     Path absPath = makeAbsPath(path).string();
 
     {
-        auto cache(_cache.read());
+        auto cache(_cache.readLock());
         auto i = cache->find(absPath);
         if (i != cache->end()) return i->second;
     }

--- a/src/libutil/sync.hh
+++ b/src/libutil/sync.hh
@@ -106,7 +106,7 @@ public:
      * Acquire read access to the inner value. When using
      * `std::shared_mutex`, this will use a shared lock.
      */
-    ReadLock read() const { return ReadLock(const_cast<SyncBase *>(this)); }
+    ReadLock readLock() const { return ReadLock(const_cast<SyncBase *>(this)); }
 };
 
 template<class T>


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Make it explicit so it's clear what it's about when I and other contributors read its call sites.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
