### PR TITLE
hydra: Restore coverage job

### DIFF
--- a/packaging/hydra.nix
+++ b/packaging/hydra.nix
@@ -223,10 +223,17 @@ in
   dockerImage = lib.genAttrs linux64BitSystems (system: self.packages.${system}.dockerImage);
 
   # # Line coverage analysis.
-  # coverage = nixpkgsFor.x86_64-linux.native.nix.override {
-  #   pname = "nix-coverage";
-  #   withCoverageChecks = true;
-  # };
+  coverage =
+    (import ./../ci/gha/tests rec {
+      withCoverage = true;
+      pkgs = nixpkgsFor.x86_64-linux.nativeForStdenv.clangStdenv;
+      nixComponents = pkgs.nixComponents2;
+      nixFlake = null;
+      getStdenv = p: p.clangStdenv;
+    }).codeCoverage.coverageReports.overrideAttrs
+      {
+        name = "nix-coverage"; # For historical consistency
+      };
 
   # Nix's manual
   manual = nixpkgsFor.x86_64-linux.native.nixComponents2.nix-manual;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Sometime ago we lost the coverage job in the midst of meson migration. Until we have something like codecov it'd be very useful to restore this job with the html reports and historical metrics.

As a bonus we get more coverage metrics by switching to LLVM tooling from LCOV.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
