### PR TITLE
fix: make sure directory exists before using `ln`

### DIFF
--- a/scripts/install-systemd-multi-user.sh
+++ b/scripts/install-systemd-multi-user.sh
@@ -96,6 +96,9 @@ poly_configure_nix_daemon_service() {
     if [ -e /run/systemd/system ]; then
         task "Setting up the nix-daemon systemd service"
 
+        _sudo "to create parent of the nix-daemon tmpfiles config" \
+              mkdir -p "$(dirname "$TMPFILES_DEST")"
+
         _sudo "to create the nix-daemon tmpfiles config" \
               ln -sfn "/nix/var/nix/profiles/default$TMPFILES_SRC" "$TMPFILES_DEST"
 


### PR DESCRIPTION
Same as https://github.com/NixOS/nix/pull/11759 but hopefully this one will run installer tests?