### PR TITLE
Fix jobset evaluation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -156,13 +156,7 @@
                   inherit officialRelease;
                   pkgs = final;
                   src = self;
-                  maintainers = with lib.maintainers; [
-                    eelco
-                    ericson2314
-                    mic92
-                    roberth
-                    tomberek
-                  ];
+                  maintainers = [ ];
                 };
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -157,9 +157,9 @@
                   pkgs = final;
                   src = self;
                   maintainers = with lib.maintainers; [
-                    edolstra
-                    Ericson2314
-                    Mic92
+                    eelco
+                    ericson2314
+                    mic92
                     roberth
                     tomberek
                   ];


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

The jobset is currently broken, see https://hydra.nixos.org/jobset/nix/maintenance-2.28:

```
in job ‘build.nix-cmd.aarch64-darwin’:
error: undefined variable 'edolstra'
       at /nix/store/2p0s1x496795sqdy51m3ky1m21bknyrn-source/flake.nix:160:21:
          159|                   maintainers = with lib.maintainers; [
          160|                     edolstra
             |                     ^
          161|                     Ericson2314
```

Some of the maintainer attribute names got changed in nixos-unstable (e.g. "edolstra" is now "eelco") but we want this flake to work on nixos-24.11 so we can't just rename them. So let's just get rid of them.

Ideally our GitHub CI would have caught this, but I guess `nix flake check` doesn't look at `meta.maintainers`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
