### PR TITLE
Set FD_CLOEXEC on sockets created by curl

### DIFF
--- a/doc/manual/rl-next/curl-cloexec.md
+++ b/doc/manual/rl-next/curl-cloexec.md
@@ -1,0 +1,10 @@
+---
+synopsis: Set FD_CLOEXEC on sockets created by curl
+issues: []
+prs: [12439]
+---
+
+
+Curl creates sockets without setting FD_CLOEXEC/SOCK_CLOEXEC, this can cause connections to remain open forever when using commands like `nix shell`
+
+This change sets the FD_CLOEXEC flag using a CURLOPT_SOCKOPTFUNCTION callback.

--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -300,6 +300,14 @@ struct curlFileTransfer : public FileTransfer
             return ((TransferItem *) userp)->readCallback(buffer, size, nitems);
         }
 
+        #if !defined(_WIN32) && LIBCURL_VERSION_NUM >= 0x071000
+        static int cloexec_callback(void *, curl_socket_t curlfd, curlsocktype purpose) {
+            unix::closeOnExec(curlfd);
+            vomit("cloexec set for fd %i", curlfd);
+            return CURL_SOCKOPT_OK;
+        }
+        #endif
+
         void init()
         {
             if (!req) req = curl_easy_init();
@@ -358,6 +366,10 @@ struct curlFileTransfer : public FileTransfer
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 0);
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0);
             }
+
+            #if !defined(_WIN32) && LIBCURL_VERSION_NUM >= 0x071000
+            curl_easy_setopt(req, CURLOPT_SOCKOPTFUNCTION, cloexec_callback);
+            #endif
 
             curl_easy_setopt(req, CURLOPT_CONNECTTIMEOUT, fileTransferSettings.connectTimeout.get());
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Curl creates sockets without setting FD_CLOEXEC/SOCK_CLOEXEC, this can cause connections to remain open forever when using commands like `nix shell`

This change sets the FD_CLOEXEC flag using a [CURLOPT_SOCKOPTFUNCTION](https://curl.se/libcurl/c/CURLOPT_SOCKOPTFUNCTION.html) callback.

## Context

<!-- Provide context. Reference open issues if available. -->
This is implemented based on comments in https://github.com/curl/curl/issues/2252

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
