### PR TITLE
Overriding the componentized build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -238,15 +238,18 @@
               nix = self.packages.${system}.nix;
             in
             assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
-            # If this fails, something might be wrong with how we've wired the scope,
-            # or something could be broken in Nixpkgs.
-            pkgs.testers.testEqualContents {
-              assertion = "trivial patch does not change source contents";
-              expected = "${./.}";
-              actual =
-                # Same for all components; nix-util is an arbitrary pick
-                (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
-            };
+            if pkgs.stdenv.buildPlatform.isDarwin then
+              lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
+            else
+              # If this fails, something might be wrong with how we've wired the scope,
+              # or something could be broken in Nixpkgs.
+              pkgs.testers.testEqualContents {
+                assertion = "trivial patch does not change source contents";
+                expected = "${./.}";
+                actual =
+                  # Same for all components; nix-util is an arbitrary pick
+                  (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
+              };
         }
         // (lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
           dockerImage = self.hydraJobs.dockerImage.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -226,6 +226,27 @@
               LANG=C.UTF-8 ${pkgs.changelog-d}/bin/changelog-d ${./doc/manual/rl-next} >$out
             '';
           repl-completion = nixpkgsFor.${system}.native.callPackage ./tests/repl-completion.nix { };
+
+          /**
+            Checks for our packaging expressions.
+            This shouldn't build anything significant; just check that things
+            (including derivations) are _set up_ correctly.
+          */
+          packaging-overriding =
+            let
+              pkgs = nixpkgsFor.${system}.native;
+              nix = self.packages.${system}.nix;
+            in
+            assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
+            # If this fails, something might be wrong with how we've wired the scope,
+            # or something could be broken in Nixpkgs.
+            pkgs.testers.testEqualContents {
+              assertion = "trivial patch does not change source contents";
+              expected = "${./.}";
+              actual =
+                # Same for all components; nix-util is an arbitrary pick
+                (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
+            };
         }
         // (lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
           dockerImage = self.hydraJobs.dockerImage.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,8 @@
                 f = import ./packaging/components.nix {
                   inherit (final) lib;
                   inherit officialRelease;
+                  inherit stdenv;
+                  pkgs = final;
                   src = self;
                 };
               };

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -1,13 +1,22 @@
 {
   lib,
+  pkgs,
   src,
+  stdenv,
   officialRelease,
 }:
 
 scope:
 
 let
-  inherit (scope) callPackage;
+  inherit (scope)
+    callPackage
+    ;
+  inherit (pkgs.buildPackages)
+    meson
+    ninja
+    pkg-config
+    ;
 
   baseVersion = lib.fileContents ../.version;
 
@@ -20,12 +29,161 @@ let
       }_${src.shortRev or "dirty"}";
 
   fineVersion = baseVersion + fineVersionSuffix;
