### PR TITLE
Fixed apply makeNotAllowedError to empty repos (backport #12869)

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -247,7 +247,7 @@ EvalState::EvalState(
     , emptyBindings(0)
     , rootFS(
         settings.restrictEval || settings.pureEval
-        ? ref<SourceAccessor>(AllowListSourceAccessor::create(getFSSourceAccessor(), {},
+        ? ref<SourceAccessor>(AllowListSourceAccessor::create(getFSSourceAccessor(), {}, {},
             [&settings](const CanonPath & path) -> RestrictedPathError {
                 auto modeInformation = settings.pureEval
                     ? "in pure evaluation mode (use '--impure' to override)"

--- a/src/libfetchers/filtering-source-accessor.cc
+++ b/src/libfetchers/filtering-source-accessor.cc
@@ -58,18 +58,23 @@ void FilteringSourceAccessor::checkAccess(const CanonPath & path)
 struct AllowListSourceAccessorImpl : AllowListSourceAccessor
 {
     std::set<CanonPath> allowedPrefixes;
+    std::unordered_set<CanonPath> allowedPaths;
 
     AllowListSourceAccessorImpl(
         ref<SourceAccessor> next,
         std::set<CanonPath> && allowedPrefixes,
+        std::unordered_set<CanonPath> && allowedPaths,
         MakeNotAllowedError && makeNotAllowedError)
         : AllowListSourceAccessor(SourcePath(next), std::move(makeNotAllowedError))
         , allowedPrefixes(std::move(allowedPrefixes))
+        , allowedPaths(std::move(allowedPaths))
     { }
 
     bool isAllowed(const CanonPath & path) override
     {
-        return path.isAllowed(allowedPrefixes);
+        return
+            allowedPaths.contains(path)
+            || path.isAllowed(allowedPrefixes);
     }
 
     void allowPrefix(CanonPath prefix) override
@@ -81,9 +86,14 @@ struct AllowListSourceAccessorImpl : AllowListSourceAccessor
 ref<AllowListSourceAccessor> AllowListSourceAccessor::create(
     ref<SourceAccessor> next,
     std::set<CanonPath> && allowedPrefixes,
+    std::unordered_set<CanonPath> && allowedPaths,
     MakeNotAllowedError && makeNotAllowedError)
 {
-    return make_ref<AllowListSourceAccessorImpl>(next, std::move(allowedPrefixes), std::move(makeNotAllowedError));
+    return make_ref<AllowListSourceAccessorImpl>(
+        next,
+        std::move(allowedPrefixes),
+        std::move(allowedPaths),
+        std::move(makeNotAllowedError));
 }
 
 bool CachingFilteringSourceAccessor::isAllowed(const CanonPath & path)

--- a/src/libfetchers/filtering-source-accessor.hh
+++ b/src/libfetchers/filtering-source-accessor.hh
@@ -2,6 +2,8 @@
 
 #include "source-path.hh"
 
+#include <unordered_set>
+
 namespace nix {
 
 /**
@@ -70,6 +72,7 @@ struct AllowListSourceAccessor : public FilteringSourceAccessor
     static ref<AllowListSourceAccessor> create(
         ref<SourceAccessor> next,
         std::set<CanonPath> && allowedPrefixes,
+        std::unordered_set<CanonPath> && allowedPaths,
         MakeNotAllowedError && makeNotAllowedError);
 
     using FilteringSourceAccessor::FilteringSourceAccessor;

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -28,6 +28,8 @@ suites += {
     'commit-lock-file-summary.sh',
     'non-flake-inputs.sh',
     'relative-paths.sh',
+    'debugger.sh',
+    'source-paths.sh',
   ],
   'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/flakes/source-paths.sh
+++ b/tests/functional/flakes/source-paths.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+requireGit
+
+repo=$TEST_ROOT/repo
+
+createGitRepo "$repo"
+
+cat > "$repo/flake.nix" <<EOF
+{
+  outputs = { ... }: {
+    x = 1;
+  };
+}
+EOF
+
+expectStderr 1 nix eval "$repo#x" | grepQuiet "error: Path 'flake.nix' in the repository \"$repo\" is not tracked by Git."
+
+git -C "$repo" add flake.nix
+
+[[ $(nix eval "$repo#x") = 1 ]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This fixes an issue in nix that causes builds to fail in empty git repositories. The original [backport](https://github.com/NixOS/nix/pull/12880) failed. Credit: @edolstra for original pull, @Mic92 for review.

## Context

#12869
Closes #12880
Closes #13035

The main issue seemed to be that rootFS access control has been expanded in newer nix versions (2.27+). The merge failed because it couldn't integrate the minor change (a single empty argument) into the changed context. Adding this change turns out to be trivial for a human. The other issue was git was confused about the symlink-paths test, which doesn't exist in 2.26.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
