### PR TITLE
Meson fixes for msys2 builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -22,10 +22,12 @@ subproject('libcmd')
 subproject('nix')
 
 # Docs
-subproject('internal-api-docs')
-subproject('external-api-docs')
-if not meson.is_cross_build()
-  subproject('nix-manual')
+if get_option('doc-gen')
+  subproject('internal-api-docs')
+  subproject('external-api-docs')
+  if not meson.is_cross_build()
+    subproject('nix-manual')
+  endif
 endif
 
 # External C wrapper libraries
@@ -35,17 +37,19 @@ subproject('libexpr-c')
 subproject('libmain-c')
 
 # Language Bindings
-if not meson.is_cross_build()
+if get_option('bindings') and not meson.is_cross_build()
   subproject('perl')
 endif
 
 # Testing
-subproject('libutil-test-support')
-subproject('libutil-tests')
-subproject('libstore-test-support')
-subproject('libstore-tests')
-subproject('libfetchers-tests')
-subproject('libexpr-test-support')
-subproject('libexpr-tests')
-subproject('libflake-tests')
+if get_option('unit-tests')
+  subproject('libutil-test-support')
+  subproject('libutil-tests')
+  subproject('libstore-test-support')
+  subproject('libstore-tests')
+  subproject('libfetchers-tests')
+  subproject('libexpr-test-support')
+  subproject('libexpr-tests')
+  subproject('libflake-tests')
+endif
 subproject('nix-functional-tests')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,13 @@
+# vim: filetype=meson
+
+option('doc-gen', type : 'boolean', value : true,
+  description : 'Generate documentation',
+)
+
+option('unit-tests', type : 'boolean', value : true,
+  description : 'Build unit tests',
+)
+
+option('bindings', type : 'boolean', value : true,
+  description : 'Build language bindings (e.g. Perl)',
+)

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -34,6 +34,8 @@ subdir('build-utils-meson/subprojects')
 run_command('ln', '-s',
   meson.project_build_root() / '__nothing_link_target',
   meson.project_build_root() / '__nothing_symlink',
+  # native doesn't allow dangling symlinks, which the tests require
+  env : { 'MSYS' : 'winsymlinks:lnk' },
   check : true,
 )
 can_link_symlink = run_command('ln',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -76,6 +76,11 @@ if host_machine.system() == 'darwin'
   deps_other += [sandbox]
 endif
 
+if host_machine.system() == 'windows'
+  wsock32 = cxx.find_library('wsock32')
+  deps_other += [wsock32]
+endif
+
 subdir('build-utils-meson/threads')
 
 boost = dependency(

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -229,6 +229,8 @@ foreach linkname : nix_symlinks
   t = custom_target(
     command: ['ln', '-sf', fs.name(this_exe), '@OUTPUT@'],
     output: linkname + executable_suffix,
+    # native doesn't allow dangling symlinks, but the target executable often doesn't exist at this time
+    env : { 'MSYS' : 'winsymlinks:lnk' },
     # TODO(Ericson2314): Don't do this once we have the `meson.override_find_program` working)
     build_by_default: true
   )
@@ -247,6 +249,8 @@ install_symlink(
 custom_target(
   command: ['ln', '-sf', fs.name(this_exe), '@OUTPUT@'],
   output: 'build-remote' + executable_suffix,
+  # native doesn't allow dangling symlinks, but the target executable often doesn't exist at this time
+  env : { 'MSYS' : 'winsymlinks:lnk' },
   # TODO(Ericson2314): Don't do this once we have the `meson.override_find_program` working)
   build_by_default: true
 )

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -17,7 +17,12 @@ fs = import('fs')
 nix = find_program('nix')
 bash = find_program('bash', native : true)
 busybox = find_program('busybox', native : true, required : false)
-coreutils = find_program('coreutils', native : true)
+if host_machine.system() == 'windows'
+  # Because of the state of symlinks on Windows, coreutils.exe doesn't usually exist, but things like ls.exe will
+  coreutils = find_program('ls', native : true)
+else
+  coreutils = find_program('coreutils', native : true)
+endif
 dot = find_program('dot', native : true, required : false)
 
 nix_bin_dir = fs.parent(nix.full_path())


### PR DESCRIPTION
# Motivation

Building Nix using mingw64, using Meson.

# Context

I've been using the Makefile to build using mingw64. With these changes (and #11808) I can now use Meson.

One core difference is that symlinks are very important to both the Meson infrastructure (due to build-utils-meson) and the Meson builds (e.g. things pointing to nix.exe) - so you have to change the Windows settings in order to build. This was not needed using Make.