### PR TITLE
Use close_range when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ static char buf[1024];]],
 AC_LANG_POP(C++)
 
 
-AC_CHECK_FUNCS([statvfs pipe2])
+AC_CHECK_FUNCS([statvfs pipe2 close_range])
 
 
 # Check for lutimes, optionally used for changing the mtime of

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -28,6 +28,7 @@ subdir('build-utils-meson/subprojects')
 # HAVE_LUTIMES 1`. The `#define` is unconditional, 0 for not found and 1
 # for found. One therefore uses it with `#if` not `#ifdef`.
 check_funcs = [
+  'close_range',
   # Optionally used for changing the mtime of symlinks.
   'lutimes',
   # Optionally used for creating pipes on Unix

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -121,10 +121,13 @@ void Pipe::create()
 //////////////////////////////////////////////////////////////////////
 
 #if __linux__ || __FreeBSD__
-// In future we can use a syscall wrapper, but at the moment musl and older glibc version don't support it.
 static int unix_close_range(unsigned int first, unsigned int last, int flags)
 {
+#if !HAVE_CLOSE_RANGE
     return syscall(SYS_close_range, first, last, (unsigned int)flags);
+#else
+    return close_range(first, last, flags);
+#endif
 }
 #endif
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
This fixes the FreeBSD build of nix-util

# Context


https://hydra.nixos.org/eval/1808904#tabs-still-fail

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
