### PR TITLE
Add unit of measurement for download-buffer-size

### DIFF
--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -52,7 +52,7 @@ struct FileTransferSettings : Config
         R"(
           The size of Nix's internal download buffer in bytes during `curl` transfers. If data is
           not processed quickly enough to exceed the size of this buffer, downloads may stall.
-          The default is 67108864 (64MB).
+          The default is 67108864 (64 MiB).
         )"};
 };
 

--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -50,8 +50,9 @@ struct FileTransferSettings : Config
 
     Setting<size_t> downloadBufferSize{this, 64 * 1024 * 1024, "download-buffer-size",
         R"(
-          The size of Nix's internal download buffer during `curl` transfers. If data is
+          The size of Nix's internal download buffer in bytes during `curl` transfers. If data is
           not processed quickly enough to exceed the size of this buffer, downloads may stall.
+          The default is 67108864 (64MB).
         )"};
 };
 


### PR DESCRIPTION


## Motivation

I started getting these warnings `warning: download buffer is full; consider increasing the 'download-buffer-size' setting` but the documentation does not make it obvious what unit of measurement it accepts.

## Context

This is a trivial change to improve the option documentation.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
