### PR TITLE
Fix #9052

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -278,8 +278,6 @@
               ''^src/libstore/include/nix/store/store-dir-config\.hh$''
               ''^src/libstore/build/derivation-goal\.cc$''
               ''^src/libstore/include/nix/store/build/derivation-goal\.hh$''
-              ''^src/libstore/build/drv-output-substitution-goal\.cc$''
-              ''^src/libstore/include/nix/store/build/drv-output-substitution-goal\.hh$''
               ''^src/libstore/build/entry-points\.cc$''
               ''^src/libstore/build/goal\.cc$''
               ''^src/libstore/include/nix/store/build/goal\.hh$''

--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -1,4 +1,4 @@
-#include "fetchers.hh"
+#include "nix/fetchers/fetchers.hh"
 
 namespace nix::fetchers {
 

--- a/src/libstore/build/derivation-creation-and-realisation-goal.cc
+++ b/src/libstore/build/derivation-creation-and-realisation-goal.cc
@@ -1,0 +1,128 @@
+#include "nix/store/build/derivation-creation-and-realisation-goal.hh"
+#include "nix/store/build/worker.hh"
+
+namespace nix {
+
+DerivationCreationAndRealisationGoal::DerivationCreationAndRealisationGoal(
+    ref<const SingleDerivedPath> drvReq, const OutputsSpec & wantedOutputs, Worker & worker, BuildMode buildMode)
+    : Goal(worker)
+    , drvReq(drvReq)
+    , wantedOutputs(wantedOutputs)
+    , buildMode(buildMode)
+{
+    name =
+        fmt("outer obtaining drv from '%s' and then building outputs %s",
+            drvReq->to_string(worker.store),
+            std::visit(
+                overloaded{
+                    [&](const OutputsSpec::All) -> std::string { return "* (all of them)"; },
+                    [&](const OutputsSpec::Names os) { return concatStringsSep(", ", quoteStrings(os)); },
+                },
+                wantedOutputs.raw));
+    trace("created outer");
+
+    worker.updateProgress();
+}
+
+DerivationCreationAndRealisationGoal::~DerivationCreationAndRealisationGoal() {}
+
+static StorePath pathPartOfReq(const SingleDerivedPath & req)
+{
+    return std::visit(
+        overloaded{
+            [&](const SingleDerivedPath::Opaque & bo) { return bo.path; },
+            [&](const SingleDerivedPath::Built & bfd) { return pathPartOfReq(*bfd.drvPath); },
+        },
+        req.raw());
+}
+
+std::string DerivationCreationAndRealisationGoal::key()
+{
+    /* Ensure that derivations get built in order of their name,
+       i.e. a derivation named "aardvark" always comes before "baboon". And
+       substitution goals and inner derivation goals always happen before
+       derivation goals (due to "b$"). */
+    return "c$" + std::string(pathPartOfReq(*drvReq).name()) + "$" + drvReq->to_string(worker.store);
+}
+
+void DerivationCreationAndRealisationGoal::timedOut(Error && ex) {}
+
+void DerivationCreationAndRealisationGoal::addWantedOutputs(const OutputsSpec & outputs)
+{
+    /* If we already want all outputs, there is nothing to do. */
+    auto newWanted = wantedOutputs.union_(outputs);
+    bool needRestart = !newWanted.isSubsetOf(wantedOutputs);
+    wantedOutputs = newWanted;
+
+    if (!needRestart)
+        return;
+
+    if (!optDrvPath)
+        // haven't started steps where the outputs matter yet
+        return;
+    worker.makeDerivationGoal(*optDrvPath, outputs, buildMode);
+}
+
+Goal::Co DerivationCreationAndRealisationGoal::init()
+{
+    trace("outer init");
+
+    /* The first thing to do is to make sure that the derivation
+       exists.  If it doesn't, it may be created through a
+       substitute. */
+    if (auto optDrvPath = [this]() -> std::optional<StorePath> {
+            if (buildMode != bmNormal)
+                return std::nullopt;
+
+            auto drvPath = StorePath::dummy;
+            try {
+                drvPath = resolveDerivedPath(worker.store, *drvReq);
+            } catch (MissingRealisation &) {
+                return std::nullopt;
+            }
+            auto cond = worker.evalStore.isValidPath(drvPath) || worker.store.isValidPath(drvPath);
+            return cond ? std::optional{drvPath} : std::nullopt;
+        }()) {
+        trace(
+            fmt("already have drv '%s' for '%s', can go straight to building",
+                worker.store.printStorePath(*optDrvPath),
+                drvReq->to_string(worker.store)));
+    } else {
+        trace("need to obtain drv we want to build");
+        Goals waitees{worker.makeGoal(DerivedPath::fromSingle(*drvReq))};
+        co_await await(std::move(waitees));
+    }
+
+    trace("outer load and build derivation");
+
+    if (nrFailed != 0) {
+        co_return amDone(ecFailed, Error("cannot build missing derivation '%s'", drvReq->to_string(worker.store)));
+    }
+
+    StorePath drvPath = resolveDerivedPath(worker.store, *drvReq);
+    /* Build this step! */
+    concreteDrvGoal = worker.makeDerivationGoal(drvPath, wantedOutputs, buildMode);
+    {
+        auto g = upcast_goal(concreteDrvGoal);
+        /* We will finish with it ourselves, as if we were the derivational goal. */
+        g->preserveException = true;
+    }
+    optDrvPath = std::move(drvPath);
+    {
+        Goals waitees{upcast_goal(concreteDrvGoal)};
+        co_await await(std::move(waitees));
+    }
+
+    trace("outer build done");
+
+    buildResult = upcast_goal(concreteDrvGoal)
+                      ->getBuildResult(DerivedPath::Built{
+                          .drvPath = drvReq,
+                          .outputs = wantedOutputs,
+                      });
+
+    auto g = upcast_goal(concreteDrvGoal);
+    co_return amDone(g->exitCode, g->ex);
+}
+
+}

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -123,20 +123,7 @@ Goal::Co DerivationGoal::init() {
     trace("init");
 
     if (useDerivation) {
-        /* The first thing to do is to make sure that the derivation
-           exists.  If it doesn't, it may be created through a
-           substitute. */
-
-        if (buildMode != bmNormal || !worker.evalStore.isValidPath(drvPath)) {
-            Goals waitees{upcast_goal(worker.makePathSubstitutionGoal(drvPath))};
-            co_await await(std::move(waitees));
-        }
-
         trace("loading derivation");
-
-        if (nrFailed != 0) {
-            co_return done(BuildResult::MiscFailure, {}, Error("cannot build missing derivation '%s'", worker.store.printStorePath(drvPath)));
-        }
 
         /* `drvPath' should already be a root, but let's be on the safe
            side: if the user forgot to make it a root, we wouldn't want

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -7,17 +7,13 @@
 namespace nix {
 
 DrvOutputSubstitutionGoal::DrvOutputSubstitutionGoal(
-    const DrvOutput & id,
-    Worker & worker,
-    RepairFlag repair,
-    std::optional<ContentAddress> ca)
+    const DrvOutput & id, Worker & worker, RepairFlag repair, std::optional<ContentAddress> ca)
     : Goal(worker)
     , id(id)
 {
     name = fmt("substitution of '%s'", id.to_string());
     trace("created");
 }
-
 
 Goal::Co DrvOutputSubstitutionGoal::init()
 {
@@ -39,32 +35,35 @@ Goal::Co DrvOutputSubstitutionGoal::init()
            some other error occurs), so it must not touch `this`. So put
            the shared state in a separate refcounted object. */
         auto outPipe = std::make_shared<MuxablePipe>();
-    #ifndef _WIN32
+#ifndef _WIN32
         outPipe->create();
-    #else
+#else
         outPipe->createAsyncPipe(worker.ioport.get());
-    #endif
+#endif
 
         auto promise = std::make_shared<std::promise<std::shared_ptr<const Realisation>>>();
 
         sub->queryRealisation(
-            id,
-            { [outPipe(outPipe), promise(promise)](std::future<std::shared_ptr<const Realisation>> res) {
+            id, {[outPipe(outPipe), promise(promise)](std::future<std::shared_ptr<const Realisation>> res) {
                 try {
                     Finally updateStats([&]() { outPipe->writeSide.close(); });
                     promise->set_value(res.get());
                 } catch (...) {
                     promise->set_exception(std::current_exception());
                 }
-            } });
+            }});
 
-        worker.childStarted(shared_from_this(), {
-    #ifndef _WIN32
-            outPipe->readSide.get()
-    #else
-            &*outPipe
-    #endif
-        }, true, false);
+        worker.childStarted(
+            shared_from_this(),
+            {
+#ifndef _WIN32
+                outPipe->readSide.get()
+#else
+                &*outPipe
+#endif
+            },
+            true,
+            false);
 
         co_await Suspend{};
 
@@ -83,7 +82,8 @@ Goal::Co DrvOutputSubstitutionGoal::init()
             substituterFailed = true;
         }
 
-        if (!outputInfo) continue;
+        if (!outputInfo)
+            continue;
 
         bool failed = false;
 
@@ -100,8 +100,7 @@ Goal::Co DrvOutputSubstitutionGoal::init()
                         sub->getUri(),
                         depId.to_string(),
                         worker.store.printStorePath(localOutputInfo->outPath),
-                        worker.store.printStorePath(depPath)
-                    );
+                        worker.store.printStorePath(depPath));
                     failed = true;
                     break;
                 }
