### PR TITLE
libutil: fix data race in PosixSourceAccessor mtime field

### DIFF
--- a/src/libutil/archive.cc
+++ b/src/libutil/archive.cc
@@ -107,7 +107,7 @@ time_t dumpPathAndGetMtime(const Path & path, Sink & sink, PathFilter & filter)
 {
     auto path2 = PosixSourceAccessor::createAtRoot(path);
     path2.dumpPath(sink, filter);
-    return path2.accessor.dynamic_pointer_cast<PosixSourceAccessor>()->mtime;
+    return path2.accessor.dynamic_pointer_cast<PosixSourceAccessor>()->mtime.load();
 }
 
 void dumpPath(const Path & path, Sink & sink, PathFilter & filter)

--- a/src/libutil/include/nix/util/posix-source-accessor.hh
+++ b/src/libutil/include/nix/util/posix-source-accessor.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nix/util/source-accessor.hh"
+#include <atomic>
 
 namespace nix {
 
@@ -25,7 +26,7 @@ struct PosixSourceAccessor : virtual SourceAccessor
      * The most recent mtime seen by lstat(). This is a hack to
      * support dumpPathAndGetMtime(). Should remove this eventually.
      */
-    time_t mtime = 0;
+    std::atomic<time_t> mtime{0};
 
     void readFile(const CanonPath & path, Sink & sink, std::function<void(uint64_t)> sizeCallback) override;
 


### PR DESCRIPTION
The global singleton PosixSourceAccessor returned by getFSSourceAccessor() has a mutable `mtime` field that is updated without synchronization in maybeLstat(). When multiple threads call filesystem operations through the shared accessor, this produces a data race with undefined behavior.

Fixed by making mtime an atomic<time_t> and using compare-exchange for the max operation.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
