### PR TITLE
Troubleshoot remote build tests

### DIFF
--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -104,6 +104,11 @@ in
         builder.succeed("mkdir -p -m 700 /root/.ssh")
         builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
         builder.wait_for_unit("sshd")
+        # Make sure the builder can handle our login correctly
+        builder.wait_for_unit("multi-user.target")
+        # Make sure there's no funny business on the client either
+        # (should not be necessary, but we have reason to be careful)
+        client.wait_for_unit("multi-user.target")
         client.succeed(f"""
           ssh -o StrictHostKeyChecking=no {builder.name} \
             'echo hello world on $(hostname)' >&2

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -104,7 +104,10 @@ in
         builder.succeed("mkdir -p -m 700 /root/.ssh")
         builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
         builder.wait_for_unit("sshd")
-        client.succeed(f"ssh -o StrictHostKeyChecking=no {builder.name} 'echo hello world'")
+        client.succeed(f"""
+          ssh -o StrictHostKeyChecking=no {builder.name} \
+            'echo hello world on $(hostname)' >&2
+        """)
 
       # Perform a build and check that it was performed on the builder.
       out = client.succeed(


### PR DESCRIPTION
# Motivation

Learn more about https://hydra.nixos.org/build/267517233/nixlog/8 and if we are very lucky, fix it.

# Context


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
