### PR TITLE
libstore: Call canonPath for constructing LocalFSStoreConfig::rootDir

### DIFF
--- a/src/libstore/include/nix/store/local-fs-store.hh
+++ b/src/libstore/include/nix/store/local-fs-store.hh
@@ -9,6 +9,18 @@ namespace nix {
 
 struct LocalFSStoreConfig : virtual StoreConfig
 {
+private:
+    static OptionalPathSetting makeRootDirSetting(LocalFSStoreConfig & self, std::optional<Path> defaultValue)
+    {
+        return {
+            &self,
+            std::move(defaultValue),
+            "root",
+            "Directory prefixed to all other paths.",
+        };
+    }
+
+public:
     using StoreConfig::StoreConfig;
 
     /**
@@ -20,7 +32,7 @@ struct LocalFSStoreConfig : virtual StoreConfig
      */
     LocalFSStoreConfig(PathView path, const Params & params);
 
-    OptionalPathSetting rootDir{this, std::nullopt, "root", "Directory prefixed to all other paths."};
+    OptionalPathSetting rootDir = makeRootDirSetting(*this, std::nullopt);
 
 private:
 

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -24,7 +24,7 @@ LocalFSStoreConfig::LocalFSStoreConfig(PathView rootDir, const Params & params)
     // FIXME don't duplicate description once we don't have root setting
     , rootDir{
           this,
-          !rootDir.empty() && params.count("root") == 0 ? (std::optional<Path>{rootDir}) : std::nullopt,
+          !rootDir.empty() && params.count("root") == 0 ? (std::optional{canonPath(rootDir)}) : std::nullopt,
           "root",
           "Directory prefixed to all other paths."}
 {

--- a/src/libstore/local-fs-store.cc
+++ b/src/libstore/local-fs-store.cc
@@ -20,13 +20,17 @@ Path LocalFSStoreConfig::getDefaultLogDir()
 
 LocalFSStoreConfig::LocalFSStoreConfig(PathView rootDir, const Params & params)
     : StoreConfig(params)
-    // Default `?root` from `rootDir` if non set
-    // FIXME don't duplicate description once we don't have root setting
-    , rootDir{
-          this,
-          !rootDir.empty() && params.count("root") == 0 ? (std::optional{canonPath(rootDir)}) : std::nullopt,
-          "root",
-          "Directory prefixed to all other paths."}
+    /* Default `?root` from `rootDir` if non set
+     * NOTE: We would like to just do rootDir.set(...), which would take care of
+     * all normalization and error checking for us. Unfortunately we cannot do
+     * that because of the complicated initialization order of other fields with
+     * the virtual class hierarchy of nix store configs, and the design of the
+     * settings system. As such, we have no choice but to redefine the field and
+     * manually repeat the same normalization logic.
+     */
+    , rootDir{makeRootDirSetting(
+          *this,
+          !rootDir.empty() && params.count("root") == 0 ? std::optional<Path>{canonPath(rootDir)} : std::nullopt)}
 {
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This mirrors what `OptionalPathSetting` does. Otherwise we run into an assertion failure for relative paths specified as the authority + path:

```
nix build nixpkgs#hello --store "local://a/b"
nix: ../posix-source-accessor.cc:13: nix::PosixSourceAccessor::PosixSourceAccessor(std::filesystem::__cxx11::path&&): Assertion `root.empty() || root.is_absolute()' failed.
```

This is now diagnosed properly:

`error: not an absolute path: 'a/b'`

Just as you'd specify the root via a query parameter:

`nix build nixpkgs#hello --store "local?root=a/b"`

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
