### PR TITLE
hydra: Fix otherNixes.nix_2_3

### DIFF
--- a/tests/nixos/default.nix
+++ b/tests/nixos/default.nix
@@ -79,7 +79,15 @@ let
     { lib, pkgs, ... }:
     {
       imports = [ checkOverrideNixVersion ];
-      nix.package = lib.mkForce pkgs.nixVersions.nix_2_3;
+      nix.package = lib.mkForce (
+        pkgs.nixVersions.nix_2_3.overrideAttrs (o: {
+          meta = o.meta // {
+            # This version shouldn't be used by end-users, but we run tests against
+            # it to ensure we don't break protocol compatibility.
+            knownVulnerabilities = [ ];
+          };
+        })
+      );
     };
 
   otherNixes.nix_2_13.setNixPackage =
@@ -90,6 +98,8 @@ let
         nixpkgs-23-11.legacyPackages.${pkgs.stdenv.hostPlatform.system}.nixVersions.nix_2_13.overrideAttrs
           (o: {
             meta = o.meta // {
+              # This version shouldn't be used by end-users, but we run tests against
+              # it to ensure we don't break protocol compatibility.
               knownVulnerabilities = [ ];
             };
           })


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

25.05 has it marked as insecure, but we don't care about it for testing purposes.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

https://hydra.nixos.org/eval/1817769#tabs-removed

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
