### PR TITLE
WIP: accumulate attrset updates, use k-way merge

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -819,6 +819,9 @@ private:
     unsigned long nrOpUpdates = 0;
     unsigned long nrOpUpdateValuesCopied = 0;
     unsigned long nrListConcats = 0;
+    std::map<int, int> nrMultiConcats;
+    std::map<int, int> nrMultiConcatCapacityPercent;
+    unsigned long nrMultiConcatCapacityTotalWaste = 0;
     unsigned long nrPrimOpCalls = 0;
     unsigned long nrFunctionCalls = 0;
 


### PR DESCRIPTION
This seems to be slower as of yet. Main point was showing an implementation strategy for an optimization that applies also to other semigroups, like string concatenation and lists.
I didn't originally plan to pursue this, as mentioned, so if you're interested in algorithms and performance optimization you are more than welcome to work on this.

TODO

- [ ] remove merge pass 2 into 1:
  - pass 1: fill UpdateQueue
  - pass 2: stats (like max output size)
  - pass 3: k-way merge
- [ ] maybe tracking sortedness, if useful and cheap? in pass 1, building the UpdateQueue
- [ ] make it actually fast; different algorithm depending on size distribution and number of update ops?
  - currently solution is the min-heap or priority queue approach
  - divide and conquer (see also Nixpkgs which manually implements this for pkgs/by-name) binary tree-shaped sorted merge operations
    - can we take the size of attrsets into account to balance the work? 1000 + (1 + (1 + 1)) is better than ((1000+1)+1)+1  (where number refers to attrset size)
  - iterative pairwise merging is more or less what we had, the tree of updates is flattened. Probably worse.
  - perhaps some combination of solutions, depending on a heuristic
- [ ] split callFunction into two parts, effectively - call2Thunk (create the new scope's Env etc) - eval that thunk (evaluate the body)
- [ ] implement ExprApply::evalForUpdate - easy after the split
- [ ] make foldl' (//) work?
- [ ] optimize listToAttrs and other primops?


# Context

Yesterday's meeting (will post notes in a minute)
@tomberek

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
