### PR TITLE
nix flake archive: Skip relative path inputs

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1090,12 +1090,14 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun
             nlohmann::json jsonObj2 = json ? json::object() : nlohmann::json(nullptr);
             for (auto & [inputName, input] : node.inputs) {
                 if (auto inputNode = std::get_if<0>(&input)) {
+                    if ((*inputNode)->lockedRef.input.isRelative())
+                        continue;
                     auto storePath =
                         dryRun
                         ? (*inputNode)->lockedRef.input.computeStorePath(*store)
                         : (*inputNode)->lockedRef.input.fetchToStore(store).first;
                     if (json) {
-                        auto& jsonObj3 = jsonObj2[inputName];
+                        auto & jsonObj3 = jsonObj2[inputName];
                         jsonObj3["path"] = store->printStorePath(storePath);
                         sources.insert(std::move(storePath));
                         jsonObj3["inputs"] = traverse(**inputNode);

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -76,6 +76,9 @@ if ! isTestOnNixOS; then
 fi
 (! grep narHash "$subflake2/flake.lock")
 
+# Test `nix flake archive` with relative path flakes.
+nix flake archive --json "$rootFlake"
+
 # Test circular relative path flakes. FIXME: doesn't work at the moment.
 if false; then
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes #12438.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
