### PR TITLE
Disable packaging-overriding test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -230,24 +230,28 @@
             This shouldn't build anything significant; just check that things
             (including derivations) are _set up_ correctly.
           */
-          packaging-overriding =
-            let
-              pkgs = nixpkgsFor.${system}.native;
-              nix = self.packages.${system}.nix;
-            in
-            assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
-            if pkgs.stdenv.buildPlatform.isDarwin then
-              lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
-            else
-              # If this fails, something might be wrong with how we've wired the scope,
-              # or something could be broken in Nixpkgs.
-              pkgs.testers.testEqualContents {
-                assertion = "trivial patch does not change source contents";
-                expected = "${./.}";
-                actual =
-                  # Same for all components; nix-util is an arbitrary pick
-                  (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
-              };
+          # Disabled due to a bug in `testEqualContents` (see
+          # https://github.com/NixOS/nix/issues/12690).
+          /*
+            packaging-overriding =
+              let
+                pkgs = nixpkgsFor.${system}.native;
+                nix = self.packages.${system}.nix;
+              in
+              assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
+              if pkgs.stdenv.buildPlatform.isDarwin then
+                lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
+              else
+                # If this fails, something might be wrong with how we've wired the scope,
+                # or something could be broken in Nixpkgs.
+                pkgs.testers.testEqualContents {
+                  assertion = "trivial patch does not change source contents";
+                  expected = "${./.}";
+                  actual =
+                    # Same for all components; nix-util is an arbitrary pick
+                    (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
+                };
+          */
         }
         // (lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
           dockerImage = self.hydraJobs.dockerImage.${system};


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

`testEqualContents` is broken (see https://github.com/NixOS/nix/issues/12690#issuecomment-2766443473, https://github.com/NixOS/nixpkgs/issues/393375) so let's disable this test for now until https://github.com/NixOS/nixpkgs/pull/393381 is merged.

Fixes #12690.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
