### PR TITLE
nix flake prefetch: Add --out-link option

### DIFF
--- a/src/nix/flake-prefetch.md
+++ b/src/nix/flake-prefetch.md
@@ -5,10 +5,14 @@ R""(
 * Download a tarball and unpack it:
 
   ```console
-  # nix flake prefetch https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.5.tar.xz
+  # nix flake prefetch https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.5.tar.xz --out-link ./result
   Downloaded 'https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.5.tar.xz?narHash=sha256-3XYHZANT6AFBV0BqegkAZHbba6oeDkIUCDwbATLMhAY='
   to '/nix/store/sl5vvk8mb4ma1sjyy03kwpvkz50hd22d-source' (hash
   'sha256-3XYHZANT6AFBV0BqegkAZHbba6oeDkIUCDwbATLMhAY=').
+
+  # cat ./result/README
+  Linux kernel
+  …
   ```
 
 * Download the `dwarffs` flake (looked up in the flake registry):

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -18,6 +18,7 @@
 #include "markdown.hh"
 #include "users.hh"
 #include "fetch-to-store.hh"
+#include "local-fs-store.hh"
 
 #include <filesystem>
 #include <nlohmann/json.hpp>
@@ -1430,8 +1431,18 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
 struct CmdFlakePrefetch : FlakeCommand, MixJSON
 {
+    std::optional<std::filesystem::path> outLink;
+
     CmdFlakePrefetch()
     {
+        addFlag({
+            .longName = "out-link",
+            .shortName = 'o',
+            .description = "Create symlink named *path* to the resulting store path.",
+            .labels = {"path"},
+            .handler = {&outLink},
+            .completer = completePath
+        });
     }
 
     std::string description() override
@@ -1466,6 +1477,13 @@ struct CmdFlakePrefetch : FlakeCommand, MixJSON
                 lockedRef.to_string(),
                 store->printStorePath(storePath),
                 hash.to_string(HashFormat::SRI, true));
+        }
+
+        if (outLink) {
+            if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
+                createOutLinks(*outLink, {BuiltPath::Opaque{storePath}}, *store2);
+            else
+                throw Error("'--out-link' is not supported for this Nix store");
         }
     }
 };

--- a/tests/functional/tarball.sh
+++ b/tests/functional/tarball.sh
@@ -73,13 +73,13 @@ test_tarball .gz gzip
 # All entries in tree.tar.gz refer to the same file, and all have the same inode when unpacked by GNU tar.
 # We don't preserve the hard links, because that's an optimization we think is not worth the complexity,
 # so we only make sure that the contents are copied correctly.
-path="$(nix flake prefetch --json "tarball+file://$(pwd)/tree.tar.gz" | jq -r .storePath)"
-[[ $(cat "$path/a/b/foo") = bar ]]
-[[ $(cat "$path/a/b/xyzzy") = bar ]]
-[[ $(cat "$path/a/yyy") = bar ]]
-[[ $(cat "$path/a/zzz") = bar ]]
-[[ $(cat "$path/c/aap") = bar ]]
-[[ $(cat "$path/fnord") = bar ]]
+nix flake prefetch --json "tarball+file://$(pwd)/tree.tar.gz" --out-link "$TEST_ROOT/result"
+[[ $(cat "$TEST_ROOT/result/a/b/foo") = bar ]]
+[[ $(cat "$TEST_ROOT/result/a/b/xyzzy") = bar ]]
+[[ $(cat "$TEST_ROOT/result/a/yyy") = bar ]]
+[[ $(cat "$TEST_ROOT/result/a/zzz") = bar ]]
+[[ $(cat "$TEST_ROOT/result/c/aap") = bar ]]
+[[ $(cat "$TEST_ROOT/result/fnord") = bar ]]
 
 # Test a tarball that has multiple top-level directories.
 rm -rf "$TEST_ROOT/tar_root"


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This makes `nix flake prefetch` more useful for scripting and prevents the result from being GC'ed prematurely.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
