### PR TITLE
tests/functional/meson.build: always look up `ls` as a `coreutils` proxy

### DIFF
--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -17,12 +17,10 @@ fs = import('fs')
 nix = find_program('nix')
 bash = find_program('bash', native : true)
 busybox = find_program('busybox', native : true, required : false)
-if host_machine.system() == 'windows'
-  # Because of the state of symlinks on Windows, coreutils.exe doesn't usually exist, but things like ls.exe will
-  coreutils = find_program('ls', native : true)
-else
-  coreutils = find_program('coreutils', native : true)
-endif
+# Look up `coreutils` package by searching for `ls` binary.
+# Previously we looked up `coreutils` on `linux`, but that is not
+# guaranteed to exist either.
+coreutils = find_program('ls', native : true)
 dot = find_program('dot', native : true, required : false)
 
 nix_bin_dir = fs.parent(nix.full_path())


### PR DESCRIPTION
Without the change `meson setup` fails on `Gentoo or Debian as those don't use multicall binary:

    $ meson setup ..
    ...
    Executing subproject nix-functional-tests
    ...
    ../src/nix-functional-tests/meson.build:24:14: ERROR: Program 'coreutils' not found or not executable

The change always uses `ls` to look `coreutils` up.

Closes: https://github.com/NixOS/nix/issues/11975

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
