### PR TITLE
x86_64-darwin: Disable LTO

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -79,6 +79,8 @@ let
         !stdenv.hostPlatform.isWindows
         # build failure
         && !stdenv.hostPlatform.isStatic
+        # LTO breaks exception handling on x86-64-darwin.
+        && stdenv.system != "x86_64-darwin"
       ) ''
         case "$mesonBuildType" in
         release|minsize) appendToVar mesonFlags "-Db_lto=true"  ;;


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

LTO on x86_64-darwin appears to break the ability to catch exceptions correctly (maybe just for exception types defined in different libraries). This leads to many weird test failures, e.g. https://hydra.nixos.org/build/286312387 and
https://hydra.nixos.org/build/286312341.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
