### PR TITLE
Move exportPaths() / importPaths() out of the Store class

### DIFF
--- a/src/libstore/export-import.cc
+++ b/src/libstore/export-import.cc
@@ -1,3 +1,4 @@
+#include "nix/store/export-import.hh"
 #include "nix/util/serialise.hh"
 #include "nix/store/store-api.hh"
 #include "nix/util/archive.hh"
@@ -8,27 +9,14 @@
 
 namespace nix {
 
-void Store::exportPaths(const StorePathSet & paths, Sink & sink)
+static void exportPath(Store & store, const StorePath & path, Sink & sink)
 {
-    auto sorted = topoSortPaths(paths);
-    std::reverse(sorted.begin(), sorted.end());
-
-    for (auto & path : sorted) {
-        sink << 1;
-        exportPath(path, sink);
-    }
-
-    sink << 0;
-}
-
-void Store::exportPath(const StorePath & path, Sink & sink)
-{
-    auto info = queryPathInfo(path);
+    auto info = store.queryPathInfo(path);
 
     HashSink hashSink(HashAlgorithm::SHA256);
     TeeSink teeSink(sink, hashSink);
 
-    narFromPath(path, teeSink);
+    store.narFromPath(path, teeSink);
 
     /* Refuse to export paths that have changed.  This prevents
        filesystem corruption from spreading to other machines.
@@ -37,16 +25,29 @@ void Store::exportPath(const StorePath & path, Sink & sink)
     if (hash != info->narHash && info->narHash != Hash(info->narHash.algo))
         throw Error(
             "hash of path '%s' has changed from '%s' to '%s'!",
-            printStorePath(path),
+            store.printStorePath(path),
             info->narHash.to_string(HashFormat::Nix32, true),
             hash.to_string(HashFormat::Nix32, true));
 
-    teeSink << exportMagic << printStorePath(path);
-    CommonProto::write(*this, CommonProto::WriteConn{.to = teeSink}, info->references);
-    teeSink << (info->deriver ? printStorePath(*info->deriver) : "") << 0;
+    teeSink << exportMagic << store.printStorePath(path);
+    CommonProto::write(store, CommonProto::WriteConn{.to = teeSink}, info->references);
+    teeSink << (info->deriver ? store.printStorePath(*info->deriver) : "") << 0;
 }
 
-StorePaths Store::importPaths(Source & source, CheckSigsFlag checkSigs)
+void exportPaths(Store & store, const StorePathSet & paths, Sink & sink)
+{
+    auto sorted = store.topoSortPaths(paths);
+    std::reverse(sorted.begin(), sorted.end());
+
+    for (auto & path : sorted) {
+        sink << 1;
+        exportPath(store, path, sink);
+    }
+
+    sink << 0;
+}
+
+StorePaths importPaths(Store & store, Source & source, CheckSigsFlag checkSigs)
 {
     StorePaths res;
     while (true) {
@@ -66,17 +67,17 @@ StorePaths Store::importPaths(Source & source, CheckSigsFlag checkSigs)
         if (magic != exportMagic)
             throw Error("Nix archive cannot be imported; wrong format");
 
-        auto path = parseStorePath(readString(source));
+        auto path = store.parseStorePath(readString(source));
 
         // Activity act(*logger, lvlInfo, "importing path '%s'", info.path);
 
-        auto references = CommonProto::Serialise<StorePathSet>::read(*this, CommonProto::ReadConn{.from = source});
+        auto references = CommonProto::Serialise<StorePathSet>::read(store, CommonProto::ReadConn{.from = source});
         auto deriver = readString(source);
         auto narHash = hashString(HashAlgorithm::SHA256, saved.s);
 
         ValidPathInfo info{path, narHash};
         if (deriver != "")
-            info.deriver = parseStorePath(deriver);
+            info.deriver = store.parseStorePath(deriver);
         info.references = references;
         info.narSize = saved.s.size();
 
@@ -86,7 +87,7 @@ StorePaths Store::importPaths(Source & source, CheckSigsFlag checkSigs)
 
         // Can't use underlying source, which would have been exhausted
         auto source = StringSource(saved.s);
-        addToStore(info, source, NoRepair, checkSigs);
+        store.addToStore(info, source, NoRepair, checkSigs);
 
         res.push_back(info.path);
     }

--- a/src/libstore/include/nix/store/export-import.hh
+++ b/src/libstore/include/nix/store/export-import.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "nix/store/store-api.hh"
+
+namespace nix {
+
+/**
+ * Magic header of exportPath() output (obsolete).
+ */
+const uint32_t exportMagic = 0x4558494e;
+
+/**
+ * Export multiple paths in the format expected by `nix-store
+ * --import`. The paths will be sorted topologically.
+ */
+void exportPaths(Store & store, const StorePathSet & paths, Sink & sink);
+
+/**
+ * Import a sequence of NAR dumps created by `exportPaths()` into the
+ * Nix store.
+ */
+StorePaths importPaths(Store & store, Source & source, CheckSigsFlag checkSigs = CheckSigs);
+
+} // namespace nix

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -34,6 +34,7 @@ headers = [ config_pub_h ] + files(
   'derived-path-map.hh',
   'derived-path.hh',
   'downstream-placeholder.hh',
+  'export-import.hh',
   'filetransfer.hh',
   'gc-store.hh',
   'globals.hh',

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -48,11 +48,6 @@ enum CheckSigsFlag : bool { NoCheckSigs = false, CheckSigs = true };
 
 enum SubstituteFlag : bool { NoSubstitute = false, Substitute = true };
 
-/**
- * Magic header of exportPath() output (obsolete).
- */
-const uint32_t exportMagic = 0x4558494e;
-
 enum BuildMode : uint8_t { bmNormal, bmRepair, bmCheck };
 
 enum TrustedFlag : bool { NotTrusted = false, Trusted = true };
@@ -803,21 +798,6 @@ public:
      * relation.  If p refers to q, then p precedes q in this list.
      */
     StorePaths topoSortPaths(const StorePathSet & paths);
-
-    /**
-     * Export multiple paths in the format expected by ‘nix-store
-     * --import’.
-     */
-    void exportPaths(const StorePathSet & paths, Sink & sink);
-
-    void exportPath(const StorePath & path, Sink & sink);
-
-    /**
-     * Import a sequence of NAR dumps created by exportPaths() into the
-     * Nix store. Optionally, the contents of the NARs are preloaded
-     * into the specified FS accessor to speed up subsequent access.
-     */
-    StorePaths importPaths(Source & source, CheckSigsFlag checkSigs = CheckSigs);
 
     struct Stats
     {

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -14,6 +14,7 @@
 #include "nix/util/posix-source-accessor.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/path-with-outputs.hh"
+#include "nix/store/export-import.hh"
 
 #include "man-pages.hh"
 
@@ -774,7 +775,7 @@ static void opExport(Strings opFlags, Strings opArgs)
         paths.insert(store->followLinksToStorePath(i));
 
     FdSink sink(getStandardOutput());
-    store->exportPaths(paths, sink);
+    exportPaths(*store, paths, sink);
     sink.flush();
 }
 
@@ -787,7 +788,7 @@ static void opImport(Strings opFlags, Strings opArgs)
         throw UsageError("no arguments expected");
 
     FdSource source(STDIN_FILENO);
-    auto paths = store->importPaths(source, NoCheckSigs);
+    auto paths = importPaths(*store, source, NoCheckSigs);
 
     for (auto & i : paths)
         cout << fmt("%s\n", store->printStorePath(i)) << std::flush;

--- a/src/perl/lib/Nix/Store.xs
+++ b/src/perl/lib/Nix/Store.xs
@@ -11,6 +11,7 @@
 #include "nix/store/globals.hh"
 #include "nix/store/store-open.hh"
 #include "nix/util/posix-source-accessor.hh"
+#include "nix/store/export-import.hh"
 
 #include <sodium.h>
 #include <nlohmann/json.hpp>
@@ -233,7 +234,7 @@ StoreWrapper::exportPaths(int fd, ...)
             StorePathSet paths;
             for (int n = 2; n < items; ++n) paths.insert(THIS->store->parseStorePath(SvPV_nolen(ST(n))));
             FdSink sink(fd);
-            THIS->store->exportPaths(paths, sink);
+            exportPaths(*THIS->store, paths, sink);
         } catch (Error & e) {
             croak("%s", e.what());
         }
@@ -244,7 +245,7 @@ StoreWrapper::importPaths(int fd, int dontCheckSigs)
     PPCODE:
         try {
             FdSource source(fd);
-            THIS->store->importPaths(source, dontCheckSigs ? NoCheckSigs : CheckSigs);
+            importPaths(*THIS->store, source, dontCheckSigs ? NoCheckSigs : CheckSigs);
         } catch (Error & e) {
             croak("%s", e.what());
         }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Making the `Store` class a bit smaller.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
