### PR TITLE
Remove support for worker protocol version < 18

### DIFF
--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -546,17 +546,6 @@ static void performOp(
         break;
     }
 
-    case WorkerProto::Op::ExportPath: {
-        auto path = store->parseStorePath(readString(conn.from));
-        readInt(conn.from); // obsolete
-        logger->startWork();
-        TunnelSink sink(conn.to);
-        store->exportPath(path, sink);
-        logger->stopWork();
-        conn.to << 1;
-        break;
-    }
-
     case WorkerProto::Op::ImportPaths: {
         logger->startWork();
         TunnelSource source(conn.from, conn.to);

--- a/src/libstore/daemon.cc
+++ b/src/libstore/daemon.cc
@@ -546,18 +546,6 @@ static void performOp(
         break;
     }
 
-    case WorkerProto::Op::ImportPaths: {
-        logger->startWork();
-        TunnelSource source(conn.from, conn.to);
-        auto paths = store->importPaths(source, trusted ? NoCheckSigs : CheckSigs);
-        logger->stopWork();
-        Strings paths2;
-        for (auto & i : paths)
-            paths2.push_back(store->printStorePath(i));
-        conn.to << paths2;
-        break;
-    }
-
     case WorkerProto::Op::BuildPaths: {
         auto drvs = WorkerProto::Serialise<DerivedPaths>::read(*store, rconn);
         BuildMode mode = bmNormal;

--- a/src/libstore/include/nix/store/worker-protocol-connection.hh
+++ b/src/libstore/include/nix/store/worker-protocol-connection.hh
@@ -130,8 +130,6 @@ struct WorkerProto::BasicClientConnection : WorkerProto::BasicConnection
         bool * daemonException,
         const StorePath & path,
         std::function<void(Source &)> fun);
-
-    void importPaths(const StoreDirConfig & store, bool * daemonException, Source & source);
 };
 
 struct WorkerProto::BasicServerConnection : WorkerProto::BasicConnection

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -152,7 +152,6 @@ enum struct WorkerProto::Op : uint64_t {
     AddIndirectRoot = 12,
     SyncWithGC = 13,
     FindRoots = 14,
-    ExportPath = 16,   // obsolete
     QueryDeriver = 18, // obsolete
     SetOptions = 19,
     CollectGarbage = 20,

--- a/src/libstore/include/nix/store/worker-protocol.hh
+++ b/src/libstore/include/nix/store/worker-protocol.hh
@@ -161,7 +161,6 @@ enum struct WorkerProto::Op : uint64_t {
     QueryFailedPaths = 24,
     ClearFailedPaths = 25,
     QueryPathInfo = 26,
-    ImportPaths = 27,                // obsolete
     QueryDerivationOutputNames = 28, // obsolete
     QueryPathFromHashPart = 29,
     QuerySubstitutablePathInfos = 30,

--- a/src/libstore/worker-protocol-connection.cc
+++ b/src/libstore/worker-protocol-connection.cc
@@ -313,12 +313,4 @@ void WorkerProto::BasicClientConnection::narFromPath(
     fun(from);
 }
 
-void WorkerProto::BasicClientConnection::importPaths(
-    const StoreDirConfig & store, bool * daemonException, Source & source)
-{
-    to << WorkerProto::Op::ImportPaths;
-    processStderr(daemonException, 0, &source);
-    auto importedPaths = WorkerProto::Serialise<StorePathSet>::read(store, *this);
-    assert(importedPaths.size() <= importedPaths.size());
-}
 } // namespace nix


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This drops support for worker protocol versions before 18 (introduced in November 2016).

It also drops the `WorkerProto::Op::{ImportPaths,ExportPath}` operations, obsolete since May 2016.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Doing some work on the export/import functionality and ran into this cruft.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
