### PR TITLE
libstore-tests: Don't leak memory in tests

### DIFF
--- a/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
+++ b/src/libstore-test-support/include/nix/store/tests/nix_api_store.hh
@@ -34,6 +34,8 @@ public:
     Store * store;
     std::string nixDir;
     std::string nixStoreDir;
+    std::string nixStateDir;
+    std::string nixLogDir;
 
 protected:
     void init_local_store()
@@ -53,11 +55,13 @@ protected:
 #endif
 
         nixStoreDir = nixDir + "/my_nix_store";
+        nixStateDir = nixDir + "/my_state";
+        nixLogDir = nixDir + "/my_log";
 
         // Options documented in `nix help-stores`
         const char * p1[] = {"store", nixStoreDir.c_str()};
-        const char * p2[] = {"state", (new std::string(nixDir + "/my_state"))->c_str()};
-        const char * p3[] = {"log", (new std::string(nixDir + "/my_log"))->c_str()};
+        const char * p2[] = {"state", nixStateDir.c_str()};
+        const char * p3[] = {"log", nixLogDir.c_str()};
 
         const char ** params[] = {p1, p2, p3, nullptr};
 

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -71,17 +71,21 @@ TEST_F(nix_api_store_test, ReturnsValidStorePath)
     ASSERT_NE(result, nullptr);
     ASSERT_STREQ("name", result->path.name().data());
     ASSERT_STREQ(PATH_SUFFIX.substr(1).c_str(), result->path.to_string().data());
+    nix_store_path_free(result);
 }
 
 TEST_F(nix_api_store_test, SetsLastErrCodeToNixOk)
 {
-    nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
+    StorePath * path = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
     ASSERT_EQ(ctx->last_err_code, NIX_OK);
+    nix_store_path_free(path);
 }
 
 TEST_F(nix_api_store_test, DoesNotCrashWhenContextIsNull)
 {
-    ASSERT_NO_THROW(nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str()));
+    StorePath * path = nullptr;
+    ASSERT_NO_THROW(path = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str()));
+    nix_store_path_free(path);
 }
 
 TEST_F(nix_api_store_test, get_version)
@@ -119,6 +123,7 @@ TEST_F(nix_api_store_test, nix_store_is_valid_path_not_in_store)
 {
     StorePath * path = nix_store_parse_path(ctx, store, (nixStoreDir + PATH_SUFFIX).c_str());
     ASSERT_EQ(false, nix_store_is_valid_path(ctx, store, path));
+    nix_store_path_free(path);
 }
 
 TEST_F(nix_api_store_test, nix_store_real_path)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

We shouldn't leak memory in unit tests in order
to make enabling ASAN easier.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
