### PR TITLE
fix: bash mangles flake ref completion

### DIFF
--- a/misc/bash/completion.sh
+++ b/misc/bash/completion.sh
@@ -12,9 +12,16 @@ function _complete_nix {
             elif [[ $completion == attrs ]]; then
                 compopt -o nospace
             fi
-        else
-            COMPREPLY+=("$completion")
+            continue
         fi
+
+        if [[ "${cur}" =~ "=" ]]; then
+            # drop everything up to the first =. if a = is included, bash assumes this to be
+            # an arg=value argument and the completion gets mangled (see #11208)
+            completion="${completion#*=}"
+        fi
+
+        COMPREPLY+=("${completion}")
     done < <(NIX_GET_COMPLETIONS=$cword "${words[@]}" 2>/dev/null)
     __ltrim_colon_completions "$cur"
 }


### PR DESCRIPTION
# Motivation

When trying to complete an argument that contains an equal sign, bash seems to assume that it has the form `arg=value` and only replaces the `value` part. 
I fixed this by dropping everything before the first `=` in the completion result. I also tested this with multiple equal signs, and it still works. 

First contribution, yay!

# Context
<!-- Provide context. Reference open issues if available. -->
Fixes #11208 

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
