### PR TITLE
nix-profile.fish: Do not check $USER

### DIFF
--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,5 +1,5 @@
 # Only execute this file once per shell.
-if test -z "$HOME" || test -z "$USER" || \
+if test -z "$HOME" || \
     test -n "$__ETC_PROFILE_NIX_SOURCED"
     exit
 end


### PR DESCRIPTION
## Motivation

While it seems unlikely that `$USER` will be unset while `$HOME` is set, as `$USER` is not used in the script and as `nix-profile-daemon.fish` is not checking `$USER`, it seems better to remove this check.

## Context

If both https://github.com/NixOS/nix/pull/12423 and https://github.com/NixOS/nix/pull/13040 are merged in addition to this change, `nix-profile.fish` and `nix-profile-daemon.fish` become identical.

The original list of changes between these files is tracked [here](https://github.com/NixOS/nix/issues/9441).

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
