### PR TITLE
`appendLogTailErrorMsg`: Take a "smaller" arugment

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -873,7 +873,7 @@ void runPostBuildHook(
 
 
 void appendLogTailErrorMsg(
-    Worker & worker,
+    const Store & store,
     const StorePath & drvPath,
     const std::list<std::string> & logTail,
     std::string & msg)
@@ -893,7 +893,7 @@ void appendLogTailErrorMsg(
         // command will not put it at the start of the line unfortunately.
         msg += fmt("For full logs, run:\n  " ANSI_BOLD "%s %s" ANSI_NORMAL,
             nixLogCommand,
-            worker.store.printStorePath(drvPath));
+            store.printStorePath(drvPath));
     }
 }
 
@@ -940,7 +940,7 @@ Goal::Co DerivationGoal::hookDone()
             Magenta(worker.store.printStorePath(drvPath)),
             statusToString(status));
 
-        appendLogTailErrorMsg(worker, drvPath, logTail, msg);
+        appendLogTailErrorMsg(worker.store, drvPath, logTail, msg);
 
         outputLocks.unlock();
 

--- a/src/libstore/build/derivation-goal.hh
+++ b/src/libstore/build/derivation-goal.hh
@@ -64,7 +64,7 @@ void runPostBuildHook(
 
 /** Used internally */
 void appendLogTailErrorMsg(
-    Worker & worker,
+    const Store & store,
     const StorePath & drvPath,
     const std::list<std::string> & logTail,
     std::string & msg);

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -621,7 +621,7 @@ Goal::Co LocalDerivationGoal::tryLocalBuild()
                 Magenta(worker.store.printStorePath(drvPath)),
                 statusToString(status));
 
-            appendLogTailErrorMsg(worker, drvPath, logTail, msg);
+            appendLogTailErrorMsg(worker.store, drvPath, logTail, msg);
 
             if (diskFull)
                 msg += "\nnote: build failure may have been caused by lack of free disk space";


### PR DESCRIPTION
## Motivation

We just need a `const Store &`, not a `Worker &`.

## Context

One small step for the #12628 cleanups

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
