### PR TITLE
shellcheck fix functional/dyn-drv/build-built-drv.sh

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -116,7 +116,6 @@
               ''^tests/functional/dependencies\.builder0\.sh$''
               ''^tests/functional/dependencies\.sh$''
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/dyn-drv/build-built-drv\.sh$''
               ''^tests/functional/dyn-drv/common\.sh$''
               ''^tests/functional/dyn-drv/dep-built-drv\.sh$''
               ''^tests/functional/dyn-drv/eval-outputOf\.sh$''

--- a/tests/functional/dyn-drv/build-built-drv.sh
+++ b/tests/functional/dyn-drv/build-built-drv.sh
@@ -23,4 +23,4 @@ requireDaemonNewerThan "2.30pre20250515"
 
 out2=$(nix build "${drvDep}^out^out" --no-link)
 
-test $out1 == $out2
+test "$out1" == "$out2"


### PR DESCRIPTION
## Motivation

Making my way down shellcheck exclusions fixing them one at a time.
If I can make sensible fixes myself, I do so, otherwise I mark it as a shellcheck line exclusion.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
