### PR TITLE
nix-profile-daemon.fish: XDG_DATA_DIRS: .profile/share

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -21,14 +21,21 @@ function add_path --argument-names new_path
 end
 
 # Main configuration
+
+# Set up the per-user profile.
+
+set NIX_LINK $HOME/.nix-profile
+
+# Set up environment.
+# This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
 set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
 
 # Populate bash completions, .desktop files, etc
 if test -z "$XDG_DATA_DIRS"
     # According to XDG spec the default is /usr/local/share:/usr/share, don't set something that prevents that default
-    set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:/nix/var/nix/profiles/default/share"
+    set --export XDG_DATA_DIRS "/usr/local/share:/usr/share:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
 else
-    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:/nix/var/nix/profiles/default/share"
+    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
 end
 
 # Set $NIX_SSL_CERT_FILE so that Nixpkgs applications like curl work.
@@ -56,7 +63,8 @@ else
 end
 
 add_path "@localstatedir@/nix/profiles/default/bin"
-add_path "$HOME/.nix-profile/bin"
+add_path "$NIX_LINK/bin"
+set --erase NIX_LINK
 
 # Cleanup
 


### PR DESCRIPTION
## Motivation

It seems reasonable to add the `share` folder from the user profile into `$XDG_DATA_DIRS` both for daemon and profile execution.  Nix could add package shared files into this folder regardless of how the nix daemon itself is running.

This change reduces the differences between `nix-profile-daemon.fish` and `nix-profil.fish` to the following:

https://gist.github.com/ilya-bobyr/c957a9f998b85833064b2d64b4ae4062#file-nix-profile-fish-2-diff

## Context

This is related to point 6 in [the issue where the difference between daemon and non-daemon profiles are listed](https://github.com/NixOS/nix/issues/9441).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
