### PR TITLE
More `std::filesystem` for `nix-collect-garbage`

### DIFF
--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -11,6 +11,8 @@
 #include <iostream>
 #include <cerrno>
 
+namespace nix::fs { using namespace std::filesystem; }
+
 using namespace nix;
 
 std::string deleteOlderThan;
@@ -21,23 +23,23 @@ bool dryRun = false;
  * Of course, this makes rollbacks to before this point in time
  * impossible. */
 
-void removeOldGenerations(std::filesystem::path dir)
+void removeOldGenerations(fs::path dir)
 {
     if (access(dir.string().c_str(), R_OK) != 0) return;
 
     bool canWrite = access(dir.string().c_str(), W_OK) == 0;
 
-    for (auto & i : std::filesystem::directory_iterator{dir}) {
+    for (auto & i : fs::directory_iterator{dir}) {
         checkInterrupt();
 
         auto path = i.path().string();
         auto type = i.symlink_status().type();
 
-        if (type == std::filesystem::file_type::symlink && canWrite) {
+        if (type == fs::file_type::symlink && canWrite) {
             std::string link;
             try {
                 link = readLink(path);
-            } catch (std::filesystem::filesystem_error & e) {
+            } catch (fs::filesystem_error & e) {
                 if (e.code() == std::errc::no_such_file_or_directory) continue;
                 throw;
             }
@@ -49,7 +51,7 @@ void removeOldGenerations(std::filesystem::path dir)
                 } else
                     deleteOldGenerations(path, dryRun);
             }
-        } else if (type == std::filesystem::file_type::directory) {
+        } else if (type == fs::file_type::directory) {
             removeOldGenerations(path);
         }
     }
@@ -81,8 +83,11 @@ static int main_nix_collect_garbage(int argc, char * * argv)
         });
 
         if (removeOld) {
-            std::set<std::filesystem::path> dirsToClean = {
-                profilesDir(), settings.nixStateDir + "/profiles", dirOf(getDefaultProfile())};
+            std::set<fs::path> dirsToClean = {
+                profilesDir(),
+                fs::path{settings.nixStateDir} / "profiles",
+                fs::path{getDefaultProfile()}.parent_path(),
+            };
             for (auto & dir : dirsToClean)
                 removeOldGenerations(dir);
         }


### PR DESCRIPTION
# Motivation

Progress on #9205

# Context

Depends on #11362. It's just one small commit on top.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
