### PR TITLE
nix upgrade-nix: Give a better error message if the profile is using 'nix profile'

### DIFF
--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -15,7 +15,7 @@ using namespace nix;
 
 struct CmdUpgradeNix : MixDryRun, StoreCommand
 {
-    Path profileDir;
+    std::filesystem::path profileDir;
 
     CmdUpgradeNix()
     {
@@ -64,7 +64,7 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
         if (profileDir == "")
             profileDir = getProfileDir(store);
 
-        printInfo("upgrading Nix in profile '%s'", profileDir);
+        printInfo("upgrading Nix in profile %s", profileDir);
 
         auto storePath = getLatestNix(store);
 
@@ -93,7 +93,9 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
 
         {
             Activity act(*logger, lvlInfo, actUnknown,
-                fmt("installing '%s' into profile '%s'...", store->printStorePath(storePath), profileDir));
+                fmt("installing '%s' into profile %s...", store->printStorePath(storePath), profileDir));
+
+            // FIXME: don't call an external process.
             runProgram(getNixBin("nix-env").string(), false,
                 {"--profile", profileDir, "-i", store->printStorePath(storePath), "--no-sandbox"});
         }
@@ -102,31 +104,33 @@ struct CmdUpgradeNix : MixDryRun, StoreCommand
     }
 
     /* Return the profile in which Nix is installed. */
-    Path getProfileDir(ref<Store> store)
+    std::filesystem::path getProfileDir(ref<Store> store)
     {
         auto whereOpt = ExecutablePath::load().findName(OS_STR("nix-env"));
         if (!whereOpt)
             throw Error("couldn't figure out how Nix is installed, so I can't upgrade it");
         const auto & where = whereOpt->parent_path();
 
-        printInfo("found Nix in '%s'", where);
+        printInfo("found Nix in %s", where);
 
         if (hasPrefix(where.string(), "/run/current-system"))
             throw Error("Nix on NixOS must be upgraded via 'nixos-rebuild'");
 
-        Path profileDir = where.parent_path().string();
+        auto profileDir = where.parent_path();
 
         // Resolve profile to /nix/var/nix/profiles/<name> link.
-        while (canonPath(profileDir).find("/profiles/") == std::string::npos && std::filesystem::is_symlink(profileDir))
+        while (canonPath(profileDir.string()).find("/profiles/") == std::string::npos && std::filesystem::is_symlink(profileDir))
             profileDir = readLink(profileDir);
 
-        printInfo("found profile '%s'", profileDir);
+        printInfo("found profile %s", profileDir);
 
-        Path userEnv = canonPath(profileDir, true);
+        Path userEnv = canonPath(profileDir.string(), true);
 
-        if (where.filename() != "bin" ||
-            !hasSuffix(userEnv, "user-environment"))
-            throw Error("directory %s does not appear to be part of a Nix profile", where);
+        if (std::filesystem::exists(profileDir / "manifest.json"))
+            throw Error("directory %s is managed by 'nix profile' and currently cannot be upgraded by 'nix upgrade-nix'", profileDir);
+
+        if (!std::filesystem::exists(profileDir / "manifest.nix"))
+            throw Error("directory %s does not appear to be part of a Nix profile", profileDir);
 
         if (!store->isValidPath(store->parseStorePath(userEnv)))
             throw Error("directory '%s' is not in the Nix store", userEnv);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

https://github.com/DeterminateSystems/nix-installer/issues/1362

Before:

```
error: directory '/nix/var/nix/profiles/per-user/eelco/test/bin' does not appear to be part of a Nix profile
```

After:

```
error: directory "/nix/var/nix/profiles/per-user/eelco/test" is managed by 'nix profile' and currently cannot be upgraded by 'nix upgrade-nix'
```


## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
