### PR TITLE
Remove `buildUser` from `DerivationBuilder`

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -655,8 +655,8 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
         builder->startBuilder();
 
     } catch (BuildError & e) {
+        builder.reset();
         outputLocks.unlock();
-        builder->buildUser.reset();
         worker.permanentFailure = true;
         co_return done(BuildResult::InputRejected, {}, std::move(e));
     }

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -107,6 +107,11 @@ public:
 private:
 
     /**
+     * User selected for running the builder.
+     */
+    std::unique_ptr<UserLock> buildUser;
+
+    /**
      * The cgroup of the builder, if any.
      */
     std::optional<Path> cgroup;
@@ -264,7 +269,7 @@ public:
     /**
      * Start building a derivation.
      */
-    void startBuilder() override;;
+    void startBuilder() override;
 
     /**
      * Tear down build environment after the builder exits (either on

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -256,30 +256,10 @@ private:
 
 public:
 
-    /**
-     * Set up build environment / sandbox, acquiring resources (e.g.
-     * locks as needed). After this is run, the builder should be
-     * started.
-     *
-     * @returns true if successful, false if we could not acquire a build
-     * user. In that case, the caller must wait and then try again.
-     */
     bool prepareBuild() override;
 
-    /**
-     * Start building a derivation.
-     */
     void startBuilder() override;
 
-    /**
-     * Tear down build environment after the builder exits (either on
-     * its own or if it is killed).
-     *
-     * @returns The first case indicates failure during output
-     * processing. A status code and exception are returned, providing
-     * more information. The second case indicates success, and
-     * realisations for each output of the derivation are returned.
-     */
     std::variant<std::pair<BuildResult::Status, Error>, SingleDrvOutputs> unprepareBuild() override;
 
 private:
@@ -311,10 +291,6 @@ private:
 
 public:
 
-    /**
-     * Stop the in-process nix daemon thread.
-     * @see startDaemon
-     */
     void stopDaemon() override;
 
 private:
@@ -346,15 +322,8 @@ private:
 
 public:
 
-    /**
-     * Delete the temporary directory, if we have one.
-     */
     void deleteTmpDir(bool force) override;
 
-    /**
-     * Kill any processes running under the build user UID or in the
-     * cgroup of the build.
-     */
     void killSandbox(bool getStats) override;
 
 private:

--- a/src/libstore/unix/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/unix/include/nix/store/build/derivation-builder.hh
@@ -139,11 +139,6 @@ struct DerivationBuilderCallbacks
 struct DerivationBuilder : RestrictionContext
 {
     /**
-     * User selected for running the builder.
-     */
-    std::unique_ptr<UserLock> buildUser;
-
-    /**
      * The process ID of the builder.
      */
     Pid pid;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Slight cleanup of the `DerivationBuilder` interface. `buildUser` is an implementation detail that `DerivationGoal` doesn't need to know about.

Also, remove duplicate comments on `DerivationBuilderImpl`'s overriden methods. Having the exact same doc comments isn't very useful/maintainable.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
