### PR TITLE
Use `std::filesystem` in canonPath and local store symlink detection

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -212,16 +212,15 @@ LocalStore::LocalStore(
 
     /* Ensure that the store and its parents are not symlinks. */
     if (!settings.allowSymlinkedStore) {
-        Path path = realStoreDir;
-        struct stat st;
-        while (path != "/") {
-            st = lstat(path);
-            if (S_ISLNK(st.st_mode))
+        std::filesystem::path path = realStoreDir.get();
+        std::filesystem::path root = path.root_path();
+        while (path != root) {
+            if (std::filesystem::is_symlink(path))
                 throw Error(
                         "the path '%1%' is a symlink; "
                         "this is not allowed for the Nix store and its parent directories",
                         path);
-            path = dirOf(path);
+            path = path.parent_path();
         }
     }
 

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -90,7 +90,19 @@ Path canonPath(PathView path, bool resolveSymlinks)
     // The standard filesystem library will behave differently. For example,
     // libstd++ in GCC will only resolve 40 symlinks.
     // I hope that isn't a problem!
-    return (resolveSymlinks ? fs::canonical(path) : fs::path { path }.lexically_normal()).string();
+    auto result = resolveSymlinks ? fs::weakly_canonical(path) : fs::path { path }.lexically_normal();
+
+    // Strip trailing slashes
+    while (!result.has_filename() && result.has_parent_path())
+    {
+        // The parent of "D:/" is "D:/" so we need to be careful.
+        fs::path parent = result.parent_path();
+        if (parent == result)
+            break;
+        result = parent;
+    }
+
+    return result.string();
 }
 
 


### PR DESCRIPTION
# Motivation

Nix on Windows.

# Context

Local store wouldn't work on Windows due to an infinite loop (paths never become "/" on Windows)

Canon path was always prepending the root path (e.g. D:/) which ended up with silly paths (e.g. D:/D:/nix/store) and it was quite a complicated function.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
