### PR TITLE
docs: installable remove alternate expression flag

### DIFF
--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -65,7 +65,7 @@ The following types of installable are supported by most commands:
 - [Nix file](#nix-file), optionally qualified by an attribute path
   - Specified with `--file`/`-f`
 - [Nix expression](#nix-expression), optionally qualified by an attribute path
-  - Specified with `--expr`/`-E`
+  - Specified with `--expr`
 
 For most commands, if no installable is specified, `.` is assumed.
 That is, Nix will operate on the default flake output attribute of the flake in the current directory.
@@ -200,17 +200,17 @@ operate are determined as follows:
   …
   ```
 
-  For `-e`/`--expr` and `-f`/`--file`, the derivation output is specified as part of the attribute path:
+  For `--expr` and `-f`/`--file`, the derivation output is specified as part of the attribute path:
 
   ```console
   $ nix build -f '<nixpkgs>' 'glibc^dev,static'
-  $ nix build --impure -E 'import <nixpkgs> { }' 'glibc^dev,static'
+  $ nix build --impure --expr 'import <nixpkgs> { }' 'glibc^dev,static'
   ```
 
   This syntax is the same even if the actual attribute path is empty:
 
   ```console
-  $ nix build -E 'let pkgs = import <nixpkgs> { }; in pkgs.glibc' '^dev,static'
+  $ nix build --impure --expr 'let pkgs = import <nixpkgs> { }; in pkgs.glibc' '^dev,static'
   ```
 
 * You can also specify that *all* outputs should be used using the


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Remove the alternate shorthand form for `--expr`, `-E` from the documentation, since it doesn't exist.
# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
