### PR TITLE
Revert "fix: Error on malformed URI query parameter"

### DIFF
--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -81,7 +81,7 @@ std::map<std::string, std::string> decodeQuery(const std::string & query)
         auto e = s.find('=');
 
         if (e == std::string::npos) {
-            warn("dubious URI query '%s' is missing equal sign '%s'", s, "=");
+            warn("invalid URI query '%s', did you forget an equals sign `=`?", s);
             continue;
         }
 

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -79,15 +79,10 @@ std::map<std::string, std::string> decodeQuery(const std::string & query)
 
     for (auto s : tokenizeString<Strings>(query, "&")) {
         auto e = s.find('=');
-
-        if (e == std::string::npos) {
-            warn("invalid URI query '%s', did you forget an equals sign `=`?", s);
-            continue;
-        }
-
-        result.emplace(
-            s.substr(0, e),
-            percentDecode(std::string_view(s).substr(e + 1)));
+        if (e != std::string::npos)
+            result.emplace(
+                s.substr(0, e),
+                percentDecode(std::string_view(s).substr(e + 1)));
     }
 
     return result;


### PR DESCRIPTION
This now triggers on simple cases like `nix build .#nix`:

```
warning: dubious URI query 'nix' is missing equal sign '='
```

Reverting for now.