### PR TITLE
Don't build the API docs in the devshell

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -1,6 +1,6 @@
 # vim: filetype=meson
 
-option('doc-gen', type : 'boolean', value : true,
+option('doc-gen', type : 'boolean', value : false,
   description : 'Generate documentation',
 )
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

A simpler alternative to #11860.

The API docs build is extremely noisy (#11841) and probably not many people care about it anyway. Also, they get rebuilt on *every* ninja invocation which is generally a waste of time.

Of course, you can still build the docs via `nix build .#nix-{internal,external}-api-docs`, which is pretty fast.

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
