### PR TITLE
Fix meson build on darwin

### DIFF
--- a/src/libutil/strings.cc
+++ b/src/libutil/strings.cc
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <string>
+#include <sstream>
 
 #include "strings-inline.hh"
 #include "os-string.hh"


### PR DESCRIPTION
# Motivation

Fix meson build on darwin. CI needs investigation, or we could just switch over to meson by now.

# Context

`std::stringbuf` is defined in `<sstream>`

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
