### PR TITLE
libcmd/repl: Fix missing runNix in repl

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -839,7 +839,7 @@ std::unique_ptr<AbstractNixRepl> AbstractNixRepl::create(
 {
     return std::make_unique<NixRepl>(
         lookupPath,
-        openStore(),
+        std::move(store),
         state,
         getValues
     );

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -124,7 +124,7 @@ std::string removeWhitespace(std::string s)
 
 
 NixRepl::NixRepl(const LookupPath & lookupPath, nix::ref<Store> store, ref<EvalState> state,
-            std::function<NixRepl::AnnotatedValues()> getValues, RunNix * runNix = nullptr)
+            std::function<NixRepl::AnnotatedValues()> getValues, RunNix * runNix)
     : AbstractNixRepl(state)
     , debugTraceIndex(0)
     , getValues(getValues)
@@ -841,7 +841,8 @@ std::unique_ptr<AbstractNixRepl> AbstractNixRepl::create(
         lookupPath,
         std::move(store),
         state,
-        getValues
+        getValues,
+        runNix
     );
 }
 
@@ -859,7 +860,8 @@ ReplExitStatus AbstractNixRepl::runSimple(
             lookupPath,
             openStore(),
             evalState,
-            getValues
+            getValues,
+            /*runNix=*/nullptr
         );
 
     repl->initEnv();

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -56,6 +56,10 @@ testRepl () {
     nix repl "${nixArgs[@]}" 2>&1 <<< "builtins.currentSystem" \
       | grep "$(nix-instantiate --eval -E 'builtins.currentSystem')"
 
+    # regression test for #12163
+    replOutput=$(nix repl "${nixArgs[@]}" 2>&1 <<< ":sh import $testDir/simple.nix")
+    echo "$replOutput" | grepInverse "error: Cannot run 'nix-shell'"
+
     expectStderr 1 nix repl "${testDir}/simple.nix" \
       | grepQuiet -s "error: path '$testDir/simple.nix' is not a flake"
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

Without this `:u`, `:sh` and `:i` repl commands fail with:

> Cannot run 'nix-shell'/'nix-env' because no method of calling the Nix
> CLI was provided. This is a configuration problem pertaining to how
> this program was built.

Remove the default ctor argument as it evidently makes catching
refactoring bugs much harder. `NixRepl` implementation lives completely
in `repl.cc`, so we can be as explicit as necessary.

First patch is a no-op fix unrelated to the issue, but makes `AbstractNixRepl::create`
respect its `store` argument. Added a regression test for this bug. Verify that the 
test reproduces the bug by dropping the second patch.

## Motivation

Fixes #12163

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Broken in https://github.com/NixOS/nix/pull/11178. cc @Ericson2314. Affects versions down to 2.25

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
