### PR TITLE
Backport #11610 to 2.20 maintenance

### DIFF
--- a/src/libstore/build/local-derivation-goal.cc
+++ b/src/libstore/build/local-derivation-goal.cc
@@ -1847,11 +1847,18 @@ void LocalDerivationGoal::runChild()
                     if (pathExists(path))
                         ss.push_back(path);
 
-                if (settings.caFile != "")
-                    pathsInChroot.try_emplace("/etc/ssl/certs/ca-certificates.crt", settings.caFile, true);
+                if (settings.caFile != "" && pathExists(settings.caFile)) {
+                    Path caFile = settings.caFile;
+                    pathsInChroot.try_emplace("/etc/ssl/certs/ca-certificates.crt", canonPath(caFile, true), true);
+                }
             }
 
-            for (auto & i : ss) pathsInChroot.emplace(i, i);
+            for (auto & i : ss) {
+                // For backwards-compatibiliy, resolve all the symlinks in the
+                // chroot paths
+                auto canonicalPath = canonPath(i, true);
+                pathsInChroot.emplace(i, canonicalPath);
+            }
 
             /* Bind-mount all the directories from the "host"
                filesystem that we want in the chroot

--- a/src/libstore/builtins.hh
+++ b/src/libstore/builtins.hh
@@ -6,7 +6,9 @@
 namespace nix {
 
 // TODO: make pluggable.
-void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData);
+void builtinFetchurl(const BasicDerivation & drv,
+    const std::string & netrcData,
+    const std::string & caFileData);
 void builtinUnpackChannel(const BasicDerivation & drv);
 
 }

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -6,7 +6,10 @@
 
 namespace nix {
 
-void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
+void builtinFetchurl(
+    const BasicDerivation & drv,
+    const std::string & netrcData,
+    const std::string & caFileData)
 {
     /* Make the host's netrc data available. Too bad curl requires
        this to be stored in a file. It would be nice if we could just
@@ -15,6 +18,9 @@ void builtinFetchurl(const BasicDerivation & drv, const std::string & netrcData)
         settings.netrcFile = "netrc";
         writeFile(settings.netrcFile, netrcData, 0600);
     }
+
+    settings.caFile = "ca-certificates.crt";
+    writeFile(settings.caFile, caFileData, 0600);
 
     auto out = get(drv.outputs, "out");
     if (!out)

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -50,6 +50,8 @@ struct curlFileTransfer : public FileTransfer
         bool done = false; // whether either the success or failure function has been called
         Callback<FileTransferResult> callback;
         CURL * req = 0;
+        // buffer to accompany the `req` above
+        char errbuf[CURL_ERROR_SIZE];
         bool active = false; // whether the handle has been added to the multi object
         std::string statusMsg;
 
@@ -352,6 +354,9 @@ struct curlFileTransfer : public FileTransfer
             if (writtenToSink)
                 curl_easy_setopt(req, CURLOPT_RESUME_FROM_LARGE, writtenToSink);
 
+            curl_easy_setopt(req, CURLOPT_ERRORBUFFER, errbuf);
+            errbuf[0] = 0;
+
             result.data.clear();
             result.bodySize = 0;
         }
@@ -465,8 +470,8 @@ struct curlFileTransfer : public FileTransfer
                         code == CURLE_OK ? "" : fmt(" (curl error: %s)", curl_easy_strerror(code)))
                     : FileTransferError(err,
                         std::move(response),
-                        "unable to %s '%s': %s (%d)",
-                        request.verb(), request.uri, curl_easy_strerror(code), code);
+                        "unable to %s '%s': %s (%d) %s",
+                        request.verb(), request.uri, curl_easy_strerror(code), code, errbuf);
 
                 /* If this is a transient error, then maybe retry the
                    download after a while. If we're writing to a

--- a/tests/functional/linux-sandbox.sh
+++ b/tests/functional/linux-sandbox.sh
@@ -61,9 +61,11 @@ testCert () {
 nocert=$TEST_ROOT/no-cert-file.pem
 cert=$TEST_ROOT/some-cert-file.pem
 symlinkcert=$TEST_ROOT/symlink-cert-file.pem
+transitivesymlinkcert=$TEST_ROOT/transitive-symlink-cert-file.pem
 symlinkDir=$TEST_ROOT/symlink-dir
 echo -n "CERT_CONTENT" > $cert
 ln -s $cert $symlinkcert
+ln -s $symlinkcert $transitivesymlinkcert
 ln -s $TEST_ROOT $symlinkDir
 
 # No cert in sandbox when not a fixed-output derivation
@@ -78,8 +80,9 @@ testCert missing fixed-output "$nocert"
 # Cert in sandbox when ssl-cert-file is set to an existing file
 testCert present fixed-output "$cert"
 
-# Cert in sandbox when ssl-cert-file is set to a symlink to an existing file
+# Cert in sandbox when ssl-cert-file is set to a (potentially transitive) symlink to an existing file
 testCert present fixed-output "$symlinkcert"
+testCert present fixed-output "$transitivesymlinkcert"
 
 # Symlinks should be added in the sandbox directly and not followed
 nix-sandbox-build symlink-derivation.nix -A depends_on_symlink

--- a/tests/functional/symlink-derivation.nix
+++ b/tests/functional/symlink-derivation.nix
@@ -15,22 +15,45 @@ let
     '';
   };
 in
-mkDerivation {
-  name = "depends-on-symlink";
-  buildCommand = ''
-    (
-      set -x
+{
+  depends_on_symlink = mkDerivation {
+    name = "depends-on-symlink";
+    buildCommand = ''
+      (
+        set -x
 
-      # `foo_symlink` should be a symlink pointing to `foo_in_store`
-      [[ -L ${foo_symlink} ]]
-      [[ $(readlink ${foo_symlink}) == ${foo_in_store} ]]
+        # `foo_symlink` should be a symlink pointing to `foo_in_store`
+        [[ -L ${foo_symlink} ]]
+        [[ $(readlink ${foo_symlink}) == ${foo_in_store} ]]
 
-      # `symlink_to_not_in_store` should be a symlink pointing to `./.`, which
-      # is not available in the sandbox
-      [[ -L ${symlink_to_not_in_store} ]]
-      [[ $(readlink ${symlink_to_not_in_store}) == ${builtins.toString ./.} ]]
-      (! ls ${symlink_to_not_in_store}/)
-    )
-    echo "Success!" > $out
-  '';
+        # `symlink_to_not_in_store` should be a symlink pointing to `./.`, which
+        # is not available in the sandbox
+        [[ -L ${symlink_to_not_in_store} ]]
+        [[ $(readlink ${symlink_to_not_in_store}) == ${builtins.toString ./.} ]]
+        (! ls ${symlink_to_not_in_store}/)
+
+        # Native paths
+      )
+      echo "Success!" > $out
+    '';
+  };
+
+  test_sandbox_paths = mkDerivation {
+    # Depends on the caller to set a bunch of `--sandbox-path` arguments
+    name = "test-sandbox-paths";
+    buildCommand = ''
+      (
+        set -x
+        [[ -f /file ]]
+        [[ -d /dir ]]
+
+        # /symlink and /symlinkDir should be available as raw symlinks
+        # (pointing to files outside of the sandbox)
+        [[ -L /symlink ]] && [[ ! -e $(readlink /symlink) ]]
+        [[ -L /symlinkDir ]] && [[ ! -e $(readlink /symlinkDir) ]]
+      )
+
+      touch $out
+    '';
+  };
 }

--- a/tests/nixos/fetchurl.nix
+++ b/tests/nixos/fetchurl.nix
@@ -67,6 +67,9 @@ in
     out = machine.succeed("curl https://good/index.html")
     assert out == "hello world\n"
 
+    out = machine.succeed("cat ${badCert}/cert.pem > /tmp/cafile.pem; curl --cacert /tmp/cafile.pem https://bad/index.html")
+    assert out == "foobar\n"
+
     # Fetching from a server with a trusted cert should work.
     machine.succeed("nix build --no-substitute --expr 'import <nix/fetchurl.nix> { url = \"https://good/index.html\"; hash = \"sha256-qUiQTy8PR5uPgZdpSzAYSw0u0cHNKh7A+4XSmaGSpEc=\"; }'")
 
@@ -74,5 +77,8 @@ in
     err = machine.fail("nix build --no-substitute --expr 'import <nix/fetchurl.nix> { url = \"https://bad/index.html\"; hash = \"sha256-rsBwZF/lPuOzdjBZN2E08FjMM3JHyXit0Xi2zN+wAZ8=\"; }' 2>&1")
     print(err)
     assert "SSL certificate problem: self-signed certificate" in err
+
+    # Fetching from a server with a trusted cert should work via environment variable override.
+    machine.succeed("NIX_SSL_CERT_FILE=/tmp/cafile.pem nix build --no-substitute --expr 'import <nix/fetchurl.nix> { url = \"https://bad/index.html\"; hash = \"sha256-rsBwZF/lPuOzdjBZN2E08FjMM3JHyXit0Xi2zN+wAZ8=\"; }'")
   '';
 }

--- a/tests/nixos/fetchurl.nix
+++ b/tests/nixos/fetchurl.nix
@@ -1,7 +1,7 @@
 # Test whether builtin:fetchurl properly performs TLS certificate
 # checks on HTTPS servers.
 
-{ lib, config, pkgs, ... }:
+{ pkgs, ... }:
 
 let
 
@@ -25,7 +25,7 @@ in
   name = "nss-preload";
 
   nodes = {
-    machine = { lib, pkgs, ... }: {
+    machine = { pkgs, ... }: {
       services.nginx = {
         enable = true;
 
@@ -60,7 +60,7 @@ in
     };
   };
 
-  testScript = { nodes, ... }: ''
+  testScript = ''
     machine.wait_for_unit("nginx")
     machine.wait_for_open_port(443)
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

- Manual backport of  #11610
- Trivial backport of #10482 (dependency for tests to pass)
  - As requested: https://github.com/NixOS/nix/issues/11004#issuecomment-2269656685
- Trivial backport of #11246 (dependency for tests to pass)
- Closes https://github.com/NixOS/nix/pull/11645
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
