### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/mk/libraries.mk
+++ b/mk/libraries.mk
@@ -86,7 +86,9 @@ define build-library
     else
       ifndef HOST_DARWIN
         ifndef HOST_WINDOWS
-          $(1)_LDFLAGS += -Wl,-z,defs
+	  ifndef HOST_OPENBSD
+            $(1)_LDFLAGS += -Wl,-z,defs
+          endif
         endif
       endif
     endif

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -21,6 +21,10 @@ ifdef HOST_OS
     HOST_NETBSD = 1
     HOST_UNIX = 1
   endif
+  ifeq ($(patsubst openbsd%,,$(HOST_KERNEL)),)
+    HOST_OPENBSD = 1
+    HOST_UNIX = 1
+  endif
   ifeq ($(HOST_KERNEL), linux)
     HOST_LINUX = 1
     HOST_UNIX = 1

--- a/package.nix
+++ b/package.nix
@@ -76,7 +76,9 @@
 #
 # Temporarily disabled on Windows because the `GC_throw_bad_alloc`
 # symbol is missing during linking.
-, enableGC ? !stdenv.hostPlatform.isWindows
+#
+# Disabled on OpenBSD because of missing `_data_start` symbol while linking
+, enableGC ? !stdenv.hostPlatform.isWindows && !stdenv.hostPlatform.isOpenBSD
 
 # Whether to enable Markdown rendering in the Nix binary.
 , enableMarkdown ? !stdenv.hostPlatform.isWindows


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This is part of the larger NixBSD project, attempting to build a NixOS-like system on *BSD. As part of this, we want Nix to run well on several different BSD variants.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

OpenBSD has some peculiarities around its dynamic linking. Shared libraries never link to libc directly, only the main executable does that. The libc symbols in shared libraries are left undefined until they are dealt with by the dynamic linker.

Therefore, adding `-Wl,-z,defs` will always fail and we must disable it in the Makefiles. There is no similar rule in the meson build system, from what I can tell.

Separately, GC fails to work due to a missing symbol `_data_start` symbol. I'm not sure why, but we might as well disable it until we can find a better workaround.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
