### PR TITLE
Fixes for `nix-everything` wrapper

### DIFF
--- a/packaging/everything.nix
+++ b/packaging/everything.nix
@@ -42,29 +42,34 @@
 }:
 
 let
+  libs = {
+    inherit
+      nix-util
+      nix-util-c
+      nix-store
+      nix-store-c
+      nix-fetchers
+      nix-expr
+      nix-expr-c
+      nix-flake
+      nix-flake-c
+      nix-main
+      nix-main-c
+    ;
+  } // lib.optionalAttrs (!stdenv.hostPlatform.isStatic && stdenv.buildPlatform.canExecute stdenv.hostPlatform) {
+    # Currently fails in static build
+    inherit
+      nix-perl-bindings
+    ;
+  };
+
   dev = stdenv.mkDerivation (finalAttrs: {
     name = "nix-${nix-cli.version}-dev";
     pname = "nix";
     version = nix-cli.version;
     dontUnpack = true;
     dontBuild = true;
-    libs = map lib.getDev [
-      nix-cmd
-      nix-expr
-      nix-expr-c
-      nix-fetchers
-      nix-flake
-      nix-flake-c
-      nix-main
-      nix-main-c
-      nix-store
-      nix-store-c
-      nix-util
-      nix-util-c
-    ] ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
-      # Currently fails in static build
-      nix-perl-bindings
-    ];
+    libs = map lib.getDev (lib.attrValues libs);
     installPhase = ''
       mkdir -p $out/nix-support
       echo $libs >> $out/nix-support/propagated-build-inputs
@@ -129,22 +134,16 @@ in
     nix-fetchers-tests.tests.run
     nix-flake-tests.tests.run
 
+    # Make sure the functional tests have passed
+    nix-functional-tests
+
     # dev bundle is ok
     # (checkInputs must be empty paths??)
     (runCommand "check-pkg-config" { checked = dev.tests.pkg-config; } "mkdir $out")
-  ] ++
-    lib.optionals (!stdenv.hostPlatform.isStatic) (
+  ] ++ lib.optionals (!stdenv.hostPlatform.isStatic && stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     # Perl currently fails in static build
-    (if stdenv.buildPlatform.canExecute stdenv.hostPlatform
-    then [
-      # TODO: add perl.tests
-      nix-perl-bindings
-    ]
-    else [
-      nix-perl-bindings
-    ]));
-  installCheckInputs = [
-    nix-functional-tests
+    # TODO: Split out tests into a separate derivation?
+    nix-perl-bindings
   ];
   passthru = prevAttrs.passthru // {
     inherit (nix-cli) version;
@@ -166,21 +165,7 @@ in
         disallowedReferences = nix.all;
       ```
      */
-    libs = {
-      inherit
-        nix-util
-        nix-util-c
-        nix-store
-        nix-store-c
-        nix-fetchers
-        nix-expr
-        nix-expr-c
-        nix-flake
-        nix-flake-c
-        nix-main
-        nix-main-c
-      ;
-    };
+    inherit libs;
 
     tests = prevAttrs.passthru.tests or {} // {
       # TODO: create a proper fixpoint and:

--- a/src/perl/meson.build
+++ b/src/perl/meson.build
@@ -82,6 +82,9 @@ nix_store_dep = dependency('nix-store')
 # pkgconfig available, are not in a standard location,
 # and are installed into a version folder. Use the
 # Perl binary to give hints about perl include dir.
+#
+# Note that until we have a better solution for this, cross-compiling
+# the perl bindings does not appear to be possible.
 #-------------------------------------------------
 perl_archname = run_command(
   perl, '-e', 'use Config; print $Config{archname};', check: true).stdout()


### PR DESCRIPTION
## Motivation

1. Fix this eval error: https://hydra.nixos.org/jobset/nix/master#tabs-errors

   The dev package output (actually a separate derivation) needs to skip this for cross just as the main package output does.

2. Deduplicate libs attrset and list.

3. Move `nix-functional-tests` to `checkInputs`.

   With the Meson build system, we no longer need a `check` vs `install-check` distinction, so it is simpler to just keeep everything in one place.

## Context

Fixing errors before the release.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
