### PR TITLE
Add `shortName` for `quiet` flag

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -118,6 +118,14 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
         });
 
         addFlag({
+            .longName = "quiet",
+            .shortName = 'q',
+            .description = "Decrease the logging verbosity level.",
+            .category = loggingCategory,
+            .handler = {[]() { verbosity = verbosity > lvlError ? (Verbosity) (verbosity - 1) : lvlError; }},
+        });
+
+        addFlag({
             .longName = "print-build-logs",
             .shortName = 'L',
             .description = "Print full build logs on standard error.",


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
This PR adds `q` as a `shortName` for the `quiet` flag for `nix`
command, overriding https://github.com/NixOS/nix/blob/26c3fc11eada3fa7df0284190095868a947fefe2/src/libmain/common-args.cc#L23-L28.
Since this flag can be repeated, it simplifies usage by allowing `nix
-qq ...` instead of `nix --quiet --quiet ...`.


<!-- Briefly explain what the change is about and why it is desirable. —>



<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
