### PR TITLE
Add functional test for no-url-literals experimental feature

### DIFF
--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -113,6 +113,7 @@ suites = [
       'pure-eval.sh',
       'eval.sh',
       'short-path-literals.sh',
+      'no-url-literals.sh',
       'repl.sh',
       'binary-cache-build-remote.sh',
       'search.sh',

--- a/tests/functional/no-url-literals.sh
+++ b/tests/functional/no-url-literals.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+clearStoreIfPossible
+
+# Test 1: By default, unquoted URLs are accepted
+nix eval --expr 'http://example.com' 2>&1 | grepQuietInverse "error: URL literals are disabled"
+
+# Test 2: With the experimental feature enabled, unquoted URLs are rejected
+expect 1 nix eval --extra-experimental-features 'no-url-literals' --expr 'http://example.com' 2>&1 | grepQuiet "error: URL literals are disabled"
+
+# Test 3: Quoted URLs are always accepted
+nix eval --extra-experimental-features 'no-url-literals' --expr '"http://example.com"' 2>&1 | grepQuietInverse "error: URL literals are disabled"
+
+# Test 4: URLs with parameters (which must be quoted) are accepted
+nix eval --extra-experimental-features 'no-url-literals' --expr '"http://example.com?foo=bar"' 2>&1 | grepQuietInverse "error: URL literals are disabled"
+
+# Test 5: The feature can be enabled via NIX_CONFIG
+expect 1 env NIX_CONFIG='extra-experimental-features = no-url-literals' nix eval --expr 'http://example.com' 2>&1 | grepQuiet "error: URL literals are disabled"
+
+# Test 6: The feature can be enabled via CLI even if not set in config
+expect 1 env NIX_CONFIG='' nix eval --extra-experimental-features 'no-url-literals' --expr 'http://example.com' 2>&1 | grepQuiet "error: URL literals are disabled"
+
+# Test 7: Evaluation still works for quoted URLs
+nix eval --raw --extra-experimental-features no-url-literals --expr '"http://example.com"' | grepQuiet "^http://example.com$"
+
+echo "no-url-literals test passed!"


### PR DESCRIPTION
## Motivation

This experimental feature has been untested since it's addition. It's easy to cover it, so I did that.

Sorry if the test's suboptimal, I don't have much experience.

## Context

Closes: #13533

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
