### PR TITLE
meson: Fix `nix_system_cpu` for MIPS and 32 bit ARM systems

### DIFF
--- a/doc/manual/source/development/building.md
+++ b/doc/manual/source/development/building.md
@@ -215,14 +215,18 @@ nix build .#nix-everything-x86_64-w64-mingw32
 
 For historic reasons and backward-compatibility, some CPU and OS identifiers are translated as follows:
 
-| `config.guess`             | Nix                 |
-|----------------------------|---------------------|
-| `amd64`                    | `x86_64`            |
-| `i*86`                     | `i686`              |
-| `arm6`                     | `arm6l`             |
-| `arm7`                     | `arm7l`             |
-| `linux-gnu*`               | `linux`             |
-| `linux-musl*`              | `linux`             |
+| `host_machine.cpu_family()` | `host_machine.endian()` | Nix                 |
+|-----------------------------|-------------------------|---------------------|
+| `x86`                       |                         | `i686`              |
+| `arm`                       |                         | `host_machine.cpu()`|
+| `ppc`                       | `little`                | `powerpcle`         |
+| `ppc64`                     | `little`                | `powerpc64le`       |
+| `ppc`                       | `big`                   | `powerpc`           |
+| `ppc64`                     | `big`                   | `powerpc64`         |
+| `mips`                      | `little`                | `mipsel`            |
+| `mips64`                    | `little`                | `mips64el`          |
+| `mips`                      | `big`                   | `mips`              |
+| `mips64`                    | `big`                   | `mips64`            |
 
 ## Compilation environments
 

--- a/nix-meson-build-support/default-system-cpu/meson.build
+++ b/nix-meson-build-support/default-system-cpu/meson.build
@@ -1,10 +1,19 @@
-powerpc_system_cpus = [ 'ppc64', 'ppc' ]
+# This attempts to translate meson cpu_family and cpu_name specified via
+# --cross-file [1] into a nix *system double*. Nixpkgs mostly respects ([2]) the
+# conventions outlined in [1].
+#
+# [1]: https://mesonbuild.com/Reference-tables.html#cpu-families
+# [2]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/lib/meson.nix
 
 nix_system_cpu = {'ppc64' : 'powerpc64', 'ppc' : 'powerpc', 'x86' : 'i686'}.get(
   host_machine.cpu_family(),
   host_machine.cpu_family(),
 )
 
-if powerpc_system_cpus.contains(host_machine.cpu_family()) and host_machine.endian() == 'little'
+if (host_machine.cpu_family() in [ 'ppc64', 'ppc' ]) and host_machine.endian() == 'little'
   nix_system_cpu += 'le'
+elif host_machine.cpu_family() in [ 'mips64', 'mips' ] and host_machine.endian() == 'little'
+  nix_system_cpu += 'el'
+elif host_machine.cpu_family() == 'arm'
+  nix_system_cpu = host_machine.cpu()
 endif


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Prior patches in 54dc5314e85b2803c1d870fde61ec4105a35adee and 6db61900028ec641f12b1d36fe4ece5a9bdaa66f fixed the default system double for i686 and ppc/ppc64. This also patch also covers 32 bit arm and mips. ARM cpu names are taken from `host_machine.cpu()` for a lack of a better option, but `host_machine.cpu_family()` is preferred, since that is supposed to be somewhat standard for cross files. Endianness is handled correctly by looking at `host_machine.endian()`.

This also updates the documentation to be up to date to how system cpu is translated from the host_machine specification.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
