### PR TITLE
maintainers/release-notes: Let it fail

### DIFF
--- a/maintainers/release-notes
+++ b/maintainers/release-notes
@@ -2,6 +2,8 @@
 # vim: set filetype=bash:
 #!nix shell .#changelog-d --command bash
 
+set -euo pipefail
+
 # --- CONFIGURATION ---
 
 # This does double duty for


### PR DESCRIPTION
Fail when a command fails.

Basic error handling was missing, which would lead to errors getting obscured a bit by subsequent successful logging.

Backport label: this script works for minor releases too!

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
