### PR TITLE
nix-profile.fish: set --local NIX_LINK

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -24,7 +24,7 @@ end
 
 # Set up the per-user profile.
 
-set NIX_LINK $HOME/.nix-profile
+set --local NIX_LINK $HOME/.nix-profile
 
 # Set up environment.
 # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
@@ -64,7 +64,6 @@ end
 
 add_path "@localstatedir@/nix/profiles/default/bin"
 add_path "$NIX_LINK/bin"
-set --erase NIX_LINK
 
 # Cleanup
 

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -24,7 +24,7 @@ end
 
 # Set up the per-user profile.
 
-set NIX_LINK $HOME/.nix-profile
+set --local NIX_LINK $HOME/.nix-profile
 
 # Set up environment.
 # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
@@ -63,7 +63,6 @@ if set --query MANPATH
 end
 
 add_path "$NIX_LINK/bin"
-set --erase NIX_LINK
 
 # Cleanup
 


### PR DESCRIPTION

## Motivation

This is a minor cleanup.

Using `set --local` is better than using `set`/`set --erase`.
`--local` will preserve any existing `NIX_LINK` value.
And the local variable is automatically removed for any execution path.

## Context

More idiomatic fish style.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
