### PR TITLE
nix-profile{,-daemon}.fish: Do not source twice, fmt

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -1,3 +1,13 @@
+# Only execute this file once per shell.
+if test -z "$HOME" || \
+    test -n "$__ETC_PROFILE_NIX_SOURCED"
+    exit
+end
+
+set --global __ETC_PROFILE_NIX_SOURCED 1
+
+# Local helpers
+
 function add_path --argument-names new_path
     if type -q fish_add_path
         # fish 3.2.0 or newer
@@ -10,13 +20,7 @@ function add_path --argument-names new_path
     end
 end
 
-# Only execute this file once per shell.
-if test -n "$__ETC_PROFILE_NIX_SOURCED"
-    exit
-end
-
-set __ETC_PROFILE_NIX_SOURCED 1
-
+# Main configuration
 set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
 # Populate bash completions, .desktop files, etc
@@ -53,5 +57,7 @@ end
 
 add_path "@localstatedir@/nix/profiles/default/bin"
 add_path "$HOME/.nix-profile/bin"
+
+# Cleanup
 
 functions -e add_path

--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -12,7 +12,7 @@ end
 
 # Only execute this file once per shell.
 if test -n "$__ETC_PROFILE_NIX_SOURCED"
-  exit
+    exit
 end
 
 set __ETC_PROFILE_NIX_SOURCED 1
@@ -29,26 +29,26 @@ end
 
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
 if test -n "$NIX_SSL_CERT_FILE"
-  : # Allow users to override the NIX_SSL_CERT_FILE
+    : # Allow users to override the NIX_SSL_CERT_FILE
 else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
-  set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+    set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 else if test -e /etc/ssl/ca-bundle.pem # openSUSE Tumbleweed
-  set --export NIX_SSL_CERT_FILE /etc/ssl/ca-bundle.pem
+    set --export NIX_SSL_CERT_FILE /etc/ssl/ca-bundle.pem
 else if test -e /etc/ssl/certs/ca-bundle.crt # Old NixOS
-  set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
+    set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
 else if test -e /etc/pki/tls/certs/ca-bundle.crt # Fedora, CentOS
-  set --export NIX_SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
+    set --export NIX_SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
 else if test -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" # fall back to cacert in Nix profile
-  set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+    set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
 else if test -e "$NIX_LINK/etc/ca-bundle.crt" # old cacert in Nix profile
-  set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
+    set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
 else
-  # Fall back to what is in the nix profiles, favouring whatever is defined last.
-  for i in (string split ' ' $NIX_PROFILES)
-    if test -e "$i/etc/ssl/certs/ca-bundle.crt"
-      set --export NIX_SSL_CERT_FILE "$i/etc/ssl/certs/ca-bundle.crt"
+    # Fall back to what is in the nix profiles, favouring whatever is defined last.
+    for i in (string split ' ' $NIX_PROFILES)
+        if test -e "$i/etc/ssl/certs/ca-bundle.crt"
+            set --export NIX_SSL_CERT_FILE "$i/etc/ssl/certs/ca-bundle.crt"
+        end
     end
-  end
 end
 
 add_path "@localstatedir@/nix/profiles/default/bin"

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,3 +1,13 @@
+# Only execute this file once per shell.
+if test -z "$HOME" || test -z "$USER" || \
+    test -n "$__ETC_PROFILE_NIX_SOURCED"
+    exit
+end
+
+set --global __ETC_PROFILE_NIX_SOURCED 1
+
+# Local helpers
+
 function add_path --argument-names new_path
     if type -q fish_add_path
         # fish 3.2.0 or newer
@@ -10,50 +20,51 @@ function add_path --argument-names new_path
     end
 end
 
-if test -n "$HOME" && test -n "$USER"
+# Main configuration
 
-    # Set up the per-user profile.
+# Set up the per-user profile.
 
-    set NIX_LINK $HOME/.nix-profile
+set NIX_LINK $HOME/.nix-profile
 
