### PR TITLE
fix: make sure directory exists before using `ln`

### DIFF
--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -96,6 +96,9 @@ poly_configure_nix_daemon_service() {
     if [ -e /run/systemd/system ]; then
         task "Setting up the nix-daemon systemd service"
 
+        _sudo "to create parent of the nix-daemon tmpfiles config" \
+              mkdir -p "$(dirname "$TMPFILES_DEST")"
+
         _sudo "to create the nix-daemon tmpfiles config" \
               ln -sfn "/nix/var/nix/profiles/default$TMPFILES_SRC" "$TMPFILES_DEST"
 


### PR DESCRIPTION
# Motivation

Unable to install Nix using the official installer when `/etc/tmpfiles.d` doesn't exist.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
