### PR TITLE
shellcheck fix functional/db-migration.sh

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -108,7 +108,6 @@
               # We haven't linted these files yet
               ''^scripts/install-systemd-multi-user\.sh$''
               ''^tests/functional/compute-levels\.sh$''
-              ''^tests/functional/db-migration\.sh$''
               ''^tests/functional/dependencies\.builder0\.sh$''
               ''^tests/functional/dump-db\.sh$''
               ''^tests/functional/dyn-drv/eval-outputOf\.sh$''

--- a/tests/functional/db-migration.sh
+++ b/tests/functional/db-migration.sh
@@ -19,14 +19,15 @@ PATH_WITH_NEW_NIX="$PATH"
 export PATH="${NIX_DAEMON_PACKAGE}/bin:$PATH"
 clearStore
 nix-build simple.nix --no-out-link
-nix-store --generate-binary-cache-key cache1.example.org $TEST_ROOT/sk1 $TEST_ROOT/pk1
+nix-store --generate-binary-cache-key cache1.example.org "$TEST_ROOT/sk1" "$TEST_ROOT/pk1"
 dependenciesOutPath=$(nix-build dependencies.nix --no-out-link --secret-key-files "$TEST_ROOT/sk1")
 fixedOutPath=$(IMPURE_VAR1=foo IMPURE_VAR2=bar nix-build fixed.nix -A good.0 --no-out-link)
 
 # Migrate to the new schema and ensure that everything's there
 export PATH="$PATH_WITH_NEW_NIX"
-info=$(nix path-info --json $dependenciesOutPath)
+info=$(nix path-info --json "$dependenciesOutPath")
 [[ $info =~ '"ultimate":true' ]]
+# shellcheck disable=SC2076
 [[ $info =~ 'cache1.example.org' ]]
 nix verify -r "$fixedOutPath"
-nix verify -r "$dependenciesOutPath" --sigs-needed 1 --trusted-public-keys $(cat $TEST_ROOT/pk1)
+nix verify -r "$dependenciesOutPath" --sigs-needed 1 --trusted-public-keys "$(cat "$TEST_ROOT/pk1")"


### PR DESCRIPTION
## Motivation

Making my way down shellcheck exclusions fixing them one at a time.
If I can make sensible fixes myself, I do so, otherwise I mark it as a shellcheck line exclusion.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
