### PR TITLE
Add a test case where fetchGit is failing to cache due to packed-refs

### DIFF
--- a/tests/functional/git/meson.build
+++ b/tests/functional/git/meson.build
@@ -1,0 +1,6 @@
+suites += {
+  'name' : 'git',
+  'deps' : [],
+  'tests' : [ 'packed-refs-no-cache.sh' ],
+  'workdir' : meson.current_source_dir(),
+}

--- a/tests/functional/git/packed-refs-no-cache.sh
+++ b/tests/functional/git/packed-refs-no-cache.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+source ../common.sh
+
+requireGit
+
+clearStoreIfPossible
+
+# Intentionally not in a canonical form
+# See https://github.com/NixOS/nix/issues/6195
+repo=$TEST_ROOT/./git
+
+export _NIX_FORCE_HTTP=1
+
+rm -rf "$repo" "${repo}-tmp" "$TEST_HOME/.cache/nix"
+
+git init --initial-branch="master" "$repo"
+git -C "$repo" config user.email "nix-tests@example.com"
+git -C "$repo" config user.name "Nix Tests"
+
+echo "hello world" > "$repo/hello_world"
+git -C "$repo" add hello_world
+git -C "$repo" commit -m 'My first commit.'
+
+# We now do an eval
+nix eval --impure --raw --expr "builtins.fetchGit { url = file://$repo; }"
+
+# test that our eval even worked by checking for the presence of the file
+[[ $(nix eval --impure --raw --expr "builtins.readFile ((builtins.fetchGit { url = file://$repo; }) + \"/hello_world\")") = 'hello world' ]]
+
+# Validate that refs/heads/master exists
+shopt -s nullglob
+matches=("$TEST_HOME/.cache/nix/gitv3/*/refs/heads/master")
+shopt -u nullglob
+
+if [[ ${#matches[@]} -eq 0 ]]; then
+  echo "refs/heads/master does not exist."
+  exit 1
+fi
+# pack refs
+git -C "$TEST_HOME"/.cache/nix/gitv3/*/ pack-refs --all
+
+shopt -s nullglob
+matches=("$TEST_HOME"/.cache/nix/gitv3/*/refs/heads/master)
+shopt -u nullglob
+
+# ensure refs/heads/master is now gone
+if [[ ${#matches[@]} -ne 0 ]]; then
+  echo "refs/heads/master still exists after pack-refs"
+  exit 1
+fi
+
+# create a new commit
+echo "hello again" > "$repo/hello_again"
+git -C "$repo" add hello_again
+git -C "$repo" commit -m 'Second commit.'
+
+# re-eval — this should return the path to the cached version
+store_path=$(nix eval --tarball-ttl 3600 --impure --raw --expr "(builtins.fetchGit { url = file://$repo; }).outPath")
+echo "Fetched store path: $store_path"
+
+# Validate that the new file is *not* there
+# FIXME: This is a broken test case and we should swap the assertion here.
+if [[ -e "$store_path/hello_again" ]]; then
+  echo "ERROR: Cached fetchGit should not include the new commit."
+  exit 0
+else
+  echo "PASS: New commit was not fetched due to caching (as expected)."
+  exit 1
+fi

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -211,6 +211,7 @@ endif
 subdir('ca')
 subdir('dyn-drv')
 subdir('flakes')
+subdir('git')
 subdir('git-hashing')
 subdir('local-overlay-store')
 


### PR DESCRIPTION
builtins.fetchGit is not using the cached Git directory if packed-references are used.
This is because the ref file for the fetchGit `refs/heads/master` is used to check the mtime for whether to cache or not.

Let's at least codify this failure in a test case.
For now the test case **expects failure** but we should change it once the issue is resolved.
---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
