### PR TITLE
`MonitorFdHup::~MonitorFdHup`: use proper close method instead of lib…

### DIFF
--- a/src/libutil/unix/monitor-fd.hh
+++ b/src/libutil/unix/monitor-fd.hh
@@ -122,7 +122,7 @@ public:
 
     ~MonitorFdHup()
     {
-        close(notifyPipe.writeSide.get());
+        notifyPipe.writeSide.close();
         thread.join();
     }
 };


### PR DESCRIPTION
…c close()

Otherwise closing it again will cause an EBADF in the AutoCloseFd class.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
