### PR TITLE
doc: document global builtins

### DIFF
--- a/doc/manual/source/language/builtins-prefix.md
+++ b/doc/manual/source/language/builtins-prefix.md
@@ -5,12 +5,28 @@ All built-ins are available through the global [`builtins`](#builtins-builtins) 
 
 Some built-ins are also exposed directly in the global scope:
 
-<!-- TODO(@rhendric, #10970): this list is incomplete -->
-
 - [`derivation`](#builtins-derivation)
-- [`import`](#builtins-import)
+- `derivationStrict`
 - [`abort`](#builtins-abort)
+- [`baseNameOf`](#builtins-baseNameOf)
+- [`break`](#builtins-break)
+- [`dirOf`](#builtins-dirOf)
+- [`false`](#builtins-false)
+- [`fetchGit`](#builtins-fetchGit)
+- `fetchMercurial`
+- [`fetchTarball`](#builtins-fetchTarball)
+- [`fetchTree`](#builtins-fetchTree)
+- [`fromTOML`](#builtins-fromTOML)
+- [`import`](#builtins-import)
+- [`isNull`](#builtins-isNull)
+- [`map`](#builtins-map)
+- [`null`](#builtins-null)
+- [`placeholder`](#builtins-placeholder)
+- [`removeAttrs`](#builtins-removeAttrs)
+- `scopedImport`
 - [`throw`](#builtins-throw)
+- [`toString`](#builtins-toString)
+- [`true`](#builtins-true)
 
 <dl>
   <dt id="builtins-derivation"><a href="#builtins-derivation"><code>derivation <var>attrs</var></code></a></dt>


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Indicate all globally-available builtins (that aren't prefixed with `__`).
Not sure if I should include `builtins` in this list since the previous sentence already talks about it?

Built the manual locally and checked these one-by-one to make sure all the links work.
Some aren't documented so there's nothing to link to.


<img width="500" alt="image" src="https://github.com/user-attachments/assets/5af540f7-fc9f-4a41-b66c-d35d72cbd6a4" />



<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

* closes #7290
* #10970

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
