### PR TITLE
Use a union source accessor to put chroot stores in the logical location

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -37,7 +37,7 @@ EvalSettings evalSettings {
                 auto [accessor, lockedRef] = flakeRef.resolve(state.store).lazyFetch(state.store);
                 auto storePath = nix::fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
                 state.allowPath(storePath);
-                return state.rootPath(state.store->toRealPath(storePath));
+                return state.rootPath(state.store->printStorePath(storePath));
             },
         },
     },
@@ -179,7 +179,7 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * bas
             state.fetchSettings,
             EvalSettings::resolvePseudoUrl(s));
         auto storePath = fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy);
-        return state.rootPath(CanonPath(state.store->toRealPath(storePath)));
+        return state.rootPath(CanonPath(state.store->printStorePath(storePath)));
     }
 
     else if (hasPrefix(s, "flake:")) {
@@ -188,7 +188,7 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * bas
         auto [accessor, lockedRef] = flakeRef.resolve(state.store).lazyFetch(state.store);
         auto storePath = nix::fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
         state.allowPath(storePath);
-        return state.rootPath(CanonPath(state.store->toRealPath(storePath)));
+        return state.rootPath(CanonPath(state.store->printStorePath(storePath)));
     }
 
     else if (s.size() > 2 && s.at(0) == '<' && s.at(s.size() - 1) == '>') {

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2051,7 +2051,7 @@ void ExprConcatStrings::eval(EvalState & state, Env & env, Value & v)
     else if (firstType == nPath) {
         if (!context.empty())
             state.error<EvalError>("a string that refers to a store path cannot be appended to a path").atPos(pos).withFrame(env, *this).debugThrow();
-        v.mkPath(state.rootPath(CanonPath(canonPath(str()))));
+        v.mkPath(state.rootPath(CanonPath(str())));
     } else
         v.mkStringMove(c_str(), context);
 }

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -251,6 +251,11 @@ public:
     const ref<SourceAccessor> rootFS;
 
     /**
+     * The accessor for the store.
+     */
+    const ref<SourceAccessor> storeFS;
+
+    /**
      * The in-memory filesystem for <nix/...> paths.
      */
     const ref<MemorySourceAccessor> corepkgsFS;
@@ -390,6 +395,18 @@ public:
     SourcePath rootPath(PathView path);
 
     /**
+     * Convert `s` to a path. If `context` is not empty, the resulting
+     * path will use the `storeFS` accessor; otherwise it will use
+     * `rootFS`. When using a chroot store, this allows us to
+     * distinguish between store paths resulting from
+     * import-from-derivation and sources stored in the actual
+     * /nix/store.
+     */
+    SourcePath stringWithContextToPath(
+        std::string_view s,
+        const NixStringContext & context);
+
+    /**
      * Allow access to a path.
      */
     void allowPath(const Path & path);
@@ -411,17 +428,6 @@ public:
     void allowAndSetStorePathString(const StorePath & storePath, Value & v);
 
     void checkURI(const std::string & uri);
-
-    /**
-     * When using a diverted store and 'path' is in the Nix store, map
-     * 'path' to the diverted location (e.g. /nix/store/foo is mapped
-     * to /home/alice/my-nix/nix/store/foo). However, this is only
-     * done if the context is not empty, since otherwise we're
-     * probably trying to read from the actual /nix/store. This is
-     * intended to distinguish between import-from-derivation and
-     * sources stored in the actual /nix/store.
-     */
-    Path toRealPath(const Path & path, const NixStringContext & context);
 
     /**
      * Parse a Nix expression from the specified file.

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -251,11 +251,6 @@ public:
     const ref<SourceAccessor> rootFS;
 
     /**
-     * The accessor for the store.
-     */
-    const ref<SourceAccessor> storeFS;
-
-    /**
      * The in-memory filesystem for <nix/...> paths.
      */
     const ref<MemorySourceAccessor> corepkgsFS;
@@ -393,18 +388,6 @@ public:
      * Variant which accepts relative paths too.
      */
     SourcePath rootPath(PathView path);
