### PR TITLE
libfetchers-tests: Add back git-utils.cc

### DIFF
--- a/src/libfetchers-tests/git-utils.cc
+++ b/src/libfetchers-tests/git-utils.cc
@@ -11,10 +11,14 @@
 
 namespace nix {
 
+namespace fs {
+using namespace std::filesystem;
+}
+
 class GitUtilsTest : public ::testing::Test
 {
     // We use a single repository for all tests.
-    Path tmpDir;
+    fs::path tmpDir;
     std::unique_ptr<AutoDelete> delTmpDir;
 
 public:
@@ -41,6 +45,11 @@ public:
     ref<GitRepo> openRepo()
     {
         return GitRepo::openRepo(tmpDir, true, false);
+    }
+
+    std::string getRepoName() const
+    {
+        return tmpDir.filename();
     }
 };
 
@@ -79,7 +88,7 @@ TEST_F(GitUtilsTest, sink_basic)
     // sink->createHardlink("foo-1.1/links/foo-2", CanonPath("foo-1.1/hello"));
 
     auto result = repo->dereferenceSingletonDirectory(sink->flush());
-    auto accessor = repo->getAccessor(result, false);
+    auto accessor = repo->getAccessor(result, false, getRepoName());
     auto entries = accessor->readDirectory(CanonPath::root);
     ASSERT_EQ(entries.size(), 5);
     ASSERT_EQ(accessor->readFile(CanonPath("hello")), "hello world");
@@ -109,132 +118,5 @@ TEST_F(GitUtilsTest, sink_hardlink)
         ASSERT_THAT(e.msg(), testing::HasSubstr("foo-1.1/link"));
     }
 };
-
-namespace lfs {
-
-TEST_F(GitUtilsTest, parseGitRemoteUrl)
-{
-    {
-        GitUrl result = parseGitUrl("git@example.com:path/repo.git");
-        EXPECT_EQ(result.protocol, "ssh");
-        EXPECT_EQ(result.user, "git");
-        EXPECT_EQ(result.host, "example.com");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "path/repo.git");
-    }
-
-    {
-        GitUrl result = parseGitUrl("example.com:/path/repo.git");
-        EXPECT_EQ(result.protocol, "ssh");
-        EXPECT_EQ(result.user, "");
-        EXPECT_EQ(result.host, "example.com");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "/path/repo.git");
-    }
-
-    {
-        GitUrl result = parseGitUrl("example.com:path/repo.git");
-        EXPECT_EQ(result.protocol, "ssh");
-        EXPECT_EQ(result.user, "");
-        EXPECT_EQ(result.host, "example.com");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "path/repo.git");
-    }
-
-    {
-        GitUrl result = parseGitUrl("https://example.com/path/repo.git");
-        EXPECT_EQ(result.protocol, "https");
-        EXPECT_EQ(result.user, "");
-        EXPECT_EQ(result.host, "example.com");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "path/repo.git");
-    }
-
-    {
-        GitUrl result = parseGitUrl("ssh://git@example.com/path/repo.git");
-        EXPECT_EQ(result.protocol, "ssh");
-        EXPECT_EQ(result.user, "git");
-        EXPECT_EQ(result.host, "example.com");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "path/repo.git");
-    }
-
-    {
-        GitUrl result = parseGitUrl("ssh://example/path/repo.git");
-        EXPECT_EQ(result.protocol, "ssh");
-        EXPECT_EQ(result.user, "");
-        EXPECT_EQ(result.host, "example");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "path/repo.git");
-    }
-
-    {
-        GitUrl result = parseGitUrl("http://example.com:8080/path/repo.git");
-        EXPECT_EQ(result.protocol, "http");
-        EXPECT_EQ(result.user, "");
-        EXPECT_EQ(result.host, "example.com");
-        EXPECT_EQ(result.port, "8080");
-        EXPECT_EQ(result.path, "path/repo.git");
-    }
-
-    {
-        GitUrl result = parseGitUrl("invalid-url");
-        EXPECT_EQ(result.protocol, "");
-        EXPECT_EQ(result.user, "");
-        EXPECT_EQ(result.host, "");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "");
-    }
-
-    {
-        GitUrl result = parseGitUrl("");
-        EXPECT_EQ(result.protocol, "");
-        EXPECT_EQ(result.user, "");
-        EXPECT_EQ(result.host, "");
-        EXPECT_EQ(result.port, "");
-        EXPECT_EQ(result.path, "");
-    }
-}
-TEST_F(GitUtilsTest, gitUrlToHttp)
-{
-    {
-        const GitUrl url = parseGitUrl("git@github.com:user/repo.git");
-        EXPECT_EQ(url.toHttp(), "https://github.com/user/repo.git");
-    }
-    {
-        const GitUrl url = parseGitUrl("https://github.com/user/repo.git");
-        EXPECT_EQ(url.toHttp(), "https://github.com/user/repo.git");
-    }
-    {
-        const GitUrl url = parseGitUrl("http://github.com/user/repo.git");
-        EXPECT_EQ(url.toHttp(), "http://github.com/user/repo.git");
-    }
-    {
-        const GitUrl url = parseGitUrl("ssh://git@github.com:22/user/repo.git");
-        EXPECT_EQ(url.toHttp(), "https://github.com:22/user/repo.git");
-    }
-    {
-        const GitUrl url = parseGitUrl("invalid-url");
-        EXPECT_EQ(url.toHttp(), "");
-    }
-}
-
-TEST_F(GitUtilsTest, gitUrlToSsh)
-{
-    {
-        const GitUrl url = parseGitUrl("https://example.com/user/repo.git");
-        const auto [host, path] = url.toSsh();
-        EXPECT_EQ(host, "example.com");
-        EXPECT_EQ(path, "user/repo.git");
-    }
-    {
-        const GitUrl url = parseGitUrl("git@example.com:user/repo.git");
-        const auto [host, path] = url.toSsh();
-        EXPECT_EQ(host, "git@example.com");
-        EXPECT_EQ(path, "user/repo.git");
-    }
-}
-
-} // namespace lfs
 
 } // namespace nix

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -31,6 +31,9 @@ deps_private += rapidcheck
 gtest = dependency('gtest', main : true)
 deps_private += gtest
 
+libgit2 = dependency('libgit2')
+deps_private += libgit2
+
 add_project_arguments(
   # TODO(Qyriad): Yes this is how the autoconf+Make system did it.
   # It would be nice for our headers to be idempotent instead.
@@ -44,6 +47,7 @@ subdir('nix-meson-build-support/common')
 
 sources = files(
   'public-key.cc',
+  'git-utils.cc'
 )
 
 include_dirs = [include_directories('.')]

--- a/src/libfetchers-tests/package.nix
+++ b/src/libfetchers-tests/package.nix
@@ -7,6 +7,7 @@
   nix-fetchers,
   nix-store-test-support,
 
+  libgit2,
   rapidcheck,
   gtest,
   runCommand,
@@ -42,6 +43,7 @@ mkMesonExecutable (finalAttrs: {
     nix-store-test-support
     rapidcheck
     gtest
+    libgit2
   ];
 
   mesonFlags = [


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Seems like this got dropped at some point during meson migration, so
put it back in the build system.

Drop all tests for `parseGitUrl`, since that function doesn't exist
and migrating doesn't look sensible because git-lfs stuff seems to use
`ParsedURL`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
