### PR TITLE
Fix deep flake input overrides

### DIFF
--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -170,6 +170,9 @@ static FlakeInput parseFlakeInput(
             input.ref = parseFlakeRef(state.fetchSettings, *url, {}, true, input.isFlake, true);
     }
 
+    if (input.ref && input.follows)
+        throw Error("flake input has both a flake reference and a follows attribute, at %s", state.positions[pos]);
+
     return input;
 }
 

--- a/tests/functional/flakes/follow-paths.sh
+++ b/tests/functional/flakes/follow-paths.sh
@@ -401,7 +401,6 @@ EOF
 cat <<EOF > $flakeFollowsB/flake.nix
 {
   inputs.C.url = "path:nosuchflake";
-  inputs.D.url = "path:nosuchflake";
   inputs.D.follows = "C/D";
   outputs = _: {};
 }
@@ -419,3 +418,15 @@ EOF
 nix flake lock $flakeFollowsA --recreate-lock-file
 
 [[ $(jq -c .nodes.B.inputs.D $flakeFollowsA/flake.lock) = '["B","C","D"]' ]]
+
+# Check that you can't have both a flakeref and a follows attribute on an input.
+cat <<EOF > $flakeFollowsB/flake.nix
+{
+  inputs.C.url = "path:nosuchflake";
+  inputs.D.url = "path:nosuchflake";
+  inputs.D.follows = "C/D";
+  outputs = _: {};
+}
+EOF
+
+expectStderr 1 nix flake lock $flakeFollowsA --recreate-lock-file | grepQuiet "flake input has both a flake reference and a follows attribute"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

An override like

```    
inputs.foo.inputs.bar.inputs.nixpkgs.follows = "nixpkgs";
```
    
implicitly set `inputs.foo.inputs.bar` to `flake:bar`, which led to an unexpected error like
    
```
error: cannot find flake 'flake:bar' in the flake registries
```
    
We now no longer create a parent override (like for `foo.bar` in the example above) if it doesn't set an explicit ref or follows attribute. We only recursively apply its child overrides.
    
Fixes https://github.com/NixOS/nix/issues/8325, https://github.com/DeterminateSystems/nix-src/issues/95, https://github.com/NixOS/nix/issues/12083, https://github.com/NixOS/nix/issues/5790. Based in part on https://github.com/NixOS/nix/pull/6621 by @Kha.

Also, we now disallow having both a flakeref and a follows attribute on an input, since it doesn't make sense to have both.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
