### PR TITLE
Remove broken stack size logic from Windows

### DIFF
--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -19,10 +19,6 @@
 # include "namespaces.hh"
 #endif
 
-#ifndef _WIN32
-# include <sys/resource.h>
-#endif
-
 namespace nix {
 
 unsigned int getMaxCPU()
@@ -73,29 +69,6 @@ void setStackSize(size_t stackSize)
                     stackSize,
                     limit.rlim_max,
                     std::strerror(errno)
-                ).str()
-            );
-        }
-    }
-    #else
-    ULONG_PTR stackLow, stackHigh;
-    GetCurrentThreadStackLimits(&stackLow, &stackHigh);
-    ULONG maxStackSize = stackHigh - stackLow;
-    ULONG currStackSize = 0;
-    // This retrieves the current promised stack size
-    SetThreadStackGuarantee(&currStackSize);
-    if (currStackSize < stackSize) {
-        savedStackSize = currStackSize;
-        ULONG newStackSize = std::min(static_cast<ULONG>(stackSize), maxStackSize);
-        if (SetThreadStackGuarantee(&newStackSize) == 0) {
-            logger->log(
-                lvlError,
-                HintFmt(
-                    "Failed to increase stack size from %1% to %2% (maximum allowed stack size: %3%): %4%",
-                    savedStackSize,
-                    stackSize,
-                    maxStackSize,
-                    std::to_string(GetLastError())
                 ).str()
             );
         }

--- a/src/libutil/current-process.cc
+++ b/src/libutil/current-process.cc
@@ -51,11 +51,11 @@ unsigned int getMaxCPU()
 //////////////////////////////////////////////////////////////////////
 
 
+#ifndef _WIN32
 size_t savedStackSize = 0;
 
 void setStackSize(size_t stackSize)
 {
-    #ifndef _WIN32
     struct rlimit limit;
     if (getrlimit(RLIMIT_STACK, &limit) == 0 && limit.rlim_cur < stackSize) {
         savedStackSize = limit.rlim_cur;
@@ -73,8 +73,8 @@ void setStackSize(size_t stackSize)
             );
         }
     }
-    #endif
 }
+#endif
 
 void restoreProcessContext(bool restoreMounts)
 {

--- a/src/libutil/current-process.hh
+++ b/src/libutil/current-process.hh
@@ -17,10 +17,13 @@ namespace nix {
  */
 unsigned int getMaxCPU();
 
+// It does not seem possible to dynamically change stack size on Windows.
+#ifndef _WIN32
 /**
  * Change the stack size.
  */
 void setStackSize(size_t stackSize);
+#endif
 
 /**
  * Restore the original inherited Unix process context (such as signal

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -557,9 +557,11 @@ void mainWrapped(int argc, char * * argv)
 
 int main(int argc, char * * argv)
 {
+#ifndef _WIN32
     // Increase the default stack size for the evaluator and for
     // libstdc++'s std::regex.
     nix::setStackSize(64 * 1024 * 1024);
+#endif
 
     return nix::handleExceptions(argv[0], [&]() {
         nix::mainWrapped(argc, argv);


### PR DESCRIPTION
The API only changes the stack size once there's already a stack overflow exception. Pretty useless.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
