### PR TITLE
Add nix store kill-build command

### DIFF
--- a/doc/manual/rl-next/kill-build.md
+++ b/doc/manual/rl-next/kill-build.md
@@ -1,0 +1,9 @@
+---
+synopsis: Terminate active builds
+prs: 13813
+---
+
+The new [`nix store kill-build`](@docroot@/command-ref/new-cli/nix3-store-kill-build.md) command asks the Nix process holding the output locks for a specified output path or registered derivation to terminate.
+It does not remove lock files.
+Output locks are also used during substitution and registration, so the command can terminate those operations.
+A Nix process can manage multiple builds, so the command can also cancel other builds managed by that process.

--- a/src/libstore-tests/local-store.cc
+++ b/src/libstore-tests/local-store.cc
@@ -1,6 +1,17 @@
 #include <gtest/gtest.h>
 
+#include "nix/store/build-control-store.hh"
 #include "nix/store/local-store.hh"
+#include "nix/store/pathlocks.hh"
+#include "nix/store/store-open.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/processes.hh"
+
+#ifndef _WIN32
+#  include <csignal>
+#  include <sys/wait.h>
+#  include <unistd.h>
+#endif
 
 // Needed for template specialisations. This is not good! When we
 // overhaul how store configs work, this should be fixed.
@@ -71,5 +82,121 @@ TEST(LocalStore, constructConfig_to_string)
     LocalStoreConfig config{"", {}};
     EXPECT_EQ(config.getReference().to_string(), "local");
 }
