### PR TITLE
nix hash convert: Support SRI hashes that lack trailing '=' characters

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -134,7 +134,8 @@ std::string Hash::to_string(HashFormat hashFormat, bool includeAlgo) const
 
 Hash Hash::dummy(HashAlgorithm::SHA256);
 
-Hash Hash::parseSRI(std::string_view original) {
+Hash Hash::parseSRI(std::string_view original)
+{
     auto rest = original;
 
     // Parse the has type before the separater, if there was one.

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -163,8 +163,11 @@ struct CmdToBase : Command
     HashFormat hashFormat;
     std::optional<HashAlgorithm> hashAlgo;
     std::vector<std::string> args;
+    bool legacyCli;
 
-    CmdToBase(HashFormat hashFormat) : hashFormat(hashFormat)
+    CmdToBase(HashFormat hashFormat, bool legacyCli = false)
+        : hashFormat(hashFormat)
+        , legacyCli(legacyCli)
     {
         addFlag(flag::hashAlgoOpt("type", &hashAlgo));
         expectArgs("strings", &args);
@@ -181,7 +184,8 @@ struct CmdToBase : Command
 
     void run() override
     {
-        warn("The old format conversion sub commands of `nix hash` were deprecated in favor of `nix hash convert`.");
+        if (!legacyCli)
+            warn("The old format conversion subcommands of `nix hash` were deprecated in favor of `nix hash convert`.");
         for (const auto & s : args)
             logger->cout(Hash::parseAny(s, hashAlgo).to_string(hashFormat, hashFormat == HashFormat::SRI));
     }
@@ -328,7 +332,7 @@ static int compatNixHash(int argc, char * * argv)
     }
 
     else {
-        CmdToBase cmd(hashFormat);
+        CmdToBase cmd(hashFormat, true);
         cmd.args = ss;
         if (hashAlgo.has_value()) cmd.hashAlgo = hashAlgo;
         cmd.run();

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -222,9 +222,12 @@ struct CmdHashConvert : Command
     Category category() override { return catUtility; }
 
     void run() override {
-        for (const auto& s: hashStrings) {
-            Hash h = Hash::parseAny(s, algo);
-            if (from && h.to_string(*from, from == HashFormat::SRI) != s) {
+        for (const auto & s: hashStrings) {
+            Hash h =
+                from == HashFormat::SRI
+                ? Hash::parseSRI(s)
+                : Hash::parseAny(s, algo);
+            if (from && from != HashFormat::SRI && h.to_string(*from, false) != s) {
                 auto from_as_string = printHashFormat(*from);
                 throw BadHash("input hash '%s' does not have the expected format '--from %s'", s, from_as_string);
             }

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -222,14 +222,18 @@ struct CmdHashConvert : Command
     Category category() override { return catUtility; }
 
     void run() override {
-        for (const auto & s: hashStrings) {
+        for (const auto & s : hashStrings) {
             Hash h =
                 from == HashFormat::SRI
                 ? Hash::parseSRI(s)
                 : Hash::parseAny(s, algo);
-            if (from && from != HashFormat::SRI && h.to_string(*from, false) != s) {
+            if (from
+                && from != HashFormat::SRI
+                && h.to_string(*from, false) !=
+                    (from == HashFormat::Base16 ? toLower(s) : s))
+            {
                 auto from_as_string = printHashFormat(*from);
-                throw BadHash("input hash '%s' does not have the expected format '--from %s'", s, from_as_string);
+                throw BadHash("input hash '%s' does not have the expected format for '--from %s'", s, from_as_string);
             }
             logger->cout(h.to_string(to, to == HashFormat::SRI));
         }

--- a/tests/functional/hash-convert.sh
+++ b/tests/functional/hash-convert.sh
@@ -93,15 +93,17 @@ try3() {
     # Asserting input format fails.
     #
 
-    fail=$(nix hash convert --hash-algo "$1" --from nix32 "$2" 2>&1 || echo "exit: $?")
-    [[ "$fail" == *"error: input hash"*"exit: 1" ]]
-    fail=$(nix hash convert --hash-algo "$1" --from base16 "$3" 2>&1 || echo "exit: $?")
-    [[ "$fail" == *"error: input hash"*"exit: 1" ]]
-    fail=$(nix hash convert --hash-algo "$1" --from nix32 "$4" 2>&1 || echo "exit: $?")
-    [[ "$fail" == *"error: input hash"*"exit: 1" ]]
+    expectStderr 1 nix hash convert --hash-algo "$1" --from sri "$2" | grepQuiet "is not SRI"
+    expectStderr 1 nix hash convert --hash-algo "$1" --from nix32 "$2" | grepQuiet "input hash"
+    expectStderr 1 nix hash convert --hash-algo "$1" --from base16 "$3" | grepQuiet "input hash"
+    expectStderr 1 nix hash convert --hash-algo "$1" --from nix32 "$4" | grepQuiet "input hash"
 
 }
 
 try3 sha1 "800d59cfcd3c05e900cb4e214be48f6b886a08df" "vw46m23bizj4n8afrc0fj19wrp7mj3c0" "gA1Zz808BekAy04hS+SPa4hqCN8="
 try3 sha256 "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" "1b8m03r63zqhnjf7l5wnldhh7c134ap5vpj0850ymkq1iyzicy5s" "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
 try3 sha512 "204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445" "12k9jiq29iyqm03swfsgiw5mlqs173qazm3n7daz43infy12pyrcdf30fkk3qwv4yl2ick8yipc2mqnlh48xsvvxl60lbx8vp38yji0" "IEqPxt2oLwoM7XvrjgikFlfBbvRosiioJ5vjMacDwzWW/RXBOxsH+aodO+pXeJygMa2Fx6cd1wNU7GMSOMo0RQ=="
+
+# Test SRI hashes that lack trailing '=' characters. These are incorrect but we need to support them for backward compatibility.
+[[ $(nix hash convert --from sri "sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0") = sha256-ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0= ]]
+[[ $(nix hash convert --from sri "sha512-IEqPxt2oLwoM7XvrjgikFlfBbvRosiioJ5vjMacDwzWW/RXBOxsH+aodO+pXeJygMa2Fx6cd1wNU7GMSOMo0RQ") = sha512-IEqPxt2oLwoM7XvrjgikFlfBbvRosiioJ5vjMacDwzWW/RXBOxsH+aodO+pXeJygMa2Fx6cd1wNU7GMSOMo0RQ== ]]

--- a/tests/functional/hash-convert.sh
+++ b/tests/functional/hash-convert.sh
@@ -98,6 +98,8 @@ try3() {
     expectStderr 1 nix hash convert --hash-algo "$1" --from base16 "$3" | grepQuiet "input hash"
     expectStderr 1 nix hash convert --hash-algo "$1" --from nix32 "$4" | grepQuiet "input hash"
 
+    # Base-16 hashes can be in uppercase.
+    nix hash convert --hash-algo "$1" --from base16 "$(echo $2 | tr [a-z] [A-Z])"
 }
 
 try3 sha1 "800d59cfcd3c05e900cb4e214be48f6b886a08df" "vw46m23bizj4n8afrc0fj19wrp7mj3c0" "gA1Zz808BekAy04hS+SPa4hqCN8="


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes #11996, #11997.

Also, don't fail on uppercase base-16 hashes.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
