### PR TITLE
Add `json-log-path` setting

### DIFF
--- a/doc/manual/rl-next/json-logger.md
+++ b/doc/manual/rl-next/json-logger.md
@@ -1,0 +1,6 @@
+---
+synopsis: "`json-log-path` setting"
+prs: [13003]
+---
+
+New setting `json-log-path` that sends a copy of all Nix log messages (in JSON format) to a file or Unix domain socket.

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -15,6 +15,7 @@
 #include "nix/store/derivations.hh"
 #include "nix/util/args.hh"
 #include "nix/util/git.hh"
+#include "nix/util/logging.hh"
 
 #ifndef _WIN32 // TODO need graceful async exit support on Windows?
 # include "nix/util/monitor-fd.hh"
@@ -1050,6 +1051,7 @@ void processConnection(
     if (!recursive) {
         prevLogger_ = std::move(logger);
         logger = std::move(tunnelLogger_);
+        applyJSONLogger();
     }
 
     unsigned int opCount = 0;

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -84,9 +84,7 @@ ref<RemoteStore::Connection> UDSRemoteStore::openConnection()
     auto conn = make_ref<Connection>();
 
     /* Connect to a daemon that does the privileged work for us. */
-    conn->fd = createUnixDomainSocket();
-
-    nix::connect(toSocket(conn->fd.get()), path);
+    conn->fd = nix::connect(path);
 
     conn->from.fd = conn->fd.get();
     conn->to.fd = conn->fd.get();

--- a/src/libutil/include/nix/util/unix-domain-socket.hh
+++ b/src/libutil/include/nix/util/unix-domain-socket.hh
@@ -9,6 +9,8 @@
 #endif
 #include <unistd.h>
 
+#include <filesystem>
+
 namespace nix {
 
 /**
@@ -79,5 +81,10 @@ void bind(Socket fd, const std::string & path);
  * Connect to a Unix domain socket.
  */
 void connect(Socket fd, const std::string & path);
+
+/**
+ * Connect to a Unix domain socket.
+ */
+AutoCloseFD connect(const std::filesystem::path & path);
 
 }

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -7,6 +7,7 @@
 #include "nix/util/source-path.hh"
 #include "nix/util/position.hh"
 #include "nix/util/sync.hh"
+#include "nix/util/unix-domain-socket.hh"
 
 #include <atomic>
 #include <sstream>
@@ -182,8 +183,12 @@ void to_json(nlohmann::json & json, std::shared_ptr<Pos> pos)
 
 struct JSONLogger : Logger {
     Descriptor fd;
+    bool includeNixPrefix;
 
-    JSONLogger(Descriptor fd) : fd(fd) { }
+    JSONLogger(Descriptor fd, bool includeNixPrefix)
+        : fd(fd)
+        , includeNixPrefix(includeNixPrefix)
+    { }
 
     bool isVerbose() override {
         return true;
@@ -204,6 +209,7 @@ struct JSONLogger : Logger {
 
     struct State
     {
+        bool enabled = true;
     };
 
     Sync<State> _state;
@@ -211,13 +217,23 @@ struct JSONLogger : Logger {
     void write(const nlohmann::json & json)
     {
         auto line =
-            "@nix " +
+            (includeNixPrefix ? "@nix " : "") +
             json.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
 
         /* Acquire a lock to prevent log messages from clobbering each
            other. */
-        auto state(_state.lock());
-        writeLine(fd, line);
+        try {
+            auto state(_state.lock());
+            if (state->enabled)
+                writeLine(fd, line);
+        } catch (...) {
+            bool enabled = false;
+            std::swap(_state.lock()->enabled, enabled);
+            if (enabled) {
+                ignoreExceptionExceptInterrupt();
+                logger->warn("disabling JSON logger due to write errors");
+            }
+        }
     }
 
     void log(Verbosity lvl, std::string_view s) override
@@ -289,9 +305,49 @@ struct JSONLogger : Logger {
     }
 };
 
-std::unique_ptr<Logger> makeJSONLogger(Descriptor fd)
+std::unique_ptr<Logger> makeJSONLogger(Descriptor fd, bool includeNixPrefix)
 {
-    return std::make_unique<JSONLogger>(fd);
+    return std::make_unique<JSONLogger>(fd, includeNixPrefix);
+}
+
+std::unique_ptr<Logger> makeJSONLogger(const std::filesystem::path & path, bool includeNixPrefix)
+{
+    struct JSONFileLogger : JSONLogger {
+        AutoCloseFD fd;
+
+        JSONFileLogger(AutoCloseFD && fd, bool includeNixPrefix)
+            : JSONLogger(fd.get(), includeNixPrefix)
+            , fd(std::move(fd))
+        { }
+    };
+
+    AutoCloseFD fd =
+        std::filesystem::is_socket(path)
+        ? connect(path)
+        : toDescriptor(open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0644));
+    if (!fd)
+        throw SysError("opening log file %1%", path);
+
+    return std::make_unique<JSONFileLogger>(std::move(fd), includeNixPrefix);
+}
+
+void applyJSONLogger()
+{
+    if (!loggerSettings.jsonLogPath.get().empty()) {
+        try {
+            std::vector<std::unique_ptr<Logger>> loggers;
+            loggers.push_back(makeJSONLogger(std::filesystem::path(loggerSettings.jsonLogPath.get()), false));
+            try {
+                logger = makeTeeLogger(std::move(logger), std::move(loggers));
+            } catch (...) {
+                // `logger` is now gone so give up.
+                abort();
+            }
+        } catch (...) {
+            ignoreExceptionExceptInterrupt();
+        }
+
+    }
 }
 
 static Logger::Fields getFields(nlohmann::json & json)

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -146,6 +146,7 @@ sources = [config_priv_h] + files(
   'strings.cc',
   'suggestions.cc',
   'tarfile.cc',
+  'tee-logger.cc',
   'terminal.cc',
   'thread-pool.cc',
   'union-source-accessor.cc',

--- a/src/libutil/tee-logger.cc
+++ b/src/libutil/tee-logger.cc
@@ -1,0 +1,107 @@
+#include "nix/util/logging.hh"
+
+namespace nix {
+
+struct TeeLogger : Logger
+{
+    std::vector<std::unique_ptr<Logger>> loggers;
+
+    TeeLogger(std::vector<std::unique_ptr<Logger>> && loggers)
+        : loggers(std::move(loggers))
+    {
+    }
+
+    void stop() override
+    {
+        for (auto & logger : loggers)
+            logger->stop();
+    };
+
+    void pause() override
+    {
+        for (auto & logger : loggers)
+            logger->pause();
+    };
+
+    void resume() override
+    {
+        for (auto & logger : loggers)
+            logger->resume();
+    };
+
+    void log(Verbosity lvl, std::string_view s) override
+    {
+        for (auto & logger : loggers)
+            logger->log(lvl, s);
+    }
+
+    void logEI(const ErrorInfo & ei) override
+    {
+        for (auto & logger : loggers)
+            logger->logEI(ei);
+    }
+
+    void startActivity(
+        ActivityId act,
+        Verbosity lvl,
+        ActivityType type,
+        const std::string & s,
+        const Fields & fields,
+        ActivityId parent) override
+    {
+        for (auto & logger : loggers)
+            logger->startActivity(act, lvl, type, s, fields, parent);
+    }
+
+    void stopActivity(ActivityId act) override
+    {
+        for (auto & logger : loggers)
+            logger->stopActivity(act);
+    }
+
+    void result(ActivityId act, ResultType type, const Fields & fields) override
+    {
+        for (auto & logger : loggers)
+            logger->result(act, type, fields);
+    }
+
+    void writeToStdout(std::string_view s) override
+    {
+        for (auto & logger : loggers) {
+            /* Let only the first logger write to stdout to avoid
+               duplication. This means that the first logger needs to
+               be the one managing stdout/stderr
+               (e.g. `ProgressBar`). */
+            logger->writeToStdout(s);
+            break;
+        }
+    }
+
+    std::optional<char> ask(std::string_view s) override
+    {
+        for (auto & logger : loggers) {
+            auto c = logger->ask(s);
+            if (c)
+                return c;
+        }
+        return std::nullopt;
+    }
+
+    void setPrintBuildLogs(bool printBuildLogs) override
+    {
+        for (auto & logger : loggers)
+            logger->setPrintBuildLogs(printBuildLogs);
+    }
+};
+
+std::unique_ptr<Logger>
+makeTeeLogger(std::unique_ptr<Logger> mainLogger, std::vector<std::unique_ptr<Logger>> && extraLoggers)
+{
+    std::vector<std::unique_ptr<Logger>> allLoggers;
+    allLoggers.push_back(std::move(mainLogger));
+    for (auto & l : extraLoggers)
+        allLoggers.push_back(std::move(l));
+    return std::make_unique<TeeLogger>(std::move(allLoggers));
+}
+
+}

--- a/src/libutil/unix-domain-socket.cc
+++ b/src/libutil/unix-domain-socket.cc
@@ -114,4 +114,11 @@ void connect(Socket fd, const std::string & path)
     bindConnectProcHelper("connect", ::connect, fd, path);
 }
 
+AutoCloseFD connect(const std::filesystem::path & path)
+{
+    auto fd = createUnixDomainSocket();
+    nix::connect(toSocket(fd.get()), path);
+    return fd;
+}
+
 }

--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -493,6 +493,8 @@ void mainWrapped(int argc, char * * argv)
         if (!args.helpRequested && !args.completions) throw;
     }
 
+    applyJSONLogger();
+
     if (args.helpRequested) {
         std::vector<std::string> subcommand;
         MultiCommand * command = &args;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

The `json-log-path` setting specifies a path (which can be a regular file or Unix domain socket) that receives a copy of all Nix log messages (in the same format used by `--log-format internal-json` but without the `@nix ` prefixes). Internally this is implemented using the new `TeeLogger` class that dispatches log messages to multiple underlying loggers (i.e. the JSON logger and the regular progress bar).

The main use case is to provide an easy way in CI to process all Nix log messages centrally to extract hash mismatches, build/substitution results, etc.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
