### PR TITLE
flake: Restore `packaging-overriding` check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -233,28 +233,24 @@
             This shouldn't build anything significant; just check that things
             (including derivations) are _set up_ correctly.
           */
-          # Disabled due to a bug in `testEqualContents` (see
-          # https://github.com/NixOS/nix/issues/12690).
-          /*
-            packaging-overriding =
-              let
-                pkgs = nixpkgsFor.${system}.native;
-                nix = self.packages.${system}.nix;
-              in
-              assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
-              if pkgs.stdenv.buildPlatform.isDarwin then
-                lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
-              else
-                # If this fails, something might be wrong with how we've wired the scope,
-                # or something could be broken in Nixpkgs.
-                pkgs.testers.testEqualContents {
-                  assertion = "trivial patch does not change source contents";
-                  expected = "${./.}";
-                  actual =
-                    # Same for all components; nix-util is an arbitrary pick
-                    (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
-                };
-          */
+          packaging-overriding =
+            let
+              pkgs = nixpkgsFor.${system}.native;
+              nix = self.packages.${system}.nix;
+            in
+            assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
+            if pkgs.stdenv.buildPlatform.isDarwin then
+              lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
+            else
+              # If this fails, something might be wrong with how we've wired the scope,
+              # or something could be broken in Nixpkgs.
+              pkgs.testers.testEqualContents {
+                assertion = "trivial patch does not change source contents";
+                expected = "${./.}";
+                actual =
+                  # Same for all components; nix-util is an arbitrary pick
+                  (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
+              };
         }
         // (lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
           dockerImage = self.hydraJobs.dockerImage.${system};


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

The underlying bug seems to have been fixed in diffoscope 293 [1] [2]. Our nixpkgs input has 295.

[1]: https://github.com/NixOS/nixpkgs/pull/393381#issuecomment-2766703347
[2]: https://diffoscope.org/news/diffoscope-292-released/

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
