### PR TITLE
libexpr: Preparation for more k-way updates of attribute sets (NFC)

### DIFF
--- a/src/libexpr/include/nix/expr/gc-small-vector.hh
+++ b/src/libexpr/include/nix/expr/gc-small-vector.hh
@@ -26,4 +26,20 @@ using SmallValueVector = SmallVector<Value *, nItems>;
 template<size_t nItems>
 using SmallTemporaryValueVector = SmallVector<Value, nItems>;
 
+/**
+ * For functions where we do not expect deep recursion, we can use a sizable
+ * part of the stack a free allocation space.
+ *
+ * Note: this is expected to be multiplied by sizeof(Value), or about 24 bytes.
+ */
+constexpr size_t nonRecursiveStackReservation = 128;
+
+/**
+ * Functions that maybe applied to self-similar inputs, such as concatMap on a
+ * tree, should reserve a smaller part of the stack for allocation.
+ *
+ * Note: this is expected to be multiplied by sizeof(Value), or about 24 bytes.
+ */
+constexpr size_t conservativeStackReservation = 16;
+
 } // namespace nix

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -614,8 +614,12 @@ MakeBinOp(ExprOpNEq, "!=");
 MakeBinOp(ExprOpAnd, "&&");
 MakeBinOp(ExprOpOr, "||");
 MakeBinOp(ExprOpImpl, "->");
-MakeBinOp(ExprOpUpdate, "//");
 MakeBinOp(ExprOpConcatLists, "++");
+
+struct ExprOpUpdate : Expr
+{
+    MakeBinOpMembers(ExprOpUpdate, "//")
+};
 
 struct ExprConcatStrings : Expr
 {

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -574,37 +574,40 @@ struct ExprOpNot : Expr
     COMMON_METHODS
 };
 
-#define MakeBinOp(name, s)                                                                   \
-    struct name : Expr                                                                       \
-    {                                                                                        \
-        PosIdx pos;                                                                          \
-        Expr *e1, *e2;                                                                       \
-        name(Expr * e1, Expr * e2)                                                           \
-            : e1(e1)                                                                         \
-            , e2(e2) {};                                                                     \
-        name(const PosIdx & pos, Expr * e1, Expr * e2)                                       \
-            : pos(pos)                                                                       \
-            , e1(e1)                                                                         \
-            , e2(e2) {};                                                                     \
-        void show(const SymbolTable & symbols, std::ostream & str) const override            \
-        {                                                                                    \
-            str << "(";                                                                      \
-            e1->show(symbols, str);                                                          \
-            str << " " s " ";                                                                \
-            e2->show(symbols, str);                                                          \
-            str << ")";                                                                      \
-        }                                                                                    \
-        void bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env) override \
-        {                                                                                    \
-            e1->bindVars(es, env);                                                           \
-            e2->bindVars(es, env);                                                           \
-        }                                                                                    \
-        void eval(EvalState & state, Env & env, Value & v) override;                         \
-        PosIdx getPos() const override                                                       \
-        {                                                                                    \
-            return pos;                                                                      \
-        }                                                                                    \
+#define MakeBinOpMembers(name, s)                                                        \
+    PosIdx pos;                                                                          \
+    Expr *e1, *e2;                                                                       \
+    name(Expr * e1, Expr * e2)                                                           \
+        : e1(e1)                                                                         \
+        , e2(e2){};                                                                      \
+    name(const PosIdx & pos, Expr * e1, Expr * e2)                                       \
+        : pos(pos)                                                                       \
+        , e1(e1)                                                                         \
+        , e2(e2){};                                                                      \
+    void show(const SymbolTable & symbols, std::ostream & str) const override            \
+    {                                                                                    \
+        str << "(";                                                                      \
+        e1->show(symbols, str);                                                          \
+        str << " " s " ";                                                                \
+        e2->show(symbols, str);                                                          \
+        str << ")";                                                                      \
+    }                                                                                    \
+    void bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env) override \
+    {                                                                                    \
+        e1->bindVars(es, env);                                                           \
+        e2->bindVars(es, env);                                                           \
+    }                                                                                    \
+    void eval(EvalState & state, Env & env, Value & v) override;                         \
+    PosIdx getPos() const override                                                       \
+    {                                                                                    \
+        return pos;                                                                      \
     }
+
+#define MakeBinOp(name, s)        \
+    struct name : Expr            \
+    {                             \
+        MakeBinOpMembers(name, s) \
+    };
 
 MakeBinOp(ExprOpEq, "==");
 MakeBinOp(ExprOpNEq, "!=");

--- a/src/libexpr/include/nix/expr/primops.hh
+++ b/src/libexpr/include/nix/expr/primops.hh
@@ -8,22 +8,6 @@
 
 namespace nix {
 
-/**
- * For functions where we do not expect deep recursion, we can use a sizable
- * part of the stack a free allocation space.
- *
- * Note: this is expected to be multiplied by sizeof(Value), or about 24 bytes.
- */
-constexpr size_t nonRecursiveStackReservation = 128;
-
-/**
- * Functions that maybe applied to self-similar inputs, such as concatMap on a
- * tree, should reserve a smaller part of the stack for allocation.
- *
- * Note: this is expected to be multiplied by sizeof(Value), or about 24 bytes.
- */
-constexpr size_t conservativeStackReservation = 16;
-
 struct RegisterPrimOp
 {
     typedef std::vector<PrimOp> PrimOps;

--- a/tests/functional/lang/eval-fail-recursion.err.exp
+++ b/tests/functional/lang/eval-fail-recursion.err.exp
@@ -1,9 +1,9 @@
 error:
        … in the right operand of the update (//) operator
-         at /pwd/lang/eval-fail-recursion.nix:2:11:
+         at /pwd/lang/eval-fail-recursion.nix:2:14:
             1| let
             2|   a = { } // a;
-             |           ^
+             |              ^
             3| in
 
        error: infinite recursion encountered


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Preparatory steps split from https://github.com/NixOS/nix/pull/11290. No big algorithmic change for now - just the changes necessary for accumulating attrset updates on expression level. In follow-ups I will make the `Bindings::iterator` a standalone utility that can be reused for performing a k-way merge of the whole queue at once. We already somewhat have k-way update accumulation, but it's less efficient than necessary because each "layering" operation currently requires doing an eager iteration over the merged range to calculate the "real" size of the Bindings. This can be avoided with the merge queue introduced here.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
