### PR TITLE
Get rid of `addWantedOutputs`

### DIFF
--- a/src/libfetchers/include/nix/fetchers/input-cache.hh
+++ b/src/libfetchers/include/nix/fetchers/input-cache.hh
@@ -1,4 +1,4 @@
-#include "fetchers.hh"
+#include "nix/fetchers/fetchers.hh"
 
 namespace nix::fetchers {
 

--- a/src/libstore/build/derivation-trampoline-goal.cc
+++ b/src/libstore/build/derivation-trampoline-goal.cc
@@ -1,0 +1,175 @@
+#include "nix/store/build/derivation-trampoline-goal.hh"
+#include "nix/store/build/worker.hh"
+#include "nix/store/derivations.hh"
+
+namespace nix {
+
+DerivationTrampolineGoal::DerivationTrampolineGoal(
+    ref<const SingleDerivedPath> drvReq, const OutputsSpec & wantedOutputs, Worker & worker, BuildMode buildMode)
+    : Goal(worker, init())
+    , drvReq(drvReq)
+    , wantedOutputs(wantedOutputs)
+    , buildMode(buildMode)
+{
+    commonInit();
+}
+
+DerivationTrampolineGoal::DerivationTrampolineGoal(
+    const StorePath & drvPath,
+    const OutputsSpec & wantedOutputs,
+    const Derivation & drv,
+    Worker & worker,
+    BuildMode buildMode)
+    : Goal(worker, haveDerivation(drvPath, drv))
+    , drvReq(makeConstantStorePathRef(drvPath))
+    , wantedOutputs(wantedOutputs)
+    , buildMode(buildMode)
+{
+    commonInit();
+}
+
+void DerivationTrampolineGoal::commonInit()
+{
+    name =
+        fmt("outer obtaining drv from '%s' and then building outputs %s",
+            drvReq->to_string(worker.store),
+            std::visit(
+                overloaded{
+                    [&](const OutputsSpec::All) -> std::string { return "* (all of them)"; },
+                    [&](const OutputsSpec::Names os) { return concatStringsSep(", ", quoteStrings(os)); },
+                },
+                wantedOutputs.raw));
+    trace("created outer");
+
+    worker.updateProgress();
+}
+
+DerivationTrampolineGoal::~DerivationTrampolineGoal() {}
+
+static StorePath pathPartOfReq(const SingleDerivedPath & req)
+{
+    return std::visit(
+        overloaded{
+            [&](const SingleDerivedPath::Opaque & bo) { return bo.path; },
+            [&](const SingleDerivedPath::Built & bfd) { return pathPartOfReq(*bfd.drvPath); },
+        },
+        req.raw());
+}
+
+std::string DerivationTrampolineGoal::key()
+{
+    /* Ensure that derivations get built in order of their name,
+       i.e. a derivation named "aardvark" always comes before "baboon". And
+       substitution goals, derivation goals, and derivation building goals always happen before
+       derivation goals (due to "bt$"). */
+    return "bt$" + std::string(pathPartOfReq(*drvReq).name()) + "$" + DerivedPath::Built{
+        .drvPath = drvReq,
+        .outputs = wantedOutputs,
+    }.to_string(worker.store);
+}
+
+void DerivationTrampolineGoal::timedOut(Error && ex) {}
+
+Goal::Co DerivationTrampolineGoal::init()
+{
+    trace("need to load derivation from file");
+
+    /* The first thing to do is to make sure that the derivation
+       exists.  If it doesn't, it may be built from another derivation,
+       or merely substituted. We can make goal to get it and not worry
+       about which method it takes to get the derivation. */
+    if (auto optDrvPath = [this]() -> std::optional<StorePath> {
+            if (buildMode != bmNormal)
+                return std::nullopt;
+
+            auto drvPath = StorePath::dummy;
+            try {
+                drvPath = resolveDerivedPath(worker.store, *drvReq);
+            } catch (MissingRealisation &) {
+                return std::nullopt;
+            }
+            auto cond = worker.evalStore.isValidPath(drvPath) || worker.store.isValidPath(drvPath);
+            return cond ? std::optional{drvPath} : std::nullopt;
+        }()) {
+        trace(
+            fmt("already have drv '%s' for '%s', can go straight to building",
+                worker.store.printStorePath(*optDrvPath),
+                drvReq->to_string(worker.store)));
+    } else {
+        trace("need to obtain drv we want to build");
+        Goals waitees{worker.makeGoal(DerivedPath::fromSingle(*drvReq))};
+        co_await await(std::move(waitees));
+    }
+
+    trace("outer load and build derivation");
+
+    if (nrFailed != 0) {
+        co_return amDone(ecFailed, Error("cannot build missing derivation '%s'", drvReq->to_string(worker.store)));
+    }
+
+    StorePath drvPath = resolveDerivedPath(worker.store, *drvReq);
+
+    /* `drvPath' should already be a root, but let's be on the safe
+       side: if the user forgot to make it a root, we wouldn't want
+       things being garbage collected while we're busy. */
+    worker.evalStore.addTempRoot(drvPath);
+
+    /* Get the derivation. It is probably in the eval store, but it might be in the main store:
+
+         - Resolved derivation are resolved against main store realisations, and so must be stored there.
+
+         - Dynamic derivations are built, and so are found in the main store.
+     */
+    auto drv = [&] {
+        for (auto * drvStore : {&worker.evalStore, &worker.store})
+            if (drvStore->isValidPath(drvPath))
+                return drvStore->readDerivation(drvPath);
+        assert(false);
+    }();
+
+    co_return haveDerivation(std::move(drvPath), std::move(drv));
+}
+
+Goal::Co DerivationTrampolineGoal::haveDerivation(StorePath drvPath, Derivation drv)
+{
+    trace("have derivation, will kick off derivations goals per wanted output");
+
+    auto resolvedWantedOutputs = std::visit(
+        overloaded{
+            [&](const OutputsSpec::Names & names) -> OutputsSpec::Names { return names; },
+            [&](const OutputsSpec::All &) -> OutputsSpec::Names {
+                StringSet outputs;
+                for (auto & [outputName, _] : drv.outputs)
+                    outputs.insert(outputName);
+                return outputs;
+            },
+        },
+        wantedOutputs.raw);
+
+    Goals concreteDrvGoals;
+
+    /* Build this step! */
+
+    for (auto & output : resolvedWantedOutputs) {
+        auto g = upcast_goal(worker.makeDerivationGoal(drvPath, drv, output, buildMode));
+        g->preserveException = true;
+        /* We will finish with it ourselves, as if we were the derivational goal. */
+        concreteDrvGoals.insert(std::move(g));
+    }
+
+    // Copy on purpose
+    co_await await(Goals(concreteDrvGoals));
+
+    trace("outer build done");
+
+    auto & g = *concreteDrvGoals.begin();
+    buildResult = g->buildResult;
+    for (auto & g2 : concreteDrvGoals) {
+        for (auto && [x, y] : g2->buildResult.builtOutputs)
+            buildResult.builtOutputs.insert_or_assign(x, y);
+    }
+
+    co_return amDone(g->exitCode, g->ex);
+}
+
+}

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -1,8 +1,7 @@
+#include "nix/store/derivations.hh"
 #include "nix/store/build/worker.hh"
 #include "nix/store/build/substitution-goal.hh"
-#ifndef _WIN32 // TODO Enable building on Windows
-#  include "nix/store/build/derivation-goal.hh"
-#endif
+#include "nix/store/build/derivation-trampoline-goal.hh"
 #include "nix/store/local-store.hh"
 #include "nix/util/strings.hh"
 
@@ -28,12 +27,9 @@ void Store::buildPaths(const std::vector<DerivedPath> & reqs, BuildMode buildMod
                 ex = std::move(i->ex);
         }
         if (i->exitCode != Goal::ecSuccess) {
-#ifndef _WIN32 // TODO Enable building on Windows
-            if (auto i2 = dynamic_cast<DerivationGoal *>(i.get()))
+            if (auto i2 = dynamic_cast<DerivationTrampolineGoal *>(i.get()))
                 failed.insert(i2->drvReq->to_string(*this));
-            else
-#endif
-            if (auto i2 = dynamic_cast<PathSubstitutionGoal *>(i.get()))
+            else if (auto i2 = dynamic_cast<PathSubstitutionGoal *>(i.get()))
                 failed.insert(printStorePath(i2->storePath));
         }
     }
