### PR TITLE
nix flake pin: Mark the resulting registry entry as exact

### DIFF
--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -82,13 +82,15 @@ void Registry::write(const Path & path)
 void Registry::add(
     const Input & from,
     const Input & to,
-    const Attrs & extraAttrs)
+    const Attrs & extraAttrs,
+    bool exact)
 {
     entries.emplace_back(
         Entry {
             .from = from,
             .to = to,
-            .extraAttrs = extraAttrs
+            .extraAttrs = extraAttrs,
+            .exact = exact
         });
 }
 
@@ -142,7 +144,7 @@ void overrideRegistry(
     const Input & to,
     const Attrs & extraAttrs)
 {
-    getFlagRegistry(*from.settings)->add(from, to, extraAttrs);
+    getFlagRegistry(*from.settings)->add(from, to, extraAttrs, false);
 }
 
 static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, ref<Store> store)

--- a/src/libfetchers/registry.hh
+++ b/src/libfetchers/registry.hh
@@ -45,7 +45,8 @@ struct Registry
     void add(
         const Input & from,
         const Input & to,
-        const Attrs & extraAttrs);
+        const Attrs & extraAttrs,
+        bool exact);
 
     void remove(const Input & input);
 };

--- a/src/nix/registry.cc
+++ b/src/nix/registry.cc
@@ -115,7 +115,7 @@ struct CmdRegistryAdd : MixEvalArgs, Command, RegistryCommand
         fetchers::Attrs extraAttrs;
         if (toRef.subdir != "") extraAttrs["dir"] = toRef.subdir;
         registry->remove(fromRef.input);
-        registry->add(fromRef.input, toRef.input, extraAttrs);
+        registry->add(fromRef.input, toRef.input, extraAttrs, false);
         registry->write(getRegistryPath());
     }
 };
@@ -193,7 +193,7 @@ struct CmdRegistryPin : RegistryCommand, EvalCommand
             warn("flake '%s' is not locked", resolved.to_string());
         fetchers::Attrs extraAttrs;
         if (ref.subdir != "") extraAttrs["dir"] = ref.subdir;
-        registry->add(ref.input, resolved, extraAttrs);
+        registry->add(ref.input, resolved, extraAttrs, true);
         registry->write(getRegistryPath());
     }
 };


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Since the resulting target flakeref contains attributes like `lastModified` or `narHash`, it's not suitable for overriding. This led to errors like

```
$ nix build nixpkgs/24.05#hello
error: 'lastModified' attribute mismatch in input 'github:NixOS/nixpkgs/63dacb46bf939521bdc93981b4cbb7ecb58427a0', expected 1728538411, got 1717179513
```

after doing `nix registry pin nixpkgs`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
