### PR TITLE
Fix reference to HTTP Binary Cache Store in docs

### DIFF
--- a/src/libstore/s3-binary-cache-store.md
+++ b/src/libstore/s3-binary-cache-store.md
@@ -3,7 +3,7 @@ R"(
 **Store URL format**: `s3://`*bucket-name*
 
 This store allows reading and writing a binary cache stored in an AWS S3 (or S3-compatible service) bucket.
-This store shares many idioms with the [HTTP Binary Cache Store](./http-binary-cache-store.md).
+This store shares many idioms with the [HTTP Binary Cache Store](@docroot@/store/types/http-binary-cache-store.md).
 
 For AWS S3, the binary cache URL for a bucket named `example-nix-cache` will be exactly <s3://example-nix-cache>.
 For S3 compatible binary caches, consult that cache's documentation.

--- a/src/libstore/s3-binary-cache-store.md
+++ b/src/libstore/s3-binary-cache-store.md
@@ -3,7 +3,7 @@ R"(
 **Store URL format**: `s3://`*bucket-name*
 
 This store allows reading and writing a binary cache stored in an AWS S3 (or S3-compatible service) bucket.
-This store shares many idioms with the [HTTP Binary Cache Store](#http-binary-cache-store).
+This store shares many idioms with the [HTTP Binary Cache Store](./http-binary-cache-store.md).
 
 For AWS S3, the binary cache URL for a bucket named `example-nix-cache` will be exactly <s3://example-nix-cache>.
 For S3 compatible binary caches, consult that cache's documentation.


### PR DESCRIPTION
# Motivation

The link to "HTTP Binary Cache Store" in https://nix.dev/manual/nix/2.22/store/types/s3-binary-cache-store is broken as it links to an anchor within the page rather than a separate page

https://nix.dev/manual/nix/2.22/store/types/s3-binary-cache-store#http-binary-cache-store

vs

https://nix.dev/manual/nix/2.22/store/types/http-binary-cache-store

# Context

This link was added in cd680bd53d90971211fa8926940bfe6d987ca6cf. I looked over the other links in the commit and they all seemed correct.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
