### PR TITLE
doc/manual: fix misaligned icons in custom.css

### DIFF
--- a/doc/manual/custom.css
+++ b/doc/manual/custom.css
@@ -12,8 +12,8 @@ h1.menu-title::before {
 }
 
 
-h1.menu-title {
-  padding: 0.5em;
+.menu-bar {
+  padding: 0.5em 0em;
 }
 
 .sidebar .sidebar-scrollbox {


### PR DESCRIPTION
# Motivation

Currently, the top-left icons of the manual appear misaligned on my browsers (`firefox-129.0` and `evince-46.3.1`):

![misaligned](https://github.com/user-attachments/assets/119c7a76-92a3-45ee-a5bf-793fb8419e4f)

This PR fixes the misaligned icons (sorry about my OCD):

![image](https://github.com/user-attachments/assets/c394dbe0-c953-46bb-943e-7a3fa261e73f)

# Context

This appears to be a consequence of the custom CSS added in #9870. cc @fricklerhandwerk 
The fix is a simple two-line CSS tweak. Tested by manually tuning the CSS rules through my browser dev tools.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
