### PR TITLE
Fix downstream MinGW build by not looking for Boost Regex

### DIFF
--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -40,7 +40,10 @@ endforeach
 
 boost = dependency(
   'boost',
-  modules : [ 'container', 'context' ],
+  modules : [
+    'container',
+    'context',
+  ],
   include_type : 'system',
 )
 # boost is a public dependency, but not a pkg-config dependency unfortunately, so we

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -101,7 +101,11 @@ subdir('nix-meson-build-support/libatomic')
 
 boost = dependency(
   'boost',
-  modules : [ 'container', 'regex' ],
+  modules : [
+    'container',
+    # Shouldn't list, because can header-only, and Meson currently looks for libs
+    #'regex',
+  ],
   include_type : 'system',
 )
 # boost is a public dependency, but not a pkg-config dependency unfortunately, so we

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -57,7 +57,12 @@ deps_private += blake3
 
 boost = dependency(
   'boost',
-  modules : [ 'context', 'coroutine', 'iostreams', 'url' ],
+  modules : [
+    'context',
+    'coroutine',
+    'iostreams',
+    'url',
+  ],
   include_type : 'system',
   version : '>=1.82.0',
 )


### PR DESCRIPTION
## Motivation

Fix build.

## Context

See https://github.com/mesonbuild/meson/issues/14891 and https://github.com/msys2/MINGW-packages/issues/25126

Draft until I see that this fixes the the downstream build for sure

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
