### PR TITLE
Fix Git LFS SSH issues

### DIFF
--- a/doc/manual/rl-next/git-lfs-ssh.md
+++ b/doc/manual/rl-next/git-lfs-ssh.md
@@ -1,0 +1,11 @@
+---
+synopsis: "Fix Git LFS SSH issues"
+prs: [13743]
+issues: [13337]
+---
+
+Fixed some outstanding issues with Git LFS and SSH.
+
+* Added support for `NIX_SSHOPTS`.
+* Properly use the parsed port from URL.
+* Better use of the response of `git-lfs-authenticate` to determine API endpoint when the API is not exposed on port 443.

--- a/src/libstore/include/nix/store/ssh.hh
+++ b/src/libstore/include/nix/store/ssh.hh
@@ -8,6 +8,8 @@
 
 namespace nix {
 
+Strings getNixSshOpts();
+
 class SSHMaster
 {
 private:

--- a/tests/nixos/fetch-git/testsupport/gitea-repo.nix
+++ b/tests/nixos/fetch-git/testsupport/gitea-repo.nix
@@ -49,19 +49,15 @@ in
           self.name = name
           self.path = "/tmp/repos/" + name
           self.remote = "http://gitea:3000/test/" + name
-          self.remote_ssh = "ssh://gitea/root/" + name
+          self.remote_ssh = "ssh://gitea:3001/test/" + name
           self.git = f"git -C {self.path}"
           self.private = private
           self.create()
 
         def create(self):
-          # create ssh remote repo
+          # create remote repo
           gitea.succeed(f"""
-            git init --bare -b main /root/{self.name}
-          """)
-          # create http remote repo
-          gitea.succeed(f"""
-            curl --fail -X POST http://{gitea_admin}:{gitea_admin_password}@gitea:3000/api/v1/user/repos \
+            curl --fail -X POST http://{gitea_user}:{gitea_password}@gitea:3000/api/v1/user/repos \
               -H 'Accept: application/json' -H 'Content-Type: application/json' \
               -d {shlex.quote( f'{{"name":"{self.name}", "default_branch": "main", "private": {boolToJSON(self.private)}}}' )}
           """)
@@ -70,7 +66,7 @@ in
             mkdir -p {self.path} \
             && git init -b main {self.path} \
             && {self.git} remote add origin {self.remote} \
-            && {self.git} remote add origin-ssh root@gitea:{self.name}
+            && {self.git} remote add origin-ssh {self.remote_ssh}
           """)
     '';
   };


### PR DESCRIPTION
## Motivation

* Adds support for `NIX_SSHOPTS`
* Properly uses the parsed port from URL (fixes #13337)
* Don't guess the HTTP endpoint, use the response of `git-lfs-authenticate`
* Add an SSH Git LFS test
* Removed some unused test code

## Context

Fixes some outstanding issues with Git LFS and SSH. (See #13337 and the `FIXME` in the old code)

For the tests, I had to change to clone from Gitea rather than pure SSH so that we can test fetching LFS files from an SSH server.

Also, renamed the `gitea_admin` to `gitea_user` in the tests since that user is not really an admin and it threw me for a loop until I realized why I was having issues with some of the Gitea API endpoints.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
