### PR TITLE
Revert "decrease connect-timeout to 5s (backport #12876)"

### DIFF
--- a/src/libstore/filetransfer.hh
+++ b/src/libstore/filetransfer.hh
@@ -30,7 +30,7 @@ struct FileTransferSettings : Config
         {"binary-caches-parallel-connections"}};
 
     Setting<unsigned long> connectTimeout{
-        this, 5, "connect-timeout",
+        this, 0, "connect-timeout",
         R"(
           The timeout (in seconds) for establishing connections in the
           binary cache substituter. It corresponds to `curl`’s


### PR DESCRIPTION
Not supposed to backport changes to the defaults. It was not a critical fix or something like that.

Reverts NixOS/nix#12892