### PR TITLE
Add JSON tests for `Realisation`

### DIFF
--- a/src/libstore-tests/data/realisation/simple.json
+++ b/src/libstore-tests/data/realisation/simple.json
@@ -1,0 +1,6 @@
+{
+  "dependentRealisations": {},
+  "id": "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo",
+  "outPath": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv",
+  "signatures": []
+}

--- a/src/libstore-tests/data/realisation/with-dependent-realisations.json
+++ b/src/libstore-tests/data/realisation/with-dependent-realisations.json
@@ -1,0 +1,8 @@
+{
+  "dependentRealisations": {
+    "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv"
+  },
+  "id": "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo",
+  "outPath": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv",
+  "signatures": []
+}

--- a/src/libstore-tests/data/realisation/with-signature.json
+++ b/src/libstore-tests/data/realisation/with-signature.json
@@ -1,0 +1,8 @@
+{
+  "dependentRealisations": {},
+  "id": "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad!foo",
+  "outPath": "g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv",
+  "signatures": [
+    "asdfasdfasdf"
+  ]
+}

--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -74,6 +74,7 @@ sources = files(
   'outputs-spec.cc',
   'path-info.cc',
   'path.cc',
+  'realisation.cc',
   'references.cc',
   's3-binary-cache-store.cc',
   's3.cc',

--- a/src/libstore-tests/realisation.cc
+++ b/src/libstore-tests/realisation.cc
@@ -1,0 +1,105 @@
+#include <regex>
+
+#include <nlohmann/json.hpp>
+#include <gtest/gtest.h>
+#include <rapidcheck/gtest.h>
+
+#include "nix/store/store-api.hh"
+
+#include "nix/util/tests/characterization.hh"
+#include "nix/store/tests/libstore.hh"
+
+namespace nix {
+
+class RealisationTest : public CharacterizationTest, public LibStoreTest
+{
+    std::filesystem::path unitTestData = getUnitTestData() / "realisation";
+
+public:
+
+    std::filesystem::path goldenMaster(std::string_view testStem) const override
+    {
+        return unitTestData / testStem;
+    }
+};
+
+/* ----------------------------------------------------------------------------
+ * JSON
+ * --------------------------------------------------------------------------*/
+
+using nlohmann::json;
+
+struct RealisationJsonTest : RealisationTest, ::testing::WithParamInterface<std::pair<std::string_view, Realisation>>
+{};
+
+TEST_P(RealisationJsonTest, from_json)
+{
+    auto [name, expected] = GetParam();
+    readTest(name + ".json", [&](const auto & encoded_) {
+        auto encoded = json::parse(encoded_);
+        Realisation got = static_cast<Realisation>(encoded);
+        ASSERT_EQ(got, expected);
+    });
+}
+
+TEST_P(RealisationJsonTest, to_json)
+{
+    auto [name, value] = GetParam();
+    writeTest(
+        name + ".json",
+        [&]() -> json { return static_cast<json>(value); },
+        [](const auto & file) { return json::parse(readFile(file)); },
+        [](const auto & file, const auto & got) { return writeFile(file, got.dump(2) + "\n"); });
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RealisationJSON,
+    RealisationJsonTest,
+    ([] {
+        Realisation simple{
+
+            .id =
+                {
+                    .drvHash = Hash::parseExplicitFormatUnprefixed(
+                        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                        HashAlgorithm::SHA256,
+                        HashFormat::Base16),
+                    .outputName = "foo",
+                },
+            .outPath = StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv"},
+        };
+        return ::testing::Values(
+            std::pair{
+                "simple",
+                simple,
+            },
+            std::pair{
+                "with-signature",
+                [&] {
+                    auto r = simple;
+                    // FIXME actually sign properly
+                    r.signatures = {"asdfasdfasdf"};
+                    return r;
+                }()},
+            std::pair{
+                "with-dependent-realisations",
+                [&] {
+                    auto r = simple;
+                    r.dependentRealisations = {{
+                        {
+                            .drvHash = Hash::parseExplicitFormatUnprefixed(
+                                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                                HashAlgorithm::SHA256,
+                                HashFormat::Base16),
+                            .outputName = "foo",
+                        },
+                        StorePath{"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv"},
+                    }};
+                    return r;
+                }(),
+            });
+    }
+
+     ()));
+
+} // namespace nix


### PR DESCRIPTION
## Motivation

More tests!

## Context

Part of my effort shoring up the JSON formats with #13570.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
