### PR TITLE
Fix `nix upgrade-nix` profile search

### DIFF
--- a/src/libutil/executable-path.cc
+++ b/src/libutil/executable-path.cc
@@ -73,7 +73,7 @@ ExecutablePath::findName(const OsString & exe, std::function<bool(const fs::path
     for (auto & dir : directories) {
         auto candidate = dir / exe;
         if (isExecutable(candidate))
-            return std::filesystem::canonical(candidate);
+            return candidate.lexically_normal();
     }
 
     return std::nullopt;

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -126,7 +126,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
         if (where.filename() != "bin" ||
             !hasSuffix(userEnv, "user-environment"))
-            throw Error("directory '%s' does not appear to be part of a Nix profile", where);
+            throw Error("directory %s does not appear to be part of a Nix profile", where);
 
         if (!store->isValidPath(store->parseStorePath(userEnv)))
             throw Error("directory '%s' is not in the Nix store", userEnv);

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -107,7 +107,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         auto whereOpt = ExecutablePath::load().findName(OS_STR("nix-env"));
         if (!whereOpt)
             throw Error("couldn't figure out how Nix is installed, so I can't upgrade it");
-        auto & where = *whereOpt;
+        const auto & where = whereOpt->parent_path();
 
         printInfo("found Nix in '%s'", where);
 


### PR DESCRIPTION
## Motivation

I could no longer get `nix upgrade-nix` to work on macOS or Linux after upgrading to 2.25:

```
$ sudo -i nix upgrade-nix --debug
found Nix in '"/nix/store/46p1z0w9ad605kky62dr53z4h24k2a5r-nix-2.25.2/bin/nix"'
found profile '/nix/store/46p1z0w9ad605kky62dr53z4h24k2a5r-nix-2.25.2/bin'
error: directory '"/nix/store/46p1z0w9ad605kky62dr53z4h24k2a5r-nix-2.25.2/bin/nix"' does not appear to be part of a Nix profile
```

Fix the profile search logic so that it works again without needing to explicitly give `--profile /nix/var/nix/profiles/default`.

## Context

Commit cfe66dbec (in #11218) updated `nix upgrade-nix` to use `ExecutablePath::load().find`, which broke the logic for finding the profile associated with the nix executable. This seems to happen for two reasons:

1. The original PATH search resulted in a directory, but `find` returns the path to the executable. Fixed by getting the path's parent.
2. The profile symlink cannot be found because `ExecutablePath::load().find` canonicalizes the executable path. I updated find to normalize the path instead, which seems more in line with how other programs resolve paths. I'm not sure if this affects other callers though.

I manually tested this on macOS and Linux, and it seemed to fix upgrading from 2.25.2 to 2.25.3.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 