### PR TITLE
Simplify "Store dir" superclass

### DIFF
--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -18,15 +18,17 @@ MakeError(BadStorePath, Error);
 MakeError(BadStorePathName, BadStorePath);
 
 /**
- * @todo This should just be part of `StoreDirConfig`. However, it would
- * be a huge amount of churn if `Store` didn't have these methods
+ * @todo This should just be inherited by `StoreConfig`. However, it
+ * would be a huge amount of churn if `Store` didn't have these methods
  * anymore, forcing a bunch of code to go from `store.method(...)` to
  * `store.config.method(...)`.
  *
- * So we instead pull out the methods into their own mix-in, so can put
- * them directly on the Store too.
+ * @todo this should not have "config" in its name, because it no longer
+ * uses the configuration system for `storeDir` --- in fact, `storeDir`
+ * isn't even owned, but a mere reference. But doing that rename would
+ * cause a bunch of churn.
  */
-struct MixStoreDirMethods
+struct StoreDirConfig
 {
     const Path & storeDir;
 
@@ -94,42 +96,6 @@ struct MixStoreDirMethods
         HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
         const StorePathSet & references = {},
         PathFilter & filter = defaultPathFilter) const;
-};
-
-/**
- * Need to make this a separate class so I can get the right
- * initialization order in the constructor for `StoreDirConfig`.
- */
-struct StoreDirConfigBase : Config
-{
-    using Config::Config;
-
-    const PathSetting storeDir_{
-        this,
-        settings.nixStore,
-        "store",
-        R"(
-          Logical location of the Nix store, usually
-          `/nix/store`. Note that you can only copy store paths
-          between stores if they have the same `store` setting.
-        )"};
-};
-
-/**
- * The order of `StoreDirConfigBase` and then `MixStoreDirMethods` is
- * very important. This ensures that `StoreDirConfigBase::storeDir_`
- * is initialized before we have our one chance (because references are
- * immutable) to initialize `MixStoreDirMethods::storeDir`.
- */
-struct StoreDirConfig : StoreDirConfigBase, MixStoreDirMethods
-{
-    using Params = StringMap;
-
-    StoreDirConfig(const Params & params);
-
-    StoreDirConfig() = delete;
-
-    virtual ~StoreDirConfig() = default;
 };
 
 } // namespace nix

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -27,12 +27,18 @@ using json = nlohmann::json;
 
 namespace nix {
 
-bool MixStoreDirMethods::isInStore(PathView path) const
+StoreConfig::StoreConfig(const Params & params)
+    : StoreConfigBase(params)
+    , StoreDirConfig{storeDir_}
+{
+}
+
+bool StoreDirConfig::isInStore(PathView path) const
 {
     return isInDir(path, storeDir);
 }
 
-std::pair<StorePath, Path> MixStoreDirMethods::toStorePath(PathView path) const
+std::pair<StorePath, Path> StoreDirConfig::toStorePath(PathView path) const
 {
     if (!isInStore(path))
         throw Error("path '%1%' is not in the Nix store", path);
@@ -293,7 +299,7 @@ StringSet Store::Config::getDefaultSystemFeatures()
 }
 
 Store::Store(const Store::Config & config)
-    : MixStoreDirMethods{config}
+    : StoreDirConfig{config}
     , config{config}
     , state({(size_t) config.pathInfoCacheSize})
 {
@@ -1082,7 +1088,7 @@ decodeValidPathInfo(const Store & store, std::istream & str, std::optional<HashR
     return std::optional<ValidPathInfo>(std::move(info));
 }
 
-std::string MixStoreDirMethods::showPaths(const StorePathSet & paths) const
+std::string StoreDirConfig::showPaths(const StorePathSet & paths) const
 {
     std::string s;
     for (auto & i : paths) {


### PR DESCRIPTION
## Motivation

We can cut out some gratuitous inhertence as follows:

- `MixStoreDirMethods` -> `StoreDir`

- `StoreDirConfig` deleted because no longer needed. It is just folded into `StoreConfig`.

- `StoreDirConfigBase` -> `StoreConfigBase` same trick still needed, but now is for `StoreConfig` not `StoreDirConfig`

## Context

Here's how we got here:

1. I once factored out `StoreDirConfig` in #6236.

2. I factored out `MixStoreDirMethods` in #13154.

But, I didn't realize at point (2) that we didn't need `StoreDirConfig` anymore, all uses of `StoreDirConfig` could instead be uses of `MixStoreDirMethods`. Now I am doing that, and renaming `MixStoreDirMethods` to just `StoreDirConfig` to reduce churn.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
