### PR TITLE
libflake: Fix flake id flake refs with revisions

### DIFF
--- a/src/libflake-tests/flakeref.cc
+++ b/src/libflake-tests/flakeref.cc
@@ -2,6 +2,7 @@
 
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/flake/flakeref.hh"
+#include "nix/fetchers/attrs.hh"
 
 namespace nix {
 
@@ -89,6 +90,90 @@ TEST(parseFlakeRef, GitArchiveInput)
         ASSERT_EQ(flakeref.to_string(), "github:foo/bar");
     }
 }
+
+struct InputFromURLTestCase
+{
+    std::string url;
+    fetchers::Attrs attrs;
+    std::string description;
+    std::string expectedUrl = url;
+};
+
+class InputFromURLTest : public ::testing::WithParamInterface<InputFromURLTestCase>, public ::testing::Test
+{};
+
+TEST_P(InputFromURLTest, attrsAreCorrectAndRoundTrips)
+{
+    experimentalFeatureSettings.experimentalFeatures.get().insert(Xp::Flakes);
+    fetchers::Settings fetchSettings;
+
+    const auto & testCase = GetParam();
+
+    auto flakeref = parseFlakeRef(fetchSettings, testCase.url);
+
+    EXPECT_EQ(flakeref.toAttrs(), testCase.attrs);
+    EXPECT_EQ(flakeref.to_string(), testCase.expectedUrl);
+
+    auto input = fetchers::Input::fromURL(fetchSettings, flakeref.to_string());
+
+    EXPECT_EQ(input.toURLString(), testCase.expectedUrl);
+    EXPECT_EQ(input.toAttrs(), testCase.attrs);
+
+    // Round-trip check.
+    auto input2 = fetchers::Input::fromURL(fetchSettings, input.toURLString());
+    EXPECT_EQ(input, input2);
+    EXPECT_EQ(input.toURLString(), input2.toURLString());
+}
+
+using fetchers::Attr;
+
+INSTANTIATE_TEST_SUITE_P(
+    InputFromURL,
+    InputFromURLTest,
+    ::testing::Values(
+        InputFromURLTestCase{
+            .url = "flake:nixpkgs",
+            .attrs =
+                {
+                    {"id", Attr("nixpkgs")},
+                    {"type", Attr("indirect")},
+                },
+            .description = "basic_indirect",
+        },
+        InputFromURLTestCase{
+            .url = "flake:nixpkgs/branch",
+            .attrs =
+                {
+                    {"id", Attr("nixpkgs")},
+                    {"type", Attr("indirect")},
+                    {"ref", Attr("branch")},
+                },
+            .description = "basic_indirect_branch",
+        },
+        InputFromURLTestCase{
+            .url = "nixpkgs/branch",
+            .attrs =
+                {
+                    {"id", Attr("nixpkgs")},
+                    {"type", Attr("indirect")},
+                    {"ref", Attr("branch")},
+                },
+            .description = "flake_id_ref_branch",
+            .expectedUrl = "flake:nixpkgs/branch",
+        },
+        InputFromURLTestCase{
+            .url = "nixpkgs/branch/2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+            .attrs =
+                {
+                    {"id", Attr("nixpkgs")},
+                    {"type", Attr("indirect")},
+                    {"ref", Attr("branch")},
+                    {"rev", Attr("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed")},
+                },
+            .description = "flake_id_ref_branch_trailing_slash",
+            .expectedUrl = "flake:nixpkgs/branch/2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+        }),
+    [](const ::testing::TestParamInfo<InputFromURLTestCase> & info) { return info.param.description; });
 
 TEST(to_string, doesntReencodeUrl)
 {

--- a/src/libflake/flakeref.cc
+++ b/src/libflake/flakeref.cc
@@ -198,7 +198,7 @@ parseFlakeIdRef(const fetchers::Settings & fetchSettings, const std::string & ur
     if (std::regex_match(url, match, flakeRegex)) {
         auto parsedURL = ParsedURL{
             .scheme = "flake",
-            .authority = ParsedURL::Authority{},
+            .authority = std::nullopt,
             .path = splitString<std::vector<std::string>>(match[1].str(), "/"),
         };
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Starting from c436b7a32afaf01d62f828697ddf5c49d4f8678c this used to lead to assertion failures like:

> std::string nix::ParsedURL::renderAuthorityAndPath() const: Assertion `path.empty() || path.front().empty()' failed.

This has the bugfix for the issue and regressions tests so that this gets properly tested in the future.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
