### PR TITLE
[2.3] build: backport NIX_ATTRS_*_FILE

### DIFF
--- a/src/libstore/build.cc
+++ b/src/libstore/build.cc
@@ -2584,6 +2584,7 @@ void DerivationGoal::writeStructuredAttrs()
 
     writeFile(tmpDir + "/.attrs.json", rewriteStrings(json.dump(), inputRewrites));
     chownToBuilder(tmpDir + "/.attrs.json");
+    env["NIX_ATTRS_JSON_FILE"] = tmpDirInSandbox + "/.attrs.json";
 
     /* As a convenience to bash scripts, write a shell file that
        maps all attributes that are representable in bash -
@@ -2653,6 +2654,7 @@ void DerivationGoal::writeStructuredAttrs()
 
     writeFile(tmpDir + "/.attrs.sh", rewriteStrings(jsonSh, inputRewrites));
     chownToBuilder(tmpDir + "/.attrs.sh");
+    env["NIX_ATTRS_SH_FILE"] = tmpDirInSandbox + "/.attrs.sh";
 }
 
 

--- a/tests/structured-attrs.nix
+++ b/tests/structured-attrs.nix
@@ -38,6 +38,12 @@ mkDerivation {
     [[ $json =~ '"narSize":288' ]]
     [[ $json =~ '"closureSize":288' ]]
     [[ $json =~ '"references":[]' ]]
+
+    [[ -e "$NIX_ATTRS_SH_FILE" ]]
+    [[ -e "$NIX_ATTRS_JSON_FILE" ]]
+
+    [[ "$(<"$NIX_ATTRS_SH_FILE")" = "$(<.attrs.sh)" ]]
+    [[ "$(<"$NIX_ATTRS_JSON_FILE")" = "$(<.attrs.json)" ]]
   '';
 
   buildInputs = [ "a" "b" "c" 123 "'" "\"" null ];


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation
This was originally added in #4770 to support structured attrs in `nix-shell` & `nix develop`: the issue was that it was somewhat awkward to just write those files into a project directory, especially since it'd break in case of multiple `nix-shell` invocations from the same directory. Now the files are written to another, temporary location when using `nix-shell`/`nix develop` and the correct path is referenced by NIX_ATTRS_*_FILE.

In `nixpkgs`, it's now common to use these environment variables, however we still fall back to checking to `.attrs.sh` & `.attrs.json` since the minimum Nix version we support is 2.3.17[1] which doesn't have this change.

This however makes implementing structured attrs support more complicated than needed[2] and in fact we have a few places where the check for `.attrs.sh`/`.attrs.json` isn't made, so these only break with Nix 2.3[3].

The idea is now to

* get this into 2.3.18
* bump minver once again to 2.3.18 in nixpkgs
* remove all occurrences of `.attrs.sh`/`.attrs.json` from nixpkgs.

[1] https://github.com/NixOS/nixpkgs/blob/f4bd97b8face6dc14b0ce048c20cff7e558c7be2/lib/minver.nix
[2] https://github.com/NixOS/nixpkgs/pull/357053/files#diff-791a01ef89c157eb74d9c87ab8cbc3b81e2cf082cab70b8fec3472cd75ce860dR3-R5
[3] https://github.com/NixOS/nixpkgs/pull/357053#discussion_r1857362490
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
cc @wolfgangwalther @edolstra @Ericson2314 

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
