### PR TITLE
Use `Goal::waitForAWhile` in a few more places

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -660,9 +660,8 @@ Goal::Co DerivationGoal::tryToBuild()
                 if (!actLock)
                     actLock = std::make_unique<Activity>(*logger, lvlWarn, actBuildWaiting,
                         fmt("waiting for a machine to build '%s'", Magenta(worker.store.printStorePath(drvPath))));
-                worker.waitForAWhile(shared_from_this());
                 outputLocks.unlock();
-                co_await Suspend{};
+                co_await waitForAWhile();
                 co_return tryToBuild();
             case rpDecline:
                 /* We should do it ourselves. */

--- a/src/libstore/unix/build/local-derivation-goal.cc
+++ b/src/libstore/unix/build/local-derivation-goal.cc
@@ -479,9 +479,8 @@ Goal::Co LocalDerivationGoal::tryLocalBuild()
 
     unsigned int curBuilds = worker.getNrLocalBuilds();
     if (curBuilds >= settings.maxBuildJobs) {
-        worker.waitForBuildSlot(shared_from_this());
         outputLocks.unlock();
-        co_await Suspend{};
+        co_await waitForBuildSlot();
         co_return tryToBuild();
     }
 
@@ -535,8 +534,7 @@ Goal::Co LocalDerivationGoal::tryLocalBuild()
             if (!actLock)
                 actLock = std::make_unique<Activity>(*logger, lvlWarn, actBuildWaiting,
                     fmt("waiting for a free build user ID for '%s'", Magenta(worker.store.printStorePath(drvPath))));
-            worker.waitForAWhile(shared_from_this());
-            co_await Suspend{};
+            co_await waitForAWhile();
             co_return tryLocalBuild();
         }
     }


### PR DESCRIPTION
## Motivation

Progress on https://github.com/NixOS/nix/issues/12628

## Context

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
