### PR TITLE
libstore: Make writable dummy store thread-safe 

### DIFF
--- a/src/libstore/include/nix/store/path.hh
+++ b/src/libstore/include/nix/store/path.hh
@@ -108,4 +108,13 @@ struct hash<nix::StorePath>
 
 } // namespace std
 
+namespace nix {
+
+inline std::size_t hash_value(const StorePath & path)
+{
+    return std::hash<StorePath>{}(path);
+}
+
+} // namespace nix
+
 JSON_IMPL(nix::StorePath)

--- a/src/libutil-tests/git.cc
+++ b/src/libutil-tests/git.cc
@@ -233,30 +233,30 @@ TEST_F(GitTest, both_roundrip)
         .contents{
             {
                 "foo",
-                make_ref<File>(File::Regular{
+                File::Regular{
                     .contents = "hello\n\0\n\tworld!",
-                }),
+                },
             },
             {
                 "bar",
-                make_ref<File>(File::Directory{
+                File::Directory{
                     .contents =
                         {
                             {
                                 "baz",
-                                make_ref<File>(File::Regular{
+                                File::Regular{
                                     .executable = true,
                                     .contents = "good day,\n\0\n\tworld!",
-                                }),
+                                },
                             },
                             {
                                 "quux",
-                                make_ref<File>(File::Symlink{
+                                File::Symlink{
                                     .target = "/over/there",
-                                }),
+                                },
                             },
                         },
-                }),
+                },
             },
         },
     };

--- a/src/libutil/include/nix/util/memory-source-accessor.hh
+++ b/src/libutil/include/nix/util/memory-source-accessor.hh
@@ -35,7 +35,7 @@ struct MemorySourceAccessor : virtual SourceAccessor
         {
             using Name = std::string;
 
-            std::map<Name, ref<File>, std::less<>> contents;
+            std::map<Name, File, std::less<>> contents;
 
             bool operator==(const Directory &) const noexcept;
             // TODO libc++ 16 (used by darwin) missing `std::map::operator <=>`, can't do yet.
@@ -89,21 +89,13 @@ struct MemorySourceAccessor : virtual SourceAccessor
     SourcePath addFile(CanonPath path, std::string && contents);
 };
 
-inline bool
-MemorySourceAccessor::File::Directory::operator==(const MemorySourceAccessor::File::Directory & other) const noexcept
-{
-    return std::ranges::equal(contents, other.contents, [](const auto & lhs, const auto & rhs) -> bool {
-        return lhs.first == rhs.first && *lhs.second == *rhs.second;
-    });
-};
+inline bool MemorySourceAccessor::File::Directory::operator==(
+    const MemorySourceAccessor::File::Directory &) const noexcept = default;
 
 inline bool
 MemorySourceAccessor::File::Directory::operator<(const MemorySourceAccessor::File::Directory & other) const noexcept
 {
-    return std::ranges::lexicographical_compare(
-        contents, other.contents, [](const auto & lhs, const auto & rhs) -> bool {
-            return lhs.first < rhs.first && *lhs.second < *rhs.second;
-        });
+    return contents < other.contents;
 }
 
 inline bool MemorySourceAccessor::File::operator==(const MemorySourceAccessor::File &) const noexcept = default;

--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -39,11 +39,11 @@ MemorySourceAccessor::File * MemorySourceAccessor::open(const CanonPath & path, 
                     i,
                     {
                         std::string{name},
-                        make_ref<File>(File::Directory{}),
+                        File::Directory{},
                     });
             }
         }
-        cur = &*i->second;
+        cur = &i->second;
     }
 
     if (newF && create)
@@ -107,7 +107,7 @@ MemorySourceAccessor::DirEntries MemorySourceAccessor::readDirectory(const Canon
     if (auto * d = std::get_if<File::Directory>(&f->raw)) {
         DirEntries res;
         for (auto & [name, file] : d->contents)
-            res.insert_or_assign(name, file->lstat().type);
+            res.insert_or_assign(name, file.lstat().type);
         return res;
     } else
         throw Error("file '%s' is not a directory", path);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Tested by building with `b_sanitize=thread` and running:

```
nix flake prefetch-inputs --store "dummy://?read-only=false"
```

It might make sense to move this utility class out of `dummy-store.cc`,
but it seems fine for now.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/14036
Follow-up to https://github.com/NixOS/nix/pull/14023

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
