### PR TITLE
libstore: Fix dangling pointers in DerivationGoal constructors

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -34,11 +34,10 @@ DerivationGoal::DerivationGoal(
     , drvPath(drvPath)
     , wantedOutput(wantedOutput)
     , outputHash{[&] {
-        if (auto * mOutputHash = get(staticOutputHashes(worker.evalStore, drv), wantedOutput))
+        auto outputHashes = staticOutputHashes(worker.evalStore, drv);
+        if (auto * mOutputHash = get(outputHashes, wantedOutput))
             return *mOutputHash;
-        else
-            throw Error(
-                "derivation '%s' does not have output '%s'", worker.store.printStorePath(drvPath), wantedOutput);
+        throw Error("derivation '%s' does not have output '%s'", worker.store.printStorePath(drvPath), wantedOutput);
     }()}
     , buildMode(buildMode)
 {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This leads to a use-after free, because staticOutputHashes returns a temporary object that dies before we can do a `return *mOutputHash`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

This is most likely the cause for random failures in Hydra [1].

[1]: https://hydra.nixos.org/build/305091330/nixlog/2

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
