### PR TITLE
fromJSON/fromTOML: throw if string contains null byte

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3178,5 +3178,14 @@ std::ostream & operator << (std::ostream & str, const ExternalValueBase & v) {
     return v.print(str);
 }
 
+void forceNoNullByte(std::string_view s)
+{
+    if (s.find('\0') != s.npos) {
+        using namespace std::string_view_literals;
+        auto str = replaceStrings(std::string(s), "\0"sv, "␀"sv);
+        throw Error("input string '%s' cannot be represented as Nix string because it contains null bytes", str);
+    }
+}
+
 
 }

--- a/src/libexpr/json-to-value.cc
+++ b/src/libexpr/json-to-value.cc
@@ -50,6 +50,7 @@ class JSONSax : nlohmann::json_sax<json> {
     public:
         void key(string_t & name, EvalState & state)
         {
+            forceNoNullByte(name);
             attrs.insert_or_assign(state.symbols.create(name), &value(state));
         }
     };
@@ -122,6 +123,7 @@ public:
 
     bool string(string_t & val) override
     {
+        forceNoNullByte(val);
         rs->value(state).mkString(val);
         rs->add();
         return true;

--- a/src/libexpr/primops/fromTOML.cc
+++ b/src/libexpr/primops/fromTOML.cc
@@ -28,8 +28,10 @@ static void prim_fromTOML(EvalState & state, const PosIdx pos, Value * * args, V
 
                     auto attrs = state.buildBindings(size);
 
-                    for(auto & elem : table)
+                    for(auto & elem : table) {
+                        forceNoNullByte(elem.first);
                         visit(attrs.alloc(elem.first), elem.second);
+                    }
 
                     v.mkAttrs(attrs);
                 }
@@ -54,7 +56,11 @@ static void prim_fromTOML(EvalState & state, const PosIdx pos, Value * * args, V
                 v.mkFloat(toml::get<NixFloat>(t));
                 break;;
             case toml::value_t::string:
-                v.mkString(toml::get<std::string>(t));
+                {
+                    auto s = toml::get<std::string_view>(t);
+                    forceNoNullByte(s);
+                    v.mkString(s);
+                }
                 break;;
             case toml::value_t::local_datetime:
             case toml::value_t::offset_datetime:
@@ -66,7 +72,9 @@ static void prim_fromTOML(EvalState & state, const PosIdx pos, Value * * args, V
                         attrs.alloc("_type").mkString("timestamp");
                         std::ostringstream s;
                         s << t;
-                        attrs.alloc("value").mkString(toView(s));
+                        auto str = toView(s);
+                        forceNoNullByte(str);
+                        attrs.alloc("value").mkString(str);
                         v.mkAttrs(attrs);
                     } else {
                         throw std::runtime_error("Dates and times are not supported");

--- a/src/libexpr/value.hh
+++ b/src/libexpr/value.hh
@@ -510,4 +510,6 @@ typedef std::shared_ptr<Value *> RootValue;
 
 RootValue allocRootValue(Value * v);
 
+void forceNoNullByte(std::string_view s);
+
 }

--- a/tests/functional/lang/eval-fail-fromJSON-keyWithNullByte.err.exp
+++ b/tests/functional/lang/eval-fail-fromJSON-keyWithNullByte.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fromJSON' builtin
+         at /pwd/lang/eval-fail-fromJSON-keyWithNullByte.nix:1:1:
+            1| builtins.fromJSON ''{"a\u0000b": 1}''
+             | ^
+            2|
+
+       error: input string 'a␀b' cannot be represented as Nix string because it contains null bytes

--- a/tests/functional/lang/eval-fail-fromJSON-keyWithNullByte.nix
+++ b/tests/functional/lang/eval-fail-fromJSON-keyWithNullByte.nix
@@ -1,0 +1,1 @@
+builtins.fromJSON ''{"a\u0000b": 1}''

--- a/tests/functional/lang/eval-fail-fromJSON-valueWithNullByte.err.exp
+++ b/tests/functional/lang/eval-fail-fromJSON-valueWithNullByte.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fromJSON' builtin
+         at /pwd/lang/eval-fail-fromJSON-valueWithNullByte.nix:1:1:
+            1| builtins.fromJSON ''"a\u0000b"''
+             | ^
+            2|
+
+       error: input string 'a␀b' cannot be represented as Nix string because it contains null bytes

--- a/tests/functional/lang/eval-fail-fromJSON-valueWithNullByte.nix
+++ b/tests/functional/lang/eval-fail-fromJSON-valueWithNullByte.nix
@@ -1,0 +1,1 @@
+builtins.fromJSON ''"a\u0000b"''

--- a/tests/functional/lang/eval-fail-fromTOML-keyWithNullByte.err.exp
+++ b/tests/functional/lang/eval-fail-fromTOML-keyWithNullByte.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fromTOML' builtin
+         at /pwd/lang/eval-fail-fromTOML-keyWithNullByte.nix:1:1:
+            1| builtins.fromTOML ''"a\u0000b" = 1''
+             | ^
+            2|
+
+       error: while parsing TOML: error: input string 'a␀b' cannot be represented as Nix string because it contains null bytes

--- a/tests/functional/lang/eval-fail-fromTOML-keyWithNullByte.nix
+++ b/tests/functional/lang/eval-fail-fromTOML-keyWithNullByte.nix
@@ -1,0 +1,1 @@
+builtins.fromTOML ''"a\u0000b" = 1''

--- a/tests/functional/lang/eval-fail-fromTOML-valueWithNullByte.err.exp
+++ b/tests/functional/lang/eval-fail-fromTOML-valueWithNullByte.err.exp
@@ -1,0 +1,8 @@
+error:
+       … while calling the 'fromTOML' builtin
+         at /pwd/lang/eval-fail-fromTOML-valueWithNullByte.nix:1:1:
+            1| builtins.fromTOML ''k = "a\u0000b"''
+             | ^
+            2|
+
+       error: while parsing TOML: error: input string 'a␀b' cannot be represented as Nix string because it contains null bytes

--- a/tests/functional/lang/eval-fail-fromTOML-valueWithNullByte.nix
+++ b/tests/functional/lang/eval-fail-fromTOML-valueWithNullByte.nix
@@ -1,0 +1,1 @@
+builtins.fromTOML ''k = "a\u0000b"''


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
Internally Nix uses C-strings, i.e. it's not possible to represent the `NUL` character. `builtins.fromJSON` and `builtins.fromTOML` allow escaping of the`NUL` character, so that null bytes can appear in strings causing inconsistent behaviour.

`builtins.readFile` already throws an error, if the input file contains a null byte.

## Context

<!-- Provide context. Reference open issues if available. -->
Fixes #10317 by throwing an error when a null byte is encountered.

Tests of the new behaviour are provided.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
