### PR TITLE
Fix flakes follow symlinks

### DIFF
--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -107,7 +107,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
            to 'baseDir'). If so, search upward to the root of the
            repo (i.e. the directory containing .git). */
 
-        path = absPath(path, baseDir);
+        path = absPath(path, baseDir, true);
 
         if (isFlake) {
 

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -28,6 +28,7 @@ suites += {
     'commit-lock-file-summary.sh',
     'non-flake-inputs.sh',
     'relative-paths.sh',
+    'symlink-paths.sh'
   ],
   'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/flakes/symlink-paths.sh
+++ b/tests/functional/flakes/symlink-paths.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+requireGit
+
+create_flake() {
+    local flakeDir="$1"
+    createGitRepo $flakeDir
+    cat > $flakeDir/flake.nix <<EOF
+{
+    outputs = { self }: { x = 2; };
+}
+EOF
+    git -C $flakeDir add flake.nix
+    git -C $flakeDir commit -m Initial
+}
+
+test_symlink_points_to_flake() {
+    create_flake "$TEST_ROOT/flake1"
+    ln -sn "$TEST_ROOT/flake1" "$TEST_ROOT/flake1_sym"
+    [[ $(nix eval "$TEST_ROOT/flake1_sym#x") = 2 ]]
+    rm -rf "$TEST_ROOT/flake1" "$TEST_ROOT/flake1_sym"
+}
+test_symlink_points_to_flake
+
+test_symlink_points_to_flake_in_subdir() {
+    create_flake "$TEST_ROOT/subdir/flake1"
+    ln -sn "$TEST_ROOT/subdir" "$TEST_ROOT/subdir_sym"
+    [[ $(nix eval "$TEST_ROOT/subdir_sym/flake1#x") = 2 ]]
+    rm -rf "$TEST_ROOT/subdir" "$TEST_ROOT/subdir_sym"
+}
+test_symlink_points_to_flake_in_subdir
+
+test_symlink_points_to_dir_in_repo() {
+    local repoDir="$TEST_ROOT/flake1"
+    createGitRepo $repoDir
+    mkdir -p "$repoDir/subdir"
+    cat > $repoDir/subdir/flake.nix <<EOF
+{
+    outputs = { self }: { x = 2; };
+}
+EOF
+    git -C $repoDir add subdir/flake.nix
+    git -C $repoDir commit -m Initial
+    ln -sn "$TEST_ROOT/flake1/subdir" "$TEST_ROOT/flake1_sym"
+    [[ $(nix eval "$TEST_ROOT/flake1_sym#x") = 2 ]]
+    rm -rf "$TEST_ROOT/flake1" "$TEST_ROOT/flake1_sym"
+}
+test_symlink_points_to_dir_in_repo
+
+test_symlink_from_repo_to_another() {
+    local repoDir="$TEST_ROOT/repo1"
+    createGitRepo $repoDir
+    echo "Hello" > $repoDir/file
+    mkdir $repoDir/subdir
+    cat > $repoDir/subdir/flake.nix <<EOF
+{
+    outputs = { self }: { x = builtins.readFile ../file; };
+}
+EOF
+    git -C $repoDir add subdir/flake.nix file
+    git -C $repoDir commit -m Initial
+    [[ $(nix eval "$TEST_ROOT/repo1/subdir#x") == \"Hello\\n\" ]]
+
+    local repo2Dir="$TEST_ROOT/repo2"
+    createGitRepo $repo2Dir
+    ln -sn "$repoDir/subdir" "$repo2Dir/flake1_sym"
+    echo "World" > $repo2Dir/file
+    git -C "$repo2Dir" add flake1_sym file
+    git -C "$repo2Dir" commit -m Initial
+    [[ $(nix eval "$repo2Dir/flake1_sym#x") == \"Hello\\n\" ]]
+    rm -rf "$TEST_ROOT/repo1" "$TEST_ROOT/repo2"
+}
+test_symlink_from_repo_to_another


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->


## Motivation

This is a port of #9499 by @con-f-use with tests requested by @roberth 

- symlink points to flake
- symlink points to directory with a subdir that's a flake (ie the symlink isn't the final component but in between)
- symlink points to a directory in a repo
- symlink points from a repo to another directory. Needs --impure? Also test the error.

The last point should be discussed. The current behavior is nix respects the original flake that symlink is pointing to, no `--impure` needed. This is IMO the desired behavior that I can store links of all the flakes in each project in one place, like how nix manages profiles. 

But if someone wants to have one _general_ flake that applies to multiple projects, and for example, uses relative path to files, it's not the case. ~~But I think `path:` should be the solution.~~ 

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Closes: #9463 
Closes: #9499 

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
