### PR TITLE
libfetchers/github: Use getFSAccessor for downloadFile result

### DIFF
--- a/src/libfetchers/github.cc
+++ b/src/libfetchers/github.cc
@@ -398,8 +398,9 @@ struct GitHubInputScheme : GitArchiveInputScheme
 
         Headers headers = makeHeadersWithAuthTokens(*input.settings, host, input);
 
-        auto json = nlohmann::json::parse(
-            readFile(store->toRealPath(downloadFile(store, *input.settings, url, "source", headers).storePath)));
+        auto accessor = store->getFSAccessor();
+        auto downloadResult = downloadFile(store, *input.settings, url, "source", headers);
+        auto json = nlohmann::json::parse(accessor->readFile(CanonPath(downloadResult.storePath.to_string())));
 
         return RefInfo{
             .rev = Hash::parseAny(std::string{json["sha"]}, HashAlgorithm::SHA1),
@@ -472,8 +473,9 @@ struct GitLabInputScheme : GitArchiveInputScheme
 
         Headers headers = makeHeadersWithAuthTokens(*input.settings, host, input);
 
-        auto json = nlohmann::json::parse(
-            readFile(store->toRealPath(downloadFile(store, *input.settings, url, "source", headers).storePath)));
+        auto accessor = store->getFSAccessor();
+        auto downloadResult = downloadFile(store, *input.settings, url, "source", headers);
+        auto json = nlohmann::json::parse(accessor->readFile(CanonPath(downloadResult.storePath.to_string())));
 
         if (json.is_array() && json.size() >= 1 && json[0]["id"] != nullptr) {
             return RefInfo{.rev = Hash::parseAny(std::string(json[0]["id"]), HashAlgorithm::SHA1)};


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

We should use proper abstractions for reading files from the store. E.g. this caused errors when trying to download github flakes into an in-memory store in #14023.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Useful for https://github.com/NixOS/nix/pull/14023.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
