### PR TITLE
tests: derivation-advanced-attributes unset NIX_STORE

### DIFF
--- a/tests/functional/derivation-advanced-attributes.sh
+++ b/tests/functional/derivation-advanced-attributes.sh
@@ -13,7 +13,7 @@ badExitCode=0
 store="$TEST_ROOT/store"
 
 for nixFile in derivation/*.nix; do
-    drvPath=$(nix-instantiate --store "$store" --pure-eval --expr "$(< "$nixFile")")
+    drvPath=$(env -u NIX_STORE nix-instantiate --store "$store" --pure-eval --expr "$(< "$nixFile")")
     testName=$(basename "$nixFile" .nix)
     got="${store}${drvPath}"
     expected="derivation/$testName.drv"


### PR DESCRIPTION
when built by Nix, `NIX_STORE` is set, which breaks `$got` when it is not the default /nix/store

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

derivation-advanced-attributes fails when building inside a Nix that's running with a different logical store path.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

When Nix itself builds this project in a derivation, https://nix.dev/manual/nix/2.24/language/derivations.html?highlight=NIX_STORE#builder-execution it sets the `NIX_STORE` environment variable. That causes nix-instantiate to... behave in some complicated way. For example, if you run this:

```sh
NIX_STORE=/unusual-store \
  nix-instantiate \
  --store /tmp/chroot-store \
  --pure-eval \
  --expr 'derivation { name = "test"; builder = "/bin/false"; system = "my-system"; }'
```

Then:

1. it prints `/unusual-store/xxx-test.drv` to stdout
2. it writes the store derivation to `/tmp/chroot-store/nix/store/xxx-test.drv`
3. the derivation contains out path `/unusual-store/xxx-test`
4. `/tmp/chroot-store/unusual-store` does not exist

That leads to `got="${store}${drvPath}"` specifying the nonexistent path in (4), and subsequently `diff` will complain that one of its files is not found.

> diff: /tmp/nix-build-nix-2.24.10.drv-0/nix-test/derivation-advanced-attributes/store/(outer NIX_STORE_DIR)/xxx-advanced-attributes-defaults.drv: No such file or directory

(with the derivation having been written to /tmp/nix-build-nix-2.24.10.drv-0/nix-test/derivation-advanced-attributes/store/nix/store/xxx-advanced-attributes-defaults.drv)

I don't know if (1) and (2) are both intended to be correct, but they're at least not new. So I'm submitting a fix to this test.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
