### PR TITLE
Improve 'cannot read file from tarball' error

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -215,7 +215,7 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
                     std::vector<unsigned char> buf(128 * 1024);
                     auto n = archive_read_data(archive.archive, buf.data(), buf.size());
                     if (n < 0)
-                        throw Error("cannot read file '%s' from tarball", path);
+                        checkLibArchive(archive.archive, n, "cannot read file from tarball: %s");
                     if (n == 0)
                         break;
                     crf(std::string_view{


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This improves the error message when GitHub sends a truncated tarball (in particular this was happening in a flake regression test, see https://github.com/informalsystems/cosmos.nix/issues/284). It now says e.g.
```
error: cannot read file from tarball: Truncated tar archive detected while reading data
```
instead of
```
error: cannot read file 'osmosis-labs-osmosis-b0aee00/ingest/sqs/router/usecase/routertesting/parsing/pools.json' from tarball
```

It would be even better to show the HTTP error, but it's not clear there is one, since the debug output shows:
```
curl: HTTP/2 stream 1 was not closed cleanly: CANCEL (err 8)
finished download of 'https://api.github.com/repos/osmosis-labs/osmosis/tarball/b0aee0006ce55d0851773084bd7880db7e32ad70'; curl status = 92, HTTP status = 200, body = 20447232 bytes, duration = 121.86 s
```

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
