### PR TITLE
libutil: remove template id from constructors

### DIFF
--- a/src/libutil/ref.hh
+++ b/src/libutil/ref.hh
@@ -23,14 +23,14 @@ public:
         : p(r.p)
     { }
 
-    explicit ref<T>(const std::shared_ptr<T> & p)
+    explicit ref(const std::shared_ptr<T> & p)
         : p(p)
     {
         if (!p)
             throw std::invalid_argument("null pointer cast to ref");
     }
 
-    explicit ref<T>(T * p)
+    explicit ref(T * p)
         : p(p)
     {
         if (!p)


### PR DESCRIPTION
# Motivation

The template id when defining constructors is not allowed in C++20, and GCC 14 warns about it:

```
../src/libutil/ref.hh:26:20: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   26 |     explicit ref<T>(const std::shared_ptr<T> & p)
      |                    ^
../src/libutil/ref.hh:26:20: note: remove the '< >'
../src/libutil/ref.hh:33:21: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
   33 |     explicit ref<T>(T * p)
      |                     ^
../src/libutil/ref.hh:33:21: note: remove the '< >'
```

# Context

Remove build warnings when using a newer compiler (GCC 14). There should be no behaviour change.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
