### PR TITLE
installers, tests: remove --preserve=mode from cp invocations

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -834,8 +834,13 @@ install_from_extracted_nix() {
     (
         cd "$EXTRACTED_NIX_PATH"
 
-        _sudo "to copy the basic Nix files to the new store at $NIX_ROOT/store" \
-              cp -RPp ./store/* "$NIX_ROOT/store/"
+        if is_os_darwin; then
+            _sudo "to copy the basic Nix files to the new store at $NIX_ROOT/store" \
+                  cp -RPp ./store/* "$NIX_ROOT/store/"
+        else
+            _sudo "to copy the basic Nix files to the new store at $NIX_ROOT/store" \
+                  cp -RP --preserve=ownership,timestamps ./store/* "$NIX_ROOT/store/"
+        fi
 
         _sudo "to make the new store non-writable at $NIX_ROOT/store" \
               chmod -R ugo-w "$NIX_ROOT/store/"

--- a/scripts/install-nix-from-tarball.sh
+++ b/scripts/install-nix-from-tarball.sh
@@ -167,7 +167,11 @@ for i in $(cd "$self/store" >/dev/null && echo ./*); do
         rm -rf "$i_tmp"
     fi
     if ! [ -e "$dest/store/$i" ]; then
-        cp -RPp "$self/store/$i" "$i_tmp"
+        if [ "$(uname -s)" = "Darwin" ]; then
+            cp -RPp "$self/store/$i" "$i_tmp"
+        else
+            cp -RP --preserve=ownership,timestamps "$self/store/$i" "$i_tmp"
+        fi
         chmod -R a-w "$i_tmp"
         chmod +w "$i_tmp"
         mv "$i_tmp" "$dest/store/$i"

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -81,7 +81,7 @@ let
     mkdir -p $out/archive
 
     dir=NixOS-nixpkgs-${nixpkgs.shortRev}
-    cp -prd ${nixpkgs} $dir
+    cp -rd --preserve=ownership,timestamps ${nixpkgs} $dir
     # Set the correct timestamp in the tarball.
     find $dir -print0 | xargs -0 touch -h -t ${builtins.substring 0 12 nixpkgs.lastModifiedDate}.${
       builtins.substring 12 2 nixpkgs.lastModifiedDate

--- a/tests/nixos/sourcehut-flakes.nix
+++ b/tests/nixos/sourcehut-flakes.nix
@@ -48,7 +48,7 @@ let
 
   nixpkgs-repo = pkgs.runCommand "nixpkgs-flake" { } ''
     dir=NixOS-nixpkgs-${nixpkgs.shortRev}
-    cp -prd ${nixpkgs} $dir
+    cp -rd --preserve=ownership,timestamps ${nixpkgs} $dir
 
     # Set the correct timestamp in the tarball.
     find $dir -print0 | xargs -0 touch -h -t ${builtins.substring 0 12 nixpkgs.lastModifiedDate}.${

--- a/tests/nixos/tarball-flakes.nix
+++ b/tests/nixos/tarball-flakes.nix
@@ -13,7 +13,7 @@ let
 
     set -x
     dir=nixpkgs-${nixpkgs.shortRev}
-    cp -prd ${nixpkgs} $dir
+    cp -rd --preserve=ownership,timestamps ${nixpkgs} $dir
     # Set the correct timestamp in the tarball.
     find $dir -print0 | xargs -0 touch -h -t ${builtins.substring 0 12 nixpkgs.lastModifiedDate}.${
       builtins.substring 12 2 nixpkgs.lastModifiedDate


### PR DESCRIPTION
-p preserves xattrs and acls which can be incompatible between filesystems

Note that `--preserve=ownership` can also be problematic on NFS because of the root-squashing mechanism.

Fixes #13426