### PR TITLE
nix_store_free: fix not calling store destructors

### DIFF
--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -53,7 +53,7 @@ Store * nix_store_open(nix_c_context * context, const char * uri, const char ***
 
 void nix_store_free(Store * store)
 {
-    delete store;
+    delete &(*store->ptr);
 }
 
 nix_err nix_store_get_uri(nix_c_context * context, Store * store, nix_get_string_callback callback, void * user_data)


### PR DESCRIPTION
Discovered because files (e.g. db.sqlite) weren't being closed by nix_store_free, which should be the main purpose of the function. On Windows, open files prevent deletion, breaking unit tests.

There's no destructor on a ref, only what it points to.