### PR TITLE
Fix documentation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -45,7 +45,7 @@ assignees: ''
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open bug issues and pull requests] for possible duplicates
 
-[latest Nix manual]: https://nixos.org/manual/nix/unstable/
+[latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open bug issues and pull requests]: https://github.com/NixOS/nix/labels/bug
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -30,7 +30,7 @@ assignees: ''
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open feature issues and pull requests] for possible duplicates
 
-[latest Nix manual]: https://nixos.org/manual/nix/unstable/
+[latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open feature issues and pull requests]: https://github.com/NixOS/nix/labels/feature
 

--- a/.github/ISSUE_TEMPLATE/installer.md
+++ b/.github/ISSUE_TEMPLATE/installer.md
@@ -38,7 +38,7 @@ assignees: ''
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open installer issues and pull requests] for possible duplicates
 
-[latest Nix manual]: https://nixos.org/manual/nix/unstable/
+[latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open installer issues and pull requests]: https://github.com/NixOS/nix/labels/installer
 

--- a/.github/ISSUE_TEMPLATE/missing_documentation.md
+++ b/.github/ISSUE_TEMPLATE/missing_documentation.md
@@ -22,7 +22,7 @@ assignees: ''
 - [ ] checked [latest Nix manual] \([source])
 - [ ] checked [open documentation issues and pull requests] for possible duplicates
 
-[latest Nix manual]: https://nixos.org/manual/nix/unstable/
+[latest Nix manual]: https://nix.dev/manual/nix/development/
 [source]: https://github.com/NixOS/nix/tree/master/doc/manual/source
 [open documentation issues and pull requests]: https://github.com/NixOS/nix/labels/documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Check out the [security policy](https://github.com/NixOS/nix/security/policy).
 
 ## Making changes to the Nix manual
 
