### PR TITLE
nix store delete: Show why deletion fails

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -730,6 +730,7 @@ static void performOp(TunnelLogger * logger, ref<Store> store,
         options.action = (GCOptions::GCAction) readInt(conn.from);
         options.pathsToDelete = WorkerProto::Serialise<StorePathSet>::read(*store, rconn);
         conn.from >> options.ignoreLiveness >> options.maxFreed;
+        options.censor = !trusted;
         // obsolete fields
         readInt(conn.from);
         readInt(conn.from);

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -717,6 +717,15 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                 } catch (InvalidPath &) { }
             };
 
+            if (options.action == GCOptions::gcDeleteSpecific
+                && !options.pathsToDelete.count(*path))
+            {
+                throw Error(
+                    "Cannot delete path '%s' because it's referenced by path '%s'.",
+                    printStorePath(start),
+                    printStorePath(*path));
+            }
+
             /* If this is a root, bail out. */
             if (auto i = roots.find(*path); i != roots.end()) {
                 if (options.action == GCOptions::gcDeleteSpecific)
@@ -726,15 +735,6 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
                         *i->second.begin());
                 debug("cannot delete '%s' because it's a root", printStorePath(*path));
                 return markAlive();
-            }
-
-            if (options.action == GCOptions::gcDeleteSpecific
-                && !options.pathsToDelete.count(*path))
-            {
-                throw Error(
-                    "Cannot delete path '%s' because it's referenced by path '%s'.",
-                    printStorePath(start),
-                    printStorePath(*path));
             }
 
             {

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -614,12 +614,12 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
        permanent roots cannot increase now. */
     printInfo("finding garbage collector roots...");
     if (!options.ignoreLiveness)
-        findRootsNoTemp(roots, true);
+        findRootsNoTemp(roots, options.censor);
 
     /* Read the temporary roots created before we acquired the global
        GC root. Any new roots will be sent to our socket. */
     Roots tempRoots;
-    findTempRoots(tempRoots, true);
+    findTempRoots(tempRoots, options.censor);
     for (auto & root : tempRoots)
         _shared.lock()->tempRoots.insert(std::string(root.first.hashPart()));
 

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -7,8 +7,11 @@
 
 namespace nix {
 
+// FIXME: should turn this into an std::variant to represent the
+// several root types.
+using GcRootInfo = std::string;
 
-typedef std::unordered_map<StorePath, std::unordered_set<std::string>> Roots;
+typedef std::unordered_map<StorePath, std::unordered_set<GcRootInfo>> Roots;
 
 
 struct GCOptions

--- a/src/libstore/include/nix/store/gc-store.hh
+++ b/src/libstore/include/nix/store/gc-store.hh
@@ -53,6 +53,12 @@ struct GCOptions
      * Stop after at least `maxFreed` bytes have been freed.
      */
     uint64_t maxFreed{std::numeric_limits<uint64_t>::max()};
+
+    /**
+     * Whether to hide potentially sensitive information about GC
+     * roots (such as PIDs).
+     */
+    bool censor = false;
 };
 
 

--- a/tests/functional/gc-runtime.nix
+++ b/tests/functional/gc-runtime.nix
@@ -9,6 +9,7 @@ mkDerivation {
 
       cat > $out/program <<EOF
       #! ${shell}
+      echo x > \$TEST_ROOT/fifo
       sleep 10000
       EOF
 

--- a/tests/functional/gc.sh
+++ b/tests/functional/gc.sh
@@ -23,10 +23,10 @@ if nix-store --gc --print-dead | grep -E "$outPath"$; then false; fi
 nix-store --gc --print-dead
 
 inUse=$(readLink "$outPath/reference-to-input-2")
-if nix-store --delete "$inUse"; then false; fi
+expectStderr 1 nix-store --delete "$inUse" | grepQuiet "Cannot delete path.*because it's referenced by the GC root "
 test -e "$inUse"
 
-if nix-store --delete "$outPath"; then false; fi
+expectStderr 1 nix-store --delete "$outPath" | grepQuiet "Cannot delete path.*because it's referenced by the GC root "
 test -e "$outPath"
 
 for i in "$NIX_STORE_DIR"/*; do

--- a/tests/functional/gc.sh
+++ b/tests/functional/gc.sh
@@ -23,7 +23,7 @@ if nix-store --gc --print-dead | grep -E "$outPath"$; then false; fi
 nix-store --gc --print-dead
 
 inUse=$(readLink "$outPath/reference-to-input-2")
-expectStderr 1 nix-store --delete "$inUse" | grepQuiet "Cannot delete path.*because it's referenced by the GC root "
+expectStderr 1 nix-store --delete "$inUse" | grepQuiet "Cannot delete path.*because it's referenced by path '"
 test -e "$inUse"
 
 expectStderr 1 nix-store --delete "$outPath" | grepQuiet "Cannot delete path.*because it's referenced by the GC root "

--- a/tests/functional/local-overlay-store/delete-refs-inner.sh
+++ b/tests/functional/local-overlay-store/delete-refs-inner.sh
@@ -22,14 +22,14 @@ input2=$(nix-build ../hermetic.nix --no-out-link --arg busybox "$busybox" --arg 
 input3=$(nix-build ../hermetic.nix --no-out-link --arg busybox "$busybox" --arg withFinalRefs true --arg seed 2 -A passthru.input3 -j0)
 
 # Can't delete because referenced
-expectStderr 1 nix-store --delete $input1 | grepQuiet "Cannot delete path"
-expectStderr 1 nix-store --delete $input2 | grepQuiet "Cannot delete path"
-expectStderr 1 nix-store --delete $input3 | grepQuiet "Cannot delete path"
+expectStderr 1 nix-store --delete $input1 | grepQuiet "Cannot delete path.*because it's referenced by path"
+expectStderr 1 nix-store --delete $input2 | grepQuiet "Cannot delete path.*because it's referenced by path"
+expectStderr 1 nix-store --delete $input3 | grepQuiet "Cannot delete path.*because it's referenced by path"
 
 # These same paths are referenced in the lower layer (by the seed 1
 # build done in `initLowerStore`).
-expectStderr 1 nix-store --store "$storeA" --delete $input2 | grepQuiet "Cannot delete path"
-expectStderr 1 nix-store --store "$storeA" --delete $input3 | grepQuiet "Cannot delete path"
+expectStderr 1 nix-store --store "$storeA" --delete $input2 | grepQuiet "Cannot delete path.*because it's referenced by path"
+expectStderr 1 nix-store --store "$storeA" --delete $input3 | grepQuiet "Cannot delete path.*because it's referenced by path"
 
 # Can delete
 nix-store --delete $hermetic


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This replaces the unhelpful error `Cannot delete path '...' since it is still alive. To find out why, use: nix-store --query --roots and nix-store --query --referrers` .

Examples:

```
error: Cannot delete path '/nix/store/6fcrjgfjip2ww3sx51rrmmghfsf60jvi-patchelf-0.14.3' 
  because it's referenced by the GC root '/home/eelco/Dev/nix-master/build/result'.
    
error: Cannot delete path '/nix/store/rn0qyn3kmky26xgpr2n10vr787g57lff-cowsay-3.8.4' 
  because it's referenced by the GC root '/proc/3600568/environ'.

error: Cannot delete path '/nix/store/klyng5rpdkwi5kbxkncy4gjwb490dlhb-foo.drv' 
  because it's in use by '{nix-process:3605324}'.
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Closes #4850

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
