### PR TITLE
buildNoTests: Disable unit tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -143,6 +143,7 @@
 
           nix_noTests = final.nix.override {
             doInstallCheck = false;
+            doCheck = false;
           };
 
           # See https://github.com/NixOS/nixpkgs/pull/214409


### PR DESCRIPTION
This seems to have been the intent all along.

The odd combination of unit tests, but no functional tests caused a build error where some data for the unit test was source-filtered out. Apparently. It's unclear to me why that happened, so I'm proposing this alternate "fix" to get the buildNoTests to pass.

It would be nice to test more configurations, but this mode of building is on the way out anyway, so let's just make it pass and see what configurations make sense to test as part of the meson migration.

