### PR TITLE
Backport git+file:./ fixes to 2.24 (#12107 + #12277)

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -438,7 +438,7 @@ void EvalState::checkURI(const std::string & uri)
 
     /* If the URI is a path, then check it against allowedPaths as
        well. */
-    if (hasPrefix(uri, "/")) {
+    if (isAbsolute(uri)) {
         if (auto rootFS2 = rootFS.dynamic_pointer_cast<AllowListSourceAccessor>())
             rootFS2->checkAccess(CanonPath(uri));
         return;

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -434,7 +434,16 @@ struct GitInputScheme : InputScheme
         //
         // See: https://discourse.nixos.org/t/57783 and #9708
         //
-        repoInfo.url = repoInfo.isLocal ? std::filesystem::absolute(url.path).string() : url.to_string();
+        if (repoInfo.isLocal) {
+            if (!isAbsolute(url.path)) {
+                warn(
+                    "Fetching Git repository '%s', which uses a path relative to the current directory. "
+                    "This is not supported and will stop working in a future release.",
+                    url.to_string());
+            }
+            repoInfo.url = std::filesystem::absolute(url.path).string();
+        } else
+            repoInfo.url = url.to_string();
 
         // If this is a local directory and no ref or revision is
         // given, then allow the use of an unclean working tree.

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -438,7 +438,8 @@ struct GitInputScheme : InputScheme
             if (!isAbsolute(url.path)) {
                 warn(
                     "Fetching Git repository '%s', which uses a path relative to the current directory. "
-                    "This is not supported and will stop working in a future release.",
+                    "This is not supported and will stop working in a future release. "
+                    "See https://github.com/NixOS/nix/issues/12281 for details.",
                     url.to_string());
             }
             repoInfo.url = std::filesystem::absolute(url.path).string();

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -425,7 +425,16 @@ struct GitInputScheme : InputScheme
         auto url = parseURL(getStrAttr(input.attrs, "url"));
         bool isBareRepository = url.scheme == "file" && !pathExists(url.path + "/.git");
         repoInfo.isLocal = url.scheme == "file" && !forceHttp && !isBareRepository;
-        repoInfo.url = repoInfo.isLocal ? url.path : url.base;
+        //
+        // FIXME: here we turn a possibly relative path into an absolute path.
+        // This allows relative git flake inputs to be resolved against the
+        // **current working directory** (as in POSIX), which tends to work out
+        // ok in the context of flakes, but is the wrong behavior,
+        // as it should resolve against the flake.nix base directory instead.
+        //
+        // See: https://discourse.nixos.org/t/57783 and #9708
+        //
+        repoInfo.url = repoInfo.isLocal ? std::filesystem::absolute(url.path).string() : url.to_string();
 
         // If this is a local directory and no ref or revision is
         // given, then allow the use of an unclean working tree.

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -96,7 +96,7 @@ struct PathInputScheme : InputScheme
     std::optional<std::string> isRelative(const Input & input) const
     {
         auto path = getStrAttr(input.attrs, "path");
-        if (hasPrefix(path, "/"))
+        if (isAbsolute(path))
             return std::nullopt;
         else
             return path;

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -156,7 +156,7 @@ static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, re
             return std::make_shared<Registry>(settings, Registry::Global); // empty registry
         }
 
-        if (!hasPrefix(path, "/")) {
+        if (!isAbsolute(path)) {
             auto storePath = downloadFile(store, path, "flake-registry.json").storePath;
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
                 store2->addPermRoot(storePath, getCacheDir() + "/nix/flake-registry.json");

--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -175,7 +175,7 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
         }
 
     } else {
-        if (!hasPrefix(path, "/"))
+        if (!isAbsolute(path))
             throw BadURL("flake reference '%s' is not an absolute path", url);
         path = canonPath(path + "/" + getOr(query, "dir", ""));
     }

--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -29,12 +29,7 @@ namespace fs = std::filesystem;
 
 namespace nix {
 
-/**
- * Treat the string as possibly an absolute path, by inspecting the
- * start of it. Return whether it was probably intended to be
- * absolute.
- */
-static bool isAbsolute(PathView path)
+bool isAbsolute(PathView path)
 {
     return fs::path { path }.is_absolute();
 }

--- a/src/libutil/file-system.hh
+++ b/src/libutil/file-system.hh
@@ -43,6 +43,11 @@ struct Sink;
 struct Source;
 
 /**
+ * Return whether the path denotes an absolute path.
+ */
+bool isAbsolute(PathView path);
+
+/**
  * @return An absolutized path, resolving paths relative to the
  * specified directory, or the current directory otherwise.  The path
  * is also canonicalised.

--- a/src/libutil/source-accessor.cc
+++ b/src/libutil/source-accessor.cc
@@ -94,7 +94,7 @@ CanonPath SourceAccessor::resolveSymlinks(
                         throw Error("infinite symlink recursion in path '%s'", showPath(path));
                     auto target = readLink(res);
                     res.pop();
-                    if (hasPrefix(target, "/"))
+                    if (isAbsolute(target))
                         res = CanonPath::root;
                     todo.splice(todo.begin(), tokenizeString<std::list<std::string>>(target, "/"));
                 }

--- a/tests/functional/flakes/flake-in-submodule.sh
+++ b/tests/functional/flakes/flake-in-submodule.sh
@@ -63,3 +63,21 @@ flakeref=git+file://$rootRepo\?submodules=1\&dir=submodule
 echo '"foo"' > "$rootRepo"/submodule/sub.nix
 [[ $(nix eval --json "$flakeref#sub" ) = '"foo"' ]]
 [[ $(nix flake metadata --json "$flakeref" | jq -r .locked.rev) = null ]]
+
+# The root repo may use the submodule repo as an input
+# through the relative path. This may change in the future;
+# see: https://discourse.nixos.org/t/57783 and #9708.
+cat > "$rootRepo"/flake.nix <<EOF
+{
+    inputs.subRepo.url = "git+file:./submodule";
+    outputs = { ... }: { };
+}
+EOF
+git -C "$rootRepo" add flake.nix
+git -C "$rootRepo" commit -m "Add subRepo input"
+(
+  cd "$rootRepo"
+  # The submodule must be locked to the relative path,
+  # _not_ the absolute path:
+  [[ $(nix flake metadata --json | jq -r .locks.nodes.subRepo.locked.url) = "file:./submodule" ]]
+)

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -228,6 +228,14 @@ nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir#default"
 nix build -o "$TEST_ROOT/result" "$flake1Dir?ref=HEAD#default"
 nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default"
 
+# Check that relative paths are allowed for git flakes.
+# This may change in the future once git submodule support is refined.
+# See: https://discourse.nixos.org/t/57783 and #9708.
+(
+  cd "$flake1Dir/.."
+  nix build -o "$TEST_ROOT/result" "git+file:./$(basename "$flake1Dir")"
+)
+
 # Check that store symlinks inside a flake are not interpreted as flakes.
 nix build -o "$flake1Dir/result" "git+file://$flake1Dir"
 nix path-info "$flake1Dir/result"

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -232,6 +232,7 @@ nix build -o "$TEST_ROOT/result" "git+file://$flake1Dir?ref=HEAD#default"
 # This may change in the future once git submodule support is refined.
 # See: https://discourse.nixos.org/t/57783 and #9708.
 (
+  # This `cd` should not be required and is indicative of aforementioned bug.
   cd "$flake1Dir/.."
   nix build -o "$TEST_ROOT/result" "git+file:./$(basename "$flake1Dir")"
 )


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This PR rolls up some backports of `git+file:./` fixes to **2.24**, including the warning against the use of it in flake inputs.

- backports: #12107, closes #12265
- backports: ff9d886f3cb28db13bfb88d1dc4d6fe3dc83270f, necessary for later fixes
- backports: #12277

<!-- Briefly explain what the change is about and why it is desirable. -->

Note however, that:
- **I could _not_ backport** #12280 successfully as it depends on many previous commits, so we should probably just close #12284.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
