### PR TITLE
More flexible typing for `get` in `util.hh`

### DIFF
--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -196,8 +196,8 @@ std::pair<std::string_view, std::string_view> getLine(std::string_view s);
 /**
  * Get a value for the specified key from an associate container.
  */
-template<class T>
-const typename T::mapped_type * get(const T & map, const typename T::key_type & key)
+template<class T, typename K>
+const typename T::mapped_type * get(const T & map, K & key)
 {
     auto i = map.find(key);
     if (i == map.end())
@@ -205,8 +205,8 @@ const typename T::mapped_type * get(const T & map, const typename T::key_type & 
     return &i->second;
 }
 
-template<class T>
-typename T::mapped_type * get(T & map, const typename T::key_type & key)
+template<class T, typename K>
+typename T::mapped_type * get(T & map, K & key)
 {
     auto i = map.find(key);
     if (i == map.end())
@@ -221,9 +221,8 @@ typename T::mapped_type * get(T && map, const typename T::key_type & key) = dele
 /**
  * Get a value for the specified key from an associate container, or a default value if the key isn't present.
  */
-template<class T>
-const typename T::mapped_type &
-getOr(T & map, const typename T::key_type & key, const typename T::mapped_type & defaultValue)
+template<class T, typename K>
+const typename T::mapped_type & getOr(T & map, K & key, const typename T::mapped_type & defaultValue)
 {
     auto i = map.find(key);
     if (i == map.end())


### PR DESCRIPTION
## Motivation

This is good for e.g. `std::string_view` and `StringMap`.

## Context

Needed by #11139 

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
