### PR TITLE
`ParsedDerivation`: don't take `drvPath`

### DIFF
--- a/src/libstore-tests/derivation-advanced-attrs.cc
+++ b/src/libstore-tests/derivation-advanced-attrs.cc
@@ -81,7 +81,7 @@ TEST_F(DerivationAdvancedAttrsTest, Derivation_advancedAttributes_defaults)
 
         auto drvPath = writeDerivation(*store, got, NoRepair, true);
 
-        ParsedDerivation parsedDrv(drvPath, got);
+        ParsedDerivation parsedDrv(got);
         DerivationOptions options = DerivationOptions::fromParsedDerivation(parsedDrv);
 
         EXPECT_TRUE(!parsedDrv.hasStructuredAttrs());
@@ -116,7 +116,7 @@ TEST_F(DerivationAdvancedAttrsTest, Derivation_advancedAttributes)
 
         auto drvPath = writeDerivation(*store, got, NoRepair, true);
 
-        ParsedDerivation parsedDrv(drvPath, got);
+        ParsedDerivation parsedDrv(got);
         DerivationOptions options = DerivationOptions::fromParsedDerivation(parsedDrv);
 
         StringSet systemFeatures{"rainbow", "uid-range"};
@@ -157,7 +157,7 @@ TEST_F(DerivationAdvancedAttrsTest, Derivation_advancedAttributes_structuredAttr
 
         auto drvPath = writeDerivation(*store, got, NoRepair, true);
 
-        ParsedDerivation parsedDrv(drvPath, got);
+        ParsedDerivation parsedDrv(got);
         DerivationOptions options = DerivationOptions::fromParsedDerivation(parsedDrv);
 
         EXPECT_TRUE(parsedDrv.hasStructuredAttrs());
@@ -191,7 +191,7 @@ TEST_F(DerivationAdvancedAttrsTest, Derivation_advancedAttributes_structuredAttr
 
         auto drvPath = writeDerivation(*store, got, NoRepair, true);
 
-        ParsedDerivation parsedDrv(drvPath, got);
+        ParsedDerivation parsedDrv(got);
         DerivationOptions options = DerivationOptions::fromParsedDerivation(parsedDrv);
 
         StringSet systemFeatures{"rainbow", "uid-range"};

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -180,8 +180,13 @@ Goal::Co DerivationGoal::haveDerivation()
 {
     trace("have derivation");
 
-    parsedDrv = std::make_unique<ParsedDerivation>(drvPath, *drv);
-    drvOptions = std::make_unique<DerivationOptions>(DerivationOptions::fromParsedDerivation(*parsedDrv));
+    parsedDrv = std::make_unique<ParsedDerivation>(*drv);
+    try {
+        drvOptions = std::make_unique<DerivationOptions>(DerivationOptions::fromParsedDerivation(*parsedDrv));
+    } catch (Error & e) {
+        e.addTrace({}, "while parsing derivation '%s'", worker.store.printStorePath(drvPath));
+        throw;
+    }
 
     if (!drv->type().hasKnownOutputPaths())
         experimentalFeatureSettings.require(Xp::CaDerivations);

--- a/src/libstore/include/nix/store/parsed-derivations.hh
+++ b/src/libstore/include/nix/store/parsed-derivations.hh
@@ -12,7 +12,6 @@ struct DerivationOptions;
 
 class ParsedDerivation
 {
-    StorePath drvPath;
     BasicDerivation & drv;
     std::unique_ptr<nlohmann::json> structuredAttrs;
 
@@ -34,7 +33,7 @@ class ParsedDerivation
 
 public:
 
-    ParsedDerivation(const StorePath & drvPath, BasicDerivation & drv);
+    ParsedDerivation(BasicDerivation & drv);
 
     ~ParsedDerivation();
 

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -222,8 +222,14 @@ void Store::queryMissing(const std::vector<DerivedPath> & targets,
             if (knownOutputPaths && invalid.empty()) return;
 
             auto drv = make_ref<Derivation>(derivationFromPath(drvPath));
-            ParsedDerivation parsedDrv(StorePath(drvPath), *drv);
-            DerivationOptions drvOptions = DerivationOptions::fromParsedDerivation(parsedDrv);
+            ParsedDerivation parsedDrv(*drv);
+            DerivationOptions drvOptions;
+            try {
+                drvOptions = DerivationOptions::fromParsedDerivation(parsedDrv);
+            } catch (Error & e) {
+                e.addTrace({}, "while parsing derivation '%s'", printStorePath(drvPath));
+                throw;
+            }
 
             if (!knownOutputPaths && settings.useSubstitutes && drvOptions.substitutesAllowed()) {
                 experimentalFeatureSettings.require(Xp::CaDerivations);

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -5,8 +5,8 @@
 
 namespace nix {
 
-ParsedDerivation::ParsedDerivation(const StorePath & drvPath, BasicDerivation & drv)
-    : drvPath(drvPath), drv(drv)
+ParsedDerivation::ParsedDerivation(BasicDerivation & drv)
+    : drv(drv)
 {
     /* Parse the __json attribute, if any. */
     auto jsonAttr = drv.env.find("__json");
@@ -14,7 +14,7 @@ ParsedDerivation::ParsedDerivation(const StorePath & drvPath, BasicDerivation & 
         try {
             structuredAttrs = std::make_unique<nlohmann::json>(nlohmann::json::parse(jsonAttr->second));
         } catch (std::exception & e) {
-            throw Error("cannot process __json attribute of '%s': %s", drvPath.to_string(), e.what());
+            throw Error("cannot process __json attribute: %s", e.what());
         }
     }
 }
@@ -29,7 +29,7 @@ std::optional<std::string> ParsedDerivation::getStringAttr(const std::string & n
             return {};
         else {
             if (!i->is_string())
-                throw Error("attribute '%s' of derivation '%s' must be a string", name, drvPath.to_string());
+                throw Error("attribute '%s' of must be a string", name);
             return i->get<std::string>();
         }
     } else {
@@ -49,7 +49,7 @@ bool ParsedDerivation::getBoolAttr(const std::string & name, bool def) const
             return def;
         else {
             if (!i->is_boolean())
-                throw Error("attribute '%s' of derivation '%s' must be a Boolean", name, drvPath.to_string());
+                throw Error("attribute '%s' must be a Boolean", name);
             return i->get<bool>();
         }
     } else {
@@ -69,11 +69,11 @@ std::optional<Strings> ParsedDerivation::getStringsAttr(const std::string & name
             return {};
         else {
             if (!i->is_array())
-                throw Error("attribute '%s' of derivation '%s' must be a list of strings", name, drvPath.to_string());
+                throw Error("attribute '%s' must be a list of strings", name);
             Strings res;
             for (auto j = i->begin(); j != i->end(); ++j) {
                 if (!j->is_string())
-                    throw Error("attribute '%s' of derivation '%s' must be a list of strings", name, drvPath.to_string());
+                    throw Error("attribute '%s' must be a list of strings", name);
                 res.push_back(j->get<std::string>());
             }
             return res;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -544,8 +544,14 @@ static void main_nix_build(int argc, char * * argv)
         env["NIX_STORE"] = store->storeDir;
         env["NIX_BUILD_CORES"] = std::to_string(settings.buildCores);
 
-        ParsedDerivation parsedDrv(packageInfo.requireDrvPath(), drv);
-        DerivationOptions drvOptions = DerivationOptions::fromParsedDerivation(parsedDrv);
+        ParsedDerivation parsedDrv(drv);
+        DerivationOptions drvOptions;
+        try {
+            drvOptions = DerivationOptions::fromParsedDerivation(parsedDrv);
+        } catch (Error & e) {
+            e.addTrace({}, "while parsing derivation '%s'", store->printStorePath(packageInfo.requireDrvPath()));
+            throw;
+        }
 
         int fileNr = 0;
 


### PR DESCRIPTION
## Motivation

It is just use for adding context to errors, but we have `addTrace` to do that. Let the callers do that instead.

The callers doing so is a bit duplicated, yes, but this will get better once `DerivationOptions` is included in `Derivation`.

## Context

Preparing the way for https://github.com/NixOS/nix/pull/10760, and the issues it addresses.

Progress on #9846 

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
