### PR TITLE
`nix flake show`: Support `meta` attribute for `apps`

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1251,8 +1251,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                         }
                         j.emplace("type", "derivation");
                         j.emplace("name", name);
-                        if (description)
-                            j.emplace("description", *description);
+                        j.emplace("description", description ? *description : "");
                     } else {
                         logger->cout("%s: %s '%s'",
                             headerPrefix,
@@ -1340,12 +1339,19 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                     (attrPath.size() == 3 && attrPathS[0] == "apps"))
                 {
                     auto aType = visitor.maybeGetAttr("type");
+                    std::optional<std::string> description;
+                    if (auto aMeta = visitor.maybeGetAttr(state->sMeta)) {
+                        if (auto aDescription = aMeta->maybeGetAttr(state->sDescription))
+                            description = aDescription->getString();
+                    }
                     if (!aType || aType->getString() != "app")
                         state->error<EvalError>("not an app definition").debugThrow();
                     if (json) {
                         j.emplace("type", "app");
+                        if (description)
+                            j.emplace("description", *description);
                     } else {
-                        logger->cout("%s: app", headerPrefix);
+                        logger->cout("%s: app: " ANSI_BOLD "%s" ANSI_NORMAL, headerPrefix, description ? *description : "no description");
                     }
                 }
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -437,14 +437,39 @@ struct CmdFlakeCheck : FlakeCommand
 
         auto checkApp = [&](const std::string & attrPath, Value & v, const PosIdx pos) {
             try {
-                #if 0
-                // FIXME
-                auto app = App(*state, v);
-                for (auto & i : app.context) {
-                    auto [drvPathS, outputName] = NixStringContextElem::parse(i);
-                    store->parseStorePath(drvPathS);
+                Activity act(*logger, lvlInfo, actUnknown, fmt("checking app '%s'", attrPath));
+                state->forceAttrs(v, pos, "");
+                if (auto attr = v.attrs()->get(state->symbols.create("type")))
+                    state->forceStringNoCtx(*attr->value, attr->pos, "");
+                else
+                    throw Error("app '%s' lacks attribute 'type'", attrPath);
+
+                if (auto attr = v.attrs()->get(state->symbols.create("program"))) {
+                    if (attr->name == state->symbols.create("program")) {
+                        NixStringContext context;
+                        state->forceString(*attr->value, context, attr->pos, "");
+                    }
+                } else
+                    throw Error("app '%s' lacks attribute 'program'", attrPath);
+
+                if (auto attr = v.attrs()->get(state->symbols.create("meta"))) {
+                    state->forceAttrs(*attr->value, attr->pos, "");
+                    if (auto dAttr = attr->value->attrs()->get(state->symbols.create("description")))
+                        state->forceStringNoCtx(*dAttr->value, dAttr->pos, "");
+                    else
+                        logWarning({
+                            .msg = HintFmt("app '%s' lacks attribute 'meta.description'", attrPath),
+                        });
+                } else
+                    logWarning({
+                        .msg = HintFmt("app '%s' lacks attribute 'meta'", attrPath),
+                    });
+
+                for (auto & attr : *v.attrs()) {
+                    std::string_view name(state->symbols[attr.name]);
+                    if (name != "type" && name != "program" && name != "meta")
+                        throw Error("app '%s' has unsupported attribute '%s'", attrPath, name);
                 }
-                #endif
             } catch (Error & e) {
                 e.addTrace(resolve(pos), HintFmt("while checking the app definition '%s'", attrPath));
                 reportError(e);
@@ -629,7 +654,7 @@ struct CmdFlakeCheck : FlakeCommand
                                 const auto & attr_name = state->symbols[attr.name];
                                 checkSystemName(attr_name, attr.pos);
                                 if (checkSystemType(attr_name, attr.pos)) {
-                                    checkApp(
+                                    checkDerivation(
                                         fmt("%s.%s", name, attr_name),
                                         *attr.value, attr.pos);
                                 };

--- a/src/nix/run.md
+++ b/src/nix/run.md
@@ -80,6 +80,7 @@ An app is specified by a flake output attribute named
 apps.x86_64-linux.blender_2_79 = {
   type = "app";
   program = "${self.packages.x86_64-linux.blender_2_79}/bin/blender";
+  meta.description = "Run Blender, a free and open-source 3D creation suite.";
 };
 ```
 
@@ -89,5 +90,7 @@ The only supported attributes are:
 
 * `program` (required): The full path of the executable to run. It
   must reside in the Nix store.
+
+* `meta.description` (optional): A description of the app.
 
 )""


### PR DESCRIPTION
# Motivation
Metadata information for flake apps will be useful while exploring a
flake using `nix flake show`

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

The outputs that follow, uses the flake:

```nix
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
  outputs = { nixpkgs, ... }: {
    apps.aarch64-darwin.hello = {
      program = "${nixpkgs.lib.getExe nixpkgs.legacyPackages.aarch64-darwin.hello}";
      type = "app";
      meta.description = "I say hello!";
    };
  };
}
```

**Output without the description:**

```sh
❯ nix flake show
path:/Users/shivaraj/oss/tmp?lastModified=1723627908&narHash=sha256-D89aZ1hTqNCzvUIHLD6meJVNiApUoGvyMzEiowdf/dU%3D
└───apps
    └───aarch64-darwin
        └───hello: app
```

**Output with the description:**
```sh
❯ ../nix/outputs/out/bin/nix flake show
path:/Users/shivaraj/oss/tmp?lastModified=1723627908&narHash=sha256-D89aZ1hTqNCzvUIHLD6meJVNiApUoGvyMzEiowdf/dU%3D
└───apps
    └───aarch64-darwin
        └───hello: app: I say hello!
```

**The description is also included in the `json` output of `nix flake show`:**

```json
{
  "apps": {
    "aarch64-darwin": {
      "hello": {
        "description": "I say hello!",
        "type": "app"
      }
    }
  }
}
```
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
