### PR TITLE
Filter OSC 8 correctly

### DIFF
--- a/src/libutil-tests/terminal.cc
+++ b/src/libutil-tests/terminal.cc
@@ -57,4 +57,9 @@ TEST(filterANSIEscapes, utf8)
     ASSERT_EQ(filterANSIEscapes("f𐍈𐍈bär", true, 4), "f𐍈𐍈b");
 }
 
+TEST(filterANSIEscapes, osc8)
+{
+    ASSERT_EQ(filterANSIEscapes("\e]8;;http://example.com\e\\This is a link\e]8;;\e\\"), "This is a link");
+}
+
 } // namespace nix

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -45,6 +45,13 @@ std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int w
                 while (i != s.end() && *i >= 0x20 && *i <= 0x2f) e += *i++;
                 // eat final byte
                 if (i != s.end() && *i >= 0x40 && *i <= 0x7e) e += last = *i++;
+            } else if (i != s.end() && *i == ']') {
+                // OSC
+                e += *i++;
+                // eat ESC
+                while (i != s.end() && *i != '\e') e += *i++;
+                // eat backslash
+                if (i != s.end() && *i == '\\') e += last = *i++;
             } else {
                 if (i != s.end() && *i >= 0x40 && *i <= 0x5f) e += *i++;
             }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
[lowdown 1.2.0](https://github.com/kristapsdz/lowdown/releases/tag/VERSION_1_2_0) now outputs OSC-8 links in terminal output mode. `filterANSIEscapes` doesn't handle these properly, causing https://github.com/NixOS/nixpkgs/issues/355548.

# Context
This change makes `filterANSIEscapes` eat all OSCs up to the closing `\e\`.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
