### PR TITLE
Revert "Unexpose config headers (low hanging fruit only) (backport #1…

### DIFF
--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -63,7 +63,9 @@ add_project_arguments(
   # It would be nice for our headers to be idempotent instead.
   '-include', 'config-util.hh',
   '-include', 'config-store.hh',
+  # '-include', 'config-fetchers.h',
   '-include', 'config-expr.hh',
+  '-include', 'config-main.hh',
   '-include', 'config-cmd.hh',
   language : 'cpp',
 )
@@ -91,7 +93,7 @@ sources = files(
 
 include_dirs = [include_directories('.')]
 
-headers = files(
+headers = [config_h] + files(
   'built-path.hh',
   'command-installable-value.hh',
   'command.hh',
@@ -117,7 +119,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixcmd',
   sources,
-  config_h,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args: linker_export_flags,

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -14,6 +14,8 @@ cxx = meson.get_compiler('cpp')
 
 subdir('nix-meson-build-support/deps-lists')
 
+configdata = configuration_data()
+
 deps_private_maybe_subproject = [
   dependency('nix-util'),
   dependency('nix-store'),
@@ -25,6 +27,14 @@ deps_public_maybe_subproject = [
 ]
 subdir('nix-meson-build-support/subprojects')
 
+# TODO rename, because it will conflict with downstream projects
+configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+
+config_h = configure_file(
+  configuration : configdata,
+  output : 'config-expr.h',
+)
+
 add_project_arguments(
   # TODO(Qyriad): Yes this is how the autoconf+Make system did it.
   # It would be nice for our headers to be idempotent instead.
@@ -34,6 +44,10 @@ add_project_arguments(
   '-include', 'config-store.hh',
   '-include', 'config-expr.hh',
 
+  # From C libraries, for our public, installed headers too
+  '-include', 'config-util.h',
+  '-include', 'config-store.h',
+  '-include', 'config-expr.h',
   language : 'cpp',
 )
 
@@ -47,7 +61,7 @@ sources = files(
 
 include_dirs = [include_directories('.')]
 
-headers = files(
+headers = [config_h] + files(
   'nix_api_expr.h',
   'nix_api_external.h',
   'nix_api_value.h',

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -41,6 +41,9 @@ add_project_arguments(
   '-include', 'config-util.hh',
   '-include', 'config-store.hh',
   '-include', 'config-expr.hh',
+  '-include', 'config-util.h',
+  '-include', 'config-store.h',
+  '-include', 'config-expr.h',
   language : 'cpp',
 )
 

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -14,6 +14,8 @@ cxx = meson.get_compiler('cpp')
 
 subdir('nix-meson-build-support/deps-lists')
 
+configdata = configuration_data()
+
 deps_private_maybe_subproject = [
   dependency('nix-util'),
   dependency('nix-store'),
@@ -27,6 +29,14 @@ deps_public_maybe_subproject = [
 ]
 subdir('nix-meson-build-support/subprojects')
 
+# TODO rename, because it will conflict with downstream projects
+configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+
+config_h = configure_file(
+  configuration : configdata,
+  output : 'config-flake.h',
+)
+
 add_project_arguments(
   # TODO(Qyriad): Yes this is how the autoconf+Make system did it.
   # It would be nice for our headers to be idempotent instead.
@@ -38,6 +48,11 @@ add_project_arguments(
   # not generated (yet?)
   # '-include', 'config-flake.hh',
 
+  # From C libraries, for our public, installed headers too
+  '-include', 'config-util.h',
+  '-include', 'config-store.h',
+  '-include', 'config-expr.h',
+  '-include', 'config-flake.h',
   language : 'cpp',
 )
 
@@ -49,7 +64,7 @@ sources = files(
 
 include_dirs = [include_directories('.')]
 
-headers = files(
+headers = [config_h] + files(
   'nix_api_flake.h',
 )
 

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -14,6 +14,8 @@ cxx = meson.get_compiler('cpp')
 
 subdir('nix-meson-build-support/deps-lists')
 
+configdata = configuration_data()
+
 deps_private_maybe_subproject = [
   dependency('nix-util'),
   dependency('nix-store'),
@@ -25,6 +27,14 @@ deps_public_maybe_subproject = [
 ]
 subdir('nix-meson-build-support/subprojects')
 
+# TODO rename, because it will conflict with downstream projects
+configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+
+config_h = configure_file(
+  configuration : configdata,
+  output : 'config-main.h',
+)
+
 add_project_arguments(
   # TODO(Qyriad): Yes this is how the autoconf+Make system did it.
   # It would be nice for our headers to be idempotent instead.
@@ -32,7 +42,12 @@ add_project_arguments(
   # From C++ libraries, only for internals
   '-include', 'config-util.hh',
   '-include', 'config-store.hh',
+  '-include', 'config-main.hh',
 
+  # From C libraries, for our public, installed headers too
+  '-include', 'config-util.h',
+  '-include', 'config-store.h',
+  '-include', 'config-main.h',
   language : 'cpp',
 )
 
@@ -44,7 +59,7 @@ sources = files(
 
 include_dirs = [include_directories('.')]
 
-headers = files(
+headers = [config_h] + files(
   'nix_api_main.h',
 )
 

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -74,7 +74,7 @@ endif
 
 include_dirs = [include_directories('.')]
 
-headers = files(
+headers = [config_h] + files(
   'common-args.hh',
   'loggers.hh',
   'plugin.hh',
@@ -88,7 +88,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixmain',
   sources,
-  config_h,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args: linker_export_flags,

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -14,6 +14,8 @@ cxx = meson.get_compiler('cpp')
 
 subdir('nix-meson-build-support/deps-lists')
 
+configdata = configuration_data()
+
 deps_private_maybe_subproject = [
   dependency('nix-util'),
   dependency('nix-store'),
@@ -23,6 +25,14 @@ deps_public_maybe_subproject = [
 ]
 subdir('nix-meson-build-support/subprojects')
 
+# TODO rename, because it will conflict with downstream projects
+configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+
+config_h = configure_file(
+  configuration : configdata,
+  output : 'config-store.h',
+)
+
 add_project_arguments(
   # TODO(Qyriad): Yes this is how the autoconf+Make system did it.
   # It would be nice for our headers to be idempotent instead.
@@ -31,6 +41,9 @@ add_project_arguments(
   '-include', 'config-util.hh',
   '-include', 'config-store.hh',
 
+  # From C libraries, for our public, installed headers too
+  '-include', 'config-util.h',
+  '-include', 'config-store.h',
   language : 'cpp',
 )
 
@@ -42,7 +55,7 @@ sources = files(
 
 include_dirs = [include_directories('.')]
 
-headers = files(
+headers = [config_h] + files(
   'nix_api_store.h',
 )
 

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -45,6 +45,8 @@ add_project_arguments(
   # It would be nice for our headers to be idempotent instead.
   '-include', 'config-util.hh',
   '-include', 'config-store.hh',
+  '-include', 'config-util.h',
+  '-include', 'config-store.h',
   language : 'cpp',
 )
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -67,7 +67,6 @@ endforeach
 has_acl_support = cxx.has_header('sys/xattr.h') \
   and cxx.has_function('llistxattr') \
   and cxx.has_function('lremovexattr')
-# TODO: used in header - make proper public header and make sure it's included. Affects ABI!
 configdata.set('HAVE_ACL_SUPPORT', has_acl_support.to_int())
 
 if host_machine.system() == 'darwin'

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -23,6 +23,7 @@ deps_public_maybe_subproject = [
 ]
 subdir('nix-meson-build-support/subprojects')
 
+# TODO rename, because it will conflict with downstream projects
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
 
 config_h = configure_file(
@@ -37,6 +38,8 @@ add_project_arguments(
   # From C++ libraries, only for internals
   '-include', 'config-util.hh',
 
+  # From C libraries, for our public, installed headers too
+  '-include', 'config-util.h',
   language : 'cpp',
 )
 
@@ -48,7 +51,7 @@ sources = files(
 
 include_dirs = [include_directories('.')]
 
-headers = files(
+headers = [config_h] + files(
   'nix_api_util.h',
 )
 
@@ -61,7 +64,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixutilc',
   sources,
-  config_h,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args: linker_export_flags,

--- a/src/libutil-c/nix_api_util.cc
+++ b/src/libutil-c/nix_api_util.cc
@@ -7,8 +7,6 @@
 #include <cxxabi.h>
 #include <typeinfo>
 
-#include "config-util.h"
-
 nix_c_context * nix_c_context_create()
 {
     return new nix_c_context();

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -32,16 +32,11 @@ deps_private += rapidcheck
 gtest = dependency('gtest', main : true)
 deps_private += gtest
 
-configdata = configuration_data()
-configdata.set_quoted('PACKAGE_VERSION', meson.project_version())
-
-config_h = configure_file(
-  configuration : configdata,
-  output : 'config-util-tests.hh',
-)
-
 add_project_arguments(
-  '-include', 'config-util-tests.hh',
+  # TODO(Qyriad): Yes this is how the autoconf+Make system did it.
+  # It would be nice for our headers to be idempotent instead.
+  '-include', 'config-util.hh',
+  '-include', 'config-util.h',
   language : 'cpp',
 )
 
@@ -84,7 +79,6 @@ include_dirs = [include_directories('.')]
 this_exe = executable(
   meson.project_name(),
   sources,
-  config_h,
   dependencies : deps_private_subproject + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: -lrapidcheck, see ../libutil-support/build.meson

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -33,14 +33,12 @@ check_funcs = [
   'pipe2',
   # Optionally used to preallocate files to be large enough before
   # writing to them.
-  # WARNING: define also used in libstore
   'posix_fallocate',
   # Optionally used to get more information about processes failing due
   # to a signal on Unix.
   'strsignal',
   # Optionally used to try to close more file descriptors (e.g. before
   # forking) on Unix.
-  # WARNING: also used in libexpr
   'sysconf',
   # Optionally used for changing the mtime of files and symlinks.
   'utimensat',

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -57,6 +57,9 @@ add_project_arguments(
   '-include', 'config-util.hh',
   '-include', 'config-store.hh',
   '-include', 'config-expr.hh',
+  #'-include', 'config-fetchers.hh',
+  '-include', 'config-main.hh',
+  '-include', 'config-cmd.hh',
   '-include', 'config-nix-cli.hh',
   language : 'cpp',
 )

--- a/tests/functional/plugins/meson.build
+++ b/tests/functional/plugins/meson.build
@@ -6,6 +6,7 @@ libplugintest = shared_module(
     # It would be nice for our headers to be idempotent instead.
     '-include', 'config-util.hh',
     '-include', 'config-store.hh',
+    # '-include', 'config-fetchers.hh',
     '-include', 'config-expr.hh',
   ],
   dependencies : [


### PR DESCRIPTION
## Motivation

We didn't backport to 2.27, so we also shouldn't do 2.26.

## Context

https://github.com/NixOS/nix/pull/12779#issuecomment-2762967992

https://github.com/NixOS/nix/pull/12780#issuecomment-2762191326

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
