### PR TITLE
docs/testing: add --verbose flag for running single tests

### DIFF
--- a/doc/manual/src/development/testing.md
+++ b/doc/manual/src/development/testing.md
@@ -162,7 +162,7 @@ ninja: no work to do.
 Individual tests can be run with `meson`:
 
 ```shell-session
-$ meson test ${testName}
+$ meson test --verbose ${testName}
 ninja: Entering directory `/home/jcericson/src/nix/master/build'
 ninja: no work to do.
 1/1 nix-functional-tests:main / ${testName}        OK               0.41s
@@ -177,7 +177,11 @@ Timeout:            0
 Full log written to /home/jcericson/src/nix/master/build/meson-logs/testlog.txt
 ```
 
-or without `meson`, showing the output:
+The `--verbose` flag will make Meson also show the console output of each test for easier debugging.
+The test script will then be traced with `set -x` and the output displayed as it happens,
+regardless of whether the test succeeds or fails.
+
+Tests can be also run directly without `meson`:
 
 ```shell-session
 $ TEST_NAME=${testName} NIX_REMOTE='' PS4='+(${BASH_SOURCE[0]-$0}:$LINENO) tests/functional/${testName}.sh
@@ -187,8 +191,6 @@ output from foo
 output from bar
 ...
 ```
-
-The test script will then be traced with `set -x` and the output displayed as it happens, regardless of whether the test succeeds or fails.
 
 ### Debugging failing functional tests
 


### PR DESCRIPTION
Most of the time people run single tests for debugging reason, so it's a sane default to have them see all the console output.

This commit still retains the section about running tests directly with meson, because in some debugging cases it's just nice to have less abstractions i.e. when using strace.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
