### PR TITLE
outdated building instructions, update documentation.md

### DIFF
--- a/doc/manual/source/development/documentation.md
+++ b/doc/manual/source/development/documentation.md
@@ -19,10 +19,11 @@ nix-build -E '(import ./.).packages.${builtins.currentSystem}.nix.doc'
 or
 
 ```console
-nix build .#nix^doc
+nix build .#nix-manual
 ```
 
-and open `./result-doc/share/doc/nix/manual/index.html`.
+and open `./result/share/doc/nix/manual/index.html`.
+
 
 To build the manual incrementally, [enter the development shell](./building.md) and run:
 


### PR DESCRIPTION
## Motivation

The current instructions for building the Nix manual include a command that doesn't work as described. 

## Context

Specifically:

```
nix build .#nix^doc
```

Running this command results in the error:

```
error: derivation '/nix/store/hddqxzfqgx2fhj8q66ss3idym7pk7aj1-nix-2.26.0pre20250107_383ab87.drv' does not have wanted outputs 'doc'
```

However, this command works if you specify the Nix version explicitly, such as:

```
nix build nix/2.24.11#nix^doc
```

Additionally, these commands are run within the Nix root directory. 

However, the nix build .#nix^doc command does work when run from the nixpkgs directory and generates the NixOS manual.

I'm not sure if I'm missing something. Is the `nix^doc` supposed to be added somehow to flake outputs?

## Changes applied

Replaced the `nix build .#nix^doc` command with `nix build .#nix-manual`.


## Changes to apply?

The incremental build section does not work since as make has been decommissioned in favor of Meson. Should this be simply deleted?

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
