### PR TITLE
fix: use SymbolStr in constructor

### DIFF
--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -325,9 +325,9 @@ public:
 
     void mkStringMove(const char * s, const NixStringContext & context);
 
-    inline void mkString(const Symbol & s)
+    inline void mkString(const SymbolStr & s)
     {
-        mkString(((const std::string &) s).c_str());
+        mkString(s.c_str());
     }
 
     void mkPath(const SourcePath & path);


### PR DESCRIPTION
# Motivation
Operations like mapAttrs already have values in the symbol table. They are stored as std::string and can bypass makeImmutableString. The current constructor for "Symbol" doesn't seem to ever trigger, but converting it to "SymbolStr" makes it function as expected. (currently it seems we export to string_view and use makeImmutable on it again?) This changes the number of string allocations for a default NixOS eval from 900k -> 100k with a reduced memory usage of 2-3%. Speedup is slight, likely due to more time spent in lookup.

# Context
Was looking at performance.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
