### PR TITLE
libutil/tarfile: Create the scratch `std::vector` only once

### DIFF
--- a/src/libutil/tarfile.cc
+++ b/src/libutil/tarfile.cc
@@ -178,6 +178,10 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
 {
     time_t lastModified = 0;
 
+    /* Only allocate the buffer once. Use the heap because 131 KiB is a bit too
+       much for the stack. */
+    std::vector<unsigned char> buf(128 * 1024);
+
     for (;;) {
         // FIXME: merge with extract_archive
         struct archive_entry * entry;
@@ -212,7 +216,6 @@ time_t unpackTarfileToSink(TarArchive & archive, ExtendedFileSystemObjectSink & 
                     crf.isExecutable();
 
                 while (true) {
-                    std::vector<unsigned char> buf(128 * 1024);
                     auto n = archive_read_data(archive.archive, buf.data(), buf.size());
                     if (n < 0)
                         throw Error("cannot read file '%s' from tarball", path);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

AFAICT there is no reason to keep a copy of the data since it always gets fed into the sink and there are no coroutines/threads in sight.

I can't find a good way to benchmark in isolation from the git cache, but common sense dictates that creating (and destroying) a 131KiB `std::vector` for each 131KiB chunk of a regular file from the archive imposes quite a significant overhead regardless of the IO bound git cache.

cc @edolstra git blame points me to https://github.com/NixOS/nix/pull/9485 for when this was first introduced. Since then code was moved quite a bit by @Ericson2314. Is there some reason this was done this way and stuff just got lost during refactorings?

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Should help a bit with https://github.com/NixOS/nix/issues/10683

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
