### PR TITLE
`getUri` should be `const` and on `Store::Config` not `Store`

### DIFF
--- a/src/libcmd/repl.cc
+++ b/src/libcmd/repl.cc
@@ -574,14 +574,14 @@ ProcessLineResult NixRepl::processLine(std::string line)
             for (auto & sub : subs) {
                 auto * logSubP = dynamic_cast<LogStore *>(&*sub);
                 if (!logSubP) {
-                    printInfo("Skipped '%s' which does not support retrieving build logs", sub->getUri());
+                    printInfo("Skipped '%s' which does not support retrieving build logs", sub->config.getUri());
                     continue;
                 }
                 auto & logSub = *logSubP;
 
                 auto log = logSub.getBuildLog(drvPath);
                 if (log) {
-                    printInfo("got build log for '%s' from '%s'", drvPathRaw, logSub.getUri());
+                    printInfo("got build log for '%s' from '%s'", drvPathRaw, logSub.config.getUri());
                     logger->writeToStdout(*log);
                     foundLog = true;
                     break;

--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -62,7 +62,7 @@ nix_err nix_store_get_uri(nix_c_context * context, Store * store, nix_get_string
     if (context)
         context->last_err_code = NIX_OK;
     try {
-        auto res = store->ptr->getUri();
+        auto res = store->ptr->config.getUri();
         return call_nix_get_string_callback(res, callback, user_data);
     }
     NIXC_CATCH_ERRS

--- a/src/libstore-tests/legacy-ssh-store.cc
+++ b/src/libstore-tests/legacy-ssh-store.cc
@@ -27,6 +27,6 @@ TEST(LegacySSHStore, constructConfig)
         }));
 
     auto store = config->openStore();
-    EXPECT_EQ(store->getUri(), "ssh://me@localhost:2222?remote-program=foo%20bar");
+    EXPECT_EQ(store->config.getUri(), "ssh://me@localhost:2222?remote-program=foo%20bar");
 }
 } // namespace nix

--- a/src/libstore-tests/nix_api_store.cc
+++ b/src/libstore-tests/nix_api_store.cc
@@ -104,7 +104,7 @@ TEST_F(nix_api_util_context, nix_store_open_dummy)
     nix_libstore_init(ctx);
     Store * store = nix_store_open(ctx, "dummy://", nullptr);
     ASSERT_EQ(NIX_OK, ctx->last_err_code);
-    ASSERT_STREQ("dummy", store->ptr->getUri().c_str());
+    ASSERT_STREQ("dummy", store->ptr->config.getUri().c_str());
 
     std::string str;
     nix_store_get_version(ctx, store, OBSERVE_STRING(str));

--- a/src/libstore-tests/ssh-store.cc
+++ b/src/libstore-tests/ssh-store.cc
@@ -8,9 +8,7 @@ namespace nix {
 
 TEST(SSHStore, constructConfig)
 {
-    initLibStore(/*loadConfig=*/false);
-
-    auto config = make_ref<SSHStoreConfig>(
+    SSHStoreConfig config{
         "ssh-ng",
         "me@localhost:2222",
         StoreConfig::Params{
@@ -19,20 +17,19 @@ TEST(SSHStore, constructConfig)
                 // TODO #11106, no more split on space
                 "foo bar",
             },
-        });
+        },
+    };
 
     EXPECT_EQ(
-        config->remoteProgram.get(),
+        config.remoteProgram.get(),
         (Strings{
             "foo",
             "bar",
         }));
 
-    auto store = config->openStore();
-    EXPECT_EQ(store->getUri(), "ssh-ng://me@localhost:2222?remote-program=foo%20bar");
-    config->resetOverridden();
-    store = config->openStore();
-    EXPECT_EQ(store->getUri(), "ssh-ng://me@localhost:2222");
+    EXPECT_EQ(config.getUri(), "ssh-ng://me@localhost:2222?remote-program=foo%20bar");
+    config.resetOverridden();
+    EXPECT_EQ(config.getUri(), "ssh-ng://me@localhost:2222");
 }
 
 TEST(MountedSSHStore, constructConfig)

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -58,7 +58,10 @@ void BinaryCacheStore::init()
             if (name == "StoreDir") {
                 if (value != storeDir)
                     throw Error(
-                        "binary cache '%s' is for Nix stores with prefix '%s', not '%s'", getUri(), value, storeDir);
+                        "binary cache '%s' is for Nix stores with prefix '%s', not '%s'",
+                        config.getUri(),
+                        value,
+                        storeDir);
             } else if (name == "WantMassQuery") {
                 config.wantMassQuery.setDefault(value == "1");
             } else if (name == "Priority") {
@@ -129,7 +132,8 @@ void BinaryCacheStore::writeNarInfo(ref<NarInfo> narInfo)
     }
 
     if (diskCache)
