### PR TITLE
libutil: amend OSC 8 escape stripping for xterm-style separator

### DIFF
--- a/src/libutil-tests/terminal.cc
+++ b/src/libutil-tests/terminal.cc
@@ -66,4 +66,12 @@ TEST(filterANSIEscapes, osc8)
     ASSERT_EQ(filterANSIEscapes("\e]8;;http://example.com\e\\This is a link\e]8;;\e\\"), "This is a link");
 }
 
+TEST(filterANSIEscapes, osc8_bell_as_sep)
+{
+    // gcc-14 uses \a as a separator, xterm style:
+    //   https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+    ASSERT_EQ(filterANSIEscapes("\e]8;;http://example.com\aThis is a link\e]8;;\a"), "This is a link");
+    ASSERT_EQ(filterANSIEscapes("\e]8;;http://example.com\a\\This is a link\e]8;;\a"), "\\This is a link");
+}
+
 } // namespace nix

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -95,10 +95,19 @@ std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int w
             } else if (i != s.end() && *i == ']') {
                 // OSC
                 e += *i++;
-                // eat ESC
-                while (i != s.end() && *i != '\e') e += *i++;
-                // eat backslash
-                if (i != s.end() && *i == '\\') e += last = *i++;
+                // https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda defines
+                // two forms of a URI separator:
+                // 1. ESC '\' (standard)
+                // 2. BEL ('\a') (xterm-style, used by gcc)
+
+                // eat ESC or BEL
+                while (i != s.end() && *i != '\e' && *i != '\a') e += *i++;
+                if (i != s.end()) {
+                  char v = *i;
+                  e += *i++;
+                  // eat backslash after ESC
+                  if (i != s.end() && v == '\e' && *i == '\\') e += last = *i++;
+                }
             } else {
                 if (i != s.end() && *i >= 0x40 && *i <= 0x5f) e += *i++;
             }


### PR DESCRIPTION
Before the change `nix` was stripping warning flags reported by `gcc-14` too eagerly:

    $ nix build -f. texinfo4
    error: builder for '/nix/store/i9948l91s3df44ip5jlpp6imbrcs646x-texinfo-4.13a.drv' failed with exit code 2;
           last 25 log lines:
           >  1495 | info_tag (mbi_iterator_t iter, int handle, size_t *plen)
           >       |                                            ~~~~~~~~^~~~
           > window.c:1887:39: error: passing argument 4 of 'printed_representation' from incompatible pointer type []
           >  1887 |                                       &replen);
           >       |                                       ^~~~~~~
           >       |                                       |
           >       |                                       int *

After the change the compiler flag remains:

    $ ~/patched.nix build -f. texinfo4
    error: builder for '/nix/store/i9948l91s3df44ip5jlpp6imbrcs646x-texinfo-4.13a.drv' failed with exit code 2;
       last 25 log lines:
       >  1495 | info_tag (mbi_iterator_t iter, int handle, size_t *plen)
       >       |                                            ~~~~~~~~^~~~
       > window.c:1887:39: error: passing argument 4 of 'printed_representation' from incompatible pointer type [-Wincompatible-pointer-types]
       >  1887 |                                       &replen);
       >       |                                       ^~~~~~~
       >       |                                       |
       >       |                                       int *

Note the difference in flag rendering around the warning.

https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda has a good sumamry of why it happens. Befomre the change `nix` was handling just one form or URL separator:

    $ printf '\e]8;;http://example.com\e\\This is a link\e]8;;\e\\\n'

Now it also handled another for (used by gcc-14`):

    printf '\e]8;;http://example.com\aThis is a link\e]8;;\a\n'

While at it fixed accumulation of trailing escape `\e\\` symbol.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
