### PR TITLE
libexpr: Use C++20 heterogeneous lookup for RegexCache

### DIFF
--- a/src/libutil/include/nix/util/strings.hh
+++ b/src/libutil/include/nix/util/strings.hh
@@ -97,4 +97,39 @@ extern template std::string dropEmptyInitThenConcatStringsSep(std::string_view, 
  * Arguments that need to be passed to ssh with spaces in them.
  */
 std::list<std::string> shellSplitString(std::string_view s);
+
+/**
+ * Hash implementation that can be used for zero-copy heterogenous lookup from
+ * P1690R1[1] in unordered containers.
+ *
+ * [1]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1690r1.html
+ */
+struct StringViewHash
+{
+private:
+    using HashType = std::hash<std::string_view>;
+
+public:
+    using is_transparent = void;
+
+    auto operator()(const char * str) const
+    {
+        /* This has a slight overhead due to an implicit strlen, but there isn't
+           a good way around it because the hash value of all overloads must be
+           consistent. Delegating to string_view is the solution initially proposed
+           in P0919R3. */
+        return HashType{}(std::string_view{str});
+    }
+
+    auto operator()(std::string_view str) const
+    {
+        return HashType{}(str);
+    }
+
+    auto operator()(const std::string & str) const
+    {
+        return HashType{}(std::string_view{str});
+    }
+};
+
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Resolving a TODO and making progress on switching to transparent hash/equal from C++20's P0919R3 [1] and P1690R1 [2].

[1]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0919r3.html
[2]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1690r1.html
 
 > [!NOTE]  
> Maybe `RegexCache` really ought to be `LRUCache`? The transparent comparator/functor/hash improvements could be ported over to that as well. Having an unbounded memoization might be somewhat problematic if there are lots of different regexes used in the nix expressions.
 
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
