### PR TITLE
Add mergify backport rule for 2.26

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -106,3 +106,14 @@ pull_request_rules:
         labels:
           - automatic backport
           - merge-queue
+
+  - name: backport patches to 2.26
+    conditions:
+      - label=backport 2.26-maintenance
+    actions:
+      backport:
+        branches:
+          - "2.26-maintenance"
+        labels:
+          - automatic backport
+          - merge-queue

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -144,11 +144,9 @@ release:
 
   Make a pull request and auto-merge it.
 
-* Create a milestone for the next release, move all unresolved issues
-  from the previous milestone, and close the previous milestone. Set
-  the date for the next milestone 6 weeks from now.
-
 * Create a backport label.
+
+* Add the new backport label to `.mergify.yml`.
 
 * Post an [announcement on Discourse](https://discourse.nixos.org/c/announcements/8), including the contents of
   `rl-$VERSION.md`.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
