### PR TITLE
[RFC]: feat: use OSX keychain

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -77,6 +77,23 @@ Settings::Settings()
     if (sslOverride != "")
         caFile = sslOverride;
 
+#ifdef __APPLE__
+    if(caFile.get().starts_with("keychain:")){
+        debug("reading %s",caFile.get());
+        auto caContents = runProgram("/usr/bin/security", false, {"find-certificate", "-a", "-p", caFile.get().substr(9)});
+        if (caContents.empty()){
+            warn("reading '%s' found no certificates",caFile.get());
+        }
+        auto caFilePath = settings.nixConfDir + "/ssl-cert-file.keychain";
+        auto caFilePathTmp = caFilePath + ".tmp";
+        debug("writing to %s",caFilePathTmp);
+        writeFile(caFilePathTmp.c_str(),caContents);
+        // check failure?
+        std::rename(caFilePathTmp.c_str(), caFilePath.c_str());
+        caFile = caFilePath;
+    }
+#endif
+
     /* Backwards compatibility. */
     auto s = getEnv("NIX_REMOTE_SYSTEMS");
     if (s) {

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -1061,6 +1061,12 @@ public:
 
           1. `NIX_SSL_CERT_FILE`
           2. `SSL_CERT_FILE`
+
+          Darwin only: The path can also be of form keychain:/path-to-keychain
+          which will read the OSX keychain and write it to the config directory
+          and use that file as the CA file. For example, setting
+          "keychain:/System/Library/Keychains/SystemRootCertificates.keychain"
+          will write to "/etc/nix/ssl-cert-file.keychain".
         )"};
 
 #if __linux__


### PR DESCRIPTION
# Motivation
make it easier for people to use their OSX keychain to provide the SSL CA.

# Context
Uses `security find-certificate -a -p` to write a file. This is probably not the right approach.

# Alternatives
- considering a `nix config get-certificates` command
- `nix doctor`
- better error messages


Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
