### PR TITLE
Remove some pointless `std::visit`

### DIFF
--- a/src/nix/build.cc
+++ b/src/nix/build.cc
@@ -12,7 +12,7 @@ static nlohmann::json derivedPathsToJSON(const DerivedPaths & paths, Store & sto
 {
     auto res = nlohmann::json::array();
     for (auto & t : paths) {
-        std::visit([&](const auto & t) { res.push_back(t.toJSON(store)); }, t.raw());
+        res.push_back(t.toJSON(store));
     }
     return res;
 }
@@ -22,22 +22,18 @@ builtPathsWithResultToJSON(const std::vector<BuiltPathWithResult> & buildables, 
 {
     auto res = nlohmann::json::array();
     for (auto & b : buildables) {
-        std::visit(
-            [&](const auto & t) {
-                auto j = t.toJSON(store);
-                if (b.result) {
-                    if (b.result->startTime)
-                        j["startTime"] = b.result->startTime;
-                    if (b.result->stopTime)
-                        j["stopTime"] = b.result->stopTime;
-                    if (b.result->cpuUser)
-                        j["cpuUser"] = ((double) b.result->cpuUser->count()) / 1000000;
-                    if (b.result->cpuSystem)
-                        j["cpuSystem"] = ((double) b.result->cpuSystem->count()) / 1000000;
-                }
-                res.push_back(j);
-            },
-            b.path.raw());
+        auto j = b.path.toJSON(store);
+        if (b.result) {
+            if (b.result->startTime)
+                j["startTime"] = b.result->startTime;
+            if (b.result->stopTime)
+                j["stopTime"] = b.result->stopTime;
+            if (b.result->cpuUser)
+                j["cpuUser"] = ((double) b.result->cpuUser->count()) / 1000000;
+            if (b.result->cpuSystem)
+                j["cpuSystem"] = ((double) b.result->cpuSystem->count()) / 1000000;
+        }
+        res.push_back(j);
     }
     return res;
 }


### PR DESCRIPTION
## Motivation

These are not needed, because the `toJSON` methods are already implemented for the variant wrapper too.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
