### PR TITLE
shellcheck: multiple file fixes

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/fetchClosure\.sh$''
               ''^tests/functional/fetchGit\.sh$''
               ''^tests/functional/fetchGitRefs\.sh$''
               ''^tests/functional/fetchGitSubmodules\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/export\.sh$''
               ''^tests/functional/fetchClosure\.sh$''
               ''^tests/functional/fetchGit\.sh$''
               ''^tests/functional/fetchGitRefs\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/fetchGitRefs\.sh$''
               ''^tests/functional/fetchGitSubmodules\.sh$''
               ''^tests/functional/fetchGitVerification\.sh$''
               ''^tests/functional/fetchMercurial\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/dyn-drv/eval-outputOf\.sh$''
               ''^tests/functional/dyn-drv/old-daemon-error-hack\.sh$''
               ''^tests/functional/dyn-drv/recursive-mod-json\.sh$''
               ''^tests/functional/eval-store\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/fetchGit\.sh$''
               ''^tests/functional/fetchGitRefs\.sh$''
               ''^tests/functional/fetchGitSubmodules\.sh$''
               ''^tests/functional/fetchGitVerification\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/export-graph\.sh$''
               ''^tests/functional/export\.sh$''
               ''^tests/functional/extra-sandbox-profile\.sh$''
               ''^tests/functional/fetchClosure\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -108,7 +108,6 @@
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
               ''^tests/functional/export\.sh$''
