### PR TITLE
Reinstate Darwin minversion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -171,7 +171,7 @@
               {
                 otherSplices = final.generateSplicesForMkScope "nixDependencies";
                 f = import ./packaging/dependencies.nix {
-                  inherit stdenv;
+                  inherit inputs stdenv;
                   pkgs = final;
                 };
               };

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -26,6 +26,9 @@ let
   # Despite the use of the 10.13 deployment target here, the aligned
   # allocation function Clang uses with this setting actually works
   # all the way back to 10.6.
+  # NOTE: this is not just a version constraint, but a request to make Darwin
+  #       provide this version level of support. Removing this minimum version
+  #       request will regress the above error.
   darwinStdenv = pkgs.overrideSDK prevStdenv { darwinMinVersion = "10.13"; };
 
 in

--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -1,6 +1,9 @@
 # These overrides are applied to the dependencies of the Nix components.
 
 {
+  # Flake inputs; used for sources
+  inputs,
+
   # The raw Nixpkgs, not affected by this scope
   pkgs,
 
@@ -8,7 +11,23 @@
 }:
 
 let
+  prevStdenv = stdenv;
+in
+
+let
   inherit (pkgs) lib;
+
+  stdenv = if prevStdenv.isDarwin && prevStdenv.isx86_64 then darwinStdenv else prevStdenv;
+
+  # Fix the following error with the default x86_64-darwin SDK:
+  #
+  #     error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer
+  #
+  # Despite the use of the 10.13 deployment target here, the aligned
+  # allocation function Clang uses with this setting actually works
+  # all the way back to 10.6.
+  darwinStdenv = pkgs.overrideSDK prevStdenv { darwinMinVersion = "10.13"; };
+
 in
 scope: {
   inherit stdenv;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

This reverts commit https://github.com/NixOS/nix/commit/d91310bb32b9efca2f1e1a6a767cbe5b0a7f072c.

> Some packages require setting a non-default deployment target
> (or minimum version) to gain access to certain APIs. You do
> that using the darwinMinVersionHook, which takes the deployment
> target version as a parameter.

-- https://github.com/NixOS/nixpkgs/blob/60b54c7aee3c0cefde72d1a151bb7d3a46361ca2/doc/stdenv/platform-notes.chapter.md#what-is-a-deployment-target-or-minimum-version-sec-darwin-troubleshooting-using-deployment-targets

This will again solve error:

    ../nix_api_expr.cc:38:18: error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.13 or newer

-- https://hydra.nixos.org/build/294088946

## Motivation

Fix error and clarify to prevent later regressions.
(Unfortunately only Hydra will spot this, so we get the failure async)

## Context

- Partially reverts https://github.com/NixOS/nix/pull/12863

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
