### PR TITLE
Allow non fs stores as lower layer of overlay stores.

### DIFF
--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -97,7 +97,7 @@ class LocalOverlayStore : public virtual LocalOverlayStoreConfig, public virtual
      * is that store's store dir, and the upper layer is some
      * scratch storage just for us.
      */
-    ref<LocalFSStore> lowerStore;
+    ref<Store> lowerStore;
 
 public:
     LocalOverlayStore(const Params & params)


### PR DESCRIPTION
The local-overlay:// documentation states that any store can be specified as lower, e.g. another daemon store, but the code currently downcasts the store to LocalFSStore unconditionally, which makes it impossible to use any other store as lower.

The only reason I found to do the downcast is to perform an optional check-mount action, which checks if the lower and upper stores are indeed overlayed correctly.

This change relaxes that undocumented constraint and unlocks non-trivial store compositions.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
