### PR TITLE
Prepare nix to run with clang-tidy

### DIFF
--- a/src/libexpr/lexer-helpers.hh
+++ b/src/libexpr/lexer-helpers.hh
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <cstddef>
+
+// inluding the generated headers twice leads to errors
+#ifndef BISON_HEADER
+#include "lexer-tab.hh"
+#include "parser-tab.hh"
+#endif
+
 namespace nix::lexer::internal {
 
 void initLoc(YYLTYPE * loc);

--- a/src/libexpr/lexer-helpers.hh
+++ b/src/libexpr/lexer-helpers.hh
@@ -4,8 +4,8 @@
 
 // inluding the generated headers twice leads to errors
 #ifndef BISON_HEADER
-#include "lexer-tab.hh"
-#include "parser-tab.hh"
+#  include "lexer-tab.hh"
+#  include "parser-tab.hh"
 #endif
 
 namespace nix::lexer::internal {

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -168,7 +168,7 @@ struct ExprVar : Expr
        the set stored in the environment that is `level` levels up
        from the current one.*/
     Level level;
-    Displacement displ;
+    Displacement displ = 0;
 
     ExprVar(Symbol name) : name(name) { };
     ExprVar(const PosIdx & pos, Symbol name) : pos(pos), name(name) { };
@@ -242,7 +242,7 @@ struct ExprAttrs : Expr
         Kind kind;
         Expr * e;
         PosIdx pos;
-        Displacement displ; // displacement
+        Displacement displ = 0; // displacement
         AttrDef(Expr * e, const PosIdx & pos, Kind kind = Kind::Plain)
             : kind(kind), e(e), pos(pos) { };
         AttrDef() { };

--- a/src/libexpr/print-options.hh
+++ b/src/libexpr/print-options.hh
@@ -5,6 +5,7 @@
  */
 
 #include <limits>
+#include <stddef.h>
 
 namespace nix {
 

--- a/src/libstore/path-regex.hh
+++ b/src/libstore/path-regex.hh
@@ -1,6 +1,8 @@
 #pragma once
 ///@file
 
+#include <string_view>
+
 namespace nix {
 
 

--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -2,10 +2,12 @@
 #include "pathlocks.hh"
 #include "signals.hh"
 #include "util.hh"
-#include <errhandlingapi.h>
-#include <fileapi.h>
-#include <windows.h>
-#include "windows-error.hh"
+
+#ifdef WIN32
+#  include <errhandlingapi.h>
+#  include <fileapi.h>
+#  include <windows.h>
+#  include "windows-error.hh"
 
 namespace nix {
 
@@ -154,3 +156,4 @@ FdLock::FdLock(Descriptor desc, LockType lockType, bool wait, std::string_view w
 }
 
 }
+#endif

--- a/src/libutil/callback.hh
+++ b/src/libutil/callback.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <cassert>
 #include <future>
 #include <functional>
 

--- a/src/libutil/config-impl.hh
+++ b/src/libutil/config-impl.hh
@@ -13,6 +13,7 @@
  */
 
 #include "config.hh"
+#include "args.hh"
 
 namespace nix {
 

--- a/src/libutil/regex-combinators.hh
+++ b/src/libutil/regex-combinators.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include <string_view>
+#include <string>
 
 namespace nix::regex {
 

--- a/src/libutil/regex-combinators.hh
+++ b/src/libutil/regex-combinators.hh
@@ -3,6 +3,7 @@
 
 #include <string_view>
 #include <string>
+#include <sstream>
 
 namespace nix::regex {
 
@@ -11,22 +12,23 @@ namespace nix::regex {
 
 static inline std::string either(std::string_view a, std::string_view b)
 {
-    return std::string { a } + "|" + b;
+    std::stringstream ss;
+    ss << a << "|" << b;
+    return ss.str();
 }
 
 static inline std::string group(std::string_view a)
 {
-    return std::string { "(" } + a + ")";
-}
-
-static inline std::string many(std::string_view a)
-{
-    return std::string { "(?:" } + a + ")*";
+    std::stringstream ss;
+    ss << "(" << a << ")";
+    return ss.str();
 }
 
 static inline std::string list(std::string_view a)
 {
-    return std::string { a } + many(group("," + a));
+    std::stringstream ss;
+    ss << a << "(," << a << ")*";
+    return ss.str();
 }
 
 }

--- a/src/libutil/unix/signals-impl.hh
+++ b/src/libutil/unix/signals-impl.hh
@@ -14,6 +14,7 @@
 #include "error.hh"
 #include "logging.hh"
 #include "ansicolor.hh"
+#include "signals.hh"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -1,6 +1,7 @@
 #include "environment-variables.hh"
 
-#include "processenv.h"
+#ifdef WIN32
+#  include "processenv.h"
 
 namespace nix {
 
@@ -43,3 +44,4 @@ int setEnvOs(const OsString & name, const OsString & value)
 }
 
 }
+#endif

--- a/src/libutil/windows/file-descriptor.cc
+++ b/src/libutil/windows/file-descriptor.cc
@@ -5,6 +5,7 @@
 #include "windows-error.hh"
 #include "file-path.hh"
 
+#ifdef WIN32
 #include <fileapi.h>
 #include <error.h>
 #include <namedpipeapi.h>
@@ -152,3 +153,4 @@ Path windows::handleToPath(HANDLE handle) {
 #endif
 
 }
+#endif

--- a/src/libutil/windows/file-system.cc
+++ b/src/libutil/windows/file-system.cc
@@ -1,5 +1,6 @@
 #include "file-system.hh"
 
+#ifdef WIN32
 namespace nix {
 
 Descriptor openDirectory(const std::filesystem::path & path)
@@ -15,3 +16,4 @@ Descriptor openDirectory(const std::filesystem::path & path)
 }
 
 }
+#endif

--- a/src/libutil/windows/muxable-pipe.cc
+++ b/src/libutil/windows/muxable-pipe.cc
@@ -1,9 +1,10 @@
-#include <ioapiset.h>
-#include "windows-error.hh"
+#ifdef WIN32
+#  include <ioapiset.h>
+#  include "windows-error.hh"
 
-#include "logging.hh"
-#include "util.hh"
-#include "muxable-pipe.hh"
+#  include "logging.hh"
+#  include "util.hh"
+#  include "muxable-pipe.hh"
 
 namespace nix {
 
@@ -68,3 +69,4 @@ void MuxablePipePollState::iterate(
 }
 
 }
+#endif

--- a/src/libutil/windows/os-string.cc
+++ b/src/libutil/windows/os-string.cc
@@ -7,6 +7,8 @@
 #include "file-path-impl.hh"
 #include "util.hh"
 
+#ifdef WIN32
+
 namespace nix {
 
 std::string os_string_to_string(PathViewNG::string_view path)
@@ -22,3 +24,5 @@ std::filesystem::path::string_type string_to_os_string(std::string_view s)
 }
 
 }
+
+#endif

--- a/src/libutil/windows/processes.cc
+++ b/src/libutil/windows/processes.cc
@@ -23,6 +23,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifdef WIN32
+
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
@@ -386,3 +388,5 @@ int execvpe(const wchar_t * file0, const wchar_t * const argv[], const wchar_t *
 }
 
 }
+
+#endif

--- a/src/libutil/windows/users.cc
+++ b/src/libutil/windows/users.cc
@@ -4,6 +4,7 @@
 #include "file-system.hh"
 #include "windows-error.hh"
 
+#ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
@@ -50,3 +51,4 @@ bool isRootUser() {
 }
 
 }
+#endif

--- a/src/libutil/windows/windows-async-pipe.cc
+++ b/src/libutil/windows/windows-async-pipe.cc
@@ -1,6 +1,8 @@
 #include "windows-async-pipe.hh"
 #include "windows-error.hh"
 
+#ifdef WIN32
+
 namespace nix::windows {
 
 void AsyncPipe::createAsyncPipe(HANDLE iocp)
@@ -47,3 +49,5 @@ void AsyncPipe::close()
 }
 
 }
+
+#endif

--- a/src/libutil/windows/windows-async-pipe.hh
+++ b/src/libutil/windows/windows-async-pipe.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include "file-descriptor.hh"
+#ifdef WIN32
 
 namespace nix::windows {
 
@@ -25,3 +26,4 @@ public:
 };
 
 }
