### PR TITLE
Fix use-after-free warning in repl.cc

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -917,6 +917,7 @@ ReplExitStatus AbstractNixRepl::runSimple(
         return values;
     };
     LookupPath lookupPath = {};
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
     auto repl = std::make_unique<NixRepl>(
             lookupPath,
             openStore(),


### PR DESCRIPTION
NixRepl inherits from gc which uses Boehm GC for memory management. Using std::unique_ptr with GC-managed objects causes use-after-free because unique_ptr calls delete while the GC expects to manage the memory itself.

Replace std::make_unique with raw pointer allocation to let the GC handle memory management properly.

Fixes clang-tidy warning: Use of memory after it is freed [clang-analyzer-cplusplus.NewDelete]

Isolated from: https://github.com/NixOS/nix/pull/13494 because of https://github.com/NixOS/nix/pull/13494#discussion_r2213573617
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
