### PR TITLE
Make sure `settings.sandboxedPaths` is closed outside `DerivationBuilder`

### DIFF
--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -59,6 +59,12 @@ struct DerivationBuilderParams
 
     const BuildMode & buildMode;
 
+    /**
+     * Extra paths we want to be in the chroot, regardless of the
+     * derivation we are building.
+     */
+    PathsInChroot defaultPathsInChroot;
+
     struct EnvEntry
     {
         /**
@@ -96,6 +102,7 @@ struct DerivationBuilderParams
         const DerivationOptions & drvOptions,
         const StorePathSet & inputPaths,
         std::map<std::string, InitialOutput> & initialOutputs,
+        PathsInChroot defaultPathsInChroot,
         std::map<std::string, EnvEntry, std::less<>> finalEnv,
         StringMap extraFiles)
         : drvPath{drvPath}
@@ -105,6 +112,7 @@ struct DerivationBuilderParams
         , inputPaths{inputPaths}
         , initialOutputs{initialOutputs}
         , buildMode{buildMode}
+        , defaultPathsInChroot{std::move(defaultPathsInChroot)}
         , finalEnv{std::move(finalEnv)}
         , extraFiles{std::move(extraFiles)}
     {


### PR DESCRIPTION
## Motivation

This is a nicer separation of concerns --- `DerivationBuilder` just mounts the extra paths you tell it too, and the outside world is responsible for making sure those extra paths make sense.

Since the closure only depends on global settings, and not per-derivation information, we also have the option of moving this up further and caching it across all local builds. (I only just realized this after having done this refactor. I am not doing that change at this time, however.)

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
