### PR TITLE
Modify docker.nix to use mapAttrsToList instead of mapAttrsFlatten

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -155,7 +155,7 @@ let
 
   nixConfContents =
     (lib.concatStringsSep "\n" (
-      lib.mapAttrsFlatten (
+      lib.mapAttrsToList (
         n: v:
         let
           vStr = if builtins.isList v then lib.concatStringsSep " " v else v;


### PR DESCRIPTION
The latter alias is deprecated in favor of the former, and produces a warning.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

`docker.nix` currently produces a warning: 

```
lib.misc.mapAttrsFlatten is deprecated, please use lib.attrsets.mapAttrsToList instead
```

This PR fixes it by changing the function to `mapAttrsToList`.

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
