### PR TITLE
shellcheck fixes CA functional tests

### DIFF
--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -172,7 +172,6 @@
               # Content-addressed test files that use recursive-*looking* sourcing
               # (cd .. && source <self>), causing shellcheck to loop
               # They're small wrapper scripts with not a lot going on
-              ''^tests/functional/ca/build-delete\.sh$''
               ''^tests/functional/ca/build-dry\.sh$''
               ''^tests/functional/ca/eval-store\.sh$''
               ''^tests/functional/ca/gc\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -172,7 +172,6 @@
               # Content-addressed test files that use recursive-*looking* sourcing
               # (cd .. && source <self>), causing shellcheck to loop
               # They're small wrapper scripts with not a lot going on
-              ''^tests/functional/ca/build-dry\.sh$''
               ''^tests/functional/ca/eval-store\.sh$''
               ''^tests/functional/ca/gc\.sh$''
               ''^tests/functional/ca/import-from-derivation\.sh$''

--- a/maintainers/flake-module.nix
+++ b/maintainers/flake-module.nix
@@ -168,21 +168,6 @@
               ''^tests/functional/user-envs\.builder\.sh$''
               ''^tests/functional/user-envs\.sh$''
               ''^tests/functional/why-depends\.sh$''
-
-              # Content-addressed test files that use recursive-*looking* sourcing
-              # (cd .. && source <self>), causing shellcheck to loop
-              # They're small wrapper scripts with not a lot going on
-              ''^tests/functional/ca/eval-store\.sh$''
-              ''^tests/functional/ca/gc\.sh$''
-              ''^tests/functional/ca/import-from-derivation\.sh$''
-              ''^tests/functional/ca/multiple-outputs\.sh$''
-              ''^tests/functional/ca/new-build-cmd\.sh$''
-              ''^tests/functional/ca/nix-shell\.sh$''
-              ''^tests/functional/ca/post-hook\.sh$''
-              ''^tests/functional/ca/recursive\.sh$''
-              ''^tests/functional/ca/repl\.sh$''
-              ''^tests/functional/ca/selfref-gc\.sh$''
-              ''^tests/functional/ca/why-depends\.sh$''
             ];
           };
         };

--- a/tests/functional/ca/build-delete.sh
+++ b/tests/functional/ca/build-delete.sh
@@ -4,4 +4,5 @@ source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 cd ..
+# shellcheck source=/dev/null
 source ./build-delete.sh

--- a/tests/functional/ca/build-dry.sh
+++ b/tests/functional/ca/build-dry.sh
@@ -2,5 +2,6 @@ source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 
+# shellcheck source=/dev/null
 cd .. && source build-dry.sh
 

--- a/tests/functional/ca/build-dry.sh
+++ b/tests/functional/ca/build-dry.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1

--- a/tests/functional/ca/eval-store.sh
+++ b/tests/functional/ca/eval-store.sh
@@ -7,4 +7,5 @@ source common.sh
 export NIX_TESTS_CA_BY_DEFAULT=1
 
 cd ..
+# shellcheck source=/dev/null
 source eval-store.sh

--- a/tests/functional/ca/gc.sh
+++ b/tests/functional/ca/gc.sh
@@ -7,4 +7,5 @@ source common.sh
 export NIX_TESTS_CA_BY_DEFAULT=1
 
 cd ..
+# shellcheck source=/dev/null
 source gc.sh

--- a/tests/functional/ca/import-from-derivation.sh
+++ b/tests/functional/ca/import-from-derivation.sh
@@ -3,6 +3,6 @@
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1
-
+# shellcheck source=/dev/null
 cd .. && source import-from-derivation.sh
 

--- a/tests/functional/ca/multiple-outputs.sh
+++ b/tests/functional/ca/multiple-outputs.sh
@@ -4,4 +4,5 @@ source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 cd ..
+# shellcheck source=/dev/null
 source ./multiple-outputs.sh

--- a/tests/functional/ca/new-build-cmd.sh
+++ b/tests/functional/ca/new-build-cmd.sh
@@ -4,4 +4,5 @@ source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 cd ..
+# shellcheck source=/dev/null
 source ./build.sh

--- a/tests/functional/ca/nix-shell.sh
+++ b/tests/functional/ca/nix-shell.sh
@@ -2,6 +2,8 @@
 
 source common.sh
 
+# shellcheck disable=SC2034
 NIX_TESTS_CA_BY_DEFAULT=true
 cd ..
+# shellcheck source=/dev/null
 source ./nix-shell.sh

--- a/tests/functional/ca/post-hook.sh
+++ b/tests/functional/ca/post-hook.sh
@@ -6,6 +6,7 @@ requireDaemonNewerThan "2.4pre20210626"
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 cd ..
+# shellcheck source=/dev/null
 source ./post-hook.sh
 
 

--- a/tests/functional/ca/recursive.sh
+++ b/tests/functional/ca/recursive.sh
@@ -6,4 +6,5 @@ requireDaemonNewerThan "2.4pre20210623"
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 cd ..
+# shellcheck source=/dev/null
 source ./recursive.sh

--- a/tests/functional/ca/repl.sh
+++ b/tests/functional/ca/repl.sh
@@ -3,5 +3,5 @@
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1
-
+# shellcheck source=/dev/null
 cd .. && source repl.sh

--- a/tests/functional/ca/selfref-gc.sh
+++ b/tests/functional/ca/selfref-gc.sh
@@ -8,4 +8,5 @@ enableFeatures "ca-derivations nix-command flakes"
 
 export NIX_TESTS_CA_BY_DEFAULT=1
 cd ..
+# shellcheck source=/dev/null
 source ./selfref-gc.sh

--- a/tests/functional/ca/why-depends.sh
+++ b/tests/functional/ca/why-depends.sh
@@ -3,5 +3,5 @@
 source common.sh
 
 export NIX_TESTS_CA_BY_DEFAULT=1
-
+# shellcheck source=/dev/null
 cd .. && source why-depends.sh


### PR DESCRIPTION
## Motivation

Ignore recursive sourcing within same file to remove exclusions.


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
