### PR TITLE
Fix meson warning about meson_version 1.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,8 @@ project('nix-dev-shell', 'cpp',
   subproject_dir : 'src',
   default_options : [
     'localstatedir=/nix/var',
-  ]
+  ],
+  meson_version : '>= 1.1'
 )
 
 # Internal Libraries


### PR DESCRIPTION
## Motivation

meson.options requires that we set meson_version to at least 1.1

similar to #12956

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
