### PR TITLE
Clear `displayPrefix` in `makeEmptySourceAccessor`

### DIFF
--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -187,6 +187,10 @@ void MemorySink::createSymlink(const CanonPath & path, const std::string & targe
 ref<SourceAccessor> makeEmptySourceAccessor()
 {
     static auto empty = make_ref<MemorySourceAccessor>().cast<SourceAccessor>();
+    /* Don't forget to clear the display prefix, as the default constructed
+       SourceAccessor has the «unknown» prefix. Since this accessor is supposed
+       to mimic an empty root directory the prefix needs to be empty. */
+    empty->setPathDisplay("");
     return empty;
 }
 

--- a/tests/functional/pure-eval.sh
+++ b/tests/functional/pure-eval.sh
@@ -34,3 +34,15 @@ rm -rf $TEST_ROOT/eval-out
 (! nix eval --store dummy:// --write-to $TEST_ROOT/eval-out --expr '{ "." = "bla"; }')
 
 (! nix eval --expr '~/foo')
+
+expectStderr 0 nix eval --expr "/some/absolute/path" \
+  | grepQuiet "/some/absolute/path"
+
+expectStderr 0 nix eval --expr "/some/absolute/path" --impure \
+  | grepQuiet "/some/absolute/path"
+
+expectStderr 0 nix eval --expr "some/relative/path" \
+  | grepQuiet "$PWD/some/relative/path"
+
+expectStderr 0 nix eval --expr "some/relative/path" --impure \
+  | grepQuiet "$PWD/some/relative/path"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Judging by the comment for `makeEmptySourceAccessor` the prefix has to be empty:

> Return a source accessor that contains only an empty root directory.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes #13295.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
