### PR TITLE
Args::Flag: Add `required` attribute

### DIFF
--- a/src/libutil/include/nix/util/args.hh
+++ b/src/libutil/include/nix/util/args.hh
@@ -202,8 +202,12 @@ public:
         Strings labels;
         Handler handler;
         CompleterClosure completer;
+        bool required = false;
 
         std::optional<ExperimentalFeature> experimentalFeature;
+
+        // FIXME: this should be private, but that breaks designated initializers.
+        size_t timesUsed = 0;
     };
 
 protected:
@@ -282,6 +286,8 @@ protected:
     }
 
     StringSet hiddenCategories;
+
+    virtual void checkArgs();
 
     /**
      * Called after all command line flags before the first non-flag
@@ -428,6 +434,8 @@ public:
 protected:
     std::string commandName = "";
     bool aliasUsed = false;
+
+    void checkArgs() override;
 };
 
 Strings argvToStrings(int argc, char ** argv);

--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -144,7 +144,7 @@ static auto rCmdSign = registerCommand2<CmdSign>({"store", "sign"});
 
 struct CmdKeyGenerateSecret : Command
 {
-    std::optional<std::string> keyName;
+    std::string keyName;
 
     CmdKeyGenerateSecret()
     {
@@ -153,6 +153,7 @@ struct CmdKeyGenerateSecret : Command
             .description = "Identifier of the key (e.g. `cache.example.org-1`).",
             .labels = {"name"},
             .handler = {&keyName},
+            .required = true,
         });
     }
 
@@ -170,11 +171,8 @@ struct CmdKeyGenerateSecret : Command
 
     void run() override
     {
-        if (!keyName)
-            throw UsageError("required argument '--key-name' is missing");
-
         logger->stop();
-        writeFull(getStandardOutput(), SecretKey::generate(*keyName).to_string());
+        writeFull(getStandardOutput(), SecretKey::generate(keyName).to_string());
     }
 };
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This allows specifying flags that are mandatory. The motivation was `nix nario export` (#13969), which has a required `--format` flag.

Note: The `timesUsed` counter could also be used to warn about flags being set multiple times (#13899).

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
