### PR TITLE
Make `readFileType` doc string consistent

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2045,7 +2045,7 @@ static RegisterPrimOp primop_readFileType({
     .args = {"p"},
     .doc = R"(
       Determine the directory entry type of a filesystem node, being
-      one of "directory", "regular", "symlink", or "unknown".
+      one of `"directory"`, `"regular"`, `"symlink"`, or `"unknown"`.
     )",
     .fun = prim_readFileType,
 });


### PR DESCRIPTION
## Motivation

The primitive [`readDir path`](https://nix.dev/manual/nix/2.23/language/builtins#builtins-readDir) has a list of acceptable types, and so does [`readFileType path`](https://nix.dev/manual/nix/2.23/language/builtins#builtins-readFileType). This edit 


This edit makes the formatting of the list consistent between themselves, and other parts of the documentation. 
## Context


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
