### PR TITLE
WIP: Add scoped expressions inspired by OCaml

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -697,7 +697,9 @@ void mapStaticEnvBindings(const SymbolTable & st, const StaticEnv & se, const En
     if (env.up && se.up) {
         mapStaticEnvBindings(st, *se.up, *env.up, vm);
 
-        if (se.isWith && !env.values[0]->isThunk()) {
+        if (se.isWith &&
+            se.isWith->binding == ExprWith::Binding::Outermost &&
+            !env.values[0]->isThunk()) {
             // add 'with' bindings.
             for (auto & j : *env.values[0]->attrs())
                 vm.insert_or_assign(std::string(st[j.name]), j.value);

--- a/src/libexpr/nixexpr.hh
+++ b/src/libexpr/nixexpr.hh
@@ -381,12 +381,21 @@ struct ExprLet : Expr
 
 struct ExprWith : Expr
 {
+    enum class Binding {
+        /** Classic `with` behaviour */
+        Outermost,
+        /** `with` behaviour mimicking OCaml's `foo.( <expr> )` */
+        Innermost,
+    };
+
     PosIdx pos;
     Expr * attrs, * body;
     size_t prevWith;
     ExprWith * parentWith;
-    ExprWith(const PosIdx & pos, Expr * attrs, Expr * body) : pos(pos), attrs(attrs), body(body) { };
+    ExprWith(const PosIdx & pos, Expr * attrs, Expr * body, Binding binding)
+          : pos(pos), attrs(attrs), body(body), binding(binding) { };
     PosIdx getPos() const override { return pos; }
+    const Binding binding;
     COMMON_METHODS
 };
 

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -211,7 +211,7 @@ expr_function
   | ASSERT expr ';' expr_function
     { $$ = new ExprAssert(CUR_POS, $2, $4); }
   | WITH expr ';' expr_function
-    { $$ = new ExprWith(CUR_POS, $2, $4); }
+    { $$ = new ExprWith(CUR_POS, $2, $4, ExprWith::Binding::Outermost); }
   | LET binds IN_KW expr_function
     { if (!$2->dynamicAttrs.empty())
         throw ParseError({
@@ -286,6 +286,9 @@ expr_select
        be used to emit a warning when an affected expression is parsed. */
     expr_simple OR_KW
     { $$ = new ExprCall(CUR_POS, $1, {new ExprVar(CUR_POS, state->s.or_)}, state->positions.add(state->origin, @$.endOffset)); }
+  | expr_simple '.' '(' expr ')'      { $$ = new ExprWith(CUR_POS, $1, $4, ExprWith::Binding::Innermost); }
+  | expr_simple '.' '[' expr_list ']' { $$ = new ExprWith(CUR_POS, $1, $4, ExprWith::Binding::Innermost); }
+  | expr_simple '.' '{' binds '}'     { $$ = new ExprWith(CUR_POS, $1, $4, ExprWith::Binding::Innermost); }
   | expr_simple
   ;
 

--- a/tests/functional/lang/eval-okay-scope-dot.exp
+++ b/tests/functional/lang/eval-okay-scope-dot.exp
@@ -1,0 +1,1 @@
+"x: (as-a as-b) y: (bs-a bs-b)"

--- a/tests/functional/lang/eval-okay-scope-dot.nix
+++ b/tests/functional/lang/eval-okay-scope-dot.nix
@@ -1,0 +1,20 @@
+let {
+
+  a = "let-a";
+
+  as = {
+    a = "as-a";
+    b = "as-b";
+  };
+
+  bs = {
+    a = "bs-a";
+    b = "bs-b";
+  };
+
+  x = as.(a + " " + b);
+
+  y = as.(bs.(a + " " + b));
+
+  body = "x: (" + x + ") y: (" + y + ")";
+}


### PR DESCRIPTION
The parsing works but it has the semantics of normal `with` currently.

I am currently calling it `scoped dot`, because calling it `innermost with` would maybe make people confuse them with the current `outermost with` expressions

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->
This solution took inspiration from OCaml: "module access notation" in https://ocaml.org/docs/modules and "local open" in https://ocaml.org/manual/5.3/moduleexamples.html.
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

With expressions are convenient, but confusing (i.e. taking the outermost binding), but the alternative of using `builtins.attrValues { inherit (foo) a b c; }` instead of `with foo; [a b c]` is cumbersome.

This is taking inspiration from OCaml.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->
Changing the parser is always something to be done with care. I should definitely add more tests, and people should try it out before it gets merged with something suboptimal.

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
