### PR TITLE
Fix doc code example

### DIFF
--- a/src/nix/shell.md
+++ b/src/nix/shell.md
@@ -83,7 +83,7 @@ import prettytable
 # Print a simple table.
 t = prettytable.PrettyTable(["N", "N^2"])
 for n in range(1, 10): t.add_row([n, n * n])
-print t
+print(t)
 ```
 
 Similarly, the following is a Perl script that specifies that it


### PR DESCRIPTION
Fixed nix shell's doc's shebang python example

## Motivation

The python code example for [nix shell](https://nix.dev/manual/nix/2.30/command-ref/new-cli/nix3-env-shell.html) usage as a script interpreter doesn't work.

## Context

Python's `print` builtin started needing parentheses on version 3.

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
