### PR TITLE
libexpr: Add `EvalProfiler` and use it for `FunctionCallTrace`

### DIFF
--- a/src/libexpr/eval-profiler.cc
+++ b/src/libexpr/eval-profiler.cc
@@ -1,0 +1,48 @@
+#include "nix/expr/eval-profiler.hh"
+#include "nix/expr/nixexpr.hh"
+
+namespace nix {
+
+void EvalProfiler::preFunctionCallHook(
+    const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+{
+}
+
+void EvalProfiler::postFunctionCallHook(
+    const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+{
+}
+
+void MultiEvalProfiler::preFunctionCallHook(
+    const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+{
+    for (auto & profiler : profilers) {
+        if (profiler->getNeededHooks().test(Hook::preFunctionCall))
+            profiler->preFunctionCallHook(state, v, args, pos);
+    }
+}
+
+void MultiEvalProfiler::postFunctionCallHook(
+    const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+{
+    for (auto & profiler : profilers) {
+        if (profiler->getNeededHooks().test(Hook::postFunctionCall))
+            profiler->postFunctionCallHook(state, v, args, pos);
+    }
+}
+
+EvalProfiler::Hooks MultiEvalProfiler::getNeededHooksImpl() const
+{
+    Hooks hooks;
+    for (auto & p : profilers)
+        hooks |= p->getNeededHooks();
+    return hooks;
+}
+
+void MultiEvalProfiler::addProfiler(ref<EvalProfiler> profiler)
+{
+    profilers.push_back(profiler);
+    invalidateNeededHooks();
+}
+
+}

--- a/src/libexpr/function-trace.cc
+++ b/src/libexpr/function-trace.cc
@@ -3,16 +3,20 @@
 
 namespace nix {
 
-FunctionCallTrace::FunctionCallTrace(const Pos & pos) : pos(pos) {
+void FunctionCallTrace::preFunctionCallHook(
+    const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+{
     auto duration = std::chrono::high_resolution_clock::now().time_since_epoch();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
-    printMsg(lvlInfo, "function-trace entered %1% at %2%", pos, ns.count());
+    printMsg(lvlInfo, "function-trace entered %1% at %2%", state.positions[pos], ns.count());
 }
 
-FunctionCallTrace::~FunctionCallTrace() {
+void FunctionCallTrace::postFunctionCallHook(
+    const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos)
+{
     auto duration = std::chrono::high_resolution_clock::now().time_since_epoch();
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
-    printMsg(lvlInfo, "function-trace exited %1% at %2%", pos, ns.count());
+    printMsg(lvlInfo, "function-trace exited %1% at %2%", state.positions[pos], ns.count());
 }
 
 }

--- a/src/libexpr/include/nix/expr/eval-profiler.hh
+++ b/src/libexpr/include/nix/expr/eval-profiler.hh
@@ -1,0 +1,113 @@
+#pragma once
+/**
+ * @file
+ *
+ * Evaluation profiler interface definitions and builtin implementations.
+ */
+
+#include "nix/util/ref.hh"
+
+#include <vector>
+#include <span>
+#include <bitset>
+#include <optional>
+
+namespace nix {
+
+class EvalState;
+class PosIdx;
+struct Value;
+
+class EvalProfiler
+{
+public:
+    enum Hook {
+        preFunctionCall,
+        postFunctionCall,
+    };
+
+    static constexpr std::size_t numHooks = Hook::postFunctionCall + 1;
+    using Hooks = std::bitset<numHooks>;
+
+private:
+    std::optional<Hooks> neededHooks;
+
+protected:
+    /** Invalidate the cached neededHooks. */
+    void invalidateNeededHooks()
+    {
+        neededHooks = std::nullopt;
+    }
+
+    /**
+     * Get which hooks need to be called.
+     *
+     * This is the actual implementation which has to be defined by subclasses.
+     * Public API goes through the needsHooks, which is a
+     * non-virtual interface (NVI) which caches the return value.
+     */
+    virtual Hooks getNeededHooksImpl() const
+    {
+        return Hooks{};
+    }
+
+public:
+    /**
+     * Hook called in the EvalState::callFunction preamble.
+     * Gets called only if (getNeededHooks().test(Hook::preFunctionCall)) is true.
+     *
+     * @param state Evaluator state.
+     * @param v Function being invoked.
+     * @param args Function arguments.
+     * @param pos Function position.
+     */
+    virtual void
+    preFunctionCallHook(const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos);
+
+    /**
+     * Hook called on EvalState::callFunction exit.
+     * Gets called only if (getNeededHooks().test(Hook::postFunctionCall)) is true.
+     *
+     * @param state Evaluator state.
+     * @param v Function being invoked.
+     * @param args Function arguments.
+     * @param pos Function position.
+     */
+    virtual void
+    postFunctionCallHook(const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos);
+
+    virtual ~EvalProfiler() = default;
+
+    /**
+     * Get which hooks need to be invoked for this EvalProfiler instance.
+     */
+    Hooks getNeededHooks()
+    {
+        if (neededHooks.has_value())
+            return *neededHooks;
+        return *(neededHooks = getNeededHooksImpl());
+    }
+};
+
+/**
+ * Profiler that invokes multiple profilers at once.
+ */
+class MultiEvalProfiler : public EvalProfiler
+{
+    std::vector<ref<EvalProfiler>> profilers;
+
+    [[gnu::noinline]] Hooks getNeededHooksImpl() const override;
+
+public:
+    MultiEvalProfiler() = default;
+
+    /** Register a profiler instance. */
+    void addProfiler(ref<EvalProfiler> profiler);
+
+    [[gnu::noinline]] void
+    preFunctionCallHook(const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    [[gnu::noinline]] void
+    postFunctionCallHook(const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+};
+
+}

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -3,6 +3,7 @@
 
 #include "nix/expr/attr-set.hh"
 #include "nix/expr/eval-error.hh"
+#include "nix/expr/eval-profiler.hh"
 #include "nix/util/types.hh"
 #include "nix/expr/value.hh"
 #include "nix/expr/nixexpr.hh"
@@ -902,6 +903,9 @@ private:
 
     typedef std::map<ExprLambda *, size_t> FunctionCalls;
     FunctionCalls functionCalls;
+
+    /** Evaluation/call profiler. */
+    MultiEvalProfiler profiler;
 
     void incrFunctionCall(ExprLambda * fun);
 

--- a/src/libexpr/include/nix/expr/function-trace.hh
+++ b/src/libexpr/include/nix/expr/function-trace.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include "nix/expr/eval.hh"
+#include "nix/expr/eval-profiler.hh"
 
 #include <chrono>
 

--- a/src/libexpr/include/nix/expr/function-trace.hh
+++ b/src/libexpr/include/nix/expr/function-trace.hh
@@ -4,14 +4,22 @@
 #include "nix/expr/eval.hh"
 #include "nix/expr/eval-profiler.hh"
 
-#include <chrono>
-
 namespace nix {
 
-struct FunctionCallTrace
+class FunctionCallTrace : public EvalProfiler
 {
-    const Pos pos;
-    FunctionCallTrace(const Pos & pos);
-    ~FunctionCallTrace();
+    Hooks getNeededHooksImpl() const override
+    {
+        return Hooks().set(preFunctionCall).set(postFunctionCall);
+    }
+
+public:
+    FunctionCallTrace() = default;
+
+    [[gnu::noinline]] void
+    preFunctionCallHook(const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
+    [[gnu::noinline]] void
+    postFunctionCallHook(const EvalState & state, const Value & v, std::span<Value *> args, const PosIdx pos) override;
 };
+
 }

--- a/src/libexpr/include/nix/expr/meson.build
+++ b/src/libexpr/include/nix/expr/meson.build
@@ -14,6 +14,7 @@ headers = [config_pub_h] + files(
   'eval-error.hh',
   'eval-gc.hh',
   'eval-inline.hh',
+  'eval-profiler.hh',
   'eval-settings.hh',
   'eval.hh',
   'function-trace.hh',

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -140,6 +140,7 @@ sources = files(
   'eval-cache.cc',
   'eval-error.cc',
   'eval-gc.cc',
+  'eval-profiler.cc',
   'eval-settings.cc',
   'eval.cc',
   'function-trace.cc',


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Having and extensible framework for evaluation profiling is much needed if we want to get flamegraph/tracy-based profilers https://github.com/NixOS/nix/pull/9967, https://github.com/NixOS/nix/pull/11373. This patch adds a `EvalProfiler` interface and `MultiEvalProfiler`, which support `preFunctionCallHook` and `postFunctionCallHook` that get call on entering and exiting `callFunction`. The actual hook invocation is guarded behind a simple cached boolean check with an `[[unlikely]]` annotation. This machinery is enough to reimplement existing `FunctionCallTrace`.

I hope this patch can pave the way forward for https://github.com/NixOS/nix/pull/9967, https://github.com/NixOS/nix/pull/11373 in an extensible and well-architected manner. Since the actual profiler implementation is hidden behind an interface, multiple profilers can be easily supported, so flamegraph/tracy can hopefully co-exist behind a `--eval-profiler` flag. (Current setting `trace-function-calls` can also be absorbed into that hypothetical feature).

(Inlined message from the second commit, which has non-tracing performance measurements)

Note that branches when the hook gets called are marked with `[[unlikely]]`
as a hint to the compiler that this is not a hot path. For non-tracing
evaluation this should be a 100% predictable branch, so the performance
cost is nonexistent.

Some measurements to support this point:

```
nix build .#nix-cli
nix build github:nixos/nix/d692729759e4e370361cc5105fbeb0e33137ca9e#nix-cli --out-link before
```

(Before)

```
$ taskset -c 2,3 hyperfine "GC_INITIAL_HEAP_SIZE=16g before/bin/nix eval nixpkgs#gnome --no-eval-cache" --warmup 4
Benchmark 1: GC_INITIAL_HEAP_SIZE=16g before/bin/nix eval nixpkgs#gnome --no-eval-cache
  Time (mean ± σ):      2.517 s ±  0.032 s    [User: 1.464 s, System: 0.476 s]
  Range (min … max):    2.464 s …  2.557 s    10 runs
```

(After)

```
$ taskset -c 2,3 hyperfine "GC_INITIAL_HEAP_SIZE=16g result/bin/nix eval nixpkgs#gnome --no-eval-cache" --warmup 4
Benchmark 1: GC_INITIAL_HEAP_SIZE=16g result/bin/nix eval nixpkgs#gnome --no-eval-cache
  Time (mean ± σ):      2.499 s ±  0.022 s    [User: 1.448 s, System: 0.478 s]
  Range (min … max):    2.472 s …  2.537 s    10 runs
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/pull/9967
https://github.com/NixOS/nix/pull/11373

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
