### PR TITLE
treewide: Futher improve compile times for clangStdenv builds

### DIFF
--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -75,6 +75,7 @@ this_exe = executable(
   # TODO: -lrapidcheck, see ../libutil-support/build.meson
   link_args : linker_export_flags + [ '-lrapidcheck' ],
   install : true,
+  cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )
 
 test(

--- a/src/libexpr-tests/pch/precompiled-headers.hh
+++ b/src/libexpr-tests/pch/precompiled-headers.hh
@@ -1,0 +1,4 @@
+#include "nix/expr/tests/libexpr.hh"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>

--- a/src/libfetchers/git-lfs-fetch.cc
+++ b/src/libfetchers/git-lfs-fetch.cc
@@ -292,7 +292,7 @@ void Fetch::fetch(
             auto authIt = headerIt->find("Authorization");
             if (authIt == headerIt->end())
                 return std::nullopt;
-            return *authIt;
+            return std::string(*authIt);
         }();
         const uint64_t size = obj.at("size");
         sizeCallback(size);

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -66,6 +66,7 @@ this_library = library(
   link_args : linker_export_flags,
   prelink : true, # For C++ static initializers
   install : true,
+  cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )
 
 install_headers(headers, subdir : 'nix/fetchers', preserve_path : true)

--- a/src/libfetchers/pch/precompiled-headers.hh
+++ b/src/libfetchers/pch/precompiled-headers.hh
@@ -1,0 +1,3 @@
+#include "nix/fetchers/fetchers.hh"
+#include "nix/store/store-api.hh"
+#include "nix/util/json-utils.hh"

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -94,6 +94,7 @@ this_exe = executable(
   link_args : linker_export_flags + [ '-lrapidcheck' ],
   # get main from gtest
   install : true,
+  cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )
 
 test(
@@ -127,6 +128,7 @@ if get_option('benchmarks')
     include_directories : include_dirs,
     link_args : linker_export_flags,
     install : true,
+    cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
     cpp_args : [
       '-DNIX_UNIT_TEST_DATA="' + meson.current_source_dir() + '/data"',
     ],

--- a/src/libstore-tests/pch/precompiled-headers.hh
+++ b/src/libstore-tests/pch/precompiled-headers.hh
@@ -1,0 +1,9 @@
+#include "nix/store/store-api.hh"
+#include "nix/store/tests/libstore.hh"
+#include "nix/util/util.hh"
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+#include <rapidcheck/gtest.h>
+
+#include <regex>

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -89,6 +89,7 @@ this_exe = executable(
   link_args : linker_export_flags + [ '-lrapidcheck' ],
   # get main from gtest
   install : true,
+  cpp_pch : do_pch ? [ 'pch/precompiled-headers.hh' ] : [],
 )
 
 test(

--- a/src/libutil-tests/pch/precompiled-headers.hh
+++ b/src/libutil-tests/pch/precompiled-headers.hh
@@ -1,0 +1,5 @@
+#include "nix/util/util.hh"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <rapidcheck/gtest.h>

--- a/src/nix/pch/precompiled-headers.hh
+++ b/src/nix/pch/precompiled-headers.hh
@@ -1,3 +1,6 @@
 #include "nix/cmd/command.hh"
 #include "nix/expr/eval.hh"
 #include "nix/main/shared.hh"
+#include "nix/store/derivations.hh"
+
+#include <nlohmann/json.hpp>


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Follow-ups to https://github.com/NixOS/nix/pull/13519 and 6ec50ba73664838993d645dc78c936542eb2012c.

Local builds are significantly faster. For individual components see individual commit messages.

(Before locally)

```
Command being timed: "ninja"
User time (seconds): 1927.20
System time (seconds): 87.50
Percent of CPU this job got: 2017%
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:39.87
```

(After locally)

```
Command being timed: "ninja"
User time (seconds): 1642.38
System time (seconds): 72.15
Percent of CPU this job got: 2109%
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:21.27
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
