### PR TITLE
Add another `fixGitURL` test

### DIFF
--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -127,6 +127,15 @@ TEST(FixGitURLTestSuite, scpLikeNoUserParsesPoorly)
         }));
 }
 
+TEST(FixGitURLTestSuite, properlyRejectFileURLWithAuthority)
+{
+    /* From the underlying `parseURL` validations. */
+    EXPECT_THAT(
+        []() { fixGitURL("file://var/repos/x"); },
+        ::testing::ThrowsMessage<BadURL>(
+            testing::HasSubstrIgnoreANSIMatcher("file:// URL 'file://var/repos/x' has unexpected authority 'var'")));
+}
+
 TEST(FixGitURLTestSuite, scpLikePathLeadingSlashParsesPoorly)
 {
     // SCP-like URL (no user)
@@ -246,8 +255,10 @@ TEST(parseURL, parsesFilePlusHttpsUrl)
 
 TEST(parseURL, rejectsAuthorityInUrlsWithFileTransportation)
 {
-    auto s = "file://www.example.org/video.mp4";
-    ASSERT_THROW(parseURL(s), Error);
+    EXPECT_THAT(
+        []() { parseURL("file://www.example.org/video.mp4"); },
+        ::testing::ThrowsMessage<BadURL>(
+            testing::HasSubstrIgnoreANSIMatcher("has unexpected authority 'www.example.org'")));
 }
 
 TEST(parseURL, parseIPv4Address)


### PR DESCRIPTION
## Motivation

Also improve a similar `parseURL` test.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
