### PR TITLE
Make a few more things use `StoreDirConfig` instead of `Store`

### DIFF
--- a/src/libstore-test-support/include/nix/store/tests/protocol.hh
+++ b/src/libstore-test-support/include/nix/store/tests/protocol.hh
@@ -10,7 +10,7 @@
 namespace nix {
 
 template<class Proto, const char * protocolDir>
-class ProtoTest : public CharacterizationTest, public LibStoreTest
+class ProtoTest : public CharacterizationTest
 {
     std::filesystem::path unitTestData = getUnitTestData() / protocolDir;
 
@@ -18,6 +18,10 @@ class ProtoTest : public CharacterizationTest, public LibStoreTest
     {
         return unitTestData / (std::string{testStem + ".bin"});
     }
+
+public:
+    Path storeDir = "/nix/store";
+    StoreDirConfig store{storeDir};
 };
 
 template<class Proto, const char * protocolDir>
@@ -34,7 +38,7 @@ public:
             T got = ({
                 StringSource from{encoded};
                 Proto::template Serialise<T>::read(
-                    *LibStoreTest::store,
+                    this->store,
                     typename Proto::ReadConn{
                         .from = from,
                         .version = version,
@@ -54,7 +58,7 @@ public:
         CharacterizationTest::writeTest(testStem, [&]() {
             StringSink to;
             Proto::template Serialise<T>::write(
-                *LibStoreTest::store,
+                this->store,
                 typename Proto::WriteConn{
                     .to = to,
                     .version = version,

--- a/src/libstore-tests/common-protocol.cc
+++ b/src/libstore-tests/common-protocol.cc
@@ -25,7 +25,7 @@ public:
         CharacterizationTest::readTest(testStem, [&](const auto & encoded) {
             T got = ({
                 StringSource from{encoded};
-                CommonProto::Serialise<T>::read(*store, CommonProto::ReadConn{.from = from});
+                CommonProto::Serialise<T>::read(store, CommonProto::ReadConn{.from = from});
             });
 
             ASSERT_EQ(got, expected);
@@ -40,7 +40,7 @@ public:
     {
         CharacterizationTest::writeTest(testStem, [&]() -> std::string {
             StringSink to;
-            CommonProto::Serialise<T>::write(*store, CommonProto::WriteConn{.to = to}, decoded);
+            CommonProto::Serialise<T>::write(store, CommonProto::WriteConn{.to = to}, decoded);
             return to.s;
         });
     }

--- a/src/libstore-tests/serve-protocol.cc
+++ b/src/libstore-tests/serve-protocol.cc
@@ -275,7 +275,7 @@ VERSIONED_CHARACTERIZATION_TEST(
         }),
         ({
             ValidPathInfo info{
-                *LibStoreTest::store,
+                store,
                 "foo",
                 FixedOutputInfo{
                     .method = FileIngestionMethod::NixArchive,

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -516,7 +516,7 @@ VERSIONED_CHARACTERIZATION_TEST(
         }),
         ({
             ValidPathInfo info{
-                *LibStoreTest::store,
+                store,
                 "foo",
                 FixedOutputInfo{
                     .method = FileIngestionMethod::NixArchive,

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -132,7 +132,7 @@ struct value_comparison
     }
 };
 
-std::string showKnownOutputs(Store & store, const Derivation & drv)
+std::string showKnownOutputs(const StoreDirConfig & store, const Derivation & drv)
 {
     std::string msg;
     StorePathSet expectedOutputPaths;
@@ -743,7 +743,8 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
 #endif
 }
 
-void runPostBuildHook(Store & store, Logger & logger, const StorePath & drvPath, const StorePathSet & outputPaths)
+void runPostBuildHook(
+    const StoreDirConfig & store, Logger & logger, const StorePath & drvPath, const StorePathSet & outputPaths)
 {
     auto hook = settings.postBuildHook;
     if (hook == "")

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -21,9 +21,6 @@ struct DerivationBuilder;
 
 typedef enum { rpAccept, rpDecline, rpPostpone } HookReply;
 
-/** Used internally */
-void runPostBuildHook(Store & store, Logger & logger, const StorePath & drvPath, const StorePathSet & outputPaths);
-
 /**
  * A goal for building a derivation. Substitution, (or any other method of
  * obtaining the outputs) will not be attempted, so it is the calling goal's

--- a/src/libstore/include/nix/store/build/derivation-building-misc.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-misc.hh
@@ -50,11 +50,12 @@ struct InitialOutput
     std::optional<InitialOutputStatus> known;
 };
 
-void runPostBuildHook(Store & store, Logger & logger, const StorePath & drvPath, const StorePathSet & outputPaths);
+void runPostBuildHook(
+    const StoreDirConfig & store, Logger & logger, const StorePath & drvPath, const StorePathSet & outputPaths);
 
 /**
  * Format the known outputs of a derivation for use in error messages.
  */
-std::string showKnownOutputs(Store & store, const Derivation & drv);
+std::string showKnownOutputs(const StoreDirConfig & store, const Derivation & drv);
 
 } // namespace nix

--- a/src/libstore/include/nix/store/nar-info.hh
+++ b/src/libstore/include/nix/store/nar-info.hh
@@ -7,7 +7,7 @@
 
 namespace nix {
 
-class Store;
+struct StoreDirConfig;
 
 struct NarInfo : ValidPathInfo
 {
@@ -18,7 +18,7 @@ struct NarInfo : ValidPathInfo
 
     NarInfo() = delete;
 
-    NarInfo(const Store & store, std::string name, ContentAddressWithReferences ca, Hash narHash)
+    NarInfo(const StoreDirConfig & store, std::string name, ContentAddressWithReferences ca, Hash narHash)
         : ValidPathInfo(store, std::move(name), std::move(ca), narHash)
     {
     }
@@ -33,16 +33,16 @@ struct NarInfo : ValidPathInfo
     {
     }
 
-    NarInfo(const Store & store, const std::string & s, const std::string & whence);
+    NarInfo(const StoreDirConfig & store, const std::string & s, const std::string & whence);
 
     bool operator==(const NarInfo &) const = default;
     // TODO libc++ 16 (used by darwin) missing `std::optional::operator <=>`, can't do yet
     // auto operator <=>(const NarInfo &) const = default;
 
-    std::string to_string(const Store & store) const;
+    std::string to_string(const StoreDirConfig & store) const;
 
-    nlohmann::json toJSON(const Store & store, bool includeImpureInfo, HashFormat hashFormat) const override;
-    static NarInfo fromJSON(const Store & store, const StorePath & path, const nlohmann::json & json);
+    nlohmann::json toJSON(const StoreDirConfig & store, bool includeImpureInfo, HashFormat hashFormat) const override;
+    static NarInfo fromJSON(const StoreDirConfig & store, const StorePath & path, const nlohmann::json & json);
 };
 
 } // namespace nix

--- a/src/libstore/include/nix/store/path-info.hh
+++ b/src/libstore/include/nix/store/path-info.hh
@@ -12,6 +12,7 @@
 namespace nix {
 
 class Store;
+struct StoreDirConfig;
 
 struct SubstitutablePathInfo
 {
@@ -116,8 +117,8 @@ struct UnkeyedValidPathInfo
      * @param includeImpureInfo If true, variable elements such as the
      * registration time are included.
      */
-    virtual nlohmann::json toJSON(const Store & store, bool includeImpureInfo, HashFormat hashFormat) const;
-    static UnkeyedValidPathInfo fromJSON(const Store & store, const nlohmann::json & json);
+    virtual nlohmann::json toJSON(const StoreDirConfig & store, bool includeImpureInfo, HashFormat hashFormat) const;
+    static UnkeyedValidPathInfo fromJSON(const StoreDirConfig & store, const nlohmann::json & json);
 };
 
 struct ValidPathInfo : UnkeyedValidPathInfo
@@ -135,7 +136,7 @@ struct ValidPathInfo : UnkeyedValidPathInfo
      * speaking superfluous, but might prevent endless/excessive data
      * attacks.
      */
-    std::string fingerprint(const Store & store) const;
+    std::string fingerprint(const StoreDirConfig & store) const;
 
     void sign(const Store & store, const Signer & signer);
     void sign(const Store & store, const std::vector<std::unique_ptr<Signer>> & signers);
@@ -150,7 +151,7 @@ struct ValidPathInfo : UnkeyedValidPathInfo
     /**
      * @return true iff the path is verifiably content-addressed.
      */
-    bool isContentAddressed(const Store & store) const;
+    bool isContentAddressed(const StoreDirConfig & store) const;
 
     static const size_t maxSigs = std::numeric_limits<size_t>::max();
 
@@ -159,12 +160,12 @@ struct ValidPathInfo : UnkeyedValidPathInfo
      * produced by one of the specified keys, or maxSigs if the path
      * is content-addressed.
      */
-    size_t checkSignatures(const Store & store, const PublicKeys & publicKeys) const;
+    size_t checkSignatures(const StoreDirConfig & store, const PublicKeys & publicKeys) const;
 
     /**
      * Verify a single signature.
      */
-    bool checkSignature(const Store & store, const PublicKeys & publicKeys, const std::string & sig) const;
+    bool checkSignature(const StoreDirConfig & store, const PublicKeys & publicKeys, const std::string & sig) const;
 
     /**
      * References as store path basenames, including a self reference if it has one.
@@ -178,7 +179,8 @@ struct ValidPathInfo : UnkeyedValidPathInfo
         : UnkeyedValidPathInfo(info)
         , path(path) {};
 
-    ValidPathInfo(const Store & store, std::string_view name, ContentAddressWithReferences && ca, Hash narHash);
+    ValidPathInfo(
+        const StoreDirConfig & store, std::string_view name, ContentAddressWithReferences && ca, Hash narHash);
 };
 
 static_assert(std::is_move_assignable_v<ValidPathInfo>);

--- a/src/libstore/nar-info.cc
+++ b/src/libstore/nar-info.cc
@@ -6,7 +6,7 @@
 
 namespace nix {
 
-NarInfo::NarInfo(const Store & store, const std::string & s, const std::string & whence)
+NarInfo::NarInfo(const StoreDirConfig & store, const std::string & s, const std::string & whence)
     : ValidPathInfo(StorePath(StorePath::dummy), Hash(Hash::dummy)) // FIXME: hack
 {
     unsigned line = 1;
@@ -102,7 +102,7 @@ NarInfo::NarInfo(const Store & store, const std::string & s, const std::string &
     }
 }
 
-std::string NarInfo::to_string(const Store & store) const
+std::string NarInfo::to_string(const StoreDirConfig & store) const
 {
     std::string res;
     res += "StorePath: " + store.printStorePath(path) + "\n";
@@ -130,7 +130,7 @@ std::string NarInfo::to_string(const Store & store) const
     return res;
 }
 
-nlohmann::json NarInfo::toJSON(const Store & store, bool includeImpureInfo, HashFormat hashFormat) const
+nlohmann::json NarInfo::toJSON(const StoreDirConfig & store, bool includeImpureInfo, HashFormat hashFormat) const
 {
     using nlohmann::json;
 
@@ -150,7 +150,7 @@ nlohmann::json NarInfo::toJSON(const Store & store, bool includeImpureInfo, Hash
     return jsonObject;
 }
 
-NarInfo NarInfo::fromJSON(const Store & store, const StorePath & path, const nlohmann::json & json)
+NarInfo NarInfo::fromJSON(const StoreDirConfig & store, const StorePath & path, const nlohmann::json & json)
 {
     using nlohmann::detail::value_t;
 

--- a/src/libstore/path-info.cc
+++ b/src/libstore/path-info.cc
@@ -22,7 +22,7 @@ GENERATE_CMP_EXT(
     me->sigs,
     me->ca);
 
-std::string ValidPathInfo::fingerprint(const Store & store) const
+std::string ValidPathInfo::fingerprint(const StoreDirConfig & store) const
 {
     if (narSize == 0)
         throw Error(
@@ -81,7 +81,7 @@ std::optional<ContentAddressWithReferences> ValidPathInfo::contentAddressWithRef
     }
 }
 
-bool ValidPathInfo::isContentAddressed(const Store & store) const
+bool ValidPathInfo::isContentAddressed(const StoreDirConfig & store) const
 {
     auto fullCaOpt = contentAddressWithReferences();
 
@@ -98,7 +98,7 @@ bool ValidPathInfo::isContentAddressed(const Store & store) const
     return res;
 }
 
-size_t ValidPathInfo::checkSignatures(const Store & store, const PublicKeys & publicKeys) const
+size_t ValidPathInfo::checkSignatures(const StoreDirConfig & store, const PublicKeys & publicKeys) const
 {
     if (isContentAddressed(store))
         return maxSigs;
@@ -110,7 +110,8 @@ size_t ValidPathInfo::checkSignatures(const Store & store, const PublicKeys & pu
     return good;
 }
 
-bool ValidPathInfo::checkSignature(const Store & store, const PublicKeys & publicKeys, const std::string & sig) const
+bool ValidPathInfo::checkSignature(
+    const StoreDirConfig & store, const PublicKeys & publicKeys, const std::string & sig) const
 {
     return verifyDetached(fingerprint(store), sig, publicKeys);
 }
@@ -124,7 +125,7 @@ Strings ValidPathInfo::shortRefs() const
 }
 
 ValidPathInfo::ValidPathInfo(
-    const Store & store, std::string_view name, ContentAddressWithReferences && ca, Hash narHash)
+    const StoreDirConfig & store, std::string_view name, ContentAddressWithReferences && ca, Hash narHash)
     : UnkeyedValidPathInfo(narHash)
     , path(store.makeFixedOutputPathFromCA(name, ca))
 {
@@ -144,7 +145,8 @@ ValidPathInfo::ValidPathInfo(
         std::move(ca).raw);
 }
 
-nlohmann::json UnkeyedValidPathInfo::toJSON(const Store & store, bool includeImpureInfo, HashFormat hashFormat) const
+nlohmann::json
+UnkeyedValidPathInfo::toJSON(const StoreDirConfig & store, bool includeImpureInfo, HashFormat hashFormat) const
 {
     using nlohmann::json;
 
@@ -176,7 +178,7 @@ nlohmann::json UnkeyedValidPathInfo::toJSON(const Store & store, bool includeImp
     return jsonObject;
 }
 
-UnkeyedValidPathInfo UnkeyedValidPathInfo::fromJSON(const Store & store, const nlohmann::json & _json)
+UnkeyedValidPathInfo UnkeyedValidPathInfo::fromJSON(const StoreDirConfig & store, const nlohmann::json & _json)
 {
     UnkeyedValidPathInfo res{
         Hash(Hash::dummy),


### PR DESCRIPTION
## Motivation

It is good to take the lighter-weight argument where possible.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
