### PR TITLE
libutil: Create empty directory at the root for makeEmptySourceAccessor

### DIFF
--- a/src/libutil/memory-source-accessor.cc
+++ b/src/libutil/memory-source-accessor.cc
@@ -208,11 +208,16 @@ void MemorySink::createSymlink(const CanonPath & path, const std::string & targe
 
 ref<SourceAccessor> makeEmptySourceAccessor()
 {
-    static auto empty = make_ref<MemorySourceAccessor>().cast<SourceAccessor>();
-    /* Don't forget to clear the display prefix, as the default constructed
-       SourceAccessor has the «unknown» prefix. Since this accessor is supposed
-       to mimic an empty root directory the prefix needs to be empty. */
-    empty->setPathDisplay("");
+    static auto empty = []() {
+        auto empty = make_ref<MemorySourceAccessor>();
+        MemorySink sink{*empty};
+        sink.createDirectory(CanonPath::root);
+        /* Don't forget to clear the display prefix, as the default constructed
+           SourceAccessor has the «unknown» prefix. Since this accessor is supposed
+           to mimic an empty root directory the prefix needs to be empty. */
+        empty->setPathDisplay("");
+        return empty.cast<SourceAccessor>();
+    }();
     return empty;
 }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

This is my SNAFU. Accidentally broken in 02c9ac445ff527a7b4c5105d20d9ab401117dcee.

There's very dubious behavior for 'builtins.readDir /.':

```nix
{
  outputs =
    { ... }:
    {
      lib.a = builtins.readDir /.;
    };
}
```

nix eval /tmp/test-flake#lib.a

Starting from 2.27 this now returns an empty set. This really isn't supposed to happen, but this change in the semantics of makeEmptySourceAccessor accidentally changed the behavior of this.


<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- Problem in https://github.com/NixOS/nix/pull/14023

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
