### PR TITLE
flake: disable eval cache on local repos

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -154,6 +154,11 @@ bool Input::isLocked() const
     return scheme && scheme->isLocked(*this);
 }
 
+bool Input::isLocal(const ref<Store> & store) const
+{
+    return !scheme || scheme->isLocal(*this, store);
+}
+
 bool Input::isFinal() const
 {
     return maybeGetBoolAttr(attrs, "__final").value_or(false);

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -96,6 +96,11 @@ public:
     bool isLocked() const;
 
     /**
+     * Return whenever the input is on the local filesystem and not in the store.
+     */
+    bool isLocal(const ref<Store> & nixStore) const;
+
+    /**
      * Return whether this is a "final" input, meaning that fetching
      * it will not add, remove or change any attributes. (See
      * `checkLocks()` for the semantics.) Only "final" inputs can be
@@ -252,13 +257,16 @@ struct InputScheme
      */
     virtual std::optional<ExperimentalFeature> experimentalFeature() const;
 
+    virtual std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const
+        { return std::nullopt; }
+
     virtual bool isDirect(const Input & input) const
     { return true; }
 
-    virtual std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const
-    { return std::nullopt; }
-
     virtual bool isLocked(const Input & input) const
+    { return false; }
+
+    virtual bool isLocal(const Input & input, const ref<Store> & store) const
     { return false; }
 };
 

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -827,6 +827,12 @@ struct GitInputScheme : InputScheme
     {
         return (bool) input.getRev();
     }
+
+    bool isLocal(const Input & input, const ref<Store> & store) const override
+    {
+        auto info = getRepoInfo(input);
+        return info.isLocal;
+    }
 };
 
 static auto rGitInputScheme = OnStartup([] { registerInputScheme(std::make_unique<GitInputScheme>()); });

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -312,6 +312,11 @@ struct GitArchiveInputScheme : InputScheme
                 input.getNarHash().has_value());
     }
 
+    bool isLocal(const Input & input, const ref<Store> & nixStore) const override
+    {
+        return false;
+    }
+
     std::optional<ExperimentalFeature> experimentalFeature() const override
     {
         return Xp::Flakes;

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -351,6 +351,12 @@ struct MercurialInputScheme : InputScheme
         return (bool) input.getRev();
     }
 
+    bool isLocal(const Input & input, const ref<Store> & store) const override
+    {
+        auto url = parseURL(getStrAttr(input.attrs, "url"));
+        return url.scheme == "file" && !store->isInStore(url.path);
+    }
+
     std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const override
     {
         if (auto rev = input.getRev())

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -108,6 +108,12 @@ struct PathInputScheme : InputScheme
         return (bool) input.getNarHash();
     }
 
+    bool isLocal(const Input & input, const ref<Store> & store) const override
+    {
+        auto path = getStrAttr(input.attrs, "path");
+        return !store->isInStore(path);
+    }
+
     CanonPath getAbsPath(const Input & input) const
     {
         auto path = getStrAttr(input.attrs, "path");


### PR DESCRIPTION
flakes: turn off eval cache on local repos

## Motivation

The most common complaint about flakes is that it copies the repo to the
/nix/store on each eval. This is especially annoying on large monorepos where
copying multiple GiB to the /nix/store outweighs whatever gains the eval cache
could bring.

## Context

To solve this, turn off eval caching on local repositories.

I am aware of the lazy tree PR. This is a much simpler solution.

The current PR only implements 1/2 of the solution and turns off the eval
cache. The second change will be to stop copying the paths to the store.

Making this change will also automatically solve:
* Eval error messages pointing to the /nix/store instead of local repos.
* Files not added to the git index not being taken into account.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
