### PR TITLE
add cross-references to `nix-path` overriding

### DIFF
--- a/doc/manual/src/language/constructs/lookup-path.md
+++ b/doc/manual/src/language/constructs/lookup-path.md
@@ -4,11 +4,8 @@
 >
 > *lookup-path* = `<` *identifier* [ `/` *identifier* ]... `>`
 
-A lookup path is an identifier with an optional path suffix that resolves to a [path value](@docroot@/language/types.md#type-path) if the identifier matches a search path entry.
-
-The value of a lookup path is determined by [`builtins.nixPath`](@docroot@/language/builtins.md#builtins-nixPath).
-
-See [`builtins.findFile`](@docroot@/language/builtins.md#builtins-findFile) for details on lookup path resolution.
+A lookup path is an identifier with an optional path suffix that resolves to a [path value](@docroot@/language/types.md#type-path) if the identifier matches a search path entry in [`builtins.nixPath`](@docroot@/language/builtins.md#builtins-nixPath).
+The algorithm for search path resolution is described in the documentation on [`builtins.findFile`](@docroot@/language/builtins.md#builtins-findFile).
 
 > **Example**
 >

--- a/doc/manual/src/language/constructs/lookup-path.md
+++ b/doc/manual/src/language/constructs/lookup-path.md
@@ -5,7 +5,7 @@
 > *lookup-path* = `<` *identifier* [ `/` *identifier* ]... `>`
 
 A lookup path is an identifier with an optional path suffix that resolves to a [path value](@docroot@/language/types.md#type-path) if the identifier matches a search path entry in [`builtins.nixPath`](@docroot@/language/builtins.md#builtins-nixPath).
-The algorithm for search path resolution is described in the documentation on [`builtins.findFile`](@docroot@/language/builtins.md#builtins-findFile).
+The algorithm for lookup path resolution is described in the documentation on [`builtins.findFile`](@docroot@/language/builtins.md#builtins-findFile).
 
 > **Example**
 >

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4858,7 +4858,7 @@ void EvalState::createBaseEnv()
         .type = nList,
         .doc = R"(
           A list of search path entries used to resolve [lookup paths](@docroot@/language/constructs/lookup-path.md).
-          Its value is primarily determined by the [`nix-path` configuration setting](@docroot@/command-ref/conf-file.md#conf-nix-path), which can be
+          Its value is primarily determined by the [`nix-path` configuration setting](@docroot@/command-ref/conf-file.md#conf-nix-path), which are
           - Overridden by the [`NIX_PATH`](@docroot@/command-ref/env-common.md#env-NIX_PATH) environment variable or the `--nix-path` option
           - Extended by the [`-I` option](@docroot@/command-ref/opt-common.md#opt-I) or `--extra-nix-path`
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4857,7 +4857,10 @@ void EvalState::createBaseEnv()
     addConstant("__nixPath", v, {
         .type = nList,
         .doc = R"(
-          The value of the [`nix-path` configuration setting](@docroot@/command-ref/conf-file.md#conf-nix-path): a list of search path entries used to resolve [lookup paths](@docroot@/language/constructs/lookup-path.md).
+          A list of search path entries used to resolve [lookup paths](@docroot@/language/constructs/lookup-path.md).
+          Its value is primarily determined by the [`nix-path` configuration setting](@docroot@/command-ref/conf-file.md#conf-nix-path), which can be
+          - Overridden by the [`NIX_PATH`](@docroot@/command-ref/env-common.md#env-NIX_PATH) environment variable or the `--nix-path` option
+          - Extended by the [`-I` option](@docroot@/command-ref/opt-common.md#opt-I) or `--extra-nix-path`
 
           > **Example**
           >


### PR DESCRIPTION
# Motivation
closes https://github.com/NixOS/nix/issues/8228

this would make pretty much everything you need to know about the mechanics of lookup paths accessible within one or two link traversals, and all of it within three.
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
while this information is already present in the settings, it's more
likely to be first accessed through the "lookup path" page, which
currently requires following two links to get to the practically
important bits.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).