### PR TITLE
tests: Wait for network *online* targets and/or multi-user targets (more)

### DIFF
--- a/tests/nixos/git-submodules.nix
+++ b/tests/nixos/git-submodules.nix
@@ -46,6 +46,7 @@
       remote.wait_for_unit("sshd")
       remote.wait_for_unit("multi-user.target")
       remote.wait_for_unit("network-online.target")
+      client.wait_for_unit("network-online.target")
       client.succeed(f"ssh -o StrictHostKeyChecking=no {remote.name} 'echo hello world'")
 
       remote.succeed("""

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -161,7 +161,9 @@ in
          github.succeed("cat /var/log/httpd/*.log >&2")
 
     github.wait_for_unit("httpd.service")
+    github.wait_for_unit("network-online.target")
 
+    client.wait_for_unit("network-online.target")
     client.succeed("curl -v https://github.com/ >&2")
     out = client.succeed("nix registry list")
     print(out)

--- a/tests/nixos/nix-docker.nix
+++ b/tests/nixos/nix-docker.nix
@@ -37,6 +37,7 @@ in {
 
   testScript = { nodes }: ''
     cache.wait_for_unit("harmonia.service")
+    cache.wait_for_unit("network-online.target")
 
     machine.succeed("mkdir -p /etc/containers")
     machine.succeed("""echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json""")

--- a/tests/nixos/nss-preload.nix
+++ b/tests/nixos/nss-preload.nix
@@ -102,6 +102,7 @@ in
   };
 
   testScript = { nodes, ... }: ''
+    http_dns.wait_for_unit("network-online.target")
     http_dns.wait_for_unit("nginx")
     http_dns.wait_for_open_port(80)
     http_dns.wait_for_unit("unbound")
@@ -109,6 +110,7 @@ in
 
     client.start()
     client.wait_for_unit('multi-user.target')
+    client.wait_for_unit('network-online.target')
 
     with subtest("can fetch data from a remote server outside sandbox"):
         client.succeed("nix --version >&2")

--- a/tests/nixos/s3-binary-cache-store.nix
+++ b/tests/nixos/s3-binary-cache-store.nix
@@ -52,11 +52,14 @@ in {
 
     # Create a binary cache.
     server.wait_for_unit("minio")
+    server.wait_for_unit("network-online.target")
 
     server.succeed("mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4")
     server.succeed("mc mb minio/my-cache")
 
     server.succeed("${env} nix copy --to '${storeUrl}' ${pkgA}")
+
+    client.wait_for_unit("network-online.target")
 
     # Test fetchurl on s3:// URLs while we're at it.
     client.succeed("${env} nix eval --impure --expr 'builtins.fetchurl { name = \"foo\"; url = \"s3://my-cache/nix-cache-info?endpoint=http://server:9000&region=eu-west-1\"; }'")

--- a/tests/nixos/sourcehut-flakes.nix
+++ b/tests/nixos/sourcehut-flakes.nix
@@ -122,6 +122,8 @@ in
       start_all()
 
       sourcehut.wait_for_unit("httpd.service")
+      sourcehut.wait_for_unit("network-online.target")
+      client.wait_for_unit("network-online.target")
 
       client.succeed("curl -v https://git.sr.ht/ >&2")
       client.succeed("nix registry list | grep nixpkgs")


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

More prevalent than I thought in https://github.com/NixOS/nix/pull/12302

See also https://github.com/NixOS/nix/actions/runs/12872412321/job/35887830320?pr=12310 which is a failed github-flakes test without "Network is Online"


## Context

- Similar to https://github.com/NixOS/nix/pull/12302

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
