### PR TITLE
Remove global fetcher cache

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -34,7 +34,12 @@ EvalSettings evalSettings {
                 auto flakeRef = parseFlakeRef(fetchSettings, std::string { rest }, {}, true, false);
                 debug("fetching flake search path element '%s''", rest);
                 auto [accessor, lockedRef] = flakeRef.resolve(state.store).lazyFetch(state.store);
-                auto storePath = nix::fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
+                auto storePath = nix::fetchToStore(
+                    state.fetchSettings,
+                    *state.store,
+                    SourcePath(accessor),
+                    FetchMode::Copy,
+                    lockedRef.input.getName());
                 state.allowPath(storePath);
                 return state.storePath(storePath);
             },
@@ -177,7 +182,11 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * bas
             state.store,
             state.fetchSettings,
             EvalSettings::resolvePseudoUrl(s));
-        auto storePath = fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy);
+        auto storePath = fetchToStore(
+            state.fetchSettings,
+            *state.store,
+            SourcePath(accessor),
+            FetchMode::Copy);
         return state.storePath(storePath);
     }
 
@@ -185,7 +194,12 @@ SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * bas
         experimentalFeatureSettings.require(Xp::Flakes);
         auto flakeRef = parseFlakeRef(fetchSettings, std::string(s.substr(6)), {}, true, false);
         auto [accessor, lockedRef] = flakeRef.resolve(state.store).lazyFetch(state.store);
-        auto storePath = nix::fetchToStore(*state.store, SourcePath(accessor), FetchMode::Copy, lockedRef.input.getName());
+        auto storePath = nix::fetchToStore(
+            state.fetchSettings,
+            *state.store,
+            SourcePath(accessor),
+            FetchMode::Copy,
+            lockedRef.input.getName());
         state.allowPath(storePath);
         return state.storePath(storePath);
     }

