### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -65,7 +65,7 @@ struct DocComment {
 struct AttrName
 {
     Symbol symbol;
-    Expr * expr;
+    Expr * expr = nullptr;
     AttrName(Symbol s) : symbol(s) {};
     AttrName(Expr * e) : expr(e) {};
 };
@@ -159,7 +159,7 @@ struct ExprVar : Expr
 
        `nullptr`: Not from a `with`.
        Valid pointer: the nearest, innermost `with` expression to query first. */
-    ExprWith * fromWith;
+    ExprWith * fromWith = nullptr;
 
     /* In the former case, the value is obtained by going `level`
        levels up from the current environment and getting the
@@ -167,7 +167,7 @@ struct ExprVar : Expr
        value is obtained by getting the attribute named `name` from
        the set stored in the environment that is `level` levels up
        from the current one.*/
-    Level level;
+    Level level = 0;
     Displacement displ = 0;
 
     ExprVar(Symbol name) : name(name) { };


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
