### PR TITLE
meson: link to libatomic on powerpc-linux

### DIFF
--- a/nix-meson-build-support/libatomic/meson.build
+++ b/nix-meson-build-support/libatomic/meson.build
@@ -3,6 +3,6 @@
 # This is needed for std::atomic on some platforms
 # We did not manage to test this reliably on all platforms, so we hardcode
 # it for now.
-if host_machine.cpu_family() == 'arm'
+if host_machine.cpu_family() in [ 'arm', 'ppc' ]
   deps_other += cxx.find_library('atomic')
 endif


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->
Fixes building nix for 32-bit PowerPC
Like 32-bit Arm, 32-bit PowerPC also needs linking against libatomic because it doesn't support some atomic instructions in hardware.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
