### PR TITLE
Recognize "identity" compression method

### DIFF
--- a/src/libutil/compression.cc
+++ b/src/libutil/compression.cc
@@ -215,7 +215,7 @@ std::string decompress(const std::string & method, std::string_view in)
 
 std::unique_ptr<FinishSink> makeDecompressionSink(const std::string & method, Sink & nextSink)
 {
-    if (method == "none" || method == "")
+    if (method == "none" || method == "" || method == "identity")
         return std::make_unique<NoneSink>(nextSink);
     else if (method == "br")
         return std::make_unique<BrotliDecompressionSink>(nextSink);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Some binary caches (incorrectly) use this header to indicate lack of compression, inspired by the valid "identity" token in the "Accept-Encoding" header.

Fixes https://github.com/DeterminateSystems/nix-src/issues/154

## Context

- Cache server bug report: https://github.com/nix-community/harmonia/issues/578
- `Content-Encoding` MDN docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding
- `Accept-Encoding` MDN docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Encoding
- HTTP RFC: https://datatracker.ietf.org/doc/html/rfc7694

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
