### PR TITLE
Address ifdef problem with macOS/BSD sandboxing

### DIFF
--- a/src/libstore/unix/user-lock.cc
+++ b/src/libstore/unix/user-lock.cc
@@ -197,7 +197,7 @@ bool useBuildUsers()
     #ifdef __linux__
     static bool b = (settings.buildUsersGroup != "" || settings.autoAllocateUids) && isRootUser();
     return b;
-    #elif defined(__APPLE__) && defined(__FreeBSD__)
+    #elif defined(__APPLE__) || defined(__FreeBSD__)
     static bool b = settings.buildUsersGroup != "" && isRootUser();
     return b;
     #else


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This PR addresses an issue we identified for macOS users. The `#ifdef` condition seems impossible, and causes some (but not all) builds to fail.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
