### PR TITLE
nix-profile.sh.in: fix envvar condition

### DIFF
--- a/scripts/nix-profile.sh.in
+++ b/scripts/nix-profile.sh.in
@@ -1,9 +1,9 @@
 # This file is tested by tests/installer/default.nix.
-if [ -n "$HOME" ] && [ -n "$USER" ]; then
+if [ -n "${HOME-}" ] && [ -n "${USER-}" ]; then
 
     # Set up the per-user profile.
 
-    if [ -n "$NIX_STATE_HOME" ]; then
+    if [ -n "${NIX_STATE_HOME-}" ]; then
         NIX_LINK="$NIX_STATE_HOME/profile"
     else
         NIX_LINK="$HOME/.nix-profile"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
https://github.com/NixOS/nix/pull/11351 introduced a regression. The check for the existence of an environment variable caused an error for some shell versions.

# Context
Should fix https://github.com/NixOS/nix/issues/11535.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
