### PR TITLE
libutil, libexpr: #10542 abstract over getrusage for getting cpuTime stat and implement windows version

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -3,21 +3,23 @@
 #include "nix/expr/primops.hh"
 #include "nix/expr/print-options.hh"
 #include "nix/expr/symbol-table.hh"
+#include "nix/expr/eval-inline.hh"
+#include "nix/expr/function-trace.hh"
+#include "nix/expr/print.hh"
+#include "nix/expr/gc-small-vector.hh"
+#include "nix/util/util.hh"
+#include "nix/util/current-process.hh"
 #include "nix/util/exit.hh"
 #include "nix/util/types.hh"
-#include "nix/util/util.hh"
+#include "nix/util/url.hh"
+#include "nix/util/memory-source-accessor.hh"
+#include "nix/util/strings-inline.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/downstream-placeholder.hh"
-#include "nix/expr/eval-inline.hh"
 #include "nix/store/filetransfer.hh"
-#include "nix/expr/function-trace.hh"
 #include "nix/store/profiles.hh"
-#include "nix/expr/print.hh"
 #include "nix/fetchers/filtering-source-accessor.hh"
-#include "nix/util/memory-source-accessor.hh"
-#include "nix/expr/gc-small-vector.hh"
-#include "nix/util/url.hh"
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/fetchers/tarball.hh"
 #include "nix/fetchers/input-cache.hh"
@@ -36,12 +38,6 @@
 
 #include <nlohmann/json.hpp>
 #include <boost/container/small_vector.hpp>
-
-#ifndef _WIN32 // TODO use portable implementation
-#  include <sys/resource.h>
-#endif
-
-#include "nix/util/strings-inline.hh"
 
 using json = nlohmann::json;
 
@@ -2888,12 +2884,7 @@ void EvalState::maybePrintStats()
 
 void EvalState::printStatistics()
 {
-#ifndef _WIN32 // TODO use portable implementation
-    struct rusage buf;
-    getrusage(RUSAGE_SELF, &buf);
-    float cpuTime = buf.ru_utime.tv_sec + ((float) buf.ru_utime.tv_usec / 1000000);
-#endif
-
+    float cpuTime = getCpuUserTime();
     uint64_t bEnvs = nrEnvs * sizeof(Env) + nrValuesInEnvs * sizeof(Value *);
     uint64_t bLists = nrListElems * sizeof(Value *);
     uint64_t bValues = nrValues * sizeof(Value);
@@ -2914,18 +2905,12 @@ void EvalState::printStatistics()
     if (outPath != "-")
         fs.open(outPath, std::fstream::out);
     json topObj = json::object();
-#ifndef _WIN32 // TODO implement
     topObj["cpuTime"] = cpuTime;
-#endif
     topObj["time"] = {
-#ifndef _WIN32 // TODO implement
         {"cpu", cpuTime},
-#endif
 #if NIX_USE_BOEHMGC
         {GC_is_incremental_mode() ? "gcNonIncremental" : "gc", gcFullOnlyTime},
-#  ifndef _WIN32 // TODO implement
         {GC_is_incremental_mode() ? "gcNonIncrementalFraction" : "gcFraction", gcFullOnlyTime / cpuTime},
-#  endif
 #endif
     };
     topObj["envs"] = {

--- a/src/libutil/include/nix/util/current-process.hh
+++ b/src/libutil/include/nix/util/current-process.hh
@@ -12,6 +12,12 @@
 namespace nix {
 
 /**
+ * Get the current process's user time in seconds.
+ * If an error occurrs, the result will be `nan`
+ */
+float getCpuUserTime();
+
+/**
  * If cgroups are active, attempt to calculate the number of CPUs available.
  * If cgroups are unavailable or if cpu.max is set to "max", return 0.
  */

--- a/src/libutil/unix/current-process.cc
+++ b/src/libutil/unix/current-process.cc
@@ -1,0 +1,19 @@
+#include "nix/util/current-process.hh"
+#include <cmath>
+
+#include <sys/resource.h>
+
+namespace nix {
+
+float getCpuUserTime()
+{
+    struct rusage buf;
+
+    if (getrusage(RUSAGE_SELF, &buf) != 0) {
+        return std::nan("cpuUserTime");
+    }
+
+    return buf.ru_utime.tv_sec + ((float) buf.ru_utime.tv_usec / 1e6);
+}
+
+} // namespace nix

--- a/src/libutil/unix/meson.build
+++ b/src/libutil/unix/meson.build
@@ -49,6 +49,7 @@ config_unix_priv_h = configure_file(
 sources += config_unix_priv_h
 
 sources += files(
+  'current-process.cc',
   'environment-variables.cc',
   'file-descriptor.cc',
   'file-path.cc',

--- a/src/libutil/windows/current-process.cc
+++ b/src/libutil/windows/current-process.cc
@@ -1,0 +1,25 @@
+#include "nix/util/current-process.hh"
+#include <cmath>
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+
+namespace nix {
+
+float getCpuUserTime()
+{
+	FILETIME usertime;
+
+    if (!GetProcessTimes(GetCurrentProcess(), NULL, NULL, NULL, &usertime)) {
+        return std::nan("cpuUserTime");
+    }
+
+    // FILETIME stores units of 100 nanoseconds.
+    // Dividing by 10 gives microseconds, then by 1,000,000 gives seconds.
+    // So getting from 100 nanoseconds to seconds is dividing by 10,000,000.
+    return (float)li.QuadPart / 1e7;
+}
+
+} // namespace nix
+#endif // ifdef _WIN32

--- a/src/libutil/windows/meson.build
+++ b/src/libutil/windows/meson.build
@@ -1,4 +1,5 @@
 sources += files(
+  'current-process.cc',
   'environment-variables.cc',
   'file-descriptor.cc',
   'file-path.cc',


### PR DESCRIPTION
Motivation is to move towards Nix on Windows.

`libexpr` uses `getrusage` from the `sys/resource.h` Unix header to get the current process's running duration. This PR creates a new function in `libutil` which has both a Unix implementation and a new Windows implementation, and removes several conditional compile guards related to getting the cpu-time on Windows.

The expected behavior is entirely unchanged because Nix doesn't target Windows yet.

The test suite is passing on my machine, but I did not do anything to test the change itself.

