### PR TITLE
docs: fix duplicate anchor

### DIFF
--- a/doc/manual/source/store/derivation/index.md
+++ b/doc/manual/source/store/derivation/index.md
@@ -282,7 +282,7 @@ type DerivingPath = ConstantPath | OutputPath;
 
 Under this extended model, `DerivingPath`s are thus inductively built up from a root `ConstantPath`, wrapped with zero or more outer `OutputPath`s.
 
-### Encoding {#deriving-path-encoding}
+### Encoding {#deriving-path-encoding-higher-order}
 
 The encoding is adjusted in the natural way, encoding the `drv` field recursively using the same deriving path encoding.
 The result of this is that it is possible to have a chain of `^<output-name>` at the end of the final string, as opposed to just a single one.


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

`#deriving-path-encoding` is defined in two places, I _think_ this is the correct one to change.


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
