### PR TITLE
Git fetcher: Improve error message for untracked files

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -535,7 +535,7 @@ struct GitInputScheme : InputScheme
         return [repoPath{std::move(repoPath)}](const CanonPath & path) -> RestrictedPathError {
             if (nix::pathExists(repoPath / path.rel()))
                 return RestrictedPathError(
-                    "File '%1%' in the repository %2% is not tracked by Git.\n"
+                    "Path '%1%' in the repository %2% is not tracked by Git.\n"
                     "\n"
                     "To make it visible to Nix, run:\n"
                     "\n"
@@ -543,7 +543,7 @@ struct GitInputScheme : InputScheme
                     path.rel(),
                     repoPath);
             else
-                return RestrictedPathError("path '%s' does not exist in Git repository %s", path, repoPath);
+                return RestrictedPathError("Path '%s' does not exist in Git repository %s.", path.rel(), repoPath);
         };
     }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation
It now says:
```
error: Path 'foo/bar' in the repository "/path/to/repo" is not tracked by Git.

       To make it visible to Nix, run:

       git -C "/path/to/repo" add "foo/bar"
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
