### PR TITLE
Warn against the use of relative 'git+file:' flake inputs

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -435,7 +435,16 @@ struct GitInputScheme : InputScheme
         //
         // See: https://discourse.nixos.org/t/57783 and #9708
         //
-        repoInfo.url = repoInfo.isLocal ? std::filesystem::absolute(url.path).string() : url.to_string();
+        if (repoInfo.isLocal) {
+            if (!isAbsolute(url.path)) {
+                warn(
+                    "Fetching Git repository '%s', which uses a path relative to the current directory. "
+                    "This is not supported and will stop working in a future release.",
+                    url);
+            }
+            repoInfo.url = std::filesystem::absolute(url.path).string();
+        } else
+            repoInfo.url = url.to_string();
 
         // If this is a local directory and no ref or revision is
         // given, then allow the use of an unclean working tree.

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -439,7 +439,8 @@ struct GitInputScheme : InputScheme
             if (!isAbsolute(url.path)) {
                 warn(
                     "Fetching Git repository '%s', which uses a path relative to the current directory. "
-                    "This is not supported and will stop working in a future release.",
+                    "This is not supported and will stop working in a future release. "
+                    "See https://github.com/NixOS/nix/issues/12281 for details.",
                     url);
             }
             repoInfo.url = std::filesystem::absolute(url.path).string();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Make sure that users know that use of relative `git+file:` inputs is not supposed to work. 

## Context

See https://github.com/NixOS/nix/pull/12107 for more discussion.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
