### PR TITLE
libexpr-tests: Add unit tests for broken readDir /. for pure eval

### DIFF
--- a/src/libexpr-test-support/include/nix/expr/tests/libexpr.hh
+++ b/src/libexpr-test-support/include/nix/expr/tests/libexpr.hh
@@ -26,11 +26,20 @@ public:
     }
 
 protected:
-    LibExprTest()
+    LibExprTest(ref<Store> store, auto && makeEvalSettings)
         : LibStoreTest()
+        , evalSettings(makeEvalSettings(readOnlyMode))
         , state({}, store, fetchSettings, evalSettings, nullptr)
     {
-        evalSettings.nixPath = {};
+    }
+
+    LibExprTest()
+        : LibExprTest(openStore("dummy://"), [](bool & readOnlyMode) {
+            EvalSettings settings{readOnlyMode};
+            settings.nixPath = {};
+            return settings;
+        })
+    {
     }
 
     Value eval(std::string input, bool forceValue = true)

--- a/src/libstore-test-support/include/nix/store/tests/libstore.hh
+++ b/src/libstore-test-support/include/nix/store/tests/libstore.hh
@@ -19,14 +19,13 @@ public:
     }
 
 protected:
+    LibStoreTest(ref<Store> store)
+        : store(std::move(store))
+    {
+    }
+
     LibStoreTest()
-        : store(openStore({
-              .variant =
-                  StoreReference::Specified{
-                      .scheme = "dummy",
-                  },
-              .params = {},
-          }))
+        : LibStoreTest(openStore("dummy://"))
     {
     }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

A very unfortunate interaction of current filtering with pure eval is that the following actually leads to `lib.a = {}`. This just adds a unit test for this broken behavior. This is really good to be done as a unit test via the in-memory store.

```
{
  outputs =
    { ... }:
    {
      lib.a = builtins.readDir /.;
    };
}
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Maybe https://github.com/NixOS/nix/pull/10505 could help with this broken behavior.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
