### PR TITLE
doc/nix fmt: Mention nixfmt-rfc-style instead of nixfmt(-classic)

### DIFF
--- a/src/nix/fmt.md
+++ b/src/nix/fmt.md
@@ -22,13 +22,13 @@ With [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt):
 }
 ```
 
-With [nixfmt](https://github.com/serokell/nixfmt):
+With [nixfmt](https://github.com/NixOS/nixfmt):
 
 ```nix
 # flake.nix
 {
   outputs = { nixpkgs, self }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt;
+    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
   };
 }
 ```


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation
The Nixpkgs package `nixfmt` is currently an alias to `nixfmt-classic`, a package that has effectively been superseded by `nixfmt-rfc-style`. This change should help increase the usage of the new nixfmt as new Nix users may look in the man pages on what a command, like `nix fmt`, does.

# Context
Alternatives for consideration:

1. Do nothing and leave the manual as-is
2. Replace the nixfmt example with nixfmt-rfc-style, which is what this PR does
3. Replace the nixpkgs-fmt example with nixfmt-rfc-style, then placing that after the old nixfmt(-classic)
4. Simply rename `nixpkgs.legacyPackages.x86_64-linux.nixfmt;` in the example to `nixpkgs.legacyPackages.x86_64-linux.nixfmt-classic;` as the `nixfmt` package may change to reference `nixfmt-rfc-style`, rendering the manual obselete.

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
