### PR TITLE
fixup: use the real bindir for systemd unit's bindir

### DIFF
--- a/misc/systemd/meson.build
+++ b/misc/systemd/meson.build
@@ -8,7 +8,7 @@ foreach config : [ 'nix-daemon.socket', 'nix-daemon.service' ]
     configuration : {
       'storedir' : store_dir,
       'localstatedir' : localstatedir,
-      'bindir' : get_option('datadir'),
+      'bindir' : bindir,
     },
   )
 endforeach


### PR DESCRIPTION
Prior to this commit, the unit contained this line:

     ExecStart=@share/nix-daemon nix-daemon --daemon

which caused systemd to complain:

     Failed to restart nix-daemon.service: Unit nix-daemon.service has a bad unit file setting.
     See system logs and 'systemctl status nix-daemon.service' for details.

and had this in the unit output:

     Sep 03 13:34:59 scadrial systemd[1]: /etc/systemd/system/nix-daemon.service:10: Neither a valid executable name nor an absolute path: share/nix-daemon
     Sep 03 13:34:59 scadrial systemd[1]: nix-daemon.service: Unit configuration has fatal error, unit will not be started.

(Notice how it's trying to execute `share/nix-daemon`, which is unlikely
to exist.)

Now with this commit, the path to the daemon binary is properly set:

     ExecStart=@/nix/store/lcbx6d8gzznf3z3c8lsv9jy3j6c67x6r-nix-2.25.0pre20240903_dirty/bin/nix-daemon nix-daemon --daemon

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
Broken in https://github.com/NixOS/nix/pull/11302/.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
