### PR TITLE
Actually ignore system/user registries during locking (2nd attempt)

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -40,7 +40,7 @@ void completeFlakeInputAttrPath(
     std::string_view prefix)
 {
     for (auto & flakeRef : flakeRefs) {
-        auto flake = flake::getFlake(*evalState, flakeRef, true);
+        auto flake = flake::getFlake(*evalState, flakeRef, fetchers::UseRegistries::All);
         for (auto & input : flake.inputs)
             if (hasPrefix(input.first, prefix))
                 completions.add(input.first);

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -181,7 +181,7 @@ static void fetchTree(
     }
 
     if (!state.settings.pureEval && !input.isDirect() && experimentalFeatureSettings.isEnabled(Xp::Flakes))
-        input = lookupInRegistries(state.store, input).first;
+        input = lookupInRegistries(state.store, input, fetchers::UseRegistries::Limited).first;
 
     if (state.settings.pureEval && !input.isLocked()) {
         if (input.getNarHash())

--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -2,6 +2,8 @@
 
 namespace nix::fetchers {
 
+enum class UseRegistries : int;
+
 struct InputCache
 {
     struct CachedResult
@@ -11,7 +13,7 @@ struct InputCache
         Input lockedInput;
     };
 
-    CachedResult getAccessor(ref<Store> store, const Input & originalInput, bool useRegistries);
+    CachedResult getAccessor(ref<Store> store, const Input & originalInput, UseRegistries useRegistries);
 
     struct CachedInput
     {

--- a/src/libfetchers/include/nix/fetchers/registry.hh
+++ b/src/libfetchers/include/nix/fetchers/registry.hh
@@ -65,7 +65,11 @@ void overrideRegistry(
     const Input & to,
     const Attrs & extraAttrs);
 
-using RegistryFilter = std::function<bool(Registry::RegistryType)>;
+enum class UseRegistries : int {
+    No,
+    All,
+    Limited, // global and flag registry only
+};
 
 /**
  * Rewrite a flakeref using the registries. If `filter` is set, only
@@ -74,6 +78,6 @@ using RegistryFilter = std::function<bool(Registry::RegistryType)>;
 std::pair<Input, Attrs> lookupInRegistries(
     ref<Store> store,
     const Input & input,
-    const RegistryFilter & filter = {});
+    UseRegistries useRegistries);
 
 }

--- a/src/libfetchers/input-cache.cc
+++ b/src/libfetchers/input-cache.cc
@@ -5,7 +5,8 @@
 
 namespace nix::fetchers {
 
-InputCache::CachedResult InputCache::getAccessor(ref<Store> store, const Input & originalInput, bool useRegistries)
+InputCache::CachedResult
+InputCache::getAccessor(ref<Store> store, const Input & originalInput, UseRegistries useRegistries)
 {
     auto fetched = lookup(originalInput);
     Input resolvedInput = originalInput;
@@ -15,13 +16,8 @@ InputCache::CachedResult InputCache::getAccessor(ref<Store> store, const Input &
             auto [accessor, lockedInput] = originalInput.getAccessor(store);
             fetched.emplace(CachedInput{.lockedInput = lockedInput, .accessor = accessor});
         } else {
-            if (useRegistries) {
-                auto [res, extraAttrs] =
-                    lookupInRegistries(store, originalInput, [](fetchers::Registry::RegistryType type) {
-                        /* Only use the global registry and CLI flags
-                           to resolve indirect flakerefs. */
-                        return type == fetchers::Registry::Flag || type == fetchers::Registry::Global;
-                    });
+            if (useRegistries != UseRegistries::No) {
+                auto [res, extraAttrs] = lookupInRegistries(store, originalInput, useRegistries);
                 resolvedInput = std::move(res);
                 fetched = lookup(resolvedInput);
                 if (!fetched) {

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -39,7 +39,7 @@ FlakeRef FlakeRef::resolve(
     ref<Store> store,
     const fetchers::RegistryFilter & filter) const
 {
-    auto [input2, extraAttrs] = lookupInRegistries(store, input);
+    auto [input2, extraAttrs] = lookupInRegistries(store, input, filter);
     return FlakeRef(std::move(input2), fetchers::maybeGetStrAttr(extraAttrs, "dir").value_or(subdir));
 }
 

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -37,9 +37,9 @@ std::ostream & operator << (std::ostream & str, const FlakeRef & flakeRef)
 
 FlakeRef FlakeRef::resolve(
     ref<Store> store,
-    const fetchers::RegistryFilter & filter) const
+    fetchers::UseRegistries useRegistries) const
 {
-    auto [input2, extraAttrs] = lookupInRegistries(store, input, filter);
+    auto [input2, extraAttrs] = lookupInRegistries(store, input, useRegistries);
     return FlakeRef(std::move(input2), fetchers::maybeGetStrAttr(extraAttrs, "dir").value_or(subdir));
 }
 

--- a/src/libflake/include/nix/flake/flake.hh
+++ b/src/libflake/include/nix/flake/flake.hh
@@ -115,7 +115,7 @@ struct Flake
     }
 };
 
-Flake getFlake(EvalState & state, const FlakeRef & flakeRef, bool useRegistries);
+Flake getFlake(EvalState & state, const FlakeRef & flakeRef, fetchers::UseRegistries useRegistries);
 
 /**
  * Fingerprint of a locked flake; used as a cache key.

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -65,7 +65,7 @@ struct FlakeRef
 
     FlakeRef resolve(
         ref<Store> store,
-        const fetchers::RegistryFilter & filter = {}) const;
+        fetchers::UseRegistries useRegistries = fetchers::UseRegistries::All) const;
 
     static FlakeRef fromAttrs(
         const fetchers::Settings & fetchSettings,

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -223,7 +223,7 @@ mv "$registry.tmp" "$registry"
 # Ensure that locking ignores the user registry.
 mkdir -p "$TEST_HOME/.config/nix"
 ln -sfn "$registry" "$TEST_HOME/.config/nix/registry.json"
-nix flake metadata flake1
+nix flake metadata --flake-registry '' flake1
 expectStderr 1 nix flake update --flake-registry '' --flake "$flake3Dir" | grepQuiet "cannot find flake 'flake:flake1' in the flake registries"
 rm "$TEST_HOME/.config/nix/registry.json"
 

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -220,6 +220,13 @@ nix store gc
 nix registry list --flake-registry "file://$registry" --refresh | grepQuiet flake3
 mv "$registry.tmp" "$registry"
 
+# Ensure that locking ignores the user registry.
+mkdir -p "$TEST_HOME/.config/nix"
+ln -sfn "$registry" "$TEST_HOME/.config/nix/registry.json"
+nix flake metadata flake1
+expectStderr 1 nix flake update --flake-registry '' --flake "$flake3Dir" | grepQuiet "cannot find flake 'flake:flake1' in the flake registries"
+rm "$TEST_HOME/.config/nix/registry.json"
+
 # Test whether flakes are registered as GC roots for offline use.
 # FIXME: use tarballs rather than git.
 rm -rf "$TEST_HOME/.cache"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Makes https://github.com/NixOS/nix/pull/12068 actually work. All registries are used for resolving top-level flakerefs, but only the global and flag registries are used for resolving flake inputs.

Fixes #13050.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
