### PR TITLE
DerivationBuilderImpl: Drop std::optional from derivationType

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -100,6 +100,7 @@ public:
         : DerivationBuilderParams{std::move(params)}
         , store{store}
         , miscMethods{std::move(miscMethods)}
+        , derivationType{drv.type()}
       { }
 
       LocalStore & getLocalStore();
@@ -168,9 +169,9 @@ private:
     /**
      * The sort of derivation we are building.
      *
-     * Just a cached value, can be recomputed from `drv`.
+     * Just a cached value, computed from `drv`.
      */
-    std::optional<DerivationType> derivationType;
+    const DerivationType derivationType;
 
     /**
      * Stuff we need to pass to initChild().
@@ -438,9 +439,6 @@ void DerivationBuilderImpl::killSandbox(bool getStats)
 
 bool DerivationBuilderImpl::prepareBuild()
 {
-    /* Cache this */
-    derivationType = drv.type();
-
     /* Are we doing a chroot build? */
     {
         if (settings.sandboxMode == smEnabled) {
@@ -457,7 +455,7 @@ bool DerivationBuilderImpl::prepareBuild()
         else if (settings.sandboxMode == smDisabled)
             useChroot = false;
         else if (settings.sandboxMode == smRelaxed)
-            useChroot = derivationType->isSandboxed() && !drvOptions.noChroot;
+            useChroot = derivationType.isSandboxed() && !drvOptions.noChroot;
     }
 
     auto & localStore = getLocalStore();
@@ -594,11 +592,10 @@ std::variant<std::pair<BuildResult::Status, Error>, SingleDrvOutputs> Derivation
         return std::move(builtOutputs);
 
     } catch (BuildError & e) {
-        assert(derivationType);
         BuildResult::Status st =
             dynamic_cast<NotDeterministic*>(&e) ? BuildResult::NotDeterministic :
             statusOk(status) ? BuildResult::OutputRejected :
-            !derivationType->isSandboxed() || diskFull ? BuildResult::TransientFailure :
+            !derivationType.isSandboxed() || diskFull ? BuildResult::TransientFailure :
             BuildResult::PermanentFailure;
 
         return std::pair{std::move(st), std::move(e)};
@@ -1068,7 +1065,7 @@ void DerivationBuilderImpl::startBuilder()
                 "nogroup:x:65534:\n", sandboxGid()));
 
         /* Create /etc/hosts with localhost entry. */
-        if (derivationType->isSandboxed())
+        if (derivationType.isSandboxed())
             writeFile(chrootRootDir + "/etc/hosts", "127.0.0.1 localhost\n::1 localhost\n");
 
         /* Make the closure of the inputs available in the chroot,
@@ -1296,7 +1293,7 @@ void DerivationBuilderImpl::startBuilder()
 
                 ProcessOptions options;
                 options.cloneFlags = CLONE_NEWPID | CLONE_NEWNS | CLONE_NEWIPC | CLONE_NEWUTS | CLONE_PARENT | SIGCHLD;
-                if (derivationType->isSandboxed())
+                if (derivationType.isSandboxed())
                     options.cloneFlags |= CLONE_NEWNET;
                 if (usingUserNamespace)
                     options.cloneFlags |= CLONE_NEWUSER;
@@ -1502,7 +1499,7 @@ void DerivationBuilderImpl::initEnv()
        derivation, tell the builder, so that for instance `fetchurl'
        can skip checking the output.  On older Nixes, this environment
        variable won't be set, so `fetchurl' will do the check. */
-    if (derivationType->isFixed()) env["NIX_OUTPUT_CHECKED"] = "1";
+    if (derivationType.isFixed()) env["NIX_OUTPUT_CHECKED"] = "1";
 
     /* *Only* if this is a fixed-output derivation, propagate the
        values of the environment variables specified in the
@@ -1513,7 +1510,7 @@ void DerivationBuilderImpl::initEnv()
        to the builder is generally impure, but the output of
        fixed-output derivations is by definition pure (since we
        already know the cryptographic hash of the output). */
-    if (!derivationType->isSandboxed()) {
+    if (!derivationType.isSandboxed()) {
         auto & impureEnv = settings.impureEnv.get();
         if (!impureEnv.empty())
             experimentalFeatureSettings.require(Xp::ConfigurableImpureEnv);
@@ -1863,7 +1860,7 @@ void DerivationBuilderImpl::runChild()
 
             userNamespaceSync.readSide = -1;
 
-            if (derivationType->isSandboxed()) {
+            if (derivationType.isSandboxed()) {
 
                 /* Initialise the loopback interface. */
                 AutoCloseFD fd(socket(PF_INET, SOCK_DGRAM, IPPROTO_IP));
@@ -1939,7 +1936,7 @@ void DerivationBuilderImpl::runChild()
             /* Fixed-output derivations typically need to access the
                network, so give them access to /etc/resolv.conf and so
                on. */
-            if (!derivationType->isSandboxed()) {
+            if (!derivationType.isSandboxed()) {
                 // Only use nss functions to resolve hosts and
                 // services. Don’t use it for anything else that may
                 // be configured for this system. This limits the
@@ -2172,7 +2169,7 @@ void DerivationBuilderImpl::runChild()
                 #include "sandbox-defaults.sb"
                 ;
 
-            if (!derivationType->isSandboxed())
+            if (!derivationType.isSandboxed())
                 sandboxProfile +=
                     #include "sandbox-network.sb"
                     ;


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

No point in computing this lazily, since it's pretty much the first thing the `DerivationBuilder` does.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