@@ -109,7 +108,8 @@ Goal::Co DrvOutputSubstitutionGoal::init()
             }
         }
 
-        if (failed) continue;
+        if (failed)
+            continue;
 
         co_return realisationFetched(std::move(waitees), outputInfo, sub);
     }
@@ -129,7 +129,9 @@ Goal::Co DrvOutputSubstitutionGoal::init()
     co_return amDone(substituterFailed ? ecFailed : ecNoSubstituters);
 }
 
-Goal::Co DrvOutputSubstitutionGoal::realisationFetched(Goals waitees, std::shared_ptr<const Realisation> outputInfo, nix::ref<nix::Store> sub) {
+Goal::Co DrvOutputSubstitutionGoal::realisationFetched(
+    Goals waitees, std::shared_ptr<const Realisation> outputInfo, nix::ref<nix::Store> sub)
+{
     waitees.insert(worker.makePathSubstitutionGoal(outputInfo->outPath));
 
     co_await await(std::move(waitees));
@@ -158,6 +160,5 @@ void DrvOutputSubstitutionGoal::handleEOF(Descriptor fd)
 {
     worker.wakeUp(shared_from_this());
 }
-
 
 }

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -1,6 +1,7 @@
 #include "nix/store/build/worker.hh"
 #include "nix/store/build/substitution-goal.hh"
 #ifndef _WIN32 // TODO Enable building on Windows
+#  include "nix/store/build/derivation-creation-and-realisation-goal.hh"
 #  include "nix/store/build/derivation-goal.hh"
 #endif
 #include "nix/store/local-store.hh"
@@ -29,8 +30,8 @@ void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMod
         }
         if (i->exitCode != Goal::ecSuccess) {
 #ifndef _WIN32 // TODO Enable building on Windows
-            if (auto i2 = dynamic_cast<DerivationGoal *>(i.get()))
-                failed.insert(printStorePath(i2->drvPath));
+            if (auto i2 = dynamic_cast<DerivationCreationAndRealisationGoal *>(i.get()))
+                failed.insert(i2->drvReq->to_string(*this));
             else
 #endif
             if (auto i2 = dynamic_cast<PathSubstitutionGoal *>(i.get()))

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -155,7 +155,7 @@ Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
     exitCode = result;
 
     if (ex) {
-        if (!waiters.empty())
+        if (!preserveException && !waiters.empty())
             logError(ex->info());
         else
             this->ex = std::move(*ex);

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -146,12 +146,19 @@ Co Goal::await(Goals new_waitees)
     co_return Return{};
 }
 
+
+bool Goal::finalExitCode(ExitCode result)
+{
+    return result == ecSuccess || result == ecFailed || result == ecNoSubstituters || result == ecIncompleteClosure;
+}
+
+
 Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
 {
     trace("done");
     assert(top_co);
     assert(exitCode == ecBusy);
-    assert(result == ecSuccess || result == ecFailed || result == ecNoSubstituters || result == ecIncompleteClosure);
+    assert(finalExitCode(result));
     exitCode = result;
 
     if (ex) {

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -4,6 +4,7 @@
 #include "nix/store/build/substitution-goal.hh"
 #include "nix/store/build/drv-output-substitution-goal.hh"
 #include "nix/store/build/derivation-goal.hh"
+#include "nix/store/build/derivation-creation-and-realisation-goal.hh"
 #ifndef _WIN32 // TODO Enable building on Windows
 #  include "nix/store/build/local-derivation-goal.hh"
 #  include "nix/store/build/hook-instance.hh"
@@ -40,6 +41,24 @@ Worker::~Worker()
     assert(expectedSubstitutions == 0);
     assert(expectedDownloadSize == 0);
     assert(expectedNarSize == 0);
+}
+
+
+std::shared_ptr<DerivationCreationAndRealisationGoal> Worker::makeDerivationCreationAndRealisationGoal(
+    ref<const SingleDerivedPath> drvReq,
+    const OutputsSpec & wantedOutputs,
+    BuildMode buildMode)
+{
+    std::weak_ptr<DerivationCreationAndRealisationGoal> & goal_weak = outerDerivationGoals.ensureSlot(*drvReq).value;
+    std::shared_ptr<DerivationCreationAndRealisationGoal> goal = goal_weak.lock();
+    if (!goal) {
+        goal = std::make_shared<DerivationCreationAndRealisationGoal>(drvReq, wantedOutputs, *this, buildMode);
+        goal_weak = goal;
+        wakeUp(goal);
+    } else {
+        goal->addWantedOutputs(wantedOutputs);
+    }
+    return goal;
 }
 
 
@@ -120,10 +139,7 @@ GoalPtr Worker::makeGoal(const DerivedPath & req, BuildMode buildMode)
 {
     return std::visit(overloaded {
         [&](const DerivedPath::Built & bfd) -> GoalPtr {
-            if (auto bop = std::get_if<DerivedPath::Opaque>(&*bfd.drvPath))
-                return makeDerivationGoal(bop->path, bfd.outputs, buildMode);
-            else
-                throw UnimplementedError("Building dynamic derivations in one shot is not yet implemented.");
+            return makeDerivationCreationAndRealisationGoal(bfd.drvPath, bfd.outputs, buildMode);
         },
         [&](const DerivedPath::Opaque & bo) -> GoalPtr {
             return makePathSubstitutionGoal(bo.path, buildMode == bmRepair ? Repair : NoRepair);
@@ -132,24 +148,46 @@ GoalPtr Worker::makeGoal(const DerivedPath & req, BuildMode buildMode)
 }
 
 
+template<typename K, typename V, typename F>
+static void cullMap(std::map<K, V> & goalMap, F f)
+{
+    for (auto i = goalMap.begin(); i != goalMap.end();)
+        if (!f(i->second))
+            i = goalMap.erase(i);
+        else ++i;
+}
+
+
 template<typename K, typename G>
 static void removeGoal(std::shared_ptr<G> goal, std::map<K, std::weak_ptr<G>> & goalMap)
 {
     /* !!! inefficient */
-    for (auto i = goalMap.begin();
-         i != goalMap.end(); )
-        if (i->second.lock() == goal) {
-            auto j = i; ++j;
-            goalMap.erase(i);
-            i = j;
-        }
-        else ++i;
+    cullMap(goalMap, [&](const std::weak_ptr<G> & gp) -> bool {
+        return gp.lock() != goal;
+    });
+}
+
+template<typename K>
+static void removeGoal(std::shared_ptr<DerivationCreationAndRealisationGoal> goal, std::map<K, DerivedPathMap<std::weak_ptr<DerivationCreationAndRealisationGoal>>::ChildNode> & goalMap);
+
+template<typename K>
+static void removeGoal(std::shared_ptr<DerivationCreationAndRealisationGoal> goal, std::map<K, DerivedPathMap<std::weak_ptr<DerivationCreationAndRealisationGoal>>::ChildNode> & goalMap)
+{
+    /* !!! inefficient */
+    cullMap(goalMap, [&](DerivedPathMap<std::weak_ptr<DerivationCreationAndRealisationGoal>>::ChildNode & node) -> bool {
+        if (node.value.lock() == goal)
+            node.value.reset();
+        removeGoal(goal, node.childMap);
+        return !node.value.expired() || !node.childMap.empty();
+    });
 }
 
 
 void Worker::removeGoal(GoalPtr goal)
 {
-    if (auto drvGoal = std::dynamic_pointer_cast<DerivationGoal>(goal))
+    if (auto drvGoal = std::dynamic_pointer_cast<DerivationCreationAndRealisationGoal>(goal))
+        nix::removeGoal(drvGoal, outerDerivationGoals.map);
+    else if (auto drvGoal = std::dynamic_pointer_cast<DerivationGoal>(goal))
         nix::removeGoal(drvGoal, derivationGoals);
     else
     if (auto subGoal = std::dynamic_pointer_cast<PathSubstitutionGoal>(goal))
@@ -215,6 +253,9 @@ void Worker::childStarted(GoalPtr goal, const std::set<MuxablePipePollState::Com
         case JobCategory::Build:
             nrLocalBuilds++;
             break;
+        case JobCategory::Administration:
+            /* Intentionally not limited, see docs */
+            break;
         default:
             unreachable();
         }
@@ -237,6 +278,9 @@ void Worker::childTerminated(Goal * goal, bool wakeSleepers)
         case JobCategory::Build:
             assert(nrLocalBuilds > 0);
             nrLocalBuilds--;
+            break;
+        case JobCategory::Administration:
+            /* Intentionally not limited, see docs */
             break;
         default:
             unreachable();
@@ -290,9 +334,9 @@ void Worker::run(const Goals & _topGoals)
 
     for (auto & i : _topGoals) {
         topGoals.insert(i);
-        if (auto goal = dynamic_cast<DerivationGoal *>(i.get())) {
+        if (auto goal = dynamic_cast<DerivationCreationAndRealisationGoal *>(i.get())) {
             topPaths.push_back(DerivedPath::Built {
-                .drvPath = makeConstantStorePathRef(goal->drvPath),
+                .drvPath = goal->drvReq,
                 .outputs = goal->wantedOutputs,
             });
         } else

--- a/src/libstore/derived-path-map.cc
+++ b/src/libstore/derived-path-map.cc
@@ -52,6 +52,7 @@ typename DerivedPathMap<V>::ChildNode * DerivedPathMap<V>::findSlot(const Single
 
 // instantiations
 
+#include "nix/store/build/derivation-creation-and-realisation-goal.hh"
 namespace nix {
 
 template<>
@@ -67,5 +68,8 @@ std::strong_ordering DerivedPathMap<std::set<std::string>>::ChildNode::operator 
 
 template struct DerivedPathMap<std::set<std::string>>::ChildNode;
 template struct DerivedPathMap<std::set<std::string>>;
+
+template struct DerivedPathMap<std::weak_ptr<DerivationCreationAndRealisationGoal>>;
+
 
 };

--- a/src/libstore/include/nix/store/build/derivation-creation-and-realisation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-creation-and-realisation-goal.hh
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "nix/store/parsed-derivations.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/pathlocks.hh"
+#include "nix/store/build/goal.hh"
+
+namespace nix {
+
+struct DerivationGoal;
+
+/**
+ * This goal type is essentially the serial composition (like function
+ * composition) of a goal for getting a derivation, and then a
+ * `DerivationGoal` using the newly-obtained derivation.
+ *
+ * In the (currently experimental) general inductive case of derivations
+ * that are themselves build outputs, that first goal will be *another*
+ * `DerivationCreationAndRealisationGoal`. In the (much more common) base-case
+ * where the derivation has no provence and is just referred to by
+ * (content-addressed) store path, that first goal is a
+ * `SubstitutionGoal`.
+ *
+ * If we already have the derivation (e.g. if the evaluator has created
+ * the derivation locally and then instructured the store to build it),
+ * we can skip the first goal entirely as a small optimization.
+ */
+struct DerivationCreationAndRealisationGoal : public Goal
+{
+    /**
+     * How to obtain a store path of the derivation to build.
+     */
+    ref<const SingleDerivedPath> drvReq;
+
+    /**
+     * The path of the derivation, once obtained.
+     **/
+    std::optional<StorePath> optDrvPath;
+
+    /**
+     * The goal for the corresponding concrete derivation.
+     **/
+    std::shared_ptr<DerivationGoal> concreteDrvGoal;
+
+    /**
+     * The specific outputs that we need to build.
+     */
+    OutputsSpec wantedOutputs;
+
+    /**
+     * The final output paths of the build.
+     *
+     * - For input-addressed derivations, always the precomputed paths
+     *
+     * - For content-addressed derivations, calcuated from whatever the
+     *   hash ends up being. (Note that fixed outputs derivations that
+     *   produce the "wrong" output still install that data under its
+     *   true content-address.)
+     */
+    OutputPathMap finalOutputs;
+
+    BuildMode buildMode;
+
+    DerivationCreationAndRealisationGoal(
+        ref<const SingleDerivedPath> drvReq,
+        const OutputsSpec & wantedOutputs,
+        Worker & worker,
+        BuildMode buildMode = bmNormal);
+    virtual ~DerivationCreationAndRealisationGoal();
+
+    void timedOut(Error && ex) override;
+
+    std::string key() override;
+
+    /**
+     * Add wanted outputs to an already existing derivation goal.
+     */
+    void addWantedOutputs(const OutputsSpec & outputs);
+
+    Co init() override;
+
+    JobCategory jobCategory() const override
+    {
+        return JobCategory::Administration;
+    };
+};
+
+}

--- a/src/libstore/include/nix/store/build/derivation-creation-and-realisation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-creation-and-realisation-goal.hh
@@ -48,6 +48,11 @@ struct DerivationCreationAndRealisationGoal : public Goal
     OutputsSpec wantedOutputs;
 
     /**
+     * Inner goal got recreated, need to wait again potentially.
+     */
+    bool needsRestart = false;
+
+    /**
      * The final output paths of the build.
      *
      * - For input-addressed derivations, always the precomputed paths

--- a/src/libstore/include/nix/store/build/derivation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-goal.hh
@@ -29,6 +29,10 @@ void runPostBuildHook(
 
 /**
  * A goal for building some or all of the outputs of a derivation.
+ *
+ * The derivation must already be present, either in the store in a drv
+ * or in memory. If the derivation itself needs to be gotten first, a
+ * `DerivationCreationAndRealisationGoal` goal must be used instead.
  */
 struct DerivationGoal : public Goal
 {

--- a/src/libstore/include/nix/store/build/drv-output-substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/drv-output-substitution-goal.hh
@@ -20,7 +20,8 @@ class Worker;
  * 2. Substitute the corresponding output path
  * 3. Register the output info
  */
-class DrvOutputSubstitutionGoal : public Goal {
+class DrvOutputSubstitutionGoal : public Goal
+{
 
     /**
      * The drv output we're trying to substitute
@@ -28,7 +29,11 @@ class DrvOutputSubstitutionGoal : public Goal {
     DrvOutput id;
 
 public:
-    DrvOutputSubstitutionGoal(const DrvOutput& id, Worker & worker, RepairFlag repair = NoRepair, std::optional<ContentAddress> ca = std::nullopt);
+    DrvOutputSubstitutionGoal(
+        const DrvOutput & id,
+        Worker & worker,
+        RepairFlag repair = NoRepair,
+        std::optional<ContentAddress> ca = std::nullopt);
 
     typedef void (DrvOutputSubstitutionGoal::*GoalState)();
     GoalState state;
@@ -36,13 +41,17 @@ public:
     Co init() override;
     Co realisationFetched(Goals waitees, std::shared_ptr<const Realisation> outputInfo, nix::ref<nix::Store> sub);
 
-    void timedOut(Error && ex) override { unreachable(); };
+    void timedOut(Error && ex) override
+    {
+        unreachable();
+    };
 
     std::string key() override;
 
     void handleEOF(Descriptor fd) override;
 
-    JobCategory jobCategory() const override {
+    JobCategory jobCategory() const override
+    {
         return JobCategory::Substitution;
     };
 };

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -50,6 +50,16 @@ enum struct JobCategory {
      * A substitution an arbitrary store object; it will use network resources.
      */
     Substitution,
+    /**
+     * A goal that does no "real" work by itself, and just exists to depend on
+     * other goals which *do* do real work. These goals therefore are not
+     * limited.
+     *
+     * These goals cannot infinitely create themselves, so there is no risk of
+     * a "fork bomb" type situation (which would be a problem even though the
+     * goal do no real work) either.
+     */
+    Administration,
 };
 
 struct Goal : public std::enable_shared_from_this<Goal>
@@ -376,6 +386,17 @@ public:
      * ensures we don't.
      */
     BuildResult getBuildResult(const DerivedPath &) const;
+
+    /**
+     * Hack to say that this goal should not log `ex`, but instead keep
+     * it around. Set by a waitee which sees itself as the designated
+     * continuation of this goal, responsible for reporting its
+     * successes or failures.
+     *
+     * @todo this is yet another not-nice hack in the goal system that
+     * we ought to get rid of. See #11927
+     */
+    bool preserveException = false;
 
     /**
      * Exception containing an error message, if any.

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -372,6 +372,18 @@ protected:
      */
     Done amDone(ExitCode result, std::optional<Error> ex = {});
 
+    /**
+     * @return true just for those `ExitCode`s that are avalid argument
+     * to `amDone`.
+     *
+     * Used for an assert in `amDone`, and also in some not-so-pretty
+     * goal-retry logic.
+     *
+     * @todo If the latter caller is removed, then this function no
+     * longer needs to be exposed.
+     */
+    static bool finalExitCode(ExitCode result);
+
 public:
     virtual void cleanup() { }
 

--- a/src/libstore/include/nix/store/derived-path-map.hh
+++ b/src/libstore/include/nix/store/derived-path-map.hh
@@ -21,8 +21,11 @@ namespace nix {
  *
  * @param V A type to instantiate for each output. It should probably
  * should be an "optional" type so not every interior node has to have a
- * value. `* const Something` or `std::optional<Something>` would be
- * good choices for "optional" types.
+ * value. For example, the scheduler uses
+ * `DerivedPathMap<std::weak_ptr<DerivationCreationAndRealisationGoal>>` to
+ * remember which goals correspond to which outputs. `* const Something`
+ * or `std::optional<Something>` would also be good choices for
+ * "optional" types.
  */
 template<typename V>
 struct DerivedPathMap {

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -14,6 +14,7 @@ headers = [config_pub_h] + files(
   'build-result.hh',
   'build/derivation-goal.hh',
   'build/derivation-building-misc.hh',
+  'build/derivation-creation-and-realisation-goal.hh',
   'build/drv-output-substitution-goal.hh',
   'build/goal.hh',
   'build/substitution-goal.hh',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -254,6 +254,7 @@ sources = files(
   'binary-cache-store.cc',
   'build-result.cc',
   'build/derivation-goal.cc',
+  'build/derivation-creation-and-realisation-goal.cc',
   'build/drv-output-substitution-goal.cc',
   'build/entry-points.cc',
   'build/goal.cc',

--- a/tests/functional/dyn-drv/build-built-drv.sh
+++ b/tests/functional/dyn-drv/build-built-drv.sh
@@ -18,4 +18,9 @@ clearStore
 
 drvDep=$(nix-instantiate ./text-hashed-output.nix -A producingDrv)
 
-expectStderr 1 nix build "${drvDep}^out^out" --no-link | grepQuiet "Building dynamic derivations in one shot is not yet implemented"
+# Store layer needs bugfix
+requireDaemonNewerThan "2.27pre20250205"
+
+out2=$(nix build "${drvDep}^out^out" --no-link)
+
+test $out1 == $out2

--- a/tests/functional/dyn-drv/dep-built-drv-2.sh
+++ b/tests/functional/dyn-drv/dep-built-drv-2.sh
@@ -13,4 +13,4 @@ restartDaemon
 NIX_BIN_DIR="$(dirname "$(type -p nix)")"
 export NIX_BIN_DIR
 
-expectStderr 1 nix build -L --file ./non-trivial.nix --no-link | grepQuiet "Building dynamic derivations in one shot is not yet implemented"
+nix build -L --file ./non-trivial.nix --no-link

--- a/tests/functional/dyn-drv/dep-built-drv.sh
+++ b/tests/functional/dyn-drv/dep-built-drv.sh
@@ -4,8 +4,11 @@ source common.sh
 
 out1=$(nix-build ./text-hashed-output.nix -A hello --no-out-link)
 
+# Store layer needs bugfix
+requireDaemonNewerThan "2.27pre20250205"
+
 clearStore
 
-expectStderr 1 nix-build ./text-hashed-output.nix -A wrapper --no-out-link | grepQuiet "Building dynamic derivations in one shot is not yet implemented"
+out2=$(nix-build ./text-hashed-output.nix -A wrapper --no-out-link)
 
-# diff -r $out1 $out2
+diff -r $out1 $out2

--- a/tests/functional/dyn-drv/failing-outer.sh
+++ b/tests/functional/dyn-drv/failing-outer.sh
@@ -5,8 +5,6 @@ source common.sh
 # Store layer needs bugfix
 requireDaemonNewerThan "2.27pre20250205"
 
-skipTest "dyn drv input scheduling had to be reverted for 2.27"
-
 expected=100
 if [[ -v NIX_DAEMON_PACKAGE ]]; then expected=1; fi # work around the daemon not returning a 100 status correctly
 


### PR DESCRIPTION
## Motivation

Fix #9052

## Context

It's hard to reproduce this race condition going forward (e.g. it depends on the precise order that goals are scheduled, but https://github.com/roberth/nix-9052 current reproduces it, and this fixes that.

I don't really like how the fix just piles on more complexity, but I have some ideas on how a larger re-work can clean things up.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
