### PR TITLE
dependencies: Centralize aws-sdk-cpp and sync with Nixpkgs

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -237,10 +237,7 @@ in {
     ++ lib.optional stdenv.hostPlatform.isx86_64 libcpuid
     # There have been issues building these dependencies
     ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin))
-      (aws-sdk-cpp.override {
-        apis = ["s3" "transfer"];
-        customMemoryManagement = false;
-      })
+      aws-sdk-cpp
   ;
 
   propagatedBuildInputs = [

--- a/package.nix
+++ b/package.nix
@@ -216,7 +216,8 @@ in {
   ] ++ lib.optional stdenv.hostPlatform.isStatic unixtools.hexdump
   ;
 
-  buildInputs = lib.optionals doBuild [
+  buildInputs = lib.optionals doBuild (
+  [
     brotli
     bzip2
     curl
@@ -238,12 +239,13 @@ in {
     # There have been issues building these dependencies
     ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin))
       aws-sdk-cpp
-  ;
+  );
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = lib.optionals doBuild ([
     boost
     nlohmann_json
-  ] ++ lib.optional enableGC boehmgc;
+  ] ++ lib.optional enableGC boehmgc
+  );
 
   dontBuild = !attrs.doBuild;
   doCheck = attrs.doCheck;

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -79,6 +79,15 @@ scope: {
   inherit stdenv versionSuffix;
   version = lib.fileContents ../.version + versionSuffix;
 
+  aws-sdk-cpp = (pkgs.aws-sdk-cpp.override {
+    apis = [ "s3" "transfer" ];
+    customMemoryManagement = false;
+  }).overrideAttrs {
+    # only a stripped down version is built, which takes a lot less resources
+    # to build, so we don't need a "big-parallel" machine.
+    requiredSystemFeatures = [ ];
+  };
+
   libseccomp = pkgs.libseccomp.overrideAttrs (_: rec {
     version = "2.5.5";
     src = pkgs.fetchurl {

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -66,10 +66,7 @@ mkMesonDerivation (finalAttrs: {
   ] ++ lib.optional stdenv.hostPlatform.isLinux libseccomp
     # There have been issues building these dependencies
     ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin))
-      (aws-sdk-cpp.override {
-        apis = ["s3" "transfer"];
-        customMemoryManagement = false;
-      })
+      aws-sdk-cpp
   ;
 
   propagatedBuildInputs = [


### PR DESCRIPTION
By syncing with Nixpkgs, we reuse the same derivation, which is generally a good idea, and has the benefit that it is transitively a channel blocker.

Changes:

- https://github.com/NixOS/nixpkgs/pull/163313 (SuperSandro2000)

  > nix: disable big-parallel for aws-sdk-cpp

  > aws-sdk-cpp only takes ~1m52s on a 4 core machine under 50% load
  > which does not justify the requirement on big parallel.

  > Tested with `nix-build -A nixVersions.nix_2_6.aws-sdk-cpp`.

  > I can finally build nix without requiring a big-parallel machine.

- https://github.com/NixOS/nixpkgs/pull/227506 (Artturin)

  > nix: use [ ] instead null to empty requiredSystemFeatures

  > fixes 'error: value is null while a list was expected' with 'nixpkgs.hostPlatform.gcc.arch = "x86_64";'

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
