### PR TITLE
installer: prepend nix paths to shell config files instead of appending

### DIFF
--- a/scripts/install-multi-user.sh
+++ b/scripts/install-multi-user.sh
@@ -915,9 +915,11 @@ configure_shell_profile() {
         fi
 
         if [ -e "$profile_target" ]; then
-            shell_source_lines \
-                | _sudo "extend your $profile_target with nix-daemon settings" \
-                        tee -a "$profile_target"
+            {
+                shell_source_lines
+                cat "$profile_target"
+            } | _sudo "extend your $profile_target with nix-daemon settings" \
+                      tee "$profile_target"
         fi
     done
 


### PR DESCRIPTION
Some distribution will stop evaluating the shell config file if they are not running in an interactive shell. As we append the nix paths to the end of the file, they will not be evaluated. Eg running `ssh host nix --version` would fail as if nix is not installed on the system.

We better prepend the nix paths to the shell config files to be sure that once nix is installed, nix path will be available in any shell.

Note that this is already the case for the detsys installer script for a while: https://github.com/DeterminateSystems/nix-installer/pull/148

Possibly related errors:

https://github.com/NixOS/nix/issues/8061
https://github.com/NixOS/nix/pull/6628
https://github.com/NixOS/nix/issues/2587