### PR TITLE
tests/nixos: Fix daemon store reference in authorization test

### DIFF
--- a/tests/nixos/authorization.nix
+++ b/tests/nixos/authorization.nix
@@ -84,7 +84,7 @@
           su --login mallory -c '
             nix-store --generate-binary-cache-key cache1.example.org sk1 pk1
             (! nix store sign --key-file sk1 ${pathFour} 2>&1)' | tee diag 1>&2
-          grep -F "cannot open connection to remote store 'daemon'" diag
+          grep -F "cannot open connection to remote store 'unix://'" diag
       """)
 
       machine.succeed("""


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Recent store reference cleanups have started canonicalizing daemon -> unix://.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
