### PR TITLE
libexpr: Remove non-const overload of `listElems`

### DIFF
--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -410,11 +410,6 @@ public:
         return internalType == tList1 || internalType == tList2 || internalType == tListN;
     }
 
-    Value * const * listElems()
-    {
-        return internalType == tList1 || internalType == tList2 ? payload.smallList : payload.bigList.elems;
-    }
-
     std::span<Value * const> listItems() const
     {
         assert(isList());


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This overload isn't actually necessary anywhere and doesn't make much sense. The pointers to `Value`s are themselves const, but the `Value`s are mutable.
A non-const member function implies that the object itself can be modified but this doesn't make much sense considering the return type: `Value * const * `, which is a pointer to a constant array of pointers to mutable values.

cc @roberth, @edolstra as you've been cleaning up the meaning of const throughout the codebase.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