+
+#if defined(__linux__) || defined(__APPLE__)
+struct KillBuildTest
+{
+    std::filesystem::path tempDir = createTempDir();
+    AutoDelete deleteTempDir{tempDir, true};
+    std::filesystem::path realStoreDir = tempDir / "nix/store";
+    ref<Store> store;
+    BuildControlStore & buildControlStore;
+    StorePath path;
+    std::filesystem::path realPath;
+
+    explicit KillBuildTest(std::string_view name)
+        : store([&] {
+            createDirs(realStoreDir);
+            return openStore(fmt("local?root=%s", tempDir.string()));
+        }())
+        , buildControlStore(dynamic_cast<BuildControlStore &>(*store))
+        , path(StorePath::random(name))
+        , realPath(realStoreDir / std::string{path.to_string()})
+    {
+    }
+};
+
+TEST(LocalStore, killActiveBuild)
+{
+    KillBuildTest test("active-build-test");
+
+    Pipe ready;
+    ready.create();
+    Pid child = startProcess([&] {
+        ready.readSide.close();
+        PathLocks owner({test.realPath}, "", LockOwnerTracking::Yes);
+        writeFull(ready.writeSide.get(), "1", false);
+        while (true)
+            pause();
+    });
+    auto childPid = static_cast<uint64_t>(static_cast<pid_t>(child));
+    ready.writeSide.close();
+
+    char ignored;
+    readFull(ready.readSide.get(), &ignored, 1);
+
+    EXPECT_EQ(test.buildControlStore.killBuild(test.path), childPid);
+    auto status = child.wait();
+    EXPECT_TRUE(WIFSIGNALED(status));
+    EXPECT_EQ(WTERMSIG(status), SIGTERM);
+}
+
+TEST(LocalStore, refusesUnsafeForcedTermination)
+{
+    KillBuildTest test("stubborn-build-test");
+
+    Pipe ready;
+    ready.create();
+    Pid child = startProcess([&] {
+        ready.readSide.close();
+        signal(SIGTERM, SIG_IGN);
+        PathLocks owner({test.realPath}, "", LockOwnerTracking::Yes);
+        writeFull(ready.writeSide.get(), "1", false);
+        while (true)
+            pause();
+    });
+    auto childPid = static_cast<pid_t>(child);
+    ready.writeSide.close();
+
+    char ignored;
+    readFull(ready.readSide.get(), &ignored, 1);
+
+    EXPECT_THROW(test.buildControlStore.killBuild(test.path), Error);
+    EXPECT_EQ(::kill(childPid, 0), 0);
+    ASSERT_EQ(::kill(childPid, SIGKILL), 0);
+    auto status = child.wait();
+    EXPECT_TRUE(WIFSIGNALED(status));
+}
+
+TEST(LocalStore, doesNotTerminateAReplacementLockOwner)
+{
+    KillBuildTest test("replacement-build-test");
+
+    Pipe firstReady;
+    firstReady.create();
+    Pid first = startProcess([&] {
+        firstReady.readSide.close();
+        PathLocks owner({test.realPath}, "", LockOwnerTracking::Yes);
+        writeFull(firstReady.writeSide.get(), "1", false);
+        while (true)
+            pause();
+    });
+    firstReady.writeSide.close();
+
+    char ignored;
+    readFull(firstReady.readSide.get(), &ignored, 1);
+
+    Pipe secondReady;
+    secondReady.create();
+    Pid second = startProcess([&] {
+        secondReady.readSide.close();
+        PathLocks owner({test.realPath}, "", LockOwnerTracking::Yes);
+        writeFull(secondReady.writeSide.get(), "1", false);
+        while (true)
+            pause();
+    });
+    secondReady.writeSide.close();
+
+    EXPECT_EQ(test.buildControlStore.killBuild(test.path), static_cast<uint64_t>(static_cast<pid_t>(first)));
+    auto firstStatus = first.wait();
+    EXPECT_TRUE(WIFSIGNALED(firstStatus));
+    readFull(secondReady.readSide.get(), &ignored, 1);
+    EXPECT_EQ(::kill(static_cast<pid_t>(second), 0), 0);
+
+    ASSERT_EQ(::kill(static_cast<pid_t>(second), SIGTERM), 0);
+    auto secondStatus = second.wait();
+    EXPECT_TRUE(WIFSIGNALED(secondStatus));
+}
+#endif
 
 } // namespace nix

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -81,6 +81,7 @@ sources = files(
   'outputs-spec.cc',
   'path-info.cc',
   'path.cc',
+  'pathlocks.cc',
   'realisation.cc',
   'references.cc',
   's3-binary-cache-store.cc',
@@ -95,7 +96,7 @@ sources = files(
   'write-derivation.cc',
 )
 
-include_dirs = [ include_directories('.') ]
+include_dirs = [ include_directories('.', '../libstore') ]
 
 
 this_exe = executable(

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -39,6 +39,7 @@ mkMesonExecutable (finalAttrs: {
     ./.version
     ./meson.build
     ./meson.options
+    ../libstore/pathlocks-internal.hh
     (fileset.fileFilter (file: file.hasExt "cc") ./.)
     (fileset.fileFilter (file: file.hasExt "hh") ./.)
   ];

--- a/src/libstore-tests/pathlocks.cc
+++ b/src/libstore-tests/pathlocks.cc
@@ -1,0 +1,202 @@
+#include <gtest/gtest.h>
+
+#include "nix/store/pathlocks.hh"
+#include "pathlocks-internal.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/finally.hh"
+#include "nix/util/processes.hh"
+#include "nix/util/util.hh"
+
+#ifndef _WIN32
+#  include <csignal>
+
+#  include <sys/wait.h>
+#  include <unistd.h>
+#endif
+
+#ifdef __APPLE__
+#  include <fcntl.h>
+#  include <libproc.h>
+#  include <sys/xattr.h>
+#endif
+
+namespace nix {
+
+#if defined(__linux__) || defined(__APPLE__)
+
+TEST(FileLockOwners, excludesProcessesThatOnlyHaveTheFileOpen)
+{
+    auto tempDir = createTempDir();
+    AutoDelete deleteTempDir(tempDir, true);
+    auto lockPath = tempDir / "build.lock";
+
+    Pipe ready;
+    ready.create();
+    Pipe finish;
+    finish.create();
+
+    Pid child = startProcess([&] {
+        ready.readSide.close();
+        finish.writeSide.close();
+
+        PathLocks owner({tempDir / "build"}, "", LockOwnerTracking::Yes);
+        auto lockOwner = getFileLockOwner(lockPath);
+        if (!lockOwner || lockOwner->pid != static_cast<uint64_t>(getpid()))
+            _exit(1);
+        writeFull(ready.writeSide.get(), "1", false);
+
+        char ignored;
+        readFull(finish.readSide.get(), &ignored, 1);
+        _exit(0);
+    });
+
+    ready.writeSide.close();
+    finish.readSide.close();
+
+    char ignored;
+    readFull(ready.readSide.get(), &ignored, 1);
+
+    auto openOnlyFd = openLockFile(lockPath, false);
+    ASSERT_TRUE(openOnlyFd);
+    auto owner = getFileLockOwner(lockPath);
+    ASSERT_TRUE(owner);
+    EXPECT_EQ(owner->pid, static_cast<uint64_t>(static_cast<pid_t>(child)));
+
+    auto staleOwner = *owner;
+    ++staleOwner.startTime;
+    EXPECT_FALSE(signalFileLockOwner(lockPath, staleOwner, SIGKILL));
+    EXPECT_EQ(::kill(static_cast<pid_t>(child), 0), 0);
+
+    EXPECT_TRUE(signalFileLockOwner(lockPath, *owner, SIGTERM));
+    auto status = child.wait();
+    EXPECT_TRUE(WIFSIGNALED(status));
+    EXPECT_EQ(WTERMSIG(status), SIGTERM);
+}
+
+#  ifdef __linux__
+TEST(FileLockOwners, refusesToGuessAtAnInheritedLockOwner)
+{
+    auto tempDir = createTempDir();
+    AutoDelete deleteTempDir(tempDir, true);
+    auto lockPath = tempDir / "build.lock";
+
+    Pipe ready;
+    ready.create();
+
+    Pid child = startProcess([&] {
+        ready.readSide.close();
+        PathLocks owner({tempDir / "build"}, "", LockOwnerTracking::Yes);
+
+        auto descendant = fork();
+        if (descendant == -1)
+            _exit(1);
+        if (descendant == 0) {
+            ready.writeSide.close();
+            while (true)
+                pause();
+        }
+
+        writeLine(ready.writeSide.get(), std::to_string(descendant));
+        _exit(0);
+    });
+
+    ready.writeSide.close();
+    auto descendant = string2Int<pid_t>(readLine(ready.readSide.get()));
+    ASSERT_TRUE(descendant);
+    Finally cleanup([&] { ::kill(*descendant, SIGKILL); });
+
+    EXPECT_EQ(child.wait(), 0);
+    EXPECT_THROW(getFileLockOwner(lockPath), MissingLockOwner);
+}
+#  endif
+
+#  ifdef __APPLE__
+TEST(FileLockOwners, replacesAStaleCompanionLock)
+{
+    auto tempDir = createTempDir();
+    AutoDelete deleteTempDir(tempDir, true);
+    auto path = tempDir / "build";
+    auto lockPath = tempDir / "build.lock";
+    auto ownerPath = tempDir / "build.lock.owner";
+
+    Pipe ready;
+    ready.create();
+    Pipe finish;
+    finish.create();
+
+    Pid child = startProcess([&] {
+        ready.readSide.close();
+        finish.writeSide.close();
+
+        auto lockFd = openLockFile(lockPath, true);
+        auto ownerFd = openLockFile(ownerPath, true);
+        struct flock lock{
+            .l_start = 0,
+            .l_len = 0,
+            .l_pid = 0,
+            .l_type = F_WRLCK,
+            .l_whence = SEEK_SET,
+        };
+        if (fcntl(ownerFd.get(), F_SETLK, &lock) == -1)
+            _exit(1);
+
+        proc_bsdinfo info{};
+        if (proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info)) != sizeof(info))
+            _exit(1);
+        auto metadata = fmt("%d:%d:%d", getpid(), info.pbi_start_tvsec, info.pbi_start_tvusec);
+        if (fsetxattr(lockFd.get(), "org.nixos.nix.lock-owner", metadata.data(), metadata.size(), 0, 0) == -1)
+            _exit(1);
+
+        writeFull(ready.writeSide.get(), "1", false);
+        char ignored;
+        readFull(finish.readSide.get(), &ignored, 1);
+        _exit(0);
+    });
+
+    ready.writeSide.close();
+    finish.readSide.close();
+    char ignored;
+    readFull(ready.readSide.get(), &ignored, 1);
+
+    PathLocks owner({path}, "", LockOwnerTracking::Yes);
+    auto current = getFileLockOwner(lockPath);
+    ASSERT_TRUE(current);
+    EXPECT_EQ(current->pid, static_cast<uint64_t>(getpid()));
+
+    owner.unlock();
+    EXPECT_TRUE(pathExists(lockPath));
+    EXPECT_FALSE(pathExists(ownerPath));
+
+    writeFull(finish.writeSide.get(), "1", false);
+    EXPECT_EQ(child.wait(), 0);
+}
+#  endif
+
+#endif
+
+#ifndef _WIN32
+
+#  ifdef __linux__
+TEST(FileLockOwners, readsKernelOwnerWithoutMetadata)
+#  else
+TEST(FileLockOwners, refusesToGuessWhenOwnerMetadataIsMissing)
+#  endif
+{
+    auto tempDir = createTempDir();
+    AutoDelete deleteTempDir(tempDir, true);
+    auto lockPath = tempDir / "build.lock";
+
+    auto ownerFd = openLockFile(lockPath, true);
+    ASSERT_TRUE(lockFile(ownerFd.get(), ltWrite, false));
+
+#  ifdef __linux__
+    ASSERT_TRUE(getFileLockOwner(lockPath));
+    EXPECT_EQ(getFileLockOwner(lockPath)->pid, static_cast<uint64_t>(getpid()));
+#  else
+    EXPECT_THROW(getFileLockOwner(lockPath), MissingLockOwner);
+#  endif
+}
+
+#endif
+
+} // namespace nix

--- a/src/libstore/build-control-store.cc
+++ b/src/libstore/build-control-store.cc
@@ -1,0 +1,7 @@
+#include "nix/store/build-control-store.hh"
+
+namespace nix {
+
+void BuildControlStore::anchor() {}
+
+} // namespace nix

--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -20,6 +20,8 @@
 #include "nix/store/globals.hh"
 #include "nix/util/current-process.hh"
 
+#include "../pathlocks-internal.hh"
+
 #include <algorithm>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -400,18 +402,10 @@ Goal::Co DerivationBuildingGoal::tryToBuild(StorePathSet inputPaths)
             /* FIXME: find some way to lock for scheduling for the other stores so
                a forking daemon with --store still won't farm out redundant builds.
                */
-            for (auto & i : drv->outputsAndOptPaths(worker.store)) {
-                if (i.second.second)
-                    lockFiles.insert(localStore->toRealPath(*i.second.second));
-                else {
-                    auto lockPath = localStore->toRealPath(drvPath);
-                    lockPath += "." + i.first;
-                    lockFiles.insert(std::move(lockPath));
-                }
-            }
+            lockFiles = getDerivationOutputLockPaths(*localStore, drvPath, drv->outputsAndOptPaths(worker.store));
         }
 
