### PR TITLE
packaging: Fix lowdown cross

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -70,7 +70,7 @@ scope: {
       url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
       hash = "sha512-cfzhuF4EnGmLJf5EGSIbWqJItY3npbRSALm+GarZ7SMU7Hr1xw0gtBFMpOdi5PBar4TgtvbnG4oRPh+COINGlA==";
     };
-    nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ pkgs.bmake ];
+    nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ pkgs.buildPackages.bmake ];
     postInstall =
       lib.replaceStrings [ "lowdown.so.1" "lowdown.1.dylib" ] [ "lowdown.so.2" "lowdown.2.dylib" ]
         prevAttrs.postInstall;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Stupid mistake on my part. `binaryTarballCross.x86_64-linux.x86_64-unknown-freebsd` now builds as expected.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://github.com/NixOS/nix/pull/13780#issuecomment-3195839626

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
