### PR TITLE
Git fetcher: Don't create refs when fetching by revision

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -611,16 +611,16 @@ struct GitInputScheme : InputScheme
                 try {
                     auto fetchRef =
                         getAllRefsAttr(input)
-                        ? "refs/*"
+                        ? "refs/*:refs/*"
                         : input.getRev()
                         ? input.getRev()->gitRev()
                         : ref.compare(0, 5, "refs/") == 0
-                        ? ref
+                        ? fmt("%1%:%1%", ref)
                         : ref == "HEAD"
                         ? ref
-                        : "refs/heads/" + ref;
+                        : fmt("%1%:%1%", "refs/heads/" + ref);
 
-                    repo->fetch(repoUrl.to_string(), fmt("%s:%s", fetchRef, fetchRef), getShallowAttr(input));
+                    repo->fetch(repoUrl.to_string(), fetchRef, getShallowAttr(input));
                 } catch (Error & e) {
                     if (!std::filesystem::exists(localRefFile)) throw;
                     logError(e.info());

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -69,7 +69,7 @@ std::optional<std::string> readHead(const Path & path)
 
     std::string_view line = output;
     line = line.substr(0, line.find("\n"));
-    if (const auto parseResult = git::parseLsRemoteLine(line)) {
+    if (const auto parseResult = git::parseLsRemoteLine(line); parseResult && parseResult->reference == "HEAD") {
         switch (parseResult->kind) {
             case git::LsRemoteRefLine::Kind::Symbolic:
                 debug("resolved HEAD ref '%s' for repo '%s'", parseResult->target, path);

--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -459,8 +459,14 @@ struct GitInputScheme : InputScheme
                     url);
             }
             repoInfo.location = std::filesystem::absolute(url.path);
-        } else
+        } else {
+            if (url.scheme == "file")
+                /* Query parameters are meaningless for file://, but
+                   Git interprets them as part of the file name. So get
+                   rid of them. */
+                url.query.clear();
             repoInfo.location = url;
+        }
 
         // If this is a local directory and no ref or revision is
         // given, then allow the use of an unclean working tree.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This fixes a couple of issues with the Git fetcher:

* When fetching by revision, don't create a ref named `refs/head/<revision>`. (This was caused by doing `git fetch <revision>:<revision>`.) This is unnecessary and triggers the next bug. 

* When parsing the output of `git ls-remote --symref`, make sure that the first line references `HEAD`, otherwise a line like

  ```
  5c4410e3b9891c05ab40d723de78c6f0be45ad30        refs/heads/5c4410e3b9891c05ab40d723de78c6f0be45ad30
  ```

  will cause `5c44...` (created by the previous bug) to be interpreted as a ref, leading to errors like 

  ```
  fatal: Refusing to point HEAD outside of refs/
  warning: could not update cached head 'd275d93aa0bb8a004939b2f1e87f559f989453be' for 'file:///tmp/repo'
  ```
<!-- Briefly explain what the change is about and why it is desirable. -->

* Don't pass URL query parameters for `file://` URLs. Git interprets them as part of the file name, so passing parameters like `rev` breaks. Only relevant for testing (when `_NIX_FORCE_HTTP` is set) and local bare repos.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
