### PR TITLE
Move `runPostBuildHook` out of `DerivationBuilder`

### DIFF
--- a/src/libstore/include/nix/store/build/derivation-building-misc.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-misc.hh
@@ -49,9 +49,6 @@ struct InitialOutput
     std::optional<InitialOutputStatus> known;
 };
 
-void runPostBuildHook(
-    const StoreDirConfig & store, Logger & logger, const StorePath & drvPath, const StorePathSet & outputPaths);
-
 /**
  * Format the known outputs of a derivation for use in error messages.
  */

--- a/src/libstore/include/nix/store/build/derivation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-goal.hh
@@ -14,9 +14,6 @@ namespace nix {
 
 using std::map;
 
-/** Used internally */
-void runPostBuildHook(Store & store, Logger & logger, const StorePath & drvPath, const StorePathSet & outputPaths);
-
 /**
  * A goal for realising a single output of a derivation. Various sorts of
  * fetching (which will be done by other goal types) is tried, and if none of

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -506,11 +506,6 @@ std::variant<std::pair<BuildResult::Status, Error>, SingleDrvOutputs> Derivation
            being valid. */
         auto builtOutputs = registerOutputs();
 
-        StorePathSet outputPaths;
-        for (auto & [_, output] : builtOutputs)
-            outputPaths.insert(output.outPath);
-        runPostBuildHook(store, *logger, drvPath, outputPaths);
-
         /* Delete unused redirected outputs (when doing hash rewriting). */
         for (auto & i : redirectedOutputs)
             deletePath(store.Store::toRealPath(i.second));


### PR DESCRIPTION
## Motivation

It is supposed to be "post build" not "during the build" after all. Its location now matches that for the hook case (see elsewhere in `DerivationdBuildingGoal`).

It was in a try-catch before, and now it isn't, but I believe that it is impossible for it to throw `BuildError`, which is sufficient for this code motion to be correct.

## Context

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
