### PR TITLE
Add a test for #12339

### DIFF
--- a/tests/functional/nix-channel.sh
+++ b/tests/functional/nix-channel.sh
@@ -68,4 +68,14 @@ nix-env -i dependencies-top
 [ -e $TEST_HOME/.nix-profile/foobar ]
 
 # Test evaluation through a channel symlink (#9882).
-nix-instantiate '<foo/dependencies.nix>'
+drvPath=$(nix-instantiate '<foo/dependencies.nix>')
+
+# Add a test for the special case behaviour of 'nixpkgs' in the
+# channels for root (see EvalSettings::getDefaultNixPath()).
+if ! isTestOnNixOS; then
+    nix-channel --add file://$TEST_ROOT/foo nixpkgs
+    nix-channel --update
+    mv $TEST_HOME/.local/state/nix/profiles $TEST_ROOT/var/nix/profiles/per-user/root
+    drvPath2=$(nix-instantiate '<nixpkgs>')
+    [[ "$drvPath" = "$drvPath2" ]]
+fi


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This adds a regression test for the issue in #12339 (which only happens for the specific case of the `nixpkgs` channel for root).

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
