### PR TITLE
[Backport 2.25] Fix argument order in the Windows implementation of `getEnvOs`

### DIFF
--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -13,7 +13,7 @@ std::optional<OsString> getEnvOs(const OsString & key)
     }
 
     // Allocate a buffer to hold the environment variable value
-    std::wstring value{L'\0', bufferSize};
+    std::wstring value{bufferSize, L'\0'};
 
     // Retrieve the environment variable value
     DWORD resultSize = GetEnvironmentVariableW(key.c_str(), &value[0], bufferSize);


### PR DESCRIPTION
# Motivation

Backport of #11855

# Context

Carefully picked the base branch so I could use the same commit for both, heh :)

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
