### PR TITLE
c-api: fix a few memory leaks

### DIFF
--- a/src/libexpr-c/nix_api_expr.cc
+++ b/src/libexpr-c/nix_api_expr.cc
@@ -199,7 +199,9 @@ EvalState * nix_state_create(nix_c_context * context, const char ** lookupPath_c
             != NIX_OK)
         return nullptr;
 
-    return nix_eval_state_build(context, builder);
+    auto *state = nix_eval_state_build(context, builder);
+    nix_eval_state_builder_free(builder);
+    return state;
 }
 
 void nix_state_free(EvalState * state)

--- a/src/libexpr-tests/nix_api_external.cc
+++ b/src/libexpr-tests/nix_api_external.cc
@@ -63,6 +63,9 @@ TEST_F(nix_api_expr_test, nix_expr_eval_external)
     std::string string_value;
     nix_get_string(nullptr, valueResult, OBSERVE_STRING(string_value));
     ASSERT_STREQ("nix-external<MyExternalValueDesc( 42 )>", string_value.c_str());
+
+    nix_state_free(stateResult);
+    nix_state_free(stateFn);
 }
 
 }

--- a/src/libflake-tests/nix_api_flake.cc
+++ b/src/libflake-tests/nix_api_flake.cc
@@ -43,6 +43,9 @@ TEST_F(nix_api_store_test, nix_api_init_global_getFlake_exists)
     ASSERT_NE(nullptr, value);
 
     nix_err err = nix_expr_eval_from_string(ctx, state, "builtins.getFlake", ".", value);
+
+    nix_state_free(state);
+
     assert_ctx_ok();
     ASSERT_EQ(NIX_OK, err);
     ASSERT_EQ(NIX_TYPE_FUNCTION, nix_get_type(ctx, value));


### PR DESCRIPTION
Discovered when Windows couldn't delete files because the local store deconstructor hadn't run to close files handles.