### PR TITLE
Add mbig-obj flag to allow cross-compiling libexpr to mingw32

### DIFF
--- a/nix-meson-build-support/big-objs/meson.build
+++ b/nix-meson-build-support/big-objs/meson.build
@@ -1,0 +1,4 @@
+# libexpr's primops creates a large object
+# Without the following flag, we'll get errors when cross-compiling to mingw32:
+# Fatal error: can't write 66 bytes to section .text of src/libexpr/libnixexpr.dll.p/primops.cc.obj: 'file too big'
+add_project_arguments([ '-Wa,-mbig-obj' ], language: 'cpp')

--- a/nix-meson-build-support/big-objs/meson.build
+++ b/nix-meson-build-support/big-objs/meson.build
@@ -1,4 +1,6 @@
-# libexpr's primops creates a large object
-# Without the following flag, we'll get errors when cross-compiling to mingw32:
-# Fatal error: can't write 66 bytes to section .text of src/libexpr/libnixexpr.dll.p/primops.cc.obj: 'file too big'
-add_project_arguments([ '-Wa,-mbig-obj' ], language: 'cpp')
+if host_machine.system() == 'windows'
+  # libexpr's primops creates a large object
+  # Without the following flag, we'll get errors when cross-compiling to mingw32:
+  # Fatal error: can't write 66 bytes to section .text of src/libexpr/libnixexpr.dll.p/primops.cc.obj: 'file too big'
+  add_project_arguments([ '-Wa,-mbig-obj' ], language: 'cpp')
+endif

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -24,6 +24,7 @@ deps_public_maybe_subproject = [
   dependency('nix-fetchers'),
 ]
 subdir('nix-meson-build-support/subprojects')
+subdir('nix-meson-build-support/big-objs')
 
 boost = dependency(
   'boost',


### PR DESCRIPTION
## Motivation

primops is huge, GCC for mingw32 needs a flag.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
