### PR TITLE
[2.18] Fix exportReferencesGraph when given store subpath

### DIFF
--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -151,7 +151,7 @@ std::optional<nlohmann::json> ParsedDerivation::prepareStructuredAttrs(Store & s
         for (auto i = e->begin(); i != e->end(); ++i) {
             StorePathSet storePaths;
             for (auto & p : *i)
-                storePaths.insert(store.parseStorePath(p.get<std::string>()));
+                storePaths.insert(store.toStorePath(p.get<std::string>()).first);
             json[i.key()] = store.pathInfoToJSON(
                 store.exportReferences(storePaths, inputPaths), false, true);
         }


### PR DESCRIPTION
Manual backport of #10549.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
