### PR TITLE
Improve the documentation of store path

### DIFF
--- a/doc/manual/source/protocols/store-path.md
+++ b/doc/manual/source/protocols/store-path.md
@@ -7,7 +7,7 @@ The format of this specification is close to [Extended Backus–Naur form](https
 Regular users do *not* need to know this information --- store paths can be treated as black boxes computed from the properties of the store objects they refer to.
 But for those interested in exactly how Nix works, e.g. if they are reimplementing it, this information can be useful.
 
-[store path](@docroot@/store/store-path.md)
+[store path]: @docroot@/store/store-path.md
 
 ## Store path proper
 
@@ -30,7 +30,7 @@ the end, while base-16 processes in from the beginning.
 ## Fingerprint
 
 - ```ebnf
-  fingerprint = type ":" sha256 ":" inner-digest ":" store ":" name
+  fingerprint = type ":sha256:" inner-digest ":" store ":" name
   ```
 
   Note that it includes the location of the store as well as the name to make sure that changes to either of those are reflected in the hash


### PR DESCRIPTION

## Motivation
>fingerprint = type ":" sha256 ":" inner-digest ":" store ":" name

https://github.com/NixOS/nix/blob/2cfd0315113edebefc38dd7f9d7dd57599629dc6/src/libstore/store-api.cc#L86


The `sha256` should be a string not a variable

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
