### PR TITLE
index.md: add warning for installing as root

### DIFF
--- a/doc/manual/source/installation/index.md
+++ b/doc/manual/source/installation/index.md
@@ -30,6 +30,8 @@ $ curl -L https://nixos.org/nix/install | sh -s -- --daemon
 
 > Single-user is not supported on Mac.
 
+> `warning: installing Nix as root is not supported by this script!`
+
 This installation has less requirements than the multi-user install, however it
 cannot offer equivalent sharing, isolation, or security.
 


### PR DESCRIPTION
Can't install as root:
```console
#  bash <(curl -L https://nixos.org/nix/install) --no-daemon
...
warning: installing Nix as root is not supported by this script!
performing a single-user installation of Nix...
copying Nix to /nix/store....................................................... ......
warning: the group 'nixbld' specified in 'build-users-group' does not exist
warning: the group 'nixbld' specified in 'build-users-group' does not exist
installing 'nix-2.28.3'
error: the group 'nixbld' specified in 'build-users-group' does not exist
/tmp/nix-binary-tarball-unpack.2j3lCU0A89/unpack/nix-2.28.3-x86_64-linux/install: unable to install Nix into your default profile
#
```