### PR TITLE
Fix indentation of "Unable to start any build" error message

### DIFF
--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -362,23 +362,14 @@ void Worker::run(const Goals & _topGoals)
         else if (awake.empty() && 0U == settings.maxBuildJobs) {
             if (getMachines().empty())
                throw Error(
-                    R"(
-                    Unable to start any build;
-                    either increase '--max-jobs' or enable remote builds.
-
-                    For more information run 'man nix.conf' and search for '/machines'.
-                    )"
-                );
+                   "Unable to start any build; either increase '--max-jobs' or enable remote builds.\n"
+                   "\n"
+                   "For more information run 'man nix.conf' and search for '/machines'.");
             else
                throw Error(
-                    R"(
-                    Unable to start any build;
-                    remote machines may not have all required system features.
-
-                    For more information run 'man nix.conf' and search for '/machines'.
-                    )"
-                );
-
+                   "Unable to start any build; remote machines may not have all required system features.\n"
+                   "\n"
+                   "For more information run 'man nix.conf' and search for '/machines'.");
         } else assert(!awake.empty());
     }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

The use of R"(...)" added a bunch of unnecessary whitespace, e.g.

```
error:
                           Unable to start any build;
                           either increase '--max-jobs' or enable remote builds.

                           For more information run 'man nix.conf' and search for '/machines'.
```

Now we get

```
error: Unable to start any build; either increase '--max-jobs' or enable remote builds.

       For more information run 'man nix.conf' and search for '/machines'.
```


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
