### PR TITLE
add stack sampling profiler for flamegraphs

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -15,6 +15,7 @@
 #include "search-path.hh"
 #include "repl-exit-status.hh"
 #include "ref.hh"
+#include "pos-idx.hh"
 
 #include <map>
 #include <optional>
@@ -374,6 +375,10 @@ private:
 #endif
 
 public:
+
+    std::vector<PosIdx> stack = {};
+    std::map<std::vector<PosIdx>, int> callCount = {};
+    std::chrono::time_point<std::chrono::high_resolution_clock> lastStackSample = std::chrono::high_resolution_clock::now();
 
     EvalState(
         const LookupPath & _lookupPath,
@@ -849,6 +854,7 @@ private:
     unsigned long nrFunctionCalls = 0;
 
     bool countCalls;
+
 
     typedef std::map<std::string, size_t> PrimOpCalls;
     PrimOpCalls primOpCalls;


### PR DESCRIPTION
This is code is a bit rough in the sense that I have taken shortcuts to quickly iterate.
This is not ready for merging yet, but I think it's already useful for people that want to generate flamegraphs for things as large as NixOS.

Usage:

```
$ NIX_PROFILE_FILE=/tmp/nixos-trace nix run github:mic92/nix-1/sampling-profiler eval -v --no-eval-cache github:mic92/dotfiles#nixosConfigurations.turingmachine.config.system.build.toplevel    
```

The result is in this example stored in /tmp/nixos-trace. It can be imported in tools that support folded stacks i.e. https://www.speedscope.app/ or the original flamegraph script (https://github.com/brendangregg/FlameGraph)
                                                                                                              
The profiler records stack trace of the nix evaluation every 10ms (100Hz).
    
The resulting file compresses well with zstd:

```
/tmp/nixos-trace     :  0.27%   (  2.15 GiB =>   5.95 MiB, /tmp/nixos-trace.zst) 
```

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
