### PR TITLE
Complain when using --pure-eval with --file

### DIFF
--- a/src/libcmd/installables.cc
+++ b/src/libcmd/installables.cc
@@ -491,7 +491,11 @@ Installables SourceExprCommand::parseInstallables(
             throw UsageError("'--file' and '--expr' are exclusive");
 
         // FIXME: backward compatibility hack
-        if (file) evalSettings.pureEval = false;
+        if (file) {
+            if (evalSettings.pureEval && evalSettings.pureEval.overridden)
+                throw UsageError("'--file' is not compatible with '--pure-eval'");
+            evalSettings.pureEval = false;
+        }
 
         auto state = getEvalState();
         auto vFile = state->allocValue();

--- a/tests/functional/eval.sh
+++ b/tests/functional/eval.sh
@@ -39,6 +39,9 @@ nix-instantiate --eval -E 'assert 1 + 2 == 3; true'
 ln -sfn cycle.nix "$TEST_ROOT/cycle.nix"
 (! nix eval --file "$TEST_ROOT/cycle.nix")
 
+# --file and --pure-eval don't mix.
+expectStderr 1 nix eval --pure-eval --file "$TEST_ROOT/cycle.nix" | grepQuiet "not compatible"
+
 # Check that relative symlinks are resolved correctly.
 mkdir -p "$TEST_ROOT/xyzzy" "$TEST_ROOT/foo"
 ln -sfn ../xyzzy "$TEST_ROOT/foo/bar"


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Closes #12608.

Using `--pure-eval` with `--file` never worked and cannot work because in pure eval mode, the evaluator doesn't have access to the file. So let's throw an error.

If we're worried that throwing an error breaks scripts, we could also print a warning.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
