### PR TITLE
nix-profile.fish: Add local state bin to $PATH

### DIFF
--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -69,6 +69,7 @@ if set --query MANPATH
     set --export --prepend --path MANPATH "$NIX_LINK/share/man"
 end
 
+add_path "@localstatedir@/nix/profiles/default/bin"
 add_path "$NIX_LINK/bin"
 
 # Cleanup


### PR DESCRIPTION
## Motivation

It seems reasonable to add both `$HOME/.profile/bin` and `@localstatedir@/nix/profiles/default/bin` to `$PATH` for both user local and daemon based nix execution.
Nix daemon execution mode does not affect these paths.

## Context

Further reduce differences between `nix-profile.fish` and `nix-profile-daemon.fish`.
A higher level list of all the differences is [here](https://github.com/NixOS/nix/issues/9441).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
