### PR TITLE
docker: use `callPackage`, parametrise the image build

### DIFF
--- a/docker.nix
+++ b/docker.nix
@@ -33,7 +33,7 @@
   cacert,
   findutils,
   iana-etc,
-  git,
+  gitMinimal,
   openssh,
   # Other dependencies
   shadow,
@@ -54,7 +54,7 @@ let
     cacert.out
     findutils
     iana-etc
-    git
+    gitMinimal
     openssh
   ] ++ extraPkgs;
 

--- a/docker.nix
+++ b/docker.nix
@@ -1,6 +1,10 @@
 {
-  pkgs ? import <nixpkgs> { },
-  lib ? pkgs.lib,
+  # Core dependencies
+  pkgs,
+  lib,
+  runCommand,
+  buildPackages,
+  # Image configuration
   name ? "nix",
   tag ? "latest",
   bundleNixpkgs ? true,
@@ -14,36 +18,52 @@
   gid ? 0,
   uname ? "root",
   gname ? "root",
+  # Default Packages
+  nix,
+  bashInteractive,
+  coreutils-full,
+  gnutar,
+  gzip,
+  gnugrep,
+  which,
+  curl,
+  less,
+  wget,
+  man,
+  cacert,
+  findutils,
+  iana-etc,
+  git,
+  openssh,
+  # Other dependencies
+  shadow,
 }:
 let
