### PR TITLE
JSONLogger: Log to a file descriptor instead of another Logger

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -51,7 +51,7 @@ static bool allSupportedLocally(Store & store, const std::set<std::string>& requ
 static int main_build_remote(int argc, char * * argv)
 {
     {
-        logger = makeJSONLogger(STDERR_FILENO);
+        logger = makeJSONLogger(getStandardError());
 
         /* Ensure we don't get any SSH passphrase or host key popups. */
         unsetenv("DISPLAY");

--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -51,7 +51,7 @@ static bool allSupportedLocally(Store & store, const std::set<std::string>& requ
 static int main_build_remote(int argc, char * * argv)
 {
     {
-        logger = makeJSONLogger(*logger);
+        logger = makeJSONLogger(STDERR_FILENO);
 
         /* Ensure we don't get any SSH passphrase or host key popups. */
         unsetenv("DISPLAY");

--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -27,7 +27,7 @@ Logger * makeDefaultLogger() {
     case LogFormat::rawWithLogs:
         return makeSimpleLogger(true);
     case LogFormat::internalJSON:
-        return makeJSONLogger(STDERR_FILENO);
+        return makeJSONLogger(getStandardError());
     case LogFormat::bar:
         return makeProgressBar();
     case LogFormat::barWithLogs: {

--- a/src/libmain/loggers.cc
+++ b/src/libmain/loggers.cc
@@ -27,7 +27,7 @@ Logger * makeDefaultLogger() {
     case LogFormat::rawWithLogs:
         return makeSimpleLogger(true);
     case LogFormat::internalJSON:
-        return makeJSONLogger(*makeSimpleLogger(true));
+        return makeJSONLogger(STDERR_FILENO);
     case LogFormat::bar:
         return makeProgressBar();
     case LogFormat::barWithLogs: {

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -2225,7 +2225,7 @@ void LocalDerivationGoal::runChild()
         /* Execute the program.  This should not return. */
         if (drv->isBuiltin()) {
             try {
-                logger = makeJSONLogger(*logger);
+                logger = makeJSONLogger(STDERR_FILENO);
 
                 std::map<std::string, Path> outputs;
                 for (auto & e : drv->outputs)

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -2225,7 +2225,7 @@ void LocalDerivationGoal::runChild()
         /* Execute the program.  This should not return. */
         if (drv->isBuiltin()) {
             try {
-                logger = makeJSONLogger(STDERR_FILENO);
+                logger = makeJSONLogger(getStandardError());
 
                 std::map<std::string, Path> outputs;
                 for (auto & e : drv->outputs)

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -167,9 +167,9 @@ void to_json(nlohmann::json & json, std::shared_ptr<Pos> pos)
 }
 
 struct JSONLogger : Logger {
-    Logger & prevLogger;
+    Descriptor fd;
 
-    JSONLogger(Logger & prevLogger) : prevLogger(prevLogger) { }
+    JSONLogger(Descriptor fd) : fd(fd) { }
 
     bool isVerbose() override {
         return true;
@@ -190,7 +190,7 @@ struct JSONLogger : Logger {
 
     void write(const nlohmann::json & json)
     {
-        prevLogger.log(lvlError, "@nix " + json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace));
+        writeLine(fd, "@nix " + json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace));
     }
 
     void log(Verbosity lvl, std::string_view s) override
@@ -262,9 +262,9 @@ struct JSONLogger : Logger {
     }
 };
 
-Logger * makeJSONLogger(Logger & prevLogger)
+Logger * makeJSONLogger(Descriptor fd)
 {
-    return new JSONLogger(prevLogger);
+    return new JSONLogger(fd);
 }
 
 static Logger::Fields getFields(nlohmann::json & json)

--- a/src/libutil/logging.hh
+++ b/src/libutil/logging.hh
@@ -3,6 +3,7 @@
 
 #include "error.hh"
 #include "config.hh"
+#include "file-descriptor.hh"
 
 #include <nlohmann/json_fwd.hpp>
 
@@ -183,7 +184,7 @@ extern Logger * logger;
 
 Logger * makeSimpleLogger(bool printBuildLogs = true);
 
-Logger * makeJSONLogger(Logger & prevLogger);
+Logger * makeJSONLogger(Descriptor fd);
 
 /**
  * @param source A noun phrase describing the source of the message, e.g. "the builder".


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Logging to another Logger was kind of nonsensical - it was really just an easy way to get it to write its output to stderr, but that only works if the underlying logger writes to stderr.

This change is needed to make it easy to log JSON output somewhere else (like a file or socket).

## Context

This is a prerequisity for if we want to log JSON messages to some other file descriptor.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
