### PR TITLE
Make dummy store also store path info

### DIFF
--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -176,7 +176,13 @@ struct DummyStore : virtual Store
 
     void narFromPath(const StorePath & path, Sink & sink) override
     {
-        unsupported("narFromPath");
+        auto object = contents.find(path);
+        if (object == contents.end())
+            throw Error("path '%s' is not valid", printStorePath(path));
+
+        const auto & [info, accessor] = object->second;
+        SourcePath sourcePath(accessor);
+        dumpPath(sourcePath, sink, FileSerialisationMethod::NixArchive);
     }
 
     void

--- a/src/libstore/dummy-store.md
+++ b/src/libstore/dummy-store.md
@@ -4,7 +4,7 @@ R"(
 
 This store type represents a store in memory.
 Store objects can be read and written, but only so long as the store is open.
-Once the store is closed, all data will be forgoton.
+Once the store is closed, all data will be discarded.
 
 It's useful when you want to use the Nix evaluator when no actual Nix store exists, e.g.
 

--- a/src/libstore/include/nix/store/dummy-store.hh
+++ b/src/libstore/include/nix/store/dummy-store.hh
@@ -4,10 +4,15 @@ namespace nix {
 
 struct DummyStoreConfig : public std::enable_shared_from_this<DummyStoreConfig>, virtual StoreConfig
 {
-    using StoreConfig::StoreConfig;
+    DummyStoreConfig(const Params & params)
+        : StoreConfig(params)
+    {
+        // Disable caching since this a temporary in-memory store.
+        pathInfoCacheSize = 0;
+    }
 
     DummyStoreConfig(std::string_view scheme, std::string_view authority, const Params & params)
-        : StoreConfig(params)
+        : DummyStoreConfig(params)
     {
         if (!authority.empty())
             throw UsageError("`%s` store URIs must not contain an authority part %s", scheme, authority);

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -233,30 +233,30 @@ TEST_F(GitTest, both_roundrip)
         .contents{
             {
                 "foo",
-                File::Regular{
+                make_ref<File>(File::Regular{
                     .contents = "hello\n\0\n\tworld!",
-                },
+                }),
             },
             {
                 "bar",
-                File::Directory{
+                make_ref<File>(File::Directory{
                     .contents =
                         {
                             {
                                 "baz",
-                                File::Regular{
+                                make_ref<File>(File::Regular{
                                     .executable = true,
                                     .contents = "good day,\n\0\n\tworld!",
-                                },
+                                }),
                             },
                             {
                                 "quux",
-                                File::Symlink{
+                                make_ref<File>(File::Symlink{
                                     .target = "/over/there",
-                                },
+                                }),
                             },
                         },
-                },
+                }),
             },
         },
     };

--- a/src/libutil/include/nix/util/memory-source-accessor.hh
+++ b/src/libutil/include/nix/util/memory-source-accessor.hh
@@ -58,7 +58,7 @@ struct MemorySourceAccessor : virtual SourceAccessor
         Stat lstat() const;
     };
 
-    File root{File::Directory{}};
+    std::optional<File> root;
 
     bool operator==(const MemorySourceAccessor &) const noexcept = default;
 

--- a/src/libutil/include/nix/util/memory-source-accessor.hh
+++ b/src/libutil/include/nix/util/memory-source-accessor.hh
@@ -35,7 +35,7 @@ struct MemorySourceAccessor : virtual SourceAccessor
         {
             using Name = std::string;
 
-            std::map<Name, File, std::less<>> contents;
+            std::map<Name, ref<File>, std::less<>> contents;
 
             bool operator==(const Directory &) const noexcept;
             // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
@@ -89,13 +89,21 @@ struct MemorySourceAccessor : virtual SourceAccessor
     SourcePath addFile(CanonPath path, std::string && contents);
 };
 
-inline bool MemorySourceAccessor::File::Directory::operator==(
-    const MemorySourceAccessor::File::Directory &) const noexcept = default;
+inline bool
+MemorySourceAccessor::File::Directory::operator==(const MemorySourceAccessor::File::Directory & other) const noexcept
+{
+    return std::ranges::equal(contents, other.contents, [](const auto & lhs, const auto & rhs) -> bool {
+        return lhs.first == rhs.first && *lhs.second == *rhs.second;
+    });
+};
 
 inline bool
 MemorySourceAccessor::File::Directory::operator<(const MemorySourceAccessor::File::Directory & other) const noexcept
 {
-    return contents < other.contents;
+    return std::ranges::lexicographical_compare(
+        contents, other.contents, [](const auto & lhs, const auto & rhs) -> bool {
+            return lhs.first < rhs.first && *lhs.second < *rhs.second;
+        });
 }
 
 inline bool MemorySourceAccessor::File::operator==(const MemorySourceAccessor::File &) const noexcept = default;

--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -4,7 +4,22 @@ namespace nix {
 
 MemorySourceAccessor::File * MemorySourceAccessor::open(const CanonPath & path, std::optional<File> create)
 {
-    File * cur = &root;
+    bool hasRoot = root.has_value();
+
+    // Special handling of root directory.
+    if (path.isRoot() && !hasRoot) {
+        if (create) {
+            root = std::move(*create);
+            return &root.value();
+        }
+        return nullptr;
+    }
+
+    // Root does not exist.
+    if (!hasRoot)
+        return nullptr;
+
+    File * cur = &root.value();
 
     bool newF = false;
 
@@ -112,6 +127,10 @@ std::string MemorySourceAccessor::readLink(const CanonPath & path)
 
 SourcePath MemorySourceAccessor::addFile(CanonPath path, std::string && contents)
 {
+    // Create root directory automatically if necessary as a convenience.
+    if (!root && !path.isRoot())
+        open(CanonPath::root, File::Directory{});
+
     auto * f = open(path, File{File::Regular{}});
     if (!f)
         throw Error("file '%s' cannot be made because some parent file is not a directory", path);

--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -24,11 +24,11 @@ MemorySourceAccessor::File * MemorySourceAccessor::open(const CanonPath & path, 
                     i,
                     {
                         std::string{name},
-                        File::Directory{},
+                        make_ref<File>(File::Directory{}),
                     });
             }
         }
-        cur = &i->second;
+        cur = &*i->second;
     }
 
     if (newF && create)
@@ -92,7 +92,7 @@ MemorySourceAccessor::DirEntries MemorySourceAccessor::readDirectory(const Canon
     if (auto * d = std::get_if<File::Directory>(&f->raw)) {
         DirEntries res;
         for (auto & [name, file] : d->contents)
-            res.insert_or_assign(name, file.lstat().type);
+            res.insert_or_assign(name, file->lstat().type);
         return res;
     } else
         throw Error("file '%s' is not a directory", path);

--- a/tests/functional/eval-store.sh
+++ b/tests/functional/eval-store.sh
@@ -52,3 +52,7 @@ rm -rf "$eval_store"
 [[ $(nix eval --eval-store "$eval_store?require-sigs=false" --impure --raw --file ./ifd.nix) = hi ]]
 ls $NIX_STORE_DIR/*dependencies-top/foobar
 (! ls $eval_store/nix/store/*dependencies-top/foobar)
+
+# Can't write .drv by default
+(! nix-instantiate dependencies.nix --eval-store "dummy://")
+nix-instantiate dependencies.nix --eval-store "dummy://?read-only=false"

--- a/tests/functional/flakes/flakes.sh
+++ b/tests/functional/flakes/flakes.sh
@@ -406,6 +406,7 @@ nix flake update flake1 flake2/flake1 --flake "$flake3Dir"
 
 # Test 'nix flake metadata --json'.
 nix flake metadata "$flake3Dir" --json | jq .
+nix flake metadata "$flake3Dir" --json --eval-store "dummy://?read-only=false" | jq .
 
 # Test flake in store does not evaluate.
 rm -rf $badFlakeDir

--- a/tests/nixos/github-flakes.nix
+++ b/tests/nixos/github-flakes.nix
@@ -219,6 +219,7 @@ in
 
       client.succeed("nix registry pin nixpkgs")
       client.succeed("nix flake metadata nixpkgs --tarball-ttl 0 >&2")
+      client.succeed("nix eval nixpkgs#hello --eval-store dummy://?read-only=false >&2")
 
       # Test fetchTree on a github URL.
       hash = client.succeed(f"nix eval --no-trust-tarballs-from-git-forges --raw --expr '(fetchTree {info['url']}).narHash'")


### PR DESCRIPTION
## Motivation

Filling in the missing methods.

## Context

See discussion in #10915. We might hereafter split `dummy://` and `memory://`.

Depends on #14035.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
