### PR TITLE
[WIP] also detect certificate bundles on opensuse

### DIFF
--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -238,7 +238,13 @@ bool Settings::isWSL1()
 
 Path Settings::getDefaultSSLCertFile()
 {
-    for (auto & fn : {"/etc/ssl/certs/ca-certificates.crt", "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"})
+    for (auto & fn : {
+        // NixOS, fedora, debian, ubuntu
+        "/etc/ssl/certs/ca-certificates.crt",
+        // openSUSE
+        "/var/lib/ca-certificates/ca-bundle.pem",
+        "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+    })
         if (pathAccessible(fn)) return fn;
     return "";
 }


### PR DESCRIPTION
Now that we require valid certificates in builtins:fetchurl, we also need to support standard locations for certificate authorities on various platforms.

I haven't validated yet, this works.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
