### PR TITLE
Make @nix json structured build log parsing warn instead of fail

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -1161,7 +1161,7 @@ HookReply DerivationGoal::tryBuildHook()
                     throw;
                 }
             }();
-            if (handleJSONLogMessage(s, worker.act, worker.hook->activities, true))
+            if (handleJSONLogMessage(s, worker.act, worker.hook->activities, "the build hook", true))
                 ;
             else if (s.substr(0, 2) == "# ") {
                 reply = s.substr(2);
@@ -1346,9 +1346,9 @@ void DerivationGoal::handleChildOutput(Descriptor fd, std::string_view data)
     if (hook && fd == hook->fromHook.readSide.get()) {
         for (auto c : data)
             if (c == '\n') {
-                auto json = parseJSONMessage(currentHookLine);
+                auto json = parseJSONMessage(currentHookLine, "the derivation builder");
                 if (json) {
-                    auto s = handleJSONLogMessage(*json, worker.act, hook->activities, true);
+                    auto s = handleJSONLogMessage(*json, worker.act, hook->activities, "the derivation builder", true);
                     // ensure that logs from a builder using `ssh-ng://` as protocol
                     // are also available to `nix log`.
                     if (s && !isWrittenToLog && logSink) {
@@ -1390,7 +1390,7 @@ void DerivationGoal::handleEOF(Descriptor fd)
 
 void DerivationGoal::flushLine()
 {
-    if (handleJSONLogMessage(currentLogLine, *act, builderActivities, false))
+    if (handleJSONLogMessage(currentLogLine, *act, builderActivities, "the derivation builder", false))
         ;
 
     else {

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -331,7 +331,7 @@ bool handleJSONLogMessage(nlohmann::json & json,
         return true;
     } catch (const nlohmann::json::exception &e) {
         warn(
-            "warning: Unable to handle a JSON message from %s: %s",
+            "Unable to handle a JSON message from %s: %s",
             Uncolored(source),
             e.what()
         );

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -295,37 +295,45 @@ bool handleJSONLogMessage(nlohmann::json & json,
     const Activity & act, std::map<ActivityId, Activity> & activities,
     bool trusted)
 {
-    std::string action = json["action"];
+    try {
+        std::string action = json["action"];
 
-    if (action == "start") {
-        auto type = (ActivityType) json["type"];
-        if (trusted || type == actFileTransfer)
-            activities.emplace(std::piecewise_construct,
-                std::forward_as_tuple(json["id"]),
-                std::forward_as_tuple(*logger, (Verbosity) json["level"], type,
-                    json["text"], getFields(json["fields"]), act.id));
+        if (action == "start") {
+            auto type = (ActivityType) json["type"];
+            if (trusted || type == actFileTransfer)
+                activities.emplace(std::piecewise_construct,
+                    std::forward_as_tuple(json["id"]),
+                    std::forward_as_tuple(*logger, (Verbosity) json["level"], type,
+                        json["text"], getFields(json["fields"]), act.id));
+        }
+
+        else if (action == "stop")
+            activities.erase((ActivityId) json["id"]);
+
+        else if (action == "result") {
+            auto i = activities.find((ActivityId) json["id"]);
+            if (i != activities.end())
+                i->second.result((ResultType) json["type"], getFields(json["fields"]));
+        }
+
+        else if (action == "setPhase") {
+            std::string phase = json["phase"];
+            act.result(resSetPhase, phase);
+        }
+
+        else if (action == "msg") {
+            std::string msg = json["msg"];
+            logger->log((Verbosity) json["level"], msg);
+        }
+
+        return true;
+    } catch (const nlohmann::json::exception &e) {
+        warn(
+            "warning: Unable to handle a JSON message from the builder: %s",
+            e.what()
+        );
+        return false;
     }
-
-    else if (action == "stop")
-        activities.erase((ActivityId) json["id"]);
-
-    else if (action == "result") {
-        auto i = activities.find((ActivityId) json["id"]);
-        if (i != activities.end())
-            i->second.result((ResultType) json["type"], getFields(json["fields"]));
-    }
-
-    else if (action == "setPhase") {
-        std::string phase = json["phase"];
-        act.result(resSetPhase, phase);
-    }
-
-    else if (action == "msg") {
-        std::string msg = json["msg"];
-        logger->log((Verbosity) json["level"], msg);
-    }
-
-    return true;
 }
 
 bool handleJSONLogMessage(const std::string & msg,

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -280,20 +280,22 @@ static Logger::Fields getFields(nlohmann::json & json)
     return fields;
 }
 
-std::optional<nlohmann::json> parseJSONMessage(const std::string & msg)
+std::optional<nlohmann::json> parseJSONMessage(const std::string & msg, std::string_view source)
 {
     if (!hasPrefix(msg, "@nix ")) return std::nullopt;
     try {
         return nlohmann::json::parse(std::string(msg, 5));
     } catch (std::exception & e) {
-        printError("bad JSON log message from builder: %s", e.what());
+        printError("bad JSON log message from %s: %s",
+            Uncolored(source),
+            e.what());
     }
     return std::nullopt;
 }
 
 bool handleJSONLogMessage(nlohmann::json & json,
     const Activity & act, std::map<ActivityId, Activity> & activities,
-    bool trusted)
+    std::string_view source, bool trusted)
 {
     try {
         std::string action = json["action"];
@@ -329,7 +331,8 @@ bool handleJSONLogMessage(nlohmann::json & json,
         return true;
     } catch (const nlohmann::json::exception &e) {
         warn(
-            "warning: Unable to handle a JSON message from the builder: %s",
+            "warning: Unable to handle a JSON message from %s: %s",
+            Uncolored(source),
             e.what()
         );
         return false;
@@ -337,12 +340,12 @@ bool handleJSONLogMessage(nlohmann::json & json,
 }
 
 bool handleJSONLogMessage(const std::string & msg,
-    const Activity & act, std::map<ActivityId, Activity> & activities, bool trusted)
+    const Activity & act, std::map<ActivityId, Activity> & activities, std::string_view source, bool trusted)
 {
-    auto json = parseJSONMessage(msg);
+    auto json = parseJSONMessage(msg, source);
     if (!json) return false;
 
-    return handleJSONLogMessage(*json, act, activities, trusted);
+    return handleJSONLogMessage(*json, act, activities, source, trusted);
 }
 
 Activity::~Activity()

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -185,14 +185,25 @@ Logger * makeSimpleLogger(bool printBuildLogs = true);
 
 Logger * makeJSONLogger(Logger & prevLogger);
 
-std::optional<nlohmann::json> parseJSONMessage(const std::string & msg);
+/**
+ * @param source A noun phrase describing the source of the message, e.g. "the builder".
+ */
+std::optional<nlohmann::json> parseJSONMessage(const std::string & msg, std::string_view source);
 
+/**
+ * @param source A noun phrase describing the source of the message, e.g. "the builder".
+ */
 bool handleJSONLogMessage(nlohmann::json & json,
     const Activity & act, std::map<ActivityId, Activity> & activities,
+    std::string_view source,
     bool trusted);
 
+/**
+ * @param source A noun phrase describing the source of the message, e.g. "the builder".
+ */
 bool handleJSONLogMessage(const std::string & msg,
     const Activity & act, std::map<ActivityId, Activity> & activities,
+    std::string_view source,
     bool trusted);
 
 /**

--- a/tests/functional/dependencies.nix
+++ b/tests/functional/dependencies.nix
@@ -40,6 +40,8 @@ let
         echo "@nix 1"
         echo "@nix {}"
         echo '@nix {"action": null}'
+        echo '@nix {"action": 123}'
+        echo '@nix ]['
       } >&$NIX_LOG_FD
       touch $out
     '';

--- a/tests/functional/dependencies.nix
+++ b/tests/functional/dependencies.nix
@@ -1,7 +1,7 @@
 { hashInvalidator ? "" }:
 with import ./config.nix;
 
-let {
+let
 
   input0 = mkDerivation {
     name = "dependencies-input-0";
@@ -33,16 +33,15 @@ let {
     outputHash = "1dq9p0hnm1y75q2x40fws5887bq1r840hzdxak0a9djbwvx0b16d";
   };
 
-  body = mkDerivation {
-    name = "dependencies-top";
-    builder = ./dependencies.builder0.sh + "/FOOBAR/../.";
-    input1 = input1 + "/.";
-    input2 = "${input2}/.";
-    input1_drv = input1;
-    input2_drv = input2;
-    input0_drv = input0;
-    fod_input_drv = fod_input;
-    meta.description = "Random test package";
-  };
-
+in
+mkDerivation {
+  name = "dependencies-top";
+  builder = ./dependencies.builder0.sh + "/FOOBAR/../.";
+  input1 = input1 + "/.";
+  input2 = "${input2}/.";
+  input1_drv = input1;
+  input2_drv = input2;
+  input0_drv = input0;
+  fod_input_drv = fod_input;
+  meta.description = "Random test package";
 }

--- a/tests/functional/dependencies.nix
+++ b/tests/functional/dependencies.nix
@@ -33,6 +33,18 @@ let
     outputHash = "1dq9p0hnm1y75q2x40fws5887bq1r840hzdxak0a9djbwvx0b16d";
   };
 
+  unusual-logging = mkDerivation {
+    name = "unusual-logging";
+    buildCommand = ''
+      {
+        echo "@nix 1"
+        echo "@nix {}"
+        echo '@nix {"action": null}'
+      } >&$NIX_LOG_FD
+      touch $out
+    '';
+  };
+
 in
 mkDerivation {
   name = "dependencies-top";
@@ -42,6 +54,7 @@ mkDerivation {
   input1_drv = input1;
   input2_drv = input2;
   input0_drv = input0;
+  unusual_logging_drv = unusual-logging;
   fod_input_drv = fod_input;
   meta.description = "Random test package";
 }

--- a/tests/functional/dependencies.nix
+++ b/tests/functional/dependencies.nix
@@ -33,20 +33,6 @@ let
     outputHash = "1dq9p0hnm1y75q2x40fws5887bq1r840hzdxak0a9djbwvx0b16d";
   };
 
-  unusual-logging = mkDerivation {
-    name = "unusual-logging";
-    buildCommand = ''
-      {
-        echo "@nix 1"
-        echo "@nix {}"
-        echo '@nix {"action": null}'
-        echo '@nix {"action": 123}'
-        echo '@nix ]['
-      } >&$NIX_LOG_FD
-      touch $out
-    '';
-  };
-
 in
 mkDerivation {
   name = "dependencies-top";
@@ -56,7 +42,6 @@ mkDerivation {
   input1_drv = input1;
   input2_drv = input2;
   input0_drv = input0;
-  unusual_logging_drv = unusual-logging;
   fod_input_drv = fod_input;
   meta.description = "Random test package";
 }

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -28,3 +28,6 @@ outp="$(nix-build -E \
 test -d "$outp"
 
 nix log "$outp"
+
+# Build works despite ill-formed structured build log entries.
+expectStderr 0 nix build -f ./logging/unusual-logging.nix --no-link | grepQuiet 'warning: Unable to handle a JSON message from the derivation builder:'

--- a/tests/functional/logging.sh
+++ b/tests/functional/logging.sh
@@ -29,5 +29,7 @@ test -d "$outp"
 
 nix log "$outp"
 
-# Build works despite ill-formed structured build log entries.
-expectStderr 0 nix build -f ./logging/unusual-logging.nix --no-link | grepQuiet 'warning: Unable to handle a JSON message from the derivation builder:'
+if isDaemonNewer "2.26"; then
+    # Build works despite ill-formed structured build log entries.
+    expectStderr 0 nix build -f ./logging/unusual-logging.nix --no-link | grepQuiet 'warning: Unable to handle a JSON message from the derivation builder:'
+fi

--- a/tests/functional/logging/unusual-logging.nix
+++ b/tests/functional/logging/unusual-logging.nix
@@ -1,0 +1,16 @@
+let
+  inherit (import ../config.nix) mkDerivation;
+in
+mkDerivation {
+  name = "unusual-logging";
+  buildCommand = ''
+    {
+      echo "@nix 1"
+      echo "@nix {}"
+      echo '@nix {"action": null}'
+      echo '@nix {"action": 123}'
+      echo '@nix ]['
+    } >&$NIX_LOG_FD
+    touch $out
+  '';
+}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

# Motivation

A build may log with `@nix something` without the intent to write Nix structured logs, resulting in an obscure error.
This makes it easy to understand and continues the build.

Example:
```bash
echo '@nix ]['
```
```
bad JSON log message from builder: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected ']'; expected '[', '{', or a literal
@nix ][
```

# Context

Cherry-picked from https://gerrit.lix.systems/c/lix/+/2057
Author @lheckemann 

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Priorities and Process

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
