### PR TITLE
Fix non-Flakes build instructions

### DIFF
--- a/doc/manual/src/development/building.md
+++ b/doc/manual/src/development/building.md
@@ -35,7 +35,7 @@ To build Nix itself in this shell:
 
 ```console
 [nix-shell]$ mesonFlags+=" --prefix=$(pwd)/outputs/out"
-[nix-shell]$ dontAddPrefix=1 mesonConfigurePhase
+[nix-shell]$ mesonConfigurePhase
 [nix-shell]$ ninjaBuildPhase
 ```
 


### PR DESCRIPTION
dontAddPrefix=1 means that the prefix added to mesonFlags on the line before will be ignored, which can't have been the intention.  This Flakes build instructions already had this right.

Fixes: ceae25825 ("Update documentation to refer to Meson not Make in most places")

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
