### PR TITLE
fix(treewide): clean up move semantics

### DIFF
--- a/src/libcmd/installable-flake.hh
+++ b/src/libcmd/installable-flake.hh
@@ -26,7 +26,7 @@ struct ExtraPathInfoFlake : ExtraPathInfoValue
     Flake flake;
 
     ExtraPathInfoFlake(Value && v, Flake && f)
-        : ExtraPathInfoValue(std::move(v)), flake(f)
+        : ExtraPathInfoValue(std::move(v)), flake(std::move(f))
     { }
 };
 

--- a/src/libcmd/installable-value.hh
+++ b/src/libcmd/installable-value.hh
@@ -59,7 +59,7 @@ struct ExtraPathInfoValue : ExtraPathInfo
     Value value;
 
     ExtraPathInfoValue(Value && v)
-        : value(v)
+        : value(std::move(v))
     { }
 
     virtual ~ExtraPathInfoValue() = default;

--- a/src/libstore/derivations.hh
+++ b/src/libstore/derivations.hh
@@ -298,6 +298,10 @@ struct BasicDerivation
     std::string name;
 
     BasicDerivation() = default;
+    BasicDerivation(BasicDerivation &&) = default;
+    BasicDerivation(const BasicDerivation &) = default;
+    BasicDerivation& operator=(BasicDerivation &&) = default;
+    BasicDerivation& operator=(const BasicDerivation &) = default;
     virtual ~BasicDerivation() { };
 
     bool isBuiltin() const;

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -153,7 +153,7 @@ struct curlFileTransfer : public FileTransfer
         template<class T>
         void fail(T && e)
         {
-            failEx(std::make_exception_ptr(std::move(e)));
+            failEx(std::make_exception_ptr(std::forward<T>(e)));
         }
 
         LambdaSink finalSink;

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -33,7 +33,7 @@ Machine::Machine(
     systemTypes(systemTypes),
     sshKey(sshKey),
     maxJobs(maxJobs),
-    speedFactor(speedFactor == 0.0f ? 1.0f : std::move(speedFactor)),
+    speedFactor(speedFactor == 0.0f ? 1.0f : speedFactor),
     supportedFeatures(supportedFeatures),
     mandatoryFeatures(mandatoryFeatures),
     sshPublicHostKey(sshPublicHostKey)

--- a/src/libstore/path-info.hh
+++ b/src/libstore/path-info.hh
@@ -176,16 +176,17 @@ struct ValidPathInfo : UnkeyedValidPathInfo {
      */
     Strings shortRefs() const;
 
-    ValidPathInfo(const ValidPathInfo & other) = default;
-
     ValidPathInfo(StorePath && path, UnkeyedValidPathInfo info) : UnkeyedValidPathInfo(info), path(std::move(path)) { };
     ValidPathInfo(const StorePath & path, UnkeyedValidPathInfo info) : UnkeyedValidPathInfo(info), path(path) { };
 
     ValidPathInfo(const Store & store,
         std::string_view name, ContentAddressWithReferences && ca, Hash narHash);
-
-    virtual ~ValidPathInfo() { }
 };
+
+static_assert(std::is_move_assignable_v<ValidPathInfo>);
+static_assert(std::is_copy_assignable_v<ValidPathInfo>);
+static_assert(std::is_copy_constructible_v<ValidPathInfo>);
+static_assert(std::is_move_constructible_v<ValidPathInfo>);
 
 using ValidPathInfos = std::map<StorePath, ValidPathInfo>;
 

--- a/src/libutil/executable-path.cc
+++ b/src/libutil/executable-path.cc
@@ -35,7 +35,7 @@ ExecutablePath ExecutablePath::parse(const OsString & path)
         std::make_move_iterator(strings.begin()),
         std::make_move_iterator(strings.end()),
         std::back_inserter(ret),
-        [](auto && str) {
+        [](OsString && str) {
             return fs::path{
                 str.empty()
                     // "A zero-length prefix is a legacy feature that

--- a/src/libutil/position.cc
+++ b/src/libutil/position.cc
@@ -9,7 +9,7 @@ Pos::Pos(const Pos * other)
     }
     line = other->line;
     column = other->column;
-    origin = std::move(other->origin);
+    origin = other->origin;
 }
 
 Pos::operator std::shared_ptr<Pos>() const

--- a/src/libutil/ref.hh
+++ b/src/libutil/ref.hh
@@ -18,11 +18,6 @@ private:
     std::shared_ptr<T> p;
 
 public:
-
-    ref(const ref<T> & r)
-        : p(r.p)
-    { }
-
     explicit ref(const std::shared_ptr<T> & p)
         : p(p)
     {
@@ -74,8 +69,6 @@ public:
     {
         return ref<T2>((std::shared_ptr<T2>) p);
     }
-
-    ref<T> & operator=(ref<T> const & rhs) = default;
 
     bool operator == (const ref<T> & other) const
     {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

Running `clang-tidy` with the following config has revealed some incorrect/inefficient usage of move semantics.

```yaml
Checks:
  - -*
  - performance-no-automatic-move
  - performance-move-constructor-init
  - performance-move-const-arg
```

These fixes are for the more egregious problems I was able to find. These pessimizations can pretty negatively affect the compiler codegen and the final performance.

# Context

One more reason to enable regular `clang-tidy` runs: https://github.com/NixOS/nix/issues/11839

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
