### PR TITLE
Support fine-grained database schema migrations

### DIFF
--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -356,6 +356,8 @@ private:
 
     void openDB(State & state, bool create);
 
+    void upgradeDBSchema(State & state);
+
     void makeStoreWritable();
 
     uint64_t queryValidPathId(State & state, const StorePath & path);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Backward-compatible schema changes (e.g. those that add tables or nullable columns) now no longer need a change to the global schema file (`/nix/var/nix/db/schema`). Thus, old Nix versions can continue to access the database.

This is especially useful for schema changes required by experimental features. In particular, it replaces the ad-hoc handling of the schema changes for CA derivations (i.e. the file `/nix/var/nix/db/ca-schema`).

Schema versions 8 and 10 could have been handled by this mechanism in a backward-compatible way as well.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
