### PR TITLE
repl: Don't wait on incomplete parses from imported file

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -839,6 +839,8 @@ void NixRepl::evalString(std::string s, Value & v)
             // For parse errors on incomplete input, we continue waiting for the next line of
             // input without clearing the input so far.
             throw IncompleteReplExpr(e.msg());
+        else
+            throw;
     }
     e->eval(*state, *env, v);
     state->forceValue(v, v.determinePos(noPos));

--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -158,6 +158,8 @@ static std::ostream & showDebugTrace(std::ostream & out, const PosTable & positi
     return out;
 }
 
+MakeError(IncompleteReplExpr, ParseError);
+
 static bool isFirstRepl = true;
 
 ReplExitStatus NixRepl::mainLoop()
@@ -205,16 +207,8 @@ ReplExitStatus NixRepl::mainLoop()
                 default:
                     unreachable();
             }
-        } catch (ParseError & e) {
-            if (e.msg().find("unexpected end of file") != std::string::npos) {
-                // For parse errors on incomplete input, we continue waiting for the next line of
-                // input without clearing the input so far.
-                continue;
-            } else {
-              printMsg(lvlError, e.msg());
-            }
-        } catch (EvalError & e) {
-            printMsg(lvlError, e.msg());
+        } catch (IncompleteReplExpr &) {
+            continue;
         } catch (Error & e) {
             printMsg(lvlError, e.msg());
         } catch (Interrupted & e) {
@@ -837,7 +831,15 @@ Expr * NixRepl::parseString(std::string s)
 
 void NixRepl::evalString(std::string s, Value & v)
 {
-    Expr * e = parseString(s);
+    Expr * e;
+    try {
+        e = parseString(s);
+    } catch (ParseError & e) {
+        if (e.msg().find("unexpected end of file") != std::string::npos)
+            // For parse errors on incomplete input, we continue waiting for the next line of
+            // input without clearing the input so far.
+            throw IncompleteReplExpr(e.msg());
+    }
     e->eval(*state, *env, v);
     state->forceValue(v, v.determinePos(noPos));
 }

--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -277,6 +277,12 @@ testReplResponseNoRegex '
 }
 '
 
+# Don't prompt for more input when getting unexpected EOF in imported files.
+testReplResponse "
+import $testDir/lang/parse-fail-eof-pos.nix
+" \
+'.*error: syntax error, unexpected end of file.*'
+
 # TODO: move init to characterisation/framework.sh
 badDiff=0
 badExitCode=0


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

The repl should only catch "unexpected end of file" parse errors from the top-level expression, not from imported files.

Fixes #13332.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
