### PR TITLE
Set minimum Windows API to Windows 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ ifdef HOST_WINDOWS
   #
   # TODO do not do this, and instead do fine-grained export annotations.
   GLOBAL_LDFLAGS += -Wl,--export-all-symbols
+  GLOBAL_CXXFLAGS += -D_WIN32_WINNT=0x0602
 endif
 
 GLOBAL_CXXFLAGS += -g -Wall -Wdeprecated-copy -Wignored-qualifiers -Wimplicit-fallthrough -Werror=unused-result -Werror=suggest-override -include $(buildprefix)config.h -std=c++2a -I src


### PR DESCRIPTION
Anything less won't compile because we're using GetCurrentThreadStackLimits from Windows 8.

# Motivation

Discovered when trying to compile under mingw64, which seems to set a value of 0x0601 (Windows 7)

# Context

https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170