### PR TITLE
libexpr: Reduce the size of Value down to 16 bytes (on 64 bit systems)

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -256,7 +256,6 @@
               ''^src/libexpr/include/nix/expr/value-to-json\.hh$''
               ''^src/libexpr/value-to-xml\.cc$''
               ''^src/libexpr/include/nix/expr/value-to-xml\.hh$''
-              ''^src/libexpr/include/nix/expr/value\.hh$''
               ''^src/libexpr/value/context\.cc$''
               ''^src/libexpr/include/nix/expr/value/context\.hh$''
               ''^src/libfetchers/attrs\.cc$''

--- a/src/libexpr-c/nix_api_value.cc
+++ b/src/libexpr-c/nix_api_value.cc
@@ -324,7 +324,7 @@ nix_value * nix_get_list_byidx(nix_c_context * context, const nix_value * value,
     try {
         auto & v = check_value_in(value);
         assert(v.type() == nix::nList);
-        auto * p = v.listElems()[ix];
+        auto * p = v.listView()[ix];
         nix_gc_incref(nullptr, p);
         if (p != nullptr)
             state->state.forceValue(*p, nix::noPos);

--- a/src/libexpr-tests/primops.cc
+++ b/src/libexpr-tests/primops.cc
@@ -150,8 +150,8 @@ namespace nix {
     TEST_F(PrimOpTest, attrValues) {
         auto v = eval("builtins.attrValues { x = \"foo\";  a = 1; }");
         ASSERT_THAT(v, IsListOfSize(2));
-        ASSERT_THAT(*v.listElems()[0], IsIntEq(1));
-        ASSERT_THAT(*v.listElems()[1], IsStringEq("foo"));
+        ASSERT_THAT(*v.listView()[0], IsIntEq(1));
+        ASSERT_THAT(*v.listView()[1], IsStringEq("foo"));
     }
 
     TEST_F(PrimOpTest, getAttr) {
@@ -250,8 +250,8 @@ namespace nix {
     TEST_F(PrimOpTest, catAttrs) {
         auto v = eval("builtins.catAttrs \"a\" [{a = 1;} {b = 0;} {a = 2;}]");
         ASSERT_THAT(v, IsListOfSize(2));
-        ASSERT_THAT(*v.listElems()[0], IsIntEq(1));
-        ASSERT_THAT(*v.listElems()[1], IsIntEq(2));
+        ASSERT_THAT(*v.listView()[0], IsIntEq(1));
+        ASSERT_THAT(*v.listView()[1], IsIntEq(2));
     }
 
     TEST_F(PrimOpTest, functionArgs) {
@@ -320,7 +320,8 @@ namespace nix {
     TEST_F(PrimOpTest, tail) {
         auto v = eval("builtins.tail [ 3 2 1 0 ]");
         ASSERT_THAT(v, IsListOfSize(3));
-        for (const auto [n, elem] : enumerate(v.listItems()))
+        auto listView = v.listView();
+        for (const auto [n, elem] : enumerate(listView))
             ASSERT_THAT(*elem, IsIntEq(2 - static_cast<int>(n)));
     }
 
@@ -331,17 +332,17 @@ namespace nix {
     TEST_F(PrimOpTest, map) {
         auto v = eval("map (x: \"foo\" + x) [ \"bar\" \"bla\" \"abc\" ]");
         ASSERT_THAT(v, IsListOfSize(3));
-        auto elem = v.listElems()[0];
+        auto elem = v.listView()[0];
         ASSERT_THAT(*elem, IsThunk());
         state.forceValue(*elem, noPos);
         ASSERT_THAT(*elem, IsStringEq("foobar"));
 
-        elem = v.listElems()[1];
+        elem = v.listView()[1];
         ASSERT_THAT(*elem, IsThunk());
         state.forceValue(*elem, noPos);
         ASSERT_THAT(*elem, IsStringEq("foobla"));
 
-        elem = v.listElems()[2];
+        elem = v.listView()[2];
         ASSERT_THAT(*elem, IsThunk());
         state.forceValue(*elem, noPos);
         ASSERT_THAT(*elem, IsStringEq("fooabc"));
@@ -350,7 +351,7 @@ namespace nix {
     TEST_F(PrimOpTest, filter) {
         auto v = eval("builtins.filter (x: x == 2) [ 3 2 3 2 3 2 ]");
         ASSERT_THAT(v, IsListOfSize(3));
-        for (const auto elem : v.listItems())
+        for (const auto elem : v.listView())
             ASSERT_THAT(*elem, IsIntEq(2));
     }
 
@@ -367,7 +368,8 @@ namespace nix {
     TEST_F(PrimOpTest, concatLists) {
         auto v = eval("builtins.concatLists [[1 2] [3 4]]");
         ASSERT_THAT(v, IsListOfSize(4));
-        for (const auto [i, elem] : enumerate(v.listItems()))
+        auto listView = v.listView();
+        for (const auto [i, elem] : enumerate(listView))
             ASSERT_THAT(*elem, IsIntEq(static_cast<int>(i)+1));
     }
 
@@ -405,7 +407,8 @@ namespace nix {
         auto v = eval("builtins.genList (x: x + 1) 3");
         ASSERT_EQ(v.type(), nList);
         ASSERT_EQ(v.listSize(), 3u);
-        for (const auto [i, elem] : enumerate(v.listItems())) {
+        auto listView = v.listView();
+        for (const auto [i, elem] : enumerate(listView)) {
             ASSERT_THAT(*elem, IsThunk());
             state.forceValue(*elem, noPos);
             ASSERT_THAT(*elem, IsIntEq(static_cast<int>(i)+1));
@@ -418,7 +421,8 @@ namespace nix {
         ASSERT_EQ(v.listSize(), 6u);
 
         const std::vector<int> numbers = { 42, 77, 147, 249, 483, 526 };
-        for (const auto [n, elem] : enumerate(v.listItems()))
+        auto listView = v.listView();
+        for (const auto [n, elem] : enumerate(listView))
             ASSERT_THAT(*elem, IsIntEq(numbers[n]));
     }
 
@@ -429,17 +433,17 @@ namespace nix {
         auto right = v.attrs()->get(createSymbol("right"));
         ASSERT_NE(right, nullptr);
         ASSERT_THAT(*right->value, IsListOfSize(2));
-        ASSERT_THAT(*right->value->listElems()[0], IsIntEq(23));
-        ASSERT_THAT(*right->value->listElems()[1], IsIntEq(42));
+        ASSERT_THAT(*right->value->listView()[0], IsIntEq(23));
+        ASSERT_THAT(*right->value->listView()[1], IsIntEq(42));
 
         auto wrong = v.attrs()->get(createSymbol("wrong"));
         ASSERT_NE(wrong, nullptr);
         ASSERT_EQ(wrong->value->type(), nList);
         ASSERT_EQ(wrong->value->listSize(), 3u);
         ASSERT_THAT(*wrong->value, IsListOfSize(3));
-        ASSERT_THAT(*wrong->value->listElems()[0], IsIntEq(1));
-        ASSERT_THAT(*wrong->value->listElems()[1], IsIntEq(9));
-        ASSERT_THAT(*wrong->value->listElems()[2], IsIntEq(3));
+        ASSERT_THAT(*wrong->value->listView()[0], IsIntEq(1));
+        ASSERT_THAT(*wrong->value->listView()[1], IsIntEq(9));
+        ASSERT_THAT(*wrong->value->listView()[2], IsIntEq(3));
     }
 
     TEST_F(PrimOpTest, concatMap) {
@@ -448,7 +452,8 @@ namespace nix {
         ASSERT_EQ(v.listSize(), 6u);
 
         const std::vector<int> numbers = { 1, 2, 0, 3, 4, 0 };
-        for (const auto [n, elem] : enumerate(v.listItems()))
+        auto listView = v.listView();
+        for (const auto [n, elem] : enumerate(listView))
             ASSERT_THAT(*elem, IsIntEq(numbers[n]));
     }
 
@@ -682,7 +687,8 @@ namespace nix {
         ASSERT_THAT(v, IsListOfSize(4));
 
         const std::vector<std::string_view> strings = { "1", "2", "3", "git" };
-        for (const auto [n, p] : enumerate(v.listItems()))
+        auto listView = v.listView();
+        for (const auto [n, p] : enumerate(listView))
             ASSERT_THAT(*p, IsStringEq(strings[n]));
     }
 
@@ -772,12 +778,12 @@ namespace nix {
         auto v = eval("builtins.split \"(a)b\" \"abc\"");
         ASSERT_THAT(v, IsListOfSize(3));
 
-        ASSERT_THAT(*v.listElems()[0], IsStringEq(""));
+        ASSERT_THAT(*v.listView()[0], IsStringEq(""));
 
-        ASSERT_THAT(*v.listElems()[1], IsListOfSize(1));
-        ASSERT_THAT(*v.listElems()[1]->listElems()[0], IsStringEq("a"));
+        ASSERT_THAT(*v.listView()[1], IsListOfSize(1));
+        ASSERT_THAT(*v.listView()[1]->listView()[0], IsStringEq("a"));
 
-        ASSERT_THAT(*v.listElems()[2], IsStringEq("c"));
+        ASSERT_THAT(*v.listView()[2], IsStringEq("c"));
     }
 
     TEST_F(PrimOpTest, split2) {
@@ -785,17 +791,17 @@ namespace nix {
         auto v = eval("builtins.split \"([ac])\" \"abc\"");
         ASSERT_THAT(v, IsListOfSize(5));
 
-        ASSERT_THAT(*v.listElems()[0], IsStringEq(""));
+        ASSERT_THAT(*v.listView()[0], IsStringEq(""));
 
-        ASSERT_THAT(*v.listElems()[1], IsListOfSize(1));
-        ASSERT_THAT(*v.listElems()[1]->listElems()[0], IsStringEq("a"));
+        ASSERT_THAT(*v.listView()[1], IsListOfSize(1));
+        ASSERT_THAT(*v.listView()[1]->listView()[0], IsStringEq("a"));
 
-        ASSERT_THAT(*v.listElems()[2], IsStringEq("b"));
+        ASSERT_THAT(*v.listView()[2], IsStringEq("b"));
 
-        ASSERT_THAT(*v.listElems()[3], IsListOfSize(1));
-        ASSERT_THAT(*v.listElems()[3]->listElems()[0], IsStringEq("c"));
+        ASSERT_THAT(*v.listView()[3], IsListOfSize(1));
+        ASSERT_THAT(*v.listView()[3]->listView()[0], IsStringEq("c"));
 
-        ASSERT_THAT(*v.listElems()[4], IsStringEq(""));
+        ASSERT_THAT(*v.listView()[4], IsStringEq(""));
     }
 
     TEST_F(PrimOpTest, split3) {
@@ -803,36 +809,36 @@ namespace nix {
         ASSERT_THAT(v, IsListOfSize(5));
 
         // First list element
-        ASSERT_THAT(*v.listElems()[0], IsStringEq(""));
+        ASSERT_THAT(*v.listView()[0], IsStringEq(""));
 
         // 2nd list element is a list [ "" null ]
-        ASSERT_THAT(*v.listElems()[1], IsListOfSize(2));
-        ASSERT_THAT(*v.listElems()[1]->listElems()[0], IsStringEq("a"));
-        ASSERT_THAT(*v.listElems()[1]->listElems()[1], IsNull());
+        ASSERT_THAT(*v.listView()[1], IsListOfSize(2));
+        ASSERT_THAT(*v.listView()[1]->listView()[0], IsStringEq("a"));
+        ASSERT_THAT(*v.listView()[1]->listView()[1], IsNull());
 
         // 3rd element
-        ASSERT_THAT(*v.listElems()[2], IsStringEq("b"));
+        ASSERT_THAT(*v.listView()[2], IsStringEq("b"));
 
         // 4th element is a list: [ null "c" ]
-        ASSERT_THAT(*v.listElems()[3], IsListOfSize(2));
-        ASSERT_THAT(*v.listElems()[3]->listElems()[0], IsNull());
-        ASSERT_THAT(*v.listElems()[3]->listElems()[1], IsStringEq("c"));
+        ASSERT_THAT(*v.listView()[3], IsListOfSize(2));
+        ASSERT_THAT(*v.listView()[3]->listView()[0], IsNull());
+        ASSERT_THAT(*v.listView()[3]->listView()[1], IsStringEq("c"));
 
         // 5th element is the empty string
-        ASSERT_THAT(*v.listElems()[4], IsStringEq(""));
+        ASSERT_THAT(*v.listView()[4], IsStringEq(""));
     }
 
     TEST_F(PrimOpTest, split4) {
         auto v = eval("builtins.split \"([[:upper:]]+)\" \" FOO \"");
         ASSERT_THAT(v, IsListOfSize(3));
-        auto first = v.listElems()[0];
-        auto second = v.listElems()[1];
-        auto third = v.listElems()[2];
+        auto first = v.listView()[0];
+        auto second = v.listView()[1];
+        auto third = v.listView()[2];
 
         ASSERT_THAT(*first, IsStringEq(" "));
 
         ASSERT_THAT(*second, IsListOfSize(1));
-        ASSERT_THAT(*second->listElems()[0], IsStringEq("FOO"));
+        ASSERT_THAT(*second->listView()[0], IsStringEq("FOO"));
 
         ASSERT_THAT(*third, IsStringEq(" "));
     }
@@ -850,14 +856,14 @@ namespace nix {
     TEST_F(PrimOpTest, match3) {
         auto v = eval("builtins.match \"a(b)(c)\" \"abc\"");
         ASSERT_THAT(v, IsListOfSize(2));
-        ASSERT_THAT(*v.listElems()[0], IsStringEq("b"));
-        ASSERT_THAT(*v.listElems()[1], IsStringEq("c"));
+        ASSERT_THAT(*v.listView()[0], IsStringEq("b"));
+        ASSERT_THAT(*v.listView()[1], IsStringEq("c"));
     }
 
     TEST_F(PrimOpTest, match4) {
         auto v = eval("builtins.match \"[[:space:]]+([[:upper:]]+)[[:space:]]+\" \"  FOO   \"");
         ASSERT_THAT(v, IsListOfSize(1));
-        ASSERT_THAT(*v.listElems()[0], IsStringEq("FOO"));
+        ASSERT_THAT(*v.listView()[0], IsStringEq("FOO"));
     }
 
     TEST_F(PrimOpTest, match5) {
@@ -874,7 +880,8 @@ namespace nix {
 
         // ensure that the list is sorted
         const std::vector<std::string_view> expected { "a", "x", "y", "z" };
-        for (const auto [n, elem] : enumerate(v.listItems()))
+        auto listView = v.listView();
+        for (const auto [n, elem] : enumerate(listView))
             ASSERT_THAT(*elem, IsStringEq(expected[n]));
     }
 

--- a/src/libexpr/attr-path.cc
+++ b/src/libexpr/attr-path.cc
@@ -95,7 +95,7 @@ std::pair<Value *, PosIdx> findAlongAttrPath(EvalState & state, const std::strin
             if (*attrIndex >= v->listSize())
                 throw AttrPathNotFound("list index %1% in selection path '%2%' is out of range", *attrIndex, attrPath);
 
-            v = v->listElems()[*attrIndex];
+            v = v->listView()[*attrIndex];
             pos = noPos;
         }
 

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -721,7 +721,7 @@ std::vector<std::string> AttrCursor::getListOfStrings()
 
     std::vector<std::string> res;
 
-    for (auto & elem : v.listItems())
+    for (auto elem : v.listView())
         res.push_back(std::string(root->state.forceStringNoCtx(*elem, noPos, "while evaluating an attribute for caching")));
 
     if (root->db)

--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -4,6 +4,7 @@
 #include "nix/util/config-global.hh"
 #include "nix/util/serialise.hh"
 #include "nix/expr/eval-gc.hh"
+#include "nix/expr/value.hh"
 
 #include "expr-config-private.hh"
 
@@ -51,6 +52,13 @@ static inline void initGCReal()
     GC_start_performance_measurement();
 
     GC_INIT();
+
+    /* Register valid displacements in case we are using alignment niches
+       for storing the type information. This way tagged pointers are considered
+       to be valid, even when they are not aligned. */
+    if constexpr (detail::useBitPackedValueStorage<sizeof(void *)>)
+        for (std::size_t i = 1; i < sizeof(std::uintptr_t); ++i)
+            GC_register_displacement(i);
 
     GC_set_oom_fn(oomHandler);
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -502,7 +502,7 @@ void EvalState::addConstant(const std::string & name, Value * v, Constant info)
         /* Install value the base environment. */
         staticBaseEnv->vars.emplace_back(symbols.create(name), baseEnvDispl);
         baseEnv.values[baseEnvDispl++] = v;
-        getBuiltins().payload.attrs->push_back(Attr(symbols.create(name2), v));
+        const_cast<Bindings *>(getBuiltins().attrs())->push_back(Attr(symbols.create(name2), v));
     }
 }
 
@@ -540,7 +540,7 @@ const PrimOp * Value::primOpAppPrimOp() const
 void Value::mkPrimOp(PrimOp * p)
 {
     p->check();
-    finishValue(tPrimOp, { .primOp = p });
+    setStorage(p);
 }
 
 
@@ -572,7 +572,7 @@ Value * EvalState::addPrimOp(PrimOp && primOp)
     else {
         staticBaseEnv->vars.emplace_back(envName, baseEnvDispl);
         baseEnv.values[baseEnvDispl++] = v;
-        getBuiltins().payload.attrs->push_back(Attr(symbols.create(primOp.name), v));
+        const_cast<Bindings *>(getBuiltins().attrs())->push_back(Attr(symbols.create(primOp.name), v));
     }
 
     return v;

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -125,7 +125,7 @@ std::string showType(const Value & v)
     // Allow selecting a subset of enum values
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wswitch-enum"
-    switch (v.internalType) {
+    switch (v.getInternalType()) {
         case tString: return v.context() ? "a string with context" : "a string";
         case tPrimOp:
             return fmt("the built-in function '%s'", std::string(v.primOp()->name));
@@ -145,7 +145,7 @@ PosIdx Value::determinePos(const PosIdx pos) const
     // Allow selecting a subset of enum values
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wswitch-enum"
-    switch (internalType) {
+    switch (getInternalType()) {
         case tAttrs: return attrs()->pos;
         case tLambda: return lambda().fun->pos;
         case tApp: return app().left->determinePos(pos);
@@ -157,9 +157,8 @@ PosIdx Value::determinePos(const PosIdx pos) const
 bool Value::isTrivial() const
 {
     return
-        internalType != tApp
-        && internalType != tPrimOpApp
-        && (internalType != tThunk
+        !isa<tApp, tPrimOpApp>()
+        && (!isa<tThunk>()
             || (dynamic_cast<ExprAttrs *>(thunk().expr)
                 && ((ExprAttrs *) thunk().expr)->dynamicAttrs.empty())
             || dynamic_cast<ExprLambda *>(thunk().expr)

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2007,9 +2007,10 @@ void EvalState::concatLists(Value & v, size_t nrLists, Value * const * lists, co
     auto list = buildList(len);
     auto out = list.elems;
     for (size_t n = 0, pos = 0; n < nrLists; ++n) {
-        auto l = lists[n]->listSize();
+        auto listView = lists[n]->listView();
+        auto l = listView.size();
         if (l)
-            memcpy(out + pos, lists[n]->listElems(), l * sizeof(Value *));
+            memcpy(out + pos, listView.data(), l * sizeof(Value *));
         pos += l;
     }
     v.mkList(list);
@@ -2174,7 +2175,7 @@ void EvalState::forceValueDeep(Value & v)
         }
 
         else if (v.isList()) {
-            for (auto v2 : v.listItems())
+            for (auto v2 : v.listView())
                 recurse(*v2);
         }
     };
@@ -2411,7 +2412,8 @@ BackedStringView EvalState::coerceToString(
 
         if (v.isList()) {
             std::string result;
-            for (auto [n, v2] : enumerate(v.listItems())) {
+            auto listView = v.listView();
+            for (auto [n, v2] : enumerate(listView)) {
                 try {
                     result += *coerceToString(pos, *v2, context,
                             "while evaluating one element of the list",
@@ -2666,7 +2668,7 @@ void EvalState::assertEqValues(Value & v1, Value & v2, const PosIdx pos, std::st
         }
         for (size_t n = 0; n < v1.listSize(); ++n) {
             try {
-                assertEqValues(*v1.listElems()[n], *v2.listElems()[n], pos, errorCtx);
+                assertEqValues(*v1.listView()[n], *v2.listView()[n], pos, errorCtx);
             } catch (Error & e) {
                 e.addTrace(positions[pos], "while comparing list element %d", n);
                 throw;
@@ -2818,7 +2820,7 @@ bool EvalState::eqValues(Value & v1, Value & v2, const PosIdx pos, std::string_v
         case nList:
             if (v1.listSize() != v2.listSize()) return false;
             for (size_t n = 0; n < v1.listSize(); ++n)
-                if (!eqValues(*v1.listElems()[n], *v2.listElems()[n], pos, errorCtx)) return false;
+                if (!eqValues(*v1.listView()[n], *v2.listView()[n], pos, errorCtx)) return false;
             return true;
 
         case nAttrs: {

--- a/src/libexpr/get-drvs.cc
+++ b/src/libexpr/get-drvs.cc
@@ -117,7 +117,7 @@ PackageInfo::Outputs PackageInfo::queryOutputs(bool withPaths, bool onlyOutputsT
             state->forceList(*i->value, i->pos, "while evaluating the 'outputs' attribute of a derivation");
 
             /* For each output... */
-            for (auto elem : i->value->listItems()) {
+            for (auto elem : i->value->listView()) {
                 std::string output(state->forceStringNoCtx(*elem, i->pos, "while evaluating the name of an output of a derivation"));
 
                 if (withPaths) {
@@ -159,7 +159,7 @@ PackageInfo::Outputs PackageInfo::queryOutputs(bool withPaths, bool onlyOutputsT
             /* ^ this shows during `nix-env -i` right under the bad derivation */
         if (!outTI->isList()) throw errMsg;
         Outputs result;
-        for (auto elem : outTI->listItems()) {
+        for (auto elem : outTI->listView()) {
             if (elem->type() != nString) throw errMsg;
             auto out = outputs.find(elem->c_str());
             if (out == outputs.end()) throw errMsg;
@@ -206,7 +206,7 @@ bool PackageInfo::checkMeta(Value & v)
 {
     state->forceValue(v, v.determinePos(noPos));
     if (v.type() == nList) {
-        for (auto elem : v.listItems())
+        for (auto elem : v.listView())
             if (!checkMeta(*elem)) return false;
         return true;
     }
@@ -400,7 +400,8 @@ static void getDerivations(EvalState & state, Value & vIn,
     }
 
     else if (v.type() == nList) {
-        for (auto [n, elem] : enumerate(v.listItems())) {
+        auto listView = v.listView();
+        for (auto [n, elem] : enumerate(listView)) {
             std::string pathPrefix2 = addToPath(pathPrefix, fmt("%d", n));
             if (getDerivation(state, *elem, pathPrefix2, drvs, done, ignoreAssertionFailures))
                 getDerivations(state, *elem, pathPrefix2, autoArgs, drvs, done, ignoreAssertionFailures);

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -25,8 +25,7 @@ typedef enum {
     tPath,
     tNull,
     tAttrs,
-    tList1,
-    tList2,
+    tListSmall,
     tListN,
     tThunk,
     tApp,
@@ -318,8 +317,7 @@ public:
             return nNull;
         case tAttrs:
             return nAttrs;
-        case tList1:
-        case tList2:
+        case tListSmall:
         case tListN:
             return nList;
         case tLambda:
@@ -405,9 +403,9 @@ public:
     void mkList(const ListBuilder & builder)
     {
         if (builder.size == 1)
-            finishValue(tList1, {.smallList = {builder.inlineElems[0]}});
+            finishValue(tListSmall, {.smallList = {builder.inlineElems[0], nullptr}});
         else if (builder.size == 2)
-            finishValue(tList2, {.smallList = {builder.inlineElems[0], builder.inlineElems[1]}});
+            finishValue(tListSmall, {.smallList = {builder.inlineElems[0], builder.inlineElems[1]}});
         else
             finishValue(tListN, {.bigList = {.size = builder.size, .elems = builder.elems}});
     }
@@ -453,7 +451,7 @@ public:
 
     bool isList() const
     {
-        return internalType == tList1 || internalType == tList2 || internalType == tListN;
+        return internalType == tListSmall || internalType == tListN;
     }
 
     std::span<Value * const> listItems() const
@@ -464,12 +462,12 @@ public:
 
     Value * const * listElems() const
     {
-        return internalType == tList1 || internalType == tList2 ? payload.smallList : payload.bigList.elems;
+        return internalType == tListSmall ? payload.smallList : payload.bigList.elems;
     }
 
     size_t listSize() const
     {
-        return internalType == tList1 ? 1 : internalType == tList2 ? 2 : payload.bigList.size;
+        return internalType == tListSmall ? (payload.smallList[1] == nullptr ? 1 : 2) : payload.bigList.size;
     }
 
     PosIdx determinePos(const PosIdx pos) const;

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -17,7 +17,6 @@ namespace nix {
 struct Value;
 class BindingsBuilder;
 
-
 typedef enum {
     tUninitialized = 0,
     tInt = 1,
@@ -54,7 +53,7 @@ typedef enum {
     nAttrs,
     nList,
     nFunction,
-    nExternal
+    nExternal,
 } ValueType;
 
 class Bindings;
@@ -81,15 +80,15 @@ using NixFloat = double;
  */
 class ExternalValueBase
 {
-    friend std::ostream & operator << (std::ostream & str, const ExternalValueBase & v);
+    friend std::ostream & operator<<(std::ostream & str, const ExternalValueBase & v);
     friend class Printer;
-    protected:
+protected:
     /**
      * Print out the value
      */
     virtual std::ostream & print(std::ostream & str) const = 0;
 
-    public:
+public:
     /**
      * Return a simple string describing the type
      */
@@ -104,41 +103,44 @@ class ExternalValueBase
      * Coerce the value to a string. Defaults to uncoercable, i.e. throws an
      * error.
      */
-    virtual std::string coerceToString(EvalState & state, const PosIdx & pos, NixStringContext & context, bool copyMore, bool copyToStore) const;
+    virtual std::string coerceToString(
+        EvalState & state, const PosIdx & pos, NixStringContext & context, bool copyMore, bool copyToStore) const;
 
     /**
      * Compare to another value of the same type. Defaults to uncomparable,
      * i.e. always false.
      */
-    virtual bool operator ==(const ExternalValueBase & b) const noexcept;
+    virtual bool operator==(const ExternalValueBase & b) const noexcept;
 
     /**
      * Print the value as JSON. Defaults to unconvertable, i.e. throws an error
      */
-    virtual nlohmann::json printValueAsJSON(EvalState & state, bool strict,
-        NixStringContext & context, bool copyToStore = true) const;
+    virtual nlohmann::json
+    printValueAsJSON(EvalState & state, bool strict, NixStringContext & context, bool copyToStore = true) const;
 
     /**
      * Print the value as XML. Defaults to unevaluated
      */
-    virtual void printValueAsXML(EvalState & state, bool strict, bool location,
-        XMLWriter & doc, NixStringContext & context, PathSet & drvsSeen,
+    virtual void printValueAsXML(
+        EvalState & state,
+        bool strict,
+        bool location,
+        XMLWriter & doc,
+        NixStringContext & context,
+        PathSet & drvsSeen,
         const PosIdx pos) const;
 
-    virtual ~ExternalValueBase()
-    {
-    };
+    virtual ~ExternalValueBase() {};
 };
 
-std::ostream & operator << (std::ostream & str, const ExternalValueBase & v);
-
+std::ostream & operator<<(std::ostream & str, const ExternalValueBase & v);
 
 class ListBuilder
 {
     const size_t size;
     Value * inlineElems[2] = {nullptr, nullptr};
 public:
-    Value * * elems;
+    Value ** elems;
     ListBuilder(EvalState & state, size_t size);
 
     // NOTE: Can be noexcept because we are just copying integral values and
@@ -147,21 +149,27 @@ public:
         : size(x.size)
         , inlineElems{x.inlineElems[0], x.inlineElems[1]}
         , elems(size <= 2 ? inlineElems : x.elems)
-    { }
+    {
+    }
 
-    Value * & operator [](size_t n)
+    Value *& operator[](size_t n)
     {
         return elems[n];
     }
 
-    typedef Value * * iterator;
+    typedef Value ** iterator;
 
-    iterator begin() { return &elems[0]; }
-    iterator end() { return &elems[size]; }
+    iterator begin()
+    {
+        return &elems[0];
+    }
+    iterator end()
+    {
+        return &elems[size];
+    }
 
     friend struct Value;
 };
-
 
 struct Value
 {
@@ -177,21 +185,36 @@ public:
      */
     static Value * toPtr(SymbolStr str) noexcept;
 
-    void print(EvalState &state, std::ostream &str, PrintOptions options = PrintOptions {});
+    void print(EvalState & state, std::ostream & str, PrintOptions options = PrintOptions{});
 
     // Functions needed to distinguish the type
     // These should be removed eventually, by putting the functionality that's
     // needed by callers into methods of this type
 
     // type() == nThunk
-    inline bool isThunk() const { return internalType == tThunk; };
-    inline bool isApp() const { return internalType == tApp; };
+    inline bool isThunk() const
+    {
+        return internalType == tThunk;
+    };
+    inline bool isApp() const
+    {
+        return internalType == tApp;
+    };
     inline bool isBlackhole() const;
 
     // type() == nFunction
-    inline bool isLambda() const { return internalType == tLambda; };
-    inline bool isPrimOp() const { return internalType == tPrimOp; };
-    inline bool isPrimOpApp() const { return internalType == tPrimOpApp; };
+    inline bool isLambda() const
+    {
+        return internalType == tLambda;
+    };
+    inline bool isPrimOp() const
+    {
+        return internalType == tPrimOp;
+    };
+    inline bool isPrimOpApp() const
+    {
+        return internalType == tPrimOpApp;
+    };
 
     /**
      * Strings in the evaluator carry a so-called `context` which
@@ -215,26 +238,31 @@ public:
 
      * For canonicity, the store paths should be in sorted order.
      */
-    struct StringWithContext {
+    struct StringWithContext
+    {
         const char * c_str;
-        const char * * context; // must be in sorted order
+        const char ** context; // must be in sorted order
     };
 
-    struct Path {
+    struct Path
+    {
         SourceAccessor * accessor;
         const char * path;
     };
 
-    struct ClosureThunk {
+    struct ClosureThunk
+    {
         Env * env;
         Expr * expr;
     };
 
-    struct FunctionApplicationThunk {
-        Value * left, * right;
+    struct FunctionApplicationThunk
+    {
+        Value *left, *right;
     };
 
-    struct Lambda {
+    struct Lambda
+    {
         Env * env;
         ExprLambda * fun;
     };
@@ -249,7 +277,8 @@ public:
         Path path;
 
         Bindings * attrs;
-        struct {
+        struct
+        {
             size_t size;
             Value * const * elems;
         } bigList;
@@ -275,18 +304,35 @@ public:
     inline ValueType type(bool invalidIsThunk = false) const
     {
         switch (internalType) {
-            case tUninitialized: break;
-            case tInt: return nInt;
-            case tBool: return nBool;
-            case tString: return nString;
-            case tPath: return nPath;
-            case tNull: return nNull;
-            case tAttrs: return nAttrs;
-            case tList1: case tList2: case tListN: return nList;
-            case tLambda: case tPrimOp: case tPrimOpApp: return nFunction;
-            case tExternal: return nExternal;
-            case tFloat: return nFloat;
-            case tThunk: case tApp: return nThunk;
+        case tUninitialized:
+            break;
+        case tInt:
+            return nInt;
+        case tBool:
+            return nBool;
+        case tString:
+            return nString;
+        case tPath:
+            return nPath;
+        case tNull:
+            return nNull;
+        case tAttrs:
+            return nAttrs;
+        case tList1:
+        case tList2:
+        case tListN:
+            return nList;
+        case tLambda:
+        case tPrimOp:
+        case tPrimOpApp:
+            return nFunction;
+        case tExternal:
+            return nExternal;
+        case tFloat:
+            return nFloat;
+        case tThunk:
+        case tApp:
+            return nThunk;
         }
         if (invalidIsThunk)
             return nThunk;
@@ -317,17 +363,17 @@ public:
 
     inline void mkInt(NixInt n)
     {
-        finishValue(tInt, { .integer = n });
+        finishValue(tInt, {.integer = n});
     }
 
     inline void mkBool(bool b)
     {
-        finishValue(tBool, { .boolean = b });
+        finishValue(tBool, {.boolean = b});
     }
 
-    inline void mkString(const char * s, const char * * context = 0)
+    inline void mkString(const char * s, const char ** context = 0)
     {
-        finishValue(tString, { .string = { .c_str = s, .context = context } });
+        finishValue(tString, {.string = {.c_str = s, .context = context}});
     }
 
     void mkString(std::string_view s);
@@ -341,7 +387,7 @@ public:
 
     inline void mkPath(SourceAccessor * accessor, const char * path)
     {
-        finishValue(tPath, { .path = { .accessor = accessor, .path = path } });
+        finishValue(tPath, {.path = {.accessor = accessor, .path = path}});
     }
 
     inline void mkNull()
@@ -351,7 +397,7 @@ public:
 
     inline void mkAttrs(Bindings * a)
     {
-        finishValue(tAttrs, { .attrs = a });
+        finishValue(tAttrs, {.attrs = a});
     }
 
     Value & mkAttrs(BindingsBuilder & bindings);
@@ -359,26 +405,26 @@ public:
     void mkList(const ListBuilder & builder)
     {
         if (builder.size == 1)
-            finishValue(tList1, { .smallList = { builder.inlineElems[0] } });
+            finishValue(tList1, {.smallList = {builder.inlineElems[0]}});
         else if (builder.size == 2)
-            finishValue(tList2, { .smallList = { builder.inlineElems[0], builder.inlineElems[1] } });
+            finishValue(tList2, {.smallList = {builder.inlineElems[0], builder.inlineElems[1]}});
         else
-            finishValue(tListN, { .bigList = { .size = builder.size, .elems = builder.elems } });
+            finishValue(tListN, {.bigList = {.size = builder.size, .elems = builder.elems}});
     }
 
     inline void mkThunk(Env * e, Expr * ex)
     {
-        finishValue(tThunk, { .thunk = { .env = e, .expr = ex } });
+        finishValue(tThunk, {.thunk = {.env = e, .expr = ex}});
     }
 
     inline void mkApp(Value * l, Value * r)
     {
-        finishValue(tApp, { .app = { .left = l, .right = r } });
+        finishValue(tApp, {.app = {.left = l, .right = r}});
     }
 
     inline void mkLambda(Env * e, ExprLambda * f)
     {
-        finishValue(tLambda, { .lambda = { .env = e, .fun = f } });
+        finishValue(tLambda, {.lambda = {.env = e, .fun = f}});
     }
 
     inline void mkBlackhole();
@@ -387,7 +433,7 @@ public:
 
     inline void mkPrimOpApp(Value * l, Value * r)
     {
-        finishValue(tPrimOpApp, { .primOpApp = { .left = l, .right = r } });
+        finishValue(tPrimOpApp, {.primOpApp = {.left = l, .right = r}});
     }
 
     /**
@@ -397,12 +443,12 @@ public:
 
     inline void mkExternal(ExternalValueBase * e)
     {
-        finishValue(tExternal, { .external = e });
+        finishValue(tExternal, {.external = e});
     }
 
     inline void mkFloat(NixFloat n)
     {
-        finishValue(tFloat, { .fpoint = n });
+        finishValue(tFloat, {.fpoint = n});
     }
 
     bool isList() const
@@ -438,9 +484,7 @@ public:
     SourcePath path() const
     {
         assert(internalType == tPath);
-        return SourcePath(
-            ref(pathAccessor()->shared_from_this()),
-            CanonPath(CanonPath::unchecked_t(), pathStr()));
+        return SourcePath(ref(pathAccessor()->shared_from_this()), CanonPath(CanonPath::unchecked_t(), pathStr()));
     }
 
     std::string_view string_view() const
@@ -455,54 +499,77 @@ public:
         return payload.string.c_str;
     }
 
-    const char * * context() const
+    const char ** context() const
     {
         return payload.string.context;
     }
 
     ExternalValueBase * external() const
-    { return payload.external; }
+    {
+        return payload.external;
+    }
 
     const Bindings * attrs() const
-    { return payload.attrs; }
+    {
+        return payload.attrs;
+    }
 
     const PrimOp * primOp() const
-    { return payload.primOp; }
+    {
+        return payload.primOp;
+    }
 
     bool boolean() const
-    { return payload.boolean; }
+    {
+        return payload.boolean;
+    }
 
     NixInt integer() const
-    { return payload.integer; }
+    {
+        return payload.integer;
+    }
 
     NixFloat fpoint() const
-    { return payload.fpoint; }
+    {
+        return payload.fpoint;
+    }
 
     Lambda lambda() const
-    { return payload.lambda; }
+    {
+        return payload.lambda;
+    }
 
     ClosureThunk thunk() const
-    { return payload.thunk; }
+    {
+        return payload.thunk;
+    }
 
     FunctionApplicationThunk primOpApp() const
-    { return payload.primOpApp; }
+    {
+        return payload.primOpApp;
+    }
 
     FunctionApplicationThunk app() const
-    { return payload.app; }
+    {
+        return payload.app;
+    }
 
     const char * pathStr() const
-    { return payload.path.path; }
+    {
+        return payload.path.path;
+    }
 
     SourceAccessor * pathAccessor() const
-    { return payload.path.accessor; }
+    {
+        return payload.path.accessor;
+    }
 };
-
 
 extern ExprBlackHole eBlackHole;
 
 bool Value::isBlackhole() const
 {
-    return internalType == tThunk && thunk().expr == (Expr*) &eBlackHole;
+    return internalType == tThunk && thunk().expr == (Expr *) &eBlackHole;
 }
 
 void Value::mkBlackhole()
@@ -510,11 +577,16 @@ void Value::mkBlackhole()
     mkThunk(nullptr, (Expr *) &eBlackHole);
 }
 
-
 typedef std::vector<Value *, traceable_allocator<Value *>> ValueVector;
-typedef std::unordered_map<Symbol, Value *, std::hash<Symbol>, std::equal_to<Symbol>, traceable_allocator<std::pair<const Symbol, Value *>>> ValueMap;
-typedef std::map<Symbol, ValueVector, std::less<Symbol>, traceable_allocator<std::pair<const Symbol, ValueVector>>> ValueVectorMap;
-
+typedef std::unordered_map<
+    Symbol,
+    Value *,
+    std::hash<Symbol>,
+    std::equal_to<Symbol>,
+    traceable_allocator<std::pair<const Symbol, Value *>>>
+    ValueMap;
+typedef std::map<Symbol, ValueVector, std::less<Symbol>, traceable_allocator<std::pair<const Symbol, ValueVector>>>
+    ValueVectorMap;
 
 /**
  * A value allocated in traceable memory.

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -415,7 +415,7 @@ void prim_importNative(EvalState & state, const PosIdx pos, Value * * args, Valu
 void prim_exec(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
     state.forceList(*args[0], pos, "while evaluating the first argument passed to builtins.exec");
-    auto elems = args[0]->listElems();
+    auto elems = args[0]->listView();
     auto count = args[0]->listSize();
     if (count == 0)
         state.error<EvalError>("at least one argument to 'exec' required").atPos(pos).debugThrow();
@@ -660,8 +660,8 @@ struct CompareValues
                             return false;
                         } else if (i == v1->listSize()) {
                             return true;
-                        } else if (!state.eqValues(*v1->listElems()[i], *v2->listElems()[i], pos, errorCtx)) {
-                            return (*this)(v1->listElems()[i], v2->listElems()[i], "while comparing two list elements");
+                        } else if (!state.eqValues(*v1->listView()[i], *v2->listView()[i], pos, errorCtx)) {
+                            return (*this)(v1->listView()[i], v2->listView()[i], "while comparing two list elements");
                         }
                     }
                 default:
@@ -689,7 +689,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value * * a
     state.forceList(*startSet->value, noPos, "while evaluating the 'startSet' attribute passed as argument to builtins.genericClosure");
 
     ValueList workSet;
-    for (auto elem : startSet->value->listItems())
+    for (auto elem : startSet->value->listView())
         workSet.push_back(elem);
 
     if (startSet->value->listSize() == 0) {
@@ -727,7 +727,7 @@ static void prim_genericClosure(EvalState & state, const PosIdx pos, Value * * a
         state.forceList(newElements, noPos, "while evaluating the return value of the `operator` passed to builtins.genericClosure");
 
         /* Add the values returned by the operator to the work set. */
-        for (auto elem : newElements.listItems()) {
+        for (auto elem : newElements.listView()) {
             state.forceValue(*elem, noPos); // "while evaluating one one of the elements returned by the `operator` passed to builtins.genericClosure");
             workSet.push_back(elem);
         }
@@ -1367,7 +1367,7 @@ static void derivationStrictInternal(
                command-line arguments to the builder. */
             else if (i->name == state.sArgs) {
                 state.forceList(*i->value, pos, context_below);
-                for (auto elem : i->value->listItems()) {
+                for (auto elem : i->value->listView()) {
                     auto s = state.coerceToString(pos, *elem, context,
                             "while evaluating an element of the argument list",
                             true).toOwned();
@@ -1399,7 +1399,7 @@ static void derivationStrictInternal(
                         /* Require ‘outputs’ to be a list of strings. */
                         state.forceList(*i->value, pos, context_below);
                         Strings ss;
-                        for (auto elem : i->value->listItems())
+                        for (auto elem : i->value->listView())
                             ss.emplace_back(state.forceStringNoCtx(*elem, pos, context_below));
                         handleOutputs(ss);
                     }
@@ -1882,7 +1882,7 @@ static void prim_findFile(EvalState & state, const PosIdx pos, Value * * args, V
 
     LookupPath lookupPath;
 
-    for (auto v2 : args[0]->listItems()) {
+    for (auto v2 : args[0]->listView()) {
         state.forceAttrs(*v2, pos, "while evaluating an element of the list passed to builtins.findFile");
 
         std::string prefix;
@@ -2920,7 +2920,7 @@ static void prim_removeAttrs(EvalState & state, const PosIdx pos, Value * * args
     // 64: large enough to fit the attributes of a derivation
     boost::container::small_vector<Attr, 64> names;
     names.reserve(args[1]->listSize());
-    for (auto elem : args[1]->listItems()) {
+    for (auto elem : args[1]->listView()) {
         state.forceStringNoCtx(*elem, pos, "while evaluating the values of the second argument passed to builtins.removeAttrs");
         names.emplace_back(state.symbols.create(elem->string_view()), nullptr);
     }
@@ -2963,11 +2963,12 @@ static void prim_listToAttrs(EvalState & state, const PosIdx pos, Value * * args
     state.forceList(*args[0], pos, "while evaluating the argument passed to builtins.listToAttrs");
 
     // Step 1. Sort the name-value attrsets in place using the memory we allocate for the result
-    size_t listSize = args[0]->listSize();
+    auto listView = args[0]->listView();
+    size_t listSize = listView.size();
     auto & bindings = *state.allocBindings(listSize);
     using ElemPtr = decltype(&bindings[0].value);
 
-    for (const auto & [n, v2] : enumerate(args[0]->listItems())) {
+    for (const auto & [n, v2] : enumerate(listView)) {
         state.forceAttrs(*v2, pos, "while evaluating an element of the list passed to builtins.listToAttrs");
 
         auto j = state.getAttr(state.sName, v2->attrs(), "in a {name=...; value=...;} pair");
@@ -3122,7 +3123,7 @@ static void prim_catAttrs(EvalState & state, const PosIdx pos, Value * * args, V
     SmallValueVector<nonRecursiveStackReservation> res(args[1]->listSize());
     size_t found = 0;
 
-    for (auto v2 : args[1]->listItems()) {
+    for (auto v2 : args[1]->listView()) {
         state.forceAttrs(*v2, pos, "while evaluating an element in the list passed as second argument to builtins.catAttrs");
         if (auto i = v2->attrs()->get(attrName))
             res[found++] = i->value;
@@ -3247,7 +3248,7 @@ static void prim_zipAttrsWith(EvalState & state, const PosIdx pos, Value * * arg
 
     state.forceFunction(*args[0], pos, "while evaluating the first argument passed to builtins.zipAttrsWith");
     state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.zipAttrsWith");
-    const auto listItems = args[1]->listItems();
+    const auto listItems = args[1]->listView();
 
     for (auto & vElem : listItems) {
         state.forceAttrs(*vElem, noPos, "while evaluating a value of the list passed as second argument to builtins.zipAttrsWith");
@@ -3346,8 +3347,8 @@ static void prim_elemAt(EvalState & state, const PosIdx pos, Value * * args, Val
             n,
             args[0]->listSize()
         ).atPos(pos).debugThrow();
-    state.forceValue(*args[0]->listElems()[n], pos);
-    v = *args[0]->listElems()[n];
+    state.forceValue(*args[0]->listView()[n], pos);
+    v = *args[0]->listView()[n];
 }
 
 static RegisterPrimOp primop_elemAt({
@@ -3368,8 +3369,8 @@ static void prim_head(EvalState & state, const PosIdx pos, Value * * args, Value
         state.error<EvalError>(
             "'builtins.head' called on an empty list"
         ).atPos(pos).debugThrow();
-    state.forceValue(*args[0]->listElems()[0], pos);
-    v = *args[0]->listElems()[0];
+    state.forceValue(*args[0]->listView()[0], pos);
+    v = *args[0]->listView()[0];
 }
 
 static RegisterPrimOp primop_head({
@@ -3394,7 +3395,7 @@ static void prim_tail(EvalState & state, const PosIdx pos, Value * * args, Value
 
     auto list = state.buildList(args[0]->listSize() - 1);
     for (const auto & [n, v] : enumerate(list))
-        v = args[0]->listElems()[n + 1];
+        v = args[0]->listView()[n + 1];
     v.mkList(list);
 }
 
@@ -3429,7 +3430,7 @@ static void prim_map(EvalState & state, const PosIdx pos, Value * * args, Value 
     auto list = state.buildList(args[1]->listSize());
     for (const auto & [n, v] : enumerate(list))
         (v = state.allocValue())->mkApp(
-            args[0], args[1]->listElems()[n]);
+            args[0], args[1]->listView()[n]);
     v.mkList(list);
 }
 
@@ -3470,9 +3471,9 @@ static void prim_filter(EvalState & state, const PosIdx pos, Value * * args, Val
     bool same = true;
     for (size_t n = 0; n < len; ++n) {
         Value res;
-        state.callFunction(*args[0], *args[1]->listElems()[n], res, noPos);
+        state.callFunction(*args[0], *args[1]->listView()[n], res, noPos);
         if (state.forceBool(res, pos, "while evaluating the return value of the filtering function passed to builtins.filter"))
-            vs[k++] = args[1]->listElems()[n];
+            vs[k++] = args[1]->listView()[n];
         else
             same = false;
     }
@@ -3501,7 +3502,7 @@ static void prim_elem(EvalState & state, const PosIdx pos, Value * * args, Value
 {
     bool res = false;
     state.forceList(*args[1], pos, "while evaluating the second argument passed to builtins.elem");
-    for (auto elem : args[1]->listItems())
+    for (auto elem : args[1]->listView())
         if (state.eqValues(*args[0], *elem, pos, "while searching for the presence of the given element in the list")) {
             res = true;
             break;
@@ -3523,7 +3524,8 @@ static RegisterPrimOp primop_elem({
 static void prim_concatLists(EvalState & state, const PosIdx pos, Value * * args, Value & v)
 {
     state.forceList(*args[0], pos, "while evaluating the first argument passed to builtins.concatLists");
-    state.concatLists(v, args[0]->listSize(), args[0]->listElems(), pos, "while evaluating a value of the list passed to builtins.concatLists");
+    auto listView = args[0]->listView();
+    state.concatLists(v, args[0]->listSize(), listView.data(), pos, "while evaluating a value of the list passed to builtins.concatLists");
 }
 
 static RegisterPrimOp primop_concatLists({
@@ -3561,7 +3563,8 @@ static void prim_foldlStrict(EvalState & state, const PosIdx pos, Value * * args
     if (args[2]->listSize()) {
         Value * vCur = args[1];
 
-        for (auto [n, elem] : enumerate(args[2]->listItems())) {
+        auto listView = args[2]->listView();
+        for (auto [n, elem] : enumerate(listView)) {
             Value * vs []{vCur, elem};
             vCur = n == args[2]->listSize() - 1 ? &v : state.allocValue();
             state.callFunction(*args[0], vs, *vCur, pos);
@@ -3603,7 +3606,7 @@ static void anyOrAll(bool any, EvalState & state, const PosIdx pos, Value * * ar
         : "while evaluating the return value of the function passed to builtins.all";
 
     Value vTmp;
-    for (auto elem : args[1]->listItems()) {
+    for (auto elem : args[1]->listView()) {
         state.callFunction(*args[0], *elem, vTmp, pos);
         bool res = state.forceBool(vTmp, pos, errorCtx);
         if (res == any) {
@@ -3701,7 +3704,7 @@ static void prim_sort(EvalState & state, const PosIdx pos, Value * * args, Value
 
     auto list = state.buildList(len);
     for (const auto & [n, v] : enumerate(list))
-        state.forceValue(*(v = args[1]->listElems()[n]), pos);
+        state.forceValue(*(v = args[1]->listView()[n]), pos);
 
     auto comparator = [&](Value * a, Value * b) {
         /* Optimization: if the comparator is lessThan, bypass
@@ -3787,7 +3790,7 @@ static void prim_partition(EvalState & state, const PosIdx pos, Value * * args, 
     ValueVector right, wrong;
 
     for (size_t n = 0; n < len; ++n) {
-        auto vElem = args[1]->listElems()[n];
+        auto vElem = args[1]->listView()[n];
         state.forceValue(*vElem, pos);
         Value res;
         state.callFunction(*args[0], *vElem, res, pos);
@@ -3844,7 +3847,7 @@ static void prim_groupBy(EvalState & state, const PosIdx pos, Value * * args, Va
 
     ValueVectorMap attrs;
 
-    for (auto vElem : args[1]->listItems()) {
+    for (auto vElem : args[1]->listView()) {
         Value res;
         state.callFunction(*args[0], *vElem, res, pos);
         auto name = state.forceStringNoCtx(res, pos, "while evaluating the return value of the grouping function passed to builtins.groupBy");
@@ -3900,7 +3903,7 @@ static void prim_concatMap(EvalState & state, const PosIdx pos, Value * * args, 
     size_t len = 0;
 
     for (size_t n = 0; n < nrLists; ++n) {
-        Value * vElem = args[1]->listElems()[n];
+        Value * vElem = args[1]->listView()[n];
         state.callFunction(*args[0], *vElem, lists[n], pos);
         state.forceList(lists[n], lists[n].determinePos(args[0]->determinePos(pos)), "while evaluating the return value of the function passed to builtins.concatMap");
         len += lists[n].listSize();
@@ -3909,9 +3912,10 @@ static void prim_concatMap(EvalState & state, const PosIdx pos, Value * * args, 
     auto list = state.buildList(len);
     auto out = list.elems;
     for (size_t n = 0, pos = 0; n < nrLists; ++n) {
-        auto l = lists[n].listSize();
+        auto listView = lists[n].listView();
+        auto l = listView.size();
         if (l)
-            memcpy(out + pos, lists[n].listElems(), l * sizeof(Value *));
+            memcpy(out + pos, listView.data(), l * sizeof(Value *));
         pos += l;
     }
     v.mkList(list);
@@ -4587,7 +4591,7 @@ static void prim_concatStringsSep(EvalState & state, const PosIdx pos, Value * *
     res.reserve((args[1]->listSize() + 32) * sep.size());
     bool first = true;
 
-    for (auto elem : args[1]->listItems()) {
+    for (auto elem : args[1]->listView()) {
         if (first) first = false; else res += sep;
         res += *state.coerceToString(pos, *elem, context, "while evaluating one element of the list of strings to concat passed to builtins.concatStringsSep");
     }
@@ -4617,11 +4621,11 @@ static void prim_replaceStrings(EvalState & state, const PosIdx pos, Value * * a
 
     std::vector<std::string_view> from;
     from.reserve(args[0]->listSize());
-    for (auto elem : args[0]->listItems())
+    for (auto elem : args[0]->listView())
         from.emplace_back(state.forceString(*elem, pos, "while evaluating one of the strings to replace passed to builtins.replaceStrings"));
 
     std::unordered_map<size_t, std::string_view> cache;
-    auto to = args[1]->listItems();
+    auto to = args[1]->listView();
 
     NixStringContext context;
     auto s = state.forceString(*args[2], context, pos, "while evaluating the third argument passed to builtins.replaceStrings");

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -5050,7 +5050,7 @@ void EvalState::createBaseEnv(const EvalSettings & evalSettings)
 
     /* Now that we've added all primops, sort the `builtins' set,
        because attribute lookups expect it to be sorted. */
-    getBuiltins().payload.attrs->sort();
+    const_cast<Bindings *>(getBuiltins().attrs())->sort();
 
     staticBaseEnv->sort();
 

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -312,7 +312,7 @@ static void prim_appendContext(EvalState & state, const PosIdx pos, Value * * ar
                     name
                 ).atPos(i.pos).debugThrow();
             }
-            for (auto elem : attr->value->listItems()) {
+            for (auto elem : attr->value->listView()) {
                 auto outputName = state.forceStringNoCtx(*elem, attr->pos, "while evaluating an output name within a string context");
                 context.emplace(NixStringContextElem::Built {
                     .drvPath = makeConstantStorePathRef(namePath),

--- a/src/libexpr/print-ambiguous.cc
+++ b/src/libexpr/print-ambiguous.cc
@@ -50,11 +50,13 @@ void printAmbiguous(
         break;
     }
     case nList:
-        if (seen && v.listSize() && !seen->insert(v.listElems()).second)
+        /* Use pointer to the Value instead of pointer to the elements, because
+           that would need to explicitly handle the case of SmallList. */
+        if (seen && v.listSize() && !seen->insert(&v).second)
             str << "«repeated»";
         else {
             str << "[ ";
-            for (auto v2 : v.listItems()) {
+            for (auto v2 : v.listView()) {
                 if (v2)
                     printAmbiguous(*v2, symbols, str, seen, depth - 1);
                 else

--- a/src/libexpr/print.cc
+++ b/src/libexpr/print.cc
@@ -415,8 +415,8 @@ private:
         if (depth < options.maxDepth) {
             increaseIndent();
             output << "[";
-            auto listItems = v.listItems();
-            auto prettyPrint = shouldPrettyPrintList(listItems);
+            auto listItems = v.listView();
+            auto prettyPrint = shouldPrettyPrintList(listItems.span());
 
             size_t currentListItemsPrinted = 0;
 

--- a/src/libexpr/value-to-json.cc
+++ b/src/libexpr/value-to-json.cc
@@ -73,7 +73,7 @@ json printValueAsJSON(EvalState & state, bool strict,
         case nList: {
             out = json::array();
             int i = 0;
-            for (auto elem : v.listItems()) {
+            for (auto elem : v.listView()) {
                 try {
                     out.push_back(printValueAsJSON(state, strict, *elem, pos, context, copyToStore));
                 } catch (Error & e) {

--- a/src/libexpr/value-to-xml.cc
+++ b/src/libexpr/value-to-xml.cc
@@ -114,7 +114,7 @@ static void printValueAsXML(EvalState & state, bool strict, bool location,
 
         case nList: {
             XMLOpenElement _(doc, "list");
-            for (auto v2 : v.listItems())
+            for (auto v2 : v.listView())
                 printValueAsXML(state, strict, location, *v2, doc, context, drvsSeen, pos);
             break;
         }

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -289,7 +289,7 @@ static Flake readFlake(
                     Explicit<bool> { state.forceBool(*setting.value, setting.pos, "") });
             else if (setting.value->type() == nList) {
                 std::vector<std::string> ss;
-                for (auto elem : setting.value->listItems()) {
+                for (auto elem : setting.value->listView()) {
                     if (elem->type() != nString)
                         state.error<TypeError>("list element in flake configuration setting '%s' is %s while a string is expected",
                             state.symbols[setting.name], showType(*setting.value)).debugThrow();

--- a/src/nix-env/nix-env.cc
+++ b/src/nix-env/nix-env.cc
@@ -1265,7 +1265,7 @@ static void opQuery(Globals & globals, Strings opFlags, Strings opArgs)
                             } else if (v->type() == nList) {
                                 attrs2["type"] = "strings";
                                 XMLOpenElement m(xml, "meta", attrs2);
-                                for (auto elem : v->listItems()) {
+                                for (auto elem : v->listView()) {
                                     if (elem->type() != nString) continue;
                                     XMLAttrs attrs3;
                                     attrs3["value"] = elem->c_str();

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -46,7 +46,7 @@ std::string resolveMirrorUrl(EvalState & state, const std::string & url)
     if (mirrorList->value->listSize() < 1)
         throw Error("mirror URL '%s' did not expand to anything", url);
 
-    std::string mirror(state.forceString(*mirrorList->value->listElems()[0], noPos, "while evaluating the first available mirror"));
+    std::string mirror(state.forceString(*mirrorList->value->listView()[0], noPos, "while evaluating the first available mirror"));
     return mirror + (hasSuffix(mirror, "/") ? "" : "/") + s.substr(p + 1);
 }
 
@@ -221,7 +221,7 @@ static int main_nix_prefetch_url(int argc, char * * argv)
             state->forceList(*attr->value, noPos, "while evaluating the urls to prefetch");
             if (attr->value->listSize() < 1)
                 throw Error("'urls' list is empty");
-            url = state->forceString(*attr->value->listElems()[0], noPos, "while evaluating the first url from the urls list");
+            url = state->forceString(*attr->value->listView()[0], noPos, "while evaluating the first url from the urls list");
 
             /* Extract the hash mode. */
             auto attr2 = v.attrs()->get(state->symbols.create("outputHashMode"));


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This shaves off a very significant (~20% percent reduction in maximum heap size and ~17% in total bytes) amount of memory used for evaluation as well as reduces the GC-managed heap. See the results below. The fraction of collected memory is not affected.

<details>

<summary>Memory usage comparison</summary>

Below are the comparisons for `NIX_SHOW_STATS=1 nix-env --query --available --out-path --file ../nixpkgs --eval-system x86_64-linux > /dev/null`

### Before

```json
{
  ....
  "gc": {
    "cycles": 14,
    "heapSize": 14818668544,
    "totalBytes": 27457473440
  },
  ....
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 8,
    "Value": 24
  },
  ....
  "values": {
    "bytes": 7345779024,
    "number": 306074126
  }
}
```

### After

```json
{
  ....
  "gc": {
    "cycles": 14,
    "heapSize": 11916210176,
    "totalBytes": 22553098160
  },
  ....
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 8,
    "Value": 16
  },
  ....
  "values": {
    "bytes": 4897186016,
    "number": 306074126
  }
}
```

So the savings are around `4.9` GiB on a full nixpkgs eval.

</details>

Previously the union discriminator (`InternalType`) was
stored as a separate field in the Value, which takes up
whole 8 bytes due to padding needed for member alignment.
This effectively wasted 7 whole bytes of memory. Instead
of doing that `InternalType` is packed into pointer
alignment niches. As it turns out, there's more than enough
unused bits there for the bit packing to be effective.

See the doxygen comment in the `ValueStorage` specialization
for more details.

This does not add any performance overhead, even though
we now consistently assert the `InternalType` in all getters.

This can also be made atomic with a double width compare-and-swap
instruction on x86_64 (`CMPXCHG16B` instruction) for parallel evaluation.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

This is the best we can do with the current data model to address https://github.com/NixOS/nix/issues/8621.
The improvement is very significant and should give more leeway to the ever growing nixpkgs.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 