### PR TITLE
Fix overriding gtest with gmock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ result-*
 .DS_Store
 
 flake-regressions
+
+# direnv
+.direnv/

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -32,8 +32,8 @@ deps_private += rapidcheck
 gtest = dependency('gtest')
 deps_private += gtest
 
-gtest = dependency('gmock')
-deps_private += gtest
+gmock = dependency('gmock')
+deps_private += gmock
 
 configdata = configuration_data()
 configdata.set_quoted('PACKAGE_VERSION', meson.project_version())


### PR DESCRIPTION
Just a naming typo but at least this is more clear.

* Added .direnv/ to gitignore
---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
