### PR TITLE
Rename FlakeCache to InputCache and move it to libfetchers

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -28,6 +28,7 @@
 #include "nix/expr/print.hh"
 #include "nix/util/ref.hh"
 #include "nix/expr/value.hh"
+#include "nix/fetchers/input-cache.hh"
 
 #include "nix/util/strings.hh"
 
@@ -458,6 +459,7 @@ ProcessLineResult NixRepl::processLine(std::string line)
 
     else if (command == ":l" || command == ":load") {
         state->resetFileCache();
+        fetchers::InputCache::getCache()->clear();
         loadFile(arg);
     }
 
@@ -467,6 +469,7 @@ ProcessLineResult NixRepl::processLine(std::string line)
 
     else if (command == ":r" || command == ":reload") {
         state->resetFileCache();
+        fetchers::InputCache::getCache()->clear();
         reloadFiles();
     }
 

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -28,7 +28,6 @@
 #include "nix/expr/print.hh"
 #include "nix/util/ref.hh"
 #include "nix/expr/value.hh"
-#include "nix/fetchers/input-cache.hh"
 
 #include "nix/util/strings.hh"
 
@@ -459,7 +458,6 @@ ProcessLineResult NixRepl::processLine(std::string line)
 
     else if (command == ":l" || command == ":load") {
         state->resetFileCache();
-        fetchers::InputCache::getCache()->clear();
         loadFile(arg);
     }
 
@@ -469,7 +467,6 @@ ProcessLineResult NixRepl::processLine(std::string line)
 
     else if (command == ":r" || command == ":reload") {
         state->resetFileCache();
-        fetchers::InputCache::getCache()->clear();
         reloadFiles();
     }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -19,6 +19,7 @@
 #include "nix/util/url.hh"
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/fetchers/tarball.hh"
+#include "nix/fetchers/input-cache.hh"
 
 #include "parser-tab.hh"
 
@@ -310,6 +311,7 @@ EvalState::EvalState(
     )}
     , store(store)
     , buildStore(buildStore ? buildStore : store)
+    , inputCache(fetchers::InputCache::create())
     , debugRepl(nullptr)
     , debugStop(false)
     , trylevel(0)
