### PR TITLE
C API: add log format and verbosity functions

### DIFF
--- a/src/libmain-c/nix_api_main.cc
+++ b/src/libmain-c/nix_api_main.cc
@@ -4,6 +4,7 @@
 #include "nix_api_util_internal.h"
 
 #include "nix/main/plugin.hh"
+#include "nix/main/loggers.hh"
 
 extern "C" {
 
@@ -13,6 +14,18 @@ nix_err nix_init_plugins(nix_c_context * context)
         context->last_err_code = NIX_OK;
     try {
         nix::initPlugins();
+    }
+    NIXC_CATCH_ERRS
+}
+
+nix_err nix_set_log_format(nix_c_context * context, const char * format)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    if (format == nullptr)
+        return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Log format is null");
+    try {
+        nix::setLogFormat(format);
     }
     NIXC_CATCH_ERRS
 }

--- a/src/libmain-c/nix_api_main.h
+++ b/src/libmain-c/nix_api_main.h
@@ -30,6 +30,14 @@ extern "C" {
  */
 nix_err nix_init_plugins(nix_c_context * context);
 
+/**
+ * @brief Sets the log format
+ *
+ * @param[out] context Optional, stores error information
+ * @param[in] format The string name of the format.
+ */
+nix_err nix_set_log_format(nix_c_context * context, const char * format);
+
 // cffi end
 #ifdef __cplusplus
 }

--- a/src/libutil-c/nix_api_util.cc
+++ b/src/libutil-c/nix_api_util.cc
@@ -159,4 +159,16 @@ nix_err call_nix_get_string_callback(const std::string str, nix_get_string_callb
     return NIX_OK;
 }
 
+nix_err nix_set_verbosity(nix_c_context * context, nix_verbosity level)
+{
+    if (context)
+        context->last_err_code = NIX_OK;
+    if (level > NIX_LVL_VOMIT || level < NIX_LVL_ERROR)
+        return nix_set_err_msg(context, NIX_ERR_UNKNOWN, "Invalid verbosity level");
+    try {
+        nix::verbosity = static_cast<nix::Verbosity>(level);
+    }
+    NIXC_CATCH_ERRS
+}
+
 } // extern "C"

--- a/src/libutil-c/nix_api_util.h
+++ b/src/libutil-c/nix_api_util.h
@@ -103,6 +103,24 @@ enum nix_err {
 typedef enum nix_err nix_err;
 
 /**
+ * @brief Verbosity level
+ *
+ * @note This should be kept in sync with the C++ implementation (nix::Verbosity)
+ */
+enum nix_verbosity {
+    NIX_LVL_ERROR = 0,
+    NIX_LVL_WARN,
+    NIX_LVL_NOTICE,
+    NIX_LVL_INFO,
+    NIX_LVL_TALKATIVE,
+    NIX_LVL_CHATTY,
+    NIX_LVL_DEBUG,
+    NIX_LVL_VOMIT,
+};
+
+typedef enum nix_verbosity nix_verbosity;
+
+/**
  * @brief This object stores error state.
  * @struct nix_c_context
  *
@@ -315,6 +333,14 @@ nix_err nix_set_err_msg(nix_c_context * context, nix_err err, const char * msg);
  * This failure can be avoided by clearing the error message after handling it.
  */
 void nix_clear_err(nix_c_context * context);
+
+/**
+ * @brief Sets the verbosity level
+ *
+ * @param[out] context Optional, additional error context.
+ * @param[in] level Verbosity level
+ */
+nix_err nix_set_verbosity(nix_c_context * context, nix_verbosity level);
 
 /**
  *  @}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

Adds a C API way of interacting with some of the logging, this is useful for supporting tools like NOM (Nix Output Monitor).

## Context

Upstreams https://github.com/DeterminateSystems/nix-src/pull/211

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
