### PR TITLE
Small string optimization for `Value`s

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -825,7 +825,10 @@ DebugTraceStacker::DebugTraceStacker(EvalState & evalState, DebugTrace t)
 
 void Value::mkString(std::string_view s)
 {
-    mkStringNoCopy(makeImmutableString(s));
+    if (s.length() < SmallString::size)
+        mkStringSmall(s);
+    else
+        mkStringNoCopy(makeImmutableString(s));
 }
 
 static const char ** encodeContext(const NixStringContext & context)

--- a/src/libexpr/include/nix/expr/value.hh
+++ b/src/libexpr/include/nix/expr/value.hh
@@ -310,9 +310,9 @@ struct PayloadTypeToInternalType
     MACRO(ValueBase::PrimOpApplicationThunk, primOpApp, tPrimOpApp) \
     MACRO(ExternalValueBase *, external, tExternal)                 \
     MACRO(NixFloat, fpoint, tFloat)
-    // small string is accessed as though it is an ordinary string, so it must be handled specially
-    // MACRO(ValueBase::StringWithContext, string, tString)
-    // MACRO(ValueBase::SmallString, smallString, tSmallString)
+// small string is accessed as though it is an ordinary string, so it must be handled specially
+// MACRO(ValueBase::StringWithContext, string, tString)
+// MACRO(ValueBase::SmallString, smallString, tSmallString)
 
 #define NIX_VALUE_PAYLOAD_TYPE(T, FIELD_NAME, DISCRIMINATOR) \
     template<>                                               \
@@ -375,8 +375,7 @@ protected:
         else if (internalType == tSmallString) {
             val.context = nullptr;
             val.c_str = payload.smallString.small_str;
-        }
-        else
+        } else
             unreachable();
     }
 
@@ -476,8 +475,9 @@ class alignas(16) ValueStorage<ptrSize, std::enable_if_t<detail::useBitPackedVal
         pdListN, //< layout: Single untaggable field.
         pdString,
         pdPath,
-        // in some sense this is a different layout, but it's still tagged in the same place, so it could be lumped in with the types above
-        pdSmallString, //< layout: first 15 bytes occupied, last byte free.
+        // in some sense this is a different layout, but it's still tagged in the same place, so it could be lumped in
+        // with the types above
+        pdSmallString,    //< layout: first 15 bytes occupied, last byte free.
         pdPairOfPointers, //< layout: Pair of pointers payload
     };
 
@@ -640,8 +640,7 @@ protected:
         if (getInternalType() == tSmallString) {
             string.context = nullptr;
             string.c_str = &reinterpret_cast<const char *>(this)[small_string_payload_start];
-        }
-        else if (getInternalType() == tString) {
+        } else if (getInternalType() == tString) {
             string.context = untagPointer<decltype(string.context)>(payload[primaryIdx]);
             string.c_str = std::bit_cast<const char *>(payload[secondaryIdx]);
         }
@@ -954,7 +953,8 @@ private:
         return out;
     }
 
-    // You should probably be accessing SmallString via getStorage<StringWithContext>() above, which does the appropriate conversion
+    // You should probably be accessing SmallString via getStorage<StringWithContext>() above, which does the
+    // appropriate conversion
     template<>
     SmallString getStorage() const noexcept = delete;
 
@@ -1083,7 +1083,7 @@ public:
 
     void mkStringSmall(SmallString::SmallStr s) noexcept
     {
-        setStorage(SmallString{ .small_str = s});
+        setStorage(SmallString{.small_str = s});
     }
 
     void mkStringNoCopy(const char * s, const char ** context = 0) noexcept


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

See [this tracking issue](https://github.com/NixOS/nix/issues/14088) for more big-picture motivation.

This change in particular stores small strings that have no context directly in the value payload itself. This reduces memory usage by the string length, and also removes a layer of indirection.

## Context
-  [tracking issue](https://github.com/NixOS/nix/issues/14088) for more big-picture motivation.
- @xokdvium [already attempted this work](https://github.com/NixOS/nix/pull/13895), with the conclusion that it doesn't help that much and therefore is not worth a type tag.
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
