### PR TITLE
libutil: Use correct argument to Error format ctor

### DIFF
--- a/src/libutil/git.cc
+++ b/src/libutil/git.cc
@@ -134,7 +134,7 @@ void parseTree(
         RawMode rawMode = std::stoi(perms, 0, 8);
         auto modeOpt = decodeMode(rawMode);
         if (!modeOpt)
-            throw Error("Unknown Git permission: %o", perms);
+            throw Error("Unknown Git permission: %o", rawMode);
         auto mode = std::move(*modeOpt);
 
         std::string name = getStringUntil(source, '\0');


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

It seems that the intention was to format a number in base 8 (as suggested by the %o format specifier), but `perms` is a `std::string` and not a number. Looks like `rawMode` is the correct thing to use here.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
