### PR TITLE
Reduce maxLayers to 70 in docker build

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -7,7 +7,7 @@
   channelName ? "nixpkgs",
   channelURL ? "https://nixos.org/channels/nixpkgs-unstable",
   extraPkgs ? [ ],
-  maxLayers ? 100,
+  maxLayers ? 70,
   nixConf ? { },
   flake-registry ? null,
   uid ? 0,


### PR DESCRIPTION
Hey folks :heart: 

This is a single commit, reducing the maxLayers in the docker build from 100 to 70.

## Motivation

The nixos/nix docker image is built using `buildLayeredImage`, which spreads the nix store over a configured number of layers. This number was set to create an image with 100 layers. Because there is a limit of (typically) 127 layers in AUFS, this only left 27 layers to build on top. At the same time, nearly half of the created layers were only <100kb in size, many even <10kb, negating the intended advantage in cachability.

## Context

Layer sizes for the 2.28.3 nixos/nix image: https://hub.docker.com/layers/nixos/nix/2.28.3/images/sha256-d078d7153763895fce17c5fbbdeb86fcfcac414ca0ba875d413c1df57be19931