### PR TITLE
libstore: always canonicalize directory permissions

### DIFF
--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -21,9 +21,9 @@ static void canonicaliseTimestampAndPermissions(const Path & path, const struct 
 
         /* Mask out all type related bits. */
         mode_t mode = st.st_mode & ~S_IFMT;
-
-        if (mode != 0444 && mode != 0555) {
-            mode = (st.st_mode & S_IFMT) | 0444 | (st.st_mode & S_IXUSR ? 0111 : 0);
+        bool isDir = S_ISDIR(st.st_mode);
+        if ((mode != 0444 || isDir) && mode != 0555) {
+            mode = (st.st_mode & S_IFMT) | 0444 | (st.st_mode & S_IXUSR || isDir ? 0111 : 0);
             if (chmod(path.c_str(), mode) == -1)
                 throw SysError("changing mode of '%1%' to %2$o", path, mode);
         }


### PR DESCRIPTION
## Motivation

Prior to this patch, mode 0444 is not updated to 0555 for directories. That means for instance 0554 is canonicalized, but not 0444. 

We don't believe this has any implications for backwards compatibility, because directories do not have permissions in NAR format and so are always 0555 after de-serialization, and store paths with wrong permissions can’t be copied to another host.

This patch was proposed by @roberth in #12786.

I'd love to add a unit test for this, but I saw no existing examples for code in this file.

## Context

- https://github.com/NixOS/nix/issues/12786
- https://github.com/NixOS/nixpkgs/pull/393381

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
