### PR TITLE
nix-ng: add meta.mainProgram

### DIFF
--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -39,7 +39,7 @@
   nix-perl-bindings,
 }:
 
-(buildEnv rec {
+(buildEnv {
   name = "nix-${nix-cli.version}";
   paths = [
     nix-util
@@ -76,6 +76,8 @@
   ] ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     nix-perl-bindings
   ];
+
+  meta.mainProgram = "nix";
 }).overrideAttrs (finalAttrs: prevAttrs: {
   doCheck = true;
   doInstallCheck = true;


### PR DESCRIPTION
I've been using `packages.<system>.default` and the switch over to "`nix-ng`" 
started spitting the `meta.mainProgram` warning

also removed a dead code `rec` which my LSP was complaining about