### PR TITLE
Make the default stdenv phases do the right thing

### DIFF
--- a/doc/manual/source/development/building.md
+++ b/doc/manual/source/development/building.md
@@ -35,20 +35,20 @@ To build Nix itself in this shell:
 
 ```console
 [nix-shell]$ mesonFlags+=" --prefix=$(pwd)/outputs/out"
-[nix-shell]$ dontAddPrefix=1 mesonConfigurePhase
-[nix-shell]$ ninjaBuildPhase
+[nix-shell]$ dontAddPrefix=1 configurePhase
+[nix-shell]$ buildPhase
 ```
 
 To test it:
 
 ```console
-[nix-shell]$ mesonCheckPhase
+[nix-shell]$ checkPhase
 ```
 
 To install it in `$(pwd)/outputs`:
 
 ```console
-[nix-shell]$ ninjaInstallPhase
+[nix-shell]$ installPhase
 [nix-shell]$ ./outputs/out/bin/nix --version
 nix (Nix) 2.12
 ```
@@ -90,20 +90,20 @@ $ nix develop .#native-clangStdenvPackages
 To build Nix itself in this shell:
 
 ```console
-[nix-shell]$ mesonConfigurePhase
-[nix-shell]$ ninjaBuildPhase
+[nix-shell]$ configurePhase
+[nix-shell]$ buildPhase
 ```
 
 To test it:
 
 ```console
-[nix-shell]$ mesonCheckPhase
+[nix-shell]$ checkPhase
 ```
 
 To install it in `$(pwd)/outputs`:
 
 ```console
-[nix-shell]$ ninjaInstallPhase
+[nix-shell]$ installPhase
 [nix-shell]$ nix --version
 nix (Nix) 2.12
 ```
@@ -167,7 +167,7 @@ It is useful to perform multiple cross and native builds on the same source tree
 for example to ensure that better support for one platform doesn't break the build for another.
 Meson thankfully makes this very easy by confining all build products to the build directory --- one simple shares the source directory between multiple build directories, each of which contains the build for Nix to a different platform.
 
-Nixpkgs's `mesonConfigurePhase` always chooses `build` in the current directory as the name and location of the build.
+Nixpkgs's `configurePhase` always chooses `build` in the current directory as the name and location of the build.
 This makes having multiple build directories slightly more inconvenient.
 The good news is that Meson/Ninja seem to cope well with relocating the build directory after it is created.
 
@@ -176,13 +176,13 @@ Here's how to do that
 1. Configure as usual
 
    ```bash
-   mesonConfigurePhase
+   configurePhase
    ```
 
 2. Rename the build directory
 
    ```bash
-   cd .. # since `mesonConfigurePhase` cd'd inside
+   cd .. # since `configurePhase` cd'd inside
    mv build build-linux # or whatever name we want
    cd build-linux
    ```
@@ -190,7 +190,7 @@ Here's how to do that
 3. Build as usual
 
    ```bash
-   ninjaBuildPhase
+   buildPhase
    ```
 
 > **N.B.**

--- a/doc/manual/source/development/documentation.md
+++ b/doc/manual/source/development/documentation.md
@@ -203,7 +203,7 @@ $ xdg-open ./result/share/doc/nix/internal-api/html/index.html
 or inside `nix-shell` or `nix develop`:
 
 ```console
-$ mesonConfigurePhase
+$ configurePhase
 $ ninja src/internal-api-docs/html
 $ xdg-open src/internal-api-docs/html/index.html
 ```
@@ -224,7 +224,7 @@ $ xdg-open ./result/share/doc/nix/external-api/html/index.html
 or inside `nix-shell` or `nix develop`:
 
 ```
-$ mesonConfigurePhase
+$ configurePhase
 $ ninja src/external-api-docs/html
 $ xdg-open src/external-api-docs/html/index.html
 ```

--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -137,7 +137,7 @@ Functional tests are run during `installCheck` in the `nix` package build, as we
 The whole test suite (functional and unit tests) can be run with:
 
 ```shell-session
-$ mesonCheckPhase
+$ checkPhase
 ```
 
 ### Grouping tests

--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -31,6 +31,35 @@ in {
 
     # Make bash completion work.
     XDG_DATA_DIRS+=:$out/share
+
+    # Make the default phases do the right thing.
+    # FIXME: this wouldn't be needed if the ninja package set buildPhase() instead of $buildPhase.
+    # FIXME: mesonConfigurePhase shouldn't cd to the build directory. It would be better to pass '-C <dir>' to ninja.
+
+    cdToBuildDir() {
+        if [[ ! -e build.ninja ]]; then
+            cd build
+        fi
+    }
+
+    configurePhase() {
+        mesonConfigurePhase
+    }
+
+    buildPhase() {
+        cdToBuildDir
+        ninjaBuildPhase
+    }
+
+    checkPhase() {
+        cdToBuildDir
+        mesonCheckPhase
+    }
+
+    installPhase() {
+        cdToBuildDir
+        ninjaInstallPhase
+    }
   '';
 
   # We use this shell with the local checkout, not unpackPhase.


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Fixes #11858.

Ultimately it would be better to have the Meson/Ninja setup hooks define `buildPhase()` etc. (they already set the corresponding environment variables). Or we could tell people to use `runHook` but that's not very user-friendly...

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
