### PR TITLE
More interesting dyn drv test case

### DIFF
--- a/tests/functional/dyn-drv/dep-built-drv-2.sh
+++ b/tests/functional/dyn-drv/dep-built-drv-2.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# Store layer needs bugfix
+requireDaemonNewerThan "2.27pre20250205"
+
+TODO_NixOS # can't enable a sandbox feature easily
+
+enableFeatures 'recursive-nix'
+restartDaemon
+
+NIX_BIN_DIR="$(dirname "$(type -p nix)")"
+export NIX_BIN_DIR
+
+nix build -L --file ./non-trivial.nix

--- a/tests/functional/dyn-drv/meson.build
+++ b/tests/functional/dyn-drv/meson.build
@@ -15,6 +15,7 @@ suites += {
     'failing-outer.sh',
     'dep-built-drv.sh',
     'old-daemon-error-hack.sh',
+    'dep-built-drv-2.sh',
   ],
   'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/dyn-drv/non-trivial.nix
+++ b/tests/functional/dyn-drv/non-trivial.nix
@@ -1,0 +1,77 @@
+with import ./config.nix;
+
+builtins.outputOf
+  (mkDerivation {
+    name = "make-derivations.drv";
+
+    requiredSystemFeatures = [ "recursive-nix" ];
+
+    buildCommand = ''
+      set -e
+      set -u
+
+      PATH=${builtins.getEnv "NIX_BIN_DIR"}:$PATH
+
+      export NIX_CONFIG='extra-experimental-features = nix-command ca-derivations dynamic-derivations'
+
+      declare -A deps=(
+        [a]=""
+        [b]="a"
+        [c]="a"
+        [d]="b c"
+        [e]="b c d"
+      )
+
+      # Cannot just literally include this, or Nix will think it is the
+      # *outer* derivation that's trying to refer to itself, and
+      # substitute the string too soon.
+      placeholder=$(nix eval --raw --expr 'builtins.placeholder "out"')
+
+      declare -A drvs=()
+      for word in a b c d e; do
+        inputDrvs=""
+        for dep in ''${deps[$word]}; do
+          if [[ "$inputDrvs" != "" ]]; then
+            inputDrvs+=","
+          fi
+          read -r -d "" line <<EOF || true
+          "''${drvs[$dep]}": {
+            "outputs": ["out"],
+            "dynamicOutputs": {}
+          }
+      EOF
+          inputDrvs+="$line"
+        done
+        read -r -d "" json <<EOF || true
+        {
+          "args": ["-c", "set -xeu; echo \"word env vav $word is \$$word\" >> \"\$out\""],
+          "builder": "${shell}",
+          "env": {
+            "out": "$placeholder",
+            "$word": "hello, from $word!",
+            "PATH": ${builtins.toJSON path}
+          },
+          "inputDrvs": {
+            $inputDrvs
+          },
+          "inputSrcs": [],
+          "name": "build-$word",
+          "outputs": {
+            "out": {
+              "method": "nar",
+              "hashAlgo": "sha256"
+            }
+          },
+          "system": "${system}"
+        }
+      EOF
+        drvs[$word]="$(echo "$json" | nix derivation add)"
+      done
+      cp "''${drvs[e]}" $out
+    '';
+
+    __contentAddressed = true;
+    outputHashMode = "text";
+    outputHashAlgo = "sha256";
+  }).outPath
+  "out"


### PR DESCRIPTION
## Motivation

The existing ones did not shine enough light on this feature.

## Context

depends on #9415

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
