### PR TITLE
experimental-features.hh: Don't include json-utils.hh

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -11,6 +11,8 @@
 #include "value-to-json.hh"
 #include "fetch-to-store.hh"
 
+#include <nlohmann/json.hpp>
+
 #include <ctime>
 #include <iomanip>
 #include <regex>

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -13,8 +13,8 @@
 #include "git-utils.hh"
 #include "logging.hh"
 #include "finally.hh"
-
 #include "fetch-settings.hh"
+#include "json-utils.hh"
 
 #include <regex>
 #include <string.h>

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -13,6 +13,8 @@
 #include "value-to-json.hh"
 #include "local-fs-store.hh"
 
+#include <nlohmann/json.hpp>
+
 namespace nix {
 
 using namespace flake;

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -7,10 +7,11 @@
 #include "split.hh"
 #include "common-protocol.hh"
 #include "common-protocol-impl.hh"
+#include "strings-inline.hh"
+#include "json-utils.hh"
+
 #include <boost/container/small_vector.hpp>
 #include <nlohmann/json.hpp>
-
-#include "strings-inline.hh"
 
 namespace nix {
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -50,6 +50,8 @@
 
 #include <sqlite3.h>
 
+#include <nlohmann/json.hpp>
+
 #include "strings.hh"
 
 

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -2,6 +2,7 @@
 #include "nar-info.hh"
 #include "store-api.hh"
 #include "strings.hh"
+#include "json-utils.hh"
 
 namespace nix {
 

--- a/src/libutil/config-global.cc
+++ b/src/libutil/config-global.cc
@@ -1,5 +1,7 @@
 #include "config-global.hh"
 
+#include <nlohmann/json.hpp>
+
 namespace nix {
 
 bool GlobalConfig::set(const std::string & name, const std::string & value)

--- a/src/libutil/experimental-features.hh
+++ b/src/libutil/experimental-features.hh
@@ -2,8 +2,9 @@
 ///@file
 
 #include "error.hh"
-#include "json-utils.hh"
 #include "types.hh"
+
+#include <nlohmann/json_fwd.hpp>
 
 namespace nix {
 
@@ -97,11 +98,5 @@ public:
  */
 void to_json(nlohmann::json &, const ExperimentalFeature &);
 void from_json(const nlohmann::json &, ExperimentalFeature &);
-
-/**
- * It is always rendered as a string
- */
-template<>
-struct json_avoids_null<ExperimentalFeature> : std::true_type {};
 
 }

--- a/src/libutil/json-utils.hh
+++ b/src/libutil/json-utils.hh
@@ -3,11 +3,12 @@
 
 #include <nlohmann/json.hpp>
 #include <list>
-#include <nlohmann/json_fwd.hpp>
 
 #include "types.hh"
 
 namespace nix {
+
+enum struct ExperimentalFeature;
 
 const nlohmann::json * get(const nlohmann::json & map, const std::string & key);
 
@@ -70,6 +71,12 @@ struct json_avoids_null<std::list<T>> : std::true_type {};
 
 template<typename K, typename V>
 struct json_avoids_null<std::map<K, V>> : std::true_type {};
+
+/**
+ * `ExperimentalFeature` is always rendered as a string.
+ */
+template<>
+struct json_avoids_null<ExperimentalFeature> : std::true_type {};
 
 }
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -19,6 +19,7 @@
 #include "eval-cache.hh"
 #include "flake/flake.hh"
 #include "self-exe.hh"
+#include "json-utils.hh"
 
 #include <sys/types.h>
 #include <regex>

--- a/tests/unit/libstore/derivation-advanced-attrs.cc
+++ b/tests/unit/libstore/derivation-advanced-attrs.cc
@@ -1,4 +1,3 @@
-#include <nlohmann/json.hpp>
 #include <gtest/gtest.h>
 #include <optional>
 
@@ -9,6 +8,7 @@
 #include "tests/characterization.hh"
 #include "parsed-derivations.hh"
 #include "types.hh"
+#include "json-utils.hh"
 
 namespace nix {
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
This caused nlohmann/json.hpp to leak into a lot of compilation units, which is slow (when not using precompiled headers).

Cuts build time from 46m24s to 42m5s (real time with -j24: 2m42s to 2m24s).

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
