### PR TITLE
create cache entry for paths already in the nix store

### DIFF
--- a/src/libfetchers/include/nix/fetchers/fetch-to-store.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-to-store.hh
@@ -5,6 +5,7 @@
 #include "nix/util/file-system.hh"
 #include "nix/util/repair-flag.hh"
 #include "nix/util/file-content-address.hh"
+#include "nix/fetchers/cache.hh"
 
 namespace nix {
 
@@ -21,5 +22,8 @@ StorePath fetchToStore(
     ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive,
     PathFilter * filter = nullptr,
     RepairFlag repair = NoRepair);
+
+fetchers::Cache::Key makeFetchToStoreCacheKey(
+    const std::string & name, const std::string & fingerprint, ContentAddressMethod method, const std::string & path);
 
 }

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -2,6 +2,8 @@
 #include "nix/store/store-api.hh"
 #include "nix/util/archive.hh"
 #include "nix/fetchers/store-path-accessor.hh"
+#include "nix/fetchers/cache.hh"
+#include "nix/fetchers/fetch-to-store.hh"
 
 namespace nix::fetchers {
 
@@ -140,6 +142,14 @@ struct PathInputScheme : InputScheme
                 mtime = dumpPathAndGetMtime(absPath.string(), sink, defaultPathFilter);
             });
             storePath = store->addToStoreFromDump(*src, "source");
+        }
+
+        // To avoid copying the path again to the /nix/store, we need to add a cache entry.
+        ContentAddressMethod method = ContentAddressMethod::Raw::NixArchive;
+        auto fp = getFingerprint(store, input);
+        if (fp) {
+            auto cacheKey = makeFetchToStoreCacheKey(input.getName(), *fp, method, "/");
+            fetchers::getCache()->upsert(cacheKey, *store, {}, *storePath);
         }
 
         /* Trust the lastModified value supplied by the user, if


### PR DESCRIPTION
This allows path:/nix/store/* paths to not be copied twice to the nix store.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
