### PR TITLE
sequoia-nixbld-user-migration: nail down PATH

### DIFF
--- a/scripts/sequoia-nixbld-user-migration.sh
+++ b/scripts/sequoia-nixbld-user-migration.sh
@@ -2,6 +2,9 @@
 
 set -eo pipefail
 
+# stock path to avoid unexpected command versions
+PATH="$(/usr/bin/getconf PATH)"
+
 ((NEW_NIX_FIRST_BUILD_UID=351))
 ((TEMP_NIX_FIRST_BUILD_UID=31000))
 


### PR DESCRIPTION
## Motivation

Fixes user-reported trouble caused by toybox grep on PATH in the script for migrating the UIDs of nixbld users for macOS Sequoia and avoids same basic issue with other utils. 

## Context

For most-relevant context see comments between these two links (inclusive):
- https://github.com/NixOS/nix/issues/10892#issuecomment-2588097014
- https://github.com/NixOS/nix/issues/10892#issuecomment-2590777388

If needed, the whole thread those comments are in provides context on the purpose of the migration script.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
