### PR TITLE
add documentation of tarball-ttl to nix-channel

### DIFF
--- a/doc/manual/source/command-ref/nix-channel.md
+++ b/doc/manual/source/command-ref/nix-channel.md
@@ -55,7 +55,7 @@ This command has the following operations:
 
   > **Note**
   >
-  > `--update` uses [fetchTarball](@docroot@/language/builtins.md#builtins-fetchTarball) under the hood, so it will cache channels.
+  > Downloaded channel contents are cached.
   > Use `--tarball-ttl` or the nix configuration option `tarball-ttl` to change this behavior.
 
 - `--list-generations`

--- a/doc/manual/source/command-ref/nix-channel.md
+++ b/doc/manual/source/command-ref/nix-channel.md
@@ -53,6 +53,11 @@ This command has the following operations:
   Download the Nix expressions of subscribed channels and create a new generation.
   Update all channels if none is specified, and only those included in *names* otherwise.
 
+  > **Note**
+  >
+  > `--update` uses [fetchTarball](@docroot@/language/builtins.md#builtins-fetchTarball) under the hood, so it will cache channels.
+  > Use `--tarball-ttl` or the nix configuration option `tarball-ttl` to change this behavior.
+
 - `--list-generations`
 
   Prints a list of all the current existing generations for the

--- a/doc/manual/source/command-ref/nix-channel.md
+++ b/doc/manual/source/command-ref/nix-channel.md
@@ -56,7 +56,7 @@ This command has the following operations:
   > **Note**
   >
   > Downloaded channel contents are cached.
-  > Use `--tarball-ttl` or the nix configuration option `tarball-ttl` to change this behavior.
+  > Use `--tarball-ttl` or the [`tarball-ttl` configuration option](@docroot@/command-ref/conf-file.md#conf-tarball-ttl) to change the validity period of cached downloads.
 
 - `--list-generations`
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

`nix-channel` is affected by the `tarball-ttl` setting, meaning that channels will only be updated if their tarballs are not in the cache. This patch simply adds documentation to the `nix-channel` command to point out this fact.

## Context

<!-- Provide context. Reference open issues if available. -->

https://discourse.nixos.org/t/nix-channel-forcing-an-update/64940?u=donttellmetonottellu

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
