### PR TITLE
treewide: Move private types and code into anonymous namespaces 

### DIFF
--- a/src/libstore/builtins/buildenv.cc
+++ b/src/libstore/builtins/buildenv.cc
@@ -10,11 +10,15 @@
 
 namespace nix {
 
+namespace {
+
 struct State
 {
     std::map<Path, int> priorities;
     unsigned long symlinks = 0;
 };
+
+} // namespace
 
 /* For each activated package, create symlinks */
 static void createLinks(State & state, const Path & srcDir, const Path & dstDir, int priority)

--- a/src/libutil/args.cc
+++ b/src/libutil/args.cc
@@ -81,6 +81,8 @@ std::optional<std::string> RootArgs::needsCompletion(std::string_view s)
     return {};
 }
 
+namespace {
+
 /**
  * Basically this is `typedef std::optional<Parser> Parser(std::string_view s, Strings & r);`
  *
@@ -245,6 +247,8 @@ void ParseQuoted::operator()(std::shared_ptr<Parser> & state, Strings & r)
     }
     assert(false);
 }
+
+} // namespace
 
 Strings parseShebangContent(std::string_view s)
 {

--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -273,7 +273,7 @@ Hash newHashAllowEmpty(std::string_view hashStr, std::optional<HashAlgorithm> ha
         return Hash::parseAny(hashStr, ha);
 }
 
-union Ctx
+union Hash::Ctx
 {
     blake3_hasher blake3;
     MD5_CTX md5;
@@ -282,7 +282,7 @@ union Ctx
     SHA512_CTX sha512;
 };
 
-static void start(HashAlgorithm ha, Ctx & ctx)
+static void start(HashAlgorithm ha, Hash::Ctx & ctx)
 {
     if (ha == HashAlgorithm::BLAKE3)
         blake3_hasher_init(&ctx.blake3);
@@ -317,7 +317,7 @@ void blake3_hasher_update_with_heuristics(blake3_hasher * blake3, std::string_vi
     }
 }
 
-static void update(HashAlgorithm ha, Ctx & ctx, std::string_view data)
+static void update(HashAlgorithm ha, Hash::Ctx & ctx, std::string_view data)
 {
     if (ha == HashAlgorithm::BLAKE3)
         blake3_hasher_update_with_heuristics(&ctx.blake3, data);
@@ -331,7 +331,7 @@ static void update(HashAlgorithm ha, Ctx & ctx, std::string_view data)
         SHA512_Update(&ctx.sha512, data.data(), data.size());
 }
 
-static void finish(HashAlgorithm ha, Ctx & ctx, unsigned char * hash)
+static void finish(HashAlgorithm ha, Hash::Ctx & ctx, unsigned char * hash)
 {
     if (ha == HashAlgorithm::BLAKE3)
         blake3_hasher_finalize(&ctx.blake3, hash, BLAKE3_OUT_LEN);
@@ -347,7 +347,7 @@ static void finish(HashAlgorithm ha, Ctx & ctx, unsigned char * hash)
 
 Hash hashString(HashAlgorithm ha, std::string_view s, const ExperimentalFeatureSettings & xpSettings)
 {
-    Ctx ctx;
+    Hash::Ctx ctx;
     Hash hash(ha, xpSettings);
     start(ha, ctx);
     update(ha, ctx, s);
@@ -365,7 +365,7 @@ Hash hashFile(HashAlgorithm ha, const Path & path)
 HashSink::HashSink(HashAlgorithm ha)
     : ha(ha)
 {
-    ctx = new Ctx;
+    ctx = new Hash::Ctx;
     bytes = 0;
     start(ha, *ctx);
 }
@@ -393,7 +393,7 @@ HashResult HashSink::finish()
 HashResult HashSink::currentHash()
 {
     flush();
-    Ctx ctx2 = *ctx;
+    Hash::Ctx ctx2 = *ctx;
     Hash hash(ha);
     nix::finish(ha, ctx2, hash.hash);
     return HashResult(hash, bytes);

--- a/src/libutil/include/nix/util/hash.hh
+++ b/src/libutil/include/nix/util/hash.hh
@@ -57,6 +57,9 @@ extern const StringSet hashFormats;
 
 struct Hash
 {
+    /** Opaque handle type for the hash calculation state. */
+    union Ctx;
+
     constexpr static size_t maxHashSize = 64;
     size_t hashSize = 0;
     uint8_t hash[maxHashSize] = {};
@@ -224,8 +227,6 @@ std::optional<HashAlgorithm> parseHashAlgoOpt(std::string_view s);
  */
 std::string_view printHashAlgo(HashAlgorithm ha);
 
-union Ctx;
-
 struct AbstractHashSink : virtual Sink
 {
     virtual HashResult finish() = 0;
@@ -235,7 +236,7 @@ class HashSink : public BufferedSink, public AbstractHashSink
 {
 private:
     HashAlgorithm ha;
-    Ctx * ctx;
+    Hash::Ctx * ctx;
     uint64_t bytes;
 
 public:

--- a/src/nix/diff-closures.cc
+++ b/src/nix/diff-closures.cc
@@ -10,10 +10,14 @@
 
 namespace nix {
 
+namespace {
+
 struct Info
 {
     std::string outputName;
 };
+
+} // namespace
 
 // name -> version -> store paths
 typedef std::map<std::string, std::map<std::string, std::map<StorePath, Info>>> GroupedPaths;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Having a class with a generic name like `State` in the nix namespace is asking
for ODR trouble, since it would blow up if another such class were to appear.
A lot of other library classes can be moved to anonymous namespaces. We could
start being a bit more principled about this. Maybe clang-tidy tooling can help
with this in the future?

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
