### PR TITLE
install: Allow to specify alternative `sudo` command

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -56,6 +56,9 @@ readonly NIX_INSTALLED_CACERT="@cacert@"
 #readonly NIX_INSTALLED_CACERT="/nix/store/7dxhzymvy330i28ii676fl1pqwcahv2f-nss-cacert-3.49.2"
 readonly EXTRACTED_NIX_PATH="$(dirname "$0")"
 
+# allow to override identity change command
+readonly NIX_BECOME=${NIX_BECOME:-sudo}
+
 readonly ROOT_HOME=~root
 
 if [ -t 0 ] && [ -z "${NIX_INSTALLER_YES:-}" ]; then
@@ -123,7 +126,7 @@ uninstall_directions() {
             cat <<EOF
 $step. Restore $profile_target$PROFILE_BACKUP_SUFFIX back to $profile_target
 
-  sudo mv $profile_target$PROFILE_BACKUP_SUFFIX $profile_target
+  $NIX_BECOME mv $profile_target$PROFILE_BACKUP_SUFFIX $profile_target
 
 (after this one, you may need to re-open any terminals that were
 opened while it existed.)
@@ -136,7 +139,7 @@ EOF
     cat <<EOF
 $step. Delete the files Nix added to your system:
 
-  sudo rm -rf "/etc/nix" "$NIX_ROOT" "$ROOT_HOME/.nix-profile" "$ROOT_HOME/.nix-defexpr" "$ROOT_HOME/.nix-channels" "$ROOT_HOME/.local/state/nix" "$ROOT_HOME/.cache/nix" "$HOME/.nix-profile" "$HOME/.nix-defexpr" "$HOME/.nix-channels" "$HOME/.local/state/nix" "$HOME/.cache/nix"
+  $NIX_BECOME rm -rf "/etc/nix" "$NIX_ROOT" "$ROOT_HOME/.nix-profile" "$ROOT_HOME/.nix-defexpr" "$ROOT_HOME/.nix-channels" "$ROOT_HOME/.local/state/nix" "$ROOT_HOME/.cache/nix" "$HOME/.nix-profile" "$HOME/.nix-defexpr" "$HOME/.nix-channels" "$HOME/.local/state/nix" "$HOME/.cache/nix"
 
 and that is it.
 
@@ -343,7 +346,7 @@ __sudo() {
 
     echo "I am executing:"
     echo ""
-    printf "    $ sudo %s\\n" "$cmd"
+    printf "    $ $NIX_BECOME %s\\n" "$cmd"
     echo ""
     echo "$expl"
     echo ""
@@ -361,7 +364,9 @@ _sudo() {
     if is_root; then
         env "$@"
     else
-        sudo "$@"
+        # env sets environment variables for sudo alternatives
+        # that don't support "VAR=value command" syntax
+        $NIX_BECOME env "$@"
     fi
 }
 

--- a/scripts/install-nix-from-tarball.sh
+++ b/scripts/install-nix-from-tarball.sh
@@ -9,6 +9,8 @@ self="$(dirname "$0")"
 nix="@nix@"
 cacert="@cacert@"
 
+# allow to override identity change command
+readonly NIX_BECOME="${NIX_BECOME:-sudo}"
 
 if ! [ -e "$self/.reginfo" ]; then
     echo "$0: incomplete installer (.reginfo is missing)" >&2
@@ -63,7 +65,6 @@ while [ $# -gt 0 ]; do
                 exit 1
             fi
             INSTALL_MODE=no-daemon
-            # intentional tail space
             ACTION=install
             ;;
         --yes)
@@ -135,8 +136,8 @@ echo "performing a single-user installation of Nix..." >&2
 
 if ! [ -e "$dest" ]; then
     cmd="mkdir -m 0755 $dest && chown $USER $dest"
-    echo "directory $dest does not exist; creating it by running '$cmd' using sudo" >&2
-    if ! sudo sh -c "$cmd"; then
+    echo "directory $dest does not exist; creating it by running '$cmd' using $NIX_BECOME" >&2
+    if ! $NIX_BECOME sh -c "$cmd"; then
         echo "$0: please manually run '$cmd' as root to create $dest" >&2
         exit 1
     fi


### PR DESCRIPTION
This allows to specify identity change command for `nix` installation.

And also prepends such command with `env` to set environment variables, because not all `sudo` alternatives support this.

**Testing**: I haven't found a way to test this yet. Looks like it needs building binary package, which requires `nix` installed, and I can't install it, because I don't have `sudo`. :D catch22

# Motivation

Some systems do not use `sudo` but its alternatives like `doas`.

# Context

* https://github.com/NixOS/nix/issues/7651
* https://github.com/NixOS/nix/issues/11396

Prior work.

* https://github.com/NixOS/nix/pull/4690
* https://github.com/NixOS/nix/pull/7240
* https://github.com/NixOS/nix/pull/8606

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

A good testing strategy would be to run CI tests with Arch box and only `doas` installed, but I am not proficient yet with `nix` testing infrastructure to add it here.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
