### PR TITLE
libstore: Make all StoreConfig::getReference implementations return s…

### DIFF
--- a/src/libstore-tests/http-binary-cache-store.cc
+++ b/src/libstore-tests/http-binary-cache-store.cc
@@ -18,4 +18,20 @@ TEST(HttpBinaryCacheStore, constructConfigNoTrailingSlash)
     EXPECT_EQ(config.cacheUri.to_string(), "https://foo.bar.baz/a/b");
 }
 
+TEST(HttpBinaryCacheStore, constructConfigWithParams)
+{
+    StoreConfig::Params params{{"compression", "xz"}};
+    HttpBinaryCacheStoreConfig config{"https", "foo.bar.baz/a/b/", params};
+    EXPECT_EQ(config.cacheUri.to_string(), "https://foo.bar.baz/a/b");
+    EXPECT_EQ(config.getReference().params, params);
+}
+
+TEST(HttpBinaryCacheStore, constructConfigWithParamsAndUrlWithParams)
+{
+    StoreConfig::Params params{{"compression", "xz"}};
+    HttpBinaryCacheStoreConfig config{"https", "foo.bar.baz/a/b?some-param=some-value", params};
+    EXPECT_EQ(config.cacheUri.to_string(), "https://foo.bar.baz/a/b?some-param=some-value");
+    EXPECT_EQ(config.getReference().params, params);
+}
+
 } // namespace nix

--- a/src/libstore-tests/uds-remote-store.cc
+++ b/src/libstore-tests/uds-remote-store.cc
@@ -22,4 +22,24 @@ TEST(UDSRemoteStore, constructConfig_to_string)
     EXPECT_EQ(config.getReference().to_string(), "daemon");
 }
 
+TEST(UDSRemoteStore, constructConfigWithParams)
+{
+    StoreConfig::Params params{{"max-connections", "1"}};
+    UDSRemoteStoreConfig config{"unix", "/tmp/socket", params};
+    auto storeReference = config.getReference();
+    EXPECT_EQ(storeReference.to_string(), "unix:///tmp/socket?max-connections=1");
+    EXPECT_EQ(storeReference.render(/*withParams=*/false), "unix:///tmp/socket");
+    EXPECT_EQ(storeReference.params, params);
+}
+
+TEST(UDSRemoteStore, constructConfigWithParamsNoPath)
+{
+    StoreConfig::Params params{{"max-connections", "1"}};
+    UDSRemoteStoreConfig config{"unix", "", params};
+    auto storeReference = config.getReference();
+    EXPECT_EQ(storeReference.to_string(), "daemon?max-connections=1");
+    EXPECT_EQ(storeReference.render(/*withParams=*/false), "daemon");
+    EXPECT_EQ(storeReference.params, params);
+}
+
 } // namespace nix

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -39,7 +39,7 @@ StoreReference HttpBinaryCacheStoreConfig::getReference() const
                 .scheme = cacheUri.scheme,
                 .authority = cacheUri.renderAuthorityAndPath(),
             },
-        .params = cacheUri.query,
+        .params = getQueryParams(),
     };
 }
 

--- a/src/libstore/include/nix/store/dummy-store.hh
+++ b/src/libstore/include/nix/store/dummy-store.hh
@@ -48,6 +48,7 @@ struct DummyStoreConfig : public std::enable_shared_from_this<DummyStoreConfig>,
                 StoreReference::Specified{
                     .scheme = *uriSchemes().begin(),
                 },
+            .params = getQueryParams(),
         };
     }
 };

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -262,6 +262,7 @@ StoreReference S3BinaryCacheStoreConfig::getReference() const
                 .scheme = *uriSchemes().begin(),
                 .authority = bucketName,
             },
+        .params = getQueryParams(),
     };
 }
 

--- a/src/libstore/uds-remote-store.cc
+++ b/src/libstore/uds-remote-store.cc
@@ -61,13 +61,17 @@ StoreReference UDSRemoteStoreConfig::getReference() const
      * to be more compatible with older versions of nix. Some tooling out there
      * tries hard to parse store references and it might not be able to handle "unix://". */
     if (path == settings.nixDaemonSocketFile)
-        return {.variant = StoreReference::Daemon{}};
+        return {
+            .variant = StoreReference::Daemon{},
+            .params = getQueryParams(),
+        };
     return {
         .variant =
             StoreReference::Specified{
                 .scheme = *uriSchemes().begin(),
                 .authority = path,
             },
+        .params = getQueryParams(),
     };
 }
 


### PR DESCRIPTION
…tore parameters

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

These stragglers have been accidentally left out when implementing the StoreConfig::getReference. Also HttpBinaryCacheStore::getReference now returns the actual store parameters, not the cacheUri parameters.


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
