### PR TITLE
Fix thread-safety issue with ptsname() usage

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -18,6 +18,7 @@
 #include "nix/store/user-lock.hh"
 #include "nix/store/globals.hh"
 #include "nix/store/build/derivation-env-desugar.hh"
+#include "nix/util/terminal.hh"
 
 #include <queue>
 
@@ -808,8 +809,7 @@ std::optional<Descriptor> DerivationBuilderImpl::startBuild()
     if (!builderOut)
         throw SysError("opening pseudoterminal master");
 
-    // FIXME: not thread-safe, use ptsname_r
-    std::string slaveName = ptsname(builderOut.get());
+    std::string slaveName = getPtsName(builderOut.get());
 
     if (buildUser) {
         if (chmod(slaveName.c_str(), 0600))
@@ -923,7 +923,7 @@ void DerivationBuilderImpl::prepareSandbox()
 
 void DerivationBuilderImpl::openSlave()
 {
-    std::string slaveName = ptsname(builderOut.get());
+    std::string slaveName = getPtsName(builderOut.get());
 
     AutoCloseFD builderOut = open(slaveName.c_str(), O_RDWR | O_NOCTTY);
     if (!builderOut)

--- a/src/libutil/include/nix/util/terminal.hh
+++ b/src/libutil/include/nix/util/terminal.hh
@@ -36,4 +36,12 @@ void updateWindowSize();
  */
 std::pair<unsigned short, unsigned short> getWindowSize();
 
+/**
+ * Get the slave name of a pseudoterminal in a thread-safe manner.
+ *
+ * @param fd The file descriptor of the pseudoterminal master
+ * @return The slave device name as a string
+ */
+std::string getPtsName(int fd);
+
 } // namespace nix

--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -1,6 +1,7 @@
 #include "nix/util/terminal.hh"
 #include "nix/util/environment-variables.hh"
 #include "nix/util/sync.hh"
+#include "nix/util/error.hh"
 
 #ifdef _WIN32
 #  include <io.h>
@@ -12,6 +13,8 @@
 #endif
 #include <unistd.h>
 #include <widechar_width.h>
+#include <mutex>
+#include <cstdlib> // for ptsname and ptsname_r
 
 namespace {
 
@@ -174,6 +177,31 @@ void updateWindowSize()
 std::pair<unsigned short, unsigned short> getWindowSize()
 {
     return *windowSize.lock();
+}
+
+std::string getPtsName(int fd)
+{
+#ifdef __APPLE__
+    static std::mutex ptsnameMutex;
+    // macOS doesn't have ptsname_r, use mutex-protected ptsname
+    std::lock_guard<std::mutex> lock(ptsnameMutex);
+    const char * name = ptsname(fd);
+    if (!name) {
+        throw SysError("getting pseudoterminal slave name");
+    }
+    return name;
+#else
+    // Use thread-safe ptsname_r on platforms that support it
+    // PTY names are typically short:
+    // - Linux: /dev/pts/N (where N is usually < 1000)
+    // - FreeBSD: /dev/pts/N
+    // 64 bytes is more than sufficient for any Unix PTY name
+    char buf[64];
+    if (ptsname_r(fd, buf, sizeof(buf)) != 0) {
+        throw SysError("getting pseudoterminal slave name");
+    }
+    return buf;
+#endif
 }
 
 } // namespace nix


### PR DESCRIPTION
Replace non-thread-safe ptsname() calls with a new getPtsName() helper function that:
- Uses thread-safe ptsname_r() on Linux/BSD platforms
- Uses mutex-protected ptsname() on macOS (which lacks ptsname_r())

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
