### PR TITLE
Update documentation to refer to Meson not Make in most places

### DIFF
--- a/doc/manual/src/development/testing.md
+++ b/doc/manual/src/development/testing.md
@@ -135,60 +135,52 @@ Functional tests are run during `installCheck` in the `nix` package build, as we
 
 ### Running the whole test suite
 
-The whole test suite can be run with:
+The whole test suite (functional and unit tests) can be run with:
 
 ```shell-session
-$ make install && make installcheck
-ran test tests/functional/foo.sh... [PASS]
-ran test tests/functional/bar.sh... [PASS]
-...
+$ mesonCheckPhase
 ```
 
 ### Grouping tests
 
 Sometimes it is useful to group related tests so they can be easily run together without running the entire test suite.
 Each test group is in a subdirectory of `tests`.
-For example, `tests/functional/ca/local.mk` defines a `ca` test group for content-addressed derivation outputs.
+For example, `tests/functional/ca/meson.build` defines a `ca` test group for content-addressed derivation outputs.
 
 That test group can be run like this:
 
 ```shell-session
-$ make ca.test-group -j50
-ran test tests/functional/ca/nix-run.sh... [PASS]
-ran test tests/functional/ca/import-derivation.sh... [PASS]
-...
-```
-
-The test group is defined in Make like this:
-```makefile
-$(test-group-name)-tests := \
-  $(d)/test0.sh \
-  $(d)/test1.sh \
-  ...
-
-install-tests-groups += $(test-group-name)
+$ meson test --suite ca
+ninja: Entering directory `/home/jcericson/src/nix/master/build'
+ninja: no work to do.
+[1-20/20] 🌑 nix-functional-tests:ca / ca/why-depends                                1/20 nix-functional-tests:ca / ca/nix-run                                  OK               0.16s
+[2-20/20] 🌒 nix-functional-tests:ca / ca/why-depends                                2/20 nix-functional-tests:ca / ca/import-derivation                        OK               0.17s
 ```
 
 ### Running individual tests
 
-Individual tests can be run with `make`:
+Individual tests can be run with `meson`:
 
 ```shell-session
-$ make tests/functional/${testName}.sh.test
-ran test tests/functional/${testName}.sh... [PASS]
+$ meson test ${testName}
+ninja: Entering directory `/home/jcericson/src/nix/master/build'
+ninja: no work to do.
+1/1 nix-functional-tests:main / ${testName}        OK               0.41s
+
+Ok:                 1
+Expected Fail:      0
+Fail:               0
+Unexpected Pass:    0
+Skipped:            0
+Timeout:            0
+
+Full log written to /home/jcericson/src/nix/master/build/meson-logs/testlog.txt
 ```
 
-or without `make`:
+or without `meson`, showing the output:
 
 ```shell-session
-$ ./mk/run-test.sh tests/functional/${testName}.sh
-ran test tests/functional/${testName}.sh... [PASS]
-```
-
-To see the complete output, one can also run:
-
-```shell-session
-$ ./mk/debug-test.sh tests/functional/${testName}.sh
+$ TEST_NAME=${testName} NIX_REMOTE='' PS4='+(${BASH_SOURCE[0]-$0}:$LINENO) tests/functional/${testName}.sh
 +(${testName}.sh:1) foo
 output from foo
 +(${testName}.sh:2) bar
@@ -254,7 +246,7 @@ It is frequently useful to regenerate the expected output.
 To do that, rerun the failed test(s) with `_NIX_TEST_ACCEPT=1`.
 For example:
 ```bash
-_NIX_TEST_ACCEPT=1 make tests/functional/lang.sh.test
+_NIX_TEST_ACCEPT=1 meson test lang
 ```
 This convention is shared with the [characterisation unit tests](#characterisation-testing-unit) too.
 

--- a/doc/manual/src/installation/building-source.md
+++ b/doc/manual/src/installation/building-source.md
@@ -1,31 +1,26 @@
 # Building Nix from Source
 
-After cloning Nix's Git repository, issue the following commands:
+Nix is built with [Meson](https://mesonbuild.com/).
+It is broken up into multiple Meson packages, which are optionally combined in a single project using Meson's [subprojects](https://mesonbuild.com/Subprojects.html) feature.
 
-```console
-$ autoreconf -vfi
-$ ./configure options...
-$ make
-$ make install
-```
+There are no mandatory extra steps to the building process:
+generic Meson installation instructions like [this](https://mesonbuild.com/Quick-guide.html#using-meson-as-a-distro-packager) should work.
 
-Nix requires GNU Make so you may need to invoke `gmake` instead.
-
-The installation path can be specified by passing the `--prefix=prefix`
+The installation path can be specified by passing the `-Dprefix=prefix`
 to `configure`. The default installation directory is `/usr/local`. You
 can change this to any location you like. You must have write permission
 to the *prefix* path.
 
 Nix keeps its *store* (the place where packages are stored) in
 `/nix/store` by default. This can be changed using
-`--with-store-dir=path`.
+`-Dstore-dir=path`.
 
 > **Warning**
-> 
+>
 > It is best *not* to change the Nix store from its default, since doing
 > so makes it impossible to use pre-built binaries from the standard
 > Nixpkgs channels — that is, all packages will need to be built from
 > source.
 
 Nix keeps state (such as its database and log files) in `/nix/var` by
-default. This can be changed using `--localstatedir=path`.
+default. This can be changed using `-Dlocalstatedir=path`.

--- a/maintainers/format.sh
+++ b/maintainers/format.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if ! type -p pre-commit &>/dev/null; then
+  echo "format.sh: pre-commit not found. Please use \`nix develop\`.";
+  exit 1;
+fi;
+if test -z "$_NIX_PRE_COMMIT_HOOKS_CONFIG"; then
+  echo "format.sh: _NIX_PRE_COMMIT_HOOKS_CONFIG not set. Please use \`nix develop\`.";
+  exit 1;
+fi;
+pre-commit run --config "$_NIX_PRE_COMMIT_HOOKS_CONFIG" --all-files

--- a/maintainers/local.mk
+++ b/maintainers/local.mk
@@ -3,13 +3,6 @@
 print-top-help += echo '  format: Format source code'
 
 # This uses the cached .pre-commit-hooks.yaml file
+fmt_script := $(d)/format.sh
 format:
-	@if ! type -p pre-commit &>/dev/null; then \
-	  echo "make format: pre-commit not found. Please use \`nix develop\`."; \
-	  exit 1; \
-	fi; \
-	if test -z "$$_NIX_PRE_COMMIT_HOOKS_CONFIG"; then \
-	  echo "make format: _NIX_PRE_COMMIT_HOOKS_CONFIG not set. Please use \`nix develop\`."; \
-	  exit 1; \
-	fi; \
-	pre-commit run --config $$_NIX_PRE_COMMIT_HOOKS_CONFIG --all-files
+	@$(fmt_script)


### PR DESCRIPTION
# Motivation

This is necessary to make the Meson one the default and preferred one.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
