### PR TITLE
libexpr-tests: Enable when test setup for building succeeds

### DIFF
--- a/src/libexpr-tests/main.cc
+++ b/src/libexpr-tests/main.cc
@@ -1,14 +1,18 @@
 #include <gtest/gtest.h>
 
 #include "nix/store/tests/test-main.hh"
+#include "nix/util/config-global.hh"
 
 using namespace nix;
 
 int main(int argc, char ** argv)
 {
     auto res = testMainForBuidingPre(argc, argv);
-    if (!res)
+    if (res)
         return res;
+
+    // For pipe operator tests in trivial.cc
+    experimentalFeatureSettings.set("experimental-features", "pipe-operators");
 
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->
This fixes a crucial typo for libexpr-tests.

## Motivation

Tests should run, also when the test setup succeeds.

## Context

Accidentally disabled by 9bc218ca3fc98889719684abba73b5d8a168cf3c
- https://github.com/NixOS/nix/pull/13907

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
