### PR TITLE
Restore dynamic derivations!

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -296,7 +296,7 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution()
 
             // FIXME wanted outputs
             auto resolvedDrvGoal = worker.makeDerivationGoal(
-                pathResolved, OutputsSpec::All{}, buildMode);
+                makeConstantStorePathRef(pathResolved), OutputsSpec::All{}, buildMode);
             {
                 Goals waitees{resolvedDrvGoal};
                 co_await await(std::move(waitees));
@@ -338,7 +338,7 @@ Goal::Co DerivationBuildingGoal::gaveUpOnSubstitution()
 
                       throw Error(
                           "derivation '%s' doesn't have expected output '%s' (derivation-goal.cc/realisation)",
-                          worker.store.printStorePath(resolvedDrvGoal->drvPath), outputName);
+                          resolvedDrvGoal->drvReq->to_string(worker.store), outputName);
                     }();
 
                     if (!drv->type().isImpure()) {

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -30,7 +30,7 @@ void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMod
         if (i->exitCode != Goal::ecSuccess) {
 #ifndef _WIN32 // TODO Enable building on Windows
             if (auto i2 = dynamic_cast<DerivationGoal *>(i.get()))
-                failed.insert(printStorePath(i2->drvPath));
+                failed.insert(i2->drvReq->to_string(*this));
             else
 #endif
             if (auto i2 = dynamic_cast<PathSubstitutionGoal *>(i.get()))

--- a/src/libstore/derived-path-map.cc
+++ b/src/libstore/derived-path-map.cc
@@ -52,6 +52,7 @@ typename DerivedPathMap<V>::ChildNode * DerivedPathMap<V>::findSlot(const Single
 
 // instantiations
 
+#include "nix/store/build/derivation-goal.hh"
 namespace nix {
 
 template<>
@@ -67,5 +68,8 @@ std::strong_ordering DerivedPathMap<StringSet>::ChildNode::operator <=> (
 
 template struct DerivedPathMap<StringSet>::ChildNode;
 template struct DerivedPathMap<StringSet>;
+
+template struct DerivedPathMap<std::weak_ptr<DerivationGoal>>;
+
 
 };

--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -3,6 +3,7 @@
 
 #include "nix/util/types.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/derived-path-map.hh"
 #include "nix/store/build/goal.hh"
 #include "nix/store/realisation.hh"
 #include "nix/util/muxable-pipe.hh"
@@ -104,7 +105,9 @@ private:
      * Maps used to prevent multiple instantiations of a goal for the
      * same derivation / path.
      */
-    std::map<StorePath, std::weak_ptr<DerivationGoal>> derivationGoals;
+
+    DerivedPathMap<std::weak_ptr<DerivationGoal>> derivationGoals;
+
     std::map<StorePath, std::weak_ptr<DerivationBuildingGoal>> derivationBuildingGoals;
     std::map<StorePath, std::weak_ptr<PathSubstitutionGoal>> substitutionGoals;
     std::map<DrvOutput, std::weak_ptr<DrvOutputSubstitutionGoal>> drvOutputSubstitutionGoals;
@@ -202,11 +205,11 @@ private:
     std::shared_ptr<G> initGoalIfNeeded(std::weak_ptr<G> & goal_weak, Args && ...args);
 
     std::shared_ptr<DerivationGoal> makeDerivationGoalCommon(
-        const StorePath & drvPath, const OutputsSpec & wantedOutputs,
+        ref<const SingleDerivedPath> drvReq, const OutputsSpec & wantedOutputs,
         std::function<std::shared_ptr<DerivationGoal>()> mkDrvGoal);
 public:
     std::shared_ptr<DerivationGoal> makeDerivationGoal(
-        const StorePath & drvPath,
+        ref<const SingleDerivedPath> drvReq,
         const OutputsSpec & wantedOutputs, BuildMode buildMode = bmNormal);
     std::shared_ptr<DerivationGoal> makeBasicDerivationGoal(
         const StorePath & drvPath, const BasicDerivation & drv,

--- a/src/libstore/include/nix/store/derived-path-map.hh
+++ b/src/libstore/include/nix/store/derived-path-map.hh
@@ -21,8 +21,11 @@ namespace nix {
  *
  * @param V A type to instantiate for each output. It should probably
  * should be an "optional" type so not every interior node has to have a
- * value. `* const Something` or `std::optional<Something>` would be
- * good choices for "optional" types.
+ * value. For example, the scheduler uses
+ * `DerivedPathMap<std::weak_ptr<DerivationCreationAndRealisationGoal>>` to
+ * remember which goals correspond to which outputs. `* const Something`
+ * or `std::optional<Something>` would also be good choices for
+ * "optional" types.
  */
 template<typename V>
 struct DerivedPathMap {

--- a/tests/functional/dyn-drv/build-built-drv.sh
+++ b/tests/functional/dyn-drv/build-built-drv.sh
@@ -18,4 +18,9 @@ clearStore
 
 drvDep=$(nix-instantiate ./text-hashed-output.nix -A producingDrv)
 
-expectStderr 1 nix build "${drvDep}^out^out" --no-link | grepQuiet "Building dynamic derivations in one shot is not yet implemented"
+# Store layer needs bugfix
+requireDaemonNewerThan "2.30pre20250515"
+
+out2=$(nix build "${drvDep}^out^out" --no-link)
+
+test $out1 == $out2

--- a/tests/functional/dyn-drv/dep-built-drv-2.sh
+++ b/tests/functional/dyn-drv/dep-built-drv-2.sh
@@ -3,7 +3,7 @@
 source common.sh
 
 # Store layer needs bugfix
-requireDaemonNewerThan "2.27pre20250205"
+requireDaemonNewerThan "2.30pre20250515"
 
 TODO_NixOS # can't enable a sandbox feature easily
 
@@ -13,4 +13,4 @@ restartDaemon
 NIX_BIN_DIR="$(dirname "$(type -p nix)")"
 export NIX_BIN_DIR
 
-expectStderr 1 nix build -L --file ./non-trivial.nix --no-link | grepQuiet "Building dynamic derivations in one shot is not yet implemented"
+nix build -L --file ./non-trivial.nix --no-link

--- a/tests/functional/dyn-drv/dep-built-drv.sh
+++ b/tests/functional/dyn-drv/dep-built-drv.sh
@@ -4,8 +4,11 @@ source common.sh
 
 out1=$(nix-build ./text-hashed-output.nix -A hello --no-out-link)
 
+# Store layer needs bugfix
+requireDaemonNewerThan "2.30pre20250515"
+
 clearStore
 
-expectStderr 1 nix-build ./text-hashed-output.nix -A wrapper --no-out-link | grepQuiet "Building dynamic derivations in one shot is not yet implemented"
+out2=$(nix-build ./text-hashed-output.nix -A wrapper --no-out-link)
 
-# diff -r $out1 $out2
+diff -r $out1 $out2

--- a/tests/functional/dyn-drv/failing-outer.sh
+++ b/tests/functional/dyn-drv/failing-outer.sh
@@ -3,9 +3,7 @@
 source common.sh
 
 # Store layer needs bugfix
-requireDaemonNewerThan "2.27pre20250205"
-
-skipTest "dyn drv input scheduling had to be reverted for 2.27"
+requireDaemonNewerThan "2.30pre20250515"
 
 expected=100
 if [[ -v NIX_DAEMON_PACKAGE ]]; then expected=1; fi # work around the daemon not returning a 100 status correctly


### PR DESCRIPTION
## Motivation

This method does *not* create a new type of goal. We instead just make `DerivationGoal` more sophisticated, which is much easier to do now that `DerivationBuildingGoal` has been split from it (and so many fields are gone, or or local variables instead).

This avoids the need for a secondarily trampoline goal that interacted poorly with `addWantedOutputs`. That, I hope, will mean the bugs from before do not reappear.

## Context

There may in fact be a reason to introduce such a trampoline in the future, but it would only happen in conjunction with getting rid of `addWantedOutputs`.

Restores the functionality (and tests) that was reverted in https://github.com/NixOS/nix/commit/f4f28cdd0e01a9bfb0901e8a53ead719265fa9b8.

depends on #13181

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
