### PR TITLE
clarify that the Nix language is not called "Nix epxressions"

### DIFF
--- a/doc/manual/source/introduction.md
+++ b/doc/manual/source/introduction.md
@@ -102,8 +102,9 @@ a currently running program.
 
 ## Functional package language
 
-Packages are built from _Nix expressions_, which is a simple
-functional language.  A Nix expression describes everything that goes
+Packages are built from expressions in Nix, which is a simple
+functional language with the same name as the Package Manager.
+A _Nix expression_ describes everything that goes
 into a package build task (a “derivation”): other packages, sources,
 the build script, environment variables for the build script, etc.
 Nix tries very hard to ensure that Nix expressions are


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

I had a student come by with a first draft of his thesis, and in it he referred to the Nix language as _Nix expressions_.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
