### PR TITLE
Nix language reference: highlight characteristic features

### DIFF
--- a/doc/manual/source/language/index.md
+++ b/doc/manual/source/language/index.md
@@ -11,7 +11,14 @@ The language is:
 
 - *domain-specific*
 
-  It comes with [built-in functions](@docroot@/language/builtins.md) to integrate with the Nix store, which manages files and performs the derivations declared in the Nix language.
+  The Nix language is purpose-built for working with text files.
+  Its most characteristic features are:
+
+  - [File system path primitives](@docroot@/language/types.md#type-path), for accessing source files
+  - [Indented strings](@docroot@/language/string-literals.md) and [string interpolation](@docroot@/language/string-interpolation.md), for creating file contents
+  - [Strings with contexts](@docroot@/language/string-context.md), for transparently linking files
+
+  It comes with [built-in functions](@docroot@/language/builtins.md) to integrate with the [Nix store](@docroot@/store/index.md), which manages files and enables [realising](@docroot@/glossary.md#gloss-realise) derivations declared in the Nix language.
 
 - *declarative*
 

--- a/doc/manual/source/language/string-context.md
+++ b/doc/manual/source/language/string-context.md
@@ -13,8 +13,8 @@ The purpose of string contexts is to collect non-string values attached to strin
 [string concatenation](./operators.md#string-concatenation),
 [string interpolation](./string-interpolation.md),
 and similar operations.
-The idea is that a user can combine together values to create a build instructions for derivations without manually keeping track of where they come from.
-Then the Nix language implicitly does that bookkeeping to efficiently obtain the closure of derivation inputs.
+The idea is that a user can reference other files when creating text files through Nix expressions, without manually keeping track of the exact paths.
+Nix will ensure that the all referenced files are accessible – that all [store paths](@docroot@/glossary.md#gloss-store-path) are [valid](@docroot@/glossary.md#gloss-validitiy).
 
 > **Note**
 >


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Nix shipping with Yet Another Programming Language is often questioned among beginners. This change highlights distinctive aspects of the Nix language to ease the learning curve and better orient readers around what really matters for using Nix.

Since it's on topic, this change also polishes the wording on the motivation for string contexts.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).