### PR TITLE
nix-cli: Add --json --pretty / --no-pretty

### DIFF
--- a/src/libmain/common-args.cc
+++ b/src/libmain/common-args.cc
@@ -1,3 +1,5 @@
+#include <nlohmann/json.hpp>
+
 #include "common-args.hh"
 #include "args/root.hh"
 #include "config-global.hh"
@@ -93,5 +95,18 @@ void MixCommonArgs::initialFlagsProcessed()
     pluginsInited();
 }
 
-
+template <typename T, typename>
+void MixPrintJSON::printJSON(const T /* nlohmann::json */ & json)
+{
+    auto suspension = logger->suspend();
+    if (outputPretty) {
+        logger->writeToStdout(json.dump(2));
+    } else {
+        logger->writeToStdout(json.dump());
+    }
 }
+
+template void MixPrintJSON::printJSON(const nlohmann::json & json);
+
+
+} // namespace nix

--- a/src/libmain/common-args.hh
+++ b/src/libmain/common-args.hh
@@ -29,7 +29,6 @@ struct MixDryRun : virtual Args
         addFlag({
             .longName = "dry-run",
             .description = "Show what this command would do without doing it.",
-            //.category = commonArgsCategory,
             .handler = {&dryRun, true},
         });
     }
@@ -58,7 +57,6 @@ struct MixPrintJSON : virtual Args
 
                     This option is only effective when `--json` is also specified.
                 )",
-            //.category = commonArgsCategory,
             .handler = {&outputPretty, true},
         });
         addFlag({
@@ -70,7 +68,6 @@ struct MixPrintJSON : virtual Args
 
                     See `--pretty`.
                 )",
-            //.category = commonArgsCategory,
             .handler = {&outputPretty, false},
         });
     };
@@ -103,7 +100,6 @@ struct MixJSON : virtual Args, virtual MixPrintJSON
         addFlag({
             .longName = "json",
             .description = "Produce output in JSON format, suitable for consumption by another program.",
-            //.category = commonArgsCategory,
             .handler = {&json, true},
         });
     }

--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -101,7 +101,7 @@ struct CmdBuild : InstallablesCommand, MixDryRun, MixJSON, MixProfile
             printMissing(store, pathsToBuild, lvlError);
 
             if (json)
-                logger->cout("%s", derivedPathsToJSON(pathsToBuild, *store).dump());
+                printJSON(derivedPathsToJSON(pathsToBuild, *store));
 
             return;
         }

--- a/src/nix/config.cc
+++ b/src/nix/config.cc
@@ -63,7 +63,7 @@ struct CmdConfigShow : Command, MixJSON
 
         if (json) {
             // FIXME: use appropriate JSON types (bool, ints, etc).
-            logger->cout("%s", globalConfig.toJSON().dump());
+            printJSON(globalConfig.toJSON());
         } else {
             logger->cout("%s", globalConfig.toKeyValue());
         }

--- a/src/nix/derivation-show.cc
+++ b/src/nix/derivation-show.cc
@@ -11,7 +11,7 @@
 using namespace nix;
 using json = nlohmann::json;
 
-struct CmdShowDerivation : InstallablesCommand
+struct CmdShowDerivation : InstallablesCommand, MixPrintJSON
 {
     bool recursive = false;
 
@@ -57,7 +57,7 @@ struct CmdShowDerivation : InstallablesCommand
             jsonRoot[store->printStorePath(drvPath)] =
                 store->readDerivation(drvPath).toJSON(*store);
         }
-        logger->cout(jsonRoot.dump(2));
+        printJSON(jsonRoot);
     }
 };
 

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -118,7 +118,7 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
         }
 
         else if (json) {
-            logger->cout("%s", printValueAsJSON(*state, true, *v, pos, context, false));
+            printJSON(printValueAsJSON(*state, true, *v, pos, context, false));
         }
 
         else {

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -242,7 +242,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
             j["locks"] = lockedFlake.lockFile.toJSON().first;
             if (auto fingerprint = lockedFlake.getFingerprint(store, fetchSettings))
                 j["fingerprint"] = fingerprint->to_string(HashFormat::Base16, false);
-            logger->cout("%s", j.dump());
+            printJSON(j);
         } else {
             logger->cout(
                 ANSI_BOLD "Resolved URL:" ANSI_NORMAL "  %s",
@@ -1115,7 +1115,7 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun
                 {"path", store->printStorePath(storePath)},
                 {"inputs", traverse(*flake.lockFile.root)},
             };
-            logger->cout("%s", jsonRoot);
+            printJSON(jsonRoot);
         } else {
             traverse(*flake.lockFile.root);
         }
@@ -1427,7 +1427,7 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
 
         auto j = visit(*cache->getRoot(), {}, fmt(ANSI_BOLD "%s" ANSI_NORMAL, flake->flake.lockedRef), "");
         if (json)
-            logger->cout("%s", j.dump());
+            printJSON(j);
     }
 };
 
@@ -1473,7 +1473,7 @@ struct CmdFlakePrefetch : FlakeCommand, MixJSON
             res["hash"] = hash.to_string(HashFormat::SRI, true);
             res["original"] = fetchers::attrsToJSON(resolvedRef.toAttrs());
             res["locked"] = fetchers::attrsToJSON(lockedRef.toAttrs());
