### PR TITLE
refactor: Extract EvalState::realiseString

### DIFF
--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -613,12 +613,8 @@ nix_realised_string * nix_string_realise(nix_c_context * context, EvalState * st
         context->last_err_code = NIX_OK;
     try {
         auto & v = check_value_in(value);
-        nix::NixStringContext stringContext;
-        auto rawStr = state->state.coerceToString(nix::noPos, v, stringContext, "while realising a string").toOwned();
         nix::StorePathSet storePaths;
-        auto rewrites = state->state.realiseContext(stringContext, &storePaths);
-
-        auto s = nix::rewriteStrings(rawStr, rewrites);
+        auto s = state->state.realiseString(v, &storePaths, isIFD);
 
         // Convert to the C API StorePath type and convert to vector for index-based access
         std::vector<StorePath> vec;

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -820,6 +820,15 @@ public:
      */
     [[nodiscard]] StringMap realiseContext(const NixStringContext & context, StorePathSet * maybePaths = nullptr, bool isIFD = true);
 
+    /**
+     * Realise the given string with context, and return the string with outputs instead of downstream output placeholders.
+     * @param[in] str the string to realise
+     * @param[out] paths all referenced store paths will be added to this set
+     * @return the realised string
+     * @throw EvalError if the value is not a string, path or derivation (see `coerceToString`)
+     */
+    std::string realiseString(Value & str, StorePathSet * storePathsOutMaybe, bool isIFD = true, const PosIdx pos = noPos);
+
     /* Call the binary path filter predicate used builtins.path etc. */
     bool callPathFilter(
         Value * filterFun,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -47,6 +47,15 @@ static inline Value * mkString(EvalState & state, const std::csub_match & match)
     return v;
 }
 
+std::string EvalState::realiseString(Value & s, StorePathSet * storePathsOutMaybe, bool isIFD, const PosIdx pos)
+{
+    nix::NixStringContext stringContext;
+    auto rawStr = coerceToString(pos, s, stringContext, "while realising a string").toOwned();
+    auto rewrites = realiseContext(stringContext, storePathsOutMaybe, isIFD);
+
+    return nix::rewriteStrings(rawStr, rewrites);
+}
+
 StringMap EvalState::realiseContext(const NixStringContext & context, StorePathSet * maybePathsOut, bool isIFD)
 {
     std::vector<DerivedPath::Built> drvs;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This is an operation that's needed in a couple of places for
- https://github.com/NixOS/nix/issues/11263

## Context

We'll want something similar for path coercions. Scoped out for this one.

This is a trivial refactor to support fixes, so I propose to backport this.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
