### PR TITLE
doc/manual: Add 'Debugging Nix' section

### DIFF
--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -121,6 +121,7 @@
 - [Development](development/index.md)
   - [Building](development/building.md)
   - [Testing](development/testing.md)
+  - [Debugging](development/debugging.md)
   - [Documentation](development/documentation.md)
   - [CLI guideline](development/cli-guideline.md)
   - [JSON guideline](development/json-guideline.md)

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -1,0 +1,61 @@
+# Debugging Nix
+
+This section provides instructions on how to build and debug Nix with debug
+symbols enabled. It assumes you are using Nix with the [`flakes`] and
+[`nix-command`] experimental features enabled.
+
+[`flakes`]: @docroot@/development/experimental-features.md#xp-feature-flakes
+[`nix-command`]: @docroot@/development/experimental-features.md#xp-nix-command
+
+## Building Nix with Debug Symbols
+
+First, ensure you have set up the development environment as described in the
+[building documentation](./building.md).
+
+In the development shell, set the `mesonBuildType` environment variable to
+`debug` before configuring the build:
+
+```console
+[nix-shell]$ export mesonBuildType=debug
+```
+
+Then, configure and build Nix:
+
+```console
+[nix-shell]$ mesonConfigurePhase
+[nix-shell]$ ninjaBuildPhase
+```
+
+This will build Nix with debug symbols, which are essential for effective
+debugging.
+
+## Debugging the Nix Binary
+
+### Installing a Debugger
+
+Install your preferred debugger within the development shell. For example, to
+install `lldb`:
+
+```console
+[nix-shell]$ nix shell nixpkgs#lldb
+```
+
+### Launching the Debugger
+
+To debug the Nix binary you just built:
+
+```console
+[nix-shell]$ lldb -- ./subprojects/nix/nix
+```
+
+### Using the Debugger
+
+Inside `lldb`, you can set breakpoints, run the program, and inspect variables:
+
+```lldb
+(lldb) breakpoint set --name main
+(lldb) process launch -- <arguments>
+```
+
+Refer to the [LLDB Tutorial](https://lldb.llvm.org/use/tutorial.html) for
+comprehensive usage instructions.

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -1,61 +1,41 @@
 # Debugging Nix
 
-This section provides instructions on how to build and debug Nix with debug
-symbols enabled.
-It assumes you are using Nix with the [`flakes`] and [`nix-command`]
-experimental features enabled.
-
-[`flakes`]: @docroot@/development/experimental-features.md#xp-feature-flakes
-[`nix-command`]: @docroot@/development/experimental-features.md#xp-nix-command
+This section shows how to build and debug Nix with debug symbols enabled.
 
 ## Building Nix with Debug Symbols
 
-First, ensure you have set up the development environment as described in the
-[building documentation](./building.md).
-
-In the development shell, set the `mesonBuildType` environment variable to
-`debug` before configuring the build:
+In the development shell, set the `mesonBuildType` environment variable to `debug` before configuring the build:
 
 ```console
 [nix-shell]$ export mesonBuildType=debugoptimized
 ```
 
-Then, configure and build Nix:
-
-```console
-[nix-shell]$ mesonConfigurePhase
-[nix-shell]$ ninjaInstallPhase
-```
-
-This will build Nix with debug symbols, which are essential for effective
-debugging.
+Then, proceed to build Nix as described in [Building Nix](./building.md).
+This will build Nix with debug symbols, which are essential for effective debugging.
 
 ## Debugging the Nix Binary
 
-### Installing a Debugger
-
-Install your preferred debugger within the development shell.
+Obtain your preferred debugger within the development shell:
 
 ```console
-[nix-shell]$ nix shell nixpkgs#gdb
+[nix-shell]$ nix-shell -p gdb
 ```
 
-For macOS systems, use `lldb`:
+On macOS, use `lldb`:
 
 ```console
-[nix-shell]$ nix shell nixpkgs#lldb
+[nix-shell]$ nix-shell -p lldb
 ```
 
 ### Launching the Debugger
 
-To debug the Nix binary you just run:
+To debug the Nix binary, run:
 
 ```console
 [nix-shell]$ gdb --args ../outputs/out/bin/nix
-
 ```
 
-#### On macOS:
+On macOS, use `lldb`:
 
 ```console
 [nix-shell]$ lldb -- ../outputs/out/bin/nix
@@ -70,15 +50,13 @@ Inside the debugger, you can set breakpoints, run the program, and inspect varia
 (gdb) run <arguments>
 ```
 
-Refer to the [GDB Documentation](https://www.gnu.org/software/gdb/documentation/) for
-comprehensive usage instructions.
+Refer to the [GDB Documentation](https://www.gnu.org/software/gdb/documentation/) for comprehensive usage instructions.
 
-#### Using LLDB (macOS):
+On macOS, use `lldb`:
 
 ```lldb
 (lldb) breakpoint set --name main
 (lldb) process launch -- <arguments>
 ```
 
-Refer to the [LLDB Tutorial](https://lldb.llvm.org/use/tutorial.html) for
-comprehensive usage instructions.
+Refer to the [LLDB Tutorial](https://lldb.llvm.org/use/tutorial.html) for comprehensive usage instructions.

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -16,7 +16,7 @@ In the development shell, set the `mesonBuildType` environment variable to
 `debug` before configuring the build:
 
 ```console
-[nix-shell]$ export mesonBuildType=debug
+[nix-shell]$ export mesonBuildType=debugoptimized
 ```
 
 Then, configure and build Nix:

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -23,7 +23,7 @@ Then, configure and build Nix:
 
 ```console
 [nix-shell]$ mesonConfigurePhase
-[nix-shell]$ ninjaBuildPhase
+[nix-shell]$ ninjaInstallPhase
 ```
 
 This will build Nix with debug symbols, which are essential for effective

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -1,8 +1,9 @@
 # Debugging Nix
 
 This section provides instructions on how to build and debug Nix with debug
-symbols enabled. It assumes you are using Nix with the [`flakes`] and
-[`nix-command`] experimental features enabled.
+symbols enabled.
+It assumes you are using Nix with the [`flakes`] and [`nix-command`]
+experimental features enabled.
 
 [`flakes`]: @docroot@/development/experimental-features.md#xp-feature-flakes
 [`nix-command`]: @docroot@/development/experimental-features.md#xp-nix-command

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -34,8 +34,13 @@ debugging.
 
 ### Installing a Debugger
 
-Install your preferred debugger within the development shell. For example, to
-install `lldb`:
+Install your preferred debugger within the development shell.
+
+```console
+[nix-shell]$ nix shell nixpkgs#gdb
+```
+
+For macOS systems, use `lldb`:
 
 ```console
 [nix-shell]$ nix shell nixpkgs#lldb
@@ -43,7 +48,13 @@ install `lldb`:
 
 ### Launching the Debugger
 
-To debug the Nix binary you just built:
+To debug the Nix binary you just run:
+
+```console
+[nix-shell]$ gdb --args ./subprojects/nix/nix
+```
+
+#### On macOS:
 
 ```console
 [nix-shell]$ lldb -- ./subprojects/nix/nix
@@ -51,7 +62,17 @@ To debug the Nix binary you just built:
 
 ### Using the Debugger
 
-Inside `lldb`, you can set breakpoints, run the program, and inspect variables:
+Inside the debugger, you can set breakpoints, run the program, and inspect variables.
+
+```gdb
+(gdb) break main
+(gdb) run <arguments>
+```
+
+Refer to the [GDB Documentation](https://www.gnu.org/software/gdb/documentation/) for
+comprehensive usage instructions.
+
+#### Using LLDB (macOS):
 
 ```lldb
 (lldb) breakpoint set --name main

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -51,13 +51,14 @@ For macOS systems, use `lldb`:
 To debug the Nix binary you just run:
 
 ```console
-[nix-shell]$ gdb --args ./subprojects/nix/nix
+[nix-shell]$ gdb --args ../outputs/out/bin/nix
+
 ```
 
 #### On macOS:
 
 ```console
-[nix-shell]$ lldb -- ./subprojects/nix/nix
+[nix-shell]$ lldb -- ../outputs/out/bin/nix
 ```
 
 ### Using the Debugger


### PR DESCRIPTION
This PR adds a new 'Debugging Nix' section to the Nix manual. It provides instructions on how to build Nix with debug symbols and how to debug the Nix binary using debuggers like `lldb`.



# Motivation

Currently, it's hard to get started with launching a debuggable instance of Nix. Building Nix with debug symbols requires knowledge of internal environment variables like mesonBuildType, which are not well-documented. 

# Context

Please see #11502.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
