### PR TITLE
libgit2: use upstream version if possible

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -170,7 +170,7 @@
               {
                 otherSplices = final.generateSplicesForMkScope "nixDependencies";
                 f = import ./packaging/dependencies.nix {
-                  inherit inputs stdenv;
+                  inherit stdenv;
                   pkgs = final;
                 };
               };

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -65,39 +65,37 @@ scope: {
         installPhase = lib.replaceStrings [ "--without-python" ] [ "" ] old.installPhase;
       });
 
-  libgit2 = pkgs.libgit2.overrideAttrs (
-    attrs:
-    {
-      cmakeFlags = attrs.cmakeFlags or [ ] ++ [ "-DUSE_SSH=exec" ];
-    }
-    # libgit2: Nixpkgs 24.11 has < 1.9.0, which needs our patches
-    // lib.optionalAttrs (!lib.versionAtLeast pkgs.libgit2.version "1.9.0") {
-      nativeBuildInputs =
-        attrs.nativeBuildInputs or [ ]
-        # gitMinimal does not build on Windows. See packbuilder patch.
-        ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
-          # Needed for `git apply`; see `prePatch`
-          pkgs.buildPackages.gitMinimal
-        ];
-      # Only `git apply` can handle git binary patches
-      prePatch =
-        attrs.prePatch or ""
-        + lib.optionalString (!stdenv.hostPlatform.isWindows) ''
-          patch() {
-            git apply
-          }
-        '';
-      patches =
-        attrs.patches or [ ]
-        ++ [
-          ./patches/libgit2-mempack-thin-packfile.patch
-        ]
-        # gitMinimal does not build on Windows, but fortunately this patch only
-        # impacts interruptibility
-        ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
-          # binary patch; see `prePatch`
-          ./patches/libgit2-packbuilder-callback-interruptible.patch
-        ];
-    }
-  );
+  libgit2 =
+    if lib.versionAtLeast pkgs.libgit2.version "1.9.0" then
+      pkgs.libgit2
+    else
+      pkgs.libgit2.overrideAttrs (attrs: {
+        # libgit2: Nixpkgs 24.11 has < 1.9.0, which needs our patches
+        nativeBuildInputs =
+          attrs.nativeBuildInputs or [ ]
+          # gitMinimal does not build on Windows. See packbuilder patch.
+          ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
+            # Needed for `git apply`; see `prePatch`
+            pkgs.buildPackages.gitMinimal
+          ];
+        # Only `git apply` can handle git binary patches
+        prePatch =
+          attrs.prePatch or ""
+          + lib.optionalString (!stdenv.hostPlatform.isWindows) ''
+            patch() {
+              git apply
+            }
+          '';
+        patches =
+          attrs.patches or [ ]
+          ++ [
+            ./patches/libgit2-mempack-thin-packfile.patch
+          ]
+          # gitMinimal does not build on Windows, but fortunately this patch only
+          # impacts interruptibility
+          ++ lib.optionals (!stdenv.hostPlatform.isWindows) [
+            # binary patch; see `prePatch`
+            ./patches/libgit2-packbuilder-callback-interruptible.patch
+          ];
+      });
 }

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -1,9 +1,6 @@
 # These overrides are applied to the dependencies of the Nix components.
 
 {
-  # Flake inputs; used for sources
-  inputs,
-
   # The raw Nixpkgs, not affected by this scope
   pkgs,
 
@@ -11,23 +8,7 @@
 }:
 
 let
-  prevStdenv = stdenv;
-in
-
-let
   inherit (pkgs) lib;
-
-  stdenv = if prevStdenv.isDarwin && prevStdenv.isx86_64 then darwinStdenv else prevStdenv;
-
-  # Fix the following error with the default x86_64-darwin SDK:
-  #
-  #     error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer
-  #
-  # Despite the use of the 10.13 deployment target here, the aligned
-  # allocation function Clang uses with this setting actually works
-  # all the way back to 10.6.
-  darwinStdenv = pkgs.overrideSDK prevStdenv { darwinMinVersion = "10.13"; };
-
 in
 scope: {
   inherit stdenv;


### PR DESCRIPTION
we don't seem to use libgit2 for fetching via ssh, hence it shouldn't matter if it's using libssh or the ssh binary.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
