### PR TITLE
use createDirs consistently everywhere

### DIFF
--- a/src/libstore/builtins/unpack-channel.cc
+++ b/src/libstore/builtins/unpack-channel.cc
@@ -23,11 +23,7 @@ void builtinUnpackChannel(
         throw Error("channelName is not allowed to contain filesystem separators, got %1%", channelName);
     }
 
-    try {
-        fs::create_directories(out);
-    } catch (fs::filesystem_error &) {
-        throw SysError("creating directory '%1%'", out.string());
-    }
+    createDirs(out);
 
     unpackTarfile(src, out);
 

--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -166,7 +166,7 @@ void unpackTarfile(Source & source, const fs::path & destDir)
 {
     auto archive = TarArchive(source);
 
-    fs::create_directories(destDir);
+    createDirs(destDir);
     extract_archive(archive, destDir);
 }
 
@@ -174,7 +174,7 @@ void unpackTarfile(const fs::path & tarFile, const fs::path & destDir)
 {
     auto archive = TarArchive(tarFile);
 
-    fs::create_directories(destDir);
+    createDirs(destDir);
     extract_archive(archive, destDir);
 }
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -905,7 +905,7 @@ struct CmdFlakeInitCommon : virtual Args, EvalCommand
         std::function<void(const SourcePath & from, const fs::path & to)> copyDir;
         copyDir = [&](const SourcePath & from, const fs::path & to)
         {
-            fs::create_directories(to);
+            createDirs(to);
 
             for (auto & [name, entry] : from.readDirectory()) {
                 checkInterrupt();


### PR DESCRIPTION
It wraps errors properly

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
