### PR TITLE
libexpr: allocate ExprPath strings in the allocator

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -212,14 +212,16 @@ struct ExprString : Expr
 struct ExprPath : Expr
 {
     ref<SourceAccessor> accessor;
-    std::string s;
     Value v;
 
-    ExprPath(ref<SourceAccessor> accessor, std::string s)
+    ExprPath(std::pmr::polymorphic_allocator<char> & alloc, ref<SourceAccessor> accessor, std::string_view sv)
         : accessor(accessor)
-        , s(std::move(s))
     {
-        v.mkPath(&*accessor, this->s.c_str());
+        auto len = sv.length();
+        char * s = alloc.allocate(len + 1);
+        sv.copy(s, len);
+        s[len] = '\0';
+        v.mkPath(&*accessor, s);
     }
 
     Value * maybeThunk(EvalState & state, Env & env) override;

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -45,7 +45,7 @@ void ExprString::show(const SymbolTable & symbols, std::ostream & str) const
 
 void ExprPath::show(const SymbolTable & symbols, std::ostream & str) const
 {
-    str << s;
+    str << v.pathStr();
 }
 
 void ExprVar::show(const SymbolTable & symbols, std::ostream & str) const

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -392,8 +392,8 @@ path_start
            root filesystem accessor, rather than the accessor of the
            current Nix expression. */
         literal.front() == '/'
-        ? new ExprPath(state->rootFS, std::move(path))
-        : new ExprPath(state->basePath.accessor, std::move(path));
+        ? new ExprPath(state->alloc, state->rootFS, path)
+        : new ExprPath(state->alloc, state->basePath.accessor, path);
   }
   | HPATH {
     if (state->settings.pureEval) {
@@ -403,7 +403,7 @@ path_start
         );
     }
     Path path(getHome() + std::string($1.p + 1, $1.l - 1));
-    $$ = new ExprPath(ref<SourceAccessor>(state->rootFS), std::move(path));
+    $$ = new ExprPath(state->alloc, ref<SourceAccessor>(state->rootFS), path);
   }
   ;
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation
See [this tracking issue](https://github.com/NixOS/nix/issues/14088) for big-picture plan and motivation

Where does this fall in that picture?

- Removes 24-32 bytes from each ExprPath (size of std::string)
  - This is not very much. ~500KB
- Cut excess allocations off the ends of strings
  - This is more than I would have expected. ~5MB (unless there's some other memory reduction I'm not accounting for)
- Once Exprs live in a std::vector, they will need to be trivially moveable. Because of the small string optimization of std::string, moving an ExprPath invalidates its Value's pointer.

Note that we've added a bunch of copies that weren't necessary before. This doesn't seem to impact performance. In the future, we can address this by passing the allocator down into functions like `getHome()` and having them allocate directly there instead.
<details>
  <summary>Rant about plans for removing the `accessor` field as well</summary>
I would like to also remove `ref<SourceAccessor> accessor`. It does take up 16 needless bytes, but the bigger reason is that eventually I want `ExprInt`, `ExprFloat`, `ExprString`, and `ExprPath`, all the "literals" to be referred to **as** Values directly (See tracking issue's todo item "Combine `Expr`s and `Value`s into one address space...") This would remove a layer of indirection and the need to store the Expr at all, but it requires that they not have any other fields (i.e. `accessor`).

The only thing `accessor` is doing is incrementing/decrementing a refcount for the `SourceAccessor`. I scoured the internet and could not find a reasonable way to manually increment / decrement the refcount of an `std::shared_ptr`. I did come up with a janky way that involves using `memset` and `memcpy` to skip constructors/destructors, but that seemed like a bad path to go down.

I'm now thinking [`boost::intrusive_ptr`](https://www.boost.org/doc/libs/1_40_0/libs/smart_ptr/intrusive_ptr.html) is the way to go here, but I think we should tackle that down the road when it actually becomes relevant.

</details>

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
