### PR TITLE
Handle empty ports with new URL parsing

### DIFF
--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -273,6 +273,23 @@ TEST(parseURL, emptyStringIsInvalidURL)
     ASSERT_THROW(parseURL(""), Error);
 }
 
+TEST(parseURL, parsesHttpUrlWithEmptyPort)
+{
+    auto s = "http://www.example.org:/file.tar.gz?foo=bar";
+    auto parsed = parseURL(s);
+
+    ParsedURL expected{
+        .scheme = "http",
+        .authority = Authority{.hostType = HostType::Name, .host = "www.example.org"},
+        .path = "/file.tar.gz",
+        .query = (StringMap) {{"foo", "bar"}},
+        .fragment = "",
+    };
+
+    ASSERT_EQ(parsed, expected);
+    ASSERT_EQ("http://www.example.org/file.tar.gz?foo=bar", parsed.to_string());
+}
+
 /* ----------------------------------------------------------------------------
  * decodeQuery
  * --------------------------------------------------------------------------*/

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -33,7 +33,7 @@ ParsedURL::Authority ParsedURL::Authority::parse(std::string_view encodedAuthori
     }();
 
     auto port = [&]() -> std::optional<uint16_t> {
-        if (!parsed->has_port())
+        if (!parsed->has_port() || parsed->port() == "")
             return std::nullopt;
         /* If the port number is non-zero and representable. */
         if (auto portNumber = parsed->port_number())


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation
Fix #13830

## Context

@sbc64 mentioned he had an issue with the new URL handling and it looked simple to fix, so I took the liberty of doing so.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
