### PR TITLE
Add option `disallow-copy-paths`

### DIFF
--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -255,6 +255,8 @@ struct EvalSettings : Config
           This is useful for finding expressions which copy sources, which can slow down evaluation.
           You may find copied sources by running `nix` commands with increased verbosity, such as `nix build -vvvv 2>&1 | grep /nix/store`.
           After identifying one more more paths, run `nix build --option disallow-copy-paths /nix/store/... --show-trace` to find the expression that copies the path, or add `--debugger`.
+
+          A filtering copy is always allowed, such as `builtins.filterSource` or `builtins.path { filter = ...; }`.
         )"};
 };
 

--- a/src/libexpr/eval-settings.hh
+++ b/src/libexpr/eval-settings.hh
@@ -247,6 +247,15 @@ struct EvalSettings : Config
 
           This option can be enabled by setting `NIX_ABORT_ON_WARN=1` in the environment.
         )"};
+
+    Setting<std::set<std::string>> disallowCopyPaths{this, {}, "disallow-copy-paths",
+        R"(
+          A list of paths that are not allowed to be copied.
+
+          This is useful for finding expressions which copy sources, which can slow down evaluation.
+          You may find copied sources by running `nix` commands with increased verbosity, such as `nix build -vvvv 2>&1 | grep /nix/store`.
+          After identifying one more more paths, run `nix build --option disallow-copy-paths /nix/store/... --show-trace` to find the expression that copies the path, or add `--debugger`.
+        )"};
 };
 
 /**

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2390,7 +2390,8 @@ StorePath EvalState::fetchToStore(
     PathFilter * filter,
     RepairFlag repair)
 {
-    checkDisallowCopyPath(path);
+    if (!filter)
+        checkDisallowCopyPath(path);
     return ::nix::fetchToStore(*store, path, mode, name, method, filter, repair);
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2384,6 +2384,9 @@ StorePath EvalState::fetchToStore(
     PathFilter * filter,
     RepairFlag repair)
 {
+    if (path.accessor == rootFS && settings.disallowCopyPaths.get().contains(path.path.abs())) {
+        error<EvalError>("not allowed to copy '%1%' due to option '%2%'", path.path.abs(), settings.disallowCopyPaths.name).debugThrow();
+    }
     return ::nix::fetchToStore(*store, path, mode, name, method, filter, repair);
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2376,6 +2376,12 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
     return dstPath;
 }
 
+void EvalState::checkDisallowCopyPath(const SourcePath & path) {
+    if (path.accessor == rootFS && settings.disallowCopyPaths.get().contains(path.path.abs())) {
+        error<EvalError>("not allowed to copy '%1%' due to option '%2%'", path.path.abs(), settings.disallowCopyPaths.name).debugThrow();
+    }
+}
+
 StorePath EvalState::fetchToStore(
     const SourcePath & path,
     FetchMode mode,
@@ -2384,9 +2390,7 @@ StorePath EvalState::fetchToStore(
     PathFilter * filter,
     RepairFlag repair)
 {
-    if (path.accessor == rootFS && settings.disallowCopyPaths.get().contains(path.path.abs())) {
-        error<EvalError>("not allowed to copy '%1%' due to option '%2%'", path.path.abs(), settings.disallowCopyPaths.name).debugThrow();
-    }
+    checkDisallowCopyPath(path);
     return ::nix::fetchToStore(*store, path, mode, name, method, filter, repair);
 }
 

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -813,6 +813,9 @@ public:
         PathFilter * filter = nullptr,
         RepairFlag repair = NoRepair);
 
+    /** Throws if path occurs in the disallow-copy-path option. */
+    void checkDisallowCopyPath(const SourcePath & path);
+
 private:
 
     /**

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -3,6 +3,7 @@
 
 #include "attr-set.hh"
 #include "eval-error.hh"
+#include "fetch-to-store.hh"
 #include "types.hh"
 #include "value.hh"
 #include "nixexpr.hh"
@@ -803,6 +804,14 @@ public:
         PosIdx pos);
 
     DocComment getDocCommentForPos(PosIdx pos);
+
+    StorePath fetchToStore(
+        const SourcePath & path,
+        FetchMode mode,
+        std::string_view name = "source",
+        ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive,
+        PathFilter * filter = nullptr,
+        RepairFlag repair = NoRepair);
 
 private:
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2473,8 +2473,7 @@ static void addPath(
                 {}));
 
         if (!expectedHash || !state.store->isValidPath(*expectedStorePath)) {
-            auto dstPath = fetchToStore(
-                *state.store,
+            auto dstPath = state.fetchToStore(
                 path.resolveSymlinks(),
                 settings.readOnlyMode ? FetchMode::DryRun : FetchMode::Copy,
                 name,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2486,8 +2486,12 @@ static void addPath(
                     path
                 ).atPos(pos).debugThrow();
             state.allowAndSetStorePathString(dstPath, v);
-        } else
+        } else {
+            if (!filterFun)
+                state.checkDisallowCopyPath(path);
+
             state.allowAndSetStorePathString(*expectedStorePath, v);
+        }
     } catch (Error & e) {
         e.addTrace(state.positions[pos], "while adding path '%s'", path);
         throw;

--- a/tests/functional/disallow-copy-paths.sh
+++ b/tests/functional/disallow-copy-paths.sh
@@ -7,10 +7,44 @@ clearStoreIfPossible
 # shellcheck disable=SC2016
 path="$(nix eval --raw --impure --expr '"${./disallow-copy-paths.sh}"')"
 
-# shellcheck disable=SC2016
-expectStderr 1 nix-instantiate \
-  --disallow-copy-paths "$path" \
-  --expr --strict \
-  --argstr path "$path" \
-  '{ path }: "${/. + path}" + "bla bla"' \
-  | grepQuiet "error.*not allowed to copy.*$path.* due to option.*disallow-copy-paths"
+all_tests() {
+
+  # shellcheck disable=SC2016
+  expectStderr 1 nix-instantiate \
+    --disallow-copy-paths "$path" \
+    --expr --strict \
+    --argstr path "$path" \
+    '{ path }: "${/. + path}" + "bla bla"' \
+    "$@" \
+    | grepQuiet "error.*not allowed to copy.*$path.* due to option.*disallow-copy-paths"
+
+  # shellcheck disable=SC2016
+  expectStderr 1 nix-instantiate \
+    --disallow-copy-paths "$path" \
+    --expr --strict \
+    --argstr path "$path" \
+    "$@" \
+    '{ path }: builtins.path { path = /. + path; name = "source"; } + "bla bla"' \
+    | grepQuiet "error.*not allowed to copy.*$path.* due to option.*disallow-copy-paths"
+
+  # shellcheck disable=SC2016
+  expectStderr 1 nix-instantiate \
+    --disallow-copy-paths "$path" \
+    --expr --strict \
+    --argstr path "$path" \
+    "$@" \
+    '{ path }: builtins.path { path = path; name = "source"; } + "bla bla"' \
+    | grepQuiet "error.*not allowed to copy.*$path.* due to option.*disallow-copy-paths"
+
+  # shellcheck disable=SC2016
+  nix-instantiate \
+    --disallow-copy-paths "$path" \
+    --expr --eval --strict \
+    "$@" \
+    --argstr path "$path" \
+    '{ path }: builtins.path { path = path; name = "source"; filter = _: _: true; } + "bla bla"' \
+
+}
+
+all_tests
+all_tests --readonly-mode

--- a/tests/functional/disallow-copy-paths.sh
+++ b/tests/functional/disallow-copy-paths.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+clearStoreIfPossible
+
+# shellcheck disable=SC2016
+path="$(nix eval --raw --impure --expr '"${./disallow-copy-paths.sh}"')"
+
+# shellcheck disable=SC2016
+expectStderr 1 nix-instantiate \
+  --disallow-copy-paths "$path" \
+  --expr --strict \
+  --argstr path "$path" \
+  '{ path }: "${/. + path}" + "bla bla"' \
+  | grepQuiet "error.*not allowed to copy.*$path.* due to option.*disallow-copy-paths"

--- a/tests/functional/local.mk
+++ b/tests/functional/local.mk
@@ -1,5 +1,6 @@
 nix_tests = \
   test-infra.sh \
+  disallow-copy-paths.sh \
   gc.sh \
   nix-collect-garbage-d.sh \
   remote-store.sh \

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -69,6 +69,7 @@ suites = [
     'deps': [],
     'tests': [
       'test-infra.sh',
+      'disallow-copy-paths.sh',
       'gc.sh',
       'nix-collect-garbage-d.sh',
       'remote-store.sh',


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

To quote the docs:

This is useful for finding expressions which copy sources, which can slow down evaluation.
You may find copied sources by running `nix` commands with increased verbosity, such as `nix build -vvvv 2>&1 | grep /nix/store`.
After identifying one more more paths, run `nix build --option disallow-copy-paths /nix/store/... --show-trace` to find the expression that copies the path, or add `--debugger`.


# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
