### PR TITLE
Use feature_level field from libcpuid

### DIFF
--- a/src/libutil/compute-levels.cc
+++ b/src/libutil/compute-levels.cc
@@ -23,9 +23,9 @@ StringSet computeLevels() {
     if (cpu_identify(NULL, &data) < 0)
         return levels;
 
-    for (cpu_feature_level_t level = FEATURE_LEVEL_X86_64_V1; level <= FEATURE_LEVEL_X86_64_V4; level++)
+    for (auto & [level, levelString] : feature_strings)
         if (data.feature_level >= level)
-            levels.insert(feature_strings.at(level));
+            levels.insert(levelString);
 
     return levels;
 }

--- a/src/libutil/compute-levels.cc
+++ b/src/libutil/compute-levels.cc
@@ -2,6 +2,7 @@
 
 #if HAVE_LIBCPUID
 #include <libcpuid/libcpuid.h>
+#include <map>
 #endif
 
 namespace nix {
@@ -10,61 +11,21 @@ namespace nix {
 
 StringSet computeLevels() {
     StringSet levels;
+    struct cpu_id_t data;
 
-    if (!cpuid_present())
+    const std::map<cpu_feature_level_t, std::string> feature_strings = {
+        { FEATURE_LEVEL_X86_64_V1, "x86_64-v1" },
+        { FEATURE_LEVEL_X86_64_V2, "x86_64-v2" },
+        { FEATURE_LEVEL_X86_64_V3, "x86_64-v3" },
+        { FEATURE_LEVEL_X86_64_V4, "x86_64-v4" },
+    };
+
+    if (cpu_identify(NULL, &data) < 0)
         return levels;
 
-    cpu_raw_data_t raw;
-    cpu_id_t data;
-
-    if (cpuid_get_raw_data(&raw) < 0)
-        return levels;
-
-    if (cpu_identify(&raw, &data) < 0)
-        return levels;
-
-    if (!(data.flags[CPU_FEATURE_CMOV] &&
-            data.flags[CPU_FEATURE_CX8] &&
-            data.flags[CPU_FEATURE_FPU] &&
-            data.flags[CPU_FEATURE_FXSR] &&
-            data.flags[CPU_FEATURE_MMX] &&
-            data.flags[CPU_FEATURE_SSE] &&
-            data.flags[CPU_FEATURE_SSE2]))
-        return levels;
-
-    levels.insert("x86_64-v1");
-
-    if (!(data.flags[CPU_FEATURE_CX16] &&
-            data.flags[CPU_FEATURE_LAHF_LM] &&
-            data.flags[CPU_FEATURE_POPCNT] &&
-            // SSE3
-            data.flags[CPU_FEATURE_PNI] &&
-            data.flags[CPU_FEATURE_SSSE3] &&
-            data.flags[CPU_FEATURE_SSE4_1] &&
-            data.flags[CPU_FEATURE_SSE4_2]))
-        return levels;
-
-    levels.insert("x86_64-v2");
-
-    if (!(data.flags[CPU_FEATURE_AVX] &&
-            data.flags[CPU_FEATURE_AVX2] &&
-            data.flags[CPU_FEATURE_F16C] &&
-            data.flags[CPU_FEATURE_FMA3] &&
-            // LZCNT
-            data.flags[CPU_FEATURE_ABM] &&
-            data.flags[CPU_FEATURE_MOVBE]))
-        return levels;
-
-    levels.insert("x86_64-v3");
-
-    if (!(data.flags[CPU_FEATURE_AVX512F] &&
-            data.flags[CPU_FEATURE_AVX512BW] &&
-            data.flags[CPU_FEATURE_AVX512CD] &&
-            data.flags[CPU_FEATURE_AVX512DQ] &&
-            data.flags[CPU_FEATURE_AVX512VL]))
-        return levels;
-
-    levels.insert("x86_64-v4");
+    for (cpu_feature_level_t level = FEATURE_LEVEL_X86_64_V1; level <= FEATURE_LEVEL_X86_64_V4; level++)
+        if (data.feature_level >= level)
+            levels.insert(feature_strings.at(level));
 
     return levels;
 }

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -105,7 +105,7 @@ cpuid_required = get_option('cpuid')
 if host_machine.cpu_family() != 'x86_64' and cpuid_required.enabled()
   warning('Force-enabling seccomp on non-x86_64 does not make sense')
 endif
-cpuid = dependency('libcpuid', 'cpuid', required : cpuid_required)
+cpuid = dependency('libcpuid', 'cpuid', version : '>= 0.7.0', required : cpuid_required)
 configdata.set('HAVE_LIBCPUID', cpuid.found().to_int())
 deps_private += cpuid
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

In anrieff/libcpuid#177, it was requested to add x86_64 architecture levels to libcpuid.
Since libcpuid v0.7.0, this feature is available in `feature_level` field.
The goal of this PR is to simplify the `computeLevels()` function.

## Context

<!-- Provide context. Reference open issues if available. -->
Refer to #11375.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
