### PR TITLE
Render upcoming notes

### DIFF
--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -11,6 +11,8 @@
   python3,
   rsync,
   nix-cli,
+  changelog-d,
+  officialRelease,
 
   # Configuration Options
 
@@ -44,16 +46,24 @@ mkMesonDerivation (finalAttrs: {
   ];
 
   # Hack for sake of the dev shell
-  passthru.externalNativeBuildInputs = [
-    meson
-    ninja
-    (lib.getBin lowdown-unsandboxed)
-    mdbook
-    mdbook-linkcheck
-    jq
-    python3
-    rsync
-  ];
+  passthru.externalNativeBuildInputs =
+    [
+      meson
+      ninja
+      (lib.getBin lowdown-unsandboxed)
+      mdbook
+      mdbook-linkcheck
+      jq
+      python3
+      rsync
+      changelog-d
+    ]
+    ++ lib.optionals (!officialRelease) [
+      # When not an official release, we likely have changelog entries that have
+      # yet to be rendered.
+      # When released, these are rendered into a committed file to save a dependency.
+      changelog-d
+    ];
 
   nativeBuildInputs = finalAttrs.passthru.externalNativeBuildInputs ++ [
     nix-cli

--- a/doc/manual/rl-next/c-api.md
+++ b/doc/manual/rl-next/c-api.md
@@ -1,0 +1,19 @@
+---
+synopsis: "C API: functions for locking and loading a flake"
+issues: 10435
+prs: [12877, 13098]
+---
+
+This release adds functions to the C API for handling the loading of flakes. Previously, this had to be worked around by using `builtins.getFlake`.
+C API consumers and language bindings now have access to basic locking functionality.
+
+It does not expose the full locking API, so that the implementation can evolve more freely.
+Locking is controlled with the functions, which cover the common use cases for consuming a flake:
+- `nix_flake_lock_flags_set_mode_check`
+- `nix_flake_lock_flags_set_mode_virtual`
+- `nix_flake_lock_flags_set_mode_write_as_needed`
+- `nix_flake_lock_flags_add_input_override`, which also enables `virtual`
+
+This change also introduces the new `nix-fetchers-c` library, whose single purpose for now is to manage the (`nix.conf`) settings for the built-in fetchers.
+
+More details can be found in the [C API documentation](@docroot@/c-api.md).

--- a/packaging/components.nix
+++ b/packaging/components.nix
@@ -211,6 +211,7 @@ in
 {
   version = baseVersion + versionSuffix;
   inherit versionSuffix;
+  inherit officialRelease;
   inherit maintainers;
 
   inherit filesetToSource;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->


This renders the rl-next notes when `officialRelease = false`, which
corresponds to the case where we're not on a release branch.

Previously we had disabled this behavior because changelog-d is
somewhat of a heavy dependency, being the only Haskell package.
However, we now have new circumstances that topple the tradeoff.

- We render `master` docs to https://nix.dev/manual/nix/development/release-notes/rl-next.html

- `.#manual` is a separate build now, so `nix build nix/foo` is
  not affected by the increased closure of build input outputs.

Because of these factors, I believe adding this functionality back
is more valuable, as we can use it to

- Previous release notes

- Showcase the upcoming release to the community
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Currently includes a commit from #13189 so that there's something to render

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
