### PR TITLE
Read-only sandbox paths mounts (Linux)

### DIFF
--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -632,13 +632,18 @@ public:
     Setting<PathSet> sandboxPaths{
         this, {}, "sandbox-paths",
         R"(
-          A list of paths bind-mounted into Nix sandbox environments. You can
-          use the syntax `target=source` to mount a path in a different
-          location in the sandbox; for instance, `/bin=/nix-bin` will mount
-          the path `/nix-bin` as `/bin` inside the sandbox. If *source* is
-          followed by `?`, then it is not an error if *source* does not exist;
-          for example, `/dev/nvidiactl?` specifies that `/dev/nvidiactl` will
-          only be mounted in the sandbox if it exists in the host filesystem.
+          A list of paths bind-mounted into Nix sandbox environments. Use the
+          syntax `target[=source][:ro][?]` to control the mount:
+
+          - `=source` will mount a different path at target location; for
+            instance, `/bin=/nix-bin` will mount the path `/nix-bin` as `/bin`
+            inside the sandbox.
+
+          - `:ro` makes the mount read-only (Linux only).
+
+          - `?` makes it not an error if *source* does not exist; for example,
+            `/dev/nvidiactl?` specifies that `/dev/nvidiactl` will only be
+            mounted in the sandbox if it exists in the host filesystem.
 
           If the source is in the Nix store, then its closure will be added to
           the sandbox as well.

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -77,6 +77,9 @@ StorePath StorePath::random(std::string_view name)
 
 StorePath MixStoreDirMethods::parseStorePath(std::string_view path) const
 {
+    if (path.empty())
+        throw BadStorePath("empty path is not a valid store path");
+
     // On Windows, `/nix/store` is not a canonical path. More broadly it
     // is unclear whether this function should be using the native
     // notion of a canonical path at all. For example, it makes to


### PR DESCRIPTION
## Motivation

This extends the `sandbox-paths` syntax to allow the extra optional suffix `:ro` for marking that path so as to be mounted read-only in the sandbox. The suffix is excluded from the mounted source or target path. It will only cause the mount `MS_RDONLY` flag to be set.

## Context

...well, technically we make then another `mount(2)` call on the target path right after mounting the path for the first time, in order to do a second mount (or rather remount, `MS_REMOUNT`) with `MS_RDONLY`. For some reason single `mount` syscall can't both create a new bind-mount and assign the read-only flag to it (its mount-point really) ... or propagation properties for that matter.

The `mount(8)` cli from `util-linux` abstracts over this with a second syscall as necessary as well (more even sometimes, it seems).

There's a better, modern API since about linux 5.12 with `open_tree()`, `mount_setattr()` and `move_mount()`. Probably doesn't really make a difference until there's some need or want for those features though.

---

One of the commits (2eaca522e8adecfcbb3dd96c853ede26c5e484cc) is not related to to the bulk of the changes in this. it's a small change to fix a certain edge-case (think user launching `nix` or running tests with a `PATH` that still works, for all intents and purposes, but looks like it fell through a slipstream portal sideways).

---

add :+1: to [pull requests you find important](https://github.com/nixos/nix/pulls?q=is%3aopen+sort%3areactions-%2b1-desc).

the nix maintainer team uses a [github project board](https://github.com/orgs/nixos/projects/19) to [schedule and track reviews](https://github.com/nixos/nix/tree/master/maintainers#project-board-protocol)