### PR TITLE
nix flake: clarify error message when file is an unknown type

### DIFF
--- a/src/libstore/nar-accessor.cc
+++ b/src/libstore/nar-accessor.cc
@@ -291,7 +291,11 @@ json listNar(ref<SourceAccessor> accessor, const CanonPath & path, bool recurse)
         obj["type"] = "symlink";
         obj["target"] = accessor->readLink(path);
         break;
-    case SourceAccessor::Type::tMisc:
+    case SourceAccessor::Type::tBlock:
+    case SourceAccessor::Type::tChar:
+    case SourceAccessor::Type::tSocket:
+    case SourceAccessor::Type::tFifo:
+    case SourceAccessor::Type::tUnknown:
         assert(false); // cannot happen for NARs
     }
     return obj;

--- a/src/libutil/fs-sink.cc
+++ b/src/libutil/fs-sink.cc
@@ -49,11 +49,13 @@ void copyRecursive(
         break;
     }
 
-    case SourceAccessor::tMisc:
-        throw Error("file '%1%' has an unsupported type", from);
-
+    case SourceAccessor::tChar:
+    case SourceAccessor::tBlock:
+    case SourceAccessor::tSocket:
+    case SourceAccessor::tFifo:
+    case SourceAccessor::tUnknown:
     default:
-        unreachable();
+        throw Error("file '%1%' has an unsupported type of %2%", from, stat.typeString());
     }
 }
 

--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -200,7 +200,11 @@ std::optional<Mode> convertMode(SourceAccessor::Type type)
     case SourceAccessor::tSymlink:   return Mode::Symlink;
     case SourceAccessor::tRegular:   return Mode::Regular;
     case SourceAccessor::tDirectory: return Mode::Directory;
-    case SourceAccessor::tMisc:      return std::nullopt;
+    case SourceAccessor::tChar:
+    case SourceAccessor::tBlock:
+    case SourceAccessor::tSocket:
+    case SourceAccessor::tFifo:      return std::nullopt;
+    case SourceAccessor::tUnknown:
     default: unreachable();
     }
 }
@@ -314,9 +318,13 @@ Mode dump(
         return Mode::Symlink;
     }
 
-    case SourceAccessor::tMisc:
+    case SourceAccessor::tChar:
+    case SourceAccessor::tBlock:
+    case SourceAccessor::tSocket:
+    case SourceAccessor::tFifo:
+    case SourceAccessor::tUnknown:
     default:
-        throw Error("file '%1%' has an unsupported type", path);
+        throw Error("file '%1%' has an unsupported type of %2%", path, st.typeString());
     }
 }
 

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -122,7 +122,11 @@ std::optional<SourceAccessor::Stat> PosixSourceAccessor::maybeLstat(const CanonP
             S_ISREG(st->st_mode) ? tRegular :
             S_ISDIR(st->st_mode) ? tDirectory :
             S_ISLNK(st->st_mode) ? tSymlink :
-            tMisc,
+            S_ISCHR(st->st_mode) ? tChar :
+            S_ISBLK(st->st_mode) ? tBlock :
+            S_ISSOCK(st->st_mode) ? tSocket :
+            S_ISFIFO(st->st_mode) ? tFifo :
+            tUnknown,
         .fileSize = S_ISREG(st->st_mode) ? std::optional<uint64_t>(st->st_size) : std::nullopt,
         .isExecutable = S_ISREG(st->st_mode) && st->st_mode & S_IXUSR,
     };
@@ -156,7 +160,11 @@ SourceAccessor::DirEntries PosixSourceAccessor::readDirectory(const CanonPath & 
             case std::filesystem::file_type::regular: return Type::tRegular; break;
             case std::filesystem::file_type::symlink: return Type::tSymlink; break;
             case std::filesystem::file_type::directory: return Type::tDirectory; break;
-            default: return tMisc;
+            case std::filesystem::file_type::character: return Type::tChar; break;
+            case std::filesystem::file_type::block: return Type::tBlock; break;
+            case std::filesystem::file_type::fifo: return Type::tFifo; break;
+            case std::filesystem::file_type::socket: return Type::tSocket; break;
+            default: return tUnknown;
             }
 #pragma GCC diagnostic pop
             }();

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -5,6 +5,26 @@ namespace nix {
 
 static std::atomic<size_t> nextNumber{0};
 
+bool SourceAccessor::Stat::isNotNARSerialisable()
+{
+    return this->type != tRegular && this->type != tSymlink && this->type != tDirectory;
+}
+
+std::string SourceAccessor::Stat::typeString() {
+    switch (this->type) {
+        case tRegular: return "regular";
+        case tSymlink: return "symlink";
+        case tDirectory: return "directory";
+        case tChar: return "character device";
+        case tBlock: return "block device";
+        case tSocket: return "socket";
+        case tFifo: return "fifo";
+        case tUnknown:
+        default: return "unknown";
+    }
+    return "unknown";
+}
+
 SourceAccessor::SourceAccessor()
     : number(++nextNumber)
     , displayPrefix{"«unknown»"}

--- a/src/libutil/source-accessor.hh
+++ b/src/libutil/source-accessor.hh
@@ -88,12 +88,13 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
 
         Unlike `DT_UNKNOWN`, this must not be used for deferring the lookup of types.
       */
-      tMisc
+      tChar, tBlock, tSocket, tFifo,
+      tUnknown
     };
 
     struct Stat
     {
-        Type type = tMisc;
+        Type type = tUnknown;
 
         /**
          * For regular files only: the size of the file. Not all
@@ -112,6 +113,9 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
          * file in the NAR. Only returned by NAR accessors.
          */
         std::optional<uint64_t> narOffset;
+
+        bool isNotNARSerialisable();
+        std::string typeString();
     };
 
     Stat lstat(const CanonPath & path);

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -941,7 +941,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
                         createSymlink(target, os_string_to_string(PathViewNG { to2 }));
                 }
                 else
-                    throw Error("file '%s' has unsupported type", from2);
+                    throw Error("path '%s' needs to be a symlink, file, or directory but instead is a %s", from2, st.typeString());
                 changedFiles.push_back(to2);
                 notice("wrote: %s", to2);
             }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Clarify the error as seen in #11217

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

#11217 is where this behavior has been seen

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

Simply clarifying the error makes the user know why the failure occurred.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
