### PR TITLE
Enable parallel marking in boehm-gc

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -50,9 +50,19 @@ scope: {
         requiredSystemFeatures = [ ];
       };
 
-  boehmgc = pkgs.boehmgc.override {
-    enableLargeConfig = true;
-  };
+  boehmgc =
+    (pkgs.boehmgc.override {
+      enableLargeConfig = true;
+    }).overrideAttrs
+      (attrs: {
+        # Increase the initial mark stack size to avoid stack
+        # overflows, since these inhibit parallel marking (see
+        # GC_mark_some()). To check whether the mark stack is too
+        # small, run Nix with GC_PRINT_STATS=1 and look for messages
+        # such as `Mark stack overflow`, `No room to copy back mark
+        # stack`, and `Grew mark stack to ... frames`.
+        NIX_CFLAGS_COMPILE = "-DINITIAL_MARK_STACK_SIZE=1048576";
+      });
 
   # TODO Hack until https://github.com/NixOS/nixpkgs/issues/45462 is fixed.
   boost =

--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -53,6 +53,9 @@ static inline void initGCReal()
 
     GC_INIT();
 
+    /* Enable parallel marking. */
+    GC_allow_register_threads();
+
     /* Register valid displacements in case we are using alignment niches
        for storing the type information. This way tagged pointers are considered
        to be valid, even when they are not aligned. */

--- a/src/libexpr/eval-gc.cc
+++ b/src/libexpr/eval-gc.cc
@@ -15,8 +15,6 @@
 #    include <pthread_np.h>
 #  endif
 
-#  include <gc/gc.h>
-#  include <gc/gc_cpp.h>
 #  include <gc/gc_allocator.h>
 
 #  include <boost/coroutine2/coroutine.hpp>

--- a/src/libexpr/include/nix/expr/eval-gc.hh
+++ b/src/libexpr/include/nix/expr/eval-gc.hh
@@ -3,12 +3,13 @@
 
 #include <cstddef>
 
-// For `NIX_USE_BOEHMGC`, and if that's set, `GC_THREADS`
+// For `NIX_USE_BOEHMGC`
 #include "nix/expr/config.hh"
 
 #if NIX_USE_BOEHMGC
 
 #  define GC_INCLUDE_NEW
+#  define GC_THREADS 1
 
 #  include <gc/gc.h>
 #  include <gc/gc_cpp.h>

--- a/src/libexpr/include/nix/expr/eval-inline.hh
+++ b/src/libexpr/include/nix/expr/eval-inline.hh
@@ -6,9 +6,6 @@
 #include "nix/expr/eval-error.hh"
 #include "nix/expr/eval-settings.hh"
 
-// For `NIX_USE_BOEHMGC`, and if that's set, `GC_THREADS`
-#include "nix/expr/config.hh"
-
 namespace nix {
 
 /**

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -61,8 +61,6 @@ if bdw_gc.found()
     define_value = cxx.has_function(funcspec).to_int()
     configdata_priv.set(define_name, define_value)
   endforeach
-  # Affects ABI, because it changes what bdw_gc itself does!
-  configdata_pub.set('GC_THREADS', 1)
 endif
 # Used in public header. Affects ABI!
 configdata_pub.set('NIX_USE_BOEHMGC', bdw_gc.found().to_int())


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Previously marking was done by only one thread, which takes a long time if the heap gets big. Enabling parallel marking speeds up evaluation a lot, for example (on a Ryzen 9 5900X 12-Core):

* `nix search nixpkgs` from 24.3s to 18.9s.
* Evaluating the `NixOS/nix/2.21.2` flake regression test from 86.1s to 71.2s.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
