### PR TITLE
Update `nix fmt` man page with official formatter example

### DIFF
--- a/src/nix/formatter-run.md
+++ b/src/nix/formatter-run.md
@@ -9,37 +9,15 @@ Flags can be forwarded to the formatter by using `--` followed by the flags.
 Any arguments will be forwarded to the formatter. Typically these are the files to format.
 
 
-# Examples
+# Example
 
-With [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt):
-
-```nix
-# flake.nix
-{
-  outputs = { nixpkgs, self }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
-  };
-}
-```
-
-With [nixfmt](https://github.com/NixOS/nixfmt):
+To use the [official Nix formatter](https://github.com/NixOS/nixfmt):
 
 ```nix
 # flake.nix
 {
   outputs = { nixpkgs, self }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
-  };
-}
-```
-
-With [Alejandra](https://github.com/kamadorueda/alejandra):
-
-```nix
-# flake.nix
-{
-  outputs = { nixpkgs, self }: {
-    formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.alejandra;
+    formatter.x86_64-linux = nixpkgs.legacyPackages.${system}.nixfmt-tree;
   };
 }
 ```


### PR DESCRIPTION
(ping @NixOS/nix-formatting)

Note: I'm opening this as a draft because it links to documentation on nix.dev that has not been merged/deployed yet: https://github.com/NixOS/nix.dev/pull/1129

The current example relies upon [nixfmt's deprecated tree traversal behavior](https://github.com/NixOS/nixfmt/pull/240). The simplest alternative is the new `nixfmt-tree` wrapper for `nixfmt`/`treefmt`.