### PR TITLE
Disable the armv6l and freebsd cross-builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,11 +33,11 @@
       systems = linuxSystems ++ darwinSystems;
 
       crossSystems = [
-        "armv6l-unknown-linux-gnueabihf"
+        #"armv6l-unknown-linux-gnueabihf"
         "armv7l-unknown-linux-gnueabihf"
         "riscv64-unknown-linux-gnu"
         "x86_64-unknown-netbsd"
-        "x86_64-unknown-freebsd"
+        #"x86_64-unknown-freebsd"
         "x86_64-w64-mingw32"
       ];
 

--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -123,7 +123,7 @@ in
     self.hydraJobs.binaryTarball."x86_64-darwin"
     self.hydraJobs.binaryTarball."aarch64-darwin"
     # Cross
-    self.hydraJobs.binaryTarballCross."x86_64-linux"."armv6l-unknown-linux-gnueabihf"
+    #self.hydraJobs.binaryTarballCross."x86_64-linux"."armv6l-unknown-linux-gnueabihf"
     self.hydraJobs.binaryTarballCross."x86_64-linux"."armv7l-unknown-linux-gnueabihf"
     self.hydraJobs.binaryTarballCross."x86_64-linux"."riscv64-unknown-linux-gnu"
   ];
@@ -132,7 +132,7 @@ in
     self.hydraJobs.binaryTarball."x86_64-linux"
     self.hydraJobs.binaryTarball."aarch64-darwin"
     # Cross
-    self.hydraJobs.binaryTarballCross."x86_64-linux"."armv6l-unknown-linux-gnueabihf"
+    #self.hydraJobs.binaryTarballCross."x86_64-linux"."armv6l-unknown-linux-gnueabihf"
     self.hydraJobs.binaryTarballCross."x86_64-linux"."armv7l-unknown-linux-gnueabihf"
     self.hydraJobs.binaryTarballCross."x86_64-linux"."riscv64-unknown-linux-gnu"
   ];

--- a/scripts/install.in
+++ b/scripts/install.in
@@ -40,11 +40,6 @@ case "$(uname -s).$(uname -m)" in
         path=@tarballPath_aarch64-linux@
         system=aarch64-linux
         ;;
-    Linux.armv6l)
-        hash=@tarballHash_armv6l-linux@
-        path=@tarballPath_armv6l-linux@
-        system=armv6l-linux
-        ;;
     Linux.armv7l)
         hash=@tarballHash_armv7l-linux@
         path=@tarballPath_armv7l-linux@


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
These have been broken for a while (in fact the armv6l build has never succeeded in Hydra), so let's disable them until somebody fixes them.

See https://hydra.nixos.org/eval/1808904#tabs-still-fail.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
