### PR TITLE
cgroups: reapp child processes before destroying cgroup

### DIFF
--- a/src/libutil/linux/cgroup.cc
+++ b/src/libutil/linux/cgroup.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <regex>
 #include <unordered_set>
+#include <sys/wait.h>
 #include <thread>
 
 #include <dirent.h>
@@ -101,6 +102,11 @@ static CgroupStats destroyCgroup(const std::filesystem::path & cgroup, bool retu
             // FIXME: pid wraparound
             if (kill(pid, SIGKILL) == -1 && errno != ESRCH)
                 throw SysError("killing member %d of cgroup '%s'", pid, cgroup);
+
+            while (waitpid(pid, nullptr, 0) == -1) {
+                if (errno == ECHILD) break; // Process already reaped
+                if (errno != EINTR) throw SysError("waiting for pid %d", pid);
+            }
         }
 
         auto sleep = std::chrono::milliseconds((int) std::pow(2.0, std::min(round, 10)));


### PR DESCRIPTION
killing is enough to destroy a cgroup, we need to remove the wait state of zombie processes before we can destroy the cgroup.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
