### PR TITLE
Fix flake-c out of bounds access

### DIFF
--- a/src/libflake-c/nix_api_flake.cc
+++ b/src/libflake-c/nix_api_flake.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "nix_api_flake.h"
 #include "nix_api_flake_internal.hh"
 #include "nix_api_util.h"
@@ -78,7 +80,7 @@ nix_err nix_flake_reference_and_fragment_from_string(
     nix_clear_err(context);
     *flakeReferenceOut = nullptr;
     try {
-        std::string str(strData, 0, strSize);
+        std::string str(strData, strSize);
 
         auto [flakeRef, fragment] =
             nix::parseFlakeRefWithFragment(*fetchSettings->settings, str, parseFlags->baseDirectory, true);


### PR DESCRIPTION
Note: this was not exploitable because `substr(0, n)` (below) would still filter away anything that shouldn't have been copied.

This mistake was added in new code 2 weeks ago, unreleased, https://github.com/NixOS/nix/pull/12877

> `#include <string>`

The explicit include is needed for clangd to not get confused somehow, which is also what threw me off initially and made me pick the wrong constructor.

The (pointer, number, number) constructor first constructs a C string and then takes a substring from that, but we didn't specify that the buffer needs to be NUL-terminated, and then what would be the point of the size argument anyway...


## Context

- https://github.com/NixOS/nix/pull/12877

Surprise in `basic_string.h`:

> ```
>	basic_string(const _Tp& __t, size_type __pos, size_type __n,
>		     const _Alloc& __a = _Alloc())
>	: basic_string(_S_to_string_view(__t).substr(__pos, __n), __a) { }
> ```

Valgrind on nixops4/rust/nix-flake tests:

```
==1344422== Conditional jump or move depends on uninitialised value(s)
==1344422==    at 0x48513E8: strlen (vg_replace_strmem.c:505)
==1344422==    by 0x488E941: UnknownInlinedFun (char_traits.h:391)
==1344422==    by 0x488E941: UnknownInlinedFun (string_view:141)
==1344422==    by 0x488E941: UnknownInlinedFun (basic_string.h:790)
==1344422==    by 0x488E941: nix_flake_reference_and_fragment_from_string (nix_api_flake.cc:81)
==1344422==    by 0x127332: nix_flake::FlakeReference::parse_with_fragment (lib.rs:123)
```

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
