### PR TITLE
Clean up the `package.nix` files

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -60,6 +60,16 @@ let
       workDir = null;
     };
 
+  mesonLayer = finalAttrs: prevAttrs:
+    {
+      mesonFlags = prevAttrs.mesonFlags or [];
+      nativeBuildInputs = [
+        pkgs.buildPackages.meson
+        pkgs.buildPackages.ninja
+        pkgs.buildPackages.pkg-config
+      ] ++ prevAttrs.nativeBuildInputs or [];
+    };
+
   # Work around weird `--as-needed` linker behavior with BSD, see
   # https://github.com/mesonbuild/meson/issues/3593
   bsdNoLinkAsNeeded = finalAttrs: prevAttrs:
@@ -177,6 +187,7 @@ scope: {
       miscGoodPractice
       bsdNoLinkAsNeeded
       localSourceLayer
+      mesonLayer
     ];
   in stdenv.mkDerivation
    (lib.extends

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -180,6 +180,6 @@ scope: {
     ];
   in stdenv.mkDerivation
    (lib.extends
-     (lib.foldr lib.composeExtensions (_: _: {}) exts)
+     (lib.composeManyExtensions exts)
      f);
 }

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -38,6 +38,10 @@ let
   # Indirection for Nixpkgs to override when package.nix files are vendored
   filesetToSource = lib.fileset.toSource;
 
+  /** Given a set of layers, create a mkDerivation-like function */
+  mkPackageBuilder = exts: userFn:
+    stdenv.mkDerivation (lib.extends (lib.composeManyExtensions exts) userFn);
+
   localSourceLayer = finalAttrs: prevAttrs:
     let
       workDirPath =
