### PR TITLE
doc/command-ref/nix-shell: Shebangs can occur anywhere

### DIFF
--- a/doc/manual/src/command-ref/nix-shell.md
+++ b/doc/manual/src/command-ref/nix-shell.md
@@ -297,3 +297,9 @@ with import <nixpkgs> {};
 
 runCommand "dummy" { buildInputs = [ python pythonPackages.prettytable ]; } ""
 ```
+
+Aside from the very first line, which is a directive to the operating system,
+the `#! nix-shell` lines do not need to be at the beginning of the file. This
+can be useful for working around syntactic restrictions in languages like
+ECMAScript, Erlang, PHP, and Ruby, where the `#! nix-shell` lines must be
+hidden inside comments.

--- a/doc/manual/src/command-ref/nix-shell.md
+++ b/doc/manual/src/command-ref/nix-shell.md
@@ -298,8 +298,7 @@ with import <nixpkgs> {};
 runCommand "dummy" { buildInputs = [ python pythonPackages.prettytable ]; } ""
 ```
 
-Aside from the very first line, which is a directive to the operating system,
-the `#! nix-shell` lines do not need to be at the beginning of the file. This
-can be useful for working around syntactic restrictions in languages like
-ECMAScript, Erlang, PHP, and Ruby, where the `#! nix-shell` lines must be
-hidden inside comments.
+The script's file name is passed as the first argument to the interpreter specified by the `-i` flag.
+
+Aside from the very first line, which is a directive to the operating system, the additional `#! nix-shell` lines do not need to be at the beginning of the file.
+This allows wrapping them in block comments for languages where `#` does not start a comment, such as ECMAScript, Erlang, PHP, or Ruby.


### PR DESCRIPTION
I tested this more-or-less with:

    $ nix build .#nix
    $ MANPATH=result/share/man man nix-shell

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Refs #2570, where this was discovered, discussed, embraced, and turned from a bug into a feature.

# Context
<!-- Provide context. Reference open issues if available. -->

`nix-shell` directives are given via shebang-like lines which look like comments to some interpreted languages. By allowing those lines to occur throughout a script, more languages are available as`nix-shell` interpreters. This change is non-breaking; it adds a single paragraph describing the current behavior to the end of the appropriate section.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
