### PR TITLE
Fix 'nix copy' VM test

### DIFF
--- a/tests/nixos/nix-copy.nix
+++ b/tests/nixos/nix-copy.nix
@@ -37,7 +37,8 @@ in {
         { config, pkgs, ... }:
         { services.openssh.enable = true;
           services.openssh.settings.PermitRootLogin = "yes";
-					users.users.root.password = "foobar";
+          users.users.root.hashedPasswordFile = null;
+          users.users.root.password = "foobar";
           virtualisation.writableStore = true;
           virtualisation.additionalPaths = [ pkgB pkgC ];
         };
@@ -64,7 +65,7 @@ in {
     # Copy the closure of package A from the client to the server using password authentication,
     # and check that all prompts are visible
     server.fail("nix-store --check-validity ${pkgA}")
-    client.send_chars("nix copy --to ssh://server ${pkgA} >&2; echo done\n")
+    client.send_chars("nix copy --to ssh://server ${pkgA} >&2; echo -n do; echo ne\n")
     client.wait_for_text("continue connecting")
     client.send_chars("yes\n")
     client.wait_for_text("Password:")


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

This was broken since June because the root password wasn't getting set correctly. Also, the check for `done` appearing on screen was broken because `echo done` already made `done` appear.

https://hydra.nixos.org/build/277366631

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
