### PR TITLE
Support blobs and trees in fetchGit

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -128,6 +128,7 @@
               ''^tests/functional/extra-sandbox-profile\.sh$''
               ''^tests/functional/fetchClosure\.sh$''
               ''^tests/functional/fetchGit\.sh$''
+              ''^tests/functional/fetchGitObjects\.sh$''
               ''^tests/functional/fetchGitRefs\.sh$''
               ''^tests/functional/fetchGitSubmodules\.sh$''
               ''^tests/functional/fetchGitVerification\.sh$''

--- a/src/libexpr/primops/fetchTree.cc
+++ b/src/libexpr/primops/fetchTree.cc
@@ -44,17 +44,15 @@ void emitTreeAttrs(
         if (auto rev = input.getRev()) {
             attrs.alloc("rev").mkString(rev->gitRev());
             attrs.alloc("shortRev").mkString(rev->gitShortRev());
+            if (auto revCount = input.getRevCount())
+                attrs.alloc("revCount").mkInt(*revCount);
         } else if (emptyRevFallback) {
             // Backwards compat for `builtins.fetchGit`: dirty repos return an empty sha1 as rev
             auto emptyHash = Hash(HashAlgorithm::SHA1);
             attrs.alloc("rev").mkString(emptyHash.gitRev());
             attrs.alloc("shortRev").mkString(emptyHash.gitShortRev());
-        }
-
-        if (auto revCount = input.getRevCount())
-            attrs.alloc("revCount").mkInt(*revCount);
-        else if (emptyRevFallback)
             attrs.alloc("revCount").mkInt(0);
+        }
     }
 
     if (auto dirtyRev = fetchers::maybeGetStrAttr(input.attrs, "dirtyRev")) {

--- a/src/libfetchers/include/nix/fetchers/git-utils.hh
+++ b/src/libfetchers/include/nix/fetchers/git-utils.hh
@@ -28,9 +28,9 @@ struct GitRepo
 
     static ref<GitRepo> openRepo(const std::filesystem::path & path, bool create = false, bool bare = false);
 
-    virtual uint64_t getRevCount(const Hash & rev) = 0;
+    virtual std::optional<uint64_t> getRevCount(const Hash & rev) = 0;
 
-    virtual uint64_t getLastModified(const Hash & rev) = 0;
+    virtual std::optional<uint64_t> getLastModified(const Hash & rev) = 0;
 
     virtual bool isShallow() = 0;
 

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -298,6 +298,11 @@ expected_attrs="{ lastModified = 0; lastModifiedDate = \"19700101000000\"; narHa
 result=$(nix eval --impure --expr "builtins.removeAttrs (builtins.fetchGit $empty) [\"outPath\"]")
 [[ "$result" = "$expected_attrs" ]]
 
+# fetchTree shouldn't have rev, revCount or shortRev
+expected_attrs="{ lastModified = 0; lastModifiedDate = \"19700101000000\"; narHash = \"sha256-wzlAGjxKxpaWdqVhlq55q5Gxo4Bf860+kLeEa/v02As=\"; submodules = false; }"
+result=$(nix eval --impure --expr "builtins.removeAttrs (builtins.fetchTree { type = \"git\"; url = \"file://$empty\"; }) [\"outPath\"]")
+[[ "$result" = "$expected_attrs" ]]
+
 # Test a repo with an empty commit.
 git -C "$empty" rm -f x
 

--- a/tests/functional/fetchGitObjects.sh
+++ b/tests/functional/fetchGitObjects.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+requireGit
+
+clearStoreIfPossible
+
+repo="$TEST_ROOT/git"
+
+rm -rf "$repo" "${repo}-tmp" "$TEST_HOME/.cache/nix"
+
+git init "$repo"
+git -C "$repo" config user.email "foobar@example.com"
+git -C "$repo" config user.name "Foobar"
+
+echo foo > "$repo/blob"
+mkdir "$repo/tree"
+echo bar > "$repo/tree/blob"
+git -C "$repo" add blob tree
+git -C "$repo" commit -m 'Bla1'
+
+rev=$(git -C $repo rev-parse HEAD)
+blobrev=$(git -C $repo rev-parse HEAD:blob)
+treerev=$(git -C $repo rev-parse HEAD:tree)
+
+git -C $repo update-ref refs/blob $blobrev
+git -C $repo update-ref refs/tree $treerev
+
+git -C $repo tag -a blobtag -m "annotated tag" $blobrev
+git -C $repo tag -a treetag -m "annotated tag" $treerev
+
+# Fetch by hash
+nix-instantiate --eval -E "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$blobrev\"; shallow = true; }) == \"foo\n\""
+nix-instantiate --eval -E "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$treerev\"; shallow = true; } + \"/blob\") == \"bar\n\""
+
+# Fetch by ref
+nix-instantiate --eval -E "builtins.readFile (builtins.fetchGit { url = file://$repo; ref = \"refs/blob\"; shallow = true; }) == \"foo\n\""
+nix-instantiate --eval -E "builtins.readFile (builtins.fetchGit { url = file://$repo; ref = \"refs/tree\"; shallow = true; } + \"/blob\") == \"bar\n\""
+
+# Fetch by annotated tag
+nix-instantiate --eval -E "builtins.readFile (builtins.fetchGit { url = file://$repo; ref = \"refs/tags/blobtag\"; shallow = true; }) == \"foo\n\""
+nix-instantiate --eval -E "builtins.readFile (builtins.fetchGit { url = file://$repo; ref = \"refs/tags/treetag\"; shallow = true; } + \"/blob\") == \"bar\n\""
+
+# fetchGit attributes
+expectedAttrs="{ narHash = \"sha256-QvtAMbUl/uvi+LCObmqOhvNOapHdA2raiI4xG5zI5pA=\"; rev = \"$blobrev\"; shortRev = \"${blobrev:0:7}\"; submodules = false; }"
+result=$(nix eval --impure --expr "builtins.removeAttrs (builtins.fetchGit { url = file://$repo; rev = \"$blobrev\"; shallow = true; }) [\"outPath\"]")
+[[ "$result" = "$expectedAttrs" ]]
+
+expectedAttrs="{ narHash = \"sha256-R/LfkvSLnUzdPeKhbQ6lGFpSfLdKvDw3LLicN46rUR4=\"; rev = \"$treerev\"; shortRev = \"${treerev:0:7}\"; submodules = false; }"
+result=$(nix eval --impure --expr "builtins.removeAttrs (builtins.fetchGit { url = file://$repo; rev = \"$treerev\"; shallow = true; }) [\"outPath\"]")
+[[ "$result" = "$expectedAttrs" ]]
+
+# fetchTree attributes
+expectedAttrs="{ narHash = \"sha256-QvtAMbUl/uvi+LCObmqOhvNOapHdA2raiI4xG5zI5pA=\"; rev = \"$blobrev\"; shortRev = \"${blobrev:0:7}\"; submodules = false; }"
+result=$(nix eval --impure --expr "builtins.removeAttrs (builtins.fetchTree { type = \"git\"; url = file://$repo; rev = \"$blobrev\"; shallow = true; }) [\"outPath\"]")
+[[ "$result" = "$expectedAttrs" ]]
+
+expectedAttrs="{ narHash = \"sha256-R/LfkvSLnUzdPeKhbQ6lGFpSfLdKvDw3LLicN46rUR4=\"; rev = \"$treerev\"; shortRev = \"${treerev:0:7}\"; submodules = false; }"
+result=$(nix eval --impure --expr "builtins.removeAttrs (builtins.fetchTree { type = \"git\"; url = file://$repo; rev = \"$treerev\"; shallow = true; }) [\"outPath\"]")
+[[ "$result" = "$expectedAttrs" ]]

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -76,6 +76,7 @@ suites = [
       'gc-runtime.sh',
       'tarball.sh',
       'fetchGit.sh',
+      'fetchGitObjects.sh',
       'fetchGitShallow.sh',
       'fetchurl.sh',
       'fetchPath.sh',


### PR DESCRIPTION
## Motivation

This adds support for fetching trees / blobs to fetchGit / fetchTree, making it possible to fetch the source for specific subfolders of a repo. This is especially useful in a monorepo setting as it enables fetching the source for a particular project, and also avoids needless rebuilds if that project hasn't changed.

## Context

Robert suggested that this might be possible at NixCon. I did an some initial poking at this a few weeks ago, and Ericson provided some good suggestions on how to approach this for real[1]. I deviated slightly from his suggestions and put some awareness of blobs + trees into GitRepo.getRevCount and GitRepo.getLastModified as they're ultimately only called from GitInputScheme which currently doesn't have any visibility into the types of objects.

A few things of note:
* When using this via fetchGit, shallow is required as there's no history to fetch.
* Since .gitattributes isn't available, submodules and lfs have no effect.
* When fetching blobs and trees, revCount and lastModified are omitted from the resulting attribute set as those attributes only really make sense for commits (or things that point at commits like annotated tags).

I've opted to not add documentation as it's pretty succinct currently and I didn't want to bloat it with a relatively niche use case, but I can if that's desired. The existing documentation in fetchTree kind of implies that fetching tree objects could work[2].

[1] https://github.com/NixOS/nix/issues/13962
[2] https://github.com/NixOS/nix/blob/d9de675357cd93a9a4094bc3d76494a89be3b8b4/src/libexpr/primops/fetchTree.cc#L337

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
