### PR TITLE
libstore/filetransfer,http-binary-cache-store: disable on substituter 500s instead of throwing

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -496,11 +496,9 @@ struct curlFileTransfer : public FileTransfer
                     // Most 4xx errors are client errors and are probably not worth retrying:
                     //   * 408 means the server timed out waiting for us, so we try again
                     err = Misc;
-                } else if (httpStatus == 501 || httpStatus == 505 || httpStatus == 511) {
-                    // Let's treat most 5xx (server) errors as transient, except for a handful:
-                    //   * 501 not implemented
-                    //   * 505 http version not supported
-                    //   * 511 we're behind a captive portal
+                } else if (httpStatus >= 500 && httpStatus <= 599) {
+                    // a server is unlikely to 5xx unless there is a critical configuration/system error
+                    // we can't recover from an error that isn't our fault so give up
                     err = Misc;
                 } else {
 // Don't bother retrying on certain cURL errors either

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -225,12 +225,12 @@ protected:
         } catch (FileTransferError & e) {
             if (e.error == FileTransfer::NotFound)
                 return std::nullopt;
-            if (e.error == FileTransfer::Misc) {
-                maybeDisable();
-                return std::nullopt;
-            }
+
             maybeDisable();
-            throw;
+            if (e.error == FileTransfer::Misc) {
+                /* FIXME It's a bit of an abuse to say that the cache doesn't have info, rather than we just failed to fetch it, but we don't want the caller of this to throw, because that would interfere with trying out subsequent substituters. */
+                return std::nullopt;
+            } else throw;
         }
     }
 


### PR DESCRIPTION
## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Right now, if a substituter returns a 5xx other than 501, 505 or 511, nix will keep trying to use it even though it is broken/misconfigured at least four more times before trying to use the next one (given the necessary patch is applied, otherwise it throws), resulting in unnecessary log spam.
Also, if you are receiving 504s (such as if an nginx proxy is trying to connect to a substituter but timing out) this can lead to rather nasty waits - I have personally seen it take 20-30s, with it timing out at each individual request, before it timing out completely and giving up. Awful.

This doesn't really make sense because 500s wont go away unless the server is fixed? This change would make nix disable an http substituter on the first 500 it gets and immediately switch to the next substituter (intuitive default behaviour?)

This also preserves `settings.tryFallback` as it will still throw if false and all the substituters have been disabled because they have had (terminal) errors. (that logic is unrelated to the http binary cache store and is in substition-goal/store-api, see https://github.com/NixOS/nix/pull/13301 )


## Context

<!-- Provide context. Reference open issues if available. -->

linked to https://github.com/NixOS/nix/pull/13301

<img width="870" height="1163" alt="image" src="https://github.com/user-attachments/assets/cc2a7911-4298-43fa-a3b6-b68eaf88132a" />

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
