### PR TITLE
Move code related to NIX_MAN_DIR from libstore to nix-cli

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -315,20 +315,6 @@ void printVersion(const std::string & programName)
     throw Exit();
 }
 
-
-void showManPage(const std::string & name)
-{
-    restoreProcessContext();
-    setEnv("MANPATH", settings.nixManDir.c_str());
-    execlp("man", "man", name.c_str(), nullptr);
-    if (errno == ENOENT) {
-        // Not SysError because we don't want to suffix the errno, aka No such file or directory.
-        throw Error("The '%1%' command was not found, but it is needed for '%2%' and some other '%3%' commands' help text. Perhaps you could install the '%1%' command?", "man", name.c_str(), "nix-*");
-    }
-    throw SysError("command 'man %1%' failed", name.c_str());
-}
-
-
 int handleExceptions(const std::string & programName, std::function<void()> fun)
 {
     ReceiveInterrupts receiveInterrupts; // FIXME: need better place for this

--- a/src/libmain/shared.hh
+++ b/src/libmain/shared.hh
@@ -71,11 +71,6 @@ struct LegacyArgs : public MixCommonArgs, public RootArgs
 
 
 /**
- * Show the manual page for the specified program.
- */
-void showManPage(const std::string & name);
-
-/**
  * The constructor of this class starts a pager if standard output is a
  * terminal and $PAGER is set. Standard output is redirected to the
  * pager.

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -65,7 +65,6 @@ Settings::Settings()
     , nixStateDir(canonPath(getEnvNonEmpty("NIX_STATE_DIR").value_or(NIX_STATE_DIR)))
     , nixConfDir(canonPath(getEnvNonEmpty("NIX_CONF_DIR").value_or(NIX_CONF_DIR)))
     , nixUserConfFiles(getUserConfigFiles())
-    , nixManDir(canonPath(NIX_MAN_DIR))
     , nixDaemonSocketFile(canonPath(getEnvNonEmpty("NIX_DAEMON_SOCKET_PATH").value_or(nixStateDir + DEFAULT_SOCKET_PATH)))
 {
 #ifndef _WIN32

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -85,11 +85,6 @@ public:
     std::vector<Path> nixUserConfFiles;
 
     /**
-     * The directory where the man pages are stored.
-     */
-    Path nixManDir;
-
-    /**
      * File name of the socket the daemon listens to.
      */
     Path nixDaemonSocketFile;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -28,6 +28,7 @@
 #include "users.hh"
 #include "network-proxy.hh"
 #include "compatibility-settings.hh"
+#include "man-pages.hh"
 
 using namespace nix;
 using namespace std::string_literals;

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -8,6 +8,7 @@
 #include "users.hh"
 #include "tarball.hh"
 #include "self-exe.hh"
+#include "man-pages.hh"
 
 #include <fcntl.h>
 #include <regex>

--- a/src/nix-collect-garbage/nix-collect-garbage.cc
+++ b/src/nix-collect-garbage/nix-collect-garbage.cc
@@ -7,6 +7,7 @@
 #include "shared.hh"
 #include "globals.hh"
 #include "legacy.hh"
+#include "man-pages.hh"
 
 #include <iostream>
 #include <cerrno>

--- a/src/nix-copy-closure/nix-copy-closure.cc
+++ b/src/nix-copy-closure/nix-copy-closure.cc
@@ -2,6 +2,7 @@
 #include "realisation.hh"
 #include "store-api.hh"
 #include "legacy.hh"
+#include "man-pages.hh"
 
 using namespace nix;
 

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -17,6 +17,7 @@
 #include "legacy.hh"
 #include "eval-settings.hh" // for defexpr
 #include "terminal.hh"
+#include "man-pages.hh"
 
 #include <cerrno>
 #include <ctime>

--- a/src/nix-instantiate/nix-instantiate.cc
+++ b/src/nix-instantiate/nix-instantiate.cc
@@ -12,6 +12,7 @@
 #include "local-fs-store.hh"
 #include "common-eval-args.hh"
 #include "legacy.hh"
+#include "man-pages.hh"
 
 #include <map>
 #include <iostream>

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -12,6 +12,7 @@
 #include "legacy.hh"
 #include "posix-source-accessor.hh"
 #include "path-with-outputs.hh"
+#include "man-pages.hh"
 
 #ifndef _WIN32 // TODO implement on Windows or provide allowed-to-noop interface
 # include "local-store.hh"

--- a/src/nix/hash.cc
+++ b/src/nix/hash.cc
@@ -8,6 +8,7 @@
 #include "git.hh"
 #include "posix-source-accessor.hh"
 #include "misc-store-flags.hh"
+#include "man-pages.hh"
 
 using namespace nix;
 

--- a/src/nix/man-pages.cc
+++ b/src/nix/man-pages.cc
@@ -1,0 +1,29 @@
+#include "man-pages.hh"
+#include "file-system.hh"
+#include "current-process.hh"
+#include "environment-variables.hh"
+
+namespace nix {
+
+std::filesystem::path getNixManDir()
+{
+    return canonPath(NIX_MAN_DIR);
+}
+
+void showManPage(const std::string & name)
+{
+    restoreProcessContext();
+    setEnv("MANPATH", getNixManDir().c_str());
+    execlp("man", "man", name.c_str(), nullptr);
+    if (errno == ENOENT) {
+        // Not SysError because we don't want to suffix the errno, aka No such file or directory.
+        throw Error(
+            "The '%1%' command was not found, but it is needed for '%2%' and some other '%3%' commands' help text. Perhaps you could install the '%1%' command?",
+            "man",
+            name.c_str(),
+            "nix-*");
+    }
+    throw SysError("command 'man %1%' failed", name.c_str());
+}
+
+}

--- a/src/nix/man-pages.hh
+++ b/src/nix/man-pages.hh
@@ -1,0 +1,28 @@
+#pragma once
+///@file
+
+#include <filesystem>
+#include <string>
+
+namespace nix {
+
+/**
+ * @brief Get path to the nix manual dir.
+ *
+ * Nix relies on the man pages being available at a NIX_MAN_DIR for
+ * displaying help messaged for legacy cli.
+ *
+ * NIX_MAN_DIR is a compile-time parameter, so man pages are unlikely to work
+ * for cases when the nix executable is installed out-of-store or as a static binary.
+ *
+ */
+std::filesystem::path getNixManDir();
+
+/**
+ * Show the manual page for the specified program.
+ *
+ * @param name Name of the man item.
+ */
+void showManPage(const std::string & name);
+
+}

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -90,6 +90,7 @@ nix_sources = [config_h] + files(
   'ls.cc',
   'main.cc',
   'make-content-addressed.cc',
+  'man-pages.cc',
   'nar.cc',
   'optimise-store.cc',
   'path-from-hash-part.cc',
@@ -182,6 +183,16 @@ if host_machine.system() != 'windows'
   ]
 endif
 
+fs = import('fs')
+prefix = get_option('prefix')
+
+mandir = get_option('mandir')
+mandir = fs.is_absolute(mandir) ? mandir : prefix / mandir
+
+cpp_args= [
+  '-DNIX_MAN_DIR="@0@"'.format(mandir)
+]
+
 include_dirs = [include_directories('.')]
 
 this_exe = executable(
@@ -189,6 +200,7 @@ this_exe = executable(
   sources,
   dependencies : deps_private_subproject + deps_private + deps_other,
   include_directories : include_dirs,
+  cpp_args : cpp_args,
   link_args: linker_export_flags,
   install : true,
 )

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -12,6 +12,7 @@
 #include "posix-source-accessor.hh"
 #include "misc-store-flags.hh"
 #include "terminal.hh"
+#include "man-pages.hh"
 
 #include <nlohmann/json.hpp>
 

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -15,6 +15,7 @@
 #include "finally.hh"
 #include "legacy.hh"
 #include "daemon.hh"
+#include "man-pages.hh"
 
 #include <algorithm>
 #include <climits>


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This is a prerequisite to properly fixing man-pages once and for all [1]. Note that this patch leaves manpages for legacy commands in a borked state, pending the movement of manpages from nix-manual to nix-cli [2].

[1]: https://www.github.com/NixOS/nix/issues/12382
[2]: https://www.github.com/NixOS/nix/issues/12382#issuecomment-2663782043

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/issues/12382
https://github.com/NixOS/nix/issues/12382#issuecomment-2663782043
Should supersede https://github.com/NixOS/nix/pull/12488

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
