### PR TITLE
nix-profile{,-daemon}.fish: check for profile in XDG_DATA_HOME

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -24,7 +24,33 @@ end
 
 # Set up the per-user profile.
 
-set --local NIX_LINK $HOME/.nix-profile
+set --local NIX_LINK "$HOME/.nix-profile"
+set --local NIX_LINK_NEW
+if test -n "$XDG_STATE_HOME"
+    set NIX_LINK_NEW "$XDG_STATE_HOME/nix/profile"
+else
+    set NIX_LINK_NEW "$HOME/.local/state/nix/profile"
+end
+if test -e "$NIX_LINK_NEW"
+    if test -t 2; and test -e "$NIX_LINK"
+        set --local warning "\033[1;35mwarning:\033[0m "
+        printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
+
+        if test (realpath "$NIX_LINK") = (realpath "$NIX_LINK_NEW")
+            printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
+        else
+            # This should be an exceptionally rare occasion: the only way to get it would be to
+            # 1. Update to newer Nix;
+            # 2. Remove .nix-profile;
+            # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
+            # 4. Roll back to older Nix.
+            # If someone did all that, they can probably figure out how to migrate the profile.
+            printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
+        end
+    end
+
+    set NIX_LINK "$NIX_LINK_NEW"
+end
 
 # Set up environment.
 # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -24,7 +24,38 @@ end
 
 # Set up the per-user profile.
 
-set --local NIX_LINK $HOME/.nix-profile
+set --local NIX_LINK
+if test -n "$NIX_STATE_HOME"
+    set NIX_LINK "$NIX_STATE_HOME/.nix-profile"
+else
+    set NIX_LINK "$HOME/.nix-profile"
+    set --local NIX_LINK_NEW
+    if test -n "$XDG_STATE_HOME"
+        set NIX_LINK_NEW "$XDG_STATE_HOME/nix/profile"
+    else
+        set NIX_LINK_NEW "$HOME/.local/state/nix/profile"
+    end
+    if test -e "$NIX_LINK_NEW"
+        if test -t 2; and test -e "$NIX_LINK"
+            set --local warning "\033[1;35mwarning:\033[0m "
+            printf "$warning Both %s and legacy %s exist; using the former.\n" "$NIX_LINK_NEW" "$NIX_LINK" 1>&2
+
+            if test (realpath "$NIX_LINK") = (realpath "$NIX_LINK_NEW")
+                printf "         Since the profiles match, you can safely delete either of them.\n" 1>&2
+            else
+                # This should be an exceptionally rare occasion: the only way to get it would be to
+                # 1. Update to newer Nix;
+                # 2. Remove .nix-profile;
+                # 3. Set the $NIX_LINK_NEW to something other than the default user profile;
+                # 4. Roll back to older Nix.
+                # If someone did all that, they can probably figure out how to migrate the profile.
+                printf "$warning Profiles do not match. You should manually migrate from %s to %s.\n" "$NIX_LINK" "$NIX_LINK_NEW" 1>&2
+            end
+        end
+
+        set NIX_LINK "$NIX_LINK_NEW"
+    end
+end
 
 # Set up environment.
 # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

...and also NIX_STATE_HOME in nix-profile.fish. This is directly translated from the bash scripts and makes the fish scripts equivalent in functionality to the bash scripts.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Note that `nix-profile.fish` checks for `NIX_STATE_HOME` and `nix-profile-daemon.fish` does not, so the two scripts are no longer identical.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
