### PR TITLE
libutil: Fix handling of unescaped spaces, quotes and shevrons in queries and fragments

### DIFF
--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -74,6 +74,20 @@ TEST(parseFlakeRef, GitArchiveInput)
         auto flakeref = parseFlakeRef(fetchSettings, s);
         ASSERT_EQ(flakeref.to_string(), "github:foo/bar/branch%23");
     }
+
+    {
+        auto s = "github:foo/bar?ref=branch#\"name.with.dot\""; // unescaped quotes `"`
+        auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
+        ASSERT_EQ(fragment, "\"name.with.dot\"");
+        ASSERT_EQ(flakeref.to_string(), "github:foo/bar/branch");
+    }
+
+    {
+        auto s = "github:foo/bar#\"name.with.dot\""; // unescaped quotes `"`
+        auto [flakeref, fragment] = parseFlakeRefWithFragment(fetchSettings, s);
+        ASSERT_EQ(fragment, "\"name.with.dot\"");
+        ASSERT_EQ(flakeref.to_string(), "github:foo/bar");
+    }
 }
 
 TEST(to_string, doesntReencodeUrl)

--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -212,6 +212,26 @@ TEST(parseURL, parsedUrlsIsEqualToItself)
     ASSERT_TRUE(url == url);
 }
 
+TEST(parseURL, parsedUrlsWithUnescapedChars)
+{
+    /* Test for back-compat. Behavior is rather questionable, but
+     * is ingrained pretty deep into how URL parsing is shared between
+     * flakes and libstore.
+     * 1. Unescaped spaces, quotes and shevron (^) in fragment.
+     * 2. Unescaped spaces and quotes in query.
+     */
+    auto s = "http://www.example.org/file.tar.gz?query \"= 123\"#shevron^quote\"space ";
+    auto url = parseURL(s);
+
+    ASSERT_EQ(url.fragment, "shevron^quote\"space ");
+
+    auto query = StringMap{
+        {"query \"", " 123\""},
+    };
+
+    ASSERT_EQ(url.query, query);
+}
+
 TEST(parseURL, parseFTPUrl)
 {
     auto s = "ftp://ftp.nixos.org/downloads/nixos.iso";

--- a/src/libutil/include/nix/util/url.hh
+++ b/src/libutil/include/nix/util/url.hh
@@ -104,8 +104,8 @@ std::string encodeQuery(const StringMap & query);
  * Parse a Nix URL into a ParsedURL.
  *
  * Nix URI is mostly compliant with RFC3986, but with some deviations:
- * - Literal spaces are allowed and don't have to be percent encoded.
- *   This is mostly done for backward compatibility.
+ * - Fragments can contain unescaped (not URL encoded) '^', '"' or space literals.
+ * - Queries may contain unescaped '"' or spaces.
  *
  * @note IPv6 ZoneId literals (RFC4007) are represented in URIs according to RFC6874.
  *


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Turns out we didn't have tests for some of the important behavior introduced for flake reference fragments and url queries [1]. This is rather important and is relied upon by existing tooling. This fixes up these exact cases before handing off the URL to the Boost.URL parser.

To the best of my knowledge this implements the same behavior as prior regex-based parser did [2]:

> `fragmentRegex = "(?:" + pcharRegex + "|[/? \"^])*";`
> `queryRegex = "(?:" + pcharRegex + "|[/? \"])*";`

[1]: 9c0a09f09fbb930483b26f60f8552fbe5236b777
[2]: https://github.com/NixOS/nix/blob/2.30.2/src/libutil/include/nix/util/url-parts.hh

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes #13772. Thankfully we didn't have a release with this refactoring yet.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