--- a/src/libcmd/installable-value.cc
+++ b/src/libcmd/installable-value.cc
@@ -45,7 +45,7 @@ ref<InstallableValue> InstallableValue::require(ref<Installable> installable)
 std::optional<DerivedPathWithInfo> InstallableValue::trySinglePathToDerivedPaths(Value & v, const PosIdx pos, std::string_view errorCtx)
 {
     if (v.type() == nPath) {
-        auto storePath = fetchToStore(*state->store, v.path(), FetchMode::Copy);
+        auto storePath = fetchToStore(state->fetchSettings, *state->store, v.path(), FetchMode::Copy);
         return {{
             .path = DerivedPath::Opaque {
                 .path = std::move(storePath),

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2423,6 +2423,7 @@ StorePath EvalState::copyPathToStore(NixStringContext & context, const SourcePat
         ? *dstPathCached
         : [&]() {
             auto dstPath = fetchToStore(
+                fetchSettings,
                 *store,
                 path.resolveSymlinks(SymlinkResolution::Ancestors),
                 settings.readOnlyMode ? FetchMode::DryRun : FetchMode::Copy,
@@ -3125,7 +3126,7 @@ std::optional<SourcePath> EvalState::resolveLookupPathPath(const LookupPath::Pat
                 store,
                 fetchSettings,
                 EvalSettings::resolvePseudoUrl(value));
-            auto storePath = fetchToStore(*store, SourcePath(accessor), FetchMode::Copy);
+            auto storePath = fetchToStore(fetchSettings, *store, SourcePath(accessor), FetchMode::Copy);
             return finish(this->storePath(storePath));
         } catch (Error & e) {
             logWarning({

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -2545,6 +2545,7 @@ static void addPath(
 
         if (!expectedHash || !state.store->isValidPath(*expectedStorePath)) {
             auto dstPath = fetchToStore(
+                state.fetchSettings,
                 *state.store,
                 path.resolveSymlinks(),
                 settings.readOnlyMode ? FetchMode::DryRun : FetchMode::Copy,

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -537,11 +537,12 @@ static void fetch(EvalState & state, const PosIdx pos, Value * * args, Value & v
     auto storePath =
         unpack
         ? fetchToStore(
+            state.fetchSettings,
             *state.store,
             fetchers::downloadTarball(state.store, state.fetchSettings, *url),
             FetchMode::Copy,
             name)
-        : fetchers::downloadFile(state.store, *url, name).storePath;
+        : fetchers::downloadFile(state.store, state.fetchSettings, *url, name).storePath;
 
     if (expectedHash) {
         auto hash = unpack

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -1,4 +1,5 @@
 #include "nix/fetchers/cache.hh"
+#include "nix/fetchers/fetch-settings.hh"
 #include "nix/util/users.hh"
 #include "nix/store/sqlite.hh"
 #include "nix/util/sync.hh"
@@ -162,10 +163,12 @@ struct CacheImpl : Cache
     }
 };
 
-ref<Cache> getCache()
+ref<Cache> Settings::getCache() const
 {
-    static auto cache = std::make_shared<CacheImpl>();
-    return ref<Cache>(cache);
+    auto cache(_cache.lock());
+    if (!*cache)
+        *cache = std::make_shared<CacheImpl>();
+    return ref<Cache>(*cache);
 }
 
 }

--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -198,7 +198,7 @@ std::pair<StorePath, Input> Input::fetchToStore(ref<Store> store) const
         try {
             auto [accessor, result] = getAccessorUnchecked(store);
 
-            auto storePath = nix::fetchToStore(*store, SourcePath(accessor), FetchMode::Copy, result.getName());
+            auto storePath = nix::fetchToStore(*settings, *store, SourcePath(accessor), FetchMode::Copy, result.getName());
 
             auto narHash = store->queryPathInfo(storePath)->narHash;
             result.attrs.insert_or_assign("narHash", narHash.to_string(HashFormat::SRI, true));

--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -265,7 +265,7 @@ struct GitArchiveInputScheme : InputScheme
         input.attrs.erase("ref");
         input.attrs.insert_or_assign("rev", rev->gitRev());
 
-        auto cache = getCache();
+        auto cache = input.settings->getCache();
 
         Cache::Key treeHashKey{"gitRevToTreeHash", {{"rev", rev->gitRev()}}};
         Cache::Key lastModifiedKey{"gitRevToLastModified", {{"rev", rev->gitRev()}}};
@@ -407,7 +407,7 @@ struct GitHubInputScheme : GitArchiveInputScheme
         auto json = nlohmann::json::parse(
             readFile(
                 store->toRealPath(
-                    downloadFile(store, url, "source", headers).storePath)));
+                    downloadFile(store, *input.settings, url, "source", headers).storePath)));
 
         return RefInfo {
             .rev = Hash::parseAny(std::string { json["sha"] }, HashAlgorithm::SHA1),
@@ -481,7 +481,7 @@ struct GitLabInputScheme : GitArchiveInputScheme
         auto json = nlohmann::json::parse(
             readFile(
                 store->toRealPath(
-                    downloadFile(store, url, "source", headers).storePath)));
+                    downloadFile(store, *input.settings, url, "source", headers).storePath)));
 
         if (json.is_array() && json.size() >= 1 && json[0]["id"] != nullptr) {
           return RefInfo {
@@ -551,7 +551,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::string refUri;
         if (ref == "HEAD") {
             auto file = store->toRealPath(
-                downloadFile(store, fmt("%s/HEAD", base_url), "source", headers).storePath);
+                downloadFile(store, *input.settings, fmt("%s/HEAD", base_url), "source", headers).storePath);
             std::ifstream is(file);
             std::string line;
             getline(is, line);
@@ -567,7 +567,7 @@ struct SourceHutInputScheme : GitArchiveInputScheme
         std::regex refRegex(refUri);
 
         auto file = store->toRealPath(
-            downloadFile(store, fmt("%s/info/refs", base_url), "source", headers).storePath);
+            downloadFile(store, *input.settings, fmt("%s/info/refs", base_url), "source", headers).storePath);
         std::ifstream is(file);
 
         std::string line;

--- a/src/libfetchers/include/nix/fetchers/cache.hh
+++ b/src/libfetchers/include/nix/fetchers/cache.hh
@@ -91,6 +91,4 @@ struct Cache
         Store & store) = 0;
 };
 
-ref<Cache> getCache();
-
 }

--- a/src/libfetchers/include/nix/fetchers/fetch-settings.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-settings.hh
@@ -3,6 +3,8 @@
 
 #include "nix/util/types.hh"
 #include "nix/util/configuration.hh"
+#include "nix/util/ref.hh"
+#include "nix/util/sync.hh"
 
 #include <map>
 #include <limits>
@@ -10,6 +12,8 @@
 #include <sys/types.h>
 
 namespace nix::fetchers {
+
+struct Cache;
 
 struct Settings : public Config
 {
@@ -110,6 +114,11 @@ struct Settings : public Config
           When empty, disables the global flake registry.
         )",
         {}, true, Xp::Flakes};
+
+    ref<Cache> getCache() const;
+
+private:
+    mutable Sync<std::shared_ptr<Cache>> _cache;
 };
 
 }

--- a/src/libfetchers/include/nix/fetchers/fetch-to-store.hh
+++ b/src/libfetchers/include/nix/fetchers/fetch-to-store.hh
@@ -15,6 +15,7 @@ enum struct FetchMode { DryRun, Copy };
  * Copy the `path` to the Nix store.
  */
 StorePath fetchToStore(
+    const fetchers::Settings & settings,
     Store & store,
     const SourcePath & path,
     FetchMode mode,

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -5,7 +5,7 @@
 
 namespace nix {
 
-namespace fetchers { struct PublicKey; }
+namespace fetchers { struct PublicKey; struct Settings; }
 
 /**
  * A sink that writes into a Git repository. Note that nothing may be written
@@ -115,7 +115,7 @@ struct GitRepo
      * Given a Git tree hash, compute the hash of its NAR
      * serialisation. This is memoised on-disk.
      */
-    virtual Hash treeHashToNarHash(const Hash & treeHash) = 0;
+    virtual Hash treeHashToNarHash(const fetchers::Settings & settings, const Hash & treeHash) = 0;
 
     /**
      * If the specified Git object is a directory with a single entry

--- a/src/libfetchers/include/nix/fetchers/tarball.hh
+++ b/src/libfetchers/include/nix/fetchers/tarball.hh
@@ -26,6 +26,7 @@ struct DownloadFileResult
 
 DownloadFileResult downloadFile(
     ref<Store> store,
+    const Settings & settings,
     const std::string & url,
     const std::string & name,
     const Headers & headers = {});

--- a/src/libfetchers/mercurial.cc
+++ b/src/libfetchers/mercurial.cc
@@ -253,13 +253,13 @@ struct MercurialInputScheme : InputScheme
         }};
 
         if (!input.getRev()) {
-            if (auto res = getCache()->lookupWithTTL(refToRevKey))
+            if (auto res = input.settings->getCache()->lookupWithTTL(refToRevKey))
                 input.attrs.insert_or_assign("rev", getRevAttr(*res, "rev").gitRev());
         }
 
         /* If we have a rev, check if we have a cached store path. */
         if (auto rev = input.getRev()) {
-            if (auto res = getCache()->lookupStorePath(revInfoKey(*rev), *store))
+            if (auto res = input.settings->getCache()->lookupStorePath(revInfoKey(*rev), *store))
                 return makeResult(res->value, res->storePath);
         }
 
@@ -309,7 +309,7 @@ struct MercurialInputScheme : InputScheme
 
         /* Now that we have the rev, check the cache again for a
            cached store path. */
-        if (auto res = getCache()->lookupStorePath(revInfoKey(rev), *store))
+        if (auto res = input.settings->getCache()->lookupStorePath(revInfoKey(rev), *store))
             return makeResult(res->value, res->storePath);
 
         Path tmpDir = createTempDir();
@@ -326,9 +326,9 @@ struct MercurialInputScheme : InputScheme
         });
 
         if (!origRev)
-            getCache()->upsert(refToRevKey, {{"rev", rev.gitRev()}});
+            input.settings->getCache()->upsert(refToRevKey, {{"rev", rev.gitRev()}});
 
-        getCache()->upsert(revInfoKey(rev), *store, infoAttrs, storePath);
+        input.settings->getCache()->upsert(revInfoKey(rev), *store, infoAttrs, storePath);
 
         return makeResult(infoAttrs, std::move(storePath));
     }

--- a/src/libfetchers/path.cc
+++ b/src/libfetchers/path.cc
@@ -4,6 +4,7 @@
 #include "nix/fetchers/store-path-accessor.hh"
 #include "nix/fetchers/cache.hh"
 #include "nix/fetchers/fetch-to-store.hh"
+#include "nix/fetchers/fetch-settings.hh"
 
 namespace nix::fetchers {
 
@@ -149,7 +150,7 @@ struct PathInputScheme : InputScheme
         auto fp = getFingerprint(store, input);
         if (fp) {
             auto cacheKey = makeFetchToStoreCacheKey(input.getName(), *fp, method, "/");
-            fetchers::getCache()->upsert(cacheKey, *store, {}, *storePath);
+            input.settings->getCache()->upsert(cacheKey, *store, {}, *storePath);
         }
 
         /* Trust the lastModified value supplied by the user, if

--- a/src/libfetchers/registry.cc
+++ b/src/libfetchers/registry.cc
@@ -156,7 +156,7 @@ static std::shared_ptr<Registry> getGlobalRegistry(const Settings & settings, re
         }
 
         if (!isAbsolute(path)) {
-            auto storePath = downloadFile(store, path, "flake-registry.json").storePath;
+            auto storePath = downloadFile(store, settings, path, "flake-registry.json").storePath;
             if (auto store2 = store.dynamic_pointer_cast<LocalFSStore>())
                 store2->addPermRoot(storePath, getCacheDir() + "/flake-registry.json");
             path = store->toRealPath(storePath);

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -30,7 +30,7 @@ static StorePath copyInputToStore(
     const fetchers::Input & originalInput,
     ref<SourceAccessor> accessor)
 {
-    auto storePath = fetchToStore(*state.store, accessor, FetchMode::Copy, input.getName());
+    auto storePath = fetchToStore(*input.settings, *state.store, accessor, FetchMode::Copy, input.getName());
 
     state.allowPath(storePath);
 
@@ -276,7 +276,7 @@ static Flake readFlake(
                     state.symbols[setting.name],
                     std::string(state.forceStringNoCtx(*setting.value, setting.pos, "")));
             else if (setting.value->type() == nPath) {
-                auto storePath = fetchToStore(*state.store, setting.value->path(), FetchMode::Copy);
+                auto storePath = fetchToStore(state.fetchSettings, *state.store, setting.value->path(), FetchMode::Copy);
                 flake.config.settings.emplace(
                     state.symbols[setting.name],
                     state.store->printStorePath(storePath));

--- a/src/libutil/include/nix/util/sync.hh
+++ b/src/libutil/include/nix/util/sync.hh
@@ -39,6 +39,7 @@ public:
     SyncBase() { }
     SyncBase(const T & data) : data(data) { }
     SyncBase(T && data) noexcept : data(std::move(data)) { }
+    SyncBase(SyncBase && other) noexcept : data(std::move(*other.lock())) { }
 
     template<class L>
     class Lock

--- a/src/nix-channel/nix-channel.cc
+++ b/src/nix-channel/nix-channel.cc
@@ -4,9 +4,11 @@
 #include "nix/store/filetransfer.hh"
 #include "nix/store/store-open.hh"
 #include "nix/cmd/legacy.hh"
+#include "nix/cmd/common-eval-args.hh"
 #include "nix/expr/eval-settings.hh" // for defexpr
 #include "nix/util/users.hh"
 #include "nix/fetchers/tarball.hh"
+#include "nix/fetchers/fetch-settings.hh"
 #include "self-exe.hh"
 #include "man-pages.hh"
 
@@ -114,7 +116,7 @@ static void update(const StringSet & channelNames)
             // We want to download the url to a file to see if it's a tarball while also checking if we
             // got redirected in the process, so that we can grab the various parts of a nix channel
             // definition from a consistent location if the redirect changes mid-download.
-            auto result = fetchers::downloadFile(store, url, std::string(baseNameOf(url)));
+            auto result = fetchers::downloadFile(store, fetchSettings, url, std::string(baseNameOf(url)));
             auto filename = store->toRealPath(result.storePath);
             url = result.effectiveUrl;
 
@@ -128,9 +130,9 @@ static void update(const StringSet & channelNames)
             if (!unpacked) {
                 // Download the channel tarball.
                 try {
-                    filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.xz", "nixexprs.tar.xz").storePath);
+                    filename = store->toRealPath(fetchers::downloadFile(store, fetchSettings, url + "/nixexprs.tar.xz", "nixexprs.tar.xz").storePath);
                 } catch (FileTransferError & e) {
-                    filename = store->toRealPath(fetchers::downloadFile(store, url + "/nixexprs.tar.bz2", "nixexprs.tar.bz2").storePath);
+                    filename = store->toRealPath(fetchers::downloadFile(store, fetchSettings, url + "/nixexprs.tar.bz2", "nixexprs.tar.bz2").storePath);
                 }
             }
             // Regardless of where it came from, add the expression representing this channel to accumulated expression

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1488,7 +1488,7 @@ struct CmdFlakePrefetch : FlakeCommand, MixJSON
         auto originalRef = getFlakeRef();
         auto resolvedRef = originalRef.resolve(store);
         auto [accessor, lockedRef] = resolvedRef.lazyFetch(store);
-        auto storePath = fetchToStore(*store, accessor, FetchMode::Copy, lockedRef.input.getName());
+        auto storePath = fetchToStore(getEvalState()->fetchSettings, *store, accessor, FetchMode::Copy, lockedRef.input.getName());
         auto hash = store->queryPathInfo(storePath)->narHash;
 
         if (json) {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This removes the global fetcher cache object (the `getCache()` singleton) and moves the cache into `fetchers::Settings`. This is a bit of an abuse of `fetchers::Settings` but I didn't want to add another class to pass around everywhere.

## Context

This is cherry-picked from https://github.com/DeterminateSystems/nix-src/pull/49, which adds a `builtin:fetch-tree` builtin builder. Since builtin builders run in a forked child process, we cannot use any of the parent's global state (like the fetcher cache's SQLite database) since that's invalid in the child (e.g. it refers to file handles that don't exist in the child). Thus we use a new `fetchers::Settings` object to avoid touching the parent's fetcher cache.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