@@ -1152,6 +1154,7 @@ void EvalState::resetFileCache()
 {
     fileEvalCache.clear();
     fileParseCache.clear();
+    inputCache->clear();
 }
 
 

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -33,7 +33,10 @@ namespace nix {
 constexpr size_t maxPrimOpArity = 8;
 
 class Store;
-namespace fetchers { struct Settings; }
+namespace fetchers {
+struct Settings;
+struct InputCache;
+}
 struct EvalSettings;
 class EvalState;
 class StorePath;
@@ -299,6 +302,8 @@ public:
     const ref<Store> buildStore;
 
     RootValue vImportedDrvToDerivation = nullptr;
+
+    ref<fetchers::InputCache> inputCache;
 
     /**
      * Debugger

--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -2,14 +2,23 @@
 
 namespace nix::fetchers {
 
-struct CachedInput
-{
-    Input lockedInput;
-    ref<SourceAccessor> accessor;
-};
-
 struct InputCache
 {
+    struct CachedResult
+    {
+        ref<SourceAccessor> accessor;
+        Input resolvedInput;
+        Input lockedInput;
+    };
+
+    CachedResult getAccessor(ref<Store> store, const Input & originalInput, bool useRegistries);
+
+    struct CachedInput
+    {
+        Input lockedInput;
+        ref<SourceAccessor> accessor;
+    };
+
     virtual std::optional<CachedInput> lookup(const Input & originalInput) const = 0;
 
     virtual void upsert(Input key, CachedInput cachedInput) = 0;

--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -1,0 +1,22 @@
+#include "fetchers.hh"
+
+namespace nix::fetchers {
+
+struct CachedInput
+{
+    Input lockedInput;
+    ref<SourceAccessor> accessor;
+};
+
+struct InputCache
+{
+    virtual std::optional<CachedInput> lookup(const Input & originalInput) const = 0;
+
+    virtual void upsert(Input key, CachedInput cachedInput) = 0;
+
+    virtual void clear() = 0;
+
+    static ref<InputCache> getCache();
+};
+
+}

--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -25,7 +25,7 @@ struct InputCache
 
     virtual void clear() = 0;
 
-    static ref<InputCache> getCache();
+    static ref<InputCache> create();
 };
 
 }

--- a/src/libfetchers/include/nix/fetchers/meson.build
+++ b/src/libfetchers/include/nix/fetchers/meson.build
@@ -9,6 +9,7 @@ headers = files(
   'filtering-source-accessor.hh',
   'git-lfs-fetch.hh',
   'git-utils.hh',
+  'input-cache.hh',
   'registry.hh',
   'store-path-accessor.hh',
   'tarball.hh',

--- a/src/libfetchers/input-cache.cc
+++ b/src/libfetchers/input-cache.cc
@@ -72,10 +72,9 @@ struct InputCacheImpl : InputCache
     }
 };
 
-ref<InputCache> InputCache::getCache()
+ref<InputCache> InputCache::create()
 {
-    static auto cache = make_ref<InputCacheImpl>();
-    return cache;
+    return make_ref<InputCacheImpl>();
 }
 
 }

--- a/src/libfetchers/input-cache.cc
+++ b/src/libfetchers/input-cache.cc
@@ -1,0 +1,41 @@
+#include "nix/fetchers/input-cache.hh"
+#include "nix/util/sync.hh"
+
+namespace nix::fetchers {
+
+struct InputCacheImpl : InputCache
+{
+    Sync<std::map<Input, CachedInput>> cache_;
+
+    std::optional<CachedInput> lookup(const Input & originalInput) const override
+    {
+        auto cache(cache_.readLock());
+        auto i = cache->find(originalInput);
+        if (i == cache->end())
+            return std::nullopt;
+        debug(
+            "mapping '%s' to previously seen input '%s' -> '%s",
+            originalInput.to_string(),
+            i->first.to_string(),
+            i->second.lockedInput.to_string());
+        return i->second;
+    }
+
+    void upsert(Input key, CachedInput cachedInput) override
+    {
+        cache_.lock()->insert_or_assign(std::move(key), std::move(cachedInput));
+    }
+
+    void clear() override
+    {
+        cache_.lock()->clear();
+    }
+};
+
+ref<InputCache> InputCache::getCache()
+{
+    static auto cache = make_ref<InputCacheImpl>();
+    return cache;
+}
+
+}

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -44,6 +44,7 @@ sources = files(
   'git.cc',
   'github.cc',
   'indirect.cc',
+  'input-cache.cc',
   'mercurial.cc',
   'path.cc',
   'registry.cc',

--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -7,7 +7,6 @@
 #include "nix_api_fetchers.h"
 
 #include "nix/flake/flake.hh"
-#include "nix/fetchers/input-cache.hh"
 
 nix_flake_settings * nix_flake_settings_new(nix_c_context * context)
 {
@@ -178,7 +177,7 @@ nix_locked_flake * nix_flake_lock(
 {
     nix_clear_err(context);
     try {
-        nix::fetchers::InputCache::getCache()->clear();
+        eval_state->state.resetFileCache();
         auto lockedFlake = nix::make_ref<nix::flake::LockedFlake>(nix::flake::lockFlake(
             *flakeSettings->settings, eval_state->state, *flakeReference->flakeRef, *flags->lockFlags));
         return new nix_locked_flake{lockedFlake};

--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -7,6 +7,7 @@
 #include "nix_api_fetchers.h"
 
 #include "nix/flake/flake.hh"
+#include "nix/fetchers/input-cache.hh"
 
 nix_flake_settings * nix_flake_settings_new(nix_c_context * context)
 {
@@ -177,6 +178,7 @@ nix_locked_flake * nix_flake_lock(
 {
     nix_clear_err(context);
     try {
+        nix::fetchers::InputCache::getCache()->clear();
         auto lockedFlake = nix::make_ref<nix::flake::LockedFlake>(nix::flake::lockFlake(
             *flakeSettings->settings, eval_state->state, *flakeReference->flakeRef, *flags->lockFlags));
         return new nix_locked_flake{lockedFlake};

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -341,7 +341,7 @@ static Flake getFlake(
     const InputAttrPath & lockRootAttrPath)
 {
     // Fetch a lazy tree first.
-    auto cachedInput = fetchers::InputCache::getCache()->getAccessor(state.store, originalRef.input, useRegistries);
+    auto cachedInput = state.inputCache->getAccessor(state.store, originalRef.input, useRegistries);
 
     auto resolvedRef = FlakeRef(std::move(cachedInput.resolvedInput), originalRef.subdir);
     auto lockedRef = FlakeRef(std::move(cachedInput.lockedInput), originalRef.subdir);
@@ -356,7 +356,7 @@ static Flake getFlake(
         debug("refetching input '%s' due to self attribute", newLockedRef);
         // FIXME: need to remove attrs that are invalidated by the changed input attrs, such as 'narHash'.
         newLockedRef.input.attrs.erase("narHash");
-        auto cachedInput2 = fetchers::InputCache::getCache()->getAccessor(state.store, newLockedRef.input, useRegistries);
+        auto cachedInput2 = state.inputCache->getAccessor(state.store, newLockedRef.input, useRegistries);
         cachedInput.accessor = cachedInput2.accessor;
         lockedRef = FlakeRef(std::move(cachedInput2.lockedInput), newLockedRef.subdir);
     }
@@ -717,7 +717,7 @@ LockedFlake lockFlake(
                                 if (auto resolvedPath = resolveRelativePath()) {
                                     return {*resolvedPath, *input.ref};
                                 } else {
-                                    auto cachedInput = fetchers::InputCache::getCache()->getAccessor(state.store, input.ref->input, useRegistries);
+                                    auto cachedInput = state.inputCache->getAccessor(state.store, input.ref->input, useRegistries);
 
                                     auto lockedRef = FlakeRef(std::move(cachedInput.lockedInput), input.ref->subdir);
 

--- a/src/libflake/flake/flake.cc
+++ b/src/libflake/flake/flake.cc
@@ -23,64 +23,64 @@ using namespace flake;
 
 namespace flake {
 
-struct FetchedFlake
+struct CachedInput
 {
-    FlakeRef lockedRef;
+    Input lockedInput;
     ref<SourceAccessor> accessor;
 };
 
-typedef std::map<FlakeRef, FetchedFlake> FlakeCache;
+typedef std::map<Input, CachedInput> InputCache;
 
-static std::optional<FetchedFlake> lookupInFlakeCache(
-    const FlakeCache & flakeCache,
-    const FlakeRef & flakeRef)
+static std::optional<CachedInput> lookupInInputCache(
+    const InputCache & inputCache,
+    const Input & originalInput)
 {
-    auto i = flakeCache.find(flakeRef);
-    if (i == flakeCache.end()) return std::nullopt;
+    auto i = inputCache.find(originalInput);
+    if (i == inputCache.end()) return std::nullopt;
     debug("mapping '%s' to previously seen input '%s' -> '%s",
-        flakeRef, i->first, i->second.lockedRef);
+        originalInput.to_string(), i->first.to_string(), i->second.lockedInput.to_string());
     return i->second;
 }
 
-static std::tuple<ref<SourceAccessor>, FlakeRef, FlakeRef> fetchOrSubstituteTree(
+static std::tuple<ref<SourceAccessor>, Input, Input> getAccessorCached(
     EvalState & state,
-    const FlakeRef & originalRef,
+    const Input & originalInput,
     bool useRegistries,
-    FlakeCache & flakeCache)
+    InputCache & inputCache)
 {
-    auto fetched = lookupInFlakeCache(flakeCache, originalRef);
-    FlakeRef resolvedRef = originalRef;
+    auto fetched = lookupInInputCache(inputCache, originalInput);
+    Input resolvedInput = originalInput;
 
     if (!fetched) {
-        if (originalRef.input.isDirect()) {
-            auto [accessor, lockedRef] = originalRef.lazyFetch(state.store);
-            fetched.emplace(FetchedFlake{.lockedRef = lockedRef, .accessor = accessor});
+        if (originalInput.isDirect()) {
+            auto [accessor, lockedInput] = originalInput.getAccessor(state.store);
+            fetched.emplace(CachedInput{.lockedInput = lockedInput, .accessor = accessor});
         } else {
             if (useRegistries) {
-                resolvedRef = originalRef.resolve(
-                    state.store,
+                auto [res, extraAttrs] = lookupInRegistries(state.store, originalInput,
                     [](fetchers::Registry::RegistryType type) {
                         /* Only use the global registry and CLI flags
                            to resolve indirect flakerefs. */
                         return type == fetchers::Registry::Flag || type == fetchers::Registry::Global;
                     });
