### PR TITLE
Improve the documentation of store path

### DIFF
--- a/doc/manual/source/protocols/store-path.md
+++ b/doc/manual/source/protocols/store-path.md
@@ -7,7 +7,7 @@ The format of this specification is close to [Extended Backus–Naur form](https
 Regular users do *not* need to know this information --- store paths can be treated as black boxes computed from the properties of the store objects they refer to.
 But for those interested in exactly how Nix works, e.g. if they are reimplementing it, this information can be useful.
 
-[store path](@docroot@/store/store-path.md)
+[store path]: @docroot@/store/store-path.md
 
 ## Store path proper
 
@@ -20,14 +20,14 @@ where
 
 - `store-dir` = the [store directory](@docroot@/store/store-path.md#store-directory)
 
-- `digest` = base-32 representation of the first 160 bits of a [SHA-256] hash of `fingerprint`
+- `digest` = base-32 representation of the first 160 bits of a [SHA-256] hash of `fingerprint`, with the extra 96 bits XORed with the first 160 bits.
 
-  This the hash part of the store name
+  This is the hash part of the store name
 
 ## Fingerprint
 
 - ```ebnf
-  fingerprint = type ":" sha256 ":" inner-digest ":" store ":" name
+  fingerprint = type ":sha256:" inner-digest ":" store ":" name
   ```
 
   Note that it includes the location of the store as well as the name to make sure that changes to either of those are reflected in the hash


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

> digest = base-32 representation of the first 160 bits of a [SHA-256](https://en.m.wikipedia.org/wiki/SHA-256) hash of fingerprint

This is the code used for compressing
https://github.com/NixOS/nix/blob/2cfd0315113edebefc38dd7f9d7dd57599629dc6/src/libutil/hash.cc#L387-L394
The  fucntion `compressHash` not only takes the first 160 bits but also with a XOR operaton.

>fingerprint = type ":" sha256 ":" inner-digest ":" store ":" name

https://github.com/NixOS/nix/blob/2cfd0315113edebefc38dd7f9d7dd57599629dc6/src/libstore/store-api.cc#L86


The `sha256` should be a string not a variable


## Context


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
