### PR TITLE
Optionally allow git filters to be applied when reading blobs

### DIFF
--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -497,13 +497,15 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
      */
     ref<GitSourceAccessor> getRawAccessor(
         const Hash & rev,
-        bool smudgeLfs = false);
+        bool smudgeLfs = false,
+        bool applyFilters = false);
 
     ref<SourceAccessor> getAccessor(
         const Hash & rev,
         bool exportIgnore,
         std::string displayPrefix,
-        bool smudgeLfs = false) override;
+        bool smudgeLfs = false,
+        bool applyFilters = false) override;
 
     ref<SourceAccessor> getAccessor(const WorkdirInfo & wd, bool exportIgnore, MakeNotAllowedError e) override;
 
@@ -668,20 +670,22 @@ struct GitSourceAccessor : SourceAccessor
     struct State
     {
         ref<GitRepoImpl> repo;
-        std::string gitRev;
+        git_oid oid;
         Object root;
         std::optional<lfs::Fetch> lfsFetch = std::nullopt;
+        bool applyFilters;
     };
 
     Sync<State> state_;
 
-    GitSourceAccessor(ref<GitRepoImpl> repo_, const Hash & rev, bool smudgeLfs)
+    GitSourceAccessor(ref<GitRepoImpl> repo_, const Hash & rev, bool smudgeLfs, bool applyFilters_)
         : state_{
                 State {
                     .repo = repo_,
-                    .gitRev = rev.gitRev(),
+                    .oid = hashToOID(rev),
                     .root = peelToTreeOrBlob(lookupObject(*repo_, hashToOID(rev)).get()),
                     .lfsFetch = smudgeLfs ? std::make_optional(lfs::Fetch(*repo_, hashToOID(rev))) : std::nullopt,
+                    .applyFilters = applyFilters_,
                 }
             }
     {
@@ -709,28 +713,28 @@ struct GitSourceAccessor : SourceAccessor
             }
         }
 
-        // Apply git filters including CRLF conversion
-        git_buf filtered = GIT_BUF_INIT;
-        git_blob_filter_options opts = GIT_BLOB_FILTER_OPTIONS_INIT;
+        if (!state->applyFilters)
+            return std::string((const char *) git_blob_rawcontent(blob.get()), git_blob_rawsize(blob.get()));
+        else {
+            // Apply git filters including potential CRLF conversion
+            git_buf filtered = GIT_BUF_INIT;
+            git_blob_filter_options opts = GIT_BLOB_FILTER_OPTIONS_INIT;
 
-        git_oid oid;
-        if (git_oid_fromstr(&oid, state->gitRev.c_str()))
-            throw Error("cannot convert '%s' to a Git OID", state->gitRev.c_str());
+            opts.attr_commit_id = state->oid;
+            opts.flags = GIT_BLOB_FILTER_ATTRIBUTES_FROM_COMMIT;
 
-        opts.attr_commit_id = oid;
-        opts.flags = GIT_BLOB_FILTER_ATTRIBUTES_FROM_COMMIT;
-
-        int error = git_blob_filter(&filtered, blob.get(), path.rel_c_str(), &opts);
-        if (error != 0) {
-            const git_error *e = git_error_last();
-            std::string errorMsg = e ? e->message : "Unknown error";
+            int error = git_blob_filter(&filtered, blob.get(), path.rel_c_str(), &opts);
+            if (error != 0) {
+                const git_error *e = git_error_last();
+                std::string errorMsg = e ? e->message : "Unknown error";
+                git_buf_dispose(&filtered);
+                throw Error("Failed to filter blob: " + errorMsg);
+            }
+            std::string result(filtered.ptr, filtered.size);
             git_buf_dispose(&filtered);
-            throw Error("Failed to filter blob: " + errorMsg);
-        }
-        std::string result(filtered.ptr, filtered.size);
-        git_buf_dispose(&filtered);
 
-        return result;
+            return result;
+        }
     }
 
     std::string readFile(const CanonPath & path) override
