### PR TITLE
Revert "packaging: Build with toml11 4.4.0"

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -54,16 +54,6 @@ scope: {
     enableLargeConfig = true;
   };
 
-  toml11 = pkgs.toml11.overrideAttrs rec {
-    version = "4.4.0";
-    src = pkgs.fetchFromGitHub {
-      owner = "ToruNiina";
-      repo = "toml11";
-      tag = "v${version}";
-      hash = "sha256-sgWKYxNT22nw376ttGsTdg0AMzOwp8QH3E8mx0BZJTQ=";
-    };
-  };
-
   # TODO Hack until https://github.com/NixOS/nixpkgs/issues/45462 is fixed.
   boost =
     (pkgs.boost.override {


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This reverts commit 306d8838abe47196b01334fd770a6ddcdbf91c8f.

This was included in the backport (https://github.com/NixOS/nix/pull/13747) accidentally.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
