### PR TITLE
fetchers/git: make relative path absolute for local repo

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -426,7 +426,16 @@ struct GitInputScheme : InputScheme
         auto url = parseURL(getStrAttr(input.attrs, "url"));
         bool isBareRepository = url.scheme == "file" && !pathExists(url.path + "/.git");
         repoInfo.isLocal = url.scheme == "file" && !forceHttp && !isBareRepository;
-        repoInfo.url = repoInfo.isLocal ? url.path : url.to_string();
+        //
+        // FIXME: here we turn a possibly relative path into an absolute path.
+        // This allows relative git flake inputs to be resolved against the
+        // **current working directory** (as in POSIX), which tends to work out
+        // ok in the context of flakes, but is the wrong behavior,
+        // as it should resolve against the flake.nix base directory instead.
+        //
+        // See: https://discourse.nixos.org/t/57783 and #9708
+        //
+        repoInfo.url = repoInfo.isLocal ? std::filesystem::absolute(url.path).string() : url.to_string();
 
         // If this is a local directory and no ref or revision is
         // given, then allow the use of an unclean working tree.

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -110,6 +110,7 @@ nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default"
 # This may change in the future once git submodule support is refined.
 # See: https://discourse.nixos.org/t/57783 and #9708.
 (
+  # This `cd` should not be required and is indicative of aforementioned bug.
   cd "$flake1Dir/.."
   nix build -o "$TEST_ROOT/result" "git+file:./$(basename "$flake1Dir")"
 )

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -106,6 +106,14 @@ nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir#default"
 nix build -o "$TEST_ROOT/result" "$flake1Dir?ref=HEAD#default"
 nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default"
 
+# Check that relative paths are allowed for git flakes.
+# This may change in the future once git submodule support is refined.
+# See: https://discourse.nixos.org/t/57783 and #9708.
+(
+  cd "$flake1Dir/.."
+  nix build -o "$TEST_ROOT/result" "git+file:./$(basename "$flake1Dir")"
+)
+
 # Check that store symlinks inside a flake are not interpreted as flakes.
 nix build -o "$flake1Dir/result" "git+file://$flake1Dir"
 nix path-info "$flake1Dir/result"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Closes #9708 (again).

This patch:
- (naively) Resolves relative paths to local git repos, returning absolute paths, thus allowing flake URIs such as `git+file:./${submodule}` to continue working.
- Adds tests to prevent future breakages.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Flake URIs such as `git+file:./${submodule}` used to work before 2.18, but broke in 2.19, was fixed later, and broke again recently since 3e0129ce3b9eb094d4a3cc8023884f372f1d7ff6, resulting in a core-dumped assertion error in https://github.com/NixOS/nix/issues/9708#issuecomment-2559095657.

This PR suppresses the error and allows `git+file:./${submodule}`to continue working. However, this fix is not ideal and should potentially be superseded by a better submodule implementation in the future. See:
- #9708
- #9897

A better fix is outlined by @roberth in https://discourse.nixos.org/t/57783, namely:

> This bug seems to have allowed relative git flake inputs to be resolved against the current working directory (as in POSIX), and this tends to work out ok in the context of flakes, but is the wrong behavior, as it should resolve against the flake.nix base directory instead.
> Supporting relative paths in fetchTree would add significant value.
> This behavior was used as a workaround for lacking relative flake input or “subflake” support.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

Friendly pings:
- @roberth and @tomberek for reviews
- @DamienCassou and @aij for testing
