### PR TITLE
doc: don't use bash substitution in install command

### DIFF
--- a/doc/manual/src/installation/index.md
+++ b/doc/manual/src/installation/index.md
@@ -23,7 +23,7 @@ This option requires either:
 > when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
 
 ```console
-$ bash <(curl -L https://nixos.org/nix/install) --daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
 
 ## Single-user
@@ -36,7 +36,7 @@ cannot offer equivalent sharing, isolation, or security.
 This option is suitable for systems without systemd.
 
 ```console
-$ bash <(curl -L https://nixos.org/nix/install) --no-daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
 ```
 
 ## Distributions


### PR DESCRIPTION
apparently we forgot one of the too many places with installation instructions: https://github.com/NixOS/nix.dev/issues/424

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).