### PR TITLE
local-derivation-goal: improve "illegal reference" error

### DIFF
--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -2992,15 +2992,10 @@ void LocalDerivationGoal::checkOutputs(const std::map<std::string, ValidPathInfo
                     else if (auto output = get(outputs, i))
                         spec.insert(output->path);
                     else {
-                        std::string allOutputs;
-                        for (auto & o : outputs) {
-                            if (! allOutputs.empty())
-                                allOutputs.append(", ");
-                            allOutputs.append(o.first);
-                        }
+                        std::string outputsListing = concatMapStringsSep(", ", outputs, [](auto & o) { return o.first; });
                         throw BuildError("derivation '%s' output check for '%s' contains an illegal reference specifier '%s',"
                             " expected store path or output name (one of [%s])",
-                            worker.store.printStorePath(drvPath), outputName, i, allOutputs);
+                            worker.store.printStorePath(drvPath), outputName, i, outputsListing);
                     }
                 }
 

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -2991,8 +2991,17 @@ void LocalDerivationGoal::checkOutputs(const std::map<std::string, ValidPathInfo
                         spec.insert(worker.store.parseStorePath(i));
                     else if (auto output = get(outputs, i))
                         spec.insert(output->path);
-                    else
-                        throw BuildError("derivation contains an illegal reference specifier '%s'", i);
+                    else {
+                        std::string allOutputs;
+                        for (auto & o : outputs) {
+                            if (! allOutputs.empty())
+                                allOutputs.append(", ");
+                            allOutputs.append(o.first);
+                        }
+                        throw BuildError("derivation '%s' output check for '%s' contains an illegal reference specifier '%s',"
+                            " expected store path or output name (one of [%s])",
+                            worker.store.printStorePath(drvPath), outputName, i, allOutputs);
+                    }
                 }
 
                 auto used = recursive

--- a/src/libutil-tests/strings.cc
+++ b/src/libutil-tests/strings.cc
@@ -80,6 +80,42 @@ TEST(concatStringsSep, buildSingleString)
     ASSERT_EQ(concatStringsSep(",", strings), "this");
 }
 
+TEST(concatMapStringsSep, empty)
+{
+    Strings strings;
+
+    ASSERT_EQ(concatMapStringsSep(",", strings, [](const std::string & s) { return s; }), "");
+}
+
+TEST(concatMapStringsSep, justOne)
+{
+    Strings strings;
+    strings.push_back("this");
+
+    ASSERT_EQ(concatMapStringsSep(",", strings, [](const std::string & s) { return s; }), "this");
+}
+
+TEST(concatMapStringsSep, two)
+{
+    Strings strings;
+    strings.push_back("this");
+    strings.push_back("that");
+
+    ASSERT_EQ(concatMapStringsSep(",", strings, [](const std::string & s) { return s; }), "this,that");
+}
+
+TEST(concatMapStringsSep, map)
+{
+    std::map<std::string, std::string> strings;
+    strings["this"] = "that";
+    strings["1"] = "one";
+
+    ASSERT_EQ(
+        concatMapStringsSep(
+            ", ", strings, [](const std::pair<std::string, std::string> & s) { return s.first + " -> " + s.second; }),
+        "1 -> one, this -> that");
+}
+
 /* ----------------------------------------------------------------------------
  * dropEmptyInitThenConcatStringsSep
  * --------------------------------------------------------------------------*/

