### PR TITLE
Make `sandbox-settings` better typed, get `globals.hh` out of other headers

### DIFF
--- a/src/libcmd/common-eval-args.cc
+++ b/src/libcmd/common-eval-args.cc
@@ -15,6 +15,7 @@
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/cmd/compatibility-settings.hh"
 #include "nix/expr/eval-settings.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 

--- a/src/libexpr/eval-cache.cc
+++ b/src/libexpr/eval-cache.cc
@@ -4,6 +4,7 @@
 #include "nix/expr/eval.hh"
 #include "nix/expr/eval-inline.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/globals.hh"
 // Need specialization involving `SymbolStr` just in this one module.
 #include "nix/util/strings-inline.hh"
 

--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -6,6 +6,7 @@
 #include "nix/util/exit.hh"
 #include "nix/util/types.hh"
 #include "nix/util/util.hh"
+#include "nix/util/environment-variables.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/downstream-placeholder.hh"

--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -5,6 +5,7 @@
 #include "nix/expr/eval-settings.hh"
 #include "nix/expr/gc-small-vector.hh"
 #include "nix/expr/json-to-value.hh"
+#include "nix/store/globals.hh"
 #include "nix/store/names.hh"
 #include "nix/store/path-references.hh"
 #include "nix/store/store-api.hh"

--- a/src/libexpr/primops/context.cc
+++ b/src/libexpr/primops/context.cc
@@ -2,6 +2,7 @@
 #include "nix/expr/eval-inline.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 

--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -3,6 +3,7 @@
 #include "nix/store/realisation.hh"
 #include "nix/store/make-content-addressed.hh"
 #include "nix/util/url.hh"
