### PR TITLE
Fix warning when `HAVE_EMBEDDED_SANDBOX_SHELL` is not set

### DIFF
--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -685,7 +685,9 @@ struct LinuxDerivationBuilder : DerivationBuilderImpl
                 chmod_(dst, 0555);
             } else
 #  endif
+            {
                 doBind(i.second.source, chrootRootDir + i.first, i.second.optional);
+            }
         }
 
         /* Bind a new instance of procfs on /proc. */


### PR DESCRIPTION
## Motivation

Clang doesn't like the double indent that is needed for the `if...else` that is CPP'd away. Adding braces is fine in the `if...else...` case, and fine as a naked block in the CPP'd away case, and properly-indented both ways.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
