### PR TITLE
Add layers to catching IFDs in `nix flake show`

### DIFF
--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1206,10 +1206,15 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                         || attrPathS[0] == "legacyPackages"
                         || attrPathS[0] == "packages")
                     && (attrPathS.size() == 1 || attrPathS.size() == 2)) {
-                    for (const auto &subAttr : visitor2->getAttrs()) {
-                        if (hasContent(*visitor2, attrPath2, subAttr)) {
-                            return true;
+                    try {
+                        for (const auto &subAttr : visitor2->getAttrs()) {
+                            if (hasContent(*visitor2, attrPath2, subAttr)) {
+                                return true;
+                            }
                         }
+                    } catch (IFDError & e) {
+                        // allow IFD errors here; as we handle them during `visit()`
+                        return true;
                     }
                     return false;
                 }
@@ -1220,10 +1225,14 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
                         || attrPathS[0] == "nixosModules"
                         || attrPathS[0] == "overlays"
                         )) {
-                    for (const auto &subAttr : visitor2->getAttrs()) {
-                        if (hasContent(*visitor2, attrPath2, subAttr)) {
-                            return true;
+                    try {
+                        for (const auto &subAttr : visitor2->getAttrs()) {
+                            if (hasContent(*visitor2, attrPath2, subAttr)) {
+                                return true;
+                            }
                         }
+                    } catch (IFDError & e) {
+                        return true;
                     }
                     return false;
                 }
@@ -1261,12 +1270,20 @@ struct CmdFlakeShow : FlakeCommand, MixJSON
             try {
                 auto recurse = [&]()
                 {
-                    if (!json)
-                        logger->cout("%s", headerPrefix);
                     std::vector<Symbol> attrs;
-                    for (const auto &attr : visitor.getAttrs()) {
-                        if (hasContent(visitor, attrPath, attr))
-                            attrs.push_back(attr);
+                    try {
+                        for (const auto &attr : visitor.getAttrs()) {
+                            if (hasContent(visitor, attrPath, attr))
+                                attrs.push_back(attr);
+                        }
+                        if (!json)
+                            logger->cout("%s", headerPrefix);
+                    } catch (IFDError & e) {
+                        if (!json) {
+                            logger->cout(fmt("%s " ANSI_WARNING "omitted due to use of import from derivation" ANSI_NORMAL, headerPrefix));
+                        } else {
+                            logger->warn(fmt("%s omitted due to use of import from derivation", concatStringsSep(".", attrPathS)));
+                        }
                     }
 
                     for (const auto & [i, attr] : enumerate(attrs)) {


### PR DESCRIPTION
## Motivation

Fixes https://github.com/NixOS/nix/issues/13335.

## Context

Expands the scope of #12583; allowing recursion into "derivation containers" even when their attributes can't be evaluated due to an IFD, and then catches the IFD error when trying to visit those nodes.

Flake:
```
{
  outputs = { nixpkgs, ... }:
    let
      system = "aarch64-linux";
      pkgs = import nixpkgs { inherit system; };
    in
    {
      packages.${system} =
        (import (pkgs.writeText "nix-expr" "{}"));
      checks.${system} = {
        test = pkgs.hello;
      };
    };
}
```

Before:
```
error:
       … while calling the 'import' builtin
         at /nix/store/4rw0d5agbcz96rhjwkmgx5v3bpjnz8bh-source/build/flake.nix:9:10:
            8|       packages.${system} =
            9|         (import (pkgs.writeText "nix-expr" "{}"));
             |          ^
           10|       checks.${system} = {

       … while realising the context of path '/nix/store/35006aqknvcnq3l5w4dryw1j851qng30-nix-expr'

       error: cannot build '/nix/store/2m3x8phhksw5fl039d0dwv2hk2izapwm-nix-expr.drv^out' during evaluation because the option 'allow-import-from-derivation' is disabled
```

After:
```
git+file:///software/nix?dir=build
├───checks
│   └───aarch64-linux
│       └───test omitted (use '--all-systems' to show)
└───packages
    └───aarch64-linux omitted due to use of import from derivation
```