@@ -1243,20 +1247,22 @@ struct GitFileSystemObjectSinkImpl : GitFileSystemObjectSink
 
 ref<GitSourceAccessor> GitRepoImpl::getRawAccessor(
     const Hash & rev,
-    bool smudgeLfs)
+    bool smudgeLfs,
+    bool applyFilters)
 {
     auto self = ref<GitRepoImpl>(shared_from_this());
-    return make_ref<GitSourceAccessor>(self, rev, smudgeLfs);
+    return make_ref<GitSourceAccessor>(self, rev, smudgeLfs, applyFilters);
 }
 
 ref<SourceAccessor> GitRepoImpl::getAccessor(
     const Hash & rev,
     bool exportIgnore,
     std::string displayPrefix,
-    bool smudgeLfs)
+    bool smudgeLfs,
+    bool applyFilters)
 {
     auto self = ref<GitRepoImpl>(shared_from_this());
-    ref<GitSourceAccessor> rawGitAccessor = getRawAccessor(rev, smudgeLfs);
+    ref<GitSourceAccessor> rawGitAccessor = getRawAccessor(rev, smudgeLfs, applyFilters);
     rawGitAccessor->setPathDisplay(std::move(displayPrefix));
     if (exportIgnore)
         return make_ref<GitExportIgnoreSourceAccessor>(self, rawGitAccessor, rev);

--- a/src/libfetchers/git-utils.cc
+++ b/src/libfetchers/git-utils.cc
@@ -725,7 +725,7 @@ struct GitSourceAccessor : SourceAccessor
             const git_error *e = git_error_last();
             std::string errorMsg = e ? e->message : "Unknown error";
             git_buf_dispose(&filtered);
-            throw std::runtime_error("Failed to filter blob: " + errorMsg);
+            throw Error("Failed to filter blob: " + errorMsg);
         }
         std::string result(filtered.ptr, filtered.size);
         git_buf_dispose(&filtered);

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -90,7 +90,8 @@ struct GitRepo
         const Hash & rev,
         bool exportIgnore,
         std::string displayPrefix,
-        bool smudgeLfs = false) = 0;
+        bool smudgeLfs = false,
+        bool applyFilters = false) = 0;
 
     virtual ref<SourceAccessor> getAccessor(const WorkdirInfo & wd, bool exportIgnore, MakeNotAllowedError makeNotAllowedError) = 0;
 

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -326,3 +326,4 @@ export GIT_CONFIG_GLOBAL="$TEST_ROOT/gitconfig"
 git config --global core.autocrlf true
 new_narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; }).narHash")
 [[ "$new_narhash" = "$narhash" ]]
+unset GIT_CONFIG_GLOBAL

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -318,12 +318,18 @@ echo 'test.txt eol=crlf' > "$repo/.gitattributes"
 git -C "$repo" add .gitattributes
 git -C "$repo" commit -m 'Add eol=crlf to gitattributes'
 narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; }).narHash")
+[[ "$narhash" = "sha256-BBhuj+vOnwCUnk5az22PwAnF32KE1aulWAVfCQlbW7U=" ]]
+
+narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; applyFilters = true; }).narHash")
 [[ "$narhash" = "sha256-k7u7RAaF+OvrbtT3KCCDQA8e9uOdflUo5zSgsosoLzA=" ]]
+
 
 # Ensure that NAR hash doesn't depend on user configuration.
 rm -rf $TEST_HOME/.cache/nix
 export GIT_CONFIG_GLOBAL="$TEST_ROOT/gitconfig"
 git config --global core.autocrlf true
-new_narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; }).narHash")
-[[ "$new_narhash" = "$narhash" ]]
+narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; }).narHash")
+[[ "$narhash" = "sha256-BBhuj+vOnwCUnk5az22PwAnF32KE1aulWAVfCQlbW7U=" ]]
+narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; applyFilters = true; }).narHash")
+[[ "$narhash" = "sha256-k7u7RAaF+OvrbtT3KCCDQA8e9uOdflUo5zSgsosoLzA=" ]]
 unset GIT_CONFIG_GLOBAL

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -303,3 +303,26 @@ git -C "$empty" config user.name "Foobar"
 git -C "$empty" commit --allow-empty --allow-empty-message --message ""
 
 nix eval --impure --expr "let attrs = builtins.fetchGit $empty; in assert attrs.lastModified != 0; assert attrs.rev != \"0000000000000000000000000000000000000000\"; assert attrs.revCount == 1; true"
