### PR TITLE
Fix NAR tests on Linux+ZFS+normalize

### DIFF
--- a/tests/functional/nars.sh
+++ b/tests/functional/nars.sh
@@ -103,9 +103,10 @@ rm -rf "$TEST_ROOT/out"
 set +e
 unicodeTestOut=$(nix-store --restore "$TEST_ROOT/out" < unnormalized.nar 2>&1)
 unicodeTestCode=$?
-touch "$TEST_ROOT/unicode-â"
-touch "$TEST_ROOT/unicode-â"
 set -e
+
+touch "$TEST_ROOT/unicode-â" # non-canonical version
+touch "$TEST_ROOT/unicode-â"
 
 touchFilesCount=$(find "$TEST_ROOT" -maxdepth 1 -name "unicode-*" -type f | wc -l)
 


### PR DESCRIPTION
Closes #11595.

## Motivation & context

A test added recently checks that when trying to deserialize a NAR with two files that Unicode-normalize to the same result either succeeds on Linux, or fails with an "already exists" error on Darwin. However, failing with an "already exists" error can in fact also happen on Linux, when using ZFS with the proper utf8 and Unicode normalization options set.

This commit fixes the issue by not assuming the behavior from the current system, but just by blindly checking that either one of the two aforementioned possibilities happen, whether on Darwin or on Linux.

This has been tested on a Linux+ZFS+normalize runner here: https://github.com/tweag/nickel/actions/runs/11073351502/job/30769680803?pr=2037

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
