### PR TITLE
New CLI flag `--replace-eval-errors`

### DIFF
--- a/doc/manual/source/command-ref/nix-instantiate.md
+++ b/doc/manual/source/command-ref/nix-instantiate.md
@@ -112,6 +112,11 @@ standard input.
   When used with `--eval`, print the resulting value as an JSON
   representation of the abstract syntax tree rather than as a Nix expression.
 
+- `--replace-eval-errors`
+
+  When used with `--eval` and `--json`, replace any evaluation errors with the string
+  `"«evaluation error»"`.
+
 - `--xml`
 
   When used with `--eval`, print the resulting value as an XML
@@ -204,4 +209,11 @@ $ nix-instantiate --eval --xml --strict --expr '{ x = {}; }'
     </attr>
   </attrs>
 </expr>
+```
+
+Replacing evaluation errors:
+
+```console
+$ nix-instantiate --eval --json --replace-eval-errors --expr '{ a = throw "fail"; }'
+{"a":"«evaluation error»"}
 ```

--- a/src/libexpr-tests/json.cc
+++ b/src/libexpr-tests/json.cc
@@ -9,7 +9,7 @@ namespace nix {
             std::string getJSONValue(Value& value) {
                 std::stringstream ss;
                 NixStringContext ps;
-                printValueAsJSON(state, true, value, noPos, ss, ps);
+                printValueAsJSON(state, true, false, value, noPos, ss, ps);
                 return ss.str();
             }
     };

--- a/src/libexpr/include/nix/expr/value-to-json.hh
+++ b/src/libexpr/include/nix/expr/value-to-json.hh
@@ -10,10 +10,10 @@
 
 namespace nix {
 
-nlohmann::json printValueAsJSON(EvalState & state, bool strict,
+nlohmann::json printValueAsJSON(EvalState & state, bool strict, bool replaceEvalErrors,
     Value & v, const PosIdx pos, NixStringContext & context, bool copyToStore = true);
 
-void printValueAsJSON(EvalState & state, bool strict,
+void printValueAsJSON(EvalState & state, bool strict, bool replaceEvalErrors,
     Value & v, const PosIdx pos, std::ostream & str, NixStringContext & context, bool copyToStore = true);
 
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1388,7 +1388,7 @@ static void derivationStrictInternal(
 
                     if (i->name == state.sStructuredAttrs) continue;
 
-                    jsonObject->emplace(key, printValueAsJSON(state, true, *i->value, pos, context));
+                    jsonObject->emplace(key, printValueAsJSON(state, true, false, *i->value, pos, context));
 
                     if (i->name == state.sBuilder)
                         drv.builder = state.forceString(*i->value, context, pos, context_below);
@@ -2328,7 +2328,7 @@ static void prim_toJSON(EvalState & state, const PosIdx pos, Value * * args, Val
 {
     std::ostringstream out;
     NixStringContext context;
-    printValueAsJSON(state, true, *args[0], pos, out, context);
+    printValueAsJSON(state, true, false, *args[0], pos, out, context);
     v.mkString(toView(out), context);
 }
 

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -135,7 +135,7 @@ static void fetchTree(
                 attrs.emplace(state.symbols[attr.name], uint64_t(intValue));
             } else if (state.symbols[attr.name] == "publicKeys") {
                 experimentalFeatureSettings.require(Xp::VerifiedFetches);
-                attrs.emplace(state.symbols[attr.name], printValueAsJSON(state, true, *attr.value, pos, context).dump());
+                attrs.emplace(state.symbols[attr.name], printValueAsJSON(state, true, false, *attr.value, pos, context).dump());
             }
             else
                 state.error<TypeError>("argument '%s' to '%s' is %s while a string, Boolean or integer is expected",

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -6,12 +6,13 @@
 #include <cstdlib>
 #include <iomanip>
 #include <nlohmann/json.hpp>
+#include <typeinfo>
 
 
 namespace nix {
 using json = nlohmann::json;
 // TODO: rename. It doesn't print.
-json printValueAsJSON(EvalState & state, bool strict,
+json printValueAsJSON(EvalState & state, bool strict, bool replaceEvalErrors,
     Value & v, const PosIdx pos, NixStringContext & context, bool copyToStore)
 {
     checkInterrupt();
@@ -54,13 +55,27 @@ json printValueAsJSON(EvalState & state, bool strict,
                 break;
             }
             if (auto i = v.attrs()->get(state.sOutPath))
-                return printValueAsJSON(state, strict, *i->value, i->pos, context, copyToStore);
+                return printValueAsJSON(state, strict, replaceEvalErrors, *i->value, i->pos, context, copyToStore);
             else {
                 out = json::object();
                 for (auto & a : v.attrs()->lexicographicOrder(state.symbols)) {
                     try {
-                        out.emplace(state.symbols[a->name], printValueAsJSON(state, strict, *a->value, a->pos, context, copyToStore));
+                        out.emplace(state.symbols[a->name], printValueAsJSON(state, strict, replaceEvalErrors, *a->value, a->pos, context, copyToStore));
                     } catch (Error & e) {
+                        std::cerr << "Caught an Error of type: " << typeid(e).name() << std::endl;
+                        // std::cerr << "Caught an Error of type: " << e.message() << std::endl;
+                        // std::cerr << "Caught an Error of type: " << e.what() << std::endl;
+
+                        // TODO: Figure out what Error is here?
+                        // We seem to be not catching FileNotFoundError.
+                        bool isEvalError = dynamic_cast<EvalError *>(&e);
+                        bool isFileNotFoundError = dynamic_cast<FileNotFound *>(&e);
+                        // Restrict replaceEvalErrors only only evaluation errors
+                        if (replaceEvalErrors && (isEvalError || isFileNotFoundError)) {
+                            out.emplace(state.symbols[a->name], "«evaluation error»");
+                            continue;
+                        }
+
                         e.addTrace(state.positions[a->pos],
                             HintFmt("while evaluating attribute '%1%'", state.symbols[a->name]));
                         throw;
@@ -75,8 +90,9 @@ json printValueAsJSON(EvalState & state, bool strict,
             int i = 0;
             for (auto elem : v.listItems()) {
                 try {
-                    out.push_back(printValueAsJSON(state, strict, *elem, pos, context, copyToStore));
+                    out.push_back(printValueAsJSON(state, strict, replaceEvalErrors, *elem, pos, context, copyToStore));
                 } catch (Error & e) {
+                    // TODO: Missing catch
                     e.addTrace(state.positions[pos],
                         HintFmt("while evaluating list element at index %1%", i));
                     throw;
@@ -106,11 +122,11 @@ json printValueAsJSON(EvalState & state, bool strict,
     return out;
 }
 
-void printValueAsJSON(EvalState & state, bool strict,
+void printValueAsJSON(EvalState & state, bool strict, bool replaceEvalErrors,
     Value & v, const PosIdx pos, std::ostream & str, NixStringContext & context, bool copyToStore)
 {
     try {
-        str << printValueAsJSON(state, strict, v, pos, context, copyToStore);
+        str << printValueAsJSON(state, strict, replaceEvalErrors, v, pos, context, copyToStore);
     } catch (nlohmann::json::exception & e) {
         throw JSONSerializationError("JSON serialization error: %s", e.what());
     }

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -91,7 +91,7 @@ static void parseFlakeInputAttr(
             if (attr.name == state.symbols.create("publicKeys")) {
                 experimentalFeatureSettings.require(Xp::VerifiedFetches);
                 NixStringContext emptyContext = {};
-                attrs.emplace(state.symbols[attr.name], printValueAsJSON(state, true, *attr.value, attr.pos, emptyContext).dump());
+                attrs.emplace(state.symbols[attr.name], printValueAsJSON(state, true, false, *attr.value, attr.pos, emptyContext).dump());
             } else
                 state.error<TypeError>("flake input attribute '%s' is %s while a string, Boolean, or integer is expected",
                     state.symbols[attr.name], showType(*attr.value)).debugThrow();

--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -54,7 +54,7 @@ void PosixSourceAccessor::readFile(
     #endif
         ));
     if (!fd)
-        throw SysError("opening file '%1%'", ap.string());
+        throw SysError("opening file9 '%1%'", ap.string());
 
     struct stat st;
     if (fstat(fromDescriptorReadOnly(fd.get()), &st) == -1)

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -984,7 +984,7 @@ static void queryJSON(Globals & globals, std::vector<PackageInfo> & elems, bool 
                         metaObj[j] = nullptr;
                     } else {
                         NixStringContext context;
-                        metaObj[j] = printValueAsJSON(*globals.state, true, *v, noPos, context);
+                        metaObj[j] = printValueAsJSON(*globals.state, true, false, *v, noPos, context);
                     }
                 }
             }

--- a/src/nix/eval.cc
+++ b/src/nix/eval.cc
@@ -15,6 +15,7 @@ namespace nix::fs { using namespace std::filesystem; }
 struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
 {
     bool raw = false;
+    bool replaceEvalErrors = false;
     std::optional<std::string> apply;
     std::optional<std::filesystem::path> writeTo;
 
@@ -38,6 +39,12 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
             .description = "Write a string or attrset of strings to *path*.",
             .labels = {"path"},
             .handler = {&writeTo},
+        });
+
+        addFlag({
+            .longName = "replace-eval-errors",
+            .description = "When used with `--json` the Nix evaluator will replace evaluation errors with a fixed value.",
+            .handler = {&replaceEvalErrors, true},
         });
     }
 
@@ -118,7 +125,7 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
         }
 
         else if (json) {
-            printJSON(printValueAsJSON(*state, true, *v, pos, context, false));
+            printJSON(printValueAsJSON(*state, true, replaceEvalErrors, *v, pos, context, false));
         }
 
         else {

--- a/src/nix/eval.md
+++ b/src/nix/eval.md
@@ -48,6 +48,13 @@ R""(
   # cat ./out/subdir/bla
   123
 
+* Replace evaluation errors:
+
+  ```console
+  $ nix eval --json --replace-eval-errors --expr '{ a = throw "fail"; }'
+  {"a":"«evaluation error»"}
+  ```
+
 # Description
 
 This command evaluates the given Nix expression, and prints the result on standard output.

--- a/tests/functional/replace-eval-errors.nix
+++ b/tests/functional/replace-eval-errors.nix
@@ -1,0 +1,11 @@
+{
+  missingAttr = let bar = { }; in bar.notExist;
+  insideAList = [ (throw "a throw") ];
+  deeper = { v = throw "v"; };
+  failedAssertion = assert true; assert false; null;
+  missingFile = builtins.readFile ./missing-file.txt;
+  missingImport = import ./missing-import.nix;
+  outOfBounds = builtins.elemAt [ 1 2 3 ] 100;
+  failedCoersion = "${1}";
+  failedAddition = 1.0 + "a string";
+}


### PR DESCRIPTION
Supersedes #12705

Co-authored-by: Farid Zakaria <farid.m.zakaria@gmail.com>

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Following up from #12705 but provides for the use case with a new CLI flag.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Ditto.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
