### PR TITLE
flake: Enable UBSAN for checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -263,18 +263,46 @@
           flatMapAttrs
             (
               {
-                "" = nixpkgsFor.${system}.native;
+                # Run all tests with UBSAN enabled. Running both with ubsan and
+                # without doesn't seem to have much immediate benefit for doubling
+                # the GHA CI workaround.
+                #
+                # TODO: Work toward enabling "address,undefined" if it seems feasible.
+                # This would maybe require dropping Boost coroutines and ignoring intentional
+                # memory leaks with detect_leaks=0.
+                "" = rec {
+                  nixpkgs = nixpkgsFor.${system}.native;
+                  nixComponents = nixpkgs.nixComponents.overrideScope (
+                    nixCompFinal: nixCompPrev: {
+                      mesonComponentOverrides = _finalAttrs: prevAttrs: {
+                        mesonFlags =
+                          (prevAttrs.mesonFlags or [ ])
+                          # TODO: Macos builds instrumented with ubsan take very long
+                          # to run functional tests.
+                          ++ lib.optionals (!nixpkgs.stdenv.hostPlatform.isDarwin) [
+                            (lib.mesonOption "b_sanitize" "undefined")
+                          ];
+                      };
+                    }
+                  );
+                };
               }
               // lib.optionalAttrs (!nixpkgsFor.${system}.native.stdenv.hostPlatform.isDarwin) {
                 # TODO: enable static builds for darwin, blocked on:
                 #       https://github.com/NixOS/nixpkgs/issues/320448
                 # TODO: disabled to speed up GHA CI.
-                #"static-" = nixpkgsFor.${system}.native.pkgsStatic;
+                # "static-" = {
+                #   nixpkgs = nixpkgsFor.${system}.native.pkgsStatic;
+                # };
               }
             )
             (
-              nixpkgsPrefix: nixpkgs:
-              flatMapAttrs nixpkgs.nixComponents (
+              nixpkgsPrefix:
+              {
+                nixpkgs,
+                nixComponents ? nixpkgs.nixComponents,
+              }:
+              flatMapAttrs nixComponents (
                 pkgName: pkg:
                 flatMapAttrs pkg.tests or { } (
                   testName: test: {
@@ -283,7 +311,7 @@
                 )
               )
               // lib.optionalAttrs (nixpkgs.stdenv.hostPlatform == nixpkgs.stdenv.buildPlatform) {
-                "${nixpkgsPrefix}nix-functional-tests" = nixpkgs.nixComponents.nix-functional-tests;
+                "${nixpkgsPrefix}nix-functional-tests" = nixComponents.nix-functional-tests;
               }
             )
         // devFlake.checks.${system} or { }

--- a/src/libutil/strings.cc
+++ b/src/libutil/strings.cc
@@ -17,8 +17,10 @@ struct view_stringbuf : public std::stringbuf
     }
 };
 
-std::string_view toView(const std::ostringstream & os)
+__attribute__((no_sanitize("undefined"))) std::string_view toView(const std::ostringstream & os)
 {
+    /* Downcasting like this is very much undefined behavior, so we disable
+       UBSAN for this function. */
     auto buf = static_cast<view_stringbuf *>(os.rdbuf());
     return buf->toView();
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Doing this makes catching non-obvious bugs easier. GHA CI workload is already a concern and there isn't much benefit in running the tests with and without sanitizers at the same time, so UBSAN is enabled for default checks.

This change doesn't affect production builds in any way, but is rather a step in the direction of improving automated testing during development.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Relates to #10969.

cc @roberth @Ericson2314

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
