### PR TITLE
eval: remove superfluous strdup

### DIFF
--- a/src/libexpr/eval-gc.hh
+++ b/src/libexpr/eval-gc.hh
@@ -23,7 +23,6 @@ template<typename T>
 using gc_allocator = std::allocator<T>;
 
 #  define GC_MALLOC_ATOMIC std::malloc
-#  define GC_STRDUP strdup
 
 struct gc
 {};

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -53,15 +53,6 @@ static char * allocString(size_t size)
 }
 
 
-static char * dupString(const char * s)
-{
-    char * t;
-    t = GC_STRDUP(s);
-    if (!t) throw std::bad_alloc();
-    return t;
-}
-
-
 // When there's no need to write to the string, we can optimize away empty
 // string allocations.
 // This function handles makeImmutableString(std::string_view()) by returning
@@ -832,9 +823,10 @@ static const char * * encodeContext(const NixStringContext & context)
         size_t n = 0;
         auto ctx = (const char * *)
             allocBytes((context.size() + 1) * sizeof(char *));
-        for (auto & i : context)
-            ctx[n++] = dupString(i.to_string().c_str());
-        ctx[n] = 0;
+        for (auto & i : context) {
+            ctx[n++] = makeImmutableString({i.to_string()});
+        }
+        ctx[n] = nullptr;
         return ctx;
     } else
         return nullptr;


### PR DESCRIPTION
# Motivation
Remove the call of the `dupString()` function and replace it by `makeImmutableString()` because the string length of a `std::string` is known. This saves an implicit call of `strlen()` and enables code de-duplication.