### PR TITLE
libexpr: Actually cache line information in PosTable

### DIFF
--- a/src/libutil/include/nix/util/lru-cache.hh
+++ b/src/libutil/include/nix/util/lru-cache.hh
@@ -33,6 +33,18 @@ private:
     Data data;
     LRU lru;
 
+    /**
+     * Move this item to the back of the LRU list.
+     */
+    void promote(LRU::iterator it)
+    {
+        /* Think of std::list iterators as stable pointers to the list node,
+         * which never get invalidated. Thus, we can reuse the same lru list
+         * element and just splice it to the back of the list without the need
+         * to update its value in the key -> list iterator map. */
+        lru.splice(/*pos=*/lru.end(), /*other=*/lru, it);
+    }
+
 public:
 
     LRUCache(size_t capacity)
@@ -83,7 +95,9 @@ public:
     /**
      * Look up an item in the cache. If it exists, it becomes the most
      * recently used item.
-     * */
+     *
+     * @returns corresponding cache entry, std::nullopt if it's not in the cache
+     */
     template<typename K>
     std::optional<Value> get(const K & key)
     {
@@ -91,18 +105,28 @@ public:
         if (i == data.end())
             return {};
 
-        /**
-         * Move this item to the back of the LRU list.
-         *
-         * Think of std::list iterators as stable pointers to the list node,
-         * which never get invalidated. Thus, we can reuse the same lru list
-         * element and just splice it to the back of the list without the need
-         * to update its value in the key -> list iterator map.
-         */
         auto & [it, value] = i->second;
-        lru.splice(/*pos=*/lru.end(), /*other=*/lru, it.it);
-
+        promote(it.it);
         return value;
+    }
+
+    /**
+     * Look up an item in the cache. If it exists, it becomes the most
+     * recently used item.
+     *
+     * @returns mutable pointer to the corresponding cache entry, nullptr if
+     * it's not in the cache
+     */
+    template<typename K>
+    Value * getOrNullptr(const K & key)
+    {
+        auto i = data.find(key);
+        if (i == data.end())
+            return nullptr;
+
+        auto & [it, value] = i->second;
+        promote(it.it);
+        return &value;
     }
 
     size_t size() const noexcept

--- a/src/libutil/include/nix/util/pos-table.hh
+++ b/src/libutil/include/nix/util/pos-table.hh
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "nix/util/lru-cache.hh"
 #include "nix/util/pos-idx.hh"
 #include "nix/util/position.hh"
 #include "nix/util/sync.hh"
@@ -37,10 +38,20 @@ public:
     };
 
 private:
+    /**
+     * Vector of byte offsets (in the virtual input buffer) of initial line character's position.
+     * Sorted by construction. Binary search over it allows for efficient translation of arbitrary
+     * byte offsets in the virtual input buffer to its line + column position.
+     */
     using Lines = std::vector<uint32_t>;
+    /**
+     * Cache from byte offset in the virtual buffer of Origins -> @ref Lines in that origin.
+     */
+    using LinesCache = LRUCache<uint32_t, Lines>;
 
     std::map<uint32_t, Origin> origins;
-    mutable Sync<std::map<uint32_t, Lines>> lines;
+
+    mutable Sync<LinesCache> linesCache;
 
     const Origin * resolve(PosIdx p) const
     {
@@ -56,6 +67,11 @@ private:
     }
 
 public:
+    PosTable(std::size_t linesCacheCapacity = 65536)
+        : linesCache(linesCacheCapacity)
+    {
+    }
+
     Origin addOrigin(Pos::Origin origin, size_t size)
     {
         uint32_t offset = 0;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Previous code had a sneaky bug due to which no caching
actually happened:

```cpp
auto linesForInput = (*lines)[origin->offset];
```

That should have been:
```cpp
auto & linesForInput = (*lines)[origin->offset];
```

See [1].

Now that it also makes sense to make the cache bound in side
in order not to memoize all the sources without freeing any memory.
The default cache size has been chosen somewhat arbitrarily to be ~64k
origins. For reference, 25.05 nixpkgs has ~50k .nix files.

Simple benchmark:

```nix
let
  pkgs = import <nixpkgs> { };
in
builtins.foldl' (acc: el: acc + el.line) 0 (
  builtins.genList (x: builtins.unsafeGetAttrPos "gcc" pkgs) 10000
)
```

(After)

```
$ hyperfine "result/bin/nix eval -f ./test.nix"
Benchmark 1: result/bin/nix eval -f ./test.nix
  Time (mean ± σ):     292.7 ms ±   3.9 ms    [User: 131.0 ms, System: 120.5 ms]
  Range (min … max):   288.1 ms … 300.5 ms    10 runs
```

(Before)

```
hyperfine "nix eval -f ./test.nix"
Benchmark 1: nix eval -f ./test.nix
  Time (mean ± σ):     666.7 ms ±   6.4 ms    [User: 428.3 ms, System: 191.2 ms]
  Range (min … max):   659.7 ms … 681.3 ms    10 runs
```

If the origin happens to be a `all-packages.nix` or similar in size then the
difference is much more dramatic.

[1]: https://www.github.com/lix-project/lix/commit/22e3f0e9875082be7f4eec8e3caeb134a7f1c05f

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/pull/12645#discussion_r1993656021

@roberth As it turns out the `PosTable` was indeed supposed to do the caching, but didn't due to the bug I described above.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
