### PR TITLE
libutil-tests/json-utils: fix -Werror=sign-compare error

### DIFF
--- a/src/libutil-tests/json-utils.cc
+++ b/src/libutil-tests/json-utils.cc
@@ -131,7 +131,7 @@ TEST(getString, wrongAssertions) {
 TEST(getIntegralNumber, rightAssertions) {
     auto simple = R"({ "int": 0, "signed": -1 })"_json;
 
-    ASSERT_EQ(getUnsigned(valueAt(getObject(simple), "int")), 0);
+    ASSERT_EQ(getUnsigned(valueAt(getObject(simple), "int")), 0u);
     ASSERT_EQ(getInteger<int8_t>(valueAt(getObject(simple), "int")), 0);
     ASSERT_EQ(getInteger<int8_t>(valueAt(getObject(simple), "signed")), -1);
 }


### PR DESCRIPTION
I am on a newer different nixpkgs branch, so I am getting this error

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
