### PR TITLE
ci: split of eval and build into two jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,32 @@ jobs:
             free -h
           done
         ) &
-    - run: nix --experimental-features 'nix-command flakes' flake check -L
-    - run: nix --experimental-features 'nix-command flakes' flake show --all-systems --json
+    - run: nix run --inputs-from . nixpkgs#nix-fast-build -- --skip-cached --no-nom
+  show-flake:
+      runs-on: ubuntu-latest
+      timeout-minutes: 60
+      steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@V27
+        with:
+          # The sandbox would otherwise be disabled by default on Darwin
+          extra_nix_config: "sandbox = true"
+      - run: nix --experimental-features 'nix-command flakes' flake show --all-systems --json
+  eval-hydra-jobs:
+      runs-on: ubuntu-latest
+      timeout-minutes: 60
+      steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@V27
+        with:
+          # The sandbox would otherwise be disabled by default on Darwin
+          extra_nix_config: "sandbox = true"
+      - run: nix run --inputs-from . nixpkgs#nix-eval-jobs -- --force-recurse --gc-roots-dir gcroot --flake git+file://$(pwd)#hydraJobs
+
 
   # Steps to test CI automation in your own fork.
   # Cachix:


### PR DESCRIPTION
nix flake show will go over the whole flake but than only build a subset. It does this also for both macOS and Linux, however we only need this to be done once.
For the actually builds, this commit switches to nix-fast-build. Since there are a fair amount of nixos tests in .#checks this will speed up the run by having both evaluation and build in parallel, furthermore nix-fast-build will skip any packages already present in cachix. Also it will try to build all flake outputs and than report the failed one at the end. This has the advantage that successful ones will be skipped on the next run and we get a list of all failed attributes.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

Depends on https://github.com/NixOS/nix/pull/11581 + a nix patch release.

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

- Works around https://github.com/NixOS/nix/issues/5200

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