@@ -62,7 +66,6 @@ let
 
   mesonLayer = finalAttrs: prevAttrs:
     {
-      mesonFlags = prevAttrs.mesonFlags or [];
       nativeBuildInputs = [
         pkgs.buildPackages.meson
         pkgs.buildPackages.ninja
@@ -182,15 +185,11 @@ scope: {
 
   inherit resolvePath filesetToSource;
 
-  mkMesonDerivation = f: let
-    exts = [
+  mkMesonDerivation =
+    mkPackageBuilder [
       miscGoodPractice
       bsdNoLinkAsNeeded
       localSourceLayer
       mesonLayer
     ];
-  in stdenv.mkDerivation
-   (lib.extends
-     (lib.composeManyExtensions exts)
-     f);
 }

--- a/src/external-api-docs/package.nix
+++ b/src/external-api-docs/package.nix
@@ -1,8 +1,6 @@
 { lib
 , mkMesonDerivation
 
-, meson
-, ninja
 , doxygen
 
 # Configuration Options
@@ -37,8 +35,6 @@ mkMesonDerivation (finalAttrs: {
     ];
 
   nativeBuildInputs = [
-    meson
-    ninja
     doxygen
   ];
 

--- a/src/internal-api-docs/package.nix
+++ b/src/internal-api-docs/package.nix
@@ -1,8 +1,6 @@
 { lib
 , mkMesonDerivation
 
-, meson
-, ninja
 , doxygen
 
 # Configuration Options
@@ -32,8 +30,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    meson
-    ninja
     doxygen
   ];
 

--- a/src/libcmd/package.nix
+++ b/src/libcmd/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util
 , nix-store
@@ -33,7 +33,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-cmd";
   inherit version;
 
@@ -48,8 +48,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   buildInputs = [
     ({ inherit editline readline; }.${readlineFlavor})
@@ -81,10 +79,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libcmd/package.nix
+++ b/src/libcmd/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util
 , nix-store
@@ -55,12 +50,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   buildInputs = [
     ({ inherit editline readline; }.${readlineFlavor})

--- a/src/libexpr-c/package.nix
+++ b/src/libexpr-c/package.nix
@@ -2,10 +2,6 @@
 , stdenv
 , mkMesonDerivation
 
-, meson
-, ninja
-, pkg-config
-
 , nix-store-c
 , nix-expr
 
@@ -36,12 +32,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-store-c

--- a/src/libexpr-c/package.nix
+++ b/src/libexpr-c/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-store-c
 , nix-expr
@@ -14,7 +14,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-expr-c";
   inherit version;
 
@@ -30,8 +30,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
     (fileset.fileFilter (file: file.hasExt "h") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-store-c
@@ -52,10 +50,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -1,11 +1,7 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
 
-, meson
-, ninja
-, pkg-config
 , bison
 , flex
 , cmake # for resolving toml11 dep
@@ -64,9 +60,6 @@ mkMesonDerivation (finalAttrs: {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
     bison
     flex
     cmake

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , bison
 , flex
@@ -34,7 +34,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-expr";
   inherit version;
 
@@ -56,8 +56,6 @@ mkMesonDerivation (finalAttrs: {
       ./package.nix
     )
   ];
-
-  outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
     bison
@@ -97,10 +95,6 @@ mkMesonDerivation (finalAttrs: {
   } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -55,7 +55,10 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
     ./lexer.l
     ./parser.y
-    (fileset.fileFilter (file: file.hasExt "nix") ./.)
+    (fileset.difference
+      (fileset.fileFilter (file: file.hasExt "nix") ./.)
+      ./package.nix
+    )
   ];
 
   outputs = [ "out" "dev" ];

--- a/src/libfetchers/package.nix
+++ b/src/libfetchers/package.nix
@@ -1,17 +1,11 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util
 , nix-store
 , nlohmann_json
 , libgit2
-, man
 
 # Configuration Options
 
@@ -38,12 +32,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   buildInputs = [
     libgit2

--- a/src/libfetchers/package.nix
+++ b/src/libfetchers/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util
 , nix-store
@@ -16,7 +16,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-fetchers";
   inherit version;
 
@@ -30,8 +30,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   buildInputs = [
     libgit2
@@ -54,10 +52,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libflake/package.nix
+++ b/src/libflake/package.nix
@@ -1,19 +1,12 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util
 , nix-store
 , nix-fetchers
 , nix-expr
 , nlohmann_json
-, libgit2
-, man
 
 # Configuration Options
 
@@ -40,12 +33,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-store

--- a/src/libflake/package.nix
+++ b/src/libflake/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util
 , nix-store
@@ -17,7 +17,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-flake";
   inherit version;
 
@@ -31,8 +31,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-store
@@ -53,10 +51,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libmain-c/package.nix
+++ b/src/libmain-c/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util-c
 , nix-store
@@ -39,12 +34,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-util-c

--- a/src/libmain-c/package.nix
+++ b/src/libmain-c/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util-c
 , nix-store
@@ -16,7 +16,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-main-c";
   inherit version;
 
@@ -32,8 +32,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
     (fileset.fileFilter (file: file.hasExt "h") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-util-c
@@ -56,10 +54,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libmain/package.nix
+++ b/src/libmain/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , openssl
 
@@ -16,7 +16,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-main";
   inherit version;
 
@@ -30,8 +30,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-util
@@ -50,10 +48,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libmain/package.nix
+++ b/src/libmain/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , openssl
 
@@ -37,12 +32,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-util

--- a/src/libstore-c/package.nix
+++ b/src/libstore-c/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util-c
 , nix-store
@@ -14,7 +14,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-store-c";
   inherit version;
 
@@ -30,8 +30,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
     (fileset.fileFilter (file: file.hasExt "h") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-util-c
@@ -52,10 +50,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libstore-c/package.nix
+++ b/src/libstore-c/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util-c
 , nix-store
@@ -37,12 +32,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-util-c

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -1,11 +1,7 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
 
-, meson
-, ninja
-, pkg-config
 , unixtools
 
 , nix-util
@@ -53,11 +49,8 @@ mkMesonDerivation (finalAttrs: {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ] ++ lib.optional embeddedSandboxShell unixtools.hexdump;
+  nativeBuildInputs =
+    lib.optional embeddedSandboxShell unixtools.hexdump;
 
   buildInputs = [
     boost

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , unixtools
 
@@ -25,7 +25,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-store";
   inherit version;
 
@@ -46,8 +46,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "md") ./.)
     (fileset.fileFilter (file: file.hasExt "sql") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   nativeBuildInputs =
     lib.optional embeddedSandboxShell unixtools.hexdump;
@@ -90,10 +88,6 @@ mkMesonDerivation (finalAttrs: {
   } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libutil-c/package.nix
+++ b/src/libutil-c/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util
 
@@ -13,7 +13,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-util-c";
   inherit version;
 
@@ -29,8 +29,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
     (fileset.fileFilter (file: file.hasExt "h") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-util
@@ -50,10 +48,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libutil-c/package.nix
+++ b/src/libutil-c/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util
 
@@ -36,12 +31,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-util

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , boost
 , brotli
@@ -19,7 +19,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-util";
   inherit version;
 
@@ -37,8 +37,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   buildInputs = [
     brotli
@@ -76,10 +74,6 @@ mkMesonDerivation (finalAttrs: {
   } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , boost
 , brotli
@@ -44,12 +39,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   buildInputs = [
     brotli

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -1,20 +1,11 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-store
 , nix-expr
 , nix-main
 , nix-cmd
-
-, rapidcheck
-, gtest
-, runCommand
 
 # Configuration Options
 
@@ -89,12 +80,6 @@ mkMesonDerivation (finalAttrs: {
       ../nix-store
     ]
   );
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   buildInputs = [
     nix-store

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonExecutable
 
 , nix-store
 , nix-expr
@@ -16,7 +16,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonExecutable (finalAttrs: {
   pname = "nix";
   inherit version;
 
@@ -102,10 +102,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/src/perl/package.nix
+++ b/src/perl/package.nix
@@ -3,11 +3,7 @@
 , mkMesonDerivation
 , perl
 , perlPackages
-, meson
-, ninja
-, pkg-config
 , nix-store
-, darwin
 , version
 , curl
 , bzip2
@@ -36,9 +32,6 @@ perl.pkgs.toPerlModule (mkMesonDerivation (finalAttrs: {
   ]);
 
   nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
     perl
     curl
   ];

--- a/src/perl/package.nix
+++ b/src/perl/package.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , mkMesonDerivation
+, pkg-config
 , perl
 , perlPackages
 , nix-store
@@ -32,6 +33,7 @@ perl.pkgs.toPerlModule (mkMesonDerivation (finalAttrs: {
   ]);
 
   nativeBuildInputs = [
+    pkg-config
     perl
     curl
   ];

--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -75,7 +75,6 @@ mkMesonDerivation (finalAttrs: {
     nix-expr
   ];
 
-
   preConfigure =
     # "Inline" .version so it's not a symlink, and includes the suffix.
     # Do the meson utils, without modification.

--- a/tests/unit/libexpr-support/package.nix
+++ b/tests/unit/libexpr-support/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-store-test-support
 , nix-expr
@@ -16,7 +16,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-util-test-support";
   inherit version;
 
@@ -31,8 +31,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-store-test-support
@@ -54,10 +52,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/tests/unit/libexpr-support/package.nix
+++ b/tests/unit/libexpr-support/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-store-test-support
 , nix-expr
@@ -38,12 +33,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-store-test-support

--- a/tests/unit/libexpr/package.nix
+++ b/tests/unit/libexpr/package.nix
@@ -2,11 +2,6 @@
 , buildPackages
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-expr
 , nix-expr-c
@@ -40,12 +35,6 @@ mkMesonDerivation (finalAttrs: {
     # ./meson.options
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
   ];
 
   buildInputs = [

--- a/tests/unit/libexpr/package.nix
+++ b/tests/unit/libexpr/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPackages
 , stdenv
-, mkMesonDerivation
+, mkMesonExecutable
 
 , nix-expr
 , nix-expr-c
@@ -21,7 +21,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonExecutable (finalAttrs: {
   pname = "nix-expr-tests";
   inherit version;
 
@@ -59,10 +59,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   passthru = {
     tests = {

--- a/tests/unit/libfetchers/package.nix
+++ b/tests/unit/libfetchers/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPackages
 , stdenv
-, mkMesonDerivation
+, mkMesonExecutable
 
 , nix-fetchers
 , nix-store-test-support
@@ -20,7 +20,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonExecutable (finalAttrs: {
   pname = "nix-fetchers-tests";
   inherit version;
 
@@ -57,10 +57,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   passthru = {
     tests = {

--- a/tests/unit/libfetchers/package.nix
+++ b/tests/unit/libfetchers/package.nix
@@ -2,11 +2,6 @@
 , buildPackages
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-fetchers
 , nix-store-test-support
@@ -39,12 +34,6 @@ mkMesonDerivation (finalAttrs: {
     # ./meson.options
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
   ];
 
   buildInputs = [

--- a/tests/unit/libflake/package.nix
+++ b/tests/unit/libflake/package.nix
@@ -2,11 +2,6 @@
 , buildPackages
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-flake
 , nix-expr-test-support
@@ -39,12 +34,6 @@ mkMesonDerivation (finalAttrs: {
     # ./meson.options
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
   ];
 
   buildInputs = [

--- a/tests/unit/libflake/package.nix
+++ b/tests/unit/libflake/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPackages
 , stdenv
-, mkMesonDerivation
+, mkMesonExecutable
 
 , nix-flake
 , nix-expr-test-support
@@ -20,7 +20,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonExecutable (finalAttrs: {
   pname = "nix-flake-tests";
   inherit version;
 
@@ -57,10 +57,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   passthru = {
     tests = {

--- a/tests/unit/libstore-support/package.nix
+++ b/tests/unit/libstore-support/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util-test-support
 , nix-store
@@ -16,7 +16,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-store-test-support";
   inherit version;
 
@@ -31,8 +31,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-util-test-support
@@ -54,10 +52,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/tests/unit/libstore-support/package.nix
+++ b/tests/unit/libstore-support/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util-test-support
 , nix-store
@@ -38,12 +33,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-util-test-support

--- a/tests/unit/libstore/package.nix
+++ b/tests/unit/libstore/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPackages
 , stdenv
-, mkMesonDerivation
+, mkMesonExecutable
 
 , nix-store
 , nix-store-c
@@ -22,7 +22,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonExecutable (finalAttrs: {
   pname = "nix-store-tests";
   inherit version;
 
@@ -61,10 +61,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   passthru = {
     tests = {

--- a/tests/unit/libstore/package.nix
+++ b/tests/unit/libstore/package.nix
@@ -2,11 +2,6 @@
 , buildPackages
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-store
 , nix-store-c
@@ -41,12 +36,6 @@ mkMesonDerivation (finalAttrs: {
     # ./meson.options
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
   ];
 
   buildInputs = [

--- a/tests/unit/libutil-support/package.nix
+++ b/tests/unit/libutil-support/package.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, mkMesonDerivation
+, mkMesonLibrary
 
 , nix-util
 
@@ -15,7 +15,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonLibrary (finalAttrs: {
   pname = "nix-util-test-support";
   inherit version;
 
@@ -30,8 +30,6 @@ mkMesonDerivation (finalAttrs: {
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];
-
-  outputs = [ "out" "dev" ];
 
   propagatedBuildInputs = [
     nix-util
@@ -52,10 +50,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;

--- a/tests/unit/libutil-support/package.nix
+++ b/tests/unit/libutil-support/package.nix
@@ -1,11 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util
 
@@ -37,12 +32,6 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   outputs = [ "out" "dev" ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-  ];
 
   propagatedBuildInputs = [
     nix-util

--- a/tests/unit/libutil/package.nix
+++ b/tests/unit/libutil/package.nix
@@ -2,11 +2,6 @@
 , buildPackages
 , stdenv
 , mkMesonDerivation
-, releaseTools
-
-, meson
-, ninja
-, pkg-config
 
 , nix-util
 , nix-util-c
@@ -39,12 +34,6 @@ mkMesonDerivation (finalAttrs: {
     # ./meson.options
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
   ];
 
   buildInputs = [

--- a/tests/unit/libutil/package.nix
+++ b/tests/unit/libutil/package.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPackages
 , stdenv
-, mkMesonDerivation
+, mkMesonExecutable
 
 , nix-util
 , nix-util-c
@@ -20,7 +20,7 @@ let
   inherit (lib) fileset;
 in
 
-mkMesonDerivation (finalAttrs: {
+mkMesonExecutable (finalAttrs: {
   pname = "nix-util-tests";
   inherit version;
 
@@ -58,10 +58,6 @@ mkMesonDerivation (finalAttrs: {
   env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
     LDFLAGS = "-fuse-ld=gold";
   };
-
-  separateDebugInfo = !stdenv.hostPlatform.isStatic;
-
-  hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
 
   passthru = {
     tests = {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Since the componentization with meson, we have a large number of expressions containing a bit of boilerplate that we haven't factored out yet.

# Summary

- Add `mkMesonLibrary` and `mkMesonExecutable` functions that set some attributes
  - If we need a third function, it's easy with the layers
- Checked with `nix-diff`.
  - only change is: `pkg-config` has moved position in `nativeBuildInputs`, keeping it equivalent.
  - `nix-diff $(nix eval --raw .?ref=$(git merge-base upstream/master HEAD)#default.drvPath) $(nix eval --raw .#default.drvPath)`

# Context

We deliberately postponed abstraction until the end to keep it simple, and so that we could abstract the right thing with confidence.

More could be done: probably the `ld.gold` and `.version`.


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
