### PR TITLE
Add error message when git returns non-0 for fetch

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -552,11 +552,12 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             // we're using --quiet for now. Should process its stderr.
             .args = gitArgs,
             .input = {},
+            .mergeStderrToStdout = true,
             .isInteractive = true
         });
-        
+
         if (status > 0) {
-            throw Error("Failed to fetch git repository %s: %s", url, output);
+            throw Error("Failed to fetch git repository %s : %s", url, output);
         }
     }
 

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -545,7 +545,7 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             append(gitArgs, {"--depth", "1"});
         append(gitArgs, {std::string("--"), url, refspec});
 
-        runProgram(RunOptions {
+        auto [status, output] = runProgram(RunOptions {
             .program = "git",
             .lookupPath = true,
             // FIXME: git stderr messes up our progress indicator, so
@@ -554,6 +554,10 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
             .input = {},
             .isInteractive = true
         });
+        
+        if (status > 0) {
+            throw Error("Failed to fetch git repository %s: %s", url, output);
+        }
     }
 
     void verifyCommit(

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -53,6 +53,27 @@ rm -rf $TEST_HOME/.cache/nix
 path=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
 [[ $(cat $path/hello) = world ]]
 
+# Fetch again. This should be cached.
+# NOTE: This has to be done before the test case below which tries to pack-refs
+# the reason being that the lookup on the cache uses the ref-file `/refs/heads/master`
+# which does not exist after packing.
+mv $repo ${repo}-tmp
+path2=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
+[[ $path = $path2 ]]
+
+[[ $(nix eval --impure --expr "(builtins.fetchGit file://$repo).revCount") = 2 ]]
+[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).rev") = $rev2 ]]
+[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).shortRev") = ${rev2:0:7} ]]
+
+# Fetching with a explicit hash should succeed.
+path2=$(nix eval --refresh --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev2\"; }).outPath")
+[[ $path = $path2 ]]
+
+path2=$(nix eval --refresh --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev1\"; }).outPath")
+[[ $(cat $path2/hello) = utrecht ]]
+
+mv ${repo}-tmp $repo
+
 # Fetch when the cache has packed-refs
 # Regression test of #8822
 git -C $TEST_HOME/.cache/nix/gitv3/*/ pack-refs --all
@@ -82,24 +103,6 @@ path2=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"
 
 # But without a hash, it fails.
 expectStderr 1 nix eval --expr 'builtins.fetchGit "file:///foo"' | grepQuiet "'fetchGit' doesn't fetch unlocked input"
-
-# Fetch again. This should be cached.
-mv $repo ${repo}-tmp
-path2=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
-[[ $path = $path2 ]]
-
-[[ $(nix eval --impure --expr "(builtins.fetchGit file://$repo).revCount") = 2 ]]
-[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).rev") = $rev2 ]]
-[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).shortRev") = ${rev2:0:7} ]]
-
-# Fetching with a explicit hash should succeed.
-path2=$(nix eval --refresh --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev2\"; }).outPath")
-[[ $path = $path2 ]]
-
-path2=$(nix eval --refresh --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev1\"; }).outPath")
-[[ $(cat $path2/hello) = utrecht ]]
-
-mv ${repo}-tmp $repo
 
 # Using a clean working tree should produce the same result.
 path2=$(nix eval --impure --raw --expr "(builtins.fetchGit $repo).outPath")


### PR DESCRIPTION
Users have complained that fetchGit is flaky however the culprit is likely that `git fetch` was unable itself to download the repository for whatever reason (i.e. poor network etc..)

Nothing was checking the status of `git fetch` and the error message that would eventually surface to the users were that the commit was not found.

Add explicit error checking for status code from `git fetch` and return a message earlier on to indicate that the failure was from that point.

fixes #10431

**validation**

```
# create netnamespace
> sudo ip netns add no-dns

# enter it
> sudo ip netns exec no-dns zsh

# try to eval
> ./build/src/nix/nix eval --expr ' builtins.fetchGit { url = "https://github.com/intel/ipu6-drivers.git"; ref = "master"; rev =  "b4ba63df5922150ec14ef7f202b3589896e0301a"; }'

warning: you don't have Internet access; disabling some network-dependent features
fatal: unable to access 'https://github.com/intel/ipu6-drivers.git/': Failed to connect to github.com port 443 after 24 ms: Could not connect to server
error:
       … while calling the 'fetchGit' builtin
         at «string»:1:2:
            1|  builtins.fetchGit { url = "https://github.com/intel/ipu6-drivers.git"; ref = "master"; rev =  "b4ba63df5922150ec14ef7f202b3589896e0301a"; }
             |  ^

       … while fetching the input 'git+https://github.com/intel/ipu6-drivers.git?exportIgnore=1&ref=master&rev=b4ba63df5922150ec14ef7f202b3589896e0301a'

  error: Failed to fetch git repository https://github.com/intel/ipu6-drivers.git : fatal: unable to access 'https://github.com/intel/ipu6-drivers.git/': Failed to connect to github.com port 443 after 4 ms: Could not connect to server
```

This message is different from the previous one that looks like the following when the commit is checked to be in the repo which was causing confusion.
```
       error: Cannot find Git revision '84956ea0e3ab4cc44919e4a06862644b58c09469' in ref 'refs/heads/flox/remove_recording_struct' of repository 'https://github.com/flox/httpmock.git'! Please make sure that the rev exists on the ref you've specified or add allRefs = true; to fetchGit.

```

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
