### PR TITLE
Fix perl store bindings

### DIFF
--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -194,7 +194,7 @@ StoreWrapper::computeFSClosure(int flipDirection, int includeOutputs, ...)
     PPCODE:
         try {
             StorePathSet paths;
-            for (int n = 2; n < items; ++n)
+            for (int n = 3; n < items; ++n)
                 THIS->store->computeFSClosure(THIS->store->parseStorePath(SvPV_nolen(ST(n))), paths, flipDirection, includeOutputs);
             for (auto & i : paths)
                 XPUSHs(sv_2mortal(newSVpv(THIS->store->printStorePath(i).c_str(), 0)));
@@ -208,7 +208,7 @@ StoreWrapper::topoSortPaths(...)
     PPCODE:
         try {
             StorePathSet paths;
-            for (int n = 0; n < items; ++n) paths.insert(THIS->store->parseStorePath(SvPV_nolen(ST(n))));
+            for (int n = 1; n < items; ++n) paths.insert(THIS->store->parseStorePath(SvPV_nolen(ST(n))));
             auto sorted = THIS->store->topoSortPaths(paths);
             for (auto & i : sorted)
                 XPUSHs(sv_2mortal(newSVpv(THIS->store->printStorePath(i).c_str(), 0)));
@@ -234,7 +234,7 @@ StoreWrapper::exportPaths(int fd, ...)
     PPCODE:
         try {
             StorePathSet paths;
-            for (int n = 1; n < items; ++n) paths.insert(THIS->store->parseStorePath(SvPV_nolen(ST(n))));
+            for (int n = 2; n < items; ++n) paths.insert(THIS->store->parseStorePath(SvPV_nolen(ST(n))));
             FdSink sink(fd);
             THIS->store->exportPaths(paths, sink);
         } catch (Error & e) {


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
Hydra currently fails to show the build dependencies of it's builds (NixOS/hydra#1401) with an error like this:

```
error: not an absolute path: 'Nix::Store=SCALAR(0x3f5338e8)'
```

The invalid path the error is referring to, is produced in the current Perl bindings itself.

## Context

When #9863 converted the `Nix::Store` free functions into member functions, the implicit `this` argument was not accounted for when iterating over the variable number of arguments in some functions.

The following functions are affected:
- `computeFSClosure`
- `topoSortPaths` (this causes the hydra error)
- `exportPaths`

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

#### `flake.nix` reproducing the error:

```nix
{
  # Current rev of github:NixOS/nix/2.26-maintenance
  inputs.nix.url = "github:NixOS/nix/0d039d4abec82c7c7c2787edea7fd3c732965f82";

  inputs.nixpkgs.follows = "nix/nixpkgs";

  outputs = {
    self,
    nixpkgs,
    nix,
    ...
  }: {
    packages.x86_64-linux.default =
      nixpkgs.legacyPackages.x86_64-linux.writers.writePerlBin "example" {
        libraries = [nix.hydraJobs.perlBindings.x86_64-linux];
      } ''
        use Nix::Store;

        my $store = Nix::Store->new();

        $store->computeFSClosure(0,0);
        # error: not an absolute path: '0' at /nix/store/y1g5c8wz7s2fr29fliq06v161asj6npr-example/bin/example line 6.

        $store->topoSortPaths();
        # error: not an absolute path: 'Nix::Store=SCALAR(0x3eca46b0)' at /nix/store/7vxyv8kcv01dz0gjs9cys27frbqj5bir-example/bin/example line 9.

        $store->exportPaths(1);
        # error: not an absolute path: '1' at /nix/store/ras8ghkb0pff4zwp8jycg48p5y3qgfdq-example/bin/example line 12.
      '';
  };
}
```

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
