### PR TITLE
libutil: Try to call std::terminate for panic, use C++20 std::source_location

### DIFF
--- a/src/libutil/error.cc
+++ b/src/libutil/error.cc
@@ -6,6 +6,7 @@
 #include "nix/util/terminal.hh"
 #include "nix/util/position.hh"
 
+#include <cinttypes>
 #include <iostream>
 #include <optional>
 #include "nix/util/serialise.hh"
@@ -439,10 +440,16 @@ void panic(std::string_view msg)
     std::terminate();
 }
 
-void panic(const char * file, int line, const char * func)
+void unreachable(std::source_location loc)
 {
     char buf[512];
-    int n = snprintf(buf, sizeof(buf), "Unexpected condition in %s at %s:%d", func, file, line);
+    int n = snprintf(
+        buf,
+        sizeof(buf),
+        "Unexpected condition in %s at %s:%" PRIuLEAST32,
+        loc.function_name(),
+        loc.file_name(),
+        loc.line());
     if (n < 0)
         panic("Unexpected condition and could not format error message");
     panic(std::string_view(buf, std::min(static_cast<int>(sizeof(buf)), n)));

--- a/src/libutil/include/nix/util/error.hh
+++ b/src/libutil/include/nix/util/error.hh
@@ -22,6 +22,7 @@
 #include <list>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -306,16 +307,9 @@ void panic(std::string_view msg);
 
 /**
  * Print a basic error message with source position and std::terminate().
- * Use the unreachable() macro to call this.
- */
-[[noreturn]]
-void panic(const char * file, int line, const char * func);
-
-/**
- * Print a basic error message with source position and std::terminate().
  *
  * @note: This assumes that the logger is operational
  */
-#define unreachable() (::nix::panic(__FILE__, __LINE__, __func__))
+[[gnu::noinline, gnu::cold, noreturn]] void unreachable(std::source_location loc = std::source_location::current());
 
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

We now have a terminate handler that prints a
stack trace, which is useful to have when encountering
an unreachable.

Make unreachable a function instead of a macro, since
C++20 provides a convenience class as a replacement for
older `__FILE__`, `__LINE__` macros.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
