### PR TITLE
nix-profile{,-daemon}.fish: fix do not source twice

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -3,7 +3,7 @@ if test -z "$HOME" || test -n "$__ETC_PROFILE_NIX_SOURCED"
     exit
 end
 
-set --global __ETC_PROFILE_NIX_SOURCED 1
+set --global --export __ETC_PROFILE_NIX_SOURCED 1
 
 # Local helpers
 

--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -1,6 +1,5 @@
 # Only execute this file once per shell.
-if test -z "$HOME" || \
-    test -n "$__ETC_PROFILE_NIX_SOURCED"
+if test -z "$HOME" || test -n "$__ETC_PROFILE_NIX_SOURCED"
     exit
 end
 
@@ -11,7 +10,7 @@ set --global __ETC_PROFILE_NIX_SOURCED 1
 function add_path --argument-names new_path
     if type -q fish_add_path
         # fish 3.2.0 or newer
-	fish_add_path --prepend --global $new_path
+        fish_add_path --prepend --global $new_path
     else
         # older versions of fish
         if not contains $new_path $fish_user_paths

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -3,7 +3,7 @@ if test -z "$HOME" || test -n "$__ETC_PROFILE_NIX_SOURCED"
     exit
 end
 
-set --global __ETC_PROFILE_NIX_SOURCED 1
+set --global --export __ETC_PROFILE_NIX_SOURCED 1
 
 # Local helpers
 

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -1,6 +1,5 @@
 # Only execute this file once per shell.
-if test -z "$HOME" || \
-    test -n "$__ETC_PROFILE_NIX_SOURCED"
+if test -z "$HOME" || test -n "$__ETC_PROFILE_NIX_SOURCED"
     exit
 end
 
@@ -11,7 +10,7 @@ set --global __ETC_PROFILE_NIX_SOURCED 1
 function add_path --argument-names new_path
     if type -q fish_add_path
         # fish 3.2.0 or newer
-	fish_add_path --prepend --global $new_path
+        fish_add_path --prepend --global $new_path
     else
         # older versions of fish
         if not contains $new_path $fish_user_paths


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I was running into an issue with `nix develop -c fish` where binaries in my profile were overriding binaries from my dev shell. This because the `nix-profile.fish` scripts were sourced again in the child shell, which prepended the nix profile to `PATH`.

This PR exports `__ETC_PROFILE_NIX_SOURCED` from the fish profile scripts to prevent the scripts from running in child shells. This matches the bash profile scripts behavior.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Commit https://github.com/NixOS/nix/commit/b36637c8f7ab7a2b93c6eae1139ea1c672700186 set `__ETC_PROFILE_NIX_SOURCED` globally, but this is not enough to prevent the script from being run again by child shells, because the variable was not exported and thus not inherited by any child process.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
