### PR TITLE
Add --print-errorlogs to mesonCheckFlags

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -70,6 +70,9 @@ let
         pkgs.buildPackages.meson
         pkgs.buildPackages.ninja
       ] ++ prevAttrs.nativeBuildInputs or [];
+      mesonCheckFlags = prevAttrs.mesonCheckFlags or [] ++ [
+        "--print-errorlogs"
+      ];
     };
 
   mesonBuildLayer = finalAttrs: prevAttrs:


### PR DESCRIPTION
This prints the error logs in the tests, including when they're run with `checkPhase` in the dev shell.

Does not affect manual `meson test` invocations.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

We need to what goes wrong, when it goes wrong.


# Context

- #2503

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
