### PR TITLE
docs: clarify syntax for escaping dollar curlies

### DIFF
--- a/doc/manual/source/language/string-literals.md
+++ b/doc/manual/source/language/string-literals.md
@@ -150,6 +150,21 @@ These special characters are escaped as follows:
 
 `''\` escapes any other character.
 
+A "dollar-curly" (`${`) can be written as follows: 
+> **Example**
+>
+> ```nix
+> ''
+>   echo ''${PATH}
+> ''
+> ```
+>
+>     "echo ${PATH}\n"
+
+> **Note**
+>
+> This differs from the syntax for escaping a dollar-curly within double quotes (`"\${"`). Be aware of which one is needed at a given moment.
+
 A "double-dollar-curly" (`$${`) can be written literally.
 
 > **Example**


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
https://github.com/NixOS/nix/commit/3b388f6629938317d96ce72a1cfbee64372d8ce8 added some wonderful information on escaping dollar curlies within a multiline string. This is specifically helpful for writing shell scripts within something like writeShellScriptBin / writeShellApplication. 

However, this information was only added to the String Interpolation page of the manual. While it is useful there, the String Literals page also could do with a mention of it. The String Literals page already mentions escaping dollar curlies within a double-quoted string (`"\${"`). Because the syntax for doing this within multiline strings differs, it should be mentioned on the same page. I think having this info in both locations is correct -- it's relevant for both sections.

I'm sure some of my wording could be rephrased, and the markdown could be tweaked to make the example and note more readable. Feel free to nitpick small details.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
