### PR TITLE
doc: ssl-cert-file leaks into OSX builds

### DIFF
--- a/src/libstore/globals.hh
+++ b/src/libstore/globals.hh
@@ -1059,7 +1059,10 @@ public:
 
           1. `NIX_SSL_CERT_FILE`
           2. `SSL_CERT_FILE`
-        )"};
+        )",
+        {},
+        // Don't document the machine-specific default value
+        false};
 
 #if __linux__
     Setting<bool> filterSyscalls{


### PR DESCRIPTION
On OSX builds, the ssl-cert-file default leaks in from the machine.

## Motivation

```
├── nix.conf.5
│ @@ -2166,15 +2166,15 @@
│  .sp -1
│  .if t \
│  .sp -0.25v
│  .IP "2." 3
│  \f(CRSSL_CERT_FILE\fR
│  .RE
│  .IP
│ -\fBDefault:\fR \f(CR/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt\fR
│ +\fBDefault:\fR \f(CR/etc/ssl/certs/ca-certificates.crt\fR
│  .IP "\(bu" 3
```

## Context

https://github.com/NixOS/nix/pull/9443