### PR TITLE
libexpr: Use `attrs.alreadySorted()` in primop_functionArgs

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -306,6 +306,9 @@ struct Formal
 struct Formals
 {
     typedef std::vector<Formal> Formals_;
+    /**
+     * @pre Sorted according to predicate (std::tie(a.name, a.pos) < std::tie(b.name, b.pos)).
+     */
     Formals_ formals;
     bool ellipsis;
 

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3148,10 +3148,16 @@ static void prim_functionArgs(EvalState & state, const PosIdx pos, Value * * arg
         return;
     }
 
-    auto attrs = state.buildBindings(args[0]->payload.lambda.fun->formals->formals.size());
-    for (auto & i : args[0]->payload.lambda.fun->formals->formals)
+    const auto &formals = args[0]->payload.lambda.fun->formals->formals;
+    auto attrs = state.buildBindings(formals.size());
+    for (auto & i : formals)
         attrs.insert(i.name, state.getBool(i.def), i.pos);
-    v.mkAttrs(attrs);
+    /* Optimization: avoid sorting bindings. `formals` must already be sorted according to
+       (std::tie(a.name, a.pos) < std::tie(b.name, b.pos)) predicate, so the following assertion
+       always holds:
+       assert(std::is_sorted(attrs.alreadySorted()->begin(), attrs.alreadySorted()->end()));
+       .*/
+    v.mkAttrs(attrs.alreadySorted());
 }
 
 static RegisterPrimOp primop_functionArgs({


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Formals are already sorted as it's an invariant of `Formals`. It's not really significant for `nixpkgs`, but synthetic benchmarks can surface this inefficiency.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
