### PR TITLE
libstore/filetransfer: add support for MTLS authentication

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -371,6 +371,11 @@ struct curlFileTransfer : public FileTransfer
                 curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0);
             }
 
+            if (settings.clientCertFile != "" && settings.clientKeyFile != "") {
+              curl_easy_setopt(req, CURLOPT_SSLCERT, settings.clientCertFile.get().c_str());
+              curl_easy_setopt(req, CURLOPT_SSLKEY, settings.clientKeyFile.get().c_str());
+            }
+
             #if !defined(_WIN32) && LIBCURL_VERSION_NUM >= 0x071000
             curl_easy_setopt(req, CURLOPT_SOCKOPTFUNCTION, cloexec_callback);
             #endif

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -1066,6 +1066,26 @@ public:
         // Don't document the machine-specific default value
         false};
 
+    Setting<Path> clientCertFile{
+        this,
+        "",
+        "client-ssl-cert-file",
+        R"(
+          The path of a file containing a client TLS certificate used
+          to authenticate Nix to servers when using `https://`
+          downloads.
+        )"};
+
+    Setting<Path> clientKeyFile{
+        this,
+        "",
+        "client-ssl-key-file",
+        R"(
+          The path of a file containing a client TLS private key used
+          to authenticate Nix to servers when using `https://`
+          downloads.
+        )",};
+
 #ifdef __linux__
     Setting<bool> filterSyscalls{
         this, true, "filter-syscalls",


### PR DESCRIPTION
Certificate/private-key pair can be configured globally and it will be handled by libcurl.

## Motivation

In our setup, we use client certificate authentication extensively to access company resources. It would be very easy for us to deploy a binary cache and setup authentication the same way.

## Context

Fixes #13002 

## Questions
- [ ] Is it okay to support only one certificate globally?  
  I've gone with that as I don't think, that many people use different certificates for different HTTPS services, and implementing per-domain certificate handling would greatly complicate the implementation
- [ ] I've added the settings to globals, as netrc and CA verification settings are already there. IDK if that is the rignt place.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
