### PR TITLE
scripts/install-multi-user: fix typo

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -562,7 +562,7 @@ create_build_user_for_core() {
         if [ "$actual_uid" != "$uid" ]; then
             failure <<EOF
 It seems the build user $username already exists, but with the UID
-with the UID '$actual_uid'. This script can't really handle that right
+'$actual_uid'. This script can't really handle that right
 now, so I'm going to give up.
 
 If you already created the users and you know they start from


### PR DESCRIPTION

## Motivation

I was fixing an error message and this typo was annoying me.

## Context

Current error messages are like this : 

```
---- oh no! --------------------------------------------------------------------
It seems the build user _nixbld1 already exists, but with the UID
with the UID '301'. This script can't really handle that right
now, so I'm going to give up.

If you already created the users and you know they start from
301 and go up from there, you can edit this script and change
NIX_FIRST_BUILD_UID near the top of the file to 301 and try
again.

We'd love to help if you need it.
```

you see "with the UID" repeated twice.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
