### PR TITLE
Implement shellSplitString for proper handling of NIX_SSHOPTS with spaces and quotes

### DIFF
--- a/doc/manual/rl-next/nix-sshopts-parsing.md
+++ b/doc/manual/rl-next/nix-sshopts-parsing.md
@@ -1,0 +1,21 @@
+---
+synopsis: "Improved `NIX_SSHOPTS` parsing for better SSH option handling"
+issues: [5181]
+prs: [12020]
+---
+
+The parsing of the `NIX_SSHOPTS` environment variable has been improved to handle spaces and quotes correctly.
+Previously, incorrectly split SSH options could cause failures in CLIs like `nix-copy-closure`,
+especially when using complex ssh invocations such as `-o ProxyCommand="ssh -W %h:%p ..."`.
+
+This change introduces a `shellSplitString` function to ensure
+that `NIX_SSHOPTS` is parsed in a manner consistent with shell
+behavior, addressing common parsing errors.
+
+For example, the following now works as expected:
+
+```bash
+export NIX_SSHOPTS='-o ProxyCommand="ssh -W %h:%p ..."'
+```
+
+This update improves the reliability of SSH-related operations using `NIX_SSHOPTS` across Nix CLIs.

--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -41,8 +41,17 @@ void SSHMaster::addCommonSSHOpts(Strings & args)
 {
     auto state(state_.lock());
 
-    for (auto & i : tokenizeString<Strings>(getEnv("NIX_SSHOPTS").value_or("")))
-        args.push_back(i);
+    std::string sshOpts = getEnv("NIX_SSHOPTS").value_or("");
+
+    try {
+        std::list<std::string> opts = shellSplitString(sshOpts);
+        for (auto & i : opts)
+            args.push_back(i);
+    } catch (Error & e) {
+        e.addTrace({}, "while splitting NIX_SSHOPTS '%s'", sshOpts);
+        throw;
+    }
+
     if (!keyFile.empty())
         args.insert(args.end(), {"-i", keyFile});
     if (!sshPublicHostKey.empty()) {

--- a/src/libutil/strings.cc
+++ b/src/libutil/strings.cc
@@ -4,6 +4,7 @@
 
 #include "strings-inline.hh"
 #include "os-string.hh"
+#include "error.hh"
 
 namespace nix {
 
@@ -48,4 +49,107 @@ template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const s
 template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::set<std::string> &);
 template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::vector<std::string> &);
 
+/**
+ * Shell split string: split a string into shell arguments, respecting quotes and backslashes.
+ *
+ * Used for NIX_SSHOPTS handling, which previously used `tokenizeString` and was broken by
+ * Arguments that need to be passed to ssh with spaces in them.
+ *
+ * Read https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html for the
+ * POSIX shell specification, which is technically what we are implementing here.
+ */
+std::list<std::string> shellSplitString(std::string_view s)
+{
+    std::list<std::string> result;
+    std::string current;
+    bool startedCurrent = false;
+    bool escaping = false;
+
+    auto pushCurrent = [&]() {
+        if (startedCurrent) {
+            result.push_back(current);
+            current.clear();
+            startedCurrent = false;
+        }
+    };
+
+    auto pushChar = [&](char c) {
+        current.push_back(c);
+        startedCurrent = true;
+    };
+
+    auto pop = [&]() {
+        auto c = s[0];
+        s.remove_prefix(1);
+        return c;
+    };
+
+    auto inDoubleQuotes = [&]() {
+        startedCurrent = true;
+        // in double quotes, escaping with backslash is only effective for $, `, ", and backslash
+        while (!s.empty()) {
+            auto c = pop();
+            if (escaping) {
+                switch (c) {
+                case '$':
+                case '`':
+                case '"':
+                case '\\':
+                    pushChar(c);
+                    break;
+                default:
+                    pushChar('\\');
+                    pushChar(c);
+                    break;
+                }
+                escaping = false;
+            } else if (c == '\\') {
+                escaping = true;
+            } else if (c == '"') {
+                return;
+            } else {
+                pushChar(c);
+            }
+        }
+        if (s.empty()) {
+            throw Error("unterminated double quote");
+        }
+    };
+
+    auto inSingleQuotes = [&]() {
+        startedCurrent = true;
+        while (!s.empty()) {
+            auto c = pop();
+            if (c == '\'') {
+                return;
+            }
+            pushChar(c);
+        }
+        if (s.empty()) {
+            throw Error("unterminated single quote");
+        }
+    };
+
+    while (!s.empty()) {
+        auto c = pop();
+        if (escaping) {
+            pushChar(c);
+            escaping = false;
+        } else if (c == '\\') {
+            escaping = true;
+        } else if (c == ' ' || c == '\t') {
+            pushCurrent();
+        } else if (c == '"') {
+            inDoubleQuotes();
+        } else if (c == '\'') {
+            inSingleQuotes();
+        } else {
+            pushChar(c);
+        }
+    }
+
+    pushCurrent();
+
+    return result;
+}
 } // namespace nix

--- a/src/libutil/strings.hh
+++ b/src/libutil/strings.hh
@@ -71,4 +71,11 @@ extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, 
 extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::set<std::string> &);
 extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::vector<std::string> &);
 
+/**
+ * Shell split string: split a string into shell arguments, respecting quotes and backslashes.
+ *
+ * Used for NIX_SSHOPTS handling, which previously used `tokenizeString` and was broken by
+ * Arguments that need to be passed to ssh with spaces in them.
+ */
+std::list<std::string> shellSplitString(std::string_view s);
 }


### PR DESCRIPTION
Solves #5181 

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

With NIX_SSHOPTS='-o ProxyCommand="ssh -W %h:%p ..."' nix-copy-closure tool will fail with error.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

See #5181 

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

Added `shellSplitString` to [strings.cc](https://github.com/NixOS/nix/compare/master...elikoga:nix:ssh-opts-split-as-shell-args?expand=1#diff-a37a841d9f9dcbfe63d651a4a4ee1962b7f000c663bbb83d0e66393fda3895a9)

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
