### PR TITLE
Fix documentation of the NAR archive structure

### DIFF
--- a/doc/manual/source/protocols/nix-archive.md
+++ b/doc/manual/source/protocols/nix-archive.md
@@ -24,7 +24,7 @@ nar-obj-inner
   | str("type"), str("directory") directory
   ;
 
-regular = [ str("executable"), str("") ], str("contents"), str(contents);
+regular = [ str("executable") ], str("contents"), str(contents);
 
 symlink = str("target"), str(target);
 


### PR DESCRIPTION
For regular, non-executable files, there is no str("") between str("regular") and str("contents"). Note that str("") is exactly 8 zero bytes, while just "" is actual empty string (0 bytes).

<!--


## Motivation

This saves the work for everybody who wants to re-implement NAR format.
