### PR TITLE
fix(nix fmt): remove the default "." argument

### DIFF
--- a/doc/manual/rl-next/nix-fmt-default-argument.md
+++ b/doc/manual/rl-next/nix-fmt-default-argument.md
@@ -1,0 +1,17 @@
+---
+synopsis: Removing the default argument passed to the `nix fmt` formatter
+issues: []
+prs: [11438]
+---
+
+The underlying formatter no longer receives the ". " default argument when `nix fmt` is called with no arguments.
+
+This change was necessary as the formatter wasn't able to distinguish between
+a user wanting to format the current folder with `nix fmt .` or the generic
+`nix fmt`.
+
+The default behaviour is now the responsibility of the formatter itself, and
+allows tools such as treefmt to format the whole tree instead of only the
+current directory and below.
+
+Author: [**@zimbatm**](https://github.com/zimbatm)

--- a/src/nix/fmt.cc
+++ b/src/nix/fmt.cc
@@ -40,14 +40,8 @@ struct CmdFmt : SourceExprCommand {
         Strings programArgs{app.program};
 
         // Propagate arguments from the CLI
-        if (args.empty()) {
-            // Format the current flake out of the box
-            programArgs.push_back(".");
-        } else {
-            // User wants more power, let them decide which paths to include/exclude
-            for (auto &i : args) {
-                programArgs.push_back(i);
-            }
+        for (auto &i : args) {
+            programArgs.push_back(i);
         }
 
         // Release our references to eval caches to ensure they are persisted to disk, because

--- a/tests/functional/fmt.sh
+++ b/tests/functional/fmt.sh
@@ -5,11 +5,11 @@ source common.sh
 TODO_NixOS # Provide a `shell` variable. Try not to `export` it, perhaps.
 
 clearStoreIfPossible
-rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
+rm -rf "$TEST_HOME"/.cache "$TEST_HOME"/.config "$TEST_HOME"/.local
 
-cp ./simple.nix ./simple.builder.sh ./fmt.simple.sh ./config.nix $TEST_HOME
+cp ./simple.nix ./simple.builder.sh ./fmt.simple.sh ./config.nix "$TEST_HOME"
 
-cd $TEST_HOME
+cd "$TEST_HOME"
 
 nix fmt --help | grep "Format"
 
@@ -30,6 +30,9 @@ cat << EOF > flake.nix
   };
 }
 EOF
-nix fmt ./file ./folder | grep 'Formatting: ./file ./folder'
+# No arguments check
+[[ "$(nix fmt)" = "Formatting(0):" ]]
+# Argument forwarding check
+nix fmt ./file ./folder | grep 'Formatting(2): ./file ./folder'
 nix flake check
 nix flake show | grep -P "package 'formatter'"

--- a/tests/functional/fmt.simple.sh
+++ b/tests/functional/fmt.simple.sh
@@ -1,1 +1,2 @@
-echo Formatting: "${@}"
+#!/usr/bin/env bash
+echo "Formatting(${#}):" "${@}"


### PR DESCRIPTION
# Motivation

Allow treefmt to function as expected.

# Context

When `nix fmt` is called without an argument, Nix appends the "." argument before calling the formatter. The comment in the code is:
> Format the current flake out of the box

This also happens when formatting sub-folders.

This means that the formatter is now unable to distinguish, as an interface, whether the "." argument is coming from the flake or the user's intent to format the current folder. This decision should be up to the formatter.

Treefmt, for example, will automatically look up the project's root and format all the files. This is the desired behaviour. But because the "." argument is passed, it cannot function as expected.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
