### PR TITLE
libexpr: fix various overflows and type mismatches

### DIFF
--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -301,6 +301,7 @@ namespace nix {
 
     TEST_F(PrimOpTest, elemtAtOutOfBounds) {
         ASSERT_THROW(eval("builtins.elemAt [0 1 2 3] 5"), Error);
+        ASSERT_THROW(eval("builtins.elemAt [0] 4294967296"), Error);
     }
 
     TEST_F(PrimOpTest, head) {
@@ -590,6 +591,16 @@ namespace nix {
     TEST_F(PrimOpTest, substringSmallerString){
         auto v = eval("builtins.substring 0 3 \"n\"");
         ASSERT_THAT(v, IsStringEq("n"));
+    }
+
+    TEST_F(PrimOpTest, substringHugeStart){
+        auto v = eval("builtins.substring 4294967296 5 \"nixos\"");
+        ASSERT_THAT(v, IsStringEq(""));
+    }
+
+    TEST_F(PrimOpTest, substringHugeLength){
+        auto v = eval("builtins.substring 0 4294967296 \"nixos\"");
+        ASSERT_THAT(v, IsStringEq("nixos"));
     }
 
     TEST_F(PrimOpTest, substringEmptyString){


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I found wrong casts of `NixInt` values, which can cause crashes of current Nix versions because of `sizeof(unsigned int) < sizeof(NixInt::Inner)`, e.g.
```
nix-repl> builtins.substring 4294967296 5 "hello"  
error: basic_string_view::substr: __pos (which is 4294967296) > __size (which is 5)
```

Furthermore usually `sizeof(unsigned int) < sizeof(size_t)` on 64 bit systems, which becomes problematic when a list contains more than `2^32` values and this case isn't impossible. Thus `size_t` is used as index type.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

Includes tests for cases, where `NixInt::Inner` was incorrectly casted.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
