### PR TITLE
packaging: A few small improvements

### DIFF
--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -102,7 +102,7 @@ let
         let
           n = lib.length finalScope.patches;
         in
-        if n == 0 then finalAttrs.version else finalAttrs.version + "+${toString n}";
+        if n == 0 then prevAttrs.version else prevAttrs.version + "+${toString n}";
 
       # Clear what `derivation` can't/shouldn't serialize; see prevAttrs.workDir.
       fileset = null;
@@ -256,7 +256,10 @@ in
                 inherit (finalScope) src patches;
               }
             );
+
         resolvePath = p: finalScope.patchedSrc + "/${resolveRelPath p}";
+        filesetToSource = { root, fileset }: finalScope.resolvePath root;
+
         appendPatches = appendPatches finalScope;
       }
     );

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -17,6 +17,7 @@
 
   version,
   filesetToSource,
+  resolvePath,
 }:
 
 let
@@ -79,7 +80,7 @@ mkMesonExecutable (finalAttrs: {
               mkdir -p "$HOME"
             ''
             + ''
-              export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
+              export _NIX_TEST_UNIT_DATA=${resolvePath ./data/src/libstore-tests/data}
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
               touch $out
             ''

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -15,6 +15,7 @@
   # Configuration Options
 
   version,
+  resolvePath,
 }:
 
 let
@@ -61,7 +62,7 @@ mkMesonExecutable (finalAttrs: {
               mkdir -p "$HOME"
             ''
             + ''
-              export _NIX_TEST_UNIT_DATA=${./data}
+              export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
               touch $out
             ''


### PR DESCRIPTION
These are some small improvements gathered while working on Nixpkgs packaging, https://github.com/NixOS/nixpkgs/pull/383508. They're low hanging fruit, while the Nixpkgs packaging is still in flux (e.g. filesets aren't appreciated, nor is the everything.nix multi-derivation package)

This makes the files more readily transferable.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
