### PR TITLE
implement CLICOLOR_FORCE environment variable

### DIFF
--- a/src/libcmd/markdown.cc
+++ b/src/libcmd/markdown.cc
@@ -45,7 +45,7 @@ static std::string doRenderMarkdownToTerminal(std::string_view markdown)
 #  endif
     };
 
-    if (!isTTY())
+    if (!shouldANSI())
         opts.oflags |= LOWDOWN_TERM_NOANSI;
 
     auto doc = lowdown_doc_new(&opts);

--- a/src/libmain/include/nix/main/common-args.hh
+++ b/src/libmain/include/nix/main/common-args.hh
@@ -3,6 +3,7 @@
 
 #include "nix/util/args.hh"
 #include "nix/util/repair-flag.hh"
+#include "nix/util/terminal.hh"
 
 namespace nix {
 
@@ -43,7 +44,7 @@ struct MixDryRun : virtual Args
  */
 struct MixPrintJSON : virtual Args
 {
-    bool outputPretty = isatty(STDOUT_FILENO);
+    bool outputPretty = shouldANSI(StandardOutputStream::Stdout);
 
     MixPrintJSON()
     {

--- a/src/libmain/progress-bar.cc
+++ b/src/libmain/progress-bar.cc
@@ -608,7 +608,7 @@ public:
 
 std::unique_ptr<Logger> makeProgressBar()
 {
-    return std::make_unique<ProgressBar>(isTTY());
+    return std::make_unique<ProgressBar>(shouldANSI());
 }
 
 } // namespace nix

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -7,6 +7,7 @@
 #include "nix/main/progress-bar.hh"
 #include "nix/util/signals.hh"
 #include "nix/util/util.hh"
+#include "nix/util/terminal.hh"
 
 #include <algorithm>
 #include <exception>
@@ -353,7 +354,7 @@ int handleExceptions(const std::string & programName, std::function<void()> fun)
 
 RunPager::RunPager()
 {
-    if (!isatty(STDOUT_FILENO))
+    if (!isOutputARealTerminal(StandardOutputStream::Stdout))
         return;
     char * pager = getenv("NIX_PAGER");
     if (!pager)

--- a/src/libutil/include/nix/util/terminal.hh
+++ b/src/libutil/include/nix/util/terminal.hh
@@ -5,11 +5,43 @@
 #include <string>
 
 namespace nix {
+
+enum class StandardOutputStream {
+    Stdout = 1,
+    Stderr = 2,
+};
+
+/**
+ * Determine whether the output is a real terminal (i.e. not dumb, not a pipe).
+ *
+ * This is probably not what you want, you may want shouldANSI() or something
+ * more specific. Think about how the output should work with a pager or
+ * entirely non-interactive scripting use.
+ *
+ * The user may be redirecting the Nix output to a pager, but have stderr
+ * connected to a terminal. Think about where you are outputting the text when
+ * deciding whether to use STDERR_FILENO or STDOUT_FILENO.
+ *
+ * \param fileno file descriptor number to check if it is a tty
+ */
+bool isOutputARealTerminal(StandardOutputStream fileno);
+
 /**
  * Determine whether ANSI escape sequences are appropriate for the
  * present output.
+ *
+ * This follows the rules described on https://bixense.com/clicolors/
+ * with CLICOLOR defaulted to enabled (and thus ignored).
+ *
+ * That is to say, the following procedure is followed in order:
+ * - NO_COLOR or NOCOLOR set             -> always disable colour
+ * - CLICOLOR_FORCE or FORCE_COLOR set   -> enable colour
+ * - The output is a tty; TERM != "dumb" -> enable colour
+ * - Otherwise                           -> disable colour
+ *
+ * \param fileno which file descriptor number to consider. Use the one you are outputting to
  */
-bool isTTY();
+bool shouldANSI(StandardOutputStream fileno = StandardOutputStream::Stderr);
 
 /**
  * Truncate a string to 'width' printable characters. If 'filterAll'

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -70,7 +70,7 @@ public:
         : printBuildLogs(printBuildLogs)
     {
         systemd = getEnv("IN_SYSTEMD") == "1";
-        tty = isTTY();
+        tty = shouldANSI();
     }
 
     bool isVerbose() override

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -64,12 +64,28 @@ inline std::pair<int, size_t> charWidthUTF8Helper(std::string_view s)
 
 namespace nix {
 
-bool isTTY()
+bool isOutputARealTerminal(StandardOutputStream fileno)
 {
-    static const bool tty = isatty(STDERR_FILENO) && getEnv("TERM").value_or("dumb") != "dumb"
-                            && !(getEnv("NO_COLOR").has_value() || getEnv("NOCOLOR").has_value());
+    return isatty(int(fileno)) && getEnv("TERM").value_or("dumb") != "dumb";
+}
 
-    return tty;
+bool shouldANSI(StandardOutputStream fileno)
+{
+    // Implements the behaviour described by https://bixense.com/clicolors/
+    // As well as https://force-color.org/ for compatibility, since it fits in the same shape.
+    // NO_COLOR  CLICOLOR_FORCE  Colours?
+    // set       (any value)     No
+    // unset     set             Yes
+    // unset     unset           If attached to a terminal
+    //                           [we choose the "modern" approach of colour-by-default]
+    auto compute = [](StandardOutputStream fileno) -> bool {
+        bool mustNotColour = getEnv("NO_COLOR").has_value() || getEnv("NOCOLOR").has_value();
+        bool shouldForce = getEnv("CLICOLOR_FORCE").has_value() || getEnv("FORCE_COLOR").has_value();
+        bool isTerminal = isOutputARealTerminal(fileno);
+        return !mustNotColour && (shouldForce || isTerminal);
+    };
+    static bool cached[2] = {compute(StandardOutputStream::Stdout), compute(StandardOutputStream::Stderr)};
+    return cached[int(fileno) - 1];
 }
 
 std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int width)

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -408,7 +408,7 @@ void mainWrapped(int argc, char ** argv)
     settings.verboseBuild = false;
 
     // If on a terminal, progress will be displayed via progress bars etc. (thus verbosity=notice)
-    if (nix::isTTY()) {
+    if (nix::isOutputARealTerminal(StandardOutputStream::Stderr)) {
         verbosity = lvlNotice;
     } else {
         verbosity = lvlInfo;

--- a/src/nix/nix-env/nix-env.cc
+++ b/src/nix/nix-env/nix-env.cc
@@ -1073,7 +1073,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
         return;
     }
 
-    bool tty = isTTY();
+    bool tty = shouldANSI();
     RunPager pager;
 
     Table table;


### PR DESCRIPTION
This allows to force colors but not disable other features such as the progress bar. This is for instance useful in CI environments.

Adapted from
https://git.lix.systems/lix-project/lix/commit/378ec5fb0611e314511a7afc806664205846fc2e and others.

Tested in https://buildbot.thalheim.io/#/builders/103/builds/1490

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
