### PR TITLE
Revert: Make $HOME=/proc/homeless-shelter instead of /homeless-shelter

### DIFF
--- a/doc/manual/rl-next/homeless-shelter-to-proc.md
+++ b/doc/manual/rl-next/homeless-shelter-to-proc.md
@@ -1,9 +1,0 @@
----
-synopsis: On linux, set $HOME=/proc/homeless-shelter instead of /homeless-shelter
-issues: [8313, 11295]
-prs: [11300]
----
-
-When building, $HOME is set to a non-existing directory. Previously it was always set to `/homeless-shelter`. Before a build, Nix verifies that it doesn't exist. In some scenarios (specifically when using the Linux sandbox with a single-user installation), it is possible to create the `/homeless-shelter` directory, and some tools will create it, resulting in a build error.
-
-Now, on Linux, $HOME is set to `/proc/homeless-shelter`. This directory can never be created, since `/proc` is a virtual filesystem. This resolves the issue.

--- a/doc/manual/src/language/derivations.md
+++ b/doc/manual/src/language/derivations.md
@@ -264,8 +264,7 @@ The [`builder`](#attr-builder) is executed as follows:
   - `PATH` is set to `/path-not-set` to prevent shells from
     initialising it to their built-in default value.
 
-  - `HOME` is set to `/proc/homeless-shelter` on Linux and `/homeless-shelter`
-    on OSX, to prevent programs from
+  - `HOME` is set to `/homeless-shelter` to prevent programs from
     using `/etc/passwd` or the like to find the user's home
     directory, which could cause impurity. Usually, when `HOME` is
     set, it is used as the location of the home directory, even if

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -102,14 +102,7 @@ void handleDiffHook(
     }
 }
 
-// We want $HOME to be un-creatable in the sandbox. On Linux,
-// you can't create anything inside /proc since it's a virtual filesystem.
-// On Darwin it seems that `/homeless-shelter` is good enough.
-#if __linux__
-const Path LocalDerivationGoal::homeDir = "/proc/homeless-shelter";
-#else
 const Path LocalDerivationGoal::homeDir = "/homeless-shelter";
-#endif
 
 
 LocalDerivationGoal::~LocalDerivationGoal()


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Since /proc/homeless-shelter returns a different errno than /homeless-shelter (ENOENT vs EACCES), we need to revert this change. Software depends on this error code i.e. cargo and therefore breaks.                                                                                                 

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

https://github.com/NixOS/nix/pull/11300

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
