### PR TITLE
Slight clean up the constructors for `Hash`

### DIFF
--- a/src/libutil/include/nix/util/hash.hh
+++ b/src/libutil/include/nix/util/hash.hh
@@ -92,13 +92,6 @@ struct Hash
 
     static Hash parseSRI(std::string_view original);
 
-private:
-    /**
-     * The type must be provided, the string view must not include <type>
-     * prefix. `isSRI` helps disambigate the various base-* encodings.
-     */
-    Hash(std::string_view s, HashAlgorithm algo, bool isSRI);
-
 public:
     /**
      * Check whether two hashes are equal.


### PR DESCRIPTION
- No more private constructor that is kinda weird

- Two new static functions, `baseFromSize` and `baseFromSize`, that do one thing, and one thing only (simple).

- Two `Hash::parse*` that previously used the private constructor now can use these two functions directly.

- The remaining `Hash::parseAny*` methods, which are inherently more complex, are written in terms of a `parseAnyHelper` static function which is also complex, but keeps the complexity in one spot.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
