### PR TITLE
docs: rework profiles page

### DIFF
--- a/doc/manual/redirects.js
+++ b/doc/manual/redirects.js
@@ -373,6 +373,9 @@ const redirects = {
     "gloss-local-store": "store/types/local-store.html",
     "gloss-chroot-store": "store/types/local-store.html",
   },
+  "files/profiles.html": {
+    "filesystem-layout": "#profile-contents",
+  },
 };
 
 // the following code matches the current page's URL against the set of redirects.

--- a/doc/manual/src/command-ref/files/profiles.md
+++ b/doc/manual/src/command-ref/files/profiles.md
@@ -1,58 +1,38 @@
 ## Profiles
 
-A directory that contains links to profiles managed by [`nix-env`] and [`nix profile`]:
+Profiles are a rudimentary mechanism for version control.
+Versions of a profile are also called *generations*.
+
+## Profiles directory
+
+A directory managed by [`nix-env`] and [`nix profile`]\ (experimental) that contains symlinks to files in the [Nix store](@docroot@/glossary.md#gloss-store):
 
 - `$XDG_STATE_HOME/nix/profiles` for regular users
 - `$NIX_STATE_DIR/profiles/per-user/root` if the user is `root`
 
-A profile is a directory of symlinks to files in the Nix store.
+## Profile contents
 
-### Filesystem layout
+For a profile named *path*, the entry *path* in the [profiles directory](#profiles-directory) is a symlink to *path*`-`*N*`-link`, where *N* is the version of the profile.
+In turn, *path*`-`*N*`-link` is a symlink to a [store path](@docroot@/glossary.md#gloss-store-path).
 
-Profiles are versioned as follows. When using a profile named *path*, *path* is a symlink to *path*`-`*N*`-link`, where *N* is the version of the profile.
-In turn, *path*`-`*N*`-link` is a symlink to a path in the Nix store.
-For example:
-
-```console
-$ ls -l ~alice/.local/state/nix/profiles/profile*
-lrwxrwxrwx 1 alice users 14 Nov 25 14:35 /home/alice/.local/state/nix/profiles/profile -> profile-7-link
-lrwxrwxrwx 1 alice users 51 Oct 28 16:18 /home/alice/.local/state/nix/profiles/profile-5-link -> /nix/store/q69xad13ghpf7ir87h0b2gd28lafjj1j-profile
-lrwxrwxrwx 1 alice users 51 Oct 29 13:20 /home/alice/.local/state/nix/profiles/profile-6-link -> /nix/store/6bvhpysd7vwz7k3b0pndn7ifi5xr32dg-profile
-lrwxrwxrwx 1 alice users 51 Nov 25 14:35 /home/alice/.local/state/nix/profiles/profile-7-link -> /nix/store/mp0x6xnsg0b8qhswy6riqvimai4gm677-profile
-```
-
-Each of these symlinks is a root for the Nix garbage collector.
-
-The contents of the store path corresponding to each version of the
-profile is a tree of symlinks to the files of the installed packages,
-e.g.
-
-```console
-$ ll -R ~eelco/.local/state/nix/profiles/profile-7-link/
-/home/eelco/.local/state/nix/profiles/profile-7-link/:
-total 20
-dr-xr-xr-x 2 root root 4096 Jan  1  1970 bin
--r--r--r-- 2 root root 1402 Jan  1  1970 manifest.nix
-dr-xr-xr-x 4 root root 4096 Jan  1  1970 share
-
-/home/eelco/.local/state/nix/profiles/profile-7-link/bin:
-total 20
-lrwxrwxrwx 5 root root 79 Jan  1  1970 chromium -> /nix/store/ijm5k0zqisvkdwjkc77mb9qzb35xfi4m-chromium-86.0.4240.111/bin/chromium
-lrwxrwxrwx 7 root root 87 Jan  1  1970 spotify -> /nix/store/w9182874m1bl56smps3m5zjj36jhp3rn-spotify-1.1.26.501.gbe11e53b-15/bin/spotify
-lrwxrwxrwx 3 root root 79 Jan  1  1970 zoom-us -> /nix/store/wbhg2ga8f3h87s9h5k0slxk0m81m4cxl-zoom-us-5.3.469451.0927/bin/zoom-us
-
-/home/eelco/.local/state/nix/profiles/profile-7-link/share/applications:
-total 12
-lrwxrwxrwx 4 root root 120 Jan  1  1970 chromium-browser.desktop -> /nix/store/4cf803y4vzfm3gyk3vzhzb2327v0kl8a-chromium-unwrapped-86.0.4240.111/share/applications/chromium-browser.desktop
-lrwxrwxrwx 7 root root 110 Jan  1  1970 spotify.desktop -> /nix/store/w9182874m1bl56smps3m5zjj36jhp3rn-spotify-1.1.26.501.gbe11e53b-15/share/applications/spotify.desktop
-lrwxrwxrwx 3 root root 107 Jan  1  1970 us.zoom.Zoom.desktop -> /nix/store/wbhg2ga8f3h87s9h5k0slxk0m81m4cxl-zoom-us-5.3.469451.0927/share/applications/us.zoom.Zoom.desktop
-
-…
-```
+Each of these symlinks is a root for the Nix [garbage collector](@docroot@/command-ref/nix-store/gc.md).
 
 Each profile version contains a manifest file:
-- [`manifest.nix`](@docroot@/command-ref/files/manifest.nix.md) used by [`nix-env`](@docroot@/command-ref/nix-env.md).
-- [`manifest.json`](@docroot@/command-ref/files/manifest.json.md) used by [`nix profile`](@docroot@/command-ref/new-cli/nix3-profile.md) (experimental).
+- [`manifest.nix`](@docroot@/command-ref/files/manifest.nix.md) used by [`nix-env`]
+- [`manifest.json`](@docroot@/command-ref/files/manifest.json.md) used by [`nix profile`]\ (experimental)
+
+> **Example**
+>
+> The default profile of user `alice` points to generation 7.
+> The oldest generation available is 5.
+>
+> ```console
+> $ ls -l ~alice/.local/state/nix/profiles/profile*
+> lrwxrwxrwx 1 alice users 14 Nov 25 14:35 /home/alice/.local/state/nix/profiles/profile -> profile-7-link
+> lrwxrwxrwx 1 alice users 51 Oct 28 16:18 /home/alice/.local/state/nix/profiles/profile-5-link -> /nix/store/q69xad13ghpf7ir87h0b2gd28lafjj1j-profile
+> lrwxrwxrwx 1 alice users 51 Oct 29 13:20 /home/alice/.local/state/nix/profiles/profile-6-link -> /nix/store/6bvhpysd7vwz7k3b0pndn7ifi5xr32dg-profile
+> lrwxrwxrwx 1 alice users 51 Nov 25 14:35 /home/alice/.local/state/nix/profiles/profile-7-link -> /nix/store/mp0x6xnsg0b8qhswy6riqvimai4gm677-profile
+> ```
 
 ## User profile link
 
@@ -66,9 +46,9 @@ By default, this symlink points to:
 - `$XDG_STATE_HOME/nix/profiles/profile` for regular users
 - `$NIX_STATE_DIR/profiles/per-user/root/profile` for `root`
 
-The `PATH` environment variable should include `/bin` subdirectory of the profile link (e.g. `~/.nix-profile/bin`) for the user environment to be visible to the user.
-The [installer](@docroot@/installation/installing-binary.md) sets this up by default, unless you enable [`use-xdg-base-directories`].
+The `PATH` environment variable should include the `/bin` subdirectory of the profile link (e.g. `~/.nix-profile/bin`) for executables in that profile to be exposed to the user.
+The [Nix installer](@docroot@/installation/installing-binary.md) sets this up by default, unless you enable [`use-xdg-base-directories`].
 
-[`nix-env`]: @docroot@/command-ref/nix-env.md
 [`nix profile`]: @docroot@/command-ref/new-cli/nix3-profile.md
+[`nix-env`]: @docroot@/command-ref/nix-env.md
 [`use-xdg-base-directories`]: @docroot@/command-ref/conf-file.md#conf-use-xdg-base-directories


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
Moving parts and mutability is still in the way to explain Nix properly. Trying to remove the noise to help others see the forest between the trees again...

# Context
- clarify distinction between the concept of profiles and the directory where they are stored
- highlight the helpful example
- remove the voluminous example

  it doesn't help here because it's specific to how `nix-env` manages
  profiles via `buildEnv`. this would need dedicated documentation.
- rename "Filesystem layout" to "Profile contents",
  add a redirect for the moved anchor

still to do is https://github.com/NixOS/nix/issues/7976
<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).