### PR TITLE
Restore multiline formatting of lists in meson files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,10 @@ project(
   'cpp',
   version : files('.version'),
   subproject_dir : 'src',
-  default_options : [ 'localstatedir=/nix/var' ],
+  default_options : [
+    'localstatedir=/nix/var',
+    # hack for trailing newline
+  ],
   meson_version : '>= 1.1',
 )
 

--- a/src/libexpr-test-support/include/nix/expr/tests/meson.build
+++ b/src/libexpr-test-support/include/nix/expr/tests/meson.build
@@ -2,4 +2,9 @@
 
 include_dirs = [ include_directories('../../..') ]
 
-headers = files('libexpr.hh', 'nix_api_expr.hh', 'value/context.hh')
+headers = files(
+  'libexpr.hh',
+  'nix_api_expr.hh',
+  'value/context.hh',
+  # hack for trailing newline
+)

--- a/src/libstore/linux/include/nix/store/meson.build
+++ b/src/libstore/linux/include/nix/store/meson.build
@@ -1,3 +1,6 @@
 include_dirs += include_directories('../..')
 
-headers += files('personality.hh')
+headers += files(
+  'personality.hh',
+  # hack for trailing newline
+)

--- a/src/libstore/linux/meson.build
+++ b/src/libstore/linux/meson.build
@@ -1,3 +1,6 @@
-sources += files('personality.cc')
+sources += files(
+  'personality.cc',
+  # hack for trailing newline
+)
 
 subdir('include/nix/store')

--- a/src/libutil/freebsd/include/nix/util/meson.build
+++ b/src/libutil/freebsd/include/nix/util/meson.build
@@ -2,4 +2,7 @@
 
 include_dirs += include_directories('../..')
 
-headers += files('freebsd-jail.hh')
+headers += files(
+  'freebsd-jail.hh',
+  # hack for trailing newline
+)

--- a/src/libutil/freebsd/meson.build
+++ b/src/libutil/freebsd/meson.build
@@ -1,3 +1,6 @@
-sources += files('freebsd-jail.cc')
+sources += files(
+  'freebsd-jail.cc',
+  # hack for trailing newline
+)
 
 subdir('include/nix/util')

--- a/src/libutil/linux/include/nix/util/meson.build
+++ b/src/libutil/linux/include/nix/util/meson.build
@@ -2,4 +2,8 @@
 
 include_dirs += include_directories('../..')
 
-headers += files('cgroup.hh', 'linux-namespaces.hh')
+headers += files(
+  'cgroup.hh',
+  'linux-namespaces.hh',
+  # hack for trailing newline
+)

--- a/src/libutil/linux/meson.build
+++ b/src/libutil/linux/meson.build
@@ -1,3 +1,7 @@
-sources += files('cgroup.cc', 'linux-namespaces.cc')
+sources += files(
+  'cgroup.cc',
+  'linux-namespaces.cc',
+  # hack for trailing newline
+)
 
 subdir('include/nix/util')

--- a/src/libutil/windows/include/nix/util/meson.build
+++ b/src/libutil/windows/include/nix/util/meson.build
@@ -2,4 +2,9 @@
 
 include_dirs += include_directories('../..')
 
-headers += files('signals-impl.hh', 'windows-async-pipe.hh', 'windows-error.hh')
+headers += files(
+  'signals-impl.hh',
+  'windows-async-pipe.hh',
+  'windows-error.hh',
+  # hack for trailing newline
+)

--- a/src/perl/t/meson.build
+++ b/src/perl/t/meson.build
@@ -5,7 +5,10 @@
 # src
 #---------------------------------------------------
 
-nix_perl_tests = files('init.t')
+nix_perl_tests = files(
+  'init.t',
+  # hack for trailing newline
+)
 
 
 foreach f : nix_perl_tests

--- a/tests/functional/plugins/meson.build
+++ b/tests/functional/plugins/meson.build
@@ -1,6 +1,9 @@
 libplugintest = shared_module(
   'plugintest',
   'plugintest.cc',
-  dependencies : [ dependency('nix-expr') ],
+  dependencies : [
+    dependency('nix-expr'),
+    # hack for trailing newline
+  ],
   build_by_default : false,
 )

--- a/tests/functional/test-libstoreconsumer/meson.build
+++ b/tests/functional/test-libstoreconsumer/meson.build
@@ -1,6 +1,9 @@
 libstoreconsumer_tester = executable(
   'test-libstoreconsumer',
   'main.cc',
-  dependencies : [ dependency('nix-store') ],
+  dependencies : [
+    dependency('nix-store'),
+    # hack for trailing newline
+  ],
   build_by_default : false,
 )


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Applies a workaround to enforce multiline formatting of lists to reduce code churn introduced in 93a42a597145a2ff0214ddc6a9828921056c3657.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Requested by @Ericson2314 in https://github.com/NixOS/nix/issues/13377. Hopefully this could be made configurable in meson, but for now this doesn't seem too painful of a workaround.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
