### PR TITLE
tests: Wait for network *online* and multi-user targets

### DIFF
--- a/tests/nixos/git-submodules.nix
+++ b/tests/nixos/git-submodules.nix
@@ -39,11 +39,13 @@
       client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
       # Install the SSH key on the builders.
-      client.wait_for_unit("network.target")
+      client.wait_for_unit("network-online.target")
 
       remote.succeed("mkdir -p -m 700 /root/.ssh")
       remote.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
       remote.wait_for_unit("sshd")
+      remote.wait_for_unit("multi-user.target")
+      remote.wait_for_unit("network-online.target")
       client.succeed(f"ssh -o StrictHostKeyChecking=no {remote.name} 'echo hello world'")
 
       remote.succeed("""

--- a/tests/nixos/nix-copy-closure.nix
+++ b/tests/nixos/nix-copy-closure.nix
@@ -48,7 +48,10 @@ in {
     server.succeed("mkdir -m 700 /root/.ssh")
     server.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
     server.wait_for_unit("sshd")
-    client.wait_for_unit("network.target")
+    server.wait_for_unit("multi-user.target")
+    server.wait_for_unit("network-online.target")
+
+    client.wait_for_unit("network-online.target")
     client.succeed(f"ssh -o StrictHostKeyChecking=no {server.name} 'echo hello world'")
 
     # Copy the closure of package A from the client to the server.

--- a/tests/nixos/nix-copy.nix
+++ b/tests/nixos/nix-copy.nix
@@ -56,7 +56,10 @@ in {
     start_all()
 
     server.wait_for_unit("sshd")
-    client.wait_for_unit("network.target")
+    server.wait_for_unit("multi-user.target")
+    server.wait_for_unit("network-online.target")
+
+    client.wait_for_unit("network-online.target")
     client.wait_for_unit("getty@tty1.service")
     # Either the prompt: ]#
     # or an OCR misreading of it: 1#

--- a/tests/nixos/remote-builds-ssh-ng.nix
+++ b/tests/nixos/remote-builds-ssh-ng.nix
@@ -89,10 +89,13 @@ in
       client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
       # Install the SSH key on the builder.
-      client.wait_for_unit("network.target")
+      client.wait_for_unit("network-online.target")
       builder.succeed("mkdir -p -m 700 /root/.ssh")
       builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
       builder.wait_for_unit("sshd")
+      builder.wait_for_unit("multi-user.target")
+      builder.wait_for_unit("network-online.target")
+
       client.succeed(f"ssh -o StrictHostKeyChecking=no {builder.name} 'echo hello world'")
 
       # Perform a build

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -112,11 +112,12 @@ in
       client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
       # Install the SSH key on the builders.
-      client.wait_for_unit("network.target")
+      client.wait_for_unit("network-online.target")
       for builder in [builder1, builder2]:
         builder.succeed("mkdir -p -m 700 /root/.ssh")
         builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
         builder.wait_for_unit("sshd")
+        builder.wait_for_unit("network-online.target")
         # Make sure the builder can handle our login correctly
         builder.wait_for_unit("multi-user.target")
         # Make sure there's no funny business on the client either


### PR DESCRIPTION
This should help prevent some test stalls.

By default, multi-user.target does not imply that the network is fully up.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Make the tests  more robust.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- https://hydra.nixos.org/build/285626708

Relevant log lines, lots of omissions, but in order:

```
remote # [   15.628032] sshd-session[872]: Accepted publickey for root from 2001:db8:1::1 port 56514 ssh2: ED25519 SHA256:4ogA6akWufoJq7wuED/32LiLaVjB3+cw9gkbZ3/ugFk
remote # [   15.661248] sshd-session[872]: pam_unix(sshd:session): session opened for user root(uid=0) by (uid=0)
remote # [   16.800083] systemd[1]: Started Session 1 of User root.
remote # [   17.051388] sshd-session[892]: Received disconnect from 2001:db8:1::1 port 56514:11: disconnected by user
remote # [   17.067639] systemd-logind[703]: Session 1 logged out. Waiting for processes to exit.
client # [   18.222952] systemd[1]: Started DHCP Client.
client # [   18.232062] systemd[1]: Reached target Network is Online.
client # [   18.234925] systemd[1]: Reached target Multi-User System.
remote # [ 2489.293345] <irrelevant message, but note the timestamp>
timeout reached; test terminating...
```

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
