### PR TITLE
Make $HOME=/proc/homeless-shelter instead of /homeless-shelter

### DIFF
--- a/doc/manual/src/language/derivations.md
+++ b/doc/manual/src/language/derivations.md
@@ -264,7 +264,8 @@ The [`builder`](#attr-builder) is executed as follows:
   - `PATH` is set to `/path-not-set` to prevent shells from
     initialising it to their built-in default value.
 
-  - `HOME` is set to `/proc/homeless-shelter` to prevent programs from
+  - `HOME` is set to `/proc/homeless-shelter` on Linux and `/homeless-shelter`
+    on OSX, to prevent programs from
     using `/etc/passwd` or the like to find the user's home
     directory, which could cause impurity. Usually, when `HOME` is
     set, it is used as the location of the home directory, even if

--- a/doc/manual/src/language/derivations.md
+++ b/doc/manual/src/language/derivations.md
@@ -264,7 +264,7 @@ The [`builder`](#attr-builder) is executed as follows:
   - `PATH` is set to `/path-not-set` to prevent shells from
     initialising it to their built-in default value.
 
-  - `HOME` is set to `/homeless-shelter` to prevent programs from
+  - `HOME` is set to `/proc/homeless-shelter` to prevent programs from
     using `/etc/passwd` or the like to find the user's home
     directory, which could cause impurity. Usually, when `HOME` is
     set, it is used as the location of the home directory, even if

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -102,7 +102,7 @@ void handleDiffHook(
     }
 }
 
-const Path LocalDerivationGoal::homeDir = "/homeless-shelter";
+const Path LocalDerivationGoal::homeDir = "/proc/homeless-shelter";
 
 
 LocalDerivationGoal::~LocalDerivationGoal()

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -102,7 +102,14 @@ void handleDiffHook(
     }
 }
 
+// We want $HOME to be un-creatable in the sandbox. On Linux,
+// you can't create anything inside /proc since it's a virtual filesystem.
+// On Darwin it seems that `/homeless-shelter` is good enough.
+#if __linux__
 const Path LocalDerivationGoal::homeDir = "/proc/homeless-shelter";
+#else
+const Path LocalDerivationGoal::homeDir = "/homeless-shelter";
+#endif
 
 
 LocalDerivationGoal::~LocalDerivationGoal()


### PR DESCRIPTION
# Motivation

When building, $HOME is currently set to `/homeless-shelter`. In some scenarios (specifically when using the linux sandbox with a single-user installation), it is possible to create this directory, and some tools will make it, resulting in a build error. 

Instead, if $HOME is set to `/proc/homeless-shelter`, it is never possible to create it, since /proc is a virtual filesystem which doesn't allow creating files or directories. This resolves the issue mentioned.

# Context
https://github.com/NixOS/nix/issues/11295 - nix build fails because /homeless-shelter exists.
https://github.com/NixOS/nix/issues/8313 - a suggestion to do what this PR does.

I prefer to put /homeless-shelter in /proc rather than /sys, since /proc is standard in linux, and /sys seems less standard. See https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/c23.html, of the Linux Documentation Project, which describes `/proc` and doesn't describe `/sys`.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
