### PR TITLE
shellcheck fix functional/config.sh

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -110,7 +110,6 @@
               ''^scripts/install-systemd-multi-user\.sh$''
               ''^tests/functional/completions\.sh$''
               ''^tests/functional/compute-levels\.sh$''
-              ''^tests/functional/config\.sh$''
               ''^tests/functional/db-migration\.sh$''
               ''^tests/functional/debugger\.sh$''
               ''^tests/functional/dependencies\.builder0\.sh$''

--- a/tests/functional/config.sh
+++ b/tests/functional/config.sh
@@ -62,7 +62,7 @@ prev=$(nix config show | grep '^cores' | cut -d '=' -f 2 | xargs)
 export NIX_CONFIG="cores = 4242"$'\n'"experimental-features = nix-command flakes"
 exp_cores=$(nix config show | grep '^cores' | cut -d '=' -f 2 | xargs)
 exp_features=$(nix config show | grep '^experimental-features' | cut -d '=' -f 2 | xargs)
-[[ $prev != $exp_cores ]]
+[[ $prev != "$exp_cores" ]]
 [[ $exp_cores == "4242" ]]
 # flakes implies fetch-tree
 [[ $exp_features == "fetch-tree flakes nix-command" ]]
@@ -70,7 +70,7 @@ exp_features=$(nix config show | grep '^experimental-features' | cut -d '=' -f 2
 # Test that it's possible to retrieve a single setting's value
 val=$(nix config show | grep '^warn-dirty' | cut -d '=' -f  2 | xargs)
 val2=$(nix config show warn-dirty)
-[[ $val == $val2 ]]
+[[ $val == "$val2" ]]
 
 # Test unit prefixes.
 [[ $(nix config show --min-free 64K min-free) = 65536 ]]


### PR DESCRIPTION
## Motivation

Making my way down shellcheck exclusions fixing them one at a time.
If I can make sensible fixes myself, I do so, otherwise I mark it as a shellcheck line exclusion.

This one was already passing :)

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
