### PR TITLE
Fix non-virtual destructor warning

### DIFF
--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -26,6 +26,8 @@ struct InputCache
     virtual void clear() = 0;
 
     static ref<InputCache> create();
+
+    virtual ~InputCache() = default;
 };
 
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation
```
/nix/store/2agih0y5ns3sgbviw2xhivdgg59b41g9-gcc-14-20241116/include/c++/14-20241116/bits/stl_construct.h:88:2: warning: destructor called on non-final 'nix::fetchers::InputCacheImpl' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
```
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
