### PR TITLE
doc: Manage expectations for eval-cache

### DIFF
--- a/doc/manual/src/release-notes/rl-2.4.md
+++ b/doc/manual/src/release-notes/rl-2.4.md
@@ -141,6 +141,8 @@ more than 2800 commits from 195 contributors since release 2.3.
   the evaluation cache. This is made possible by the hermetic
   evaluation model of flakes.
 
+  Intermediate results are not cached.
+
 * The new `--offline` flag disables substituters and causes all
   locally cached tarballs and repositories to be considered
   up-to-date.

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -185,7 +185,11 @@ struct EvalSettings : Config
         )"};
 
     Setting<bool> useEvalCache{this, true, "eval-cache",
-        "Whether to use the flake evaluation cache."};
+        R"(
+            Whether to use the flake evaluation cache.
+            Certain commands won't have to evaluate when invoked for the second time with a particular version of a flake.
+            Intermediate results are not cached.
+        )"};
 
     Setting<bool> ignoreExceptionsDuringTry{this, false, "ignore-try",
         R"(


### PR DESCRIPTION
# Motivation

Incorrectly high expectations lead to frustration for users who stick around to experience how useless it is for e.g. a devShell

https://functional.cafe/@arianvp/112976284363120036:

> Flakes doesn't have eval caching. It has command line argument
> caching. It literally just stores the cli argument you passed
> in a sqlite database and yes that's as useless as it sounds

> When I discovered flakes had no expression level caching whatsoever
> I kind of felt lied to and betrayed.

cc @arianvp

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

- #4511

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
