### PR TITLE
Document `--max-freed` for `nix-collect-garbage`

### DIFF
--- a/doc/manual/source/command-ref/nix-collect-garbage.md
+++ b/doc/manual/source/command-ref/nix-collect-garbage.md
@@ -64,13 +64,13 @@ These options are for deleting old [profiles] prior to deleting unreachable [sto
 
   - `--max-freed` *bytes*
 
+<!-- duplication from https://github.com/NixOS/nix/blob/442a2623e48357ff72c77bb11cf2cf06d94d2f90/doc/manual/source/command-ref/nix-store/gc.md?plain=1#L39-L44 -->
+
   Keep deleting paths until at least *bytes* bytes have been deleted,
   then stop. The argument *bytes* can be followed by the
   multiplicative suffix `K`, `M`, `G` or `T`, denoting KiB, MiB, GiB
   or TiB units.
-
-  <!-- duplication from https://github.com/NixOS/nix/blob/442a2623e48357ff72c77bb11cf2cf06d94d2f90/doc/manual/source/command-ref/nix-store/gc.md?plain=1#L39-L44 -->
-
+  
 {{#include ./opt-common.md}}
 
 {{#include ./env-common.md}}

--- a/doc/manual/source/command-ref/nix-collect-garbage.md
+++ b/doc/manual/source/command-ref/nix-collect-garbage.md
@@ -62,7 +62,7 @@ These options are for deleting old [profiles] prior to deleting unreachable [sto
   This is the equivalent of invoking [`nix-env --delete-generations <period>`](@docroot@/command-ref/nix-env/delete-generations.md#generations-time) on each found profile.
   See the documentation of that command for additional information about the *period* argument.
 
-  - `--max-freed` *bytes*
+  - <span id="opt-max-freed">[`--max-freed`](#opt-max-freed)</span> *bytes*
 
 <!-- duplication from https://github.com/NixOS/nix/blob/442a2623e48357ff72c77bb11cf2cf06d94d2f90/doc/manual/source/command-ref/nix-store/gc.md?plain=1#L39-L44 -->
 

--- a/doc/manual/source/command-ref/nix-collect-garbage.md
+++ b/doc/manual/source/command-ref/nix-collect-garbage.md
@@ -62,6 +62,15 @@ These options are for deleting old [profiles] prior to deleting unreachable [sto
   This is the equivalent of invoking [`nix-env --delete-generations <period>`](@docroot@/command-ref/nix-env/delete-generations.md#generations-time) on each found profile.
   See the documentation of that command for additional information about the *period* argument.
 
+  - `--max-freed` *bytes*
+
+  Keep deleting paths until at least *bytes* bytes have been deleted,
+  then stop. The argument *bytes* can be followed by the
+  multiplicative suffix `K`, `M`, `G` or `T`, denoting KiB, MiB, GiB
+  or TiB units.
+
+  <!-- duplication from https://github.com/NixOS/nix/blob/442a2623e48357ff72c77bb11cf2cf06d94d2f90/doc/manual/source/command-ref/nix-store/gc.md?plain=1#L39-L44 -->
+
 {{#include ./opt-common.md}}
 
 {{#include ./env-common.md}}


### PR DESCRIPTION
Referencing issue at: https://github.com/NixOS/nix/issues/12132

Copied the description of `--max-freed` option from https://github.com/NixOS/nix/blob/442a2623e48357ff72c77bb11cf2cf06d94d2f90/doc/manual/source/command-ref/nix-store/gc.md?plain=1#L39-L44

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
