### PR TITLE
Don't copy nix store path to nix store

### DIFF
--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -150,7 +150,7 @@ struct PathInputScheme : InputScheme
             store->addTempRoot(*storePath);
 
         time_t mtime = 0;
-        if (!storePath || storePath->name() != "source" || !store->isValidPath(*storePath)) {
+        if (!storePath || !store->isValidPath(*storePath)) {
             // FIXME: try to substitute storePath.
             auto src = sinkToSource([&](Sink & sink) {
                 mtime = dumpPathAndGetMtime(absPath, sink, defaultPathFilter);


### PR DESCRIPTION
# Motivation
Avoid unnecessary store -> store copies

# Context
See #11228 

I checked the PR introduced this change, and didn't find an explanation why this `== "source"` check is necessary.

IMO all store -> store copies are unnecessary. And even if there is indeed a valid reason this is only done for store paths named "source", it's not like the user can't just name their derivation "source".

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
