### PR TITLE
Fix client disconnect when queryPathInfo() returns a negative result

### DIFF
--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -311,6 +311,8 @@ protected:
         LRUCache<std::string, PathInfoCacheValue> pathInfoCache;
     };
 
+    void invalidatePathInfoCacheFor(const StorePath & path);
+
     SharedSync<State> state;
 
     std::shared_ptr<NarInfoDiskCache> diskCache;

--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -109,7 +109,8 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
         const StorePathSet & paths,
         SubstituteFlag maybeSubstitute);
 
-    UnkeyedValidPathInfo queryPathInfo(const StoreDirConfig & store, bool * daemonException, const StorePath & path);
+    std::optional<UnkeyedValidPathInfo>
+    queryPathInfo(const StoreDirConfig & store, bool * daemonException, const StorePath & path);
 
     void putBuildDerivationRequest(
         const StoreDirConfig & store,

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -457,7 +457,9 @@ StorePath RemoteStore::addToStoreFromDump(
     }
     if (fsm != dumpMethod)
         unsupported("RemoteStore::addToStoreFromDump doesn't support this `dumpMethod` `hashMethod` combination");
-    return addCAToStore(dump, name, hashMethod, hashAlgo, references, repair)->path;
+    auto storePath = addCAToStore(dump, name, hashMethod, hashAlgo, references, repair)->path;
+    invalidatePathInfoCacheFor(storePath);
+    return storePath;
 }
 
 void RemoteStore::addToStore(const ValidPathInfo & info, Source & source, RepairFlag repair, CheckSigsFlag checkSigs)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -259,13 +259,14 @@ void RemoteStore::queryPathInfoUncached(
     const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept
 {
     try {
-        std::shared_ptr<const ValidPathInfo> info;
-        {
+        auto info = ({
             auto conn(getConnection());
-            info = std::make_shared<ValidPathInfo>(
-                StorePath{path}, conn->queryPathInfo(*this, &conn.daemonException, path));
-        }
-        callback(std::move(info));
+            conn->queryPathInfo(*this, &conn.daemonException, path);
+        });
+        if (!info)
+            callback(nullptr);
+        else
+            callback(std::make_shared<ValidPathInfo>(StorePath{path}, *info));
     } catch (...) {
         callback.rethrow();
     }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -319,6 +319,11 @@ bool Store::PathInfoCacheValue::isKnownNow()
     return std::chrono::steady_clock::now() < time_point + ttl;
 }
 
+void Store::invalidatePathInfoCacheFor(const StorePath & path)
+{
+    state.lock()->pathInfoCache.erase(path.to_string());
+}
+
 std::map<std::string, std::optional<StorePath>> Store::queryStaticPartialDerivationOutputMap(const StorePath & path)
 {
     std::map<std::string, std::optional<StorePath>> outputs;

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -244,7 +244,7 @@ void WorkerProto::BasicServerConnection::postHandshake(const StoreDirConfig & st
     WorkerProto::write(store, *this, info);
 }
 
-UnkeyedValidPathInfo WorkerProto::BasicClientConnection::queryPathInfo(
+std::optional<UnkeyedValidPathInfo> WorkerProto::BasicClientConnection::queryPathInfo(
     const StoreDirConfig & store, bool * daemonException, const StorePath & path)
 {
     to << WorkerProto::Op::QueryPathInfo << store.printStorePath(path);
@@ -253,14 +253,14 @@ UnkeyedValidPathInfo WorkerProto::BasicClientConnection::queryPathInfo(
     } catch (Error & e) {
         // Ugly backwards compatibility hack.
         if (e.msg().find("is not valid") != std::string::npos)
-            throw InvalidPath(std::move(e.info()));
+            return std::nullopt;
         throw;
     }
     if (GET_PROTOCOL_MINOR(protoVersion) >= 17) {
         bool valid;
         from >> valid;
         if (!valid)
-            throw InvalidPath("path '%s' is not valid", store.printStorePath(path));
+            return std::nullopt;
     }
     return WorkerProto::Serialise<UnkeyedValidPathInfo>::read(store, *this);
 }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This fixes a bug in `RemoteStore::queryPathInfoUncached()` where the client disconnects from the daemon if the path is invalid. This is because `WorkerProto::BasicClientConnection::queryPathInfo()` throws an exception, which causes `RemoteStore::ConnectionHandle::~ConnectionHandle()` to unnecessarily drop the connection. These disconnects/reconnects can cause big slowdowns for the client.

Since this has the side-effect of fixing negative path info lookup caching for remote stores, we now need to make sure to invalidate path info cache entries in `RemoteStore::addToStoreFromDump()`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
