### PR TITLE
builtin:fetchurl: Enable TLS verification

### DIFF
--- a/doc/manual/rl-next/verify-tls.md
+++ b/doc/manual/rl-next/verify-tls.md
@@ -1,0 +1,8 @@
+---
+synopsis: "`<nix/fetchurl.nix>` uses TLS verification"
+prs: [11585]
+---
+
+Previously `<nix/fetchurl.nix>` did not do TLS verification. This was because the Nix sandbox in the past did not have access to TLS certificates, and Nix checks the hash of the fetched file anyway. However, this can expose authentication data from `netrc` and URLs to man-in-the-middle attackers. In addition, Nix now in some cases (such as when using impure derivations) does *not* check the hash. Therefore we have now enabled TLS verification. This means that downloads by `<nix/fetchurl.nix>` will now fail if you're fetching from a HTTPS server that does not have a valid certificate.
+
+`<nix/fetchurl.nix>` is also known as the builtin derivation builder `builtin:fetchurl`. It's not to be confused with the evaluation-time function `builtins.fetchurl`, which was not affected by this issues.

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -38,10 +38,7 @@ void builtinFetchurl(
 
         auto source = sinkToSource([&](Sink & sink) {
 
-            /* No need to do TLS verification, because we check the hash of
-               the result anyway. */
             FileTransferRequest request(url);
-            request.verifyTLS = false;
             request.decompress = false;
 
             auto decompressor = makeDecompressionSink(

--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -159,4 +159,6 @@ in
   fsync = runNixOSTestFor "x86_64-linux" ./fsync.nix;
 
   cgroups = runNixOSTestFor "x86_64-linux" ./cgroups;
+
+  fetchurl = runNixOSTestFor "x86_64-linux" ./fetchurl.nix;
 }

--- a/tests/nixos/fetchurl.nix
+++ b/tests/nixos/fetchurl.nix
@@ -1,0 +1,78 @@
+# Test whether builtin:fetchurl properly performs TLS certificate
+# checks on HTTPS servers.
+
+{ lib, config, pkgs, ... }:
+
+let
+
+  makeTlsCert = name: pkgs.runCommand name {
+    nativeBuildInputs = with pkgs; [ openssl ];
+  } ''
+    mkdir -p $out
+    openssl req -x509 \
+      -subj '/CN=${name}/' -days 49710 \
+      -addext 'subjectAltName = DNS:${name}' \
+      -keyout "$out/key.pem" -newkey ed25519 \
+      -out "$out/cert.pem" -noenc
+  '';
+
+  goodCert = makeTlsCert "good";
+  badCert = makeTlsCert "bad";
+
+in
+
+{
+  name = "nss-preload";
+
+  nodes = {
+    machine = { lib, pkgs, ... }: {
+      services.nginx = {
+        enable = true;
+
+        virtualHosts."good" = {
+          addSSL = true;
+          sslCertificate = "${goodCert}/cert.pem";
+          sslCertificateKey = "${goodCert}/key.pem";
+          root = pkgs.runCommand "nginx-root" {} ''
+            mkdir "$out"
+            echo 'hello world' > "$out/index.html"
+          '';
+        };
+
+        virtualHosts."bad" = {
+          addSSL = true;
+          sslCertificate = "${badCert}/cert.pem";
+          sslCertificateKey = "${badCert}/key.pem";
+          root = pkgs.runCommand "nginx-root" {} ''
+            mkdir "$out"
+            echo 'foobar' > "$out/index.html"
+          '';
+        };
+      };
+
+      security.pki.certificateFiles = [ "${goodCert}/cert.pem" ];
+
+      networking.hosts."127.0.0.1" = [ "good" "bad" ];
+
+      virtualisation.writableStore = true;
+
+      nix.settings.experimental-features = "nix-command";
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    machine.wait_for_unit("nginx")
+    machine.wait_for_open_port(443)
+
+    out = machine.succeed("curl https://good/index.html")
+    assert out == "hello world\n"
+
+    # Fetching from a server with a trusted cert should work.
+    machine.succeed("nix build --no-substitute --expr 'import <nix/fetchurl.nix> { url = \"https://good/index.html\"; hash = \"sha256-qUiQTy8PR5uPgZdpSzAYSw0u0cHNKh7A+4XSmaGSpEc=\"; }'")
+
+    # Fetching from a server with an untrusted cert should fail.
+    err = machine.fail("nix build --no-substitute --expr 'import <nix/fetchurl.nix> { url = \"https://bad/index.html\"; hash = \"sha256-rsBwZF/lPuOzdjBZN2E08FjMM3JHyXit0Xi2zN+wAZ8=\"; }' 2>&1")
+    print(err)
+    assert "SSL certificate problem: self-signed certificate" in err
+  '';
+}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Once upon a time we disabled this because we didn't have access to the certificates in the sandbox, and verification wasn't really needed because we're checking the hash of the download afterwards. But these days we do have access to certificates in the sandbox, and features like impure derivations make the second assumption no longer valid. So let's re-enable checking.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
