### PR TITLE
packaging: Typo in setVersionLayer / preConfigure

### DIFF
--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -51,7 +51,7 @@ let
 
   setVersionLayer = finalAttrs: prevAttrs: {
     preConfigure =
-      prevAttrs.prevAttrs or ""
+      prevAttrs.preConfigure or ""
       +
         # Update the repo-global .version file.
         # Symlink ./.version points there, but by default only workDir is writable.


### PR DESCRIPTION
Apparently dead code in our use case, but good to keep nonetheless. Credit: ztzg in https://github.com/NixOS/nix/pull/12498#pullrequestreview-2658031853

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
