### PR TITLE
libexpr: Use value getters (NFC)

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -126,7 +126,7 @@ std::string showType(const Value & v)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wswitch-enum"
     switch (v.internalType) {
-        case tString: return v.payload.string.context ? "a string with context" : "a string";
+        case tString: return v.context() ? "a string with context" : "a string";
         case tPrimOp:
             return fmt("the built-in function '%s'", std::string(v.primOp()->name));
         case tPrimOpApp:
@@ -2297,8 +2297,8 @@ std::string_view EvalState::forceString(Value & v, const PosIdx pos, std::string
 
 void copyContext(const Value & v, NixStringContext & context, const ExperimentalFeatureSettings & xpSettings)
 {
-    if (v.payload.string.context)
-        for (const char * * p = v.payload.string.context; *p; ++p)
+    if (v.context())
+        for (const char * * p = v.context(); *p; ++p)
             context.insert(NixStringContextElem::parse(*p, xpSettings));
 }
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -128,7 +128,7 @@ std::string showType(const Value & v)
     switch (v.internalType) {
         case tString: return v.payload.string.context ? "a string with context" : "a string";
         case tPrimOp:
-            return fmt("the built-in function '%s'", std::string(v.payload.primOp->name));
+            return fmt("the built-in function '%s'", std::string(v.primOp()->name));
         case tPrimOpApp:
             return fmt("the partially applied built-in function '%s'", v.primOpAppPrimOp()->name);
         case tExternal: return v.external()->showType();

--- a/src/libexpr/include/nix/expr/symbol-table.hh
+++ b/src/libexpr/include/nix/expr/symbol-table.hh
@@ -29,7 +29,7 @@ class SymbolValue : protected Value
 public:
     operator std::string_view() const noexcept
     {
-        return {payload.string.c_str, size_};
+        return {c_str(), size_};
     }
 };
 
@@ -122,7 +122,7 @@ public:
     [[gnu::always_inline]]
     const char * c_str() const noexcept
     {
-        return s->payload.string.c_str;
+        return s->c_str();
     }
 
     [[gnu::always_inline]]


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

The goal here is to start decoupling code from the internal representation of `Value`s. By going through getters we make it easier to change the underlying value storage implementation / validate invariants. Ideally `payload` would just be a private field.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

My ultimate goal in the future is to slim down `Value` to be just 16 bytes on 64 bit machines by doing bit packing and using alignment bits to store the union discriminator. This is just some preparatory work to make that easier. cc @roberth

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
