### PR TITLE
Fix meson build on macOS in sandbox

### DIFF
--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -427,7 +427,7 @@ extra_pkg_config_variables = {
 }
 
 # Working around https://github.com/mesonbuild/meson/issues/13584
-if host_machine.system() != 'macos'
+if host_machine.system() != 'darwin'
   extra_pkg_config_variables += {
     'localstatedir' : get_option('localstatedir'),
   }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Workaround at [src/libstore/meson.build#L429-L434](https://github.com/NixOS/nix/blob/799abea0c46365c5782c959dcb7e5bc84aa92133/src/libstore/meson.build#L429-L434) by @Ericson2314 from https://github.com/NixOS/nix/pull/11302 erroneously used `macos` instead of `darwin` to distinguish macOS, while meson docs list only `darwin`: https://mesonbuild.com/Reference-tables.html#operating-system-names.

# Context

Original thread: https://github.com/NixOS/nix/issues/2503#issuecomment-2353184049

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