+
+# Test a repo with `eol=crlf`.
+repo="$TEST_ROOT/crlf"
+git init "$repo"
+git -C $repo config user.email "foobar@example.com"
+git -C $repo config user.name "Foobar"
+
+echo -n -e 'foo\nbar\nbaz' > "$repo/newlines.txt"
+echo -n -e 'foo\nbar\nbaz' > "$repo/test.txt"
+git -C "$repo" add newlines.txt test.txt
+git -C "$repo" commit -m 'Add files containing LF line endings'
+echo 'test.txt eol=crlf' > "$repo/.gitattributes"
+git -C "$repo" add .gitattributes
+git -C "$repo" commit -m 'Add eol=crlf to gitattributes'
+narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; }).narHash")
+[[ "$narhash" = "sha256-k7u7RAaF+OvrbtT3KCCDQA8e9uOdflUo5zSgsosoLzA=" ]]
+
+# Ensure that NAR hash doesn't depend on user configuration.
+rm -rf $TEST_HOME/.cache/nix
+export GIT_CONFIG_GLOBAL="$TEST_ROOT/gitconfig"
+git config --global core.autocrlf true
+new_narhash=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = \"$repo\"; ref = \"master\"; }).narHash")
+[[ "$new_narhash" = "$narhash" ]]