-
-    /**
-     * Convert `s` to a path. If `context` is not empty, the resulting
-     * path will use the `storeFS` accessor; otherwise it will use
-     * `rootFS`. When using a chroot store, this allows us to
-     * distinguish between store paths resulting from
-     * import-from-derivation and sources stored in the actual
-     * /nix/store.
-     */
-    SourcePath stringWithContextToPath(
-        std::string_view s,
-        const NixStringContext & context);
 
     /**
      * Allow access to a path.

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -1,5 +1,4 @@
 #include "eval.hh"
-#include "store-api.hh"
 
 namespace nix {
 

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -13,10 +13,4 @@ SourcePath EvalState::rootPath(PathView path)
     return {rootFS, CanonPath(absPath(path))};
 }
 
-SourcePath EvalState::stringWithContextToPath(std::string_view s, const NixStringContext & context)
-{
-    auto path = CanonPath(s);
-    return !context.empty() ? SourcePath{storeFS, std::move(path)} : rootPath(std::move(path));
-}
-
 }

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -1,4 +1,5 @@
 #include "eval.hh"
+#include "store-api.hh"
 
 namespace nix {
 
@@ -10,6 +11,12 @@ SourcePath EvalState::rootPath(CanonPath path)
 SourcePath EvalState::rootPath(PathView path)
 {
     return {rootFS, CanonPath(absPath(path))};
+}
+
+SourcePath EvalState::stringWithContextToPath(std::string_view s, const NixStringContext & context)
+{
+    auto path = CanonPath(s);
+    return !context.empty() ? SourcePath{storeFS, std::move(path)} : rootPath(std::move(path));
 }
 
 }

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -143,7 +143,7 @@ static SourcePath realisePath(EvalState & state, const PosIdx pos, Value & v, st
     auto path = state.coerceToPath(noPos, v, context, "while realising the context of a path");
 
     try {
-        if (!context.empty() && path.accessor == state.storeFS) {
+        if (!context.empty() && path.accessor == state.rootFS) {
             auto rewrites = state.realiseContext(context);
             path = {path.accessor, CanonPath(rewriteStrings(path.path.abs(), rewrites))};
         }
@@ -2480,7 +2480,7 @@ static void addPath(
     try {
         StorePathSet refs;
 
-        if (path.accessor == state.storeFS && state.store->isInStore(path.path.abs())) {
+        if (path.accessor == state.rootFS && state.store->isInStore(path.path.abs())) {
             // FIXME: handle CA derivation outputs (where path needs to
             // be rewritten to the actual output).
             auto rewrites = state.realiseContext(context);

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2478,8 +2478,6 @@ static void addPath(
     const NixStringContext & context)
 {
     try {
-        StorePathSet refs;
-
         if (path.accessor == state.rootFS && state.store->isInStore(path.path.abs())) {
             // FIXME: handle CA derivation outputs (where path needs to
             // be rewritten to the actual output).

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -921,21 +921,6 @@ LockedFlake lockFlake(
     }
 }
 
-std::pair<StorePath, Path> sourcePathToStorePath(
-    ref<Store> store,
-    const SourcePath & _path)
-{
-    auto path = _path.path.abs();
-
-    if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>()) {
-        auto realStoreDir = store2->getRealStoreDir();
-        if (isInDir(path, realStoreDir))
-            path = store2->storeDir + path.substr(realStoreDir.size());
-    }
-
-    return store->toStorePath(path);
-}
-
 void callFlake(EvalState & state,
     const LockedFlake & lockedFlake,
     Value & vRes)
@@ -953,7 +938,7 @@ void callFlake(EvalState & state,
 
         auto lockedNode = node.dynamic_pointer_cast<const LockedNode>();
 
-        auto [storePath, subdir] = sourcePathToStorePath(state.store, sourcePath);
+        auto [storePath, subdir] = state.store->toStorePath(sourcePath.path.abs());
 
         emitTreeAttrs(
             state,

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -337,7 +337,7 @@ static Flake readFlake(
                 auto storePath = fetchToStore(*state.store, setting.value->path(), FetchMode::Copy);
                 flake.config.settings.emplace(
                     state.symbols[setting.name],
-                    state.store->toRealPath(storePath));
+                    state.store->printStorePath(storePath));
             }
             else if (setting.value->type() == nInt)
                 flake.config.settings.emplace(
@@ -423,7 +423,7 @@ static Flake getFlake(
     auto storePath = copyInputToStore(state, lockedRef.input, originalRef.input, accessor);
 
     // Re-parse flake.nix from the store.
-    return readFlake(state, originalRef, resolvedRef, lockedRef, state.rootPath(state.store->toRealPath(storePath)), lockRootAttrPath);
+    return readFlake(state, originalRef, resolvedRef, lockedRef, state.rootPath(state.store->printStorePath(storePath)), lockRootAttrPath);
 }
 
 Flake getFlake(EvalState & state, const FlakeRef & originalRef, bool useRegistries)
@@ -784,7 +784,7 @@ LockedFlake lockFlake(
                                     // FIXME: allow input to be lazy.
                                     auto storePath = copyInputToStore(state, lockedRef.input, input.ref->input, accessor);
 
-                                    return {state.rootPath(state.store->toRealPath(storePath)), lockedRef};
+                                    return {state.rootPath(state.store->printStorePath(storePath)), lockedRef};
                                 }
                             }();
 

--- a/src/libflake/flake/flake.hh
+++ b/src/libflake/flake/flake.hh
@@ -234,16 +234,6 @@ void callFlake(
     const LockedFlake & lockedFlake,
     Value & v);
 
-/**
- * Map a `SourcePath` to the corresponding store path. This is a
- * temporary hack to support chroot stores while we don't have full
- * lazy trees. FIXME: Remove this once we can pass a sourcePath rather
- * than a storePath to call-flake.nix.
- */
-std::pair<StorePath, Path> sourcePathToStorePath(
-    ref<Store> store,
-    const SourcePath & path);
-
 }
 
 void emitTreeAttrs(

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -167,6 +167,7 @@ sources = files(
   'tarfile.cc',
   'terminal.cc',
   'thread-pool.cc',
+  'union-source-accessor.cc',
   'unix-domain-socket.cc',
   'url.cc',
   'users.cc',

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -23,12 +23,6 @@ struct MountedSourceAccessor : SourceAccessor
         return accessor->readFile(subpath);
     }
 
-    bool pathExists(const CanonPath & path) override
-    {
-        auto [accessor, subpath] = resolve(path);
-        return accessor->pathExists(subpath);
-    }
-
     std::optional<Stat> maybeLstat(const CanonPath & path) override
     {
         auto [accessor, subpath] = resolve(path);

--- a/src/libutil/mounted-source-accessor.cc
+++ b/src/libutil/mounted-source-accessor.cc
@@ -63,6 +63,12 @@ struct MountedSourceAccessor : SourceAccessor
             path.pop();
         }
     }
