### PR TITLE
docs: reword glossary entry on Nix expression

### DIFF
--- a/doc/manual/src/glossary.md
+++ b/doc/manual/src/glossary.md
@@ -182,13 +182,18 @@
 
 - [Nix expression]{#gloss-nix-expression}
 
-  1. Commonly, a high-level description of software packages and compositions
-    thereof. Deploying software using Nix entails writing Nix
-    expressions for your packages. Nix expressions specify [derivations][derivation],
-    which are [instantiated][instantiate] into the Nix store as [store derivations][store derivation].
-    These derivations can then be [realised][realise] to produce [outputs][output].
+  A syntactically valid use of the [Nix language].
 
-  2. A syntactically valid use of the [Nix language]. For example, the contents of a `.nix` file form an expression.
+  > **Example**
+  >
+  > The contents of a `.nix` file form a Nix expression.
+
+  Nix expressions specify [derivations][derivation], which are [instantiated][instantiate] into the Nix store as [store derivations][store derivation].
+  These derivations can then be [realised][realise] to produce [outputs][output].
+
+  > **Example**
+  >
+  > Building and deploying software using Nix entails writing Nix expressions as a high-level description of packages and compositions thereof.
 
 - [reference]{#gloss-reference}
 


### PR DESCRIPTION
this makes it less cumbersome to read and puts the statements in meaningful order.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
I'd prefer glossary entries to be about what those terms mean in the technical context, and less about how they are used colloquially. We essentially have no control about the second, and trying to keep up with what people think we mean makes little sense. Also arguably not controlling for meaning of technical terms is a source of confusion on our users' end.


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).