### PR TITLE
speed up ci by splitting off eval and build + fix ci with restricted namespaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    # Since ubuntu 22.30, unprivileged usernamespaces are no longer allowed to map to the root user:
+    # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
+    - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      if: matrix.os == 'ubuntu-latest'
     - run: scripts/build-checks
 
   # Steps to test CI automation in your own fork.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
 permissions: read-all
 
 jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: cachix/install-nix-action@v30
+    - run: nix --experimental-features 'nix-command flakes' flake show --all-systems --json
 
   tests:
     needs: [check_secrets]
@@ -33,25 +41,7 @@ jobs:
         name: '${{ env.CACHIX_NAME }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - if: matrix.os == 'ubuntu-latest'
-      run: |
-        free -h
-        swapon --show
-        swap=$(swapon --show --noheadings | head -n 1 | awk '{print $1}')
-        echo "Found swap: $swap"
-        sudo swapoff $swap
-        # resize it (fallocate)
-        sudo fallocate -l 10G $swap
-        sudo mkswap $swap
-        sudo swapon $swap
-        free -h
-        (
-          while sleep 60; do
-            free -h
-          done
-        ) &
-    - run: nix --experimental-features 'nix-command flakes' flake check -L
-    - run: nix --experimental-features 'nix-command flakes' flake show --all-systems --json
+    - run: scripts/build-checks
 
   # Steps to test CI automation in your own fork.
   # Cachix:

--- a/scripts/binary-tarball.nix
+++ b/scripts/binary-tarball.nix
@@ -65,7 +65,7 @@ runCommand "nix-binary-tarball-${version}" env ''
   fn=$out/$dir.tar.xz
   mkdir -p $out/nix-support
   echo "file binary-dist $fn" >> $out/nix-support/hydra-build-products
-  tar cvfJ $fn \
+  tar cfJ $fn \
     --owner=0 --group=0 --mode=u+rw,uga+r \
     --mtime='1970-01-01' \
     --absolute-names \

--- a/scripts/build-checks
+++ b/scripts/build-checks
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+system=$(nix eval --raw --impure --expr builtins.currentSystem)
+nix eval --json ".#checks.$system" --apply builtins.attrNames | \
+  jq -r '.[]' | \
+  xargs -P0 -I '{}' sh -c "nix build -L .#checks.$system.{} || { echo 'FAILED: \033[0;31mnix build -L .#checks.$system.{}\\033[0m'; kill 0; }"


### PR DESCRIPTION
 - This speeds up macOS builds from 30 minutes to 11 minutes (3x faster).        
 - Also improve error reporting e.g. printing out what actually failed to build. 
 - As a result we also no longer need swap.
 - The resulting script is also very useful for running checks locally as it does not need so much RAM as before (we used significantly more memory than what our nixpkgs eval ci these days consume)