### PR TITLE
Revert "Actually ignore system/user registries during locking"

### DIFF
--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -39,7 +39,7 @@ FlakeRef FlakeRef::resolve(
     ref<Store> store,
     const fetchers::RegistryFilter & filter) const
 {
-    auto [input2, extraAttrs] = lookupInRegistries(store, input, filter);
+    auto [input2, extraAttrs] = lookupInRegistries(store, input);
     return FlakeRef(std::move(input2), fetchers::maybeGetStrAttr(extraAttrs, "dir").value_or(subdir));
 }
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -220,13 +220,6 @@ nix store gc
 nix registry list --flake-registry "file://$registry" --refresh | grepQuiet flake3
 mv "$registry.tmp" "$registry"
 
-# Ensure that locking ignores the user registry.
-mkdir -p "$TEST_HOME/.config/nix"
-ln -sfn "$registry" "$TEST_HOME/.config/nix/registry.json"
-nix flake metadata flake1
-expectStderr 1 nix flake update --flake-registry '' --flake "$flake3Dir" | grepQuiet "cannot find flake 'flake:flake1' in the flake registries"
-rm "$TEST_HOME/.config/nix/registry.json"
-
 # Test whether flakes are registered as GC roots for offline use.
 # FIXME: use tarballs rather than git.
 rm -rf "$TEST_HOME/.cache"


### PR DESCRIPTION
This reverts commit 77d4316353deaf8f429025738891b625eb0b5d8a.
Fixes https://github.com/NixOS/nix/issues/13050

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
