### PR TITLE
nix flake {metadata,archive}: Fix chroot stores

### DIFF
--- a/src/libflake/flake/flake.hh
+++ b/src/libflake/flake/flake.hh
@@ -214,6 +214,16 @@ void callFlake(
     const LockedFlake & lockedFlake,
     Value & v);
 
+/**
+ * Map a `SourcePath` to the corresponding store path. This is a
+ * temporary hack to support chroot stores while we don't have full
+ * lazy trees. FIXME: Remove this once we can pass a sourcePath rather
+ * than a storePath to call-flake.nix.
+ */
+std::pair<StorePath, Path> sourcePathToStorePath(
+    ref<Store> store,
+    const SourcePath & path);
+
 }
 
 void emitTreeAttrs(

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -214,7 +214,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
         auto & flake = lockedFlake.flake;
 
         // Currently, all flakes are in the Nix store via the rootFS accessor.
-        auto storePath = store->printStorePath(store->toStorePath(flake.path.path.abs()).first);
+        auto storePath = store->printStorePath(sourcePathToStorePath(store, flake.path).first);
 
         if (json) {
             nlohmann::json j;
@@ -1079,7 +1079,7 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun
 
         StorePathSet sources;
 
-        auto storePath = store->toStorePath(flake.flake.path.path.abs()).first;
+        auto storePath = sourcePathToStorePath(store, flake.flake.path).first;
 
         sources.insert(storePath);
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -184,6 +184,9 @@ nix registry list | grepInverse '^user' # nothing in user registry
 nix flake metadata flake1
 nix flake metadata flake1 | grepQuiet 'Locked URL:.*flake1.*'
 
+# Test 'nix flake metadata' on a chroot store.
+nix flake metadata --store $TEST_ROOT/chroot-store flake1
+
 # Test 'nix flake metadata' on a local flake.
 (cd "$flake1Dir" && nix flake metadata) | grepQuiet 'URL:.*flake1.*'
 (cd "$flake1Dir" && nix flake metadata .) | grepQuiet 'URL:.*flake1.*'


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
Fixes

```
$ nix flake metadata --store /tmp/nix nixpkgs
error: path '/tmp/nix/nix/store/65xpqkz92d9j7k5ric4z8lzhiigxsfbg-source/flake.nix' is not in the Nix store
```

This has been broken since 598deb2b23bc59df61c92ea25745d675686f3991.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
