### PR TITLE
Simplify state machine 2

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -382,12 +382,7 @@ Goal::Co DerivationGoal::gaveUpOnSubstitution()
     }
 
     if (!waitees.empty()) co_await Suspend{}; /* to prevent hang (no wake-up event) */
-    co_return inputsRealised();
-}
 
-
-Goal::Co DerivationGoal::inputsRealised()
-{
     trace("all inputs realised");
 
     if (nrFailed != 0) {

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -80,7 +80,7 @@ struct DerivationGoal : public Goal
     /**
      * Mapping from input derivations + output names to actual store
      * paths. This is filled in by waiteeDone() as each dependency
-     * finishes, before inputsRealised() is reached.
+     * finishes, before `trace("all inputs realised")` is reached.
      */
     std::map<std::pair<StorePath, std::string>, StorePath> inputDrvOutputs;
 
@@ -235,7 +235,6 @@ struct DerivationGoal : public Goal
     Co init() override;
     Co haveDerivation();
     Co gaveUpOnSubstitution();
-    Co inputsRealised();
     Co tryToBuild();
     virtual Co tryLocalBuild();
     Co buildDone();


### PR DESCRIPTION
## Motivation

Follow-up from #12392, see that for motivation.

The first commit moves the function out of the way. The second joins together now-adjacent functions into a single larger function.

## Context

Depends on #12392

These last two commits were split out because they (necessarily) have a bigger diff.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
