### PR TITLE
stop spamming 'Nix search path entry...' warnings

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3116,11 +3116,6 @@ std::optional<SourcePath> EvalState::resolveLookupPathPath(const LookupPath::Pat
 
         if (path.resolveSymlinks().pathExists())
             return finish(std::move(path));
-        else {
-            logWarning({
-                .msg = HintFmt("Nix search path entry '%1%' does not exist, ignoring", value)
-            });
-        }
     }
 
     debug("failed to resolve search path element '%s'", value);


### PR DESCRIPTION
## Motivation

Ever since c527fe0f960857a67eb76d9068d78ac85e42061b nix will repeatedly spam logs about a missing defexpr file. I suspect this is because I had a broken symlink in place before, and after that change nix resolves the symlink. Anyways, i get a ton of these logs:

```
warning: Nix search path entry '/Users/andyhamon/.nix-defexpr/channels' does not exist, ignoring
```

I don't use defexpr or channels in any way, though I do evaluate nix in impure mode on a regular basis (tl;dr repo too big to use flakes). As far as I can tell there is no way to suppress this other than to actually make the expected file exist, but I shouldn't have to do that, imo.

At this point, I think the warning is doing a lot more harm than good. If you search the web for this warning you find countless people confused about it, and being given the probaly bad advice to configure a channel.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
