### PR TITLE
No longer copy functional tests to the build dir

### DIFF
--- a/mk/common-test.sh
+++ b/mk/common-test.sh
@@ -9,12 +9,20 @@ test_name=$(echo -n "${test?must be defined by caller (test runner)}" | sed \
     -e "s|\.sh$||" \
     )
 
+# Layer violation, but I am not inclined to care too much, as this code
+# is about to be deleted.
+src_dir=$(realpath tests/functional)
+
 # shellcheck disable=SC2016
 TESTS_ENVIRONMENT=(
     "TEST_NAME=$test_name"
     'NIX_REMOTE='
     'PS4=+(${BASH_SOURCE[0]-$0}:$LINENO) '
+    "_NIX_TEST_SOURCE_DIR=${src_dir}"
+    "_NIX_TEST_BUILD_DIR=${src_dir}"
 )
+
+unset src_dir
 
 read -r -a bash <<< "${BASH:-/usr/bin/env bash}"
 

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -238,7 +238,7 @@ clearCache
 # preserve quotes variables in the single-quoted string
 # shellcheck disable=SC2016
 outPath=$(nix-build --no-out-link -E '
-  with import ./config.nix;
+  with import '"${config_nix}"';
   mkDerivation {
     name = "nar-listing";
     buildCommand = "mkdir $out; echo foo > $out/bar; ln -s xyzzy $out/link";
@@ -258,7 +258,7 @@ clearCache
 # preserve quotes variables in the single-quoted string
 # shellcheck disable=SC2016
 outPath=$(nix-build --no-out-link -E '
-  with import ./config.nix;
+  with import '"${config_nix}"';
   mkDerivation {
     name = "debug-info";
     buildCommand = "mkdir -p $out/lib/debug/.build-id/02; echo foo > $out/lib/debug/.build-id/02/623eda209c26a59b1a8638ff7752f6b945c26b.debug";
@@ -276,7 +276,7 @@ diff -u \
 # preserve quotes variables in the single-quoted string
 # shellcheck disable=SC2016
 expr='
-  with import ./config.nix;
+  with import '"${config_nix}"';
   mkDerivation {
     name = "multi-output";
     buildCommand = "mkdir -p $out; echo foo > $doc; echo $doc > $out/docref";

--- a/tests/functional/build-hook-ca-fixed.nix
+++ b/tests/functional/build-hook-ca-fixed.nix
@@ -1,6 +1,6 @@
 { busybox }:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let
 

--- a/tests/functional/build-hook.nix
+++ b/tests/functional/build-hook.nix
@@ -1,6 +1,6 @@
 { busybox, contentAddressed ? false }:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let
 

--- a/tests/functional/ca/content-addressed.nix
+++ b/tests/functional/ca/content-addressed.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/ca/config.nix";
 
 let mkCADerivation = args: mkDerivation ({
     __contentAddressed = true;

--- a/tests/functional/ca/derivation-json.sh
+++ b/tests/functional/ca/derivation-json.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/functional/ca/duplicate-realisation-in-closure.sh
+++ b/tests/functional/ca/duplicate-realisation-in-closure.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source ./common.sh
+source common.sh
 
 requireDaemonNewerThan "2.4pre20210625"
 

--- a/tests/functional/ca/import-from-derivation.sh
+++ b/tests/functional/ca/import-from-derivation.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/functional/ca/meson.build
+++ b/tests/functional/ca/meson.build
@@ -29,5 +29,5 @@ suites += {
     'substitute.sh',
     'why-depends.sh',
   ],
-  'workdir': meson.current_build_dir(),
+  'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/ca/new-build-cmd.sh
+++ b/tests/functional/ca/new-build-cmd.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/functional/ca/nix-run.sh
+++ b/tests/functional/ca/nix-run.sh
@@ -2,6 +2,11 @@
 
 source common.sh
 
-FLAKE_PATH=path:$PWD
+flakeDir="$TEST_HOME/flake"
+mkdir -p "${flakeDir}"
+cp flake.nix "${_NIX_TEST_BUILD_DIR}/ca/config.nix" content-addressed.nix "${flakeDir}"
 
-nix run --no-write-lock-file "$FLAKE_PATH#runnable"
+# `config.nix` cannot be gotten via build dir / env var (runs afoul pure eval). Instead get from flake.
+removeBuildDirRef "$flakeDir"/*.nix
+
+nix run --no-write-lock-file "path:${flakeDir}#runnable"

--- a/tests/functional/ca/nix-shell.sh
+++ b/tests/functional/ca/nix-shell.sh
@@ -5,4 +5,3 @@ source common.sh
 CONTENT_ADDRESSED=true
 cd ..
 source ./nix-shell.sh
-

--- a/tests/functional/ca/nondeterministic.nix
+++ b/tests/functional/ca/nondeterministic.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/ca/config.nix";
 
 let mkCADerivation = args: mkDerivation ({
     __contentAddressed = true;

--- a/tests/functional/ca/racy.nix
+++ b/tests/functional/ca/racy.nix
@@ -2,7 +2,7 @@
 # build it at once.
 
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/ca/config.nix";
 
 mkDerivation {
   name = "simple";

--- a/tests/functional/ca/repl.sh
+++ b/tests/functional/ca/repl.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/functional/ca/why-depends.sh
+++ b/tests/functional/ca/why-depends.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/functional/check-refs.nix
+++ b/tests/functional/check-refs.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
 

--- a/tests/functional/check-reqs.nix
+++ b/tests/functional/check-reqs.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
   dep1 = mkDerivation {

--- a/tests/functional/check.nix
+++ b/tests/functional/check.nix
@@ -1,6 +1,6 @@
 {checkBuildId ? 0}:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 {
   nondeterministic = mkDerivation {

--- a/tests/functional/chroot-store.sh
+++ b/tests/functional/chroot-store.sh
@@ -37,7 +37,10 @@ if canUseSandbox; then
 }
 EOF
 
-    cp simple.nix shell.nix simple.builder.sh config.nix "$flakeDir/"
+    cp simple.nix shell.nix simple.builder.sh "${config_nix}" "$flakeDir/"
+
+    # `config.nix` cannot be gotten via build dir / env var (runs afoul pure eval). Instead get from flake.
+    removeBuildDirRef "$flakeDir"/*.nix
 
     TODO_NixOS
 

--- a/tests/functional/common/functions.sh
+++ b/tests/functional/common/functions.sh
@@ -343,6 +343,15 @@ count() {
   echo $#
 }
 
+# Sometimes, e.g. due to pure eval, restricted eval, or sandboxing, we
+# cannot look up `config.nix` in the build dir, and have to instead get
+# it from the current directory. (In this case, the current directly
+# will be somewhere in `$TEST_ROOT`.)
+removeBuildDirRef() {
+  # shellcheck disable=SC2016 # The ${} in this is Nix, not shell
+  sed -i -e 's,"${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/[^ ]*config.nix",./config.nix,' "$@"
+}
+
 trap onError ERR
 
 fi # COMMON_FUNCTIONS_SH_SOURCED

--- a/tests/functional/common/paths.sh
+++ b/tests/functional/common/paths.sh
@@ -8,11 +8,10 @@ COMMON_PATHS_SH_SOURCED=1
 
 commonDir="$(readlink -f "$(dirname "${BASH_SOURCE[0]-$0}")")"
 
-# Since these are generated files
-# shellcheck disable=SC1091
+# Just for `isTestOnNixOS`
 source "$commonDir/functions.sh"
 # shellcheck disable=SC1091
-source "$commonDir/subst-vars.sh"
+source "${_NIX_TEST_BUILD_DIR}/common/subst-vars.sh"
 # Make sure shellcheck knows this will be defined by the above generated snippet
 : "${bash?}" "${bindir?}"
 

--- a/tests/functional/common/vars.sh
+++ b/tests/functional/common/vars.sh
@@ -6,11 +6,14 @@ if [[ -z "${COMMON_VARS_SH_SOURCED-}" ]]; then
 
 COMMON_VARS_SH_SOURCED=1
 
+_NIX_TEST_SOURCE_DIR=$(realpath "${_NIX_TEST_SOURCE_DIR}")
+_NIX_TEST_BUILD_DIR=$(realpath "${_NIX_TEST_BUILD_DIR}")
+
 commonDir="$(readlink -f "$(dirname "${BASH_SOURCE[0]-$0}")")"
 
 # Since this is a generated file
 # shellcheck disable=SC1091
-source "$commonDir/subst-vars.sh"
+source "${_NIX_TEST_BUILD_DIR}/common/subst-vars.sh"
 # Make sure shellcheck knows all these will be defined by the above generated snippet
 : "${bindir?} ${coreutils?} ${dot?} ${SHELL?} ${busybox?} ${version?} ${system?}"
 export coreutils dot busybox version system
@@ -68,5 +71,10 @@ cacheDir=$TEST_ROOT/binary-cache
 if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user true; then
     _canUseSandbox=1
 fi
+
+# Very common, shorthand helps
+# Used in other files
+# shellcheck disable=SC2034
+config_nix="${_NIX_TEST_BUILD_DIR}/config.nix"
 
 fi # COMMON_VARS_SH_SOURCED

--- a/tests/functional/dependencies.nix
+++ b/tests/functional/dependencies.nix
@@ -1,5 +1,5 @@
 { hashInvalidator ? "" }:
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let {
 

--- a/tests/functional/dyn-drv/meson.build
+++ b/tests/functional/dyn-drv/meson.build
@@ -15,5 +15,5 @@ suites += {
     'dep-built-drv.sh',
     'old-daemon-error-hack.sh',
   ],
-  'workdir': meson.current_build_dir(),
+  'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/dyn-drv/old-daemon-error-hack.nix
+++ b/tests/functional/dyn-drv/old-daemon-error-hack.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/dyn-drv/config.nix";
 
 # A simple content-addressed derivation.
 # The derivation can be arbitrarily modified by passing a different `seed`,

--- a/tests/functional/dyn-drv/recursive-mod-json.nix
+++ b/tests/functional/dyn-drv/recursive-mod-json.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/dyn-drv/config.nix";
 
 let innerName = "foo"; in
 

--- a/tests/functional/dyn-drv/text-hashed-output.nix
+++ b/tests/functional/dyn-drv/text-hashed-output.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/dyn-drv/config.nix";
 
 # A simple content-addressed derivation.
 # The derivation can be arbitrarily modified by passing a different `seed`,

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -45,7 +45,7 @@ printf 123 > "$TEST_ROOT/xyzzy/default.nix"
 [[ $(nix eval --impure --expr "import $TEST_ROOT/foo/bar") = 123 ]]
 
 # Test --arg-from-file.
-[[ "$(nix eval --raw --arg-from-file foo config.nix --expr '{ foo }: { inherit foo; }' foo)" = "$(cat config.nix)" ]]
+[[ "$(nix eval --raw --arg-from-file foo "${config_nix}" --expr '{ foo }: { inherit foo; }' foo)" = "$(cat "${config_nix}")" ]]
 
 # Check that special(-ish) files are drained.
 if [[ -e /proc/version ]]; then

--- a/tests/functional/export-graph.nix
+++ b/tests/functional/export-graph.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
 

--- a/tests/functional/extra-sandbox-profile.nix
+++ b/tests/functional/extra-sandbox-profile.nix
@@ -1,6 +1,6 @@
 { destFile, seed }:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation {
   name = "simple";

--- a/tests/functional/failing.nix
+++ b/tests/functional/failing.nix
@@ -1,5 +1,5 @@
 { busybox }:
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 let
 
   mkDerivation = args:

--- a/tests/functional/filter-source.nix
+++ b/tests/functional/filter-source.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation {
   name = "filter";

--- a/tests/functional/fixed.nix
+++ b/tests/functional/fixed.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
 

--- a/tests/functional/flakes/build-paths.sh
+++ b/tests/functional/flakes/build-paths.sh
@@ -79,7 +79,7 @@ cat > "$flake1Dir"/flake.nix <<EOF
 }
 EOF
 
-cp ../simple.nix ../simple.builder.sh ../config.nix "$flake1Dir/"
+cp ../simple.nix ../simple.builder.sh "${config_nix}" "$flake1Dir/"
 
 echo bar > "$flake1Dir/foo"
 

--- a/tests/functional/flakes/bundle.sh
+++ b/tests/functional/flakes/bundle.sh
@@ -2,7 +2,10 @@
 
 source common.sh
 
-cp ../simple.nix ../simple.builder.sh ../config.nix "$TEST_HOME"
+cp ../simple.nix ../simple.builder.sh "${config_nix}" "$TEST_HOME"
+
+# `config.nix` cannot be gotten via build dir / env var (runs afoul pure eval). Instead get from flake.
+removeBuildDirRef "$TEST_HOME"/*.nix
 
 cd "$TEST_HOME"
 

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -34,7 +34,10 @@ writeSimpleFlake() {
 }
 EOF
 
-    cp ../simple.nix ../shell.nix ../simple.builder.sh ../config.nix "$flakeDir/"
+    cp ../simple.nix ../shell.nix ../simple.builder.sh "${config_nix}" "$flakeDir/"
+
+    # `config.nix` cannot be gotten via build dir / env var (runs afoul pure eval). Instead get from flake.
+    removeBuildDirRef "$flakeDir"/*.nix
 }
 
 createSimpleGitFlake() {

--- a/tests/functional/flakes/config.sh
+++ b/tests/functional/flakes/config.sh
@@ -2,7 +2,8 @@
 
 source common.sh
 
-cp ../simple.nix ../simple.builder.sh ../config.nix $TEST_HOME
+cp ../simple.nix ../simple.builder.sh "${config_nix}" $TEST_HOME
+removeBuildDirRef "$TEST_HOME/simple.nix"
 
 cd $TEST_HOME
 

--- a/tests/functional/flakes/develop.sh
+++ b/tests/functional/flakes/develop.sh
@@ -8,7 +8,7 @@ clearStore
 rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
 
 # Create flake under test.
-cp ../shell-hello.nix ../config.nix $TEST_HOME/
+cp ../shell-hello.nix "${config_nix}" $TEST_HOME/
 cat <<EOF >$TEST_HOME/flake.nix
 {
     inputs.nixpkgs.url = "$TEST_HOME/nixpkgs";
@@ -25,7 +25,11 @@ EOF
 
 # Create fake nixpkgs flake.
 mkdir -p $TEST_HOME/nixpkgs
-cp ../config.nix ../shell.nix $TEST_HOME/nixpkgs
+cp "${config_nix}" ../shell.nix $TEST_HOME/nixpkgs
+
+# `config.nix` cannot be gotten via build dir / env var (runs afoul pure eval). Instead get from flake.
+removeBuildDirRef "$TEST_HOME/nixpkgs"/*.nix
+
 cat <<EOF >$TEST_HOME/nixpkgs/flake.nix
 {
     outputs = {self}: {

--- a/tests/functional/flakes/eval-cache.sh
+++ b/tests/functional/flakes/eval-cache.sh
@@ -7,7 +7,7 @@ requireGit
 flake1Dir="$TEST_ROOT/eval-cache-flake"
 
 createGitRepo "$flake1Dir" ""
-cp ../simple.nix ../simple.builder.sh ../config.nix "$flake1Dir/"
+cp ../simple.nix ../simple.builder.sh "${config_nix}" "$flake1Dir/"
 git -C "$flake1Dir" add simple.nix simple.builder.sh config.nix
 git -C "$flake1Dir" commit -m "config.nix"
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -390,7 +390,7 @@ cat > "$flake3Dir/flake.nix" <<EOF
 }
 EOF
 
-cp ../config.nix "$flake3Dir"
+cp "${config_nix}" "$flake3Dir"
 
 git -C "$flake3Dir" add flake.nix config.nix
 git -C "$flake3Dir" commit -m 'Add nonFlakeInputs'

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -25,5 +25,5 @@ suites += {
     'show.sh',
     'dubious-query.sh',
   ],
-  'workdir': meson.current_build_dir(),
+  'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/flakes/run.sh
+++ b/tests/functional/flakes/run.sh
@@ -6,7 +6,10 @@ TODO_NixOS
 
 clearStore
 rm -rf $TEST_HOME/.cache $TEST_HOME/.config $TEST_HOME/.local
-cp ../shell-hello.nix ../config.nix $TEST_HOME
+
+cp ../shell-hello.nix "${config_nix}" $TEST_HOME
+# `config.nix` cannot be gotten via build dir / env var (runs afoul pure eval). Instead get from flake.
+removeBuildDirRef "$TEST_HOME"/*.nix
 cd $TEST_HOME
 
 cat <<EOF > flake.nix

--- a/tests/functional/fmt.sh
+++ b/tests/functional/fmt.sh
@@ -7,7 +7,7 @@ TODO_NixOS # Provide a `shell` variable. Try not to `export` it, perhaps.
 clearStoreIfPossible
 rm -rf "$TEST_HOME"/.cache "$TEST_HOME"/.config "$TEST_HOME"/.local
 
-cp ./simple.nix ./simple.builder.sh ./fmt.simple.sh ./config.nix "$TEST_HOME"
+cp ./simple.nix ./simple.builder.sh ./fmt.simple.sh "${config_nix}" "$TEST_HOME"
 
 cd "$TEST_HOME"
 

--- a/tests/functional/fod-failing.nix
+++ b/tests/functional/fod-failing.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 rec {
   x1 = mkDerivation {
     name = "x1";

--- a/tests/functional/gc-auto.sh
+++ b/tests/functional/gc-auto.sh
@@ -23,7 +23,7 @@ fifoLock=$TEST_ROOT/fifoLock
 mkfifo "$fifoLock"
 
 expr=$(cat <<EOF
-with import ./config.nix; mkDerivation {
+with import ${config_nix}; mkDerivation {
   name = "gc-A";
   buildCommand = ''
     set -x
@@ -51,7 +51,7 @@ EOF
 )
 
 expr2=$(cat <<EOF
-with import ./config.nix; mkDerivation {
+with import ${config_nix}; mkDerivation {
   name = "gc-B";
   buildCommand = ''
     set -x

--- a/tests/functional/gc-concurrent.nix
+++ b/tests/functional/gc-concurrent.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 { lockFifo ? null }:
 

--- a/tests/functional/gc-non-blocking.sh
+++ b/tests/functional/gc-non-blocking.sh
@@ -38,7 +38,7 @@ pid2=$!
 
 # Start a build. This should not be blocked by the GC in progress.
 outPath=$(nix-build --max-silent-time 60 -o "$TEST_ROOT/result" -E "
-  with import ./config.nix;
+  with import ${config_nix};
   mkDerivation {
     name = \"non-blocking\";
     buildCommand = \"set -x; test -e $running; mkdir \$out; echo > $fifo2\";

--- a/tests/functional/gc-runtime.nix
+++ b/tests/functional/gc-runtime.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation {
   name = "gc-runtime";

--- a/tests/functional/git-hashing/meson.build
+++ b/tests/functional/git-hashing/meson.build
@@ -4,5 +4,5 @@ suites += {
   'tests': [
     'simple.sh',
   ],
-  'workdir': meson.current_build_dir(),
+  'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/hermetic.nix
+++ b/tests/functional/hermetic.nix
@@ -5,7 +5,7 @@
 , withFinalRefs ? false
 }:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let
   contentAddressedByDefault = builtins.getEnv "NIX_TESTS_CA_BY_DEFAULT" == "1";

--- a/tests/functional/ifd.nix
+++ b/tests/functional/ifd.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 import (
   mkDerivation {
     name = "foo";

--- a/tests/functional/import-from-derivation.nix
+++ b/tests/functional/import-from-derivation.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
   bar = mkDerivation {

--- a/tests/functional/impure-derivations.nix
+++ b/tests/functional/impure-derivations.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
 

--- a/tests/functional/impure-env.nix
+++ b/tests/functional/impure-env.nix
@@ -1,6 +1,6 @@
 { var, value }:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation {
   name = "test";

--- a/tests/functional/linux-sandbox-cert-test.nix
+++ b/tests/functional/linux-sandbox-cert-test.nix
@@ -1,6 +1,6 @@
 { mode }:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation (
   {

--- a/tests/functional/linux-sandbox.sh
+++ b/tests/functional/linux-sandbox.sh
@@ -47,7 +47,7 @@ grepQuiet 'may not be deterministic' $TEST_ROOT/log
 
 # Test that sandboxed builds cannot write to /etc easily
 # `100` means build failure without extra info, see doc/manual/source/command-ref/status-build-failure.md
-expectStderr 100 nix-sandbox-build -E 'with import ./config.nix; mkDerivation { name = "etc-write"; buildCommand = "echo > /etc/test"; }' |
+expectStderr 100 nix-sandbox-build -E 'with import '"${config_nix}"'; mkDerivation { name = "etc-write"; buildCommand = "echo > /etc/test"; }' |
     grepQuiet "/etc/test: Permission denied"
 
 

--- a/tests/functional/local-overlay-store/meson.build
+++ b/tests/functional/local-overlay-store/meson.build
@@ -14,5 +14,5 @@ suites += {
     'optimise.sh',
     'stale-file-handle.sh',
   ],
-  'workdir': meson.current_build_dir(),
+  'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -22,7 +22,7 @@ nix-build dependencies.nix --no-out-link --compress-build-log
 builder="$(realpath "$(mktemp)")"
 echo -e "#!/bin/sh\nmkdir \$out" > "$builder"
 outp="$(nix-build -E \
-    'with import ./config.nix; mkDerivation { name = "fnord"; builder = '"$builder"'; }' \
+    'with import '"${config_nix}"'; mkDerivation { name = "fnord"; builder = '"$builder"'; }' \
     --out-link "$(mktemp -d)/result")"
 
 test -d "$outp"

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -14,27 +14,6 @@ project('nix-functional-tests', 'cpp',
 
 fs = import('fs')
 
-# Need to combine source and build trees
-run_command(
-  'rsync',
-  '-a',
-  '--copy-unsafe-links',
-  meson.current_source_dir() / '',
-  meson.current_build_dir() / '',
-)
-# This current-source-escaping relative is no good because we don't know
-# where the build directory will be, therefore we fix it up. Once the
-# Make build system is gone, we should think about doing this better.
-scripts_dir = fs.relative_to(
-  meson.current_source_dir() / '..' / '..' / 'scripts',
-  meson.current_build_dir(),
-)
-run_command(
-  'sed',
-  '-i', meson.current_build_dir() / 'bash-profile.sh',
-  '-e', 's^../../scripts^@0@^'.format(scripts_dir),
-)
-
 nix = find_program('nix')
 bash = find_program('bash', native : true)
 busybox = find_program('busybox', native : true, required : false)
@@ -185,7 +164,7 @@ suites = [
       'extra-sandbox-profile.sh',
       'help.sh',
     ],
-    'workdir': meson.current_build_dir(),
+    'workdir': meson.current_source_dir(),
   },
 ]
 
@@ -200,7 +179,7 @@ if nix_store.found()
     'tests': [
       'test-libstoreconsumer.sh',
     ],
-    'workdir': meson.current_build_dir(),
+    'workdir': meson.current_source_dir(),
   }
 
 endif
@@ -217,7 +196,7 @@ if nix_expr.found() and get_option('default_library') != 'static'
     'tests': [
       'plugins.sh',
     ],
-    'workdir': meson.current_build_dir(),
+    'workdir': meson.current_source_dir(),
   }
 endif
 
@@ -228,14 +207,12 @@ subdir('git-hashing')
 subdir('local-overlay-store')
 
 foreach suite : suites
+  workdir = suite['workdir']
+  suite_name = suite['name']
   foreach script : suite['tests']
-    workdir = suite['workdir']
-    prefix = fs.relative_to(workdir, meson.project_build_root())
-
-    script = script
     # Turns, e.g., `tests/functional/flakes/show.sh` into a Meson test target called
     # `functional-flakes-show`.
-    name = fs.replace_suffix(prefix / script, '')
+    name = fs.replace_suffix(script, '')
 
     test(
       name,
@@ -247,9 +224,11 @@ foreach suite : suites
         '-o', 'pipefail',
         script,
       ],
-      suite : suite['name'],
+      suite : suite_name,
       env : {
-        'TEST_NAME': name,
+        '_NIX_TEST_SOURCE_DIR': meson.current_source_dir(),
+        '_NIX_TEST_BUILD_DIR': meson.current_build_dir(),
+        'TEST_NAME': suite_name / name,
         'NIX_REMOTE': '',
         'PS4': '+(${BASH_SOURCE[0]-$0}:$LINENO) ',
       },

--- a/tests/functional/multiple-outputs.nix
+++ b/tests/functional/multiple-outputs.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
 

--- a/tests/functional/nar-access.nix
+++ b/tests/functional/nar-access.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
     a = mkDerivation {

--- a/tests/functional/nested-sandboxing.sh
+++ b/tests/functional/nested-sandboxing.sh
@@ -8,6 +8,15 @@ TODO_NixOS
 
 requireSandboxSupport
 
+start="$TEST_ROOT/start"
+mkdir -p "$start"
+cp -r common common.sh ${config_nix} ./nested-sandboxing "$start"
+cp "${_NIX_TEST_BUILD_DIR}/common/subst-vars.sh" "$start/common"
+# N.B. redefine
+_NIX_TEST_SOURCE_DIR="$start"
+_NIX_TEST_BUILD_DIR="$start"
+cd "$start"
+
 source ./nested-sandboxing/command.sh
 
 expectStderr 100 runNixBuild badStoreUrl 2 | grepQuiet '`sandbox-build-dir` must not contain'

--- a/tests/functional/nested-sandboxing/runner.nix
+++ b/tests/functional/nested-sandboxing/runner.nix
@@ -19,6 +19,9 @@ mkDerivation {
 
     export PATH=${builtins.getEnv "NIX_BIN_DIR"}:$PATH
 
+    export _NIX_TEST_SOURCE_DIR=$PWD
+    export _NIX_TEST_BUILD_DIR=$PWD
+
     source common.sh
     source ./nested-sandboxing/command.sh
 

--- a/tests/functional/nix-build-examples.nix
+++ b/tests/functional/nix-build-examples.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
 

--- a/tests/functional/nix-channel.sh
+++ b/tests/functional/nix-channel.sh
@@ -35,7 +35,7 @@ drvPath=$(nix-instantiate dependencies.nix)
 nix copy --to file://$TEST_ROOT/foo?compression="bzip2" $(nix-store -r "$drvPath")
 rm -rf $TEST_ROOT/nixexprs
 mkdir -p $TEST_ROOT/nixexprs
-cp config.nix dependencies.nix dependencies.builder*.sh $TEST_ROOT/nixexprs/
+cp "${config_nix}" dependencies.nix dependencies.builder*.sh $TEST_ROOT/nixexprs/
 ln -s dependencies.nix $TEST_ROOT/nixexprs/default.nix
 (cd $TEST_ROOT && tar cvf - nixexprs) | bzip2 > $TEST_ROOT/foo/nixexprs.tar.bz2
 

--- a/tests/functional/nix-profile.sh
+++ b/tests/functional/nix-profile.sh
@@ -47,7 +47,7 @@ printf World > $flake1Dir/who
 printf 1.0 > $flake1Dir/version
 printf false > $flake1Dir/ca.nix
 
-cp ./config.nix $flake1Dir/
+cp "${config_nix}" $flake1Dir/
 
 # Test upgrading from nix-env.
 nix-env -f ./user-envs.nix -i foo-1.0
@@ -140,7 +140,7 @@ nix profile install $(nix-build --no-out-link ./simple.nix)
 
 # Test packages with same name from different sources
 mkdir $TEST_ROOT/simple-too
-cp ./simple.nix ./config.nix simple.builder.sh $TEST_ROOT/simple-too
+cp ./simple.nix "${config_nix}" simple.builder.sh $TEST_ROOT/simple-too
 nix profile install --file $TEST_ROOT/simple-too/simple.nix ''
 nix profile list | grep -A4 'Name:.*simple' | grep 'Name:.*simple-1'
 nix profile remove simple 2>&1 | grep 'removed 1 packages'

--- a/tests/functional/nix-shell.sh
+++ b/tests/functional/nix-shell.sh
@@ -79,7 +79,7 @@ sed -e "s|@ENV_PROG@|$(type -P env)|" shell.shebang.expr > $TEST_ROOT/shell.sheb
 chmod a+rx $TEST_ROOT/shell.shebang.expr
 # Should fail due to expressions using relative path
 ! $TEST_ROOT/shell.shebang.expr bar
-cp shell.nix config.nix $TEST_ROOT
+cp shell.nix "${config_nix}" $TEST_ROOT
 # Should succeed
 echo "cwd: $PWD"
 output=$($TEST_ROOT/shell.shebang.expr bar)
@@ -126,7 +126,7 @@ $TEST_ROOT/shell.shebang.nix
 mkdir $TEST_ROOT/lookup-test $TEST_ROOT/empty
 
 echo "import $shellDotNix" > $TEST_ROOT/lookup-test/shell.nix
-cp config.nix $TEST_ROOT/lookup-test/
+cp "${config_nix}" $TEST_ROOT/lookup-test/
 echo 'abort "do not load default.nix!"' > $TEST_ROOT/lookup-test/default.nix
 
 nix-shell $TEST_ROOT/lookup-test -A shellDrv --run 'echo "it works"' | grepQuiet "it works"

--- a/tests/functional/optimise-store.sh
+++ b/tests/functional/optimise-store.sh
@@ -4,8 +4,8 @@ source common.sh
 
 clearStoreIfPossible
 
-outPath1=$(echo 'with import ./config.nix; mkDerivation { name = "foo1"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link --auto-optimise-store)
-outPath2=$(echo 'with import ./config.nix; mkDerivation { name = "foo2"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link --auto-optimise-store)
+outPath1=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo1"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link --auto-optimise-store)
+outPath2=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo2"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link --auto-optimise-store)
 
 TODO_NixOS # ignoring the client-specified setting 'auto-optimise-store', because it is a restricted setting and you are not a trusted user
   # TODO: only continue when trusted user or root
@@ -23,7 +23,7 @@ if [ "$nlink" != 3 ]; then
     exit 1
 fi
 
-outPath3=$(echo 'with import ./config.nix; mkDerivation { name = "foo3"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link)
+outPath3=$(echo 'with import '"${config_nix}"'; mkDerivation { name = "foo3"; builder = builtins.toFile "builder" "mkdir $out; echo hello > $out/foo"; }' | nix-build - --no-out-link)
 
 inode3="$(stat --format=%i $outPath3/foo)"
 if [ "$inode1" = "$inode3" ]; then

--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -6,7 +6,6 @@
 , meson
 , ninja
 , pkg-config
-, rsync
 
 , jq
 , git
@@ -52,7 +51,6 @@ mkMesonDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    rsync
 
     jq
     git

--- a/tests/functional/parallel.nix
+++ b/tests/functional/parallel.nix
@@ -1,6 +1,6 @@
 {sleepTime ? 3}:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let
 

--- a/tests/functional/pass-as-file.sh
+++ b/tests/functional/pass-as-file.sh
@@ -5,7 +5,7 @@ source common.sh
 clearStoreIfPossible
 
 outPath=$(nix-build --no-out-link -E "
-with import ./config.nix;
+with import ${config_nix};
 
 mkDerivation {
   name = \"pass-as-file\";

--- a/tests/functional/path.nix
+++ b/tests/functional/path.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation {
   name = "filter";

--- a/tests/functional/placeholders.sh
+++ b/tests/functional/placeholders.sh
@@ -5,7 +5,7 @@ source common.sh
 clearStoreIfPossible
 
 nix-build --no-out-link -E '
-  with import ./config.nix;
+  with import '"${config_nix}"';
 
   mkDerivation {
     name = "placeholders";

--- a/tests/functional/plugins.sh
+++ b/tests/functional/plugins.sh
@@ -3,7 +3,7 @@
 source common.sh
 
 for ext in so dylib; do
-    plugin="$PWD/plugins/libplugintest.$ext"
+    plugin="${_NIX_TEST_BUILD_DIR}/plugins/libplugintest.$ext"
     [[ -f "$plugin" ]] && break
 done
 

--- a/tests/functional/readfile-context.nix
+++ b/tests/functional/readfile-context.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let
 

--- a/tests/functional/recursive.nix
+++ b/tests/functional/recursive.nix
@@ -1,4 +1,5 @@
-with import ./config.nix;
+let config_nix = /. + "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix"; in
+with import config_nix;
 
 mkDerivation rec {
   name = "recursive";
@@ -41,7 +42,7 @@ mkDerivation rec {
 
     # Build a derivation.
     nix $opts build -L --impure --expr '
-      with import ${./config.nix};
+      with import ${config_nix};
       mkDerivation {
         name = "inner1";
         buildCommand = "echo $fnord blaat > $out";

--- a/tests/functional/restricted.sh
+++ b/tests/functional/restricted.sh
@@ -7,8 +7,19 @@ clearStoreIfPossible
 nix-instantiate --restrict-eval --eval -E '1 + 2'
 (! nix-instantiate --eval --restrict-eval ./restricted.nix)
 (! nix-instantiate --eval --restrict-eval <(echo '1 + 2'))
+
+mkdir -p "$TEST_ROOT/nix"
+cp ./simple.nix "$TEST_ROOT/nix"
+cp ./simple.builder.sh "$TEST_ROOT/nix"
+cp "${config_nix}" "$TEST_ROOT/nix"
+simple_nix="$TEST_ROOT/nix/simple.nix"
+# N.B. redefine
+config_nix="$TEST_ROOT/nix/config.nix"
+removeBuildDirRef "${simple_nix}"
+cd "$TEST_ROOT/nix"
+
 nix-instantiate --restrict-eval ./simple.nix -I src=.
-nix-instantiate --restrict-eval ./simple.nix -I src1=simple.nix -I src2=config.nix -I src3=./simple.builder.sh
+nix-instantiate --restrict-eval ./simple.nix -I src1=./simple.nix -I src2=./config.nix -I src3=./simple.builder.sh
 
 # no default NIX_PATH
 (unset NIX_PATH; ! nix-instantiate --restrict-eval --find-file .)
@@ -19,25 +30,25 @@ nix-instantiate --restrict-eval --eval -E 'builtins.readFile ./simple.nix' -I sr
 expectStderr 1 nix-instantiate --restrict-eval --eval -E 'let __nixPath = [ { prefix = "foo"; path = ./.; } ]; in builtins.readFile <foo/simple.nix>' | grepQuiet "forbidden in restricted mode"
 nix-instantiate --restrict-eval --eval -E 'let __nixPath = [ { prefix = "foo"; path = ./.; } ]; in builtins.readFile <foo/simple.nix>' -I src=.
 
-p=$(nix eval --raw --expr "builtins.fetchurl file://$(pwd)/restricted.sh" --impure --restrict-eval --allowed-uris "file://$(pwd)")
-cmp $p restricted.sh
+p=$(nix eval --raw --expr "builtins.fetchurl file://${_NIX_TEST_SOURCE_DIR}/restricted.sh" --impure --restrict-eval --allowed-uris "file://${_NIX_TEST_SOURCE_DIR}")
+cmp "$p" "${_NIX_TEST_SOURCE_DIR}/restricted.sh"
 
-(! nix eval --raw --expr "builtins.fetchurl file://$(pwd)/restricted.sh" --impure --restrict-eval)
+(! nix eval --raw --expr "builtins.fetchurl file://${_NIX_TEST_SOURCE_DIR}/restricted.sh" --impure --restrict-eval)
 
-(! nix eval --raw --expr "builtins.fetchurl file://$(pwd)/restricted.sh" --impure --restrict-eval --allowed-uris "file://$(pwd)/restricted.sh/")
+(! nix eval --raw --expr "builtins.fetchurl file://${_NIX_TEST_SOURCE_DIR}/restricted.sh" --impure --restrict-eval --allowed-uris "file://${_NIX_TEST_SOURCE_DIR}/restricted.sh/")
 
-nix eval --raw --expr "builtins.fetchurl file://$(pwd)/restricted.sh" --impure --restrict-eval --allowed-uris "file://$(pwd)/restricted.sh"
+nix eval --raw --expr "builtins.fetchurl file://${_NIX_TEST_SOURCE_DIR}/restricted.sh" --impure --restrict-eval --allowed-uris "file://${_NIX_TEST_SOURCE_DIR}/restricted.sh"
 
 (! nix eval --raw --expr "builtins.fetchurl https://github.com/NixOS/patchelf/archive/master.tar.gz" --impure --restrict-eval)
 (! nix eval --raw --expr "builtins.fetchTarball https://github.com/NixOS/patchelf/archive/master.tar.gz" --impure --restrict-eval)
 (! nix eval --raw --expr "fetchGit git://github.com/NixOS/patchelf.git" --impure --restrict-eval)
 
-ln -sfn $(pwd)/restricted.nix $TEST_ROOT/restricted.nix
+ln -sfn "${_NIX_TEST_SOURCE_DIR}/restricted.nix" "$TEST_ROOT/restricted.nix"
 [[ $(nix-instantiate --eval $TEST_ROOT/restricted.nix) == 3 ]]
 (! nix-instantiate --eval --restrict-eval $TEST_ROOT/restricted.nix)
 (! nix-instantiate --eval --restrict-eval $TEST_ROOT/restricted.nix -I $TEST_ROOT)
 (! nix-instantiate --eval --restrict-eval $TEST_ROOT/restricted.nix -I .)
-nix-instantiate --eval --restrict-eval $TEST_ROOT/restricted.nix -I $TEST_ROOT -I .
+nix-instantiate --eval --restrict-eval "$TEST_ROOT/restricted.nix" -I "$TEST_ROOT" -I "${_NIX_TEST_SOURCE_DIR}"
 
 [[ $(nix eval --raw --impure --restrict-eval -I . --expr 'builtins.readFile "${import ./simple.nix}/hello"') == 'Hello World!' ]]
 
@@ -54,12 +65,12 @@ expectStderr 1 nix-instantiate --restrict-eval --eval -E "let __nixPath = [ { pr
 [[ $(nix-instantiate --restrict-eval --eval -E "let __nixPath = [ { prefix = \"foo\"; path = $TEST_ROOT/tunnel.d; } ]; in builtins.readDir <foo/tunnel>" -I $TEST_ROOT/tunnel.d) == '{ "tunnel.d" = "directory"; }' ]]
 
 # Check whether we can leak symlink information through directory traversal.
-traverseDir="$(pwd)/restricted-traverse-me"
-ln -sfn "$(pwd)/restricted-secret" "$(pwd)/restricted-innocent"
+traverseDir="${_NIX_TEST_SOURCE_DIR}/restricted-traverse-me"
+ln -sfn "${_NIX_TEST_SOURCE_DIR}/restricted-secret" "${_NIX_TEST_SOURCE_DIR}/restricted-innocent"
 mkdir -p "$traverseDir"
 goUp="..$(echo "$traverseDir" | sed -e 's,[^/]\+,..,g')"
 output="$(nix eval --raw --restrict-eval -I "$traverseDir" \
-    --expr "builtins.readFile \"$traverseDir/$goUp$(pwd)/restricted-innocent\"" \
+    --expr "builtins.readFile \"$traverseDir/$goUp${_NIX_TEST_SOURCE_DIR}/restricted-innocent\"" \
     2>&1 || :)"
 echo "$output" | grep "is forbidden"
 echo "$output" | grepInverse -F restricted-secret

--- a/tests/functional/search.nix
+++ b/tests/functional/search.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 {
   hello = mkDerivation rec {

--- a/tests/functional/secure-drv-outputs.nix
+++ b/tests/functional/secure-drv-outputs.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 {
 

--- a/tests/functional/selfref-gc.sh
+++ b/tests/functional/selfref-gc.sh
@@ -7,7 +7,7 @@ requireDaemonNewerThan "2.6.0pre20211215"
 clearStoreIfPossible
 
 nix-build --no-out-link -E '
-  with import ./config.nix;
+  with import '"${config_nix}"';
 
   let d1 = mkDerivation {
     name = "selfref-gc";

--- a/tests/functional/shell-hello.nix
+++ b/tests/functional/shell-hello.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 rec {
   hello = mkDerivation {

--- a/tests/functional/shell.nix
+++ b/tests/functional/shell.nix
@@ -1,6 +1,6 @@
 { inNixShell ? false, contentAddressed ? false, fooContents ? "foo" }:
 
-let cfg = import ./config.nix; in
+let cfg = import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix"; in
 with cfg;
 
 let

--- a/tests/functional/simple-failing.nix
+++ b/tests/functional/simple-failing.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation {
   name = "simple-failing";

--- a/tests/functional/simple.nix
+++ b/tests/functional/simple.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 mkDerivation {
   name = "simple";

--- a/tests/functional/structured-attrs-shell.nix
+++ b/tests/functional/structured-attrs-shell.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 let
   dep = mkDerivation {
     name = "dep";

--- a/tests/functional/structured-attrs.nix
+++ b/tests/functional/structured-attrs.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let
 

--- a/tests/functional/symlink-derivation.nix
+++ b/tests/functional/symlink-derivation.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 let
   foo_in_store = builtins.toFile "foo" "foo";

--- a/tests/functional/tarball.sh
+++ b/tests/functional/tarball.sh
@@ -10,7 +10,7 @@ tarroot=$TEST_ROOT/tarball
 rm -rf "$tarroot"
 mkdir -p "$tarroot"
 cp dependencies.nix "$tarroot/default.nix"
-cp config.nix dependencies.builder*.sh "$tarroot/"
+cp "${config_nix}" dependencies.builder*.sh "$tarroot/"
 touch -d '@1000000000' "$tarroot" "$tarroot"/*
 
 hash=$(nix hash path "$tarroot")
@@ -45,7 +45,7 @@ test_tarball() {
     nix-instantiate --eval -E 'with <fnord/xyzzy>; 1 + 2' -I fnord=file:///no-such-tarball"$ext"
     (! nix-instantiate --eval -E '<fnord/xyzzy> 1' -I fnord=file:///no-such-tarball"$ext")
 
-    nix-instantiate --eval -E '<fnord/config.nix>' -I fnord=file:///no-such-tarball"$ext" -I fnord=.
+    nix-instantiate --eval -E '<fnord/config.nix>' -I fnord=file:///no-such-tarball"$ext" -I fnord="${_NIX_TEST_BUILD_DIR}"
 
     # Ensure that the `name` attribute isn’t accepted as that would mess
     # with the content-addressing

--- a/tests/functional/test-libstoreconsumer.sh
+++ b/tests/functional/test-libstoreconsumer.sh
@@ -4,5 +4,5 @@ source common.sh
 
 drv="$(nix-instantiate simple.nix)"
 cat "$drv"
-out="$(./test-libstoreconsumer/test-libstoreconsumer "$drv")"
+out="$("${_NIX_TEST_BUILD_DIR}/test-libstoreconsumer/test-libstoreconsumer" "$drv")"
 grep -F "Hello World!" < "$out/hello"

--- a/tests/functional/timeout.nix
+++ b/tests/functional/timeout.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 {
 

--- a/tests/functional/user-envs.nix
+++ b/tests/functional/user-envs.nix
@@ -2,7 +2,7 @@
 { foo ? "foo"
 }:
 
-with import ./config.nix;
+with import "${builtins.getEnv "_NIX_TEST_BUILD_DIR"}/config.nix";
 
 assert foo == "foo";
 

--- a/tests/functional/why-depends.sh
+++ b/tests/functional/why-depends.sh
@@ -4,7 +4,7 @@ source common.sh
 
 clearStoreIfPossible
 
-cp ./dependencies.nix ./dependencies.builder0.sh ./config.nix $TEST_HOME
+cp ./dependencies.nix ./dependencies.builder0.sh "${config_nix}" $TEST_HOME
 
 cd $TEST_HOME
 

--- a/tests/nixos/functional/common.nix
+++ b/tests/nixos/functional/common.nix
@@ -55,6 +55,10 @@ in
             -e 's!nix_tests += test-libstoreconsumer\.sh!!' \
             ;
 
+          _NIX_TEST_SOURCE_DIR="$(realpath tests/functional)"
+          export _NIX_TEST_SOURCE_DIR
+          export _NIX_TEST_BUILD_DIR="''${_NIX_TEST_SOURCE_DIR}"
+
           export isTestOnNixOS=1
           export version=${config.nix.package.version}
           export NIX_REMOTE_=daemon


### PR DESCRIPTION
# Motivation

This should make `_NIX_TEST_ACCEPT=1` work again, fixing #11369.

# Context

Progress on #2503

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
