### PR TITLE
libutil/windows: Finally use the correct constructor for std::wstring

### DIFF
--- a/src/libutil/windows/environment-variables.cc
+++ b/src/libutil/windows/environment-variables.cc
@@ -13,8 +13,10 @@ std::optional<OsString> getEnvOs(const OsString & key)
         return std::nullopt;
     }
 
-    // Allocate a buffer to hold the environment variable value
-    std::wstring value{bufferSize, L'\0'};
+    /* Allocate a buffer to hold the environment variable value.
+       WARNING: Do not even think about using uniform initialization here,
+       we DONT want to call the initializer list ctor accidentally. */
+    std::wstring value(bufferSize, L'\0');
 
     // Retrieve the environment variable value
     DWORD resultSize = GetEnvironmentVariableW(key.c_str(), &value[0], bufferSize);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

C++ is very intuitive /s [1]. https://github.com/NixOS/nix/issues/12631#issuecomment-2713557095

[1]: https://godbolt.org/z/jMa9GP5sq

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes #12631.

cc @Ericson2314

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
