### PR TITLE
libstore: fixup unformatted uri when S3 getObject fails

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -767,7 +767,7 @@ struct curlFileTransfer : public FileTransfer
                 auto s3Res = s3Helper.getObject(bucketName, key);
                 FileTransferResult res;
                 if (!s3Res.data)
-                    throw FileTransferError(NotFound, "S3 object '%s' does not exist", request.uri);
+                    throw FileTransferError(NotFound, {}, "S3 object '%s' does not exist", request.uri);
                 res.data = std::move(*s3Res.data);
                 res.urls.push_back(request.uri);
                 callback(std::move(res));

--- a/tests/nixos/s3-binary-cache-store.nix
+++ b/tests/nixos/s3-binary-cache-store.nix
@@ -21,7 +21,10 @@ in {
         { virtualisation.writableStore = true;
           virtualisation.additionalPaths = [ pkgA ];
           environment.systemPackages = [ pkgs.minio-client ];
-          nix.extraOptions = "experimental-features = nix-command";
+          nix.extraOptions = ''
+            experimental-features = nix-command
+            substituters =
+          '';
           services.minio = {
             enable = true;
             region = "eu-west-1";
@@ -36,7 +39,10 @@ in {
       client =
         { config, pkgs, ... }:
         { virtualisation.writableStore = true;
-          nix.extraOptions = "experimental-features = nix-command";
+          nix.extraOptions = ''
+            experimental-features = nix-command
+            substituters =
+          '';
         };
     };
 

--- a/tests/nixos/s3-binary-cache-store.nix
+++ b/tests/nixos/s3-binary-cache-store.nix
@@ -10,6 +10,7 @@ let
   env = "AWS_ACCESS_KEY_ID=${accessKey} AWS_SECRET_ACCESS_KEY=${secretKey}";
 
   storeUrl = "s3://my-cache?endpoint=http://server:9000&region=eu-west-1";
+  objectThatDoesNotExist = "s3://my-cache/foo-that-does-not-exist?endpoint=http://server:9000&region=eu-west-1";
 
 in {
   name = "s3-binary-cache-store";
@@ -53,6 +54,12 @@ in {
 
     # Test fetchurl on s3:// URLs while we're at it.
     client.succeed("${env} nix eval --impure --expr 'builtins.fetchurl { name = \"foo\"; url = \"s3://my-cache/nix-cache-info?endpoint=http://server:9000&region=eu-west-1\"; }'")
+
+    # Test that the format string in the error message is properly setup and won't display `%s` instead of the failed URI
+    msg = client.fail("${env} nix eval --impure --expr 'builtins.fetchurl { name = \"foo\"; url = \"${objectThatDoesNotExist}\"; }' 2>&1")
+    if "S3 object '${objectThatDoesNotExist}' does not exist" not in msg:
+      print(msg) # So that you can see the message that was improperly formatted
+      raise Exception("Error message formatting didn't work")
 
     # Copy a package from the binary cache.
     client.fail("nix path-info ${pkgA}")


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes https://github.com/NixOS/nix/issues/12090.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

---

Drafted because I want to add a test that catches / validates this.
