### PR TITLE
fix: include missing header when GC is disabled

### DIFF
--- a/src/libexpr/eval-gc.hh
+++ b/src/libexpr/eval-gc.hh
@@ -13,6 +13,8 @@
 
 #else
 
+#  include <memory>
+
 /* Some dummy aliases for Boehm GC definitions to reduce the number of
    #ifdefs. */
 


### PR DESCRIPTION
# Context
When the GC is disabled, then `std::allocator` from `<memory>` is explicitly used as allocator, but the header is not included, and compilation fails.
Tested in dev-shell with `configure --disable-gc`.