### PR TITLE
Sometimes build `nix-manual` when cross compiling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ subproject('nix')
 if get_option('doc-gen')
   subproject('internal-api-docs')
   subproject('external-api-docs')
-  if not meson.is_cross_build()
+  if meson.can_run_host_binaries()
     subproject('nix-manual')
   endif
 endif


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

At the moment, the `nix-manual` Meson subproject won’t be built if you’re cross compiling. This pull request makes it so that the `nix-manual` Meson subproject will be built if you’re cross compiling Nix and the build system is capable of executing host system binaries. (See the commit message for additional details).

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

The main motivation behind this change is to deal with [this Nixpkgs issue][1]. Building `pkgs.nixStatic` counts as cross compiling Nix, and `pkgs.nixStatic` is supposed to produce a `man` output. Building `pkgs.nixStatic` currently fails because it isn’t actually producing a `man` output. That issue will go away once this pull request gets backported to Nix 2.28.x.

You can verify that this pull request fixes that Nixpkgs issue by doing the following:

1. Create a file named `nix-static.nix` that contains this Nix expression:

    ```nix
    # This file is dedicated to the public domain using 🅭🄍1.0:
    # <https://creativecommons.org/publicdomain/zero/1.0>.
    let
      nixpkgsCommit = "17f6bd177404d6d43017595c5264756764444ab8";
      nixpkgsTarball = builtins.fetchTarball {
        url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgsCommit}.tar.gz";
        sha256 = "1nwqbj0bmhdqf34d0y6qbpnwqa9bkhlqd03ffv60yami7fppnyb6";
      };
      pkgs = import nixpkgsTarball { };
    in
    {
      upstreamVersion = pkgs.nixStatic;
      versionFromThisPR = pkgs.nixStatic.overrideAttrs (
        finalAttrs: previousAttrs: {
          src = pkgs.fetchFromGitHub {
            owner = "Jayman2000";
            repo = "nix-pr";
            rev = "5e407e6abb5738f72b8b5aeeaa003728fe584c2f";
            hash = "sha256-s9lK09RpKklka/xDwPhmmUge19oR/zYp9lfuJkb+XHo=";
          };
        }
      );
    }
    ```

1. Build that expression by running this command:

    ```bash
    nix-build --keep-going <path to nix-static.nix>
    ```

1. Make sure that the build fails with exactly one error. The `upstreamVersion` attribute should fail to build with an error about the builder not creating a `man` output. The `versionFromThisPR` attribute should build successfully.

[1]: https://github.com/NixOS/nixpkgs/issues/426410

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
