### PR TITLE
Make functional tests depend on nix binary so they auto recompile

### DIFF
--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -211,6 +211,7 @@ if host_machine.system() == 'windows'
   executable_suffix = '.exe'
 endif
 
+nix_symlinks_targets = []
 foreach linkname : nix_symlinks
   install_symlink(
     linkname + executable_suffix,
@@ -220,7 +221,7 @@ foreach linkname : nix_symlinks
     # The 'runtime' tag is what executables default to, which we want to emulate here.
     install_tag : 'runtime',
   )
-  custom_target(
+  symlink_target = custom_target(
     command : [ 'ln', '-sf', fs.name(this_exe), '@OUTPUT@' ],
     output : linkname + executable_suffix,
     # native doesn't allow dangling symlinks, but the target executable often doesn't exist at this time
@@ -230,6 +231,7 @@ foreach linkname : nix_symlinks
   )
   # TODO(Ericson3214): Doesn't yet work
   #meson.override_find_program(linkname, t)
+  nix_symlinks_targets += symlink_target
 endforeach
 
 install_symlink(

--- a/src/perl/lib/Nix/meson.build
+++ b/src/perl/lib/Nix/meson.build
@@ -16,8 +16,9 @@ nix_perl_scripts = files(
   'Utils.pm',
 )
 
+nix_perl_scripts_copy_tgts = []
 foreach f : nix_perl_scripts
-  fs.copyfile(f)
+  nix_perl_scripts_copy_tgts += fs.copyfile(f)
 endforeach
 
 

--- a/src/perl/meson.build
+++ b/src/perl/meson.build
@@ -191,6 +191,6 @@ if get_option('tests').enabled()
     yath,
     args : [ 'test' ],
     workdir : meson.current_build_dir(),
-    depends : [ nix_perl_store_lib ],
+    depends : [ nix_perl_store_lib ] + nix_perl_tests_copy_tgts + nix_perl_scripts_copy_tgts,
   )
 endif

--- a/src/perl/t/meson.build
+++ b/src/perl/t/meson.build
@@ -9,7 +9,7 @@ nix_perl_tests = files(
   'init.t',
 )
 
-
+nix_perl_tests_copy_tgts = []
 foreach f : nix_perl_tests
-  fs.copyfile(f)
+  nix_perl_tests_copy_tgts += fs.copyfile(f)
 endforeach

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -223,6 +223,18 @@ subdir('local-overlay-store')
 foreach suite : suites
   workdir = suite['workdir']
   suite_name = suite['name']
+  # This is workaround until [1] is resolved. When building in a devshell
+  # as a subproject we want the tests to depend on the nix build target, so
+  # that it gets automatically rebuilt.
+  # However, when the functional test suite is built separately (via componentized
+  # builds or in NixOS tests) we can't depend on the nix executable, since it's
+  # an external program. The following is a simple heuristic that suffices for now.
+  # [1]: https://github.com/mesonbuild/meson/issues/13877
+  deps = suite['deps']
+  if meson.is_subproject()
+    nix_subproject = subproject('nix')
+    deps += [ nix ] + nix_subproject.get_variable('nix_symlinks_targets')
+  endif
   foreach script : suite['tests']
     # Turns, e.g., `tests/functional/flakes/show.sh` into a Meson test target called
     # `functional-flakes-show`.
@@ -252,7 +264,7 @@ foreach suite : suites
       # them more time than the default of 30 seconds.
       timeout : 300,
       # Used for target dependency/ordering tracking, not adding compiler flags or anything.
-      depends : suite['deps'],
+      depends : deps,
       workdir : workdir,
     )
   endforeach


### PR DESCRIPTION
Trivial improvement to Meson.
I noticed plenty of tests don't depend on `nix` itself which is frustrating since I forget to do `meson compile`.

Slowly making the build graph more "correct".
I'm not an expert in Meson so not sure if this is ultimately correct but it does what I expect.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
