### PR TITLE
port crash-handler from lix to nix

### DIFF
--- a/src/nix/crash-handler.cc
+++ b/src/nix/crash-handler.cc
@@ -1,0 +1,67 @@
+#include "crash-handler.hh"
+#include "fmt.hh"
+#include "logging.hh"
+
+#include <boost/core/demangle.hpp>
+#include <exception>
+#include <sstream>
+
+// Darwin and FreeBSD stdenv do not define _GNU_SOURCE but do have _Unwind_Backtrace.
+#if __APPLE__ || __FreeBSD__
+#  define BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED
+#endif
+
+#include <boost/stacktrace/stacktrace.hpp>
+
+#ifndef _WIN32
+#  include <syslog.h>
+#endif
+
+namespace nix {
+
+namespace {
+
+void logFatal(std::string const & s)
+{
+    writeToStderr(s + "\n");
+    // std::string for guaranteed null termination
+#ifndef _WIN32
+    syslog(LOG_CRIT, "%s", s.c_str());
+#endif
+}
+
+void onTerminate()
+{
+    logFatal(
+        "Nix crashed. This is a bug. Please report this at https://github.com/NixOS/nix/issues with the following information included:\n");
+    try {
+        std::exception_ptr eptr = std::current_exception();
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        } else {
+            logFatal("std::terminate() called without exception");
+        }
+    } catch (const std::exception & ex) {
+        logFatal(fmt("Exception: %s: %s", boost::core::demangle(typeid(ex).name()), ex.what()));
+    } catch (...) {
+        logFatal("Unknown exception!");
+    }
+
+    logFatal("Stack trace:");
+    std::stringstream ss;
+    ss << boost::stacktrace::stacktrace();
+    logFatal(ss.str());
+
+    std::abort();
+}
+}
+
+void registerCrashHandler()
+{
+    // DO NOT use this for signals. Boost stacktrace is very much not
+    // async-signal-safe, and in a world with ASLR, addr2line is pointless.
+    //
+    // If you want signals, set up a minidump system and do it out-of-process.
+    std::set_terminate(onTerminate);
+}
+}

--- a/src/nix/crash-handler.hh
+++ b/src/nix/crash-handler.hh
@@ -1,0 +1,11 @@
+#pragma once
+/// @file Crash handler for Nix that prints back traces (hopefully in instances where it is not just going to crash the
+/// process itself).
+
+namespace nix {
+
+/** Registers the Nix crash handler for std::terminate (currently; will support more crashes later). See also
+ * detectStackOverflow().  */
+void registerCrashHandler();
+
+}

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -20,6 +20,7 @@
 #include "flake/flake.hh"
 #include "self-exe.hh"
 #include "json-utils.hh"
+#include "crash-handler.hh"
 
 #include <sys/types.h>
 #include <regex>
@@ -353,6 +354,8 @@ static auto rCmdHelpStores = registerCommand<CmdHelpStores>("help-stores");
 void mainWrapped(int argc, char * * argv)
 {
     savedArgv = argv;
+
+    registerCrashHandler();
 
     /* The chroot helper needs to be run before any threads have been
        started. */

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -77,6 +77,7 @@ nix_sources = [config_h] + files(
   'config-check.cc',
   'config.cc',
   'copy.cc',
+  'crash-handler.cc',
   'derivation-add.cc',
   'derivation-show.cc',
   'derivation.cc',


### PR DESCRIPTION
It was first introduced in https://git.lix.systems/lix-project/lix/commit/19e0ce2c03d8e0baa16998b086665664c420c1df

In Nix we only register the crash handler in main instead of initNix, because library user may want to use their own crash handler.

Sample output:

```
Mar 12 08:38:06 eve nix[2303762]: Nix crashed. This is a bug. Please report this at https://github.com/NixOS/nix/issues with the following information included: Mar 12 08:38:06 eve nix[2303762]: Exception: nix::SysError: error: writing to file: Resource temporarily unavailable Mar 12 08:38:06 eve nix[2303762]: Stack trace:
Mar 12 08:38:06 eve nix[2303762]:  0# 0x000000000076876A in nix
                                   1# 0x00007FDA40E9F20A in /nix/store/2lhklm5aizx30qbw49acnrrzkj9lbmij-gcc-14-20241116-lib/lib/libstdc++.so.6
                                   2# std::unexpected() in /nix/store/2lhklm5aizx30qbw49acnrrzkj9lbmij-gcc-14-20241116-lib/lib/libstdc++.so.6
                                   3# 0x00007FDA40E9F487 in /nix/store/2lhklm5aizx30qbw49acnrrzkj9lbmij-gcc-14-20241116-lib/lib/libstdc++.so.6
                                   4# nix::writeFull(int, std::basic_string_view<char, std::char_traits<char> >, bool) in /home/joerg/git/nix/inst/lib/libnixutil.so
                                   5# nix::writeLine(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) in /home/joerg/git/nix/inst/lib/libnixutil.so
                                   6# nix::JSONLogger::write(nlohmann::json_abi_v3_11_3::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_3::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> >, void> const&) in /home/joerg/git/nix/inst/lib/libnixutil.so
                                   7# nix::JSONLogger::logEI(nix::ErrorInfo const&) in /home/joerg/git/nix/inst/lib/libnixutil.so
                                   8# nix::Logger::logEI(nix::Verbosity, nix::ErrorInfo) in nix
                                   9# nix::handleExceptions(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()>) in /home/joerg/git/nix/inst/lib/libnixmain.so
                                  10# 0x000000000087A563 in nix
                                  11# 0x00007FDA40BD41FE in /nix/store/6q2mknq81cyscjmkv72fpcsvan56qhmg-glibc-2.40-66/lib/libc.so.6
                                  12# __libc_start_main in /nix/store/6q2mknq81cyscjmkv72fpcsvan56qhmg-glibc-2.40-66/lib/libc.so.6
                                  13# 0x00000000006F4DF5 in nix

```
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
