### PR TITLE
Bare minimum `ssh-ng://` extensions for Hydra

### DIFF
--- a/src/libstore/remote-store.hh
+++ b/src/libstore/remote-store.hh
@@ -122,6 +122,16 @@ public:
     BuildResult buildDerivation(const StorePath & drvPath, const BasicDerivation & drv,
         BuildMode buildMode) override;
 
+    /**
+     * Note, the returned function must only be called once, or we'll
+     * try to read from the connection twice.
+     *
+     * @todo Use C++23 `std::move_only_function`.
+     */
+    std::function<BuildResult()> buildDerivationAsync(
+        const StorePath & drvPath, const BasicDerivation & drv,
+        BuildMode buildMode);
+
     void ensurePath(const StorePath & path) override;
 
     void addTempRoot(const StorePath & path) override;

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -209,7 +209,7 @@ ref<RemoteStore::Connection> SSHStore::openConnection()
     }
     command.insert(command.end(),
         extraRemoteProgramArgs.begin(), extraRemoteProgramArgs.end());
-    conn->sshConn = master.startCommand(std::move(command));
+    conn->sshConn = master.startCommand(std::move(command), std::list{extraSshArgs});
     conn->to = FdSink(conn->sshConn->in.get());
     conn->from = FdSource(conn->sshConn->out.get());
     return conn;

--- a/src/libstore/ssh-store.hh
+++ b/src/libstore/ssh-store.hh
@@ -18,6 +18,11 @@ struct SSHStoreConfig : virtual RemoteStoreConfig, virtual CommonSSHStoreConfig
     const Setting<Strings> remoteProgram{
         this, {"nix-daemon"}, "remote-program", "Path to the `nix-daemon` executable on the remote machine."};
 
+    /**
+     * Hack for hydra
+     */
+    Strings extraSshArgs = {};
+
     const std::string name() override
     {
         return "Experimental SSH Store";


### PR DESCRIPTION
## Motivation

This is not as comprehensive as #10748, but I am also interested in figuring out whether all those additions are in fact necessary.

This is bare minimum needed for
https://github.com/NixOS/hydra/pull/1445, which has notable gaps but nevertheless reimplements enough with `ssh-ng://` to past all tests.

I would like to merge this change as definitely necessary, and unclear whether sufficient. Then I would iterate on the corresponding Hydra PR until it seems potentially correct, seeing what, if any, further Nix API changes are necessary.


## Context

https://github.com/NixOS/hydra/pull/1445, https://github.com/NixOS/hydra/issues/688 and #4665

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
