### PR TITLE
path fetcher: Allow the lastModified attribute to be overriden again

### DIFF
--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -157,7 +157,11 @@ struct PathInputScheme : InputScheme
             });
             storePath = store->addToStoreFromDump(*src, "source");
         }
-        input.attrs.insert_or_assign("lastModified", uint64_t(mtime));
+
+        /* Trust the lastModified value supplied by the user, if
+           any. It's not a "secure" attribute so we don't care. */
+        if (!input.getLastModified())
+            input.attrs.insert_or_assign("lastModified", uint64_t(mtime));
 
         return {makeStorePathAccessor(store, *storePath), std::move(input)};
     }

--- a/tests/functional/fetchPath.sh
+++ b/tests/functional/fetchPath.sh
@@ -6,3 +6,6 @@ touch "$TEST_ROOT/foo" -t 202211111111
 # We only check whether 2022-11-1* **:**:** is the last modified date since
 # `lastModified` is transformed into UTC in `builtins.fetchTarball`.
 [[ "$(nix eval --impure --raw --expr "(builtins.fetchTree \"path://$TEST_ROOT/foo\").lastModifiedDate")" =~ 2022111.* ]]
+
+# Check that we can override lastModified for "path:" inputs.
+[[ "$(nix eval --impure --expr "(builtins.fetchTree { type = \"path\"; path = \"$TEST_ROOT/foo\"; lastModified = 123; }).lastModified")" = 123 ]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

It's common to have local registry overrides like
```json
      "from": {
        "id": "nixpkgs",
        "type": "indirect"
      },
      "to": {
        "lastModified": 1728500571,
        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
        "path": "/nix/store/m1szqwijms610n6325mwjswslha4nd92-source",
        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
        "revCount": 635766,
        "type": "path"
      }
```

However, this only worked by accident because the presence of the `narHash` attribute inhibited checking of attributes (see #10601, #10612). Now that we *do* check them, we have to explicitly respect the user-supplied `lastModified`.

Fixes #11660.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
