### PR TITLE
Remove unused parameter to the goal constructor

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -38,7 +38,7 @@ namespace nix {
 
 DerivationGoal::DerivationGoal(const StorePath & drvPath,
     const OutputsSpec & wantedOutputs, Worker & worker, BuildMode buildMode)
-    : Goal(worker, DerivedPath::Built { .drvPath = makeConstantStorePathRef(drvPath), .outputs = wantedOutputs })
+    : Goal(worker)
     , useDerivation(true)
     , drvPath(drvPath)
     , wantedOutputs(wantedOutputs)
@@ -56,7 +56,7 @@ DerivationGoal::DerivationGoal(const StorePath & drvPath,
 
 DerivationGoal::DerivationGoal(const StorePath & drvPath, const BasicDerivation & drv,
     const OutputsSpec & wantedOutputs, Worker & worker, BuildMode buildMode)
-    : Goal(worker, DerivedPath::Built { .drvPath = makeConstantStorePathRef(drvPath), .outputs = wantedOutputs })
+    : Goal(worker)
     , useDerivation(false)
     , drvPath(drvPath)
     , wantedOutputs(wantedOutputs)

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -11,7 +11,7 @@ DrvOutputSubstitutionGoal::DrvOutputSubstitutionGoal(
     Worker & worker,
     RepairFlag repair,
     std::optional<ContentAddress> ca)
-    : Goal(worker, DerivedPath::Opaque { StorePath::dummy })
+    : Goal(worker)
     , id(id)
 {
     name = fmt("substitution of '%s'", id.to_string());

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -378,7 +378,7 @@ public:
      */
     std::optional<Error> ex;
 
-    Goal(Worker & worker, DerivedPath path)
+    Goal(Worker & worker)
         : worker(worker), top_co(init_wrapper())
     {
         // top_co shouldn't have a goal already, should be nullptr.

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -8,7 +8,7 @@
 namespace nix {
 
 PathSubstitutionGoal::PathSubstitutionGoal(const StorePath & storePath, Worker & worker, RepairFlag repair, std::optional<ContentAddress> ca)
-    : Goal(worker, DerivedPath::Opaque { storePath })
+    : Goal(worker)
     , storePath(storePath)
     , repair(repair)
     , ca(ca)


### PR DESCRIPTION
## Context

It has been unused since 37fca662b0acef3c104a159709a394832e297dda.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
