### PR TITLE
Expose flake directory to `nix fmt` as `PRJ_ROOT` env var

### DIFF
--- a/src/nix/formatter-run.md
+++ b/src/nix/formatter-run.md
@@ -8,6 +8,10 @@ Flags can be forwarded to the formatter by using `--` followed by the flags.
 
 Any arguments will be forwarded to the formatter. Typically these are the files to format.
 
+The environment variable `PRJ_ROOT` (according to [prj-spec](https://github.com/numtide/prj-spec))
+will be set to the absolute path to the directory containing the closest parent `flake.nix`
+relative to the current directory.
+
 
 # Example
 

--- a/src/nix/formatter.cc
+++ b/src/nix/formatter.cc
@@ -1,8 +1,10 @@
 #include "nix/cmd/command.hh"
+#include "nix/cmd/installable-flake.hh"
 #include "nix/cmd/installable-value.hh"
 #include "nix/expr/eval.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/cmd/installable-derived-path.hh"
+#include "nix/util/environment-variables.hh"
 #include "run.hh"
 
 using namespace nix;
@@ -72,9 +74,13 @@ struct CmdFormatterRun : MixFormatter, MixJSON
         auto evalState = getEvalState();
         auto evalStore = getEvalStore();
 
-        auto installable_ = parseInstallable(store, ".");
+        auto installable_ = parseInstallable(store, ".").cast<InstallableFlake>();
         auto & installable = InstallableValue::require(*installable_);
         auto app = installable.toApp(*evalState).resolve(evalStore, store);
+
+        auto maybeFlakeDir = installable_->flakeRef.input.getSourcePath();
+        assert(maybeFlakeDir.has_value());
+        auto flakeDir = maybeFlakeDir.value();
 
         Strings programArgs{app.program};
 
@@ -83,11 +89,22 @@ struct CmdFormatterRun : MixFormatter, MixJSON
             programArgs.push_back(i);
         }
 
+        // Add the path to the flake as an environment variable. This enables formatters to format the entire flake even
+        // if run from a subdirectory.
+        StringMap env = getEnv();
+        env["PRJ_ROOT"] = flakeDir;
+
         // Release our references to eval caches to ensure they are persisted to disk, because
         // we are about to exec out of this process without running C++ destructors.
         evalState->evalCaches.clear();
 
-        execProgramInStore(store, UseLookupPath::DontUse, app.program, programArgs);
+        execProgramInStore(
+            store,
+            UseLookupPath::DontUse,
+            app.program,
+            programArgs,
+            std::nullopt, // Use default system
+            env);
     };
 };
 

--- a/src/nix/run.hh
+++ b/src/nix/run.hh
@@ -14,6 +14,7 @@ void execProgramInStore(ref<Store> store,
     UseLookupPath useLookupPath,
     const std::string & program,
     const Strings & args,
-    std::optional<std::string_view> system = std::nullopt);
+    std::optional<std::string_view> system = std::nullopt,
+    std::optional<StringMap> env = std::nullopt);
 
 }

--- a/tests/functional/formatter.simple.sh
+++ b/tests/functional/formatter.simple.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-echo "Formatting(${#}):" "${@}"
+echo "PRJ_ROOT=$PRJ_ROOT Formatting(${#}):" "${@}"


### PR DESCRIPTION
This was discussed in https://github.com/NixOS/nix/issues/8034.

I only implemented this for `nix fmt` because it doesn't let you point
at a flake not on your filesystem.


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
