### PR TITLE
Simplify the Meson now that upstream bug is fixed

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -1,7 +1,7 @@
 project(
   'nix-manual',
   version : files('.version'),
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,15 +1,12 @@
-# This is just a stub project to include all the others as subprojects
-# for development shell purposes
+# This is just a top-level project to include all the others as subprojects
+# for development shell purposes (when building via Nix) or for distro packaging purposes.
 
 project(
-  'nix-dev-shell',
+  'Nix',
   'cpp',
   version : files('.version'),
   subproject_dir : 'src',
-  default_options : [
-    'localstatedir=/nix/var',
-  ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
 )
 
 # Internal Libraries
@@ -45,8 +42,6 @@ subproject('libexpr-c')
 subproject('libflake-c')
 subproject('libmain-c')
 
-asan_enabled = 'address' in get_option('b_sanitize')
-
 # Testing
 if get_option('unit-tests')
   subproject('libutil-test-support')
@@ -58,7 +53,11 @@ if get_option('unit-tests')
   subproject('libexpr-tests')
   subproject('libflake-tests')
 endif
-subproject('nix-functional-tests')
+
+if get_option('functional-tests')
+  subproject('nix-functional-tests')
+endif
+
 if get_option('json-schema-checks')
   subproject('json-schema-checks')
 endif

--- a/meson.options
+++ b/meson.options
@@ -15,6 +15,13 @@ option(
 )
 
 option(
+  'functional-tests',
+  type : 'boolean',
+  value : true,
+  description : 'Build functional (E2E) tests',
+)
+
+option(
   'benchmarks',
   type : 'boolean',
   value : false,

--- a/src/clang-tidy-plugin/meson.build
+++ b/src/clang-tidy-plugin/meson.build
@@ -6,7 +6,7 @@ project(
     'cpp_std=c++23',
     'warning_level=2',
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/external-api-docs/meson.build
+++ b/src/external-api-docs/meson.build
@@ -1,7 +1,7 @@
 project(
   'nix-external-api-docs',
   version : files('.version'),
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/internal-api-docs/meson.build
+++ b/src/internal-api-docs/meson.build
@@ -1,7 +1,7 @@
 project(
   'nix-internal-api-docs',
   version : files('.version'),
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/json-schema-checks/meson.build
+++ b/src/json-schema-checks/meson.build
@@ -6,7 +6,7 @@
 project(
   'nix-json-schema-checks',
   version : files('.version'),
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libflake-tests/meson.build
+++ b/src/libflake-tests/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -9,7 +9,7 @@ project(
     'errorlogs=true', # Please print logs for tests that fail
     'localstatedir=/nix/var',
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 
@@ -220,15 +220,14 @@ path_opts = [
   'libdir',
   'includedir',
   'libexecdir',
+  'localstatedir',
   # Homecooked Nix directories.
   'store-dir',
-  'localstatedir',
   'log-dir',
 ]
 # For your grepping pleasure, this loop sets the following variables that aren't mentioned
 # literally above:
 # store_dir
-# localstatedir
 # log_dir
 # profile_dir
 foreach optname : path_opts
@@ -399,13 +398,7 @@ libraries_private = []
 
 extra_pkg_config_variables = {
   'storedir' : get_option('store-dir'),
+  'localstatedir' : get_option('localstatedir'),
 }
-
-# Working around https://github.com/mesonbuild/meson/issues/13584
-if host_machine.system() != 'darwin'
-  extra_pkg_config_variables += {
-    'localstatedir' : get_option('localstatedir'),
-  }
-endif
 
 subdir('nix-meson-build-support/export')

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -8,7 +8,7 @@ project(
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -7,7 +7,6 @@ project(
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
-    'localstatedir=/nix/var',
   ],
   meson_version : '>= 1.4',
   license : 'LGPL-2.1-or-later',
@@ -262,11 +261,7 @@ custom_target(
 # TODO(Ericson3214): Doesn't yet work
 #meson.override_find_program(linkname, t)
 
-localstatedir = nix_store.get_variable(
-  'localstatedir',
-  default_value : get_option('localstatedir'),
-)
-assert(localstatedir == get_option('localstatedir'))
+localstatedir = nix_store.get_variable('localstatedir')
 store_dir = nix_store.get_variable('storedir')
 subdir('scripts')
 subdir('misc')

--- a/src/nswrapper/meson.build
+++ b/src/nswrapper/meson.build
@@ -7,9 +7,8 @@ project(
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail
-    'localstatedir=/nix/var',
   ],
-  meson_version : '>= 1.1',
+  meson_version : '>= 1.8',
   license : 'LGPL-2.1-or-later',
 )
 


### PR DESCRIPTION
## Motivation

Upstream bug is https://github.com/mesonbuild/meson/issues/13584.

~~This PR will fail for now, but eventually after Meson is bumped in Nixpkgs, it will succeed.~~

This has been fixed in https://github.com/mesonbuild/meson/commit/fc9fd42899e1e2160a69ec245931c3aa79b0d267, which is available since Meson 1.8. We now have it with nixpkgs 25.11 and distros should already be caught up.

Also does a minor spring clean of our meson accordingly. I (@xokdvium) noticed that distros have a tendency
to patch out our unconditional nix-function-tests subproject from the top-level project, so this also
adds an option to disable it.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
