### PR TITLE
meson: add soversion with nix version to give SONAME to libs

### DIFF
--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -95,6 +95,7 @@ this_library = library(
   'nixcmd',
   sources,
   config_priv_h,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -50,6 +50,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixexprc',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -44,6 +44,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-expr-test-support',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -181,6 +181,7 @@ this_library = library(
   parser_tab,
   lexer_tab,
   generated_headers,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -53,6 +53,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchersc',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -61,6 +61,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixfetchers',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -53,6 +53,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixflakec',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -58,6 +58,7 @@ this_library = library(
   'nixflake',
   sources,
   generated_headers,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -45,6 +45,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixmainc',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -77,6 +77,7 @@ this_library = library(
   'nixmain',
   sources,
   config_priv_h,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -46,6 +46,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixstorec',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -44,6 +44,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-store-test-support',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -363,6 +363,7 @@ this_library = library(
   generated_headers,
   sources,
   config_priv_h,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -53,6 +53,7 @@ this_library = library(
   'nixutilc',
   sources,
   config_priv_h,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -41,6 +41,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nix-util-test-support',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   # TODO: Remove `-lrapidcheck` when https://github.com/emil-e/rapidcheck/pull/326

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -197,6 +197,7 @@ subdir('nix-meson-build-support/windows-version')
 this_library = library(
   'nixutil',
   sources,
+  soversion : meson.project_version().replace('pre', ''),
   dependencies : deps_public + deps_private + deps_other,
   include_directories : include_dirs,
   link_args : linker_export_flags,


### PR DESCRIPTION
Maybe this is more acceptable?  It makes the `soversion` equal to the nix version.

See discussions in #13960 and #13979 etc