+#include "nix/util/environment-variables.hh"
 
 namespace nix {
 

--- a/src/libfetchers-tests/git.cc
+++ b/src/libfetchers-tests/git.cc
@@ -1,4 +1,5 @@
 #include "nix/store/store-open.hh"
+#include "nix/store/globals.hh"
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/fetchers/fetchers.hh"
 #include "nix/fetchers/git-utils.hh"

--- a/src/libfetchers/cache.cc
+++ b/src/libfetchers/cache.cc
@@ -4,6 +4,7 @@
 #include "nix/store/sqlite.hh"
 #include "nix/util/sync.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/globals.hh"
 
 #include <nlohmann/json.hpp>
 

--- a/src/libstore-test-support/include/nix/store/tests/libstore.hh
+++ b/src/libstore-test-support/include/nix/store/tests/libstore.hh
@@ -6,6 +6,7 @@
 
 #include "nix/store/store-api.hh"
 #include "nix/store/store-open.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -12,6 +12,7 @@
 #include "nix/store/common-protocol.hh"
 #include "nix/store/common-protocol-impl.hh"
 #include "nix/store/local-store.hh" // TODO remove, along with remaining downcasts
+#include "nix/store/globals.hh"
 
 #include <fstream>
 #include <sys/types.h>

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -11,7 +11,7 @@
 #include "nix/util/compression.hh"
 #include "nix/store/common-protocol.hh"
 #include "nix/store/common-protocol-impl.hh" // Don't remove is actually needed
-#include "nix/store/local-store.hh"          // TODO remove, along with remaining downcasts
+#include "nix/store/globals.hh"
 
 #include <fstream>
 #include <sys/types.h>

--- a/src/libstore/build/drv-output-substitution-goal.cc
+++ b/src/libstore/build/drv-output-substitution-goal.cc
@@ -4,6 +4,7 @@
 #include "nix/store/build/substitution-goal.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/store-open.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 

--- a/src/libstore/build/goal.cc
+++ b/src/libstore/build/goal.cc
@@ -1,5 +1,6 @@
 #include "nix/store/build/goal.hh"
 #include "nix/store/build/worker.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 

--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -4,6 +4,8 @@
 #include "nix/store/nar-info.hh"
 #include "nix/util/finally.hh"
 #include "nix/util/signals.hh"
+#include "nix/store/globals.hh"
+
 #include <coroutine>
 
 namespace nix {

--- a/src/libstore/build/worker.cc
+++ b/src/libstore/build/worker.cc
@@ -10,6 +10,7 @@
 #  include "nix/store/build/hook-instance.hh"
 #endif
 #include "nix/util/signals.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 

--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -1,6 +1,7 @@
 #include "nix/store/builtins.hh"
 #include "nix/store/filetransfer.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/globals.hh"
 #include "nix/util/archive.hh"
 #include "nix/util/compression.hh"
 

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -16,6 +16,7 @@
 #include "nix/util/args.hh"
 #include "nix/util/git.hh"
 #include "nix/util/logging.hh"
+#include "nix/store/globals.hh"
 
 #ifndef _WIN32 // TODO need graceful async exit support on Windows?
 #  include "nix/util/monitor-fd.hh"

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -5,6 +5,7 @@
 #include "nix/store/store-api.hh"
 #include "nix/util/types.hh"
 #include "nix/util/util.hh"
+#include "nix/store/globals.hh"
 
 #include <optional>
 #include <string>

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -86,13 +86,22 @@ Settings::Settings()
     }
 
 #if (defined(__linux__) || defined(__FreeBSD__)) && defined(SANDBOX_SHELL)
-    sandboxPaths = tokenizeString<StringSet>("/bin/sh=" SANDBOX_SHELL);
+    sandboxPaths = {{"/bin/sh", {.source = SANDBOX_SHELL}}};
 #endif
 
     /* chroot-like behavior from Apple's sandbox */
 #ifdef __APPLE__
-    sandboxPaths = tokenizeString<StringSet>(
-        "/System/Library/Frameworks /System/Library/PrivateFrameworks /bin/sh /bin/bash /private/tmp /private/var/tmp /usr/lib");
+    for (PathView p : {
+             "/System/Library/Frameworks",
+             "/System/Library/PrivateFrameworks",
+             "/bin/sh",
+             "/bin/bash",
+             "/private/tmp",
+             "/private/var/tmp",
+             "/usr/lib",
+         }) {
+        sandboxPaths.get().insert_or_assign(std::string{p}, ChrootPath{.source = std::string{p}});
+    }
     allowedImpureHostPrefixes = tokenizeString<StringSet>("/System/Library /usr/lib /dev /bin/sh");
 #endif
 }
@@ -317,6 +326,42 @@ void BaseSetting<SandboxMode>::convertToArg(Args & args, const std::string & cat
     });
 }
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ChrootPath, source, optional)
+
+template<>
+PathsInChroot BaseSetting<PathsInChroot>::parse(const std::string & str) const
+{
+    PathsInChroot pathsInChroot;
+    for (auto i : tokenizeString<StringSet>(str)) {
+        if (i.empty())
+            continue;
+        bool optional = false;
+        if (i[i.size() - 1] == '?') {
+            optional = true;
+            i.pop_back();
+        }
+        size_t p = i.find('=');
+        if (p == std::string::npos)
+            pathsInChroot[i] = {.source = i, .optional = optional};
+        else
+            pathsInChroot[i.substr(0, p)] = {.source = i.substr(p + 1), .optional = optional};
+    }
+    return pathsInChroot;
+}
+
+template<>
+std::string BaseSetting<PathsInChroot>::to_string() const
+{
+    std::vector<std::string> accum;
+    for (auto & [name, cp] : value) {
+        std::string s = name == cp.source ? name : name + "=" + cp.source;
+        if (cp.optional)
+            s += "?";
+        accum.push_back(std::move(s));
+    }
+    return concatStringsSep(" ", accum);
+}
+
 unsigned int MaxBuildJobsSetting::parse(const std::string & str) const
 {
     if (str == "auto")
@@ -327,6 +372,14 @@ unsigned int MaxBuildJobsSetting::parse(const std::string & str) const
         else
             throw UsageError("configuration setting '%s' should be 'auto' or an integer", name);
     }
