### PR TITLE
Use -Wno-dangling-reference

### DIFF
--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -14,5 +14,6 @@ add_project_arguments(
   '-Wignored-qualifiers',
   '-Wimplicit-fallthrough',
   '-Wno-deprecated-declarations',
+  '-Wno-dangling-reference',
   language : 'cpp',
 )

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -1228,13 +1228,13 @@ DerivationOutput DerivationOutput::fromJSON(
         keys.insert(key);
 
     auto methodAlgo = [&]() -> std::pair<ContentAddressMethod, HashAlgorithm> {
-        auto & method_ = getString(valueAt(json, "method"));
-        ContentAddressMethod method = ContentAddressMethod::parse(method_);
+        ContentAddressMethod method = ContentAddressMethod::parse(
+            getString(valueAt(json, "method")));
         if (method == ContentAddressMethod::Raw::Text)
             xpSettings.require(Xp::DynamicDerivations);
 
-        auto & hashAlgo_ = getString(valueAt(json, "hashAlgo"));
-        auto hashAlgo = parseHashAlgo(hashAlgo_);
+        auto hashAlgo = parseHashAlgo(
+            getString(valueAt(json, "hashAlgo")));
         return { std::move(method), std::move(hashAlgo) };
     };
 

--- a/src/libutil-tests/json-utils.cc
+++ b/src/libutil-tests/json-utils.cc
@@ -63,9 +63,7 @@ TEST(valueAt, simpleObject) {
 
     auto nested = R"({ "hello": { "world": "" } })"_json;
 
-    auto & nestedObject = valueAt(getObject(nested), "hello");
-
-    ASSERT_EQ(valueAt(nestedObject, "world"), "");
+    ASSERT_EQ(valueAt(valueAt(getObject(nested), "hello"), "world"), "");
 }
 
 TEST(valueAt, missingKey) {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This shuts up the GCC 14 warnings about the functions in json-utils.hh that return references, e.g.

```
../src/libstore/derivations.cc:1354:78: warning: possibly dangling reference to a temporary [-Wdangling-reference]
 1354 |         for (auto & [outputName, output] : getObject(valueAt(json, "outputs"))) {
```

There is no actual lifetime problem here but I can't convince GCC of that. So let's just disable the warning.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
