### PR TITLE
fix: make setuid tests use new build-dir location /nix/var/nix/builds

### DIFF
--- a/tests/nixos/user-sandboxing/default.nix
+++ b/tests/nixos/user-sandboxing/default.nix
@@ -104,15 +104,16 @@ in
 
           # Wait for the build to be ready
           # This is OK because it runs as root, so we can access everything
-          machine.wait_for_file("/tmp/nix-build-open-build-dir.drv-0/build/syncPoint")
+          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-build-open-build-dir.drv-*/build/syncPoint")
+          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-build-open-build-dir.drv-*").strip()
 
           # But Alice shouldn't be able to access the build directory
-          machine.fail("su alice -c 'ls /tmp/nix-build-open-build-dir.drv-0/build'")
-          machine.fail("su alice -c 'touch /tmp/nix-build-open-build-dir.drv-0/build/bar'")
-          machine.fail("su alice -c 'cat /tmp/nix-build-open-build-dir.drv-0/build/foo'")
+          machine.fail(f"su alice -c 'ls {dir}/build'")
+          machine.fail(f"su alice -c 'touch {dir}/build/bar'")
+          machine.fail(f"su alice -c 'cat {dir}/build/foo'")
 
           # Tell the user to finish the build
-          machine.succeed("echo foo > /tmp/nix-build-open-build-dir.drv-0/build/syncPoint")
+          machine.succeed(f"echo foo > {dir}/build/syncPoint")
 
       with subtest("Being able to execute stuff as the build user doesn't give access to the build dir"):
           machine.succeed(r"""
@@ -124,16 +125,17 @@ in
                 args = [ (builtins.storePath "${create-hello-world}") ];
             }' >&2 &
           """.strip())
-          machine.wait_for_file("/tmp/nix-build-innocent.drv-0/build/syncPoint")
+          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-build-innocent.drv-*/build/syncPoint")
+          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-build-innocent.drv-*").strip()
 
           # The build ran as `nixbld1` (which is the only build user on the
           # machine), but a process running as `nixbld1` outside the sandbox
           # shouldn't be able to touch the build directory regardless
-          machine.fail("su nixbld1 --shell ${pkgs.busybox-sandbox-shell}/bin/sh -c 'ls /tmp/nix-build-innocent.drv-0/build'")
-          machine.fail("su nixbld1 --shell ${pkgs.busybox-sandbox-shell}/bin/sh -c 'echo pwned > /tmp/nix-build-innocent.drv-0/build/result'")
+          machine.fail(f"su nixbld1 --shell ${pkgs.busybox-sandbox-shell}/bin/sh -c 'ls {dir}/build'")
+          machine.fail(f"su nixbld1 --shell ${pkgs.busybox-sandbox-shell}/bin/sh -c 'echo pwned > {dir}/build/result'")
 
           # Finish the build
-          machine.succeed("echo foo > /tmp/nix-build-innocent.drv-0/build/syncPoint")
+          machine.succeed(f"echo foo > {dir}/build/syncPoint")
 
           # Check that the build was not affected
           machine.succeed(r"""


### PR DESCRIPTION
The setuid tests used /tmp. This updates the tests to use /nix/var/nix/builds per the defaults.