### PR TITLE
Use -O3 again

### DIFF
--- a/build-utils-meson/common/meson.build
+++ b/build-utils-meson/common/meson.build
@@ -16,3 +16,7 @@ add_project_arguments(
   '-Wno-deprecated-declarations',
   language : 'cpp',
 )
+
+if get_option('buildtype') not in ['debug']
+  add_project_arguments('-O3', language : 'cpp')
+endif

--- a/build-utils-meson/common/meson.build
+++ b/build-utils-meson/common/meson.build
@@ -1,3 +1,10 @@
+# This is only conditional to work around
+# https://github.com/mesonbuild/meson/issues/13293. It should be
+# unconditional.
+if not (host_machine.system() == 'windows' and cxx.get_id() == 'gcc')
+  deps_private += dependency('threads')
+endif
+
 add_project_arguments(
   '-Wdeprecated-copy',
   '-Werror=suggest-override',

--- a/build-utils-meson/threads/meson.build
+++ b/build-utils-meson/threads/meson.build
@@ -1,6 +1,0 @@
-# This is only conditional to work around
-# https://github.com/mesonbuild/meson/issues/13293. It should be
-# unconditional.
-if not (host_machine.system() == 'windows' and cxx.get_id() == 'gcc')
-  deps_private += dependency('threads')
-endif

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -30,8 +30,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
@@ -72,7 +70,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'built-path.cc',

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -29,8 +29,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 
@@ -55,7 +53,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'nix_api_expr.cc',

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -27,8 +27,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 
@@ -41,7 +39,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'tests/value/context.cc',

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -25,8 +25,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 subdir('build-utils-meson/export-all-symbols')
 subdir('build-utils-meson/windows-version')
 
@@ -51,7 +49,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'derived-path.cc',

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -27,8 +27,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 boost = dependency(
   'boost',
   modules : ['container', 'context'],
@@ -79,7 +77,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 parser_tab = custom_target(
   input : 'parser.y',

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -24,8 +24,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 subdir('build-utils-meson/export-all-symbols')
 subdir('build-utils-meson/windows-version')
 
@@ -44,7 +42,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'public-key.cc',

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -26,8 +26,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
@@ -43,7 +41,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'attrs.cc',

--- a/src/libflake-tests/meson.build
+++ b/src/libflake-tests/meson.build
@@ -24,8 +24,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 subdir('build-utils-meson/export-all-symbols')
 subdir('build-utils-meson/windows-version')
 
@@ -44,7 +42,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'flakeref.cc',

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -26,8 +26,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
@@ -41,7 +39,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'flake/config.cc',

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -29,8 +29,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 
@@ -55,7 +53,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'nix_api_main.cc',

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -26,8 +26,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 pubsetbuf_test = '''
 #include <iostream>
 
@@ -60,7 +58,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'common-args.cc',

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -27,8 +27,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 
@@ -51,7 +49,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'nix_api_store.cc',

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -25,8 +25,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 
@@ -38,7 +36,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'tests/derived-path.cc',

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -25,8 +25,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 subdir('build-utils-meson/export-all-symbols')
 subdir('build-utils-meson/windows-version')
 
@@ -52,7 +50,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'common-protocol.cc',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -82,7 +82,6 @@ if host_machine.system() == 'windows'
 endif
 
 subdir('build-utils-meson/libatomic')
-subdir('build-utils-meson/threads')
 
 boost = dependency(
   'boost',
@@ -180,7 +179,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'binary-cache-store.cc',

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -25,8 +25,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 # TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 
@@ -47,7 +45,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'nix_api_util.cc',

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -23,8 +23,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 
@@ -35,7 +33,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'tests/hash.cc',

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -25,8 +25,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 subdir('build-utils-meson/export-all-symbols')
 subdir('build-utils-meson/windows-version')
 
@@ -44,7 +42,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'args.cc',

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -54,7 +54,6 @@ endforeach
 configdata.set('HAVE_DECL_AT_SYMLINK_NOFOLLOW', cxx.has_header_symbol('fcntl.h', 'AT_SYMLINK_NOFOLLOW').to_int())
 
 subdir('build-utils-meson/libatomic')
-subdir('build-utils-meson/threads')
 
 if host_machine.system() == 'windows'
   socket = cxx.find_library('ws2_32')
@@ -121,7 +120,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 
 sources = files(
   'archive.cc',

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -32,8 +32,6 @@ deps_public_maybe_subproject = [
 ]
 subdir('build-utils-meson/subprojects')
 
-subdir('build-utils-meson/threads')
-
 subdir('build-utils-meson/export-all-symbols')
 subdir('build-utils-meson/windows-version')
 
@@ -65,7 +63,7 @@ add_project_arguments(
   language : 'cpp',
 )
 
-subdir('build-utils-meson/diagnostics')
+subdir('build-utils-meson/common')
 subdir('build-utils-meson/generate-header')
 
 nix_sources = [config_h] + files(


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This was lost in the switch to the new build system. -O3 provides  around a 10% performance gain compared to -O2, see    e.g. `nix-env.qaAggressive.time` in https://hydra.nixos.org/job/nix/master/metrics.nixpkgs#tabs-charts.

In addition, this PR reduces the amount of Meson boilerplate by merging a couple of `build-utils-meson` subdirs into `build-utils-meson/common`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
