### PR TITLE
Document macOS sandbox security implications and __darwinAllowLocalNetworking

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -625,6 +625,9 @@ public:
           `__darwinAllowLocalNetworking` attribute set to `true` will have a
           sandbox exception added to allow it.
 
+          The macOS sandbox has known limitations, and should not be
+          considered a strong security boundary.
+
           Currently, sandboxing only work on Linux and macOS. The use of a
           sandbox requires that Nix is run as root (so you should use the
           “build users” feature to perform the actual builds under different


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

These things are undocumented, that seems bad.

# Context

Some discussion in https://github.com/NixOS/nix/issues/11269 and https://github.com/NixOS/nix/pull/11270

I couldn’t find any better place to put this. I didn’t put it in the manual as there are currently no references (other than release notes) to the sandbox (but perhaps there should be!).

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