+
+  root = ../.;
+
+  # Nixpkgs implements this by returning a subpath into the fetched Nix sources.
+  resolvePath = p: p;
+
+  # Indirection for Nixpkgs to override when package.nix files are vendored
+  filesetToSource = lib.fileset.toSource;
+
+  /**
+    Given a set of layers, create a mkDerivation-like function
+  */
+  mkPackageBuilder =
+    exts: userFn: stdenv.mkDerivation (lib.extends (lib.composeManyExtensions exts) userFn);
+
+  setVersionLayer = finalAttrs: prevAttrs: {
+    preConfigure =
+      prevAttrs.prevAttrs or ""
+      +
+        # Update the repo-global .version file.
+        # Symlink ./.version points there, but by default only workDir is writable.
+        ''
+          chmod u+w ./.version
+          echo ${finalAttrs.version} > ./.version
+        '';
+  };
+
+  localSourceLayer =
+    finalAttrs: prevAttrs:
+    let
+      workDirPath =
+        # Ideally we'd pick finalAttrs.workDir, but for now `mkDerivation` has
+        # the requirement that everything except passthru and meta must be
+        # serialized by mkDerivation, which doesn't work for this.
+        prevAttrs.workDir;
+
+      workDirSubpath = lib.path.removePrefix root workDirPath;
+      sources =
+        assert prevAttrs.fileset._type == "fileset";
+        prevAttrs.fileset;
+      src = lib.fileset.toSource {
+        fileset = sources;
+        inherit root;
+      };
+
+    in
+    {
+      sourceRoot = "${src.name}/" + workDirSubpath;
+      inherit src;
+
+      # Clear what `derivation` can't/shouldn't serialize; see prevAttrs.workDir.
+      fileset = null;
+      workDir = null;
+    };
+
+  mesonLayer = finalAttrs: prevAttrs: {
+    # NOTE:
+    # As of https://github.com/NixOS/nixpkgs/blob/8baf8241cea0c7b30e0b8ae73474cb3de83c1a30/pkgs/by-name/me/meson/setup-hook.sh#L26,
+    # `mesonBuildType` defaults to `plain` if not specified. We want our Nix-built binaries to be optimized by default.
+    # More on build types here: https://mesonbuild.com/Builtin-options.html#details-for-buildtype.
+    mesonBuildType = "release";
+    # NOTE:
+    # Users who are debugging Nix builds are expected to set the environment variable `mesonBuildType`, per the
+    # guidance in https://github.com/NixOS/nix/blob/8a3fc27f1b63a08ac983ee46435a56cf49ebaf4a/doc/manual/source/development/debugging.md?plain=1#L10.
+    # For this reason, we don't want to refer to `finalAttrs.mesonBuildType` here, but rather use the environment variable.
+    preConfigure =
+      prevAttrs.preConfigure or ""
+      +
+        lib.optionalString
+          (
+            !stdenv.hostPlatform.isWindows
+            # build failure
+            && !stdenv.hostPlatform.isStatic
+            # LTO breaks exception handling on x86-64-darwin.
+            && stdenv.system != "x86_64-darwin"
+          )
+          ''
+            case "$mesonBuildType" in
+            release|minsize) appendToVar mesonFlags "-Db_lto=true"  ;;
+            *)               appendToVar mesonFlags "-Db_lto=false" ;;
+            esac
+          '';
+    nativeBuildInputs = [
+      meson
+      ninja
+    ] ++ prevAttrs.nativeBuildInputs or [ ];
+    mesonCheckFlags = prevAttrs.mesonCheckFlags or [ ] ++ [
+      "--print-errorlogs"
+    ];
+  };
+
+  mesonBuildLayer = finalAttrs: prevAttrs: {
+    nativeBuildInputs = prevAttrs.nativeBuildInputs or [ ] ++ [
+      pkg-config
+    ];
+    separateDebugInfo = !stdenv.hostPlatform.isStatic;
+    hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
+    env =
+      prevAttrs.env or { }
+      // lib.optionalAttrs (
+        stdenv.isLinux
+        && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")
+        && !(stdenv.hostPlatform.useLLVM or false)
+      ) { LDFLAGS = "-fuse-ld=gold"; };
+  };
+
+  mesonLibraryLayer = finalAttrs: prevAttrs: {
+    outputs = prevAttrs.outputs or [ "out" ] ++ [ "dev" ];
+  };
+
+  # Work around weird `--as-needed` linker behavior with BSD, see
+  # https://github.com/mesonbuild/meson/issues/3593
+  bsdNoLinkAsNeeded =
+    finalAttrs: prevAttrs:
+    lib.optionalAttrs stdenv.hostPlatform.isBSD {
+      mesonFlags = [ (lib.mesonBool "b_asneeded" false) ] ++ prevAttrs.mesonFlags or [ ];
+    };
+
+  miscGoodPractice = finalAttrs: prevAttrs: {
+    strictDeps = prevAttrs.strictDeps or true;
+    enableParallelBuilding = true;
+  };
+
 in
 
 # This becomes the pkgs.nixComponents attribute set
 {
   version = baseVersion + versionSuffix;
   inherit versionSuffix;
+
+  inherit resolvePath filesetToSource;
+
+  mkMesonDerivation = mkPackageBuilder [
+    miscGoodPractice
+    localSourceLayer
+    setVersionLayer
+    mesonLayer
+  ];
+  mkMesonExecutable = mkPackageBuilder [
+    miscGoodPractice
+    bsdNoLinkAsNeeded
+    localSourceLayer
+    setVersionLayer
+    mesonLayer
+    mesonBuildLayer
+  ];
+  mkMesonLibrary = mkPackageBuilder [
+    miscGoodPractice
+    bsdNoLinkAsNeeded
+    localSourceLayer
+    mesonLayer
+    setVersionLayer
+    mesonBuildLayer
+    mesonLibraryLayer
+  ];
 
   nix-util = callPackage ../src/libutil/package.nix { };
   nix-util-c = callPackage ../src/libutil-c/package.nix { };

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -100,6 +100,11 @@ let
     {
       sourceRoot = "${finalScope.patchedSrc.name}/" + workDirSubpath;
       src = finalScope.patchedSrc;
+      version =
+        let
+          n = lib.count (p: p != null) finalScope.patches;
+        in
+        if n == 0 then finalAttrs.version else finalAttrs.version + "+${toString n}";
 
       # Clear what `derivation` can't/shouldn't serialize; see prevAttrs.workDir.
       fileset = null;

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -93,8 +93,6 @@ let
         prevAttrs.workDir;
 
       workDirSubpath = resolveRelPath workDirPath;
-      # sources = assert prevAttrs.fileset._type == "fileset"; prevAttrs.fileset;
-      # src = lib.fileset.toSource { fileset = sources; inherit root; };
 
     in
     {

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -102,7 +102,7 @@ let
       src = finalScope.patchedSrc;
       version =
         let
-          n = lib.count (p: p != null) finalScope.patches;
+          n = lib.length finalScope.patches;
         in
         if n == 0 then finalAttrs.version else finalAttrs.version + "+${toString n}";
 

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -17,8 +17,6 @@ in
 let
   inherit (pkgs) lib;
 
-  root = ../.;
-
   stdenv = if prevStdenv.isDarwin && prevStdenv.isx86_64 then darwinStdenv else prevStdenv;
 
   # Fix the following error with the default x86_64-darwin SDK:
@@ -30,125 +28,6 @@ let
   # all the way back to 10.6.
   darwinStdenv = pkgs.overrideSDK prevStdenv { darwinMinVersion = "10.13"; };
 
-  # Nixpkgs implements this by returning a subpath into the fetched Nix sources.
-  resolvePath = p: p;
-
-  # Indirection for Nixpkgs to override when package.nix files are vendored
-  filesetToSource = lib.fileset.toSource;
-
-  /**
-    Given a set of layers, create a mkDerivation-like function
-  */
-  mkPackageBuilder =
-    exts: userFn: stdenv.mkDerivation (lib.extends (lib.composeManyExtensions exts) userFn);
-
-  setVersionLayer = finalAttrs: prevAttrs: {
-    preConfigure =
-      prevAttrs.prevAttrs or ""
-      +
-        # Update the repo-global .version file.
-        # Symlink ./.version points there, but by default only workDir is writable.
-        ''
-          chmod u+w ./.version
-          echo ${finalAttrs.version} > ./.version
-        '';
-  };
-
-  localSourceLayer =
-    finalAttrs: prevAttrs:
-    let
-      workDirPath =
-        # Ideally we'd pick finalAttrs.workDir, but for now `mkDerivation` has
-        # the requirement that everything except passthru and meta must be
-        # serialized by mkDerivation, which doesn't work for this.
-        prevAttrs.workDir;
-
-      workDirSubpath = lib.path.removePrefix root workDirPath;
-      sources =
-        assert prevAttrs.fileset._type == "fileset";
-        prevAttrs.fileset;
-      src = lib.fileset.toSource {
-        fileset = sources;
-        inherit root;
-      };
-
-    in
-    {
-      sourceRoot = "${src.name}/" + workDirSubpath;
-      inherit src;
-
-      # Clear what `derivation` can't/shouldn't serialize; see prevAttrs.workDir.
-      fileset = null;
-      workDir = null;
-    };
-
-  mesonLayer = finalAttrs: prevAttrs: {
-    # NOTE:
-    # As of https://github.com/NixOS/nixpkgs/blob/8baf8241cea0c7b30e0b8ae73474cb3de83c1a30/pkgs/by-name/me/meson/setup-hook.sh#L26,
-    # `mesonBuildType` defaults to `plain` if not specified. We want our Nix-built binaries to be optimized by default.
-    # More on build types here: https://mesonbuild.com/Builtin-options.html#details-for-buildtype.
-    mesonBuildType = "release";
-    # NOTE:
-    # Users who are debugging Nix builds are expected to set the environment variable `mesonBuildType`, per the
-    # guidance in https://github.com/NixOS/nix/blob/8a3fc27f1b63a08ac983ee46435a56cf49ebaf4a/doc/manual/source/development/debugging.md?plain=1#L10.
-    # For this reason, we don't want to refer to `finalAttrs.mesonBuildType` here, but rather use the environment variable.
-    preConfigure =
-      prevAttrs.preConfigure or ""
-      +
-        lib.optionalString
-          (
-            !stdenv.hostPlatform.isWindows
-            # build failure
-            && !stdenv.hostPlatform.isStatic
-            # LTO breaks exception handling on x86-64-darwin.
-            && stdenv.system != "x86_64-darwin"
-          )
-          ''
-            case "$mesonBuildType" in
-            release|minsize) appendToVar mesonFlags "-Db_lto=true"  ;;
-            *)               appendToVar mesonFlags "-Db_lto=false" ;;
-            esac
-          '';
-    nativeBuildInputs = [
-      pkgs.buildPackages.meson
-      pkgs.buildPackages.ninja
-    ] ++ prevAttrs.nativeBuildInputs or [ ];
-    mesonCheckFlags = prevAttrs.mesonCheckFlags or [ ] ++ [
-      "--print-errorlogs"
-    ];
-  };
-
-  mesonBuildLayer = finalAttrs: prevAttrs: {
-    nativeBuildInputs = prevAttrs.nativeBuildInputs or [ ] ++ [
-      pkgs.buildPackages.pkg-config
-    ];
-    separateDebugInfo = !stdenv.hostPlatform.isStatic;
-    hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
-    env =
-      prevAttrs.env or { }
-      // lib.optionalAttrs (
-        stdenv.isLinux
-        && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")
-        && !(stdenv.hostPlatform.useLLVM or false)
-      ) { LDFLAGS = "-fuse-ld=gold"; };
-  };
-
-  mesonLibraryLayer = finalAttrs: prevAttrs: {
-    outputs = prevAttrs.outputs or [ "out" ] ++ [ "dev" ];
-  };
-
-  # Work around weird `--as-needed` linker behavior with BSD, see
-  # https://github.com/mesonbuild/meson/issues/3593
-  bsdNoLinkAsNeeded =
-    finalAttrs: prevAttrs:
-    lib.optionalAttrs stdenv.hostPlatform.isBSD {
-      mesonFlags = [ (lib.mesonBool "b_asneeded" false) ] ++ prevAttrs.mesonFlags or [ ];
-    };
-
-  miscGoodPractice = finalAttrs: prevAttrs: {
-    strictDeps = prevAttrs.strictDeps or true;
-    enableParallelBuilding = true;
-  };
 in
 scope:
 {
@@ -187,31 +66,6 @@ scope:
         installPhase = lib.replaceStrings [ "--without-python" ] [ "" ] old.installPhase;
       });
 
