### PR TITLE
nix-everything: Remove libs, add dev and devdoc package outputs

### DIFF
--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -107,12 +107,8 @@ in
 (buildEnv {
   name = "nix-${nix-cli.version}";
   paths = [
-    # unfortunately, `buildEnv` doesn't support multiple outputs
-
     nix-cli
-
-    # TODO: separate doc output attribute?
-    nix-manual
+    nix-manual.man
   ];
 
   meta.mainProgram = "nix";
@@ -191,7 +187,8 @@ in
      */
     inherit dev;
     inherit devdoc;
-    outputs = [ "out" "dev" "devdoc" ];
+    doc = nix-manual;
+    outputs = [ "out" "dev" "devdoc" "doc" ];
     all = lib.attrValues (lib.genAttrs finalAttrs.passthru.outputs (outName: finalAttrs.finalPackage.${outName}));
   };
   meta = prevAttrs.meta // {

--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -5,12 +5,10 @@
 
   nix-util,
   nix-util-c,
-  nix-util-test-support,
   nix-util-tests,
 
   nix-store,
   nix-store-c,
-  nix-store-test-support,
   nix-store-tests,
 
   nix-fetchers,
@@ -18,7 +16,6 @@
 
   nix-expr,
   nix-expr-c,
-  nix-expr-test-support,
   nix-expr-tests,
 
   nix-flake,
@@ -38,45 +35,84 @@
   nix-external-api-docs,
 
   nix-perl-bindings,
+
+  testers,
+  runCommand,
 }:
 
+let
+  dev = stdenv.mkDerivation (finalAttrs: {
+    name = "nix-${nix-cli.version}-dev";
+    pname = "nix";
+    version = nix-cli.version;
+    dontUnpack = true;
+    dontBuild = true;
+    libs = map lib.getDev [
+      nix-cmd
+      nix-expr
+      nix-expr-c
+      nix-fetchers
+      nix-flake
+      nix-main
+      nix-main-c
+      nix-store
+      nix-store-c
+      nix-util
+      nix-util-c
+      nix-perl-bindings
+    ];
+    installPhase = ''
+      mkdir -p $out/nix-support
+      echo $libs >> $out/nix-support/propagated-build-inputs
+    '';
+    passthru = {
+      tests = {
+        pkg-config =
+          testers.hasPkgConfigModules {
+            package = finalAttrs.finalPackage;
+          };
+      };
+
+      # If we were to fully emulate output selection here, we'd confuse the Nix CLIs,
+      # because they rely on `drvPath`.
+      dev = finalAttrs.finalPackage.out;
+
+      libs = throw "`nix.dev.libs` is not meant to be used; use `nix.libs` instead.";
+    };
+    meta = {
+      pkgConfigModules = [
+        "nix-cmd"
+        "nix-expr"
+        "nix-expr-c"
+        "nix-fetchers"
+        "nix-flake"
+        "nix-main"
+        "nix-main-c"
+        "nix-store"
+        "nix-store-c"
+        "nix-util"
+        "nix-util-c"
+      ];
+    };
+  });
+  devdoc = buildEnv {
+    name = "nix-${nix-cli.version}-devdoc";
+    paths = [
+      nix-internal-api-docs
+      nix-external-api-docs
+    ];
+  };
+
+in
 (buildEnv {
   name = "nix-${nix-cli.version}";
   paths = [
-    nix-util
-    nix-util-c
-    nix-util-test-support
-    nix-util-tests
-
-    nix-store
-    nix-store-c
-    nix-store-test-support
-    nix-store-tests
-
-    nix-fetchers
-    nix-fetchers-tests
-
-    nix-expr
-    nix-expr-c
-    nix-expr-test-support
-    nix-expr-tests
-
-    nix-flake
-    nix-flake-tests
-
-    nix-main
-    nix-main-c
-
-    nix-cmd
+    # unfortunately, `buildEnv` doesn't support multiple outputs
 
     nix-cli
 
+    # TODO: separate doc output attribute?
     nix-manual
-    nix-internal-api-docs
-    nix-external-api-docs
-
-  ] ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    nix-perl-bindings
   ];
 
   meta.mainProgram = "nix";
@@ -85,12 +121,25 @@
   doInstallCheck = true;
 
   checkInputs = [
-    # Actually run the unit tests too
+    # Make sure the unit tests have passed
     nix-util-tests.tests.run
     nix-store-tests.tests.run
     nix-expr-tests.tests.run
+    nix-fetchers-tests.tests.run
     nix-flake-tests.tests.run
-  ];
+
+    # dev bundle is ok
+    # (checkInputs must be empty paths??)
+    (runCommand "check-pkg-config" { checked = dev.tests.pkg-config; } "mkdir $out")
+  ] ++
+    (if stdenv.buildPlatform.canExecute stdenv.hostPlatform
+    then [
+      # TODO: add perl.tests
+      nix-perl-bindings
+    ]
+    else [
+      nix-perl-bindings
+    ]);
   installCheckInputs = [
     nix-functional-tests
   ];
@@ -128,5 +177,25 @@
         nix-main-c
       ;
     };
+
+    tests = prevAttrs.passthru.tests or {} // {
+      # TODO: create a proper fixpoint and:
+      # pkg-config =
+      #   testers.hasPkgConfigModules {
+      #     package = finalPackage;
+      #   };
+    };
+
+    /**
+      A derivation referencing the `dev` outputs of the Nix libraries.
+     */
+    inherit dev;
+    inherit devdoc;
+    outputs = [ "out" "dev" "devdoc" ];
+    all = lib.attrValues (lib.genAttrs finalAttrs.passthru.outputs (outName: finalAttrs.finalPackage.${outName}));
+  };
+  meta = prevAttrs.meta // {
+    description = "The Nix package manager";
+    pkgConfigModules = dev.meta.pkgConfigModules;
   };
 })


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

Reshuffle `everything.nix` so that it's still tested, has multiple package outputs, but is not bloated.

# Motivation

Bring `out` back to its old size
- https://github.com/NixOS/nix/issues/11864

```console
$ nix path-info -Sh nix/2.24.10#default.out
copying '/nix/store/n41ic7p1zsjir4ra9g7khrdlgyb4jgvl-source' to the store/nix/store/hdy82qidsybc3fg561pqfwagv44vschb-nix-2.24.10          93.8 MiB

$ nix path-info -Sh result/
/nix/store/q3rv37qwyskxs9g4gpa7pfwl7gx6mj80-nix-2.26.0pre20241112_dirty   92.9 MiB
```

# Context

The new package output attributes are somewhat experimental, and provided for compatibility most of all.

We'll see how well this goes before the changes proposed in https://github.com/NixOS/nix/issues/6507

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