--- a/src/libutil/strings.cc
+++ b/src/libutil/strings.cc
@@ -39,6 +39,7 @@ basicSplitString(std::basic_string_view<OsChar> s, std::basic_string_view<OsChar
 template std::string concatStringsSep(std::string_view, const std::list<std::string> &);
 template std::string concatStringsSep(std::string_view, const std::set<std::string> &);
 template std::string concatStringsSep(std::string_view, const std::vector<std::string> &);
+template std::string concatStringsSep(std::string_view, const boost::container::small_vector<std::string, 64> &);
 
 typedef std::string_view strings_2[2];
 template std::string concatStringsSep(std::string_view, const strings_2 &);

--- a/src/libutil/strings.hh
+++ b/src/libutil/strings.hh
@@ -56,6 +56,20 @@ extern template std::string concatStringsSep(std::string_view, const std::set<st
 extern template std::string concatStringsSep(std::string_view, const std::vector<std::string> &);
 
 /**
+ * Apply a function to the `iterable`'s items and concat them with `separator`.
+ */
+template<class C, class F>
+std::string concatMapStringsSep(std::string_view separator, const C & iterable, F fn)
+{
+    std::vector<std::string> strings;
+    strings.reserve(iterable.size());
+    for (const auto & elem : iterable) {
+        strings.push_back(fn(elem));
+    }
+    return concatStringsSep(separator, strings);
+}
+
+/**
  * Ignore any empty strings at the start of the list, and then concatenate the
  * given strings with a separator between the elements.
  *

--- a/src/libutil/strings.hh
+++ b/src/libutil/strings.hh
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/container/small_vector.hpp>
+
 namespace nix {
 
 /*
@@ -54,6 +56,7 @@ std::string concatStringsSep(const std::string_view sep, const C & ss);
 extern template std::string concatStringsSep(std::string_view, const std::list<std::string> &);
 extern template std::string concatStringsSep(std::string_view, const std::set<std::string> &);
 extern template std::string concatStringsSep(std::string_view, const std::vector<std::string> &);
+extern template std::string concatStringsSep(std::string_view, const boost::container::small_vector<std::string, 64> &);
 
 /**
  * Apply a function to the `iterable`'s items and concat them with `separator`.
@@ -61,7 +64,7 @@ extern template std::string concatStringsSep(std::string_view, const std::vector
 template<class C, class F>
 std::string concatMapStringsSep(std::string_view separator, const C & iterable, F fn)
 {
-    std::vector<std::string> strings;
+    boost::container::small_vector<std::string, 64> strings;
     strings.reserve(iterable.size());
     for (const auto & elem : iterable) {
         strings.push_back(fn(elem));

--- a/tests/functional/check-refs.nix
+++ b/tests/functional/check-refs.nix
@@ -81,8 +81,11 @@ rec {
 
   test12 = makeTest 12 {
     builder = builtins.toFile "builder.sh" "mkdir $out $lib";
-    outputs = ["out" "lib"];
-    disallowedReferences = ["dev"];
+    outputs = [
+      "out"
+      "lib"
+    ];
+    disallowedReferences = [ "dev" ];
   };
 
 }

--- a/tests/functional/check-refs.nix
+++ b/tests/functional/check-refs.nix
@@ -79,4 +79,10 @@ rec {
     buildCommand = ''echo ${dep} > "''${outputs[out]}"'';
   };
 
+  test12 = makeTest 12 {
+    builder = builtins.toFile "builder.sh" "mkdir $out $lib";
+    outputs = ["out" "lib"];
+    disallowedReferences = ["dev"];
+  };
+
 }

--- a/tests/functional/check-refs.sh
+++ b/tests/functional/check-refs.sh
@@ -61,6 +61,8 @@ if ! isTestOnNixOS; then
 
 fi
 
-# test12 should fail (syntactically invalid).
-expectStderr 1 nix-build -vvv -o "$RESULT" check-refs.nix -A test12 >"$TEST_ROOT/test12.stderr"
-grepQuiet -F "output check for 'lib' contains an illegal reference specifier 'dev', expected store path or output name (one of [lib, out])" < "$TEST_ROOT/test12.stderr"
+if isDaemonNewer "2.28pre20241225"; then
+    # test12 should fail (syntactically invalid).
+    expectStderr 1 nix-build -vvv -o "$RESULT" check-refs.nix -A test12 >"$TEST_ROOT/test12.stderr"
+    grepQuiet -F "output check for 'lib' contains an illegal reference specifier 'dev', expected store path or output name (one of [lib, out])" < "$TEST_ROOT/test12.stderr"
+fi

--- a/tests/functional/check-refs.sh
+++ b/tests/functional/check-refs.sh
@@ -60,3 +60,7 @@ if ! isTestOnNixOS; then
     fi
 
 fi
+
+# test12 should fail (syntactically invalid).
+expectStderr 1 nix-build -vvv -o "$RESULT" check-refs.nix -A test12 >"$TEST_ROOT/test12.stderr"
+grepQuiet -F "output check for 'lib' contains an illegal reference specifier 'dev', expected store path or output name (one of [lib, out])" < "$TEST_ROOT/test12.stderr"


### PR DESCRIPTION
## Motivation

Before the change "illegal reference" was hard to interpret as it did not mention what derivation actually hits it.

Today's `nixpkgs` example:

Before the change:

    $ nix build --no-link -f. postgresql_14
    ...
    error: derivation contains an illegal reference specifier 'man'

After the change:

    $ nix build --no-link -f. postgresql_14
    ...
    error: derivation '/nix/store/bxp6g57limvwiga61vdlyvhy7i8rp6wd-postgresql-14.15.drv' output 'lib' contains an illegal reference specifier 'man', expected store path or output name (one of [debug, dev, doc, lib, out])

## Context

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
