### PR TITLE
HttpBinaryCacheStore: Improve error message for unauthorized caches

### DIFF
--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -39,15 +39,13 @@ BinaryCacheStore::BinaryCacheStore(const Params & params)
 
 void BinaryCacheStore::init()
 {
-    std::string cacheInfoFile = "nix-cache-info";
-
-    auto cacheInfo = getFile(cacheInfoFile);
+    auto cacheInfo = getNixCacheInfo();
     if (!cacheInfo) {
         upsertFile(cacheInfoFile, "StoreDir: " + storeDir + "\n", "text/x-nix-cache-info");
     } else {
         for (auto & line : tokenizeString<Strings>(*cacheInfo, "\n")) {
-            size_t colon= line.find(':');
-            if (colon ==std::string::npos) continue;
+            size_t colon = line.find(':');
+            if (colon == std::string::npos) continue;
             auto name = line.substr(0, colon);
             auto value = trim(line.substr(colon + 1, std::string::npos));
             if (name == "StoreDir") {
@@ -61,6 +59,11 @@ void BinaryCacheStore::init()
             }
         }
     }
+}
+
+std::optional<std::string> BinaryCacheStore::getNixCacheInfo()
+{
+    return getFile(cacheInfoFile);
 }
 
 void BinaryCacheStore::upsertFile(const std::string & path,

--- a/src/libstore/binary-cache-store.hh
+++ b/src/libstore/binary-cache-store.hh
@@ -64,6 +64,8 @@ protected:
     // The prefix under which realisation infos will be stored
     const std::string realisationsPrefix = "realisations";
 
+    const std::string cacheInfoFile = "nix-cache-info";
+
     BinaryCacheStore(const Params & params);
 
 public:
@@ -83,6 +85,12 @@ public:
      * Dump the contents of the specified file to a sink.
      */
     virtual void getFile(const std::string & path, Sink & sink);
+
+    /**
+     * Get the contents of /nix-cache-info. Return std::nullopt if it
+     * doesn't exist.
+     */
+    virtual std::optional<std::string> getNixCacheInfo();
 
     /**
      * Fetch the specified file and call the specified callback with

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -194,6 +194,19 @@ protected:
         }
     }
 
+    std::optional<std::string> getNixCacheInfo() override
+    {
+        try {
+            auto result = getFileTransfer()->download(makeRequest(cacheInfoFile));
+            return result.data;
+        } catch (FileTransferError & e) {
+            if (e.error == FileTransfer::NotFound)
+                return std::nullopt;
+            maybeDisable();
+            throw;
+        }
+    }
+
     /**
      * This isn't actually necessary read only. We support "upsert" now, so we
      * have a notion of authentication via HTTP POST/PUT.


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Instead of the unhelpful

```
warning: 'https://cache.flakehub.com' does not appear to be a binary cache
```

you now get

```
warning: unable to download 'https://cache.flakehub.com/nix-cache-info': HTTP error 401

         response body:

         {"code":401,"error":"Unauthorized","message":"Unauthorized."}
```
## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
