### PR TITLE
maint: Re-add intel mac build, on Rosetta this time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,15 @@ jobs:
         include:
           - scenario: on ubuntu
             runs-on: ubuntu-24.04
+            system: x86_64-linux
             os: linux
-          - scenario: on macos
+          - scenario: on macos (aarch64)
             runs-on: macos-14
+            system: aarch64-darwin
+            os: darwin
+          - scenario: on macos (x86_64)
+            runs-on: macos-14
+            system: x86_64-darwin
             os: darwin
     name: tests ${{ matrix.scenario }}
     runs-on: ${{ matrix.runs-on }}
@@ -40,6 +46,7 @@ jobs:
         extra_nix_config: |
           sandbox = true
           max-jobs = 1
+          system = ${{ matrix.system }}
     - uses: DeterminateSystems/magic-nix-cache-action@main
     # Since ubuntu 22.30, unprivileged usernamespaces are no longer allowed to map to the root user:
     # https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
@@ -58,6 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # No x86_64-darwin (yet?) because of poor performance and similarity to aarch64-darwin
         include:
           - scenario: on ubuntu
             runs-on: ubuntu-24.04


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Restore x86_64-darwin CI.
<!-- Briefly explain what the change is about and why it is desirable. -->

Thanks @emilazy https://github.com/NixOS/nix/pull/11144#issuecomment-2241278060 for the suggestion.

## Context

- Alternative to #11144

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
