### PR TITLE
Skip CI if merge conflict exists.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,33 @@ on:
 permissions: read-all
 
 jobs:
+  check_merge_conflicts:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check for Merge Conflicts
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request?.number;
+            if (!prNumber) {
+              console.log("Not a pull request, skipping merge conflict check.");
+              return;
+            }            
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });  
+            if (pr.mergeable === false) {
+              core.setFailed("❌ Merge conflict detected! Please resolve before CI can run.");
+            } else if (pr.mergeable === null) {
+              console.setFailed("❌ GitHub is still checking mergeability, rerun if necessary.");
+            } else {
+              console.log("✅ No merge conflicts detected.");
+            }
   eval:
+    needs: check_merge_conflicts
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
@@ -17,6 +43,7 @@ jobs:
     - run: nix --experimental-features 'nix-command flakes' flake show --all-systems --json
 
   tests:
+    needs: check_merge_conflicts
     strategy:
       fail-fast: false
       matrix:
@@ -54,7 +81,7 @@ jobs:
         path: out/*
 
   installer_test:
-    needs: [tests]
+    needs: [tests, check_merge_conflicts]
     strategy:
       fail-fast: false
       matrix:
@@ -97,6 +124,7 @@ jobs:
   # 2. Store your dockerhub username as DOCKERHUB_USERNAME in "Repository secrets" of your fork repository settings (https://github.com/$githubuser/nix/settings/secrets/actions)
   # 3. Create an access token in https://hub.docker.com/settings/security and store it as DOCKERHUB_TOKEN in "Repository secrets" of your fork
   check_secrets:
+    needs: check_merge_conflicts
     permissions:
       contents: none
     name: Check Docker secrets present for installer tests
@@ -112,7 +140,7 @@ jobs:
           echo "::set-output name=docker::${{ env._DOCKER_SECRETS != '' }}"
 
   docker_push_image:
-    needs: [tests, vm_tests, check_secrets]
+    needs: [tests, vm_tests, check_secrets, check_merge_conflicts]
     permissions:
       contents: read
       packages: write
@@ -172,6 +200,7 @@ jobs:
         docker push $IMAGE_ID:master
 
   vm_tests:
+    needs: check_merge_conflicts
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -185,8 +214,8 @@ jobs:
             .#hydraJobs.tests.tarballFlakes \
             ;
 
-  flake_regressions:
-    needs: vm_tests
+  flake_regressions:  
+    needs: [vm_tests, check_merge_conflicts]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This PR stops CI from running at all if merge conflicts exist.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

I noticed that another PR kicked off a bunch of CI despite being full of merge conflicts--this seems like a waste of resources.

I'm not sure this is the best way to fix that, or even if we want to skip CI when merge conflicts exist, but I figured this is a starting point.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
