### PR TITLE
feat(libstore): warn when kvm is enabled but /dev/kvm isn't available

### DIFF
--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -3,6 +3,7 @@
 #  include "nix/store/personality.hh"
 #  include "nix/util/cgroup.hh"
 #  include "nix/util/linux-namespaces.hh"
+#  include "nix/util/logging.hh"
 #  include "linux/fchmodat2-compat.hh"
 
 #  include <sys/ioctl.h>
@@ -492,8 +493,16 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
             createDirs(chrootRootDir + "/dev/shm");
             createDirs(chrootRootDir + "/dev/pts");
             ss.push_back("/dev/full");
-            if (systemFeatures.count("kvm") && pathExists("/dev/kvm"))
-                ss.push_back("/dev/kvm");
+            if (systemFeatures.count("kvm")) {
+                if (pathExists("/dev/kvm")) {
+                    ss.push_back("/dev/kvm");
+                } else {
+                    warn(
+                        "KVM is enabled in system-features but /dev/kvm is not available. "
+                        "QEMU builds may fall back to slow emulation. "
+                        "Consider removing 'kvm' from system-features in nix.conf if KVM is not supported on this system.");
+                }
+            }
             ss.push_back("/dev/null");
             ss.push_back("/dev/random");
             ss.push_back("/dev/tty");


### PR DESCRIPTION
## Motivation

I had a host with the `kvm` system-feature enabled, but no `/dev/kvm` available and it was causing VM tests to be extremely slow. It took me a minute to figure out that the host didn't have KVM, and that qemu was falling back to emulation. I figured it'd be nice to warn in this scenario.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
