### PR TITLE
Make self attrs overridable

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -253,10 +253,6 @@ struct GitInputScheme : InputScheme
             url.query.insert_or_assign("ref", *ref);
         if (getShallowAttr(input))
             url.query.insert_or_assign("shallow", "1");
-        if (getLfsAttr(input))
-            url.query.insert_or_assign("lfs", "1");
-        if (getSubmodulesAttr(input))
-            url.query.insert_or_assign("submodules", "1");
         if (maybeGetBoolAttr(input.attrs, "exportIgnore").value_or(false))
             url.query.insert_or_assign("exportIgnore", "1");
         if (maybeGetBoolAttr(input.attrs, "verifyCommit").value_or(false))
@@ -267,6 +263,11 @@ struct GitInputScheme : InputScheme
             url.query.insert_or_assign("publicKey", publicKeys.at(0).key);
         } else if (publicKeys.size() > 1)
             url.query.insert_or_assign("publicKeys", publicKeys_to_string(publicKeys));
+        // These are allowed as self attrs, the explicit false is important
+        if (auto lfs = maybeGetBoolAttr(input.attrs, "lfs"))
+            url.query.insert_or_assign("lfs", *lfs ? "1" : "0");
+        if (auto submodules = maybeGetBoolAttr(input.attrs, "submodules"))
+            url.query.insert_or_assign("submodules", *submodules ? "1" : "0");
         return url;
     }
 
@@ -884,8 +885,14 @@ struct GitInputScheme : InputScheme
     std::optional<std::string> getFingerprint(ref<Store> store, const Input & input) const override
     {
         auto makeFingerprint = [&](const Hash & rev) {
-            return rev.gitRev() + (getSubmodulesAttr(input) ? ";s" : "") + (getExportIgnoreAttr(input) ? ";e" : "")
-                   + (getLfsAttr(input) ? ";l" : "");
+            std::string modifiers = "";
+            if (getExportIgnoreAttr(input))
+                modifiers += ";e";
+            if (auto lfs = maybeGetBoolAttr(input.attrs, "lfs"))
+                modifiers += *lfs ? ";l1" : ";l0";
+            if (auto submodules = maybeGetBoolAttr(input.attrs, "submodules"))
+                modifiers += *submodules ? ";s1" : ";s0";
+            return rev.gitRev() + modifiers;
         };
 
         if (auto rev = input.getRev())

--- a/src/libflake/flake.cc
+++ b/src/libflake/flake.cc
@@ -325,7 +325,7 @@ static FlakeRef applySelfAttrs(const FlakeRef & ref, const Flake & flake)
     for (auto & attr : flake.selfAttrs) {
         if (!allowedAttrs.contains(attr.first))
             throw Error("flake 'self' attribute '%s' is not supported", attr.first);
-        newRef.input.attrs.insert_or_assign(attr.first, attr.second);
+        newRef.input.attrs.try_emplace(attr.first, attr.second);
     }
 
     return newRef;


### PR DESCRIPTION
## Motivation

The self attributes should (I believe) be used as defaults, but currently setting a self attribute makes it silently ignore any explicit values passed by consumers.

## Context

Noticed this while working on #13743, but decided to move it to its own PR to avoid adding noise there. Have not created an issue for it though, and cannot find any relevant issues to link against.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