-            logger->cout(res.dump());
+            printJSON(res);
         } else {
             notice("Downloaded '%s' to '%s' (hash '%s').",
                 lockedRef.to_string(),

--- a/src/nix/make-content-addressed.cc
+++ b/src/nix/make-content-addressed.cc
@@ -44,7 +44,7 @@ struct CmdMakeContentAddressed : virtual CopyCommand, virtual StorePathsCommand,
             }
             auto json = json::object();
             json["rewrites"] = jsonRewrites;
-            logger->cout("%s", json);
+            printJSON(json);
         } else {
             for (auto & path : storePaths) {
                 auto i = remappings.find(path);

--- a/src/nix/path-info.cc
+++ b/src/nix/path-info.cc
@@ -154,11 +154,11 @@ struct CmdPathInfo : StorePathsCommand, MixJSON
             pathLen = std::max(pathLen, store->printStorePath(storePath).size());
 
         if (json) {
-            logger->cout(pathInfoToJSON(
+            printJSON(pathInfoToJSON(
                 *store,
                 // FIXME: preserve order?
                 StorePathSet(storePaths.begin(), storePaths.end()),
-                showClosureSize).dump());
+                showClosureSize));
         }
 
         else {

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -326,7 +326,7 @@ struct CmdStorePrefetchFile : StoreCommand, MixJSON
             auto res = nlohmann::json::object();
             res["storePath"] = store->printStorePath(storePath);
             res["hash"] = hash.to_string(HashFormat::SRI, true);
-            logger->cout(res.dump());
+            printJSON(res);
         } else {
             notice("Downloaded '%s' to '%s' (hash '%s').",
                 url,

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -802,7 +802,7 @@ struct CmdProfileList : virtual EvalCommand, virtual StoreCommand, MixDefaultPro
         ProfileManifest manifest(*getEvalState(), *profile);
 
         if (json) {
-            std::cout << manifest.toJSON(*store).dump() << "\n";
+            printJSON(manifest.toJSON(*store));
         } else {
             for (const auto & [i, e] : enumerate(manifest.elements)) {
                 auto & [name, element] = e;

--- a/src/nix/realisation.cc
+++ b/src/nix/realisation.cc
@@ -57,7 +57,7 @@ struct CmdRealisationInfo : BuiltPathsCommand, MixJSON
 
                 res.push_back(currentPath);
             }
-            logger->cout("%s", res);
+            printJSON(res);
         }
         else {
             for (auto & path : realisations) {

--- a/src/nix/search.cc
+++ b/src/nix/search.cc
@@ -198,7 +198,7 @@ struct CmdSearch : InstallableValueCommand, MixJSON
             visit(*cursor, cursor->getAttrPath(), true);
 
         if (json)
-            logger->cout("%s", *jsonOut);
+            printJSON(*jsonOut);
 
         if (!json && !results)
             throw Error("no results for the given search term(s)!");

--- a/src/nix/store-info.cc
+++ b/src/nix/store-info.cc
@@ -33,7 +33,7 @@ struct CmdPingStore : StoreCommand, MixJSON
         } else {
             nlohmann::json res;
             Finally printRes([&]() {
-                logger->cout("%s", res);
+                printJSON(res);
             });
 
             res["url"] = store->getUri();

--- a/tests/functional/json.sh
+++ b/tests/functional/json.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+# Meson would split the output into two buffers, ruining the coherence of the log.
+exec 1>&2
+
+cat > "$TEST_HOME/expected-machine.json" <<EOF
+{"a":{"b":{"c":true}}}
+EOF
+
+cat > "$TEST_HOME/expected-pretty.json" <<EOF
+{
+  "a": {
+    "b": {
+      "c": true
+    }
+  }
+}
+EOF
+
+nix eval --json --expr '{ a.b.c = true; }' > "$TEST_HOME/actual.json"
+diff -U3 "$TEST_HOME/expected-machine.json" "$TEST_HOME/actual.json"
+
+nix eval --json --pretty --expr \
+  '{ a.b.c = true; }' > "$TEST_HOME/actual.json"
+diff -U3 "$TEST_HOME/expected-pretty.json" "$TEST_HOME/actual.json"
+
+if type script &>/dev/null; then
+  script --return --quiet --command 'nix eval --json --expr "{ a.b.c = true; }"' > "$TEST_HOME/actual.json"
+  cat "$TEST_HOME/actual.json"
+  # script isn't perfectly accurate? Let's grep for a pretty good indication, as the pretty output has a space between the key and the value.
+  # diff -U3 "$TEST_HOME/expected-pretty.json" "$TEST_HOME/actual.json"
+  grep -F '"a": {' "$TEST_HOME/actual.json"
+
+  script --return --quiet --command 'nix eval --json --pretty --expr "{ a.b.c = true; }"' > "$TEST_HOME/actual.json"
+  cat "$TEST_HOME/actual.json"
+  grep -F '"a": {' "$TEST_HOME/actual.json"
+
+  script --return --quiet --command 'nix eval --json --no-pretty --expr "{ a.b.c = true; }"' > "$TEST_HOME/actual.json"
+  cat "$TEST_HOME/actual.json"
+  grep -F '"a":{' "$TEST_HOME/actual.json"
+
+fi

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -157,6 +157,7 @@ suites = [
       'impure-derivations.sh',
       'path-from-hash-part.sh',
       'path-info.sh',
+      'json.sh',
       'toString-path.sh',
       'read-only-store.sh',
       'nested-sandboxing.sh',


### PR DESCRIPTION
- Closes #12555
- May fix cases of JSON output getting interleaved with progress bar refresh output in the terminal.
- Make `nix derivation show` _not_ a special case

Scripts are mostly unaffected because there, stdout will be a file or a pipe, not a terminal, so they get the old behavior.
(Of course scripts can be constructed that create terminals etc, as I did in the test, but taking that into account would be disproportionate.)

This refactors `nix develop` internals a bit to use the `json` type more. The assertion now operates in the in-memory json instead of re-parsing it. While this is technically a weaker guarantee, we should be able to rely on the library to get this right. It's its most essential purpose.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fix a repeating papercut.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Closes #12555

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
