### PR TITLE
libstore: Fix makeCopyPathMessage

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -803,7 +803,7 @@ makeCopyPathMessage(const StoreConfig & srcCfg, const StoreConfig & dstCfg, std:
         /* At this point StoreReference **must** be resolved. */
         const auto & specified = std::get<StoreReference::Specified>(ref.variant);
         const auto & scheme = specified.scheme;
-        return (scheme == "local" || scheme == "unix") && specified.authority.empty() && ref.params.empty();
+        return (scheme == "local" || scheme == "unix") && specified.authority.empty();
     };
 
     if (isShorthand(src))


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Old code completely ignored query parameters and it seems ok to keep that behavior. There's a lot of code out there that parses nix code like nix-output-monitor and it can't parse messages like:

> copying path '/nix/store/wha2hi4yhkjmccqhivxavbfspsg1wrsj-source' from 'https://cache.nixos.org' to 'local://'...

Let's not break these tools without a good reason. This goes in line with what other code does by ignoring parameters in logs.

The issue is just in detecting the shorthand notations for the store reference - not in printing the url in logs.

By default the daemon opens a local store with ?path-info-cache-size=0, so that leads to the erronenous 'local://'.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Broken in https://github.com/NixOS/nix/pull/13739 and not completely fixed in https://github.com/NixOS/nix/pull/13755

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
