### PR TITLE
Meson for nixos functional tests

### DIFF
--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -29,7 +29,7 @@ The unit tests are defined using the [googletest] and [rapidcheck] frameworks.
 > ```
 > src
 > ├── libexpr
-> │   ├── local.mk
+> │   ├── meson.build
 > │   ├── value/context.hh
 > │   ├── value/context.cc
 > │   …
@@ -37,25 +37,24 @@ The unit tests are defined using the [googletest] and [rapidcheck] frameworks.
 > ├── tests
 > │   │
 > │   …
-> │   └── unit
-> │       ├── libutil
-> │       │   ├── local.mk
-> │       │   …
-> │       │   └── data
-> │       │       ├── git/tree.txt
-> │       │       …
-> │       │
-> │       ├── libexpr-support
-> │       │   ├── local.mk
-> │       │   └── tests
-> │       │       ├── value/context.hh
-> │       │       ├── value/context.cc
-> │       │       …
-> │       │
-> │       ├── libexpr
-> │       …   ├── local.mk
-> │           ├── value/context.cc
-> │           …
+> │   ├── libutil-tests
+> │   │   ├── meson.build
+> │   │   …
+> │   │   └── data
+> │   │       ├── git/tree.txt
+> │   │       …
+> │   │
+> │   ├── libexpr-test-support
+> │   │   ├── meson.build
+> │   │   └── tests
+> │   │       ├── value/context.hh
+> │   │       ├── value/context.cc
+> │   │       …
+> │   │
+> │   ├── libexpr-tests
+> │   …   ├── meson.build
+> │       ├── value/context.cc
+> │       …
 > …
 > ```
 
@@ -128,7 +127,7 @@ On other platforms they wouldn't be run at all.
 
 ## Functional tests
 
-The functional tests reside under the `tests/functional` directory and are listed in `tests/functional/local.mk`.
+The functional tests reside under the `tests/functional` directory and are listed in `tests/functional/meson.build`.
 Each test is a bash script.
 
 Functional tests are run during `installCheck` in the `nix` package build, as well as separately from the build, in VM tests.

--- a/tests/functional/common/init.sh
+++ b/tests/functional/common/init.sh
@@ -19,7 +19,7 @@ EOF
 
   # When we're doing everything in the same store, we need to bring
   # dependencies into context.
-  sed -i "$(dirname "${BASH_SOURCE[0]}")"/../config.nix \
+  sed -i "${_NIX_TEST_BUILD_DIR}/config.nix" \
     -e 's^\(shell\) = "/nix/store/\([^/]*\)/\(.*\)";^\1 = builtins.appendContext "/nix/store/\2" { "/nix/store/\2".path = true; } + "/\3";^' \
     -e 's^\(path\) = "/nix/store/\([^/]*\)/\(.*\)";^\1 = builtins.appendContext "/nix/store/\2" { "/nix/store/\2".path = true; } + "/\3";^' \
     ;

--- a/tests/functional/common/subst-vars.sh.in
+++ b/tests/functional/common/subst-vars.sh.in
@@ -1,4 +1,4 @@
-# NOTE: instances of @variable@ are substituted as defined in /mk/templates.mk
+# NOTE: instances of @variable@ are substituted by the build system
 
 if [[ -z "${COMMON_SUBST_VARS_SH_SOURCED-}" ]]; then
 

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -1,4 +1,4 @@
-project('nix-functional-tests', 'cpp',
+project('nix-functional-tests',
   version : files('.version'),
   default_options : [
     'cpp_std=c++2a',
@@ -170,6 +170,7 @@ suites = [
 
 nix_store = dependency('nix-store', required : false)
 if nix_store.found()
+  add_languages('cpp')
   subdir('test-libstoreconsumer')
   suites += {
     'name': 'libstoreconsumer',
@@ -187,6 +188,7 @@ endif
 # Plugin tests require shared libraries support.
 nix_expr = dependency('nix-expr', required : false)
 if nix_expr.found() and get_option('default_library') != 'static'
+  add_languages('cpp')
   subdir('plugins')
   suites += {
     'name': 'plugins',

--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -21,7 +21,8 @@ let
       defaults = {
         nixpkgs.pkgs = nixpkgsFor.${system}.native;
         nix.checkAllErrors = false;
-        nix.package = noTests nixpkgsFor.${system}.native.nix;
+        # TODO: decide which packaging stage to use. `nix-cli` is efficient, but not the same as the user-facing `everything.nix` package (`default`). Perhaps a good compromise is `everything.nix` + `noTests` defined above?
+        nix.package = nixpkgsFor.${system}.native.nixComponents.nix-cli;
       };
       _module.args.nixpkgs = nixpkgs;
       _module.args.system = system;
@@ -33,10 +34,9 @@ let
       forNix = nixVersion: runNixOSTestFor system {
         imports = [test];
         defaults.nixpkgs.overlays = [(curr: prev: {
-          # NOTE: noTests pkg might not have been built yet for some older versions of the package
-          #       and in versions before 2.25, the untested build wasn't shared with the tested build yet
-          #       Add noTests here when those versions become irrelevant.
-          nix = (builtins.getFlake "nix/${nixVersion}").packages.${system}.nix;
+          nix = let
+            packages = (builtins.getFlake "nix/${nixVersion}").packages.${system};
+          in packages.nix-cli or packages.nix;
         })];
       };
     };


### PR DESCRIPTION
# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context

#2503

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
