### PR TITLE
nix-meson-build-support/common nix_soversion: fixup removal of 'pre'

### DIFF
--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -42,4 +42,4 @@ if cxx.get_id() == 'clang' and ('address' in get_option('b_sanitize') or 'undefi
 endif
 
 # Darwin ld doesn't like "X.Y.Zpre"
-nix_soversion = meson.project_version().strip('pre')
+nix_soversion = meson.project_version().replace('pre', '')


### PR DESCRIPTION
`.strip()` removes individual mentioned chars whereas `.replace()` acts with whole substring

Thanks @keszybz for [pointing this out](https://github.com/NixOS/nix/pull/14001#discussion_r2351809047)