### PR TITLE
Revert "tests.installer: Load profile with -o unset"

### DIFF
--- a/tests/installer/default.nix
+++ b/tests/installer/default.nix
@@ -217,16 +217,10 @@ let
         $ssh <<EOF
           set -ex
 
-          # enable nounset while loading the profile
-          # this may or may not work on all distros, depending on the quality of their scripts
-          set -u
-
           # FIXME: get rid of this; ideally ssh should just work.
           source ~/.bash_profile || true
           source ~/.bash_login || true
           source ~/.profile || true
-          set +u
-
           source /etc/bashrc || true
 
           nix-env --version


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

I must have made a mistake while testing this, because nounset does not work on any of the distributions.

This reverts commit 2f0db04da08e67f29577c27fae3c0eb758fc0879.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
