### PR TITLE
build(lib{expr,store,util}-test-support): depend on -c libraries

### DIFF
--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -24,6 +24,7 @@ deps_public_maybe_subproject = [
   dependency('nix-store'),
   dependency('nix-store-test-support'),
   dependency('nix-expr'),
+  dependency('nix-expr-c'),
 ]
 subdir('build-utils-meson/subprojects')
 

--- a/src/libexpr-test-support/package.nix
+++ b/src/libexpr-test-support/package.nix
@@ -4,6 +4,7 @@
 
 , nix-store-test-support
 , nix-expr
+, nix-expr-c
 
 , rapidcheck
 
@@ -35,6 +36,7 @@ mkMesonLibrary (finalAttrs: {
   propagatedBuildInputs = [
     nix-store-test-support
     nix-expr
+    nix-expr-c
     rapidcheck
   ];
 

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -22,6 +22,7 @@ deps_public_maybe_subproject = [
   dependency('nix-util'),
   dependency('nix-util-test-support'),
   dependency('nix-store'),
+  dependency('nix-store-c'),
 ]
 subdir('build-utils-meson/subprojects')
 

--- a/src/libstore-test-support/package.nix
+++ b/src/libstore-test-support/package.nix
@@ -4,6 +4,7 @@
 
 , nix-util-test-support
 , nix-store
+, nix-store-c
 
 , rapidcheck
 
@@ -35,6 +36,7 @@ mkMesonLibrary (finalAttrs: {
   propagatedBuildInputs = [
     nix-util-test-support
     nix-store
+    nix-store-c
     rapidcheck
   ];
 

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -20,6 +20,7 @@ deps_private_maybe_subproject = [
 ]
 deps_public_maybe_subproject = [
   dependency('nix-util'),
+  dependency('nix-util-c'),
 ]
 subdir('build-utils-meson/subprojects')
 

--- a/src/libutil-test-support/package.nix
+++ b/src/libutil-test-support/package.nix
@@ -3,6 +3,7 @@
 , mkMesonLibrary
 
 , nix-util
+, nix-util-c
 
 , rapidcheck
 
@@ -33,6 +34,7 @@ mkMesonLibrary (finalAttrs: {
 
   propagatedBuildInputs = [
     nix-util
+    nix-util-c
     rapidcheck
   ];
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Since lib{expr,store,util}-test-support subprojects define nix_api_* helpers for testing nix c bindings, they need to publicly depend on -c counterparts. This makes their headers self-sufficient and does not rely on the -tests to add necessary dependencies.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
