### PR TITLE
libexpr: Remove unused field from SymbolTable::symbols and emplace in…

### DIFF
--- a/src/libutil/include/nix/util/chunked-vector.hh
+++ b/src/libutil/include/nix/util/chunked-vector.hh
@@ -45,9 +45,10 @@ public:
         addChunk();
     }
 
-    uint32_t size() const { return size_; }
+    uint32_t size() const noexcept { return size_; }
 
-    std::pair<T &, uint32_t> add(T value)
+    template <typename... Args>
+    std::pair<T &, uint32_t> add(Args &&... args)
     {
         const auto idx = size_++;
         auto & chunk = [&] () -> auto & {
@@ -55,11 +56,16 @@ public:
                 return back;
             return addChunk();
         }();
-        auto & result = chunk.emplace_back(std::move(value));
+        auto & result = chunk.emplace_back(std::forward<Args>(args)...);
         return {result, idx};
     }
 
-    const T & operator[](uint32_t idx) const
+    /**
+     * Unchecked subscript operator.
+     * @pre add must have been called at least idx + 1 times.
+     * @throws nothing
+     */
+    const T & operator[](uint32_t idx) const noexcept
     {
         return chunks[idx / ChunkSize][idx % ChunkSize];
     }


### PR DESCRIPTION
…to the ChunkedVector.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Remove outdated and no longer relevant `TODO`. It's more confusing now, since symbol table must now be addressed by uint32_t indices in order to keep `Attr` size down to 16 bytes on 64 bit machines.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