+
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
+    {
+        auto [accessor, subpath] = resolve(path);
+        return accessor->getPhysicalPath(subpath);
+    }
 };
 
 ref<SourceAccessor> makeMountedSourceAccessor(std::map<CanonPath, ref<SourceAccessor>> mounts)

--- a/src/libutil/source-accessor.hh
+++ b/src/libutil/source-accessor.hh
@@ -216,4 +216,10 @@ ref<SourceAccessor> makeFSSourceAccessor(std::filesystem::path root);
 
 ref<SourceAccessor> makeMountedSourceAccessor(std::map<CanonPath, ref<SourceAccessor>> mounts);
 
+/**
+ * Construct an accessor that presents a "union" view of a vector of
+ * underlying accessors. Earlier accessors take precedence over later.
+ */
+ref<SourceAccessor> makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors);
+
 }

--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -1,0 +1,82 @@
+#include "source-accessor.hh"
+
+namespace nix {
+
+struct UnionSourceAccessor : SourceAccessor
+{
+    std::vector<ref<SourceAccessor>> accessors;
+
+    UnionSourceAccessor(std::vector<ref<SourceAccessor>> _accessors)
+        : accessors(std::move(_accessors))
+    {
+        displayPrefix.clear();
+    }
+
+    std::string readFile(const CanonPath & path) override
+    {
+        for (auto & accessor : accessors) {
+            auto st = accessor->maybeLstat(path);
+            if (st && st->type == Type::tRegular)
+                return accessor->readFile(path);
+        }
+        throw FileNotFound("path '%s' does not exist", showPath(path));
+    }
+
+    std::optional<Stat> maybeLstat(const CanonPath & path) override
+    {
+        for (auto & accessor : accessors) {
+            auto st = accessor->maybeLstat(path);
+            if (st)
+                return st;
+        }
+        return std::nullopt;
+    }
+
+    DirEntries readDirectory(const CanonPath & path) override
+    {
+        DirEntries result;
+        for (auto & accessor : accessors) {
+            auto st = accessor->maybeLstat(path);
+            if (!st || st->type != Type::tDirectory)
+                continue;
+            for (auto & entry : accessor->readDirectory(path))
+                // Don't override entries from previous accessors.
+                result.insert(entry);
+        }
+        return result;
+    }
+
+    std::string readLink(const CanonPath & path) override
+    {
+        for (auto & accessor : accessors) {
+            auto st = accessor->maybeLstat(path);
+            if (st && st->type == Type::tSymlink)
+                return accessor->readLink(path);
+        }
+        throw FileNotFound("path '%s' does not exist", showPath(path));
+    }
+
+    std::string showPath(const CanonPath & path) override
+    {
+        for (auto & accessor : accessors)
+            return accessor->showPath(path);
+        return SourceAccessor::showPath(path);
+    }
+
+    std::optional<std::filesystem::path> getPhysicalPath(const CanonPath & path) override
+    {
+        for (auto & accessor : accessors) {
+            auto p = accessor->getPhysicalPath(path);
+            if (p)
+                return p;
+        }
+        return std::nullopt;
+    }
+};
+
+ref<SourceAccessor> makeUnionSourceAccessor(std::vector<ref<SourceAccessor>> && accessors)
+{
+    return make_ref<UnionSourceAccessor>(std::move(accessors));
+}
+
+}

