### PR TITLE
Deduplicate the goal creation functions

### DIFF
--- a/src/libstore/include/nix/store/build/worker.hh
+++ b/src/libstore/include/nix/store/build/worker.hh
@@ -196,6 +196,9 @@ public:
      * @ref DerivationGoal "derivation goal"
      */
 private:
+    template<class G, typename... Args>
+    std::shared_ptr<G> initGoalIfNeeded(std::weak_ptr<G> & goal_weak, Args && ...args);
+
     std::shared_ptr<DerivationGoal> makeDerivationGoalCommon(
         const StorePath & drvPath, const OutputsSpec & wantedOutputs,
         std::function<std::shared_ptr<DerivationGoal>()> mkDrvGoal);


### PR DESCRIPTION
## Motivation

The weak reference logic is the same in both these cases, and if/when I get rid `addWantedOutputs`, also in the `DerivationGoal` case.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
