### PR TITLE
Enable cgroups delegation for systemd

### DIFF
--- a/misc/systemd/nix-daemon.service.in
+++ b/misc/systemd/nix-daemon.service.in
@@ -11,6 +11,7 @@ ExecStart=@@bindir@/nix-daemon nix-daemon --daemon
 KillMode=process
 LimitNOFILE=1048576
 TasksMax=1048576
+Delegate=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Motivation

When `use-cgroups` is enabled, the nix daemon creates sub-cgroups for the build processes (and itself if #11412 is merged, see #9675). `Delegate` should be set to prevent systemd from messing with the nix service's cgroups (https://github.com/systemd/systemd/blob/main/docs/CGROUP_DELEGATION.md) and ensure the OOM killer only targets the offending derivation and not the entire service (#10374).

# Context

Also submitted a PR for the same change to NixOS: NixOS/nixpkgs#339310

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
