### PR TITLE
optimize string concat

### DIFF
--- a/src/libutil/util.hh
+++ b/src/libutil/util.hh
@@ -338,7 +338,9 @@ std::string showBytes(uint64_t bytes);
  */
 inline std::string operator + (const std::string & s1, std::string_view s2)
 {
-    auto s = s1;
+    std::string s;
+    s.reserve(s1.size() + s2.size());
+    s.append(s1);
     s.append(s2);
     return s;
 }
@@ -351,10 +353,11 @@ inline std::string operator + (std::string && s, std::string_view s2)
 
 inline std::string operator + (std::string_view s1, const char * s2)
 {
+    auto s2Size = strlen(s2);
     std::string s;
-    s.reserve(s1.size() + strlen(s2));
+    s.reserve(s1.size() + s2Size);
     s.append(s1);
-    s.append(s2);
+    s.append(s2, s2Size);
     return s;
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

- reserve memory for output string
- remove implicit call to `strlen()`

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
