### PR TITLE
nix-util / meson: Add -latomic on arm

### DIFF
--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -50,6 +50,14 @@ endforeach
 
 subdir('build-utils-meson/threads')
 
+# Check if -latomic is needed
+# This is needed for std::atomic on some platforms
+# We did not manage to test this reliably on all platforms, so we hardcode
+# it for now.
+if host_machine.cpu_family() == 'arm'
+  deps_other += cxx.find_library('atomic')
+endif
+
 if host_machine.system() == 'windows'
   socket = cxx.find_library('ws2_32')
   deps_other += socket


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

The meson build did not get this flag right yet, for the armv6/7 builds.

I couldn't get the test program to work correctly after many attempts, so let's just unblock this without making it perfect.

# Context

https://hydra.nixos.org/build/272876163/nixlog/1

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