-              ''^tests/functional/extra-sandbox-profile\.sh$''
               ''^tests/functional/fetchClosure\.sh$''
               ''^tests/functional/fetchGit\.sh$''
               ''^tests/functional/fetchGitRefs\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/dyn-drv/old-daemon-error-hack\.sh$''
               ''^tests/functional/dyn-drv/recursive-mod-json\.sh$''
               ''^tests/functional/eval-store\.sh$''
               ''^tests/functional/export-graph\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/dyn-drv/recursive-mod-json\.sh$''
               ''^tests/functional/eval-store\.sh$''
               ''^tests/functional/export-graph\.sh$''
               ''^tests/functional/export\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -107,7 +107,6 @@
             excludes = [
               # We haven't linted these files yet
               ''^tests/functional/dump-db\.sh$''
-              ''^tests/functional/eval-store\.sh$''
               ''^tests/functional/export-graph\.sh$''
               ''^tests/functional/export\.sh$''
               ''^tests/functional/extra-sandbox-profile\.sh$''

--- a/tests/functional/dyn-drv/old-daemon-error-hack.sh
+++ b/tests/functional/dyn-drv/old-daemon-error-hack.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Purposely bypassing our usual common for this subgroup
 source ../common.sh
 

--- a/tests/functional/dyn-drv/recursive-mod-json.sh
+++ b/tests/functional/dyn-drv/recursive-mod-json.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 source common.sh
 
 # FIXME
@@ -10,18 +11,18 @@ restartDaemon
 
 clearStore
 
-rm -f $TEST_ROOT/result
+rm -f "$TEST_ROOT"/result
 
-EXTRA_PATH=$(dirname $(type -p nix)):$(dirname $(type -p jq))
+EXTRA_PATH=$(dirname "$(type -p nix)"):$(dirname "$(type -p jq)")
 export EXTRA_PATH
 
 # Will produce a drv
 metaDrv=$(nix-instantiate ./recursive-mod-json.nix)
 
 # computed "dynamic" derivation
-drv=$(nix-store -r $metaDrv)
+drv=$(nix-store -r "$metaDrv")
 
 # build that dyn drv
-res=$(nix-store -r $drv)
+res=$(nix-store -r "$drv")
 
-grep 'I am alive!' $res/hello
+grep 'I am alive!' "$res"/hello

--- a/tests/functional/eval-store.sh
+++ b/tests/functional/eval-store.sh
@@ -6,6 +6,7 @@ TODO_NixOS
 
 # Using `--eval-store` with the daemon will eventually copy everything
 # to the build store, invalidating most of the tests here
+# shellcheck disable=SC1111
 needLocalStore "“--eval-store” doesn't achieve much with the daemon"
 
 eval_store=$TEST_ROOT/eval-store
@@ -15,7 +16,7 @@ rm -rf "$eval_store"
 
 nix build -f dependencies.nix --eval-store "$eval_store" -o "$TEST_ROOT/result"
 [[ -e $TEST_ROOT/result/foobar ]]
-if [[ ! -n "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
+if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
     # Resolved CA derivations are written to store for building
     #
     # TODO when we something more systematic
@@ -23,35 +24,35 @@ if [[ ! -n "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
     # between scratch storage for building and the final destination
     # store, we'll be able to make this unconditional again -- resolved
     # derivations should only appear in the scratch store.
-    (! ls $NIX_STORE_DIR/*.drv)
+    (! ls "$NIX_STORE_DIR"/*.drv)
 fi
-ls $eval_store/nix/store/*.drv
+ls "$eval_store"/nix/store/*.drv
 
 clearStore
 rm -rf "$eval_store"
 
 nix-instantiate dependencies.nix --eval-store "$eval_store"
-(! ls $NIX_STORE_DIR/*.drv)
-ls $eval_store/nix/store/*.drv
+(! ls "$NIX_STORE_DIR"/*.drv)
+ls "$eval_store"/nix/store/*.drv
 
 clearStore
 rm -rf "$eval_store"
 
 nix-build dependencies.nix --eval-store "$eval_store" -o "$TEST_ROOT/result"
 [[ -e $TEST_ROOT/result/foobar ]]
-if [[ ! -n "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
+if [[ -z "${NIX_TESTS_CA_BY_DEFAULT:-}" ]]; then
     # See above
-    (! ls $NIX_STORE_DIR/*.drv)
+    (! ls "$NIX_STORE_DIR"/*.drv)
 fi
-ls $eval_store/nix/store/*.drv
+ls "$eval_store"/nix/store/*.drv
 
 clearStore
 rm -rf "$eval_store"
 
 # Confirm that import-from-derivation builds on the build store
 [[ $(nix eval --eval-store "$eval_store?require-sigs=false" --impure --raw --file ./ifd.nix) = hi ]]
-ls $NIX_STORE_DIR/*dependencies-top/foobar
-(! ls $eval_store/nix/store/*dependencies-top/foobar)
+ls "$NIX_STORE_DIR"/*dependencies-top/foobar
+(! ls "$eval_store"/nix/store/*dependencies-top/foobar)
 
 # Can't write .drv by default
 (! nix-instantiate dependencies.nix --eval-store "dummy://")

--- a/tests/functional/export-graph.sh
+++ b/tests/functional/export-graph.sh
@@ -8,27 +8,29 @@ clearStore
 clearProfiles
 
 checkRef() {
-    nix-store -q --references $TEST_ROOT/result | grepQuiet "$1"'$' || fail "missing reference $1"
+    nix-store -q --references "$TEST_ROOT"/result | grepQuiet "$1"'$' || fail "missing reference $1"
 }
 
 # Test the export of the runtime dependency graph.
 
-outPath=$(nix-build ./export-graph.nix -A 'foo."bar.runtimeGraph"' -o $TEST_ROOT/result)
+outPath=$(nix-build ./export-graph.nix -A 'foo."bar.runtimeGraph"' -o "$TEST_ROOT"/result)
 
-test $(nix-store -q --references $TEST_ROOT/result | wc -l) = 3 || fail "bad nr of references"
+test "$(nix-store -q --references "$TEST_ROOT"/result | wc -l)" = 3 || fail "bad nr of references"
 
 checkRef input-2
-for i in $(cat $outPath); do checkRef $i; done
+# shellcheck disable=SC2013
+for i in $(cat "$outPath"); do checkRef "$i"; done
 
 # Test the export of the build-time dependency graph.
 
 nix-store --gc # should force rebuild of input-1
 
-outPath=$(nix-build ./export-graph.nix -A 'foo."bar.buildGraph"' -o $TEST_ROOT/result)
+outPath=$(nix-build ./export-graph.nix -A 'foo."bar.buildGraph"' -o "$TEST_ROOT"/result)
 
 checkRef input-1
 checkRef input-1.drv
 checkRef input-2
 checkRef input-2.drv
 
-for i in $(cat $outPath); do checkRef $i; done
+# shellcheck disable=SC2013
+for i in $(cat "$outPath"); do checkRef "$i"; done

--- a/tests/functional/export.sh
+++ b/tests/functional/export.sh
@@ -8,11 +8,12 @@ clearStore
 
 outPath=$(nix-build dependencies.nix --no-out-link)
 
-nix-store --export $outPath > $TEST_ROOT/exp
+nix-store --export "$outPath" > "$TEST_ROOT"/exp
 
-nix-store --export $(nix-store -qR $outPath) > $TEST_ROOT/exp_all
+# shellcheck disable=SC2046
+nix-store --export $(nix-store -qR "$outPath") > "$TEST_ROOT"/exp_all
 
-if nix-store --export $outPath >/dev/full ; then
+if nix-store --export "$outPath" >/dev/full ; then
     echo "exporting to a bad file descriptor should fail"
     exit 1
 fi
@@ -20,7 +21,7 @@ fi
 
 clearStore
 
-if nix-store --import < $TEST_ROOT/exp; then
+if nix-store --import < "$TEST_ROOT"/exp; then
     echo "importing a non-closure should fail"
     exit 1
 fi
@@ -28,13 +29,14 @@ fi
 
 clearStore
 
-nix-store --import < $TEST_ROOT/exp_all
+nix-store --import < "$TEST_ROOT"/exp_all
 
-nix-store --export $(nix-store -qR $outPath) > $TEST_ROOT/exp_all2
+# shellcheck disable=SC2046
+nix-store --export $(nix-store -qR "$outPath") > "$TEST_ROOT"/exp_all2
 
 
 clearStore
 
 # Regression test: the derivers in exp_all2 are empty, which shouldn't
 # cause a failure.
-nix-store --import < $TEST_ROOT/exp_all2
+nix-store --import < "$TEST_ROOT"/exp_all2

--- a/tests/functional/fetchClosure.sh
+++ b/tests/functional/fetchClosure.sh
@@ -17,14 +17,14 @@ requireDaemonNewerThan "2.16.0pre20230524"
 
 # Initialize binary cache.
 nonCaPath=$(nix build --json --file ./dependencies.nix --no-link | jq -r .[].outputs.out)
-caPath=$(nix store make-content-addressed --json $nonCaPath | jq -r '.rewrites | map(.) | .[]')
-nix copy --to file://$cacheDir $nonCaPath
+caPath=$(nix store make-content-addressed --json "$nonCaPath" | jq -r '.rewrites | map(.) | .[]')
+nix copy --to file://"$cacheDir" "$nonCaPath"
 
 # Test basic fetchClosure rewriting from non-CA to CA.
 clearStore
 
-[ ! -e $nonCaPath ]
-[ ! -e $caPath ]
+[ ! -e "$nonCaPath" ]
+[ ! -e "$caPath" ]
 
 [[ $(nix eval -v --raw --expr "
   builtins.fetchClosure {
@@ -32,10 +32,10 @@ clearStore
     fromPath = $nonCaPath;
     toPath = $caPath;
   }
-") = $caPath ]]
+") = "$caPath" ]]
 
-[ ! -e $nonCaPath ]
-[ -e $caPath ]
+[ ! -e "$nonCaPath" ]
+[ -e "$caPath" ]
 
 clearStore
 
@@ -55,7 +55,7 @@ if [[ "$NIX_REMOTE" != "daemon" ]]; then
     # TODO: Should the closure be rejected, despite single user mode?
     # [ ! -e $nonCaPath ]
 
-    [ ! -e $caPath ]
+    [ ! -e "$caPath" ]
 
     # We can use non-CA paths when we ask explicitly.
     [[ $(nix eval --raw --no-require-sigs --expr "
@@ -64,15 +64,15 @@ if [[ "$NIX_REMOTE" != "daemon" ]]; then
         fromPath = $nonCaPath;
         inputAddressed = true;
       }
-    ") = $nonCaPath ]]
+    ") = "$nonCaPath" ]]
 
-    [ -e $nonCaPath ]
-    [ ! -e $caPath ]
+    [ -e "$nonCaPath" ]
+    [ ! -e "$caPath" ]
 
 
 fi
 
-[ ! -e $caPath ]
+[ ! -e "$caPath" ]
 
 # 'toPath' set to empty string should fail but print the expected path.
 expectStderr 1 nix eval -v --json --expr "
@@ -84,39 +84,41 @@ expectStderr 1 nix eval -v --json --expr "
 " | grep "error: rewriting.*$nonCaPath.*yielded.*$caPath"
 
 # If fromPath is CA, then toPath isn't needed.
-nix copy --to file://$cacheDir $caPath
+nix copy --to file://"$cacheDir" "$caPath"
 
 clearStore
 
-[ ! -e $caPath ]
+[ ! -e "$caPath" ]
 
 [[ $(nix eval -v --raw --expr "
   builtins.fetchClosure {
     fromStore = \"file://$cacheDir\";
     fromPath = $caPath;
   }
-") = $caPath ]]
+") = "$caPath" ]]
 
-[ -e $caPath ]
+[ -e "$caPath" ]
 
 # Check that URL query parameters aren't allowed.
 clearStore
 narCache=$TEST_ROOT/nar-cache
-rm -rf $narCache
+rm -rf "$narCache"
 (! nix eval -v --raw --expr "
   builtins.fetchClosure {
     fromStore = \"file://$cacheDir?local-nar-cache=$narCache\";
     fromPath = $caPath;
   }
 ")
-(! [ -e $narCache ])
+# shellcheck disable=SC2235
+(! [ -e "$narCache" ])
 
 # If toPath is specified but wrong, we check it (only) when the path is missing.
 clearStore
 
-badPath=$(echo $caPath | sed -e 's!/store/................................-!/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-!')
+# shellcheck disable=SC2001
+badPath=$(echo "$caPath" | sed -e 's!/store/................................-!/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-!')
 
-[ ! -e $badPath ]
+[ ! -e "$badPath" ]
 
 expectStderr 1 nix eval -v --raw --expr "
   builtins.fetchClosure {
@@ -126,11 +128,11 @@ expectStderr 1 nix eval -v --raw --expr "
   }
 " | grep "error: rewriting.*$nonCaPath.*yielded.*$caPath.*while.*$badPath.*was expected"
 
-[ ! -e $badPath ]
+[ ! -e "$badPath" ]
 
 # We only check it when missing, as a performance optimization similar to what we do for fixed output derivations. So if it's already there, we don't check it.
 # It would be nice for this to fail, but checking it would be too(?) slow.
-[ -e $caPath ]
+[ -e "$caPath" ]
 
 [[ $(nix eval -v --raw --expr "
   builtins.fetchClosure {
@@ -138,7 +140,7 @@ expectStderr 1 nix eval -v --raw --expr "
     fromPath = $badPath;
     toPath = $caPath;
   }
-") = $caPath ]]
+") = "$caPath" ]]
 
 
 # However, if the output address is unexpected, we can report it

--- a/tests/functional/fetchGit.sh
+++ b/tests/functional/fetchGit.sh
@@ -12,25 +12,25 @@ repo=$TEST_ROOT/./git
 
 export _NIX_FORCE_HTTP=1
 
-rm -rf $repo ${repo}-tmp $TEST_HOME/.cache/nix $TEST_ROOT/worktree $TEST_ROOT/minimal
+rm -rf "$repo" "${repo}"-tmp "$TEST_HOME"/.cache/nix "$TEST_ROOT"/worktree "$TEST_ROOT"/minimal
 
-git init $repo
-git -C $repo config user.email "foobar@example.com"
-git -C $repo config user.name "Foobar"
+git init "$repo"
+git -C "$repo" config user.email "foobar@example.com"
+git -C "$repo" config user.name "Foobar"
 
-echo utrecht > $repo/hello
-touch $repo/.gitignore
-git -C $repo add hello .gitignore
-git -C $repo commit -m 'Bla1'
-rev1=$(git -C $repo rev-parse HEAD)
-git -C $repo tag -a tag1 -m tag1
+echo utrecht > "$repo"/hello
+touch "$repo"/.gitignore
+git -C "$repo" add hello .gitignore
+git -C "$repo" commit -m 'Bla1'
+rev1=$(git -C "$repo" rev-parse HEAD)
+git -C "$repo" tag -a tag1 -m tag1
 
-echo world > $repo/hello
-git -C $repo commit -m 'Bla2' -a
-git -C $repo worktree add $TEST_ROOT/worktree
-echo hello >> $TEST_ROOT/worktree/hello
-rev2=$(git -C $repo rev-parse HEAD)
-git -C $repo tag -a tag2 -m tag2
+echo world > "$repo"/hello
+git -C "$repo" commit -m 'Bla2' -a
+git -C "$repo" worktree add "$TEST_ROOT"/worktree
+echo hello >> "$TEST_ROOT"/worktree/hello
+rev2=$(git -C "$repo" rev-parse HEAD)
+git -C "$repo" tag -a tag2 -m tag2
 
 # Check whether fetching in read-only mode works.
 nix-instantiate --eval -E "builtins.readFile ((builtins.fetchGit file://$TEST_ROOT/worktree) + \"/hello\") == \"utrecht\\n\""
@@ -40,52 +40,52 @@ unset _NIX_FORCE_HTTP
 expectStderr 0 nix eval -vvvv --impure --raw --expr "(builtins.fetchGit file://$TEST_ROOT/worktree).outPath" | grepQuiet "copying '$TEST_ROOT/worktree/' to the store"
 path0=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$TEST_ROOT/worktree).outPath")
 path0_=$(nix eval --impure --raw --expr "(builtins.fetchTree { type = \"git\"; url = file://$TEST_ROOT/worktree; }).outPath")
-[[ $path0 = $path0_ ]]
+[[ $path0 = "$path0_" ]]
 path0_=$(nix eval --impure --raw --expr "(builtins.fetchTree git+file://$TEST_ROOT/worktree).outPath")
-[[ $path0 = $path0_ ]]
+[[ $path0 = "$path0_" ]]
 export _NIX_FORCE_HTTP=1
-[[ $(tail -n 1 $path0/hello) = "hello" ]]
+[[ $(tail -n 1 "$path0"/hello) = "hello" ]]
 
 # Nuke the cache
-rm -rf $TEST_HOME/.cache/nix
+rm -rf "$TEST_HOME"/.cache/nix
 
 # Fetch the default branch.
 path=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
-[[ $(cat $path/hello) = world ]]
+[[ $(cat "$path"/hello) = world ]]
 
 # Fetch again. This should be cached.
 # NOTE: This has to be done before the test case below which tries to pack-refs
 # the reason being that the lookup on the cache uses the ref-file `/refs/heads/master`
 # which does not exist after packing.
-mv $repo ${repo}-tmp
+mv "$repo" "${repo}"-tmp
 path2=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
-[[ $path = $path2 ]]
+[[ $path = "$path2" ]]
 
 [[ $(nix eval --impure --expr "(builtins.fetchGit file://$repo).revCount") = 2 ]]
-[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).rev") = $rev2 ]]
-[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).shortRev") = ${rev2:0:7} ]]
+[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).rev") = "$rev2" ]]
+[[ $(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).shortRev") = "${rev2:0:7}" ]]
 
 # Fetching with a explicit hash should succeed.
 path2=$(nix eval --refresh --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev2\"; }).outPath")
-[[ $path = $path2 ]]
+[[ $path = "$path2" ]]
 
 path2=$(nix eval --refresh --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev1\"; }).outPath")
-[[ $(cat $path2/hello) = utrecht ]]
+[[ $(cat "$path2"/hello) = utrecht ]]
 
-mv ${repo}-tmp $repo
+mv "${repo}"-tmp "$repo"
 
 # Fetch when the cache has packed-refs
 # Regression test of #8822
-git -C $TEST_HOME/.cache/nix/gitv3/*/ pack-refs --all
+git -C "$TEST_HOME"/.cache/nix/gitv3/*/ pack-refs --all
 path=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
 
 # Fetch a rev from another branch
-git -C $repo checkout -b devtest
-echo "different file" >> $TEST_ROOT/git/differentbranch
-git -C $repo add differentbranch
-git -C $repo commit -m 'Test2'
-git -C $repo checkout master
-devrev=$(git -C $repo rev-parse devtest)
+git -C "$repo" checkout -b devtest
+echo "different file" >> "$TEST_ROOT"/git/differentbranch
+git -C "$repo" add differentbranch
+git -C "$repo" commit -m 'Test2'
+git -C "$repo" checkout master
+devrev=$(git -C "$repo" rev-parse devtest)
 nix eval --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; }"
 
 [[ $(nix eval --raw --expr "builtins.readFile (builtins.fetchGit { url = file://$repo; rev = \"$devrev\"; allRefs = true; } + \"/differentbranch\")") = 'different file' ]]
@@ -96,7 +96,7 @@ nix eval --raw --expr "builtins.fetchGit { url = file://$repo; rev = \"$devrev\"
 
 # Fetch using an explicit revision hash.
 path2=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev2\"; }).outPath")
-[[ $path = $path2 ]]
+[[ $path = "$path2" ]]
 
 # In pure eval mode, fetchGit with a revision should succeed.
 [[ $(nix eval --raw --expr "builtins.readFile (fetchGit { url = file://$repo; rev = \"$rev2\"; } + \"/hello\")") = world ]]
@@ -106,23 +106,23 @@ expectStderr 1 nix eval --expr 'builtins.fetchGit "file:///foo"' | grepQuiet "'f
 
 # Using a clean working tree should produce the same result.
 path2=$(nix eval --impure --raw --expr "(builtins.fetchGit $repo).outPath")
-[[ $path = $path2 ]]
+[[ $path = "$path2" ]]
 
 # Using an unclean tree should yield the tracked but uncommitted changes.
-mkdir $repo/dir1 $repo/dir2
-echo foo > $repo/dir1/foo
-echo bar > $repo/bar
-echo bar > $repo/dir2/bar
-git -C $repo add dir1/foo
-git -C $repo rm hello
+mkdir "$repo"/dir1 "$repo"/dir2
+echo foo > "$repo"/dir1/foo
+echo bar > "$repo"/bar
+echo bar > "$repo"/dir2/bar
+git -C "$repo" add dir1/foo
+git -C "$repo" rm hello
 
 unset _NIX_FORCE_HTTP
 path2=$(nix eval --impure --raw --expr "(builtins.fetchGit $repo).outPath")
-[ ! -e $path2/hello ]
-[ ! -e $path2/bar ]
-[ ! -e $path2/dir2/bar ]
-[ ! -e $path2/.git ]
-[[ $(cat $path2/dir1/foo) = foo ]]
+[ ! -e "$path2"/hello ]
+[ ! -e "$path2"/bar ]
+[ ! -e "$path2"/dir2/bar ]
+[ ! -e "$path2"/.git ]
+[[ $(cat "$path2"/dir1/foo) = foo ]]
 
 [[ $(nix eval --impure --raw --expr "(builtins.fetchGit $repo).rev") = 0000000000000000000000000000000000000000 ]]
 [[ $(nix eval --impure --raw --expr "(builtins.fetchGit $repo).dirtyRev") = "${rev2}-dirty" ]]
@@ -130,16 +130,16 @@ path2=$(nix eval --impure --raw --expr "(builtins.fetchGit $repo).outPath")
 
 # ... unless we're using an explicit ref or rev.
 path3=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; ref = \"master\"; }).outPath")
-[[ $path = $path3 ]]
+[[ $path = "$path3" ]]
 
 path3=$(nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; }).outPath")
-[[ $path = $path3 ]]
+[[ $path = "$path3" ]]
 
 # Committing should not affect the store path.
-git -C $repo commit -m 'Bla3' -a
+git -C "$repo" commit -m 'Bla3' -a
 
 path4=$(nix eval --impure --refresh --raw --expr "(builtins.fetchGit file://$repo).outPath")
-[[ $path2 = $path4 ]]
+[[ $path2 = "$path4" ]]
 
 [[ $(nix eval --impure --expr "builtins.hasAttr \"rev\" (builtins.fetchGit $repo)") == "true" ]]
 [[ $(nix eval --impure --expr "builtins.hasAttr \"dirtyRev\" (builtins.fetchGit $repo)") == "false" ]]
@@ -148,7 +148,7 @@ path4=$(nix eval --impure --refresh --raw --expr "(builtins.fetchGit file://$rep
 expect 102 nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-B5yIPHhEm0eysJKEsO7nqxprh9vcblFxpJG11gXJus1=\"; }).outPath"
 
 path5=$(nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath")
-[[ $path = $path5 ]]
+[[ $path = "$path5" ]]
 
 # Ensure that NAR hashes are checked.
 expectStderr 102 nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = \"$rev2\"; narHash = \"sha256-Hr8g6AqANb4xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath" | grepQuiet "error: NAR hash mismatch"
@@ -157,22 +157,22 @@ expectStderr 102 nix eval --raw --expr "(builtins.fetchGit { url = $repo; rev = 
 expectStderr 0 nix eval --raw --expr "(builtins.fetchGit { url = $repo; ref = \"tag2\"; narHash = \"sha256-Hr8g6AqANb3xqX28eu1XnjK/3ab8Gv6TJSnkb1LezG9=\"; }).outPath" | grepQuiet "warning: Input .* is unlocked"
 
 # tarball-ttl should be ignored if we specify a rev
-echo delft > $repo/hello
-git -C $repo add hello
-git -C $repo commit -m 'Bla4'
-rev3=$(git -C $repo rev-parse HEAD)
+echo delft > "$repo"/hello
+git -C "$repo" add hello
+git -C "$repo" commit -m 'Bla4'
+rev3=$(git -C "$repo" rev-parse HEAD)
 nix eval --tarball-ttl 3600 --expr "builtins.fetchGit { url = $repo; rev = \"$rev3\"; }" >/dev/null
 
 # Update 'path' to reflect latest master
 path=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
 
 # Check behavior when non-master branch is used
-git -C $repo checkout $rev2 -b dev
-echo dev > $repo/hello
+git -C "$repo" checkout "$rev2" -b dev
+echo dev > "$repo"/hello
 
 # File URI uses dirty tree unless specified otherwise
 path2=$(nix eval --impure --raw --expr "(builtins.fetchGit file://$repo).outPath")
-[ $(cat $path2/hello) = dev ]
+[ "$(cat "$path2"/hello)" = dev ]
 
 # Using local path with branch other than 'master' should work when clean or dirty
 path3=$(nix eval --impure --raw --expr "(builtins.fetchGit $repo).outPath")
@@ -181,53 +181,53 @@ path3=$(nix eval --impure --raw --expr "(builtins.fetchGit $repo).outPath")
 [[ $(nix eval --impure --raw --expr "(builtins.fetchGit $repo).shortRev") = 0000000 ]]
 # Making a dirty tree clean again and fetching it should
 # record correct revision information. See: #4140
-echo world > $repo/hello
-[[ $(nix eval --impure --raw --expr "(builtins.fetchGit $repo).rev") = $rev2 ]]
+echo world > "$repo"/hello
+[[ $(nix eval --impure --raw --expr "(builtins.fetchGit $repo).rev") = "$rev2" ]]
 
 # Committing shouldn't change store path, or switch to using 'master'
-echo dev > $repo/hello
-git -C $repo commit -m 'Bla5' -a
+echo dev > "$repo"/hello
+git -C "$repo" commit -m 'Bla5' -a
 path4=$(nix eval --impure --raw --expr "(builtins.fetchGit $repo).outPath")
-[[ $(cat $path4/hello) = dev ]]
-[[ $path3 = $path4 ]]
+[[ $(cat "$path4"/hello) = dev ]]
+[[ $path3 = "$path4" ]]
 
 # Using remote path with branch other than 'master' should fetch the HEAD revision.
 # (--tarball-ttl 0 to prevent using the cached repo above)
 export _NIX_FORCE_HTTP=1
 path4=$(nix eval --tarball-ttl 0 --impure --raw --expr "(builtins.fetchGit $repo).outPath")
-[[ $(cat $path4/hello) = dev ]]
-[[ $path3 = $path4 ]]
+[[ $(cat "$path4"/hello) = dev ]]
+[[ $path3 = "$path4" ]]
 unset _NIX_FORCE_HTTP
 
 # Confirm same as 'dev' branch
 path5=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; ref = \"dev\"; }).outPath")
-[[ $path3 = $path5 ]]
+[[ $path3 = "$path5" ]]
 
 
 # Nuke the cache
-rm -rf $TEST_HOME/.cache/nix
+rm -rf "$TEST_HOME"/.cache/nix
 
 # Try again. This should work.
 path5=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = $repo; ref = \"dev\"; }).outPath")
-[[ $path3 = $path5 ]]
+[[ $path3 = "$path5" ]]
 
 # Fetching from a repo with only a specific revision and no branches should
 # not fall back to copying files and record correct revision information. See: #5302
-mkdir $TEST_ROOT/minimal
-git -C $TEST_ROOT/minimal init
-git -C $TEST_ROOT/minimal fetch $repo $rev2
-git -C $TEST_ROOT/minimal checkout $rev2
-[[ $(nix eval --impure --raw --expr "(builtins.fetchGit { url = $TEST_ROOT/minimal; }).rev") = $rev2 ]]
+mkdir "$TEST_ROOT"/minimal
+git -C "$TEST_ROOT"/minimal init
+git -C "$TEST_ROOT"/minimal fetch "$repo" "$rev2"
+git -C "$TEST_ROOT"/minimal checkout "$rev2"
+[[ $(nix eval --impure --raw --expr "(builtins.fetchGit { url = $TEST_ROOT/minimal; }).rev") = "$rev2" ]]
 
 # Explicit ref = "HEAD" should work, and produce the same outPath as without ref
 path7=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"HEAD\"; }).outPath")
 path8=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; }).outPath")
-[[ $path7 = $path8 ]]
+[[ $path7 = "$path8" ]]
 
 # ref = "HEAD" should fetch the HEAD revision
-rev4=$(git -C $repo rev-parse HEAD)
+rev4=$(git -C "$repo" rev-parse HEAD)
 rev4_nix=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"HEAD\"; }).rev")
-[[ $rev4 = $rev4_nix ]]
+[[ $rev4 = "$rev4_nix" ]]
 
 # The name argument should be handled
 path9=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"HEAD\"; name = \"foo\"; }).outPath")
@@ -236,33 +236,36 @@ path9=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$rep
 # Specifying a ref without a rev shouldn't pick a cached rev for a different ref
 export _NIX_FORCE_HTTP=1
 rev_tag1_nix=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"refs/tags/tag1\"; }).rev")
-rev_tag1=$(git -C $repo rev-parse refs/tags/tag1^{commit})
-[[ $rev_tag1_nix = $rev_tag1 ]]
+# shellcheck disable=SC1083
+rev_tag1=$(git -C "$repo" rev-parse refs/tags/tag1^{commit})
+[[ $rev_tag1_nix = "$rev_tag1" ]]
 rev_tag2_nix=$(nix eval --impure --raw --expr "(builtins.fetchGit { url = \"file://$repo\"; ref = \"refs/tags/tag2\"; }).rev")
-rev_tag2=$(git -C $repo rev-parse refs/tags/tag2^{commit})
-[[ $rev_tag2_nix = $rev_tag2 ]]
+# shellcheck disable=SC1083
+rev_tag2=$(git -C "$repo" rev-parse refs/tags/tag2^{commit})
+[[ $rev_tag2_nix = "$rev_tag2" ]]
 unset _NIX_FORCE_HTTP
 
 # Ensure .gitattributes is respected
-touch $repo/not-exported-file
-touch $repo/exported-wonky
-echo "/not-exported-file export-ignore" >> $repo/.gitattributes
-echo "/exported-wonky export-ignore=wonk" >> $repo/.gitattributes
-git -C $repo add not-exported-file exported-wonky .gitattributes
-git -C $repo commit -m 'Bla6'
-rev5=$(git -C $repo rev-parse HEAD)
+touch "$repo"/not-exported-file
+touch "$repo"/exported-wonky
+echo "/not-exported-file export-ignore" >> "$repo"/.gitattributes
+echo "/exported-wonky export-ignore=wonk" >> "$repo"/.gitattributes
+git -C "$repo" add not-exported-file exported-wonky .gitattributes
+git -C "$repo" commit -m 'Bla6'
+rev5=$(git -C "$repo" rev-parse HEAD)
 path12=$(nix eval --raw --expr "(builtins.fetchGit { url = file://$repo; rev = \"$rev5\"; }).outPath")
 [[ ! -e $path12/not-exported-file ]]
 [[ -e $path12/exported-wonky ]]
 
 # should fail if there is no repo
-rm -rf $repo/.git
-rm -rf $TEST_HOME/.cache/nix
+rm -rf "$repo"/.git
+rm -rf "$TEST_HOME"/.cache/nix
 (! nix eval --impure --raw --expr "(builtins.fetchGit \"file://$repo\").outPath")
 
 # should succeed for a repo without commits
-git init $repo
-git -C $repo add hello # need to add at least one file to cause the root of the repo to be visible
+git init "$repo"
+git -C "$repo" add hello # need to add at least one file to cause the root of the repo to be visible
+# shellcheck disable=SC2034
 path10=$(nix eval --impure --raw --expr "(builtins.fetchGit \"file://$repo\").outPath")
 
 # should succeed for a path with a space
@@ -277,6 +280,7 @@ touch "$repo/.gitignore"
 git -C "$repo" add hello .gitignore
 git -C "$repo" commit -m 'Bla1'
 cd "$repo"
+# shellcheck disable=SC2034
 path11=$(nix eval --impure --raw --expr "(builtins.fetchGit ./.).outPath")
 
 # Test a workdir with no commits.

--- a/tests/functional/fetchGitRefs.sh
+++ b/tests/functional/fetchGitRefs.sh
@@ -38,16 +38,16 @@ path=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = $repo; ref = \
 #       10. They cannot contain a \.
 
 valid_ref() {
-    { set +x; printf >&2 '\n>>>>>>>>>> valid_ref %s\b <<<<<<<<<<\n' $(printf %s "$1" | sed -n -e l); set -x; }
+    { set +x; printf >&2 '\n>>>>>>>>>> valid_ref %s\b <<<<<<<<<<\n' "$(printf %s "$1" | sed -n -e l)"; set -x; }
     git check-ref-format --branch "$1" >/dev/null
     git -C "$repo" branch "$1" master >/dev/null
     path1=$(nix eval --raw --impure --expr "(builtins.fetchGit { url = $repo; ref = ''$1''; }).outPath")
-    [[ $path1 = $path ]]
+    [[ $path1 = "$path" ]]
     git -C "$repo" branch -D "$1" >/dev/null
 }
 
 invalid_ref() {
-    { set +x; printf >&2 '\n>>>>>>>>>> invalid_ref %s\b <<<<<<<<<<\n' $(printf %s "$1" | sed -n -e l); set -x; }
+    { set +x; printf >&2 '\n>>>>>>>>>> invalid_ref %s\b <<<<<<<<<<\n' "$(printf %s "$1" | sed -n -e l)"; set -x; }
     # special case for a sole @:
     # --branch @ will try to interpret @ as a branch reference and not fail. Thus we need --allow-onelevel
     if [ "$1" = "@" ]; then
@@ -68,6 +68,7 @@ valid_ref 'heads/foo@bar'
 valid_ref "$(printf 'heads/fu\303\237')"
 valid_ref 'foo-bar-baz'
 valid_ref 'branch#'
+# shellcheck disable=SC2016
 valid_ref '$1'
 valid_ref 'foo.locke'
 


### PR DESCRIPTION
## Motivation

1 file per commit -- many fixes in the PR.
I tried my best to either have `shellcheck` auto fix, fix myself when it made sense or disable otherwise.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
