### PR TITLE
Even more `DerivationBuilder` cleanup

### DIFF
--- a/src/libstore/build/derivation-building-goal.cc
+++ b/src/libstore/build/derivation-building-goal.cc
@@ -769,9 +769,11 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
     try {
         builtOutputs = builder->unprepareBuild();
     } catch (BuilderFailureError & e) {
+        builder.reset();
         outputLocks.unlock();
         co_return doneFailure(fixupBuilderFailureErrorMessage(std::move(e)));
     } catch (BuildError & e) {
+        builder.reset();
         outputLocks.unlock();
 // Allow selecting a subset of enum values
 #  pragma GCC diagnostic push
@@ -796,6 +798,7 @@ Goal::Co DerivationBuildingGoal::tryToBuild()
         co_return doneFailure(std::move(e));
     }
     {
+        builder.reset();
         StorePathSet outputPaths;
         for (auto & [_, output] : builtOutputs) {
             // for sake of `bmRepair`

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -484,14 +484,6 @@ bool DerivationBuilderImpl::prepareBuild()
 
 SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
 {
-    // FIXME: get rid of this, rely on RAII.
-    Finally releaseBuildUser([&]() {
-        /* Release the build user at the end of this function. We don't do
-           it right away because we don't want another build grabbing this
-           uid and then messing around with our output. */
-        buildUser.reset();
-    });
-
     /* Since we got an EOF on the logger pipe, the builder is presumed
        to have terminated.  In fact, the builder could also have
        simply have closed its end of the pipe, so just to be sure,

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -542,10 +542,6 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
        being valid. */
     auto builtOutputs = registerOutputs();
 
-    /* Delete unused redirected outputs (when doing hash rewriting). */
-    for (auto & i : redirectedOutputs)
-        deletePath(store.Store::toRealPath(i.second));
-
     cleanupBuild(true);
 
     return builtOutputs;
@@ -1855,6 +1851,12 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
 
 void DerivationBuilderImpl::cleanupBuild(bool force)
 {
+    if (force) {
+        /* Delete unused redirected outputs (when doing hash rewriting). */
+        for (auto & i : redirectedOutputs)
+            deletePath(store.Store::toRealPath(i.second));
+    }
+
     if (topTmpDir != "") {
         /* As an extra precaution, even in the event of `deletePath` failing to
          * clean up, the `tmpDir` will be chowned as if we were to move


### PR DESCRIPTION
## Motivation

See each commit for details

## Context

Depends on https://github.com/NixOS/nix/pull/13862

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
