### PR TITLE
nix-profile.fish: Typo NIX_SS{H => L}_CERT_FILE

### DIFF
--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -39,7 +39,7 @@ else
 end
 
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
-if test -n "$NIX_SSH_CERT_FILE"
+if test -n "$NIX_SSL_CERT_FILE"
     : # Allow users to override the NIX_SSL_CERT_FILE
 else if test -e /etc/ssl/certs/ca-certificates.crt # NixOS, Ubuntu, Debian, Gentoo, Arch
     set --export NIX_SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
`nix-profile.fish` has `NIX_SSL_CERT_FILE` spelled incorrectly.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
