### PR TITLE
Git fetcher: Calculate a fingerprint for dirty workdirs

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -113,7 +113,15 @@ Input Input::fromAttrs(const Settings & settings, Attrs && attrs)
 
 std::optional<std::string> Input::getFingerprint(ref<Store> store) const
 {
-    return scheme ? scheme->getFingerprint(store, *this) : std::nullopt;
+    if (!scheme) return std::nullopt;
+
+    if (cachedFingerprint) return *cachedFingerprint;
+
+    auto fingerprint = scheme->getFingerprint(store, *this);
+
+    cachedFingerprint = fingerprint;
+
+    return fingerprint;
 }
 
 ParsedURL Input::toURL() const
@@ -307,7 +315,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
 
             auto accessor = makeStorePathAccessor(store, storePath);
 
-            accessor->fingerprint = scheme->getFingerprint(store, *this);
+            accessor->fingerprint = getFingerprint(store);
 
             return {accessor, *this};
         } catch (Error & e) {
@@ -318,7 +326,7 @@ std::pair<ref<SourceAccessor>, Input> Input::getAccessorUnchecked(ref<Store> sto
     auto [accessor, result] = scheme->getAccessor(store, *this);
 
     assert(!accessor->fingerprint);
-    accessor->fingerprint = scheme->getFingerprint(store, result);
+    accessor->fingerprint = result.getFingerprint(store);
 
     return {accessor, std::move(result)};
 }

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -46,6 +46,11 @@ struct Input
      */
     std::optional<Path> parent;
 
+    /**
+     * Cached result of getFingerprint().
+     */
+    mutable std::optional<std::optional<std::string>> cachedFingerprint;
+
 public:
     /**
      * Create an `Input` from a URL.

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -1279,7 +1279,7 @@ ref<GitRepo> getTarballCache()
 
 GitRepo::WorkdirInfo GitRepo::getCachedWorkdirInfo(const std::filesystem::path & path)
 {
-    static Sync<std::unordered_map<std::filesystem::path, WorkdirInfo>> _cache;
+    static Sync<std::map<std::filesystem::path, WorkdirInfo>> _cache;
     {
         auto cache(_cache.lock());
         auto i = cache->find(path);

--- a/src/libfetchers/git-utils.hh
+++ b/src/libfetchers/git-utils.hh
@@ -55,9 +55,14 @@ struct GitRepo
            in the repo yet. */
         std::optional<Hash> headRev;
 
+        enum State { Clean, Dirty };
+
         /* All files in the working directory that are unchanged,
            modified or added, but excluding deleted files. */
-        std::set<CanonPath> files;
+        std::map<CanonPath, State> files;
+
+        /* The deleted files. */
+        std::set<CanonPath> deletedFiles;
 
         /* The submodules listed in .gitmodules of this workdir. */
         std::vector<Submodule> submodules;

--- a/src/libfetchers/git-utils.hh
+++ b/src/libfetchers/git-utils.hh
@@ -55,11 +55,12 @@ struct GitRepo
            in the repo yet. */
         std::optional<Hash> headRev;
 
-        enum State { Clean, Dirty };
-
         /* All files in the working directory that are unchanged,
            modified or added, but excluding deleted files. */
-        std::map<CanonPath, State> files;
+        std::set<CanonPath> files;
+
+        /* All modified or added files. */
+        std::set<CanonPath> dirtyFiles;
 
         /* The deleted files. */
         std::set<CanonPath> deletedFiles;

--- a/src/libfetchers/git-utils.hh
+++ b/src/libfetchers/git-utils.hh
@@ -70,6 +70,8 @@ struct GitRepo
 
     virtual WorkdirInfo getWorkdirInfo() = 0;
 
+    static WorkdirInfo getCachedWorkdirInfo(const std::filesystem::path & path);
+
     /* Get the ref that HEAD points to. */
     virtual std::optional<std::string> getWorkdirRef() = 0;
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -15,6 +15,7 @@
 #include "finally.hh"
 #include "fetch-settings.hh"
 #include "json-utils.hh"
+#include "archive.hh"
 
 #include <regex>
 #include <string.h>
@@ -802,7 +803,7 @@ struct GitInputScheme : InputScheme
             return makeFingerprint(*rev);
         else {
             auto repoInfo = getRepoInfo(input);
-            if (repoInfo.isLocal && repoInfo.workdirInfo.headRev) {
+            if (repoInfo.isLocal && repoInfo.workdirInfo.headRev && repoInfo.workdirInfo.submodules.empty()) {
                 /* Calculate a fingerprint that takes into account the
                    deleted and modified/added files. */
                 HashSink hashSink{HashAlgorithm::SHA512};
@@ -810,7 +811,7 @@ struct GitInputScheme : InputScheme
                     if (file.second == GitRepo::WorkdirInfo::State::Dirty) {
                         writeString("modified:", hashSink);
                         writeString(file.first.abs(), hashSink);
-                        readFile(std::filesystem::path(repoInfo.url) + file.first.abs(), hashSink);
+                        dumpPath(repoInfo.url + "/" + file.first.abs(), hashSink);
                     }
                 for (auto & file : repoInfo.workdirInfo.deletedFiles) {
                     writeString("deleted:", hashSink);

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -431,7 +431,7 @@ struct GitInputScheme : InputScheme
         // If this is a local directory and no ref or revision is
         // given, then allow the use of an unclean working tree.
         if (!input.getRef() && !input.getRev() && repoInfo.isLocal)
-            repoInfo.workdirInfo = GitRepo::openRepo(repoInfo.url)->getWorkdirInfo();
+            repoInfo.workdirInfo = GitRepo::getCachedWorkdirInfo(repoInfo.url);
 
         return repoInfo;
     }

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -686,7 +686,7 @@ struct GitInputScheme : InputScheme
         if (getSubmodulesAttr(input))
             /* Create mountpoints for the submodules. */
             for (auto & submodule : repoInfo.workdirInfo.submodules)
-                repoInfo.workdirInfo.files.emplace(submodule.path, GitRepo::WorkdirInfo::State::Clean);
+                repoInfo.workdirInfo.files.insert(submodule.path);
 
         auto repo = GitRepo::openRepo(repoInfo.url, false, false);
 
@@ -807,12 +807,11 @@ struct GitInputScheme : InputScheme
                 /* Calculate a fingerprint that takes into account the
                    deleted and modified/added files. */
                 HashSink hashSink{HashAlgorithm::SHA512};
-                for (auto & file : repoInfo.workdirInfo.files)
-                    if (file.second == GitRepo::WorkdirInfo::State::Dirty) {
-                        writeString("modified:", hashSink);
-                        writeString(file.first.abs(), hashSink);
-                        dumpPath(repoInfo.url + "/" + file.first.abs(), hashSink);
-                    }
+                for (auto & file : repoInfo.workdirInfo.dirtyFiles) {
+                    writeString("modified:", hashSink);
+                    writeString(file.abs(), hashSink);
+                    dumpPath(repoInfo.url + "/" + file.abs(), hashSink);
+                }
                 for (auto & file : repoInfo.workdirInfo.deletedFiles) {
                     writeString("deleted:", hashSink);
                     writeString(file.abs(), hashSink);

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -77,6 +77,7 @@ hash1=$(echo "$json" | jq -r .revision)
 echo foo > "$flake1Dir/foo"
 git -C "$flake1Dir" add $flake1Dir/foo
 [[ $(nix flake metadata flake1 --json --refresh | jq -r .dirtyRevision) == "$hash1-dirty" ]]
+[[ "$(nix flake metadata flake1 --json | jq -r .fingerprint)" != null ]]
 
 echo -n '# foo' >> "$flake1Dir/flake.nix"
 flake1OriginalCommit=$(git -C "$flake1Dir" rev-parse HEAD)


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This restores evaluation caching for dirty Git workdirs, which should help with #11985.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
