### PR TITLE
ci: lock Ubuntu and macOS runners and update Ubuntu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   eval:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -37,7 +37,7 @@ jobs:
     # Since ubuntu 22.30, unprivileged usernamespaces are no longer allowed to map to the root user:
     # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
     - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      if: matrix.os == 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-24.04'
     - run: scripts/build-checks
     - run: scripts/prepare-installer-for-github-actions
     - name: Upload installer tarball
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
         install_url: 'http://localhost:8126/install'
         install_options: "--tarball-url-prefix http://localhost:8126/"
     - run: sudo apt install fish zsh
-      if: matrix.os == 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-24.04'
     - run: brew install fish
       if: matrix.os == 'macos-latest'
     - run: exec bash -c "nix-instantiate -E 'builtins.currentTime' --eval"
@@ -86,7 +86,7 @@ jobs:
     permissions:
       contents: none
     name: Check Docker secrets present for installer tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       docker: ${{ steps.secret.outputs.docker }}
     steps:
@@ -106,7 +106,7 @@ jobs:
       needs.check_secrets.outputs.docker == 'true' &&
       github.event_name == 'push' &&
       github.ref_name == 'master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check for secrets
       id: secret
@@ -158,7 +158,7 @@ jobs:
         docker push $IMAGE_ID:master
 
   vm_tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
@@ -173,7 +173,7 @@ jobs:
 
   flake_regressions:
     needs: vm_tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout nix
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-24.04, macos-14]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-24.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     - run: sudo apt install fish zsh
       if: matrix.os == 'ubuntu-24.04'
     - run: brew install fish
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-14'
     - run: exec bash -c "nix-instantiate -E 'builtins.currentTime' --eval"
     - run: exec sh -c "nix-instantiate -E 'builtins.currentTime' --eval"
     - run: exec zsh -c "nix-instantiate -E 'builtins.currentTime' --eval"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   eval:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -37,7 +37,7 @@ jobs:
     # Since ubuntu 22.30, unprivileged usernamespaces are no longer allowed to map to the root user:
     # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
     - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-22.04'
     - run: scripts/build-checks
     - run: scripts/prepare-installer-for-github-actions
     - name: Upload installer tarball
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
         install_url: 'http://localhost:8126/install'
         install_options: "--tarball-url-prefix http://localhost:8126/"
     - run: sudo apt install fish zsh
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-22.04'
     - run: brew install fish
       if: matrix.os == 'macos-latest'
     - run: exec bash -c "nix-instantiate -E 'builtins.currentTime' --eval"
@@ -86,7 +86,7 @@ jobs:
     permissions:
       contents: none
     name: Check Docker secrets present for installer tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       docker: ${{ steps.secret.outputs.docker }}
     steps:
@@ -106,7 +106,7 @@ jobs:
       needs.check_secrets.outputs.docker == 'true' &&
       github.event_name == 'push' &&
       github.ref_name == 'master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Check for secrets
       id: secret

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   labels:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'NixOS'
     steps:
     - uses: actions/labeler@v5

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   labels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'NixOS'
     steps:
     - uses: actions/labeler@v5

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,9 +3,9 @@ queue_rules:
     # all required tests need to go here
     merge_conditions:
       - check-success=tests (macos-latest)
-      - check-success=tests (ubuntu-22.04)
+      - check-success=tests (ubuntu-24.04)
       - check-success=installer_test (macos-latest)
-      - check-success=installer_test (ubuntu-22.04)
+      - check-success=installer_test (ubuntu-24.04)
       - check-success=vm_tests
     batch_size: 5
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,9 +3,9 @@ queue_rules:
     # all required tests need to go here
     merge_conditions:
       - check-success=tests (macos-latest)
-      - check-success=tests (ubuntu-latest)
+      - check-success=tests (ubuntu-22.04)
       - check-success=installer_test (macos-latest)
-      - check-success=installer_test (ubuntu-latest)
+      - check-success=installer_test (ubuntu-22.04)
       - check-success=vm_tests
     batch_size: 5
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,9 +2,9 @@ queue_rules:
   - name: default
     # all required tests need to go here
     merge_conditions:
-      - check-success=tests (macos-latest)
+      - check-success=tests (macos-14)
       - check-success=tests (ubuntu-24.04)
-      - check-success=installer_test (macos-latest)
+      - check-success=installer_test (macos-14)
       - check-success=installer_test (ubuntu-24.04)
       - check-success=vm_tests
     batch_size: 5

--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -297,7 +297,7 @@ Creating a Cachix cache for your installer tests and adding its authorisation to
   - `armv7l-linux`
   - `x86_64-darwin`
 
-- The `installer_test` job (which runs on `ubuntu-latest` and `macos-latest`) will try to install Nix with the cached installer and run a trivial Nix command.
+- The `installer_test` job (which runs on `ubuntu-22.04` and `macos-latest`) will try to install Nix with the cached installer and run a trivial Nix command.
 
 ### One-time setup
 

--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -297,7 +297,7 @@ Creating a Cachix cache for your installer tests and adding its authorisation to
   - `armv7l-linux`
   - `x86_64-darwin`
 
-- The `installer_test` job (which runs on `ubuntu-24.04` and `macos-latest`) will try to install Nix with the cached installer and run a trivial Nix command.
+- The `installer_test` job (which runs on `ubuntu-24.04` and `macos-14`) will try to install Nix with the cached installer and run a trivial Nix command.
 
 ### One-time setup
 

--- a/doc/manual/source/development/testing.md
+++ b/doc/manual/source/development/testing.md
@@ -297,7 +297,7 @@ Creating a Cachix cache for your installer tests and adding its authorisation to
   - `armv7l-linux`
   - `x86_64-darwin`
 
-- The `installer_test` job (which runs on `ubuntu-22.04` and `macos-latest`) will try to install Nix with the cached installer and run a trivial Nix command.
+- The `installer_test` job (which runs on `ubuntu-24.04` and `macos-latest`) will try to install Nix with the cached installer and run a trivial Nix command.
 
 ### One-time setup
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

This patchset is a port of https://github.com/NixOS/nixpkgs/pull/368442:

> Lock the Ubuntu and macOS runners to avoid accidental updates [1] and increase reproduciblity. Then, update the Ubuntu runner to what `ubuntu-latest` will soon point to [1], which hopefully causes no problems on our end.
>
> [1]: https://github.com/actions/runner-images/issues/10636
>
> -- https://github.com/NixOS/nixpkgs/pull/368442

<!-- ## Context -->

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
