### PR TITLE
Update lookup-path.md

### DIFF
--- a/doc/manual/src/language/constructs/lookup-path.md
+++ b/doc/manual/src/language/constructs/lookup-path.md
@@ -4,7 +4,7 @@
 >
 > *lookup-path* = `<` *identifier* [ `/` *identifier* ]... `>`
 
-A lookup path is an identifier with an optional path suffix that resolves to a [path value](@docroot@/language/types.md#type-path) if the identifier matches a search path entry.
+A lookup path is an identifier with an optional path suffix that resolves to a file system [path value](@docroot@/language/types.md#type-path) if the identifier matches a search path entry.
 
 The value of a lookup path is determined by [`builtins.nixPath`](@docroot@/language/builtins.md#builtins-nixPath).
 
@@ -12,6 +12,8 @@ See [`builtins.findFile`](@docroot@/language/builtins.md#builtins-findFile) for 
 
 > **Example**
 >
+> Generally, `<nixpkgs>` points to the file system path of some revision of [Nixpkgs](https://nix.dev/reference/glossary#term-Nixpkgs).
+> 
 > ```nix
 > <nixpkgs>
 >```
@@ -20,6 +22,8 @@ See [`builtins.findFile`](@docroot@/language/builtins.md#builtins-findFile) for 
 
 > **Example**
 >
+> `<nixpkgs/lib>` points to the subdirectory `nixos` of the file system path `<nixpkgs>` points to:
+> 
 > ```nix
 > <nixpkgs/nixos>
 >```


### PR DESCRIPTION
# Motivation

Updated this entry with 2 sentence taken from the `nix.dev` tutorial's [lookup paths](https://nix.dev/tutorials/nix-language#lookup-paths) section as that resource makes it way easier to understand this concept.

Also added "_file system_" in front of "_path value_" because I found it an important clarification as "_path_" is an overloaded term.


# Context

Trivial change; providing minor clarification.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
