### PR TITLE
fix(treewide): remove unnecessary copying in range for loops

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -858,7 +858,7 @@ std::vector<FlakeRef> RawInstallablesCommand::getFlakeRefsForCompletion()
     applyDefaultInstallables(rawInstallables);
     std::vector<FlakeRef> res;
     res.reserve(rawInstallables.size());
-    for (auto i : rawInstallables)
+    for (const auto & i : rawInstallables)
         res.push_back(parseFlakeRefWithFragment(
             fetchSettings,
             expandTilde(i),

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4383,7 +4383,7 @@ void prim_split(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 
         for (auto i = begin; i != end; ++i) {
             assert(idx <= 2 * len + 1 - 3);
-            auto match = *i;
+            const auto & match = *i;
 
             // Add a string for non-matched characters.
             list[idx++] = mkString(state, match.prefix());

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -132,6 +132,8 @@ static void prim_addDrvOutputDependencies(EvalState & state, const PosIdx pos, V
             },
             [&](const NixStringContextElem::DrvDeep & c) -> NixStringContextElem::DrvDeep {
                 /* Reuse original item because we want this to be idempotent. */
+                /* FIXME: Suspicious move out of const. This is actually a copy, so the comment
+                 above does not make much sense. */
                 return std::move(c);
             },
         }, context.begin()->raw) }),

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -40,7 +40,7 @@ static void runFetchClosureWithRewrite(EvalState & state, const PosIdx pos, Stor
             });
     }
 
-    auto toPath = *toPathMaybe;
+    const auto & toPath = *toPathMaybe;
 
     // check and return
 

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -32,7 +32,7 @@ Goal::Co DrvOutputSubstitutionGoal::init()
 
     bool substituterFailed = false;
 
