### PR TITLE
Allowing the configure_shell_profile function to make directories

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -888,12 +888,15 @@ configure_shell_profile() {
             _sudo "to back up your current $profile_target to $profile_target$PROFILE_BACKUP_SUFFIX" \
                   cp "$profile_target" "$profile_target$PROFILE_BACKUP_SUFFIX"
         else
-            # try to create the file if its directory exists
+            # try to create the file
+            # If the directory does not exists, create it
             target_dir="$(dirname "$profile_target")"
-            if [ -d "$target_dir" ]; then
-                _sudo "to create a stub $profile_target which will be updated" \
-                    touch "$profile_target"
+            if [ ! -d "$target_dir" ]; then
+                _sudo "to create the $target_dir directory which is missing" \
+                    mkdir -p "$target_dir"
             fi
+            _sudo "to create a stub $profile_target which will be updated" \
+                touch "$profile_target"
         fi
 
         if [ -e "$profile_target" ]; then


### PR DESCRIPTION
## Motivation
After installing Nix using the [recommended method](https://nix.dev/install-nix), I noticed that nix commands were not available in my shell.

## Context

Similar to this [issue](https://github.com/NixOS/nix/issues/4286) i'm using Solus linux ( Solus-Budgie-Release-2025-01-26 ).
When configuring shells the `configure_shell_profile()` function will try to configure nix at several places : 
- `/etc/bashrc`
- `/etc/profile.d/nix.sh`
- `/etc/zshrc`
- `/etc/bash.bashrc`
- `/etc/zsh/zshrc`

This has been added in the following [commit](https://github.com/NixOS/nix/commit/c40bad415104398450866d32682011db0acb0310) by @abathur.
However, the code does not create directories if it's missing, it's assuming that `/etc/` `/etc/profile.d/` and `/etc/zsh/` exists.

Unfortunately in Solus linux the `/etc/profile.d/` directory does not exist.
It becomes a problem because solus linux's user `.bashrc` only source the `/etc/profile` file.

default `~/.bashrc`
```bash
source /usr/share/defaults/etc/profile
```
The sourced file will source the `/etc/profile.d/` directory **if it exists**.

`/usr/share/defaults/etc/profile`
```bash
if [ -d /usr/share/defaults/etc/profile.d ] ; then
    for script in /usr/share/defaults/etc/profile.d/*.sh; do
        if [ -r $script ] ; then
            source $script
        fi
    done
    unset script
fi

if [ -d /etc/profile.d ] ; then
    for script in /etc/profile.d/*.sh; do
        if [ -r $script ] ; then
            source $script
        fi
    done
    unset script
fi
```
So to set up the shell of solus linux's user, the install script must create **at least** the `profile.d` directory.


PS : I'm struggling to find a way to make test for this. 
The test tool seems to automatically create `/outputs/out/etc/profile.d` before testing the install script.