### PR TITLE
Restore detailed Nix CLI version

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -42,6 +42,18 @@ let
   mkPackageBuilder =
     exts: userFn: stdenv.mkDerivation (lib.extends (lib.composeManyExtensions exts) userFn);
 
+  setVersionLayer = finalAttrs: prevAttrs: {
+    preConfigure =
+      prevAttrs.prevAttrs or ""
+      +
+        # Update the repo-global .version file.
+        # Symlink ./.version points there, but by default only workDir is writable.
+        ''
+          chmod u+w ./.version
+          echo ${finalAttrs.version} > ./.version
+        '';
+  };
+
   localSourceLayer =
     finalAttrs: prevAttrs:
     let
@@ -180,12 +192,14 @@ scope:
   mkMesonDerivation = mkPackageBuilder [
     miscGoodPractice
     localSourceLayer
+    setVersionLayer
     mesonLayer
   ];
   mkMesonExecutable = mkPackageBuilder [
     miscGoodPractice
     bsdNoLinkAsNeeded
     localSourceLayer
+    setVersionLayer
     mesonLayer
     mesonBuildLayer
   ];
@@ -194,6 +208,7 @@ scope:
     bsdNoLinkAsNeeded
     localSourceLayer
     mesonLayer
+    setVersionLayer
     mesonBuildLayer
     mesonLibraryLayer
   ];

