### PR TITLE
treewide: Bump C++ standard version to C++23

### DIFF
--- a/doc/manual/source/installation/prerequisites-source.md
+++ b/doc/manual/source/installation/prerequisites-source.md
@@ -10,7 +10,7 @@
   - Bash Shell. The `./configure` script relies on bashisms, so Bash is
     required.
 
-  - A version of GCC or Clang that supports C++20.
+  - A version of GCC or Clang that supports C++23.
 
   - `pkg-config` to locate dependencies. If your distribution does not
     provide it, you can get it from

--- a/nix-meson-build-support/export/meson.build
+++ b/nix-meson-build-support/export/meson.build
@@ -14,7 +14,7 @@ extra_pkg_config_variables = get_variable('extra_pkg_config_variables', {})
 
 extra_cflags = []
 if not meson.project_name().endswith('-c')
-  extra_cflags += [ '-std=c++2a' ]
+  extra_cflags += [ '-std=c++23' ]
 endif
 
 import('pkgconfig').generate(
@@ -34,7 +34,7 @@ meson.override_dependency(
   declare_dependency(
     include_directories : include_dirs,
     link_with : this_library,
-    compile_args : [ '-std=c++2a' ],
+    compile_args : [ '-std=c++23' ],
     dependencies : deps_public_subproject + deps_public,
     variables : extra_pkg_config_variables,
   ),

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libexpr-test-support/tests/value/context.cc
+++ b/src/libexpr-test-support/tests/value/context.cc
@@ -1,3 +1,4 @@
+#include <exception> // Needed by rapidcheck on Darwin
 #include <rapidcheck.h>
 
 #include "nix/store/tests/path.hh"

--- a/src/libexpr-tests/derived-path.cc
+++ b/src/libexpr-tests/derived-path.cc
@@ -1,5 +1,6 @@
 #include <nlohmann/json.hpp>
 #include <gtest/gtest.h>
+#include <exception> // Needed by rapidcheck on Darwin
 #include <rapidcheck/gtest.h>
 
 #include "nix/store/tests/derived-path.hh"

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libflake-tests/meson.build
+++ b/src/libflake-tests/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libstore-test-support/derived-path.cc
+++ b/src/libstore-test-support/derived-path.cc
@@ -1,5 +1,6 @@
 #include <regex>
 
+#include <exception> // Needed by rapidcheck on Darwin
 #include <rapidcheck.h>
 
 #include "nix/store/tests/derived-path.hh"

--- a/src/libstore-test-support/include/nix/store/tests/outputs-spec.hh
+++ b/src/libstore-test-support/include/nix/store/tests/outputs-spec.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <exception> // Needed by rapidcheck on Darwin
 #include <rapidcheck/gen/Arbitrary.h>
 
 #include "nix/store/outputs-spec.hh"

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libstore-test-support/path.cc
+++ b/src/libstore-test-support/path.cc
@@ -1,6 +1,7 @@
-#include <rapidcheck/gen/Arbitrary.h>
+#include <exception> // Needed by rapidcheck on Darwin
 #include <regex>
 
+#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck.h>
 
 #include "nix/store/path-regex.hh"

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libutil-test-support/hash.cc
+++ b/src/libutil-test-support/hash.cc
@@ -1,5 +1,6 @@
 #include <regex>
 
+#include <exception> // Needed by rapidcheck on Darwin
 #include <rapidcheck.h>
 
 #include "nix/util/hash.hh"

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -2,7 +2,7 @@ project(
   'nix-functional-tests',
   version : files('.version'),
   default_options : [
-    'cpp_std=c++2a',
+    'cpp_std=c++23',
     # TODO(Qyriad): increase the warning level
     'warning_level=1',
     'errorlogs=true', # Please print logs for tests that fail


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Compilers in nixpkgs have caught up and major distros should also have recent enough compilers. It would be nice to have newer features like more full featured ranges and deducing this.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
