### PR TITLE
Add nix_store_copy_closure to libstore-c

### DIFF
--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -144,3 +144,15 @@ StorePath * nix_store_path_clone(const StorePath * p)
 {
     return new StorePath{p->path};
 }
+
+nix_err nix_store_copy_closure(nix_c_context * context, Store * srcStore, Store * dstStore, StorePath * path)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    try {
+        nix::RealisedPath::Set paths;
+        paths.insert(path->path);
+        nix::copyClosure(*srcStore->ptr, *dstStore->ptr, paths);
+    }
+    NIXC_CATCH_ERRS
+}

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -161,6 +161,16 @@ nix_err nix_store_realise(
 nix_err
 nix_store_get_version(nix_c_context * context, Store * store, nix_get_string_callback callback, void * user_data);
 
+/**
+ * @brief Copy the closure of `path` from `srcStore` to `dstStore`.
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] srcStore nix source store reference
+ * @param[in] srcStore nix destination store reference
+ * @param[in] path Path to copy
+ */
+nix_err nix_store_copy_closure(nix_c_context * context, Store * srcStore, Store * dstStore, StorePath * path);
+
 // cffi end
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# Motivation
The C API currently does not expose cross-store copying.

# Context

I've tested this using a Nim wrapper.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