-                fetched = lookupInFlakeCache(flakeCache, originalRef);
+                resolvedInput = std::move(res);
+                fetched = lookupInInputCache(inputCache, originalInput);
                 if (!fetched) {
-                    auto [accessor, lockedRef] = resolvedRef.lazyFetch(state.store);
-                    fetched.emplace(FetchedFlake{.lockedRef = lockedRef, .accessor = accessor});
+                    auto [accessor, lockedInput] = resolvedInput.getAccessor(state.store);
+                    fetched.emplace(CachedInput{.lockedInput = lockedInput, .accessor = accessor});
                 }
-                flakeCache.insert_or_assign(resolvedRef, *fetched);
+                inputCache.insert_or_assign(resolvedInput, *fetched);
             }
             else {
-                throw Error("'%s' is an indirect flake reference, but registry lookups are not allowed", originalRef);
+                throw Error("'%s' is an indirect flake reference, but registry lookups are not allowed", originalInput.to_string());
             }
         }
-        flakeCache.insert_or_assign(originalRef, *fetched);
+        inputCache.insert_or_assign(originalInput, *fetched);
     }
 
-    debug("got tree '%s' from '%s'", fetched->accessor, fetched->lockedRef);
+    debug("got tree '%s' from '%s'", fetched->accessor, fetched->lockedInput.to_string());
 
