### PR TITLE
libflake: add lock file path to invalid json error

### DIFF
--- a/src/libflake/flake/lockfile.cc
+++ b/src/libflake/flake/lockfile.cc
@@ -108,8 +108,13 @@ LockFile::LockFile(
     const fetchers::Settings & fetchSettings,
     std::string_view contents, std::string_view path)
 {
-    auto json = nlohmann::json::parse(contents);
-
+    auto json = [=] {
+        try {
+            return nlohmann::json::parse(contents);
+        } catch (const nlohmann::json::parse_error & e) {
+            throw Error("Could not parse '%s': %s", path, e.what());
+        }
+    }();
     auto version = json.value("version", 0);
     if (version < 5 || version > 7)
         throw Error("lock file '%s' has unsupported version %d", path, version);


### PR DESCRIPTION
## Motivation

Previously, when lock file contained invalid JSON nix reported a parser
error without specifying the file it came from. This behavior is confusing.

## Context

- Fixes: https://github.com/NixOS/nix/issues/12933
This change adds flake.lock file path to the error message to avoid confusion.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
