### PR TITLE
Provide a "nix" package again

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -218,8 +218,9 @@
           # for which we don't apply the full build matrix such as cross or static.
           inherit (nixpkgsFor.${system}.native)
             changelog-d;
+          default = self.packages.${system}.nix;
           # TODO probably should be `nix-cli`
-          default = self.packages.${system}.nix-everything;
+          nix = self.packages.${system}.nix-everything;
           nix-manual = nixpkgsFor.${system}.native.nixComponents.nix-manual;
           nix-internal-api-docs = nixpkgsFor.${system}.native.nixComponents.nix-internal-api-docs;
           nix-external-api-docs = nixpkgsFor.${system}.native.nixComponents.nix-external-api-docs;

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -95,6 +95,8 @@
     nix-functional-tests
   ];
   passthru = prevAttrs.passthru // {
+    inherit (nix-cli) version;
+
     /**
       These are the libraries that are part of the Nix project. They are used
       by the Nix CLI and other tools.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

As mentioned in #11826, the `nix` flake should really have a `nix` package.

Also fixes the issue mentioned in #11862 that `nix-everything` doesn't have a `version` attribute.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
