### PR TITLE
Re-introduce mkStringNoCopy

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -326,10 +326,10 @@ EvalState::EvalState(
     vNull.mkNull();
     vTrue.mkBool(true);
     vFalse.mkBool(false);
-    vStringRegular.mkString("regular");
-    vStringDirectory.mkString("directory");
-    vStringSymlink.mkString("symlink");
-    vStringUnknown.mkString("unknown");
+    vStringRegular.mkStringNoCopy("regular");
+    vStringDirectory.mkStringNoCopy("directory");
+    vStringSymlink.mkStringNoCopy("symlink");
+    vStringUnknown.mkStringNoCopy("unknown");
 
     /* Construct the Nix expression search path. */
     assert(lookupPath.elements.empty());
@@ -845,7 +845,7 @@ DebugTraceStacker::DebugTraceStacker(EvalState & evalState, DebugTrace t)
 
 void Value::mkString(std::string_view s)
 {
-    mkString(makeImmutableString(s));
+    mkStringNoCopy(makeImmutableString(s));
 }
 
 
@@ -865,12 +865,12 @@ static const char * * encodeContext(const NixStringContext & context)
 
 void Value::mkString(std::string_view s, const NixStringContext & context)
 {
-    mkString(makeImmutableString(s), encodeContext(context));
+    mkStringNoCopy(makeImmutableString(s), encodeContext(context));
 }
 
 void Value::mkStringMove(const char * s, const NixStringContext & context)
 {
-    mkString(s, encodeContext(context));
+    mkStringNoCopy(s, encodeContext(context));
 }
 
 void Value::mkPath(const SourcePath & path)

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4053,7 +4053,7 @@ static void prim_substring(EvalState & state, const PosIdx pos, Value * * args, 
     if (len == 0) {
         state.forceValue(*args[2], pos);
         if (args[2]->type() == nString) {
-            v.mkString("", args[2]->context());
+            v.mkStringNoCopy("", args[2]->context());
             return;
         }
     }

--- a/src/libexpr/primops/fromTOML.cc
+++ b/src/libexpr/primops/fromTOML.cc
@@ -63,7 +63,7 @@ static void prim_fromTOML(EvalState & state, const PosIdx pos, Value * * args, V
                 {
                     if (experimentalFeatureSettings.isEnabled(Xp::ParseTomlTimestamps)) {
                         auto attrs = state.buildBindings(2);
-                        attrs.alloc("_type").mkString("timestamp");
+                        attrs.alloc("_type").mkStringNoCopy("timestamp");
                         std::ostringstream s;
                         s << t;
                         attrs.alloc("value").mkString(s.str());

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -320,7 +320,7 @@ public:
         finishValue(tBool, { .boolean = b });
     }
 
-    inline void mkString(const char * s, const char * * context = 0)
+    inline void mkStringNoCopy(const char * s, const char * * context = 0)
     {
         finishValue(tString, { .string = { .c_str = s, .context = context } });
     }
@@ -333,7 +333,7 @@ public:
 
     inline void mkString(const SymbolStr & s)
     {
-        mkString(s.c_str());
+        mkStringNoCopy(s.c_str());
     }
 
     void mkPath(const SourcePath & path);

--- a/src/nix-env/user-env.cc
+++ b/src/nix-env/user-env.cc
@@ -61,7 +61,7 @@ bool createUserEnv(EvalState & state, PackageInfos & elems,
 
         auto attrs = state.buildBindings(7 + outputs.size());
 
-        attrs.alloc(state.sType).mkString("derivation");
+        attrs.alloc(state.sType).mkStringNoCopy("derivation");
         attrs.alloc(state.sName).mkString(i.queryName());
         auto system = i.querySystem();
         if (!system.empty())


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
In b70d22baca3e8826392b61aa53955c6da74b8724 `mkStringNoCopy()` was renamed to `mkString()`, but this is a bit risky since in code like

    vStringRegular.mkString("regular");

we want to be sure that the right overload is picked. (This is especially problematic since the overload that takes an `std::string_view` *does* allocate.)  So let's be explicit.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
