### PR TITLE
Modify readHead for git to use libgit2

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -56,30 +56,7 @@ Path getCachePath(std::string_view key, bool shallow)
 //   ...
 std::optional<std::string> readHead(const Path & path)
 {
-    auto [status, output] = runProgram(
-        RunOptions{
-            .program = "git",
-            // FIXME: use 'HEAD' to avoid returning all refs
-            .args = {"ls-remote", "--symref", path},
-            .isInteractive = true,
-        });
-    if (status != 0)
-        return std::nullopt;
-
-    std::string_view line = output;
-    line = line.substr(0, line.find("\n"));
-    if (const auto parseResult = git::parseLsRemoteLine(line); parseResult && parseResult->reference == "HEAD") {
-        switch (parseResult->kind) {
-        case git::LsRemoteRefLine::Kind::Symbolic:
-            debug("resolved HEAD ref '%s' for repo '%s'", parseResult->target, path);
-            break;
-        case git::LsRemoteRefLine::Kind::Object:
-            debug("resolved HEAD rev '%s' for repo '%s'", parseResult->target, path);
-            break;
-        }
-        return parseResult->target;
-    }
-    return std::nullopt;
+    return git::defaultRemoteBranch(path);
 }
 
 // Persist the HEAD ref from the remote repo in the local cached repo.
@@ -115,7 +92,7 @@ std::optional<std::string> readHeadCached(const std::string & actualUrl, bool sh
     struct stat st;
     std::optional<std::string> cachedRef;
     if (stat(headRefFile.c_str(), &st) == 0) {
-        cachedRef = readHead(cacheDir);
+        cachedRef = readFile(headRefFile);
         if (cachedRef != std::nullopt && *cachedRef != gitInitialBranch && isCacheFileWithinTtl(now, st)) {
             debug("using cached HEAD ref '%s' for repo '%s'", *cachedRef, actualUrl);
             return cachedRef;
@@ -123,8 +100,9 @@ std::optional<std::string> readHeadCached(const std::string & actualUrl, bool sh
     }
 
     auto ref = readHead(actualUrl);
-    if (ref)
+    if (ref) {
         return ref;
+    }
 
     if (cachedRef) {
         // If the cached git ref is expired in fetch() below, and the 'git fetch'

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -22,6 +22,10 @@ struct GitFileSystemObjectSink : ExtendedFileSystemObjectSink
     virtual Hash flush() = 0;
 };
 
+namespace git {
+std::optional<std::string> defaultRemoteBranch(const std::string & path);
+}
+
 struct GitRepo
 {
     virtual ~GitRepo() {}


### PR DESCRIPTION
We should avoid runProgram from the C++ code whenever possible. This moves the readHead command `ls-remote --symref` to the equivalent libgit2 API.

* Additionally I found that we were never reading the cached head also.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