-    for (auto sub : subs) {
+    for (const auto & sub : subs) {
         trace("trying next substituter");
 
         /* The callback of the curl download below can outlive `this` (if

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -57,7 +57,7 @@ Goal::Co PathSubstitutionGoal::init()
 
     bool substituterFailed = false;
 
-    for (auto sub : subs) {
+    for (const auto & sub : subs) {
         trace("trying next substituter");
 
         cleanup();

--- a/src/libstore/keys.cc
+++ b/src/libstore/keys.cc
@@ -10,12 +10,12 @@ PublicKeys getDefaultPublicKeys()
 
     // FIXME: filter duplicates
 
-    for (auto s : settings.trustedPublicKeys.get()) {
+    for (const auto & s : settings.trustedPublicKeys.get()) {
         PublicKey key(s);
         publicKeys.emplace(key.name, key);
     }
 
-    for (auto secretKeyFile : settings.secretKeyFiles.get()) {
+    for (const auto & secretKeyFile : settings.secretKeyFiles.get()) {
         try {
             SecretKey secretKey(readFile(secretKeyFile));
             publicKeys.emplace(secretKey.name, secretKey.toPublicKey());

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -156,7 +156,7 @@ void LocalOverlayStore::queryGCReferrers(const StorePath & path, StorePathSet & 
 StorePathSet LocalOverlayStore::queryValidDerivers(const StorePath & path)
 {
     auto res = LocalStore::queryValidDerivers(path);
-    for (auto p : lowerStore->queryValidDerivers(path))
+    for (const auto & p : lowerStore->queryValidDerivers(path))
         res.insert(p);
     return res;
 }

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -118,7 +118,7 @@ std::string NarInfo::to_string(const Store & store) const
     if (deriver)
         res += "Deriver: " + std::string(deriver->to_string()) + "\n";
 
-    for (auto sig : sigs)
+    for (const auto & sig : sigs)
         res += "Sig: " + sig + "\n";
 
     if (ca)

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -454,7 +454,7 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStoreConfig, public virtual
             debug("got %d keys, next marker '%s'",
                 contents.size(), res.GetNextMarker());
 
-            for (auto object : contents) {
+            for (const auto & object : contents) {
                 auto & key = object.GetKey();
                 if (key.size() != 40 || !hasSuffix(key, ".narinfo")) continue;
                 paths.insert(parseStorePath(storeDir + "/" + key.substr(0, key.size() - 8) + "-" + MissingName));

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1332,7 +1332,7 @@ ref<Store> openStore(StoreReference && storeURI)
                 return std::make_shared<LocalStore>(params);
         },
         [&](const StoreReference::Specified & g) {
-            for (auto implem : *Implementations::registered)
+            for (const auto & implem : *Implementations::registered)
                 if (implem.uriSchemes.count(g.scheme))
                     return implem.create(g.scheme, g.authority, params);
 
@@ -1363,7 +1363,7 @@ std::list<ref<Store>> getDefaultSubstituters()
             }
         };
 
-        for (auto uri : settings.substituters.get())
+        for (const auto & uri : settings.substituters.get())
             addStore(uri);
 
         stores.sort([](ref<Store> & a, ref<Store> & b) {

--- a/src/libutil-tests/hilite.cc
+++ b/src/libutil-tests/hilite.cc
@@ -52,8 +52,7 @@ namespace nix {
             std::regex("pt"),
         };
         std::vector<std::smatch> matches;
-        for(auto regex : regexes)
-        {
+        for (const auto & regex : regexes) {
             for(auto it = std::sregex_iterator(str.begin(), str.end(), regex); it != std::sregex_iterator(); ++it) {
                 matches.push_back(*it);
             }

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -348,7 +348,7 @@ void RootArgs::parseCmdline(const Strings & _cmdline, bool allowShebang)
 
     /* Now that all the other args are processed, run the deferred completions.
      */
-    for (auto d : deferredCompletions)
+    for (const auto & d : deferredCompletions)
         d.completer(*completions, d.n, d.prefix);
 }
 

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -77,7 +77,7 @@ std::map<std::string, std::string> decodeQuery(const std::string & query)
 {
     std::map<std::string, std::string> result;
 
-    for (auto s : tokenizeString<Strings>(query, "&")) {
+    for (const auto & s : tokenizeString<Strings>(query, "&")) {
         auto e = s.find('=');
         if (e == std::string::npos) {
             warn("dubious URI query '%s' is missing equal sign '%s', ignoring", s, "=");

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -222,7 +222,7 @@ static void opPrintFixedPath(Strings opFlags, Strings opArgs)
 {
     auto method = FileIngestionMethod::Flat;
 
-    for (auto i : opFlags)
+    for (const auto & i : opFlags)
         if (i == "--recursive") method = FileIngestionMethod::NixArchive;
         else throw UsageError("unknown flag '%1%'", i);
 

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -611,7 +611,7 @@ struct CmdDevelop : Common, MixEnvironment
         else if (!command.empty()) {
             std::vector<std::string> args;
             args.reserve(command.size());
-            for (auto s : command)
+            for (const auto & s : command)
                 args.push_back(shellEscape(s));
             script += fmt("exec %s\n", concatStringsSep(" ", args));
         }

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -94,7 +94,7 @@ public:
             .label="inputs",
             .optional=true,
             .handler={[&](std::vector<std::string> inputsToUpdate){
-                for (auto inputToUpdate : inputsToUpdate) {
+                for (const auto & inputToUpdate : inputsToUpdate) {
                     InputPath inputPath;
                     try {
                         inputPath = flake::parseInputPath(inputToUpdate);

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -79,7 +79,7 @@ struct CmdHashBase : Command
 
     void run() override
     {
-        for (auto path : paths) {
+        for (const auto & path : paths) {
             auto makeSink = [&]() -> std::unique_ptr<AbstractHashSink> {
                 if (modulus)
                     return std::make_unique<HashModuloSink>(hashAlgo, *modulus);
@@ -182,7 +182,7 @@ struct CmdToBase : Command
     void run() override
     {
         warn("The old format conversion sub commands of `nix hash` were deprecated in favor of `nix hash convert`.");
-        for (auto s : args)
+        for (const auto & s : args)
             logger->cout(Hash::parseAny(s, hashAlgo).to_string(hashFormat, hashFormat == HashFormat::SRI));
     }
 };

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -180,9 +180,9 @@ void chrootHelper(int argc, char * * argv)
         if (mount(realStoreDir.c_str(), (tmpDir + storeDir).c_str(), "", MS_BIND, 0) == -1)
             throw SysError("mounting '%s' on '%s'", realStoreDir, storeDir);
 
-        for (auto entry : fs::directory_iterator{"/"}) {
+        for (const auto & entry : fs::directory_iterator{"/"}) {
             checkInterrupt();
-            auto src = entry.path();
+            const auto & src = entry.path();
             fs::path dst = tmpDir / entry.path().filename();
             if (pathExists(dst)) continue;
             auto st = entry.symlink_status();

--- a/src/nix/verify.cc
+++ b/src/nix/verify.cc
@@ -129,7 +129,7 @@ struct CmdVerify : StorePathsCommand
                         size_t validSigs = 0;
 
                         auto doSigs = [&](StringSet sigs) {
-                            for (auto sig : sigs) {
+                            for (const auto & sig : sigs) {
                                 if (!sigsSeen.insert(sig).second) continue;
                                 if (validSigs < ValidPathInfo::maxSigs && info->checkSignature(*store, publicKeys, sig))
                                     validSigs++;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This gets rid of unnecessary copies in range-based-for loops and local variables, when they are used solely as `const &`.

Also added a fixme comment about a suspicious move out of const, which might not be intended.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
