### PR TITLE
`Store::registerDrvOutput` make pure virtual

### DIFF
--- a/src/libstore/dummy-store.cc
+++ b/src/libstore/dummy-store.cc
@@ -258,6 +258,11 @@ struct DummyStore : virtual Store
         return path;
     }
 
+    void registerDrvOutput(const Realisation & output) override
+    {
+        unsupported("registerDrvOutput");
+    }
+
     void narFromPath(const StorePath & path, Sink & sink) override
     {
         bool visited = contents.cvisit(path, [&](const auto & kv) {

--- a/src/libstore/include/nix/store/legacy-ssh-store.hh
+++ b/src/libstore/include/nix/store/legacy-ssh-store.hh
@@ -109,7 +109,7 @@ struct LegacySSHStore : public virtual Store
         unsupported("addToStore");
     }
 
-    virtual StorePath addToStoreFromDump(
+    StorePath addToStoreFromDump(
         Source & dump,
         std::string_view name,
         FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
@@ -119,6 +119,11 @@ struct LegacySSHStore : public virtual Store
         RepairFlag repair = NoRepair) override
     {
         unsupported("addToStore");
+    }
+
+    void registerDrvOutput(const Realisation & output) override
+    {
+        unsupported("registerDrvOutput");
     }
 
 public:

--- a/src/libstore/include/nix/store/store-api.hh
+++ b/src/libstore/include/nix/store/store-api.hh
@@ -598,10 +598,7 @@ public:
      * floating-ca derivations and their dependencies as there's no way to
      * retrieve this information otherwise.
      */
-    virtual void registerDrvOutput(const Realisation & output)
-    {
-        unsupported("registerDrvOutput");
-    }
+    virtual void registerDrvOutput(const Realisation & output) = 0;
 
     virtual void registerDrvOutput(const Realisation & output, CheckSigsFlag checkSigs)
     {


### PR DESCRIPTION
## Motivation

It should be the responsibility of implementations that don't implement it to say so.

## Context

See also PR #9799, and issue #5729

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
