### PR TITLE
Fix diskutil deleteVolume command in Uninstall guide

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -61,7 +61,7 @@ which you may remove.
    # End Nix
    ```
 
-3. Stop and remove the Nix daemon services:
+2. Stop and remove the Nix daemon services:
 
    ```console
    sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
@@ -72,7 +72,7 @@ which you may remove.
 
    This stops the Nix daemon and prevents it from being started next time you boot the system.
 
-4. Remove the `nixbld` group and the `_nixbuildN` users:
+3. Remove the `nixbld` group and the `_nixbuildN` users:
 
    ```console
    sudo dscl . -delete /Groups/nixbld
@@ -81,7 +81,7 @@ which you may remove.
 
    This will remove all the build users that no longer serve a purpose.
 
-5. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
+4. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
 
    ```
    UUID=<uuid> /nix apfs rw,noauto,nobrowse,suid,owners
@@ -96,7 +96,7 @@ which you may remove.
 
    This will prevent automatic mounting of the Nix Store volume.
 
-6. Edit `/etc/synthetic.conf` to remove the `nix` line.
+5. Edit `/etc/synthetic.conf` to remove the `nix` line.
    If this is the only line in the file you can remove it entirely:
 
    ```bash
@@ -111,14 +111,14 @@ which you may remove.
 
    This will prevent the creation of the empty `/nix` directory.
 
-7. Remove the files Nix added to your system, except for the store:
+6. Remove the files Nix added to your system, except for the store:
 
    ```console
    sudo rm -rf /etc/nix /var/root/.nix-profile /var/root/.nix-defexpr /var/root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
    ```
 
 
-8. Remove the Nix Store volume:
+7. Remove the Nix Store volume:
 
    ```console
    sudo diskutil apfs deleteVolume /nix

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -52,6 +52,7 @@ which you may remove.
    ```
 
    Otherwise, edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing `nix-daemon.sh`, which should look like this:
+   
    ```bash
    # Nix
    if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
@@ -60,7 +61,7 @@ which you may remove.
    # End Nix
    ```
 
-3. Stop and remove the Nix daemon services:
+2. Stop and remove the Nix daemon services:
 
    ```console
    sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
@@ -71,7 +72,7 @@ which you may remove.
 
    This stops the Nix daemon and prevents it from being started next time you boot the system.
 
-4. Remove the `nixbld` group and the `_nixbuildN` users:
+3. Remove the `nixbld` group and the `_nixbuildN` users:
 
    ```console
    sudo dscl . -delete /Groups/nixbld
@@ -80,7 +81,7 @@ which you may remove.
 
    This will remove all the build users that no longer serve a purpose.
 
-5. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
+4. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
 
    ```
    UUID=<uuid> /nix apfs rw,noauto,nobrowse,suid,owners
@@ -95,7 +96,7 @@ which you may remove.
 
    This will prevent automatic mounting of the Nix Store volume.
 
-6. Edit `/etc/synthetic.conf` to remove the `nix` line.
+5. Edit `/etc/synthetic.conf` to remove the `nix` line.
    If this is the only line in the file you can remove it entirely:
 
    ```bash
@@ -110,14 +111,14 @@ which you may remove.
 
    This will prevent the creation of the empty `/nix` directory.
 
-7. Remove the files Nix added to your system, except for the store:
+6. Remove the files Nix added to your system, except for the store:
 
    ```console
    sudo rm -rf /etc/nix /var/root/.nix-profile /var/root/.nix-defexpr /var/root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
    ```
 
 
-8. Remove the Nix Store volume:
+7. Remove the Nix Store volume:
 
    ```console
    sudo diskutil apfs deleteVolume /nix

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -135,7 +135,7 @@ which you may remove.
 
    If you _do_ find a "Nix Store" volume, delete it by running `diskutil apfs deleteVolume` with the store volume's `diskXsY` identifier.
 
-   If you get an error that the volume is in use by the kernel you might have to reboot and immediately delete the volume before atrting any other process.
+   If you get an error that the volume is in use by the kernel, reboot and immediately delete the volume before starting any other process.
 
 > **Note**
 >

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -43,15 +43,7 @@ which you may remove.
 
 ### macOS
 
-1. If system-wide shell initialisation files haven't been altered since installing Nix, use the backups made by the installer:
-
-   ```console
-   sudo mv /etc/zshrc.backup-before-nix /etc/zshrc
-   sudo mv /etc/bashrc.backup-before-nix /etc/bashrc
-   sudo mv /etc/bash.bashrc.backup-before-nix /etc/bash.bashrc
-   ```
-
-   Otherwise, edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing `nix-daemon.sh`, which should look like this:
+1. Edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing `nix-daemon.sh`, which should look like this:
 
    ```bash
    # Nix
@@ -133,7 +125,9 @@ which you may remove.
    diskutil list
    ```
 
