### PR TITLE
Allow fetching using NAR hash without --allow-dirty-locks

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -183,7 +183,7 @@ static void fetchTree(
     if (!state.settings.pureEval && !input.isDirect() && experimentalFeatureSettings.isEnabled(Xp::Flakes))
         input = lookupInRegistries(state.store, input).first;
 
-    if (state.settings.pureEval && !input.isConsideredLocked(state.fetchSettings)) {
+    if (state.settings.pureEval && !input.isLocked()) {
         if (input.getNarHash())
             warn(
                 "Input '%s' is unlocked (e.g. lacks a Git revision) but does have a NAR hash. "

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -184,10 +184,15 @@ static void fetchTree(
         input = lookupInRegistries(state.store, input).first;
 
     if (state.settings.pureEval && !input.isConsideredLocked(state.fetchSettings)) {
-        state.error<EvalError>(
-            "in pure evaluation mode, '%s' will not fetch unlocked input '%s'",
-            fetcher, input.to_string()
-        ).atPos(pos).debugThrow();
+        if (input.getNarHash())
+            warn(
+                "Input '%s' is unlocked (e.g. lacks a Git revision) but does have a NAR hash. "
+                "This is deprecated since such inputs are verifiable but may not be reproducible.",
+                input.to_string());
+        else
+            state.error<EvalError>(
+                "in pure evaluation mode, '%s' will not fetch unlocked input '%s'",
+                fetcher, input.to_string()).atPos(pos).debugThrow();
     }
 
     state.checkURI(input.toURLString());

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -155,12 +155,6 @@ bool Input::isLocked() const
     return scheme && scheme->isLocked(*this);
 }
 
-bool Input::isConsideredLocked(
-    const Settings & settings) const
-{
-    return isLocked() || (settings.allowDirtyLocks && getNarHash());
-}
-
 bool Input::isFinal() const
 {
     return maybeGetBoolAttr(attrs, "__final").value_or(false);

--- a/src/libfetchers/fetchers.hh
+++ b/src/libfetchers/fetchers.hh
@@ -91,15 +91,6 @@ public:
     bool isLocked() const;
 
     /**
-     * Return whether the input is either locked, or, if
-     * `allow-dirty-locks` is enabled, it has a NAR hash. In the
-     * latter case, we can verify the input but we may not be able to
-     * fetch it from anywhere.
-     */
-    bool isConsideredLocked(
-        const Settings & settings) const;
-
-    /**
      * Only for relative path flakes, i.e. 'path:./foo', returns the
      * relative path, i.e. './foo'.
      */

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -141,12 +141,13 @@ path4=$(nix eval --impure --refresh --raw --expr "(builtins.fetchGit file://$rep
 [[ $(nix eval --impure --expr "builtins.hasAttr \"dirtyRev\" (builtins.fetchGit $repo)") == "false" ]]
 [[ $(nix eval --impure --expr "builtins.hasAttr \"dirtyShortRev\" (builtins.fetchGit $repo)") == "false" ]]
 
-status=0
-nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-B5yIPHhEm0eysJKEsO7nqxprh9vcblFxpJG11gXJus1=\"; }).outPath" || status=$?
-[[ "$status" = "102" ]]
+expect 102 nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-B5yIPHhEm0eysJKEsO7nqxprh9vcblFxpJG11gXJus1=\"; }).outPath"
 
 path5=$(nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath")
 [[ $path = $path5 ]]
+
+# It's allowed to use only a narHash, but you should get a warning.
+expectStderr 0 nix eval --raw --expr "(builtins.fetchGit { url = $repo; ref = \"tag2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath" | grepQuiet "warning: Input .* is unlocked"
 
 # tarball-ttl should be ignored if we specify a rev
 echo delft > $repo/hello

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -146,6 +146,9 @@ expect 102 nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev
 path5=$(nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath")
 [[ $path = $path5 ]]
 
+# Ensure that NAR hashes are checked.
+expectStderr 102 nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-Hr8g6AqANb4xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath" | grepQuiet "error: NAR hash mismatch"
+
 # It's allowed to use only a narHash, but you should get a warning.
 expectStderr 0 nix eval --raw --expr "(builtins.fetchGit { url = $repo; ref = \"tag2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath" | grepQuiet "warning: Input .* is unlocked"
 

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -64,7 +64,7 @@ git -C $repo add differentbranch
 git -C $repo commit -m 'Test2'
 git -C $repo checkout master
 devrev=$(git -C $repo rev-parse devtest)
-nix eval --impure --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; }"
+nix eval --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; }"
 
 [[ $(nix eval --raw --expr "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; allRefs = true; } + \"/differentbranch\")") = 'different file' ]]
 
@@ -142,10 +142,10 @@ path4=$(nix eval --impure --refresh --raw --expr "(builtins.fetchGit file://$rep
 [[ $(nix eval --impure --expr "builtins.hasAttr \"dirtyShortRev\" (builtins.fetchGit $repo)") == "false" ]]
 
 status=0
-nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-B5yIPHhEm0eysJKEsO7nqxprh9vcblFxpJG11gXJus1=\"; }).outPath" || status=$?
+nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-B5yIPHhEm0eysJKEsO7nqxprh9vcblFxpJG11gXJus1=\"; }).outPath" || status=$?
 [[ "$status" = "102" ]]
 
-path5=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath")
+path5=$(nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath")
 [[ $path = $path5 ]]
 
 # tarball-ttl should be ignored if we specify a rev
@@ -255,7 +255,7 @@ echo "/exported-wonky export-ignore=wonk" >> $repo/.gitattributes
 git -C $repo add not-exported-file exported-wonky .gitattributes
 git -C $repo commit -m 'Bla6'
 rev5=$(git -C $repo rev-parse HEAD)
-path12=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev5\"; }).outPath")
+path12=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev5\"; }).outPath")
 [[ ! -e $path12/not-exported-file ]]
 [[ -e $path12/exported-wonky ]]
 

--- a/tests/functional/flakes/unlocked-override.sh
+++ b/tests/functional/flakes/unlocked-override.sh
@@ -37,8 +37,8 @@ expectStderr 1 nix flake lock "$flake2Dir" --override-input flake1 "$TEST_ROOT/f
 
 nix flake lock "$flake2Dir" --override-input flake1 "$TEST_ROOT/flake1" --allow-dirty-locks
 
-# Using a lock file with a dirty lock requires --allow-dirty-locks as well.
-expectStderr 1 nix eval "$flake2Dir#x" |
-  grepQuiet "Lock file contains unlocked input"
+# Using a lock file with a dirty lock does not require --allow-dirty-locks, but should print a warning.
+expectStderr 0 nix eval "$flake2Dir#x" |
+  grepQuiet "warning: Lock file entry .* is unlocked"
 
-[[ $(nix eval "$flake2Dir#x" --allow-dirty-locks) = 456 ]]
+[[ $(nix eval "$flake2Dir#x") = 456 ]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This allows calling `fetchGit` with only a NAR hash in pure mode, and allows using a lock file that has entries that are unlocked but do have a NAR hash. In both cases, a warning is printed to let users know this is deprecated behavior.

Fixes #12027, #12364.

Depends on  #12375.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
