### PR TITLE
refactor(libfetchers/registry): use standard remove_if + erase

### DIFF
--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -94,12 +94,9 @@ void Registry::add(
 
 void Registry::remove(const Input & input)
 {
-    // FIXME: use C++20 std::erase.
-    for (auto i = entries.begin(); i != entries.end(); )
-        if (i->from == input)
-            i = entries.erase(i);
-        else
-            ++i;
+    entries.erase(
+        std::remove_if(entries.begin(), entries.end(), [&](const Entry & entry) { return entry.from == input; }),
+        entries.end());
 }
 
 static Path getSystemRegistryPath()


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Get rid of this fixme. This does not appear to be used anywhere in
the nix codebase itself. Not sure why the comment mentioned C++20 erase
member function with predicate, but iterator-based algorithms are also fine.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
