### PR TITLE
Fetch Git submodules lazily

### DIFF
--- a/src/libutil/lazy-source-accessor.hh
+++ b/src/libutil/lazy-source-accessor.hh
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "source-accessor.hh"
+#include "sync.hh"
+
+#include <variant>
+
+namespace nix {
+
+/**
+ * A wrapper `SourceAccessor` that lazily constructs an underlying
+ * `SourceAccessor`.
+ */
+struct LazySourceAccessor : SourceAccessor
+{
+    using Fun = std::function<ref<SourceAccessor>()>;
+
+    Sync<std::variant<ref<SourceAccessor>, Fun>> next_;
+
+    LazySourceAccessor(Fun next)
+        : next_{{std::move(next)}}
+    {
+    }
+
+    ref<SourceAccessor> getNext()
+    {
+        auto next(next_.lock());
+        if (auto accessor = std::get_if<ref<SourceAccessor>>(&*next))
+            return *accessor;
+        else {
+            auto fun = std::get<Fun>(*next);
+            auto acc = fun();
+            *next = acc;
+            return acc;
+        }
+        abort();
+    }
+
+    std::string readFile(const CanonPath & path) override
+    {
+        return getNext()->readFile(path);
+    }
+
+    void readFile(const CanonPath & path, Sink & sink, std::function<void(uint64_t)> sizeCallback) override
+    {
+        return getNext()->readFile(path, sink, sizeCallback);
+    }
+
+    bool pathExists(const CanonPath & path) override
+    {
+        return getNext()->pathExists(path);
+    }
+
+    std::optional<Stat> maybeLstat(const CanonPath & path) override
+    {
+        return getNext()->maybeLstat(path);
+    }
+
+    DirEntries readDirectory(const CanonPath & path) override
+    {
+        return getNext()->readDirectory(path);
+    }
+
+    std::string readLink(const CanonPath & path) override
+    {
+        return getNext()->readLink(path);
+    }
+};
+
+}

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -202,6 +202,7 @@ headers = [config_h] + files(
   'hilite.hh',
   'json-impls.hh',
   'json-utils.hh',
+  'lazy-source-accessor.hh',
   'logging.hh',
   'lru-cache.hh',
   'memory-source-accessor.hh',


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

This isn't particularly useful right now, since we still copy the entire Git input to the store. But once we have lazy trees, this will avoid fetching submodules unless they're actually needed.

Note: submodules in workdirs are not lazy yet.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
