### PR TITLE
docs: add links to string context documentation

### DIFF
--- a/doc/manual/source/language/operators.md
+++ b/doc/manual/source/language/operators.md
@@ -102,7 +102,7 @@ The `+` operator is overloaded to also work on strings and paths.
 >
 > *string* `+` *string*
 
-Concatenate two [strings][string] and merge their string contexts.
+Concatenate two [strings][string] and merge their [string contexts](./string-context.md).
 
 [String concatenation]: #string-concatenation
 
@@ -128,7 +128,7 @@ The result is a path.
 
 > **Note**
 >
-> The string must not have a string context that refers to a [store path].
+> The string must not have a [string context](./string-context.md) that refers to a [store path].
 
 [Path and string concatenation]: #path-and-string-concatenation
 


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
operators are an everyday thing in the Nix language, and this page will hopefully be consulted by many users. string contexts are quite exotic, and not linking to the detailed explanation will require readers to figure out manually what this is about, or worse, skim over and run into problems later.

# Context
Thanks to @ellyxir for pointing out friction in the language tutorial in https://github.com/NixOS/nix.dev/pull/1070, which made me re-read the relevant part of reference documentation.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).