### PR TITLE
nix-flake-archive: add --no-check-sigs/--substitute-on-destination

### DIFF
--- a/src/nix/flake-command.hh
+++ b/src/nix/flake-command.hh
@@ -12,6 +12,8 @@ class FlakeCommand : virtual Args, public MixFlakeOptions
 {
 protected:
     std::string flakeUrl = ".";
+    CheckSigsFlag checkSigs = CheckSigs;
+    SubstituteFlag substitute = NoSubstitute;
 
 public:
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -36,13 +36,27 @@ struct CmdFlakeUpdate;
 
 FlakeCommand::FlakeCommand()
 {
-    expectArgs(
-        {.label = "flake-url",
-         .optional = true,
-         .handler = {&flakeUrl},
-         .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
-             completeFlakeRef(completions, getStore(), prefix);
-         }}});
+    expectArgs({
+        .label = "flake-url",
+        .optional = true,
+        .handler = {&flakeUrl},
+        .completer = {[&](AddCompletions & completions, size_t, std::string_view prefix) {
+            completeFlakeRef(completions, getStore(), prefix);
+        }}
+    });
+
+    addFlag({
+        .longName = "no-check-sigs",
+        .description = "Do not require that paths are signed by trusted keys.",
+        .handler = {&checkSigs, NoCheckSigs},
+    });
+
+    addFlag({
+        .longName = "substitute-on-destination",
+        .shortName = 's',
+        .description = "Whether to try substitutes on the destination store (only supported by SSH stores).",
+        .handler = {&substitute, Substitute},
+    });
 }
 
 FlakeRef FlakeCommand::getFlakeRef()
@@ -1086,7 +1100,6 @@ struct CmdFlakeArchive : FlakeCommand, MixJSON, MixDryRun
 
         if (!dryRun && !dstUri.empty()) {
             ref<Store> dstStore = dstUri.empty() ? openStore() : openStore(dstUri);
-
             copyPaths(*store, *dstStore, sources, NoRepair, checkSigs, substitute);
         }
     }


### PR DESCRIPTION
`nix flake archive` is a useful tool for building deployment tools, where the evaluation is done on a remote machine.
When we deal with a a remote store, we cannot push unsigned flake inputs (probably the default for most user) even if we are trusted nix user otherwise. For consistency, also allow --substitute-on-destination, The latter flag can speed up `nix flake archive` on large inputs present in the binary cache i.e. nixpkgs channe.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
