### PR TITLE
WIP: feat(fmt): use nixfmt-rfc-style

### DIFF
--- a/src/libcmd/installable-flake.hh
+++ b/src/libcmd/installable-flake.hh
@@ -74,7 +74,7 @@ struct InstallableFlake : InstallableValue
  * have their own Nixpkgs input, or other installables.
  *
  * It is a layer violation for Nix to know about Nixpkgs; currently just
- * `nix develop` does. Be wary of using this /
+ * `nix develop` and `nix fmt` does. Be wary of using this /
  * `InstallableFlake::nixpkgsFlakeRef` more places.
  */
 static inline FlakeRef defaultNixpkgsFlakeRef()

--- a/src/nix/fmt.md
+++ b/src/nix/fmt.md
@@ -2,48 +2,24 @@ R""(
 
 # Examples
 
-With [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt):
-
-```nix
-# flake.nix
-{
-  outputs = { nixpkgs, self }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
-  };
-}
-```
+With [nixfmt](https://github.com/NixOS/nixfmt):
 
 - Format the current flake: `$ nix fmt`
 
 - Format a specific folder or file: `$ nix fmt ./folder ./file.nix`
-
-With [nixfmt](https://github.com/serokell/nixfmt):
-
-```nix
-# flake.nix
-{
-  outputs = { nixpkgs, self }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt;
-  };
-}
-```
 
 - Format specific files: `$ nix fmt ./file1.nix ./file2.nix`
 
-With [Alejandra](https://github.com/kamadorueda/alejandra):
-
+## **disabled** Overriding the formatter used
 ```nix
 # flake.nix
 {
   outputs = { nixpkgs, self }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
+    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
   };
 }
 ```
 
-- Format the current flake: `$ nix fmt`
-
-- Format a specific folder or file: `$ nix fmt ./folder ./file.nix`
 
 # Description
 


### PR DESCRIPTION
# Motivation
Make `nix fmt` usable by default.

- Evaluating for `.#formatters.SYSTEM` or `inputs.nixpkgs` is too slow for the moment, so disabling that override for now.
- Using the same mechanism as `nix develop` to obtain an ambient nixpkgs
- defaulting to `nixfmt-rfc-style`
- could read+evaluate `ci/pinned-nixpkgs.json`, this can cost another download+copy to store, but will be more stable over time in case someone has flake:nixpkgs set to a moving branch

# Context
https://github.com/NixOS/nix/pull/6087

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
