### PR TITLE
builtins.getFlake: Allow inputs to overridden

### DIFF
--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -99,7 +99,7 @@ static std::map<FlakeId, FlakeInput> parseFlakeInputs(
     const std::optional<Path> & baseDir, InputPath lockRootPath);
 
 static FlakeInput parseFlakeInput(EvalState & state,
-    std::string_view inputName, Value * value, const PosIdx pos,
+    std::optional<std::string_view> inputName, Value * value, const PosIdx pos,
     const std::optional<Path> & baseDir, InputPath lockRootPath)
 {
     expectType(state, nAttrs, *value, pos);
@@ -185,8 +185,8 @@ static FlakeInput parseFlakeInput(EvalState & state,
             input.ref = parseFlakeRef(state.fetchSettings, *url, baseDir, true, input.isFlake);
     }
 
-    if (!input.follows && !input.ref)
-        input.ref = FlakeRef::fromAttrs(state.fetchSettings, {{"type", "indirect"}, {"id", std::string(inputName)}});
+    if (inputName && !input.follows && !input.ref)
+        input.ref = FlakeRef::fromAttrs(state.fetchSettings, {{"type", "indirect"}, {"id", std::string(*inputName)}});
 
     return input;
 }
@@ -735,7 +735,10 @@ LockedFlake lockFlake(
                 } else
                     throw Error("cannot write modified lock file of flake '%s' (use '--no-write-lock-file' to ignore)", topRef);
             } else {
-                warn("not writing modified lock file of flake '%s':\n%s", topRef, chomp(diff));
+                if (lockFlags.warnModifiedLockFile)
+                    warn("not writing modified lock file of flake '%s':\n%s", topRef, chomp(diff));
+                else
+                    debug("not writing modified lock file of flake '%s':\n%s", topRef, chomp(diff));
                 flake.forceDirty = true;
             }
         }
