### PR TITLE
nix flake check: Skip substitutable derivations

### DIFF
--- a/doc/manual/rl-next/faster-nix-flake-check.md
+++ b/doc/manual/rl-next/faster-nix-flake-check.md
@@ -1,0 +1,9 @@
+---
+synopsis: "`nix flake check` now skips derivations that can be substituted"
+prs: [13574]
+---
+
+Previously, `nix flake check` would evaluate and build/substitute all
+derivations. Now, it will skip downloading derivations that can be substituted.
+This can drastically decrease the time invocations take in environments where
+checks may already be cached (like in CI).


### PR DESCRIPTION
This is a rebased version of https://github.com/NixOS/nix/pull/13574 Check the previous discussion there.

Since `nix flake check` doesn't produce a `result` symlink, it doesn't actually need to build/substitute derivations that are already known to have succeeded, i.e. that are substitutable.

This can speed up CI jobs in cases where the derivations have already been built by other jobs. For instance, a command like

  nix flake check github:NixOS/hydra/aa62c7f7db31753f0cde690f8654dd1907fc0ce2

should no longer build anything because the outputs are already in cache.nixos.org.

Based-on: https://github.com/DeterminateSystems/nix-src/pull/134
Based-on: https://gerrit.lix.systems/c/lix/+/3841

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
