### PR TITLE
Don't override default man search paths

### DIFF
--- a/src/nix/man-pages.cc
+++ b/src/nix/man-pages.cc
@@ -13,7 +13,7 @@ std::filesystem::path getNixManDir()
 void showManPage(const std::string & name)
 {
     restoreProcessContext();
-    setEnv("MANPATH", getNixManDir().c_str());
+    setEnv("MANPATH", (getNixManDir().string() + ":").c_str());
     execlp("man", "man", name.c_str(), nullptr);
     if (errno == ENOENT) {
         // Not SysError because we don't want to suffix the errno, aka No such file or directory.


### PR DESCRIPTION
By appending a colon to MANPATH NIX_MAN_DIR gets prepended to the
final MANPATH before default search paths.
This makes man still consider default search paths, but prefers
NIX_MAN_DIR (if it exists).

It still makes sense to point NIX_MAN_DIR to a correct location
by moving man pages build from nix-manual.man to nix-cli.man, but
this should fix most common use-cases where nix is installed globally.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/pull/12488#issuecomment-2665114252

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
