### PR TITLE
Failing test for broken gitlab url parsing

### DIFF
--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -382,6 +382,25 @@ TEST(percentEncode, yen)
     ASSERT_EQ(percentDecode(e), s);
 }
 
+TEST(parseURL, gitlabNamespacedProjectUrls)
+{
+    // Test GitLab URL patterns with namespaced projects
+    // These should preserve %2F encoding in the path
+    auto s = "https://gitlab.example.com/api/v4/projects/group%2Fsubgroup%2Fproject/repository/archive.tar.gz";
+    auto parsed = parseURL(s);
+
+    ParsedURL expected{
+        .scheme = "https",
+        .authority = Authority{.hostType = HostType::Name, .host = "gitlab.example.com"},
+        .path = "/api/v4/projects/group%2Fsubgroup%2Fproject/repository/archive.tar.gz",
+        .query = {},
+        .fragment = "",
+    };
+
+    ASSERT_EQ(parsed, expected);
+    ASSERT_EQ(s, parsed.to_string());
+}
+
 TEST(nix, isValidSchemeName)
 {
     ASSERT_TRUE(isValidSchemeName("http"));


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