-  inherit resolvePath filesetToSource;
-
-  mkMesonDerivation = mkPackageBuilder [
-    miscGoodPractice
-    localSourceLayer
-    setVersionLayer
-    mesonLayer
-  ];
-  mkMesonExecutable = mkPackageBuilder [
-    miscGoodPractice
-    bsdNoLinkAsNeeded
-    localSourceLayer
-    setVersionLayer
-    mesonLayer
-    mesonBuildLayer
-  ];
-  mkMesonLibrary = mkPackageBuilder [
-    miscGoodPractice
-    bsdNoLinkAsNeeded
-    localSourceLayer
-    mesonLayer
-    setVersionLayer
-    mesonBuildLayer
-    mesonLibraryLayer
-  ];
 }
 # libgit2: Nixpkgs 24.11 has < 1.9.0
 // lib.optionalAttrs (!lib.versionAtLeast pkgs.libgit2.version "1.9.0") {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->


## Motivation

- _Keep Nix and Nixpkgs packaging harmonized_
- Multiple user requests for adding patches
  - https://github.com/NixOS/nixpkgs/pull/375856#issuecomment-2664122375
  - [Matrix: Nix Package Manager Development](https://matrix.to/#/#nix-dev:nixos.org)
  - https://discourse.nixos.org/t/overriding-the-nix-2-26-componentized-build/60428
- Make it easier for Nixpkgs to use a fetched source when vendoring or maintaining a copy of these packaging expressions

## Changes

This adds

- `overrideSource`, switching to Nixpkgs-style packaging with a fetched source
- `appendPatches`, which applies patches to all components
- `overrideAllMesonComponents` to do arbitrary stuff to the meson-based builds (can be used to target individual derivations as well, with a conditional on `prevAttrs.name`)

## Context

- Probably depended on #12498

- Closes https://github.com/NixOS/nix/issues/12472

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
