### PR TITLE
libutil: fix/improve includes in current-process.cc

### DIFF
--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -15,13 +15,12 @@
 
 #if __linux__
 # include <mutex>
-# include <sys/resource.h>
 # include "cgroup.hh"
 # include "namespaces.hh"
 #endif
 
 #ifndef _WIN32
-# include <sys/mount.h>
+# include <sys/resource.h>
 #endif
 
 namespace nix {


### PR DESCRIPTION
# Motivation

Shuffle a couple of system includes in `current-process.cc`:
- move `<sys/resource.h>` from a `__linux__` block to a `!_WIN32` block: this matches what the actual code does, using `getrlimit()` & `setrlimit()` in `!_WIN32` blocks
- drop `<sys/mount.h>`, which is not portable, and it is not used

# Context

Simplify the used includes, matching what is actually needed in the file. There is no behaviour change.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
