### PR TITLE
fix: add flake headers

### DIFF
--- a/src/libflake/flake/nix-flake.pc.in
+++ b/src/libflake/flake/nix-flake.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Nix
+Description: Nix Package Manager
+Version: @PACKAGE_VERSION@
+Requires: nix-util nix-store nix-expr
+Libs: -L${libdir} -lnixflake
+Cflags: -I${includedir}/nix -std=c++2a

--- a/src/libflake/local.mk
+++ b/src/libflake/local.mk
@@ -15,3 +15,8 @@ libflake_CXXFLAGS += $(INCLUDE_libutil) $(INCLUDE_libstore) $(INCLUDE_libfetcher
 libflake_LDFLAGS += $(THREAD_LDFLAGS)
 
 libflake_LIBS = libutil libstore libfetchers libexpr
+
+$(eval $(call install-file-in, $(buildprefix)$(d)/flake/nix-flake.pc, $(libdir)/pkgconfig, 0644))
+
+$(foreach i, $(wildcard src/libflake/flake/*.hh), \
+  $(eval $(call install-file-in, $(i), $(includedir)/nix/flake, 0644)))

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -20,6 +20,7 @@ deps_private_maybe_subproject = [
   dependency('nix-util'),
   dependency('nix-store'),
   dependency('nix-expr'),
+  dependency('nix-flake'),
   dependency('nix-fetchers'),
   dependency('nix-main'),
   dependency('nix-cmd'),


### PR DESCRIPTION
# Motivation
Allow for usage of the flake API in external projects (eg: nix-eval-jobs)

# Context

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
