### PR TITLE
libstore: curl retry: reset content-encoding and don't use string after move

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -21,10 +21,8 @@
 
 #include <curl/curl.h>
 
-#include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <iostream>
 #include <queue>
 #include <random>
 #include <thread>
@@ -536,6 +534,8 @@ struct curlFileTransfer : public FileTransfer
                         warn("%s; retrying from offset %d in %d ms", exc.what(), writtenToSink, ms);
                     else
                         warn("%s; retrying in %d ms", exc.what(), ms);
+                    decompressionSink.reset();
+                    errorSink.reset();
                     embargo = std::chrono::steady_clock::now() + std::chrono::milliseconds(ms);
                     fileTransfer.enqueueItem(shared_from_this());
                 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

While analyzing #12419 I discovered that in case of a HTTP error `429` the retry behavior is problematic. The same `TransferItem` is issued again. `decompressionSink` is not reinitialized, so that it might be used after `finish()` is called. Furthermore it's possible that `errorSink` is used again after `errorSink->s` is moved.

Additionally the `Content-Encoding` header of the HTTP `429` response and of the HTTP `200` response might be different. In this case the decompression of the HTTP `200` response body might fail.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Might fix #12419, although I wasn't able to provoke any HTTP error `429` on Github. Github seems to prefer `gzip` encoding and the response body of the error response shown in the issue seems to be short, but not empty. Thus it seems to be unlikely that this error response contained the header `Content-Encoding: gzip`, while the reply with the content probably had it set. More details about the responses would be helpful.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
