### PR TITLE
Avoid unnecessarily updating old lock files with 'dir' parameters

### DIFF
--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -595,7 +595,7 @@ LockedFlake lockFlake(
                                 oldLock = *oldLock3;
 
                     if (oldLock
-                        && oldLock->originalRef == *input.ref
+                        && oldLock->originalRef.canonicalize() == input.ref->canonicalize()
                         && oldLock->parentInputAttrPath == overridenParentPath
                         && !hasCliOverride)
                     {

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -72,6 +72,12 @@ struct FlakeRef
         const fetchers::Attrs & attrs);
 
     std::pair<ref<SourceAccessor>, FlakeRef> lazyFetch(ref<Store> store) const;
+
+    /**
+     * Canonicalize a flakeref for the purpose of comparing "old" and
+     * "new" `original` fields in lock files.
+     */
+    FlakeRef canonicalize() const;
 };
 
 std::ostream & operator << (std::ostream & str, const FlakeRef & flakeRef);

--- a/tests/functional/flakes/meson.build
+++ b/tests/functional/flakes/meson.build
@@ -32,6 +32,7 @@ suites += {
     'symlink-paths.sh',
     'debugger.sh',
     'source-paths.sh',
+    'old-lockfiles.sh',
   ],
   'workdir': meson.current_source_dir(),
 }

--- a/tests/functional/flakes/old-lockfiles.sh
+++ b/tests/functional/flakes/old-lockfiles.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+
+requireGit
+
+repo="$TEST_ROOT/repo"
+
+createGitRepo "$repo"
+
+cat > "$repo/flake.nix" <<EOF
+{
+  inputs = {
+    dependency.url = "git+file:///no-such-path?dir=subdir";
+  };
+  outputs = { dependency, self }: {
+    hi = dependency.an_output;
+  };
+}
+EOF
+
+cat > "$repo/flake.lock" <<EOF
+{
+  "nodes": {
+    "dependency": {
+      "locked": {
+        "dir": "subdir",
+        "lastModified": 1746721011,
+        "narHash": "sha256-9aIDvIdyHAfQyvT5SwPgYxUUhf1GwQVAWq+qa5LcEQE=",
+        "ref": "refs/heads/master",
+        "rev": "432058dbfc82b0369bc9cce440e4af2aece52b54",
+        "revCount": 1,
+        "type": "git",
+        "url": "file:///no-such-path?dir=subdir"
+      },
+      "original": {
+        "dir": "subdir",
+        "type": "git",
+        "url": "file:///no-such-path?dir=subdir"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dependency": "dependency"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+EOF
+
+git -C "$repo" add flake.nix flake.lock
+git -C "$repo" commit -a -m foo
+
+cp "$repo/flake.lock" "$repo/flake.lock.old"
+
+nix flake lock "$repo"
+
+cmp "$repo/flake.lock" "$repo/flake.lock.old"


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

In old versions of Nix, if you had a flake input like
```nix
inputs.foo.url = "git+https://foo/bar?dir=subdir";
```
it would result in a lock file entry like
```json
"original": {
  "dir": "subdir",
  "type": "git",
  "url": "https://foo/bar?dir=subdir"
}
```

New versions of Nix remove `?dir=subdir` from the `url` field, since the subdirectory is intended for `FlakeRef`, not the fetcher (and specifically the remote server), that is, the flakeref is parsed into
```json
"original": {
  "dir": "subdir",
  "type": "git",
  "url": "https://foo/bar"
}
```

However, this causes new versions of Nix to consider the lock file entry to be stale since the `original` ref no longer matches exactly.

For this reason, we now canonicalise the `original` ref by filtering the `dir` query parameter from the URL.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