-    # Set up environment.
-    # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
-    set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+# Set up environment.
+# This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
+set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
-    # Populate bash completions, .desktop files, etc
-    if test -z "$XDG_DATA_DIRS"
-        # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
-        set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
-    else
-        set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
-    end
-
-    # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
-    if test -n "$NIX_SSH_CERT_FILE"
-        : # Allow users to override the NIX_SSL_CERT_FILE
-    else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
-        set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
-    else if test -e /etc/ssl/ca-bundle.pem # openSUSE Tumbleweed
-        set --export NIX_SSL_CERT_FILE /etc/ssl/ca-bundle.pem
-    else if test -e /etc/ssl/certs/ca-bundle.crt # Old NixOS
-        set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
-    else if test -e /etc/pki/tls/certs/ca-bundle.crt # Fedora, CentOS
-        set --export NIX_SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
-    else if test -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" # fall back to cacert in Nix profile
-        set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
-    else if test -e "$NIX_LINK/etc/ca-bundle.crt" # old cacert in Nix profile
-        set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
-    end
-
-    # Only use MANPATH if it is already set. In general `man` will just simply
-    # pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
-    # which is in the $PATH. For more info, run `manpath -d`.
-    if set --query MANPATH
-      set --export --prepend --path MANPATH "$NIX_LINK/share/man"
-    end
-
-    add_path "$NIX_LINK/bin"
-    set --erase NIX_LINK
+# Populate bash completions, .desktop files, etc
+if test -z "$XDG_DATA_DIRS"
+    # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
+    set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
+else
+    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
 end
+
+# Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
+if test -n "$NIX_SSH_CERT_FILE"
+    : # Allow users to override the NIX_SSL_CERT_FILE
+else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
+    set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+else if test -e /etc/ssl/ca-bundle.pem # openSUSE Tumbleweed
+    set --export NIX_SSL_CERT_FILE /etc/ssl/ca-bundle.pem
+else if test -e /etc/ssl/certs/ca-bundle.crt # Old NixOS
+    set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt
+else if test -e /etc/pki/tls/certs/ca-bundle.crt # Fedora, CentOS
+    set --export NIX_SSL_CERT_FILE /etc/pki/tls/certs/ca-bundle.crt
+else if test -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" # fall back to cacert in Nix profile
+    set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
+else if test -e "$NIX_LINK/etc/ca-bundle.crt" # old cacert in Nix profile
+    set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
+end
+
+# Only use MANPATH if it is already set. In general `man` will just simply
+# pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
+# which is in the $PATH. For more info, run `manpath -d`.
+if set --query MANPATH
+    set --export --prepend --path MANPATH "$NIX_LINK/share/man"
+end
+
+add_path "$NIX_LINK/bin"
+set --erase NIX_LINK
+
+# Cleanup
 
 functions -e add_path


### PR DESCRIPTION
## Motivation

`nix-profile-daemon.fish` and `nix-profile.fish` scripts perform almost identical actions.
Yet, they are written with slight differences that make it harder to see what is actually the same and what is different.

This is already discussed in https://github.com/NixOS/nix/issues/9441

I think `nix-profile-daemon.fish` and `nix-profile.fish` might eventually turn out to be identical or use a common implementation.
This change is a step is a step in this direction.

You can see the differences between `nix-profile-daemon.fish` and `nix-profile.fish` here:

https://gist.github.com/ilya-bobyr/c957a9f998b85833064b2d64b4ae4062

## Context

A few bug fixes and indentation changes on both sides:

* `nix-profile-daemon.fish`:

  1. When checking for repeated execution, exit before the helper function `add_path` is defined.  Making sure it does not leak to the caller.

  2. Check that `$HOME` is set, as it is actually used in the configuration.

  3. Use 4 space indentation in the configuration subsection, as this is the indentation used for the rest of the file and in `nix-profile.fish`.

  4. Mark `__ETC_PROFILE_NIX_SOURCED` as `--global` as, by default, `set` creates a `--local` variable that might not be visible to a subsequent execution of this script in the same shell.  Effectively breaking the protection.

* `nix-profile.fish`:

  1. Use early exit when checking for required environment variables and double execution.
     Identical to the `nix-profile-daemon.fish`.

  2. Use `__ETC_PROFILE_NIX_SOURCED` for double execution protection, similarly to `nix-profile-daemon.fish`.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
