### PR TITLE
Fix another machine config parsing bug

### DIFF
--- a/src/libstore-tests/machines.cc
+++ b/src/libstore-tests/machines.cc
@@ -85,6 +85,20 @@ TEST(machines, getMachinesWithCommentsAndSemicolonSeparator) {
     EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@scabby.labs.cs.uu.nl"))));
 }
 
+TEST(machines, getMachinesWithFunnyWhitespace) {
+    auto actual = Machine::parseConfig({},
+        "        # commment ; comment\n"
+        "   nix@scratchy.labs.cs.uu.nl ; nix@itchy.labs.cs.uu.nl   \n"
+        "\n    \n"
+        "\n ;;; \n"
+        "\n ; ; \n"
+        "nix@scabby.labs.cs.uu.nl\n\n");
+    EXPECT_THAT(actual, SizeIs(3));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@scratchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@itchy.labs.cs.uu.nl"))));
+    EXPECT_THAT(actual, Contains(Field(&Machine::storeUri, AuthorityMatches("nix@scabby.labs.cs.uu.nl"))));
+}
+
 TEST(machines, getMachinesWithCorrectCompleteSingleBuilder) {
     auto actual = Machine::parseConfig({},
         "nix@scratchy.labs.cs.uu.nl     i686-linux      "

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -106,13 +106,14 @@ static std::vector<std::string> expandBuilderLines(const std::string & builders)
 {
     std::vector<std::string> result;
     for (auto line : tokenizeString<std::vector<std::string>>(builders, "\n")) {
-        trim(line);
         line.erase(std::find(line.begin(), line.end(), '#'), line.end());
         for (auto entry : tokenizeString<std::vector<std::string>>(line, ";")) {
-            if (entry.empty()) continue;
+            entry = trim(entry);
 
-            if (entry[0] == '@') {
-                const std::string path = trim(std::string(entry, 1));
+            if (entry.empty()) {
+                // skip blank entries
+            } else if (entry[0] == '@') {
+                const std::string path = trim(std::string_view{entry}.substr(1));
                 std::string text;
                 try {
                     text = readFile(path);


### PR DESCRIPTION
We were ignorning the result of `trim`, and after my last change we were also trimmming too early.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
