### PR TITLE
Fix `Interrupted` falling out of thread crash

### DIFF
--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -65,6 +65,7 @@
 #include <iostream>
 
 #include "strings.hh"
+#include "signals.hh"
 
 namespace nix {
 
@@ -1579,6 +1580,8 @@ void LocalDerivationGoal::startDaemon()
                         FdSink(remote.get()),
                         NotTrusted, daemon::Recursive);
                     debug("terminated daemon connection");
+                } catch (const Interrupted &) {
+                    debug("interrupted daemon connection");
                 } catch (SystemError &) {
                     ignoreExceptionExceptInterrupt();
                 }

--- a/src/libstore/unix/build/local-derivation-goal.hh
+++ b/src/libstore/unix/build/local-derivation-goal.hh
@@ -225,8 +225,15 @@ struct LocalDerivationGoal : public DerivationGoal
      */
     void writeStructuredAttrs();
 
+    /**
+     * Start an in-process nix daemon thread for recursive-nix.
+     */
     void startDaemon();
 
+    /**
+     * Stop the in-process nix daemon thread.
+     * @see startDaemon
+     */
     void stopDaemon();
 
     /**

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -110,6 +110,11 @@ void ThreadPool::doWork(bool mainThread)
                            propagate it. */
                         try {
                             std::rethrow_exception(exc);
+                        } catch (const Interrupted &) {
+                            // The interrupted state may be picked up multiple
+                            // workers, which is expected, so we should ignore
+                            // it silently and let the first one bubble up,
+                            // rethrown via the original state->exception.
                         } catch (std::exception & e) {
                             if (!dynamic_cast<ThreadPoolShutDown*>(&e))
                                 ignoreExceptionExceptInterrupt();

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -119,7 +119,6 @@ void ThreadPool::doWork(bool mainThread)
                             // Similarly expected.
                         } catch (std::exception & e) {
                             ignoreExceptionExceptInterrupt();
-                        } catch (...) {
                         }
                     }
                 }

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -111,7 +111,7 @@ void ThreadPool::doWork(bool mainThread)
                         try {
                             std::rethrow_exception(exc);
                         } catch (const Interrupted &) {
-                            // The interrupted state may be picked up multiple
+                            // The interrupted state may be picked up by multiple
                             // workers, which is expected, so we should ignore
                             // it silently and let the first one bubble up,
                             // rethrown via the original state->exception.

--- a/src/libutil/thread-pool.cc
+++ b/src/libutil/thread-pool.cc
@@ -115,9 +115,10 @@ void ThreadPool::doWork(bool mainThread)
                             // workers, which is expected, so we should ignore
                             // it silently and let the first one bubble up,
                             // rethrown via the original state->exception.
+                        } catch (const ThreadPoolShutDown &) {
+                            // Similarly expected.
                         } catch (std::exception & e) {
-                            if (!dynamic_cast<ThreadPoolShutDown*>(&e))
-                                ignoreExceptionExceptInterrupt();
+                            ignoreExceptionExceptInterrupt();
                         } catch (...) {
                         }
                     }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

- Fix a problem with #11618
- Add implicit `checkInterrupt` calls to these loops to pick up on shutdowns sooner

# Context

What I missed is that threads will crash the process if they end in an uncaught exception.
Thank you @lf- for pinging me about this bug!

This does not need a backport unless 2.25 is released first somehow.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
