### PR TITLE
meson: libfetchers needs libgit2 1.9+

### DIFF
--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -27,7 +27,7 @@ subdir('nix-meson-build-support/subprojects')
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
-libgit2 = dependency('libgit2')
+libgit2 = dependency('libgit2', version : '>= 1.9')
 deps_private += libgit2
 
 subdir('nix-meson-build-support/common')


### PR DESCRIPTION
libfetchers uses `git_mempack_write_thin_pack` which was introduced in libgit2-1.9.0

This avoids a compilation error like:
```
../src/libfetchers/git-utils.cc: In member function ‘virtual void nix::GitRepoImpl::flush()’: ../src/libfetchers/git-utils.cc:270:13: error: ‘git_mempack_write_thin_pack’ was not declared in this scope
  270 |             git_mempack_write_thin_pack(mempack_backend, packBuilder.get())
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
on older libgit2 (like 1.7.2 in Centos Stream 10)

## Motivation

libfetchers fails to compile with older libgit2.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