-    return {fetched->accessor, resolvedRef, fetched->lockedRef};
+    return {fetched->accessor, resolvedInput, fetched->lockedInput};
 }
 
 static StorePath copyInputToStore(
@@ -397,12 +397,15 @@ static Flake getFlake(
     EvalState & state,
     const FlakeRef & originalRef,
     bool useRegistries,
-    FlakeCache & flakeCache,
+    InputCache & inputCache,
     const InputAttrPath & lockRootAttrPath)
 {
     // Fetch a lazy tree first.
-    auto [accessor, resolvedRef, lockedRef] = fetchOrSubstituteTree(
-        state, originalRef, useRegistries, flakeCache);
+    auto [accessor, resolvedInput, lockedInput] = getAccessorCached(
+        state, originalRef.input, useRegistries, inputCache);
+
+    auto resolvedRef = FlakeRef(std::move(resolvedInput), originalRef.subdir);
+    auto lockedRef = FlakeRef(std::move(lockedInput), originalRef.subdir);
 
     // Parse/eval flake.nix to get at the input.self attributes.
     auto flake = readFlake(state, originalRef, resolvedRef, lockedRef, {accessor}, lockRootAttrPath);
@@ -414,10 +417,10 @@ static Flake getFlake(
         debug("refetching input '%s' due to self attribute", newLockedRef);
         // FIXME: need to remove attrs that are invalidated by the changed input attrs, such as 'narHash'.
         newLockedRef.input.attrs.erase("narHash");
-        auto [accessor2, resolvedRef2, lockedRef2] = fetchOrSubstituteTree(
-            state, newLockedRef, false, flakeCache);
+        auto [accessor2, resolvedInput2, lockedInput2] = getAccessorCached(
+            state, newLockedRef.input, false, inputCache);
         accessor = accessor2;
-        lockedRef = lockedRef2;
+        lockedRef = FlakeRef(std::move(lockedInput2), newLockedRef.subdir);
     }
 
     // Copy the tree to the store.
@@ -429,8 +432,8 @@ static Flake getFlake(
 
 Flake getFlake(EvalState & state, const FlakeRef & originalRef, bool useRegistries)
 {
-    FlakeCache flakeCache;
-    return getFlake(state, originalRef, useRegistries, flakeCache, {});
+    InputCache inputCache;
+    return getFlake(state, originalRef, useRegistries, inputCache, {});
 }
 
 static LockFile readLockFile(
@@ -452,11 +455,11 @@ LockedFlake lockFlake(
 {
     experimentalFeatureSettings.require(Xp::Flakes);
 
-    FlakeCache flakeCache;
+    InputCache inputCache;
 
     auto useRegistries = lockFlags.useRegistries.value_or(settings.useRegistries);
 
-    auto flake = getFlake(state, topRef, useRegistries, flakeCache, {});
+    auto flake = getFlake(state, topRef, useRegistries, inputCache, {});
 
     if (lockFlags.applyNixConfig) {
         flake.config.apply(settings);
@@ -631,7 +634,7 @@ LockedFlake lockFlake(
                         if (auto resolvedPath = resolveRelativePath()) {
                             return readFlake(state, ref, ref, ref, *resolvedPath, inputAttrPath);
                         } else {
-                            return getFlake(state, ref, useRegistries, flakeCache, inputAttrPath);
+                            return getFlake(state, ref, useRegistries, inputCache, inputAttrPath);
                         }
                     };
 
@@ -779,8 +782,10 @@ LockedFlake lockFlake(
                                 if (auto resolvedPath = resolveRelativePath()) {
                                     return {*resolvedPath, *input.ref};
                                 } else {
-                                    auto [accessor, resolvedRef, lockedRef] = fetchOrSubstituteTree(
-                                        state, *input.ref, useRegistries, flakeCache);
+                                    auto [accessor, resolvedInput, lockedInput] = getAccessorCached(
+                                        state, input.ref->input, useRegistries, inputCache);
+
+                                    auto lockedRef = FlakeRef(std::move(lockedInput), input.ref->subdir);
 
                                     // FIXME: allow input to be lazy.
                                     auto storePath = copyInputToStore(state, lockedRef.input, input.ref->input, accessor);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

`InputCache` is now keyed on `Inputs` rather than `FlakeRefs`. This prepares it to be used by `fetchTree` (in a future PR).

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
