### PR TITLE
more readable errors if symlinks cannot be created

### DIFF
--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -602,7 +602,11 @@ std::pair<AutoCloseFD, Path> createTempFile(const Path & prefix)
 
 void createSymlink(const Path & target, const Path & link)
 {
-    fs::create_symlink(target, link);
+    try {
+        fs::create_symlink(target, link);
+    } catch (fs::filesystem_error & e) {
+        throw SysError("creating symlink '%1%' -> '%2%'", link, target);
+    }
 }
 
 void replaceSymlink(const fs::path & target, const fs::path & link)
@@ -615,10 +619,16 @@ void replaceSymlink(const fs::path & target, const fs::path & link)
             fs::create_symlink(target, tmp);
         } catch (fs::filesystem_error & e) {
             if (e.code() == std::errc::file_exists) continue;
-            throw;
+            throw SysError("creating symlink '%1%' -> '%2%'", tmp, target);
         }
 
-        fs::rename(tmp, link);
+        try {
+            fs::rename(tmp, link);
+        } catch (fs::filesystem_error & e) {
+            if (e.code() == std::errc::file_exists) continue;
+            throw SysError("renaming '%1%' to '%2%'", tmp, link);
+        }
+
 
         break;
     }

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -250,8 +250,6 @@ void setWriteTime(const std::filesystem::path & path, const struct stat & st);
 /**
  * Create a symlink.
  *
- * In the process of being deprecated for
- * `std::filesystem::create_symlink`.
  */
 void createSymlink(const Path & target, const Path & link);
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -937,7 +937,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                         }
                         continue;
                     } else
-                        fs::create_symlink(target, to2);
+                        createSymlink(target, to2);
                 }
                 else
                     throw Error("file '%s' has unsupported type", from2);


### PR DESCRIPTION
Before:

filesystem error: cannot create symlink: Permission denied [/nix/store/1s2p3a4rs172336hj2l8n20nz74hf71j-nix-eval-jobs-2.24.1.drv] [/1s2p3a4rs172336hj2l8n20nz74hf71j-nix-eval-jobs-2.24.1.drv.tmp-2772352-1316231068]

Now:

creating symlink '/wfxz2q489c811n08cdqj7ywxm3n4z6m5-nix-eval-jobs-2.24.1.drv.tmp-2971297-324653080' -> '/nix/store/wfxz2q489c811n08cdqj7ywxm3n4z6m5-nix-eval-jobs-2.24.1.drv': Permission denied

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
