### PR TITLE
sequoia-nixbld-user-migration: halt on error

### DIFF
--- a/scripts/sequoia-nixbld-user-migration.sh
+++ b/scripts/sequoia-nixbld-user-migration.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 ((NEW_NIX_FIRST_BUILD_UID=351))
 ((TEMP_NIX_FIRST_BUILD_UID=31000))
 


### PR DESCRIPTION
Addressing user feedback about a case where actions the script takes may fail without a specific permission if run over SSH.

Apologies for the noise on these, but it won't shock me if there's a little more as we scramble to be ready for Monday... :)

cc @emilazy @Enzime 

# Context
- #10892 
- #11075

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
