### PR TITLE
Deprecate hacky way of making structured attrs

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -212,6 +212,7 @@ EvalState::EvalState(
     , sRight(symbols.create("right"))
     , sWrong(symbols.create("wrong"))
     , sStructuredAttrs(symbols.create("__structuredAttrs"))
+    , sJson(symbols.create("__json"))
     , sAllowedReferences(symbols.create("allowedReferences"))
     , sAllowedRequisites(symbols.create("allowedRequisites"))
     , sDisallowedReferences(symbols.create("disallowedReferences"))

--- a/src/libexpr/include/nix/expr/eval.hh
+++ b/src/libexpr/include/nix/expr/eval.hh
@@ -213,7 +213,7 @@ public:
     const Symbol sWith, sOutPath, sDrvPath, sType, sMeta, sName, sValue,
         sSystem, sOverrides, sOutputs, sOutputName, sIgnoreNulls,
         sFile, sLine, sColumn, sFunctor, sToString,
-        sRight, sWrong, sStructuredAttrs,
+        sRight, sWrong, sStructuredAttrs, sJson,
         sAllowedReferences, sAllowedRequisites, sDisallowedReferences, sDisallowedRequisites,
         sMaxSize, sMaxClosureSize,
         sBuilder, sArgs,

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1419,6 +1419,8 @@ static void derivationStrictInternal(
                     else if (i->name == state.sOutputHashMode) handleHashMode(s);
                     else if (i->name == state.sOutputs)
                         handleOutputs(tokenizeString<Strings>(s));
+                    else if (i->name == state.sJson)
+                        warn("In a derivation named '%s', setting structured attrs via '__json' is deprecated, and may be removed in a future version of Nix", drvName);
                 }
 
             }

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -45,6 +45,9 @@ test "$(<<<"$jsonOut" jq '.variables.outputs.value.out' -r)" = "$(<<<"$jsonOut" 
 
 hackyExpr='derivation { name = "a"; system = "foo"; builder = "/bin/sh"; __json = builtins.toJSON { a = 1; }; }'
 
+# Check for deprecation message
+expectStderr 0 nix-instantiate --expr "$hackyExpr" --eval --strict | grepQuiet "In a derivation named 'a', setting structured attrs via '__json' is deprecated, and may be removed in a future version of Nix"
+
 # Check it works with the expected structured attrs
 hacky=$(nix-instantiate --expr "$hackyExpr")
 nix derivation show "$hacky" | jq --exit-status '."'"$hacky"'".env.__json | fromjson | . == {"a": 1}'


### PR DESCRIPTION
## Motivation

The first commit adds a test for a trick with `builtins.derivation` that currently works today.

The second commit adds a deprecation message for that trick, and extends the test to check for the deprecation message.

## Context

Thanks to @puckipedia for telling me about this, while we went over #13263.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
