### PR TITLE
lookupInFlakeCache(): Fix O(n) time lookup

### DIFF
--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -104,9 +104,9 @@ public:
 
     bool operator ==(const Input & other) const noexcept;
 
-    auto operator <=>(const Input & other) const
+    bool operator <(const Input & other) const
     {
-        return attrs <=> other.attrs;
+        return attrs < other.attrs;
     }
 
     bool contains(const Input & other) const;

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -104,6 +104,11 @@ public:
 
     bool operator ==(const Input & other) const noexcept;
 
+    auto operator <=>(const Input & other) const
+    {
+        return attrs <=> other.attrs;
+    }
+
     bool contains(const Input & other) const;
 
     /**

--- a/src/libflake/flake/flakeref.hh
+++ b/src/libflake/flake/flakeref.hh
@@ -49,7 +49,10 @@ struct FlakeRef
 
     bool operator ==(const FlakeRef & other) const = default;
 
-    auto operator <=>(const FlakeRef &) const = default;
+    bool operator <(const FlakeRef & other) const
+    {
+        return std::tie(input, subdir) < std::tie(other.input, other.subdir);
+    }
 
     FlakeRef(fetchers::Input && input, const Path & subdir)
         : input(std::move(input)), subdir(subdir)

--- a/src/libflake/flake/flakeref.hh
+++ b/src/libflake/flake/flakeref.hh
@@ -49,6 +49,8 @@ struct FlakeRef
 
     bool operator ==(const FlakeRef & other) const = default;
 
+    auto operator <=>(const FlakeRef &) const = default;
+
     FlakeRef(fetchers::Input && input, const Path & subdir)
         : input(std::move(input)), subdir(subdir)
     { }

--- a/src/libutil/types.hh
+++ b/src/libutil/types.hh
@@ -45,7 +45,10 @@ struct Explicit {
 
     bool operator ==(const Explicit<T> & other) const = default;
 
-    auto operator <=>(const Explicit<T> & other) const = default;
+    bool operator <(const Explicit<T> & other) const
+    {
+        return t < other.t;
+    }
 };
 
 

--- a/src/libutil/types.hh
+++ b/src/libutil/types.hh
@@ -43,10 +43,9 @@ template<typename T>
 struct Explicit {
     T t;
 
-    bool operator ==(const Explicit<T> & other) const
-    {
-        return t == other.t;
-    }
+    bool operator ==(const Explicit<T> & other) const = default;
+
+    auto operator <=>(const Explicit<T> & other) const = default;
 };
 
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This makes `FlakeRef` and `Input` comparable so they can be used as keys in an `std::map`. It also makes `FetchedFlake` a struct instead of an `std::pair`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
