### PR TITLE
Properly separater builder failure content and presentation

### DIFF
--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -12,6 +12,29 @@
 namespace nix {
 
 /**
+ * Denotes a build failure that stemmed from the builder exiting with a
+ * failing exist status.
+ */
+struct BuilderFailureError : BuildError
+{
+    int builderStatus;
+
+    std::string extraMsgAfter;
+
+    BuilderFailureError(BuildResult::Status status, int builderStatus, std::string extraMsgAfter)
+        : BuildError{
+            status,
+              /* No message for now, because the caller will make for
+                 us, with extra context */
+              "",
+          }
+        , builderStatus{std::move(builderStatus)}
+        , extraMsgAfter{std::move(extraMsgAfter)}
+    {
+    }
+};
+
+/**
  * Stuff we need to pass to initChild().
  */
 struct ChrootPath
@@ -119,8 +142,6 @@ struct DerivationBuilderCallbacks
      * Close the log file.
      */
     virtual void closeLogFile() = 0;
-
-    virtual void appendLogTailErrorMsg(std::string & msg) = 0;
 
     /**
      * Hook up `builderOut` to some mechanism to ingest the log

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -14,6 +14,7 @@ namespace nix {
 
 using std::map;
 
+struct BuilderFailureError;
 #ifndef _WIN32 // TODO enable build hook on Windows
 struct HookInstance;
 struct DerivationBuilder;
@@ -174,7 +175,7 @@ struct DerivationBuildingGoal : public Goal
 
     Done doneFailure(BuildError ex);
 
-    void appendLogTailErrorMsg(std::string & msg);
+    BuildError fixupBuilderFailureErrorMessage(BuilderFailureError msg);
 
     JobCategory jobCategory() const override
     {


### PR DESCRIPTION
## Motivation

Before, had a very ugly `appendLogTailErrorMsg` callback. Now, we instead have a `fixupBuilderFailureErrorMessage` that is just used by `DerivationBuildingGoal`, and `DerivationBuilder` just returns the raw data needed by this.

## Context

Depends on #13860

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
