### PR TITLE
repl: improve continuation prompt for incomplete expressions

### DIFF
--- a/src/libcmd/repl-interacter.cc
+++ b/src/libcmd/repl-interacter.cc
@@ -135,7 +135,7 @@ static constexpr const char * promptForType(ReplPromptType promptType)
     case ReplPromptType::ReplPrompt:
         return "nix-repl> ";
     case ReplPromptType::ContinuationPrompt:
-        return "          ";
+        return "        > "; // 9 spaces + >
     }
     assert(false);
 }


### PR DESCRIPTION
### Motivation

This PR improves the REPL experience by making it clearer when the user is entering an incomplete expression.

Previously, when users entered an incomplete expression in the REPL, the continuation prompt was just 10 blank spaces, which looked invisible and gave the impression that the REPL had stalled or was unresponsive.

This change updates the prompt to `" > "`, aligning it visually with `'nix-repl> '` and clearly indicating that the REPL is waiting for more input.

### Context

Fixes: https://github.com/NixOS/nix/issues/12702

The continuation prompt logic already existed (`ReplPromptType::ContinuationPrompt`) but used a prompt that was functionally invisible. This small change makes it visible and improves user feedback in multi-line expressions.
Implementation Notes

This is a small change in `libcmd/repl-interacter.cc`:

```
- return "          ";
+ return "         > ";
```

This makes no functional changes to how the REPL parses or evaluates input. It purely affects the string shown to the user when continuing a multi-line expression.

Add :+1: to pull requests you find important.

The Nix maintainer team uses a GitHub project board to schedule and track reviews.