### PR TITLE
fix(libutil/terminal): require both stderr/stdout to be tty to output color

### DIFF
--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -18,6 +18,7 @@ bool isTTY()
 {
     static const bool tty =
         isatty(STDERR_FILENO)
+        && isatty(STDOUT_FILENO)
         && getEnv("TERM").value_or("dumb") != "dumb"
         && !(getEnv("NO_COLOR").has_value() || getEnv("NOCOLOR").has_value());
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes https://github.com/NixOS/nix/issues/11583
Fixes https://github.com/NixOS/nix/issues/4848

This is a bit more conservative and safe for cli composability. A common use-case for nix cli is to filter/transform output with grep/ripgrep/jq from stdout. Those tools usually have their own colored output. It's best not to step on their toes.

Once example of such command is: `nix registry list | rg nixpkgs`

Note that this is more of a band-aid solution. Nix generally handles ANSI colors in an ad-hoc way and there might be some other unexpected bugs related to control characters.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
