### PR TITLE
Revert to Nixpkgs 24.11 [2.28]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,16 +63,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1734359947,
+        "narHash": "sha256-1Noao/H+N8nFB4Beoy8fgwrcOQLVm9o4zKW1ODaqK9E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "48d12d5e70ee91fe8481378e540433a7303dbf6a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "release-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "The purely functional package manager";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
 
   inputs.nixpkgs-regression.url = "github:NixOS/nixpkgs/215d4d0fd80ca5163643b03a33fde804a29cc1e2";
   inputs.nixpkgs-23-11.url = "github:NixOS/nixpkgs/a62e6edd6d5e1fa0329b8653c801147986f8d446";

--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -44,11 +44,10 @@ static void downloadToSink(
 
 static std::string getLfsApiToken(const ParsedURL & url)
 {
-    auto [status, output] = runProgram(
-        RunOptions{
-            .program = "ssh",
-            .args = {*url.authority, "git-lfs-authenticate", url.path, "download"},
-        });
+    auto [status, output] = runProgram(RunOptions{
+        .program = "ssh",
+        .args = {*url.authority, "git-lfs-authenticate", url.path, "download"},
+    });
 
     if (output.empty())
         throw Error(

--- a/src/libstore-test-support/outputs-spec.cc
+++ b/src/libstore-test-support/outputs-spec.cc
@@ -14,9 +14,8 @@ Gen<OutputsSpec> Arbitrary<OutputsSpec>::arbitrary()
                 return gen::just((OutputsSpec) OutputsSpec::All{});
             case 1:
                 return gen::map(
-                    gen::nonEmpty(
-                        gen::container<StringSet>(
-                            gen::map(gen::arbitrary<StorePathName>(), [](StorePathName n) { return n.name; }))),
+                    gen::nonEmpty(gen::container<StringSet>(
+                        gen::map(gen::arbitrary<StorePathName>(), [](StorePathName n) { return n.name; }))),
                     [](StringSet names) { return (OutputsSpec) OutputsSpec::Names{names}; });
             default:
                 assert(false);

--- a/tests/nixos/git-submodules.nix
+++ b/tests/nixos/git-submodules.nix
@@ -45,14 +45,14 @@
         client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
         # Install the SSH key on the builders.
-        client.wait_for_unit("network-addresses-eth1.service")
+        client.wait_for_unit("network-online.target")
 
         remote.succeed("mkdir -p -m 700 /root/.ssh")
         remote.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
         remote.wait_for_unit("sshd")
         remote.wait_for_unit("multi-user.target")
-        remote.wait_for_unit("network-addresses-eth1.service")
-        client.wait_for_unit("network-addresses-eth1.service")
+        remote.wait_for_unit("network-online.target")
+        client.wait_for_unit("network-online.target")
         client.succeed(f"ssh -o StrictHostKeyChecking=no {remote.name} 'echo hello world'")
 
         remote.succeed("""

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -187,9 +187,9 @@ in
            github.succeed("cat /var/log/httpd/*.log >&2")
 
       github.wait_for_unit("httpd.service")
-      github.wait_for_unit("network-addresses-eth1.service")
+      github.wait_for_unit("network-online.target")
 
-      client.wait_for_unit("network-addresses-eth1.service")
+      client.wait_for_unit("network-online.target")
       client.succeed("curl -v https://github.com/ >&2")
       out = client.succeed("nix registry list")
       print(out)

--- a/tests/nixos/nix-copy-closure.nix
+++ b/tests/nixos/nix-copy-closure.nix
@@ -70,9 +70,9 @@ in
       server.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
       server.wait_for_unit("sshd")
       server.wait_for_unit("multi-user.target")
-      server.wait_for_unit("network-addresses-eth1.service")
+      server.wait_for_unit("network-online.target")
 
-      client.wait_for_unit("network-addresses-eth1.service")
+      client.wait_for_unit("network-online.target")
       client.succeed(f"ssh -o StrictHostKeyChecking=no {server.name} 'echo hello world'")
 
       # Copy the closure of package A from the client to the server.

--- a/tests/nixos/nix-copy.nix
+++ b/tests/nixos/nix-copy.nix
@@ -79,9 +79,9 @@ in
 
       server.wait_for_unit("sshd")
       server.wait_for_unit("multi-user.target")
-      server.wait_for_unit("network-addresses-eth1.service")
+      server.wait_for_unit("network-online.target")
 
-      client.wait_for_unit("network-addresses-eth1.service")
+      client.wait_for_unit("network-online.target")
       client.wait_for_unit("getty@tty1.service")
       # Either the prompt: ]#
       # or an OCR misreading of it: 1#

--- a/tests/nixos/nix-docker.nix
+++ b/tests/nixos/nix-docker.nix
@@ -61,7 +61,7 @@ in
     { nodes }:
     ''
       cache.wait_for_unit("harmonia.service")
-      cache.wait_for_unit("network-addresses-eth1.service")
+      cache.wait_for_unit("network-online.target")
 
       machine.succeed("mkdir -p /etc/containers")
       machine.succeed("""echo '{"default":[{"type":"insecureAcceptAnything"}]}' > /etc/containers/policy.json""")

--- a/tests/nixos/nss-preload.nix
+++ b/tests/nixos/nss-preload.nix
@@ -145,7 +145,7 @@ in
   testScript =
     { nodes, ... }:
     ''
-      http_dns.wait_for_unit("network-addresses-eth1.service")
+      http_dns.wait_for_unit("network-online.target")
       http_dns.wait_for_unit("nginx")
       http_dns.wait_for_open_port(80)
       http_dns.wait_for_unit("unbound")
@@ -153,7 +153,7 @@ in
 
       client.start()
       client.wait_for_unit('multi-user.target')
-      client.wait_for_unit('network-addresses-eth1.service')
+      client.wait_for_unit('network-online.target')
 
       with subtest("can fetch data from a remote server outside sandbox"):
           client.succeed("nix --version >&2")

--- a/tests/nixos/remote-builds-ssh-ng.nix
+++ b/tests/nixos/remote-builds-ssh-ng.nix
@@ -102,12 +102,12 @@ in
         client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
         # Install the SSH key on the builder.
-        client.wait_for_unit("network-addresses-eth1.service")
+        client.wait_for_unit("network-online.target")
         builder.succeed("mkdir -p -m 700 /root/.ssh")
         builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
         builder.wait_for_unit("sshd")
         builder.wait_for_unit("multi-user.target")
-        builder.wait_for_unit("network-addresses-eth1.service")
+        builder.wait_for_unit("network-online.target")
 
         client.succeed(f"ssh -o StrictHostKeyChecking=no {builder.name} 'echo hello world'")
 

--- a/tests/nixos/remote-builds.nix
+++ b/tests/nixos/remote-builds.nix
@@ -123,12 +123,12 @@ in
         client.succeed("chmod 600 /root/.ssh/id_ed25519")
 
         # Install the SSH key on the builders.
-        client.wait_for_unit("network-addresses-eth1.service")
+        client.wait_for_unit("network-online.target")
         for builder in [builder1, builder2]:
           builder.succeed("mkdir -p -m 700 /root/.ssh")
           builder.copy_from_host("key.pub", "/root/.ssh/authorized_keys")
           builder.wait_for_unit("sshd")
-          builder.wait_for_unit("network-addresses-eth1.service")
+          builder.wait_for_unit("network-online.target")
           # Make sure the builder can handle our login correctly
           builder.wait_for_unit("multi-user.target")
           # Make sure there's no funny business on the client either

--- a/tests/nixos/s3-binary-cache-store.nix
+++ b/tests/nixos/s3-binary-cache-store.nix
@@ -67,14 +67,14 @@ in
 
       # Create a binary cache.
       server.wait_for_unit("minio")
-      server.wait_for_unit("network-addresses-eth1.service")
+      server.wait_for_unit("network-online.target")
 
       server.succeed("mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4")
       server.succeed("mc mb minio/my-cache")
 
       server.succeed("${env} nix copy --to '${storeUrl}' ${pkgA}")
 
-      client.wait_for_unit("network-addresses-eth1.service")
+      client.wait_for_unit("network-online.target")
 
       # Test fetchurl on s3:// URLs while we're at it.
       client.succeed("${env} nix eval --impure --expr 'builtins.fetchurl { name = \"foo\"; url = \"s3://my-cache/nix-cache-info?endpoint=http://server:9000&region=eu-west-1\"; }'")

--- a/tests/nixos/sourcehut-flakes.nix
+++ b/tests/nixos/sourcehut-flakes.nix
@@ -139,8 +139,8 @@ in
       start_all()
 
       sourcehut.wait_for_unit("httpd.service")
-      sourcehut.wait_for_unit("network-addresses-eth1.service")
-      client.wait_for_unit("network-addresses-eth1.service")
+      sourcehut.wait_for_unit("network-online.target")
+      client.wait_for_unit("network-online.target")
 
       client.succeed("curl -v https://git.sr.ht/ >&2")
       client.succeed("nix registry list | grep nixpkgs")


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

As discussed in the team meeting yesterday, we'll keep the 2.28 branch on Nixpkgs 24.11 for now. Reverts #12862.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
