### PR TITLE
feat: turn fatal error of missing user into warning

### DIFF
--- a/src/libstore/unix/user-lock.cc
+++ b/src/libstore/unix/user-lock.cc
@@ -74,8 +74,13 @@ struct SimpleUserLock : UserLock
             debug("trying user '%s'", i);
 
             struct passwd * pw = getpwnam(i.c_str());
-            if (!pw)
-                throw Error("the user '%s' in the group '%s' does not exist", i, settings.buildUsersGroup);
+            if (!pw) {
+                printError("error: the user '%s' in the group '%s' does not exist", i, settings.buildUsersGroup);
+#if __APPLE__
+                printError("note: If you are using macOS 15.0 Sequoia or newer, you may need to run this script: https://github.com/NixOS/nix/blob/master/scripts/sequoia-nixbld-user-migration.sh");
+#endif
+               continue;
+           }
 
             auto fnUserLock = fmt("%s/userpool/%s", settings.nixStateDir,pw->pw_uid);
 


### PR DESCRIPTION
# Motivation
Turn the UID error into a warning.

# Context
With the upcoming Sequoia update, UID's 301,302,303,304 become used by Apple-provided users. This causes a hard error. This PR intends to turn this into a warning, but to allow usage of Nix nevertheless.

This warning can get noisy if trying to do a lot of builds, this is not idea, but does allow usage.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
