### PR TITLE
primops/import: add preflight check to parseExprFromFile

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3055,6 +3055,8 @@ Expr * EvalState::parseExprFromFile(const SourcePath & path)
 Expr * EvalState::parseExprFromFile(const SourcePath & path, std::shared_ptr<StaticEnv> & staticEnv)
 {
     auto buffer = path.resolveSymlinks().readFile();
+
+    if (buffer.size() == 0) throw Error("cannot import empty file '%s'", path);
     // readFile hopefully have left some extra space for terminators
     buffer.append("\0\0", 2);
     return parse(buffer.data(), buffer.size(), Pos::Origin(path), path.parent(), staticEnv);


### PR DESCRIPTION
It seems the `import` primop stalls indefinetly if the file it tries to parse is empty.

This PR adds a simple preflight check to 'parseExprFromFile' to prevent that from ever happening.

Context why i run into this issue:

https://github.com/NixOS/nixpkgs/issues/414455

I didn't find a place where i could add a unit test if needed please request during review.


Tested manually for now:

```console
nix-repl> import ../empty.nix 
error:
       … while calling the 'import' builtin
         at «string»:1:1:
            1| import ../empty.nix
             | ^

       error: cannot import empty file '/home/johannes/git/nix/empty.nix'

nix-repl> import /dev/null    
error:
       … while calling the 'import' builtin
         at «string»:1:1:
            1| import /dev/null
             | ^

       error: cannot import empty file '/dev/null'
```

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
