### PR TITLE
Fix NIX_MAN_DIR to point to nix-manual.man

### DIFF
--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -10,7 +10,7 @@
   jq,
   python3,
   rsync,
-  nix-cli,
+  nixComponents,
 
   # Configuration Options
 
@@ -19,6 +19,19 @@
 
 let
   inherit (lib) fileset;
+  inherit
+    (nixComponents.overrideScope (
+      # HACK: nix-manual depends on nix-cli, which depends on nix-store, which
+      # requires nixManDir to point to nix man pages (which get built in this derivation).
+      # To break the recursion we build a dummy nix version, which has nixManDir set
+      # to a broken value equal to the mandir output of the nix-store derivation.
+      # NOTE: Runtime closure does NOT depend on any of the "bootstrap" nix components.
+      # TODO: Fix this mess. Path to the manual has to be configured at runtime
+      # (maybe with a wrapper?) rather than compile-time.
+      final: prev: { nix-store = prev.nix-store.override { nixManDir = ""; }; }
+    ))
+    nix-cli
+    ;
 in
 
 mkMesonDerivation (finalAttrs: {

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -372,6 +372,10 @@ if not fs.is_absolute(sysconfdir)
 endif
 
 lsof = find_program('lsof', required : false)
+nix_man_dir = get_option('nix-manual-mandir')
+if nix_man_dir == ''
+   nix_man_dir = mandir
+endif
 
 # Aside from prefix itself, each of these was made into an absolute path
 # by joining it with prefix, unless it was already an absolute path
@@ -383,7 +387,7 @@ cpp_str_defines = {
   'NIX_STATE_DIR': localstatedir / 'nix',
   'NIX_LOG_DIR':   log_dir,
   'NIX_CONF_DIR':  sysconfdir / 'nix',
-  'NIX_MAN_DIR':   mandir,
+  'NIX_MAN_DIR':   nix_man_dir,
 }
 
 if lsof.found()

--- a/src/libstore/meson.options
+++ b/src/libstore/meson.options
@@ -19,3 +19,7 @@ option('store-dir', type : 'string', value : '/nix/store',
 option('log-dir', type : 'string', value : '/nix/var/log/nix',
   description : 'path to store logs in for Nix',
 )
+
+option('nix-manual-mandir', type : 'string', value : '',
+  description : 'path to the nix manual directory (empty means the project\'s mandir)'
+)

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -7,6 +7,7 @@
   darwin,
 
   nix-util,
+  nix-manual,
   boost,
   curl,
   aws-sdk-cpp,
@@ -21,6 +22,7 @@
   version,
 
   embeddedSandboxShell ? stdenv.hostPlatform.isStatic,
+  nixManDir ? "${lib.getOutput "man" nix-manual}/share/man",
 }:
 
 let
@@ -81,6 +83,7 @@ mkMesonLibrary (finalAttrs: {
     [
       (lib.mesonEnable "seccomp-sandboxing" stdenv.hostPlatform.isLinux)
       (lib.mesonBool "embedded-sandbox-shell" embeddedSandboxShell)
+      (lib.mesonOption "nix-manual-mandir" nixManDir)
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")


### PR DESCRIPTION
This is a quick band-aid solution to fix broken `--help` for nix-{env,store} and others [1]. I'm convinced that this isn't the optimal solution, but at least it works.

Doing this properly would require reworking how manual paths get looked up.

[1]: https://github.com/NixOS/nix/issues/12382

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/issues/12382

Not sure if this is correct in regard in cross, because I can't build `nix-everything-riscv64-unknown-linux-gnu` locally due to an `Exec format error`. Not sure if it's related to this patch or not.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
