### PR TITLE
Add helpful messages when file:// used as tarball

### DIFF
--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -111,6 +111,25 @@ static DownloadTarballResult downloadTarball_(
     const Headers & headers,
     const std::string & displayPrefix)
 {
+
+    // Some friendly error messages for common mistakes.
+    // Namely lets catch when the url is a local file path, but
+    // it is not in fact a tarball.
+    if (url.rfind("file://", 0) == 0) {
+        // Remove "file://" prefix to get the local file path
+        std::string localPath = url.substr(7);
+        if (!std::filesystem::exists(localPath)) {
+            throw Error("tarball '%s' does not exist.", localPath);
+        }
+        if (std::filesystem::is_directory(localPath)) {
+            if (std::filesystem::exists(localPath + "/.git")) {
+                throw Error(
+                    "tarball '%s' is a git repository, not a tarball. Please use `git+file` as the scheme.", localPath);
+            }
+            throw Error("tarball '%s' is a directory, not a file.", localPath);
+        }
+    }
+
     Cache::Key cacheKey{"tarball", {{"url", url}}};
 
     auto cached = settings.getCache()->lookupExpired(cacheKey);


### PR DESCRIPTION
## Motivation
When `file://` is used accidentally in a flake as the source it is expected to be a tarball by default.
Add some friendlier error messages to either inform the user this is not in fact a tarball or if it's a git directory, let them know they can use `git+file`.

Please see #12935 for more in depth motivation.

fixes #12935

## Validation

** Missing directory **

```bash
nix build file://$HOME/code/github.com/does-not-exist
error:
       … while fetching the input 'file:///home/fmzakari/code/github.com/does-not-exist'

       error: tarball '/home/fmzakari/code/github.com/does-not-exist' does not exist.
```

** directory BUT  is git **

```bash
nix build file://$HOME/code/github.com/fzakaria/fzakaria.com
error:
       … while fetching the input 'file:///home/fmzakari/code/github.com/fzakaria/fzakaria.com'

       error: tarball '/home/fmzakari/code/github.com/fzakaria/fzakaria.com' is a git repository, not a tarball. Please use `git+file` as the scheme.
```

** directory BUT is NOT git **

```bash
nix build file://$HOME/code/github.com/fzakaria
error:
       … while fetching the input 'file:///home/fmzakari/code/github.com/fzakaria'

       error: tarball '/home/fmzakari/code/github.com/fzakaria' is a directory, not a file.
```

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
