### PR TITLE
Use mold instead of GNU ld for faster builds

### DIFF
--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -159,13 +159,6 @@ let
     ];
     separateDebugInfo = !stdenv.hostPlatform.isStatic;
     hardeningDisable = lib.optional stdenv.hostPlatform.isStatic "pie";
-    env =
-      prevAttrs.env or { }
-      // lib.optionalAttrs (
-        stdenv.isLinux
-        && !(stdenv.hostPlatform.isStatic && stdenv.system == "aarch64-linux")
-        && !(stdenv.hostPlatform.useLLVM or false)
-      ) { LDFLAGS = "-fuse-ld=gold"; };
   };
 
   mesonLibraryLayer = finalAttrs: prevAttrs: {

--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -71,12 +71,17 @@ pkgs.nixComponents.nix-util.overrideAttrs (
     # We use this shell with the local checkout, not unpackPhase.
     src = null;
 
-    env = {
-      # For `make format`, to work without installing pre-commit
-      _NIX_PRE_COMMIT_HOOKS_CONFIG = "${(pkgs.formats.yaml { }).generate "pre-commit-config.yaml"
-        modular.pre-commit.settings.rawConfig
-      }";
-    };
+    env =
+      {
+        # For `make format`, to work without installing pre-commit
+        _NIX_PRE_COMMIT_HOOKS_CONFIG = "${(pkgs.formats.yaml { }).generate "pre-commit-config.yaml"
+          modular.pre-commit.settings.rawConfig
+        }";
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        CC_LD = "mold";
+        CXX_LD = "mold";
+      };
 
     mesonFlags =
       map (transformFlag "libutil") (ignoreCrossFile pkgs.nixComponents.nix-util.mesonFlags)
@@ -119,7 +124,8 @@ pkgs.nixComponents.nix-util.overrideAttrs (
       ++ lib.optional (stdenv.cc.isClang && !stdenv.buildPlatform.isDarwin) pkgs.buildPackages.bear
       ++ lib.optional (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) (
         lib.hiPrio pkgs.buildPackages.clang-tools
-      );
+      )
+      ++ lib.optional stdenv.hostPlatform.isLinux pkgs.buildPackages.mold-wrapped;
 
     buildInputs =
       attrs.buildInputs or [ ]


### PR DESCRIPTION
## Motivation

Linking takes up a significant portion of the build time for `nix` especially when using `nix develop .#native-ccacheStdenv` and most of the compilation artifacts are cached.

Currently the build configuration defaults to GNU `ld` for most Linux builds but the [`mold`](https://github.com/rui314/mold) linker is significantly faster.

This PR switches the linker to `mold` when the host platform is Linux.

### Benchmarks:

System: 9950X3D @ 6.0GHz with 96GB RAM @ 6400 MT/s
Testing:
  1. `nix develop .#native-ccacheStdenv`
  2. `configurePhase && buildPhase`
  4. `cd .. && rm -rf build && configurePhase && time buildPhase`

Before this PR:
```
real	0m26.456s
user	6m21.015s
sys	0m27.248s
```

After this PR:
```
real	0m18.059s
user	1m23.558s
sys	0m18.615s
```
