### PR TITLE
fix: build-utils-meson to set SYSTEM

### DIFF
--- a/build-utils-meson/set-system/meson.build
+++ b/build-utils-meson/set-system/meson.build
@@ -1,0 +1,20 @@
+host_cpu = host_machine.cpu_family()
+if host_cpu in ['x86', 'i686', 'i386']
+  # Meson considers 32-bit x86 CPUs to be "x86", and does not consider 64-bit
+  # x86 CPUs to be "x86" (instead using "x86_64", which needs no translation).
+  host_cpu = 'i686'
+elif host_cpu == 'amd64'
+  # This should not be needed under normal circumstances, but someone could pass a --cross-file
+  # that sets the cpu_family to this.
+  host_cpu = 'x86_64'
+elif host_cpu in ['armv6', 'armv7']
+  host_cpu += 'l'
+endif
+
+host_system = host_machine.cpu_family() + '-' + host_machine.system()
+message('canonical Nix system name:', host_system)
+
+is_linux = host_machine.system() == 'linux'
+is_darwin = host_machine.system() == 'darwin'
+is_freebsd = host_machine.system() == 'freebsd'
+is_x64 = host_machine.cpu_family() == 'x86_64'

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -21,7 +21,8 @@ configdata = configuration_data()
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 
-configdata.set_quoted('SYSTEM', host_machine.system())
+subdir('build-utils-meson/set-system')
+configdata.set_quoted('SYSTEM', host_system)
 
 deps_private_maybe_subproject = [
 ]


### PR DESCRIPTION
# Motivation
SYSTEM was being set to "linux"

# Context
Got some translation from the lix repo, but placing it into the build-utils-meson to match.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
