### PR TITLE
Make the repl test more robust

### DIFF
--- a/tests/functional/repl.sh
+++ b/tests/functional/repl.sh
@@ -189,7 +189,8 @@ testReplResponseNoRegex $'
 # - Re-eval it
 # - Check that the result has changed
 mkfifo repl_fifo
-nix repl ./flake --experimental-features 'flakes' < repl_fifo > repl_output 2>&1 &
+touch repl_output
+nix repl ./flake --experimental-features 'flakes' < repl_fifo >> repl_output 2>&1 &
 repl_pid=$!
 exec 3>repl_fifo # Open fifo for writing
 echo "changingThing" >&3


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Seen in https://github.com/DeterminateSystems/nix-src/actions/runs/15590867877/job/43909540271:

```
nix-functional-tests> grep: repl_output: No such file or directory
nix-functional-tests> +(repl.sh:174) cat repl_output
```

This is because there is a small possibility that the `nix repl` child process hasn't created `repl_output` yet. So make sure it exists.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
