### PR TITLE
sequoia-nixbld-user-migration: disable trace mode

### DIFF
--- a/scripts/sequoia-nixbld-user-migration.sh
+++ b/scripts/sequoia-nixbld-user-migration.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 ((NEW_NIX_FIRST_BUILD_UID=351))
 ((TEMP_NIX_FIRST_BUILD_UID=31000))
 


### PR DESCRIPTION
Was hoping to leave this enabled for a little while as core community members test the UID migration script out, but Apple's aggressive release timeline (i.e., Monday Sept 16--the earliest in over a decade) for macOS 15 Sequoia has caught us off-guard here.

It's probably not ideal for a general audience if the script spews all of this output--and people can still force bash to run in trace mode (i.e., with `bash -x` or even via env as detailed in https://unix.stackexchange.com/a/645145/65153) if we really need to debug a problem.

cc @emilazy

# Context
- #10892 
- #11075

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
