### PR TITLE
Support libgit2 1.9.0

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -138,7 +138,8 @@ let
     enableParallelBuilding = true;
   };
 in
-scope: {
+scope:
+{
   inherit stdenv;
 
   aws-sdk-cpp =
@@ -174,6 +175,31 @@ scope: {
         installPhase = lib.replaceStrings [ "--without-python" ] [ "" ] old.installPhase;
       });
 
+  inherit resolvePath filesetToSource;
+
+  mkMesonDerivation = mkPackageBuilder [
+    miscGoodPractice
+    localSourceLayer
+    mesonLayer
+  ];
+  mkMesonExecutable = mkPackageBuilder [
+    miscGoodPractice
+    bsdNoLinkAsNeeded
+    localSourceLayer
+    mesonLayer
+    mesonBuildLayer
+  ];
+  mkMesonLibrary = mkPackageBuilder [
+    miscGoodPractice
+    bsdNoLinkAsNeeded
+    localSourceLayer
+    mesonLayer
+    mesonBuildLayer
+    mesonLibraryLayer
+  ];
+}
+# libgit2: Nixpkgs 24.11 has < 1.9.0
+// lib.optionalAttrs (!lib.versionAtLeast pkgs.libgit2.version "1.9.0") {
   libgit2 = pkgs.libgit2.overrideAttrs (attrs: {
     cmakeFlags = attrs.cmakeFlags or [ ] ++ [ "-DUSE_SSH=exec" ];
     nativeBuildInputs =
@@ -203,27 +229,4 @@ scope: {
         ./patches/libgit2-packbuilder-callback-interruptible.patch
       ];
   });
-
-  inherit resolvePath filesetToSource;
-
-  mkMesonDerivation = mkPackageBuilder [
-    miscGoodPractice
-    localSourceLayer
-    mesonLayer
-  ];
-  mkMesonExecutable = mkPackageBuilder [
-    miscGoodPractice
-    bsdNoLinkAsNeeded
-    localSourceLayer
-    mesonLayer
-    mesonBuildLayer
-  ];
-  mkMesonLibrary = mkPackageBuilder [
-    miscGoodPractice
-    bsdNoLinkAsNeeded
-    localSourceLayer
-    mesonLayer
-    mesonBuildLayer
-    mesonLibraryLayer
-  ];
 }


### PR DESCRIPTION
For when the overlay is used with nixos-unstable.
1.9.0 has our patches.

- Closes #12474 

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
