### PR TITLE
Add LLVM to Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,7 @@
         in {
           inherit stdenvs native;
           static = native.pkgsStatic;
+          llvm = native.pkgsLLVM;
           cross = forAllCrossSystems (crossSystem: make-pkgs crossSystem "stdenv");
         });
 
@@ -282,6 +283,7 @@
               # These attributes go right into `packages.<system>`.
               "${pkgName}" = nixpkgsFor.${system}.native.nixComponents.${pkgName};
               "${pkgName}-static" = nixpkgsFor.${system}.static.nixComponents.${pkgName};
+              "${pkgName}-llvm" = nixpkgsFor.${system}.llvm.nixComponents.${pkgName};
             }
             // lib.optionalAttrs supportsCross (flatMapAttrs (lib.genAttrs crossSystems (_: { })) (crossSystem: {}: {
               # These attributes go right into `packages.<system>`.
@@ -320,6 +322,9 @@
           lib.optionalAttrs (!nixpkgsFor.${system}.native.stdenv.isDarwin) (
             prefixAttrs "static" (forAllStdenvs (stdenvName: makeShell {
               pkgs = nixpkgsFor.${system}.stdenvs."${stdenvName}Packages".pkgsStatic;
+            })) //
+            prefixAttrs "llvm" (forAllStdenvs (stdenvName: makeShell {
+              pkgs = nixpkgsFor.${system}.stdenvs."${stdenvName}Packages".pkgsLLVM;
             })) //
             prefixAttrs "cross" (forAllCrossSystems (crossSystem: makeShell {
               pkgs = nixpkgsFor.${system}.cross.${crossSystem};

--- a/src/libcmd/package.nix
+++ b/src/libcmd/package.nix
@@ -76,7 +76,7 @@ mkMesonLibrary (finalAttrs: {
     (lib.mesonOption "readline-flavor" readlineFlavor)
   ];
 
-  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM or false)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -96,7 +96,7 @@ mkMesonLibrary (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/86131.
     BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
     BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-  } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM or false)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 

--- a/src/libfetchers/package.nix
+++ b/src/libfetchers/package.nix
@@ -49,7 +49,7 @@ mkMesonLibrary (finalAttrs: {
       echo ${version} > ../../.version
     '';
 
-  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM or false)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 

--- a/src/libflake/package.nix
+++ b/src/libflake/package.nix
@@ -48,7 +48,7 @@ mkMesonLibrary (finalAttrs: {
       echo ${version} > ../../.version
     '';
 
-  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM or false)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 

--- a/src/libmain/package.nix
+++ b/src/libmain/package.nix
@@ -45,7 +45,7 @@ mkMesonLibrary (finalAttrs: {
       echo ${version} > ../../.version
     '';
 
-  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM or false)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -87,7 +87,7 @@ mkMesonLibrary (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/86131.
     BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
     BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-  } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM or false)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -72,7 +72,7 @@ mkMesonLibrary (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/86131.
     BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
     BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
-  } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  } // lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM or false)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -99,7 +99,7 @@ mkMesonExecutable (finalAttrs: {
   mesonFlags = [
   ];
 
-  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")) {
+  env = lib.optionalAttrs (stdenv.isLinux && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux") && !(stdenv.hostPlatform.useLLVM)) {
     LDFLAGS = "-fuse-ld=gold";
   };
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes #12228

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Builds Nix with `pkgsLLVM`, this allows for using Clang + libcxx and all dependencies needed for Nix are dependent on LLVM this way. Adding this in can help prevent regressions of Nix under `pkgsLLVM`.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
