### PR TITLE
`nix develop`: Version the JSON + some cleanups

### DIFF
--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -227,11 +227,13 @@ const static std::string getEnvSh =
 #include "get-env.sh.gen.hh"
     ;
 
-/* Given an existing derivation, return the shell environment as
-   initialised by stdenv's setup script. We do this by building a
-   modified derivation with the same dependencies and nearly the same
-   initial environment variables, that just writes the resulting
-   environment to a file and exits. */
+/**
+ * Given an existing derivation, return the shell environment as
+ * initialised by stdenv's setup script. We do this by building a
+ * modified derivation with the same dependencies and nearly the same
+ * initial environment variables, that just writes the resulting
+ * environment to a file and exits.
+ */
 static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore, const StorePath & drvPath)
 {
     auto drv = evalStore->derivationFromPath(drvPath);

--- a/src/nix/develop.cc
+++ b/src/nix/develop.cc
@@ -299,12 +299,13 @@ static StorePath getDerivationEnvironment(ref<Store> store, ref<Store> evalStore
         bmNormal,
         evalStore);
 
+    // `get-env.sh` will write its JSON output to an arbitrary output
+    // path, so return the first non-empty output path.
     for (auto & [_0, optPath] : evalStore->queryPartialDerivationOutputMap(shellDrvPath)) {
         assert(optPath);
         auto & outPath = *optPath;
-        assert(store->isValidPath(outPath));
-        auto outPathS = store->toRealPath(outPath);
-        if (lstat(outPathS).st_size)
+        auto st = store->getFSAccessor()->lstat(CanonPath(outPath.to_string()));
+        if (st.fileSize.value_or(0))
             return outPath;
     }
 
@@ -494,17 +495,15 @@ struct Common : InstallableCommand, MixProfile
         }
     }
 
-    std::pair<BuildEnvironment, std::string> getBuildEnvironment(ref<Store> store, ref<Installable> installable)
+    std::pair<BuildEnvironment, StorePath> getBuildEnvironment(ref<Store> store, ref<Installable> installable)
     {
         auto shellOutPath = getShellOutPath(store, installable);
 
-        auto strPath = store->printStorePath(shellOutPath);
-
         updateProfile(shellOutPath);
 
-        debug("reading environment file '%s'", strPath);
+        debug("reading environment file '%s'", store->printStorePath(shellOutPath));
 
-        return {BuildEnvironment::parseJSON(readFile(store->toRealPath(shellOutPath))), strPath};
+        return {BuildEnvironment::parseJSON(store->getFSAccessor()->readFile(shellOutPath.to_string())), shellOutPath};
     }
 };
 
@@ -631,7 +630,7 @@ struct CmdDevelop : Common, MixEnvironment
 
         setEnviron();
         // prevent garbage collection until shell exits
-        setEnv("NIX_GCROOT", gcroot.c_str());
+        setEnv("NIX_GCROOT", store->printStorePath(gcroot).c_str());
 
         Path shell = "bash";
         bool foundInteractive = false;

--- a/src/nix/get-env.sh
+++ b/src/nix/get-env.sh
@@ -14,6 +14,7 @@ __functions="$(declare -F)"
 
 __dumpEnv() {
     printf '{\n'
+    printf '  "version": 1,\n'
 
     printf '  "bashFunctions": {\n'
     local __first=1


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This adds a `version: 1` field to the JSON environment file created by `nix develop`. Since these are not just internal (they are exposed by `nix develop --profile` and `nix develop <storepath>`) and could even be pushed to binary caches etc, it's good to future-proof them.

Also some miscellaneous cleanups like using `Store::getFSAccessor()`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
