### PR TITLE
chore: get rid of dead code and unused variables where appropriate

### DIFF
--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -129,7 +129,6 @@ std::pair<SourcePath, uint32_t> findPackageFilename(EvalState & state, Value & v
     try {
         auto colon = fn.rfind(':');
         if (colon == std::string::npos) fail();
-        std::string filename(fn, 0, colon);
         auto lineno = std::stoi(std::string(fn, colon + 1, std::string::npos));
         return {SourcePath{path.accessor, CanonPath(fn.substr(0, colon))}, lineno};
     } catch (std::invalid_argument & e) {

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -66,14 +66,12 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
                 ensureValid(b.drvPath->getBaseStorePath());
             },
             [&](const NixStringContextElem::Opaque & o) {
-                auto ctxS = store->printStorePath(o.path);
                 ensureValid(o.path);
                 if (maybePathsOut)
                     maybePathsOut->emplace(o.path);
             },
             [&](const NixStringContextElem::DrvDeep & d) {
                 /* Treat same as Opaque */
-                auto ctxS = store->printStorePath(d.drvPath);
                 ensureValid(d.drvPath);
                 if (maybePathsOut)
                     maybePathsOut->emplace(d.drvPath);

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -514,8 +514,6 @@ struct GitInputScheme : InputScheme
 
         auto origRev = input.getRev();
 
-        std::string name = input.getName();
-
         auto originalRef = input.getRef();
         auto ref = originalRef ? *originalRef : getDefaultRef(repoInfo);
         input.attrs.insert_or_assign("ref", ref);

--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -257,8 +257,6 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
 {
     using namespace fetchers;
 
-    std::smatch match;
-
     if (auto res = parseFlakeIdRef(fetchSettings, url, isFlake)) {
         return *res;
     } else if (auto res = parseURLFlakeRef(fetchSettings, url, baseDir, isFlake)) {

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -1229,7 +1229,7 @@ HookReply DerivationGoal::tryBuildHook()
     hook->toHook.writeSide.close();
 
     /* Create the log file and pipe. */
-    Path logFile = openLogFile();
+    [[maybe_unused]] Path logFile = openLogFile();
 
     std::set<MuxablePipePollState::CommChannel> fds;
     fds.insert(hook->fromHook.readSide.get());

--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -13,14 +13,9 @@ void Store::exportPaths(const StorePathSet & paths, Sink & sink)
     auto sorted = topoSortPaths(paths);
     std::reverse(sorted.begin(), sorted.end());
 
-    std::string doneLabel("paths exported");
-    //logger->incExpected(doneLabel, sorted.size());
-
     for (auto & path : sorted) {
-        //Activity act(*logger, lvlInfo, "exporting path '%s'", path);
         sink << 1;
         exportPath(path, sink);
-        //logger->incProgress(doneLabel);
     }
 
     sink << 0;

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -883,7 +883,7 @@ void LocalDerivationGoal::startBuilder()
         printMsg(lvlVomit, "setting builder env variable '%1%'='%2%'", i.first, i.second);
 
     /* Create the log file. */
-    Path logFile = openLogFile();
+    [[maybe_unused]] Path logFile = openLogFile();
 
     /* Create a pseudoterminal to get the output of the builder. */
     builderOut = posix_openpt(O_RDWR | O_NOCTTY);

--- a/src/libutil-tests/nix_api_util.cc
+++ b/src/libutil-tests/nix_api_util.cc
@@ -136,7 +136,6 @@ TEST_F(nix_api_util_context, nix_err_name)
     // no error
     EXPECT_THROW(nix_err_name(NULL, ctx, OBSERVE_STRING(err_name)), nix::Error);
 
-    std::string err_msg_ref;
     try {
         throw nix::Error("testing error");
     } catch (...) {

--- a/src/libutil/serialise.cc
+++ b/src/libutil/serialise.cc
@@ -90,7 +90,6 @@ void Source::operator () (std::string_view data)
 
 void Source::drainInto(Sink & sink)
 {
-    std::string s;
     std::array<char, 8192> buf;
     while (true) {
         size_t n;
@@ -427,7 +426,7 @@ Error readError(Source & source)
     auto type = readString(source);
     assert(type == "Error");
     auto level = (Verbosity) readInt(source);
-    auto name = readString(source); // removed
+    [[maybe_unused]] auto name = readString(source); // removed
     auto msg = readString(source);
     ErrorInfo info {
         .level = level,

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -26,7 +26,7 @@ bool isTTY()
 
 std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int width)
 {
-    std::string t, e;
+    std::string t;
     size_t w = 0;
     auto i = s.begin();
 

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -161,7 +161,6 @@ struct CmdSearch : InstallableValueCommand, MixJSON
                                 {"description", description},
                             };
                         } else {
-                            auto name2 = hiliteMatches(name.name, nameMatches, ANSI_GREEN, "\e[0;2m");
                             if (results > 1) logger->cout("");
                             logger->cout(
                                 "* %s%s",

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -41,7 +41,6 @@ struct CmdCopySigs : StorePathsCommand
 
         ThreadPool pool;
 
-        std::string doneLabel = "done";
         std::atomic<size_t> added{0};
 
         //logger->setExpected(doneLabel, storePaths.size());


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Looks like some cruft has been left over from previous refactorings. This removes dead variables, which should not have side effects in their constructors. In cases where the variable initialization has a purpose `[[maybe_unused]]` is inserted to silence compiler warnings.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
