### PR TITLE
disable freebsd cross builds for now

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,8 @@
         "armv7l-unknown-linux-gnueabihf"
         "riscv64-unknown-linux-gnu"
         "x86_64-unknown-netbsd"
-        "x86_64-unknown-freebsd"
+        # Cross-compilation doesn't eval at the moment: https://github.com/NixOS/nixpkgs/issues/344131
+        # "x86_64-unknown-freebsd"
         "x86_64-w64-mingw32"
       ];
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

In the current nixpkgs used, freebsd is broken and in master also evaluation broke recently.
Until this is fixed, I would disable the cross-compilation.

Nixpkgs issue: https://github.com/NixOS/nixpkgs/issues/344131