-  defaultPkgs =
-    with pkgs;
-    [
-      nix
-      bashInteractive
-      coreutils-full
-      gnutar
-      gzip
-      gnugrep
-      which
-      curl
-      less
-      wget
-      man
-      cacert.out
-      findutils
-      iana-etc
-      git
-      openssh
-    ]
-    ++ extraPkgs;
+  defaultPkgs = [
+    nix
+    bashInteractive
+    coreutils-full
+    gnutar
+    gzip
+    gnugrep
+    which
+    curl
+    less
+    wget
+    man
+    cacert.out
+    findutils
+    iana-etc
+    git
+    openssh
+  ] ++ extraPkgs;
 
   users =
     {
 
       root = {
         uid = 0;
-        shell = "${pkgs.bashInteractive}/bin/bash";
+        shell = lib.getExe bashInteractive;
         home = "/root";
         gid = 0;
         groups = [ "root" ];
@@ -52,7 +72,7 @@ let
 
       nobody = {
         uid = 65534;
-        shell = "${pkgs.shadow}/bin/nologin";
+        shell = lib.getExe' shadow "nologin";
         home = "/var/empty";
         gid = 65534;
         groups = [ "nobody" ];
@@ -63,7 +83,7 @@ let
     // lib.optionalAttrs (uid != 0) {
       "${uname}" = {
         uid = uid;
-        shell = "${pkgs.bashInteractive}/bin/bash";
+        shell = lib.getExe bashInteractive;
         home = "/home/${uname}";
         gid = gid;
         groups = [ "${gname}" ];
@@ -170,7 +190,7 @@ let
   baseSystem =
     let
       nixpkgs = pkgs.path;
-      channel = pkgs.runCommand "channel-nixos" { inherit bundleNixpkgs; } ''
+      channel = runCommand "channel-nixos" { inherit bundleNixpkgs; } ''
         mkdir $out
         if [ "$bundleNixpkgs" ]; then
           ln -s ${
@@ -182,11 +202,11 @@ let
           echo "[]" > $out/manifest.nix
         fi
       '';
-      rootEnv = pkgs.buildPackages.buildEnv {
+      rootEnv = buildPackages.buildEnv {
         name = "root-profile-env";
         paths = defaultPkgs;
       };
-      manifest = pkgs.buildPackages.runCommand "manifest.nix" { } ''
+      manifest = buildPackages.runCommand "manifest.nix" { } ''
         cat > $out <<EOF
         [
         ${lib.concatStringsSep "\n" (
@@ -215,7 +235,7 @@ let
         ]
         EOF
       '';
-      profile = pkgs.buildPackages.runCommand "user-environment" { } ''
+      profile = buildPackages.runCommand "user-environment" { } ''
         mkdir $out
         cp -a ${rootEnv}/* $out/
         ln -s ${manifest} $out/manifest.nix
@@ -228,7 +248,7 @@ let
         else
           flake-registry;
     in
-    pkgs.runCommand "base-system"
+    runCommand "base-system"
       {
         inherit
           passwdContents
@@ -290,8 +310,8 @@ let
           echo "${channelURL} ${channelName}" > $out${userHome}/.nix-channels
 
           mkdir -p $out/bin $out/usr/bin
-          ln -s ${pkgs.coreutils-full}/bin/env $out/usr/bin/env
-          ln -s ${pkgs.bashInteractive}/bin/bash $out/bin/sh
+          ln -s ${lib.getExe' coreutils-full "env"} $out/usr/bin/env
+          ln -s ${lib.getExe bashInteractive} $out/bin/sh
 
         ''
         + (lib.optionalString (flake-registry-path != null) ''
@@ -300,7 +320,7 @@ let
           globalFlakeRegistryPath="$nixCacheDir/flake-registry.json"
           ln -s ${flake-registry-path} $out$globalFlakeRegistryPath
           mkdir -p $out/nix/var/nix/gcroots/auto
-          rootName=$(${pkgs.nix}/bin/nix --extra-experimental-features nix-command hash file --type sha1 --base32 <(echo -n $globalFlakeRegistryPath))
+          rootName=$(${lib.getExe' nix "nix"} --extra-experimental-features nix-command hash file --type sha1 --base32 <(echo -n $globalFlakeRegistryPath))
           ln -s $globalFlakeRegistryPath $out/nix/var/nix/gcroots/auto/$rootName
         '')
       );
@@ -332,7 +352,7 @@ pkgs.dockerTools.buildLayeredImageWithNixDb {
   '';
 
   config = {
-    Cmd = [ "${userHome}/.nix-profile/bin/bash" ];
+    Cmd = [ (lib.getExe bashInteractive) ];
     User = "${toString uid}:${toString gid}";
     Env = [
       "USER=${uname}"

--- a/docker.nix
+++ b/docker.nix
@@ -290,7 +290,7 @@ let
           echo "${channelURL} ${channelName}" > $out${userHome}/.nix-channels
 
           mkdir -p $out/bin $out/usr/bin
-          ln -s ${pkgs.coreutils}/bin/env $out/usr/bin/env
+          ln -s ${pkgs.coreutils-full}/bin/env $out/usr/bin/env
           ln -s ${pkgs.bashInteractive}/bin/bash $out/bin/sh
 
         ''

--- a/flake.nix
+++ b/flake.nix
@@ -404,8 +404,7 @@
           dockerImage =
             let
               pkgs = nixpkgsFor.${system}.native;
-              image = import ./docker.nix {
-                inherit pkgs;
+              image = pkgs.callPackage ./docker.nix {
                 tag = pkgs.nix.version;
               };
             in

--- a/tests/nixos/nix-docker.nix
+++ b/tests/nixos/nix-docker.nix
@@ -1,21 +1,15 @@
 # Test the container built by ../../docker.nix.
 
 {
-  lib,
   config,
-  nixpkgs,
-  hostPkgs,
   ...
 }:
 
 let
   pkgs = config.nodes.machine.nixpkgs.pkgs;
 
-  nixImage = import ../../docker.nix {
-    inherit (config.nodes.machine.nixpkgs) pkgs;
-  };
-  nixUserImage = import ../../docker.nix {
-    inherit (config.nodes.machine.nixpkgs) pkgs;
+  nixImage = pkgs.callPackage ../../docker.nix { };
+  nixUserImage = pkgs.callPackage ../../docker.nix {
     name = "nix-user";
     uid = 1000;
     gid = 1000;


### PR DESCRIPTION
## Motivation

At work, I needed to prepare a custom Nix Docker image to support our internal setup, which relies on a private GitLab instance secured with custom SSL certificates. My initial intention was to reuse the official [`docker.nix`](https://github.com/NixOS/nix/blob/master/docker.nix) recipe and simply inject the custom certificates. Unfortunately, this was not straightforward, as the set of packages included in the image is not exposed as configurable parameters. It may be possible to override them in a more advanced way, but I have not found a clean solution yet.

To work around this, I copied the [`docker.nix`](https://github.com/NixOS/nix/blob/master/docker.nix) file into our project and modified it so that the packages injected into the final Docker image are now passed as parameters. This gives me full control over the contents of the image, including the ability to add our custom certificates and tools.

This PR implements the changes that I made in my own `docker.nix`, I guess it will be useful for some others.

If this PR gets merged, then I'll update my project, remove the duplicated `docker.nix` file and use something similar to:

```nix
{
  inputs,
  ...
}:
let
  myImage = callPackage ${inputs.nix}/docker.nix {
    cacert = cacert.override { #... };
  };
in
  myImage
```

The old image size is:

```
❯ nix path-info -Sh ./result.old
/nix/store/npdf6xk88whw7jpmzyfxmzmcj3n2hy04-docker-image-tarball-2.30.0pre20250611_371fcf9       206.6 MiB
```

The new image size is:

```
❯ nix path-info -Sh ./result.new 
/nix/store/6fh0030cyh50jhmaxz9f50z3cx92q3kc-docker-image-tarball-2.30.0pre20250612_053cf5c       134.2 MiB
❯
```

There's a size gain of around 17%.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
