### PR TITLE
libcmd: do not compile editline helpers when building w/ readline

### DIFF
--- a/src/libcmd/repl-interacter.cc
+++ b/src/libcmd/repl-interacter.cc
@@ -35,6 +35,7 @@ void sigintHandler(int signo)
 
 static detail::ReplCompleterMixin * curRepl; // ugly
 
+#ifndef USE_READLINE
 static char * completionCallback(char * s, int * match)
 {
     auto possible = curRepl->completePrefix(s);
@@ -101,6 +102,7 @@ static int listPossibleCallback(char * s, char *** avp)
 
     return ac;
 }
+#endif
 
 ReadlineLikeInteracter::Guard ReadlineLikeInteracter::init(detail::ReplCompleterMixin * repl)
 {


### PR DESCRIPTION

# Motivation

The internal `completionCallback` and `listPossibleCallback` helpers are used only when building with editline; hence, do not build then when using readline, matching their usage in
`ReadlineLikeInteracter::init()`.

# Context

Remove a couple of compiler warnings about unused static functions when building with readline. There is no behaviour change otherwise.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
