### PR TITLE
Add `nix flake prefetch-inputs` command

### DIFF
--- a/src/nix/flake-prefetch-inputs.cc
+++ b/src/nix/flake-prefetch-inputs.cc
@@ -1,0 +1,72 @@
+#include "flake-command.hh"
+#include "nix/fetchers/fetch-to-store.hh"
+#include "nix/util/thread-pool.hh"
+#include "nix/store/filetransfer.hh"
+#include "nix/util/exit.hh"
+
+#include <nlohmann/json.hpp>
+
+using namespace nix;
+using namespace nix::flake;
+
+struct CmdFlakePrefetchInputs : FlakeCommand
+{
+    std::string description() override
+    {
+        return "fetch the inputs of a flake";
+    }
+
+    std::string doc() override
+    {
+        return
+#include "flake-prefetch-inputs.md"
+            ;
+    }
+
+    void run(nix::ref<nix::Store> store) override
+    {
+        auto flake = lockFlake();
+
+        ThreadPool pool{fileTransferSettings.httpConnections};
+
+        struct State
+        {
+            std::set<const Node *> done;
+        };
+
+        Sync<State> state_;
+
+        std::atomic<size_t> nrFailed{0};
+
+        std::function<void(const Node & node)> visit;
+        visit = [&](const Node & node) {
+            if (!state_.lock()->done.insert(&node).second)
+                return;
+
+            if (auto lockedNode = dynamic_cast<const LockedNode *>(&node)) {
+                try {
+                    Activity act(*logger, lvlInfo, actUnknown, fmt("fetching '%s'", lockedNode->lockedRef));
+                    auto accessor = lockedNode->lockedRef.input.getAccessor(store).first;
+                    fetchToStore(
+                        fetchSettings, *store, accessor, FetchMode::Copy, lockedNode->lockedRef.input.getName());
+                } catch (Error & e) {
+                    printError("%s", e.what());
+                    nrFailed++;
+                }
+            }
+
+            for (auto & [inputName, input] : node.inputs) {
+                if (auto inputNode = std::get_if<0>(&input))
+                    pool.enqueue(std::bind(visit, **inputNode));
+            }
+        };
+
+        pool.enqueue(std::bind(visit, *flake.lockFile.root));
+
+        pool.process();
+
+        throw Exit(nrFailed ? 1 : 0);
+    }
+};
+
+static auto rCmdFlakePrefetchInputs = registerCommand2<CmdFlakePrefetchInputs>({"flake", "prefetch-inputs"});

--- a/src/nix/flake-prefetch-inputs.md
+++ b/src/nix/flake-prefetch-inputs.md
@@ -1,0 +1,17 @@
+R""(
+
+# Examples
+
+* Fetch the inputs of the `hydra` flake:
+
+  ```console
+  # nix flake prefetch-inputs github:NixOS/hydra
+  ```
+
+# Description
+
+Fetch the inputs of a flake. This ensures that they are already available for any subsequent evaluation of the flake.
+
+This operation is recursive: it will fetch not just the direct inputs of the top-level flake, but also transitive inputs.
+
+)""

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -78,6 +78,7 @@ nix_sources = [config_priv_h] + files(
   'env.cc',
   'eval.cc',
   'flake.cc',
+  'flake-prefetch-inputs.cc',
   'formatter.cc',
   'hash.cc',
   'log.cc',


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This command fetches all inputs of a flake in parallel. This can be a lot faster than the serialized on-demand fetching during regular flake evaluation. The downside is that it may fetch inputs that aren't normally used.

Example runtime for

```
$ chmod -R u+w /tmp/nix2; rm -rf /tmp/nix2; rm ~/.cache/nix/fetcher-cache-v3.sqlite*; rm -rf ~/.cache/nix/tarball-cache/ ~/.cache/nix/gitv3/; time nix flake prefetch-inputs --store /tmp/nix2 https://api.flakehub.com/f/pinned/informalsystems/cosmos.nix/0.3.0/018ce9ed-d0be-7ce5-81b6-a3c6e3ae1187/source.tar.gz
```

with `http-connections = 1`:

```
real    4m11.859s
user    2m6.931s
sys     0m25.619s
```

and `http-connections = 25` (the default):

```
real    0m57.146s
user    2m49.506s
sys     0m36.008s
```

Based on https://github.com/DeterminateSystems/nix-src/pull/127.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
