### PR TITLE
docs: update supported macOS versions and architectures in manual

### DIFF
--- a/doc/manual/source/installation/supported-platforms.md
+++ b/doc/manual/source/installation/supported-platforms.md
@@ -1,7 +1,24 @@
-# Supported Platforms
+## Supported Platforms
 
 Nix is currently supported on the following platforms:
 
-  - Linux (i686, x86\_64, aarch64).
+- **Linux** (`i686`, `x86_64`, `aarch64`)
+- **macOS** (`x86_64`, `aarch64`)
 
-  - macOS (x86\_64, aarch64).
+### macOS Support Details
+
+| macOS Version       | Status       | Notes                                                                 |
+|---------------------|--------------|------------------------------------------------------------------------|
+| 11.3 Big Sur        | ✅ Supported | Minimum required version for stable builds                            |
+| 12 Monterey         | ✅ Supported |                                                                      |
+| 13 Ventura          | ✅ Supported |                                                                      |
+| 14 Sonoma           | ✅ Supported | Baseline version for upcoming Nixpkgs 25.11 release                   |
+| 15 Sequoia          | ✅ Supported\* | Requires migration script to fix `_nixbld1-4` user conflicts post-upgrade |
+
+\* macOS 15 Sequoia introduces a change where system upgrade may overwrite the `_nixbld1–4` build users, which breaks Nix sandboxing. A [repair script](https://github.com/DeterminateSystems/nix-installer/releases/tag/v0.26.0) is available via the Determinate Nix Installer and upstream channels.
+
+#### Architectures
+- `x86_64` (Intel Macs)
+- `aarch64` (Apple Silicon)
+
+> ℹ️ Nixpkgs 25.11 and later may drop support for Sequoia and require macOS 14 Sonoma or newer.


### PR DESCRIPTION
Updated information relating to compatibility of Nix in different OS, especially macOS.

## Motivation

The current documentation on supported macOS versions is outdated. It does not reflect the current minimum system requirements (macOS ≥ 11.3), compatibility with macOS 15 Sequoia, or upcoming support changes planned for future Nixpkgs releases (25.11+). This PR updates the manual to reflect accurate architecture and OS version support as of Nixpkgs 25.05.

## Context

This PR improves clarity for users installing or upgrading Nix on macOS. It also ensures developers are aware of changes in OS-level compatibility and platform deprecation. The changes are sourced from:

- [Nixpkgs 25.05 release notes](https://nixos.org/manual/nixpkgs/stable/release-notes.html)
- [Discourse thread on macOS 15 UID issue](https://discourse.nixos.org/t/macos-15-sequoia-update-clobbers-nixbld1-4-users/52223)
- [Determinate Systems blog post on Sequoia support](https://determinate.systems/posts/nix-support-for-macos-sequoia/)
- [GitHub Issue discussing UID bug](https://github.com/NixOS/nix/issues/9405)

This change is documentation-only and non-invasive.

## Implementation Strategy

The `Supported Platforms` section of the documentation was updated to:
- List macOS versions with exact minimum support (Big Sur 11.3)
- Clarify architectures (`x86_64`, `aarch64`)
- Document compatibility and known issues with macOS 15 Sequoia
- Note the future requirement of macOS 14 Sonoma+ in Nixpkgs 25.11+

## Checklist

- [x] User documentation updated in `doc/manual/source`
- [x] Commit message explains **why** the change was made
- [x] Documentation sources are linked in this PR
- [ ] Not applicable: No code or tests modified
- [ ] Not applicable: No release notes needed (docs-only)
