### PR TITLE
`MonitorFdHup`: replace `pthread_cancel` trick with a notification pipe

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -396,7 +396,6 @@
               ''^src/libutil/types\.hh$''
               ''^src/libutil/unix/file-descriptor\.cc$''
               ''^src/libutil/unix/file-path\.cc$''
-              ''^src/libutil/unix/monitor-fd\.hh$''
               ''^src/libutil/unix/processes\.cc$''
               ''^src/libutil/unix/signals-impl\.hh$''
               ''^src/libutil/unix/signals\.cc$''

--- a/src/libutil-tests/monitorfdhup.cc
+++ b/src/libutil-tests/monitorfdhup.cc
@@ -1,0 +1,18 @@
+#include "util.hh"
+#include "monitor-fd.hh"
+
+#include <sys/file.h>
+#include <gtest/gtest.h>
+
+namespace nix {
+TEST(MonitorFdHup, shouldNotBlock)
+{
+    Pipe p;
+    p.create();
+    {
+        // when monitor gets destroyed it should cancel the
+        // background thread and do not block
+        MonitorFdHup monitor(p.readSide.get());
+    }
+}
+}

--- a/src/libutil/unix/monitor-fd.hh
+++ b/src/libutil/unix/monitor-fd.hh
@@ -18,27 +18,45 @@ class MonitorFdHup
 {
 private:
     std::thread thread;
+    Pipe notifyPipe;
 
 public:
     MonitorFdHup(int fd)
     {
-        thread = std::thread([fd]() {
+        notifyPipe.create();
+        thread = std::thread([this, fd]() {
             while (true) {
-                /* Wait indefinitely until a POLLHUP occurs. */
-                constexpr size_t num_fds = 1;
-                struct pollfd fds[num_fds] = {
-                    {
-                        .fd = fd,
-                        .events =
                 /* Polling for no specific events (i.e. just waiting
                    for an error/hangup) doesn't work on macOS
                    anymore. So wait for read events and ignore
                    them. */
+                // FIXME(jade): we have looked at the XNU kernel code and as
+                // far as we can tell, the above is bogus. It should be the
+                // case that the previous version of this and the current
+                // version are identical: waiting for POLLHUP and POLLRDNORM in
+                // the kernel *should* be identical.
+                // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/kern/sys_generic.c#L1751-L1758
+                //
+                // So, this needs actual testing and we need to figure out if
+                // this is actually bogus.
+                short hangup_events =
 #ifdef __APPLE__
-                            POLLRDNORM,
+                    POLLRDNORM
 #else
-                            0,
+                    0
 #endif
+                    ;
+
+                /* Wait indefinitely until a POLLHUP occurs. */
+                constexpr size_t num_fds = 2;
+                struct pollfd fds[num_fds] = {
+                    {
+                        .fd = fd,
+                        .events = hangup_events,
+                    },
+                    {
+                        .fd = notifyPipe.readSide.get(),
+                        .events = hangup_events,
                     },
                 };
 
@@ -48,7 +66,6 @@ public:
                         continue;
                     throw SysError("failed to poll() in MonitorFdHup");
                 }
-
                 /* This shouldn't happen, but can on macOS due to a bug.
                    See rdar://37550628.
 
@@ -62,6 +79,9 @@ public:
                     unix::triggerInterrupt();
                     break;
                 }
+                if (fds[1].revents & POLLHUP) {
+                    break;
+                }
                 /* This will only happen on macOS. We sleep a bit to
                    avoid waking up too often if the client is sending
                    input. */
@@ -72,7 +92,7 @@ public:
 
     ~MonitorFdHup()
     {
-        pthread_cancel(thread.native_handle());
+        close(notifyPipe.writeSide.get());
         thread.join();
     }
 };

--- a/src/libutil/unix/monitor-fd.hh
+++ b/src/libutil/unix/monitor-fd.hh
@@ -25,7 +25,8 @@ public:
         thread = std::thread([fd]() {
             while (true) {
                 /* Wait indefinitely until a POLLHUP occurs. */
-                struct pollfd fds[1] = {
+                constexpr size_t num_fds = 1;
+                struct pollfd fds[num_fds] = {
                     {
                         .fd = fd,
                         .events =
@@ -41,7 +42,7 @@ public:
                     },
                 };
 
-                auto count = poll(fds, 1, -1);
+                auto count = poll(fds, num_fds, -1);
                 if (count == -1) {
                     if (errno == EINTR || errno == EAGAIN)
                         continue;

--- a/src/libutil/unix/monitor-fd.hh
+++ b/src/libutil/unix/monitor-fd.hh
@@ -25,19 +25,22 @@ public:
         thread = std::thread([fd]() {
             while (true) {
                 /* Wait indefinitely until a POLLHUP occurs. */
-                struct pollfd fds[1];
-                fds[0].fd = fd;
+                struct pollfd fds[1] = {
+                    {
+                        .fd = fd,
+                        .events =
                 /* Polling for no specific events (i.e. just waiting
                    for an error/hangup) doesn't work on macOS
                    anymore. So wait for read events and ignore
                    them. */
-                fds[0].events =
 #ifdef __APPLE__
-                    POLLRDNORM
+                            POLLRDNORM,
 #else
-                    0
+                            0,
 #endif
-                    ;
+                    },
+                };
+
                 auto count = poll(fds, 1, -1);
                 if (count == -1) {
                     if (errno == EINTR || errno == EAGAIN)

--- a/src/libutil/unix/monitor-fd.hh
+++ b/src/libutil/unix/monitor-fd.hh
@@ -39,8 +39,11 @@ public:
 #endif
                     ;
                 auto count = poll(fds, 1, -1);
-                if (count == -1)
-                    unreachable();
+                if (count == -1) {
+                    if (errno == EINTR || errno == EAGAIN)
+                        continue;
+                    throw SysError("failed to poll() in MonitorFdHup");
+                }
 
                 /* This shouldn't happen, but can on macOS due to a bug.
                    See rdar://37550628.

--- a/src/libutil/unix/monitor-fd.hh
+++ b/src/libutil/unix/monitor-fd.hh
@@ -26,22 +26,38 @@ public:
         notifyPipe.create();
         thread = std::thread([this, fd]() {
             while (true) {
-                /* Polling for no specific events (i.e. just waiting
-                   for an error/hangup) doesn't work on macOS
-                   anymore. So wait for read events and ignore
-                   them. */
-                // FIXME(jade): we have looked at the XNU kernel code and as
-                // far as we can tell, the above is bogus. It should be the
-                // case that the previous version of this and the current
-                // version are identical: waiting for POLLHUP and POLLRDNORM in
-                // the kernel *should* be identical.
+                // There is a POSIX violation on macOS: you have to listen for
+                // at least POLLHUP to receive HUP events for a FD. POSIX says
+                // this is not so, and you should just receive them regardless.
+                // However, as of our testing on macOS 14.5, the events do not
+                // get delivered if in the all-bits-unset case, but do get
+                // delivered if `POLLHUP` is set.
+                //
+                // This bug filed as rdar://37537852
+                // (https://openradar.appspot.com/37537852).
+                //
+                // macOS's own man page
+                // (https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/poll.2.html)
+                // additionally says that `POLLHUP` is ignored as an input. It
+                // seems the likely order of events here was
+                //
+                // 1. macOS did not follow the POSIX spec
+                //
+                // 2. Somebody ninja-fixed this other spec violation to make
+                // sure `POLLHUP` was not forgotten about, even though they
+                // "fixed" this issue in a spec-non-compliant way. Whatever,
+                // we'll use the fix.
+                //
+                // Relevant code, current version, which shows the :
                 // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/kern/sys_generic.c#L1751-L1758
                 //
-                // So, this needs actual testing and we need to figure out if
-                // this is actually bogus.
+                // The `POLLHUP` detection was added in
+                // https://github.com/apple-oss-distributions/xnu/commit/e13b1fa57645afc8a7b2e7d868fe9845c6b08c40#diff-a5aa0b0e7f4d866ca417f60702689fc797e9cdfe33b601b05ccf43086c35d395R1468
+                // That means added in 2007 or earlier. Should be good enough
+                // for us.
                 short hangup_events =
 #ifdef __APPLE__
-                    POLLRDNORM
+                    POLLHUP
 #else
                     0
 #endif
@@ -82,9 +98,10 @@ public:
                 if (fds[1].revents & POLLHUP) {
                     break;
                 }
-                /* This will only happen on macOS. We sleep a bit to
-                   avoid waking up too often if the client is sending
-                   input. */
+                // On macOS, it is possible (although not observed on macOS
+                // 14.5) that in some limited cases on buggy kernel versions,
+                // all the non-POLLHUP events for the socket get delivered.
+                // Sleeping avoids pointlessly spinning a thread on those.
                 sleep(1);
             }
         });

--- a/src/libutil/unix/monitor-fd.hh
+++ b/src/libutil/unix/monitor-fd.hh
@@ -14,7 +14,6 @@
 
 namespace nix {
 
-
 class MonitorFdHup
 {
 private:
@@ -33,11 +32,11 @@ public:
                    anymore. So wait for read events and ignore
                    them. */
                 fds[0].events =
-                    #ifdef __APPLE__
+#ifdef __APPLE__
                     POLLRDNORM
-                    #else
+#else
                     0
-                    #endif
+#endif
                     ;
                 auto count = poll(fds, 1, -1);
                 if (count == -1)
@@ -50,7 +49,8 @@ public:
                    coordination with the main thread if spinning proves
                    too harmful.
                 */
-                if (count == 0) continue;
+                if (count == 0)
+                    continue;
                 if (fds[0].revents & POLLHUP) {
                     unix::triggerInterrupt();
                     break;
@@ -69,6 +69,5 @@ public:
         thread.join();
     }
 };
-
 
 }


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

On https://github.com/NixOS/nix/issues/8946, we faced a surprising
behaviour wrt. exception when using pthread_cancel. In a nutshell when
a thread is inside a catch block and it's getting pthread_cancel by
another one, then the original exception is bubbled up and crashes the
process.

We now poll on the notification pipe from the thread and exit when the
main thread closes its end. This solution does not exhibit surprising
behaviour wrt. exceptions.

## Context

https://github.com/NixOS/nix/issues/8946

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
