### PR TITLE
libmain: Catch logger exceptions in `handleExceptions`

### DIFF
--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -317,29 +317,34 @@ int handleExceptions(const std::string & programName, std::function<void()> fun)
     std::string error = ANSI_RED "error:" ANSI_NORMAL " ";
     try {
         try {
-            fun();
-        } catch (...) {
-            /* Subtle: we have to make sure that any `interrupted'
-               condition is discharged before we reach printMsg()
-               below, since otherwise it will throw an (uncaught)
-               exception. */
-            setInterruptThrown();
-            throw;
+            try {
+                fun();
+            } catch (...) {
+                /* Subtle: we have to make sure that any `interrupted'
+                   condition is discharged before we reach printMsg()
+                   below, since otherwise it will throw an (uncaught)
+                   exception. */
+                setInterruptThrown();
+                throw;
+            }
+        } catch (Exit & e) {
+            return e.status;
+        } catch (UsageError & e) {
+            logError(e.info());
+            printError("Try '%1% --help' for more information.", programName);
+            return 1;
+        } catch (BaseError & e) {
+            logError(e.info());
+            return e.info().status;
+        } catch (std::bad_alloc & e) {
+            printError(error + "out of memory");
+            return 1;
+        } catch (std::exception & e) {
+            printError(error + e.what());
+            return 1;
         }
-    } catch (Exit & e) {
-        return e.status;
-    } catch (UsageError & e) {
-        logError(e.info());
-        printError("Try '%1% --help' for more information.", programName);
-        return 1;
-    } catch (BaseError & e) {
-        logError(e.info());
-        return e.info().status;
-    } catch (std::bad_alloc & e) {
-        printError(error + "out of memory");
-        return 1;
-    } catch (std::exception & e) {
-        printError(error + e.what());
+    } catch (...) {
+        /* In case logger also throws just give up. */
         return 1;
     }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Avoid `std::terminate` in case logging code also throws.

This rears its head in cases when `--log-format internal-json` is used and the output gets piped to e.g. `nix-output-monitor` and nix gets interrupted. `SimpleLogger` already ignores failing writes to `stderr`, but that's not the case for `JSONLogger`. Seems like the proper solution is to catch any potential exceptions that the logging code throws.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Should fix #13246.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
