### PR TITLE
libfetchers: Add missing include guard to git-lfs-fetch.hh

### DIFF
--- a/src/libfetchers/include/nix/fetchers/git-lfs-fetch.hh
+++ b/src/libfetchers/include/nix/fetchers/git-lfs-fetch.hh
@@ -1,3 +1,6 @@
+#pragma once
+///@file
+
 #include "nix/util/canon-path.hh"
 #include "nix/util/serialise.hh"
 #include "nix/util/url.hh"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This is a publicly installed header without a header guard. Doesn't seem right.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
