### PR TITLE
Move arrays to heap, to reduce stack usage

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -142,14 +142,14 @@ static void parseContents(CreateRegularFileSink & sink, Source & source)
     sink.preallocateContents(size);
 
     uint64_t left = size;
-    std::array<char, 65536> buf;
+    auto buf = std::make_unique<std::array<char, 65536>>();
 
     while (left) {
         checkInterrupt();
-        auto n = buf.size();
+        auto n = buf->size();
         if ((uint64_t)n > left) n = left;
-        source(buf.data(), n);
-        sink({buf.data(), n});
+        source(buf->data(), n);
+        sink({buf->data(), n});
         left -= n;
     }
 

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -299,13 +299,13 @@ void writeFile(const Path & path, Source & source, mode_t mode, bool sync)
     if (!fd)
         throw SysError("opening file '%1%'", path);
 
-    std::array<char, 64 * 1024> buf;
+    auto buf = std::make_unique<std::array<char, 64 * 1024>>();
 
     try {
         while (true) {
             try {
-                auto n = source.read(buf.data(), buf.size());
-                writeFull(fd.get(), {buf.data(), n});
+                auto n = source.read(buf->data(), buf->size());
+                writeFull(fd.get(), {buf->data(), n});
             } catch (EndOfFile &) { break; }
         }
     } catch (Error & e) {

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -64,10 +64,10 @@ void PosixSourceAccessor::readFile(
 
     off_t left = st.st_size;
 
-    std::array<unsigned char, 64 * 1024> buf;
+    auto buf = std::make_unique<std::array<unsigned char, 64 * 1024>>();
     while (left) {
         checkInterrupt();
-        ssize_t rd = read(fromDescriptorReadOnly(fd.get()), buf.data(), (size_t) std::min(left, (off_t) buf.size()));
+        ssize_t rd = read(fromDescriptorReadOnly(fd.get()), buf->data(), (size_t) std::min(left, (off_t) buf->size()));
         if (rd == -1) {
             if (errno != EINTR)
                 throw SysError("reading from file '%s'", showPath(path));
@@ -76,7 +76,7 @@ void PosixSourceAccessor::readFile(
             throw SysError("unexpected end-of-file reading '%s'", showPath(path));
         else {
             assert(rd <= left);
-            sink({(char *) buf.data(), (size_t) rd});
+            sink({(char *) buf->data(), (size_t) rd});
             left -= rd;
         }
     }


### PR DESCRIPTION
I keep hitting stack issues on Windows. Let's just start by reducing the stack by quite a bit.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
