### PR TITLE
Fix relative 'path:' flakerefs in the CLI

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -406,7 +406,7 @@ void EvalState::checkURI(const std::string & uri)
 
     /* If the URI is a path, then check it against allowedPaths as
        well. */
-    if (hasPrefix(uri, "/")) {
+    if (isAbsolute(uri)) {
         if (auto rootFS2 = rootFS.dynamic_pointer_cast<AllowListSourceAccessor>())
             rootFS2->checkAccess(CanonPath(uri));
         return;

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -97,7 +97,7 @@ struct PathInputScheme : InputScheme
     std::optional<std::string> isRelative(const Input & input) const
     {
         auto path = getStrAttr(input.attrs, "path");
-        if (hasPrefix(path, "/"))
+        if (isAbsolute(path))
             return std::nullopt;
         else
             return path;

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -153,7 +153,7 @@ static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, re
             return std::make_shared<Registry>(settings, Registry::Global); // empty registry
         }
 
-        if (!hasPrefix(path, "/")) {
+        if (!isAbsolute(path)) {
             auto storePath = downloadFile(store, path, "flake-registry.json").storePath;
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
                 store2->addPermRoot(storePath, getCacheDir() + "/flake-registry.json");

--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -178,7 +178,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
         }
 
     } else {
-        if (!hasPrefix(path, "/"))
+        if (!isAbsolute(path))
             throw BadURL("flake reference '%s' is not an absolute path", url);
         path = canonPath(path + "/" + getOr(query, "dir", ""));
     }
@@ -235,7 +235,7 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
         auto parsed = parseURL(url);
         if (baseDir
             && (parsed.scheme == "path" || parsed.scheme == "git+file")
-            && !hasPrefix(parsed.path, "/"))
+            && !isAbsolute(parsed.path))
             parsed.path = absPath(parsed.path, *baseDir);
         return fromParsedURL(fetchSettings, std::move(parsed), isFlake);
     } catch (BadURL &) {

--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -102,8 +102,8 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
 
     if (baseDir) {
         /* Check if 'url' is a path (either absolute or relative
-            to 'baseDir'). If so, search upward to the root of the
-            repo (i.e. the directory containing .git). */
+           to 'baseDir'). If so, search upward to the root of the
+           repo (i.e. the directory containing .git). */
 
         path = absPath(path, baseDir);
 
@@ -232,7 +232,12 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
 )
 {
     try {
-        return fromParsedURL(fetchSettings, parseURL(url), isFlake);
+        auto parsed = parseURL(url);
+        if (baseDir
+            && (parsed.scheme == "path" || parsed.scheme == "git+file")
+            && !hasPrefix(parsed.path, "/"))
+            parsed.path = absPath(parsed.path, *baseDir);
+        return fromParsedURL(fetchSettings, std::move(parsed), isFlake);
     } catch (BadURL &) {
         return std::nullopt;
     }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -31,12 +31,7 @@ namespace nix {
 
 namespace fs { using namespace std::filesystem; }
 
-/**
- * Treat the string as possibly an absolute path, by inspecting the
- * start of it. Return whether it was probably intended to be
- * absolute.
- */
-static bool isAbsolute(PathView path)
+bool isAbsolute(PathView path)
 {
     return fs::path { path }.is_absolute();
 }

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -43,6 +43,11 @@ struct Sink;
 struct Source;
 
 /**
+ * Return whether the path denotes an absolute path.
+ */
+bool isAbsolute(PathView path);
+
+/**
  * @return An absolutized path, resolving paths relative to the
  * specified directory, or the current directory otherwise.  The path
  * is also canonicalised.

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -115,7 +115,7 @@ CanonPath SourceAccessor::resolveSymlinks(
                         throw Error("infinite symlink recursion in path '%s'", showPath(path));
                     auto target = readLink(res);
                     res.pop();
-                    if (hasPrefix(target, "/"))
+                    if (isAbsolute(target))
                         res = CanonPath::root;
                     todo.splice(todo.begin(), tokenizeString<std::list<std::string>>(target, "/"));
                 }

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -97,6 +97,9 @@ nix build -o "$TEST_ROOT/result" flake1
 
 nix build -o "$TEST_ROOT/result" "$flake1Dir"
 nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir"
+(cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" ".")
+(cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" "path:.")
+(cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" "git+file:.")
 
 # Test explicit packages.default.
 nix build -o "$TEST_ROOT/result" "$flake1Dir#default"


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes #12248.

This also handles relative `git+file:` flakerefs while we're at it (these crashed with an assertion failure).

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
