### PR TITLE
ci: Split formatting check into a separate job, gate other jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,28 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: nix flake show --all-systems --json
 
+  pre-commit-checks:
+    name: pre-commit checks
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/install-nix-action
+        with:
+          dogfood: ${{ github.event_name == 'workflow_dispatch' && inputs.dogfood || github.event_name != 'workflow_dispatch' }}
+          extra_nix_config: experimental-features = nix-command flakes
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: ./ci/gha/tests/pre-commit-checks
+
+  basic-checks:
+    name: aggregate basic checks
+    runs-on: ubuntu-24.04
+    needs: [pre-commit-checks, eval]
+    steps:
+      - run: ":" # Dummy step
+
   tests:
+    needs: basic-checks
     strategy:
       fail-fast: false
       matrix:
@@ -214,6 +235,7 @@ jobs:
         docker push $IMAGE_ID:master
 
   vm_tests:
+    needs: basic-checks
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,14 @@ jobs:
 
   basic-checks:
     name: aggregate basic checks
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     needs: [pre-commit-checks, eval]
     steps:
-      - run: ":" # Dummy step
+      - name: Exit with any errors
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          exit 1
 
   tests:
     needs: basic-checks

--- a/ci/gha/tests/pre-commit-checks
+++ b/ci/gha/tests/pre-commit-checks
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+system=$(nix eval --raw --impure --expr builtins.currentSystem)
+
+echo "::group::Running pre-commit checks"
+
+if nix build ".#checks.$system.pre-commit" -L; then
+    echo "::endgroup::"
+    exit 0
+fi
+
+echo "::error ::Changes do not pass pre-commit checks"
+
+cat <<EOF
+The code isn't formatted or doesn't pass lints. You can run pre-commit locally with:
+
+    nix develop -c ./maintainers/format.sh
+EOF
+
+echo "::endgroup::"
+
+exit 1


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This makes the CI fail fast and more explicitly in case the formatting is incorrect and provides a better error messages. This also ensures that we don't burn CI on useless checks for code that wouldn't pass lints anyway.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Suggested by @Mic92 during last meeting.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
