### PR TITLE
libstore: Make our sandbox pivot_root directory accessible to ourself

### DIFF
--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -2008,7 +2008,7 @@ void LocalDerivationGoal::runChild()
             if (chdir(chrootRootDir.c_str()) == -1)
                 throw SysError("cannot change directory to '%1%'", chrootRootDir);
 
-            if (mkdir("real-root", 0) == -1)
+            if (mkdir("real-root", 0500) == -1)
                 throw SysError("cannot create real-root directory");
 
             if (pivot_root(".", "real-root") == -1)


### PR DESCRIPTION
If you have the Nix store mounted from a nonlocal filesystem whose exporter is not running as root, making the directory mode 000 makes it inaccessible to that remote unprivileged user and therefore breaks the build. (Specifically, I am running into this with a virtiofs mount using Apple Virtualization.framework as a non-root user, but I expect the same thing would happen with virtiofs in qemu on Linux as a non-root user or with various userspace network file servers.)

Make the directory mode 500 (dr-x------) to make the sandbox work in this use case, which explicitly conveys our intention to read and search the directory.  The code only works because root can already bypass directory checks, so this does not actually grant more permissions to the directory owner / does not make the sandbox less secure.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
