### PR TITLE
mergify: Add automatic backport label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,6 +27,7 @@ pull_request_rules:
         branches:
           - 2.18-maintenance
         labels:
+          - automatic backport
           - merge-queue
 
   - name: backport patches to 2.19
@@ -37,6 +38,7 @@ pull_request_rules:
         branches:
           - 2.19-maintenance
         labels:
+          - automatic backport
           - merge-queue
 
   - name: backport patches to 2.20
@@ -47,6 +49,7 @@ pull_request_rules:
         branches:
           - 2.20-maintenance
         labels:
+          - automatic backport
           - merge-queue
 
   - name: backport patches to 2.21
@@ -57,6 +60,7 @@ pull_request_rules:
         branches:
           - 2.21-maintenance
         labels:
+          - automatic backport
           - merge-queue
 
   - name: backport patches to 2.22
@@ -67,6 +71,7 @@ pull_request_rules:
         branches:
           - 2.22-maintenance
         labels:
+          - automatic backport
           - merge-queue
 
   - name: backport patches to 2.23
@@ -77,6 +82,7 @@ pull_request_rules:
         branches:
           - 2.23-maintenance
         labels:
+          - automatic backport
           - merge-queue
 
   - name: backport patches to 2.24
@@ -87,6 +93,7 @@ pull_request_rules:
         branches:
           - "2.24-maintenance"
         labels:
+          - automatic backport
           - merge-queue
 
   - name: backport patches to 2.25
@@ -97,4 +104,5 @@ pull_request_rules:
         branches:
           - "2.25-maintenance"
         labels:
+          - automatic backport
           - merge-queue


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This label will be useful for constructing queries to find backportable PRs. Specifically, those should omit both automatic backports and "backports reviewed" PRs.

This label excludes manual backports, because those deserve attention, and might need cascading backports to even older versions.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
