### PR TITLE
Move alias support from NixArgs to MultiCommand

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -281,7 +281,6 @@ nix3_manpages = [
   'nix3-store',
   'nix3-store-optimise',
   'nix3-store-path-from-hash-part',
-  'nix3-store-ping',
   'nix3-store-prefetch-file',
   'nix3-store-repair',
   'nix3-store-sign',

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -647,4 +647,25 @@ nlohmann::json MultiCommand::toJSON()
     return res;
 }
 
+Strings::iterator MultiCommand::rewriteArgs(Strings & args, Strings::iterator pos)
+{
+    if (command)
+        return command->second->rewriteArgs(args, pos);
+
+    if (aliasUsed || pos == args.end()) return pos;
+    auto arg = *pos;
+    auto i = aliases.find(arg);
+    if (i == aliases.end()) return pos;
+    auto & info = i->second;
+    if (info.status == AliasStatus::Deprecated) {
+        warn("'%s' is a deprecated alias for '%s'",
+            arg, concatStringsSep(" ", info.replacement));
+    }
+    pos = args.erase(pos);
+    for (auto j = info.replacement.rbegin(); j != info.replacement.rend(); ++j)
+        pos = args.insert(pos, *j);
+    aliasUsed = true;
+    return pos;
+}
+
 }

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -393,8 +393,30 @@ public:
 
     nlohmann::json toJSON() override;
 
+    enum struct AliasStatus {
+        /** Aliases that don't go away */
+        AcceptedShorthand,
+        /** Aliases that will go away */
+        Deprecated,
+    };
+
+    /** An alias, except for the original syntax, which is in the map key. */
+    struct AliasInfo {
+        AliasStatus status;
+        std::vector<std::string> replacement;
+    };
+
+    /**
+     * A list of aliases (remapping a deprecated/shorthand subcommand
+     * to something else).
+     */
+    std::map<std::string, AliasInfo> aliases;
+
+    Strings::iterator rewriteArgs(Strings & args, Strings::iterator pos) override;
+
 protected:
     std::string commandName = "";
+    bool aliasUsed = false;
 };
 
 Strings argvToStrings(int argc, char * * argv);

--- a/src/nix/store-info.cc
+++ b/src/nix/store-info.cc
@@ -7,7 +7,7 @@
 
 using namespace nix;
 
-struct CmdPingStore : StoreCommand, MixJSON
+struct CmdInfoStore : StoreCommand, MixJSON
 {
     std::string description() override
     {
@@ -46,15 +46,4 @@ struct CmdPingStore : StoreCommand, MixJSON
     }
 };
 
-struct CmdInfoStore : CmdPingStore
-{
-    void run(nix::ref<nix::Store> store) override
-    {
-        warn("'nix store ping' is a deprecated alias for 'nix store info'");
-        CmdPingStore::run(store);
-    }
-};
-
-
-static auto rCmdPingStore = registerCommand2<CmdPingStore>({"store", "info"});
-static auto rCmdInfoStore = registerCommand2<CmdInfoStore>({"store", "ping"});
+static auto rCmdInfoStore = registerCommand2<CmdInfoStore>({"store", "info"});

--- a/src/nix/store.cc
+++ b/src/nix/store.cc
@@ -5,7 +5,11 @@ using namespace nix;
 struct CmdStore : NixMultiCommand
 {
     CmdStore() : NixMultiCommand("store", RegisterCommand::getCommandsFor({"store"}))
-    { }
+    {
+        aliases = {
+            {"ping", { AliasStatus::Deprecated, {"info"}}},
+        };
+    }
 
     std::string description() override
     {


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This allows subcommands to declare aliases, e.g. `nix store ping` is now a proper alias of `nix store info`. That way they don't appear in the docs as a separate command (e.g. https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-store-ping).

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
