### PR TITLE
Catch caching of transient flake evaluation error

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -4653,6 +4653,16 @@ static RegisterPrimOp primop_splitVersion({
     .fun = prim_splitVersion,
 });
 
+static void prim_testThrowErrorMaybe(EvalState & state, const PosIdx pos, Value * * args, Value & v)
+{
+    if (getEnv("_NIX_TEST_DO_THROW_ERROR") == "1") {
+        state.error<EvalError>("this is a dummy error").atPos(pos).debugThrow();
+    } else {
+        state.forceValue(*args[0], pos);
+        v = *args[0];
+    }
+}
+
 
 /*************************************************************
  * Primop registration
@@ -4879,6 +4889,16 @@ void EvalState::createBaseEnv()
         )",
         .fun = settings.traceVerbose ? prim_trace : prim_second,
     });
+
+    if (getEnv("_NIX_TEST_PRIMOPS") == "1") {
+        addPrimOp({
+            .name = "__testThrowErrorMaybe",
+            .args = { "e" },
+            .arity = 1,
+            .doc = "throw dummy error if _NIX_TEST_DO_THROW_ERROR == 1, return arg otherwise",
+            .fun = prim_testThrowErrorMaybe
+        });
+    }
 
     /* Add a value containing the current Nix expression search path. */
     auto list = buildList(lookupPath.elements.size());


### PR DESCRIPTION
Temporary description: this is currently only a test case. Fix commit pending.

Co-authored-by: Robert Hensing <robert@roberthensing.nl>

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
