### PR TITLE
PosixSourceAccessor: always require a root

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -247,14 +247,14 @@ EvalState::EvalState(
     , emptyBindings(0)
     , rootFS(
         settings.restrictEval || settings.pureEval
-        ? ref<SourceAccessor>(AllowListSourceAccessor::create(getFSSourceAccessor(), {},
+        ? ref<SourceAccessor>(AllowListSourceAccessor::create(makeFSSourceAccessor(std::filesystem::path { store->storeDir }.root_path()), {},
             [&settings](const CanonPath & path) -> RestrictedPathError {
                 auto modeInformation = settings.pureEval
                     ? "in pure evaluation mode (use '--impure' to override)"
                     : "in restricted mode";
                 throw RestrictedPathError("access to absolute path '%1%' is forbidden %2%", path, modeInformation);
             }))
-        : getFSSourceAccessor())
+        : makeFSSourceAccessor(std::filesystem::path { store->storeDir }.root_path()))
     , corepkgsFS(make_ref<MemorySourceAccessor>())
     , internalFS(make_ref<MemorySourceAccessor>())
     , derivationInternal{corepkgsFS->addFile(

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -568,7 +568,7 @@ bool Worker::pathContentsGood(const StorePath & path)
         res = false;
     else {
         auto current = hashPath(
-            {store.getFSAccessor(), CanonPath(store.printStorePath(path))},
+            {store.getFSAccessor(), store.canonStorePath(path)},
             FileIngestionMethod::NixArchive, info->narHash.algo).first;
         Hash nullHash(HashAlgorithm::SHA256);
         res = info->narHash == nullHash || info->narHash == current;

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1099,7 +1099,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source,
                     auto & specified = *info.ca;
                     auto actualHash = ({
                         auto accessor = getFSAccessor(false);
-                        CanonPath path { printStorePath(info.path) };
+                        auto path = canonStorePath(info.path);
                         Hash h { HashAlgorithm::SHA256 }; // throwaway def to appease C++
                         auto fim = specified.method.getFileIngestionMethod();
                         switch (fim) {
@@ -1383,7 +1383,7 @@ bool LocalStore::verifyStore(bool checkContents, RepairFlag repair)
             checkInterrupt();
             auto name = link.path().filename();
             printMsg(lvlTalkative, "checking contents of '%s'", name);
-            PosixSourceAccessor accessor;
+            PosixSourceAccessor accessor(std::filesystem::current_path().root_path());
             std::string hash = hashPath(
                 PosixSourceAccessor::createAtRoot(link.path()),
                 FileIngestionMethod::NixArchive, HashAlgorithm::SHA256).first.to_string(HashFormat::Nix32, false);

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -139,6 +139,7 @@ void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
         return;
     }
 
+    auto root = std::filesystem::path { storeDir }.root_path();
     /* Hash the file.  Note that hashPath() returns the hash over the
        NAR serialisation, which includes the execute bit on the file.
        Thus, executable and non-executable files with the same
@@ -150,7 +151,7 @@ void LocalStore::optimisePath_(Activity * act, OptimiseStats & stats,
        the contents of the target (which may not even exist). */
     Hash hash = ({
         hashPath(
-            {make_ref<PosixSourceAccessor>(), CanonPath(path)},
+            {make_ref<PosixSourceAccessor>(std::move(root)), CanonPath(path)},
             FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256).first;
     });
     debug("'%1%' has hash '%2%'", path, hash.to_string(HashFormat::Nix32, true));

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -120,6 +120,12 @@ std::string StoreDirConfig::printStorePath(const StorePath & path) const
     return (storeDir + "/").append(path.to_string());
 }
 
+CanonPath StoreDirConfig::canonStorePath(const StorePath & path) const
+{
+    auto relativeStoreDir = std::filesystem::path(storeDir).relative_path();
+    return CanonPath(relativeStoreDir.string()) / path.to_string();
+}
+
 PathSet StoreDirConfig::printStorePathSet(const StorePathSet & paths) const
 {
     PathSet res;

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -1232,7 +1232,7 @@ static Derivation readDerivationCommon(Store & store, const StorePath & drvPath,
     auto accessor = store.getFSAccessor(requireValidPath);
     try {
         return parseDerivation(store,
-            accessor->readFile(CanonPath(store.printStorePath(drvPath))),
+            accessor->readFile(store.canonStorePath(drvPath)),
             Derivation::nameFromPath(drvPath));
     } catch (FormatError & e) {
         throw Error("error parsing derivation '%s': %s", store.printStorePath(drvPath), e.msg());

--- a/src/libstore/store-dir-config.hh
+++ b/src/libstore/store-dir-config.hh
@@ -44,6 +44,17 @@ struct StoreDirConfig : public Config
     std::string printStorePath(const StorePath & path) const;
 
     /**
+     * Temporary.
+     *
+     * At the moment FS accessors usually have a root of / or C: or similar.
+     * Eventually FS accessors will have roots of /nix/store or C:\nix\store
+     * but for now, we have this helper function which will remove the root.
+     *
+     * \todo remove
+     */
+    CanonPath canonStorePath(const StorePath & path) const;
+
+    /**
      * Deprecated
      *
      * \todo remove

--- a/src/libutil/posix-source-accessor.hh
+++ b/src/libutil/posix-source-accessor.hh
@@ -18,7 +18,6 @@ struct PosixSourceAccessor : virtual SourceAccessor
      */
     const std::filesystem::path root;
 
-    PosixSourceAccessor();
     PosixSourceAccessor(std::filesystem::path && root);
 
     /**
@@ -41,6 +40,8 @@ struct PosixSourceAccessor : virtual SourceAccessor
     std::string readLink(const CanonPath & path) override;
 
     std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override;
+
+    virtual std::string showPath(const CanonPath & path) override;
 
     /**
      * Create a `PosixSourceAccessor` and `SourcePath` corresponding to

--- a/src/nix-store/nix-store.cc
+++ b/src/nix-store/nix-store.cc
@@ -562,7 +562,7 @@ static void registerValidity(bool reregister, bool hashGiven, bool canonicalise)
 #endif
             if (!hashGiven) {
                 HashResult hash = hashPath(
-                    {store->getFSAccessor(false), CanonPath { store->printStorePath(info->path) }},
+                    {store->getFSAccessor(false), store->canonStorePath(info->path) },
                     FileSerialisationMethod::NixArchive, HashAlgorithm::SHA256);
                 info->narHash = hash.first;
                 info->narSize = hash.second;


### PR DESCRIPTION
With the introduction of CanonPath, we don't have roots on paths we want to access. For example, /nix/store/abc doesn't say whether we need to use C: or D: on Windows.

This commit keeps getFSSourceAccessor() which does NOT have a root specified, so it pulls one from the current working directory. This is silly, since nix.exe could be on Z: but the Nix store could be on C: which means we'll build wrong paths. More commits will have to come which removes getFSSourceAccessor() altogether.

This shouldn't change anything on Unix systems, since the root should always resolve to / for every possible path.

---

This change makes a lot of path related things work on Windows. For example, things which previously would fail with something like "/nix/store/abc is not in the Nix store" now actually does the right thing, by resolving properly to "C:\nix\store\abc".

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
