### PR TITLE
decrease connect-timeout to 5s

### DIFF
--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -30,7 +30,7 @@ struct FileTransferSettings : Config
         {"binary-caches-parallel-connections"}};
 
     Setting<unsigned long> connectTimeout{
-        this, 0, "connect-timeout",
+        this, 5, "connect-timeout",
         R"(
           The timeout (in seconds) for establishing connections in the
           binary cache substituter. It corresponds to `curl`’s


### PR DESCRIPTION
For people self-hosting caches that can be occasionally down, the default timeout is very long. This is annoying if you are trying to update your binary cache at the same time you are trying to update another machine. Same if cachix has one of its rare hiccups.

We tested this value of 5s in [srvos](https://github.com/nix-community/srvos/blob/7a4dc5c1112b2cde72ab05f70f522cfecb9c48d1/shared/common/nix.nix#L7) now for years and we like to travel around the world with shitty internet, so it should be still reasonable high.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
