### PR TITLE
fix(libstore-tests): remove use-after-free bug for `StringSource`

### DIFF
--- a/src/libstore-tests/serve-protocol.cc
+++ b/src/libstore-tests/serve-protocol.cc
@@ -459,21 +459,14 @@ TEST_F(ServeProtoTest, handshake_client_truncated_replay_throws)
     CharacterizationTest::readTest("handshake-to-client", [&](std::string toClientLog) {
         for (size_t len = 0; len < toClientLog.size(); ++len) {
             NullBufferedSink nullSink;
-            StringSource in {
-                // truncate
-                toClientLog.substr(0, len)
-            };
+            auto substring = toClientLog.substr(0, len);
+            StringSource in{substring};
             if (len < 8) {
                 EXPECT_THROW(
-                    ServeProto::BasicClientConnection::handshake(
-                        nullSink, in, defaultVersion, "blah"),
-                    EndOfFile);
+                    ServeProto::BasicClientConnection::handshake(nullSink, in, defaultVersion, "blah"), EndOfFile);
             } else {
                 // Not sure why cannot keep on checking for `EndOfFile`.
-                EXPECT_THROW(
-                    ServeProto::BasicClientConnection::handshake(
-                        nullSink, in, defaultVersion, "blah"),
-                    Error);
+                EXPECT_THROW(ServeProto::BasicClientConnection::handshake(nullSink, in, defaultVersion, "blah"), Error);
             }
         }
     });

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -725,21 +725,14 @@ TEST_F(WorkerProtoTest, handshake_client_truncated_replay_throws)
     CharacterizationTest::readTest("handshake-to-client", [&](std::string toClientLog) {
         for (size_t len = 0; len < toClientLog.size(); ++len) {
             NullBufferedSink nullSink;
-            StringSource in {
-                // truncate
-                toClientLog.substr(0, len)
-            };
+            auto substring = toClientLog.substr(0, len);
+            StringSource in{substring};
             if (len < 8) {
                 EXPECT_THROW(
-                    WorkerProto::BasicClientConnection::handshake(
-                        nullSink, in, defaultVersion, {}),
-                    EndOfFile);
+                    WorkerProto::BasicClientConnection::handshake(nullSink, in, defaultVersion, {}), EndOfFile);
             } else {
                 // Not sure why cannot keep on checking for `EndOfFile`.
-                EXPECT_THROW(
-                    WorkerProto::BasicClientConnection::handshake(
-                        nullSink, in, defaultVersion, {}),
-                    Error);
+                EXPECT_THROW(WorkerProto::BasicClientConnection::handshake(nullSink, in, defaultVersion, {}), Error);
             }
         }
     });

--- a/src/libutil/serialise.hh
+++ b/src/libutil/serialise.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include <memory>
+#include <type_traits>
 
 #include "types.hh"
 #include "util.hh"
@@ -202,7 +203,14 @@ struct StringSource : Source
 {
     std::string_view s;
     size_t pos;
+
+    // NOTE: Prevent unintentional dangling views when an implicit conversion
+    // from std::string -> std::string_view occurs when the string is passed
+    // by rvalue.
+    StringSource(std::string &&) = delete;
     StringSource(std::string_view s) : s(s), pos(0) { }
+    StringSource(const std::string& str): StringSource(std::string_view(str)) {}
+
     size_t read(char * data, size_t len) override;
 };
 


### PR DESCRIPTION
Unfortunately `StringSource` class is very easy was very easy to misuse because the ctor took a plain `std::string_view` which has a bad habit of being implicitly convertible from an rvalue `std::string`. This lead to unintentional use-after-free bugs.

This patch makes `StringSource` much harder to misuse by disabling the ctor from a `std::string &&` (but `const std::string &` is ok).

Fix affected tests from libstore-tests.
Reformat those tests with clangd's range formatting since the diff is tiny and it seems appropriate.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->
Ran some tests under ASAN and UBSAN and got shocked by the amount of errors. This looks a good starting point for starting to untangle them.

# Context

For reference here's the ASAN log for one of the two tests:

