### PR TITLE
meson: Disable PCH for GCC

### DIFF
--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -19,6 +19,9 @@ add_project_arguments(
   language : 'cpp',
 )
 
+# GCC doesn't benefit much from precompiled headers.
+do_pch = cxx.get_id() == 'clang'
+
 # This is a clang-only option for improving build times.
 # It forces the instantiation of templates in the PCH itself and
 # not every translation unit it's included in.

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -92,7 +92,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
-  cpp_pch : ['pch/precompiled-headers.hh']
+  cpp_pch : do_pch ? ['pch/precompiled-headers.hh'] : []
 )
 
 install_headers(headers, subdir : 'nix/cmd', preserve_path : true)

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -178,7 +178,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
-  cpp_pch : ['pch/precompiled-headers.hh']
+  cpp_pch : do_pch ? ['pch/precompiled-headers.hh'] : []
 )
 
 install_headers(headers, subdir : 'nix/expr', preserve_path : true)

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -350,7 +350,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
-  cpp_pch : ['pch/precompiled-headers.hh']
+  cpp_pch : do_pch ? ['pch/precompiled-headers.hh'] : []
 )
 
 install_headers(headers, subdir : 'nix/store', preserve_path : true)

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -191,7 +191,7 @@ this_library = library(
   link_args: linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
-  cpp_pch : 'pch/precompiled-headers.hh'
+  cpp_pch : do_pch ? ['pch/precompiled-headers.hh'] : []
 )
 
 install_headers(headers, subdir : 'nix/util', preserve_path : true)

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -186,7 +186,7 @@ this_exe = executable(
   include_directories : include_dirs,
   link_args: linker_export_flags,
   install : true,
-  cpp_pch : ['pch/precompiled-headers.hh']
+  cpp_pch : do_pch ? ['pch/precompiled-headers.hh'] : []
 )
 
 meson.override_find_program('nix', this_exe)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

GCC doesn't really benefit as much as Clang does from using precompiled headers. Another aspect to consider is that clangd doesn't really like GCC's PCH flags in the compilation database, so GCC based devshells would continue to work with clangd.

This also has the slight advantage of ensuring that our includes are in order, since we build with both Clang and GCC.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
