### PR TITLE
libfetchers: Restore path separator ignoring behavior for indirect an…

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -38,7 +38,8 @@ struct GitArchiveInputScheme : InputScheme
         if (url.scheme != schemeName())
             return {};
 
-        const auto & path = url.path;
+        /* This ignores empty path segments for back-compat. Older versions used a tokenizeString here. */
+        auto path = url.pathSegments(/*skipEmpty=*/true) | std::ranges::to<std::vector<std::string>>();
 
         std::optional<Hash> rev;
         std::optional<std::string> ref;

--- a/src/libfetchers/indirect.cc
+++ b/src/libfetchers/indirect.cc
@@ -14,7 +14,8 @@ struct IndirectInputScheme : InputScheme
         if (url.scheme != "flake")
             return {};
 
-        const auto & path = url.path;
+        /* This ignores empty path segments for back-compat. Older versions used a tokenizeString here. */
+        auto path = url.pathSegments(/*skipEmpty=*/true) | std::ranges::to<std::vector<std::string>>();
 
         std::optional<Hash> rev;
         std::optional<std::string> ref;

--- a/src/libutil/include/nix/util/url.hh
+++ b/src/libutil/include/nix/util/url.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include <ranges>
 #include <span>
 
 #include "nix/util/error.hh"
@@ -230,6 +231,20 @@ struct ParsedURL
      * Remove `.` and `..` path segments.
      */
     ParsedURL canonicalise();
+
+    /**
+     * Get a range of path segments (the substrings separated by '/' characters).
+     *
+     * @param skipEmpty Skip all empty path segments
+     */
+    auto pathSegments(bool skipEmpty) const &
+    {
+        return std::views::filter(path, [skipEmpty](std::string_view segment) {
+            if (skipEmpty)
+                return !segment.empty();
+            return true;
+        });
+    }
 };
 
 std::ostream & operator<<(std::ostream & os, const ParsedURL & url);


### PR DESCRIPTION
…d git-archive flakerefs

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Old versions of nix happily accepted a lot of weird flake references, which we didn't have tests for, so this was accidentally broken in c436b7a32afaf01d62f828697ddf5c49d4f8678c.

This patch restores previous behavior and adds a plethora of tests to ensure we don't break this in the future.

These test cases are aligned with how 2.18/2.28 parsed flake references.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
