### PR TITLE
Fix `nix help shell` by properly handling command aliases

### DIFF
--- a/src/nix/main.cc
+++ b/src/nix/main.cc
@@ -212,6 +212,14 @@ struct NixArgs : virtual MultiCommand, virtual MixCommonArgs, virtual RootArgs
    lowdown. */
 static void showHelp(std::vector<std::string> subcommand, NixArgs & toplevel)
 {
+    // Check for aliases if subcommand has exactly one element
+    if (subcommand.size() == 1) {
+        auto alias = toplevel.aliases.find(subcommand[0]);
+        if (alias != toplevel.aliases.end()) {
+            subcommand = alias->second.replacement;
+        }
+    }
+
     auto mdName = subcommand.empty() ? "nix" : fmt("nix3-%s", concatStringsSep("-", subcommand));
 
     evalSettings.restrictEval = false;


### PR DESCRIPTION
## Fix `nix help shell` by properly handling command aliases

Closes: #13431

### Problem

The `nix help shell` command incorrectly fails with `Nix has no subcommand 'shell'` despite `nix shell --help` working correctly. This happens because `shell` is actually an alias for `env shell`, and the help system wasn't resolving these aliases when looking up documentation.

This creates a confusing user experience where the shell command both exists and doesn't exist depending on how users try to access its documentation.

### Solution

This PR modifies the `showHelp` function in `src/nix/main.cc` to check for and resolve aliases before generating the manpage name. When a user requests help for an aliased command like `shell`, the system now correctly looks up the documentation for the actual command (`env shell`).

The implementation is straightforward - it adds a few lines to the `showHelp` function to check if the requested subcommand matches any aliases in the `toplevel.aliases` map, and if so, replaces the subcommand with the actual command path before generating the manpage name.