### PR TITLE
chmod the `/build` subdir to 750

### DIFF
--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -555,7 +555,7 @@ void LocalDerivationGoal::startBuilder()
            possible. Any mitigation along these lines would have to be
            done directly in the sandbox profile. */
         tmpDir = topTmpDir + "/build";
-        createDir(tmpDir, 0700);
+        createDir(tmpDir, 0750);
     } else {
         tmpDir = topTmpDir;
     }


### PR DESCRIPTION
Due to unknown reasons, some packages (notably yarn and npm) will stall during a build process. This causes a major problem, because the process cannot be killed and a cold-reset is needed to restart the system (a shutdown or reboot will hang trying to umount the partition where the build is happening).

By letting the `/build` subdirectory be group-readable by the nixbld group, the problem is fixed.

Also we do not sacrifice build privacy, because the parrent directory is owned by `root` and set to `700`.

So even if we have a malicious setguid binary in one build and another tries to run it, it cannot access it because the parent folder is owned by `root`.

fixes #11806
fixes https://github.com/NixOS/nixpkgs/issues/353709

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

See linked issues above

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

See linked issues above

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
