### PR TITLE
Reintroduce precompiled headers

### DIFF
--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -92,6 +92,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
+  cpp_pch : ['pch/precompiled-headers.hh']
 )
 
 install_headers(headers, subdir : 'nix/cmd', preserve_path : true)

--- a/src/libcmd/pch/precompiled-headers.hh
+++ b/src/libcmd/pch/precompiled-headers.hh
@@ -1,0 +1,4 @@
+#include "nix/cmd/installables.hh"
+#include "nix/expr/eval.hh"
+#include "nix/util/util.hh"
+#include "nix/flake/flake.hh"

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -178,6 +178,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
+  cpp_pch : ['pch/precompiled-headers.hh']
 )
 
 install_headers(headers, subdir : 'nix/expr', preserve_path : true)

--- a/src/libexpr/pch/precompiled-headers.hh
+++ b/src/libexpr/pch/precompiled-headers.hh
@@ -1,0 +1,1 @@
+#include "nix/expr/eval.hh"

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -348,6 +348,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
+  cpp_pch : ['pch/precompiled-headers.hh']
 )
 
 install_headers(headers, subdir : 'nix/store', preserve_path : true)

--- a/src/libstore/pch/precompiled-headers.hh
+++ b/src/libstore/pch/precompiled-headers.hh
@@ -1,0 +1,8 @@
+#include "nix/store/store-api.hh"
+#include "nix/store/realisation.hh"
+#include "nix/store/derived-path.hh"
+#include "nix/store/derivations.hh"
+#include "nix/store/local-store.hh"
+#include "nix/util/util.hh"
+
+#include <nlohmann/json.hpp>

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -191,6 +191,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
+  cpp_pch : 'pch/precompiled-headers.hh'
 )
 
 install_headers(headers, subdir : 'nix/util', preserve_path : true)

--- a/src/libutil/pch/precompiled-headers.hh
+++ b/src/libutil/pch/precompiled-headers.hh
@@ -1,0 +1,7 @@
+#include "nix/util/util.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/serialise.hh"
+#include "nix/util/signals.hh"
+#include "nix/util/source-accessor.hh"
+
+#include <nlohmann/json.hpp>

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -186,6 +186,7 @@ this_exe = executable(
   include_directories : include_dirs,
   link_args: linker_export_flags,
   install : true,
+  cpp_pch : ['pch/precompiled-headers.hh']
 )
 
 meson.override_find_program('nix', this_exe)

--- a/src/nix/pch/precompiled-headers.hh
+++ b/src/nix/pch/precompiled-headers.hh
@@ -1,0 +1,3 @@
+#include "nix/cmd/command.hh"
+#include "nix/expr/eval.hh"
+#include "nix/main/shared.hh"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

A lot of compile time can be shaved off by just using using precompiled headers for expensive files.
Bottlenecks were discovered with the help of https://github.com/NixOS/nix/pull/13510.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