-        diskCache->upsertNarInfo(getUri(), std::string(narInfo->path.hashPart()), std::shared_ptr<NarInfo>(narInfo));
+        diskCache->upsertNarInfo(
+            config.getUri(), std::string(narInfo->path.hashPart()), std::shared_ptr<NarInfo>(narInfo));
 }
 
 ref<const ValidPathInfo> BinaryCacheStore::addToStoreCommon(
@@ -427,7 +431,7 @@ void BinaryCacheStore::narFromPath(const StorePath & storePath, Sink & sink)
 void BinaryCacheStore::queryPathInfoUncached(
     const StorePath & storePath, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
 {
-    auto uri = getUri();
+    auto uri = config.getUri();
     auto storePathS = printStorePath(storePath);
     auto act = std::make_shared<Activity>(
         *logger,
@@ -527,7 +531,7 @@ void BinaryCacheStore::queryRealisationUncached(
 void BinaryCacheStore::registerDrvOutput(const Realisation & info)
 {
     if (diskCache)
-        diskCache->upsertRealisation(getUri(), info);
+        diskCache->upsertRealisation(config.getUri(), info);
     auto filePath = realisationsPrefix + "/" + info.id.to_string() + ".doi";
     upsertFile(filePath, info.toJSON().dump(), "application/json");
 }
@@ -555,7 +559,7 @@ std::optional<std::string> BinaryCacheStore::getBuildLogExact(const StorePath & 
 {
     auto logPath = "log/" + std::string(baseNameOf(printStorePath(path)));
 
-    debug("fetching build log from binary cache '%s/%s'", getUri(), logPath);
+    debug("fetching build log from binary cache '%s/%s'", config.getUri(), logPath);
 
     return getFile(logPath);
 }

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -98,7 +98,7 @@ Goal::Co DrvOutputSubstitutionGoal::init()
                         "substituter '%s' has an incompatible realisation for '%s', ignoring.\n"
                         "Local:  %s\n"
                         "Remote: %s",
-                        sub->getUri(),
+                        sub->config.getUri(),
                         depId.to_string(),
                         worker.store.printStorePath(localOutputInfo->outPath),
                         worker.store.printStorePath(depPath));

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -101,7 +101,7 @@ Goal::Co PathSubstitutionGoal::init()
             } else {
                 printError(
                     "asked '%s' for '%s' but got '%s'",
-                    sub->getUri(),
+                    sub->config.getUri(),
                     worker.store.printStorePath(storePath),
                     sub->printStorePath(info->path));
                 continue;
@@ -127,7 +127,7 @@ Goal::Co PathSubstitutionGoal::init()
             warn(
                 "ignoring substitute for '%s' from '%s', as it's not signed by any of the keys in 'trusted-public-keys'",
                 worker.store.printStorePath(storePath),
-                sub->getUri());
+                sub->config.getUri());
             continue;
         }
 
@@ -217,7 +217,8 @@ Goal::Co PathSubstitutionGoal::tryToRun(
             /* Wake up the worker loop when we're done. */
             Finally updateStats([this]() { outPipe.writeSide.close(); });
 
-            Activity act(*logger, actSubstitute, Logger::Fields{worker.store.printStorePath(storePath), sub->getUri()});
+            Activity act(
+                *logger, actSubstitute, Logger::Fields{worker.store.printStorePath(storePath), sub->config.getUri()});
             PushActivity pact(act.id);
 
             copyStorePath(*sub, worker.store, subPath, repair, sub->config.isTrusted ? NoCheckSigs : CheckSigs);

--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -32,6 +32,11 @@ struct DummyStoreConfig : public std::enable_shared_from_this<DummyStoreConfig>,
     }
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override
+    {
+        return *uriSchemes().begin();
+    }
 };
 
 struct DummyStore : virtual Store
@@ -44,11 +49,6 @@ struct DummyStore : virtual Store
         : Store{*config}
         , config(config)
     {
-    }
-
-    std::string getUri() override
-    {
-        return *Config::uriSchemes().begin();
     }
 
     void queryPathInfoUncached(

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -62,11 +62,6 @@ public:
         diskCache = getNarInfoDiskCache();
     }
 
-    std::string getUri() override
-    {
-        return config->cacheUri;
-    }
-
     void init() override
     {
         // FIXME: do this lazily?
@@ -90,7 +85,7 @@ protected:
         auto state(_state.lock());
         if (state->enabled && settings.tryFallback) {
             int t = 60;
-            printError("disabling binary cache '%s' for %s seconds", getUri(), t);
+            printError("disabling binary cache '%s' for %s seconds", config->getUri(), t);
             state->enabled = false;
             state->disabledUntil = std::chrono::steady_clock::now() + std::chrono::seconds(t);
         }
@@ -103,10 +98,10 @@ protected:
             return;
         if (std::chrono::steady_clock::now() > state->disabledUntil) {
             state->enabled = true;
-            debug("re-enabling binary cache '%s'", getUri());
+            debug("re-enabling binary cache '%s'", config->getUri());
             return;
         }
-        throw SubstituterDisabled("substituter '%s' is disabled", getUri());
+        throw SubstituterDisabled("substituter '%s' is disabled", config->getUri());
     }
 
     bool fileExists(const std::string & path) override
@@ -159,7 +154,7 @@ protected:
             getFileTransfer()->download(std::move(request), sink);
         } catch (FileTransferError & e) {
             if (e.error == FileTransfer::NotFound || e.error == FileTransfer::Forbidden)
-                throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache '%s'", path, getUri());
+                throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache '%s'", path, config->getUri());
             maybeDisable();
             throw;
         }

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -23,6 +23,11 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
     static std::string doc();
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override
+    {
+        return cacheUri;
+    }
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -53,6 +53,8 @@ struct LegacySSHStoreConfig : std::enable_shared_from_this<LegacySSHStoreConfig>
     static std::string doc();
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override;
 };
 
 struct LegacySSHStore : public virtual Store
