### PR TITLE
PosixSourceAccessor: Use concurrent_flat_map

### DIFF
--- a/src/libutil/posix-source-accessor.cc
+++ b/src/libutil/posix-source-accessor.cc
@@ -3,7 +3,7 @@
 #include "nix/util/signals.hh"
 #include "nix/util/sync.hh"
 
-#include <unordered_map>
+#include <boost/unordered/concurrent_flat_map.hpp>
 
 namespace nix {
 
@@ -90,23 +90,21 @@ bool PosixSourceAccessor::pathExists(const CanonPath & path)
 
 std::optional<struct stat> PosixSourceAccessor::cachedLstat(const CanonPath & path)
 {
-    static SharedSync<std::unordered_map<Path, std::optional<struct stat>>> _cache;
+    using Cache = boost::concurrent_flat_map<Path, std::optional<struct stat>>;
+    static Cache cache;
 
     // Note: we convert std::filesystem::path to Path because the
     // former is not hashable on libc++.
     Path absPath = makeAbsPath(path).string();
 
-    {
-        auto cache(_cache.readLock());
-        auto i = cache->find(absPath);
-        if (i != cache->end()) return i->second;
-    }
+    std::optional<Cache::mapped_type> res;
+    cache.cvisit(absPath, [&](auto & x) { res.emplace(x.second); });
+    if (res) return *res;
 
     auto st = nix::maybeLstat(absPath.c_str());
 
-    auto cache(_cache.lock());
-    if (cache->size() >= 16384) cache->clear();
-    cache->emplace(absPath, st);
+    if (cache.size() >= 16384) cache.clear();
+    cache.emplace(absPath, st);
 
     return st;
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This should be more performant than `SharedSync<std::unordered_map>`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
