### PR TITLE
nix flake archive: Recurse into relative path inputs

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1090,21 +1090,21 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun
             nlohmann::json jsonObj2 = json ? json::object() : nlohmann::json(nullptr);
             for (auto & [inputName, input] : node.inputs) {
                 if (auto inputNode = std::get_if<0>(&input)) {
-                    if ((*inputNode)->lockedRef.input.isRelative())
-                        continue;
-                    auto storePath =
-                        dryRun
-                        ? (*inputNode)->lockedRef.input.computeStorePath(*store)
-                        : (*inputNode)->lockedRef.input.fetchToStore(store).first;
+                    std::optional<StorePath> storePath;
+                    if (!(*inputNode)->lockedRef.input.isRelative()) {
+                        storePath =
+                            dryRun
+                            ? (*inputNode)->lockedRef.input.computeStorePath(*store)
+                            : (*inputNode)->lockedRef.input.fetchToStore(store).first;
+                        sources.insert(*storePath);
+                    }
                     if (json) {
                         auto & jsonObj3 = jsonObj2[inputName];
-                        jsonObj3["path"] = store->printStorePath(storePath);
-                        sources.insert(std::move(storePath));
+                        if (storePath)
+                            jsonObj3["path"] = store->printStorePath(*storePath);
                         jsonObj3["inputs"] = traverse(**inputNode);
-                    } else {
-                        sources.insert(std::move(storePath));
+                    } else
                         traverse(**inputNode);
-                    }
                 }
             }
             return jsonObj2;

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -99,6 +99,16 @@ writeTrivialFlake() {
 EOF
 }
 
+initGitRepo() {
+    local repo="$1"
+    local extraArgs="${2-}"
+
+    # shellcheck disable=SC2086 # word splitting of extraArgs is intended
+    git -C "$repo" init $extraArgs
+    git -C "$repo" config user.email "foobar@example.com"
+    git -C "$repo" config user.name "Foobar"
+}
+
 createGitRepo() {
     local repo="$1"
     local extraArgs="${2-}"
@@ -107,7 +117,5 @@ createGitRepo() {
     mkdir -p "$repo"
 
     # shellcheck disable=SC2086 # word splitting of extraArgs is intended
-    git -C "$repo" init $extraArgs
-    git -C "$repo" config user.email "foobar@example.com"
-    git -C "$repo" config user.name "Foobar"
+    initGitRepo "$repo" $extraArgs
 }

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -45,7 +45,7 @@ EOF
 
 [[ $(nix eval "$rootFlake?dir=sub1#y") = 6 ]]
 
-git init "$rootFlake"
+initGitRepo "$rootFlake"
 git -C "$rootFlake" add flake.nix sub0/flake.nix sub1/flake.nix
 
 [[ $(nix eval "$subflake1#y") = 6 ]]
@@ -77,7 +77,17 @@ fi
 (! grep narHash "$subflake2/flake.lock")
 
 # Test `nix flake archive` with relative path flakes.
-nix flake archive --json "$rootFlake"
+git -C "$rootFlake" add flake.lock
+git -C "$rootFlake" commit -a -m Foo
+
+json=$(nix flake archive --json "$rootFlake" --to "$TEST_ROOT/store2")
+[[ $(echo "$json" | jq .inputs.sub0.inputs) = {} ]]
+[[ -n $(echo "$json" | jq .path) ]]
+
+nix flake prefetch --out-link "$TEST_ROOT/result" "$rootFlake"
+outPath=$(readlink "$TEST_ROOT/result")
+
+[ -e "$TEST_ROOT/store2/nix/store/$(basename "$outPath")" ]
 
 # Test circular relative path flakes. FIXME: doesn't work at the moment.
 if false; then


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

We can't ignore them entirely, since we do want to archive their transitive inputs.

Fixes #12438.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
