### PR TITLE
Implement --raw for nix-instantiate --eval

### DIFF
--- a/doc/manual/rl-next/nix-instantiate-raw.md
+++ b/doc/manual/rl-next/nix-instantiate-raw.md
@@ -1,0 +1,8 @@
+---
+synopsis: "`nix-instantiate --eval` now supports `--raw`"
+prs: [12119]
+---
+
+The `nix-instantiate --eval` command now supports a `--raw` flag, when used
+the evaluation result must be a string, which is printed verbatim without
+quotation marks or escaping.

--- a/doc/manual/source/command-ref/nix-copy-closure.md
+++ b/doc/manual/source/command-ref/nix-copy-closure.md
@@ -84,7 +84,7 @@ When using public key authentication, you can avoid typing the passphrase with `
 > Copy GNU Hello from a remote machine using a known store path, and run it:
 >
 > ```shell-session
-> $ storePath="$(nix-instantiate --eval '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello.outPath | tr -d '"')"
+> $ storePath="$(nix-instantiate --eval --raw '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable -A hello.outPath)"
 > $ nix-copy-closure --from alice@itchy.example.org "$storePath"
 > $ "$storePath"/bin/hello
 > Hello, world!

--- a/doc/manual/source/command-ref/nix-instantiate.md
+++ b/doc/manual/source/command-ref/nix-instantiate.md
@@ -5,7 +5,7 @@
 # Synopsis
 
 `nix-instantiate`
-  [`--parse` | `--eval` [`--strict`] [`--json`] [`--xml`] ]
+  [`--parse` | `--eval` [`--strict`] [`--raw` | `--json` | `--xml`] ]
   [`--read-write-mode`]
   [`--arg` *name* *value*]
   [{`--attr`| `-A`} *attrPath*]
@@ -101,6 +101,11 @@ standard input.
   >
   > This option can cause non-termination, because lazy data
   > structures can be infinitely large.
+
+- `--raw`
+
+  When used with `--eval`, the evaluation result must be a string,
+  which is printed verbatim, without quoting, escaping or trailing newline.
 
 - `--json`
 

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -24,7 +24,7 @@ static Path gcRoot;
 static int rootNr = 0;
 
 
-enum OutputKind { okPlain, okXML, okJSON };
+enum OutputKind { okPlain, okRaw, okXML, okJSON };
 
 void processExpr(EvalState & state, const Strings & attrPaths,
     bool parseOnly, bool strict, Bindings & autoArgs,
@@ -50,7 +50,11 @@ void processExpr(EvalState & state, const Strings & attrPaths,
                 vRes = v;
             else
                 state.autoCallFunction(autoArgs, v, vRes);
-            if (output == okXML)
+            if (output == okRaw)
+                std::cout << *state.coerceToString(noPos, vRes, context, "while generating the nix-instantiate output");
+                // We intentionally don't output a newline here. The default PS1 for Bash in NixOS starts with a newline
+                // and other interactive shells like Zsh are smart enough to print a missing newline before the prompt.
+            else if (output == okXML)
                 printValueAsXML(state, strict, location, vRes, std::cout, context, noPos);
             else if (output == okJSON) {
                 printValueAsJSON(state, strict, vRes, v.determinePos(noPos), std::cout, context);
@@ -132,6 +136,8 @@ static int main_nix_instantiate(int argc, char * * argv)
                 gcRoot = getArg(*arg, arg, end);
             else if (*arg == "--indirect")
                 ;
+            else if (*arg == "--raw")
+                outputKind = okRaw;
             else if (*arg == "--xml")
                 outputKind = okXML;
             else if (*arg == "--json")

--- a/tests/functional/eval.nix
+++ b/tests/functional/eval.nix
@@ -1,5 +1,5 @@
 {
   int = 123;
-  str = "foo";
+  str = "foo\nbar";
   attr.foo = "bar";
 }

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -29,6 +29,7 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
 [[ $(nix-instantiate -A int --eval "./eval.nix") == 123 ]]
 [[ $(nix-instantiate -A str --eval "./eval.nix") == '"foo\nbar"' ]]
+[[ $(nix-instantiate -A str --raw --eval "./eval.nix") == $'foo\nbar' ]]
 [[ "$(nix-instantiate -A attr --eval "./eval.nix")" == '{ foo = "bar"; }' ]]
 [[ $(nix-instantiate -A attr --eval --json "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix-instantiate -A int --eval - < "./eval.nix") == 123 ]]

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -16,8 +16,8 @@ EOF
 nix eval --expr 'assert 1 + 2 == 3; true'
 
 [[ $(nix eval int -f "./eval.nix") == 123 ]]
-[[ $(nix eval str -f "./eval.nix") == '"foo"' ]]
-[[ $(nix eval str --raw -f "./eval.nix") == 'foo' ]]
+[[ $(nix eval str -f "./eval.nix") == '"foo\nbar"' ]]
+[[ $(nix eval str --raw -f "./eval.nix") == $'foo\nbar' ]]
 [[ "$(nix eval attr -f "./eval.nix")" == '{ foo = "bar"; }' ]]
 [[ $(nix eval attr --json -f "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix eval int -f - < "./eval.nix") == 123 ]]
@@ -28,7 +28,7 @@ nix eval --expr 'assert 1 + 2 == 3; true'
 
 nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
 [[ $(nix-instantiate -A int --eval "./eval.nix") == 123 ]]
-[[ $(nix-instantiate -A str --eval "./eval.nix") == '"foo"' ]]
+[[ $(nix-instantiate -A str --eval "./eval.nix") == '"foo\nbar"' ]]
 [[ "$(nix-instantiate -A attr --eval "./eval.nix")" == '{ foo = "bar"; }' ]]
 [[ $(nix-instantiate -A attr --eval --json "./eval.nix") == '{"foo":"bar"}' ]]
 [[ $(nix-instantiate -A int --eval - < "./eval.nix") == 123 ]]


### PR DESCRIPTION
## Motivation

The experimental `nix eval` command already supports a `--raw` flag.
This commit implements the same flag for the stable nix-instantiate command.

Until now instructions and scripts that didn't want to rely on experimental
features had to use workarounds such as:

    nix-instantiate --eval <something> | tr -d \"

(which also undesirably also removes double quotation marks within the string), or

    nix-instantiate --eval <something> | jq -j

(which undesirably depends on another package).

## Context

Continuation of #9361.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
