### PR TITLE
Generate fallback-paths in a flake output instead of "hidden" perl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -223,6 +223,10 @@
           default = self.packages.${system}.nix-ng;
           nix-internal-api-docs = nixpkgsFor.${system}.native.nixComponents.nix-internal-api-docs;
           nix-external-api-docs = nixpkgsFor.${system}.native.nixComponents.nix-external-api-docs;
+          nix-all-output-paths = nixpkgsFor.${system}.native.callPackage ./packaging/nix-all-output-paths.nix {
+            packages =
+              lib.mapAttrs (system: packages: packages.nix) self.packages;
+          };
         }
         # We need to flatten recursive attribute sets of derivations to pass `flake check`.
         // flatMapAttrs

--- a/packaging/nix-all-output-paths.nix
+++ b/packaging/nix-all-output-paths.nix
@@ -1,0 +1,48 @@
+{ lib, formats, nix, packages, stdenv, ... }:
+
+let
+  randomPick = packages."x86_64-linux";
+in
+stdenv.mkDerivation {
+  version = randomPick.version;
+  pname = "nix-all-output-paths";
+  passAsFile = [ "content" ];
+  nativeBuildInputs = [ nix ];
+  json = (formats.json {}).generate "all-output-paths.json" (lib.mapAttrs (name: pkg: "${lib.getBin pkg}") packages);
+  nix = ''
+    {
+      ${
+        lib.concatStringsSep "\n  " (
+          lib.mapAttrsToList
+            (name: pkg: "${lib.strings.escapeNixIdentifier name} = ${lib.strings.escapeNixString "${lib.getBin pkg}"};")
+            packages
+        )
+      }
+    }
+  '';
+  buildCommand = ''
+    mkdir -p $out
+    cp $json $out/all-output-paths.json
+    echo "$nix" > $out/all-output-paths.nix
+
+    mkdir -p $out/nix-support
+    {
+      echo "file all-output-paths $out/all-output-paths.json"
+      echo "file all-output-paths-nix-deprecated $out/all-output-paths.nix"
+    } >> $out/nix-support/hydra-build-products
+
+    r=$(nix-instantiate --store dummy:// --expr --eval --json \
+        'builtins.fromJSON (builtins.readFile '$out'/all-output-paths.json) == import '$out'/all-output-paths.nix')
+    if ! [[ $r == "true" ]]; then
+      echo "The generated Nix file does not match the JSON file"
+      echo "Nix file: $out/all-output-paths.nix"
+      cat -n $out/all-output-paths.nix
+      echo "JSON file: $out/all-output-paths.json"
+      cat -n $out/all-output-paths.json
+      exit 1
+    fi
+  '';
+  meta = {
+    description = "A lookup file that gives a store path containing the Nix package manager for all supported system types";
+  };
+}


### PR DESCRIPTION
# Motivation

Currently, `nix-fallback-paths.nix` is generated in the release script. Let's make it more declarative instead, so that


 -   Users can check that the fallback paths file is correct, by building it
 -   It makes the release process easier to understand
 -   It removes a duplication of the systems attrset
 -   It simplifies the release script

The new package provides the contents for `nix-fallback-paths.nix` in NixOS, but without the weirdly specific name that's for the purpose of `nixos-rebuild`.

~TODO~ Follow-up:
- [ ] update release script to download the file instead of generating it

Question:
Do we want to rename this and provide JSON? I think using a data format for data is good, as it makes alternative use cases possible. The current name is a layer violation.

(Ideally we should have a store-level json based _package_ description format, but that's overkill for this particular use case; it would make the entire solution reusable though, whereas the current thing or this PR are still an ad hoc format.)

# Context

- Originally written for https://github.com/NixOS/nixpkgs/pull/343657. Although that wasn't the right approach, still this would be a good refactor when the release script downloads the file instead of generating it in perl.


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
