### PR TITLE
Revert "meson: add soversion to libraries (#13960)"

### DIFF
--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -95,7 +95,6 @@ this_library = library(
   'nixcmd',
   sources,
   config_priv_h,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -50,7 +50,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixexprc',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -44,7 +44,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-expr-test-support',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -181,7 +181,6 @@ this_library = library(
   parser_tab,
   lexer_tab,
   generated_headers,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -53,7 +53,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchersc',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -61,7 +61,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchers',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -53,7 +53,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixflakec',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -58,7 +58,6 @@ this_library = library(
   'nixflake',
   sources,
   generated_headers,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -45,7 +45,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixmainc',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -77,7 +77,6 @@ this_library = library(
   'nixmain',
   sources,
   config_priv_h,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -46,7 +46,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixstorec',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -44,7 +44,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-store-test-support',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -363,7 +363,6 @@ this_library = library(
   generated_headers,
   sources,
   config_priv_h,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -53,7 +53,6 @@ this_library = library(
   'nixutilc',
   sources,
   config_priv_h,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -41,7 +41,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-util-test-support',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -197,7 +197,6 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixutil',
   sources,
-  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This reverts commit bdbc739d6e87f2abf2ded4d38bb0e161f457eb68.

Such a change needs more thought put into it. By versioning shared libraries we'd make a false impression that libraries themselves are actually versioned and have some sort of stable ABI, which is not the case.

This will be useful when C bindings become stable, but as long as they are experimental it does not make sense to set SONAME.

Also this change should not have been backported, since it's severely breaking.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

FWIW there's no objection to eventually have versioned ABI for stable C bindings (that is very much desired and must be done before C bindings are declared stable), but since they are in flux at the moment we shouldn't give a false sense of security to library consumers.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
