### PR TITLE
nix-profile-daemon.fish: Set MANPATH

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -62,6 +62,13 @@ else
     end
 end
 
+# Only use MANPATH if it is already set. In general `man` will just simply
+# pick up `.nix-profile/share/man` because is it close to `.nix-profile/bin`
+# which is in the $PATH. For more info, run `manpath -d`.
+if set --query MANPATH
+    set --export --prepend --path MANPATH "$NIX_LINK/share/man"
+end
+
 add_path "@localstatedir@/nix/profiles/default/bin"
 add_path "$NIX_LINK/bin"
 


### PR DESCRIPTION
## Motivation

There seems to be no good reason for `nix-profile.fish` to set `$MANPATH` while it being unset when `nix-profile-daemon.fish` is used.

## Context

Further reduce differences between `nix-profile.fish` and `nix-profile-daemon.fish`.
A higher level list of all the differences is [here](https://github.com/NixOS/nix/issues/9441).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
