### PR TITLE
Fix S3 not interruptting

### DIFF
--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -17,8 +17,12 @@
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/client/DefaultRetryStrategy.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/http/HttpClient.h>
 #include <aws/core/utils/logging/FormattedLogSystem.h>
 #include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/ratelimiter/RateLimiterInterface.h>
 #include <aws/core/utils/threading/Executor.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
@@ -56,6 +60,49 @@ R && checkAws(std::string_view s, Aws::Utils::Outcome<R, E> && outcome)
     return outcome.GetResultWithOwnership();
 }
 
+class AwsHttpClient : public Aws::Http::HttpClient
+{
+public:
+    AwsHttpClient(const Aws::Client::ClientConfiguration& clientConfig) : HttpClient() {}
+
+    std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(const std::shared_ptr<Aws::Http::HttpRequest>& request,
+                Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+                Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override {
+        Aws::Http::URI uri = request->GetUri();
+        Aws::String url = uri.GetURIString();
+
+        debug("Making request %s", url);
+
+        std::shared_ptr<Aws::Http::Standard::StandardHttpResponse> response = std::make_shared<Aws::Http::Standard::StandardHttpResponse>(request);
+
+        if (writeLimiter != nullptr) {
+            writeLimiter->ApplyAndPayForCost(request->GetSize());
+        }
+
+        FileTransferRequest ftr = FileTransferRequest(url);
+        getFileTransfer()->download(ftr);
+        return response;
+    }
+};
+
+class AwsHttpClientFactory : public Aws::Http::HttpClientFactory
+{
+public:
+    std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(const Aws::Client::ClientConfiguration& clientConfiguration) const override {
+        return std::make_shared<AwsHttpClient>(clientConfiguration);
+    }
+
+    std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const override {
+        return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
+    }
+
+    std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(const Aws::Http::URI& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& streamFactory) const override {
+        auto request = std::make_shared<Aws::Http::Standard::StandardHttpRequest>(uri, method);
+        request->SetResponseStreamFactory(streamFactory);
+        return request;
+    }
+};
+
 class AwsLogger : public Aws::Utils::Logging::FormattedLogSystem
 {
     using Aws::Utils::Logging::FormattedLogSystem::FormattedLogSystem;
@@ -79,6 +126,10 @@ static void initAWS()
         /* We install our own OpenSSL locking function (see
            shared.cc), so don't let aws-sdk-cpp override it. */
         options.cryptoOptions.initAndCleanupOpenSSL = false;
+
+        options.httpOptions.httpClientFactory_create_fn = []() {
+            return std::make_shared<AwsHttpClientFactory>();
+        };
 
         if (verbosity >= lvlDebug) {
             options.loggingOptions.logLevel =


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes #11678

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

This is my attempt to try and get S3 transfers to interrupt properly. The only problem now is retrying doesn't interrupt but it seems the retry strategy doesn't work if you don't already have a connection.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