+}
+
+template<>
+void BaseSetting<PathsInChroot>::appendOrSet(PathsInChroot newValue, bool append)
+{
+    if (!append)
+        value.clear();
+    value.insert(std::make_move_iterator(newValue.begin()), std::make_move_iterator(newValue.end()));
 }
 
 static void preloadNSS()

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -188,7 +188,9 @@ struct DerivationBuilder : RestrictionContext
     virtual void killSandbox(bool getStats) = 0;
 };
 
+#ifndef _WIN32 // TODO enable `DerivationBuilder` on Windows
 std::unique_ptr<DerivationBuilder> makeDerivationBuilder(
     LocalStore & store, std::unique_ptr<DerivationBuilderCallbacks> miscMethods, DerivationBuilderParams params);
+#endif
 
 } // namespace nix

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -11,6 +11,7 @@
 #include "nix/util/environment-variables.hh"
 #include "nix/util/experimental-features.hh"
 #include "nix/util/users.hh"
+#include "nix/store/build/derivation-builder.hh"
 
 #include "nix/store/config.hh"
 

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -24,6 +24,20 @@ SandboxMode BaseSetting<SandboxMode>::parse(const std::string & str) const;
 template<>
 std::string BaseSetting<SandboxMode>::to_string() const;
 
+template<>
+PathsInChroot BaseSetting<PathsInChroot>::parse(const std::string & str) const;
+template<>
+std::string BaseSetting<PathsInChroot>::to_string() const;
+
+template<>
+struct BaseSetting<PathsInChroot>::trait
+{
+    static constexpr bool appendable = true;
+};
+
+template<>
+void BaseSetting<PathsInChroot>::appendOrSet(PathsInChroot newValue, bool append);
+
 struct MaxBuildJobsSetting : public BaseSetting<unsigned int>
 {
     MaxBuildJobsSetting(
@@ -698,7 +712,7 @@ public:
         )",
         {"build-use-chroot", "build-use-sandbox"}};
 
