### PR TITLE
libutil: Fix invalid boost format string in infinite symlink recursion error

### DIFF
--- a/src/libutil/file-system.cc
+++ b/src/libutil/file-system.cc
@@ -111,7 +111,7 @@ Path canonPath(PathView path, bool resolveSymlinks)
         (std::string & result, std::string_view & remaining) {
             if (resolveSymlinks && fs::is_symlink(result)) {
                 if (++followCount >= maxFollow)
-                    throw Error("infinite symlink recursion in path '%0%'", remaining);
+                    throw Error("infinite symlink recursion in path '%1%'", remaining);
                 remaining = (temp = concatStrings(readLink(result), remaining));
                 if (isAbsolute(remaining)) {
                     /* restart for symlinks pointing to absolute path */


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Found while working on an automated migration to `std::format` https://github.com/NixOS/nix/issues/10294
Boost throws a `boost::bad_format_string: format-string is ill-formed` exception when creating a format string from this.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

cc @Ericson2314, as git blame points me to your commit

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
