### PR TITLE
fix(nix/eval.cc): move call to `fs::create_directory` out of `assert`

### DIFF
--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -89,8 +89,9 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
                     // FIXME: disallow strings with contexts?
                     writeFile(path.string(), v.string_view());
                 else if (v.type() == nAttrs) {
+                    [[maybe_unused]] bool directoryCreated = fs::create_directory(path);
                     // Directory should not already exist
-                    assert(fs::create_directory(path.string()));
+                    assert(directoryCreated);
                     for (auto & attr : *v.attrs()) {
                         std::string_view name = state->symbols[attr.name];
                         try {


### PR DESCRIPTION
If the call is inside the assertion, then in non-assert builds the call would be stripped out. This is highly unexpected.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

I was looking through recently merged commits and ran across b5c88650c57ac39a1631fda29e25c7a457e2a503 and this really stood out to me. I left a comment in the original PR https://github.com/NixOS/nix/pull/11650#issuecomment-2408932294, but that did not get any traction. So I'm submitting this PR so this does not get lost.

# Context

https://github.com/NixOS/nix/pull/11650

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
