### PR TITLE
fix: allow redirected HTTP uploads

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -312,6 +312,23 @@ struct curlFileTransfer : public FileTransfer
         }
         #endif
 
+        size_t seekCallback(curl_off_t offset, int origin)
+        {
+            if (origin == SEEK_SET) {
+                readOffset = offset;
+            } else if (origin == SEEK_CUR) {
+                readOffset += offset;
+            } else if (origin == SEEK_END) {
+                readOffset = request.data->length() + offset;
+            }
+            return CURL_SEEKFUNC_OK;
+        }
+
+        static size_t seekCallbackWrapper(void *clientp, curl_off_t offset, int origin)
+        {
+            return ((TransferItem *) clientp)->seekCallback(offset, origin);
+        }
+
         void init()
         {
             if (!req) req = curl_easy_init();
@@ -364,6 +381,8 @@ struct curlFileTransfer : public FileTransfer
                 curl_easy_setopt(req, CURLOPT_READFUNCTION, readCallbackWrapper);
                 curl_easy_setopt(req, CURLOPT_READDATA, this);
                 curl_easy_setopt(req, CURLOPT_INFILESIZE_LARGE, (curl_off_t) request.data->length());
+                curl_easy_setopt(req, CURLOPT_SEEKFUNCTION, seekCallbackWrapper);
+                curl_easy_setopt(req, CURLOPT_SEEKDATA, this);
             }
 
             if (request.verifyTLS) {


### PR DESCRIPTION
When a PUT is redirected, some of the data can be sent by curl before headers are read. This means the subsequent PUT operation needs to seek back to origin.


## Motivation
Use the HTTP Binary Cache to write to signed-urls provided by a 307 Redirect.
