### PR TITLE
`nix store repair --keep-going`

### DIFF
--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -145,7 +145,7 @@ void Store::repairPath(const StorePath & path)
             }, bmRepair));
             worker.run(goals);
         } else
-            throw Error(worker.failingExitStatus(), "cannot repair path '%s'", printStorePath(path));
+            throw RepairFailure(worker.failingExitStatus(), "cannot repair path '%s'", printStorePath(path));
     }
 }
 

--- a/src/libstore/store-api.hh
+++ b/src/libstore/store-api.hh
@@ -61,6 +61,7 @@ MakeError(InvalidPath, Error);
 MakeError(Unsupported, Error);
 MakeError(SubstituteGone, Error);
 MakeError(SubstituterDisabled, Error);
+MakeError(RepairFailure, Error);
 
 MakeError(InvalidStoreReference, Error);
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

Fix what we can.

# TODO

- [ ] test
  - integration test, or better: perform the refactor below, and unit test this
- [ ] make this the default behavior
- [ ] open issue to factor out the keeping going logic
  - [ ] add concurrency (tends to go hand in hand with freedom to pick strictness behavior!)
- [ ] create/use a CLI mixin to operate on sets, not lists of paths

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
