### PR TITLE
docker: make sure `nix config check` works

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -280,7 +280,6 @@ let
 
           ln -s ${profile} $out/nix/var/nix/profiles/default-1-link
           ln -s /nix/var/nix/profiles/default-1-link $out/nix/var/nix/profiles/default
-          ln -s /nix/var/nix/profiles/default $out${userHome}/.nix-profile
 
           ln -s ${channel} $out/nix/var/nix/profiles/per-user/${uname}/channels-1-link
           ln -s /nix/var/nix/profiles/per-user/${uname}/channels-1-link $out/nix/var/nix/profiles/per-user/${uname}/channels
@@ -332,7 +331,7 @@ pkgs.dockerTools.buildLayeredImageWithNixDb {
   '';
 
   config = {
-    Cmd = [ "${userHome}/.nix-profile/bin/bash" ];
+    Cmd = [ (lib.getExe pkgs.bashInteractive) ];
     User = "${toString uid}:${toString gid}";
     Env = [
       "USER=${uname}"


### PR DESCRIPTION
## Motivation

This current PR addresses a small issue I encountered during the making of #13354.

When running `nix config check` inside the [official Nix Docker image](https://hub.docker.com/r/nixos/nix), the following failure was raised:

```
bash-5.2# nix config check
[PASS] PATH contains only one nix version.
[FAIL] Found profiles outside of /nix/var/nix/profiles.
The generation this profile points to might not have a gcroot and could be
garbage collected, resulting in broken symlinks.

  "/root/.nix-profile/bin"

[PASS] Client protocol matches store protocol.
[INFO] You are trusted by store uri: local
```

This PR proposes a fix for that issue. I would appreciate any feedback on the approach, and I am happy to adjust the implementation if needed.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
