### PR TITLE
Make sure we use `-isystem` with Meson on some deps

### DIFF
--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -32,6 +32,7 @@ subdir('build-utils-meson/threads')
 boost = dependency(
   'boost',
   modules : ['container', 'context'],
+  include_type: 'system',
 )
 # boost is a public dependency, but not a pkg-config dependency unfortunately, so we
 # put in `deps_other`.
@@ -55,7 +56,12 @@ if bdw_gc.found()
 endif
 configdata.set('HAVE_BOEHMGC', bdw_gc.found().to_int())
 
-toml11 = dependency('toml11', version : '>=3.7.0', method : 'cmake')
+toml11 = dependency(
+  'toml11',
+  version : '>=3.7.0',
+  method : 'cmake',
+  include_type: 'system',
+)
 deps_other += toml11
 
 config_h = configure_file(

--- a/src/libexpr/primops/fromTOML.cc
+++ b/src/libexpr/primops/fromTOML.cc
@@ -3,10 +3,7 @@
 
 #include <sstream>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch-enum"
 #include <toml.hpp>
-#pragma GCC diagnostic pop
 
 namespace nix {
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -73,6 +73,7 @@ subdir('build-utils-meson/threads')
 boost = dependency(
   'boost',
   modules : ['container'],
+  include_type: 'system',
 )
 # boost is a public dependency, but not a pkg-config dependency unfortunately, so we
 # put in `deps_other`.
@@ -113,7 +114,7 @@ if aws_s3.found()
       '-laws-cpp-sdk-core',
       '-laws-crt-cpp',
     ],
-  )
+  ).as_system('system')
 endif
 deps_other += aws_s3
 

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -10,8 +10,6 @@
 #include "compression.hh"
 #include "filetransfer.hh"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch-enum"
 #include <aws/core/Aws.h>
 #include <aws/core/VersionConfig.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
@@ -27,7 +25,6 @@
 #include <aws/s3/model/ListObjectsRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/transfer/TransferManager.h>
-#pragma GCC diagnostic pop
 
 using namespace Aws::Transfer;
 

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -62,6 +62,7 @@ endif
 boost = dependency(
   'boost',
   modules : ['context', 'coroutine'],
+  include_type: 'system',
 )
 # boost is a public dependency, but not a pkg-config dependency unfortunately, so we
 # put in `deps_other`.


### PR DESCRIPTION
# Motivation

Otherwise we get warnings on external code.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
