### PR TITLE
libutil: Delete footgun overloads of get and getOr

### DIFF
--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -214,6 +214,10 @@ typename T::mapped_type * get(T & map, const typename T::key_type & key)
     return &i->second;
 }
 
+/** Deleted because this is use-after-free liability. Just don't pass temporaries to this overload set. */
+template<class T>
+typename T::mapped_type * get(T && map, const typename T::key_type & key) = delete;
+
 /**
  * Get a value for the specified key from an associate container, or a default value if the key isn't present.
  */
@@ -226,6 +230,11 @@ getOr(T & map, const typename T::key_type & key, const typename T::mapped_type &
         return defaultValue;
     return i->second;
 }
+
+/** Deleted because this is use-after-free liability. Just don't pass temporaries to this overload set. */
+template<class T>
+const typename T::mapped_type &
+getOr(T && map, const typename T::key_type & key, const typename T::mapped_type & defaultValue) = delete;
 
 /**
  * Remove and return the first item from a container.


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

To avoid mistakes like the one in cea85e79ee04d428717d76d9f2cab3d5372fa718. These overloads are just asking for trouble.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