-The Nix reference manual is hosted on https://nixos.org/manual/nix.
+The Nix reference manual is hosted on https://nix.dev/manual/nix.
 The underlying source files are located in [`doc/manual/source`](./doc/manual/source).
 For small changes you can [use GitHub to edit these files](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files)
 For larger changes see the [Nix reference manual](https://nix.dev/manual/nix/development/development/contributing.html).

--- a/doc/manual/source/release-notes/rl-2.8.md
+++ b/doc/manual/source/release-notes/rl-2.8.md
@@ -48,6 +48,6 @@
 
 * `nix run` is now stricter in what it accepts: members of the `apps`
   flake output are now required to be apps (as defined in [the
-  manual](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run.html#apps)),
+  manual](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-run.html#apps)),
   and members of `packages` or `legacyPackages` must be derivations
   (not apps).

--- a/scripts/install-nix-from-tarball.sh
+++ b/scripts/install-nix-from-tarball.sh
@@ -40,7 +40,7 @@ fi
 
 # Determine if we could use the multi-user installer or not
 if [ "$(uname -s)" = "Linux" ]; then
-    echo "Note: a multi-user installation is possible. See https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation" >&2
+    echo "Note: a multi-user installation is possible. See https://nix.dev/manual/nix/stable/installation/installing-binary.html#multi-user-installation" >&2
 fi
 
 case "$(uname -s)" in
@@ -96,7 +96,7 @@ while [ $# -gt 0 ]; do
                 echo "              providing multi-user support and better isolation for local builds."
                 echo "              Both for security and reproducibility, this method is recommended if"
                 echo "              supported on your platform."
-                echo "              See https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation"
+                echo "              See https://nix.dev/manual/nix/stable/installation/installing-binary.html#multi-user-installation"
                 echo ""
                 echo " --no-daemon: Simple, single-user installation that does not require root and is"
                 echo "              trivial to uninstall."
@@ -144,7 +144,7 @@ if ! [ -e "$dest" ]; then
 fi
 
 if ! [ -w "$dest" ]; then
-    echo "$0: directory $dest exists, but is not writable by you. This could indicate that another user has already performed a single-user installation of Nix on this system. If you wish to enable multi-user support see https://nixos.org/manual/nix/stable/installation/multi-user.html. If you wish to continue with a single-user install for $USER please run 'chown -R $USER $dest' as root." >&2
+    echo "$0: directory $dest exists, but is not writable by you. This could indicate that another user has already performed a single-user installation of Nix on this system. If you wish to enable multi-user support see https://nix.dev/manual/nix/stable/installation/multi-user.html. If you wish to continue with a single-user install for $USER please run 'chown -R $USER $dest' as root." >&2
     exit 1
 fi
 

--- a/src/libcmd/include/nix/cmd/common-eval-args.hh
+++ b/src/libcmd/include/nix/cmd/common-eval-args.hh
@@ -82,7 +82,7 @@ private:
 };
 
 /**
- * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary#gloss-base-directory)
  */
 SourcePath lookupFileArg(EvalState & state, std::string_view s, const Path * baseDir = nullptr);
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1812,7 +1812,7 @@ void EvalState::autoCallFunction(const Bindings & args, Value & fun, Value & res
 Nix attempted to evaluate a function as a top level expression; in
 this case it must have its arguments supplied either by default
 values, or passed explicitly with '--arg' or '--argstr'. See
-https://nixos.org/manual/nix/stable/language/constructs.html#functions.)",
+https://nix.dev/manual/nix/stable/language/syntax.html#functions.)",
                     symbols[i.name])
                     .atPos(i.pos)
                     .withFrame(*fun.lambda().env, *fun.lambda().fun)

--- a/src/libflake/include/nix/flake/flakeref.hh
+++ b/src/libflake/include/nix/flake/flakeref.hh
@@ -81,7 +81,7 @@ struct FlakeRef
 std::ostream & operator<<(std::ostream & str, const FlakeRef & flakeRef);
 
 /**
- * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
  */
 FlakeRef parseFlakeRef(
     const fetchers::Settings & fetchSettings,
@@ -92,7 +92,7 @@ FlakeRef parseFlakeRef(
     bool preserveRelativePaths = false);
 
 /**
- * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
  */
 std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     const fetchers::Settings & fetchSettings,
@@ -103,7 +103,7 @@ std::pair<FlakeRef, std::string> parseFlakeRefWithFragment(
     bool preserveRelativePaths = false);
 
 /**
- * @param baseDir Optional [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory)
+ * @param baseDir Optional [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory)
  */
 std::tuple<FlakeRef, std::string, ExtendedOutputsSpec> parseFlakeRefWithFragmentAndExtendedOutputsSpec(
     const fetchers::Settings & fetchSettings,

--- a/src/libstore-c/nix_api_store.h
+++ b/src/libstore-c/nix_api_store.h
@@ -57,14 +57,14 @@ nix_err nix_libstore_init_no_load_config(nix_c_context * context);
  * ignores `NIX_REMOTE` and the `store` option. For this reason, `NULL` is most likely the better choice.
  *
  *   For supported store URLs, see [*Store URL format* in the Nix Reference
- * Manual](https://nixos.org/manual/nix/stable/store/types/#store-url-format).
+ * Manual](https://nix.dev/manual/nix/stable/store/types/#store-url-format).
  * @endparblock
  *
  * @param[in] params @parblock
  *   optional, null-terminated array of key-value pairs, e.g. {{"endpoint",
  * "https://s3.local"}}.
  *
- *   See [*Store Types* in the Nix Reference Manual](https://nixos.org/manual/nix/stable/store/types).
+ *   See [*Store Types* in the Nix Reference Manual](https://nix.dev/manual/nix/stable/store/types).
  * @endparblock
  *
  * @return a Store pointer, NULL in case of errors

--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -51,8 +51,8 @@ public:
     }
 
     /**
-     * @brief Get the [base directory](https://nixos.org/manual/nix/unstable/glossary#gloss-base-directory) for the
-     * command.
+     * @brief Get the [base directory](https://nix.dev/manual/nix/development/glossary.html#gloss-base-directory) for
+     * the command.
      *
      * @return Generally the working directory, but in case of a shebang
      *         interpreter, returns the directory of the script.

--- a/src/nix/nix.md
+++ b/src/nix/nix.md
@@ -44,7 +44,7 @@ R""(
 Nix is a tool for building software, configurations and other
 artifacts in a reproducible and declarative way. For more information,
 see the [Nix homepage](https://nixos.org/) or the [Nix
-manual](https://nixos.org/manual/nix/stable/).
+manual](https://nix.dev/manual/nix/stable/).
 
 # Installables
 


### PR DESCRIPTION
The file was renamed. We've also moved to nix.dev, but that was redirected properly.
- Closes #13488
- Rout cause https://github.com/NixOS/nix.dev/issues/1165

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
