### PR TITLE
libstore: fix race condition when creating state directories

### DIFF
--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -133,7 +133,7 @@ LocalStore::LocalStore(ref<const Config> config)
     Path gcRootsDir = config->stateDir + "/gcroots";
     if (!pathExists(gcRootsDir)) {
         createDirs(gcRootsDir);
-        createSymlink(profilesDir, gcRootsDir + "/profiles");
+        replaceSymlink(profilesDir, gcRootsDir + "/profiles");
     }
 
     for (auto & perUserDir : {profilesDir + "/per-user", gcRootsDir + "/per-user"}) {


### PR DESCRIPTION
Running (parallel?) nix in nix can lead to multiple instances trying to create the state directories and failing on the `createSymlink` step, because the link already exists.

`replaceSymlink` is already idempotent, so let's use that.

Resolves #2706

I only see this race appearing in Nixpkgs' CI right now, for example https://github.com/NixOS/nixpkgs/actions/runs/15426171510/job/43413501065. It only happens very infrequently. I tried reproducing locally, by just running `nix-build ci -A nixpkgs-vet` in a loop, but didn't succeed, so far. I'm running Lix locally, but that shouldn't make a difference, the relevant code is the same. I assume I can't reproduce, because I'd need to start from an empty cache, but I'm not sure.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