+#endif

--- a/src/libutil/windows/windows-error.cc
+++ b/src/libutil/windows/windows-error.cc
@@ -1,5 +1,6 @@
 #include "windows-error.hh"
 
+#ifdef WIN32
 #include <error.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -29,3 +30,4 @@ std::string WinError::renderError(DWORD lastError)
 }
 
 }
+#endif

--- a/src/libutil/windows/windows-error.hh
+++ b/src/libutil/windows/windows-error.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#ifdef WIN32
 #include <errhandlingapi.h>
 
 #include "error.hh"
@@ -49,3 +50,4 @@ private:
 };
 
 }
+#endif

--- a/src/nix/self-exe.hh
+++ b/src/nix/self-exe.hh
@@ -2,6 +2,8 @@
 ///@file
 
 #include <filesystem>
+#include <optional>
+#include <string_view>
 
 namespace nix {
 

--- a/tests/nixos/ca-fd-leak/sender.c
+++ b/tests/nixos/ca-fd-leak/sender.c
@@ -49,8 +49,8 @@ int main(int argc, char **argv) {
     msg.msg_controllen = CMSG_SPACE(sizeof(int));
 
     // Write a single null byte too.
-    msg.msg_iov = malloc(sizeof(struct iovec));
-    msg.msg_iov[0].iov_base = "";
+    msg.msg_iov = (struct iovec*) malloc(sizeof(struct iovec));
+    msg.msg_iov[0].iov_base = (void*) "";
     msg.msg_iov[0].iov_len = 1;
     msg.msg_iovlen = 1;
 

--- a/tests/nixos/ca-fd-leak/smuggler.c
+++ b/tests/nixos/ca-fd-leak/smuggler.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
     struct sockaddr_un data;
     data.sun_family = AF_UNIX;
     data.sun_path[0] = 0;
-    strcpy(data.sun_path + 1, argv[1]);
+    strncpy(data.sun_path + 1, argv[1], sizeof(data.sun_path) - 1);
     int res = bind(sock, (const struct sockaddr *)&data,
         offsetof(struct sockaddr_un, sun_path)
         + strlen(argv[1])
@@ -57,10 +57,11 @@ int main(int argc, char **argv) {
     // Wait for a second connection, which will tell us that the build is
     // done
     a = accept(sock, 0, 0);
+    if (a < 0) perror("accept");
     fprintf(stderr, "%s\n", "Got a second connection, rewriting the file");
     // Write a new content to the file
     if (ftruncate(smuggling_fd, 0)) perror("ftruncate");
-    char * new_content = "Pwned\n";
+    const char * new_content = "Pwned\n";
     int written_bytes = write(smuggling_fd, new_content, strlen(new_content));
     if (written_bytes != strlen(new_content)) perror("write");
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Since switching to `meson`, we now have a `clang-tidy` build target:

```
$ ninja clang-tidy
```

This pull request introduces various fixes to make clang-tidy run without error (but still with warnings).

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