@@ -70,8 +72,6 @@ struct LegacySSHStore : public virtual Store
     LegacySSHStore(ref<const Config>);
 
     ref<Connection> openConnection();
-
-    std::string getUri() override;
 
     void queryPathInfoUncached(
         const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;

--- a/src/libstore/include/nix/store/local-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/local-binary-cache-store.hh
@@ -26,6 +26,8 @@ struct LocalBinaryCacheStoreConfig : std::enable_shared_from_this<LocalBinaryCac
     static std::string doc();
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override;
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/local-overlay-store.hh
+++ b/src/libstore/include/nix/store/local-overlay-store.hh
@@ -88,6 +88,11 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
 
     ref<Store> openStore() const override;
 
+    std::string getUri() const override
+    {
+        return "local-overlay://";
+    }
+
 protected:
     /**
      * @return The host OS path corresponding to the store path for the
@@ -115,11 +120,6 @@ struct LocalOverlayStore : virtual LocalStore
     ref<const Config> config;
 
     LocalOverlayStore(ref<const Config>);
-
-    std::string getUri() override
-    {
-        return "local-overlay://";
-    }
 
 private:
     /**

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -111,6 +111,8 @@ struct LocalStoreConfig : std::enable_shared_from_this<LocalStoreConfig>,
     static std::string doc();
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override;
 };
 
 class LocalStore : public virtual IndirectRootStore, public virtual GcStore
@@ -195,8 +197,6 @@ public:
     /**
      * Implementations of abstract store API methods.
      */
-
-    std::string getUri() override;
 
     bool isValidPathUncached(const StorePath & path) override;
 

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -106,6 +106,8 @@ public:
     static std::string doc();
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override;
 };
 
 struct S3BinaryCacheStore : virtual BinaryCacheStore