--- a/src/libutil/union-source-accessor.cc
+++ b/src/libutil/union-source-accessor.cc
@@ -16,7 +16,7 @@ struct UnionSourceAccessor : SourceAccessor
     {
         for (auto & accessor : accessors) {
             auto st = accessor->maybeLstat(path);
-            if (st && st->type == Type::tRegular)
+            if (st)
                 return accessor->readFile(path);
         }
         throw FileNotFound("path '%s' does not exist", showPath(path));
@@ -37,7 +37,7 @@ struct UnionSourceAccessor : SourceAccessor
         DirEntries result;
         for (auto & accessor : accessors) {
             auto st = accessor->maybeLstat(path);
-            if (!st || st->type != Type::tDirectory)
+            if (!st)
                 continue;
             for (auto & entry : accessor->readDirectory(path))
                 // Don't override entries from previous accessors.
@@ -50,7 +50,7 @@ struct UnionSourceAccessor : SourceAccessor
     {
         for (auto & accessor : accessors) {
             auto st = accessor->maybeLstat(path);
-            if (st && st->type == Type::tSymlink)
+            if (st)
                 return accessor->readLink(path);
         }
         throw FileNotFound("path '%s' does not exist", showPath(path));

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -216,7 +216,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
         auto & flake = lockedFlake.flake;
 
         // Currently, all flakes are in the Nix store via the rootFS accessor.
-        auto storePath = store->printStorePath(sourcePathToStorePath(store, flake.path).first);
+        auto storePath = store->printStorePath(store->toStorePath(flake.path.path.abs()).first);
 
         if (json) {
             nlohmann::json j;
@@ -1079,7 +1079,7 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun
 
         StorePathSet sources;
 
-        auto storePath = sourcePathToStorePath(store, flake.flake.path).first;
+        auto storePath = store->toStorePath(flake.flake.path.path.abs()).first;
 
         sources.insert(storePath);
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

When using a chroot store, paths that are in the chroot store (such as those resulting from IFD or similar) should be represented in the evaluator using their logical path (e.g. `/nix/store/foo`), not their physical path (e.g. `/tmp/chroot/nix/store/foo`). This PR does that - it removes all uses of `toRealPath()` in the evaluator. To make chroot stores still work, the physical store path is "mounted" onto the logical store location of `rootFS`. And to handle the case where we also need to access a file in the *real* `/nix/store`, we use a union source accessor that provides a union view of the two stores.

Fixes #11503.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
