### PR TITLE
WIP: Allow for null packages and formatters

### DIFF
--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -1,3 +1,4 @@
+#include "nix/expr/value.hh"
 #include "nix/util/users.hh"
 #include "nix/expr/eval-cache.hh"
 #include "nix/store/sqlite.hh"
@@ -760,6 +761,14 @@ std::vector<Symbol> AttrCursor::getAttrs()
         cachedValue = {root->db->setAttrs(getKey(), attrs), attrs};
 
     return attrs;
+}
+
+bool AttrCursor::isNull()
+{
+    // <<< TODO: caching? >>>
+    auto & v = forceValue();
+
+    return v.type() == nNull;
 }
 
 bool AttrCursor::isDerivation()

--- a/src/libexpr/include/nix/expr/eval-cache.hh
+++ b/src/libexpr/include/nix/expr/eval-cache.hh
@@ -153,6 +153,8 @@ public:
 
     bool isDerivation();
 
+    bool isNull();
+
     Value & forceValue();
 
     /**

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1340,10 +1340,14 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                         }
                     } else {
                         try {
-                            if (visitor.isDerivation())
-                                showDerivation();
-                            else
-                                throw Error("expected a derivation");
+                            if (visitor.isNull()) {
+                                j = nullptr;
+                            } else{
+                                if (visitor.isDerivation())
+                                    showDerivation();
+                                else
+                                    throw Error("expected a derivation");
+                            }
                         } catch (IFDError & e) {
                             if (!json) {
                                 logger->cout(fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL, headerPrefix));

--- a/tests/functional/flakes/common.sh
+++ b/tests/functional/flakes/common.sh
@@ -16,6 +16,7 @@ writeSimpleFlake() {
       foo = import ./simple.nix;
       fooScript = (import ./shell.nix {}).foo;
       default = foo;
+      noPackage = null;
     };
     packages.someOtherSystem = rec {
       foo = import ./simple.nix;

--- a/tests/functional/flakes/show.sh
+++ b/tests/functional/flakes/show.sh
@@ -53,7 +53,7 @@ cat >flake.nix <<EOF
     packages.$system = { };
     packages.someOtherSystem = { };
 
-    formatter = { };
+    formatter.x86_64-linux = null;
     nixosConfigurations = { };
     nixosModules = { };
   };
@@ -63,7 +63,7 @@ nix flake show --json --all-systems > show-output.json
 nix eval --impure --expr '
 let show_output = builtins.fromJSON (builtins.readFile ./show-output.json);
 in
-assert show_output == { };
+assert show_output == { formatter = { x86_64-linux = null; }; };
 true
 '
 

--- a/tests/functional/formatter.sh
+++ b/tests/functional/formatter.sh
@@ -85,3 +85,40 @@ rm ./my-result
 # Flake outputs check.
 nix flake check
 nix flake show | grep -P "package 'formatter'"
+
+function expectFailWithOutputMatching() {
+    outputMustMatch=$1
+
+    if output=$(nix fmt 2>&1); then
+        echo >&2 "nix fmt unexpectedly succeeded"
+        exit 1
+    fi
+
+    if ! echo "$output" | grep "$outputMustMatch"; then
+        echo >&2 "Expected nix fmt output to match:"
+        echo >&2 "$outputMustMatch"
+        echo >&2 "However, the actual output was:"
+        echo >&2 "$output"
+        exit 1
+    fi
+}
+
+# Try a flake with no formatter.
+cat << EOF > flake.nix
+{
+  outputs = _: {};
+}
+EOF
+expectFailWithOutputMatching "does not provide attribute 'formatter.$system'"
+# Confirm that a null formatter is treated as if there is no formatter.
+cat << EOF > flake.nix
+{
+  outputs = _: {
+    formatter.$system = null;
+  };
+}
+EOF
+if nix fmt | grep "does not provide attribute 'formatter.$system'"; then
+    echo >&2 "nix fmt unexpectedly succeeded"
+    exit 1
+fi


### PR DESCRIPTION
This is useful for frameworks (such as flake-parts) to avoid unnecessary evaluation. See discussion here:
https://github.com/hercules-ci/flake-parts/issues/288#issuecomment-2912459614

While digging into this, I discovered that `nix fmt` already handles `null` formatters identically to undefined formatters. I added a couple of tests to demonstrate this behavior.

`nix flake show` needs some reworking to avoid crashing with a "error: expected a derivation" when it encounters a `null` formatter or package. My changes here avoid the crash, but has some cosmetic issues, which is why I've labeled this PR as a draft.

Cosmetic issues
===============

With the following `flake.nix`:

```nix
{
  outputs = _: {
    packages.x86_64-linux.default = null;
  };
}
```

`nix flake show` shows a weird empty system:

```
$ nix flake show
path:/tmp/tmp.uL0iGuNwXB?lastModified=1748472558&narHash=sha256-tC%2BhdXAyoeFvWHNllJbois8X%2B7wpZ6CJzEzbcaGQxtM%3D
└───packages
    └───x86_64-linux
```

Similarly, `nix flake show --json` includes an empty object:

```
$ nix flake show --json
{
  "packages": {
    "x86_64-linux": {
      "default": null
    }
  }
}
```

`nix build` crashes:

```
$ nix build .#default
error: expected flake output attribute 'packages.x86_64-linux.default' to be a derivation or path but found null: null
```

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
