### PR TITLE
Exclude 'dir' from the FlakeRef's URL

### DIFF
--- a/src/libflake/flake/flakeref.cc
+++ b/src/libflake/flake/flakeref.cc
@@ -234,15 +234,16 @@ std::optional<std::pair<FlakeRef, std::string>> parseURLFlakeRef(
         return std::nullopt;
     }
 
+    const auto subdir = getOr(parsedURL.query, "dir", "");
+    parsedURL.query.erase("dir");
+
     std::string fragment;
     std::swap(fragment, parsedURL.fragment);
 
     auto input = fetchers::Input::fromURL(fetchSettings, parsedURL, isFlake);
     input.parent = baseDir;
 
-    return std::make_pair(
-        FlakeRef(std::move(input), getOr(parsedURL.query, "dir", "")),
-        fragment);
+    return std::make_pair(FlakeRef(std::move(input), subdir), fragment);
 }
 
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(

--- a/tests/unit/libflake/flakeref.cc
+++ b/tests/unit/libflake/flakeref.cc
@@ -21,4 +21,27 @@ namespace nix {
         ASSERT_EQ(parsed, expected);
     }
 
+    /* ----------------------------------------------------------------------------
+     * parseFlakeRef
+     * --------------------------------------------------------------------------*/
+
+    TEST(parseFlakeRef, removesDirFromInputURL) {
+        fetchers::Settings fetchSettings;
+        auto s = "git+https://localhost:8181/test/test.git?dir=subdir";
+        auto flakeref = parseFlakeRef(fetchSettings, s);
+        auto expected = "git+https://localhost:8181/test/test.git";
+        auto inputURL = flakeref.input.toURLString();
+
+        ASSERT_EQ(inputURL, expected);
+    }
+
+    TEST(parseFlakeRef, setsSubdir) {
+        fetchers::Settings fetchSettings;
+        auto s = "git+https://localhost:8181/test/test.git?dir=subdir";
+        auto flakeref = parseFlakeRef(fetchSettings, s);
+        auto expected = "subdir";
+        auto flakerefSubdir = flakeref.subdir;
+
+        ASSERT_EQ(flakerefSubdir, expected);
+    }
 }


### PR DESCRIPTION
## Motivation

This fixes an issue where nix would try to check out invalid URLs, because it would pass 'dir' to the HTTP endpoint.

For later versions this was fixed in b2be6fed8600ee48c05cc9643c101d5eab4a5727. This is a backport of just the relevant part.

## Context

See #12417, where this is first discussed.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
