### PR TITLE
Give unit tests access to a $HOME directory

### DIFF
--- a/src/libflake-tests/meson.build
+++ b/src/libflake-tests/meson.build
@@ -60,6 +60,7 @@ test(
   env : {
     '_NIX_TEST_UNIT_DATA': meson.current_source_dir() / 'data',
     'NIX_CONFIG': 'extra-experimental-features = flakes',
+    'HOME': meson.current_build_dir() / 'test-home',
   },
   protocol : 'gtest',
 )

--- a/src/libflake-tests/package.nix
+++ b/src/libflake-tests/package.nix
@@ -56,18 +56,14 @@ mkMesonExecutable (finalAttrs: {
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
           }
-          (
-            lib.optionalString stdenv.hostPlatform.isWindows ''
-              export HOME="$PWD/home-dir"
-              mkdir -p "$HOME"
-            ''
-            + ''
-              export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
-              export NIX_CONFIG="extra-experimental-features = flakes"
-              ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
-              touch $out
-            ''
-          );
+          (''
+            export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
+            export NIX_CONFIG="extra-experimental-features = flakes"
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
+            touch $out
+          '');
     };
   };
 

--- a/src/libflake-tests/package.nix
+++ b/src/libflake-tests/package.nix
@@ -3,6 +3,7 @@
   buildPackages,
   stdenv,
   mkMesonExecutable,
+  writableTmpDirAsHomeHook,
 
   nix-flake,
   nix-flake-c,
@@ -55,12 +56,11 @@ mkMesonExecutable (finalAttrs: {
         runCommand "${finalAttrs.pname}-run"
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+            buildInputs = [ writableTmpDirAsHomeHook ];
           }
           (''
             export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
             export NIX_CONFIG="extra-experimental-features = flakes"
-            export HOME="$TMPDIR/home"
-            mkdir -p "$HOME"
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
             touch $out
           '');

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -100,6 +100,7 @@ test(
   this_exe,
   env : {
     '_NIX_TEST_UNIT_DATA': meson.current_source_dir() / 'data',
+    'HOME': meson.current_build_dir() / 'test-home',
   },
   protocol : 'gtest',
 )

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -101,6 +101,7 @@ test(
   env : {
     '_NIX_TEST_UNIT_DATA': meson.current_source_dir() / 'data',
     'HOME': meson.current_build_dir() / 'test-home',
+    'NIX_REMOTE': meson.current_build_dir() / 'test-home' / 'store',
   },
   protocol : 'gtest',
 )

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -28,10 +28,6 @@ TEST_F(nix_api_store_test, nix_store_get_uri)
 
 TEST_F(nix_api_util_context, nix_store_get_storedir_default)
 {
-    if (nix::getEnv("HOME").value_or("") == "/homeless-shelter") {
-        // skipping test in sandbox because nix_store_open tries to create /nix/var/nix/profiles
-        GTEST_SKIP();
-    }
     nix_libstore_init(ctx);
     Store * store = nix_store_open(ctx, nullptr, nullptr);
     assert_ctx_ok();
@@ -141,10 +137,6 @@ TEST_F(nix_api_store_test, nix_store_real_path)
 
 TEST_F(nix_api_util_context, nix_store_real_path_relocated)
 {
-    if (nix::getEnv("HOME").value_or("") == "/homeless-shelter") {
-        // Can't open default store from within sandbox
-        GTEST_SKIP();
-    }
     auto tmp = nix::createTempDir();
     std::string storeRoot = tmp + "/store";
     std::string stateDir = tmp + "/state";
@@ -184,13 +176,7 @@ TEST_F(nix_api_util_context, nix_store_real_path_relocated)
 
 TEST_F(nix_api_util_context, nix_store_real_path_binary_cache)
 {
-    if (nix::getEnv("HOME").value_or("") == "/homeless-shelter") {
-        // TODO: override NIX_CACHE_HOME?
-        // skipping test in sandbox because narinfo cache can't be written
-        GTEST_SKIP();
-    }
-
-    Store * store = nix_store_open(ctx, "https://cache.nixos.org", nullptr);
+    Store * store = nix_store_open(ctx, nix::fmt("file://%s/binary-cache", nix::createTempDir()).c_str(), nullptr);
     assert_ctx_ok();
     ASSERT_NE(store, nullptr);
 

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -73,17 +73,13 @@ mkMesonExecutable (finalAttrs: {
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
           }
-          (
-            lib.optionalString stdenv.hostPlatform.isWindows ''
-              export HOME="$PWD/home-dir"
-              mkdir -p "$HOME"
-            ''
-            + ''
-              export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
-              ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
-              touch $out
-            ''
-          );
+          (''
+            export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
+            touch $out
+          '');
     };
   };
 

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -3,6 +3,7 @@
   buildPackages,
   stdenv,
   mkMesonExecutable,
+  writableTmpDirAsHomeHook,
 
   nix-store,
   nix-store-c,
@@ -72,11 +73,10 @@ mkMesonExecutable (finalAttrs: {
         runCommand "${finalAttrs.pname}-run"
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
+            buildInputs = [ writableTmpDirAsHomeHook ];
           }
           (''
             export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
-            export HOME="$TMPDIR/home"
-            mkdir -p "$HOME"
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
             touch $out
           '');

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -77,6 +77,7 @@ mkMesonExecutable (finalAttrs: {
           }
           (''
             export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
+            export NIX_REMOTE=$HOME/store
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
             touch $out
           '');


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This allows them to not skip some tests that require a home directory (like anything that uses the fetcher cache).

Also, don't try to access cache.nixos.org in the libstore unit tests because that's bad for reproducibility.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