-        if (!outputLocks.lockPaths(lockFiles, "", false)) {
+        if (!outputLocks.lockPaths(lockFiles, "", false, LockOwnerTracking::Yes)) {
             Activity act(
                 *logger,
                 lvlWarn,
@@ -423,7 +417,7 @@ Goal::Co DerivationBuildingGoal::tryToBuild(StorePathSet inputPaths)
                boolean is true). */
             do {
                 co_await waitForAWhile();
-            } while (!outputLocks.lockPaths(lockFiles, "", false));
+            } while (!outputLocks.lockPaths(lockFiles, "", false, LockOwnerTracking::Yes));
         }
 
         /* Now check again whether the outputs are valid.  This is because

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -9,6 +9,7 @@
 #include "nix/store/store-api.hh"
 #include "nix/store/store-cast.hh"
 #include "nix/store/filetransfer.hh"
+#include "nix/store/build-control-store.hh"
 #include "nix/store/gc-store.hh"
 #include "nix/store/log-store.hh"
 #include "nix/store/indirect-root-store.hh"
@@ -885,6 +886,20 @@ static void performOp(
         auto paths = store->queryAllValidPaths();
         logger->stopWork();
         WorkerProto::write(*store, wconn, paths);
+        break;
+    }
+
+    case WorkerProto::Op::KillBuild: {
+        auto path = WorkerProto::Serialise<StorePath>::read(*store, rconn);
+        if (!trusted)
+            throw Error("you are not privileged to terminate builds");
+
+        logger->startWork();
+        auto & buildControlStore = require<BuildControlStore>(*store);
+        auto pid = buildControlStore.killBuild(path);
+        logger->stopWork();
+
+        conn.to << pid.value_or(0);
         break;
     }
 

--- a/src/libstore/include/nix/store/build-control-store.hh
+++ b/src/libstore/include/nix/store/build-control-store.hh
@@ -1,0 +1,28 @@
+#pragma once
+///@file
+
+#include "nix/store/store-api.hh"
+
+namespace nix {
+
+/**
+ * Mix-in class for stores that can terminate active builds.
+ */
+struct BuildControlStore : public virtual Store
+{
+private:
+    void anchor() override;
+
+public:
+    inline static std::string operationName = "Build termination";
+
+    /**
+     * Ask the owner of the output locks associated with `path` to terminate.
+     * `path` must be an output path or registered derivation.
+     *
+     * @return The process ID signalled, or `std::nullopt` if no associated lock is held.
+     */
+    virtual std::optional<uint64_t> killBuild(const StorePath & path) = 0;
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/local-store.hh
+++ b/src/libstore/include/nix/store/local-store.hh
@@ -4,6 +4,7 @@
 #include "nix/store/sqlite.hh"
 
 #include "nix/store/pathlocks.hh"
+#include "nix/store/build-control-store.hh"
 #include "nix/store/store-api.hh"
 #include "nix/store/indirect-root-store.hh"
 #include "nix/util/sync.hh"
@@ -179,7 +180,7 @@ public:
 
 MakeError(PathInUse, Error);
 
-class LocalStore : public virtual IndirectRootStore, public virtual GcStore
+class LocalStore : public virtual IndirectRootStore, public virtual GcStore, public virtual BuildControlStore
 {
     void anchor() override;
 
@@ -274,6 +275,8 @@ public:
     StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute) override;
 
     StorePathSet queryAllValidPaths() override;
+
+    std::optional<uint64_t> killBuild(const StorePath & path) override;
 
     void queryPathInfoUncached(
         const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -12,6 +12,7 @@ config_pub_h = configure_file(
 headers = [ config_pub_h ] + files(
   'aws-creds.hh',
   'binary-cache-store.hh',
+  'build-control-store.hh',
   'build-result.hh',
   'build.hh',
   'build/build-log.hh',

--- a/src/libstore/include/nix/store/pathlocks.hh
+++ b/src/libstore/include/nix/store/pathlocks.hh
@@ -2,6 +2,7 @@
 ///@file
 
 #include <filesystem>
+#include <set>
 
 #include "nix/util/file-descriptor.hh"
 
@@ -23,19 +24,30 @@ enum LockType { ltRead, ltWrite, ltNone };
 
 bool lockFile(Descriptor desc, LockType lockType, bool wait);
 
+enum struct LockOwnerTracking { Yes, No };
+
 class PathLocks
 {
 private:
     typedef std::pair<Descriptor, std::filesystem::path> FDPair;
     std::list<FDPair> fds;
+#ifdef __APPLE__
+    std::list<FDPair> ownerFds;
+#endif
     bool deletePaths;
 
 public:
     PathLocks();
-    PathLocks(const std::set<std::filesystem::path> & paths, const std::string & waitMsg = "");
+    PathLocks(
+        const std::set<std::filesystem::path> & paths,
+        const std::string & waitMsg = "",
+        LockOwnerTracking trackOwner = LockOwnerTracking::No);
 
     PathLocks(PathLocks && other) noexcept
         : fds(std::exchange(other.fds, {}))
+#ifdef __APPLE__
+        , ownerFds(std::exchange(other.ownerFds, {}))
+#endif
         , deletePaths(other.deletePaths)
     {
     }
@@ -43,13 +55,20 @@ public:
     PathLocks & operator=(PathLocks && other) noexcept
     {
         fds = std::exchange(other.fds, {});
+#ifdef __APPLE__
+        ownerFds = std::exchange(other.ownerFds, {});
+#endif
         deletePaths = other.deletePaths;
         return *this;
     }
 
     PathLocks(const PathLocks &) = delete;
     PathLocks & operator=(const PathLocks &) = delete;
-    bool lockPaths(const std::set<std::filesystem::path> & _paths, const std::string & waitMsg = "", bool wait = true);
+    bool lockPaths(
+        const std::set<std::filesystem::path> & _paths,
+        const std::string & waitMsg = "",
+        bool wait = true,
+        LockOwnerTracking trackOwner = LockOwnerTracking::No);
     ~PathLocks();
     void unlock();
     void setDeletion(bool deletePaths);

--- a/src/libstore/include/nix/store/remote-store.hh
+++ b/src/libstore/include/nix/store/remote-store.hh
@@ -7,6 +7,7 @@
 
 #include "nix/store/store-api.hh"
 #include "nix/store/submit-store.hh"
+#include "nix/store/build-control-store.hh"
 #include "nix/util/sync.hh"
 #include "nix/util/file-descriptor.hh"
 #include "nix/store/gc-store.hh"
@@ -47,7 +48,11 @@ public:
  * \todo RemoteStore is a misnomer - should be something like
  * DaemonStore.
  */
-struct RemoteStore : public virtual Store, public virtual GcStore, public virtual LogStore, public virtual SubmitStore
+struct RemoteStore : public virtual Store,
+                     public virtual GcStore,
+                     public virtual LogStore,
+                     public virtual SubmitStore,
+                     public virtual BuildControlStore
 {
 private:
     void anchor() override;
@@ -66,6 +71,8 @@ public:
     StorePathSet queryValidPaths(const StorePathSet & paths, SubstituteFlag maybeSubstitute = NoSubstitute) override;
 
     StorePathSet queryAllValidPaths() override;
+
+    std::optional<uint64_t> killBuild(const StorePath & path) override;
 
     void queryPathInfoUncached(
         const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -152,6 +152,11 @@ struct WorkerProto
     static constexpr std::string_view featureSubmitOutput = "submit-output";
 
     /**
+     * Feature for terminating active builds.
+     */
+    static constexpr std::string_view featureBuildControl = "build-control";
+
+    /**
      * A unidirectional read connection, to be used by the read half of the
      * canonical serializers below.
      */
@@ -275,6 +280,7 @@ enum struct WorkerProto::Op : uint64_t {
     // QueryActiveBuilds = 48, // reserved for https://github.com/NixOS/nix/pull/15979
     // AddTempRoots = 49, // reserved for https://github.com/NixOS/nix/pull/16113
     // QueryPathInfos = 50, // reserved for https://github.com/DeterminateSystems/nix-src/pull/539
+    KillBuild = 51,
     SubmitOutput = 1000, // Only used within derivations with feature
     AddToStoreScanning = 1001,
 };

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1088,7 +1088,7 @@ void LocalStore::addToStore(const ValidPathInfo & info, Source & source, RepairF
                from a build hook (whose parent process already acquired a
                lock on this path). */
             if (!locksHeld.count(printStorePath(info.path)))
-                outputLock.lockPaths({realPath});
+                outputLock.lockPaths({realPath}, "", true, LockOwnerTracking::Yes);
 
             /* The path may have been created by another process in the meantime, so check again. */
             if (repair || !isValidPathUncached(info.path)) {
@@ -1308,7 +1308,7 @@ StorePath LocalStore::addToStoreFromDump(
 
         auto realPath = toRealPath(dstPath);
 
-        PathLocks outputLock({realPath});
+        PathLocks outputLock({realPath}, "", LockOwnerTracking::Yes);
 
         /* The path may have been created by another process in the meantime, so check again. */
         if (repair || !isValidPathUncached(dstPath)) {

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -99,7 +99,11 @@ configdata_pub.set(
 
 if host_machine.system() == 'darwin'
   sandbox = cxx.find_library('sandbox')
-  deps_other += [ sandbox ]
+  bsm = cxx.find_library('bsm')
+  deps_other += [
+    sandbox,
+    bsm,
+  ]
 endif
 
 if host_machine.system() == 'windows'
@@ -257,6 +261,7 @@ subdir('nix-meson-build-support/common')
 
 sources = files(
   'binary-cache-store.cc',
+  'build-control-store.cc',
   'build-result.cc',
   'build/build-log.cc',
   'build/derivation-builder.cc',

--- a/src/libstore/pathlocks-internal.hh
+++ b/src/libstore/pathlocks-internal.hh
@@ -1,0 +1,36 @@
+#pragma once
+///@file
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <set>
+
+#include "nix/store/derivations.hh"
+#include "nix/util/error.hh"
+
+namespace nix {
+
+class LocalStore;
+
+MakeError(MissingLockOwner, Error);
+
+struct FileLockOwner
+{
+    uint64_t pid;
+    uint64_t startTime = 0;
+    uint64_t startTimeFraction = 0;
+
+    bool operator==(const FileLockOwner &) const = default;
+};
+
+std::set<std::filesystem::path> getDerivationOutputLockPaths(
+    LocalStore & localStore, const StorePath & drvPath, const DerivationOutputsAndOptPaths & outputsAndOptPaths);
+
+std::optional<FileLockOwner> getFileLockOwner(const std::filesystem::path & path);
+
+bool fileLockOwnerStillHoldsLock(const std::filesystem::path & path, const FileLockOwner & owner);
+
+bool signalFileLockOwner(const std::filesystem::path & path, const FileLockOwner & owner, int signal);
+
+} // namespace nix

--- a/src/libstore/pathlocks.cc
+++ b/src/libstore/pathlocks.cc
@@ -1,20 +1,41 @@
+#include "nix/store/derivations.hh"
+#include "nix/store/local-store.hh"
 #include "nix/store/pathlocks.hh"
 #include "nix/util/util.hh"
+
+#include "pathlocks-internal.hh"
 
 #include <cerrno>
 #include <cstdlib>
 
 namespace nix {
 
+std::set<std::filesystem::path> getDerivationOutputLockPaths(
+    LocalStore & localStore, const StorePath & drvPath, const DerivationOutputsAndOptPaths & outputsAndOptPaths)
+{
+    std::set<std::filesystem::path> lockPaths;
+    for (auto & [outputName, output] : outputsAndOptPaths) {
+        if (auto & outputPath = output.second)
+            lockPaths.insert(localStore.toRealPath(*outputPath));
+        else {
+            auto lockPath = localStore.toRealPath(drvPath);
+            lockPath += "." + outputName;
+            lockPaths.insert(std::move(lockPath));
+        }
+    }
+    return lockPaths;
+}
+
 PathLocks::PathLocks()
     : deletePaths(false)
 {
 }
 
-PathLocks::PathLocks(const std::set<std::filesystem::path> & paths, const std::string & waitMsg)
+PathLocks::PathLocks(
+    const std::set<std::filesystem::path> & paths, const std::string & waitMsg, LockOwnerTracking trackOwner)
     : deletePaths(false)
 {
-    lockPaths(paths, waitMsg);
+    lockPaths(paths, waitMsg, true, trackOwner);
 }
 
 PathLocks::~PathLocks()

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -206,6 +206,20 @@ StorePathSet RemoteStore::queryAllValidPaths()
     return WorkerProto::Serialise<StorePathSet>::read(*this, *conn);
 }
 
+std::optional<uint64_t> RemoteStore::killBuild(const StorePath & path)
+{
+    auto conn(getConnection());
+    if (!conn->protoVersion.features.contains(WorkerProto::featureBuildControl))
+        throw UsageError("build termination is not supported by store '%s'", config.getHumanReadableURI());
+
+    conn->to << WorkerProto::Op::KillBuild;
+    WorkerProto::write(*this, *conn, path);
+    conn.processStderr();
+
+    auto pid = readInt(conn->from);
+    return pid == 0 ? std::nullopt : std::optional{pid};
+}
+
 StorePathSet RemoteStore::querySubstitutablePaths(const StorePathSet & paths)
 {
     auto conn(getConnection());

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1531,7 +1531,8 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             /* Don't wait on lock for the hash-mismatching fixed-output
                derivation case, to avoid a deadlock in the case where a build
                with the correct hash is in progress. */
-            bool locked = dynamicOutputLock.lockPaths({store.toRealPath(newInfo.path)}, "", !optFixedPath);
+            bool locked = dynamicOutputLock.lockPaths(
+                {store.toRealPath(newInfo.path)}, "", !optFixedPath, LockOwnerTracking::Yes);
 
             /* If we can't lock the correct path, clean up and bail now. */
             if (!locked) {

--- a/src/libstore/unix/local-build-control.cc
+++ b/src/libstore/unix/local-build-control.cc
@@ -1,0 +1,83 @@
+#include "nix/store/derivations.hh"
+#include "nix/store/local-store.hh"
+#include "nix/store/pathlocks.hh"
+#include "nix/util/file-system.hh"
+#include "nix/util/signals.hh"
+
+#include "../pathlocks-internal.hh"
+
+#include <algorithm>
+#include <chrono>
+#include <csignal>
+#include <set>
+#include <thread>
+#include <unistd.h>
+
+namespace nix {
+
+static std::optional<uint64_t>
+terminateLockOwner(const std::set<std::filesystem::path> & lockPaths, std::chrono::steady_clock::duration timeout)
+{
+    std::optional<FileLockOwner> owner;
+    for (auto & lockPath : lockPaths) {
+        auto candidate = getFileLockOwner(lockPath);
+        if (!candidate)
+            continue;
+        if (owner && *candidate != *owner)
+            throw Error("multiple processes hold output locks for the requested derivation");
+        owner = candidate;
+    }
+
+    if (!owner)
+        return std::nullopt;
+    if (owner->pid == static_cast<uint64_t>(getpid()))
+        throw Error("refusing to terminate this Nix process while it holds an output lock");
+
+    bool signalled = false;
+    for (auto & lockPath : lockPaths)
+        if (signalFileLockOwner(lockPath, *owner, SIGTERM)) {
+            signalled = true;
+            break;
+        }
+    if (!signalled)
+        return std::nullopt;
+
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (true) {
+        checkInterrupt();
+        if (std::ranges::none_of(
+                lockPaths, [&](auto & lockPath) { return fileLockOwnerStillHoldsLock(lockPath, *owner); }))
+            return owner->pid;
+        auto now = std::chrono::steady_clock::now();
+        if (now >= deadline)
+            break;
+        auto nextCheck = now + std::chrono::milliseconds(50);
+        std::this_thread::sleep_until(nextCheck < deadline ? nextCheck : deadline);
+    }
+
+    throw Error("process %d did not release its output locks after being asked to terminate", owner->pid);
+}
+
+std::optional<uint64_t> LocalStore::killBuild(const StorePath & path)
+{
+#if !defined(__linux__) && !defined(__APPLE__)
+    throw UsageError("build termination is not supported on this platform");
+#endif
+
+    std::set<std::filesystem::path> lockPaths;
+    auto addLockPath = [&](std::filesystem::path path) {
+        path += ".lock";
+        lockPaths.insert(std::move(path));
+    };
+
+    addLockPath(toRealPath(path));
+    if (path.isDerivation() && isValidPath(path)) {
+        auto drv = readDerivation(path);
+        for (auto & outputLockPath : getDerivationOutputLockPaths(*this, path, drv.outputsAndOptPaths(*this)))
+            addLockPath(outputLockPath);
+    }
+
+    return terminateLockOwner(lockPaths, std::chrono::seconds(5));
+}
+
+} // namespace nix

--- a/src/libstore/unix/meson.build
+++ b/src/libstore/unix/meson.build
@@ -4,6 +4,7 @@ sources += files(
   'build/derivation-builder.cc',
   'build/external-derivation-builder.cc',
   'build/hook-instance.cc',
+  'local-build-control.cc',
   'pathlocks.cc',
   'user-lock.cc',
 )

--- a/src/libstore/unix/pathlocks.cc
+++ b/src/libstore/unix/pathlocks.cc
@@ -1,16 +1,38 @@
 #include "nix/store/pathlocks.hh"
 #include "nix/util/file-system-at.hh"
+#include "nix/util/file-system.hh"
 #include "nix/util/signals.hh"
+#include "nix/util/util.hh"
+
+#include "../pathlocks-internal.hh"
 
 #include <cerrno>
+#include <cstring>
 #include <cstdlib>
+#include <limits>
+#include <vector>
 
 #include <fcntl.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <sys/file.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef __APPLE__
+#  include <bsm/libbsm.h>
+#  include <libproc.h>
+#  include <mach/mach.h>
+#  include <mach/task_info.h>
+#  include <sys/xattr.h>
+#endif
+
+#ifdef __linux__
+#  include <sys/syscall.h>
+#endif
 
 namespace nix {
+
+void MissingLockOwner::anchor() {}
 
 AutoCloseFD openLockFile(const std::filesystem::path & path, bool create)
 {
@@ -68,9 +90,417 @@ bool lockFile(Descriptor desc, LockType lockType, bool wait)
     return true;
 }
 
-bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const std::string & waitMsg, bool wait)
+#ifdef __APPLE__
+static constexpr std::string_view lockOwnerAttr = "org.nixos.nix.lock-owner";
+
+struct FileLockOwnerRecord
+{
+    uint32_t version = 1;
+    uint32_t reserved = 0;
+    FileLockOwner owner;
+    audit_token_t auditToken;
+};
+
+static std::filesystem::path getOwnerLockPath(const std::filesystem::path & path)
+{
+    auto ownerPath = path;
+    ownerPath += ".owner";
+    return ownerPath;
+}
+#endif
+
+#ifdef __APPLE__
+static std::optional<FileLockOwner> getProcessIdentity(uint64_t pid)
+{
+    if (pid == 0 || pid > static_cast<uint64_t>(std::numeric_limits<pid_t>::max()))
+        throw MissingLockOwner("invalid process ID %d", pid);
+
+    proc_bsdinfo info{};
+    auto size = proc_pidinfo(static_cast<pid_t>(pid), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
+    if (size == 0 && errno == ESRCH)
+        return std::nullopt;
+    if (size != sizeof(info))
+        throw SysError("reading identity of process %d", pid);
+
+    return FileLockOwner{
+        .pid = pid,
+        .startTime = info.pbi_start_tvsec,
+        .startTimeFraction = info.pbi_start_tvusec,
+    };
+}
+#endif
+
+#ifdef __APPLE__
+static bool setFileLockOwner(Descriptor fd)
+{
+    auto identity = getProcessIdentity(getpid());
+    if (!identity) {
+        debug("cannot record the owner of a lock: current process disappeared");
+        return false;
+    }
+
+    FileLockOwnerRecord record{.owner = *identity};
+    mach_msg_type_number_t count = TASK_AUDIT_TOKEN_COUNT;
+    auto result =
+        task_info(mach_task_self(), TASK_AUDIT_TOKEN, reinterpret_cast<task_info_t>(&record.auditToken), &count);
+    if (result != KERN_SUCCESS || count != TASK_AUDIT_TOKEN_COUNT) {
+        debug("cannot record the owner of a lock: cannot read the current process audit token");
+        return false;
+    }
+
+    result = fsetxattr(fd, lockOwnerAttr.data(), &record, sizeof(record), 0, 0);
+    if (result == -1) {
+        debug("cannot record the owner of a lock: %s", strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+static void clearFileLockOwner(Descriptor fd)
+{
+    if (fremovexattr(fd, lockOwnerAttr.data(), 0) == -1 && errno != ENOATTR)
+        debug("cannot clear the owner of a lock: %s", strerror(errno));
+}
+#endif
+
+#ifdef __APPLE__
+static FileLockOwnerRecord readFileLockOwnerRecord(Descriptor fd)
+{
+    FileLockOwnerRecord record;
+    auto size = fgetxattr(fd, lockOwnerAttr.data(), &record, sizeof(record), 0, 0);
+    if (size == -1) {
+        if (errno == ENOATTR || errno == ENODATA)
+            throw MissingLockOwner("the lock owner did not record its process identity");
+        if (errno == ERANGE)
+            throw MissingLockOwner("the lock owner recorded an invalid process identity");
+        throw SysError("reading the owner of a lock");
+    }
+
+    if (size != sizeof(record) || record.version != 1 || record.reserved != 0)
+        throw MissingLockOwner("the lock owner recorded an invalid process identity");
+
+    auto pid = audit_token_to_pid(record.auditToken);
+    if (pid <= 0 || static_cast<uint64_t>(pid) != record.owner.pid)
+        throw MissingLockOwner("the lock owner recorded an invalid process identity");
+
+    return record;
+}
+#endif
+
+#ifndef __linux__
+static FileLockOwner readFileLockOwner(Descriptor fd)
+{
+#  ifdef __APPLE__
+    return readFileLockOwnerRecord(fd).owner;
+#  else
+    (void) fd;
+    throw MissingLockOwner("lock owner metadata is not supported on this platform");
+#  endif
+}
+
+#  ifdef __APPLE__
+static void validateKernelLockOwner(const std::filesystem::path & path, const FileLockOwner & owner)
+{
+    /* POSIX record locks are process-scoped. Avoid opening the companion file
+       when querying our own lock, since closing that descriptor would release
+       every record lock this process holds on the file. */
+    if (owner.pid == static_cast<uint64_t>(getpid()))
+        return;
+
+    auto fd = openLockFile(getOwnerLockPath(path), false);
+    if (!fd)
+        throw MissingLockOwner("the lock owner did not create its kernel owner lock");
+
+    struct flock lock{
+        .l_start = 0,
+        .l_len = 0,
+        .l_pid = 0,
+        .l_type = F_WRLCK,
+        .l_whence = SEEK_SET,
+    };
+    if (fcntl(fd.get(), F_GETLK, &lock) == -1)
+        throw SysError("reading the kernel owner of a lock");
+    if (lock.l_type != F_WRLCK || lock.l_pid <= 0 || static_cast<uint64_t>(lock.l_pid) != owner.pid)
+        throw MissingLockOwner("the recorded owner does not hold the kernel owner lock");
+}
+#  endif
+#endif
+
+#ifdef __linux__
+static std::optional<FileLockOwner> getProcessIdentity(uint64_t pid)
+{
+    if (pid == 0 || pid > static_cast<uint64_t>(std::numeric_limits<pid_t>::max()))
+        throw MissingLockOwner("invalid process ID %d", pid);
+
+    std::string status;
+    try {
+        status = readFile(std::filesystem::path{"/proc"} / std::to_string(pid) / "stat");
+    } catch (SystemError & e) {
+        if (e.is(std::errc::no_such_file_or_directory))
+            return std::nullopt;
+        throw;
+    }
+
+    /* The second field is parenthesised and may contain spaces or closing
+       parentheses. Fields following its final closing parenthesis have an
+       unambiguous layout; starttime is field 22. */
+    auto endOfName = status.rfind(')');
+    if (endOfName == std::string::npos)
+        throw MissingLockOwner("process %d has an invalid /proc stat record", pid);
+    auto fields = tokenizeString<std::vector<std::string>>(std::string_view{status}.substr(endOfName + 1));
+    if (fields.size() <= 19)
+        throw MissingLockOwner("process %d has an invalid /proc stat record", pid);
+    auto startTime = string2Int<uint64_t>(fields[19]);
+    if (!startTime)
+        throw MissingLockOwner("process %d has an invalid /proc stat record", pid);
+
+    return FileLockOwner{.pid = pid, .startTime = *startTime};
+}
+
+static bool matchesFileLock(
+    const std::vector<std::string> & fields,
+    size_t typeIndex,
+    size_t modeIndex,
+    size_t deviceIndex,
+    const struct stat & st)
+{
+    if (fields.size() <= deviceIndex || fields[typeIndex] != "FLOCK" || fields[modeIndex] != "WRITE")
+        return false;
+
+    auto lastColon = fields[deviceIndex].rfind(':');
+    if (lastColon == std::string::npos)
+        return false;
+
+    return string2Int<uint64_t>(std::string_view{fields[deviceIndex]}.substr(lastColon + 1)) == st.st_ino;
+}
+
+struct FileLockIdentity
+{
+    struct stat st;
+    uint64_t mountId;
+};
+
+static FileLockIdentity getFileLockIdentity(Descriptor fd)
+{
+    for (auto line : tokenizeString<std::vector<std::string>>(
+             readFile(std::filesystem::path{"/proc/self/fdinfo"} / std::to_string(fd)), "\n")) {
+        auto fields = tokenizeString<std::vector<std::string>>(line);
+        if (fields.size() == 2 && fields[0] == "mnt_id:")
+            if (auto mountId = string2Int<uint64_t>(fields[1]))
+                return {.st = nix::fstat(fd), .mountId = *mountId};
+    }
+    throw MissingLockOwner("the lock file descriptor has no mount ID");
+}
+
+static bool processHoldsFileLock(const std::filesystem::path & process, const FileLockIdentity & identity)
+{
+    for (auto & entry : DirectoryIterator{process / "fdinfo"}) {
+        bool matchingLock = false;
+        bool matchingMount = false;
+        bool matchingInode = false;
+        try {
+            for (auto line : tokenizeString<std::vector<std::string>>(readFile(entry.path()), "\n")) {
+                auto fields = tokenizeString<std::vector<std::string>>(line);
+                if (fields.size() >= 7 && fields[0] == "lock:")
+                    matchingLock = matchingLock || matchesFileLock(fields, 2, 4, 6, identity.st);
+                else if (fields.size() == 2 && fields[0] == "mnt_id:")
+                    matchingMount = string2Int<uint64_t>(fields[1]) == identity.mountId;
+                else if (fields.size() == 2 && fields[0] == "ino:")
+                    matchingInode = string2Int<uint64_t>(fields[1]) == identity.st.st_ino;
+            }
+        } catch (SystemError & e) {
+            if (e.is(std::errc::no_such_file_or_directory))
+                continue;
+            throw;
+        }
+        if (matchingLock && matchingMount && matchingInode)
+            return true;
+    }
+    return false;
+}
+
+static std::optional<FileLockOwner> getFileLockOwnerLinux(Descriptor fd)
+{
+    auto identity = getFileLockIdentity(fd);
+
+    for (auto line : tokenizeString<std::vector<std::string>>(readFile("/proc/locks"), "\n")) {
+        auto fields = tokenizeString<std::vector<std::string>>(line);
+        if (fields.size() < 6 || !matchesFileLock(fields, 1, 3, 5, identity.st))
+            continue;
+
+        auto pid = string2Int<uint64_t>(fields[4]);
+        if (!pid || *pid == 0 || *pid > static_cast<uint64_t>(std::numeric_limits<pid_t>::max()))
+            continue;
+
+        auto process = std::filesystem::path{"/proc"} / std::to_string(*pid);
+        try {
+            auto processIdentity = getProcessIdentity(*pid);
+            if (processIdentity && processHoldsFileLock(process, identity)
+                && getProcessIdentity(*pid) == processIdentity)
+                return processIdentity;
+        } catch (SystemError & e) {
+            if (!e.is(std::errc::no_such_file_or_directory) && !e.is(std::errc::permission_denied))
+                throw;
+        }
+    }
+
+    return std::nullopt;
+}
+#endif
+
+std::optional<FileLockOwner> getFileLockOwner(const std::filesystem::path & path)
+{
+    auto fd = openLockFile(path, false);
+    if (!fd)
+        return {};
+
+    FdLock probe(fd.get(), ltWrite, false, "");
+    if (probe.acquired)
+        return {};
+
+#ifdef __linux__
+    auto owner = getFileLockOwnerLinux(fd.get());
+    if (owner)
+        return owner;
+
+    FdLock retry(fd.get(), ltWrite, false, "");
+    if (retry.acquired)
+        return {};
+    throw MissingLockOwner("the process holding the lock on %s is not visible in /proc/locks", PathFmt(path));
+#else
+    auto owner = readFileLockOwner(fd.get());
+#  ifdef __APPLE__
+    if (getProcessIdentity(owner.pid) != owner)
+        throw MissingLockOwner("process %d recorded as the lock owner no longer exists", owner.pid);
+    validateKernelLockOwner(path, owner);
+#  endif
+    if (readFileLockOwner(fd.get()) != owner)
+        throw MissingLockOwner("the owner of the lock on %s changed while it was being inspected", PathFmt(path));
+#  ifdef __APPLE__
+    validateKernelLockOwner(path, owner);
+#  endif
+
+    return owner;
+#endif
+}
+
+bool fileLockOwnerStillHoldsLock(const std::filesystem::path & path, const FileLockOwner & owner)
+{
+#ifdef __linux__
+    try {
+        auto fd = openLockFile(path, false);
+        if (!fd || getProcessIdentity(owner.pid) != owner)
+            return false;
+        return processHoldsFileLock(
+            std::filesystem::path{"/proc"} / std::to_string(owner.pid), getFileLockIdentity(fd.get()));
+    } catch (SystemError & e) {
+        if (e.is(std::errc::no_such_file_or_directory))
+            return false;
+        throw;
+    }
+#elif defined(__APPLE__)
+    try {
+        return getFileLockOwner(path) == owner;
+    } catch (MissingLockOwner &) {
+        try {
+            validateKernelLockOwner(path, owner);
+            return getProcessIdentity(owner.pid) == owner;
+        } catch (MissingLockOwner &) {
+            return false;
+        }
+    }
+#else
+    (void) path;
+    (void) owner;
+    return false;
+#endif
+}
+
+bool signalFileLockOwner(const std::filesystem::path & path, const FileLockOwner & owner, int signal)
+{
+#ifdef __linux__
+#  if defined(SYS_pidfd_open) && defined(SYS_pidfd_send_signal)
+    auto rawPidFd = syscall(SYS_pidfd_open, static_cast<pid_t>(owner.pid), 0);
+    if (rawPidFd == -1) {
+        if (errno == ESRCH || errno == ENOENT || errno == ENODEV)
+            return false;
+        if (errno == ENOSYS)
+            throw UsageError("terminating builds requires pidfd support from the Linux kernel");
+        throw SysError("opening a pidfd for process %d", owner.pid);
+    }
+    AutoCloseFD pidFd(static_cast<int>(rawPidFd));
+
+    if (!fileLockOwnerStillHoldsLock(path, owner))
+        return false;
+
+    if (syscall(SYS_pidfd_send_signal, pidFd.get(), signal, nullptr, 0) == -1) {
+        if (errno == ESRCH)
+            return false;
+        if (errno == ENOSYS)
+            throw UsageError("terminating builds requires pidfd support from the Linux kernel");
+        throw SysError("sending signal %d to process %d", signal, owner.pid);
+    }
+    return true;
+#  else
+    (void) path;
+    (void) owner;
+    (void) signal;
+    throw UsageError("terminating builds requires a Nix build with Linux pidfd support");
+#  endif
+#elif defined(__APPLE__)
+    auto fd = openLockFile(path, false);
+    if (!fd)
+        return false;
+    auto record = readFileLockOwnerRecord(fd.get());
+    if (record.owner != owner)
+        return false;
+
+    if (!fileLockOwnerStillHoldsLock(path, owner))
+        return false;
+    auto error = proc_signal_with_audittoken(&record.auditToken, signal);
+    if (error != 0) {
+        if (error == ESRCH)
+            return false;
+        throw SysError(error, "sending signal %d to process %d", signal, owner.pid);
+    }
+    return true;
+#else
+    (void) path;
+    (void) owner;
+    (void) signal;
+    throw UsageError("build termination is not supported on this platform");
+#endif
+}
+
+#ifdef __APPLE__
+static bool lockOwnerFile(Descriptor fd)
+{
+    struct flock lock{
+        .l_start = 0,
+        .l_len = 0,
+        .l_pid = 0,
+        .l_type = F_WRLCK,
+        .l_whence = SEEK_SET,
+    };
+    while (fcntl(fd, F_SETLK, &lock) == -1) {
+        if (errno == EINTR) {
+            checkInterrupt();
+            continue;
+        }
+        if (errno == EACCES || errno == EAGAIN)
+            return false;
+        debug("cannot acquire a path lock owner record: %s", strerror(errno));
+        return false;
+    }
+    return true;
+}
+#endif
+
+bool PathLocks::lockPaths(
+    const std::set<std::filesystem::path> & paths, const std::string & waitMsg, bool wait, LockOwnerTracking trackOwner)
 {
     assert(fds.empty());
+    (void) trackOwner;
 
     /* Note that `fds' is built incrementally so that the destructor
        will only release those locks that we have already acquired. */
@@ -86,6 +516,9 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
         debug("locking path %1%", PathFmt(path));
 
         AutoCloseFD fd;
+#ifdef __APPLE__
+        AutoCloseFD ownerFd;
+#endif
 
         while (1) {
 
@@ -117,10 +550,37 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
                    processes may create and acquire a lock on
                    `lockPath', and proceed.  So we must retry. */
                 debug("open lock file %1% has become stale", PathFmt(lockPath));
-            else
+            else {
+#ifdef __APPLE__
+                if (trackOwner == LockOwnerTracking::Yes) {
+                    auto ownerPath = getOwnerLockPath(lockPath);
+                    clearFileLockOwner(fd.get());
+                    tryUnlink(ownerPath);
+                    try {
+                        ownerFd = openLockFile(ownerPath, true);
+                    } catch (SystemError & e) {
+                        debug("cannot create a path lock owner record: %s", e.what());
+                    }
+                    if (ownerFd && lockOwnerFile(ownerFd.get())) {
+                        try {
+                            if (!setFileLockOwner(fd.get()))
+                                ownerFd.close();
+                        } catch (Error & e) {
+                            debug("cannot record the owner of a lock: %s", e.what());
+                            ownerFd.close();
+                        }
+                    } else
+                        ownerFd.close();
+                }
+#endif
                 break;
+            }
         }
 
+#ifdef __APPLE__
+        if (ownerFd)
+            ownerFds.emplace_back(ownerFd.release(), getOwnerLockPath(lockPath));
+#endif
         /* Use borrow so that the descriptor isn't closed. */
         fds.push_back(FDPair(fd.release(), lockPath));
     }
@@ -130,6 +590,19 @@ bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const s
 
 void PathLocks::unlock()
 {
+#ifdef __APPLE__
+    if (!ownerFds.empty())
+        for (auto & [fd, _] : fds)
+            clearFileLockOwner(fd);
+
+    for (auto & [fd, path] : ownerFds) {
+        tryUnlink(path);
+        if (close(fd) == -1)
+            printError("error (ignored): cannot close lock owner record on %1%", PathFmt(path));
+    }
+    ownerFds.clear();
+#endif
+
     for (auto & i : fds) {
         if (deletePaths)
             deleteLockFile(i.second, i.first);

--- a/src/libstore/windows/local-build-control.cc
+++ b/src/libstore/windows/local-build-control.cc
@@ -1,0 +1,11 @@
+#include "nix/store/local-store.hh"
+
+namespace nix {
+
+std::optional<uint64_t> LocalStore::killBuild(const StorePath & path)
+{
+    (void) path;
+    throw UsageError("build termination is not supported on Windows");
+}
+
+} // namespace nix

--- a/src/libstore/windows/meson.build
+++ b/src/libstore/windows/meson.build
@@ -1,4 +1,5 @@
 sources += files(
+  'local-build-control.cc',
   'pathlocks.cc',
 )
 

--- a/src/libstore/windows/pathlocks.cc
+++ b/src/libstore/windows/pathlocks.cc
@@ -114,9 +114,11 @@ bool lockFile(Descriptor desc, LockType lockType, bool wait)
     }
 }
 
-bool PathLocks::lockPaths(const std::set<std::filesystem::path> & paths, const std::string & waitMsg, bool wait)
+bool PathLocks::lockPaths(
+    const std::set<std::filesystem::path> & paths, const std::string & waitMsg, bool wait, LockOwnerTracking trackOwner)
 {
     assert(fds.empty());
+    (void) trackOwner;
 
     for (auto & path : paths) {
         checkInterrupt();

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -27,6 +27,7 @@ const WorkerProto::Version WorkerProto::latest = {
         {
             std::string{WorkerProto::featureRealisationWithPath},
             std::string{WorkerProto::featureDeleteDeadSpecificReferrers},
+            std::string{WorkerProto::featureBuildControl},
         },
 };
 

--- a/src/libutil/unix/include/nix/util/signals-impl.hh
+++ b/src/libutil/unix/include/nix/util/signals-impl.hh
@@ -50,6 +50,11 @@ void _interrupted();
 void startSignalHandlerThread();
 
 /**
+ * Restart signal handling in a child that continues running after fork().
+ */
+void startSignalHandlerThreadAfterFork();
+
+/**
  * Saves the signal mask, which is the signal mask that nix will restore
  * before creating child processes.
  */

--- a/src/libutil/unix/signals.cc
+++ b/src/libutil/unix/signals.cc
@@ -8,6 +8,7 @@
 #include "unix/signals-private.hh"
 
 #include <thread>
+#include <unistd.h>
 
 namespace nix {
 
@@ -51,13 +52,30 @@ InterruptCallback::~InterruptCallback() {}
 
 /* Required to avoid static initialization order fiasco. This allows global
    objects to safely register callbacks. */
-static Sync<InterruptCallbacks> & getInterruptCallbacks()
+static Sync<InterruptCallbacks> *& getInterruptCallbacksStorage()
 {
     /* Intentionally leak, according to the Construct On First Use Idiom.
        An alternative is to use the Nifty Counter Idiom, but
        InterruptCallbacks' destructor is not very important. */
     static Sync<InterruptCallbacks> * _interruptCallbacks = new Sync<InterruptCallbacks>();
-    return *_interruptCallbacks;
+    return _interruptCallbacks;
+}
+
+static Sync<InterruptCallbacks> & getInterruptCallbacks()
+{
+    return *getInterruptCallbacksStorage();
+}
+
+static sigset_t getSignalSet()
+{
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGINT);
+    sigaddset(&set, SIGTERM);
+    sigaddset(&set, SIGHUP);
+    sigaddset(&set, SIGPIPE);
+    sigaddset(&set, SIGWINCH);
+    return set;
 }
 
 static void signalHandlerThread(sigset_t set)
@@ -120,13 +138,22 @@ void unix::startSignalHandlerThread()
 
     saveSignalMask();
 
-    sigset_t set;
-    sigemptyset(&set);
-    sigaddset(&set, SIGINT);
-    sigaddset(&set, SIGTERM);
-    sigaddset(&set, SIGHUP);
-    sigaddset(&set, SIGPIPE);
-    sigaddset(&set, SIGWINCH);
+    auto set = getSignalSet();
+    if (pthread_sigmask(SIG_BLOCK, &set, nullptr))
+        throw SysError("blocking signals");
+
+    std::thread(signalHandlerThread, set).detach();
+}
+
+void unix::startSignalHandlerThreadAfterFork()
+{
+    /* Mutexes and callbacks inherited from other threads are unusable in the
+       child. Leave that state allocated for the parent and start afresh. */
+    getInterruptCallbacksStorage() = new Sync<InterruptCallbacks>();
+    _isInterrupted = false;
+    interruptCheck = {};
+
+    auto set = getSignalSet();
     if (pthread_sigmask(SIG_BLOCK, &set, nullptr))
         throw SysError("blocking signals");
 
@@ -159,9 +186,11 @@ namespace {
 struct InterruptCallbackImpl : InterruptCallback
 {
     InterruptCallbacks::Token token;
+    pid_t creatorPid;
 
     InterruptCallbackImpl(InterruptCallbacks::Token token)
         : token(token)
+        , creatorPid(getpid())
     {
     }
 
@@ -172,6 +201,8 @@ struct InterruptCallbackImpl : InterruptCallback
 
     ~InterruptCallbackImpl() override
     {
+        if (creatorPid != getpid())
+            return;
         auto interruptCallbacks(getInterruptCallbacks().lock());
         interruptCallbacks->callbacks.erase(token);
     }

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -119,6 +119,7 @@ nix_sources = [ config_priv_h ] + files(
   'store-delete.cc',
   'store-gc.cc',
   'store-info.cc',
+  'store-kill-build.cc',
   'store-repair.cc',
   'store-submit-output.cc',
   'store.cc',

--- a/src/nix/store-kill-build.cc
+++ b/src/nix/store-kill-build.cc
@@ -1,0 +1,48 @@
+#include "nix/cmd/command.hh"
+#include "nix/main/shared.hh"
+#include "nix/store/build-control-store.hh"
+#include "nix/store/store-cast.hh"
+
+namespace nix {
+
+struct CmdStoreKillBuild : StoreCommand
+{
+    std::string path;
+
+    CmdStoreKillBuild()
+    {
+        expectArg("path", &path);
+    }
+
+    std::string description() override
+    {
+        return "terminate the active build of an output or registered derivation";
+    }
+
+    std::string doc() override
+    {
+        return
+#include "store-kill-build.md"
+            ;
+    }
+
+    void run(ref<Store> store) override
+    {
+        auto storePath = store->parseStorePath(path);
+        auto & buildControlStore = require<BuildControlStore>(*store);
+        auto pid = buildControlStore.killBuild(storePath);
+        if (!pid) {
+            warn("no process holds an output lock for '%s'", store->printStorePath(storePath));
+            return;
+        }
+
+        notice(
+            "process %d released the output locks for '%s' after being signalled",
+            *pid,
+            store->printStorePath(storePath));
+    }
+};
+
+static auto rCmdStoreKillBuild = registerCommand2<CmdStoreKillBuild>({"store", "kill-build"});
+
+} // namespace nix

--- a/src/nix/store-kill-build.md
+++ b/src/nix/store-kill-build.md
@@ -1,0 +1,41 @@
+R""(
+
+# Examples
+
+* Terminate the active build of a derivation:
+
+  ```console
+  # nix store kill-build /nix/store/abc123-package.drv
+  ```
+
+# Description
+
+This command asks the Nix process that owns the relevant output locks for the specified [store path] or registered [store derivation] to terminate.
+It sends `SIGTERM` and waits up to five seconds for the process to release the locks.
+If any lock remains held, the command fails without sending `SIGKILL`, which could leave builder processes running after the locks are released.
+
+Nix cannot determine the output locks of an unregistered store derivation, such as one sent directly to a remote builder with the `BuildDerivation` protocol operation.
+Specify a known output path instead.
+An unregistered [floating content-addressing derivation] has no known output path before it finishes, so its build cannot currently be selected.
+
+Output locks are also used during substitution and registration.
+If either operation owns a selected lock, this command terminates its Nix process.
+
+The command signals only the verified owner of each relevant output lock.
+It does not signal processes that only have the lock file open or are waiting to acquire the lock.
+
+The command does not remove lock files.
+Instead, it waits for the operating system to release the locks, allowing Nix's normal locking protocol to continue safely.
+
+A Nix process can manage multiple builds, so terminating it can cancel other builds.
+
+The selected store must support this operation.
+The Nix daemon permits only trusted clients to use it.
+
+On Linux, the kernel must support pidfds.
+
+[floating content-addressing derivation]: @docroot@/store/derivation/outputs/content-address.md#floating
+[store derivation]: @docroot@/glossary.md#gloss-store-derivation
+[store path]: @docroot@/store/store-path.md
+
+)""

--- a/src/nix/unix/daemon.cc
+++ b/src/nix/unix/daemon.cc
@@ -358,6 +358,8 @@ static void daemonLoop(
                     [&, storeConfig, closeListeners = std::move(closeListeners)]() {
                         closeListeners();
 
+                        unix::startSignalHandlerThreadAfterFork();
+
                         // Background the daemon.
                         if (setsid() == -1)
                             throw SysError("creating a new session");

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -170,6 +170,7 @@ suites = [
       'simple.sh',
       'ssh-relay.sh',
       'store-info.sh',
+      'store-kill-build.sh',
       'store-print-env.sh',
       'structured-attrs.sh',
       'substitute-with-invalid-ca.sh',

--- a/tests/functional/store-kill-build.nix
+++ b/tests/functional/store-kill-build.nix
@@ -1,0 +1,12 @@
+with import ./config.nix;
+
+mkDerivation {
+  name = "store-kill-build";
+  __contentAddressed = true;
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  buildCommand = ''
+    sleep 60
+    mkdir "$out"
+  '';
+}

--- a/tests/functional/store-kill-build.sh
+++ b/tests/functional/store-kill-build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+requireDaemonNewerThan "2.36pre"
+[[ $(uname) == Linux || $(uname) == Darwin ]] || skipTest "build termination is only supported on Linux and macOS"
+TODO_NixOS # cannot enable ca-derivations in the system daemon
+enableFeatures "ca-derivations"
+
+if ! isTestOnNixOS; then
+    # Compatibility tests start their daemon before enabling features.
+    killDaemon
+    startDaemon
+fi
+
+drvPath=$(nix-instantiate store-kill-build.nix)
+lockPath="$drvPath.out.lock"
+
+nix-store -r "$drvPath" > "$TEST_ROOT/build.out" 2> "$TEST_ROOT/build.err" &
+buildPid=$!
+cleanup() {
+    if [[ -n "${buildPid-}" ]]; then
+        kill "$buildPid" 2> /dev/null || true
+    fi
+    if [[ -n "${_NIX_TEST_DAEMON_PID-}" ]]; then
+        killDaemon
+    fi
+}
+trap cleanup EXIT
+
+killOutput=
+for _ in {1..100}; do
+    killOutput=$(nix store kill-build "$drvPath" 2>&1 || true)
+    grepQuiet "released the output locks" <<< "$killOutput" && break
+    sleep 0.05
+done
+
+grepQuiet "released the output locks" <<< "$killOutput"
+
+if wait "$buildPid"; then
+    fail "build unexpectedly succeeded after its lock owner was terminated"
+fi
+buildPid=
+
+[[ -e "$lockPath" ]]

--- a/tests/nixos/authorization.nix
+++ b/tests/nixos/authorization.nix
@@ -80,6 +80,12 @@
       """)
 
       machine.succeed("""
+        set -x
+        su --login bob -c '(! nix store kill-build ${pathFour} 2>&1)' | tee diag 1>&2
+        grep -F "you are not privileged to terminate builds" diag
+      """)
+
+      machine.succeed("""
           set -x
           su --login mallory -c '
             nix-store --generate-binary-cache-key cache1.example.org sk1 pk1


### PR DESCRIPTION
## Motivation

Stuck Nix processes can hold output locks indefinitely, for example after a hung SSH connection. Removing a locked file is unsafe because another process can create a replacement and enter the protected section concurrently.

Related to #1015.

## Changes

This replaces the original `nix store break-lock` implementation with `nix store kill-build <store-path>`, which asks the verified lock owner to terminate and waits up to five seconds for it to release the lock.

- Add an optional `BuildControlStore` interface implemented by `LocalStore` and `RemoteStore`.
- Add negotiated worker protocol operation 51; daemon access requires a trusted client. Operations 48–50 remain reserved for other work.
- Track macOS output-lock owners without changing unrelated `PathLocks` users such as profile locks.
- Restart signal handling in forked daemon workers so they respond to `SIGTERM`.
- Never unlink lock files or escalate to `SIGKILL`.

## Observability

This PR depends on #15979 for active-build discovery and should not merge first. A registered derivation reported by `nix ps` can be passed directly to `kill-build`, including a floating content-addressed derivation. An unregistered remote `BuildDerivation` request requires a known output path; an unregistered floating content-addressed build cannot currently be selected.

## Safety

On Linux, Nix identifies the kernel `FLOCK` owner through `/proc`, verifies the exact descriptor and process start time, then revalidates and signals through a pidfd. On macOS, it requires a companion kernel lock, recorded process identity, live identity, and audit token to agree before signalling. If ownership cannot be proven, the command fails without signalling.

One Nix process can coordinate multiple builds, substitutions, or registrations, so terminating it can cancel other work it manages.

## Compatibility

The capability is negotiated, so new clients continue to work with older daemons. Linux requires pidfd support; platforms other than Linux and macOS report the operation as unsupported.

## Testing

- Passed repository formatting hooks and clang-tidy.
- Built with Clang on macOS and GCC on Linux.
- Passed the complete `libstore` suite and `store-kill-build` functional test on both platforms.
- Passed the NixOS daemon authorization VM test.
- Covered exact-owner validation, PID reuse, open-only processes, inherited locks, stale macOS metadata, SIGTERM refusal, replacement owners, floating content-addressed derivations, feature negotiation, and forked-daemon signal handling.

**AI disclosure:** I used AI coding agents, including OpenAI Codex and independent Codex and Claude review agents, to help implement and review this change. I reviewed the resulting code and test results.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
