### PR TITLE
Add host attribute of github/gitlab flakerefs to URL serialization

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -149,6 +149,9 @@ struct GitArchiveInputScheme : InputScheme
         };
         if (auto narHash = input.getNarHash())
             url.query.insert_or_assign("narHash", narHash->to_string(HashFormat::SRI, true));
+        auto host = maybeGetStrAttr(input.attrs, "host");
+        if (host)
+            url.query.insert_or_assign("host", *host);
         return url;
     }
 


### PR DESCRIPTION
## Motivation

`GitArchiveInputScheme::toUrl` currently drops the `host` attribute, creating invalid urls when locking `github:` or `gitlab:` urls pointing to alterative instances and serializing the input back to a url.

## Context

```
❯ cat flake.nix
{
  inputs.gnome-2048 = {
    url = "gitlab:GNOME/gnome-2048?host=gitlab.gnome.org";
    flake = false;
  };

  outputs = inputs: {};
}
f1xb57354q79t_jpw5_h79cw0000gq/T/tmp.MOBbzbpT35
❯ nix flake metadata
warning: creating lock file '/private/var/folders/fb/f1xb57354q79t_jpw5_h79cw0000gq/T/tmp.MOBbzbpT35/flake.lock':
• Added input 'gnome-2048':
    'gitlab:GNOME/gnome-2048/70e0e430ca4bf590990433a3abdce6b631d50e6e?narHash=sha256-bya45ug2mDSU4SMn0fSBlZCuPl9y15B12ubKeb2A58s%3D' (2025-02-21)
Resolved URL:  path:/private/var/folders/fb/f1xb57354q79t_jpw5_h79cw0000gq/T/tmp.MOBbzbpT35
Locked URL:    path:/private/var/folders/fb/f1xb57354q79t_jpw5_h79cw0000gq/T/tmp.MOBbzbpT35?lastModified=1740744684&narHash=sha256-nxUL/JiTYbZX2c1XiN/TC6aA1hf%2B1YXsUvhL7ASY2uE%3D
Path:          /nix/store/f4xczpwhdxs8gal1rika1c5bvhyd472l-source
Last modified: 2025-02-28 13:11:24
Inputs:
└───gnome-2048: gitlab:GNOME/gnome-2048/70e0e430ca4bf590990433a3abdce6b631d50e6e?narHash=sha256-bya45ug2mDSU4SMn0fSBlZCuPl9y15B12ubKeb2A58s%3D (2025-02-21 23:18:46)
```

Note the gnome-2048 input url missing the original host query.

The Url after this commit:

```
[...]
Inputs:
└───gnome-2048: gitlab:GNOME/gnome-2048/70e0e430ca4bf590990433a3abdce6b631d50e6e?host=gitlab.gnome.org&narHash=sha256-bya45ug2mDSU4SMn0fSBlZCuPl9y15B12ubKeb2A58s%3D (2025-02-21 23:18:46)
```

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
