### PR TITLE
doc, src: Fix various spelling typos

### DIFF
--- a/doc/manual/src/command-ref/nix-store/query.md
+++ b/doc/manual/src/command-ref/nix-store/query.md
@@ -104,7 +104,7 @@ symlink.
 
   Prints a set of derivation files (`.drv`) which are supposed produce
   said paths when realized. Might print nothing, for example for source paths
-  or paths subsituted from a binary cache.
+  or paths substituted from a binary cache.
 
 - `--graph`
 
@@ -241,4 +241,3 @@ $ nix-store --query --roots $(which svn)
 /nix/var/nix/profiles/default-82-link
 /home/eelco/.local/state/nix/profiles/profile-97-link
 ```
-

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -86,7 +86,7 @@ static RegisterPrimOp primop_unsafeDiscardOutputDependency({
 
       This is the opposite of [`builtins.addDrvOutputDependencies`](#builtins-addDrvOutputDependencies).
 
-      This is unsafe because it allows us to "forget" store objects we would have otherwise refered to with the string context,
+      This is unsafe because it allows us to "forget" store objects we would have otherwise referred to with the string context,
       whereas Nix normally tracks all dependencies consistently.
       Safe operations "grow" but never "shrink" string contexts.
       [`builtins.addDrvOutputDependencies`] in contrast is safe because "derivation deep" string context element always refers to the underlying derivation (among many more things).

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -246,7 +246,7 @@ static RegisterPrimOp primop_fetchTree({
       The following source types and associated input attributes are supported.
 
       <!-- TODO: It would be soooo much more predictable to work with (and
-      document) if `fetchTree` was a curried call with the first paramter for
+      document) if `fetchTree` was a curried call with the first parameter for
       `type` or an attribute like `builtins.fetchTree.git`! -->
 
       - `"file"`

--- a/src/libstore/builtins/unpack-channel.cc
+++ b/src/libstore/builtins/unpack-channel.cc
@@ -20,7 +20,7 @@ void builtinUnpackChannel(
     auto & src = getAttr("src");
 
     if (fs::path{channelName}.filename().string() != channelName) {
-        throw Error("channelName is not allowed to contain filesystem seperators, got %1%", channelName);
+        throw Error("channelName is not allowed to contain filesystem separators, got %1%", channelName);
     }
 
     try {

--- a/src/libstore/local-overlay-store.md
+++ b/src/libstore/local-overlay-store.md
@@ -4,7 +4,7 @@ R"(
 
 This store type is a variation of the [local store] designed to leverage Linux's [Overlay Filesystem](https://docs.kernel.org/filesystems/overlayfs.html) (OverlayFS for short).
 Just as OverlayFS combines a lower and upper filesystem by treating the upper one as a patch against the lower, the local overlay store combines a lower store with an upper almost-[local store].
-("almost" because while the upper fileystems for OverlayFS is valid on its own, the upper almost-store is not a valid local store on its own because some references will dangle.)
+("almost" because while the upper filesystems for OverlayFS is valid on its own, the upper almost-store is not a valid local store on its own because some references will dangle.)
 To use this store, you will first need to configure an OverlayFS mountpoint [appropriately](#example-filesystem-layout) as Nix will not do this for you (though it will verify the mountpoint is configured correctly).
 
 ### Conceptual parts of a local overlay store

--- a/src/libstore/local.mk
+++ b/src/libstore/local.mk
@@ -59,7 +59,7 @@ NIX_ROOT =
 endif
 
 # Prefix all but `NIX_STORE_DIR`, since we aren't doing a local store
-# yet so a "logical" store dir that is the same as unix is prefered.
+# yet so a "logical" store dir that is the same as unix is preferred.
 #
 # Also, it keeps the unit tests working.
 

--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -302,7 +302,7 @@ or with an **expression**:
 terraform "$@"
 ```
 
-or with cascading interpreters. Note that the `#! nix` lines don't need to follow after the first line, to accomodate other interpreters.
+or with cascading interpreters. Note that the `#! nix` lines don't need to follow after the first line, to accommodate other interpreters.
 
 ```
 #!/usr/bin/env nix


### PR DESCRIPTION
# Motivation
To fix various spelling issues flagged by the debian lintian tool.
