### PR TITLE
`nix flake show`: Skip IFDs instead of throwing

### DIFF
--- a/src/libexpr/eval-error.cc
+++ b/src/libexpr/eval-error.cc
@@ -110,5 +110,6 @@ template class EvalErrorBuilder<UndefinedVarError>;
 template class EvalErrorBuilder<MissingArgumentError>;
 template class EvalErrorBuilder<InfiniteRecursionError>;
 template class EvalErrorBuilder<InvalidPathError>;
+template class EvalErrorBuilder<IFDError>;
 
 }

--- a/src/libexpr/eval-error.hh
+++ b/src/libexpr/eval-error.hh
@@ -54,6 +54,7 @@ MakeError(TypeError, EvalError);
 MakeError(UndefinedVarError, EvalError);
 MakeError(MissingArgumentError, EvalError);
 MakeError(InfiniteRecursionError, EvalError);
+MakeError(IFDError, EvalBaseError);
 
 struct InvalidPathError : public EvalError
 {

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -91,7 +91,7 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
     if (drvs.empty()) return {};
 
     if (isIFD && !settings.enableImportFromDerivation)
-        error<EvalBaseError>(
+        error<IFDError>(
             "cannot build '%1%' during evaluation because the option 'allow-import-from-derivation' is disabled",
             drvs.begin()->to_string(*store)
         ).debugThrow();

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1329,18 +1329,34 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             logger->warn(fmt("%s omitted (use '--all-systems' to show)", concatStringsSep(".", attrPathS)));
                         }
                     } else {
-                        if (visitor.isDerivation())
-                            showDerivation();
-                        else
-                            throw Error("expected a derivation");
+                        try {
+                            if (visitor.isDerivation())
+                                showDerivation();
+                            else
+                                throw Error("expected a derivation");
+                        } catch (IFDError & e) {
+                            if (!json) {
+                                logger->cout(fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL, headerPrefix));
+                            } else {
+                                logger->warn(fmt("%s omitted due to use of import from derivation", concatStringsSep(".", attrPathS)));
+                            }
+                        }
                     }
                 }
 
                 else if (attrPath.size() > 0 && attrPathS[0] == "hydraJobs") {
-                    if (visitor.isDerivation())
-                        showDerivation();
-                    else
-                        recurse();
+                    try {
+                        if (visitor.isDerivation())
+                            showDerivation();
+                        else
+                            recurse();
+                    } catch (IFDError & e) {
+                        if (!json) {
+                            logger->cout(fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL, headerPrefix));
+                        } else {
+                            logger->warn(fmt("%s omitted due to use of import from derivation", concatStringsSep(".", attrPathS)));
+                        }
+                    }
                 }
 
                 else if (attrPath.size() > 0 && attrPathS[0] == "legacyPackages") {
@@ -1359,11 +1375,19 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                             logger->warn(fmt("%s omitted (use '--all-systems' to show)", concatStringsSep(".", attrPathS)));
                         }
                     } else {
-                        if (visitor.isDerivation())
-                            showDerivation();
-                        else if (attrPath.size() <= 2)
-                            // FIXME: handle recurseIntoAttrs
-                            recurse();
+                        try {
+                            if (visitor.isDerivation())
+                                showDerivation();
+                            else if (attrPath.size() <= 2)
+                                // FIXME: handle recurseIntoAttrs
+                                recurse();
+                        } catch (IFDError & e) {
+                            if (!json) {
+                                logger->cout(fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL, headerPrefix));
+                            } else {
+                                logger->warn(fmt("%s omitted due to use of import from derivation", concatStringsSep(".", attrPathS)));
+                            }
+                        }
                     }
                 }
 

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -88,6 +88,19 @@ writeDependentFlake() {
 EOF
 }
 
+writeIfdFlake() {
+    local flakeDir="$1"
+    cat > "$flakeDir/flake.nix" <<EOF
+{
+  outputs = { self }: {
+    packages.$system.default = import ./ifd.nix;
+  };
+}
+EOF
+
+    cp -n ../ifd.nix ../dependencies.nix ../dependencies.builder0.sh "${config_nix}" "$flakeDir/"
+}
+
 writeTrivialFlake() {
     local flakeDir="$1"
     cat > "$flakeDir/flake.nix" <<EOF

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -6,7 +6,7 @@ flakeDir=$TEST_ROOT/flake
 mkdir -p "$flakeDir"
 
 writeSimpleFlake "$flakeDir"
-cd "$flakeDir"
+pushd "$flakeDir"
 
 
 # By default: Only show the packages content for the current system and no
@@ -85,5 +85,20 @@ let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
 in
 assert show_output.legacyPackages.${builtins.currentSystem}.AAAAAASomeThingsFailToEvaluate == { };
 assert show_output.legacyPackages.${builtins.currentSystem}.simple.name == "simple";
+true
+'
+
+# Test that nix flake show doesn't fail if one of the outputs contains
+# an IFD
+popd
+writeIfdFlake $flakeDir
+pushd $flakeDir
+
+
+nix flake show --json > show-output.json
+nix eval --impure --expr '
+let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
+in
+assert show_output.packages.${builtins.currentSystem}.default == { };
 true
 '


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

As mentioned in https://github.com/NixOS/nix/issues/4265#issuecomment-887406031, `nix flake show` fails if it encounters an IFD while it's trying to show the derivations inside the flake. This means that `nix flake show` is effectively broken if you are using IFD's in almost any place in your flake.

## Context

Following `--all-systems`, `nix flake show` now shows an "omitted" message when it encounters an IFD. To this end, I gave IFD errors an explicit type that made this possible.

Example output with this patch:
```
git+file:///Users/ulucs/projects/flake-filter
├───checks
│   ├───aarch64-darwin
│   │   └───flake-filter omitted due to use of import from derivation
│   ├───aarch64-linux
│   │   └───flake-filter omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   └───flake-filter omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───flake-filter omitted (use '--all-systems' to show)
├───devShells
│   ├───aarch64-darwin
│   │   ├───default: development environment 'nix-shell'
│   │   └───rust: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   ├───default omitted (use '--all-systems' to show)
│   │   └───rust omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   ├───default omitted (use '--all-systems' to show)
│   │   └───rust omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       ├───default omitted (use '--all-systems' to show)
│       └───rust omitted (use '--all-systems' to show)
└───packages
    ├───aarch64-darwin
    │   ├───default omitted due to use of import from derivation
    │   └───rust omitted due to use of import from derivation
    ├───aarch64-linux
    │   ├───default omitted (use '--all-systems' to show)
    │   └───rust omitted (use '--all-systems' to show)
    ├───x86_64-darwin
    │   ├───default omitted (use '--all-systems' to show)
    │   └───rust omitted (use '--all-systems' to show)
    └───x86_64-linux
        ├───default omitted (use '--all-systems' to show)
        └───rust omitted (use '--all-systems' to show)
```

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
