### PR TITLE
Register builtin builders

### DIFF
--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -167,17 +167,15 @@ void buildProfile(const Path & out, Packages && pkgs)
     debug("created %d symlinks in user environment", state.symlinks);
 }
 
-static void builtinBuildenv(
-    const BasicDerivation & drv,
-    const std::map<std::string, Path> & outputs)
+static void builtinBuildenv(const BuiltinBuilderContext & ctx)
 {
     auto getAttr = [&](const std::string & name) {
-        auto i = drv.env.find(name);
-        if (i == drv.env.end()) throw Error("attribute '%s' missing", name);
+        auto i = ctx.drv.env.find(name);
+        if (i == ctx.drv.env.end()) throw Error("attribute '%s' missing", name);
         return i->second;
     };
 
-    auto out = outputs.at("out");
+    auto out = ctx.outputs.at("out");
     createDirs(out);
 
     /* Convert the stuff we get from the environment back into a

--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -1,4 +1,5 @@
 #include "nix/store/builtins/buildenv.hh"
+#include "nix/store/builtins.hh"
 #include "nix/store/derivations.hh"
 #include "nix/util/signals.hh"
 
@@ -166,7 +167,7 @@ void buildProfile(const Path & out, Packages && pkgs)
     debug("created %d symlinks in user environment", state.symlinks);
 }
 
-void builtinBuildenv(
+static void builtinBuildenv(
     const BasicDerivation & drv,
     const std::map<std::string, Path> & outputs)
 {
@@ -202,5 +203,7 @@ void builtinBuildenv(
 
     createSymlink(getAttr("manifest"), out + "/manifest.nix");
 }
+
+static RegisterBuiltinBuilder registerBuildenv("buildenv", builtinBuildenv);
 
 }

--- a/src/libstore/builtins/unpack-channel.cc
+++ b/src/libstore/builtins/unpack-channel.cc
@@ -3,7 +3,7 @@
 
 namespace nix {
 
-void builtinUnpackChannel(
+static void builtinUnpackChannel(
     const BasicDerivation & drv,
     const std::map<std::string, Path> & outputs)
 {
@@ -41,5 +41,7 @@ void builtinUnpackChannel(
         throw SysError("failed to rename %1% to %2%", fileName, target.string());
     }
 }
+
+static RegisterBuiltinBuilder registerUnpackChannel("unpack-channel", builtinUnpackChannel);
 
 }

--- a/src/libstore/builtins/unpack-channel.cc
+++ b/src/libstore/builtins/unpack-channel.cc
@@ -3,17 +3,15 @@
 
 namespace nix {
 
-static void builtinUnpackChannel(
-    const BasicDerivation & drv,
-    const std::map<std::string, Path> & outputs)
+static void builtinUnpackChannel(const BuiltinBuilderContext & ctx)
 {
     auto getAttr = [&](const std::string & name) -> const std::string & {
-        auto i = drv.env.find(name);
-        if (i == drv.env.end()) throw Error("attribute '%s' missing", name);
+        auto i = ctx.drv.env.find(name);
+        if (i == ctx.drv.env.end()) throw Error("attribute '%s' missing", name);
         return i->second;
     };
 
-    std::filesystem::path out{outputs.at("out")};
+    std::filesystem::path out{ctx.outputs.at("out")};
     auto & channelName = getAttr("channelName");
     auto & src = getAttr("src");
 

--- a/src/libstore/include/nix/store/builtins.hh
+++ b/src/libstore/include/nix/store/builtins.hh
@@ -11,6 +11,7 @@ struct BuiltinBuilderContext
     std::map<std::string, Path> outputs;
     std::string netrcData;
     std::string caFileData;
+    Path tmpDirInSandbox;
 };
 
 using BuiltinBuilder = std::function<void(const BuiltinBuilderContext &)>;

--- a/src/libstore/include/nix/store/builtins.hh
+++ b/src/libstore/include/nix/store/builtins.hh
@@ -19,12 +19,15 @@ using BuiltinBuilder = std::function<void(const BuiltinBuilderContext &)>;
 struct RegisterBuiltinBuilder
 {
     typedef std::map<std::string, BuiltinBuilder> BuiltinBuilders;
-    static BuiltinBuilders * builtinBuilders;
+
+    static BuiltinBuilders & builtinBuilders() {
+        static BuiltinBuilders builders;
+        return builders;
+    }
 
     RegisterBuiltinBuilder(const std::string & name, BuiltinBuilder && fun)
     {
-        if (!builtinBuilders) builtinBuilders = new BuiltinBuilders;
-        builtinBuilders->insert_or_assign(name, std::move(fun));
+        builtinBuilders().insert_or_assign(name, std::move(fun));
     }
 };
 

--- a/src/libstore/include/nix/store/builtins.hh
+++ b/src/libstore/include/nix/store/builtins.hh
@@ -12,8 +12,19 @@ void builtinFetchurl(
     const std::string & netrcData,
     const std::string & caFileData);
 
-void builtinUnpackChannel(
-    const BasicDerivation & drv,
-    const std::map<std::string, Path> & outputs);
+using BuiltinBuilder =
+    std::function<void(const BasicDerivation & drv, const std::map<std::string, Path> & outputs)>;
+
+struct RegisterBuiltinBuilder
+{
+    typedef std::map<std::string, BuiltinBuilder> BuiltinBuilders;
+    static BuiltinBuilders * builtinBuilders;
+
+    RegisterBuiltinBuilder(const std::string & name, BuiltinBuilder && fun)
+    {
+        if (!builtinBuilders) builtinBuilders = new BuiltinBuilders;
+        builtinBuilders->insert_or_assign(name, std::move(fun));
+    }
+};
 
 }

--- a/src/libstore/include/nix/store/builtins.hh
+++ b/src/libstore/include/nix/store/builtins.hh
@@ -5,15 +5,15 @@
 
 namespace nix {
 
-// TODO: make pluggable.
-void builtinFetchurl(
-    const BasicDerivation & drv,
-    const std::map<std::string, Path> & outputs,
-    const std::string & netrcData,
-    const std::string & caFileData);
+struct BuiltinBuilderContext
+{
+    const BasicDerivation & drv;
+    std::map<std::string, Path> outputs;
+    std::string netrcData;
+    std::string caFileData;
+};
 
-using BuiltinBuilder =
-    std::function<void(const BasicDerivation & drv, const std::map<std::string, Path> & outputs)>;
+using BuiltinBuilder = std::function<void(const BuiltinBuilderContext &)>;
 
 struct RegisterBuiltinBuilder
 {

--- a/src/libstore/include/nix/store/builtins/buildenv.hh
+++ b/src/libstore/include/nix/store/builtins/buildenv.hh
@@ -45,8 +45,4 @@ typedef std::vector<Package> Packages;
 
 void buildProfile(const Path & out, Packages && pkgs);
 
-void builtinBuildenv(
-    const BasicDerivation & drv,
-    const std::map<std::string, Path> & outputs);
-
 }

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1835,9 +1835,6 @@ void setupSeccomp()
 }
 
 
-RegisterBuiltinBuilder::BuiltinBuilders * RegisterBuiltinBuilder::builtinBuilders = nullptr;
-
-
 void DerivationBuilderImpl::runChild()
 {
     /* Warning: in the child we should absolutely not make any SQLite
@@ -2298,7 +2295,7 @@ void DerivationBuilderImpl::runChild()
 
                 std::string builtinName = drv.builder.substr(8);
                 assert(RegisterBuiltinBuilder::builtinBuilders);
-                if (auto builtin = get(*RegisterBuiltinBuilder::builtinBuilders, builtinName))
+                if (auto builtin = get(RegisterBuiltinBuilder::builtinBuilders(), builtinName))
                     (*builtin)(ctx);
                 else
                     throw Error("unsupported builtin builder '%1%'", builtinName);

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1860,15 +1860,15 @@ void DerivationBuilderImpl::runChild()
         /* Make the contents of netrc and the CA certificate bundle
            available to builtin:fetchurl (which may run under a
            different uid and/or in a sandbox). */
-        std::string netrcData;
-        std::string caFileData;
+        BuiltinBuilderContext ctx{.drv = drv};
+
         if (drv.isBuiltin() && drv.builder == "builtin:fetchurl") {
            try {
-               netrcData = readFile(settings.netrcFile);
+               ctx.netrcData = readFile(settings.netrcFile);
            } catch (SystemError &) { }
 
            try {
-               caFileData = readFile(settings.caFile);
+               ctx.caFileData = readFile(settings.caFile);
            } catch (SystemError &) { }
         }
 
@@ -2289,21 +2289,16 @@ void DerivationBuilderImpl::runChild()
             try {
                 logger = makeJSONLogger(getStandardError());
 
-                std::map<std::string, Path> outputs;
                 for (auto & e : drv.outputs)
-                    outputs.insert_or_assign(e.first,
+                    ctx.outputs.insert_or_assign(e.first,
                         store.printStorePath(scratchOutputs.at(e.first)));
 
-                if (drv.builder == "builtin:fetchurl")
-                    builtinFetchurl(drv, outputs, netrcData, caFileData);
-                else {
-                    std::string builtinName = drv.builder.substr(8);
-                    assert(RegisterBuiltinBuilder::builtinBuilders);
-                    if (auto builtin = get(*RegisterBuiltinBuilder::builtinBuilders, builtinName))
-                        (*builtin)(drv, outputs);
-                    else
-                        throw Error("unsupported builtin builder '%1%'", builtinName);
-                }
+                std::string builtinName = drv.builder.substr(8);
+                assert(RegisterBuiltinBuilder::builtinBuilders);
+                if (auto builtin = get(*RegisterBuiltinBuilder::builtinBuilders, builtinName))
+                    (*builtin)(ctx);
+                else
+                    throw Error("unsupported builtin builder '%1%'", builtinName);
                 _exit(0);
             } catch (std::exception & e) {
                 writeFull(STDERR_FILENO, e.what() + std::string("\n"));

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1860,7 +1860,10 @@ void DerivationBuilderImpl::runChild()
         /* Make the contents of netrc and the CA certificate bundle
            available to builtin:fetchurl (which may run under a
            different uid and/or in a sandbox). */
-        BuiltinBuilderContext ctx{.drv = drv};
+        BuiltinBuilderContext ctx{
+            .drv = drv,
+            .tmpDirInSandbox = tmpDirInSandbox,
+        };
 
         if (drv.isBuiltin() && drv.builder == "builtin:fetchurl") {
            try {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This makes the builtin builders (`builtin:fetchurl` etc) register themselves at runtime, so that `DerivationBuilderImpl::runChild()` doesn't need to know about them.

## Context

I want to add a `builtin:fetch-tree` builtin builder (https://github.com/DeterminateSystems/nix-src/pull/49). However, this would require `libstore` to depend on `libfetchers`, which would be a cyclic dependency. So we need to be able to define builtin builders outside of `libstore`.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
