### PR TITLE
Alias traceable_allocator to std::allocator when building without GC

### DIFF
--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -127,14 +127,9 @@ ref<EvalState> EvalCommand::getEvalState()
 {
     if (!evalState) {
         evalState =
-            #if HAVE_BOEHMGC
             std::allocate_shared<EvalState>(
                 traceable_allocator<EvalState>(),
-            #else
-            std::make_shared<EvalState>(
-            #endif
-                lookupPath, getEvalStore(), fetchSettings, evalSettings, getStore())
-            ;
+                lookupPath, getEvalStore(), fetchSettings, evalSettings, getStore());
 
         evalState->repair = repair;
 

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -29,11 +29,6 @@
 #include "ref.hh"
 #include "value.hh"
 
-#if HAVE_BOEHMGC
-#define GC_INCLUDE_NEW
-#include <gc/gc_cpp.h>
-#endif
-
 #include "strings.hh"
 
 namespace nix {

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -57,9 +57,7 @@ enum class ProcessLineResult {
 struct NixRepl
     : AbstractNixRepl
     , detail::ReplCompleterMixin
-    #if HAVE_BOEHMGC
     , gc
-    #endif
 {
     size_t debugTraceIndex;
 

--- a/src/libexpr-c/nix_api_external.cc
+++ b/src/libexpr-c/nix_api_external.cc
@@ -14,12 +14,6 @@
 
 #include <nlohmann/json.hpp>
 
-#if HAVE_BOEHMGC
-# include "gc/gc.h"
-# define GC_INCLUDE_NEW 1
-# include "gc_cpp.h"
-#endif
-
 void nix_set_string_return(nix_string_return * str, const char * c)
 {
     str->str = c;

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -14,12 +14,6 @@
 #include "nix_api_value.h"
 #include "value/context.hh"
 
-#if HAVE_BOEHMGC
-#  include "gc/gc.h"
-#  define GC_INCLUDE_NEW 1
-#  include "gc_cpp.h"
-#endif
-
 // Internal helper functions to check [in] and [out] `Value *` parameters
 static const nix::Value & check_value_not_null(const nix_value * value)
 {

--- a/src/libexpr/eval-gc.hh
+++ b/src/libexpr/eval-gc.hh
@@ -13,11 +13,18 @@
 
 #else
 
+/* Some dummy aliases for Boehm GC definitions to reduce the number of
+   #ifdefs. */
+
 template<typename T>
 using traceable_allocator = std::allocator<T>;
 
 template<typename T>
 using gc_allocator = std::allocator<T>;
+
+#define GC_MALLOC_ATOMIC std::malloc
+#define GC_STRDUP std::strdup
+struct gc { };
 
 #endif
 

--- a/src/libexpr/eval-gc.hh
+++ b/src/libexpr/eval-gc.hh
@@ -3,6 +3,24 @@
 
 #include <cstddef>
 
+#if HAVE_BOEHMGC
+
+#  define GC_INCLUDE_NEW
+
+#  include <gc/gc.h>
+#  include <gc/gc_cpp.h>
+#  include <gc/gc_allocator.h>
+
+#else
+
+template<typename T>
+using traceable_allocator = std::allocator<T>;
+
+template<typename T>
+using gc_allocator = std::allocator<T>;
+
+#endif
+
 namespace nix {
 
 /**

--- a/src/libexpr/eval-gc.hh
+++ b/src/libexpr/eval-gc.hh
@@ -22,9 +22,10 @@ using traceable_allocator = std::allocator<T>;
 template<typename T>
 using gc_allocator = std::allocator<T>;
 
-#define GC_MALLOC_ATOMIC std::malloc
-#define GC_STRDUP std::strdup
-struct gc { };
+#  define GC_MALLOC_ATOMIC std::malloc
+#  define GC_STRDUP std::strdup
+struct gc
+{};
 
 #endif
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -47,11 +47,7 @@ namespace nix {
 static char * allocString(size_t size)
 {
     char * t;
-#if HAVE_BOEHMGC
     t = (char *) GC_MALLOC_ATOMIC(size);
-#else
-    t = (char *) malloc(size);
-#endif
     if (!t) throw std::bad_alloc();
     return t;
 }
@@ -60,11 +56,7 @@ static char * allocString(size_t size)
 static char * dupString(const char * s)
 {
     char * t;
-#if HAVE_BOEHMGC
     t = GC_STRDUP(s);
-#else
-    t = strdup(s);
-#endif
     if (!t) throw std::bad_alloc();
     return t;
 }

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -99,11 +99,7 @@ static const char * makeImmutableString(std::string_view s)
 
 RootValue allocRootValue(Value * v)
 {
-#if HAVE_BOEHMGC
     return std::allocate_shared<Value *>(traceable_allocator<Value *>(), v);
-#else
-    return std::make_shared<Value *>(v);
-#endif
 }
 
 // Pretty print types for assertion errors

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1,5 +1,4 @@
 #include "eval.hh"
-#include "eval-gc.hh"
 #include "eval-settings.hh"
 #include "primops.hh"
 #include "print-options.hh"
@@ -37,16 +36,6 @@
 
 #ifndef _WIN32 // TODO use portable implementation
 #  include <sys/resource.h>
-#endif
-
-#if HAVE_BOEHMGC
-
-#  define GC_INCLUDE_NEW
-
-#  include <gc/gc.h>
-#  include <gc/gc_cpp.h>
-#  include <gc/gc_allocator.h>
-
 #endif
 
 #include "strings-inline.hh"

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -139,11 +139,7 @@ struct Constant
     bool impureOnly = false;
 };
 
-#if HAVE_BOEHMGC
-    typedef std::map<std::string, Value *, std::less<std::string>, traceable_allocator<std::pair<const std::string, Value *> > > ValMap;
-#else
-    typedef std::map<std::string, Value *> ValMap;
-#endif
+typedef std::map<std::string, Value *, std::less<std::string>, traceable_allocator<std::pair<const std::string, Value *> > > ValMap;
 
 typedef std::unordered_map<PosIdx, DocComment> DocCommentMap;
 
@@ -329,21 +325,13 @@ private:
     /**
      * A cache from path names to parse trees.
      */
-#if HAVE_BOEHMGC
     typedef std::unordered_map<SourcePath, Expr *, std::hash<SourcePath>, std::equal_to<SourcePath>, traceable_allocator<std::pair<const SourcePath, Expr *>>> FileParseCache;
-#else
-    typedef std::unordered_map<SourcePath, Expr *> FileParseCache;
-#endif
     FileParseCache fileParseCache;
 
     /**
      * A cache from path names to values.
      */
-#if HAVE_BOEHMGC
     typedef std::unordered_map<SourcePath, Value, std::hash<SourcePath>, std::equal_to<SourcePath>, traceable_allocator<std::pair<const SourcePath, Value>>> FileEvalCache;
-#else
-    typedef std::unordered_map<SourcePath, Value> FileEvalCache;
-#endif
     FileEvalCache fileEvalCache;
 
     /**

--- a/src/libexpr/gc-small-vector.hh
+++ b/src/libexpr/gc-small-vector.hh
@@ -2,28 +2,15 @@
 
 #include <boost/container/small_vector.hpp>
 
-#if HAVE_BOEHMGC
-
-#include <gc/gc.h>
-#include <gc/gc_cpp.h>
-#include <gc/gc_allocator.h>
-
-#endif
+#include "value.hh"
 
 namespace nix {
-
-struct Value;
 
 /**
  * A GC compatible vector that may used a reserved portion of `nItems` on the stack instead of allocating on the heap.
  */
-#if HAVE_BOEHMGC
 template <typename T, size_t nItems>
 using SmallVector = boost::container::small_vector<T, nItems, traceable_allocator<T>>;
-#else
-template <typename T, size_t nItems>
-using SmallVector = boost::container::small_vector<T, nItems>;
-#endif
 
 /**
  * A vector of value pointers. See `SmallVector`.

--- a/src/libexpr/get-drvs.hh
+++ b/src/libexpr/get-drvs.hh
@@ -83,11 +83,7 @@ public:
 };
 
 
-#if HAVE_BOEHMGC
 typedef std::list<PackageInfo, traceable_allocator<PackageInfo>> PackageInfos;
-#else
-typedef std::list<PackageInfo> PackageInfos;
-#endif
 
 
 /**

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -631,11 +631,7 @@ struct CompareValues
 };
 
 
-#if HAVE_BOEHMGC
 typedef std::list<Value *, gc_allocator<Value *>> ValueList;
-#else
-typedef std::list<Value *> ValueList;
-#endif
 
 
 static Bindings::const_iterator getAttr(

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3136,11 +3136,7 @@ static void prim_zipAttrsWith(EvalState & state, const PosIdx pos, Value * * arg
         std::optional<ListBuilder> list;
     };
 
-#if HAVE_BOEHMGC
     std::map<Symbol, Item, std::less<Symbol>, traceable_allocator<std::pair<const Symbol, Item>>> attrsSeen;
-#else
-    std::map<Symbol, Item> attrsSeen;
-#endif
 
     state.forceFunction(*args[0], pos, "while evaluating the first argument passed to builtins.zipAttrsWith");
     state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.zipAttrsWith");

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -4,21 +4,12 @@
 #include <cassert>
 #include <span>
 
+#include "eval-gc.hh"
 #include "symbol-table.hh"
 #include "value/context.hh"
 #include "source-path.hh"
 #include "print-options.hh"
 #include "checked-arithmetic.hh"
-
-#if HAVE_BOEHMGC
-#include <gc/gc_allocator.h>
-#else
-template<typename T>
-using traceable_allocator = std::allocator<T>;
-
-template<typename T>
-using gc_allocator = std::allocator<T>;
-#endif
 
 #include <nlohmann/json_fwd.hpp>
 

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -15,6 +15,9 @@
 #else
 template<typename T>
 using traceable_allocator = std::allocator<T>;
+
+template<typename T>
+using gc_allocator = std::allocator<T>;
 #endif
 
 #include <nlohmann/json_fwd.hpp>

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -12,7 +12,11 @@
 
 #if HAVE_BOEHMGC
 #include <gc/gc_allocator.h>
+#else
+template<typename T>
+using traceable_allocator = std::allocator<T>;
 #endif
+
 #include <nlohmann/json_fwd.hpp>
 
 namespace nix {
@@ -498,15 +502,9 @@ void Value::mkBlackhole()
 }
 
 
-#if HAVE_BOEHMGC
 typedef std::vector<Value *, traceable_allocator<Value *>> ValueVector;
 typedef std::unordered_map<Symbol, Value *, std::hash<Symbol>, std::equal_to<Symbol>, traceable_allocator<std::pair<const Symbol, Value *>>> ValueMap;
 typedef std::map<Symbol, ValueVector, std::less<Symbol>, traceable_allocator<std::pair<const Symbol, ValueVector>>> ValueVectorMap;
-#else
-typedef std::vector<Value *> ValueVector;
-typedef std::unordered_map<Symbol, Value *> ValueMap;
-typedef std::map<Symbol, ValueVector> ValueVectorMap;
-#endif
 
 
 /**

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -2,7 +2,6 @@
 #include "current-process.hh"
 #include "command.hh"
 #include "common-args.hh"
-#include "eval-gc.hh"
 #include "eval.hh"
 #include "eval-settings.hh"
 #include "globals.hh"


### PR DESCRIPTION
# Motivation

This gets rid of a bunch of #ifdefs and  avoids build errors like the one mentioned in https://github.com/NixOS/nix/pull/11548#pullrequestreview-2316345551.

Depends on #11548.
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
