### PR TITLE
EvalState::realiseContext(): Allow access to the entire closure

### DIFF
--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -401,6 +401,11 @@ public:
     void allowPath(const StorePath & storePath);
 
     /**
+     * Allow access to the closure of a store path.
+     */
+    void allowClosure(const StorePath & storePath);
+
+    /**
      * Allow access to a store path and return it as a string.
      */
     void allowAndSetStorePathString(const StorePath & storePath, Value & v);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -119,11 +119,9 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
     if (store != buildStore) copyClosure(*buildStore, *store, outputsToCopyAndAllow);
 
     if (isIFD) {
-        for (auto & outputPath : outputsToCopyAndAllow) {
-            /* Add the output of this derivations to the allowed
-            paths. */
-            allowPath(outputPath);
-        }
+        /* Allow access to the output closures of this derivation. */
+        for (auto & outputPath : outputsToCopyAndAllow)
+            allowClosure(outputPath);
     }
 
     return res;

--- a/tests/functional/import-from-derivation.nix
+++ b/tests/functional/import-from-derivation.nix
@@ -1,4 +1,4 @@
-with import ./config.nix;
+with import <config>;
 
 rec {
   bar = mkDerivation {
@@ -30,4 +30,23 @@ rec {
         echo -n BLA$(cat $src) > $out
       '';
   };
+
+  step1 = mkDerivation {
+    name = "step1";
+    buildCommand = ''
+      mkdir -p $out
+      echo 'foo' > $out/bla
+    '';
+  };
+
+  addPathExpr = mkDerivation {
+    name = "add-path";
+    inherit step1;
+    buildCommand = ''
+      mkdir -p $out
+      echo "builtins.path { path = \"$step1\"; sha256 = \"7ptL+pnrZXnSa5hwwB+2SXTLkcSb5264WGGokN8OXto=\"; }" > $out/default.nix
+    '';
+  };
+
+  importAddPathExpr = import addPathExpr;
 }

--- a/tests/functional/import-from-derivation.sh
+++ b/tests/functional/import-from-derivation.sh
@@ -6,6 +6,8 @@ TODO_NixOS
 
 clearStoreIfPossible
 
+export NIX_PATH=config="${config_nix}"
+
 if nix-instantiate --readonly-mode ./import-from-derivation.nix -A result; then
     echo "read-only evaluation of an imported derivation unexpectedly failed"
     exit 1
@@ -14,6 +16,9 @@ fi
 outPath=$(nix-build ./import-from-derivation.nix -A result --no-out-link)
 
 [ "$(cat "$outPath")" = FOO579 ]
+
+# Check that we can have access to the entire closure of a derivation output.
+nix build --no-link --restrict-eval -I src=. -f ./import-from-derivation.nix importAddPathExpr -v
 
 # FIXME: the next tests are broken on CA.
 if [[ -n "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

When doing IFD, we should allow access to the entire closure of the store paths built by the derivation, not just the top-level paths.

Fixes #11030.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
