### PR TITLE
Make Goal code use abstractions over interations with Worker

### DIFF
--- a/src/libstore/build/drv-output-substitution-goal.hh
+++ b/src/libstore/build/drv-output-substitution-goal.hh
@@ -34,7 +34,7 @@ public:
     GoalState state;
 
     Co init() override;
-    Co realisationFetched(std::shared_ptr<const Realisation> outputInfo, nix::ref<nix::Store> sub);
+    Co realisationFetched(Goals waitees, std::shared_ptr<const Realisation> outputInfo, nix::ref<nix::Store> sub);
 
     void timedOut(Error && ex) override { unreachable(); };
 

--- a/src/libstore/build/goal.hh
+++ b/src/libstore/build/goal.hh
@@ -54,17 +54,19 @@ enum struct JobCategory {
 
 struct Goal : public std::enable_shared_from_this<Goal>
 {
+private:
+    /**
+     * Goals that this goal is waiting for.
+     */
+    Goals waitees;
+
+public:
     typedef enum {ecBusy, ecSuccess, ecFailed, ecNoSubstituters, ecIncompleteClosure} ExitCode;
 
     /**
      * Backlink to the worker.
      */
     Worker & worker;
-
-    /**
-     * Goals that this goal is waiting for.
-     */
-    Goals waitees;
 
     /**
      * Goals waiting for this one to finish.  Must use weak pointers
@@ -104,8 +106,8 @@ protected:
      * Build result.
      */
     BuildResult buildResult;
-public:
 
+public:
     /**
      * Suspend our goal and wait until we get `work`-ed again.
      * `co_await`-able by @ref Co.
@@ -332,6 +334,7 @@ public:
         std::suspend_always await_transform(Suspend) { return {}; };
     };
 
+protected:
     /**
      * The coroutine being currently executed.
      * MUST be updated when switching the coroutine being executed.
@@ -359,6 +362,7 @@ public:
      */
     Done amDone(ExitCode result, std::optional<Error> ex = {});
 
+public:
     virtual void cleanup() { }
 
     /**
@@ -394,10 +398,6 @@ public:
 
     void work();
 
-    void addWaitee(GoalPtr waitee);
-
-    void waiteeDone(GoalPtr waitee, ExitCode result);
-
     virtual void handleChildOutput(Descriptor fd, std::string_view data)
     {
         unreachable();
@@ -429,6 +429,13 @@ public:
      * @see JobCategory
      */
     virtual JobCategory jobCategory() const = 0;
+
+protected:
+    Co await(Goals waitees);
+
+    Co waitForAWhile();
+    Co waitForBuildSlot();
+    Co yield();
 };
 
 void addToWeakGoals(WeakGoals & goals, GoalPtr p);

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -128,13 +128,15 @@ Goal::Co PathSubstitutionGoal::init()
             continue;
         }
 
+        Goals waitees;
+
         /* To maintain the closure invariant, we first have to realise the
            paths referenced by this one. */
         for (auto & i : info->references)
             if (i != storePath) /* ignore self-references */
-                addWaitee(worker.makePathSubstitutionGoal(i));
+                waitees.insert(worker.makePathSubstitutionGoal(i));
 
-        if (!waitees.empty()) co_await Suspend{};
+        co_await await(std::move(waitees));
 
         // FIXME: consider returning boolean instead of passing in reference
         bool out = false; // is mutated by tryToRun
@@ -175,8 +177,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(StorePath subPath, nix::ref<Store> sub, 
         if (i != storePath) /* ignore self-references */
             assert(worker.store.isValidPath(i));
 
-    worker.wakeUp(shared_from_this());
-    co_await Suspend{};
+    co_await yield();
 
     trace("trying to run");
 
@@ -184,8 +185,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(StorePath subPath, nix::ref<Store> sub, 
        if maxSubstitutionJobs == 0, we still allow a substituter to run. This
        prevents infinite waiting. */
     while (worker.getNrSubstitutions() >= std::max(1U, (unsigned int) settings.maxSubstitutionJobs)) {
-        worker.waitForBuildSlot(shared_from_this());
-        co_await Suspend{};
+        co_await waitForBuildSlot();
     }
 
     auto maintainRunningSubstitutions = std::make_unique<MaintainCount<uint64_t>>(worker.runningSubstitutions);


### PR DESCRIPTION
## Motivation

I didn't write this, @L-as did. I just rebased it.
 
> Instead of calling `worker.waitForAWhile(shared_from_this())` etc., the subclasses of Goal instead call protected functions defined in Goal that abstract over these.
> 
> The code for awaiting has also been heavily simplified. Instead of calling `addWaitee`, then suspending,
> `co_await await(waitees)` is called once, which also handles the suspend.
> 
> The end-goal is to remove all manual `co_await Suspend{}`s.

## Context

It's the first commit of #12668. I am pulling commits from there and my #12663 in "order of least controversy". The overall goal is https://github.com/NixOS/nix/issues/12628.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
