### PR TITLE
libfetchers: avoid re-copying substituted inputs

### DIFF
--- a/doc/manual/rl-next/cached-substituted-inputs.md
+++ b/doc/manual/rl-next/cached-substituted-inputs.md
@@ -1,0 +1,10 @@
+---
+synopsis: "Substituted flake inputs are no longer re-copied to the store"
+prs: [14041]
+---
+
+Since 2.25, Nix would fail to store a cache entry for substituted flake inputs,
+which in turn would cause them to be re-copied to the store on initial
+evaluation. Caching these inputs results in a near doubling of a performance in
+some cases — especially on I/O-bound machines and when using commands that
+fetch many inputs, like `nix flake archive/prefetch-inputs`


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Previously, Nix would not create a cache entry for substituted/cached
inputs

This led to severe slowdowns in some scenarios where a large input (like
Nixpkgs) had already been unpacked to the store but didn't exist in a
users cache, as described in https://github.com/NixOS/nix/issues/11228

In my testing (on WSL) the speedup can be pretty drastic. As an example, here's
running `nix eval` in this repo after already ensuring inputs are in the store
with `nix flake prefetch-inputs`

Before:

```console
$ nix --version
nix (Nix) 2.32.0pre20250921_f66b56a
$ hyperfine -N -p "rm -rf $HOME/.cache/nix" 'nix eval'
Benchmark 1: nix eval
  Time (mean ± σ):     21.665 s ±  3.579 s    [User: 3.417 s, System: 5.434 s]
  Range (min … max):   18.952 s … 29.814 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```

After:

```console
$ hyperfine -N -p "rm -rf $HOME/.cache/nix" "$PWD/outputs/out/bin/nix eval"
Benchmark 1: /home/seth/repos/nix/outputs/out/bin/nix eval
  Time (mean ± σ):      1.940 s ±  0.058 s    [User: 1.163 s, System: 0.498 s]
  Range (min … max):    1.868 s …  2.014 s    10 runs
```

**This is a ~91% increase in performance!**

Speaking of `nix flake prefetch-inputs`, it seems this bug also affected it, and paths would be re-copied on any uncached invocation. In practice on my machine, this made a run of take 45.5s with this repo's flake (after running `rm -rf ~/.cache/nix`) *even though all inputs were already in the store*. With this PR, it now takes about 300ms (...and I assume this is just evaluating the flake itself)

## Context

Hopefully fixes https://github.com/NixOS/nix/issues/11228

This is basically the fix introduced in https://github.com/NixOS/nix/pull/12911, but adopted in a different, similarly affected code path

~~I'm not exactly sure if this the best solution to do that...but from what I
understand, I think it should be safe to keep the original `Input` information
and pair it with an accessor with a fingerprint of a technically different
input. After all, they should have the same contents given the same hash, and
attributes like `lastModified` go unaffected as they aren't stored in the
accessor anyways~~

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
