### PR TITLE
Coarse versions for constituent packages

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -47,7 +47,8 @@
 
 , pname ? "nix"
 
-, versionSuffix ? ""
+, version
+, versionSuffix
 
 # Whether to build Nix. Useful to skip for tasks like testing existing pre-built versions of Nix
 , doBuild ? true
@@ -111,8 +112,6 @@
 
 let
   inherit (lib) fileset;
-
-  version = lib.fileContents ./.version + versionSuffix;
 
   # selected attributes with defaults, will be used to define some
   # things which should instead be gotten via `finalAttrs` in order to

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -1,11 +1,34 @@
+{
+  lib,
+  src,
+  officialRelease,
+}:
+
 scope:
+
 let
   inherit (scope) callPackage;
+
+  baseVersion = lib.fileContents ../.version;
+
+  versionSuffix = lib.optionalString (!officialRelease) "pre";
+
+  fineVersionSuffix = lib.optionalString
+    (!officialRelease)
+    "pre${builtins.substring 0 8 (src.lastModifiedDate or src.lastModified or "19700101")}_${src.shortRev or "dirty"}";
+
+  fineVersion = baseVersion + fineVersionSuffix;
 in
 
 # This becomes the pkgs.nixComponents attribute set
 {
-  nix = callPackage ../package.nix { };
+  version = baseVersion + versionSuffix;
+  inherit versionSuffix;
+
+  nix = callPackage ../package.nix {
+    version = fineVersion;
+    versionSuffix = fineVersionSuffix;
+  };
 
   nix-util = callPackage ../src/libutil/package.nix { };
   nix-util-c = callPackage ../src/libutil-c/package.nix { };
@@ -34,10 +57,10 @@ in
   nix-cmd = callPackage ../src/libcmd/package.nix { };
 
   # Will replace `nix` once the old build system is gone.
-  nix-ng = callPackage ../src/nix/package.nix { };
+  nix-ng = callPackage ../src/nix/package.nix { version = fineVersion; };
 
-  nix-internal-api-docs = callPackage ../src/internal-api-docs/package.nix { };
-  nix-external-api-docs = callPackage ../src/external-api-docs/package.nix { };
+  nix-internal-api-docs = callPackage ../src/internal-api-docs/package.nix { version = fineVersion; };
+  nix-external-api-docs = callPackage ../src/external-api-docs/package.nix { version = fineVersion; };
 
   nix-perl-bindings = callPackage ../src/perl/package.nix { };
 }

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -8,7 +8,6 @@
   pkgs,
 
   stdenv,
-  versionSuffix,
 }:
 
 let
@@ -73,11 +72,9 @@ let
       strictDeps = prevAttrs.strictDeps or true;
       enableParallelBuilding = true;
     };
-
 in
 scope: {
-  inherit stdenv versionSuffix;
-  version = lib.fileContents ../.version + versionSuffix;
+  inherit stdenv;
 
   aws-sdk-cpp = (pkgs.aws-sdk-cpp.override {
     apis = [ "s3" "transfer" ];

--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -6,6 +6,7 @@
 , linux64BitSystems
 , nixpkgsFor
 , self
+, officialRelease
 }:
 let
   inherit (inputs) nixpkgs nixpkgs-regression;
@@ -16,7 +17,7 @@ let
     };
 
   testNixVersions = pkgs: client: daemon:
-    pkgs.callPackage ../package.nix {
+    pkgs.nixComponents.callPackage ../package.nix {
       pname =
         "nix-tests"
         + lib.optionalString
@@ -28,6 +29,12 @@ let
       test-daemon = daemon;
 
       doBuild = false;
+
+      # This could be more accurate, but a shorter version will match the
+      # fine version with rev. This functionality is already covered in
+      # the normal test, so it's fine.
+      version = pkgs.nixComponents.version;
+      versionSuffix = pkgs.nixComponents.versionSuffix;
     };
 
   # Technically we could just return `pkgs.nixComponents`, but for Hydra it's


### PR DESCRIPTION
# Motivation

As discussed in our meeting, we should use a simplified version for the libraries without the date or commit hash. This will make rebuilding a lot faster in many cases.


# Context

Progress on #10379

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
