### PR TITLE
symlink_exists: wrap exceptions into nix exception

### DIFF
--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -31,7 +31,17 @@
 
 namespace nix {
 
-namespace fs { using namespace std::filesystem; }
+namespace fs {
+  using namespace std::filesystem;
+
+  bool symlink_exists(const std::filesystem::path & path) {
+      try {
+          return std::filesystem::exists(std::filesystem::symlink_status(path));
+      } catch (const std::filesystem::filesystem_error & e) {
+          throw SysError("cannot check existence of %1%", path);
+      }
+  }
+}
 
 bool isAbsolute(PathView path)
 {

--- a/src/libutil/include/nix/util/file-system.hh
+++ b/src/libutil/include/nix/util/file-system.hh
@@ -134,6 +134,7 @@ bool pathExists(const Path & path);
 namespace fs {
 
 /**
+ * TODO: we may actually want to use pathExists instead of this function
  *  ```
  *  symlink_exists(p) = std::filesystem::exists(std::filesystem::symlink_status(p))
  *  ```
@@ -142,9 +143,7 @@ namespace fs {
  *  std::filesystem::exists(p) = std::filesystem::exists(std::filesystem::status(p))
  *  ```
  */
-inline bool symlink_exists(const std::filesystem::path & path) {
-    return std::filesystem::exists(std::filesystem::symlink_status(path));
-}
+bool symlink_exists(const std::filesystem::path & path);
 
 } // namespace fs
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
