### PR TITLE
Imply --offline during tab completion

### DIFF
--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -236,7 +236,8 @@ void ParseQuoted::operator()(std::shared_ptr<Parser> &state, Strings & r) {
     assert(false);
 }
 
-Strings parseShebangContent(std::string_view s) {
+Strings parseShebangContent(std::string_view s)
+{
     Strings result;
     std::shared_ptr<Parser> parserState(std::make_shared<ParseUnquoted>(ParseUnquoted(s)));
 

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -92,6 +92,19 @@ static bool haveInternet()
 #endif
 }
 
+static void disableNet()
+{
+    // FIXME: should check for command line overrides only.
+    if (!settings.useSubstitutes.overridden)
+        settings.useSubstitutes = false;
+    if (!settings.tarballTtl.overridden)
+        settings.tarballTtl = std::numeric_limits<unsigned int>::max();
+    if (!fileTransferSettings.tries.overridden)
+        fileTransferSettings.tries = 0;
+    if (!fileTransferSettings.connectTimeout.overridden)
+        fileTransferSettings.connectTimeout = 1;
+}
+
 std::string programPath;
 
 struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
@@ -479,10 +492,16 @@ void mainWrapped(int argc, char * * argv)
         }
     });
 
+    if (getEnv("NIX_GET_COMPLETIONS"))
+        /* Avoid fetching stuff during tab completion. We have to this
+           early because we haven't checked `haveInternet()` yet
+           (below). */
+        disableNet();
+
     try {
         auto isNixCommand = std::regex_search(programName, std::regex("nix$"));
         auto allowShebang = isNixCommand && argc > 1;
-        args.parseCmdline(argvToStrings(argc, argv),allowShebang);
+        args.parseCmdline(argvToStrings(argc, argv), allowShebang);
     } catch (UsageError &) {
         if (!args.helpRequested && !args.completions) throw;
     }
@@ -519,17 +538,8 @@ void mainWrapped(int argc, char * * argv)
         args.useNet = false;
     }
 
-    if (!args.useNet) {
-        // FIXME: should check for command line overrides only.
-        if (!settings.useSubstitutes.overridden)
-            settings.useSubstitutes = false;
-        if (!settings.tarballTtl.overridden)
-            settings.tarballTtl = std::numeric_limits<unsigned int>::max();
-        if (!fileTransferSettings.tries.overridden)
-            fileTransferSettings.tries = 0;
-        if (!fileTransferSettings.connectTimeout.overridden)
-            fileTransferSettings.connectTimeout = 1;
-    }
+    if (!args.useNet)
+        disableNet();
 
     if (args.refresh) {
         settings.tarballTtl = 0;


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Previously, if you don't have Internet connectivity, tab completion might try to fetch the flake registry, e.g.

```
$ NIX_GET_COMPLETIONS=4 nix build -vvvvv --offline /home/eelco/De
evaluating file '<nix/derivation-internal.nix>'
downloading 'https://channels.nixos.org/flake-registry.json'...
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 294 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 541 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 1230 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; retrying in 2285 ms
warning: error: unable to download 'https://channels.nixos.org/flake-registry.json': Could not resolve hostname (6) Could not resolve host: channels.nixos.org; using cached version
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