@@ -70,7 +66,7 @@ std::vector<KeyedBuildResult> Store::buildPathsWithResults(
 
     for (auto & [req, goalPtr] : state)
         results.emplace_back(KeyedBuildResult {
-            goalPtr->getBuildResult(req),
+            goalPtr->buildResult,
             /* .path = */ req,
         });
 
@@ -81,19 +77,11 @@ BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivat
     BuildMode buildMode)
 {
     Worker worker(*this, *this);
-#ifndef _WIN32 // TODO Enable building on Windows
-    auto goal = worker.makeBasicDerivationGoal(drvPath, drv, OutputsSpec::All {}, buildMode);
-#else
-    std::shared_ptr<Goal> goal;
-    throw UnimplementedError("Building derivations not yet implemented on windows.");
-#endif
+    auto goal = worker.makeDerivationTrampolineGoal(drvPath, OutputsSpec::All {}, drv, buildMode);
 
     try {
         worker.run(Goals{goal});
-        return goal->getBuildResult(DerivedPath::Built {
-            .drvPath = makeConstantStorePathRef(drvPath),
-            .outputs = OutputsSpec::All {},
-        });
+        return goal->buildResult;
     } catch (Error & e) {
         return BuildResult {
             .status = BuildResult::MiscFailure,

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -101,30 +101,6 @@ bool CompareGoalPtrs::operator() (const GoalPtr & a, const GoalPtr & b) const {
     return s1 < s2;
 }
 
-
-BuildResult Goal::getBuildResult(const DerivedPath & req) const {
-    BuildResult res { buildResult };
-
-    if (auto pbp = std::get_if<DerivedPath::Built>(&req)) {
-        auto & bp = *pbp;
-
-        /* Because goals are in general shared between derived paths
-           that share the same derivation, we need to filter their
-           results to get back just the results we care about.
-         */
-
-        for (auto it = res.builtOutputs.begin(); it != res.builtOutputs.end();) {
-            if (bp.outputs.contains(it->first))
-                ++it;
-            else
-                it = res.builtOutputs.erase(it);
-        }
-    }
-
-    return res;
-}
-
-
 void addToWeakGoals(WeakGoals & goals, GoalPtr p)
 {
     if (goals.find(p) != goals.end())

--- a/src/libstore/derived-path-map.cc
+++ b/src/libstore/derived-path-map.cc
@@ -52,7 +52,7 @@ typename DerivedPathMap<V>::ChildNode * DerivedPathMap<V>::findSlot(const Single
 
 // instantiations
 
-#include "nix/store/build/derivation-goal.hh"
+#include "nix/store/build/derivation-trampoline-goal.hh"
 namespace nix {
 
 template<>
@@ -69,7 +69,7 @@ std::strong_ordering DerivedPathMap<StringSet>::ChildNode::operator <=> (
 template struct DerivedPathMap<StringSet>::ChildNode;
 template struct DerivedPathMap<StringSet>;
 
-template struct DerivedPathMap<std::weak_ptr<DerivationGoal>>;
+template struct DerivedPathMap<std::map<OutputsSpec, std::weak_ptr<DerivationTrampolineGoal>>>;
 
 
 };

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -29,7 +29,9 @@ void runPostBuildHook(
     const StorePathSet & outputPaths);
 
 /**
- * A goal for building some or all of the outputs of a derivation.
+ * A goal for building a derivation. Substitution, (or any other method of
+ * obtaining the outputs) will not be attempted, so it is the calling goal's
+ * responsibility to try to substitute first.
  */
 struct DerivationBuildingGoal : public Goal
 {

--- a/src/libstore/include/nix/store/build/derivation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-goal.hh
@@ -22,47 +22,33 @@ void runPostBuildHook(
     const StorePathSet & outputPaths);
 
 /**
- * A goal for building some or all of the outputs of a derivation.
+ * A goal for realising a single output of a derivation. Various sorts of
+ * fetching (which will be done by other goal types) is tried, and if none of
+ * those succeed, the derivation is attempted to be built.
+ *
+ * This is a purely "administrative" goal type, which doesn't do any
+ * "real work" of substituting (that would be `PathSubstitutionGoal` or
+ * `DrvOutputSubstitutionGoal`) or building (that would be a
+ * `DerivationBuildingGoal`). This goal type creates those types of
+ * goals to attempt each way of realisation a derivation; they are tried
+ * sequentially in order of preference.
+ *
+ * The derivation must already be gotten (in memory, in C++, parsed) and passed
+ * to the caller. If the derivation itself needs to be gotten first, a
+ * `DerivationTrampolineGoal` goal must be used instead.
  */
 struct DerivationGoal : public Goal
 {
     /** The path of the derivation. */
-    ref<const SingleDerivedPath> drvReq;
+    StorePath drvPath;
 
     /**
      * The specific outputs that we need to build.
      */
-    OutputsSpec wantedOutputs;
+    OutputName wantedOutput;
 
     /**
-     * See `needRestart`; just for that field.
-     */
-    enum struct NeedRestartForMoreOutputs {
-        /**
-         * The goal state machine is progressing based on the current value of
-         * `wantedOutputs. No actions are needed.
-         */
-        OutputsUnmodifiedDontNeed,
-        /**
-         * `wantedOutputs` has been extended, but the state machine is
-         * proceeding according to its old value, so we need to restart.
-         */
-        OutputsAddedDoNeed,
-        /**
-         * The goal state machine has progressed to the point of doing a build,
-         * in which case all outputs will be produced, so extensions to
-         * `wantedOutputs` no longer require a restart.
-         */
-        BuildInProgressWillNotNeed,
-    };
-
-    /**
-     * Whether additional wanted outputs have been added.
-     */
-    NeedRestartForMoreOutputs needRestart = NeedRestartForMoreOutputs::OutputsUnmodifiedDontNeed;
-
-    /**
-     * The derivation stored at `drvReq`.
+     * The derivation stored at drvPath.
      */
     std::unique_ptr<Derivation> drv;
 
@@ -76,11 +62,8 @@ struct DerivationGoal : public Goal
 
     std::unique_ptr<MaintainCount<uint64_t>> mcExpectedBuilds;
 
-    DerivationGoal(ref<const SingleDerivedPath> drvReq,
-        const OutputsSpec & wantedOutputs, Worker & worker,
-        BuildMode buildMode = bmNormal);
-    DerivationGoal(const StorePath & drvPath, const BasicDerivation & drv,
-        const OutputsSpec & wantedOutputs, Worker & worker,
+    DerivationGoal(const StorePath & drvPath, const Derivation & drv,
+        const OutputName & wantedOutput, Worker & worker,
         BuildMode buildMode = bmNormal);
     ~DerivationGoal() = default;
 
@@ -89,23 +72,17 @@ struct DerivationGoal : public Goal
     std::string key() override;
 
     /**
-     * Add wanted outputs to an already existing derivation goal.
-     */
-    void addWantedOutputs(const OutputsSpec & outputs);
-
-    /**
      * The states.
      */
-    Co loadDerivation();
-    Co haveDerivation(StorePath drvPath);
+    Co haveDerivation();
 
     /**
      * Wrappers around the corresponding Store methods that first consult the
      * derivation.  This is currently needed because when there is no drv file
      * there also is no DB entry.
      */
-    std::map<std::string, std::optional<StorePath>> queryPartialDerivationOutputMap(const StorePath & drvPath);
-    OutputPathMap queryDerivationOutputMap(const StorePath & drvPath);
+    std::map<std::string, std::optional<StorePath>> queryPartialDerivationOutputMap();
+    OutputPathMap queryDerivationOutputMap();
 
     /**
      * Update 'initialOutputs' to determine the current status of the
@@ -113,18 +90,17 @@ struct DerivationGoal : public Goal
      * whether all outputs are valid and non-corrupt, and a
      * 'SingleDrvOutputs' structure containing the valid outputs.
      */
-    std::pair<bool, SingleDrvOutputs> checkPathValidity(const StorePath & drvPath);
+    std::pair<bool, SingleDrvOutputs> checkPathValidity();
 
     /**
      * Aborts if any output is not valid or corrupt, and otherwise
      * returns a 'SingleDrvOutputs' structure containing all outputs.
      */
-    SingleDrvOutputs assertPathValidity(const StorePath & drvPath);
+    SingleDrvOutputs assertPathValidity();
 
-    Co repairClosure(StorePath drvPath);
+    Co repairClosure();
 
     Done done(
-        const StorePath & drvPath,
         BuildResult::Status status,
         SingleDrvOutputs builtOutputs = {},
         std::optional<Error> ex = {});

--- a/src/libstore/include/nix/store/build/derivation-trampoline-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-trampoline-goal.hh
@@ -1,0 +1,134 @@
+#pragma once
+///@file
+
+#include "nix/store/parsed-derivations.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/pathlocks.hh"
+#include "nix/store/build/goal.hh"
+
+namespace nix {
+
+/**
+ * This is the "outermost" goal type relating to derivations --- by that
+ * we mean that this one calls all the others for a given derivation.
+ *
+ * This is a purely "administrative" goal type, which doesn't do any "real
+ * work". See `DerivationGoal` for what we mean by such an administrative goal.
+ *
+ * # Rationale
+ *
+ * It exists to solve two problems:
+ *
+ * 1. We want to build a derivation we don't yet have.
+ *
+ *    Traditionally, that simply means we try to substitute the missing
+ *    derivation; simple enough. However, with (currently experimental)
+ *    dynamic derivations, derivations themselves can be the outputs of
+ *    other derivations. That means the general case is that a
+ *    `DerivationTrampolineGoal` needs to create *another*
+ *    `DerivationTrampolineGoal` goal to realize the derivation it needs.
+ *    That goal in turn might need to create a third
+ *    `DerivationTrampolineGoal`, the induction down to a statically known
+ *    derivation as the base case is arbitrary deep.
+ *
+ * 2. Only a subset of outputs is needed, but such subsets are discovered
+ * dynamically.
+ *
+ *    Consider derivations:
+ *
+ *    - A has outputs x, y, and z
+ *
+ *    - B needs A^x,y
+ *
+ *    - C needs A^y,z and B's single output
+ *
+ *    With the current `Worker` architecture, we're first discover
+ *    needing `A^y,z` and then discover needing `A^x,y`. Of course, we
+ *    don't want to download `A^y` twice, either.
+ *
+ *    The way we handle sharing work for `A^y` is to have
+ *    `DerivationGoal` just handle a single output, and do slightly more
+ *    work (though it is just an "administrative" goal too), and
+ *    `DerivationTrampolineGoal` handle sets of goals, but have it (once the
+ *    derivation itself has been gotten) *just* create
+ *    `DerivationGoal`s.
+ *
+ *    That means it is fine to create man `DerivationTrampolineGoal` with
+ *    overlapping sets of outputs, because all the "real work" will be
+ *    coordinated via `DerivationGoal`s, and sharing will be discovered.
+ *
+ * Both these problems *can* be solved by having just a more powerful
+ * `DerivationGoal`, but that makes `DerivationGoal` more complex.
+ * However the more complex `DerivationGoal` has these downsides:
+ *
+ * 1. It needs to cope with only sometimes knowing a `StorePath drvPath`
+ * (as opposed to a more general `SingleDerivedPath drvPath` with will
+ * be only resolved to a `StorePath` part way through the control flow).
+ *
+ * 2. It needs complicated "restarting logic" to cope with the set of
+ * "wanted outputs" growing over time.
+ *
+ * (1) is not so bad, but (2) is quite scary, and has been a source of
+ * bugs in the past. By splitting out `DerivationTrampolineGoal`, we
+ * crucially avoid a need for (2), letting goal sharing rather than
+ * ad-hoc retry mechanisms accomplish the deduplication we need. Solving
+ * (1) is just a by-product and extra bonus of creating
+ * `DerivationTrampolineGoal`.
+ *
+ * # Misc Notes
+ *
+ * If we already have the derivation (e.g. if the evaluator has created
+ * the derivation locally and then instructed the store to build it), we
+ * can skip the derivation-getting goal entirely as a small
+ * optimization.
+ */
+struct DerivationTrampolineGoal : public Goal
+{
+    /**
+     * How to obtain a store path of the derivation to build.
+     */
+    ref<const SingleDerivedPath> drvReq;
+
+    /**
+     * The specific outputs that we need to build.
+     */
+    OutputsSpec wantedOutputs;
+
+    DerivationTrampolineGoal(
+        ref<const SingleDerivedPath> drvReq,
+        const OutputsSpec & wantedOutputs,
+        Worker & worker,
+        BuildMode buildMode = bmNormal);
+
+    DerivationTrampolineGoal(
+        const StorePath & drvPath,
+        const OutputsSpec & wantedOutputs,
+        const Derivation & drv,
+        Worker & worker,
+        BuildMode buildMode = bmNormal);
+
+    virtual ~DerivationTrampolineGoal();
+
+    void timedOut(Error && ex) override;
+
+    std::string key() override;
+
+    JobCategory jobCategory() const override
+    {
+        return JobCategory::Administration;
+    };
+
+private:
+
+    BuildMode buildMode;
+
+    Co init();
+    Co haveDerivation(StorePath drvPath, Derivation drv);
+
+    /**
+     * Shared between both constructors
+     */
+    void commonInit();
+};
+
+}

--- a/src/libstore/include/nix/store/build/goal.hh
+++ b/src/libstore/include/nix/store/build/goal.hh
@@ -105,13 +105,11 @@ public:
      */
     ExitCode exitCode = ecBusy;
 
-protected:
     /**
      * Build result.
      */
     BuildResult buildResult;
 
-public:
     /**
      * Suspend our goal and wait until we get `work`-ed again.
      * `co_await`-able by @ref Co.
@@ -357,18 +355,6 @@ protected:
 
 public:
     virtual void cleanup() { }
-
-    /**
-     * Project a `BuildResult` with just the information that pertains
-     * to the given request.
-     *
-     * In general, goals may be aliased between multiple requests, and
-     * the stored `BuildResult` has information for the union of all
-     * requests. We don't want to leak what the other request are for
-     * sake of both privacy and determinism, and this "safe accessor"
-     * ensures we don't.
-     */
-    BuildResult getBuildResult(const DerivedPath &) const;
 
     /**
      * Hack to say that this goal should not log `ex`, but instead keep

--- a/src/libstore/include/nix/store/derived-path-map.hh
+++ b/src/libstore/include/nix/store/derived-path-map.hh
@@ -22,7 +22,7 @@ namespace nix {
  * @param V A type to instantiate for each output. It should probably
  * should be an "optional" type so not every interior node has to have a
  * value. For example, the scheduler uses
- * `DerivedPathMap<std::weak_ptr<DerivationCreationAndRealisationGoal>>` to
+ * `DerivedPathMap<std::weak_ptr<DerivationTrampolineGoal>>` to
  * remember which goals correspond to which outputs. `* const Something`
  * or `std::optional<Something>` would also be good choices for
  * "optional" types.

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -403,7 +403,6 @@ private:
     void addBuildLog(const StorePath & drvPath, std::string_view log) override;
 
     friend struct PathSubstitutionGoal;
-    friend struct SubstitutionGoal;
     friend struct DerivationGoal;
 };
 

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -15,6 +15,7 @@ headers = [config_pub_h] + files(
   'build/derivation-goal.hh',
   'build/derivation-building-goal.hh',
   'build/derivation-building-misc.hh',
+  'build/derivation-trampoline-goal.hh',
   'build/drv-output-substitution-goal.hh',
   'build/goal.hh',
   'build/substitution-goal.hh',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -255,6 +255,7 @@ sources = files(
   'build-result.cc',
   'build/derivation-goal.cc',
   'build/derivation-building-goal.cc',
+  'build/derivation-trampoline-goal.cc',
   'build/drv-output-substitution-goal.cc',
   'build/entry-points.cc',
   'build/goal.cc',


### PR DESCRIPTION
## Motivation

Do this by introducing `DerivationTrampolineGoal`.

`DerivationGoal` now only tracks a single output, and is back to tracking a plain store path `drvPath`, not a deriving path one. Its `addWantedOutputs` method is gone. These changes will allow subsequent PRs to simplify it greatly.

Because the purpose of each goal is back to being immutable, we can also once again make `Goal::buildResult` a public field, and get rid of the `getBuildResult` method. This simplifies things also.

`DerivationTrampolineGoal` is, as the nane is supposed to indicate, a cheap "trampoline" goal. It takes immutable sets of wanted outputs, and just kicks of `DerivationGoal`s for them. Since now "actual work" is done in these goals, it is not wasteful to have separate ones for separate sets of outputs, even if those outputs (and the derivations they are from) overlap.

This design is described in more detail in the doc comments on the goal types, which I've now greatly expanded.

## Context

This separation of concerns will make it possible for future work on issues like #11928, and to continue the path of having more goal types, but each goal type does fewer things (issue #12628).

This commit in some sense reverts f4f28cdd0e01a9bfb0901e8a53ead719265fa9b8, but that one kept around `addWantedOutputs`. I am quite sure it was having two layers of goals with `addWantedOutputs` that caused the issues --- restarting logic like `addWantedOutputs` has is very tempermental! In this version of the change, we have *zero* layers of `addWantedOutputs` --- no goal type needs it, or otherwise has a mutable objective --- and so I think this change is safe.

---

~~depends on #13186~~
~~depends on #13294~~

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
