### PR TITLE
docs: add another equivalence for the implication operator

### DIFF
--- a/doc/manual/source/language/operators.md
+++ b/doc/manual/source/language/operators.md
@@ -196,7 +196,7 @@ All comparison operators are implemented in terms of `<`, and the following equi
 
 ## Logical implication
 
-Equivalent to `!`*b1* `||` *b2*.
+Equivalent to `!`*b1* `||` *b2*  (or `if` *b1* `then` *b2* `else true`)
 
 [Logical implication]: #logical-implication
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

the second equivalence, using a if-else expression, aligns much closer to how most humans think about implication, adding it might help some people :)


## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