--- a/src/libstore/include/nix/store/ssh-store.hh
+++ b/src/libstore/include/nix/store/ssh-store.hh
@@ -33,6 +33,8 @@ struct SSHStoreConfig : std::enable_shared_from_this<SSHStoreConfig>,
     static std::string doc();
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override;
 };
 
 struct MountedSSHStoreConfig : virtual SSHStoreConfig, virtual LocalFSStoreConfig

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -197,6 +197,13 @@ struct StoreConfig : public StoreDirConfig
      * type.
      */
     virtual ref<Store> openStore() const = 0;
+
+    /**
+     * Render the config back to a "store URL". It should round-trip
+     * with `resolveStoreConfig` (for stores configs that are
+     * registered).
+     */
+    virtual std::string getUri() const;
 };
 
 /**
@@ -276,12 +283,6 @@ public:
     virtual void init() {};
 
     virtual ~Store() {}
-
-    /**
-     * @todo move to `StoreConfig` one we store enough information in
-     * those to recover the scheme and authority in all cases.
-     */
-    virtual std::string getUri() = 0;
 
     /**
      * Follow symlinks until we end up with a path in the Nix store.
@@ -872,7 +873,7 @@ protected:
      */
     [[noreturn]] void unsupported(const std::string & op)
     {
-        throw Unsupported("operation '%s' is not supported by store '%s'", op, getUri());
+        throw Unsupported("operation '%s' is not supported by store '%s'", op, config.getUri());
     }
 };
 

--- a/src/libstore/include/nix/store/store-cast.hh
+++ b/src/libstore/include/nix/store/store-cast.hh
@@ -17,7 +17,7 @@ T & require(Store & store)
 {
     auto * castedStore = dynamic_cast<T *>(&store);
     if (!castedStore)
-        throw UsageError("%s not supported by store '%s'", T::operationName, store.getUri());
+        throw UsageError("%s not supported by store '%s'", T::operationName, store.config.getUri());
     return *castedStore;
 }
 

--- a/src/libstore/include/nix/store/uds-remote-store.hh
+++ b/src/libstore/include/nix/store/uds-remote-store.hh
@@ -44,6 +44,8 @@ struct UDSRemoteStoreConfig : std::enable_shared_from_this<UDSRemoteStoreConfig>
     }
 
     ref<Store> openStore() const override;
+
+    std::string getUri() const override;
 };
 
 struct UDSRemoteStore : virtual IndirectRootStore, virtual RemoteStore
@@ -53,8 +55,6 @@ struct UDSRemoteStore : virtual IndirectRootStore, virtual RemoteStore
     ref<const Config> config;
 
     UDSRemoteStore(ref<const Config>);
-
-    std::string getUri() override;
 
     ref<SourceAccessor> getFSAccessor(bool requireValidPath = true) override
     {

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -88,11 +88,9 @@ ref<LegacySSHStore::Connection> LegacySSHStore::openConnection()
     return conn;
 };
 
-std::string LegacySSHStore::getUri()
+std::string LegacySSHStoreConfig::getUri() const
 {
-    return ParsedURL{
-        .scheme = *Config::uriSchemes().begin(), .authority = config->authority, .query = config->getQueryParams()}
-        .to_string();
+    return ParsedURL{.scheme = *uriSchemes().begin(), .authority = authority, .query = getQueryParams()}.to_string();
 }
 
 std::map<StorePath, UnkeyedValidPathInfo> LegacySSHStore::queryPathInfosUncached(const StorePathSet & paths)

--- a/src/libstore/local-binary-cache-store.cc
+++ b/src/libstore/local-binary-cache-store.cc
@@ -23,6 +23,11 @@ std::string LocalBinaryCacheStoreConfig::doc()
         ;
 }
 
+std::string LocalBinaryCacheStoreConfig::getUri() const
+{
+    return "file://" + binaryCacheDir;
+}
+
 struct LocalBinaryCacheStore : virtual BinaryCacheStore
 {
     using Config = LocalBinaryCacheStoreConfig;
@@ -37,11 +42,6 @@ struct LocalBinaryCacheStore : virtual BinaryCacheStore
     }
 
     void init() override;
