### PR TITLE
doc: add admonitions for macOS 15 Sequoia update

### DIFF
--- a/doc/manual/src/installation/index.md
+++ b/doc/manual/src/installation/index.md
@@ -14,6 +14,14 @@ This option requires either:
 * Linux running systemd, with SELinux disabled
 * MacOS
 
+> **Updating to macOS 15 Sequoia**
+>
+> If you recently updated to macOS 15 Sequoia and are getting
+> ```console
+> error: the user '_nixbld1' in the group 'nixbld' does not exist
+> ```
+> when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
+
 ```console
 $ bash <(curl -L https://nixos.org/nix/install) --daemon
 ```

--- a/doc/manual/src/installation/installing-binary.md
+++ b/doc/manual/src/installation/installing-binary.md
@@ -1,5 +1,13 @@
 # Installing a Binary Distribution
 
+> **Updating to macOS 15 Sequoia**
+>
+> If you recently updated to macOS 15 Sequoia and are getting
+> ```console
+> error: the user '_nixbld1' in the group 'nixbld' does not exist
+> ```
+> when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
+
 To install the latest version Nix, run the following command:
 
 ```console

--- a/doc/manual/src/installation/uninstall.md
+++ b/doc/manual/src/installation/uninstall.md
@@ -43,6 +43,14 @@ which you may remove.
 
 ### macOS
 
+> **Updating to macOS 15 Sequoia**
+>
+> If you recently updated to macOS 15 Sequoia and are getting
+> ```console
+> error: the user '_nixbld1' in the group 'nixbld' does not exist
+> ```
+> when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
+
 1. If system-wide shell initialisation files haven't been altered since installing Nix, use the backups made by the installer:
 
    ```console


### PR DESCRIPTION
The impending release of macOS 15 Sequoia (Monday September 16 2024) will break many existing nix installs on macOS, which may lead to an increased number of people who are looking to try to reinstall Nix without noticing the open/pinned issue (#10892) that explains the problem and outlines how to migrate existing installs.

These admonitions are a short-term measure until we are over the hump and support volumes dwindle.

@fricklerhandwerk This is just our thinking about how to minimize total suffering here--happy to defer if you think it's inappropriate to add a ~temporary message like this to the released manuals. That said, I do intend to follow this up with similar changes to the equivalent information on the homepage and nix.dev--so this can still benefit from any thoughts/edits you have. (I'm focusing on this one first because we noticed that Nix is ~due for a 6-week release any day--ideally this can ride along if you agree.)

# Context
- #10892 
- #11075

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
