### PR TITLE
mergify: don't use rebase merge method

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ queue_rules:
       - check-success=tests (macos-latest)
       - check-success=tests (ubuntu-latest)
       - check-success=vm_tests
-    merge_method: rebase
     batch_size: 5
 
 pull_request_rules:


### PR DESCRIPTION
The repository is configured to use the rebase merge method.

https://github.com/NixOS/nix/pull/12034#issuecomment-2530341302

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