-
-    std::string getUri() override
-    {
-        return "file://" + config->binaryCacheDir;
-    }
 
 protected:
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -439,11 +439,11 @@ LocalStore::~LocalStore()
     }
 }
 
-std::string LocalStore::getUri()
+std::string LocalStoreConfig::getUri() const
 {
     std::ostringstream oss;
-    oss << *config->uriSchemes().begin();
-    auto queryParams = config->getQueryParams();
+    oss << *uriSchemes().begin();
+    auto queryParams = getQueryParams();
     if (!queryParams.empty())
         oss << "?";
     oss << encodeQuery(queryParams);

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -53,7 +53,7 @@ RemoteStore::RemoteStore(const Config & config)
 ref<RemoteStore::Connection> RemoteStore::openConnectionWrapper()
 {
     if (failed)
-        throw Error("opening a connection to remote store '%s' previously failed", getUri());
+        throw Error("opening a connection to remote store '%s' previously failed", config.getUri());
     try {
         return openConnection();
     } catch (...) {
@@ -95,7 +95,7 @@ void RemoteStore::initConnection(Connection & conn)
         if (ex)
             std::rethrow_exception(ex);
     } catch (Error & e) {
-        throw Error("cannot open connection to remote store '%s': %s", getUri(), e.what());
+        throw Error("cannot open connection to remote store '%s': %s", config.getUri(), e.what());
     }
 
     setOptions(conn);

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -57,11 +57,6 @@ struct RestrictedStore : public virtual IndirectRootStore, public virtual GcStor
         return next->config->realStoreDir;
     }
 
-    std::string getUri() override
-    {
-        return next->getUri();
-    }
-
     StorePathSet queryAllValidPaths() override;
 
     void queryPathInfoUncached(

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -254,6 +254,11 @@ std::string S3BinaryCacheStoreConfig::doc()
         ;
 }
 
+std::string S3BinaryCacheStoreConfig::getUri() const
+{
+    return "s3://" + bucketName;
+}
+
 struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStore
 {
     Stats stats;
@@ -269,19 +274,14 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStore
         diskCache = getNarInfoDiskCache();
     }
 
-    std::string getUri() override
-    {
-        return "s3://" + config->bucketName;
-    }
-
     void init() override
     {
-        if (auto cacheInfo = diskCache->upToDateCacheExists(getUri())) {
+        if (auto cacheInfo = diskCache->upToDateCacheExists(config->getUri())) {
             config->wantMassQuery.setDefault(cacheInfo->wantMassQuery);
             config->priority.setDefault(cacheInfo->priority);
         } else {
             BinaryCacheStore::init();
-            diskCache->createCache(getUri(), config->storeDir, config->wantMassQuery, config->priority);
+            diskCache->createCache(config->getUri(), config->storeDir, config->wantMassQuery, config->priority);
         }
     }
 
@@ -519,7 +519,7 @@ struct S3BinaryCacheStoreImpl : virtual S3BinaryCacheStore
 
             sink(*res.data);
         } else
-            throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache '%s'", path, getUri());
+            throw NoSuchBinaryCacheFile("file '%s' does not exist in binary cache '%s'", path, config->getUri());
     }
 
     StorePathSet queryAllValidPaths() override

--- a/src/libstore/ssh-store.cc
+++ b/src/libstore/ssh-store.cc
@@ -25,6 +25,11 @@ std::string SSHStoreConfig::doc()
         ;
 }
 
+std::string SSHStoreConfig::getUri() const
+{
+    return ParsedURL{.scheme = *uriSchemes().begin(), .authority = authority, .query = getQueryParams()}.to_string();
+}
+
 struct SSHStore : virtual RemoteStore
 {
     using Config = SSHStoreConfig;
@@ -39,13 +44,6 @@ struct SSHStore : virtual RemoteStore
               // Use SSH master only if using more than 1 connection.
               connections->capacity() > 1))
     {
-    }
-
-    std::string getUri() override
-    {
-        return ParsedURL{
-            .scheme = *Config::uriSchemes().begin(), .authority = config->authority, .query = config->getQueryParams()}
-            .to_string();
     }
 
     // FIXME extend daemon protocol, move implementation to RemoteStore

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -54,15 +54,14 @@ UDSRemoteStore::UDSRemoteStore(ref<const Config> config)
 {
 }
 
