### PR TITLE
`ProgressBar::ask`: accept EOF, as a no

### DIFF
--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -543,7 +543,7 @@ public:
         auto state(state_.lock());
         if (!state->active) return {};
         std::cerr << fmt("\r\e[K%s ", msg);
-        auto s = trim(readLine(STDIN_FILENO));
+        auto s = trim(readLine(STDIN_FILENO, true));
         if (s.size() != 1) return {};
         draw(*state);
         return s[0];

--- a/src/libutil/file-descriptor.hh
+++ b/src/libutil/file-descriptor.hh
@@ -77,8 +77,13 @@ void writeFull(Descriptor fd, std::string_view s, bool allowInterrupts = true);
 
 /**
  * Read a line from a file descriptor.
+ *
+ * @param fd The file descriptor to read from
+ * @param eofOk If true, return an unterminated line if EOF is reached. (e.g. the empty string)
+ *
+ * @return A line of text ending in `\n`, or a string without `\n` if `eofOk` is true and EOF is reached.
  */
-std::string readLine(Descriptor fd);
+std::string readLine(Descriptor fd, bool eofOk = false);
 
 /**
  * Write a line to a file descriptor.

--- a/src/libutil/unix/file-descriptor.cc
+++ b/src/libutil/unix/file-descriptor.cc
@@ -47,7 +47,7 @@ void writeFull(int fd, std::string_view s, bool allowInterrupts)
 }
 
 
-std::string readLine(int fd)
+std::string readLine(int fd, bool eofOk)
 {
     std::string s;
     while (1) {
@@ -58,8 +58,12 @@ std::string readLine(int fd)
         if (rd == -1) {
             if (errno != EINTR)
                 throw SysError("reading a line");
-        } else if (rd == 0)
-            throw EndOfFile("unexpected EOF reading a line");
+        } else if (rd == 0) {
+            if (eofOk)
+                return s;
+            else
+                throw EndOfFile("unexpected EOF reading a line");
+        }
         else {
             if (ch == '\n') return s;
             s += ch;

--- a/tests/functional/flakes/config.sh
+++ b/tests/functional/flakes/config.sh
@@ -27,7 +27,17 @@ cat <<EOF > flake.nix
 EOF
 
 # Without --accept-flake-config, the post hook should not run.
+# To test variations in stderr tty-ness, we run the command in different ways,
+# none of which should block on stdin or accept the `nixConfig`s.
 nix build < /dev/null
+nix build < /dev/null 2>&1 | cat
+# EOF counts as no, even when interactive (throw EOF error before)
+if type -p script >/dev/null && script -q -c true /dev/null; then
+    echo "script is available and GNU-like, so we can ensure a tty"
+    script -q -c 'nix build < /dev/null' /dev/null
+else
+    echo "script is not available or not GNU-like, so we skip testing with an added tty"
+fi
 (! [[ -f post-hook-ran ]])
 TODO_NixOS
 clearStore

--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -60,6 +60,7 @@ mkMesonDerivation (finalAttrs: {
     # etc.
     busybox-sandbox-shell
     # For Overlay FS tests need `mount`, `umount`, and `unshare`.
+    # For `script` command (ensuring a TTY)
     # TODO use `unixtools` to be precise over which executables instead?
     util-linux
   ];

--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , mkMesonDerivation
-, releaseTools
 
 , meson
 , ninja
@@ -15,10 +14,6 @@
 , nix-store
 , nix-expr
 , nix-cli
-
-, rapidcheck
-, gtest
-, runCommand
 
 , busybox-sandbox-shell ? null
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation


This may occur when stderr is a tty but stdin is empty. For example:

    $ nix build </dev/null
    error: unexpected EOF reading a line

This configuration of stdio handles is how some non-interactive sandboxes behave, including the Nix build sandbox and Hercules CI Effects.

# Context

- General solution to https://github.com/hercules-ci/hercules-ci-effects/pull/181

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
