### PR TITLE
Introduce `EvalStore::storePath`

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -37,7 +37,7 @@ EvalSettings evalSettings {
                 auto [accessor, lockedRef] = flakeRef.resolve(state.store).lazyFetch(state.store);
                 auto storePath = nix::fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
                 state.allowPath(storePath);
-                return state.rootPath(state.store->printStorePath(storePath));
+                return state.storePath(storePath);
             },
         },
     },
@@ -179,7 +179,7 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * bas
             state.fetchSettings,
             EvalSettings::resolvePseudoUrl(s));
         auto storePath = fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy);
-        return state.rootPath(CanonPath(state.store->printStorePath(storePath)));
+        return state.storePath(storePath);
     }
 
     else if (hasPrefix(s, "flake:")) {
@@ -188,7 +188,7 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * bas
         auto [accessor, lockedRef] = flakeRef.resolve(state.store).lazyFetch(state.store);
         auto storePath = nix::fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
         state.allowPath(storePath);
-        return state.rootPath(CanonPath(state.store->printStorePath(storePath)));
+        return state.storePath(storePath);
     }
 
     else if (s.size() > 2 && s.at(0) == '<' && s.at(s.size() - 1) == '>') {

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3103,7 +3103,7 @@ std::optional<SourcePath> EvalState::resolveLookupPathPath(const LookupPath::Pat
                 fetchSettings,
                 EvalSettings::resolvePseudoUrl(value));
             auto storePath = fetchToStore(*store, SourcePath(accessor), FetchMode::Copy);
-            return finish(rootPath(store->printStorePath(storePath)));
+            return finish(this->storePath(storePath));
         } catch (Error & e) {
             logWarning({
                 .msg = HintFmt("Nix search path entry '%1%' cannot be downloaded, ignoring", value)

--- a/src/libexpr/eval.hh
+++ b/src/libexpr/eval.hh
@@ -390,6 +390,15 @@ public:
     SourcePath rootPath(PathView path);
 
     /**
+     * Return a `SourcePath` that refers to `path` in the store.
+     *
+     * For now, this has to also be within the root filesystem for
+     * backwards compat, but for Windows and maybe also pure eval, we'll
+     * probably want to do something different.
+     */
+    SourcePath storePath(const StorePath & path);
+
+    /**
      * Allow access to a path.
      */
     void allowPath(const Path & path);

--- a/src/libexpr/paths.cc
+++ b/src/libexpr/paths.cc
@@ -1,3 +1,4 @@
+#include "store-api.hh"
 #include "eval.hh"
 
 namespace nix {
@@ -10,6 +11,11 @@ SourcePath EvalState::rootPath(CanonPath path)
 SourcePath EvalState::rootPath(PathView path)
 {
     return {rootFS, CanonPath(absPath(path))};
+}
+
+SourcePath EvalState::storePath(const StorePath & path)
+{
+    return {rootFS, CanonPath{store->printStorePath(path)}};
 }
 
 }

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -423,7 +423,7 @@ static Flake getFlake(
     auto storePath = copyInputToStore(state, lockedRef.input, originalRef.input, accessor);
 
     // Re-parse flake.nix from the store.
-    return readFlake(state, originalRef, resolvedRef, lockedRef, state.rootPath(state.store->printStorePath(storePath)), lockRootAttrPath);
+    return readFlake(state, originalRef, resolvedRef, lockedRef, state.storePath(storePath), lockRootAttrPath);
 }
 
 Flake getFlake(EvalState & state, const FlakeRef & originalRef, bool useRegistries)
@@ -784,7 +784,7 @@ LockedFlake lockFlake(
                                     // FIXME: allow input to be lazy.
                                     auto storePath = copyInputToStore(state, lockedRef.input, input.ref->input, accessor);
 
-                                    return {state.rootPath(state.store->printStorePath(storePath)), lockedRef};
+                                    return {state.storePath(storePath), lockedRef};
                                 }
                             }();
 


### PR DESCRIPTION
## Motivation

This abstracts over a common case. Good for brevity, and enabling further experiments.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
