### PR TITLE
First class cross

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -289,9 +289,21 @@
 
     in
     {
-      # A Nixpkgs overlay that overrides the 'nix' and
-      # 'nix-perl-bindings' packages.
-      overlays.default = overlayFor (p: p.stdenv);
+      overlays.internal = overlayFor (p: p.stdenv);
+
+      /**
+        A Nixpkgs overlay that sets `nix` to something like `packages.<system>.nix-everything`,
+        except dependencies aren't taken from (flake) `nix.inputs.nixpkgs`, but from the Nixpkgs packages
+        where the overlay is used.
+      */
+      overlays.default =
+        final: prev:
+        let
+          packageSets = packageSetsFor { pkgs = final; };
+        in
+        {
+          nix = packageSets.nixComponents.nix-everything;
+        };
 
       hydraJobs = import ./packaging/hydra.nix {
         inherit

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -365,18 +365,33 @@ in
 
   nix-cmd = callPackage ../src/libcmd/package.nix { };
 
+  /**
+    The Nix command line interface. Note that this does not include its tests, whereas `nix-everything` does.
+  */
   nix-cli = callPackage ../src/nix/package.nix { version = fineVersion; };
 
   nix-functional-tests = callPackage ../tests/functional/package.nix {
     version = fineVersion;
   };
 
+  /**
+    The manual as would be published on https://nix.dev/reference/nix-manual
+  */
   nix-manual = callPackage ../doc/manual/package.nix { version = fineVersion; };
+  /**
+    Doxygen pages for C++ code
+  */
   nix-internal-api-docs = callPackage ../src/internal-api-docs/package.nix { version = fineVersion; };
+  /**
+    Doxygen pages for the public C API
+  */
   nix-external-api-docs = callPackage ../src/external-api-docs/package.nix { version = fineVersion; };
 
   nix-perl-bindings = callPackage ../src/perl/package.nix { };
 
+  /**
+    Combined package that has the CLI, libraries, and (assuming non-cross, no overrides) it requires that all tests succeed.
+  */
   nix-everything = callPackage ../packaging/everything.nix { } // {
     # Note: no `passthru.overrideAllMesonComponents` etc
     #       This would propagate into `nix.overrideAttrs f`, but then discard


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Cross packaging shouldn't depend on having and using overlay.

This PR makes it possible to cross-compile without using any overlays whatsoever.

The three helper functions could perhaps be moved to Nixpkgs lib. cc @Ericson2314 

See also commit messages.

## Context

- The packaging problems in hydra and https://github.com/NixOS/nix/pull/13010 motivated me to try improve this again.

- This must have been my third attempt at this. I had previously got stuck on a Nixpkgs quirk; see comment at `fixup =`.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