-    Setting<PathSet> sandboxPaths{
+    Setting<PathsInChroot> sandboxPaths{
         this,
         {},
         "sandbox-paths",

--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -22,15 +22,31 @@ struct LocalFSStoreConfig : virtual StoreConfig
 
     OptionalPathSetting rootDir{this, std::nullopt, "root", "Directory prefixed to all other paths."};
 
+private:
+
+    /**
+     * An indirection so that we don't need to refer to global settings
+     * in headers.
+     */
+    static Path getDefaultStateDir();
+
+    /**
+     * An indirection so that we don't need to refer to global settings
+     * in headers.
+     */
+    static Path getDefaultLogDir();
+
+public:
+
     PathSetting stateDir{
         this,
-        rootDir.get() ? *rootDir.get() + "/nix/var/nix" : settings.nixStateDir,
+        rootDir.get() ? *rootDir.get() + "/nix/var/nix" : getDefaultStateDir(),
         "state",
         "Directory where Nix stores state."};
 
     PathSetting logDir{
         this,
-        rootDir.get() ? *rootDir.get() + "/nix/var/log/nix" : settings.nixLogDir,
+        rootDir.get() ? *rootDir.get() + "/nix/var/log/nix" : getDefaultLogDir(),
         "log",
         "directory where Nix stores log files."};
 

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -74,9 +74,19 @@ struct LocalStoreConfig : std::enable_shared_from_this<LocalStoreConfig>,
 
     LocalStoreConfig(std::string_view scheme, std::string_view authority, const Params & params);
 
+private:
+
+    /**
+     * An indirection so that we don't need to refer to global settings
+     * in headers.
+     */
+    bool getDefaultRequireSigs();
+
+public:
+
     Setting<bool> requireSigs{
         this,
-        settings.requireSigs,
+        getDefaultRequireSigs(),
         "require-sigs",
         "Whether store paths copied into this store should have a trusted signature."};
 

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -12,6 +12,7 @@ config_pub_h = configure_file(
 headers = [ config_pub_h ] + files(
   'binary-cache-store.hh',
   'build-result.hh',
+  'build/derivation-builder.hh',
   'build/derivation-building-goal.hh',
   'build/derivation-building-misc.hh',
   'build/derivation-goal.hh',

--- a/src/libstore/include/nix/store/restricted-store.hh
+++ b/src/libstore/include/nix/store/restricted-store.hh
@@ -1,9 +1,12 @@
 #pragma once
 ///@file
 
-#include "nix/store/local-store.hh"
+#include "nix/store/store-api.hh"
 
 namespace nix {
+
+class LocalStore;
+struct LocalStoreConfig;
 
 /**
  * A restricted store has a pointer to one of these, which manages the
@@ -55,6 +58,6 @@ struct RestrictionContext
 /**
  * Create a shared pointer to a restricted store.
  */
-ref<Store> makeRestrictedStore(ref<LocalStore::Config> config, ref<LocalStore> next, RestrictionContext & context);
+ref<Store> makeRestrictedStore(ref<LocalStoreConfig> config, ref<LocalStore> next, RestrictionContext & context);
 
 } // namespace nix

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -8,7 +8,6 @@
 #include "nix/util/serialise.hh"
 #include "nix/util/lru-cache.hh"
 #include "nix/util/sync.hh"
-#include "nix/store/globals.hh"
 #include "nix/util/configuration.hh"
 #include "nix/store/path-info.hh"
 #include "nix/util/repair-flag.hh"
@@ -89,9 +88,19 @@ struct StoreConfigBase : Config
 {
     using Config::Config;
 
+private:
+
+    /**
+     * An indirection so that we don't need to refer to global settings
+     * in headers.
+     */
+    static Path getDefaultNixStoreDir();
+
+public:
+
     const PathSetting storeDir_{
         this,
-        settings.nixStore,
+        getDefaultNixStoreDir(),
         "store",
         R"(
           Logical location of the Nix store, usually

--- a/src/libstore/include/nix/store/store-dir-config.hh
+++ b/src/libstore/include/nix/store/store-dir-config.hh
@@ -3,7 +3,6 @@
 #include "nix/store/path.hh"
 #include "nix/util/hash.hh"
 #include "nix/store/content-address.hh"
-#include "nix/store/globals.hh"
 #include "nix/util/configuration.hh"
 
 #include <map>

--- a/src/libstore/include/nix/store/store-open.hh
+++ b/src/libstore/include/nix/store/store-open.hh
@@ -30,9 +30,12 @@ ref<Store> openStore(StoreReference && storeURI);
  * Opens the store at `uri`, where `uri` is in the format expected by
  * `StoreReference::parse`
  */
-ref<Store> openStore(
-    const std::string & uri = settings.storeUri.get(),
-    const StoreReference::Params & extraParams = StoreReference::Params());
+ref<Store> openStore(const std::string & uri, const StoreReference::Params & extraParams = StoreReference::Params());
+
+/**
+ * Short-hand which opens the default store, according to global settings
+ */
+ref<Store> openStore();
 
 /**
  * @return the default substituter stores, defined by the

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -13,6 +13,7 @@
 #include "nix/store/derivations.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/store-registration.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
 

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -8,6 +8,16 @@
 
 namespace nix {
 
+Path LocalFSStoreConfig::getDefaultStateDir()
+{
+    return settings.nixStateDir;
+}
+
+Path LocalFSStoreConfig::getDefaultLogDir()
+{
+    return settings.nixLogDir;
+}
+
 LocalFSStoreConfig::LocalFSStoreConfig(PathView rootDir, const Params & params)
     : StoreConfig(params)
     // Default `?root` from `rootDir` if non set

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -86,6 +86,11 @@ ref<Store> LocalStore::Config::openStore() const
     return make_ref<LocalStore>(ref{shared_from_this()});
 }
 
+bool LocalStoreConfig::getDefaultRequireSigs()
+{
+    return settings.requireSigs;
+}
+
 struct LocalStore::State::Stmts
 {
     /* Some precompiled SQLite statements. */

--- a/src/libstore/profiles.cc
+++ b/src/libstore/profiles.cc
@@ -1,5 +1,6 @@
 #include "nix/store/profiles.hh"
 #include "nix/util/signals.hh"
+#include "nix/store/globals.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/util/users.hh"

--- a/src/libstore/restricted-store.cc
+++ b/src/libstore/restricted-store.cc
@@ -2,6 +2,7 @@
 #include "nix/store/build-result.hh"
 #include "nix/util/callback.hh"
 #include "nix/store/realisation.hh"
+#include "nix/store/local-store.hh"
 
 namespace nix {
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -27,6 +27,11 @@ using json = nlohmann::json;
 
 namespace nix {
 
+Path StoreConfigBase::getDefaultNixStoreDir()
+{
+    return settings.nixStore;
+}
+
 StoreConfig::StoreConfig(const Params & params)
     : StoreConfigBase(params)
     , StoreDirConfig{storeDir_}

--- a/src/libstore/store-registration.cc
+++ b/src/libstore/store-registration.cc
@@ -2,8 +2,14 @@
 #include "nix/store/store-open.hh"
 #include "nix/store/local-store.hh"
 #include "nix/store/uds-remote-store.hh"
+#include "nix/store/globals.hh"
 
 namespace nix {
+
+ref<Store> openStore()
+{
+    return openStore(settings.storeUri.get());
+}
 
 ref<Store> openStore(const std::string & uri, const Store::Config::Params & extraParams)
 {

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -2,6 +2,7 @@
 #include "nix/util/unix-domain-socket.hh"
 #include "nix/store/worker-protocol.hh"
 #include "nix/store/store-registration.hh"
+#include "nix/store/globals.hh"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/libstore/unix/build/chroot-derivation-builder.cc
+++ b/src/libstore/unix/build/chroot-derivation-builder.cc
@@ -135,7 +135,7 @@ struct ChrootDerivationBuilder : virtual DerivationBuilderImpl
 
         for (auto & i : inputPaths) {
             auto p = store.printStorePath(i);
-            pathsInChroot.insert_or_assign(p, store.toRealPath(p));
+            pathsInChroot.insert_or_assign(p, ChrootPath{.source = store.toRealPath(p)});
         }
 
         /* If we're repairing, checking or rebuilding part of a

--- a/src/libstore/unix/build/darwin-derivation-builder.cc
+++ b/src/libstore/unix/build/darwin-derivation-builder.cc
@@ -69,7 +69,7 @@ struct DarwinDerivationBuilder : DerivationBuilderImpl
             /* Add all our input paths to the chroot */
             for (auto & i : inputPaths) {
                 auto p = store.printStorePath(i);
-                pathsInChroot.insert_or_assign(p, p);
+                pathsInChroot.insert_or_assign(p, ChrootPath{.source = p});
             }
 
             /* Violations will go to the syslog if you set this. Unfortunately the destination does not appear to be

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -16,6 +16,7 @@
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/store/restricted-store.hh"
 #include "nix/store/user-lock.hh"
+#include "nix/store/globals.hh"
 
 #include <queue>
 

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -857,24 +857,10 @@ void DerivationBuilderImpl::startBuilder()
 
 PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
 {
-    PathsInChroot pathsInChroot;
-
     /* Allow a user-configurable set of directories from the
        host file system. */
-    for (auto i : settings.sandboxPaths.get()) {
-        if (i.empty())
-            continue;
-        bool optional = false;
-        if (i[i.size() - 1] == '?') {
-            optional = true;
-            i.pop_back();
-        }
-        size_t p = i.find('=');
-        if (p == std::string::npos)
-            pathsInChroot[i] = {.source = i, .optional = optional};
-        else
-            pathsInChroot[i.substr(0, p)] = {.source = i.substr(p + 1), .optional = optional};
-    }
+    PathsInChroot pathsInChroot = settings.sandboxPaths.get();
+
     if (hasPrefix(store.storeDir, tmpDirInSandbox())) {
         throw Error("`sandbox-build-dir` must not contain the storeDir");
     }

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -107,17 +107,6 @@ protected:
      */
     const DerivationType derivationType;
 
-    /**
-     * Stuff we need to pass to initChild().
-     */
-    struct ChrootPath
-    {
-        Path source;
-        bool optional = false;
-    };
-
-    typedef std::map<Path, ChrootPath> PathsInChroot; // maps target path to source path
-
     typedef StringMap Environment;
     Environment env;
 
@@ -865,7 +854,7 @@ void DerivationBuilderImpl::startBuilder()
     processSandboxSetupMessages();
 }
 
-DerivationBuilderImpl::PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
+PathsInChroot DerivationBuilderImpl::getPathsInSandbox()
 {
     PathsInChroot pathsInChroot;
 

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -15,6 +15,7 @@
 #include "nix/store/posix-fs-canonicalise.hh"
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/store/restricted-store.hh"
+#include "nix/store/user-lock.hh"
 
 #include <queue>
 

--- a/src/libstore/unix/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/unix/include/nix/store/build/derivation-builder.hh
@@ -8,7 +8,6 @@
 #include "nix/store/parsed-derivations.hh"
 #include "nix/util/processes.hh"
 #include "nix/store/restricted-store.hh"
-#include "nix/store/user-lock.hh"
 
 namespace nix {
 

--- a/src/libstore/unix/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/unix/include/nix/store/build/derivation-builder.hh
@@ -12,6 +12,17 @@
 namespace nix {
 
 /**
+ * Stuff we need to pass to initChild().
+ */
+struct ChrootPath
+{
+    Path source;
+    bool optional = false;
+};
+
+typedef std::map<Path, ChrootPath> PathsInChroot; // maps target path to source path
+
+/**
  * Parameters by (mostly) `const` reference for `DerivationBuilder`.
  */
 struct DerivationBuilderParams

--- a/src/libstore/unix/include/nix/store/meson.build
+++ b/src/libstore/unix/include/nix/store/meson.build
@@ -2,7 +2,6 @@ include_dirs += include_directories('../..')
 
 headers += files(
   'build/child.hh',
-  'build/derivation-builder.hh',
   'build/hook-instance.hh',
   'user-lock.hh',
 )

--- a/src/nix/build-remote/build-remote.cc
+++ b/src/nix/build-remote/build-remote.cc
@@ -22,6 +22,7 @@
 #include "nix/store/local-store.hh"
 #include "nix/cmd/legacy.hh"
 #include "nix/util/experimental-features.hh"
+#include "nix/store/globals.hh"
 
 using namespace nix;
 using std::cin;

--- a/src/nix/bundle.cc
+++ b/src/nix/bundle.cc
@@ -5,6 +5,7 @@
 #include "nix/store/store-api.hh"
 #include "nix/store/local-fs-store.hh"
 #include "nix/expr/eval-inline.hh"
+#include "nix/store/globals.hh"
 
 namespace nix::fs {
 using namespace std::filesystem;

--- a/src/nix/config-check.cc
+++ b/src/nix/config-check.cc
@@ -9,6 +9,7 @@
 #include "nix/store/local-fs-store.hh"
 #include "nix/store/worker-protocol.hh"
 #include "nix/util/executable-path.hh"
+#include "nix/store/globals.hh"
 
 namespace nix::fs {
 using namespace std::filesystem;

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -5,6 +5,7 @@
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
 #include "nix/store/store-api.hh"
+#include "nix/store/globals.hh"
 #include "nix/store/outputs-spec.hh"
 #include "nix/store/derivations.hh"
 

--- a/src/nix/env.cc
+++ b/src/nix/env.cc
@@ -6,6 +6,7 @@
 #include "run.hh"
 #include "nix/util/strings.hh"
 #include "nix/util/executable-path.hh"
+#include "nix/util/environment-variables.hh"
 
 using namespace nix;
 

--- a/src/nix/flake.cc
+++ b/src/nix/flake.cc
@@ -1,4 +1,3 @@
-#include "flake-command.hh"
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
 #include "nix/expr/eval.hh"
@@ -17,12 +16,16 @@
 #include "nix/util/users.hh"
 #include "nix/fetchers/fetch-to-store.hh"
 #include "nix/store/local-fs-store.hh"
+#include "nix/store/globals.hh"
 
 #include <filesystem>
 #include <nlohmann/json.hpp>
 #include <iomanip>
 
 #include "nix/util/strings-inline.hh"
+
+// FIXME is this supposed to be private or not?
+#include "flake-command.hh"
 
 namespace nix::fs {
 using namespace std::filesystem;

--- a/src/nix/formatter.cc
+++ b/src/nix/formatter.cc
@@ -5,6 +5,8 @@
 #include "nix/store/local-fs-store.hh"
 #include "nix/cmd/installable-derived-path.hh"
 #include "nix/util/environment-variables.hh"
+#include "nix/store/globals.hh"
+
 #include "run.hh"
 
 using namespace nix;

--- a/src/nix/log.cc
+++ b/src/nix/log.cc
@@ -1,6 +1,7 @@
 #include "nix/cmd/command.hh"
 #include "nix/main/common-args.hh"
 #include "nix/main/shared.hh"
+#include "nix/store/globals.hh"
 #include "nix/store/store-open.hh"
 #include "nix/store/log-store.hh"
 

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -12,7 +12,9 @@
 #include "graphml.hh"
 #include "nix/cmd/legacy.hh"
 #include "nix/util/posix-source-accessor.hh"
+#include "nix/store/globals.hh"
 #include "nix/store/path-with-outputs.hh"
+
 #include "man-pages.hh"
 
 #ifndef _WIN32 // TODO implement on Windows or provide allowed-to-noop interface

--- a/src/nix/prefetch.cc
+++ b/src/nix/prefetch.cc
@@ -12,6 +12,7 @@
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/cmd/misc-store-flags.hh"
 #include "nix/util/terminal.hh"
+#include "nix/util/environment-variables.hh"
 
 #include "man-pages.hh"
 

--- a/src/nix/run.cc
+++ b/src/nix/run.cc
@@ -11,6 +11,8 @@
 #include "nix/util/source-accessor.hh"
 #include "nix/expr/eval.hh"
 #include "nix/util/util.hh"
+#include "nix/store/globals.hh"
+
 #include <filesystem>
 
 #ifdef __linux__

--- a/src/nix/upgrade-nix.cc
+++ b/src/nix/upgrade-nix.cc
@@ -8,6 +8,7 @@
 #include "nix/expr/attr-path.hh"
 #include "nix/store/names.hh"
 #include "nix/util/executable-path.hh"
+#include "nix/store/globals.hh"
 #include "self-exe.hh"
 
 using namespace nix;


### PR DESCRIPTION
## Motivation

The first part was my original goal: I saw there was some settings parsing ad-hoc included in `DerivationBuilder`, and so I wanted to properly make `Settings` do that instead, and use `PathsInChroot` on `Settings` in order to do that (making `Settings::sandboxPaths` well-typed).

I did that by flipping the the header order so that `derivation-builder.hh` was used by `globals.hh`, and then this caused a bunch of include order issues. I could have fixed this by making a new header, but I instead showed to do some "deferred maintenance" and and get `globals.hh` only directly included in `*.cc` files. I think this is good for eventually migrating away from global variable settings (make using globals more "pay if and only if you use" than "oh, you are already including them, so *whatever*"). So that is now part of this PR too.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
