### PR TITLE
Add hint for --no-eval-cache on eval cached failures

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -491,7 +491,7 @@ std::shared_ptr<AttrCursor> AttrCursor::maybeGetAttr(Symbol name, bool forceErro
                         if (forceErrors)
                             debug("reevaluating failed cached attribute '%s'", getAttrPathStr(name));
                         else
-                            throw CachedEvalError("cached failure of attribute '%s'", getAttrPathStr(name));
+                            throw CachedEvalError("cached failure of attribute '%s'. Disable cache with --no-eval-cache", getAttrPathStr(name));
                     } else
                         return std::make_shared<AttrCursor>(root,
                             std::make_pair(shared_from_this(), name), nullptr, std::move(attr));


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Improve UX by making it obvious how to disable the eval-cache on cached eval failures:

**Currently:**

```bash
$ nix build .#nixosConfigurations.myhost.config.system.build.toplevel
error: cached failure of attribute 'nixosConfigurations.myhost.config.system.build.toplevel'
```

**New:**

```bash
$ nix build .#nixosConfigurations.myhost.config.system.build.toplevel
error: cached failure of attribute 'nixosConfigurations.myhost.config.system.build.toplevel'. Disable cache with --no-eval-cache
```

# Context

I've seen people repeatedly searching the nix documentation on how to disable the (presumed) "build cache" on `cached failure of attribute 'X'` errors. This is a simple hint to `--no-eval-cache`.

Note: This might break cases where the error message is parsed. I assume this is not a common use-case.


# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
