### PR TITLE
`ValidPathInfo`, `NarInfo`, turn funky constructor into static method

### DIFF
--- a/src/libfetchers/tarball.cc
+++ b/src/libfetchers/tarball.cc
@@ -74,7 +74,7 @@ DownloadFileResult downloadFile(
         StringSink sink;
         dumpString(res.data, sink);
         auto hash = hashString(HashAlgorithm::SHA256, res.data);
-        ValidPathInfo info{
+        auto info = ValidPathInfo::makeFromCA(
             *store,
             name,
             FixedOutputInfo{
@@ -82,8 +82,7 @@ DownloadFileResult downloadFile(
                 .hash = hash,
                 .references = {},
             },
-            hashString(HashAlgorithm::SHA256, sink.s),
-        };
+            hashString(HashAlgorithm::SHA256, sink.s));
         info.narSize = sink.s.size();
         auto source = StringSource{sink.s};
         store->addToStore(info, source, NoRepair, NoCheckSigs);

--- a/src/libstore-tests/nar-info.cc
+++ b/src/libstore-tests/nar-info.cc
@@ -23,7 +23,7 @@ class NarInfoTest : public CharacterizationTest, public LibStoreTest
 
 static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
 {
-    NarInfo info = ValidPathInfo{
+    auto info = NarInfo::makeFromCA(
         store,
         "foo",
         FixedOutputInfo{
@@ -41,8 +41,7 @@ static NarInfo makeNarInfo(const Store & store, bool includeImpureInfo)
                     .self = true,
                 },
         },
-        Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="),
-    };
+        Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="));
     info.narSize = 34878;
     if (includeImpureInfo) {
         info.deriver = StorePath{

--- a/src/libstore-tests/path-info.cc
+++ b/src/libstore-tests/path-info.cc
@@ -29,7 +29,7 @@ static UnkeyedValidPathInfo makeEmpty()
 
 static ValidPathInfo makeFullKeyed(const Store & store, bool includeImpureInfo)
 {
-    ValidPathInfo info = ValidPathInfo{
+    auto info = ValidPathInfo::makeFromCA(
         store,
         "foo",
         FixedOutputInfo{
@@ -47,8 +47,7 @@ static ValidPathInfo makeFullKeyed(const Store & store, bool includeImpureInfo)
                     .self = true,
                 },
         },
-        Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="),
-    };
+        Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="));
     info.narSize = 34878;
     if (includeImpureInfo) {
         info.deriver = StorePath{

--- a/src/libstore-tests/serve-protocol.cc
+++ b/src/libstore-tests/serve-protocol.cc
@@ -274,7 +274,7 @@ VERSIONED_CHARACTERIZATION_TEST(
             info;
         }),
         ({
-            ValidPathInfo info{
+            auto info = ValidPathInfo::makeFromCA(
                 store,
                 "foo",
                 FixedOutputInfo{
@@ -291,8 +291,7 @@ VERSIONED_CHARACTERIZATION_TEST(
                             .self = true,
                         },
                 },
-                Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="),
-            };
+                Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="));
             info.deriver = StorePath{
                 "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar.drv",
             };

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -515,7 +515,7 @@ VERSIONED_CHARACTERIZATION_TEST(
             info;
         }),
         ({
-            ValidPathInfo info{
+            auto info = ValidPathInfo::makeFromCA(
                 store,
                 "foo",
                 FixedOutputInfo{
@@ -532,8 +532,7 @@ VERSIONED_CHARACTERIZATION_TEST(
                             .self = true,
                         },
                 },
-                Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="),
-            };
+                Hash::parseSRI("sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc="));
             info.registrationTime = 23423;
             info.narSize = 34878;
             info;

--- a/src/libstore/binary-cache-store.cc
+++ b/src/libstore/binary-cache-store.cc
@@ -366,7 +366,7 @@ StorePath BinaryCacheStore::addToStoreFromDump(
                repair,
                CheckSigs,
                [&](HashResult nar) {
-                   ValidPathInfo info{
+                   auto info = ValidPathInfo::makeFromCA(
                        *this,
                        name,
                        ContentAddressWithReferences::fromParts(
@@ -378,8 +378,7 @@ StorePath BinaryCacheStore::addToStoreFromDump(
                                // without modulus
                                .self = false,
                            }),
-                       nar.hash,
-                   };
+                       nar.hash);
                    info.narSize = nar.numBytesDigested;
                    return info;
                })
@@ -484,7 +483,7 @@ StorePath BinaryCacheStore::addToStore(
                repair,
                CheckSigs,
                [&](HashResult nar) {
-                   ValidPathInfo info{
+                   auto info = ValidPathInfo::makeFromCA(
                        *this,
                        name,
                        ContentAddressWithReferences::fromParts(
@@ -496,8 +495,7 @@ StorePath BinaryCacheStore::addToStore(
                                // without modulus
                                .self = false,
                            }),
-                       nar.hash,
-                   };
+                       nar.hash);
                    info.narSize = nar.numBytesDigested;
                    return info;
                })

--- a/src/libstore/include/nix/store/nar-info.hh
+++ b/src/libstore/include/nix/store/nar-info.hh
@@ -18,19 +18,20 @@ struct NarInfo : ValidPathInfo
 
     NarInfo() = delete;
 
-    NarInfo(const StoreDirConfig & store, std::string name, ContentAddressWithReferences ca, Hash narHash)
-        : ValidPathInfo(store, std::move(name), std::move(ca), narHash)
+    NarInfo(ValidPathInfo info)
+        : ValidPathInfo{std::move(info)}
     {
     }
 
     NarInfo(StorePath path, Hash narHash)
-        : ValidPathInfo(std::move(path), narHash)
+        : NarInfo{ValidPathInfo{std::move(path), UnkeyedValidPathInfo(narHash)}}
     {
     }
 
-    NarInfo(const ValidPathInfo & info)
-        : ValidPathInfo(info)
+    static NarInfo
+    makeFromCA(const StoreDirConfig & store, std::string_view name, ContentAddressWithReferences ca, Hash narHash)
     {
+        return ValidPathInfo::makeFromCA(store, std::move(name), std::move(ca), narHash);
     }
 
     NarInfo(const StoreDirConfig & store, const std::string & s, const std::string & whence);

--- a/src/libstore/include/nix/store/path-info.hh
+++ b/src/libstore/include/nix/store/path-info.hh
@@ -179,8 +179,8 @@ struct ValidPathInfo : UnkeyedValidPathInfo
         : UnkeyedValidPathInfo(info)
         , path(path) {};
 
-    ValidPathInfo(
-        const StoreDirConfig & store, std::string_view name, ContentAddressWithReferences && ca, Hash narHash);
+    static ValidPathInfo
+    makeFromCA(const StoreDirConfig & store, std::string_view name, ContentAddressWithReferences && ca, Hash narHash);
 };
 
 static_assert(std::is_move_assignable_v<ValidPathInfo>);

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -1311,7 +1311,7 @@ StorePath LocalStore::addToStoreFromDump(
                 syncParent(realPath);
             }
 
-            ValidPathInfo info{*this, name, std::move(desc), narHash.hash};
+            auto info = ValidPathInfo::makeFromCA(*this, name, std::move(desc), narHash.hash);
             info.narSize = narHash.numBytesDigested;
             registerValidPath(info);
         }

--- a/src/libstore/make-content-addressed.cc
+++ b/src/libstore/make-content-addressed.cc
@@ -45,7 +45,7 @@ std::map<StorePath, StorePath> makeContentAddressed(Store & srcStore, Store & ds
 
         auto narModuloHash = hashModuloSink.finish().hash;
 
-        ValidPathInfo info{
+        auto info = ValidPathInfo::makeFromCA(
             dstStore,
             path.name(),
             FixedOutputInfo{
@@ -53,8 +53,7 @@ std::map<StorePath, StorePath> makeContentAddressed(Store & srcStore, Store & ds
                 .hash = narModuloHash,
                 .references = std::move(refs),
             },
-            Hash::dummy,
-        };
+            Hash::dummy);
 
         printInfo("rewriting '%s' to '%s'", pathS, dstStore.printStorePath(info.path));
 

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -269,7 +269,7 @@ ValidPathInfo Store::addToStoreSlow(
     if (expectedCAHash && expectedCAHash != hash)
         throw Error("hash mismatch for '%s'", srcPath);
 
-    ValidPathInfo info{
+    auto info = ValidPathInfo::makeFromCA(
         *this,
         name,
         ContentAddressWithReferences::fromParts(
@@ -279,8 +279,7 @@ ValidPathInfo Store::addToStoreSlow(
                 .others = references,
                 .self = false,
             }),
-        narHash,
-    };
+        narHash);
     info.narSize = narSize;
 
     if (!isValidPath(info.path)) {

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1591,12 +1591,11 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                 assert(false);
             }();
 
-            ValidPathInfo newInfo0{
+            auto newInfo0 = ValidPathInfo::makeFromCA(
                 store,
                 outputPathName(drv.name, outputName),
                 ContentAddressWithReferences::fromParts(outputHash.method, std::move(got), rewriteRefs()),
-                Hash::dummy,
-            };
+                Hash::dummy);
             if (*scratchPath != newInfo0.path) {
                 // If the path has some self-references, we need to rewrite
                 // them.

--- a/src/nix/profile.cc
+++ b/src/nix/profile.cc
@@ -257,7 +257,7 @@ struct ProfileManifest
 
         auto narHash = hashString(HashAlgorithm::SHA256, sink.s);
 
-        ValidPathInfo info{
+        auto info = ValidPathInfo::makeFromCA(
             *store,
             "profile",
             FixedOutputInfo{
@@ -270,8 +270,7 @@ struct ProfileManifest
                         .self = false,
                     },
             },
-            narHash,
-        };
+            narHash);
         info.narSize = sink.s.size();
 
         StringSource source(sink.s);


### PR DESCRIPTION
## Motivation

This is more flexible, and needed for me to be able to reshuffle the inheritance bureaucracy to make the JSON instances more precise.

## Context

Needed for #13942

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
