### PR TITLE
Fix few duplicate word occurrences

### DIFF
--- a/doc/manual/src/development/json-guideline.md
+++ b/doc/manual/src/development/json-guideline.md
@@ -90,7 +90,7 @@ This representation is extensible and preserves the ordering:
 
 ## Self-describing values
 
-As described in the previous section, it's crucial that schemas can be extended with with new fields without breaking compatibility.
+As described in the previous section, it's crucial that schemas can be extended with new fields without breaking compatibility.
 However, that should *not* mean we use the presence/absence of fields to indicate optional information *within* a version of the schema.
 Instead, always include the field, and use `null` to indicate the "nothing" case.
 

--- a/doc/manual/src/protocols/store-path.md
+++ b/doc/manual/src/protocols/store-path.md
@@ -82,7 +82,7 @@ where
 
   - if `type` = `"source:" ...`:
 
-    the the hash of the [Nix Archive (NAR)] serialization of the [file system object](@docroot@/store/file-system-object.md) of the store object.
+    the hash of the [Nix Archive (NAR)] serialization of the [file system object](@docroot@/store/file-system-object.md) of the store object.
 
   - if `type` = `"output:" id`:
 

--- a/doc/manual/src/release-notes/rl-2.23.md
+++ b/doc/manual/src/release-notes/rl-2.23.md
@@ -85,7 +85,7 @@
 - Store object info JSON format now uses `null` rather than omitting fields [#9995](https://github.com/NixOS/nix/pull/9995)
 
   The [store object info JSON format](@docroot@/protocols/json/store-object-info.md), used for e.g. `nix path-info`, no longer omits fields to indicate absent information, but instead includes the fields with a `null` value.
-  For example, `"ca": null` is used to to indicate a store object that isn't content-addressed rather than omitting the `ca` field entirely.
+  For example, `"ca": null` is used to indicate a store object that isn't content-addressed rather than omitting the `ca` field entirely.
   This makes records of this sort more self-describing, and easier to consume programmatically.
 
   We will follow this design principle going forward;

--- a/package.nix
+++ b/package.nix
@@ -60,7 +60,7 @@
 # Run the functional tests as part of the build.
 , doInstallCheck ? test-client != null || __forDefaults.canRunInstalled
 
-# Check test coverage of Nix. Probably want to use with with at least
+# Check test coverage of Nix. Probably want to use with at least
 # one of `doCHeck` or `doInstallCheck` enabled.
 , withCoverageChecks ? false
 

--- a/src/libstore/local-overlay-store.md
+++ b/src/libstore/local-overlay-store.md
@@ -77,13 +77,13 @@ The parts of a local overlay store are as follows:
 
     The lower store directory and upper layer directory are combined via OverlayFS to create this directory.
     Nix doesn't do this itself, because it typically wouldn't have the permissions to do so, so it is the responsibility of the user to set this up first.
-    Nix can, however, optionally check that that the OverlayFS mount settings appear as expected, matching Nix's own settings.
+    Nix can, however, optionally check that the OverlayFS mount settings appear as expected, matching Nix's own settings.
 
   - **Upper SQLite database**:
 
     > Not directly specified.
     > The location of the database instead depends on the [`state`](#store-experimental-local-overlay-store-state) setting.
-    > It is is always `${state}/db`.
+    > It is always `${state}/db`.
 
     This contains the metadata of all of the upper layer [store objects][store object] (everything beyond their file system objects), and also duplicate copies of some lower layer store object's metadta.
     The duplication is so the metadata for the [closure](@docroot@/glossary.md#gloss-closure) of upper layer [store objects][store object] can be found entirely within the upper layer.

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -120,7 +120,7 @@ Contrary to URL-like references, path-like flake references can contain arbitrar
 
 ### Examples
 
-* `.`: The flake to which the current directory belongs to.
+* `.`: The flake to which the current directory belongs.
 * `/home/alice/src/patchelf`: A flake in some other directory.
 * `./../sub directory/with Ûñî©ôδ€`: A flake in another relative directory that
   has Unicode characters in its name.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
Noticed few duplicate words when reading `nix flake` man page.
While I was at it, I did regex search `\b(\w+)\b \b\1\b` that identified few more similar cases across the codebase.

# Context
N/A

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
