### PR TITLE
export/meson: Don't require `-std=c++2a` for -c libraries in `.pc` files

### DIFF
--- a/nix-meson-build-support/export/meson.build
+++ b/nix-meson-build-support/export/meson.build
@@ -11,12 +11,18 @@ endforeach
 requires_public += deps_public
 
 extra_pkg_config_variables = get_variable('extra_pkg_config_variables', {})
+
+extra_cflags = []
+if not meson.project_name().endswith('-c')
+    extra_cflags += ['-std=c++2a']
+endif
+
 import('pkgconfig').generate(
   this_library,
   filebase : meson.project_name(),
   name : 'Nix',
   description : 'Nix Package Manager',
-  extra_cflags : ['-std=c++2a'],
+  extra_cflags : extra_cflags,
   requires : requires_public,
   requires_private : requires_private,
   libraries_private : libraries_private,


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Fixes a packaging issue for C binding.

cc @Ericson2314

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Should fix #13250.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
