### PR TITLE
Fix broken link in configuration description

### DIFF
--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -365,7 +365,7 @@ public:
 
           To build only on remote machines and disable local builds, set [`max-jobs`](#conf-max-jobs) to 0.
 
-          If you want the remote machines to use substituters, set [`builders-use-substitutes`](#conf-builders-use-substituters) to `true`.
+          If you want the remote machines to use substituters, set [`builders-use-substitutes`](#conf-builders-use-substitutes) to `true`.
         )",
         {}, false};
 


### PR DESCRIPTION
## Motivation

The correct link: https://nix.dev/manual/nix/latest/command-ref/conf-file.html#conf-builders-use-substitutes

## Context

I discovered this by accident when acting on some config output.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
