### PR TITLE
toJSON: re-throw serialization exception

### DIFF
--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -108,7 +108,11 @@ json printValueAsJSON(EvalState & state, bool strict,
 void printValueAsJSON(EvalState & state, bool strict,
     Value & v, const PosIdx pos, std::ostream & str, NixStringContext & context, bool copyToStore)
 {
-    str << printValueAsJSON(state, strict, v, pos, context, copyToStore);
+    try {
+        str << printValueAsJSON(state, strict, v, pos, context, copyToStore);
+    } catch (nlohmann::json::exception & e) {
+        throw JSONSerializationError("JSON serialization error: %s", e.what());
+    }
 }
 
 json ExternalValueBase::printValueAsJSON(EvalState & state, bool strict,

--- a/src/libexpr/value-to-json.hh
+++ b/src/libexpr/value-to-json.hh
@@ -16,4 +16,7 @@ nlohmann::json printValueAsJSON(EvalState & state, bool strict,
 void printValueAsJSON(EvalState & state, bool strict,
     Value & v, const PosIdx pos, std::ostream & str, NixStringContext & context, bool copyToStore = true);
 
+
+MakeError(JSONSerializationError, Error);
+
 }

--- a/tests/functional/lang/eval-fail-toJSON-non-utf-8.err.exp
+++ b/tests/functional/lang/eval-fail-toJSON-non-utf-8.err.exp
@@ -1,0 +1,8 @@
+error:
+       â€¦ while calling the 'toJSON' builtin
+         at /pwd/lang/eval-fail-toJSON-non-utf-8.nix:1:1:
+            1| builtins.toJSON "_invalid UTF-8: ÿ_"
+             | ^
+            2|
+
+       error: JSON serialization error: [json.exception.type_error.316] invalid UTF-8 byte at index 16: 0xFF

--- a/tests/functional/lang/eval-fail-toJSON-non-utf-8.nix
+++ b/tests/functional/lang/eval-fail-toJSON-non-utf-8.nix
@@ -1,0 +1,1 @@
+builtins.toJSON "_invalid UTF-8: ÿ_"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
`nlohmann::json` can throw an exception during the serialization of a json object and the exception is not caught by Nix. This affects `builtins.toJSON`.


## Context

The exception observed in #12060 is thrown during the serialization of the json object, not during its construction. The PR catches the exception and converts it to a Nix error.

Fixes #12060.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
