### PR TITLE
treewide: Support builds with ASAN, enable in CI

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -15,6 +15,7 @@ pymod = import('python')
 python = pymod.find_installation('python3')
 
 nix_env_for_docs = {
+  'ASAN_OPTIONS' : 'abort_on_error=1:print_summary=1:detect_leaks=0',
   'HOME' : '/dummy',
   'NIX_CONF_DIR' : '/dummy',
   'NIX_SSL_CERT_FILE' : '/dummy/no-ca-bundle.crt',

--- a/doc/manual/source/command-ref/meson.build
+++ b/doc/manual/source/command-ref/meson.build
@@ -2,6 +2,7 @@ xp_features_json = custom_target(
   command : [ nix, '__dump-xp-features' ],
   capture : true,
   output : 'xp-features.json',
+  env : nix_env_for_docs,
 )
 
 experimental_features_shortlist_md = custom_target(

--- a/doc/manual/source/development/debugging.md
+++ b/doc/manual/source/development/debugging.md
@@ -24,6 +24,19 @@ It is also possible to build without debugging for faster build:
 
 (The first line is needed because `fortify` hardening requires at least some optimization.)
 
+## Building Nix with sanitizers
+
+Nix can be built with [Address](https://clang.llvm.org/docs/AddressSanitizer.html) and
+[UB](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) sanitizers using LLVM
+or GCC. This is useful when debugging memory corruption issues.
+
+```console
+[nix-shell]$ export mesonBuildType=debugoptimized
+[nix-shell]$ appendToVar mesonFlags "-Dlibexpr:gc=disabled" # Disable Boehm
+[nix-shell]$ appendToVar mesonFlags "-Dbindings=false" # Disable nix-perl
+[nix-shell]$ appendToVar mesonFlags "-Db_sanitize=address,undefined"
+```
+
 ## Debugging the Nix Binary
 
 Obtain your preferred debugger within the development shell:

--- a/doc/manual/source/development/meson.build
+++ b/doc/manual/source/development/meson.build
@@ -7,5 +7,6 @@ experimental_feature_descriptions_md = custom_target(
     xp_features_json,
   ],
   capture : true,
+  env : nix_env_for_docs,
   output : 'experimental-feature-descriptions.md',
 )

--- a/meson.build
+++ b/meson.build
@@ -41,8 +41,10 @@ subproject('libexpr-c')
 subproject('libflake-c')
 subproject('libmain-c')
 
+asan_enabled = 'address' in get_option('b_sanitize')
+
 # Language Bindings
-if get_option('bindings') and not meson.is_cross_build()
+if get_option('bindings') and not meson.is_cross_build() and not asan_enabled
   subproject('perl')
 endif
 

--- a/nix-meson-build-support/asan-options/meson.build
+++ b/nix-meson-build-support/asan-options/meson.build
@@ -1,0 +1,12 @@
+asan_test_options_env = {
+  'ASAN_OPTIONS' : 'abort_on_error=1:print_summary=1:detect_leaks=0',
+}
+
+# Clang gets grumpy about missing libasan symbols if -shared-libasan is not
+# passed when building shared libs, at least on Linux
+if cxx.get_id() == 'clang' and ('address' in get_option('b_sanitize') or 'undefined' in get_option(
+  'b_sanitize',
+))
+  add_project_link_arguments('-shared-libasan', language : 'cpp')
+endif
+

--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -33,13 +33,5 @@ if cxx.get_id() == 'clang'
   add_project_arguments('-fpch-instantiate-templates', language : 'cpp')
 endif
 
-# Clang gets grumpy about missing libasan symbols if -shared-libasan is not
-# passed when building shared libs, at least on Linux
-if cxx.get_id() == 'clang' and ('address' in get_option('b_sanitize') or 'undefined' in get_option(
-  'b_sanitize',
-))
-  add_project_link_arguments('-shared-libasan', language : 'cpp')
-endif
-
 # Darwin ld doesn't like "X.Y.Zpre"
 nix_soversion = meson.project_version().replace('pre', '')

--- a/src/libcmd/meson.build
+++ b/src/libcmd/meson.build
@@ -67,6 +67,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'built-path.cc',

--- a/src/libexpr-c/meson.build
+++ b/src/libexpr-c/meson.build
@@ -28,6 +28,7 @@ deps_public_maybe_subproject = [
 subdir('nix-meson-build-support/subprojects')
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'nix_api_expr.cc',

--- a/src/libexpr-test-support/meson.build
+++ b/src/libexpr-test-support/meson.build
@@ -31,6 +31,7 @@ rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'tests/value/context.cc',

--- a/src/libexpr-tests/meson.build
+++ b/src/libexpr-tests/meson.build
@@ -45,6 +45,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'derived-path.cc',
@@ -82,7 +83,7 @@ this_exe = executable(
 test(
   meson.project_name(),
   this_exe,
-  env : {
+  env : asan_test_options_env + {
     '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
   },
   protocol : 'gtest',

--- a/src/libexpr-tests/package.nix
+++ b/src/libexpr-tests/package.nix
@@ -62,6 +62,7 @@ mkMesonExecutable (finalAttrs: {
               mkdir -p "$HOME"
             ''
             + ''
+              export ASAN_OPTIONS=abort_on_error=1:print_summary=1:detect_leaks=0
               export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
               touch $out

--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -53,7 +53,12 @@ deps_other += boost
 nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
-bdw_gc = dependency('bdw-gc', required : get_option('gc'))
+bdw_gc_required = get_option('gc').disable_if(
+  'address' in get_option('b_sanitize'),
+  error_message : 'Building with Boehm GC and ASAN is not supported',
+)
+
+bdw_gc = dependency('bdw-gc', required : bdw_gc_required)
 if bdw_gc.found()
   deps_public += bdw_gc
   foreach funcspec : [
@@ -88,6 +93,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 parser_tab = custom_target(
   input : 'parser.y',

--- a/src/libfetchers-c/meson.build
+++ b/src/libfetchers-c/meson.build
@@ -32,6 +32,7 @@ add_project_arguments(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'nix_api_fetchers.cc',

--- a/src/libfetchers-tests/meson.build
+++ b/src/libfetchers-tests/meson.build
@@ -37,6 +37,7 @@ libgit2 = dependency('libgit2')
 deps_private += libgit2
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'access-tokens.cc',
@@ -63,7 +64,7 @@ this_exe = executable(
 test(
   meson.project_name(),
   this_exe,
-  env : {
+  env : asan_test_options_env + {
     '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
   },
   protocol : 'gtest',

--- a/src/libfetchers-tests/package.nix
+++ b/src/libfetchers-tests/package.nix
@@ -61,6 +61,7 @@ mkMesonExecutable (finalAttrs: {
             buildInputs = [ writableTmpDirAsHomeHook ];
           }
           ''
+            export ASAN_OPTIONS=abort_on_error=1:print_summary=1:detect_leaks=0
             export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
             touch $out

--- a/src/libfetchers/meson.build
+++ b/src/libfetchers/meson.build
@@ -32,6 +32,7 @@ libgit2 = dependency('libgit2', version : '>= 1.9')
 deps_private += libgit2
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'attrs.cc',

--- a/src/libflake-c/meson.build
+++ b/src/libflake-c/meson.build
@@ -32,6 +32,7 @@ deps_public_maybe_subproject = [
 subdir('nix-meson-build-support/subprojects')
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'nix_api_flake.cc',

--- a/src/libflake-tests/meson.build
+++ b/src/libflake-tests/meson.build
@@ -34,6 +34,7 @@ gtest = dependency('gtest', main : true)
 deps_private += gtest
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'flakeref.cc',
@@ -58,7 +59,7 @@ this_exe = executable(
 test(
   meson.project_name(),
   this_exe,
-  env : {
+  env : asan_test_options_env + {
     '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
     'NIX_CONFIG' : 'extra-experimental-features = flakes',
     'HOME' : meson.current_build_dir() / 'test-home',

--- a/src/libflake-tests/package.nix
+++ b/src/libflake-tests/package.nix
@@ -59,6 +59,7 @@ mkMesonExecutable (finalAttrs: {
             buildInputs = [ writableTmpDirAsHomeHook ];
           }
           (''
+            export ASAN_OPTIONS=abort_on_error=1:print_summary=1:detect_leaks=0
             export _NIX_TEST_UNIT_DATA=${resolvePath ./data}
             export NIX_CONFIG="extra-experimental-features = flakes"
             ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}

--- a/src/libflake/meson.build
+++ b/src/libflake/meson.build
@@ -29,6 +29,7 @@ nlohmann_json = dependency('nlohmann_json', version : '>= 3.9')
 deps_public += nlohmann_json
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 subdir('nix-meson-build-support/generate-header')
 

--- a/src/libmain-c/meson.build
+++ b/src/libmain-c/meson.build
@@ -28,6 +28,7 @@ deps_public_maybe_subproject = [
 subdir('nix-meson-build-support/subprojects')
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'nix_api_main.cc',

--- a/src/libmain/meson.build
+++ b/src/libmain/meson.build
@@ -53,6 +53,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'common-args.cc',

--- a/src/libstore-c/meson.build
+++ b/src/libstore-c/meson.build
@@ -26,6 +26,7 @@ deps_public_maybe_subproject = [
 subdir('nix-meson-build-support/subprojects')
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'nix_api_store.cc',

--- a/src/libstore-test-support/meson.build
+++ b/src/libstore-test-support/meson.build
@@ -29,6 +29,7 @@ rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'derived-path.cc',

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -52,6 +52,7 @@ gtest = dependency('gmock')
 deps_private += gtest
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'common-protocol.cc',
@@ -102,7 +103,7 @@ this_exe = executable(
 test(
   meson.project_name(),
   this_exe,
-  env : {
+  env : asan_test_options_env + {
     '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
     'HOME' : meson.current_build_dir() / 'test-home',
     'NIX_REMOTE' : meson.current_build_dir() / 'test-home' / 'store',
@@ -136,7 +137,7 @@ if get_option('benchmarks')
   benchmark(
     'nix-store-benchmarks',
     benchmark_exe,
-    env : {
+    env : asan_test_options_env + {
       '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
     },
   )

--- a/src/libstore-tests/package.nix
+++ b/src/libstore-tests/package.nix
@@ -83,6 +83,7 @@ mkMesonExecutable (finalAttrs: {
           }
           (
             ''
+              export ASAN_OPTIONS=abort_on_error=1:print_summary=1:detect_leaks=0
               export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}
               export NIX_REMOTE=$HOME/store
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -265,6 +265,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'binary-cache-store.cc',

--- a/src/libutil-c/meson.build
+++ b/src/libutil-c/meson.build
@@ -32,6 +32,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'nix_api_util.cc',

--- a/src/libutil-test-support/meson.build
+++ b/src/libutil-test-support/meson.build
@@ -27,6 +27,7 @@ rapidcheck = dependency('rapidcheck')
 deps_public += rapidcheck
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'hash.cc',

--- a/src/libutil-tests/meson.build
+++ b/src/libutil-tests/meson.build
@@ -42,6 +42,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = files(
   'args.cc',
@@ -96,7 +97,7 @@ this_exe = executable(
 test(
   meson.project_name(),
   this_exe,
-  env : {
+  env : asan_test_options_env + {
     '_NIX_TEST_UNIT_DATA' : meson.current_source_dir() / 'data',
   },
   protocol : 'gtest',

--- a/src/libutil-tests/package.nix
+++ b/src/libutil-tests/package.nix
@@ -61,6 +61,7 @@ mkMesonExecutable (finalAttrs: {
               mkdir -p "$HOME"
             ''
             + ''
+              export ASAN_OPTIONS=abort_on_error=1:print_summary=1:detect_leaks=0
               export _NIX_TEST_UNIT_DATA=${./data}
               ${stdenv.hostPlatform.emulator buildPackages} ${lib.getExe finalAttrs.finalPackage}
               touch $out

--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -118,6 +118,7 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 
 sources = [ config_priv_h ] + files(
   'archive.cc',

--- a/src/nix/asan-options.cc
+++ b/src/nix/asan-options.cc
@@ -1,0 +1,6 @@
+extern "C" [[gnu::retain]] const char * __asan_default_options()
+{
+    // We leak a bunch of memory knowingly on purpose. It's not worthwhile to
+    // diagnose that memory being leaked for now.
+    return "abort_on_error=1:print_summary=1:detect_leaks=0";
+}

--- a/src/nix/meson.build
+++ b/src/nix/meson.build
@@ -56,11 +56,13 @@ config_priv_h = configure_file(
 )
 
 subdir('nix-meson-build-support/common')
+subdir('nix-meson-build-support/asan-options')
 subdir('nix-meson-build-support/generate-header')
 
 nix_sources = [ config_priv_h ] + files(
   'add-to-store.cc',
   'app.cc',
+  'asan-options.cc',
   'build.cc',
   'bundle.cc',
   'cat.cc',

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -239,6 +239,12 @@ foreach suite : suites
     # Turns, e.g., `tests/functional/flakes/show.sh` into a Meson test target called
     # `functional-flakes-show`.
     name = fs.replace_suffix(script, '')
+    asan_options = 'abort_on_error=1:print_summary=1:detect_leaks=0'
+    # Otherwise ASAN dumps warnings into stderr that make some tests fail on stderr output
+    # comparisons.
+    asan_options += ':log_path=@0@'.format(
+      meson.current_build_dir() / 'asan-log',
+    )
 
     test(
       name,
@@ -253,6 +259,7 @@ foreach suite : suites
       ],
       suite : suite_name,
       env : {
+        'ASAN_OPTIONS' : asan_options,
         '_NIX_TEST_SOURCE_DIR' : meson.current_source_dir(),
         '_NIX_TEST_BUILD_DIR' : meson.current_build_dir(),
         'TEST_NAME' : suite_name / name,

--- a/tests/functional/test-libstoreconsumer/main.cc
+++ b/tests/functional/test-libstoreconsumer/main.cc
@@ -5,6 +5,13 @@
 
 using namespace nix;
 
+extern "C" [[gnu::retain]] const char * __asan_default_options()
+{
+    // We leak a bunch of memory knowingly on purpose. It's not worthwhile to
+    // diagnose that memory being leaked for now.
+    return "abort_on_error=1:print_summary=1:detect_leaks=0";
+}
+
 int main(int argc, char ** argv)
 {
     try {

--- a/tests/functional/test-libstoreconsumer/meson.build
+++ b/tests/functional/test-libstoreconsumer/meson.build
@@ -1,3 +1,7 @@
+cxx = meson.get_compiler('cpp')
+
+subdir('nix-meson-build-support/asan-options')
+
 libstoreconsumer_tester = executable(
   'test-libstoreconsumer',
   'main.cc',

--- a/tests/functional/test-libstoreconsumer/nix-meson-build-support
+++ b/tests/functional/test-libstoreconsumer/nix-meson-build-support
@@ -1,0 +1,1 @@
+../../../nix-meson-build-support


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Enables builds with ASAN to catch memory corruption
bugs faster and in CI. This is an incredibly valuable
instrument that must be used as much as possible.

Somewhat based on jade's work from Lix, though there's a lot that
we have to do differently:

https://git.lix.systems/lix-project/lix/commit/19ae87e5cec71912c7e7ecec5dc8ff18d18c60ee

Co-authored-by: Jade Lovelace <lix@jade.fyi>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Depends on https://github.com/NixOS/nix/pull/14014.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
