### PR TITLE
nix-daemon.sh profile script: operate under `set -u` in bash

### DIFF
--- a/scripts/nix-profile-daemon.sh.in
+++ b/scripts/nix-profile-daemon.sh.in
@@ -52,7 +52,7 @@ elif [ -e /etc/pki/tls/certs/ca-bundle.crt ]; then # Fedora, CentOS
 else
   # Fall back to what is in the nix profiles, favouring whatever is defined last.
   check_nix_profiles() {
-    if [ -n "$ZSH_VERSION" ]; then
+    if [ -n "${ZSH_VERSION:-}" ]; then
       # Zsh by default doesn't split words in unquoted parameter expansion.
       # Set local_options for these options to be reverted at the end of the function
       # and shwordsplit to force splitting words in $NIX_PROFILES below.

--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -217,10 +217,16 @@ let
         $ssh <<EOF
           set -ex
 
+          # enable nounset while loading the profile
+          # this may or may not work on all distros, depending on the quality of their scripts
+          set -u
+
           # FIXME: get rid of this; ideally ssh should just work.
           source ~/.bash_profile || true
           source ~/.bash_login || true
           source ~/.profile || true
+          set +u
+
           source /etc/bashrc || true
 
           nix-env --version


### PR DESCRIPTION
Apologies, I stupidly deleted my fork and couldn't re-open https://github.com/NixOS/nix/pull/11308.
see https://github.com/NixOS/nix/commit/d459d3307c7b1b10f6489ed048fff192e7834928

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
