### PR TITLE
meson: Correctly handle endianness for PowerPC CPU families

### DIFF
--- a/nix-meson-build-support/default-system-cpu/meson.build
+++ b/nix-meson-build-support/default-system-cpu/meson.build
@@ -1,9 +1,10 @@
-nix_system_cpu = {
-  'ppc64' : 'powerpc64',
-  'ppc64le' : 'powerpc64le',
-  'ppc' : 'powerpc',
-  'ppcle' : 'powerpcle',
-}.get(
+powerpc_system_cpus = [ 'ppc64', 'ppc' ]
+
+nix_system_cpu = {'ppc64' : 'powerpc64', 'ppc' : 'powerpc'}.get(
   host_machine.cpu_family(),
   host_machine.cpu_family(),
 )
+
+if powerpc_system_cpus.contains(host_machine.cpu_family()) and host_machine.endian() == 'little'
+  nix_system_cpu += 'le'
+endif


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

I've missed this while reviewing 6db61900028ec641f12b1d36fe4ece5a9bdaa66f. I only built big endian ppc64, so that didn't occur to me.

From meson manual:

> Those porting from autotools should note that Meson does not add
> endianness to the name of the cpu_family. For example, autotools will
> call little endian PPC64 "ppc64le", Meson will not, you must also check
> the .endian() value of the machine for this information.

This code should handle that correctly.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
