### PR TITLE
Revert "Add a crude tracing mechansim for the build results"

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -1368,13 +1368,6 @@ DerivationBuildingGoal::done(BuildResult::Status status, SingleDrvOutputs builtO
 
     worker.updateProgress();
 
-    auto traceBuiltOutputsFile = getEnv("_NIX_TRACE_BUILT_OUTPUTS").value_or("");
-    if (traceBuiltOutputsFile != "") {
-        std::fstream fs;
-        fs.open(traceBuiltOutputsFile, std::fstream::out);
-        fs << worker.store.printStorePath(drvPath) << "\t" << buildResult.toString() << std::endl;
-    }
-
     return amDone(buildResult.success() ? ecSuccess : ecFailed, std::move(ex));
 }
 

--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -364,13 +364,6 @@ DerivationGoal::done(BuildResult::Status status, std::optional<Realisation> buil
 
     worker.updateProgress();
 
-    auto traceBuiltOutputsFile = getEnv("_NIX_TRACE_BUILT_OUTPUTS").value_or("");
-    if (traceBuiltOutputsFile != "") {
-        std::fstream fs;
-        fs.open(traceBuiltOutputsFile, std::fstream::out);
-        fs << worker.store.printStorePath(drvPath) << "\t" << buildResult.toString() << std::endl;
-    }
-
     return amDone(buildResult.success() ? ecSuccess : ecFailed, std::move(ex));
 }
 

--- a/src/libstore/include/nix/store/build-result.hh
+++ b/src/libstore/include/nix/store/build-result.hh
@@ -46,47 +46,6 @@ struct BuildResult
      */
     std::string errorMsg;
 
-    std::string toString() const
-    {
-        auto strStatus = [&]() {
-            switch (status) {
-            case Built:
-                return "Built";
-            case Substituted:
-                return "Substituted";
-            case AlreadyValid:
-                return "AlreadyValid";
-            case PermanentFailure:
-                return "PermanentFailure";
-            case InputRejected:
-                return "InputRejected";
-            case OutputRejected:
-                return "OutputRejected";
-            case TransientFailure:
-                return "TransientFailure";
-            case CachedFailure:
-                return "CachedFailure";
-            case TimedOut:
-                return "TimedOut";
-            case MiscFailure:
-                return "MiscFailure";
-            case DependencyFailed:
-                return "DependencyFailed";
-            case LogLimitExceeded:
-                return "LogLimitExceeded";
-            case NotDeterministic:
-                return "NotDeterministic";
-            case ResolvesToAlreadyValid:
-                return "ResolvesToAlreadyValid";
-            case NoSubstituters:
-                return "NoSubstituters";
-            default:
-                return "Unknown";
-            };
-        }();
-        return strStatus + ((errorMsg == "") ? "" : " : " + errorMsg);
-    }
-
     /**
      * How many times this build was performed.
      */


### PR DESCRIPTION
## Context

The commit says it was added for CA testing --- manual I assume, since there is no use of this in the test suite. I don't think we need it any more, and I am not sure whether it was ever supposed to have made it to `master` either.

This reverts commit 2eec2f765a86b8954f3a74ff148bc70a2d32be27.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
