### PR TITLE
No more `DerivationBuilderParams:` constructor!

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -758,16 +758,16 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
                 *localStoreP,
                 std::make_unique<DerivationBuildingGoalCallbacks>(*this, builder),
                 DerivationBuilderParams{
-                    drvPath,
-                    buildMode,
-                    buildResult,
-                    *drv,
-                    *drvOptions,
-                    inputPaths,
-                    initialOutputs,
-                    std::move(defaultPathsInChroot),
-                    std::move(finalEnv),
-                    std::move(extraFiles),
+                    .drvPath = drvPath,
+                    .buildResult = buildResult,
+                    .drv = *drv,
+                    .drvOptions = *drvOptions,
+                    .inputPaths = inputPaths,
+                    .initialOutputs = initialOutputs,
+                    .buildMode = buildMode,
+                    .defaultPathsInChroot = std::move(defaultPathsInChroot),
+                    .finalEnv = std::move(finalEnv),
+                    .extraFiles = std::move(extraFiles),
                 });
         }
 

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -93,32 +93,6 @@ struct DerivationBuilderParams
      * `EnvEntry::nameOfPassAsFile` above.
      */
     StringMap extraFiles;
-
-    DerivationBuilderParams(
-        const StorePath & drvPath,
-        const BuildMode & buildMode,
-        BuildResult & buildResult,
-        const Derivation & drv,
-        const DerivationOptions & drvOptions,
-        const StorePathSet & inputPaths,
-        std::map<std::string, InitialOutput> & initialOutputs,
-        PathsInChroot defaultPathsInChroot,
-        std::map<std::string, EnvEntry, std::less<>> finalEnv,
-        StringMap extraFiles)
-        : drvPath{drvPath}
-        , buildResult{buildResult}
-        , drv{drv}
-        , drvOptions{drvOptions}
-        , inputPaths{inputPaths}
-        , initialOutputs{initialOutputs}
-        , buildMode{buildMode}
-        , defaultPathsInChroot{std::move(defaultPathsInChroot)}
-        , finalEnv{std::move(finalEnv)}
-        , extraFiles{std::move(extraFiles)}
-    {
-    }
-
-    DerivationBuilderParams(DerivationBuilderParams &&) = default;
 };
 
 /**


### PR DESCRIPTION
## Motivation

Way nicer!


## Context

I am not sure how/why this started working. C++23?

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
