### PR TITLE
Improve documentation of `nix flake lock`

### DIFF
--- a/src/nix/flake-lock.md
+++ b/src/nix/flake-lock.md
@@ -30,9 +30,9 @@ R""(
 
 # Description
 
-This command adds inputs to the lock file of a flake (`flake.lock`)
-so that it contains a lock for every flake input specified in
-`flake.nix`. Existing lock file entries are not updated.
+This command updates the lock file of a flake (`flake.lock`)
+so that it contains an up-to-date lock for every flake input specified in
+`flake.nix`. Lock file entries are aready up-to-date are not modified.
 
 If you want to update existing lock entries, use
 [`nix flake update`](@docroot@/command-ref/new-cli/nix3-flake-update.md)


### PR DESCRIPTION
The previous documentation was inaccurate, stating that it would not update existing inputs. However these inputs will be updated if they are outdated (for example the version of an existing input has been changed). The new text properly reflects this behaviour.