### PR TITLE
Add `#pragma once` to `dummy-store.hh`

### DIFF
--- a/src/libstore/include/nix/store/dummy-store.hh
+++ b/src/libstore/include/nix/store/dummy-store.hh
@@ -1,3 +1,6 @@
+#pragma once
+///@file
+
 #include "nix/store/store-api.hh"
 
 namespace nix {


### PR DESCRIPTION
## Motivation

In later (yet to be merged at this time) commits, this started causing problems that only the sanitzer caught.

## Context

We should have a lint for this.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
