### PR TITLE
Add a test for `nix flake check` building checks

### DIFF
--- a/tests/functional/flakes/check.sh
+++ b/tests/functional/flakes/check.sh
@@ -135,3 +135,35 @@ EOF
 
 checkRes=$(nix flake check --all-systems $flakeDir 2>&1 && fail "nix flake check --all-systems should have failed" || true)
 echo "$checkRes" | grepQuiet "formatter.system-1"
+
+# Test whether `nix flake check` builds checks.
+cat > $flakeDir/flake.nix <<EOF
+{
+  outputs = { self }: {
+    checks.$system.foo = with import ./config.nix; mkDerivation {
+      name = "simple";
+      buildCommand = "mkdir \$out";
+    };
+  };
+}
+EOF
+
+cp "${config_nix}" "$flakeDir/"
+
+expectStderr 0 nix flake check "$flakeDir" | grepQuiet 'running 1 flake check'
+
+cat > $flakeDir/flake.nix <<EOF
+{
+  outputs = { self }: {
+    checks.$system.foo = with import ./config.nix; mkDerivation {
+      name = "simple";
+      buildCommand = "false";
+    };
+  };
+}
+EOF
+
+# FIXME: error code 100 doesn't get propagated from the daemon.
+if !isTestOnNixOS && $NIX_REMOTE != daemon; then
+    expectStderr 100 nix flake check "$flakeDir" | grepQuiet 'builder failed with exit code 1'
+fi


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

We lacked a test for `nix flake check` actually building stuff. Cherry-picked from https://github.com/DeterminateSystems/nix-src/pull/182.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
