### PR TITLE
flake: Factor out checks into ci/gha/tests for reusability

### DIFF
--- a/ci/gha/tests/default.nix
+++ b/ci/gha/tests/default.nix
@@ -1,0 +1,89 @@
+{
+  nixFlake ? builtins.getFlake ("git+file://" + toString ../../..),
+  system ? builtins.currentSystem,
+  pkgs ? nixFlake.inputs.nixpkgs.legacyPackages.${system},
+  getStdenv ? p: p.stdenv,
+  componentTestsPrefix ? "",
+  withSanitizers ? false,
+}:
+
+let
+  inherit (pkgs) lib;
+  hydraJobs = nixFlake.hydraJobs;
+  packages' = nixFlake.packages.${system};
+in
+
+{
+  /**
+    Top-level tests for the flake outputs, as they would be built by hydra.
+    These tests generally can't be overridden to run with sanitizers.
+  */
+  topLevel = {
+    installerScriptForGHA = hydraJobs.installerScriptForGHA.${system};
+    installTests = hydraJobs.installTests.${system};
+    nixpkgsLibTests = hydraJobs.tests.nixpkgsLibTests.${system};
+    rl-next = pkgs.buildPackages.runCommand "test-rl-next-release-notes" { } ''
+      LANG=C.UTF-8 ${pkgs.changelog-d}/bin/changelog-d ${../../../doc/manual/rl-next} >$out
+    '';
+    repl-completion = pkgs.callPackage ../../../tests/repl-completion.nix { inherit (packages') nix; };
+
+    /**
+      Checks for our packaging expressions.
+      This shouldn't build anything significant; just check that things
+      (including derivations) are _set up_ correctly.
+    */
+    packaging-overriding =
+      let
+        nix = packages'.nix;
+      in
+      assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
+      if pkgs.stdenv.buildPlatform.isDarwin then
+        lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
+      else
+        # If this fails, something might be wrong with how we've wired the scope,
+        # or something could be broken in Nixpkgs.
+        pkgs.testers.testEqualContents {
+          assertion = "trivial patch does not change source contents";
+          expected = "${../../..}";
+          actual =
+            # Same for all components; nix-util is an arbitrary pick
+            (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
+        };
+  };
+
+  componentTests =
+    let
+      nixComponents =
+        (nixFlake.lib.makeComponents {
+          inherit pkgs;
+          inherit getStdenv;
+        }).overrideScope
+          (
+            _: _: {
+              mesonComponentOverrides = finalAttrs: prevAttrs: {
+                mesonFlags =
+                  (prevAttrs.mesonFlags or [ ])
+                  ++ lib.optionals withSanitizers [
+                    # Run all tests with UBSAN enabled. Running both with ubsan and
+                    # without doesn't seem to have much immediate benefit for doubling
+                    # the GHA CI workaround.
+                    #
+                    # TODO: Work toward enabling "address,undefined" if it seems feasible.
+                    # This would maybe require dropping Boost coroutines and ignoring intentional
+                    # memory leaks with detect_leaks=0.
+                    (lib.mesonOption "b_sanitize" "undefined")
+                  ];
+              };
+            }
+          );
+    in
+    (lib.concatMapAttrs (
+      pkgName: pkg:
+      lib.concatMapAttrs (testName: test: {
+        "${componentTestsPrefix}${pkgName}-${testName}" = test;
+      }) (pkg.tests or { })
+    ) nixComponents)
+    // lib.optionalAttrs (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) {
+      "${componentTestsPrefix}nix-functional-tests" = nixComponents.nix-functional-tests;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -320,43 +320,11 @@
 
       checks = forAllSystems (
         system:
-        {
-          installerScriptForGHA = self.hydraJobs.installerScriptForGHA.${system};
-          installTests = self.hydraJobs.installTests.${system};
-          nixpkgsLibTests = self.hydraJobs.tests.nixpkgsLibTests.${system};
-          rl-next =
-            let
-              pkgs = nixpkgsFor.${system}.native;
-            in
-            pkgs.buildPackages.runCommand "test-rl-next-release-notes" { } ''
-              LANG=C.UTF-8 ${pkgs.changelog-d}/bin/changelog-d ${./doc/manual/rl-next} >$out
-            '';
-          repl-completion = nixpkgsFor.${system}.native.callPackage ./tests/repl-completion.nix { };
-
-          /**
-            Checks for our packaging expressions.
-            This shouldn't build anything significant; just check that things
-            (including derivations) are _set up_ correctly.
-          */
-          packaging-overriding =
-            let
-              pkgs = nixpkgsFor.${system}.native;
-              nix = self.packages.${system}.nix;
-            in
-            assert (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src.patches == [ pkgs.emptyFile ];
-            if pkgs.stdenv.buildPlatform.isDarwin then
-              lib.warn "packaging-overriding check currently disabled because of a permissions issue on macOS" pkgs.emptyFile
-            else
-              # If this fails, something might be wrong with how we've wired the scope,
-              # or something could be broken in Nixpkgs.
-              pkgs.testers.testEqualContents {
-                assertion = "trivial patch does not change source contents";
-                expected = "${./.}";
-                actual =
-                  # Same for all components; nix-util is an arbitrary pick
-                  (nix.appendPatches [ pkgs.emptyFile ]).libs.nix-util.src;
-              };
-        }
+        (import ./ci/gha/tests {
+          inherit system;
+          pkgs = nixpkgsFor.${system}.native;
+          nixFlake = self;
+        }).topLevel
         // (lib.optionalAttrs (builtins.elem system linux64BitSystems)) {
           dockerImage = self.hydraJobs.dockerImage.${system};
         }
@@ -371,28 +339,8 @@
           flatMapAttrs
             (
               {
-                # Run all tests with UBSAN enabled. Running both with ubsan and
-                # without doesn't seem to have much immediate benefit for doubling
-                # the GHA CI workaround.
-                #
-                # TODO: Work toward enabling "address,undefined" if it seems feasible.
-                # This would maybe require dropping Boost coroutines and ignoring intentional
-                # memory leaks with detect_leaks=0.
-                "" = rec {
-                  nixpkgs = nixpkgsFor.${system}.native;
-                  nixComponents = nixpkgs.nixComponents2.overrideScope (
-                    nixCompFinal: nixCompPrev: {
-                      mesonComponentOverrides = _finalAttrs: prevAttrs: {
-                        mesonFlags =
-                          (prevAttrs.mesonFlags or [ ])
-                          # TODO: Macos builds instrumented with ubsan take very long
-                          # to run functional tests.
-                          ++ lib.optionals (!nixpkgs.stdenv.hostPlatform.isDarwin) [
-                            (lib.mesonOption "b_sanitize" "undefined")
-                          ];
-                      };
-                    }
-                  );
+                "" = {
+                  pkgs = nixpkgsFor.${system}.native;
                 };
               }
               // lib.optionalAttrs (!nixpkgsFor.${system}.native.stdenv.hostPlatform.isDarwin) {
@@ -400,27 +348,23 @@
                 #       https://github.com/NixOS/nixpkgs/issues/320448
                 # TODO: disabled to speed up GHA CI.
                 # "static-" = {
-                #   nixpkgs = nixpkgsFor.${system}.native.pkgsStatic;
+                #   pkgs = nixpkgsFor.${system}.native.pkgsStatic;
                 # };
+                "sanitized-" = {
+                  pkgs = nixpkgsFor.${system}.native;
+                  withSanitizers = true;
+                };
               }
             )
             (
-              nixpkgsPrefix:
-              {
-                nixpkgs,
-                nixComponents ? nixpkgs.nixComponents2,
-              }:
-              flatMapAttrs nixComponents (
-                pkgName: pkg:
-                flatMapAttrs pkg.tests or { } (
-                  testName: test: {
-                    "${nixpkgsPrefix}${pkgName}-${testName}" = test;
-                  }
-                )
-              )
-              // lib.optionalAttrs (nixpkgs.stdenv.hostPlatform == nixpkgs.stdenv.buildPlatform) {
-                "${nixpkgsPrefix}nix-functional-tests" = nixComponents.nix-functional-tests;
-              }
+              nixpkgsPrefix: args:
+              (import ./ci/gha/tests (
+                args
+                // {
+                  nixFlake = self;
+                  componentTestsPrefix = nixpkgsPrefix;
+                }
+              )).componentTests
             )
         // devFlake.checks.${system} or { }
       );


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This moves out the checks that get run in GHA CI into ci/gha/tests folder and splits those into `topLevel` and `componentTests` attributes. The idea behind this is to make it easier to parametrize tests that can be run with sanitizers in order to run those as a matrix of jobs. The same can be said for static builds.

Existing stdenv selection infrastructure via `lib.makeComponents` would also allow us to switch over to using `clangStdenv` to significantly speed up pre-merge CI (though the default stdenv would still be used for non-overridable topLevel checks, like installer artifacts).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
