### PR TITLE
Primops: init concatMapAttrs

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -3398,6 +3398,59 @@ static RegisterPrimOp primop_mapAttrs({
     .fun = prim_mapAttrs,
 });
 
+
+static void prim_concatMapAttrs(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+{
+    state.forceAttrs(*args[1], pos,
+        "while evaluating the second argument passed to builtins.concatMapAttrs");
+    auto inAttrs = args[1]->attrs();
+
+    std::map<SymbolIdx, Value*> attrMap;
+
+    for (auto &i : *inAttrs) {
+        Value * vName = Value::toPtr(state.symbols[i.name]);
+        Value * funApp = state.allocValue();
+        funApp->mkApp(args[0], vName);
+        Value * result = state.allocValue();
+        result->mkApp(funApp, i.value);
+        state.forceAttrs(*result, pos,
+            "while evaluating the result of the function passed to builtins.concatMapAttrs");
+
+        // Direct insertion into map - automatically handles deduplication
+        // If duplicate keys exist, this overwrites with the later value (last-write-wins)
+        for (auto &j : *result->attrs()) {
+            attrMap[j.name] = j.value;
+        }
+    }
+
+    auto attrs = state.buildBindings(attrMap.size());
+    for (const auto& [name, value] : attrMap) {
+        attrs.insert(name, value);
+    }
+
+    v.mkAttrs(attrs.alreadySorted());
+}
+
+
+static RegisterPrimOp primop_concatMapAttrs({
+    .name = "__concatMapAttrs",
+    .args = {"f", "attrset"},
+    .doc = R"(
+      Apply function *f* to every element of *attrset*. For example,
+
+      ```nix
+      builtins.concatMapAttrs (name: value: { ${name} = value; "${name}-${value}" = value; } ]) { foo = "fizz"; bar = "buzz"; }
+      ```
+
+      evaluates to `{ foo = "fizz"; foo-fizz = "fizz"; bar = "buzz"; bar-buzz = "buzz"; }`.
+
+      If multiple applications of *f* return attribute sets with the same attribute names,
+      the last write wins. Meaning the value from the attribute set that was processed later will be kept in the final result.
+    )",
+    .fun = prim_concatMapAttrs,
+});
+
+
 static void prim_zipAttrsWith(EvalState & state, const PosIdx pos, Value ** args, Value & v)
 {
     // we will first count how many values are present for each given key.


### PR DESCRIPTION
Implements `concatMapAttrs` according to #11887 

## Motivation

This should allow efficient usage of concatMapAttrs which is currently implemented in nixpkgs/lib.
However due to heavy performance overhead (n update `//` operations) has never seen great adoption.

Adding this function to primops, may unlock faster mapping between attribute sets, which currently always require an intermediate list.

`attrsToList` -> `map` -> `listToAttrs`


## Context

see #11887 

- [ ] Needs tests
- [ ] Needs clarify whether we should use std::map, or custom deduplication. 

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

Example Ideas:

`filterAttrsRecursive` could be implemented as:

```nix
  filterAttrsRecursive = pred: set: builtins.concatMapAttrs (
    n: v:
      if pred n v then
        if builtins.isAttrs v then
          { ${n} = filterAttrsRecursive pred v; }
        else
          { ${n} = v; }
      else
        { }
  ) set;
```

Which saves the internal list conversion and concatenation.
https://github.com/NixOS/nixpkgs/blob/26833ad1dad83826ef7cc52e0009ca9b7097c79f/lib/attrsets.nix#L701:C3

There are many other functions in nixpkgs.lib that use an internal list conversion (`attrsToList` -> `map` -> `listToAttrs`) that could benefit in performance and memory allocation.