### PR TITLE
Fix issue #13018, `sourceInfo` strict in `outputs`

### DIFF
--- a/src/libflake/call-flake.nix
+++ b/src/libflake/call-flake.nix
@@ -14,6 +14,7 @@ overrides:
 fetchTreeFinal:
 
 let
+  inherit (builtins) mapAttrs;
 
   lockFile = builtins.fromJSON lockFileStr;
 
@@ -35,7 +36,7 @@ let
         (resolveInput lockFile.nodes.${nodeName}.inputs.${builtins.head path})
         (builtins.tail path);
 
-  allNodes = builtins.mapAttrs (
+  allNodes = mapAttrs (
     key: node:
     let
 
@@ -60,9 +61,7 @@ let
 
       flake = import (outPath + "/flake.nix");
 
-      inputs = builtins.mapAttrs (inputName: inputSpec: allNodes.${resolveInput inputSpec}) (
-        node.inputs or { }
-      );
+      inputs = mapAttrs (inputName: inputSpec: allNodes.${resolveInput inputSpec}) (node.inputs or { });
 
       outputs = flake.outputs (inputs // { self = result; });
 

--- a/src/libflake/call-flake.nix
+++ b/src/libflake/call-flake.nix
@@ -42,13 +42,20 @@ let
 
       parentNode = allNodes.${getInputByPath lockFile.root node.parent};
 
+      flakeDir =
+        let
+          dir = overrides.${key}.dir or node.locked.path or "";
+          parentDir = parentNode.flakeDir;
+        in
+        if node ? parent then parentDir + ("/" + dir) else dir;
+
       sourceInfo =
         if overrides ? ${key} then
           overrides.${key}.sourceInfo
         else if node.locked.type == "path" && builtins.substring 0 1 node.locked.path != "/" then
           parentNode.sourceInfo
           // {
-            outPath = parentNode.result.outPath + ("/" + node.locked.path);
+            outPath = parentNode.sourceInfo.outPath + ("/" + flakeDir);
           }
         else
           # FIXME: remove obsolete node.info.
@@ -93,6 +100,8 @@ let
           result
         else
           sourceInfo;
+
+      inherit flakeDir sourceInfo;
     }
   ) lockFile.nodes;
 

--- a/tests/functional/flakes/relative-paths.sh
+++ b/tests/functional/flakes/relative-paths.sh
@@ -108,3 +108,24 @@ EOF
 [[ $(nix eval "$rootFlake#z") = 90 ]]
 
 fi
+
+# https://github.com/NixOS/nix/pull/10089#discussion_r2041984987
+# https://github.com/NixOS/nix/issues/13018
+mkdir -p "$TEST_ROOT/issue-13018/example"
+(
+  cd "$TEST_ROOT/issue-13018"
+  git init
+  echo '{ outputs = _: { }; }' >flake.nix
+  cat >example/flake.nix <<EOF
+{
+  inputs.parent.url = ../.;
+  outputs = { parent, ... }: builtins.seq parent { ok = null; };
+}
+EOF
+  git add -N .
+  cd example
+  # Important: the error does not trigger for an in-memory lock!
+  nix flake lock
+  # would fail:
+  nix eval .#ok
+)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes a subtle ~regression~ problem, which applies to path inputs only, which were unusable before #10089

## Context

- Introduced in #10089
- Fixes #13018 

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
