### PR TITLE
Chmod build root to make it read-only

### DIFF
--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -771,6 +771,9 @@ void LocalDerivationGoal::startBuilder()
                 pathsInChroot.erase(worker.store.printStorePath(*i.second.second));
         }
 
+        // Make build root read-only, so `mkdir /homeless-shelter` would fail.
+        chmod_(chrootRootDir, 01555);
+
         if (cgroup) {
             if (mkdir(cgroup->c_str(), 0755) != 0)
                 throw SysError("creating cgroup '%s'", *cgroup);

--- a/tests/functional/build.sh
+++ b/tests/functional/build.sh
@@ -152,6 +152,11 @@ nix build --impure -f multiple-outputs.nix --json e --no-link \
     (.outputs | keys == ["a_a", "b"]))
 '
 
+# Make sure that `mkdir $HOME fails with a "Permission denied" error`
+out="$(nix build -f mkdir-home-failing.nix -L 2>&1)" && status=0 || status=$?
+test "$status" = 1
+<<<"$out" grepQuiet -E "Permission denied"
+
 # Make sure that `--stdin` works and does not apply any defaults
 printf "" | nix build --no-link --stdin --json | jq --exit-status '. == []'
 printf "%s\n" "$drv^*" | nix build --no-link --stdin --json | jq --exit-status '.[0]|has("drvPath")'

--- a/tests/functional/mkdir-home-failing.nix
+++ b/tests/functional/mkdir-home-failing.nix
@@ -1,0 +1,8 @@
+with import ./config.nix;
+mkDerivation {
+  name = "mkdir-home-no-permission";
+  builder = builtins.toFile "builder.sh"
+    ''
+      mkdir $HOME
+    '';
+}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
Currently, building Nix itself fails in single-user installation - see https://github.com/NixOS/nix/issues/11295. This is because some build steps run something like `mkdir -p $HOME/.cache`, and since $HOME is `/homeless-shelter` and `/` is writable, the directory `/homeless-shelter` is created, which may cause the builder to fail.

This PR just runs a `chmod` on the build root directory prior to `chroot`, to make it read-only. This seems to solve the issue.

# Context
* Bug report: https://github.com/NixOS/nix/issues/11295
* A PR that shows that building Nix fails in single-user installation: https://github.com/NixOS/nix/pull/11397
* A previous attempt at solving the issue, by using `/proc/homeless-shelter` instead of `/homeless-shelter`, which was reverted since it caused `mkdir $HOME` to fail with ENOENT instead of EPERM, which caused builds to fail: https://github.com/NixOS/nix/pull/11300

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
