### PR TITLE
WIP: init seqWithCallPos

### DIFF
--- a/example.nix
+++ b/example.nix
@@ -1,0 +1,20 @@
+let
+  showPos =
+    pos: if pos == null then "" else "${pos.file}:${toString pos.line}:${toString pos.column}";
+
+  # ({pos,isThunk, printValue} -> a -> b ) -> (a -> c) -> a -> c
+  tracePos = builtins.seqWithCallPos (
+    {
+      pos,
+      printValue,
+      terminalWidth,
+      ...
+    }:
+    a:
+    let
+      msg = "${showPos pos} ${printValue a}";
+    in
+    builtins.seq a builtins.trace msg null
+  ) (a: a);
+in
+  tracePos 42

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1649,7 +1649,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
                 if (countCalls) primOpCalls[fn->name]++;
 
                 try {
-                    fn->fun(*this, vCur.determinePos(noPos), args.data(), vCur);
+                    fn->fun(*this, vCur.determinePos(pos), args.data(), vCur);
                 } catch (Error & e) {
                     if (fn->addTrace)
                         addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
@@ -1697,7 +1697,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
                     // 1. Unify this and above code. Heavily redundant.
                     // 2. Create a fake env (arg1, arg2, etc.) and a fake expr (arg1: arg2: etc: builtins.name arg1 arg2 etc)
                     //    so the debugger allows to inspect the wrong parameters passed to the builtin.
-                    fn->fun(*this, vCur.determinePos(noPos), vArgs, vCur);
+                    fn->fun(*this, vCur.determinePos(pos), vArgs, vCur);
                 } catch (Error & e) {
                     if (fn->addTrace)
                         addErrorTrace(e, pos, "while calling the '%1%' builtin", fn->name);
@@ -1760,7 +1760,6 @@ void ExprCall::eval(EvalState & state, Env & env, Value & v)
     SmallValueVector<4> vArgs(args.size());
     for (size_t i = 0; i < args.size(); ++i)
         vArgs[i] = args[i]->maybeThunk(state, env);
-
     state.callFunction(vFun, vArgs, v, pos);
 }
 


### PR DESCRIPTION
Provide internal information to a function.
Since the return value of the function is completely ignored It can be considered safe.

This pattern could help to improve traces by providing access to internal state of the evaluator in a safe manner.


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
