### PR TITLE
ci: Add build profiling job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,26 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build -L --out-link ./new-nix && PATH=$(pwd)/new-nix/bin:$PATH MAX_FLAKES=25 flake-regressions/eval-all.sh
+
+  profile_build:
+    needs: tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_name == 'master'
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/install-nix-action
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        dogfood: true
+        extra_nix_config: |
+          experimental-features = flakes nix-command ca-derivations impure-derivations
+          max-jobs = 1
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - run: |
+        nix build -L --file ./ci/gha/profile-build buildTimeReport --out-link build-time-report.md
+        cat build-time-report.md >> $GITHUB_STEP_SUMMARY

--- a/ci/gha/profile-build/default.nix
+++ b/ci/gha/profile-build/default.nix
@@ -1,0 +1,101 @@
+{
+  nixFlake ? builtins.getFlake ("git+file://" + toString ../../..),
+  system ? builtins.currentSystem,
+  pkgs ? nixFlake.inputs.nixpkgs.legacyPackages.${system},
+}:
+
+let
+  inherit (pkgs) lib;
+
+  nixComponentsInstrumented =
+    (nixFlake.lib.makeComponents {
+      inherit pkgs;
+      getStdenv = p: p.clangStdenv;
+    }).overrideScope
+      (
+        _: _: {
+          mesonComponentOverrides = finalAttrs: prevAttrs: {
+            outputs = (prevAttrs.outputs or [ "out" ]) ++ [ "buildprofile" ];
+            nativeBuildInputs = [ pkgs.clangbuildanalyzer ] ++ prevAttrs.nativeBuildInputs or [ ];
+            __impure = true;
+
+            env = {
+              CFLAGS = "-ftime-trace";
+              CXXFLAGS = "-ftime-trace";
+            };
+
+            preBuild = ''
+              ClangBuildAnalyzer --start $PWD
+            '';
+
+            postBuild = ''
+              ClangBuildAnalyzer --stop $PWD $buildprofile
+            '';
+          };
+        }
+      );
+
+  componentsToProfile = {
+    "nix-util" = { };
+    "nix-util-c" = { };
+    "nix-util-test-support" = { };
+    "nix-util-tests" = { };
+    "nix-store" = { };
+    "nix-store-c" = { };
+    "nix-store-test-support" = { };
+    "nix-store-tests" = { };
+    "nix-fetchers" = { };
+    "nix-fetchers-c" = { };
+    "nix-fetchers-tests" = { };
+    "nix-expr" = { };
+    "nix-expr-c" = { };
+    "nix-expr-test-support" = { };
+    "nix-expr-tests" = { };
+    "nix-flake" = { };
+    "nix-flake-c" = { };
+    "nix-flake-tests" = { };
+    "nix-main" = { };
+    "nix-main-c" = { };
+    "nix-cmd" = { };
+    "nix-cli" = { };
+  };
+
+  componentDerivationsToProfile = builtins.intersectAttrs componentsToProfile nixComponentsInstrumented;
+  componentBuildProfiles = lib.mapAttrs (
+    n: v: lib.getOutput "buildprofile" v
+  ) componentDerivationsToProfile;
+
+  buildTimeReport =
+    pkgs.runCommand "build-time-report"
+      {
+        __impure = true;
+        __structuredAttrs = true;
+        nativeBuildInputs = [ pkgs.clangbuildanalyzer ];
+        inherit componentBuildProfiles;
+      }
+      ''
+        {
+          echo "# Build time performance profile for components:"
+          echo
+          echo "This reports the build profile collected via \`-ftime-trace\` for each component."
+          echo
+        } >> $out
+
+        for name in "''\${!componentBuildProfiles[@]}"; do
+          {
+            echo "<details><summary><strong>$name</strong></summary>"
+            echo
+            echo '````'
+            ClangBuildAnalyzer --analyze "''\${componentBuildProfiles[$name]}"
+            echo '````'
+            echo
+            echo "</details>"
+          } >> $out
+        done
+      '';
+in
+
+{
+  inherit buildTimeReport;
+  inherit componentDerivationsToProfile;
+}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This adds a GHA jobs to help analyze build times
and its regressions. It is based on `clangStdenv` with `-ftime-trace` together with `ClangBuildAnalyzer` to prepare markdown summary for individual components.

The job is only run on the master branch on pushes. Not sure that running this job for all PRs is worthwhile.

This also has the minor benefit of dogfooding CA and impure derivations.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
