### PR TITLE
packaging: Expose libs

### DIFF
--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -76,7 +76,7 @@
   ] ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     nix-perl-bindings
   ];
-}).overrideAttrs (_: {
+}).overrideAttrs (finalAttrs: prevAttrs: {
   doCheck = true;
   doInstallCheck = true;
 
@@ -90,4 +90,37 @@
   installCheckInputs = [
     nix-functional-tests
   ];
+  passthru = prevAttrs.passthru // {
+    /**
+      These are the libraries that are part of the Nix project. They are used
+      by the Nix CLI and other tools.
+
+      If you need to use these libraries in your project, we recommend to use
+      the `-c` C API libraries exclusively, if possible.
+
+      We also recommend that you build the complete package to ensure that the unit tests pass.
+      You could do this in CI, or by passing it in an unused environment variable. e.g in a `mkDerivation` call:
+
+      ```nix
+        buildInputs = [ nix.libs.nix-util-c nix.libs.nix-store-c ];
+        # Make sure the nix libs we use are ok
+        unusedInputsForTests = [ nix ];
+        disallowedReferences = nix.all;
+      ```
+     */
+    libs = {
+      inherit
+        nix-util
+        nix-util-c
+        nix-store
+        nix-store-c
+        nix-fetchers
+        nix-expr
+        nix-expr-c
+        nix-flake
+        nix-main
+        nix-main-c
+      ;
+    };
+  };
 })


### PR DESCRIPTION
This exposes the libraries in a way that is easily replicated in Nixpkgs, without having to create a package set within a package set.


# Motivation

Allow library consumers to consume individual libraries. This makes their build graph more accurate, making their builds just a bit more hermetic: if you don't declare a dependency on `nix-expr`, you won't accidentally get a runtime dependency on it.


# Context

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