-std::string UDSRemoteStore::getUri()
+std::string UDSRemoteStoreConfig::getUri() const
 {
-    return config->path == settings.nixDaemonSocketFile
-               ? // FIXME: Not clear why we return daemon here and not default
-                 // to settings.nixDaemonSocketFile
-                 //
-                 // unix:// with no path also works. Change what we return?
+    return path == settings.nixDaemonSocketFile ? // FIXME: Not clear why we return daemon here and not default
+                                                  // to settings.nixDaemonSocketFile
+                                                  //
+                                                  // unix:// with no path also works. Change what we return?
                "daemon"
-               : std::string(*Config::uriSchemes().begin()) + "://" + config->path;
+                                                : std::string(*uriSchemes().begin()) + "://" + path;
 }
 
 void UDSRemoteStore::Connection::closeWrite()

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -71,7 +71,7 @@ struct CmdConfigCheck : StoreCommand
 
     void run(ref<Store> store) override
     {
-        logger->log("Running checks against store uri: " + store->getUri());
+        logger->log("Running checks against store uri: " + store->config.getUri());
 
         if (store.dynamic_pointer_cast<LocalFSStore>()) {
             success &= checkNixInPath();
@@ -171,9 +171,9 @@ struct CmdConfigCheck : StoreCommand
     {
         if (auto trustedMay = store->isTrustedClient()) {
             std::string_view trusted = trustedMay.value() ? "trusted" : "not trusted";
-            checkInfo(fmt("You are %s by store uri: %s", trusted, store->getUri()));
+            checkInfo(fmt("You are %s by store uri: %s", trusted, store->config.getUri()));
         } else {
-            checkInfo(fmt("Store uri: %s doesn't have a notion of trusted user", store->getUri()));
+            checkInfo(fmt("Store uri: %s doesn't have a notion of trusted user", store->config.getUri()));
         }
     }
 };

--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -48,7 +48,7 @@ struct CmdLog : InstallableCommand
         for (auto & sub : subs) {
             auto * logSubP = dynamic_cast<LogStore *>(&*sub);
             if (!logSubP) {
-                printInfo("Skipped '%s' which does not support retrieving build logs", sub->getUri());
+                printInfo("Skipped '%s' which does not support retrieving build logs", sub->config.getUri());
                 continue;
             }
             auto & logSub = *logSubP;
@@ -57,7 +57,7 @@ struct CmdLog : InstallableCommand
             if (!log)
                 continue;
             logger->stop();
-            printInfo("got build log for '%s' from '%s'", installable->what(), logSub.getUri());
+            printInfo("got build log for '%s' from '%s'", installable->what(), logSub.config.getUri());
             writeFull(getStandardOutput(), *log);
             return;
         }

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -77,7 +77,7 @@ void execProgramInStore(
     auto store2 = store.dynamic_pointer_cast<LocalFSStore>();
 
     if (!store2)
-        throw Error("store '%s' is not a local store so it does not support command execution", store->getUri());
+        throw Error("store '%s' is not a local store so it does not support command execution", store->config.getUri());
 
     if (store->storeDir != store2->getRealStoreDir()) {
         Strings helperArgs = {

--- a/src/nix/store-info.cc
+++ b/src/nix/store-info.cc
@@ -24,7 +24,7 @@ struct CmdInfoStore : StoreCommand, MixJSON
     void run(ref<Store> store) override
     {
         if (!json) {
-            notice("Store URL: %s", store->getUri());
+            notice("Store URL: %s", store->config.getUri());
             store->connect();
             if (auto version = store->getVersion())
                 notice("Version: %s", *version);
@@ -34,7 +34,7 @@ struct CmdInfoStore : StoreCommand, MixJSON
             nlohmann::json res;
             Finally printRes([&]() { printJSON(res); });
 
-            res["url"] = store->getUri();
+            res["url"] = store->config.getUri();
             store->connect();
             if (auto version = store->getVersion())
                 res["version"] = *version;


### PR DESCRIPTION
## Motivation

It is a side-effect property of the configuration alone, not the rest of the store.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
