### PR TITLE
Reapply "meson: add soversion to libraries (#13960)"

### DIFF
--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -95,6 +95,7 @@ this_library = library(
   'nixcmd',
   sources,
   config_priv_h,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -50,6 +50,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixexprc',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -44,6 +44,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-expr-test-support',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -181,6 +181,7 @@ this_library = library(
   parser_tab,
   lexer_tab,
   generated_headers,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -53,6 +53,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchersc',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -61,6 +61,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchers',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -53,6 +53,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixflakec',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -58,6 +58,7 @@ this_library = library(
   'nixflake',
   sources,
   generated_headers,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -45,6 +45,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixmainc',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -77,6 +77,7 @@ this_library = library(
   'nixmain',
   sources,
   config_priv_h,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -46,6 +46,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixstorec',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -44,6 +44,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-store-test-support',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -363,6 +363,7 @@ this_library = library(
   generated_headers,
   sources,
   config_priv_h,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -53,6 +53,7 @@ this_library = library(
   'nixutilc',
   sources,
   config_priv_h,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -41,6 +41,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-util-test-support',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -197,6 +197,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixutil',
   sources,
+  soversion : 0,
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,


### PR DESCRIPTION
This reverts commit 0db2b8c8fe3d944a289a12fee3b3d8ecbeec5240.

This was original reverted to give the impression of an stable ABI.

However version 0, from the looks of it this is in conventional Linux distribtion is not considered stable but a preparation to avoid conflict with future stable versions.

https://docs.fedoraproject.org/en-US/packaging-guidelines/#_downstream_so_name_versioning

I don't really see any downside on our side to add this and follow conventions here.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
