### PR TITLE
nix/profile.cc: Fix header include path

### DIFF
--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -7,7 +7,7 @@
 #include "nix/util/archive.hh"
 #include "nix/store/builtins/buildenv.hh"
 #include "nix/flake/flakeref.hh"
-#include "../nix-env/user-env.hh"
+#include "nix-env/user-env.hh"
 #include "nix/store/profiles.hh"
 #include "nix/store/names.hh"
 #include "nix/util/url.hh"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This wasn't caught by CI for aea312dae39d8cf2c2409b03b54ca6520e29732c due to weird componentized build reasons.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
