### PR TITLE
Slightly more `std::filesystem` for `nix eval`

### DIFF
--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -11,11 +11,13 @@
 
 using namespace nix;
 
+namespace nix::fs { using namespace std::filesystem; }
+
 struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 {
     bool raw = false;
     std::optional<std::string> apply;
-    std::optional<Path> writeTo;
+    std::optional<fs::path> writeTo;
 
     CmdEval() : InstallableValueCommand()
     {
@@ -75,20 +77,20 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
         if (writeTo) {
             stopProgressBar();
 
-            if (pathExists(*writeTo))
-                throw Error("path '%s' already exists", *writeTo);
+            if (fs::symlink_exists(*writeTo))
+                throw Error("path '%s' already exists", writeTo->string());
 
-            std::function<void(Value & v, const PosIdx pos, const std::filesystem::path & path)> recurse;
+            std::function<void(Value & v, const PosIdx pos, const fs::path & path)> recurse;
 
-            recurse = [&](Value & v, const PosIdx pos, const std::filesystem::path & path)
+            recurse = [&](Value & v, const PosIdx pos, const fs::path & path)
             {
                 state->forceValue(v, pos);
                 if (v.type() == nString)
                     // FIXME: disallow strings with contexts?
                     writeFile(path.string(), v.string_view());
                 else if (v.type() == nAttrs) {
-                    // TODO abstract mkdir perms for Windows
-                    createDir(path.string(), 0777);
+                    // Directory should not already exist
+                    assert(fs::create_directory(path.string()));
                     for (auto & attr : *v.attrs()) {
                         std::string_view name = state->symbols[attr.name];
                         try {


### PR DESCRIPTION
# Context

Progress on #9205 

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
