### PR TITLE
Create `DerivationBuilderParams::exposeKVM` bool

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -768,6 +768,9 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
                     std::move(defaultPathsInChroot),
                     std::move(finalEnv),
                     std::move(extraFiles),
+#  ifdef __linux__
+                    worker.store.config.systemFeatures.get().count("kvm") > 0,
+#  endif
                 });
         }
 

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -88,6 +88,14 @@ struct DerivationBuilderParams
      */
     std::map<std::string, EnvEntry, std::less<>> finalEnv;
 
+#ifdef __linux__
+    /**
+     * On Linux, whether `/dev/kvm` should be exposed to the builder
+     * within the sandbox.
+     */
+    bool exposeKVM;
+#endif
+
     /**
      * Inserted in the temp dir, but no file names placed in env, unlike
      * `EnvEntry::nameOfPassAsFile` above.
@@ -104,7 +112,12 @@ struct DerivationBuilderParams
         std::map<std::string, InitialOutput> & initialOutputs,
         PathsInChroot defaultPathsInChroot,
         std::map<std::string, EnvEntry, std::less<>> finalEnv,
-        StringMap extraFiles)
+        StringMap extraFiles
+#ifdef __linux__
+        ,
+        bool exposeKVM
+#endif
+        )
         : drvPath{drvPath}
         , buildResult{buildResult}
         , drv{drv}

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -492,7 +492,7 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
             createDirs(chrootRootDir + "/dev/shm");
             createDirs(chrootRootDir + "/dev/pts");
             ss.push_back("/dev/full");
-            if (store.Store::config.systemFeatures.get().count("kvm") && pathExists("/dev/kvm"))
+            if (exposeKVM && pathExists("/dev/kvm"))
                 ss.push_back("/dev/kvm");
             ss.push_back("/dev/null");
             ss.push_back("/dev/random");


### PR DESCRIPTION
## Motivation

Do this to avoid checking "system features" from the store config directly.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
