### PR TITLE
ci: Cleanup docker check secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,17 +146,17 @@ jobs:
   check_secrets:
     permissions:
       contents: none
-    name: Check Docker secrets present for installer tests
+    name: Check presence of secrets
     runs-on: ubuntu-24.04
     outputs:
       docker: ${{ steps.secret.outputs.docker }}
     steps:
-      - name: Check for secrets
+      - name: Check for DockerHub secrets
         id: secret
         env:
           _DOCKER_SECRETS: ${{ secrets.DOCKERHUB_USERNAME }}${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          echo "::set-output name=docker::${{ env._DOCKER_SECRETS != '' }}"
+          echo "docker=${{ env._DOCKER_SECRETS != '' }}" >> $GITHUB_OUTPUT
 
   docker_push_image:
     needs: [tests, vm_tests, check_secrets]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,12 +169,6 @@ jobs:
       github.ref_name == 'master'
     runs-on: ubuntu-24.04
     steps:
-    - name: Check for secrets
-      id: secret
-      env:
-        _DOCKER_SECRETS: ${{ secrets.DOCKERHUB_USERNAME }}${{ secrets.DOCKERHUB_TOKEN }}
-      run: |
-        echo "::set-output name=docker::${{ env._DOCKER_SECRETS != '' }}"
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

- Remove dead step in `docker_push_image` job
- Remove deprecated set-output if favor of GITHUB_OUTPUT.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
