### PR TITLE
nix flake lock: Fail if there is an unlocked input

### DIFF
--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -672,6 +672,8 @@ LockedFlake lockFlake(
             if (lockFlags.writeLockFile) {
                 if (sourcePath || lockFlags.outputLockFilePath) {
                     if (auto unlockedInput = newLockFile.isUnlocked()) {
+                        if (lockFlags.failOnUnlocked)
+                            throw Error("cannot write lock file of flake '%s' because it has an unlocked input ('%s').\n", topRef, *unlockedInput);
                         if (state.fetchSettings.warnDirty)
                             warn("will not write lock file of flake '%s' because it has an unlocked input ('%s')", topRef, *unlockedInput);
                     } else {

--- a/src/libflake/flake/flake.hh
+++ b/src/libflake/flake/flake.hh
@@ -157,6 +157,11 @@ struct LockFlags
     bool writeLockFile = true;
 
     /**
+     * Throw an exception when the flake has an unlocked input.
+     */
+    bool failOnUnlocked = false;
+
+    /**
      * Whether to use the registries to lookup indirect flake
      * references like 'nixpkgs'.
      */

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -162,6 +162,7 @@ struct CmdFlakeLock : FlakeCommand
         settings.tarballTtl = 0;
 
         lockFlags.writeLockFile = true;
+        lockFlags.failOnUnlocked = true;
         lockFlags.applyNixConfig = true;
 
         lockFlake();

--- a/tests/functional/flakes/unlocked-override.sh
+++ b/tests/functional/flakes/unlocked-override.sh
@@ -30,3 +30,6 @@ git -C "$flake2Dir" add flake.nix
 echo 456 > "$flake1Dir"/x.nix
 
 [[ $(nix eval --json "$flake2Dir#x" --override-input flake1 "$TEST_ROOT/flake1") = 456 ]]
+
+expectStderr 1 nix flake lock "$flake2Dir" --override-input flake1 "$TEST_ROOT/flake1" |
+  grepQuiet "cannot write lock file.*because it has an unlocked input"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Since the only purpose of `nix flake lock` is to write a new lock file, it should be a fatal error if we can't write the lock file.

Fixes #12022.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
