### PR TITLE
Fix `JSON_IMPL` macro to avoid extraneous copies

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -509,7 +509,7 @@ fetchers::PublicKey adl_serializer<fetchers::PublicKey>::from_json(const json & 
     return res;
 }
 
-void adl_serializer<fetchers::PublicKey>::to_json(json & json, fetchers::PublicKey p)
+void adl_serializer<fetchers::PublicKey>::to_json(json & json, const fetchers::PublicKey & p)
 {
     json["type"] = p.type;
     json["key"] = p.key;

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -356,7 +356,7 @@ DerivationOptions adl_serializer<DerivationOptions>::from_json(const json & json
     };
 }
 
-void adl_serializer<DerivationOptions>::to_json(json & json, DerivationOptions o)
+void adl_serializer<DerivationOptions>::to_json(json & json, const DerivationOptions & o)
 {
     json["outputChecks"] = std::visit(
         overloaded{
@@ -398,7 +398,7 @@ DerivationOptions::OutputChecks adl_serializer<DerivationOptions::OutputChecks>:
     };
 }
 
-void adl_serializer<DerivationOptions::OutputChecks>::to_json(json & json, DerivationOptions::OutputChecks c)
+void adl_serializer<DerivationOptions::OutputChecks>::to_json(json & json, const DerivationOptions::OutputChecks & c)
 {
     json["ignoreSelfRefs"] = c.ignoreSelfRefs;
     json["allowedReferences"] = c.allowedReferences;

--- a/src/libstore/derivations.cc
+++ b/src/libstore/derivations.cc
@@ -1494,7 +1494,7 @@ Derivation adl_serializer<Derivation>::from_json(const json & json)
     return Derivation::fromJSON(json);
 }
 
-void adl_serializer<Derivation>::to_json(json & json, Derivation c)
+void adl_serializer<Derivation>::to_json(json & json, const Derivation & c)
 {
     json = c.toJSON();
 }

--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -150,7 +150,7 @@ OutputsSpec adl_serializer<OutputsSpec>::from_json(const json & json)
         return OutputsSpec::Names{std::move(names)};
 }
 
-void adl_serializer<OutputsSpec>::to_json(json & json, OutputsSpec t)
+void adl_serializer<OutputsSpec>::to_json(json & json, const OutputsSpec & t)
 {
     std::visit(
         overloaded{
@@ -169,7 +169,7 @@ ExtendedOutputsSpec adl_serializer<ExtendedOutputsSpec>::from_json(const json & 
     }
 }
 
-void adl_serializer<ExtendedOutputsSpec>::to_json(json & json, ExtendedOutputsSpec t)
+void adl_serializer<ExtendedOutputsSpec>::to_json(json & json, const ExtendedOutputsSpec & t)
 {
     std::visit(
         overloaded{

--- a/src/libstore/path.cc
+++ b/src/libstore/path.cc
@@ -88,7 +88,7 @@ StorePath adl_serializer<StorePath>::from_json(const json & json)
     return StorePath{getString(json)};
 }
 
-void adl_serializer<StorePath>::to_json(json & json, StorePath storePath)
+void adl_serializer<StorePath>::to_json(json & json, const StorePath & storePath)
 {
     json = storePath.to_string();
 }

--- a/src/libstore/realisation.cc
+++ b/src/libstore/realisation.cc
@@ -165,7 +165,7 @@ Realisation adl_serializer<Realisation>::from_json(const json & json0)
     };
 }
 
-void adl_serializer<Realisation>::to_json(json & json, Realisation r)
+void adl_serializer<Realisation>::to_json(json & json, const Realisation & r)
 {
     auto jsonDependentRealisations = nlohmann::json::object();
     for (auto & [depId, depOutPath] : r.dependentRealisations)

--- a/src/libutil/include/nix/util/json-impls.hh
+++ b/src/libutil/include/nix/util/json-impls.hh
@@ -4,13 +4,13 @@
 #include <nlohmann/json_fwd.hpp>
 
 // Following https://github.com/nlohmann/json#how-can-i-use-get-for-non-default-constructiblenon-copyable-types
-#define JSON_IMPL(TYPE)                           \
-    namespace nlohmann {                          \
-    using namespace nix;                          \
-    template<>                                    \
-    struct adl_serializer<TYPE>                   \
-    {                                             \
-        static TYPE from_json(const json & json); \
-        static void to_json(json & json, TYPE t); \
-    };                                            \
+#define JSON_IMPL(TYPE)                                   \
+    namespace nlohmann {                                  \
+    using namespace nix;                                  \
+    template<>                                            \
+    struct adl_serializer<TYPE>                           \
+    {                                                     \
+        static TYPE from_json(const json & json);         \
+        static void to_json(json & json, const TYPE & t); \
+    };                                                    \
     }


### PR DESCRIPTION
## Motivation

Should take the thing we're serializing by reference.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
