### PR TITLE
Use `std::variant` to enforce `BuildResult` invariants 

### DIFF
--- a/src/libstore-c/nix_api_store.cc
+++ b/src/libstore-c/nix_api_store.cc
@@ -145,9 +145,11 @@ nix_err nix_store_realise(
 
         if (callback) {
             for (const auto & result : results) {
-                for (const auto & [outputName, realisation] : result.builtOutputs) {
-                    StorePath p{realisation.outPath};
-                    callback(userdata, outputName.c_str(), &p);
+                if (auto * success = result.tryGetSuccess()) {
+                    for (const auto & [outputName, realisation] : success->builtOutputs) {
+                        StorePath p{realisation.outPath};
+                        callback(userdata, outputName.c_str(), &p);
+                    }
                 }
             }
         }

--- a/src/libstore-tests/serve-protocol.cc
+++ b/src/libstore-tests/serve-protocol.cc
@@ -127,17 +127,17 @@ VERSIONED_CHARACTERIZATION_TEST(
 VERSIONED_CHARACTERIZATION_TEST(ServeProtoTest, buildResult_2_2, "build-result-2.2", 2 << 8 | 2, ({
                                     using namespace std::literals::chrono_literals;
                                     std::tuple<BuildResult, BuildResult, BuildResult> t{
-                                        BuildResult{
-                                            .status = BuildResult::OutputRejected,
+                                        BuildResult{.inner{BuildResult::Failure{
+                                            .status = BuildResult::Failure::OutputRejected,
                                             .errorMsg = "no idea why",
-                                        },
-                                        BuildResult{
-                                            .status = BuildResult::NotDeterministic,
+                                        }}},
+                                        BuildResult{.inner{BuildResult::Failure{
+                                            .status = BuildResult::Failure::NotDeterministic,
                                             .errorMsg = "no idea why",
-                                        },
-                                        BuildResult{
-                                            .status = BuildResult::Built,
-                                        },
+                                        }}},
+                                        BuildResult{.inner{BuildResult::Success{
+                                            .status = BuildResult::Success::Built,
+                                        }}},
                                     };
                                     t;
                                 }))
@@ -145,20 +145,24 @@ VERSIONED_CHARACTERIZATION_TEST(ServeProtoTest, buildResult_2_2, "build-result-2
 VERSIONED_CHARACTERIZATION_TEST(ServeProtoTest, buildResult_2_3, "build-result-2.3", 2 << 8 | 3, ({
                                     using namespace std::literals::chrono_literals;
                                     std::tuple<BuildResult, BuildResult, BuildResult> t{
-                                        BuildResult{
-                                            .status = BuildResult::OutputRejected,
+                                        BuildResult{.inner{BuildResult::Failure{
+                                            .status = BuildResult::Failure::OutputRejected,
                                             .errorMsg = "no idea why",
-                                        },
+                                        }}},
                                         BuildResult{
-                                            .status = BuildResult::NotDeterministic,
-                                            .errorMsg = "no idea why",
+                                            .inner{BuildResult::Failure{
+                                                .status = BuildResult::Failure::NotDeterministic,
+                                                .errorMsg = "no idea why",
+                                                .isNonDeterministic = true,
+                                            }},
                                             .timesBuilt = 3,
-                                            .isNonDeterministic = true,
                                             .startTime = 30,
                                             .stopTime = 50,
                                         },
                                         BuildResult{
-                                            .status = BuildResult::Built,
+                                            .inner{BuildResult::Success{
+                                                .status = BuildResult::Success::Built,
+                                            }},
                                             .startTime = 30,
                                             .stopTime = 50,
                                         },
@@ -170,48 +174,52 @@ VERSIONED_CHARACTERIZATION_TEST(
     ServeProtoTest, buildResult_2_6, "build-result-2.6", 2 << 8 | 6, ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
-            BuildResult{
-                .status = BuildResult::OutputRejected,
+            BuildResult{.inner{BuildResult::Failure{
+                .status = BuildResult::Failure::OutputRejected,
                 .errorMsg = "no idea why",
-            },
+            }}},
             BuildResult{
-                .status = BuildResult::NotDeterministic,
-                .errorMsg = "no idea why",
+                .inner{BuildResult::Failure{
+                    .status = BuildResult::Failure::NotDeterministic,
+                    .errorMsg = "no idea why",
+                    .isNonDeterministic = true,
+                }},
                 .timesBuilt = 3,
-                .isNonDeterministic = true,
                 .startTime = 30,
                 .stopTime = 50,
             },
             BuildResult{
-                .status = BuildResult::Built,
+                .inner{BuildResult::Success{
+                    .status = BuildResult::Success::Built,
+                    .builtOutputs =
+                        {
+                            {
+                                "foo",
+                                {
+                                    .id =
+                                        DrvOutput{
+                                            .drvHash =
+                                                Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
+                                            .outputName = "foo",
+                                        },
+                                    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
+                                },
+                            },
+                            {
+                                "bar",
+                                {
+                                    .id =
+                                        DrvOutput{
+                                            .drvHash =
+                                                Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
+                                            .outputName = "bar",
+                                        },
+                                    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar"},
+                                },
+                            },
+                        },
+                }},
                 .timesBuilt = 1,
-                .builtOutputs =
-                    {
-                        {
-                            "foo",
-                            {
-                                .id =
-                                    DrvOutput{
-                                        .drvHash =
-                                            Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
-                                        .outputName = "foo",
-                                    },
-                                .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
-                            },
-                        },
-                        {
-                            "bar",
-                            {
-                                .id =
-                                    DrvOutput{
-                                        .drvHash =
-                                            Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
-                                        .outputName = "bar",
-                                    },
-                                .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar"},
-                            },
-                        },
-                    },
                 .startTime = 30,
                 .stopTime = 50,
 #if 0

--- a/src/libstore-tests/worker-protocol.cc
+++ b/src/libstore-tests/worker-protocol.cc
@@ -180,17 +180,17 @@ VERSIONED_CHARACTERIZATION_TEST(
 VERSIONED_CHARACTERIZATION_TEST(WorkerProtoTest, buildResult_1_27, "build-result-1.27", 1 << 8 | 27, ({
                                     using namespace std::literals::chrono_literals;
                                     std::tuple<BuildResult, BuildResult, BuildResult> t{
-                                        BuildResult{
-                                            .status = BuildResult::OutputRejected,
+                                        BuildResult{.inner{BuildResult::Failure{
+                                            .status = BuildResult::Failure::OutputRejected,
                                             .errorMsg = "no idea why",
-                                        },
-                                        BuildResult{
-                                            .status = BuildResult::NotDeterministic,
+                                        }}},
+                                        BuildResult{.inner{BuildResult::Failure{
+                                            .status = BuildResult::Failure::NotDeterministic,
                                             .errorMsg = "no idea why",
-                                        },
-                                        BuildResult{
-                                            .status = BuildResult::Built,
-                                        },
+                                        }}},
+                                        BuildResult{.inner{BuildResult::Success{
+                                            .status = BuildResult::Success::Built,
+                                        }}},
                                     };
                                     t;
                                 }))
@@ -199,16 +199,16 @@ VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest, buildResult_1_28, "build-result-1.28", 1 << 8 | 28, ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
-            BuildResult{
-                .status = BuildResult::OutputRejected,
+            BuildResult{.inner{BuildResult::Failure{
+                .status = BuildResult::Failure::OutputRejected,
                 .errorMsg = "no idea why",
-            },
-            BuildResult{
-                .status = BuildResult::NotDeterministic,
+            }}},
+            BuildResult{.inner{BuildResult::Failure{
+                .status = BuildResult::Failure::NotDeterministic,
                 .errorMsg = "no idea why",
-            },
-            BuildResult{
-                .status = BuildResult::Built,
+            }}},
+            BuildResult{.inner{BuildResult::Success{
+                .status = BuildResult::Success::Built,
                 .builtOutputs =
                     {
                         {
@@ -236,7 +236,7 @@ VERSIONED_CHARACTERIZATION_TEST(
                             },
                         },
                     },
-            },
+            }}},
         };
         t;
     }))
@@ -245,48 +245,52 @@ VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest, buildResult_1_29, "build-result-1.29", 1 << 8 | 29, ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
-            BuildResult{
-                .status = BuildResult::OutputRejected,
+            BuildResult{.inner{BuildResult::Failure{
+                .status = BuildResult::Failure::OutputRejected,
                 .errorMsg = "no idea why",
-            },
+            }}},
             BuildResult{
-                .status = BuildResult::NotDeterministic,
-                .errorMsg = "no idea why",
+                .inner{BuildResult::Failure{
+                    .status = BuildResult::Failure::NotDeterministic,
+                    .errorMsg = "no idea why",
+                    .isNonDeterministic = true,
+                }},
                 .timesBuilt = 3,
-                .isNonDeterministic = true,
                 .startTime = 30,
                 .stopTime = 50,
             },
             BuildResult{
-                .status = BuildResult::Built,
+                .inner{BuildResult::Success{
+                    .status = BuildResult::Success::Built,
+                    .builtOutputs =
+                        {
+                            {
+                                "foo",
+                                {
+                                    .id =
+                                        DrvOutput{
+                                            .drvHash =
+                                                Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
+                                            .outputName = "foo",
+                                        },
+                                    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
+                                },
+                            },
+                            {
+                                "bar",
+                                {
+                                    .id =
+                                        DrvOutput{
+                                            .drvHash =
+                                                Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
+                                            .outputName = "bar",
+                                        },
+                                    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar"},
+                                },
+                            },
+                        },
+                }},
                 .timesBuilt = 1,
-                .builtOutputs =
-                    {
-                        {
-                            "foo",
-                            {
-                                .id =
-                                    DrvOutput{
-                                        .drvHash =
-                                            Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
-                                        .outputName = "foo",
-                                    },
-                                .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
-                            },
-                        },
-                        {
-                            "bar",
-                            {
-                                .id =
-                                    DrvOutput{
-                                        .drvHash =
-                                            Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
-                                        .outputName = "bar",
-                                    },
-                                .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar"},
-                            },
-                        },
-                    },
                 .startTime = 30,
                 .stopTime = 50,
             },
@@ -298,48 +302,52 @@ VERSIONED_CHARACTERIZATION_TEST(
     WorkerProtoTest, buildResult_1_37, "build-result-1.37", 1 << 8 | 37, ({
         using namespace std::literals::chrono_literals;
         std::tuple<BuildResult, BuildResult, BuildResult> t{
-            BuildResult{
-                .status = BuildResult::OutputRejected,
+            BuildResult{.inner{BuildResult::Failure{
+                .status = BuildResult::Failure::OutputRejected,
                 .errorMsg = "no idea why",
-            },
+            }}},
             BuildResult{
-                .status = BuildResult::NotDeterministic,
-                .errorMsg = "no idea why",
+                .inner{BuildResult::Failure{
+                    .status = BuildResult::Failure::NotDeterministic,
+                    .errorMsg = "no idea why",
+                    .isNonDeterministic = true,
+                }},
                 .timesBuilt = 3,
-                .isNonDeterministic = true,
                 .startTime = 30,
                 .stopTime = 50,
             },
             BuildResult{
-                .status = BuildResult::Built,
+                .inner{BuildResult::Success{
+                    .status = BuildResult::Success::Built,
+                    .builtOutputs =
+                        {
+                            {
+                                "foo",
+                                {
+                                    .id =
+                                        DrvOutput{
+                                            .drvHash =
+                                                Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
+                                            .outputName = "foo",
+                                        },
+                                    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
+                                },
+                            },
+                            {
+                                "bar",
+                                {
+                                    .id =
+                                        DrvOutput{
+                                            .drvHash =
+                                                Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
+                                            .outputName = "bar",
+                                        },
+                                    .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar"},
+                                },
+                            },
+                        },
+                }},
                 .timesBuilt = 1,
-                .builtOutputs =
-                    {
-                        {
-                            "foo",
-                            {
-                                .id =
-                                    DrvOutput{
-                                        .drvHash =
-                                            Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
-                                        .outputName = "foo",
-                                    },
-                                .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo"},
-                            },
-                        },
-                        {
-                            "bar",
-                            {
-                                .id =
-                                    DrvOutput{
-                                        .drvHash =
-                                            Hash::parseSRI("sha256-b4afnqKCO9oWXgYHb9DeQ2berSwOjS27rSd9TxXDc/U="),
-                                        .outputName = "bar",
-                                    },
-                                .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-bar"},
-                            },
-                        },
-                    },
                 .startTime = 30,
                 .stopTime = 50,
                 .cpuUser = std::chrono::microseconds(500s),
@@ -353,10 +361,10 @@ VERSIONED_CHARACTERIZATION_TEST(WorkerProtoTest, keyedBuildResult_1_29, "keyed-b
                                     using namespace std::literals::chrono_literals;
                                     std::tuple<KeyedBuildResult, KeyedBuildResult /*, KeyedBuildResult*/> t{
                                         KeyedBuildResult{
-                                            {
-                                                .status = KeyedBuildResult::OutputRejected,
+                                            {.inner{BuildResult::Failure{
+                                                .status = KeyedBuildResult::Failure::OutputRejected,
                                                 .errorMsg = "no idea why",
-                                            },
+                                            }}},
                                             /* .path = */
                                             DerivedPath::Opaque{
                                                 StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-xxx"},
@@ -364,10 +372,12 @@ VERSIONED_CHARACTERIZATION_TEST(WorkerProtoTest, keyedBuildResult_1_29, "keyed-b
                                         },
                                         KeyedBuildResult{
                                             {
-                                                .status = KeyedBuildResult::NotDeterministic,
-                                                .errorMsg = "no idea why",
+                                                .inner{BuildResult::Failure{
+                                                    .status = KeyedBuildResult::Failure::NotDeterministic,
+                                                    .errorMsg = "no idea why",
+                                                    .isNonDeterministic = true,
+                                                }},
                                                 .timesBuilt = 3,
-                                                .isNonDeterministic = true,
                                                 .startTime = 30,
                                                 .stopTime = 50,
                                             },

--- a/src/libstore/build-result.cc
+++ b/src/libstore/build-result.cc
@@ -5,4 +5,10 @@ namespace nix {
 bool BuildResult::operator==(const BuildResult &) const noexcept = default;
 std::strong_ordering BuildResult::operator<=>(const BuildResult &) const noexcept = default;
 
+bool BuildResult::Success::operator==(const BuildResult::Success &) const noexcept = default;
+std::strong_ordering BuildResult::Success::operator<=>(const BuildResult::Success &) const noexcept = default;
+
+bool BuildResult::Failure::operator==(const BuildResult::Failure &) const noexcept = default;
+std::strong_ordering BuildResult::Failure::operator<=>(const BuildResult::Failure &) const noexcept = default;
+
 } // namespace nix

--- a/src/libstore/build/derivation-check.cc
+++ b/src/libstore/build/derivation-check.cc
@@ -33,7 +33,7 @@ void checkOutputs(
                 /* Throw an error after registering the path as
                    valid. */
                 throw BuildError(
-                    BuildResult::HashMismatch,
+                    BuildResult::Failure::HashMismatch,
                     "hash mismatch in fixed-output derivation '%s':\n  specified: %s\n     got:    %s",
                     store.printStorePath(drvPath),
                     wanted.to_string(HashFormat::SRI, true),
@@ -42,7 +42,7 @@ void checkOutputs(
             if (!info.references.empty()) {
                 auto numViolations = info.references.size();
                 throw BuildError(
-                    BuildResult::HashMismatch,
+                    BuildResult::Failure::HashMismatch,
                     "fixed-output derivations must not reference store paths: '%s' references %d distinct paths, e.g. '%s'",
                     store.printStorePath(drvPath),
                     numViolations,
@@ -84,7 +84,7 @@ void checkOutputs(
         auto applyChecks = [&](const DerivationOptions::OutputChecks & checks) {
             if (checks.maxSize && info.narSize > *checks.maxSize)
                 throw BuildError(
-                    BuildResult::OutputRejected,
+                    BuildResult::Failure::OutputRejected,
                     "path '%s' is too large at %d bytes; limit is %d bytes",
                     store.printStorePath(info.path),
                     info.narSize,
@@ -94,7 +94,7 @@ void checkOutputs(
                 uint64_t closureSize = getClosure(info.path).second;
                 if (closureSize > *checks.maxClosureSize)
                     throw BuildError(
-                        BuildResult::OutputRejected,
+                        BuildResult::Failure::OutputRejected,
                         "closure of path '%s' is too large at %d bytes; limit is %d bytes",
                         store.printStorePath(info.path),
                         closureSize,
@@ -115,7 +115,7 @@ void checkOutputs(
                         std::string outputsListing =
                             concatMapStringsSep(", ", outputs, [](auto & o) { return o.first; });
                         throw BuildError(
-                            BuildResult::OutputRejected,
+                            BuildResult::Failure::OutputRejected,
                             "derivation '%s' output check for '%s' contains an illegal reference specifier '%s',"
                             " expected store path or output name (one of [%s])",
                             store.printStorePath(drvPath),
@@ -148,7 +148,7 @@ void checkOutputs(
                         badPathsStr += store.printStorePath(i);
                     }
                     throw BuildError(
-                        BuildResult::OutputRejected,
+                        BuildResult::Failure::OutputRejected,
                         "output '%s' is not allowed to refer to the following paths:%s",
                         store.printStorePath(info.path),
                         badPathsStr);

--- a/src/libstore/build/derivation-trampoline-goal.cc
+++ b/src/libstore/build/derivation-trampoline-goal.cc
@@ -164,10 +164,11 @@ Goal::Co DerivationTrampolineGoal::haveDerivation(StorePath drvPath, Derivation 
 
     auto & g = *concreteDrvGoals.begin();
     buildResult = g->buildResult;
-    for (auto & g2 : concreteDrvGoals) {
-        for (auto && [x, y] : g2->buildResult.builtOutputs)
-            buildResult.builtOutputs.insert_or_assign(x, y);
-    }
+    if (auto * successP = buildResult.tryGetSuccess())
+        for (auto & g2 : concreteDrvGoals)
+            if (auto * successP2 = g2->buildResult.tryGetSuccess())
+                for (auto && [x, y] : successP2->builtOutputs)
+                    successP->builtOutputs.insert_or_assign(x, y);
 
     co_return amDone(g->exitCode, g->ex);
 }

--- a/src/libstore/build/entry-points.cc
+++ b/src/libstore/build/entry-points.cc
@@ -82,10 +82,10 @@ BuildResult Store::buildDerivation(const StorePath & drvPath, const BasicDerivat
         worker.run(Goals{goal});
         return goal->buildResult;
     } catch (Error & e) {
-        return BuildResult{
-            .status = BuildResult::MiscFailure,
+        return BuildResult{.inner{BuildResult::Failure{
+            .status = BuildResult::Failure::MiscFailure,
             .errorMsg = e.msg(),
-        };
+        }}};
     };
 }
 

--- a/src/libstore/derivation-options.cc
+++ b/src/libstore/derivation-options.cc
@@ -266,7 +266,9 @@ DerivationOptions::getParsedExportReferencesGraph(const StoreDirConfig & store) 
         for (auto & storePathS : ss) {
             if (!store.isInStore(storePathS))
                 throw BuildError(
-                    BuildResult::InputRejected, "'exportReferencesGraph' contains a non-store path '%1%'", storePathS);
+                    BuildResult::Failure::InputRejected,
+                    "'exportReferencesGraph' contains a non-store path '%1%'",
+                    storePathS);
             storePaths.insert(store.toStorePath(storePathS).first);
         }
         res.insert_or_assign(fileName, storePaths);

--- a/src/libstore/include/nix/store/build-result.hh
+++ b/src/libstore/include/nix/store/build-result.hh
@@ -12,62 +12,120 @@ namespace nix {
 
 struct BuildResult
 {
-    /**
-     * @note This is directly used in the nix-store --serve protocol.
-     * That means we need to worry about compatibility across versions.
-     * Therefore, don't remove status codes, and only add new status
-     * codes at the end of the list.
-     */
-    enum Status {
-        Built = 0,
-        Substituted = 1,
-        AlreadyValid = 2,
-        PermanentFailure = 3,
-        InputRejected = 4,
-        OutputRejected = 5,
-        /// possibly transient
-        TransientFailure = 6,
-        /// no longer used
-        CachedFailure = 7,
-        TimedOut = 8,
-        MiscFailure = 9,
-        DependencyFailed = 10,
-        LogLimitExceeded = 11,
-        NotDeterministic = 12,
-        ResolvesToAlreadyValid = 13,
-        NoSubstituters = 14,
-        /// A certain type of `OutputRejected`. The protocols do not yet
-        /// know about this one, so change it back to `OutputRejected`
-        /// before serialization.
-        HashMismatch = 15,
-    } status = MiscFailure;
+    struct Success
+    {
+        /**
+         * @note This is directly used in the nix-store --serve protocol.
+         * That means we need to worry about compatibility across versions.
+         * Therefore, don't remove status codes, and only add new status
+         * codes at the end of the list.
+         *
+         * Must be disjoint with `Failure::Status`.
+         */
+        enum Status : uint8_t {
+            Built = 0,
+            Substituted = 1,
+            AlreadyValid = 2,
+            ResolvesToAlreadyValid = 13,
+        } status;
+
+        /**
+         * For derivations, a mapping from the names of the wanted outputs
+         * to actual paths.
+         */
+        SingleDrvOutputs builtOutputs;
+
+        bool operator==(const BuildResult::Success &) const noexcept;
+        std::strong_ordering operator<=>(const BuildResult::Success &) const noexcept;
+
+        static bool statusIs(uint8_t status)
+        {
+            return status == Built || status == Substituted || status == AlreadyValid
+                   || status == ResolvesToAlreadyValid;
+        }
+    };
+
+    struct Failure
+    {
+        /**
+         * @note This is directly used in the nix-store --serve protocol.
+         * That means we need to worry about compatibility across versions.
+         * Therefore, don't remove status codes, and only add new status
+         * codes at the end of the list.
+         *
+         * Must be disjoint with `Success::Status`.
+         */
+        enum Status : uint8_t {
+            PermanentFailure = 3,
+            InputRejected = 4,
+            OutputRejected = 5,
+            /// possibly transient
+            TransientFailure = 6,
+            /// no longer used
+            CachedFailure = 7,
+            TimedOut = 8,
+            MiscFailure = 9,
+            DependencyFailed = 10,
+            LogLimitExceeded = 11,
+            NotDeterministic = 12,
+            NoSubstituters = 14,
+            /// A certain type of `OutputRejected`. The protocols do not yet
+            /// know about this one, so change it back to `OutputRejected`
+            /// before serialization.
+            HashMismatch = 15,
+        } status = MiscFailure;
+
+        /**
+         * Information about the error if the build failed.
+         *
+         * @todo This should be an entire ErrorInfo object, not just a
+         * string, for richer information.
+         */
+        std::string errorMsg;
+
+        /**
+         * If timesBuilt > 1, whether some builds did not produce the same
+         * result. (Note that 'isNonDeterministic = false' does not mean
+         * the build is deterministic, just that we don't have evidence of
+         * non-determinism.)
+         */
+        bool isNonDeterministic = false;
+
+        bool operator==(const BuildResult::Failure &) const noexcept;
+        std::strong_ordering operator<=>(const BuildResult::Failure &) const noexcept;
+
+        [[noreturn]] void rethrow() const
+        {
+            throw Error("%s", errorMsg);
+        }
+    };
+
+    std::variant<Success, Failure> inner = Failure{};
 
     /**
-     * Information about the error if the build failed.
-     *
-     * @todo This should be an entire ErrorInfo object, not just a
-     * string, for richer information.
+     * Convenience wrapper to avoid a longer `std::get_if` usage by the
+     * caller (which will have to add more `BuildResult::` than we do
+     * below also, do note.)
      */
-    std::string errorMsg;
+    auto * tryGetSuccess(this auto & self)
+    {
+        return std::get_if<Success>(&self.inner);
+    }
+
+    /**
+     * Convenience wrapper to avoid a longer `std::get_if` usage by the
+     * caller (which will have to add more `BuildResult::` than we do
+     * below also, do note.)
+     */
+    auto * tryGetFailure(this auto & self)
+    {
+        return std::get_if<Failure>(&self.inner);
+    }
 
     /**
      * How many times this build was performed.
      */
     unsigned int timesBuilt = 0;
-
-    /**
-     * If timesBuilt > 1, whether some builds did not produce the same
-     * result. (Note that 'isNonDeterministic = false' does not mean
-     * the build is deterministic, just that we don't have evidence of
-     * non-determinism.)
-     */
-    bool isNonDeterministic = false;
-
-    /**
-     * For derivations, a mapping from the names of the wanted outputs
-     * to actual paths.
-     */
-    SingleDrvOutputs builtOutputs;
 
     /**
      * The start/stop times of the build (or one of the rounds, if it
@@ -82,16 +140,6 @@ struct BuildResult
 
     bool operator==(const BuildResult &) const noexcept;
     std::strong_ordering operator<=>(const BuildResult &) const noexcept;
-
-    bool success()
-    {
-        return status == Built || status == Substituted || status == AlreadyValid || status == ResolvesToAlreadyValid;
-    }
-
-    void rethrow()
-    {
-        throw Error("%s", errorMsg);
-    }
 };
 
 /**
@@ -99,15 +147,9 @@ struct BuildResult
  */
 struct BuildError : public Error
 {
-    BuildResult::Status status;
+    BuildResult::Failure::Status status;
 
-    BuildError(BuildResult::Status status, BuildError && error)
-        : Error{std::move(error)}
-        , status{status}
-    {
-    }
-
-    BuildError(BuildResult::Status status, auto &&... args)
+    BuildError(BuildResult::Failure::Status status, auto &&... args)
         : Error{args...}
         , status{status}
     {

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -22,7 +22,7 @@ struct BuilderFailureError : BuildError
 
     std::string extraMsgAfter;
 
-    BuilderFailureError(BuildResult::Status status, int builderStatus, std::string extraMsgAfter)
+    BuilderFailureError(BuildResult::Failure::Status status, int builderStatus, std::string extraMsgAfter)
         : BuildError{
             status,
               /* No message for now, because the caller will make for

--- a/src/libstore/include/nix/store/build/derivation-building-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-building-goal.hh
@@ -147,7 +147,7 @@ private:
      */
     void killChild();
 
-    Done doneSuccess(BuildResult::Status status, SingleDrvOutputs builtOutputs);
+    Done doneSuccess(BuildResult::Success::Status status, SingleDrvOutputs builtOutputs);
 
     Done doneFailure(BuildError ex);
 

--- a/src/libstore/include/nix/store/build/derivation-goal.hh
+++ b/src/libstore/include/nix/store/build/derivation-goal.hh
@@ -99,7 +99,7 @@ private:
 
     Co repairClosure();
 
-    Done doneSuccess(BuildResult::Status status, Realisation builtOutput);
+    Done doneSuccess(BuildResult::Success::Status status, Realisation builtOutput);
 
     Done doneFailure(BuildError ex);
 };

--- a/src/libstore/include/nix/store/build/substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/substitution-goal.hh
@@ -41,7 +41,9 @@ struct PathSubstitutionGoal : public Goal
      */
     std::optional<ContentAddress> ca;
 
-    Done done(ExitCode result, BuildResult::Status status, std::optional<std::string> errorMsg = {});
+    Done doneSuccess(BuildResult::Success::Status status);
+
+    Done doneFailure(ExitCode result, BuildResult::Failure::Status status, std::string errorMsg);
 
 public:
     PathSubstitutionGoal(

--- a/src/libstore/legacy-ssh-store.cc
+++ b/src/libstore/legacy-ssh-store.cc
@@ -241,12 +241,13 @@ void LegacySSHStore::buildPaths(
 
     conn->to.flush();
 
-    BuildResult result;
-    result.status = (BuildResult::Status) readInt(conn->from);
-
-    if (!result.success()) {
-        conn->from >> result.errorMsg;
-        throw Error(result.status, result.errorMsg);
+    auto status = readInt(conn->from);
+    if (!BuildResult::Success::statusIs(status)) {
+        BuildResult::Failure failure{
+            .status = (BuildResult::Failure::Status) status,
+        };
+        conn->from >> failure.errorMsg;
+        throw Error(failure.status, std::move(failure.errorMsg));
     }
 }
 

--- a/src/libstore/local-store.cc
+++ b/src/libstore/local-store.cc
@@ -997,7 +997,7 @@ void LocalStore::registerValidPaths(const ValidPathInfos & infos)
             }},
             {[&](const StorePath & path, const StorePath & parent) {
                 return BuildError(
-                    BuildResult::OutputRejected,
+                    BuildResult::Failure::OutputRejected,
                     "cycle detected in the references of '%s' from '%s'",
                     printStorePath(path),
                     printStorePath(parent));

--- a/src/libstore/misc.cc
+++ b/src/libstore/misc.cc
@@ -322,7 +322,7 @@ StorePaths Store::topoSortPaths(const StorePathSet & paths)
         }},
         {[&](const StorePath & path, const StorePath & parent) {
             return BuildError(
-                BuildResult::OutputRejected,
+                BuildResult::Failure::OutputRejected,
                 "cycle detected in the references of '%s' from '%s'",
                 printStorePath(path),
                 printStorePath(parent));

--- a/src/libstore/posix-fs-canonicalise.cc
+++ b/src/libstore/posix-fs-canonicalise.cc
@@ -98,7 +98,7 @@ static void canonicalisePathMetaData_(
        (i.e. "touch $out/foo; ln $out/foo $out/bar"). */
     if (uidRange && (st.st_uid < uidRange->first || st.st_uid > uidRange->second)) {
         if (S_ISDIR(st.st_mode) || !inodesSeen.count(Inode(st.st_dev, st.st_ino)))
-            throw BuildError(BuildResult::OutputRejected, "invalid ownership on file '%1%'", path);
+            throw BuildError(BuildResult::Failure::OutputRejected, "invalid ownership on file '%1%'", path);
         mode_t mode = st.st_mode & ~S_IFMT;
         assert(
             S_ISLNK(st.st_mode)

--- a/src/libstore/remote-store.cc
+++ b/src/libstore/remote-store.cc
@@ -598,16 +598,15 @@ std::vector<KeyedBuildResult> RemoteStore::buildPathsWithResults(
                     [&](const DerivedPath::Opaque & bo) {
                         results.push_back(
                             KeyedBuildResult{
-                                {
-                                    .status = BuildResult::Substituted,
-                                },
+                                {.inner{BuildResult::Success{
+                                    .status = BuildResult::Success::Substituted,
+                                }}},
                                 /* .path = */ bo,
                             });
                     },
                     [&](const DerivedPath::Built & bfd) {
-                        KeyedBuildResult res{
-                            {.status = BuildResult::Built},
-                            /* .path = */ bfd,
+                        BuildResult::Success success{
+                            .status = BuildResult::Success::Built,
                         };
 
                         OutputPathMap outputs;
@@ -627,9 +626,9 @@ std::vector<KeyedBuildResult> RemoteStore::buildPathsWithResults(
                                 auto realisation = queryRealisation(outputId);
                                 if (!realisation)
                                     throw MissingRealisation(outputId);
-                                res.builtOutputs.emplace(output, *realisation);
+                                success.builtOutputs.emplace(output, *realisation);
                             } else {
-                                res.builtOutputs.emplace(
+                                success.builtOutputs.emplace(
                                     output,
                                     Realisation{
                                         .id = outputId,
@@ -638,7 +637,11 @@ std::vector<KeyedBuildResult> RemoteStore::buildPathsWithResults(
                             }
                         }
 
-                        results.push_back(res);
+                        results.push_back(
+                            KeyedBuildResult{
+                                {.inner = std::move(success)},
+                                /* .path = */ bfd,
+                            });
                     }},
                 path.raw());
         }

--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -764,7 +764,7 @@ StorePathSet Store::exportReferences(const StorePathSet & storePaths, const Stor
     for (auto & storePath : storePaths) {
         if (!inputPaths.count(storePath))
             throw BuildError(
-                BuildResult::InputRejected,
+                BuildResult::Failure::InputRejected,
                 "cannot export references of path '%s' because it is not in the input closure of the derivation",
                 printStorePath(storePath));
 

--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -50,7 +50,7 @@ namespace nix {
 struct NotDeterministic : BuildError
 {
     NotDeterministic(auto &&... args)
-        : BuildError(BuildResult::NotDeterministic, args...)
+        : BuildError(BuildResult::Failure::NotDeterministic, args...)
     {
     }
 };
@@ -518,7 +518,8 @@ SingleDrvOutputs DerivationBuilderImpl::unprepareBuild()
         cleanupBuild(false);
 
         throw BuilderFailureError{
-            !derivationType.isSandboxed() || diskFull ? BuildResult::TransientFailure : BuildResult::PermanentFailure,
+            !derivationType.isSandboxed() || diskFull ? BuildResult::Failure::TransientFailure
+                                                      : BuildResult::Failure::PermanentFailure,
             status,
             diskFull ? "\nnote: build failure may have been caused by lack of free disk space" : "",
         };
@@ -700,7 +701,7 @@ std::optional<Descriptor> DerivationBuilderImpl::startBuild()
                 fmt("\nNote: run `%s` to run programs for x86_64-darwin",
                     Magenta("/usr/sbin/softwareupdate --install-rosetta && launchctl stop org.nixos.nix-daemon"));
 
-        throw BuildError(BuildResult::InputRejected, msg);
+        throw BuildError(BuildResult::Failure::InputRejected, msg);
     }
 
     auto buildDir = store.config->getBuildDir();
@@ -1389,7 +1390,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         auto optSt = maybeLstat(actualPath.c_str());
         if (!optSt)
             throw BuildError(
-                BuildResult::OutputRejected,
+                BuildResult::Failure::OutputRejected,
                 "builder for '%s' failed to produce output path for output '%s' at '%s'",
                 store.printStorePath(drvPath),
                 outputName,
@@ -1404,7 +1405,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         if ((!S_ISLNK(st.st_mode) && (st.st_mode & (S_IWGRP | S_IWOTH)))
             || (buildUser && st.st_uid != buildUser->getUID()))
             throw BuildError(
-                BuildResult::OutputRejected,
+                BuildResult::Failure::OutputRejected,
                 "suspicious ownership or permission on '%s' for output '%s'; rejecting this build output",
                 actualPath,
                 outputName);
@@ -1442,7 +1443,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
             auto orifu = get(outputReferencesIfUnregistered, name);
             if (!orifu)
                 throw BuildError(
-                    BuildResult::OutputRejected,
+                    BuildResult::Failure::OutputRejected,
                     "no output reference for '%s' in build of '%s'",
                     name,
                     store.printStorePath(drvPath));
@@ -1467,7 +1468,7 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         {[&](const std::string & path, const std::string & parent) {
             // TODO with more -vvvv also show the temporary paths for manual inspection.
             return BuildError(
-                BuildResult::OutputRejected,
+                BuildResult::Failure::OutputRejected,
                 "cycle detected in build of '%s' in the references of output '%s' from output '%s'",
                 store.printStorePath(drvPath),
                 path,
@@ -1561,12 +1562,13 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
         auto newInfoFromCA = [&](const DerivationOutput::CAFloating outputHash) -> ValidPathInfo {
             auto st = get(outputStats, outputName);
             if (!st)
-                throw BuildError(BuildResult::OutputRejected, "output path %1% without valid stats info", actualPath);
+                throw BuildError(
+                    BuildResult::Failure::OutputRejected, "output path %1% without valid stats info", actualPath);
             if (outputHash.method.getFileIngestionMethod() == FileIngestionMethod::Flat) {
                 /* The output path should be a regular file without execute permission. */
                 if (!S_ISREG(st->st_mode) || (st->st_mode & S_IXUSR) != 0)
                     throw BuildError(
-                        BuildResult::OutputRejected,
+                        BuildResult::Failure::OutputRejected,
                         "output path '%1%' should be a non-executable regular file "
                         "since recursive hashing is not enabled (one of outputHashMode={flat,text} is true)",
                         actualPath);

--- a/src/libstore/worker-protocol.cc
+++ b/src/libstore/worker-protocol.cc
@@ -165,10 +165,14 @@ void WorkerProto::Serialise<KeyedBuildResult>::write(
 BuildResult WorkerProto::Serialise<BuildResult>::read(const StoreDirConfig & store, WorkerProto::ReadConn conn)
 {
     BuildResult res;
-    res.status = static_cast<BuildResult::Status>(readInt(conn.from));
-    conn.from >> res.errorMsg;
+    BuildResult::Success success;
+    BuildResult::Failure failure;
+
+    auto rawStatus = readInt(conn.from);
+    conn.from >> failure.errorMsg;
+
     if (GET_PROTOCOL_MINOR(conn.version) >= 29) {
-        conn.from >> res.timesBuilt >> res.isNonDeterministic >> res.startTime >> res.stopTime;
+        conn.from >> res.timesBuilt >> failure.isNonDeterministic >> res.startTime >> res.stopTime;
     }
     if (GET_PROTOCOL_MINOR(conn.version) >= 37) {
         res.cpuUser = WorkerProto::Serialise<std::optional<std::chrono::microseconds>>::read(store, conn);
@@ -177,28 +181,56 @@ BuildResult WorkerProto::Serialise<BuildResult>::read(const StoreDirConfig & sto
     if (GET_PROTOCOL_MINOR(conn.version) >= 28) {
         auto builtOutputs = WorkerProto::Serialise<DrvOutputs>::read(store, conn);
         for (auto && [output, realisation] : builtOutputs)
-            res.builtOutputs.insert_or_assign(std::move(output.outputName), std::move(realisation));
+            success.builtOutputs.insert_or_assign(std::move(output.outputName), std::move(realisation));
     }
+
+    if (BuildResult::Success::statusIs(rawStatus)) {
+        success.status = static_cast<BuildResult::Success::Status>(rawStatus);
+        res.inner = std::move(success);
+    } else {
+        failure.status = static_cast<BuildResult::Failure::Status>(rawStatus);
+        res.inner = std::move(failure);
+    }
+
     return res;
 }
 
 void WorkerProto::Serialise<BuildResult>::write(
     const StoreDirConfig & store, WorkerProto::WriteConn conn, const BuildResult & res)
 {
-    conn.to << res.status << res.errorMsg;
-    if (GET_PROTOCOL_MINOR(conn.version) >= 29) {
-        conn.to << res.timesBuilt << res.isNonDeterministic << res.startTime << res.stopTime;
-    }
-    if (GET_PROTOCOL_MINOR(conn.version) >= 37) {
-        WorkerProto::write(store, conn, res.cpuUser);
-        WorkerProto::write(store, conn, res.cpuSystem);
-    }
-    if (GET_PROTOCOL_MINOR(conn.version) >= 28) {
-        DrvOutputs builtOutputs;
-        for (auto & [output, realisation] : res.builtOutputs)
-            builtOutputs.insert_or_assign(realisation.id, realisation);
-        WorkerProto::write(store, conn, builtOutputs);
-    }
+    /* The protocol predates the use of sum types (std::variant) to
+       separate the success or failure cases. As such, it transits some
+       success- or failure-only fields in both cases. This helper
+       function helps support this: in each case, we just pass the old
+       default value for the fields that don't exist in that case. */
+    auto common = [&](std::string_view errorMsg, bool isNonDeterministic, const auto & builtOutputs) {
+        conn.to << errorMsg;
+        if (GET_PROTOCOL_MINOR(conn.version) >= 29) {
+            conn.to << res.timesBuilt << isNonDeterministic << res.startTime << res.stopTime;
+        }
+        if (GET_PROTOCOL_MINOR(conn.version) >= 37) {
+            WorkerProto::write(store, conn, res.cpuUser);
+            WorkerProto::write(store, conn, res.cpuSystem);
+        }
+        if (GET_PROTOCOL_MINOR(conn.version) >= 28) {
+            DrvOutputs builtOutputsFullKey;
+            for (auto & [output, realisation] : builtOutputs)
+                builtOutputsFullKey.insert_or_assign(realisation.id, realisation);
+            WorkerProto::write(store, conn, builtOutputsFullKey);
+        }
+    };
+    std::visit(
+        overloaded{
+            [&](const BuildResult::Failure & failure) {
+                conn.to << failure.status;
+                common(failure.errorMsg, failure.isNonDeterministic, decltype(BuildResult::Success::builtOutputs){});
+            },
+            [&](const BuildResult::Success & success) {
+                conn.to << success.status;
+                common(/*errorMsg=*/"", /*isNonDeterministic=*/false, success.builtOutputs);
+            },
+        },
+        res.inner);
 }
 
 ValidPathInfo WorkerProto::Serialise<ValidPathInfo>::read(const StoreDirConfig & store, ReadConn conn)

--- a/tests/functional/test-libstoreconsumer/main.cc
+++ b/tests/functional/test-libstoreconsumer/main.cc
@@ -34,8 +34,10 @@ int main(int argc, char ** argv)
         const auto results = store->buildPathsWithResults(paths, bmNormal, store);
 
         for (const auto & result : results) {
-            for (const auto & [outputName, realisation] : result.builtOutputs) {
-                std::cout << store->printStorePath(realisation.outPath) << "\n";
+            if (auto * successP = result.tryGetSuccess()) {
+                for (const auto & [outputName, realisation] : successP->builtOutputs) {
+                    std::cout << store->printStorePath(realisation.outPath) << "\n";
+                }
             }
         }
 


### PR DESCRIPTION
## Motivation

There is now a clean separation between successful and failing build results.

## Context

I thought about making a JSON format for it after seeing what @RossComputerGuy got from detsys in https://github.com/NixOS/nix/pull/14031, and I wanted to do this first to better understand the data structure.

(I think the JSON format should also cleanly separate the success and failure cases. Among other benefits, such a format that means that even if there is an unknown status code, success and failure could still be told apart.)

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