### PR DESCRIPTION
## Motivation
Nix 2.20 introduced a regression (a breaking change) in which git repositories do not properly have filters applied (specifically filters that are configured via [`.gitattributes`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes)). This manifests as "NAR hash mismatch" errors when users are upgrading from earlier versions and they have a dependency that uses `.gitattributes` to manipulate line endings. [`curl`](https://github.com/curl/curl) is the most notable example I am aware of which, for example, specifies in [`.gitattributes`](https://github.com/curl/curl/blob/784c17b7d98caa9b500a56e345c1aadca9d009ed/.gitattributes#L15) that `*.bat` files should have CRLF line endings.

This change differs from #13428 in that the nix 2.20 behavior is retained as the default, with the previous behavior now being opt-in via the optional `applyFilters` attribute to git flake inputs. As such, this PR does not introduce a breaking change.

## Context
Fixes #11428, alternative to #13428.

The current nix behaviour seems completely broken when it comes to handling git filters.

```shell
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

readonly REPO="https://github.com/curl/curl.git"
readonly COMMIT="6b951a6928811507d493303b2878e848c077b471"

readonly FILES=(
  # This file does not contain CRLF but has `eol=crlf` in `.gitattributes`.
  buildconf.bat

  # This file does not contain CRLF.
  README.md

  # This file contains CRLF and isn't matched by `.gitattributes`.
  winbuild/README.md
)

# Don't respect user/system configuration.
export GIT_CONFIG_GLOBAL=/dev/null
export GIT_CONFIG_NOSYSTEM=true

function check_crlf() {
  OUTPUT_DIR="curl-$(echo "$@" | sha256sum | awk '{print $1}')"

  if ! test -d "${OUTPUT_DIR}"; then
    git $@ clone --quiet "${REPO}" "${OUTPUT_DIR}"
    git $@ -C "${OUTPUT_DIR}" checkout --quiet "${COMMIT}"
  fi

  for FILE in ${FILES[@]}; do
    if grep --quiet $'\r' "${OUTPUT_DIR}/${FILE}"; then
      echo "git $@ => ${FILE} contains CRLF"
    else
      echo "git $@ => ${FILE} does not contain CRLF"
    fi
  done

  echo
}

nix --version
for FILE in ${FILES[@]}; do
  if grep --quiet $'\r' "$(nix eval --raw --expr "(builtins.fetchGit { url = \"${REPO}\"; ref = \"master\"; rev = \"${COMMIT}\"; }).outPath")/${FILE}"; then
    echo "nix $(nix --version) => ${FILE} contains CRLF"
  else
    echo "nix $(nix --version) => ${FILE} does not contain CRLF"
  fi
done
echo

check_crlf
check_crlf -c core.eol=lf
check_crlf -c core.eol=crlf
check_crlf -c core.eol=native
check_crlf -c core.autocrlf=false
check_crlf -c core.autocrlf=input
check_crlf -c core.autocrlf=true
```

The output of the above script on my machine is as follows:

```
nix (Nix) 2.29.1
nix nix (Nix) 2.29.1 => buildconf.bat does not contain CRLF
nix nix (Nix) 2.29.1 => README.md does not contain CRLF
nix nix (Nix) 2.29.1 => winbuild/README.md contains CRLF

git  => buildconf.bat contains CRLF
git  => README.md does not contain CRLF
git  => winbuild/README.md contains CRLF

git -c core.eol=lf => buildconf.bat contains CRLF
git -c core.eol=lf => README.md does not contain CRLF
git -c core.eol=lf => winbuild/README.md contains CRLF

git -c core.eol=crlf => buildconf.bat contains CRLF
git -c core.eol=crlf => README.md does not contain CRLF
git -c core.eol=crlf => winbuild/README.md contains CRLF

git -c core.eol=native => buildconf.bat contains CRLF
git -c core.eol=native => README.md does not contain CRLF
git -c core.eol=native => winbuild/README.md contains CRLF

git -c core.autocrlf=false => buildconf.bat contains CRLF
git -c core.autocrlf=false => README.md does not contain CRLF
git -c core.autocrlf=false => winbuild/README.md contains CRLF

git -c core.autocrlf=input => buildconf.bat contains CRLF
git -c core.autocrlf=input => README.md does not contain CRLF
git -c core.autocrlf=input => winbuild/README.md contains CRLF

git -c core.autocrlf=true => buildconf.bat contains CRLF
git -c core.autocrlf=true => README.md contains CRLF
git -c core.autocrlf=true => winbuild/README.md contains CRLF
```

This shows that the way Nix is handling git repositories is inconsistent with git, irrespective of the user and/or system git configuration.

Another manifestation of this bug is that the NAR hash for a git repository can change depending on the order of evaluations. This can be demonstrated by the following script:

```shell
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

nix --version
git clone --quiet https://github.com/joshuaspence/nix-crlf-test.git

rm -rf ~/.cache/nix
nix eval --impure --expr "builtins.fetchGit \"file://$(readlink -f nix-crlf-test)\""
nix eval --impure --expr "builtins.fetchGit { url = \"file://$(readlink -f nix-crlf-test)\"; ref = \"$(git -C nix-crlf-test branch --show-current)\"; rev = \"$(git -C nix-crlf-test rev-parse HEAD)\"; }"

rm -rf ~/.cache/nix
nix eval --impure --expr "builtins.fetchGit { url = \"file://$(readlink -f nix-crlf-test)\"; ref = \"$(git -C nix-crlf-test branch --show-current)\"; rev = \"$(git -C nix-crlf-test rev-parse HEAD)\"; }"
nix eval --impure --expr "builtins.fetchGit \"file://$(readlink -f nix-crlf-test)\""

rm -rf nix-crlf-test
```

The output of this script is as follows:

```
nix (Nix) 2.29.1
{ lastModified = 946684800; lastModifiedDate = "20000101000000"; narHash = "sha256-k7u7RAaF+OvrbtT3KCCDQA8e9uOdflUo5zSgsosoLzA="; outPath = "/nix/store/pbm7g5wjg44d1z7byaivhcs9rrv58fqf-source"; rev = "27fcdeab9b5edc4095160b6d9a15a5c5260bca38"; revCount = 2; shortRev = "27fcdea"; submodules = false; }
{ lastModified = 946684800; lastModifiedDate = "20000101000000"; narHash = "sha256-k7u7RAaF+OvrbtT3KCCDQA8e9uOdflUo5zSgsosoLzA="; outPath = "/nix/store/pbm7g5wjg44d1z7byaivhcs9rrv58fqf-source"; rev = "27fcdeab9b5edc4095160b6d9a15a5c5260bca38"; revCount = 2; shortRev = "27fcdea"; submodules = false; }
{ lastModified = 946684800; lastModifiedDate = "20000101000000"; narHash = "sha256-BBhuj+vOnwCUnk5az22PwAnF32KE1aulWAVfCQlbW7U="; outPath = "/nix/store/9vi7nc2507l5fjyd0cg6fgbrikncpjmw-source"; rev = "27fcdeab9b5edc4095160b6d9a15a5c5260bca38"; revCount = 2; shortRev = "27fcdea"; submodules = false; }
{ lastModified = 946684800; lastModifiedDate = "20000101000000"; narHash = "sha256-BBhuj+vOnwCUnk5az22PwAnF32KE1aulWAVfCQlbW7U="; outPath = "/nix/store/9vi7nc2507l5fjyd0cg6fgbrikncpjmw-source"; rev = "27fcdeab9b5edc4095160b6d9a15a5c5260bca38"; revCount = 2; shortRev = "27fcdea"; submodules = false; }
```

Add 👍 to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).

