### PR TITLE
More `get` / `getOr` improvements

### DIFF
--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -197,7 +197,7 @@ std::pair<std::string_view, std::string_view> getLine(std::string_view s);
  * Get a value for the specified key from an associate container.
  */
 template<class T, typename K>
-const typename T::mapped_type * get(const T & map, K & key)
+const typename T::mapped_type * get(const T & map, const K & key)
 {
     auto i = map.find(key);
     if (i == map.end())
@@ -206,7 +206,7 @@ const typename T::mapped_type * get(const T & map, K & key)
 }
 
 template<class T, typename K>
-typename T::mapped_type * get(T & map, K & key)
+typename T::mapped_type * get(T & map, const K & key)
 {
     auto i = map.find(key);
     if (i == map.end())
@@ -214,15 +214,17 @@ typename T::mapped_type * get(T & map, K & key)
     return &i->second;
 }
 
-/** Deleted because this is use-after-free liability. Just don't pass temporaries to this overload set. */
-template<class T>
-typename T::mapped_type * get(T && map, const typename T::key_type & key) = delete;
+/**
+ * Deleted because this is use-after-free liability. Just don't pass temporaries to this overload set.
+ */
+template<class T, typename K>
+typename T::mapped_type * get(T && map, const K & key) = delete;
 
 /**
  * Get a value for the specified key from an associate container, or a default value if the key isn't present.
  */
 template<class T, typename K>
-const typename T::mapped_type & getOr(T & map, K & key, const typename T::mapped_type & defaultValue)
+const typename T::mapped_type & getOr(T & map, const K & key, const typename T::mapped_type & defaultValue)
 {
     auto i = map.find(key);
     if (i == map.end())
@@ -230,10 +232,11 @@ const typename T::mapped_type & getOr(T & map, K & key, const typename T::mapped
     return i->second;
 }
 
-/** Deleted because this is use-after-free liability. Just don't pass temporaries to this overload set. */
-template<class T>
-const typename T::mapped_type &
-getOr(T && map, const typename T::key_type & key, const typename T::mapped_type & defaultValue) = delete;
+/**
+ * Deleted because this is use-after-free liability. Just don't pass temporaries to this overload set.
+ */
+template<class T, typename K>
+const typename T::mapped_type & getOr(T && map, const K & key, const typename T::mapped_type & defaultValue) = delete;
 
 /**
  * Remove and return the first item from a container.


### PR DESCRIPTION
## Motivation

- Use `const K`, not `K`, otherwise we don't get auto referencing of rvalues.

- Generalized the deleted overloads, because we don't care what the key type is --- we want to get rid of anything that has an rvalue map type.


## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
