### PR TITLE
Use transparent comparators for `std::set<std::string>` (NFC)

### DIFF
--- a/src/build-remote/build-remote.cc
+++ b/src/build-remote/build-remote.cc
@@ -42,7 +42,7 @@ static AutoCloseFD openSlotLock(const Machine & m, uint64_t slot)
     return openLockFile(fmt("%s/%s-%d", currentLoad, escapeUri(m.storeUri.render()), slot), true);
 }
 
-static bool allSupportedLocally(Store & store, const std::set<std::string>& requiredFeatures) {
+static bool allSupportedLocally(Store & store, const StringSet& requiredFeatures) {
     for (auto & feature : requiredFeatures)
         if (!store.systemFeatures.get().count(feature)) return false;
     return true;
@@ -113,7 +113,7 @@ static int main_build_remote(int argc, char * * argv)
             auto amWilling = readInt(source);
             auto neededSystem = readString(source);
             drvPath = store->parseStorePath(readString(source));
-            auto requiredFeatures = readStrings<std::set<std::string>>(source);
+            auto requiredFeatures = readStrings<StringSet>(source);
 
             /* It would be possible to build locally after some builds clear out,
                so don't show the warning now: */

--- a/src/libcmd/command.cc
+++ b/src/libcmd/command.cc
@@ -40,7 +40,7 @@ nlohmann::json NixMultiCommand::toJSON()
 void NixMultiCommand::run()
 {
     if (!command) {
-        std::set<std::string> subCommandTextLines;
+        StringSet subCommandTextLines;
         for (auto & [name, _] : commands)
             subCommandTextLines.insert(fmt("- `%s`", name));
         std::string markdownError =

--- a/src/libcmd/include/nix/cmd/command.hh
+++ b/src/libcmd/include/nix/cmd/command.hh
@@ -363,7 +363,7 @@ void completeFlakeRefWithFragment(
     const Strings & defaultFlakeAttrPaths,
     std::string_view prefix);
 
-std::string showVersions(const std::set<std::string> & versions);
+std::string showVersions(const StringSet & versions);
 
 void printClosureDiff(
     ref<Store> store, const StorePath & beforePath, const StorePath & afterPath, std::string_view indent);

--- a/src/libcmd/installable-attr-path.cc
+++ b/src/libcmd/installable-attr-path.cc
@@ -72,7 +72,7 @@ DerivedPathsWithInfo InstallableAttrPath::toDerivedPaths()
 
         auto newOutputs = std::visit(overloaded {
             [&](const ExtendedOutputsSpec::Default & d) -> OutputsSpec {
-                std::set<std::string> outputsToInstall;
+                StringSet outputsToInstall;
                 for (auto & output : packageInfo.queryOutputs(false, true))
                     outputsToInstall.insert(output.first);
                 if (outputsToInstall.empty())

--- a/src/libcmd/installable-flake.cc
+++ b/src/libcmd/installable-flake.cc
@@ -117,7 +117,7 @@ DerivedPathsWithInfo InstallableFlake::toDerivedPaths()
             .drvPath = makeConstantStorePathRef(std::move(drvPath)),
             .outputs = std::visit(overloaded {
                 [&](const ExtendedOutputsSpec::Default & d) -> OutputsSpec {
-                    std::set<std::string> outputsToInstall;
+                    StringSet outputsToInstall;
                     if (auto aOutputSpecified = attr->maybeGetAttr(state->sOutputSpecified)) {
                         if (aOutputSpecified->getBool()) {
                             if (auto aOutputName = attr->maybeGetAttr("outputName"))

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -74,7 +74,7 @@ std::pair<Value *, PosIdx> findAlongAttrPath(EvalState & state, const std::strin
 
             auto a = v->attrs()->get(state.symbols.create(attr));
             if (!a) {
-                std::set<std::string> attrNames;
+                StringSet attrNames;
                 for (auto & attr : *v->attrs())
                     attrNames.insert(std::string(state.symbols[attr.name]));
 

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -492,7 +492,7 @@ Value & AttrCursor::forceValue()
 Suggestions AttrCursor::getSuggestionsForAttr(Symbol name)
 {
     auto attrNames = getAttrs();
-    std::set<std::string> strAttrNames;
+    StringSet strAttrNames;
     for (auto & name : attrNames)
         strAttrNames.insert(std::string(root->state.symbols[name]));
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1446,7 +1446,7 @@ void ExprSelect::eval(EvalState & state, Env & env, Value & v)
             } else {
                 state.forceAttrs(*vAttrs, pos, "while selecting an attribute");
                 if (!(j = vAttrs->attrs()->get(name))) {
-                    std::set<std::string> allAttrNames;
+                    StringSet allAttrNames;
                     for (auto & attr : *vAttrs->attrs())
                         allAttrNames.insert(std::string(state.symbols[attr.name]));
                     auto suggestions = Suggestions::bestMatches(allAttrNames, state.symbols[name]);
@@ -1603,7 +1603,7 @@ void EvalState::callFunction(Value & fun, std::span<Value *> args, Value & vRes,
                        user. */
                     for (auto & i : *args[0]->attrs())
                         if (!lambda.formals->has(i.name)) {
-                            std::set<std::string> formalNames;
+                            StringSet formalNames;
                             for (auto & formal : lambda.formals->formals)
                                 formalNames.insert(std::string(symbols[formal.name]));
                             auto suggestions = Suggestions::bestMatches(formalNames, symbols[i.name]);

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -194,7 +194,7 @@ struct MercurialInputScheme : InputScheme
 
                 input.attrs.insert_or_assign("ref", chomp(runHg({ "branch", "-R", actualUrl })));
 
-                auto files = tokenizeString<std::set<std::string>>(
+                auto files = tokenizeString<StringSet>(
                     runHg({ "status", "-R", actualUrl, "--clean", "--modified", "--added", "--no-status", "--print0" }), "\0"s);
 
                 Path actualPath(absPath(actualUrl));

--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -224,7 +224,7 @@ ref<SourceAccessor> downloadTarball(
 // An input scheme corresponding to a curl-downloadable resource.
 struct CurlInputScheme : InputScheme
 {
-    const std::set<std::string> transportUrlSchemes = {"file", "http", "https"};
+    const StringSet transportUrlSchemes = {"file", "http", "https"};
 
     bool hasTarballExtension(std::string_view path) const
     {
@@ -236,7 +236,7 @@ struct CurlInputScheme : InputScheme
 
     virtual bool isValidURL(const ParsedURL & url, bool requireTree) const = 0;
 
-    static const std::set<std::string> specialParams;
+    static const StringSet specialParams;
 
     std::optional<Input> inputFromURL(
         const Settings & settings,

--- a/src/libflake/config.cc
+++ b/src/libflake/config.cc
@@ -32,7 +32,7 @@ static void writeTrustedList(const TrustedList & trustedList)
 
 void ConfigFile::apply(const Settings & flakeSettings)
 {
-    std::set<std::string> whitelist{"bash-prompt", "bash-prompt-prefix", "bash-prompt-suffix", "flake-registry", "commit-lock-file-summary", "commit-lockfile-summary"};
+    StringSet whitelist{"bash-prompt", "bash-prompt-prefix", "bash-prompt-suffix", "flake-registry", "commit-lock-file-summary", "commit-lockfile-summary"};
 
     for (auto & [name, value] : settings) {
 

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -323,7 +323,7 @@ static FlakeRef applySelfAttrs(
 {
     auto newRef(ref);
 
-    std::set<std::string> allowedAttrs{"submodules", "lfs"};
+    StringSet allowedAttrs{"submodules", "lfs"};
 
     for (auto & attr : flake.selfAttrs) {
         if (!allowedAttrs.contains(attr.first))

--- a/src/libmain/plugin.cc
+++ b/src/libmain/plugin.cc
@@ -19,7 +19,7 @@ struct PluginFilesSetting : public BaseSetting<Paths>
         const Paths & def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {})
+        const StringSet & aliases = {})
         : BaseSetting<Paths>(def, true, name, description, aliases)
     {
         options->addSetting(this);

--- a/src/libstore-tests/common-protocol.cc
+++ b/src/libstore-tests/common-protocol.cc
@@ -154,7 +154,7 @@ CHARACTERIZATION_TEST(
 CHARACTERIZATION_TEST(
     set,
     "set",
-    (std::tuple<std::set<std::string>, std::set<std::string>, std::set<std::string>, std::set<std::set<std::string>>> {
+    (std::tuple<StringSet, StringSet, StringSet, std::set<StringSet>> {
         { },
         { "" },
         { "", "foo", "bar" },

--- a/src/libstore-tests/outputs-spec.cc
+++ b/src/libstore-tests/outputs-spec.cc
@@ -7,7 +7,7 @@
 namespace nix {
 
 TEST(OutputsSpec, no_empty_names) {
-    ASSERT_DEATH(OutputsSpec::Names { std::set<std::string> { } }, "");
+    ASSERT_DEATH(OutputsSpec::Names { StringSet { } }, "");
 }
 
 #define TEST_DONT_PARSE(NAME, STR)           \

--- a/src/libstore-tests/serve-protocol.cc
+++ b/src/libstore-tests/serve-protocol.cc
@@ -374,7 +374,7 @@ VERSIONED_CHARACTERIZATION_TEST(
     set,
     "set",
     defaultVersion,
-    (std::tuple<std::set<std::string>, std::set<std::string>, std::set<std::string>, std::set<std::set<std::string>>> {
+    (std::tuple<StringSet, StringSet, StringSet, std::set<StringSet>> {
         { },
         { "" },
         { "", "foo", "bar" },

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -574,7 +574,7 @@ VERSIONED_CHARACTERIZATION_TEST(
     set,
     "set",
     defaultVersion,
-    (std::tuple<std::set<std::string>, std::set<std::string>, std::set<std::string>, std::set<std::set<std::string>>> {
+    (std::tuple<StringSet, StringSet, StringSet, std::set<StringSet>> {
         { },
         { "" },
         { "", "foo", "bar" },

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -685,7 +685,7 @@ TEST_F(WorkerProtoTest, handshake_features)
     toClient.create();
     toServer.create();
 
-    std::tuple<WorkerProto::Version, std::set<WorkerProto::Feature>> clientResult;
+    std::tuple<WorkerProto::Version, WorkerProto::FeatureSet> clientResult;
 
     auto clientThread = std::thread([&]() {
         FdSink out { toServer.writeSide.get() };
@@ -703,7 +703,7 @@ TEST_F(WorkerProtoTest, handshake_features)
 
     EXPECT_EQ(clientResult, daemonResult);
     EXPECT_EQ(std::get<0>(clientResult), 123u);
-    EXPECT_EQ(std::get<1>(clientResult), std::set<WorkerProto::Feature>({"bar", "xyzzy"}));
+    EXPECT_EQ(std::get<1>(clientResult), WorkerProto::FeatureSet({"bar", "xyzzy"}));
 }
 
 /// Has to be a `BufferedSink` for handshake.

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -123,7 +123,7 @@ void buildProfile(const Path & out, Packages && pkgs)
 {
     State state;
 
-    std::set<Path> done, postponed;
+    PathSet done, postponed;
 
     auto addPkg = [&](const Path & pkgDir, int priority) {
         if (!done.insert(pkgDir).second) return;
@@ -157,7 +157,7 @@ void buildProfile(const Path & out, Packages && pkgs)
      */
     auto priorityCounter = 1000;
     while (!postponed.empty()) {
-        std::set<Path> pkgDirs;
+        PathSet pkgDirs;
         postponed.swap(pkgDirs);
         for (const auto & pkgDir : pkgDirs)
             addPkg(pkgDir, priorityCounter++);

--- a/src/libstore/derived-path-map.cc
+++ b/src/libstore/derived-path-map.cc
@@ -55,17 +55,17 @@ typename DerivedPathMap<V>::ChildNode * DerivedPathMap<V>::findSlot(const Single
 namespace nix {
 
 template<>
-bool DerivedPathMap<std::set<std::string>>::ChildNode::operator == (
-    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept = default;
+bool DerivedPathMap<StringSet>::ChildNode::operator == (
+    const DerivedPathMap<StringSet>::ChildNode &) const noexcept = default;
 
 // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
 #if 0
 template<>
-std::strong_ordering DerivedPathMap<std::set<std::string>>::ChildNode::operator <=> (
-    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept = default;
+std::strong_ordering DerivedPathMap<StringSet>::ChildNode::operator <=> (
+    const DerivedPathMap<StringSet>::ChildNode &) const noexcept = default;
 #endif
 
-template struct DerivedPathMap<std::set<std::string>>::ChildNode;
-template struct DerivedPathMap<std::set<std::string>>;
+template struct DerivedPathMap<StringSet>::ChildNode;
+template struct DerivedPathMap<StringSet>;
 
 };

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -22,7 +22,7 @@ struct DummyStoreConfig : virtual StoreConfig {
           ;
     }
 
-    static std::set<std::string> uriSchemes() {
+    static StringSet uriSchemes() {
         return {"dummy"};
     }
 };

--- a/src/libstore/include/nix/store/common-protocol-impl.hh
+++ b/src/libstore/include/nix/store/common-protocol-impl.hh
@@ -25,11 +25,11 @@ namespace nix {
         LengthPrefixedProtoHelper<CommonProto, T >::write(store, conn, t); \
     }
 
+#define COMMA_ ,
 COMMON_USE_LENGTH_PREFIX_SERIALISER(template<typename T>, std::vector<T>)
-COMMON_USE_LENGTH_PREFIX_SERIALISER(template<typename T>, std::set<T>)
+COMMON_USE_LENGTH_PREFIX_SERIALISER(template<typename T COMMA_ typename Compare>, std::set<T COMMA_ Compare>)
 COMMON_USE_LENGTH_PREFIX_SERIALISER(template<typename... Ts>, std::tuple<Ts...>)
 
-#define COMMA_ ,
 COMMON_USE_LENGTH_PREFIX_SERIALISER(
     template<typename K COMMA_ typename V>,
     std::map<K COMMA_ V>)

--- a/src/libstore/include/nix/store/common-protocol.hh
+++ b/src/libstore/include/nix/store/common-protocol.hh
@@ -72,14 +72,14 @@ DECLARE_COMMON_SERIALISER(DrvOutput);
 template<>
 DECLARE_COMMON_SERIALISER(Realisation);
 
+#define COMMA_ ,
 template<typename T>
 DECLARE_COMMON_SERIALISER(std::vector<T>);
-template<typename T>
-DECLARE_COMMON_SERIALISER(std::set<T>);
+template<typename T, typename Compare>
+DECLARE_COMMON_SERIALISER(std::set<T COMMA_ Compare>);
 template<typename... Ts>
 DECLARE_COMMON_SERIALISER(std::tuple<Ts...>);
 
-#define COMMA_ ,
 template<typename K, typename V>
 DECLARE_COMMON_SERIALISER(std::map<K COMMA_ V>);
 #undef COMMA_

--- a/src/libstore/include/nix/store/derivations.hh
+++ b/src/libstore/include/nix/store/derivations.hh
@@ -343,7 +343,7 @@ struct Derivation : BasicDerivation
     /**
      * inputs that are sub-derivations
      */
-    DerivedPathMap<std::set<OutputName>> inputDrvs;
+    DerivedPathMap<std::set<OutputName, std::less<>>> inputDrvs;
 
     /**
      * Print a derivation.

--- a/src/libstore/include/nix/store/derived-path-map.hh
+++ b/src/libstore/include/nix/store/derived-path-map.hh
@@ -91,20 +91,20 @@ struct DerivedPathMap {
 };
 
 template<>
-bool DerivedPathMap<std::set<std::string>>::ChildNode::operator == (
-    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept;
+bool DerivedPathMap<StringSet>::ChildNode::operator == (
+    const DerivedPathMap<StringSet>::ChildNode &) const noexcept;
 
 // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
 #if 0
 template<>
-std::strong_ordering DerivedPathMap<std::set<std::string>>::ChildNode::operator <=> (
-    const DerivedPathMap<std::set<std::string>>::ChildNode &) const noexcept;
+std::strong_ordering DerivedPathMap<StringSet>::ChildNode::operator <=> (
+    const DerivedPathMap<StringSet>::ChildNode &) const noexcept;
 
 template<>
-inline auto DerivedPathMap<std::set<std::string>>::operator <=> (const DerivedPathMap<std::set<std::string>> &) const noexcept = default;
+inline auto DerivedPathMap<StringSet>::operator <=> (const DerivedPathMap<StringSet> &) const noexcept = default;
 #endif
 
-extern template struct DerivedPathMap<std::set<std::string>>::ChildNode;
-extern template struct DerivedPathMap<std::set<std::string>>;
+extern template struct DerivedPathMap<StringSet>::ChildNode;
+extern template struct DerivedPathMap<StringSet>;
 
 }

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -24,7 +24,7 @@ struct MaxBuildJobsSetting : public BaseSetting<unsigned int>
         unsigned int def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {})
+        const StringSet & aliases = {})
         : BaseSetting<unsigned int>(def, true, name, description, aliases)
     {
         options->addSetting(this);

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -15,10 +15,10 @@ struct HttpBinaryCacheStoreConfig : virtual BinaryCacheStoreConfig
         return "HTTP Binary Cache Store";
     }
 
-    static std::set<std::string> uriSchemes()
+    static StringSet uriSchemes()
     {
         static bool forceHttp = getEnv("_NIX_FORCE_HTTP") == "1";
-        auto ret = std::set<std::string>({"http", "https"});
+        auto ret = StringSet({"http", "https"});
         if (forceHttp)
             ret.insert("file");
         return ret;

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -37,7 +37,7 @@ struct LegacySSHStoreConfig : virtual CommonSSHStoreConfig
 
     const std::string name() override { return "SSH Store"; }
 
-    static std::set<std::string> uriSchemes() { return {"ssh"}; }
+    static StringSet uriSchemes() { return {"ssh"}; }
 
     std::string doc() override;
 };

--- a/src/libstore/include/nix/store/length-prefixed-protocol-helper.hh
+++ b/src/libstore/include/nix/store/length-prefixed-protocol-helper.hh
@@ -52,8 +52,10 @@ struct LengthPrefixedProtoHelper;
 template<class Inner, typename T>
 LENGTH_PREFIXED_PROTO_HELPER(Inner, std::vector<T>);
 
-template<class Inner, typename T>
-LENGTH_PREFIXED_PROTO_HELPER(Inner, std::set<T>);
+#define COMMA_ ,
+template<class Inner, typename T, typename Compare>
+LENGTH_PREFIXED_PROTO_HELPER(Inner, std::set<T COMMA_ Compare>);
+#undef COMMA_
 
 template<class Inner, typename... Ts>
 LENGTH_PREFIXED_PROTO_HELPER(Inner, std::tuple<Ts...>);
@@ -86,12 +88,11 @@ LengthPrefixedProtoHelper<Inner, std::vector<T>>::write(
     }
 }
 
-template<class Inner, typename T>
-std::set<T>
-LengthPrefixedProtoHelper<Inner, std::set<T>>::read(
+template<class Inner, typename T, typename Compare>
+std::set<T, Compare> LengthPrefixedProtoHelper<Inner, std::set<T, Compare>>::read(
     const StoreDirConfig & store, typename Inner::ReadConn conn)
 {
-    std::set<T> resSet;
+    std::set<T, Compare> resSet;
     auto size = readNum<size_t>(conn.from);
     while (size--) {
         resSet.insert(S<T>::read(store, conn));
@@ -99,10 +100,9 @@ LengthPrefixedProtoHelper<Inner, std::set<T>>::read(
     return resSet;
 }
 
-template<class Inner, typename T>
-void
-LengthPrefixedProtoHelper<Inner, std::set<T>>::write(
-    const StoreDirConfig & store, typename Inner::WriteConn conn, const std::set<T> & resSet)
+template<class Inner, typename T, typename Compare>
+void LengthPrefixedProtoHelper<Inner, std::set<T, Compare>>::write(
+    const StoreDirConfig & store, typename Inner::WriteConn conn, const std::set<T, Compare> & resSet)
 {
     conn.to << resSet.size();
     for (auto & key : resSet) {

--- a/src/libstore/include/nix/store/local-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/local-binary-cache-store.hh
@@ -15,7 +15,7 @@ struct LocalBinaryCacheStoreConfig : virtual BinaryCacheStoreConfig
         return "Local Binary Cache Store";
     }
 
-    static std::set<std::string> uriSchemes();
+    static StringSet uriSchemes();
 
     std::string doc() override;
 };

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -63,7 +63,7 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
         return ExperimentalFeature::LocalOverlayStore;
     }
 
-    static std::set<std::string> uriSchemes()
+    static StringSet uriSchemes()
     {
         return { "local-overlay" };
     }

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -67,7 +67,7 @@ struct LocalStoreConfig : virtual LocalFSStoreConfig
 
     const std::string name() override { return "Local Store"; }
 
-    static std::set<std::string> uriSchemes()
+    static StringSet uriSchemes()
     { return {"local"}; }
 
     std::string doc() override;

--- a/src/libstore/include/nix/store/machines.hh
+++ b/src/libstore/include/nix/store/machines.hh
@@ -15,12 +15,12 @@ typedef std::vector<Machine> Machines;
 struct Machine {
 
     const StoreReference storeUri;
-    const std::set<std::string> systemTypes;
+    const StringSet systemTypes;
     const std::string sshKey;
     const unsigned int maxJobs;
     const float speedFactor;
-    const std::set<std::string> supportedFeatures;
-    const std::set<std::string> mandatoryFeatures;
+    const StringSet supportedFeatures;
+    const StringSet mandatoryFeatures;
     const std::string sshPublicHostKey;
     bool enabled = true;
 
@@ -34,12 +34,12 @@ struct Machine {
      * @return Whether `features` is a subset of the union of `supportedFeatures` and
      * `mandatoryFeatures`.
      */
-    bool allSupported(const std::set<std::string> & features) const;
+    bool allSupported(const StringSet & features) const;
 
     /**
      * @return Whether `mandatoryFeatures` is a subset of `features`.
      */
-    bool mandatoryMet(const std::set<std::string> & features) const;
+    bool mandatoryMet(const StringSet & features) const;
 
     Machine(
         const std::string & storeUri,
@@ -75,7 +75,7 @@ struct Machine {
      * with `@` are interpreted as paths to other configuration files in
      * the same format.
      */
-    static Machines parseConfig(const std::set<std::string> & defaultSystems, const std::string & config);
+    static Machines parseConfig(const StringSet & defaultSystems, const std::string & config);
 };
 
 /**

--- a/src/libstore/include/nix/store/outputs-spec.hh
+++ b/src/libstore/include/nix/store/outputs-spec.hh
@@ -27,20 +27,24 @@ struct OutputsSpec {
     /**
      * A non-empty set of outputs, specified by name
      */
-    struct Names : std::set<OutputName> {
-        using std::set<OutputName>::set;
+    struct Names : std::set<OutputName, std::less<>> {
+    private:
+        using BaseType = std::set<OutputName, std::less<>>;
+
+    public:
+        using BaseType::BaseType;
 
         /* These need to be "inherited manually" */
 
-        Names(const std::set<OutputName> & s)
-            : std::set<OutputName>(s)
+        Names(const BaseType & s)
+            : BaseType(s)
         { assert(!empty()); }
 
         /**
          * Needs to be "inherited manually"
          */
-        Names(std::set<OutputName> && s)
-            : std::set<OutputName>(s)
+        Names(BaseType && s)
+            : BaseType(std::move(s))
         { assert(!empty()); }
 
         /* This set should always be non-empty, so we delete this

--- a/src/libstore/include/nix/store/path-with-outputs.hh
+++ b/src/libstore/include/nix/store/path-with-outputs.hh
@@ -19,7 +19,7 @@ struct StoreDirConfig;
 struct StorePathWithOutputs
 {
     StorePath path;
-    std::set<std::string> outputs;
+    StringSet outputs;
 
     std::string to_string(const StoreDirConfig & store) const;
 

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -98,7 +98,7 @@ public:
         return "S3 Binary Cache Store";
     }
 
-    static std::set<std::string> uriSchemes()
+    static StringSet uriSchemes()
     {
         return {"s3"};
     }

--- a/src/libstore/include/nix/store/serve-protocol-impl.hh
+++ b/src/libstore/include/nix/store/serve-protocol-impl.hh
@@ -26,7 +26,9 @@ namespace nix {
     }
 
 SERVE_USE_LENGTH_PREFIX_SERIALISER(template<typename T>, std::vector<T>)
-SERVE_USE_LENGTH_PREFIX_SERIALISER(template<typename T>, std::set<T>)
+#define COMMA_ ,
+SERVE_USE_LENGTH_PREFIX_SERIALISER(template<typename T COMMA_ typename Compare>, std::set<T COMMA_ Compare>)
+#undef COMMA_
 SERVE_USE_LENGTH_PREFIX_SERIALISER(template<typename... Ts>, std::tuple<Ts...>)
 
 #define SERVE_USE_LENGTH_PREFIX_SERIALISER_COMMA ,

--- a/src/libstore/include/nix/store/serve-protocol.hh
+++ b/src/libstore/include/nix/store/serve-protocol.hh
@@ -180,12 +180,12 @@ DECLARE_SERVE_SERIALISER(ServeProto::BuildOptions);
 
 template<typename T>
 DECLARE_SERVE_SERIALISER(std::vector<T>);
-template<typename T>
-DECLARE_SERVE_SERIALISER(std::set<T>);
+#define COMMA_ ,
+template<typename T, typename Compare>
+DECLARE_SERVE_SERIALISER(std::set<T COMMA_ Compare>);
 template<typename... Ts>
 DECLARE_SERVE_SERIALISER(std::tuple<Ts...>);
 
-#define COMMA_ ,
 template<typename K, typename V>
 DECLARE_SERVE_SERIALISER(std::map<K COMMA_ V>);
 #undef COMMA_

--- a/src/libstore/include/nix/store/ssh-store.hh
+++ b/src/libstore/include/nix/store/ssh-store.hh
@@ -23,7 +23,7 @@ struct SSHStoreConfig : virtual RemoteStoreConfig, virtual CommonSSHStoreConfig
         return "Experimental SSH Store";
     }
 
-    static std::set<std::string> uriSchemes()
+    static StringSet uriSchemes()
     {
         return {"ssh-ng"};
     }
@@ -45,7 +45,7 @@ struct MountedSSHStoreConfig : virtual SSHStoreConfig, virtual LocalFSStoreConfi
         return "Experimental SSH Store with filesystem mounted";
     }
 
-    static std::set<std::string> uriSchemes()
+    static StringSet uriSchemes()
     {
         return {"mounted-ssh-ng"};
     }

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -888,7 +888,7 @@ std::list<ref<Store>> getDefaultSubstituters();
 
 struct StoreFactory
 {
-    std::set<std::string> uriSchemes;
+    StringSet uriSchemes;
     /**
      * The `authorityPath` parameter is `<authority>/<path>`, or really
      * whatever comes after `<scheme>://` and before `?<query-params>`.

--- a/src/libstore/include/nix/store/uds-remote-store.hh
+++ b/src/libstore/include/nix/store/uds-remote-store.hh
@@ -38,7 +38,7 @@ protected:
     static constexpr char const * scheme = "unix";
 
 public:
-    static std::set<std::string> uriSchemes()
+    static StringSet uriSchemes()
     { return {scheme}; }
 };
 

--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -26,7 +26,7 @@ struct WorkerProto::BasicConnection
     /**
      * The set of features that both sides support.
      */
-    std::set<Feature> features;
+    FeatureSet features;
 
     /**
      * Coercion to `WorkerProto::ReadConn`. This makes it easy to use the
@@ -92,11 +92,8 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
      * @param supportedFeatures The protocol features that we support.
      */
     // FIXME: this should probably be a constructor.
-    static std::tuple<Version, std::set<Feature>> handshake(
-        BufferedSink & to,
-        Source & from,
-        WorkerProto::Version localVersion,
-        const std::set<Feature> & supportedFeatures);
+    static std::tuple<Version, FeatureSet> handshake(
+        BufferedSink & to, Source & from, WorkerProto::Version localVersion, const FeatureSet & supportedFeatures);
 
     /**
      * After calling handshake, must call this to exchange some basic
@@ -155,11 +152,8 @@ struct WorkerProto::BasicServerConnection : WorkerProto::BasicConnection
      * @param supportedFeatures The protocol features that we support.
      */
     // FIXME: this should probably be a constructor.
-    static std::tuple<Version, std::set<Feature>> handshake(
-        BufferedSink & to,
-        Source & from,
-        WorkerProto::Version localVersion,
-        const std::set<Feature> & supportedFeatures);
+    static std::tuple<Version, FeatureSet> handshake(
+        BufferedSink & to, Source & from, WorkerProto::Version localVersion, const FeatureSet & supportedFeatures);
 
     /**
      * After calling handshake, must call this to exchange some basic

--- a/src/libstore/include/nix/store/worker-protocol-impl.hh
+++ b/src/libstore/include/nix/store/worker-protocol-impl.hh
@@ -26,7 +26,9 @@ namespace nix {
     }
 
 WORKER_USE_LENGTH_PREFIX_SERIALISER(template<typename T>, std::vector<T>)
-WORKER_USE_LENGTH_PREFIX_SERIALISER(template<typename T>, std::set<T>)
+#define COMMA_ ,
+WORKER_USE_LENGTH_PREFIX_SERIALISER(template<typename T COMMA_ typename Compare>, std::set<T COMMA_ Compare>)
+#undef COMMA_
 WORKER_USE_LENGTH_PREFIX_SERIALISER(template<typename... Ts>, std::tuple<Ts...>)
 
 #define WORKER_USE_LENGTH_PREFIX_SERIALISER_COMMA ,

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -135,7 +135,7 @@ struct WorkerProto
     }
 
     using Feature = std::string;
-    using FeatureSet = std::set<Feature>;
+    using FeatureSet = std::set<Feature, std::less<>>;
 
     static const FeatureSet allFeatures;
 };
@@ -273,12 +273,12 @@ DECLARE_WORKER_SERIALISER(WorkerProto::ClientHandshakeInfo);
 
 template<typename T>
 DECLARE_WORKER_SERIALISER(std::vector<T>);
-template<typename T>
-DECLARE_WORKER_SERIALISER(std::set<T>);
+#define COMMA_ ,
+template<typename T, typename Compare>
+DECLARE_WORKER_SERIALISER(std::set<T COMMA_ Compare>);
 template<typename... Ts>
 DECLARE_WORKER_SERIALISER(std::tuple<Ts...>);
 
-#define COMMA_ ,
 template<typename K, typename V>
 DECLARE_WORKER_SERIALISER(std::map<K COMMA_ V>);
 #undef COMMA_

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -135,8 +135,9 @@ struct WorkerProto
     }
 
     using Feature = std::string;
+    using FeatureSet = std::set<Feature>;
 
-    static const std::set<Feature> allFeatures;
+    static const FeatureSet allFeatures;
 };
 
 enum struct WorkerProto::Op : uint64_t

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -119,7 +119,7 @@ bool LocalBinaryCacheStore::fileExists(const std::string & path)
     return pathExists(binaryCacheDir + "/" + path);
 }
 
-std::set<std::string> LocalBinaryCacheStoreConfig::uriSchemes()
+StringSet LocalBinaryCacheStoreConfig::uriSchemes()
 {
     if (getEnv("_NIX_FORCE_HTTP") == "1")
         return {};

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -535,7 +535,7 @@ void LocalStore::upgradeDBSchema(State & state)
 {
     state.db.exec("create table if not exists SchemaMigrations (migration text primary key not null);");
 
-    std::set<std::string> schemaMigrations;
+    StringSet schemaMigrations;
 
     {
         SQLiteStmt querySchemaMigrations;

--- a/src/libstore/machines.cc
+++ b/src/libstore/machines.cc
@@ -47,7 +47,7 @@ bool Machine::systemSupported(const std::string & system) const
     return system == "builtin" || (systemTypes.count(system) > 0);
 }
 
-bool Machine::allSupported(const std::set<std::string> & features) const
+bool Machine::allSupported(const StringSet & features) const
 {
     return std::all_of(features.begin(), features.end(),
         [&](const std::string & feature) {
@@ -56,7 +56,7 @@ bool Machine::allSupported(const std::set<std::string> & features) const
         });
 }
 
-bool Machine::mandatoryMet(const std::set<std::string> & features) const
+bool Machine::mandatoryMet(const StringSet & features) const
 {
     return std::all_of(mandatoryFeatures.begin(), mandatoryFeatures.end(),
         [&](const std::string & feature) {
@@ -134,7 +134,7 @@ static std::vector<std::string> expandBuilderLines(const std::string & builders)
     return result;
 }
 
-static Machine parseBuilderLine(const std::set<std::string> & defaultSystems, const std::string & line)
+static Machine parseBuilderLine(const StringSet & defaultSystems, const std::string & line)
 {
     const auto tokens = tokenizeString<std::vector<std::string>>(line);
 
@@ -178,7 +178,7 @@ static Machine parseBuilderLine(const std::set<std::string> & defaultSystems, co
         // `storeUri`
         tokens[0],
         // `systemTypes`
-        isSet(1) ? tokenizeString<std::set<std::string>>(tokens[1], ",") : defaultSystems,
+        isSet(1) ? tokenizeString<StringSet>(tokens[1], ",") : defaultSystems,
         // `sshKey`
         isSet(2) ? tokens[2] : "",
         // `maxJobs`
@@ -186,15 +186,15 @@ static Machine parseBuilderLine(const std::set<std::string> & defaultSystems, co
         // `speedFactor`
         isSet(4) ? parseFloatField(4) : 1.0f,
         // `supportedFeatures`
-        isSet(5) ? tokenizeString<std::set<std::string>>(tokens[5], ",") : std::set<std::string>{},
+        isSet(5) ? tokenizeString<StringSet>(tokens[5], ",") : StringSet{},
         // `mandatoryFeatures`
-        isSet(6) ? tokenizeString<std::set<std::string>>(tokens[6], ",") : std::set<std::string>{},
+        isSet(6) ? tokenizeString<StringSet>(tokens[6], ",") : StringSet{},
         // `sshPublicHostKey`
         isSet(7) ? ensureBase64(7) : ""
     };
 }
 
-static Machines parseBuilderLines(const std::set<std::string> & defaultSystems, const std::vector<std::string> & builders)
+static Machines parseBuilderLines(const StringSet & defaultSystems, const std::vector<std::string> & builders)
 {
     Machines result;
     std::transform(
@@ -203,7 +203,7 @@ static Machines parseBuilderLines(const std::set<std::string> & defaultSystems, 
     return result;
 }
 
-Machines Machine::parseConfig(const std::set<std::string> & defaultSystems, const std::string & s)
+Machines Machine::parseConfig(const StringSet & defaultSystems, const std::string & s)
 {
     const auto builderLines = expandBuilderLines(s);
     return parseBuilderLines(defaultSystems, builderLines);

--- a/src/libstore/path-with-outputs.cc
+++ b/src/libstore/path-with-outputs.cc
@@ -82,9 +82,9 @@ std::pair<std::string_view, StringSet> parsePathWithOutputs(std::string_view s)
 {
     size_t n = s.find("!");
     return n == s.npos
-        ? std::make_pair(s, std::set<std::string>())
+        ? std::make_pair(s, StringSet())
         : std::make_pair(s.substr(0, n),
-            tokenizeString<std::set<std::string>>(s.substr(n + 1), ","));
+            tokenizeString<StringSet>(s.substr(n + 1), ","));
 }
 
 

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -5,7 +5,7 @@
 
 namespace nix {
 
-const std::set<WorkerProto::Feature> WorkerProto::allFeatures{};
+const WorkerProto::FeatureSet WorkerProto::allFeatures{};
 
 WorkerProto::BasicClientConnection::~BasicClientConnection()
 {
@@ -146,21 +146,20 @@ void WorkerProto::BasicClientConnection::processStderr(
     }
 }
 
-static std::set<WorkerProto::Feature>
-intersectFeatures(const std::set<WorkerProto::Feature> & a, const std::set<WorkerProto::Feature> & b)
+static WorkerProto::FeatureSet intersectFeatures(const WorkerProto::FeatureSet & a, const WorkerProto::FeatureSet & b)
 {
-    std::set<WorkerProto::Feature> res;
+    WorkerProto::FeatureSet res;
     for (auto & x : a)
         if (b.contains(x))
             res.insert(x);
     return res;
 }
 
-std::tuple<WorkerProto::Version, std::set<WorkerProto::Feature>> WorkerProto::BasicClientConnection::handshake(
+std::tuple<WorkerProto::Version, WorkerProto::FeatureSet> WorkerProto::BasicClientConnection::handshake(
     BufferedSink & to,
     Source & from,
     WorkerProto::Version localVersion,
-    const std::set<WorkerProto::Feature> & supportedFeatures)
+    const WorkerProto::FeatureSet & supportedFeatures)
 {
     to << WORKER_MAGIC_1 << localVersion;
     to.flush();
@@ -178,21 +177,21 @@ std::tuple<WorkerProto::Version, std::set<WorkerProto::Feature>> WorkerProto::Ba
     auto protoVersion = std::min(daemonVersion, localVersion);
 
     /* Exchange features. */
-    std::set<WorkerProto::Feature> daemonFeatures;
+    WorkerProto::FeatureSet daemonFeatures;
     if (GET_PROTOCOL_MINOR(protoVersion) >= 38) {
         to << supportedFeatures;
         to.flush();
-        daemonFeatures = readStrings<std::set<WorkerProto::Feature>>(from);
+        daemonFeatures = readStrings<WorkerProto::FeatureSet>(from);
     }
 
     return {protoVersion, intersectFeatures(daemonFeatures, supportedFeatures)};
 }
 
-std::tuple<WorkerProto::Version, std::set<WorkerProto::Feature>> WorkerProto::BasicServerConnection::handshake(
+std::tuple<WorkerProto::Version, WorkerProto::FeatureSet> WorkerProto::BasicServerConnection::handshake(
     BufferedSink & to,
     Source & from,
     WorkerProto::Version localVersion,
-    const std::set<WorkerProto::Feature> & supportedFeatures)
+    const WorkerProto::FeatureSet & supportedFeatures)
 {
     unsigned int magic = readInt(from);
     if (magic != WORKER_MAGIC_1)
@@ -204,9 +203,9 @@ std::tuple<WorkerProto::Version, std::set<WorkerProto::Feature>> WorkerProto::Ba
     auto protoVersion = std::min(clientVersion, localVersion);
 
     /* Exchange features. */
-    std::set<WorkerProto::Feature> clientFeatures;
+    WorkerProto::FeatureSet clientFeatures;
     if (GET_PROTOCOL_MINOR(protoVersion) >= 38) {
-        clientFeatures = readStrings<std::set<WorkerProto::Feature>>(from);
+        clientFeatures = readStrings<WorkerProto::FeatureSet>(from);
         to << supportedFeatures;
         to.flush();
     }

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -593,7 +593,7 @@ MultiCommand::MultiCommand(std::string_view commandName, const Commands & comman
             assert(!command);
             auto i = commands.find(s);
             if (i == commands.end()) {
-                std::set<std::string> commandNames;
+                StringSet commandNames;
                 for (auto & [name, _] : commands)
                     commandNames.insert(name);
                 auto suggestions = Suggestions::bestMatches(commandNames, s);

--- a/src/libutil/configuration.cc
+++ b/src/libutil/configuration.cc
@@ -220,7 +220,7 @@ void Config::convertToArgs(Args & args, const std::string & category)
 AbstractSetting::AbstractSetting(
     const std::string & name,
     const std::string & description,
-    const std::set<std::string> & aliases,
+    const StringSet & aliases,
     std::optional<ExperimentalFeature> experimentalFeature)
     : name(name)
     , description(stripIndentation(description))
@@ -428,7 +428,7 @@ PathSetting::PathSetting(Config * options,
     const Path & def,
     const std::string & name,
     const std::string & description,
-    const std::set<std::string> & aliases)
+    const StringSet & aliases)
     : BaseSetting<Path>(def, true, name, description, aliases)
 {
     options->addSetting(this);
@@ -444,7 +444,7 @@ OptionalPathSetting::OptionalPathSetting(Config * options,
     const std::optional<Path> & def,
     const std::string & name,
     const std::string & description,
-    const std::set<std::string> & aliases)
+    const StringSet & aliases)
     : BaseSetting<std::optional<Path>>(def, true, name, description, aliases)
 {
     options->addSetting(this);

--- a/src/libutil/experimental-features.cc
+++ b/src/libutil/experimental-features.cc
@@ -358,7 +358,7 @@ nlohmann::json documentExperimentalFeatures()
     return (nlohmann::json) res;
 }
 
-std::set<ExperimentalFeature> parseFeatures(const std::set<std::string> & rawFeatures)
+std::set<ExperimentalFeature> parseFeatures(const StringSet & rawFeatures)
 {
     std::set<ExperimentalFeature> res;
     for (auto & rawFeature : rawFeatures)

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -32,9 +32,9 @@ static size_t regularHashSize(HashAlgorithm type) {
 }
 
 
-const std::set<std::string> hashAlgorithms = {"blake3", "md5", "sha1", "sha256", "sha512" };
+const StringSet hashAlgorithms = {"blake3", "md5", "sha1", "sha256", "sha512" };
 
-const std::set<std::string> hashFormats = {"base64", "nix32", "base16", "sri" };
+const StringSet hashFormats = {"base64", "nix32", "base16", "sri" };
 
 Hash::Hash(HashAlgorithm algo, const ExperimentalFeatureSettings & xpSettings) : algo(algo)
 {

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -179,7 +179,7 @@ public:
         using ptr = std::shared_ptr<Flag>;
 
         std::string longName;
-        std::set<std::string> aliases;
+        StringSet aliases;
         char shortName = 0;
         std::string description;
         std::string category;
@@ -263,7 +263,7 @@ protected:
     virtual Strings::iterator rewriteArgs(Strings & args, Strings::iterator pos)
     { return pos; }
 
-    std::set<std::string> hiddenCategories;
+    StringSet hiddenCategories;
 
     /**
      * Called after all command line flags before the first non-flag

--- a/src/libutil/include/nix/util/configuration.hh
+++ b/src/libutil/include/nix/util/configuration.hh
@@ -179,7 +179,7 @@ public:
 
     const std::string name;
     const std::string description;
-    const std::set<std::string> aliases;
+    const StringSet aliases;
 
     int created = 123;
 
@@ -192,7 +192,7 @@ protected:
     AbstractSetting(
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases,
+        const StringSet & aliases,
         std::optional<ExperimentalFeature> experimentalFeature = std::nullopt);
 
     virtual ~AbstractSetting();
@@ -251,7 +251,7 @@ public:
         const bool documentDefault,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {},
+        const StringSet & aliases = {},
         std::optional<ExperimentalFeature> experimentalFeature = std::nullopt)
         : AbstractSetting(name, description, aliases, experimentalFeature)
         , value(def)
@@ -323,7 +323,7 @@ public:
         const T & def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {},
+        const StringSet & aliases = {},
         const bool documentDefault = true,
         std::optional<ExperimentalFeature> experimentalFeature = std::nullopt)
         : BaseSetting<T>(def, documentDefault, name, description, aliases, std::move(experimentalFeature))
@@ -349,7 +349,7 @@ public:
         const Path & def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {});
+        const StringSet & aliases = {});
 
     Path parse(const std::string & str) const override;
 
@@ -371,7 +371,7 @@ public:
         const std::optional<Path> & def,
         const std::string & name,
         const std::string & description,
-        const std::set<std::string> & aliases = {});
+        const StringSet & aliases = {});
 
     std::optional<Path> parse(const std::string & str) const override;
 

--- a/src/libutil/include/nix/util/experimental-features.hh
+++ b/src/libutil/include/nix/util/experimental-features.hh
@@ -76,7 +76,7 @@ std::ostream & operator<<(
  * Parse a set of strings to the corresponding set of experimental
  * features, ignoring (but warning for) any unknown feature.
  */
-std::set<ExperimentalFeature> parseFeatures(const std::set<std::string> &);
+std::set<ExperimentalFeature> parseFeatures(const StringSet &);
 
 /**
  * An experimental feature was required for some (experimental)

--- a/src/libutil/include/nix/util/hash.hh
+++ b/src/libutil/include/nix/util/hash.hh
@@ -20,7 +20,7 @@ const int sha1HashSize = 20;
 const int sha256HashSize = 32;
 const int sha512HashSize = 64;
 
-extern const std::set<std::string> hashAlgorithms;
+extern const StringSet hashAlgorithms;
 
 extern const std::string nix32Chars;
 
@@ -40,7 +40,7 @@ enum struct HashFormat : int {
     SRI
 };
 
-extern const std::set<std::string> hashFormats;
+extern const StringSet hashFormats;
 
 struct Hash
 {

--- a/src/libutil/include/nix/util/json-utils.hh
+++ b/src/libutil/include/nix/util/json-utils.hh
@@ -90,8 +90,8 @@ struct json_avoids_null<std::vector<T>> : std::true_type {};
 template<typename T>
 struct json_avoids_null<std::list<T>> : std::true_type {};
 
-template<typename T>
-struct json_avoids_null<std::set<T>> : std::true_type {};
+template<typename T, typename Compare>
+struct json_avoids_null<std::set<T, Compare>> : std::true_type {};
 
 template<typename K, typename V>
 struct json_avoids_null<std::map<K, V>> : std::true_type {};

--- a/src/libutil/include/nix/util/strings.hh
+++ b/src/libutil/include/nix/util/strings.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "nix/util/types.hh"
+
 #include <list>
 #include <set>
 #include <string_view>
@@ -30,7 +32,7 @@ template<class C>
 C tokenizeString(std::string_view s, std::string_view separators = " \t\n\r");
 
 extern template std::list<std::string> tokenizeString(std::string_view s, std::string_view separators);
-extern template std::set<std::string> tokenizeString(std::string_view s, std::string_view separators);
+extern template StringSet tokenizeString(std::string_view s, std::string_view separators);
 extern template std::vector<std::string> tokenizeString(std::string_view s, std::string_view separators);
 
 /**
@@ -44,7 +46,7 @@ template<typename C>
 C splitString(std::string_view s, std::string_view separators);
 
 extern template std::list<std::string> splitString(std::string_view s, std::string_view separators);
-extern template std::set<std::string> splitString(std::string_view s, std::string_view separators);
+extern template StringSet splitString(std::string_view s, std::string_view separators);
 extern template std::vector<std::string> splitString(std::string_view s, std::string_view separators);
 
 /**
@@ -54,7 +56,7 @@ template<class C>
 std::string concatStringsSep(const std::string_view sep, const C & ss);
 
 extern template std::string concatStringsSep(std::string_view, const std::list<std::string> &);
-extern template std::string concatStringsSep(std::string_view, const std::set<std::string> &);
+extern template std::string concatStringsSep(std::string_view, const StringSet &);
 extern template std::string concatStringsSep(std::string_view, const std::vector<std::string> &);
 extern template std::string concatStringsSep(std::string_view, const boost::container::small_vector<std::string, 64> &);
 
@@ -85,7 +87,7 @@ template<class C>
 dropEmptyInitThenConcatStringsSep(const std::string_view sep, const C & ss);
 
 extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::list<std::string> &);
-extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::set<std::string> &);
+extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const StringSet &);
 extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::vector<std::string> &);
 
 /**

--- a/src/libutil/include/nix/util/suggestions.hh
+++ b/src/libutil/include/nix/util/suggestions.hh
@@ -35,7 +35,7 @@ public:
     ) const;
 
     static Suggestions bestMatches (
-        const std::set<std::string> & allMatches,
+        const StringSet & allMatches,
         std::string_view query
     );
 

--- a/src/libutil/include/nix/util/topo-sort.hh
+++ b/src/libutil/include/nix/util/topo-sort.hh
@@ -5,13 +5,13 @@
 
 namespace nix {
 
-template<typename T>
-std::vector<T> topoSort(std::set<T> items,
-        std::function<std::set<T>(const T &)> getChildren,
+template<typename T, typename Compare>
+std::vector<T> topoSort(std::set<T, Compare> items,
+        std::function<std::set<T, Compare>(const T &)> getChildren,
         std::function<Error(const T &, const T &)> makeCycleError)
 {
     std::vector<T> sorted;
-    std::set<T> visited, parents;
+    decltype(items) visited, parents;
 
     std::function<void(const T & path, const T * parent)> dfsVisit;
 
@@ -21,7 +21,7 @@ std::vector<T> topoSort(std::set<T> items,
         if (!visited.insert(path).second) return;
         parents.insert(path);
 
-        std::set<T> references = getChildren(path);
+        auto references = getChildren(path);
 
         for (auto & i : references)
             /* Don't traverse into items that don't exist in our starting set. */

--- a/src/libutil/include/nix/util/types.hh
+++ b/src/libutil/include/nix/util/types.hh
@@ -12,9 +12,21 @@
 namespace nix {
 
 typedef std::list<std::string> Strings;
-typedef std::set<std::string> StringSet;
 typedef std::map<std::string, std::string> StringMap;
 typedef std::map<std::string, std::string> StringPairs;
+
+/**
+ * Alias to ordered set container with transparent comparator.
+ *
+ * Used instead of std::set<std::string> to use C++14 N3657 [1]
+ * heterogenous lookup consistently across the whole codebase.
+ * Transparent comparators get rid of creation of unnecessary
+ * temporary variables when looking up keys by `std::string_view`
+ * or C-style `const char *` strings.
+ *
+ * [1]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3657.htm
+ */
+using StringSet = std::set<std::string, std::less<>>;
 
 /**
  * Paths are just strings.
@@ -22,7 +34,13 @@ typedef std::map<std::string, std::string> StringPairs;
 typedef std::string Path;
 typedef std::string_view PathView;
 typedef std::list<Path> Paths;
-typedef std::set<Path> PathSet;
+
+/**
+ * Alias to an ordered set of `Path`s. Uses transparent comparator.
+ *
+ * @see StringSet
+ */
+using PathSet = std::set<Path, std::less<>>;
 
 typedef std::vector<std::pair<std::string, std::string>> Headers;
 

--- a/src/libutil/strings.cc
+++ b/src/libutil/strings.cc
@@ -26,18 +26,18 @@ __attribute__((no_sanitize("undefined"))) std::string_view toView(const std::ost
 }
 
 template std::list<std::string> tokenizeString(std::string_view s, std::string_view separators);
-template std::set<std::string> tokenizeString(std::string_view s, std::string_view separators);
+template StringSet tokenizeString(std::string_view s, std::string_view separators);
 template std::vector<std::string> tokenizeString(std::string_view s, std::string_view separators);
 
 template std::list<std::string> splitString(std::string_view s, std::string_view separators);
-template std::set<std::string> splitString(std::string_view s, std::string_view separators);
+template StringSet splitString(std::string_view s, std::string_view separators);
 template std::vector<std::string> splitString(std::string_view s, std::string_view separators);
 
 template std::list<OsString>
 basicSplitString(std::basic_string_view<OsChar> s, std::basic_string_view<OsChar> separators);
 
 template std::string concatStringsSep(std::string_view, const std::list<std::string> &);
-template std::string concatStringsSep(std::string_view, const std::set<std::string> &);
+template std::string concatStringsSep(std::string_view, const StringSet &);
 template std::string concatStringsSep(std::string_view, const std::vector<std::string> &);
 template std::string concatStringsSep(std::string_view, const boost::container::small_vector<std::string, 64> &);
 
@@ -49,7 +49,7 @@ typedef std::string_view strings_4[4];
 template std::string concatStringsSep(std::string_view, const strings_4 &);
 
 template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::list<std::string> &);
-template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::set<std::string> &);
+template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const StringSet &);
 template std::string dropEmptyInitThenConcatStringsSep(std::string_view, const std::vector<std::string> &);
 
 /**

--- a/src/libutil/suggestions.cc
+++ b/src/libutil/suggestions.cc
@@ -38,7 +38,7 @@ int levenshteinDistance(std::string_view first, std::string_view second)
 }
 
 Suggestions Suggestions::bestMatches (
-    const std::set<std::string> & allMatches,
+    const StringSet & allMatches,
     std::string_view query)
 {
     std::set<Suggestion> res;

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -147,7 +147,7 @@ static void main_nix_build(int argc, char * * argv)
     std::string outLink = "./result";
 
     // List of environment variables kept for --pure
-    std::set<std::string> keepVars{
+    StringSet keepVars{
         "HOME", "XDG_RUNTIME_DIR", "USER", "LOGNAME", "DISPLAY",
         "WAYLAND_DISPLAY", "WAYLAND_SOCKET", "PATH", "TERM", "IN_NIX_SHELL",
         "NIX_SHELL_PRESERVE_PROMPT", "TZ", "PAGER", "NIX_BUILD_SHELL", "SHLVL",

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -238,9 +238,9 @@ static void checkSelectorUse(DrvNames & selectors)
 
 namespace {
 
-std::set<std::string> searchByPrefix(const PackageInfos & allElems, std::string_view prefix) {
+StringSet searchByPrefix(const PackageInfos & allElems, std::string_view prefix) {
     constexpr std::size_t maxResults = 3;
-    std::set<std::string> result;
+    StringSet result;
     for (const auto & packageInfo : allElems) {
         const auto drvName = DrvName { packageInfo.queryName() };
         if (hasPrefix(drvName.name, prefix)) {

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -67,7 +67,7 @@ struct BuildEnvironment
     {
         BuildEnvironment res;
 
-        std::set<std::string> exported;
+        StringSet exported;
 
         for (auto & [name, info] : json["variables"].items()) {
             std::string type = info["type"];
@@ -151,7 +151,7 @@ struct BuildEnvironment
         return structuredAttrs->second;
     }
 
-    void toBash(std::ostream & out, const std::set<std::string> & ignoreVars) const
+    void toBash(std::ostream & out, const StringSet & ignoreVars) const
     {
         for (auto & [name, value] : vars) {
             if (!ignoreVars.count(name)) {
@@ -308,7 +308,7 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
 
 struct Common : InstallableCommand, MixProfile
 {
-    std::set<std::string> ignoreVars{
+    StringSet ignoreVars{
         "BASHOPTS",
         "HOME", // FIXME: don't ignore in pure mode?
         "NIX_BUILD_TOP",

--- a/src/nix/diff-closures.cc
+++ b/src/nix/diff-closures.cc
@@ -47,10 +47,10 @@ GroupedPaths getClosureInfo(ref<Store> store, const StorePath & toplevel)
     return groupedPaths;
 }
 
-std::string showVersions(const std::set<std::string> & versions)
+std::string showVersions(const StringSet & versions)
 {
     if (versions.empty()) return "∅";
-    std::set<std::string> versions2;
+    StringSet versions2;
     for (auto & version : versions)
         versions2.insert(version.empty() ? "ε" : version);
     return concatStringsSep(", ", versions2);
@@ -65,7 +65,7 @@ void printClosureDiff(
     auto beforeClosure = getClosureInfo(store, beforePath);
     auto afterClosure = getClosureInfo(store, afterPath);
 
-    std::set<std::string> allNames;
+    StringSet allNames;
     for (auto & [name, _] : beforeClosure) allNames.insert(name);
     for (auto & [name, _] : afterClosure) allNames.insert(name);
 
@@ -87,11 +87,11 @@ void printClosureDiff(
         auto sizeDelta = (int64_t) afterSize - (int64_t) beforeSize;
         auto showDelta = std::abs(sizeDelta) >= 8 * 1024;
 
-        std::set<std::string> removed, unchanged;
+        StringSet removed, unchanged;
         for (auto & [version, _] : beforeVersions)
             if (!afterVersions.count(version)) removed.insert(version); else unchanged.insert(version);
 
-        std::set<std::string> added;
+        StringSet added;
         for (auto & [version, _] : afterVersions)
             if (!beforeVersions.count(version)) added.insert(version);
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -386,7 +386,7 @@ struct CmdFlakeCheck : FlakeCommand
             }
         };
 
-        std::set<std::string> omittedSystems;
+        StringSet omittedSystems;
 
         // FIXME: rewrite to use EvalCache.
 

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -67,7 +67,7 @@ struct ProfileElement
      * Return a string representing an installable corresponding to the current
      * element, either a flakeref or a plain store path
      */
-    std::set<std::string> toInstallables(Store & store)
+    StringSet toInstallables(Store & store)
     {
         if (source)
             return {source->to_string()};
@@ -600,7 +600,7 @@ public:
         });
     }
 
-    std::set<std::string> getMatchingElementNames(ProfileManifest & manifest) {
+    StringSet getMatchingElementNames(ProfileManifest & manifest) {
         if (_matchers.empty()) {
             throw UsageError("No packages specified.");
         }
@@ -614,7 +614,7 @@ public:
             return {};
         }
 
-        std::set<std::string> result;
+        StringSet result;
         for (auto & matcher : _matchers) {
             bool foundMatch = false;
             for (auto & [name, element] : manifest.elements) {

--- a/src/nix/why-depends.cc
+++ b/src/nix/why-depends.cc
@@ -193,7 +193,7 @@ struct CmdWhyDepends : SourceExprCommand, MixOperateOnOptions
             /* Sort the references by distance to `dependency` to
                ensure that the shortest path is printed first. */
             std::multimap<size_t, Node *> refs;
-            std::set<std::string> hashes;
+            StringSet hashes;
 
             for (auto & ref : node.refs) {
                 if (ref == node.path && packagePath != dependencyPath) continue;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

There's no functional change and string lookups in sets are now more efficient
and don't produce temporaries (e.g. `set.find(std::string_view{"key"})`).

Review commit-by-commit. First three patches are straightforward renames and the 
final commit has the meaningful manual changes. 

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Relates to https://github.com/NixOS/nix/issues/6519 somewhat.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
