### PR TITLE
Some fixes for GNU/Hurd

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -29,4 +29,8 @@ ifdef HOST_OS
     HOST_SOLARIS = 1
     HOST_UNIX = 1
   endif
+  ifeq ($(HOST_KERNEL), gnu)
+    HOST_HURD = 1
+    HOST_UNIX = 1
+  endif
 endif

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -137,7 +137,7 @@ std::optional<Path> getSelfExe()
 {
     static auto cached = []() -> std::optional<Path>
     {
-        #if __linux__
+        #if __linux__ || __GNU__
         return readLink("/proc/self/exe");
         #elif __APPLE__
         char buf[1024];

--- a/tests/unit/libutil/tests.cc
+++ b/tests/unit/libutil/tests.cc
@@ -17,6 +17,10 @@
 # define FS_ROOT FS_SEP
 #endif
 
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
+
 namespace nix {
 
 /* ----------- tests for util.hh ------------------------------------------------*/


### PR DESCRIPTION
# Motivation

This PR includes few build and runtime fixes for GNU/Hurd:
- recognize it in the makefile build system
- use `/proc/self/exe` to get the current executable
- add a fallback `PATH_MAX` in one test

See the message of each commit for longer explanations.

# Context

Get Nix build and run better on GNU/Hurd. There is no behaviour change on any other OS.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
