### PR TITLE
Add optimize as an alias of optimise

### DIFF
--- a/doc/manual/rl-next/optimise-alias.md
+++ b/doc/manual/rl-next/optimise-alias.md
@@ -1,0 +1,7 @@
+---
+synopsis: Add an alias for optimise.
+issues: 1902, 11326
+prs: 11577
+---
+
+Add "optimize" as a linguistic variation of "optimise". Now both the `nix-store` and `nix store` commands work with the same spelling.

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -398,6 +398,8 @@ public:
         AcceptedShorthand,
         /** Aliases that will go away */
         Deprecated,
+        /** Aliases for linguistic variation */
+        LinguisticVariation,
     };
 
     /** An alias, except for the original syntax, which is in the map key. */

--- a/src/nix/store.cc
+++ b/src/nix/store.cc
@@ -8,6 +8,7 @@ struct CmdStore : NixMultiCommand
     {
         aliases = {
             {"ping", { AliasStatus::Deprecated, {"info"}}},
+            {"optimize", { AliasStatus::LinguisticVariation, {"optimise"}}},
         };
     }
 

--- a/tests/functional/optimise-store.sh
+++ b/tests/functional/optimise-store.sh
@@ -41,6 +41,28 @@ if [ "$inode1" != "$inode3" ]; then
     exit 1
 fi
 
+outPath4=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo4"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link)
+
+NIX_REMOTE="" nix store optimise
+
+inode1="$(stat --format=%i $outPath1/foo)"
+inode4="$(stat --format=%i $outPath4/foo)"
+if [ "$inode1" != "$inode4" ]; then
+    echo "inodes do not match"
+    exit 1
+fi
+
+outPath5=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo5"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link)
+
+NIX_REMOTE="" nix store optimize # alias of optimise
+
+inode1="$(stat --format=%i $outPath1/foo)"
+inode5="$(stat --format=%i $outPath5/foo)"
+if [ "$inode1" != "$inode5" ]; then
+    echo "inodes do not match"
+    exit 1
+fi
+
 nix-store --gc
 
 if [ -n "$(ls $NIX_STORE_DIR/.links)" ]; then


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Allow both `nix store optimise` and `nix store optimize`.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Closes https://github.com/NixOS/nix/issues/1902 https://github.com/NixOS/nix/issues/11326

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
