### PR TITLE
progress-bar: Only write when truly updated

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -75,10 +75,10 @@ private:
         bool active = true;
         bool paused = false;
         bool haveUpdate = true;
-
-        /** Helps avoid unnecessary redraws, see `draw()` */
-        std::string lastOutput;
     };
+
+    /** Helps avoid unnecessary redraws, see `redraw()` */
+    Sync<std::string> lastOutput_;
 
     Sync<State> state_;
 
@@ -371,10 +371,10 @@ public:
      */
     void redraw(std::string newOutput)
     {
-        auto state(state_.lock());
-        if (newOutput != state->lastOutput) {
+        auto lastOutput(lastOutput_.lock());
+        if (newOutput != *lastOutput) {
             writeToStderr(newOutput);
-            state->lastOutput = std::move(newOutput);
+            *lastOutput = std::move(newOutput);
         }
     }
 

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -380,20 +380,6 @@ public:
 
     std::chrono::milliseconds draw(State & state)
     {
-        std::optional<std::string> newOutput;
-        auto nextWakeup = draw(state, newOutput);
-        if (newOutput)
-            redraw(*newOutput);
-        return nextWakeup;
-    }
-
-    /**
-     * @param output[out] `nullopt` if nothing is to be drawn. Otherwise, a
-     *                    string of ANSI terminal output that can be used to 
-     *                    render the progress bar.
-     */
-    std::chrono::milliseconds draw(State & state, std::optional<std::string> & output)
-    {
         auto nextWakeup = std::chrono::milliseconds::max();
 
         state.haveUpdate = false;
@@ -445,7 +431,7 @@ public:
         auto width = getWindowSize().second;
         if (width <= 0) width = std::numeric_limits<decltype(width)>::max();
 
-        output = "\r" + filterANSIEscapes(line, false, width) + ANSI_NORMAL + "\e[K";
+        redraw("\r" + filterANSIEscapes(line, false, width) + ANSI_NORMAL + "\e[K");
 
         return nextWakeup;
     }


### PR DESCRIPTION

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Excessive redrawing is noticeable on slow terminals, and it interferes with text selection in some terminals, including libvte-based terminal emulators.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
