### PR TITLE
nix-profile.fish: Look for ca-bundle.crt in $NIX_PROFILES

### DIFF
--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -53,6 +53,13 @@ else if test -e "$NIX_LINK/etc/ssl/certs/ca-bundle.crt" # fall back to cacert in
     set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ssl/certs/ca-bundle.crt"
 else if test -e "$NIX_LINK/etc/ca-bundle.crt" # old cacert in Nix profile
     set --export NIX_SSL_CERT_FILE "$NIX_LINK/etc/ca-bundle.crt"
+else
+    # Fall back to what is in the nix profiles, favouring whatever is defined last.
+    for i in (string split ' ' $NIX_PROFILES)
+        if test -e "$i/etc/ssl/certs/ca-bundle.crt"
+            set --export NIX_SSL_CERT_FILE "$i/etc/ssl/certs/ca-bundle.crt"
+        end
+    end
 end
 
 # Only use MANPATH if it is already set. In general `man` will just simply


### PR DESCRIPTION
## Motivation

There seems to be no good reason for `nix-profile.fish` and `nix-profile-daemon.fish` to differ in how they look for the location of the `ca-bundle.crt` that might be installed by one of the packages.

As `$NIX_PROFILES` points to user local paths, not checking there is strictly less useful, it seems?

## Context

Reduce differences between `nix-profile.fish` and `nix-profile-daemon.fish`.
This covers both points 8 and 9 in [a list of the differences between `nix-profile.fish` and `nix-profile-daemon.fish`](https://github.com/NixOS/nix/issues/9441).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
