### PR TITLE
tests/functional/repl: fix race condition

### DIFF
--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -162,15 +162,32 @@ foo + baz
 # - Modify the flake
 # - Re-eval it
 # - Check that the result has changed
-replResult=$( (
-echo "changingThing"
-sleep 1 # Leave the repl the time to eval 'foo'
+mkfifo repl_fifo
+nix repl ./flake --experimental-features 'flakes' < repl_fifo > repl_output 2>&1 &
+repl_pid=$!
+exec 3>repl_fifo # Open fifo for writing
+echo "changingThing" >&3
+for i in $(seq 1 1000); do
+    if grep -q "beforeChange" repl_output; then
+        break
+    fi
+    cat repl_output
+    sleep 0.1
+done
+if [[ "$i" -eq 100 ]]; then
+    echo "Timed out waiting for beforeChange"
+    exit 1
+fi
+
 sed -i 's/beforeChange/afterChange/' flake/flake.nix
-echo ":reload"
-echo "changingThing"
-) | nix repl ./flake --experimental-features 'flakes')
-echo "$replResult" | grepQuiet -s beforeChange
-echo "$replResult" | grepQuiet -s afterChange
+
+# Send reload and second command
+echo ":reload" >&3
+echo "changingThing" >&3
+echo "exit" >&3
+exec 3>&- # Close fifo
+wait $repl_pid # Wait for process to finish
+grep -q "afterChange" repl_output
 
 # Test recursive printing and formatting
 # Normal output should print attributes in lexicographical order non-recursively


### PR DESCRIPTION
the sleep 1 is not enough in some circumstances. Switching to a fifo helps.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
