### PR TITLE
Prevent infinite symlink loop in followLinksToStore()

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -58,12 +58,22 @@ std::pair<StorePath, Path> StoreDirConfig::toStorePath(PathView path) const
 Path Store::followLinksToStore(std::string_view _path) const
 {
     Path path = absPath(std::string(_path));
+
+    // Limit symlink follows to prevent infinite loops
+    unsigned int followCount = 0;
+    const unsigned int maxFollow = 1024;
+
     while (!isInStore(path)) {
         if (!std::filesystem::is_symlink(path))
             break;
+
+        if (++followCount >= maxFollow)
+            throw Error("too many symbolic links encountered while resolving '%s'", _path);
+
         auto target = readLink(path);
         path = absPath(target, dirOf(path));
     }
+
     if (!isInStore(path))
         throw BadStorePath("path '%1%' is not in the Nix store", path);
     return path;


### PR DESCRIPTION
The followLinksToStore() function could hang indefinitely when encountering symlink cycles outside the Nix store, causing 100% CPU usage and blocking any operations that use this function.

This affects multiple commands including nix-store --query, --delete, --verify, nix-env, and nix-copy-closure when given paths with symlink cycles.

The fix adds a maximum limit of 1024 symlink follows (matching the limit used by canonPath) and throws an error when exceeded, preventing the infinite loop while preserving the original semantics of stopping at the first path inside the store.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
