### PR TITLE
add removal of ~root/.cache/nix to uninstall instructions

### DIFF
--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -19,7 +19,7 @@ If you are on Linux with systemd:
 Remove files created by Nix:
 
 ```console
-sudo rm -rf /etc/nix /etc/profile.d/nix.sh /etc/tmpfiles.d/nix-daemon.conf /nix ~root/.nix-channels ~root/.nix-defexpr ~root/.nix-profile
+sudo rm -rf /etc/nix /etc/profile.d/nix.sh /etc/tmpfiles.d/nix-daemon.conf /nix ~root/.nix-channels ~root/.nix-defexpr ~root/.nix-profile ~root/.cache/nix
 ```
 
 Remove build users and their group:


### PR DESCRIPTION
# Motivation
When uninstalling nix it is important to also remove the cache located at `~root/.cache/nix` on linux systems.

In my situation, the cache had become corrupted and all nix builds were failing after hours of rebuilding packages that should have been fetched instead.  Following the uninstall instructions at https://nix.dev/manual/nix/2.18/installation/uninstall#uninstalling-nix and then reinstalling did not fix the issue.

In order to fix the issue, I had to remove `~root/.cache/nix` during uninstall and then a clean installation of nix resolved the problem.

The current documentation does not mention removing this folder, so I added this to the list of folders that should be removed during uninstall.

# Context
The greater context around the situation that led to the cache being corrupted on my machine can be addressed separately.  I believe it was caused by reaching OOM during a build, but I'm still investigating how this led to subsequent failures.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
