### PR TITLE
Revert #77

### DIFF
--- a/doc/manual/rl-next/revert-77.md
+++ b/doc/manual/rl-next/revert-77.md
@@ -1,0 +1,17 @@
+---
+synopsis: Revert incomplete closure mixed download and build feature
+issues: [77, 12628]
+prs: [13176]
+---
+
+Since Nix 1.3 (299141ecbd08bae17013226dbeae71e842b4fdd7 in 2013) Nix has attempted to mix together upstream fresh builds and downstream substitutions when remote substuters contain an "incomplete closure" (have some store objects, but not the store objects they reference).
+This feature is now removed.
+
+Worst case, removing this feature could cause more building downstream, but it should not cause outright failures, since this is not happening for opaque store objects that we don't know how to build if we decide not to substitute.
+In practice, however, we doubt even the more building is very likely to happen.
+Remote stores that are missing dependencies in arbitrary ways (e.g. corruption) don't seem to be very common.
+
+On the contrary, when remote stores fail to implement the [closure property](@docroot@/store/store-object.md#closure-property), it is usually an *intentional* choice on the part of the remote store, because it wishes to serve as an "overlay" store over another store, such as `https://cache.nixos.org`.
+If an "incomplete closure" is encountered in that situation, the right fix is not to do some sort of "franken-building" as this feature implemented, but instead to make sure both substituters are enabled in the settings.
+
+(In the future, we should make it easier for remote stores to indicate this to clients, to catch settings that won't work in general before a missing dependency is actually encountered.)

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -139,7 +139,7 @@ Goal::Co DrvOutputSubstitutionGoal::realisationFetched(Goals waitees, std::share
 
     if (nrFailed > 0) {
         debug("The output path of the derivation output '%s' could not be substituted", id.to_string());
-        co_return amDone(nrNoSubstituters > 0 || nrIncompleteClosure > 0 ? ecIncompleteClosure : ecFailed);
+        co_return amDone(nrNoSubstituters > 0 ? ecNoSubstituters : ecFailed);
     }
 
     worker.store.registerDrvOutput(*outputInfo);

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -151,7 +151,7 @@ Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
     trace("done");
     assert(top_co);
     assert(exitCode == ecBusy);
-    assert(result == ecSuccess || result == ecFailed || result == ecNoSubstituters || result == ecIncompleteClosure);
+    assert(result == ecSuccess || result == ecFailed || result == ecNoSubstituters);
     exitCode = result;
 
     if (ex) {
@@ -170,11 +170,9 @@ Goal::Done Goal::amDone(ExitCode result, std::optional<Error> ex)
 
             goal->trace(fmt("waitee '%s' done; %d left", name, goal->waitees.size()));
 
-            if (result == ecFailed || result == ecNoSubstituters || result == ecIncompleteClosure) ++goal->nrFailed;
+            if (result == ecFailed || result == ecNoSubstituters) ++goal->nrFailed;
 
             if (result == ecNoSubstituters) ++goal->nrNoSubstituters;
-
-            if (result == ecIncompleteClosure) ++goal->nrIncompleteClosure;
 
             if (goal->waitees.empty()) {
                 worker.wakeUp(goal);

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -169,7 +169,7 @@ Goal::Co PathSubstitutionGoal::tryToRun(StorePath subPath, nix::ref<Store> sub, 
 
     if (nrFailed > 0) {
         co_return done(
-            nrNoSubstituters > 0 || nrIncompleteClosure > 0 ? ecIncompleteClosure : ecFailed,
+            nrNoSubstituters > 0 ? ecNoSubstituters : ecFailed,
             BuildResult::DependencyFailed,
             fmt("some references of path '%s' could not be realised", worker.store.printStorePath(storePath)));
     }

--- a/src/libstore/include/nix/store/build/derivation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-goal.hh
@@ -74,32 +74,6 @@ struct DerivationGoal : public Goal
     NeedRestartForMoreOutputs needRestart = NeedRestartForMoreOutputs::OutputsUnmodifedDontNeed;
 
     /**
-     * See `retrySubstitution`; just for that field.
-     */
-    enum RetrySubstitution {
-        /**
-         * No issues have yet arose, no need to restart.
-         */
-        NoNeed,
-        /**
-         * Something failed and there is an incomplete closure. Let's retry
-         * substituting.
-         */
-        YesNeed,
-        /**
-         * We are current or have already retried substitution, and whether or
-         * not something goes wrong we will not retry again.
-         */
-        AlreadyRetried,
-    };
-
-    /**
-     * Whether to retry substituting the outputs after building the
-     * inputs. This is done in case of an incomplete closure.
-     */
-    RetrySubstitution retrySubstitution = RetrySubstitution::NoNeed;
-
-    /**
      * The derivation stored at drvPath.
      */
     std::unique_ptr<Derivation> drv;

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -61,7 +61,7 @@ private:
     Goals waitees;
 
 public:
-    typedef enum {ecBusy, ecSuccess, ecFailed, ecNoSubstituters, ecIncompleteClosure} ExitCode;
+    typedef enum {ecBusy, ecSuccess, ecFailed, ecNoSubstituters} ExitCode;
 
     /**
      * Backlink to the worker.
@@ -84,12 +84,6 @@ public:
      * failed because there are no substituters.
      */
     size_t nrNoSubstituters = 0;
-
-    /**
-     * Number of substitution goals we are/were waiting for that
-     * failed because they had unsubstitutable references.
-     */
-    size_t nrIncompleteClosure = 0;
 
     /**
      * Name of this goal for debugging purposes.

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -151,8 +151,11 @@ nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -
 grepQuiet "don't know how to build" "$TEST_ROOT/log"
 grepQuiet "building.*input-1" "$TEST_ROOT/log"
 grepQuiet "building.*input-2" "$TEST_ROOT/log"
-grepQuiet "copying path.*input-0" "$TEST_ROOT/log"
-grepQuiet "copying path.*top" "$TEST_ROOT/log"
+
+# Removed for now since 299141ecbd08bae17013226dbeae71e842b4fdd7 / issue #77 is reverted
+
+#grepQuiet "copying path.*input-0" "$TEST_ROOT/log"
+#grepQuiet "copying path.*top" "$TEST_ROOT/log"
 
 
 # Create a signed binary cache.


### PR DESCRIPTION
## Motivation

As summarized in
https://github.com/NixOS/nix/issues/77#issuecomment-2843228280 the motivation is that the complicated retry logic this introduced was making the cleanup task #12628 harder to accomplish. It was not easy to ascertain just what policy / semantics the extra control-flow was implementing, in order to figure out a different way to implementing it either.

After talking to Eelco about it, he decided we could just....get rid of the feature entirely! It's a bit scary removing a decade+ old feature, but I think he is right. See the release notes for more explanation.

## Context

In practice, when remote stores fail to implement the closure property (have object -> have all its dependencies), it is usually not due to arbitrary corruption, but due to the fact that the remote store was intended to act as an "overlay" store, often over `cache.nixos.org`. In that case, the right fix is not do some sort of "franken-building" (as this feature implemented) but to make sure both substituters are configured.

(In the future, we should make it easier for remote stores to indicate this to clients, to catch settings that won't work in general before a missing dependency is actually encountered.)

Any non-intentional case of stores missing dependencies, by contrast, I do not know about.

This reverts commit 299141ecbd08bae17013226dbeae71e842b4fdd7.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
