### PR TITLE
flakes: No longer compute revCount for local git repository by default

### DIFF
--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -168,8 +168,10 @@ std::pair<FlakeRef, std::string> parsePathFlakeRefWithFragment(
                         parsedURL.query.insert_or_assign("dir", subdir);
                     }
 
-                    if (pathExists(flakeRoot + "/.git/shallow"))
-                        parsedURL.query.insert_or_assign("shallow", "1");
+                    if (!parsedURL.query.count("shallow")) {
+                       // We assume shallow by default, so we don't need to compute the revCount, which is an expensive operation.
+                       parsedURL.query.insert_or_assign("shallow", "1");
+                    }
 
                     return fromParsedURL(fetchSettings, std::move(parsedURL), isFlake);
                 }

--- a/tests/functional/fetchGitShallow.sh
+++ b/tests/functional/fetchGitShallow.sh
@@ -65,3 +65,8 @@ fi
 # Verify that we can shallow fetch the worktree
 git -C "$TEST_ROOT/shallow-worktree" rev-list --count HEAD >/dev/null
 nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$TEST_ROOT/shallow-worktree\"; shallow = true; }).rev"
+
+# Normal flake operation work because they use shallow by default
+pushd "$TEST_ROOT/shallow-worktree"
+nix flake metadata
+popd


### PR DESCRIPTION
Computing a revCount is expensive and might not work if the local history is not complete.
This particular fixes a long standing crash bug in Nix: https://github.com/NixOS/nix/issues/6073

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Depends on https://github.com/NixOS/nix/pull/13265



<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