-   If you _do_ find a "Nix Store" volume, delete it by running `diskutil deleteVolume` with the store volume's `diskXsY` identifier.
+   If you _do_ find a "Nix Store" volume, delete it by running `diskutil apfs deleteVolume` with the store volume's `diskXsY` identifier.
+
+   If you get an error that the volume is in use by the kernel you might have to reboot and immediately delete the volume before atrting any other process.
 
 > **Note**
 >

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -43,8 +43,15 @@ which you may remove.
 
 ### macOS
 
-1. Edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing `nix-daemon.sh`, which should look like this:
+1. If system-wide shell initialisation files haven't been altered since installing Nix, use the backups made by the installer:
 
+   ```console
+   sudo mv /etc/zshrc.backup-before-nix /etc/zshrc
+   sudo mv /etc/bashrc.backup-before-nix /etc/bashrc
+   sudo mv /etc/bash.bashrc.backup-before-nix /etc/bash.bashrc
+   ```
+
+   Otherwise, edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing `nix-daemon.sh`, which should look like this:
    ```bash
    # Nix
    if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
@@ -53,7 +60,7 @@ which you may remove.
    # End Nix
    ```
 
-2. Stop and remove the Nix daemon services:
+3. Stop and remove the Nix daemon services:
 
    ```console
    sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
@@ -64,7 +71,7 @@ which you may remove.
 
    This stops the Nix daemon and prevents it from being started next time you boot the system.
 
-3. Remove the `nixbld` group and the `_nixbuildN` users:
+4. Remove the `nixbld` group and the `_nixbuildN` users:
 
    ```console
    sudo dscl . -delete /Groups/nixbld
@@ -73,7 +80,7 @@ which you may remove.
 
    This will remove all the build users that no longer serve a purpose.
 
-4. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
+5. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
 
    ```
    UUID=<uuid> /nix apfs rw,noauto,nobrowse,suid,owners
@@ -88,7 +95,7 @@ which you may remove.
 
    This will prevent automatic mounting of the Nix Store volume.
 
-5. Edit `/etc/synthetic.conf` to remove the `nix` line.
+6. Edit `/etc/synthetic.conf` to remove the `nix` line.
    If this is the only line in the file you can remove it entirely:
 
    ```bash
@@ -103,14 +110,14 @@ which you may remove.
 
    This will prevent the creation of the empty `/nix` directory.
 
-6. Remove the files Nix added to your system, except for the store:
+7. Remove the files Nix added to your system, except for the store:
 
    ```console
    sudo rm -rf /etc/nix /var/root/.nix-profile /var/root/.nix-defexpr /var/root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
    ```
 
 
-7. Remove the Nix Store volume:
+8. Remove the Nix Store volume:
 
    ```console
    sudo diskutil apfs deleteVolume /nix

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -52,7 +52,7 @@ which you may remove.
    ```
 
    Otherwise, edit `/etc/zshrc`, `/etc/bashrc`, and `/etc/bash.bashrc` to remove the lines sourcing `nix-daemon.sh`, which should look like this:
-   
+
    ```bash
    # Nix
    if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
@@ -61,7 +61,7 @@ which you may remove.
    # End Nix
    ```
 
-2. Stop and remove the Nix daemon services:
+3. Stop and remove the Nix daemon services:
 
    ```console
    sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
@@ -72,7 +72,7 @@ which you may remove.
 
    This stops the Nix daemon and prevents it from being started next time you boot the system.
 
-3. Remove the `nixbld` group and the `_nixbuildN` users:
+4. Remove the `nixbld` group and the `_nixbuildN` users:
 
    ```console
    sudo dscl . -delete /Groups/nixbld
@@ -81,7 +81,7 @@ which you may remove.
 
    This will remove all the build users that no longer serve a purpose.
 
-4. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
+5. Edit fstab using `sudo vifs` to remove the line mounting the Nix Store volume on `/nix`, which looks like
 
    ```
    UUID=<uuid> /nix apfs rw,noauto,nobrowse,suid,owners
@@ -96,7 +96,7 @@ which you may remove.
 
    This will prevent automatic mounting of the Nix Store volume.
 
-5. Edit `/etc/synthetic.conf` to remove the `nix` line.
+6. Edit `/etc/synthetic.conf` to remove the `nix` line.
    If this is the only line in the file you can remove it entirely:
 
    ```bash
@@ -111,14 +111,14 @@ which you may remove.
 
    This will prevent the creation of the empty `/nix` directory.
 
-6. Remove the files Nix added to your system, except for the store:
+7. Remove the files Nix added to your system, except for the store:
 
    ```console
    sudo rm -rf /etc/nix /var/root/.nix-profile /var/root/.nix-defexpr /var/root/.nix-channels ~/.nix-profile ~/.nix-defexpr ~/.nix-channels
    ```
 
 
-7. Remove the Nix Store volume:
+8. Remove the Nix Store volume:
 
    ```console
    sudo diskutil apfs deleteVolume /nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
The uninstall guide had an incorrect command to delete the Nix Store volume on MacOS. It is correct in one place but wrong in the other. 

The guide also suggests to copy the backup copies of the system shell rc files if they had not been modified since the Nix install, but there is no way to know if that is the case, so I think it is better to just have the user remove the daemon.sh lines. 

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
