### PR TITLE
refactor(treewide): make some move ctors noexcept where appropriate

### DIFF
--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -141,7 +141,9 @@ public:
     Value * * elems;
     ListBuilder(EvalState & state, size_t size);
 
-    ListBuilder(ListBuilder && x)
+    // NOTE: Can be noexcept because we are just copying integral values and
+    // raw pointers.
+    ListBuilder(ListBuilder && x) noexcept
         : size(x.size)
         , inlineElems{x.inlineElems[0], x.inlineElems[1]}
         , elems(size <= 2 ? inlineElems : x.elems)

--- a/src/libstore/remote-store-connection.hh
+++ b/src/libstore/remote-store-connection.hh
@@ -40,7 +40,7 @@ struct RemoteStore::ConnectionHandle
         : handle(std::move(handle))
     { }
 
-    ConnectionHandle(ConnectionHandle && h)
+    ConnectionHandle(ConnectionHandle && h) noexcept
         : handle(std::move(h.handle))
     { }
 

--- a/src/libstore/sqlite.hh
+++ b/src/libstore/sqlite.hh
@@ -42,7 +42,8 @@ struct SQLite
     SQLite(const Path & path, SQLiteOpenMode mode = SQLiteOpenMode::Normal);
     SQLite(const SQLite & from) = delete;
     SQLite& operator = (const SQLite & from) = delete;
-    SQLite& operator = (SQLite && from) { db = from.db; from.db = 0; return *this; }
+    // NOTE: This is noexcept since we are only copying and assigning raw pointers.
+    SQLite& operator = (SQLite && from) noexcept { db = from.db; from.db = 0; return *this; }
     ~SQLite();
     operator sqlite3 * () { return db; }
 

--- a/src/libutil/callback.hh
+++ b/src/libutil/callback.hh
@@ -21,7 +21,9 @@ public:
 
     Callback(std::function<void(std::future<T>)> fun) : fun(fun) { }
 
-    Callback(Callback && callback) : fun(std::move(callback.fun))
+    // NOTE: std::function is noexcept move-constructible since C++20.
+    Callback(Callback && callback) noexcept(std::is_nothrow_move_constructible_v<decltype(fun)>)
+        : fun(std::move(callback.fun))
     {
         auto prev = callback.done.test_and_set();
         if (prev) done.test_and_set();

--- a/src/libutil/file-descriptor.cc
+++ b/src/libutil/file-descriptor.cc
@@ -45,8 +45,9 @@ AutoCloseFD::AutoCloseFD() : fd{INVALID_DESCRIPTOR} {}
 
 AutoCloseFD::AutoCloseFD(Descriptor fd) : fd{fd} {}
 
-
-AutoCloseFD::AutoCloseFD(AutoCloseFD && that) : fd{that.fd}
+// NOTE: This can be noexcept since we are just copying a value and resetting
+// the file descriptor in the rhs.
+AutoCloseFD::AutoCloseFD(AutoCloseFD && that) noexcept : fd{that.fd}
 {
     that.fd = INVALID_DESCRIPTOR;
 }

--- a/src/libutil/file-descriptor.hh
+++ b/src/libutil/file-descriptor.hh
@@ -155,7 +155,7 @@ public:
     AutoCloseFD();
     AutoCloseFD(Descriptor fd);
     AutoCloseFD(const AutoCloseFD & fd) = delete;
-    AutoCloseFD(AutoCloseFD&& fd);
+    AutoCloseFD(AutoCloseFD&& fd) noexcept;
     ~AutoCloseFD();
     AutoCloseFD& operator =(const AutoCloseFD & fd) = delete;
     AutoCloseFD& operator =(AutoCloseFD&& fd);

--- a/src/libutil/finally.hh
+++ b/src/libutil/finally.hh
@@ -20,7 +20,11 @@ public:
     // Copying Finallys is definitely not a good idea and will cause them to be
     // called twice.
     Finally(Finally &other) = delete;
-    Finally(Finally &&other) : fun(std::move(other.fun)) {
+    // NOTE: Move constructor can be nothrow if the callable type is itself nothrow
+    // move-constructible.
+    Finally(Finally && other) noexcept(std::is_nothrow_move_constructible_v<Fn>)
+        : fun(std::move(other.fun))
+    {
         other.movedFrom = true;
     }
     ~Finally() noexcept(false)

--- a/src/libutil/pool.hh
+++ b/src/libutil/pool.hh
@@ -109,7 +109,15 @@ public:
         Handle(Pool & pool, std::shared_ptr<R> r) : pool(pool), r(r) { }
 
     public:
-        Handle(Handle && h) : pool(h.pool), r(h.r) { h.r.reset(); }
+        // NOTE: Copying std::shared_ptr and calling a .reset() on it is always noexcept.
+        Handle(Handle && h) noexcept
+            : pool(h.pool)
+            , r(h.r)
+        {
+            static_assert(noexcept(h.r.reset()));
+            static_assert(noexcept(std::shared_ptr(h.r)));
+            h.r.reset();
+        }
 
         Handle(const Handle & l) = delete;
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

This is good practice to avoid pessimisations.
Left comments for the reasoning why ctors should be noexcept. There are some tricky cases where we intentionally want throwing move ctors/assignments. But those cases should really be reviewed, since some of those can be replaced with more idiomatic copy/move-and-swap.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