```
==3145773==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fffdbca8500 at pc 0x7ffff7993882 bp 0x7ffffffeffb0 sp 0x7ffffffef770
READ of size 1 at 0x7fffdbca8500 thread T0
    #0 0x7ffff7993881 in __interceptor_memcpy (/nix/store/40yjzm7r5ki59kkk9423dnwbm86x7pyd-gcc-13.2.0-lib/lib/libasan.so.8+0x71881)
    #1 0x7fffe3d752cb in std::char_traits<char>::copy(char*, char const*, unsigned long) /nix/store/fg7ass3a5m5pgl26qzfdniicbwbgzccy-gcc-13.2.0/include/c++/13.2.0/bits/char_traits.h:445
    #2 0x7fffe3d752cb in std::char_traits<char>::copy(char*, char const*, unsigned long) /nix/store/fg7ass3a5m5pgl26qzfdniicbwbgzccy-gcc-13.2.0/include/c++/13.2.0/bits/char_traits.h:437
    #3 0x7fffe3d752cb in std::basic_string_view<char, std::char_traits<char> >::copy(char*, unsigned long, unsigned long) const /nix/store/fg7ass3a5m5pgl26qzfdniicbwbgzccy-gcc-13.2.0/include/c++/13.2.0/string_view:327
    #4 0x7fffe3d752cb in nix::StringSource::read(char*, unsigned long) ../src/libutil/serialise.cc:192
    #5 0x7fffe3d59cbf in nix::Source::operator()(char*, unsigned long) ../src/libutil/serialise.cc:81
    #6 0x7fffeeab3596 in unsigned int nix::readNum<unsigned int>(nix::Source&) ../src/libutil/serialise.hh:415
    #7 0x7fffef710339 in nix::readInt(nix::Source&) ../src/libutil/serialise.hh:428
    #8 0x7fffef710339 in nix::WorkerProto::BasicClientConnection::handshake(nix::BufferedSink&, nix::Source&, unsigned int, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) ../src/libstore/worker-protocol-connection.cc:168
    #9 0xd538b8 in operator() ../src/libstore-tests/worker-protocol.cc:733
    #10 0xd538b8 in readTest<nix::WorkerProtoTest_handshake_client_truncated_replay_throws_Test::TestBody()::<lambda(std::string)> > ../src/libutil-test-support/tests/characterization.hh:61
    #11 0xd538b8 in nix::WorkerProtoTest_handshake_client_truncated_replay_throws_Test::TestBody() ../src/libstore-tests/worker-protocol.cc:725
    #12 0x7ffff788125c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/nix/store/8br7fhn6qdrqm9f1acn35zadn0jrmlg9-gtest-1.14.0/lib/libgtest.so.1.14.0+0x6025c)
    #13 0x7ffff786806d in testing::Test::Run() (/nix/store/8br7fhn6qdrqm9f1acn35zadn0jrmlg9-gtest-1.14.0/lib/libgtest.so.1.14.0+0x4706d)
    #14 0x7ffff7868224 in testing::TestInfo::Run() (/nix/store/8br7fhn6qdrqm9f1acn35zadn0jrmlg9-gtest-1.14.0/lib/libgtest.so.1.14.0+0x47224)
    #15 0x7ffff7868456 in testing::TestSuite::Run() (/nix/store/8br7fhn6qdrqm9f1acn35zadn0jrmlg9-gtest-1.14.0/lib/libgtest.so.1.14.0+0x47456)
    #16 0x7ffff78779e6 in testing::internal::UnitTestImpl::RunAllTests() (/nix/store/8br7fhn6qdrqm9f1acn35zadn0jrmlg9-gtest-1.14.0/lib/libgtest.so.1.14.0+0x569e6)
    #17 0x7ffff786865a in testing::UnitTest::Run() (/nix/store/8br7fhn6qdrqm9f1acn35zadn0jrmlg9-gtest-1.14.0/lib/libgtest.so.1.14.0+0x4765a)
    #18 0x7ffff789e0bf in main (/nix/store/8br7fhn6qdrqm9f1acn35zadn0jrmlg9-gtest-1.14.0/lib/libgtest_main.so.1.14.0+0x10bf)
    #19 0x7fffdebe610d in __libc_start_call_main (/nix/store/87848rvrg5c7jmplpi0iapvbxyj9kfid-glibc-2.39-52/lib/libc.so.6+0x2a10d) (BuildId: 74e5f374333670d3fbe07e0abb58717eeababaa6)
    #20 0x7fffdebe61c8 in __libc_start_main_alias_1 (/nix/store/87848rvrg5c7jmplpi0iapvbxyj9kfid-glibc-2.39-52/lib/libc.so.6+0x2a1c8) (BuildId: 74e5f374333670d3fbe07e0abb58717eeababaa6)
    #21 0x4fedc4 in _start (nix/build/src/libstore-tests/nix-store-tests+0x4fedc4) (BuildId: 5ae976e9c97622accddce7010abbfe9dff93178b)


```

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
