### PR TITLE
refactor(treewide): reserve vector capacity when final size is known

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -857,6 +857,7 @@ std::vector<FlakeRef> RawInstallablesCommand::getFlakeRefsForCompletion()
 {
     applyDefaultInstallables(rawInstallables);
     std::vector<FlakeRef> res;
+    res.reserve(rawInstallables.size());
     for (auto i : rawInstallables)
         res.push_back(parseFlakeRefWithFragment(
             fetchSettings,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -91,6 +91,7 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
 
     /* Build/substitute the context. */
     std::vector<DerivedPath> buildReqs;
+    buildReqs.reserve(drvs.size());
     for (auto & d : drvs) buildReqs.emplace_back(DerivedPath { d });
     buildStore->buildPaths(buildReqs, bmNormal, store);
 

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -66,6 +66,7 @@ std::vector<KeyedBuildResult> Store::buildPathsWithResults(
     worker.run(goals);
 
     std::vector<KeyedBuildResult> results;
+    results.reserve(state.size());
 
     for (auto & [req, goalPtr] : state)
         results.emplace_back(KeyedBuildResult {

--- a/src/libstore/path-with-outputs.cc
+++ b/src/libstore/path-with-outputs.cc
@@ -37,6 +37,7 @@ DerivedPath StorePathWithOutputs::toDerivedPath() const
 std::vector<DerivedPath> toDerivedPaths(const std::vector<StorePathWithOutputs> ss)
 {
     std::vector<DerivedPath> reqs;
+    reqs.reserve(ss.size());
     for (auto & s : ss) reqs.push_back(s.toDerivedPath());
     return reqs;
 }

--- a/src/libutil/executable-path.cc
+++ b/src/libutil/executable-path.cc
@@ -56,6 +56,7 @@ ExecutablePath ExecutablePath::parse(const OsString & path)
 OsString ExecutablePath::render() const
 {
     std::vector<PathViewNG> path2;
+    path2.reserve(directories.size());
     for (auto & p : directories)
         path2.push_back(p.native());
     return basicConcatStringsSep(path_var_separator, path2);

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -610,6 +610,7 @@ struct CmdDevelop : Common, MixEnvironment
 
         else if (!command.empty()) {
             std::vector<std::string> args;
+            args.reserve(command.size());
             for (auto s : command)
                 args.push_back(shellEscape(s));
             script += fmt("exec %s\n", concatStringsSep(" ", args));


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

In these trivial cases the final vector size (or lower bound on the size) is known, so we can avoid some vector reallocations. This is not very important, but is just good practice and general hygiene.

<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
