### PR TITLE
Add a test to prove readHead is cached

### DIFF
--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -7,6 +7,7 @@
 #include "nix/store/filetransfer.hh"
 #include "nix/fetchers/registry.hh"
 #include "nix/fetchers/tarball.hh"
+#include "nix/util/environment-variables.hh"
 #include "nix/util/url.hh"
 #include "nix/expr/value-to-json.hh"
 #include "nix/fetchers/fetch-to-store.hh"
@@ -58,8 +59,12 @@ void emitTreeAttrs(
             attrs.alloc("revCount").mkInt(0);
     }
 
-    if (input.getRef() && !state.settings.pureEval) {
-        attrs.alloc("ref").mkString(*input.getRef());
+    // Unclear whether adding "ref" is yet a good idea even
+    // when it's not pure.
+    if (getEnv("_NIX_TEST_ATTRS_REF") == "1") {
+        if (input.getRef() && !state.settings.pureEval) {
+            attrs.alloc("ref").mkString(*input.getRef());
+        }
     }
 
     if (auto dirtyRev = fetchers::maybeGetStrAttr(input.attrs, "dirtyRev")) {

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -287,7 +287,7 @@ path11=$(nix eval --impure --raw --expr "(builtins.fetchGit ./.).outPath")
 empty="$TEST_ROOT/empty"
 git init "$empty"
 
-emptyAttrs="{ lastModified = 0; lastModifiedDate = \"19700101000000\"; narHash = \"sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=\"; ref = \"refs/heads/master\"; rev = \"0000000000000000000000000000000000000000\"; revCount = 0; shortRev = \"0000000\"; submodules = false; }"
+emptyAttrs="{ lastModified = 0; lastModifiedDate = \"19700101000000\"; narHash = \"sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=\"; rev = \"0000000000000000000000000000000000000000\"; revCount = 0; shortRev = \"0000000\"; submodules = false; }"
 result=$(nix eval --impure --expr "builtins.removeAttrs (builtins.fetchGit $empty) [\"outPath\"]")
 [[ "$result" = "$emptyAttrs" ]]
 

--- a/tests/functional/git/head-file-cached.sh
+++ b/tests/functional/git/head-file-cached.sh
@@ -16,6 +16,7 @@ clearStoreIfPossible
 repo=$TEST_ROOT/./git
 
 export _NIX_FORCE_HTTP=1
+export _NIX_TEST_ATTRS_REF=1
 
 rm -rf "$repo" "${repo}-tmp" "$TEST_HOME/.cache/nix"
 


### PR DESCRIPTION
We were investigating #13556 but could not figure it out. Upstreaming the unit-test however to validate and prove that the head file is cached though as there does not seem to be one present.

This augments the primops to add a `ref` variable only if impure evaluation. This makes testing for the ref much simpler. 

Co-authored-by: Yannik Sander <me@ysndr.de>

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
