### PR TITLE
packaging: Restore libgit2 USE_SSH=exec

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -29,8 +29,7 @@ let
   darwinStdenv = pkgs.overrideSDK prevStdenv { darwinMinVersion = "10.13"; };
 
 in
-scope:
-{
+scope: {
   inherit stdenv;
 
   aws-sdk-cpp =
@@ -66,36 +65,39 @@ scope:
         installPhase = lib.replaceStrings [ "--without-python" ] [ "" ] old.installPhase;
       });
 
-}
-# libgit2: Nixpkgs 24.11 has < 1.9.0
-// lib.optionalAttrs (!lib.versionAtLeast pkgs.libgit2.version "1.9.0") {
-  libgit2 = pkgs.libgit2.overrideAttrs (attrs: {
-    cmakeFlags = attrs.cmakeFlags or [ ] ++ [ "-DUSE_SSH=exec" ];
-    nativeBuildInputs =
-      attrs.nativeBuildInputs or [ ]
-      # gitMinimal does not build on Windows. See packbuilder patch.
-      ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
-        # Needed for `git apply`; see `prePatch`
-        pkgs.buildPackages.gitMinimal
-      ];
-    # Only `git apply` can handle git binary patches
-    prePatch =
-      attrs.prePatch or ""
-      + lib.optionalString (!stdenv.hostPlatform.isWindows) ''
-        patch() {
-          git apply
-        }
-      '';
-    patches =
-      attrs.patches or [ ]
-      ++ [
-        ./patches/libgit2-mempack-thin-packfile.patch
-      ]
-      # gitMinimal does not build on Windows, but fortunately this patch only
-      # impacts interruptibility
-      ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
-        # binary patch; see `prePatch`
-        ./patches/libgit2-packbuilder-callback-interruptible.patch
-      ];
-  });
+  libgit2 = pkgs.libgit2.overrideAttrs (
+    attrs:
+    {
+      cmakeFlags = attrs.cmakeFlags or [ ] ++ [ "-DUSE_SSH=exec" ];
+    }
+    # libgit2: Nixpkgs 24.11 has < 1.9.0, which needs our patches
+    // lib.optionalAttrs (!lib.versionAtLeast pkgs.libgit2.version "1.9.0") {
+      nativeBuildInputs =
+        attrs.nativeBuildInputs or [ ]
+        # gitMinimal does not build on Windows. See packbuilder patch.
+        ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
+          # Needed for `git apply`; see `prePatch`
+          pkgs.buildPackages.gitMinimal
+        ];
+      # Only `git apply` can handle git binary patches
+      prePatch =
+        attrs.prePatch or ""
+        + lib.optionalString (!stdenv.hostPlatform.isWindows) ''
+          patch() {
+            git apply
+          }
+        '';
+      patches =
+        attrs.patches or [ ]
+        ++ [
+          ./patches/libgit2-mempack-thin-packfile.patch
+        ]
+        # gitMinimal does not build on Windows, but fortunately this patch only
+        # impacts interruptibility
+        ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
+          # binary patch; see `prePatch`
+          ./patches/libgit2-packbuilder-callback-interruptible.patch
+        ];
+    }
+  );
 }


### PR DESCRIPTION
... when nixpkgs is nixos-unstable or the overlay is used.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

- Fix my mistake in #12484

## Context

Bunch of reindent. Disable whitespace in diff.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
