### PR TITLE
fix: ignore symlinks in fsync-store-paths

### DIFF
--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -331,7 +331,7 @@ void syncParent(const Path & path)
 
 void recursiveSync(const Path & path)
 {
-    /* If it's a file, just fsync and return. */
+    /* If it's a file or symlink, just fsync and return. */
     auto st = lstat(path);
     if (S_ISREG(st.st_mode)) {
         AutoCloseFD fd = toDescriptor(open(path.c_str(), O_RDONLY, 0));
@@ -339,7 +339,8 @@ void recursiveSync(const Path & path)
             throw SysError("opening file '%1%'", path);
         fd.fsync();
         return;
-    }
+    } else if (S_ISLNK(st.st_mode))
+        return;
 
     /* Otherwise, perform a depth-first traversal of the directory and
        fsync all the files. */


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

When fsync-store-paths is enabled, during nix copy symlink store entries are treated as directory, which is not correct.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/12099

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
