### PR TITLE
build-cores: detect cores automatically if set to 0

### DIFF
--- a/doc/manual/rl-next/build-cores-auto-detect.md
+++ b/doc/manual/rl-next/build-cores-auto-detect.md
@@ -1,0 +1,6 @@
+---
+synopsis: "`build-cores = 0` now auto-detects CPU cores"
+prs: [13402]
+---
+
+When `build-cores` is set to `0`, nix now automatically detects the number of available CPU cores and passes this value via `NIX_BUILD_CORES`, instead of passing `0` directly. This matches the behavior when `build-cores` is unset. This prevents the builder from having to detect the number of cores.

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -140,7 +140,7 @@ std::vector<Path> getUserConfigFiles()
     return files;
 }
 
-unsigned int Settings::getDefaultCores()
+unsigned int Settings::getDefaultCores() const
 {
     const unsigned int concurrency = std::max(1U, std::thread::hardware_concurrency());
     const unsigned int maxCPU = getMaxCPU();

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -43,8 +43,6 @@ const uint32_t maxIdsPerBuild =
 
 class Settings : public Config {
 
-    unsigned int getDefaultCores();
-
     StringSet getDefaultSystemFeatures();
 
     StringSet getDefaultExtraPlatforms();
@@ -56,6 +54,8 @@ class Settings : public Config {
 public:
 
     Settings();
+
+    unsigned int getDefaultCores() const;
 
     Path nixPrefix;
 
@@ -153,7 +153,7 @@ public:
 
     Setting<unsigned int> buildCores{
         this,
-        getDefaultCores(),
+        0,
         "cores",
         R"(
           Sets the value of the `NIX_BUILD_CORES` environment variable in the [invocation of the `builder` executable](@docroot@/language/derivations.md#builder-execution) of a derivation.
@@ -166,15 +166,13 @@ public:
           -->
           For instance, in Nixpkgs, if the attribute `enableParallelBuilding` for the `mkDerivation` build helper is set to `true`, it passes the `-j${NIX_BUILD_CORES}` flag to GNU Make.
 
-          The value `0` means that the `builder` should use all available CPU cores in the system.
+          If set to `0`, nix will detect the number of CPU cores and pass this number via NIX_BUILD_CORES.
 
           > **Note**
           >
           > The number of parallel local Nix build jobs is independently controlled with the [`max-jobs`](#conf-max-jobs) setting.
         )",
-        {"build-cores"},
-        // Don't document the machine-specific default value
-        false};
+        {"build-cores"}};
 
     /**
      * Read-only mode.  Don't copy stuff to the store, don't change

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1083,7 +1083,7 @@ void DerivationBuilderImpl::initEnv()
     env["NIX_STORE"] = store.storeDir;
 
     /* The maximum number of cores to utilize for parallel building. */
-    env["NIX_BUILD_CORES"] = fmt("%d", settings.buildCores);
+    env["NIX_BUILD_CORES"] = fmt("%d", settings.buildCores ? settings.buildCores : settings.getDefaultCores());
 
     /* In non-structured mode, set all bindings either directory in the
        environment or via a file, as specified by

--- a/src/nix-build/nix-build.cc
+++ b/src/nix-build/nix-build.cc
@@ -542,7 +542,7 @@ static void main_nix_build(int argc, char * * argv)
 
         env["NIX_BUILD_TOP"] = env["TMPDIR"] = env["TEMPDIR"] = env["TMP"] = env["TEMP"] = tmpDir.path().string();
         env["NIX_STORE"] = store->storeDir;
-        env["NIX_BUILD_CORES"] = std::to_string(settings.buildCores);
+        env["NIX_BUILD_CORES"] = fmt("%d", settings.buildCores ? settings.buildCores : settings.getDefaultCores());
 
         auto parsedDrv = StructuredAttrs::tryParse(drv.env);
         DerivationOptions drvOptions;

--- a/tests/functional/build-cores.nix
+++ b/tests/functional/build-cores.nix
@@ -1,0 +1,11 @@
+with import ./config.nix;
+
+{
+  # Test derivation that checks the NIX_BUILD_CORES environment variable
+  testCores = mkDerivation {
+    name = "test-build-cores";
+    buildCommand = ''
+      echo "$NIX_BUILD_CORES" > $out
+    '';
+  };
+}

--- a/tests/functional/build-cores.sh
+++ b/tests/functional/build-cores.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+clearStoreIfPossible
+
+echo "Testing build-cores configuration behavior..."
+
+# Test 1: When build-cores is set to a non-zero value, NIX_BUILD_CORES should have that value
+echo "Testing build-cores=4..."
+rm -f "$TEST_ROOT"/build-cores-output
+nix-build --cores 4 build-cores.nix -A testCores -o "$TEST_ROOT"/build-cores-output
+result=$(cat "$(readlink "$TEST_ROOT"/build-cores-output)")
+if [[ "$result" != "4" ]]; then
+    echo "FAIL: Expected NIX_BUILD_CORES=4, got $result"
+    exit 1
+fi
+echo "PASS: build-cores=4 correctly sets NIX_BUILD_CORES=4"
+rm -f "$TEST_ROOT"/build-cores-output
+
+# Test 2: When build-cores is set to 0, NIX_BUILD_CORES should be resolved to getDefaultCores()
+echo "Testing build-cores=0..."
+nix-build --cores 0 build-cores.nix -A testCores -o "$TEST_ROOT"/build-cores-output
+result=$(cat "$(readlink "$TEST_ROOT"/build-cores-output)")
+if [[ "$result" == "0" ]]; then
+    echo "FAIL: NIX_BUILD_CORES should not be 0 when build-cores=0"
+    exit 1
+fi
+echo "PASS: build-cores=0 resolves to NIX_BUILD_CORES=$result (should be > 0)"
+rm -f "$TEST_ROOT"/build-cores-output
+
+echo "All build-cores tests passed!"

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -145,6 +145,7 @@ suites = [
       'placeholders.sh',
       'ssh-relay.sh',
       'build.sh',
+      'build-cores.sh',
       'build-delete.sh',
       'output-normalization.sh',
       'selfref-gc.sh',


### PR DESCRIPTION
This change makes nix detect a machines available cores automatically whenever `cores` is set to 0.

So far, nix simply passed NIX_BUILD_CORES=0 whenever build-cores is set to 0. (only when `cores` is unset it was detecting cores automatically)

The behavior of passing NIX_BUILD_CORES=0 leads to a performance penalty when sourcing nixpkgs' generic builder's `setup.sh`, as setup.sh [has to execute `nproc`](https://github.com/NixOS/nixpkgs/blob/c2d8e89c022da73e133dfb625fd2af968e61766b/pkgs/stdenv/generic/setup.sh#L1000-L1003). This significantly slows down sourcing of setup.sh

~~This affects all nixos machines since the introduction of the nix settings module a couple releases ago which sets `cores` to 0 be default.~~ (It was set to 0 in nixos since at least 6 years)

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->


<!-- Briefly explain what the change is about and why it is desirable. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
