### PR TITLE
Improve `builtins.{head,elemAt}` error messages

### DIFF
--- a/src/libexpr-tests/error_traces.cc
+++ b/src/libexpr-tests/error_traces.cc
@@ -691,15 +691,15 @@ namespace nix {
         ASSERT_TRACE2("elemAt \"foo\" (-1)",
                       TypeError,
                       HintFmt("expected a list but found %s: %s", "a string", Uncolored(ANSI_MAGENTA "\"foo\"" ANSI_NORMAL)),
-                      HintFmt("while evaluating the first argument passed to builtins.elemAt"));
+                      HintFmt("while evaluating the first argument passed to 'builtins.elemAt'"));
 
         ASSERT_TRACE1("elemAt [] (-1)",
                       Error,
-                      HintFmt("list index %d is out of bounds", -1));
+                      HintFmt("'builtins.elemAt' called with index %d on a list of size %d", -1, 0));
 
         ASSERT_TRACE1("elemAt [\"foo\"] 3",
                       Error,
-                      HintFmt("list index %d is out of bounds", 3));
+                      HintFmt("'builtins.elemAt' called with index %d on a list of size %d", 3, 1));
 
     }
 
@@ -708,11 +708,11 @@ namespace nix {
         ASSERT_TRACE2("head 1",
                       TypeError,
                       HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
-                      HintFmt("while evaluating the first argument passed to builtins.elemAt"));
+                      HintFmt("while evaluating the first argument passed to 'builtins.head'"));
 
         ASSERT_TRACE1("head []",
                       Error,
-                      HintFmt("'head' called on an empty list"));
+                      HintFmt("'builtins.head' called on an empty list"));
 
     }
 
@@ -721,11 +721,11 @@ namespace nix {
         ASSERT_TRACE2("tail 1",
                       TypeError,
                       HintFmt("expected a list but found %s: %s", "an integer", Uncolored(ANSI_CYAN "1" ANSI_NORMAL)),
-                      HintFmt("while evaluating the first argument passed to builtins.tail"));
+                      HintFmt("while evaluating the first argument passed to 'builtins.tail'"));
 
         ASSERT_TRACE1("tail []",
                       Error,
-                      HintFmt("'tail' called on an empty list"));
+                      HintFmt("'builtins.tail' called on an empty list"));
 
     }
 

--- a/src/libexpr-tests/error_traces.cc
+++ b/src/libexpr-tests/error_traces.cc
@@ -712,7 +712,7 @@ namespace nix {
 
         ASSERT_TRACE1("head []",
                       Error,
-                      HintFmt("list index %d is out of bounds", 0));
+                      HintFmt("'head' called on an empty list"));
 
     }
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3259,23 +3259,19 @@ static RegisterPrimOp primop_isList({
     .fun = prim_isList,
 });
 
-static void elemAt(EvalState & state, const PosIdx pos, Value & list, int n, Value & v)
-{
-    state.forceList(list, pos, "while evaluating the first argument passed to builtins.elemAt");
-    if (n < 0 || (unsigned int) n >= list.listSize())
-        state.error<EvalError>(
-            "list index %1% is out of bounds",
-            n
-        ).atPos(pos).debugThrow();
-    state.forceValue(*list.listElems()[n], pos);
-    v = *list.listElems()[n];
-}
-
 /* Return the n-1'th element of a list. */
 static void prim_elemAt(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    NixInt::Inner elem = state.forceInt(*args[1], pos, "while evaluating the second argument passed to builtins.elemAt").value;
-    elemAt(state, pos, *args[0], elem, v);
+    NixInt::Inner n = state.forceInt(*args[1], pos, "while evaluating the second argument passed to 'builtins.elemAt'").value;
+    state.forceList(*args[0], pos, "while evaluating the first argument passed to 'builtins.elemAt'");
+    if (n < 0 || (unsigned int) n >= args[0]->listSize())
+        state.error<EvalError>(
+            "'builtins.elemAt' called with index %d on a list of size %d",
+            n,
+            args[0]->listSize()
+        ).atPos(pos).debugThrow();
+    state.forceValue(*args[0]->listElems()[n], pos);
+    v = *args[0]->listElems()[n];
 }
 
 static RegisterPrimOp primop_elemAt({
@@ -3291,7 +3287,13 @@ static RegisterPrimOp primop_elemAt({
 /* Return the first element of a list. */
 static void prim_head(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    elemAt(state, pos, *args[0], 0, v);
+    state.forceList(*args[0], pos, "while evaluating the first argument passed to 'builtins.head'");
+    if (args[0]->listSize() == 0)
+        state.error<EvalError>(
+            "'builtins.head' called on an empty list"
+        ).atPos(pos).debugThrow();
+    state.forceValue(*args[0]->listElems()[0], pos);
+    v = *args[0]->listElems()[0];
 }
 
 static RegisterPrimOp primop_head({
@@ -3310,9 +3312,9 @@ static RegisterPrimOp primop_head({
    don't want to use it!  */
 static void prim_tail(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
-    state.forceList(*args[0], pos, "while evaluating the first argument passed to builtins.tail");
+    state.forceList(*args[0], pos, "while evaluating the first argument passed to 'builtins.tail'");
     if (args[0]->listSize() == 0)
-        state.error<EvalError>("'tail' called on an empty list").atPos(pos).debugThrow();
+        state.error<EvalError>("'builtins.tail' called on an empty list").atPos(pos).debugThrow();
 
     auto list = state.buildList(args[0]->listSize() - 1);
     for (const auto & [n, v] : enumerate(list))


### PR DESCRIPTION
Sorry, I'm not sure how to implement this. So just a test change.
And hopefully will be picked up by someone who is paying attention.
A hero.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I noticed that the error for `builtins.head` is not as nice as the one for `builtins.tail`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
