### PR TITLE
More floating content-addressing derivation tests

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -233,10 +233,12 @@
               # Content-addressed test files that use recursive-*looking* sourcing
               # (cd .. && source <self>), causing shellcheck to loop
               # They're small wrapper scripts with not a lot going on
+              ''^tests/functional/ca/build-delete\.sh$''
               ''^tests/functional/ca/build-dry\.sh$''
               ''^tests/functional/ca/eval-store\.sh$''
               ''^tests/functional/ca/gc\.sh$''
               ''^tests/functional/ca/import-from-derivation\.sh$''
+              ''^tests/functional/ca/multiple-outputs\.sh$''
               ''^tests/functional/ca/new-build-cmd\.sh$''
               ''^tests/functional/ca/nix-shell\.sh$''
               ''^tests/functional/ca/post-hook\.sh$''

--- a/tests/functional/build-delete.sh
+++ b/tests/functional/build-delete.sh
@@ -43,6 +43,10 @@ issue_6572_dependent_outputs() {
     nix-store --delete "$p" # Clean up for next test
 
     # Make sure that 'nix build' tracks input-outputs correctly when a single output is already present.
+    if [[ -n "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
+        # Resolved derivations interferre with the deletion
+        nix-store --delete "${NIX_STORE_DIR}"/*.drv
+    fi
     nix-store --delete "$(jq -r <"$TEST_ROOT"/a.json .[0].outputs.second)"
     p=$(nix build -f multiple-outputs.nix use-a --no-link --print-out-paths)
     cmp "$p" <<EOF

--- a/tests/functional/ca/build-delete.sh
+++ b/tests/functional/ca/build-delete.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+export NIX_TESTS_CA_BY_DEFAULT=1
+cd ..
+source ./build-delete.sh

--- a/tests/functional/ca/meson.build
+++ b/tests/functional/ca/meson.build
@@ -9,6 +9,7 @@ suites += {
   'deps' : [],
   'tests' : [
     'build-cache.sh',
+    'build-delete.sh',
     'build-with-garbage-path.sh',
     'build.sh',
     'concurrent-builds.sh',
@@ -18,6 +19,7 @@ suites += {
     'eval-store.sh',
     'gc.sh',
     'import-from-derivation.sh',
+    'multiple-outputs.sh',
     'new-build-cmd.sh',
     'nix-copy.sh',
     'nix-run.sh',

--- a/tests/functional/ca/multiple-outputs.sh
+++ b/tests/functional/ca/multiple-outputs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+export NIX_TESTS_CA_BY_DEFAULT=1
+cd ..
+source ./multiple-outputs.sh


### PR DESCRIPTION
## Motivation

Rather than writing greenfield tests, I am making existing tests run in the CA and non-CA case alike. This is much better for coverage and tracking feature parity.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
