### PR TITLE
Fix Windows header inclusions for clang-tidy

### DIFF
--- a/src/libutil/windows/windows-async-pipe.cc
+++ b/src/libutil/windows/windows-async-pipe.cc
@@ -1,7 +1,8 @@
-#include "nix/util/windows-async-pipe.hh"
-#include "nix/util/windows-error.hh"
+
 
 #ifdef _WIN32
+#  include "nix/util/windows-async-pipe.hh"
+#  include "nix/util/windows-error.hh"
 
 namespace nix::windows {
 

--- a/src/libutil/windows/windows-error.cc
+++ b/src/libutil/windows/windows-error.cc
@@ -1,6 +1,5 @@
-#include "nix/util/windows-error.hh"
-
 #ifdef _WIN32
+#include "nix/util/windows-error.hh"
 #include <error.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>


### PR DESCRIPTION
## Summary
Move windows-error.hh includes inside _WIN32 guards to prevent clang-tidy errors when analyzing these files on non-Windows platforms.

This ensures Windows-specific headers are only included when building for Windows.