### PR TITLE
Fix deprecated example from distributed-builds.md

### DIFF
--- a/doc/manual/src/advanced-topics/distributed-builds.md
+++ b/doc/manual/src/advanced-topics/distributed-builds.md
@@ -12,14 +12,14 @@ machine is accessible via SSH and that it has Nix installed. You can
 test whether connecting to the remote Nix instance works, e.g.
 
 ```console
-$ nix store ping --store ssh://mac
+$ nix store info --store ssh://mac
 ```
 
 will try to connect to the machine named `mac`. It is possible to
 specify an SSH identity file as part of the remote store URI, e.g.
 
 ```console
-$ nix store ping --store ssh://mac?ssh-key=/home/alice/my-key
+$ nix store info --store ssh://mac?ssh-key=/home/alice/my-key
 ```
 
 Since builds should be non-interactive, the key should not have a


### PR DESCRIPTION
Fixes deprecation warning from nix build:

```
warning: 'nix store ping' is a deprecated alias for 'nix store info'
```

# Motivation
I was browsing the docs and found this page https://nix.dev/manual/nix/2.24/advanced-topics/distributed-builds and tried the included command and noticed the deprecation warning:
```
$ nix store ping --store ssh://utm-vm-nixos-builder.local
...
warning: 'nix store ping' is a deprecated alias for 'nix store info'
...
```