### PR TITLE
Lazy paths

### DIFF
--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -7,6 +7,7 @@
 namespace nix {
 
 class Store;
+struct SourcePath;
 
 struct EvalSettings : Config
 {
@@ -22,7 +23,7 @@ struct EvalSettings : Config
      * @todo Return (`std::optional` of) `SourceAccssor` or something
      * more structured instead of mere `std::string`?
      */
-    using LookupPathHook = std::optional<std::string>(ref<Store> store, std::string_view);
+    using LookupPathHook = std::optional<SourcePath>(ref<Store> store, std::string_view);
 
     /**
      * Map from "scheme" to a `LookupPathHook`.

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -315,6 +315,7 @@ EvalState::EvalState(
 {
     corepkgsFS->setPathDisplay("<nix", ">");
     internalFS->setPathDisplay("«nix-internal»", "");
+    rootFS->setPathDisplay("/", "");
 
     countCalls = getEnv("NIX_COUNT_CALLS").value_or("0") != "0";
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3087,7 +3087,7 @@ SourcePath EvalState::findFile(const LookupPath & lookupPath, const std::string_
         if (!rOpt) continue;
         auto r = *rOpt;
 
-        auto res = r / suffix;
+        auto res = r / CanonPath(suffix);
         if (res.pathExists()) return res;
     }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -249,6 +249,9 @@ public:
 
     const SourcePath callFlakeInternal;
 
+    /* A collection of InputAccessors, just to keep them alive. */
+    std::list<ref<SourceAccessor>> sourceAccessors;
+
     /**
      * Store used to materialise .drv files.
      */
@@ -339,7 +342,7 @@ private:
 
     LookupPath lookupPath;
 
-    std::map<std::string, std::optional<std::string>> lookupPathResolved;
+    std::map<std::string, std::optional<SourcePath>> lookupPathResolved;
 
     /**
      * Cache used by prim_match().
@@ -380,6 +383,8 @@ public:
      * Variant which accepts relative paths too.
      */
     SourcePath rootPath(PathView path);
+
+    void registerAccessor(ref<SourceAccessor> accessor);
 
     /**
      * Allow access to a path.
@@ -446,7 +451,7 @@ public:
      *
      * If it is not found, return `std::nullopt`
      */
-    std::optional<std::string> resolveLookupPathPath(
+    std::optional<SourcePath> resolveLookupPathPath(
         const LookupPath::Path & elem,
         bool initAccessControl = false);
 

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -45,7 +45,7 @@ void ExprString::show(const SymbolTable & symbols, std::ostream & str) const
 
 void ExprPath::show(const SymbolTable & symbols, std::ostream & str) const
 {
-    str << s;
+    str << path;
 }
 
 void ExprVar::show(const SymbolTable & symbols, std::ostream & str) const

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -131,12 +131,12 @@ struct ExprString : Expr
 
 struct ExprPath : Expr
 {
-    ref<SourceAccessor> accessor;
-    std::string s;
+    const SourcePath path;
     Value v;
-    ExprPath(ref<SourceAccessor> accessor, std::string s) : accessor(accessor), s(std::move(s))
+    ExprPath(SourcePath && path)
+        : path(path)
     {
-        v.mkPath(&*accessor, this->s.c_str());
+        v.mkPath(&*path.accessor, strdup(path.path.abs().c_str()));
     }
     Value * maybeThunk(EvalState & state, Env & env) override;
     COMMON_METHODS

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -136,7 +136,10 @@ struct ExprPath : Expr
     ExprPath(SourcePath && path)
         : path(path)
     {
-        v.mkPath(&*path.accessor, strdup(path.path.abs().c_str()));
+        v.mkPath(
+            &*path.accessor,
+            // TODO: GC_STRDUP
+            strdup(path.path.abs().c_str()));
     }
     Value * maybeThunk(EvalState & state, Env & env) override;
     COMMON_METHODS

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -136,6 +136,10 @@ static Expr * makeCall(PosIdx pos, Expr * fn, Expr * arg) {
   std::vector<std::pair<nix::AttrName, nix::PosIdx>> * inheritAttrs;
   std::vector<std::pair<nix::PosIdx, nix::Expr *>> * string_parts;
   std::vector<std::pair<nix::PosIdx, std::variant<nix::Expr *, nix::StringToken>>> * ind_string_parts;
+  struct {
+      nix::Expr * e;
+      bool appendSlash;
+  } pathStart;
 }
 
 %type <e> start expr expr_function expr_if expr_op
@@ -149,7 +153,8 @@ static Expr * makeCall(PosIdx pos, Expr * fn, Expr * arg) {
 %type <inheritAttrs> attrs
 %type <string_parts> string_parts_interpolated
 %type <ind_string_parts> ind_string_parts
-%type <e> path_start string_parts string_attr
+%type <pathStart> path_start
+%type <e> string_parts string_attr
 %type <id> attr
 %token <id> ID
 %token <str> STR IND_STR
@@ -295,9 +300,11 @@ expr_simple
       $$ = state->stripIndentation(CUR_POS, std::move(*$2));
       delete $2;
   }
-  | path_start PATH_END
+  | path_start PATH_END { $$ = $1.e; }
   | path_start string_parts_interpolated PATH_END {
-      $2->insert($2->begin(), {state->at(@1), $1});
+      if ($1.appendSlash)
+          $2->insert($2->begin(), {noPos, new ExprString("/")});
+      $2->insert($2->begin(), {state->at(@1), $1.e});
       $$ = new ExprConcatStrings(CUR_POS, false, $2);
   }
   | SPATH {
@@ -350,11 +357,17 @@ string_parts_interpolated
 
 path_start
   : PATH {
-    Path path(absPath({$1.p, $1.l}, state->basePath.path.abs()));
-    /* add back in the trailing '/' to the first segment */
-    if ($1.p[$1.l-1] == '/' && $1.l > 1)
-      path += "/";
-    $$ = new ExprPath(ref<SourceAccessor>(state->rootFS), std::move(path));
+      std::string_view path({$1.p, $1.l});
+      $$ = {
+          .e = new ExprPath(
+              /* Absolute paths are always interpreted relative to the
+                 root filesystem accessor, rather than the accessor of the
+                 current Nix expression. */
+              hasPrefix(path, "/")
+              ? SourcePath{state->rootFS, CanonPath(path)}
+              : SourcePath{state->basePath.accessor, CanonPath(path, state->basePath.path)}),
+          .appendSlash = hasSuffix(path, "/")
+      };
   }
   | HPATH {
     if (state->settings.pureEval) {
@@ -363,8 +376,8 @@ path_start
             std::string_view($1.p, $1.l)
         );
     }
-    Path path(getHome() + std::string($1.p + 1, $1.l - 1));
-    $$ = new ExprPath(ref<SourceAccessor>(state->rootFS), std::move(path));
+    CanonPath path(getHome() + std::string($1.p + 1, $1.l - 1));
+    $$ = {.e = new ExprPath(SourcePath{state->rootFS, std::move(path)}), .appendSlash = true};
   }
   ;
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -178,6 +178,9 @@ static void import(EvalState & state, const PosIdx pos, Value & vPath, Value * v
     auto path = realisePath(state, pos, vPath, std::nullopt);
     auto path2 = path.path.abs();
 
+// FIXME: corruption?
+// TODO(tomberek): re-enable this code?
+#if 0
     // FIXME
     auto isValidDerivationInStore = [&]() -> std::optional<StorePath> {
         if (!state.store->isStorePath(path2))
@@ -218,7 +221,9 @@ static void import(EvalState & state, const PosIdx pos, Value & vPath, Value * v
         state.forceAttrs(v, pos, "while calling imported-drv-to-derivation.nix.gen.hh");
     }
 
-    else {
+    else
+#endif
+    {
         if (!vScope)
             state.evalFile(path, v);
         else {

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1705,7 +1705,10 @@ static std::string_view legacyBaseNameOf(std::string_view path)
 static void prim_baseNameOf(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
     NixStringContext context;
-    v.mkString(legacyBaseNameOf(*state.coerceToString(pos, *args[0], context,
+    if (v.type() == nPath)
+        v.mkString(baseNameOf(v.path().path.abs()), context);
+    else
+        v.mkString(legacyBaseNameOf(*state.coerceToString(pos, *args[0], context,
             "while evaluating the first argument passed to builtins.baseNameOf",
             false, false)), context);
 }

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -92,7 +92,7 @@ struct FetchTreeParams {
     bool emptyRevFallback = false;
     bool allowNameArgument = false;
     bool isFetchGit = false;
-    bool returnPath = true; // whether to return a SourcePath or a StorePath
+    bool returnPath = true; // whether to return a SourcePath instead of a StorePath
 };
 
 static void fetchTree(
@@ -212,18 +212,31 @@ static void fetchTree(
 
     state.checkURI(input.toURLString());
 
-    auto [storePath, input2] = input.fetchToStore(state.store);
+    if (params.returnPath) {
+        // Clang16+: change to `auto [accessor, input2] =`
+        auto pair = input.getAccessor(state.store);
+        auto & accessor = pair.first;
+        auto & input2 = pair.second;
 
-    state.allowPath(storePath);
+        emitTreeAttrs(state, input2, v,
+            [&](Value & vOutPath) {
+                state.registerAccessor(accessor);
+                vOutPath.mkPath(SourcePath { accessor, CanonPath::root });
+            },
+            params.emptyRevFallback, false);
+    } else {
+        auto pair = input.fetchToStore(state.store);
+        auto & storePath = pair.first;
+        auto & input2 = pair.second;
 
-    emitTreeAttrs(state, input2, v,
-        [&](Value & vOutPath) {
-            if (params.returnPath)
-                vOutPath.mkPath(state.rootPath(state.store->toRealPath(storePath)));
-            else
+        state.allowPath(storePath);
+
+        emitTreeAttrs(state, input2, v,
+            [&](Value & vOutPath) {
                 state.mkStorePathString(storePath, vOutPath);
-        },
-        params.emptyRevFallback, false);
+            },
+            params.emptyRevFallback, false);
+    }
 }
 
 static void prim_fetchTree(EvalState & state, const PosIdx pos, Value * * args, Value & v)

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -167,6 +167,8 @@ bool Input::contains(const Input & other) const
 
 std::pair<StorePath, Input> Input::fetchToStore(ref<Store> store) const
 {
+// TODO: lazy-trees gets rid of this. Why?
+#if 0
     if (!scheme)
         throw Error("cannot fetch unsupported input '%s'", attrsToJSON(toAttrs()));
 
@@ -187,6 +189,7 @@ std::pair<StorePath, Input> Input::fetchToStore(ref<Store> store) const
             debug("substitution of input '%s' failed: %s", to_string(), e.what());
         }
     }
+#endif
 
     auto [storePath, input] = [&]() -> std::pair<StorePath, Input> {
         try {
@@ -194,8 +197,9 @@ std::pair<StorePath, Input> Input::fetchToStore(ref<Store> store) const
 
             auto storePath = nix::fetchToStore(*store, SourcePath(accessor), FetchMode::Copy, final.getName());
 
-            auto narHash = store->queryPathInfo(storePath)->narHash;
-            final.attrs.insert_or_assign("narHash", narHash.to_string(HashFormat::SRI, true));
+            // TODO: do we really want to throw this out?
+            // auto narHash = store->queryPathInfo(storePath)->narHash;
+            // final.attrs.insert_or_assign("narHash", narHash.to_string(HashFormat::SRI, true));
 
             scheme->checkLocks(*this, final);
 

--- a/src/libflake/flake/flake.hh
+++ b/src/libflake/flake/flake.hh
@@ -218,7 +218,7 @@ void callFlake(
 
 void emitTreeAttrs(
     EvalState & state,
-    const StorePath & storePath,
+    const SourcePath & storePath,
     const fetchers::Input & input,
     Value & v,
     bool emptyRevFallback = false,

--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -287,10 +287,10 @@ FlakeRef FlakeRef::fromAttrs(
         fetchers::maybeGetStrAttr(attrs, "dir").value_or(""));
 }
 
-std::pair<StorePath, FlakeRef> FlakeRef::fetchTree(ref<Store> store) const
+std::pair<ref<SourceAccessor>, FlakeRef> FlakeRef::lazyFetch(ref<Store> store) const
 {
-    auto [storePath, lockedInput] = input.fetchToStore(store);
-    return {std::move(storePath), FlakeRef(std::move(lockedInput), subdir)};
+    auto [accessor, lockedInput] = input.getAccessor(store);
+    return {accessor, FlakeRef(std::move(lockedInput), subdir)};
 }
 
 std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(

--- a/src/libflake/flake/flakeref.hh
+++ b/src/libflake/flake/flakeref.hh
@@ -63,7 +63,7 @@ struct FlakeRef
         const fetchers::Settings & fetchSettings,
         const fetchers::Attrs & attrs);
 
-    std::pair<StorePath, FlakeRef> fetchTree(ref<Store> store) const;
+    std::pair<ref<SourceAccessor>, FlakeRef> lazyFetch(ref<Store> store) const;
 };
 
 std::ostream & operator << (std::ostream & str, const FlakeRef & flakeRef);

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -195,4 +195,9 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root)
 {
     return make_ref<PosixSourceAccessor>(std::move(root));
 }
+
+bool PosixSourceAccessor::toStringReturnsStorePath() const {
+    return false;
+}
+
 }

--- a/src/libutil/posix-source-accessor.hh
+++ b/src/libutil/posix-source-accessor.hh
@@ -57,6 +57,8 @@ struct PosixSourceAccessor : virtual SourceAccessor
      */
     static SourcePath createAtRoot(const std::filesystem::path & path);
 
+    virtual bool toStringReturnsStorePath() const override;
+
 private:
 
     /**

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -105,4 +105,8 @@ CanonPath SourceAccessor::resolveSymlinks(
     return res;
 }
 
+bool SourceAccessor::toStringReturnsStorePath() const {
+    return true;
+}
+
 }

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -64,7 +64,9 @@ void SourceAccessor::setPathDisplay(std::string displayPrefix, std::string displ
 
 std::string SourceAccessor::showPath(const CanonPath & path)
 {
-    return displayPrefix + (displayPrefix.empty() ? "" : ":") + path.rel() + displaySuffix;
+    return displayPrefix
+        + ((displayPrefix.empty() || displayPrefix.ends_with("/")) ? "" : ":") + path.rel()
+        + displaySuffix;
 }
 
 CanonPath SourceAccessor::resolveSymlinks(

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -64,7 +64,7 @@ void SourceAccessor::setPathDisplay(std::string displayPrefix, std::string displ
 
 std::string SourceAccessor::showPath(const CanonPath & path)
 {
-    return displayPrefix + path.abs() + displaySuffix;
+    return displayPrefix + (displayPrefix.empty() ? "" : ":") + path.rel() + displaySuffix;
 }
 
 CanonPath SourceAccessor::resolveSymlinks(

--- a/src/libutil/source-accessor.hh
+++ b/src/libutil/source-accessor.hh
@@ -162,6 +162,15 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
     virtual std::string showPath(const CanonPath & path);
 
     /**
+     * System paths: `toString /foo/bar = "/foo/bar"`
+     * Virtual paths: fetched to the store
+     *
+     * In both cases, the returned string functionally identifies the path,
+     * and can still be read.
+     */
+    virtual bool toStringReturnsStorePath() const;
+
+    /**
      * Resolve any symlinks in `path` according to the given
      * resolution mode.
      *

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -213,9 +213,6 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
         auto lockedFlake = lockFlake();
         auto & flake = lockedFlake.flake;
 
-        // Currently, all flakes are in the Nix store via the rootFS accessor.
-        auto storePath = store->printStorePath(store->toStorePath(flake.path.path.abs()).first);
-
         if (json) {
             nlohmann::json j;
             if (flake.description)
@@ -236,7 +233,6 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                 j["revCount"] = *revCount;
             if (auto lastModified = flake.lockedRef.input.getLastModified())
                 j["lastModified"] = *lastModified;
-            j["path"] = storePath;
             j["locks"] = lockedFlake.lockFile.toJSON().first;
             if (auto fingerprint = lockedFlake.getFingerprint(store))
                 j["fingerprint"] = fingerprint->to_string(HashFormat::Base16, false);
@@ -253,9 +249,6 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
                 logger->cout(
                     ANSI_BOLD "Description:" ANSI_NORMAL "   %s",
                     *flake.description);
-            logger->cout(
-                ANSI_BOLD "Path:" ANSI_NORMAL "          %s",
-                storePath);
             if (auto rev = flake.lockedRef.input.getRev())
                 logger->cout(
                     ANSI_BOLD "Revision:" ANSI_NORMAL "      %s",
@@ -1523,21 +1516,15 @@ struct CmdFlakePrefetch : FlakeCommand, MixJSON
     {
         auto originalRef = getFlakeRef();
         auto resolvedRef = originalRef.resolve(store);
-        auto [storePath, lockedRef] = resolvedRef.fetchTree(store);
-        auto hash = store->queryPathInfo(storePath)->narHash;
+        auto [accessor, lockedRef] = resolvedRef.lazyFetch(store);
 
         if (json) {
             auto res = nlohmann::json::object();
-            res["storePath"] = store->printStorePath(storePath);
-            res["hash"] = hash.to_string(HashFormat::SRI, true);
             res["original"] = fetchers::attrsToJSON(resolvedRef.toAttrs());
             res["locked"] = fetchers::attrsToJSON(lockedRef.toAttrs());
             logger->cout(res.dump());
         } else {
-            notice("Downloaded '%s' to '%s' (hash '%s').",
-                lockedRef.to_string(),
-                store->printStorePath(storePath),
-                hash.to_string(HashFormat::SRI, true));
+            notice("Fetched '%s'.", lockedRef.to_string());
         }
     }
 };

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -18,6 +18,7 @@
 #include "markdown.hh"
 #include "users.hh"
 #include "terminal.hh"
+#include "value/context.hh"
 
 #include <filesystem>
 #include <nlohmann/json.hpp>
@@ -884,7 +885,9 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
         auto cursor = installable.getCursor(*evalState);
 
         auto templateDirAttr = cursor->getAttr("path");
-        auto templateDir = templateDirAttr->getString();
+        auto & v = templateDirAttr->forceValue();
+        NixStringContext ctx;
+        auto templateDir = evalState->coerceToString(noPos, v, ctx, "while casting the template value to a path", false, true).toOwned();
 
         if (!store->isInStore(templateDir))
             evalState->error<TypeError>(

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -192,7 +192,6 @@ nix flake metadata "$flake1Dir" | grepQuiet 'URL:.*flake1.*'
 # Test 'nix flake metadata --json'.
 json=$(nix flake metadata flake1 --json | jq .)
 [[ $(echo "$json" | jq -r .description) = 'Bla bla' ]]
-[[ -d $(echo "$json" | jq -r .path) ]]
 [[ $(echo "$json" | jq -r .lastModified) = $(git -C "$flake1Dir" log -n1 --format=%ct) ]]
 hash1=$(echo "$json" | jq -r .revision)
 [[ -n $(echo "$json" | jq -r .fingerprint) ]]


### PR DESCRIPTION
(This is #10252, but as an upstream branch for easier collaboration)

# Motivation

Improve performance, and make the `fetchTree` interface more capable while keeping it clean.

# Description

This makes `fetchTree` return lazy `InputAccessor`-based `SourcePath`s instead of "cowardly" fetching them to the store and returning absolute "system" paths.
It stays close to existing path semantics, including support for `readFile "${toString p}/.."`, which some expressions rely on.
It does not go as far as [lazy-trees](#6530), but judging from the amount of change I could reuse, and how little of my own I had to add, lazy-trees will be a natural extension of this PR.

Done:
- Packages and NixOS evaluate as usual
  - no hash changes, based on my limited testing
- Flake is not added to store unless e.g.
  - "${flake.outPath}"
  - uses module system (needs clever lazy source _strings_, or a change to the module system)
- _Note that the above is already an improvement over the status quo - always fetching to the store_
- iirc 0.1s reduction on `nixpkgs#hello`, and 1s reduction on `nixosTests.simple`

Conclusion so far:
**Viable**

TODO:
- [ ] Check the TODO and FIXMEs
- [ ] Update the test suite
  - probably some intended behavior change, such as removal of `narHash` in some observable places
    - do we want to do that now? not sure
  - possibly finds a bug
- [ ] Check performance again
- [ ] Cherry-pick the `toString path` behavior to lazy-trees




# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
