### PR TITLE
Implement memory-mapped IO and multi-threading for BLAKE3 hashing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745391562,
-        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "lastModified": 1746141548,
+        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
         "type": "github"
       },
       "original": {

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -61,6 +61,7 @@ scope: {
         "--with-container"
         "--with-context"
         "--with-coroutine"
+        "--with-iostreams"
       ];
     }).overrideAttrs
       (old: {

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -173,7 +173,7 @@ Descriptor openDirectory(const std::filesystem::path & path);
  */
 std::string readFile(const Path & path);
 std::string readFile(const std::filesystem::path & path);
-void readFile(const Path & path, Sink & sink);
+void readFile(const Path & path, Sink & sink, bool memory_map = true);
 
 /**
  * Write a string to a file.

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -56,7 +56,7 @@ deps_private += blake3
 
 boost = dependency(
   'boost',
-  modules : ['context', 'coroutine'],
+  modules : ['context', 'coroutine', 'iostreams'],
   include_type: 'system',
 )
 # boost is a public dependency, but not a pkg-config dependency unfortunately, so we

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -50,7 +50,8 @@ endif
 
 blake3 = dependency(
   'libblake3',
-  version: '>= 1.5.5',
+  version: '>= 1.8.2',
+  method : 'pkg-config',
 )
 deps_private += blake3
 


### PR DESCRIPTION
This PR implements memory-mapped IO and multi-threading for BLAKE3 hashing.

Performance with these changes is now on par with the proposed Rust interop: https://github.com/NixOS/nix/pull/12416.

### Benchmarks

<details>
NOTE: These numbers are taken from https://github.com/NixOS/nix/pull/12416 based on the Rust implementation, and so are only an estimate. In practice they should (for the BLAKE3 results) be nearly identical, based on my local testing and original testing for the `libblake3` TBB feature upstream.


NOTE: The non-BLAKE3 results may be faster by a small margin with this PR than what is stated in the benchmarks since they will also make use of the memory-mapping changes.

### Config

CPU: AMD Ryzen 9 7950X 16-Core @ 5.88 GHz
RAM: 96GB @ 6400 MT/s
OS: CachyOS February 2025 release w/ bpfland scx

Input files created with:

```
head -c <size> /dev/urandom > ~/<size>.bin
```

example:

```
head -c 1G /dev/urandom > 1G.bin
```

Benchmarks all used the following:

```
hyperfine --warmup 3 './outputs/out/bin/nix hash file --type <algo> <file>'
```

### 100K file

#### BLAKE3 (original)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/100K.bin
  Time (mean ± σ):       9.5 ms ±   0.1 ms    [User: 5.6 ms, System: 3.6 ms]
  Range (min … max):     9.1 ms …  10.0 ms    299 runs
```

#### BLAKE3 (memory-mapping + tbb)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/100K.bin
  Time (mean ± σ):       9.6 ms ±   0.9 ms    [User: 5.9 ms, System: 3.3 ms]
  Range (min … max):     9.2 ms …  24.7 ms    285 runs
```

#### SHA256
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha256 ~/100K.bin
  Time (mean ± σ):       9.6 ms ±   0.9 ms    [User: 5.7 ms, System: 3.5 ms]
  Range (min … max):     9.0 ms …  23.1 ms    290 runs
```

#### SHA512
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha512 ~/100K.bin
  Time (mean ± σ):       9.6 ms ±   0.9 ms    [User: 5.8 ms, System: 3.3 ms]
  Range (min … max):     9.0 ms …  23.3 ms    288 runs
```

### 10M file

#### BLAKE3 (original)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/10M.bin
  Time (mean ± σ):      11.9 ms ±   2.6 ms    [User: 6.7 ms, System: 4.5 ms]
  Range (min … max):    11.0 ms …  32.8 ms    240 runs
```

#### BLAKE3 (memory-mapping + tbb)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/10M.bin
  Time (mean ± σ):      12.9 ms ±   1.1 ms    [User: 9.9 ms, System: 22.7 ms]
  Range (min … max):    11.3 ms …  16.6 ms    215 runs
```

#### SHA256
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha256 ~/10M.bin
  Time (mean ± σ):      13.9 ms ±   0.4 ms    [User: 9.4 ms, System: 4.1 ms]
  Range (min … max):    13.3 ms …  16.3 ms    201 runs
```

#### SHA512
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha512 ~/10M.bin
  Time (mean ± σ):      18.2 ms ±   0.5 ms    [User: 13.3 ms, System: 4.4 ms]
  Range (min … max):    17.4 ms …  21.6 ms    162 runs
```

### 100M file

#### BLAKE3 (original)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/100M.bin
  Time (mean ± σ):      26.2 ms ±   0.8 ms    [User: 17.0 ms, System: 8.7 ms]
  Range (min … max):    24.9 ms …  29.1 ms    111 runs
```

#### BLAKE3 (memory-mapping + tbb)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/100M.bin
  Time (mean ± σ):      17.5 ms ±   1.6 ms    [User: 33.9 ms, System: 41.7 ms]
  Range (min … max):    15.2 ms …  23.8 ms    128 runs
```

#### SHA256
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha256 ~/100M.bin
  Time (mean ± σ):      54.1 ms ±   0.5 ms    [User: 44.0 ms, System: 9.5 ms]
  Range (min … max):    53.4 ms …  55.5 ms    55 runs
```

#### SHA512
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha512 ~/100M.bin
  Time (mean ± σ):      96.1 ms ±   0.9 ms    [User: 85.8 ms, System: 9.4 ms]
  Range (min … max):    95.1 ms …  98.5 ms    31 runs
```

### 300M file

#### BLAKE3 (original)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/300M.bin
  Time (mean ± σ):      59.2 ms ±   0.9 ms    [User: 37.7 ms, System: 20.8 ms]
  Range (min … max):    57.8 ms …  61.9 ms    49 runs
```

#### BLAKE3 (memory-mapping + tbb)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/300M.bin
  Time (mean ± σ):      26.0 ms ±   1.6 ms    [User: 85.6 ms, System: 65.8 ms]
  Range (min … max):    22.8 ms …  31.1 ms    104 runs
```

#### SHA256
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha256 ~/300M.bin
  Time (mean ± σ):     139.6 ms ±   0.8 ms    [User: 116.4 ms, System: 22.5 ms]
  Range (min … max):   138.1 ms … 141.0 ms    21 runs
```

#### SHA512
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha512 ~/300M.bin
  Time (mean ± σ):     263.5 ms ±   3.0 ms    [User: 238.0 ms, System: 22.9 ms]
  Range (min … max):   260.4 ms … 269.5 ms    11 runs
```

### 1G file

#### BLAKE3 (original)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/1G.bin
  Time (mean ± σ):     190.9 ms ±   1.5 ms    [User: 113.6 ms, System: 76.1 ms]
  Range (min … max):   188.8 ms … 194.3 ms    15 runs
```

#### BLAKE3 (memory-mapping + tbb)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/1G.bin
  Time (mean ± σ):      52.5 ms ±   5.0 ms    [User: 304.9 ms, System: 114.4 ms]
  Range (min … max):    50.0 ms …  88.9 ms    58 runs
```

#### SHA256
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha256 ~/1G.bin
  Time (mean ± σ):     465.0 ms ±   4.5 ms    [User: 384.8 ms, System: 77.4 ms]
  Range (min … max):   461.8 ms … 477.0 ms    10 runs
```

#### SHA512
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha512 ~/1G.bin
  Time (mean ± σ):     877.5 ms ±   8.9 ms    [User: 795.5 ms, System: 77.3 ms]
  Range (min … max):   870.8 ms … 900.8 ms    10 runs
```

### 20G file

#### BLAKE3 (original)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/20G.bin
  Time (mean ± σ):      3.155 s ±  0.009 s    [User: 2.236 s, System: 0.914 s]
  Range (min … max):    3.143 s …  3.168 s    10 runs
```

#### BLAKE3 (memory-mapping + tbb)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/20G.bin
  Time (mean ± σ):     574.1 ms ±   9.8 ms    [User: 8339.7 ms, System: 1430.7 ms]
  Range (min … max):   563.6 ms … 596.4 ms    10 runs
```

#### SHA256
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha256 ~/20G.bin
  Time (mean ± σ):      8.756 s ±  0.011 s    [User: 7.812 s, System: 0.933 s]
  Range (min … max):    8.737 s …  8.767 s    10 runs
```

#### SHA512
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha512 ~/20G.bin
  Time (mean ± σ):     17.280 s ±  0.077 s    [User: 16.301 s, System: 0.954 s]
  Range (min … max):   17.220 s … 17.395 s    10 runs
```

### 64G file

#### BLAKE3 (original)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/64G.bin
  Time (mean ± σ):     17.145 s ±  0.086 s    [User: 7.154 s, System: 9.578 s]
  Range (min … max):   17.018 s … 17.276 s    10 runs
```

#### BLAKE3 (memory-mapping + tbb)
```
Benchmark 1: ./outputs/out/bin/nix hash file --type blake3 ~/64G.bin
  Time (mean ± σ):      1.822 s ±  0.011 s    [User: 26.895 s, System: 4.875 s]
  Range (min … max):    1.802 s …  1.832 s    10 runs
```

#### SHA256
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha256 ~/64G.bin
  Time (mean ± σ):     27.455 s ±  0.066 s    [User: 24.323 s, System: 3.072 s]
  Range (min … max):   27.343 s … 27.554 s    10 runs
```

#### SHA512
```
Benchmark 1: ./outputs/out/bin/nix hash file --type sha512 ~/64G.bin
  Time (mean ± σ):     53.807 s ±  0.212 s    [User: 50.615 s, System: 3.118 s]
  Range (min … max):   53.446 s … 54.187 s    10 runs
```
</details>

## Motivation

This PR adds additional functionality to the existing BLAKE3 implementation in `nix` to bring the performance on par with `b3sum`.

The performance difference between the two is due `b3sum` making use of the Rust BLAKE3 implementation which uses both memory-mapped IO and multi-threading.

Until recently, multi-threading was not available for the C-based `libblake3` but is now supported in [release `1.7.0`](https://github.com/BLAKE3-team/BLAKE3/releases/tag/1.7.0).

## Context

This PR is a follow up to https://github.com/NixOS/nix/pull/12379#issuecomment-2637977897.

Related: https://github.com/NixOS/nixpkgs/pull/390458

## Design Considerations

This PR implements memory-mapped IO via [`boost::iostreams::mapped_file`](https://www.boost.org/doc/libs/1_87_0/libs/iostreams/doc/classes/mapped_file.html), which adds a boost component dependency for `iostreams`.

Enabling multi-threading for `libblake3` also adds a dependency on `tbb` of at least version `2021_11`.

Memory-mapping is performed in:

```c++
void readFile(const Path & path, Sink & sink, bool memory_map = true);
```

and a new optional parameter `memory_map` is used to control whether memory-mapping is skipped in favor of normal file reading. (If memory-mapping fails, normal file reading is also used as the fallback).

This makes memory-mapping the default, which likely has performance implications beyond hashing. I would expect this to often be more performant than the alternative given available resources and modern hardware but haven't tested beyond hashing.

It may be appropriate to only enable memory-mapping when explicitly requested and/or gate memory-mapping behind an experimental feature. I can make those changes if requested.

@Ericson2314 @edolstra