@@ -823,20 +826,63 @@ void initLib(const Settings & settings)
 {
     auto prim_getFlake = [&settings](EvalState & state, const PosIdx pos, Value * * args, Value & v)
     {
-        std::string flakeRefS(state.forceStringNoCtx(*args[0], pos, "while evaluating the argument passed to builtins.getFlake"));
-        auto flakeRef = parseFlakeRef(state.fetchSettings, flakeRefS, {}, true);
-        if (state.settings.pureEval && !flakeRef.input.isLocked())
-            throw Error("cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)", flakeRefS, state.positions[pos]);
+        state.forceValue(*args[0], pos);
 
-        callFlake(state,
-            lockFlake(settings, state, flakeRef,
-                LockFlags {
-                    .updateLockFile = false,
-                    .writeLockFile = false,
-                    .useRegistries = !state.settings.pureEval && settings.useRegistries,
-                    .allowUnlocked = !state.settings.pureEval,
-                }),
-            v);
+        LockFlags lockFlags {
+            .updateLockFile = false,
+            .writeLockFile = false,
+            .warnModifiedLockFile = false,
+            .useRegistries = !state.settings.pureEval && settings.useRegistries,
+            .allowUnlocked = !state.settings.pureEval,
+        };
+
+        auto flakeRef =
+            args[0]->type() == nString
+            ? ({
+                std::string flakeRefS(state.forceStringNoCtx(*args[0], pos, "while evaluating the argument passed to builtins.getFlake"));
+                auto flakeRef = parseFlakeRef(state.fetchSettings, flakeRefS, {}, true);
+                if (state.settings.pureEval && !flakeRef.input.isLocked())
+                    throw Error("cannot call 'getFlake' on unlocked flake reference '%s', at %s (use --impure to override)", flakeRefS, state.positions[pos]);
+                flakeRef;
+            })
+            : ({
+                auto flakeInput = parseFlakeInput(state, std::nullopt, args[0], pos, {}, {});
+
+                /* Convert the result of parseFlakeInput() into a
+                   overrides map and a top-level flakeref. */
+                std::function<void(const InputPath & inputPath, const FlakeInput & input)> recurse;
+
+                recurse = [&](const InputPath & inputPath, const FlakeInput & input)
+                {
+                    if (!input.ref)
+                        state.error<EvalError>("'builtins.getFlake' requires attribute 'url'")
+                            .atPos(*args[0])
+                            .debugThrow();
+                    if (input.follows)
+                        state.error<EvalError>("'builtins.getFlake' does not permit attribute 'follows'")
+                            .atPos(*args[0])
+                            .debugThrow();
+                    if (!input.isFlake)
+                        state.error<EvalError>("'builtins.getFlake' does not permit attribute 'flake = false'; use 'builtins.fetchTree' instead")
+                            .atPos(*args[0])
+                            .debugThrow();
+
+                    for (auto & [inputName, input2] : input.overrides) {
+                        auto inputPath2{inputPath};
+                        inputPath2.push_back(inputName);
+
+                        recurse(inputPath2, input2);
+
+                        lockFlags.inputOverrides.insert_or_assign(inputPath2, input2.ref.value());
+                    }
+                };
+
+                recurse({}, flakeInput);
+
+                flakeInput.ref.value();
+            });
+
+        callFlake(state, lockFlake(settings, state, flakeRef, lockFlags), v);
     };
 
     RegisterPrimOp::primOps->push_back({
@@ -855,6 +901,15 @@ void initLib(const Settings & settings)
 
           ```nix
           (builtins.getFlake "github:edolstra/dwarffs").rev
+          ```
+
+          It is possible to override inputs of the flake using the same syntax to specify flake inputs in `flake.nix`, e.g.
+
+          ```nix
+          builtins.getFlake {
+            url = "github:NixOS/nix/55bc52401966fbffa525c574c14f67b00bc4fb3a";
+            inputs.nixpkgs.url = "github:NixOS/nixpkgs/c69a9bffbecde46b4b939465422ddc59493d3e4d";
+          }
           ```
         )",
         .fun = prim_getFlake,

--- a/src/libflake/flake/flake.hh
+++ b/src/libflake/flake/flake.hh
@@ -92,7 +92,7 @@ struct Flake
      */
     SourcePath path;
     /**
-     * pretend that 'lockedRef' is dirty
+     * Pretend that 'lockedRef' is dirty.
      */
     bool forceDirty = false;
     std::optional<std::string> description;
@@ -155,6 +155,12 @@ struct LockFlags
      * lock file in memory only, without writing it to disk.
      */
     bool writeLockFile = true;
+
+    /**
+     * When `writeLockFile` is false, whether we're warning about
+     * modified lock files.
+     */
+    bool warnModifiedLockFile = true;
 
     /**
      * Whether to use the registries to lookup indirect flake

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -109,14 +109,6 @@ nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default"
 nix build -o "$flake1Dir/result" "git+file://$flake1Dir"
 nix path-info "$flake1Dir/result"
 
-# 'getFlake' on an unlocked flakeref should fail in pure mode, but
-# succeed in impure mode.
-(! nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default")
-nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default" --impure
-
-# 'getFlake' on a locked flakeref should succeed even in pure mode.
-nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1Dir?rev=$hash2\").packages.$system.default"
-
 # Regression test for dirOf on the root of the flake.
 [[ $(nix eval --json flake1#parent) = \""$NIX_STORE_DIR"\" ]]
 
@@ -131,12 +123,10 @@ nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1
 # Building a flake with an unlocked dependency should fail in pure mode.
 (! nix build -o "$TEST_ROOT/result" flake2#bar --no-registries)
 (! nix build -o "$TEST_ROOT/result" flake2#bar --no-use-registries)
-(! nix eval --expr "builtins.getFlake \"$flake2Dir\"")
 
 # But should succeed in impure mode.
 (! nix build -o "$TEST_ROOT/result" flake2#bar --impure)
 nix build -o "$TEST_ROOT/result" flake2#bar --impure --no-write-lock-file
-nix eval --expr "builtins.getFlake \"$flake2Dir\"" --impure
 
 # Building a local flake with an unlocked dependency should fail with --no-update-lock-file.
 expect 1 nix build -o "$TEST_ROOT/result" "$flake2Dir#bar" --no-update-lock-file 2>&1 | grep 'requires lock file changes'

--- a/tests/functional/flakes/get-flake.sh
+++ b/tests/functional/flakes/get-flake.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+TODO_NixOS
+
+createFlake1
+createFlake2
+
+# 'getFlake' on an unlocked flakeref should fail in pure mode, but
+# succeed in impure mode.
+(! nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default")
+nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"$flake1Dir\").packages.$system.default" --impure
+
+# 'getFlake' on a locked flakeref should succeed even in pure mode.
+hash=$(nix flake metadata flake1 --json --refresh | jq -r .revision)
+nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1Dir?rev=$hash\").packages.$system.default"
+
+# Building a flake with an unlocked dependency should fail in pure mode.
+(! nix eval --expr "builtins.getFlake \"$flake2Dir\"")
+
+# But should succeed in impure mode.
+nix eval --expr "builtins.getFlake \"$flake2Dir\"" --impure

--- a/tests/functional/flakes/get-flake.sh
+++ b/tests/functional/flakes/get-flake.sh
@@ -21,3 +21,23 @@ nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake \"git+file://$flake1
 
 # But should succeed in impure mode.
 nix eval --expr "builtins.getFlake \"$flake2Dir\"" --impure
+
+# Test overrides in getFlake.
+flake1Copy="$flake1Dir-copy"
+rm -rf "$flake1Copy"
+cp -r "$flake1Dir" "$flake1Copy"
+sed -i "$flake1Copy/simple.builder.sh" -e 's/World/Universe/'
+
+# Should fail in pure mode since the override is unlocked.
+(! nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake { url = \"$flake2Dir\"; inputs.flake1.url = \"$flake1Copy\"; }).packages.$system.bar")
+
+# Should succeed in impure mode.
+nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake { url = \"$flake2Dir\"; inputs.flake1.url = \"$flake1Copy\"; }).packages.$system.bar" --impure
+[[ $(cat "$TEST_ROOT/result/hello") = 'Hello Universe!' ]]
+
+# Should succeed if we lock the override.
+git -C "$flake1Copy" commit -a -m 'bla'
+
+flake1CopyLocked="$(nix flake metadata --json "$flake1Copy" | jq -r .url)"
+
+nix build -o "$TEST_ROOT/result" --expr "(builtins.getFlake { url = \"$flake2Dir\"; inputs.flake1.url = \"$flake1CopyLocked\"; }).packages.$system.bar"

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -27,6 +27,7 @@ suites += {
     'shebang.sh',
     'commit-lock-file-summary.sh',
     'non-flake-inputs.sh',
+    'get-flake.sh',
   ],
   'workdir': meson.current_source_dir(),
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes https://github.com/NixOS/nix/issues/9154.

This uses the same syntax as flake inputs in flake.nix, e.g.

```nix
builtins.getFlake {
  url = "github:NixOS/nix/55bc52401966fbffa525c574c14f67b00bc4fb3a";
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/c69a9bffbecde46b4b939465422ddc59493d3e4d";
}
```

Note that currently it's not supported to set `flake = false` or to
use `follows` (because lockFlake() doesn't support that for CLI
overrides), but it could be implemented in the future.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