--- a/src/libcmd/package.nix
+++ b/src/libcmd/package.nix
@@ -64,14 +64,6 @@ mkMesonLibrary (finalAttrs: {
     nlohmann_json
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
     (lib.mesonEnable "markdown" enableMarkdown)
     (lib.mesonOption "readline-flavor" readlineFlavor)

--- a/src/libexpr-c/package.nix
+++ b/src/libexpr-c/package.nix
@@ -36,14 +36,6 @@ mkMesonLibrary (finalAttrs: {
     nix-expr
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libexpr-test-support/package.nix
+++ b/src/libexpr-test-support/package.nix
@@ -40,14 +40,6 @@ mkMesonLibrary (finalAttrs: {
     rapidcheck
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libexpr-tests/package.nix
+++ b/src/libexpr-tests/package.nix
@@ -46,14 +46,6 @@ mkMesonExecutable (finalAttrs: {
     gtest
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libexpr/package.nix
+++ b/src/libexpr/package.nix
@@ -77,14 +77,6 @@ mkMesonLibrary (finalAttrs: {
     nlohmann_json
   ] ++ lib.optional enableGC boehmgc;
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
     (lib.mesonEnable "gc" enableGC)
   ];

--- a/src/libfetchers-tests/package.nix
+++ b/src/libfetchers-tests/package.nix
@@ -44,14 +44,6 @@ mkMesonExecutable (finalAttrs: {
     gtest
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libfetchers/package.nix
+++ b/src/libfetchers/package.nix
@@ -41,14 +41,6 @@ mkMesonLibrary (finalAttrs: {
     nlohmann_json
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;
   };

--- a/src/libflake-c/package.nix
+++ b/src/libflake-c/package.nix
@@ -38,14 +38,6 @@ mkMesonLibrary (finalAttrs: {
     nix-flake
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libflake-tests/package.nix
+++ b/src/libflake-tests/package.nix
@@ -46,14 +46,6 @@ mkMesonExecutable (finalAttrs: {
     gtest
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libflake/package.nix
+++ b/src/libflake/package.nix
@@ -40,14 +40,6 @@ mkMesonLibrary (finalAttrs: {
     nlohmann_json
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;
   };

--- a/src/libmain-c/package.nix
+++ b/src/libmain-c/package.nix
@@ -40,14 +40,6 @@ mkMesonLibrary (finalAttrs: {
     nix-main
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libmain/package.nix
+++ b/src/libmain/package.nix
@@ -37,14 +37,6 @@ mkMesonLibrary (finalAttrs: {
     openssl
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;
   };

--- a/src/libstore-c/package.nix
+++ b/src/libstore-c/package.nix
@@ -36,14 +36,6 @@ mkMesonLibrary (finalAttrs: {
     nix-store
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libstore-test-support/package.nix
+++ b/src/libstore-test-support/package.nix
@@ -40,14 +40,6 @@ mkMesonLibrary (finalAttrs: {
     rapidcheck
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -52,14 +52,6 @@ mkMesonExecutable (finalAttrs: {
     nix-store-test-support
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -242,7 +242,7 @@ Path Settings::getDefaultSSLCertFile()
     return "";
 }
 
-const std::string nixVersion = PACKAGE_VERSION;
+std::string nixVersion = PACKAGE_VERSION;
 
 NLOHMANN_JSON_SERIALIZE_ENUM(SandboxMode, {
     {SandboxMode::smEnabled, true},

--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -1248,7 +1248,15 @@ void loadConfFile(AbstractConfig & config);
 // Used by the Settings constructor
 std::vector<Path> getUserConfigFiles();
 
-extern const std::string nixVersion;
+/**
+ * The version of Nix itself.
+ *
+ * This is not `const`, so that the Nix CLI can provide a more detailed version
+ * number including the git revision, without having to "re-compile" the entire
+ * set of Nix libraries to include that version, even when those libraries are
+ * not affected by the change.
+ */
+extern std::string nixVersion;
 
 /**
  * @param loadConfig Whether to load configuration from `nix.conf`, `NIX_CONFIG`, etc. May be disabled for unit tests.

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -69,14 +69,6 @@ mkMesonLibrary (finalAttrs: {
     nlohmann_json
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags =
     [
       (lib.mesonEnable "seccomp-sandboxing" stdenv.hostPlatform.isLinux)

--- a/src/libutil-c/package.nix
+++ b/src/libutil-c/package.nix
@@ -34,14 +34,6 @@ mkMesonLibrary (finalAttrs: {
     nix-util
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libutil-test-support/package.nix
+++ b/src/libutil-test-support/package.nix
@@ -38,14 +38,6 @@ mkMesonLibrary (finalAttrs: {
     rapidcheck
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -45,14 +45,6 @@ mkMesonExecutable (finalAttrs: {
     gtest
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/src/libutil/package.nix
+++ b/src/libutil/package.nix
@@ -54,17 +54,6 @@ mkMesonLibrary (finalAttrs: {
     nlohmann_json
   ];
 
-  preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
-    #
-    # TODO: change release process to add `pre` in `.version`, remove it
-    # before tagging, and restore after.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ../../.version
-    '';
-
   mesonFlags = [
     (lib.mesonEnable "cpuid" stdenv.hostPlatform.isx86_64)
   ];

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -557,6 +557,8 @@ void mainWrapped(int argc, char * * argv)
 
 int main(int argc, char * * argv)
 {
+    // The CLI has a more detailed version than the libraries; see nixVersion.
+    nix::nixVersion = NIX_CLI_VERSION;
 #ifndef _WIN32
     // Increase the default stack size for the evaluator and for
     // libstdc++'s std::regex.

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -35,6 +35,9 @@ subdir('nix-meson-build-support/windows-version')
 
 configdata = configuration_data()
 
+# The CLI has a more detailed version string than the libraries; see `nixVersion`
+configdata.set_quoted('NIX_CLI_VERSION', meson.project_version())
+
 fs = import('fs')
 
 bindir = get_option('bindir')

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -92,11 +92,11 @@ mkMesonExecutable (finalAttrs: {
   ];
 
   preConfigure =
-    # "Inline" .version so it's not a symlink, and includes the suffix.
-    # Do the meson utils, without modification.
+    # Update the repo-global .version file.
+    # Symlink ./.version points there, but by default only workDir is writable.
     ''
       chmod u+w ./.version
-      echo ${version} > ../../../.version
+      echo ${version} > ./.version
     '';
 
   mesonFlags = [

--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -91,14 +91,6 @@ mkMesonExecutable (finalAttrs: {
     nix-cmd
   ];
 
-  preConfigure =
-    # Update the repo-global .version file.
-    # Symlink ./.version points there, but by default only workDir is writable.
-    ''
-      chmod u+w ./.version
-      echo ${version} > ./.version
-    '';
-
   mesonFlags = [
   ];
 

--- a/tests/functional/misc.sh
+++ b/tests/functional/misc.sh
@@ -11,7 +11,7 @@ source common.sh
 #nix-hash --help | grepQuiet base32
 
 # Can we ask for the version number?
-nix-env --version | grep "$version"
+nix-env --version | grep -F "${_NIX_TEST_CLIENT_VERSION:-$version}"
 
 nix_env=$(type -P nix-env)
 (PATH=""; ! $nix_env --help 2>&1 ) | grepQuiet -F "The 'man' command was not found, but it is needed for 'nix-env' and some other 'nix-*' commands' help text. Perhaps you could install the 'man' command?"

--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -75,16 +75,10 @@ mkMesonDerivation (
     ];
 
     preConfigure =
-      # "Inline" .version so it's not a symlink, and includes the suffix.
-      # Do the meson utils, without modification.
-      ''
-        chmod u+w ./.version
-        echo ${version} > ../../../.version
-      ''
       # TEMP hack for Meson before make is gone, where
       # `src/nix-functional-tests` is during the transition a symlink and
       # not the actual directory directory.
-      + ''
+      ''
         cd $(readlink -e $PWD)
         echo $PWD | grep tests/functional
       '';

--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -99,6 +99,8 @@ mkMesonDerivation (
 
   }
   // lib.optionalAttrs (test-daemon != null) {
+    # TODO rename to _NIX_TEST_DAEMON_PACKAGE
     NIX_DAEMON_PACKAGE = test-daemon;
+    _NIX_TEST_CLIENT_VERSION = nix-cli.version;
   }
 )


### PR DESCRIPTION
... as intended.

Requirements:
- don't build fresh libraries for each git commit
- have git commit in the CLI

Bug:
- `echo ${version}` went into the wrong file
   => use the fact that it's a symlink, not just for reading but also for writing.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Review commit by commit

- Refines the implementation of #2503 

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
