### PR TITLE
allocate SimpleLogger before forking

### DIFF
--- a/src/libutil/unix/processes.cc
+++ b/src/libutil/unix/processes.cc
@@ -202,6 +202,7 @@ static int childEntry(void * arg)
 
 pid_t startProcess(std::function<void()> fun, const ProcessOptions & options)
 {
+    auto newLogger = makeSimpleLogger();
     ChildWrapperFunction wrapper = [&] {
         if (!options.allowVfork) {
             /* Set a simple logger, while releasing (not destroying)
@@ -210,7 +211,7 @@ pid_t startProcess(std::function<void()> fun, const ProcessOptions & options)
                ~ProgressBar() tries to join a thread that doesn't
                exist. */
             logger.release();
-            logger = makeSimpleLogger();
+            logger = std::move(newLogger);
         }
         try {
 #ifdef __linux__


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

In #13025 a deadlock during Nix derivation builds is described. Apparently #12514 describes the same issues, where a call to `new` causes the deadlock. In both cases the `musl` library is used.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

In both issues the bug is triggered when `DerivationBuilderImpl::prepareBuild()` calls `mountAndPidNamespacesSupported()` the first time. The deadlock occurs when waiting on a forked child in `mountAndPidNamespacesSupported()` or in `userNamespacesSupported()`, which is called by `mountAndPidNamespacesSupported()`.

Even when there is no deadlock the forking can be quite expensive at this point (several 100ms), but luckily the forking is required only once.

The workaround is simply not to call `makeSimpleLogger()` in the forked child by `startProcess(...)`, which calls `new`, because the call to `new` can deadlock.

I assume that the issue might be caused by a bug in `musl` and that it might be related to the lock file, which are held at that moment by the coroutine. When calling `mountAndPidNamespacesSupported()` before the coroutine is executed, then the bug does not seem to occur. Thus is could be possible that other parts of Nix are not affected by this bug, although the forked child can still call `new`.

Should fix #12514 and #13025 (seems to be a duplicate). 

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
