### PR TITLE
Add support for `utimensat` as an alternative to `lutimes`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,9 +89,10 @@ AC_LANG_POP(C++)
 AC_CHECK_FUNCS([statvfs pipe2 close_range])
 
 
-# Check for lutimes, optionally used for changing the mtime of
-# symlinks.
-AC_CHECK_FUNCS([lutimes])
+# Check for lutimes and utimensat, optionally used for changing the
+# mtime of symlinks.
+AC_CHECK_DECLS([AT_SYMLINK_NOFOLLOW], [], [], [[#include <fcntl.h>]])
+AC_CHECK_FUNCS([lutimes utimensat])
 
 
 # Check whether the store optimiser can optimise symlinks.

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -630,7 +630,28 @@ void setWriteTime(
     time_t modificationTime,
     std::optional<bool> optIsSymlink)
 {
-#ifndef _WIN32
+#ifdef _WIN32
+    // FIXME use `fs::last_write_time`.
+    //
+    // Would be nice to use std::filesystem unconditionally, but
+    // doesn't support access time just modification time.
+    //
+    // System clock vs File clock issues also make that annoying.
+    warn("Changing file times is not yet implemented on Windows, path is '%s'", path);
+#elif HAVE_UTIMENSAT && HAVE_DECL_AT_SYMLINK_NOFOLLOW
+    struct timespec times[2] = {
+        {
+            .tv_sec = accessedTime,
+            .tv_nsec = 0,
+        },
+        {
+            .tv_sec = modificationTime,
+            .tv_nsec = 0,
+        },
+    };
+    if (utimensat(AT_FDCWD, path.c_str(), times, AT_SYMLINK_NOFOLLOW) == -1)
+        throw SysError("changing modification time of '%s' (using `utimensat`)", path);
+#else
     struct timeval times[2] = {
         {
             .tv_sec = accessedTime,
@@ -641,42 +662,21 @@ void setWriteTime(
             .tv_usec = 0,
         },
     };
-#endif
-
-    auto nonSymlink = [&]{
-        bool isSymlink = optIsSymlink
-            ? *optIsSymlink
-            : fs::is_symlink(path);
-
-        if (!isSymlink) {
-#ifdef _WIN32
-            // FIXME use `fs::last_write_time`.
-            //
-            // Would be nice to use std::filesystem unconditionally, but
-            // doesn't support access time just modification time.
-            //
-            // System clock vs File clock issues also make that annoying.
-            warn("Changing file times is not yet implemented on Windows, path is '%s'", path);
-#else
-            if (utimes(path.c_str(), times) == -1) {
-
-                throw SysError("changing modification time of '%s' (not a symlink)", path);
-            }
-#endif
-        } else {
-            throw Error("Cannot modification time of symlink '%s'", path);
-        }
-    };
-
 #if HAVE_LUTIMES
-    if (lutimes(path.c_str(), times) == -1) {
-        if (errno == ENOSYS)
-            nonSymlink();
-        else
-            throw SysError("changing modification time of '%s'", path);
-    }
+    if (lutimes(path.c_str(), times) == -1)
+        throw SysError("changing modification time of '%s'", path);
 #else
-    nonSymlink();
+    bool isSymlink = optIsSymlink
+        ? *optIsSymlink
+        : fs::is_symlink(path);
+
+    if (!isSymlink) {
+        if (utimes(path.c_str(), times) == -1)
+            throw SysError("changing modification time of '%s' (not a symlink)", path);
+    } else {
+        throw Error("Cannot modification time of symlink '%s'", path);
+    }
+#endif
 #endif
 }
 

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -42,12 +42,16 @@ check_funcs = [
   # Optionally used to try to close more file descriptors (e.g. before
   # forking) on Unix.
   'sysconf',
+  # Optionally used for changing the mtime of files and symlinks.
+  'utimensat',
 ]
 foreach funcspec : check_funcs
   define_name = 'HAVE_' + funcspec.underscorify().to_upper()
   define_value = cxx.has_function(funcspec).to_int()
   configdata.set(define_name, define_value)
 endforeach
+
+configdata.set('HAVE_DECL_AT_SYMLINK_NOFOLLOW', cxx.has_header_symbol('fcntl.h', 'AT_SYMLINK_NOFOLLOW').to_int())
 
 subdir('build-utils-meson/threads')
 


### PR DESCRIPTION
OpenBSD doesn't support `lutimes`, but does support `utimensat` which subsumes it. In fact, all the BSDs, Linux, and newer macOS all support it. So lets make this our first choice for the implementation.

In addition, let's get rid of the `lutimes` `ENOSYS` special case. The Linux manpage says

> ENOSYS
>
> The kernel does not support this call; Linux 2.6.22 or later is
> required.

which I think is the origin of this check, but that's a very old version of Linux at this point. The code can be simplified a lot of we drop support for it here (as we've done elsewhere, anyways).

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

We've been working towards a more functional nix on various *BSD systems. This fixes a nonessential feature, and is useful i combination with https://github.com/NixOS/nix/pull/11750 which fixes build on OpenBSD

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

OpenBSD does not support the `lutimes` syscall to mtime of a symlink. However, it supports the common `utimensat` syscall that allows setting mtimes with nanosecond precision for symlinks.

As part of the change, @Ericson2314 noticed that `lutimes` has been in Linux for 17 years and the fallback is no longer required, making it easier to clean up the code.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
