### PR TITLE
Factor out a new `DesugaredEnv` from `DerivationBuildingGoal`

### DIFF
--- a/src/libstore/build/derivation-check.hh
+++ b/src/libstore/build/derivation-check.hh
@@ -1,3 +1,6 @@
+#pragma once
+///@file
+
 #include "nix/store/derivations.hh"
 #include "nix/store/derivation-options.hh"
 #include "nix/store/path-info.hh"

--- a/src/libstore/build/derivation-env-desugar.cc
+++ b/src/libstore/build/derivation-env-desugar.cc
@@ -1,0 +1,59 @@
+#include "nix/store/build/derivation-env-desugar.hh"
+#include "nix/store/store-api.hh"
+#include "nix/store/derivations.hh"
+#include "nix/store/derivation-options.hh"
+
+namespace nix {
+
+std::string & DesugaredEnv::atFileEnvPair(std::string_view name, std::string fileName)
+{
+    auto & ret = extraFiles[fileName];
+    variables.insert_or_assign(
+        std::string{name},
+        EnvEntry{
+            .prependBuildDirectory = true,
+            .value = std::move(fileName),
+        });
+    return ret;
+}
+
+DesugaredEnv DesugaredEnv::create(
+    Store & store, const Derivation & drv, const DerivationOptions & drvOptions, const StorePathSet & inputPaths)
+{
+    DesugaredEnv res;
+
+    if (drv.structuredAttrs) {
+        auto json = drv.structuredAttrs->prepareStructuredAttrs(store, drvOptions, inputPaths, drv.outputs);
+        res.atFileEnvPair("NIX_ATTRS_SH_FILE", ".attrs.sh") = StructuredAttrs::writeShell(json);
+        res.atFileEnvPair("NIX_ATTRS_JSON_FILE", ".attrs.json") = json.dump();
+    } else {
+        /* In non-structured mode, set all bindings either directory in the
+           environment or via a file, as specified by
+           `DerivationOptions::passAsFile`. */
+        for (auto & [envName, envValue] : drv.env) {
+            if (!drvOptions.passAsFile.contains(envName)) {
+                res.variables.insert_or_assign(
+                    envName,
+                    EnvEntry{
+                        .value = envValue,
+                    });
+            } else {
+                res.atFileEnvPair(
+                    envName + "Path",
+                    ".attr-" + hashString(HashAlgorithm::SHA256, envName).to_string(HashFormat::Nix32, false)) =
+                    envValue;
+            }
+        }
+
+        /* Handle exportReferencesGraph(), if set. */
+        for (auto & [fileName, storePaths] : drvOptions.getParsedExportReferencesGraph(store)) {
+            /* Write closure info to <fileName>. */
+            res.extraFiles.insert_or_assign(
+                fileName, store.makeValidityRegistration(store.exportReferences(storePaths, inputPaths), false, false));
+        }
+    }
+
+    return res;
+}
+
+} // namespace nix

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -8,6 +8,7 @@
 #include "nix/store/parsed-derivations.hh"
 #include "nix/util/processes.hh"
 #include "nix/store/restricted-store.hh"
+#include "nix/store/build/derivation-env-desugar.hh"
 
 namespace nix {
 
@@ -73,34 +74,7 @@ struct DerivationBuilderParams
      */
     StringSet systemFeatures;
 
-    struct EnvEntry
-    {
-        /**
-         * Actually, this should be passed as a file, but with a custom
-         * name (rather than hash-derived name for usual "pass as file").
-         */
-        std::optional<std::string> nameOfPassAsFile;
-
-        /**
-         * String value of env var, or contents of the file
-         */
-        std::string value;
-    };
-
-    /**
-     * The final environment variables to additionally set, possibly
-     * indirectly via a file.
-     *
-     * This is used by the caller to desugar the "structured attrs"
-     * mechanism, so `DerivationBuilder` doesn't need to know about it.
-     */
-    std::map<std::string, EnvEntry, std::less<>> finalEnv;
-
-    /**
-     * Inserted in the temp dir, but no file names placed in env, unlike
-     * `EnvEntry::nameOfPassAsFile` above.
-     */
-    StringMap extraFiles;
+    DesugaredEnv desugaredEnv;
 };
 
 /**

--- a/src/libstore/include/nix/store/build/derivation-env-desugar.hh
+++ b/src/libstore/include/nix/store/build/derivation-env-desugar.hh
@@ -1,0 +1,83 @@
+#pragma once
+///@file
+
+#include "nix/util/types.hh"
+#include "nix/store/path.hh"
+
+namespace nix {
+
+class Store;
+struct Derivation;
+struct DerivationOptions;
+
+/**
+ * Derivations claim to "just" specify their environment variables, but
+ * actually do a number of different features, such as "structured
+ * attrs", "pass as file", and "export references graph", things are
+ * more complicated then they appear.
+ *
+ * The good news is that we can simplify all that to the following view,
+ * where environment variables and extra files are specified exactly,
+ * with no special cases.
+ *
+ * Because we have `DesugaredEnv`, `DerivationBuilder` doesn't need to
+ * know about any of those above features, and their special case.
+ */
+struct DesugaredEnv
+{
+    struct EnvEntry
+    {
+        /**
+         * Whether to prepend the (inside via) path to the sandbox build
+         * directory to `value`. This is useful for when the env var
+         * should point to a file visible to the builder.
+         */
+        bool prependBuildDirectory = false;
+
+        /**
+         * String value of env var, or contents of the file.
+         */
+        std::string value;
+    };
+
+    /**
+     * The final environment variables to set.
+     */
+    std::map<std::string, EnvEntry, std::less<>> variables;
+
+    /**
+     * Extra file to be placed in the build directory.
+     *
+     * @note `EnvEntry::prependBuildDirectory` can be used to refer to
+     * those files without knowing what the build directory is.
+     */
+    StringMap extraFiles;
+
+    /**
+     * A common case is to define an environment variable that points to
+     * a file, which contains some contents.
+     *
+     * In base:
+     * ```
+     * export VAR=FILE_NAME
+     * echo CONTENTS >FILE_NAME
+     * ```
+     *
+     * This function assists in doing both parts, so the file name is
+     * kept in sync.
+     */
+    std::string & atFileEnvPair(std::string_view name, std::string fileName);
+
+    /**
+     * Given a (resolved) derivation, its options, and the closure of
+     * its inputs (which we can get since the derivation is resolved),
+     * desugar the environment to create a `DesguaredEnv`.
+     *
+     * @todo drvOptions will go away as a separate argument when it is
+     * just part of `Derivation`.
+     */
+    static DesugaredEnv create(
+        Store & store, const Derivation & drv, const DerivationOptions & drvOptions, const StorePathSet & inputPaths);
+};
+
+} // namespace nix

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -15,6 +15,7 @@ headers = [ config_pub_h ] + files(
   'build/derivation-builder.hh',
   'build/derivation-building-goal.hh',
   'build/derivation-building-misc.hh',
+  'build/derivation-env-desugar.hh',
   'build/derivation-goal.hh',
   'build/derivation-trampoline-goal.hh',
   'build/drv-output-substitution-goal.hh',

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -266,6 +266,7 @@ sources = files(
   'build-result.cc',
   'build/derivation-building-goal.cc',
   'build/derivation-check.cc',
+  'build/derivation-env-desugar.cc',
   'build/derivation-goal.cc',
   'build/derivation-trampoline-goal.cc',
   'build/drv-output-substitution-goal.cc',


### PR DESCRIPTION
## Motivation

Now we have better separation of the core logic --- an integral part of the store layer spec even --- from the goal mechanism and other minutiae.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
