### PR TITLE
libflake: Remove unused maybeParseFlakeRef and maybeParseFlakeRefWith…

### DIFF
--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -57,18 +57,6 @@ FlakeRef parseFlakeRef(
     return flakeRef;
 }
 
-std::optional<FlakeRef> maybeParseFlakeRef(
-    const fetchers::Settings & fetchSettings,
-    const std::string & url,
-    const std::optional<Path> & baseDir)
-{
-    try {
-        return parseFlakeRef(fetchSettings, url, baseDir);
-    } catch (Error &) {
-        return {};
-    }
-}
-
 static std::pair<FlakeRef, std::string> fromParsedURL(
     const fetchers::Settings & fetchSettings,
     ParsedURL && parsedURL,
@@ -258,17 +246,6 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
         return *res;
     } else {
         return parsePathFlakeRefWithFragment(fetchSettings, url, baseDir, allowMissing, isFlake, preserveRelativePaths);
-    }
-}
-
-std::optional<std::pair<FlakeRef, std::string>> maybeParseFlakeRefWithFragment(
-    const fetchers::Settings & fetchSettings,
-    const std::string & url, const std::optional<Path> & baseDir)
-{
-    try {
-        return parseFlakeRefWithFragment(fetchSettings, url, baseDir);
-    } catch (Error & e) {
-        return {};
     }
 }
 

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -96,14 +96,6 @@ FlakeRef parseFlakeRef(
 /**
  * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)
  */
-std::optional<FlakeRef> maybeParseFlake(
-    const fetchers::Settings & fetchSettings,
-    const std::string & url,
-    const std::optional<Path> & baseDir = {});
-
-/**
- * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)
- */
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     const fetchers::Settings & fetchSettings,
     const std::string & url,
@@ -111,14 +103,6 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     bool allowMissing = false,
     bool isFlake = true,
     bool preserveRelativePaths = false);
-
-/**
- * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)
- */
-std::optional<std::pair<FlakeRef, std::string>> maybeParseFlakeRefWithFragment(
-    const fetchers::Settings & fetchSettings,
-    const std::string & url,
-    const std::optional<Path> & baseDir = {});
 
 /**
  * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)


### PR DESCRIPTION
…Fragment

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

These wrappers don't seem to be used anywhere in and out of tree. Also the declaration in the header has an incorrect function name `maybeParseFlake`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Closes #11948

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
