### PR TITLE
use existing GID in sequoia migration script

### DIFF
--- a/scripts/sequoia-nixbld-user-migration.sh
+++ b/scripts/sequoia-nixbld-user-migration.sh
@@ -17,18 +17,23 @@ any_nixbld(){
 	dscl . list /Users UniqueID | grep -E '\b_nixbld' >/dev/null
 }
 
+dsclattr() {
+	dscl . -read "$1" | awk "/$2/ { print \$2 }"
+}
+
 re_create_nixbld_user(){
 	local name uid
 
 	name="$1"
 	uid="$2"
+	gid="$3"
 
 	sudo /usr/bin/dscl . -create "/Users/$name" "UniqueID" "$uid"
 	sudo /usr/bin/dscl . -create "/Users/$name" "IsHidden" "1"
 	sudo /usr/bin/dscl . -create "/Users/$name" "NFSHomeDirectory" "/var/empty"
 	sudo /usr/bin/dscl . -create "/Users/$name" "RealName" "Nix build user $name"
 	sudo /usr/bin/dscl . -create "/Users/$name" "UserShell" "/sbin/nologin"
-	sudo /usr/bin/dscl . -create "/Users/$name" "PrimaryGroupID" "30001"
+	sudo /usr/bin/dscl . -create "/Users/$name" "PrimaryGroupID" "$gid"
 }
 
 hit_id_cap(){
@@ -68,11 +73,12 @@ temporarily_move_existing_nixbld_uids(){
 }
 
 change_nixbld_uids(){
-	local name next_id user_n
+	local existing_gid name next_id user_n
 
 	((next_id=NEW_NIX_FIRST_BUILD_UID))
 	((user_n=1))
 	name="$(nix_user_n "$user_n")"
+	existing_gid="$(dsclattr "/Groups/nixbld" "PrimaryGroupID")"
 
 	# we know that we have *some* nixbld users, but macOS may have
 	# already clobbered the first few users if this system has been
@@ -91,7 +97,7 @@ change_nixbld_uids(){
 			fi
 		done
 
-		re_create_nixbld_user "$name" "$next_id"
+		re_create_nixbld_user "$name" "$next_id" "$existing_gid"
 		echo "      $name was missing; created with uid: $next_id"
 
 		((user_n++))


### PR DESCRIPTION
# Motivation
I hardcoded the wrong GID (30001 instead of 30000), but it's better to just pick up the GID from the existing group.

cc @tomberek 

# Context
- https://github.com/NixOS/nix/pull/10919#issuecomment-2329413467
- https://github.com/NixOS/nix/pull/10919#issuecomment-2329777647

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
