### PR TITLE
Don't absolutize 'git+file:' in parseURLFlakeRef()

### DIFF
--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -233,7 +233,7 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
     try {
         auto parsed = parseURL(url);
         if (baseDir
-            && (parsed.scheme == "path" || parsed.scheme == "git+file")
+            && parsed.scheme == "path"
             && !isAbsolute(parsed.path))
             parsed.path = absPath(parsed.path, *baseDir);
         return fromParsedURL(fetchSettings, std::move(parsed), isFlake);

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -224,7 +224,6 @@ nix build -o "$TEST_ROOT/result" "$flake1Dir"
 nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir"
 (cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" ".")
 (cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" "path:.")
-(cd "$flake1Dir" && nix build -o "$TEST_ROOT/result" "git+file:.")
 
 # Test explicit packages.default.
 nix build -o "$TEST_ROOT/result" "$flake1Dir#default"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This is needed to unbreak the 2.25 branch due to the interaction between #12269 and #12266 which our CI didn't catch. On master, this is resolved as side-effect of https://github.com/NixOS/nix/pull/10089.

See also https://github.com/NixOS/nix/issues/12273#issuecomment-2596069519.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
