### PR TITLE
bugfix in getInteger(const nlohmann::json &) and add bounds checks

### DIFF
--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -176,7 +176,7 @@ NarInfo NarInfo::fromJSON(
             std::nullopt);
 
     if (json.contains("downloadSize"))
-        res.fileSize = getInteger(valueAt(json, "downloadSize"));
+        res.fileSize = getUnsigned(valueAt(json, "downloadSize"));
 
     return res;
 }

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -200,7 +200,7 @@ UnkeyedValidPathInfo UnkeyedValidPathInfo::fromJSON(
 
     auto & json = getObject(_json);
     res.narHash = Hash::parseAny(getString(valueAt(json, "narHash")), std::nullopt);
-    res.narSize = getInteger(valueAt(json, "narSize"));
+    res.narSize = getUnsigned(valueAt(json, "narSize"));
 
     try {
         auto references = getStringList(valueAt(json, "references"));
@@ -224,7 +224,7 @@ UnkeyedValidPathInfo UnkeyedValidPathInfo::fromJSON(
 
     if (json.contains("registrationTime"))
         if (auto * rawRegistrationTime = getNullable(valueAt(json, "registrationTime")))
-            res.registrationTime = getInteger(*rawRegistrationTime);
+            res.registrationTime = getInteger<time_t>(*rawRegistrationTime);
 
     if (json.contains("ultimate"))
         res.ultimate = getBoolean(valueAt(json, "ultimate"));

--- a/src/libutil-tests/json-utils.cc
+++ b/src/libutil-tests/json-utils.cc
@@ -128,19 +128,29 @@ TEST(getString, wrongAssertions) {
     ASSERT_THROW(getString(valueAt(json, "boolean")), Error);
 }
 
-TEST(getInteger, rightAssertions) {
-    auto simple = R"({ "int": 0 })"_json;
+TEST(getIntegralNumber, rightAssertions) {
+    auto simple = R"({ "int": 0, "signed": -1 })"_json;
 
-    ASSERT_EQ(getInteger(valueAt(getObject(simple), "int")), 0);
+    ASSERT_EQ(getUnsigned(valueAt(getObject(simple), "int")), 0);
+    ASSERT_EQ(getInteger<int8_t>(valueAt(getObject(simple), "int")), 0);
+    ASSERT_EQ(getInteger<int8_t>(valueAt(getObject(simple), "signed")), -1);
 }
 
-TEST(getInteger, wrongAssertions) {
-    auto json = R"({ "object": {}, "array": [], "string": "", "int": 0, "boolean": false })"_json;
+TEST(getIntegralNumber, wrongAssertions) {
+    auto json = R"({ "object": {}, "array": [], "string": "", "int": 0, "signed": -256, "large": 128, "boolean": false })"_json;
 
-    ASSERT_THROW(getInteger(valueAt(json, "object")), Error);
-    ASSERT_THROW(getInteger(valueAt(json, "array")), Error);
-    ASSERT_THROW(getInteger(valueAt(json, "string")), Error);
-    ASSERT_THROW(getInteger(valueAt(json, "boolean")), Error);
+    ASSERT_THROW(getUnsigned(valueAt(json, "object")), Error);
+    ASSERT_THROW(getUnsigned(valueAt(json, "array")), Error);
+    ASSERT_THROW(getUnsigned(valueAt(json, "string")), Error);
+    ASSERT_THROW(getUnsigned(valueAt(json, "boolean")), Error);
+    ASSERT_THROW(getUnsigned(valueAt(json, "signed")), Error);
+
+    ASSERT_THROW(getInteger<int8_t>(valueAt(json, "object")), Error);
+    ASSERT_THROW(getInteger<int8_t>(valueAt(json, "array")), Error);
+    ASSERT_THROW(getInteger<int8_t>(valueAt(json, "string")), Error);
+    ASSERT_THROW(getInteger<int8_t>(valueAt(json, "boolean")), Error);
+    ASSERT_THROW(getInteger<int8_t>(valueAt(json, "large")), Error);
+    ASSERT_THROW(getInteger<int8_t>(valueAt(json, "signed")), Error);
 }
 
 TEST(getBoolean, rightAssertions) {

--- a/src/libutil/include/nix/util/json-utils.hh
+++ b/src/libutil/include/nix/util/json-utils.hh
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include <list>
 
+#include "nix/util/error.hh"
 #include "nix/util/types.hh"
 
 namespace nix {
@@ -35,7 +36,26 @@ const nlohmann::json * getNullable(const nlohmann::json & value);
 const nlohmann::json::object_t & getObject(const nlohmann::json & value);
 const nlohmann::json::array_t & getArray(const nlohmann::json & value);
 const nlohmann::json::string_t & getString(const nlohmann::json & value);
-const nlohmann::json::number_integer_t & getInteger(const nlohmann::json & value);
+const nlohmann::json::number_unsigned_t & getUnsigned(const nlohmann::json & value);
+
+template<typename T>
+auto getInteger(const nlohmann::json & value) -> std::enable_if_t<std::is_signed_v<T> && std::is_integral_v<T>, T>
+{
+    if (auto ptr = value.get_ptr<const nlohmann::json::number_unsigned_t *>()) {
+        if (*ptr <= std::make_unsigned_t<T>(std::numeric_limits<T>::max())) {
+            return *ptr;
+        }
+    } else if (auto ptr = value.get_ptr<const nlohmann::json::number_integer_t *>()) {
+        if (*ptr >= std::numeric_limits<T>::min() && *ptr <= std::numeric_limits<T>::max()) {
+            return *ptr;
+        }
+    } else {
+        auto typeName = value.is_number_float() ? "floating point number" : value.type_name();
+        throw Error("Expected JSON value to be an integral number but it is of type '%s': %s", typeName, value.dump());
+    }
+    throw Error("Out of range: JSON value '%s' cannot be casted to %d-bit integer", value.dump(), 8 * sizeof(T));
+}
+
 const nlohmann::json::boolean_t & getBoolean(const nlohmann::json & value);
 Strings getStringList(const nlohmann::json & value);
 StringMap getStringMap(const nlohmann::json & value);

--- a/src/libutil/json-utils.cc
+++ b/src/libutil/json-utils.cc
@@ -92,9 +92,18 @@ const nlohmann::json::string_t & getString(const nlohmann::json & value)
     return ensureType(value, nlohmann::json::value_t::string).get_ref<const nlohmann::json::string_t &>();
 }
 
-const nlohmann::json::number_integer_t & getInteger(const nlohmann::json & value)
+const nlohmann::json::number_unsigned_t & getUnsigned(const nlohmann::json & value)
 {
-    return ensureType(value, nlohmann::json::value_t::number_integer).get_ref<const nlohmann::json::number_integer_t &>();
+    if (auto ptr = value.get<const nlohmann::json::number_unsigned_t *>()) {
+        return *ptr;
+    }
+    const char * typeName = value.type_name();
+    if (typeName == nlohmann::json(0).type_name()) {
+        typeName = value.is_number_float() ? "floating point number" : "signed integral number";
+    }
+    throw Error(
+        "Expected JSON value to be an unsigned integral number but it is of type '%s': %s",
+        typeName, value.dump());
 }
 
 const nlohmann::json::boolean_t & getBoolean(const nlohmann::json & value)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

A fix of UB in a new `nlohmann_json` version breaks Nix, namely the `getInteger(const nlohmann::json &)` function.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Actually this function is used only three times in the Nix codebase. In two cases the result is casted to `uint64_t`, i.e. an unsigned version of the function, `getUnsigned(...)`, is appropriate there. Thus a bounds checks is not required either.

In the third case the result is casted to `time_t`, which is probably a signed arithmetic type with an unknown width, although nowadays it should be `int64_t`. Here, a bounds check is required and it was missing. `getInteger(...)` is converted to a templated function because `time_t` is unspecified.

Using `get_ptr()` ensures correct behavior when using the updated or older versions of `nlohmann_json`.

Also the error messages are improved because JSON has a single number type, so that errors like `Expected JSON value to be of type 'number' but it is of type 'number'` weren't helpful.

Fixes #13046 and includes new test cases.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
