### PR TITLE
shellcheck fix for functional/compute-levels.sh

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -109,7 +109,6 @@
               ''^scripts/install-multi-user\.sh$''
               ''^scripts/install-systemd-multi-user\.sh$''
               ''^tests/functional/completions\.sh$''
-              ''^tests/functional/compute-levels\.sh$''
               ''^tests/functional/config\.sh$''
               ''^tests/functional/db-migration\.sh$''
               ''^tests/functional/debugger\.sh$''


### PR DESCRIPTION
## Motivation

Making my way down shellcheck exclusions fixing them one at a time.
If I can make sensible fixes myself, I do so, otherwise I mark it as a shellcheck line exclusion.

This one was already passing :)

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
