### PR TITLE
don't include derivation name in temporary build directories

### DIFF
--- a/doc/manual/rl-next/shorter-build-dir-names.md
+++ b/doc/manual/rl-next/shorter-build-dir-names.md
@@ -1,0 +1,6 @@
+---
+synopsis: "Temporary build directories no longer include derivation names"
+prs: [13839]
+---
+
+Temporary build directories created during derivation builds no longer include the derivation name in their path to avoid build failures when the derivation name is too long. This change ensures predictable prefix lengths for build directories under `/nix/var/nix/builds`.

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -706,7 +706,7 @@ void DerivationBuilderImpl::startBuilder()
 
     /* Create a temporary directory where the build will take
        place. */
-    topTmpDir = createTempDir(buildDir, "nix-build-" + std::string(drvPath.name()), 0700);
+    topTmpDir = createTempDir(buildDir, "nix", 0700);
     setBuildTmpDir();
     assert(!tmpDir.empty());
 

--- a/tests/functional/check.sh
+++ b/tests/functional/check.sh
@@ -52,10 +52,10 @@ test_custom_build_dir() {
   nix-build check.nix -A failed --argstr checkBuildId "$checkBuildId" \
       --no-out-link --keep-failed --option build-dir "$TEST_ROOT/custom-build-dir" 2> "$TEST_ROOT/log" || status=$?
   [ "$status" = "100" ]
-  [[ 1 == "$(count "$customBuildDir/nix-build-"*)" ]]
-  local buildDir=("$customBuildDir/nix-build-"*)
+  [[ 1 == "$(count "$customBuildDir/nix-"*)" ]]
+  local buildDir=("$customBuildDir/nix-"*)
   if [[ "${#buildDir[@]}" -ne 1 ]]; then
-    echo "expected one nix-build-* directory, got: ${buildDir[*]}" >&2
+    echo "expected one nix-* directory, got: ${buildDir[*]}" >&2
     exit 1
   fi
   if [[ -e ${buildDir[*]}/build ]]; then

--- a/tests/nixos/user-sandboxing/default.nix
+++ b/tests/nixos/user-sandboxing/default.nix
@@ -104,8 +104,8 @@ in
 
           # Wait for the build to be ready
           # This is OK because it runs as root, so we can access everything
-          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-build-open-build-dir.drv-*/build/syncPoint")
-          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-build-open-build-dir.drv-*").strip()
+          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-*/build/syncPoint")
+          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-*").strip()
 
           # But Alice shouldn't be able to access the build directory
           machine.fail(f"su alice -c 'ls {dir}/build'")
@@ -125,8 +125,8 @@ in
                 args = [ (builtins.storePath "${create-hello-world}") ];
             }' >&2 &
           """.strip())
-          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-build-innocent.drv-*/build/syncPoint")
-          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-build-innocent.drv-*").strip()
+          machine.wait_until_succeeds("stat /nix/var/nix/builds/nix-*/build/syncPoint")
+          dir = machine.succeed("ls -d /nix/var/nix/builds/nix-*").strip()
 
           # The build ran as `nixbld1` (which is the only build user on the
           # machine), but a process running as `nixbld1` outside the sandbox


### PR DESCRIPTION
With the migration to /nix/var/nix/builds we now have failing builds when the derivation name is too long.
This change removes the derivation name from the temporary build to have a predictable prefix length:

Also see: https://github.com/NixOS/infra/pull/764
for context.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
