### PR TITLE
nix-cli: restore binary-dist artifact to Hydra static builds

### DIFF
--- a/src/nix/package.nix
+++ b/src/nix/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   mkMesonExecutable,
 
@@ -93,6 +94,11 @@ mkMesonExecutable (finalAttrs: {
 
   mesonFlags = [
   ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isStatic ''
+    mkdir -p $out/nix-support
+    echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
+  '';
 
   meta = {
     mainProgram = "nix";


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes https://github.com/NixOS/nix/issues/13078.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
