### PR TITLE
Improve rendering of ignored exceptions

### DIFF
--- a/src/libstore/sqlite.cc
+++ b/src/libstore/sqlite.cc
@@ -250,7 +250,7 @@ void handleSQLiteBusy(const SQLiteBusy & e, time_t & nextWarning)
     if (now > nextWarning) {
         nextWarning = now + 10;
         logWarning({
-            .msg = HintFmt(e.what())
+            .msg = e.info().msg
         });
     }
 

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -190,8 +190,10 @@ void ignoreExceptionInDestructor(Verbosity lvl)
     try {
         try {
             throw;
+        } catch (Error & e) {
+            printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.info().msg);
         } catch (std::exception & e) {
-            printMsg(lvl, "error (ignored): %1%", e.what());
+            printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.what());
         }
     } catch (...) { }
 }
@@ -202,8 +204,10 @@ void ignoreExceptionExceptInterrupt(Verbosity lvl)
         throw;
     } catch (const Interrupted & e) {
         throw;
+    } catch (Error & e) {
+        printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.info().msg);
     } catch (std::exception & e) {
-        printMsg(lvl, "error (ignored): %1%", e.what());
+        printMsg(lvl, ANSI_RED "error (ignored):" ANSI_NORMAL " %s", e.what());
     }
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Instead of

```    
error (ignored): error: SQLite database '...' is busy
```
    
we now get
```   
error (ignored): SQLite database '...' is busy
```

Idem for the `handleSQLiteBusy()` message (this closes https://github.com/NixOS/nix/pull/10319).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
