### PR TITLE
docker: Fix command "nix profile install", Don't require --impure

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -258,14 +258,14 @@ let
       mkdir -p $out/nix/var/nix/profiles/per-user/${uname}
 
       ln -s ${profile} $out/nix/var/nix/profiles/default-1-link
-      ln -s $out/nix/var/nix/profiles/default-1-link $out/nix/var/nix/profiles/default
+      ln -s /nix/var/nix/profiles/default-1-link $out/nix/var/nix/profiles/default
       ln -s /nix/var/nix/profiles/default $out${userHome}/.nix-profile
 
       ln -s ${channel} $out/nix/var/nix/profiles/per-user/${uname}/channels-1-link
-      ln -s $out/nix/var/nix/profiles/per-user/${uname}/channels-1-link $out/nix/var/nix/profiles/per-user/${uname}/channels
+      ln -s /nix/var/nix/profiles/per-user/${uname}/channels-1-link $out/nix/var/nix/profiles/per-user/${uname}/channels
 
       mkdir -p $out${userHome}/.nix-defexpr
-      ln -s $out/nix/var/nix/profiles/per-user/${uname}/channels $out${userHome}/.nix-defexpr/channels
+      ln -s /nix/var/nix/profiles/per-user/${uname}/channels $out${userHome}/.nix-defexpr/channels
       echo "${channelURL} ${channelName}" > $out${userHome}/.nix-channels
 
       mkdir -p $out/bin $out/usr/bin


### PR DESCRIPTION
# Motivation
Since probably nix2.20 or nix2.19, now "nix profile install" checks for "pure evaluation mode". Example usage throw error:

```
$ docker run --rm -it nixos/nix
bash-5.2# nix --extra-experimental-features 'nix-command flakes' profile install nixpkgs#hello
error: access to absolute path '/nix/store/32ibcisgls7pp3y759mm00d20fcvx342-user-environment' is forbidden in pure evaluation mode (use '--impure' to override)
```

When I build docker image with nix2.18 it don't throw this error. Soo my patch fixes symlinks and now nix2.18+ works fine.

rebase of https://github.com/NixOS/nix/pull/10245 due to unresolved merge conflicts