### PR TITLE
libutil: Less unnecessary copying in `LRUCache`

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -360,7 +360,6 @@
               ''^src/libutil/linux/namespaces\.cc$''
               ''^src/libutil/logging\.cc$''
               ''^src/libutil/include/nix/util/logging\.hh$''
-              ''^src/libutil/include/nix/util/lru-cache\.hh$''
               ''^src/libutil/memory-source-accessor\.cc$''
               ''^src/libutil/include/nix/util/memory-source-accessor\.hh$''
               ''^src/libutil/include/nix/util/pool\.hh$''

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -570,7 +570,7 @@ bool Store::isValidPath(const StorePath & storePath)
 {
     {
         auto state_(state.lock());
-        auto res = state_->pathInfoCache.get(std::string(storePath.to_string()));
+        auto res = state_->pathInfoCache.get(storePath.to_string());
         if (res && res->isKnownNow()) {
             stats.narInfoReadAverted++;
             return res->didExist();
@@ -582,7 +582,7 @@ bool Store::isValidPath(const StorePath & storePath)
         if (res.first != NarInfoDiskCache::oUnknown) {
             stats.narInfoReadAverted++;
             auto state_(state.lock());
-            state_->pathInfoCache.upsert(std::string(storePath.to_string()),
+            state_->pathInfoCache.upsert(storePath.to_string(),
                 res.first == NarInfoDiskCache::oInvalid ? PathInfoCacheValue{} : PathInfoCacheValue { .value = res.second });
             return res.first == NarInfoDiskCache::oValid;
         }
@@ -641,7 +641,7 @@ std::optional<std::shared_ptr<const ValidPathInfo>> Store::queryPathInfoFromClie
     auto hashPart = std::string(storePath.hashPart());
 
     {
-        auto res = state.lock()->pathInfoCache.get(std::string(storePath.to_string()));
+        auto res = state.lock()->pathInfoCache.get(storePath.to_string());
         if (res && res->isKnownNow()) {
             stats.narInfoReadAverted++;
             if (res->didExist())
@@ -657,7 +657,7 @@ std::optional<std::shared_ptr<const ValidPathInfo>> Store::queryPathInfoFromClie
             stats.narInfoReadAverted++;
             {
                 auto state_(state.lock());
-                state_->pathInfoCache.upsert(std::string(storePath.to_string()),
+                state_->pathInfoCache.upsert(storePath.to_string(),
                     res.first == NarInfoDiskCache::oInvalid ? PathInfoCacheValue{} : PathInfoCacheValue{ .value = res.second });
                 if (res.first == NarInfoDiskCache::oInvalid ||
                     !goodStorePath(storePath, res.second->path))
@@ -701,7 +701,7 @@ void Store::queryPathInfo(const StorePath & storePath,
 
                 {
                     auto state_(state.lock());
-                    state_->pathInfoCache.upsert(std::string(storePath.to_string()), PathInfoCacheValue { .value = info });
+                    state_->pathInfoCache.upsert(storePath.to_string(), PathInfoCacheValue { .value = info });
                 }
 
                 if (!info || !goodStorePath(storePath, info->path)) {

--- a/src/libutil/include/nix/util/lru-cache.hh
+++ b/src/libutil/include/nix/util/lru-cache.hh
@@ -93,12 +93,16 @@ public:
 
         /**
          * Move this item to the back of the LRU list.
+         *
+         * Think of std::list iterators as stable pointers to the list node,
+         * which never get invalidated. Thus, we can reuse the same lru list
+         * element and just splice it to the back of the list without the need
+         * to update its value in the key -> list iterator map.
          */
-        lru.erase(i->second.first.it);
-        auto j = lru.insert(lru.end(), i);
-        i->second.first.it = j;
+        auto & [it, value] = i->second;
+        lru.splice(/*pos=*/lru.end(), /*other=*/lru, it.it);
 
-        return i->second.second;
+        return value;
     }
 
     size_t size() const

--- a/src/libutil/include/nix/util/lru-cache.hh
+++ b/src/libutil/include/nix/util/lru-cache.hh
@@ -25,21 +25,28 @@ private:
     using Data = std::map<Key, std::pair<LRUIterator, Value>>;
     using LRU = std::list<typename Data::iterator>;
 
-    struct LRUIterator { typename LRU::iterator it; };
+    struct LRUIterator
+    {
+        typename LRU::iterator it;
+    };
 
     Data data;
     LRU lru;
 
 public:
 
-    LRUCache(size_t capacity) : capacity(capacity) { }
+    LRUCache(size_t capacity)
+        : capacity(capacity)
+    {
+    }
 
     /**
      * Insert or upsert an item in the cache.
      */
     void upsert(const Key & key, const Value & value)
     {
-        if (capacity == 0) return;
+        if (capacity == 0)
+            return;
 
         erase(key);
 
@@ -64,7 +71,8 @@ public:
     bool erase(const Key & key)
     {
         auto i = data.find(key);
-        if (i == data.end()) return false;
+        if (i == data.end())
+            return false;
         lru.erase(i->second.first.it);
         data.erase(i);
         return true;
@@ -77,7 +85,8 @@ public:
     std::optional<Value> get(const Key & key)
     {
         auto i = data.find(key);
-        if (i == data.end()) return {};
+        if (i == data.end())
+            return {};
 
         /**
          * Move this item to the back of the LRU list.

--- a/src/libutil/include/nix/util/lru-cache.hh
+++ b/src/libutil/include/nix/util/lru-cache.hh
@@ -105,12 +105,12 @@ public:
         return value;
     }
 
-    size_t size() const
+    size_t size() const noexcept
     {
         return data.size();
     }
 
-    void clear()
+    void clear() noexcept
     {
         data.clear();
         lru.clear();

--- a/src/libutil/include/nix/util/lru-cache.hh
+++ b/src/libutil/include/nix/util/lru-cache.hh
@@ -11,7 +11,7 @@ namespace nix {
 /**
  * A simple least-recently used cache. Not thread-safe.
  */
-template<typename Key, typename Value>
+template<typename Key, typename Value, typename Compare = std::less<>>
 class LRUCache
 {
 private:
@@ -22,7 +22,7 @@ private:
     // and LRU.
     struct LRUIterator;
 
-    using Data = std::map<Key, std::pair<LRUIterator, Value>>;
+    using Data = std::map<Key, std::pair<LRUIterator, Value>, Compare>;
     using LRU = std::list<typename Data::iterator>;
 
     struct LRUIterator
@@ -43,7 +43,8 @@ public:
     /**
      * Insert or upsert an item in the cache.
      */
-    void upsert(const Key & key, const Value & value)
+    template<typename K>
+    void upsert(const K & key, const Value & value)
     {
         if (capacity == 0)
             return;
@@ -68,7 +69,8 @@ public:
         i->second.first.it = j;
     }
 
-    bool erase(const Key & key)
+    template<typename K>
+    bool erase(const K & key)
     {
         auto i = data.find(key);
         if (i == data.end())
@@ -82,7 +84,8 @@ public:
      * Look up an item in the cache. If it exists, it becomes the most
      * recently used item.
      * */
-    std::optional<Value> get(const Key & key)
+    template<typename K>
+    std::optional<Value> get(const K & key)
     {
         auto i = data.find(key);
         if (i == data.end())


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

There's some low hanging fruit in terms of code simplification and getting rid
of unnecessary copying (see the second commit). Also moving the cache entry to the back of the `lru` list can be
made much cheaper by just using [splice](https://en.cppreference.com/w/cpp/container/list/splice) method, which just reassigns some pointers in the linked list (having pointer stability is the main purpose of `std::list` after all).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Some unified caching primitives are useful to reuse in other places (e.g. https://github.com/NixOS/nix/pull/13137#issue-3038093870)

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
