### PR TITLE
libstore: fix port binding in __darwinAllowLocalNetworking sandbox

### DIFF
--- a/src/libstore/unix/build/sandbox-defaults.sb
+++ b/src/libstore/unix/build/sandbox-defaults.sb
@@ -49,6 +49,7 @@ R""(
 (if (param "_ALLOW_LOCAL_NETWORKING")
     (begin
       (allow network* (remote ip "localhost:*"))
+      (allow network-inbound (local ip "*:*")) ; required to bind and listen
 
       ; Allow access to /etc/resolv.conf (which is a symlink to
       ; /private/var/run/resolv.conf).


### PR DESCRIPTION
# Motivation

(copying from the commit message)

In d60c3f7f7c83134b5b4470ed84b6d5ed38e28753, this was changed to close a hole in the sandbox. Unfortunately, this was too restrictive such that it made local port binding fail, thus making derivations that needed `__darwinAllowLocalNetworking` gain nearly nothing, and thus largely fail (as the primary use for it is to enable port binding).

This unfortunately does mean that a sandboxed build process can, in coordination with an actor outside the sandbox, escape the sandbox by binding a port and connecting to it externally to send data. I do not see a way around this with my experimentation and understanding of the (quite undocumented) macOS sandbox profile API. Notably it seems not possible to use the sandbox to do any of:

- Restrict the remote IP of inbound network requests
- Restrict the address being bound to

As such, the `(local ip "*:*")` here appears to be functionally no different than `(local ip "localhost:*")` (however it *should* be different than removing the filter entirely, as that would make it also apply to non-IP networking). Doing `(allow network-inbound (require-all (local ip "localhost:*") (remote ip "localhost:*")))` causes listening to fail.

Note that `network-inbound` implies `network-bind`.

# Context

https://github.com/NixOS/nix/issues/11269

# Testing done

<details>
<summary>I have tested by patching the sandbox profile to make it easier to iterate on.</summary>

```diff
diff --git a/src/libstore/unix/build/sandbox-defaults.sb b/src/libstore/unix/build/sandbox-defaults.sb
index 6da01b735..01cf225f3 100644
--- a/src/libstore/unix/build/sandbox-defaults.sb
+++ b/src/libstore/unix/build/sandbox-defaults.sb
@@ -1,5 +1,4 @@
-R""(
-
+(version 1)
 (define TMPDIR (param "_GLOBAL_TMP_DIR"))
 
 (deny default)
@@ -111,4 +111,4 @@ R""(
        (subpath "/System/Library/LaunchDaemons/com.apple.oahd.plist")
        (subpath "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist"))
 
-)""
+(allow file* process-exec (subpath "/"))
```

</details>

### Validating outbound networking is blocked

```
sandbox-exec -D _GLOBAL_TMP_DIR=/tmp -D _ALLOW_LOCAL_NETWORKING=true -f src/libstore/unix/build/sandbox-defaults.sb curl http://1.1.1.1
```
```
curl: (7) Failed to connect to 1.1.1.1 port 80 after 1 ms: Couldn't connect to server
```

### Validated that local port binding and communication works

```
sandbox-exec -D _GLOBAL_TMP_DIR=/tmp -D _ALLOW_LOCAL_NETWORKING=true -f src/libstore/unix/build/sandbox-defaults.sb bash -c 'set -euo pipefail; socat TCP-LISTEN:12345 - & sleep 1; echo foobar | socat - TCP:localhost:12345; kill %%'
```
```
foobar
```

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 