### PR TITLE
docs: specify that flake.lock files are JSON

### DIFF
--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -565,12 +565,13 @@ or NixOS modules, which are composed into the top-level flake's
 Inputs specified in `flake.nix` are typically "unlocked" in the sense
 that they don't specify an exact revision. To ensure reproducibility,
 Nix will automatically generate and use a *lock file* called
-`flake.lock` in the flake's directory. The lock file is a UTF-8 JSON
-file. It contains a graph structure isomorphic to the graph of
-dependencies of the root flake. Each node in the graph (except the
-root node) maps the (usually) unlocked input specifications in
-`flake.nix` to locked input specifications. Each node also contains
-some metadata, such as the dependencies (outgoing edges) of the node.
+`flake.lock` in the flake's directory.
+The lock file is a UTF-8 JSON file.
+It contains a graph structure isomorphic to the graph of dependencies of the root
+flake. Each node in the graph (except the root node) maps the
+(usually) unlocked input specifications in `flake.nix` to locked input
+specifications. Each node also contains some metadata, such as the
+dependencies (outgoing edges) of the node.
 
 For example, if `flake.nix` has the inputs in the example above, then
 the resulting lock file might be:

--- a/src/nix/flake.md
+++ b/src/nix/flake.md
@@ -565,12 +565,12 @@ or NixOS modules, which are composed into the top-level flake's
 Inputs specified in `flake.nix` are typically "unlocked" in the sense
 that they don't specify an exact revision. To ensure reproducibility,
 Nix will automatically generate and use a *lock file* called
-`flake.lock` in the flake's directory. The lock file contains a graph
-structure isomorphic to the graph of dependencies of the root
-flake. Each node in the graph (except the root node) maps the
-(usually) unlocked input specifications in `flake.nix` to locked input
-specifications. Each node also contains some metadata, such as the
-dependencies (outgoing edges) of the node.
+`flake.lock` in the flake's directory. The lock file is a UTF-8 JSON
+file. It contains a graph structure isomorphic to the graph of
+dependencies of the root flake. Each node in the graph (except the
+root node) maps the (usually) unlocked input specifications in
+`flake.nix` to locked input specifications. Each node also contains
+some metadata, such as the dependencies (outgoing edges) of the node.
 
 For example, if `flake.nix` has the inputs in the example above, then
 the resulting lock file might be:


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

To make it 100% clear that `flake.lock` files should be parsed as JSON. This is desirable for people who want to write code that process `flake.lock` files and want to make sure that their code parses them correctly.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Recently, I decided that I was going to write some code that would parse `flake.lock` files. I went to the Nix Reference Manual in order to look up information on the format of `flake.lock` files, and I realized that a key detail was missing from the Nix Reference Manual: it never says that `flake.lock` files are JSON files. This PR fixes that issue.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
