### PR TITLE
libutil: Add missing format arguments to UsageError ctor

### DIFF
--- a/src/libutil-tests/file-content-address.cc
+++ b/src/libutil-tests/file-content-address.cc
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "nix/util/file-content-address.hh"
@@ -26,8 +27,11 @@ TEST(FileSerialisationMethod, testRoundTripPrintParse_2) {
     }
 }
 
-TEST(FileSerialisationMethod, testParseFileSerialisationMethodOptException) {
-    EXPECT_THROW(parseFileSerialisationMethod("narwhal"), UsageError);
+TEST(FileSerialisationMethod, testParseFileSerialisationMethodOptException)
+{
+    EXPECT_THAT(
+        []() { parseFileSerialisationMethod("narwhal"); },
+        testing::ThrowsMessage<UsageError>(testing::HasSubstr("narwhal")));
 }
 
 /* ----------------------------------------------------------------------------
@@ -54,8 +58,11 @@ TEST(FileIngestionMethod, testRoundTripPrintParse_2) {
     }
 }
 
-TEST(FileIngestionMethod, testParseFileIngestionMethodOptException) {
-    EXPECT_THROW(parseFileIngestionMethod("narwhal"), UsageError);
+TEST(FileIngestionMethod, testParseFileIngestionMethodOptException)
+{
+    EXPECT_THAT(
+        []() { parseFileIngestionMethod("narwhal"); },
+        testing::ThrowsMessage<UsageError>(testing::HasSubstr("narwhal")));
 }
 
 }

--- a/src/libutil/file-content-address.cc
+++ b/src/libutil/file-content-address.cc
@@ -22,7 +22,7 @@ FileSerialisationMethod parseFileSerialisationMethod(std::string_view input)
     if (ret)
         return *ret;
     else
-        throw UsageError("Unknown file serialiation method '%s', expect `flat` or `nar`");
+        throw UsageError("Unknown file serialiation method '%s', expect `flat` or `nar`", input);
 }
 
 
@@ -35,7 +35,7 @@ FileIngestionMethod parseFileIngestionMethod(std::string_view input)
         if (ret)
             return static_cast<FileIngestionMethod>(*ret);
         else
-            throw UsageError("Unknown file ingestion method '%s', expect `flat`, `nar`, or `git`");
+            throw UsageError("Unknown file ingestion method '%s', expect `flat`, `nar`, or `git`", input);
     }
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Once again found by an automated migration to `std::format`. I've tested that boost::format works fine with `std::string_view` arguments. https://godbolt.org/z/cqPeszxcP

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

More of the same stuff as in #13086 and #13087.
Found while testing out an automated migration tool for https://github.com/NixOS/nix/issues/10294. 
Looks like switching to `std::format` is indeed worth it for catching such subtle bugs at compile time.

cc @Ericson2314, @Mic92

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
