### PR TITLE
libutil: Use `std::shared_ptr<const Pos>` and simplify `Pos` class constructors

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -13,7 +13,7 @@
 
 namespace nix {
 
-void BaseError::addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TracePrint print)
+void BaseError::addTrace(std::shared_ptr<const Pos> && e, HintFmt hint, TracePrint print)
 {
     err.traces.push_front(Trace { .pos = std::move(e), .hint = hint, .print = print });
 }
@@ -146,7 +146,7 @@ static bool printUnknownLocations = getEnv("_NIX_EVAL_SHOW_UNKNOWN_LOCATIONS").h
  *
  * @return true if a position was printed.
  */
-static bool printPosMaybe(std::ostream & oss, std::string_view indent, const std::shared_ptr<Pos> & pos) {
+static bool printPosMaybe(std::ostream & oss, std::string_view indent, const std::shared_ptr<const Pos> & pos) {
     bool hasPos = pos && *pos;
     if (hasPos) {
         oss << indent << ANSI_BLUE << "at " ANSI_WARNING << *pos << ANSI_NORMAL << ":";

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -78,7 +78,7 @@ enum struct TracePrint {
 };
 
 struct Trace {
-    std::shared_ptr<Pos> pos;
+    std::shared_ptr<const Pos> pos;
     HintFmt hint;
     TracePrint print = TracePrint::Default;
 };
@@ -88,7 +88,7 @@ inline std::strong_ordering operator<=>(const Trace& lhs, const Trace& rhs);
 struct ErrorInfo {
     Verbosity level;
     HintFmt msg;
-    std::shared_ptr<Pos> pos;
+    std::shared_ptr<const Pos> pos;
     std::list<Trace> traces;
     /**
      * Some messages are generated directly by expressions; notably `builtins.warn`, `abort`, `throw`.
@@ -172,7 +172,7 @@ public:
         err.status = status;
     }
 
-    void atPos(std::shared_ptr<Pos> pos) {
+    void atPos(std::shared_ptr<const Pos> pos) {
         err.pos = pos;
     }
 
@@ -182,12 +182,12 @@ public:
     }
 
     template<typename... Args>
-    void addTrace(std::shared_ptr<Pos> && e, std::string_view fs, const Args & ... args)
+    void addTrace(std::shared_ptr<const Pos> && e, std::string_view fs, const Args & ... args)
     {
         addTrace(std::move(e), HintFmt(std::string(fs), args...));
     }
 
-    void addTrace(std::shared_ptr<Pos> && e, HintFmt hint, TracePrint print = TracePrint::Default);
+    void addTrace(std::shared_ptr<const Pos> && e, HintFmt hint, TracePrint print = TracePrint::Default);
 
     bool hasTrace() const { return !err.traces.empty(); }
 

--- a/src/libutil/include/nix/util/position.hh
+++ b/src/libutil/include/nix/util/position.hh
@@ -43,9 +43,6 @@ struct Pos
     Pos() { }
     Pos(uint32_t line, uint32_t column, Origin origin)
         : line(line), column(column), origin(origin) { }
-    Pos(Pos & other) = default;
-    Pos(const Pos & other) = default;
-    Pos(Pos && other) = default;
 
     explicit operator bool() const { return line > 0; }
 

--- a/src/libutil/include/nix/util/position.hh
+++ b/src/libutil/include/nix/util/position.hh
@@ -46,12 +46,10 @@ struct Pos
     Pos(Pos & other) = default;
     Pos(const Pos & other) = default;
     Pos(Pos && other) = default;
-    Pos(const Pos * other);
 
     explicit operator bool() const { return line > 0; }
 
-    /* TODO: Why std::shared_ptr<Pos> and not std::shared_ptr<const Pos>? */
-    operator std::shared_ptr<Pos>() const;
+    operator std::shared_ptr<const Pos>() const;
 
     /**
      * Return the contents of the source file.

--- a/src/libutil/logging.cc
+++ b/src/libutil/logging.cc
@@ -166,7 +166,7 @@ Activity::Activity(Logger & logger, Verbosity lvl, ActivityType type,
     logger.startActivity(id, lvl, type, s, fields, parent);
 }
 
-void to_json(nlohmann::json & json, std::shared_ptr<Pos> pos)
+void to_json(nlohmann::json & json, std::shared_ptr<const Pos> pos)
 {
     if (pos) {
         json["line"] = pos->line;

--- a/src/libutil/position.cc
+++ b/src/libutil/position.cc
@@ -2,19 +2,9 @@
 
 namespace nix {
 
-Pos::Pos(const Pos * other)
+Pos::operator std::shared_ptr<const Pos>() const
 {
-    if (!other) {
-        return;
-    }
-    line = other->line;
-    column = other->column;
-    origin = other->origin;
-}
-
-Pos::operator std::shared_ptr<Pos>() const
-{
-    return std::make_shared<Pos>(&*this);
+    return std::make_shared<const Pos>(*this);
 }
 
 std::optional<LinesOfCode> Pos::getCodeLines() const


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

There's actually no mutation happening so there's no point in using
a mutable `shared_ptr`. Furthermore, this makes it much more evident to
the reader that no actual mutation (especially in multithreaded case)
is happening.

Also get rid of redundant constructor that isn't actually used anywhere
other than `Pos::operator std::shared_ptr<Pos>` which just passes in &*this,
(identical to just `this`), which can't be nullptr.

Stop explicitly defaulting special member functions for `Pos` since that is
redundant and the compiler will generate default implementations for them anyway.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
