### PR TITLE
[backport 2.18] libstore: check additionalSandboxProfile

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -172,6 +172,10 @@ void LocalDerivationGoal::killSandbox(bool getStats)
 
 void LocalDerivationGoal::tryLocalBuild()
 {
+#if __APPLE__
+    additionalSandboxProfile = parsedDrv->getStringAttr("__sandboxProfile").value_or("");
+#endif
+
     unsigned int curBuilds = worker.getNrLocalBuilds();
     if (curBuilds >= settings.maxBuildJobs) {
         state = &DerivationGoal::tryToBuild;
@@ -477,10 +481,6 @@ void LocalDerivationGoal::startBuilder()
             worker.store.printStorePath(drvPath),
             settings.thisSystem,
             concatStringsSep<StringSet>(", ", worker.store.systemFeatures));
-
-#if __APPLE__
-    additionalSandboxProfile = parsedDrv->getStringAttr("__sandboxProfile").value_or("");
-#endif
 
     /* Create a temporary directory where the build will take
        place. */

--- a/tests/functional/extra-sandbox-profile.nix
+++ b/tests/functional/extra-sandbox-profile.nix
@@ -1,0 +1,19 @@
+{ destFile, seed }:
+
+with import ./config.nix;
+
+mkDerivation {
+  name = "simple";
+  __sandboxProfile = ''
+    # Allow writing any file in the filesystem
+    (allow file*)
+  '';
+  inherit seed;
+  buildCommand = ''
+    (
+      set -x
+      touch ${destFile}
+      touch $out
+    )
+  '';
+}

--- a/tests/functional/extra-sandbox-profile.sh
+++ b/tests/functional/extra-sandbox-profile.sh
@@ -1,0 +1,23 @@
+source common.sh
+
+if [[ $(uname) != Darwin ]]; then skipTest "Need Darwin"; fi
+
+DEST_FILE="${TEST_ROOT}/foo"
+
+testSandboxProfile () (
+    set -e
+
+    sandboxMode="$1"
+
+    rm -f "${DEST_FILE}"
+    nix-build --no-out-link ./extra-sandbox-profile.nix \
+        --option sandbox "$sandboxMode" \
+        --argstr seed "$RANDOM" \
+        --argstr destFile "${DEST_FILE}"
+
+    ls -l "${DEST_FILE}"
+)
+
+testSandboxProfile "false"
+expectStderr 2 testSandboxProfile "true"
+testSandboxProfile "relaxed"


### PR DESCRIPTION
# Motivation
backport of #10652
<!-- Briefly explain what the change is about and why it is desirable. -->

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).