### PR TITLE
Fix perl example

### DIFF
--- a/doc/manual/source/command-ref/nix-shell.md
+++ b/doc/manual/source/command-ref/nix-shell.md
@@ -242,16 +242,18 @@ print(t)
 ```
 
 Similarly, the following is a Perl script that specifies that it
-requires Perl and the `HTML::TokeParser::Simple` and `LWP` packages:
+requires Perl and the `HTML::TokeParser::Simple`, `LWP` and
+`LWP::Protocol::Https` packages:
 
 ```perl
 #! /usr/bin/env nix-shell
 #! nix-shell -i perl --packages perl perlPackages.HTMLTokeParserSimple perlPackages.LWP
+#! nix-shell -i perl --packages perl perlPackages.HTMLTokeParserSimple perlPackages.LWP perlPackages.LWPProtocolHttps
 
 use HTML::TokeParser::Simple;
 
 # Fetch nixos.org and print all hrefs.
-my $p = HTML::TokeParser::Simple->new(url => 'http://nixos.org/');
+my $p = HTML::TokeParser::Simple->new(url => 'https://nixos.org/');
 
 while (my $token = $p->get_tag("a")) {
     my $href = $token->get_attr("href");

--- a/doc/manual/source/command-ref/nix-shell.md
+++ b/doc/manual/source/command-ref/nix-shell.md
@@ -247,8 +247,11 @@ requires Perl and the `HTML::TokeParser::Simple`, `LWP` and
 
 ```perl
 #! /usr/bin/env nix-shell
-#! nix-shell -i perl --packages perl perlPackages.HTMLTokeParserSimple perlPackages.LWP
-#! nix-shell -i perl --packages perl perlPackages.HTMLTokeParserSimple perlPackages.LWP perlPackages.LWPProtocolHttps
+#! nix-shell -i perl 
+#! nix-shell --packages perl 
+#! nix-shell --packages perlPackages.HTMLTokeParserSimple 
+#! nix-shell --packages perlPackages.LWP
+#! nix-shell --packages perlPackages.LWPProtocolHttps
 
 use HTML::TokeParser::Simple;
 


### PR DESCRIPTION
The perl example does not work with http://nixos.org because it redirects.

Updating the url to https requires additional package.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
