### PR TITLE
Warn on malformed URI query parameter

### DIFF
--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -81,7 +81,7 @@ std::map<std::string, std::string> decodeQuery(const std::string & query)
         auto e = s.find('=');
 
         if (e == std::string::npos) {
-            warn("invalid URI query '%s', did you forget an equals sign `=`?", s);
+            warn("dubious URI query '%s' is missing equal sign '%s'", s, "=");
             continue;
         }
 

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -79,10 +79,15 @@ std::map<std::string, std::string> decodeQuery(const std::string & query)
 
     for (auto s : tokenizeString<Strings>(query, "&")) {
         auto e = s.find('=');
-        if (e != std::string::npos)
-            result.emplace(
-                s.substr(0, e),
-                percentDecode(std::string_view(s).substr(e + 1)));
+
+        if (e == std::string::npos) {
+            warn("invalid URI query '%s', did you forget an equals sign `=`?", s);
+            continue;
+        }
+
+        result.emplace(
+            s.substr(0, e),
+            percentDecode(std::string_view(s).substr(e + 1)));
     }
 
     return result;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

#10370 explains how `github:nixos/nixpkgs?refnixpkgs-unstable` is currently just accepted as is.
It never really checks if the query part of the URI is a tuple of 2 strings, separated by an equal sign.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Fixes #10370

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
