### PR TITLE
refactor(libstore): extract S3 URL parsing into separate files

### DIFF
--- a/src/libstore-tests/meson.build
+++ b/src/libstore-tests/meson.build
@@ -77,7 +77,7 @@ sources = files(
   'realisation.cc',
   'references.cc',
   's3-binary-cache-store.cc',
-  's3.cc',
+  's3-url.cc',
   'serve-protocol.cc',
   'ssh-store.cc',
   'store-reference.cc',

--- a/src/libstore-tests/s3-url.cc
+++ b/src/libstore-tests/s3-url.cc
@@ -1,4 +1,4 @@
-#include "nix/store/s3.hh"
+#include "nix/store/s3-url.hh"
 #include "nix/util/tests/gmock-matchers.hh"
 
 #if NIX_WITH_S3_SUPPORT

--- a/src/libstore/include/nix/store/meson.build
+++ b/src/libstore/include/nix/store/meson.build
@@ -72,6 +72,7 @@ headers = [ config_pub_h ] + files(
   'remote-store.hh',
   'restricted-store.hh',
   's3-binary-cache-store.hh',
+  's3-url.hh',
   's3.hh',
   'serve-protocol-connection.hh',
   'serve-protocol-impl.hh',

--- a/src/libstore/include/nix/store/s3-url.hh
+++ b/src/libstore/include/nix/store/s3-url.hh
@@ -1,0 +1,60 @@
+#pragma once
+///@file
+#include "nix/store/config.hh"
+
+#if NIX_WITH_S3_SUPPORT
+
+#  include "nix/util/url.hh"
+#  include "nix/util/util.hh"
+
+#  include <optional>
+#  include <string>
+#  include <variant>
+#  include <vector>
+
+namespace nix {
+
+/**
+ * Parsed S3 URL.
+ */
+struct ParsedS3URL
+{
+    std::string bucket;
+    /**
+     * @see ParsedURL::path. This is a vector for the same reason.
+     * Unlike ParsedURL::path this doesn't include the leading empty segment,
+     * since the bucket name is necessary.
+     */
+    std::vector<std::string> key;
+    std::optional<std::string> profile;
+    std::optional<std::string> region;
+    std::optional<std::string> scheme;
+    /**
+     * The endpoint can be either missing, be an absolute URI (with a scheme like `http:`)
+     * or an authority (so an IP address or a registered name).
+     */
+    std::variant<std::monostate, ParsedURL, ParsedURL::Authority> endpoint;
+
+    std::optional<std::string> getEncodedEndpoint() const
+    {
+        return std::visit(
+            overloaded{
+                [](std::monostate) -> std::optional<std::string> { return std::nullopt; },
+                [](const auto & authorityOrUrl) -> std::optional<std::string> { return authorityOrUrl.to_string(); },
+            },
+            endpoint);
+    }
+
+    static ParsedS3URL parse(const ParsedURL & uri);
+
+    /**
+     * Convert this ParsedS3URL to HTTPS ParsedURL for use with curl's AWS SigV4 authentication
+     */
+    ParsedURL toHttpsUrl() const;
+
+    auto operator<=>(const ParsedS3URL & other) const = default;
+};
+
+} // namespace nix
+
+#endif

--- a/src/libstore/include/nix/store/s3.hh
+++ b/src/libstore/include/nix/store/s3.hh
@@ -4,12 +4,9 @@
 #if NIX_WITH_S3_SUPPORT
 
 #  include "nix/util/ref.hh"
-#  include "nix/util/url.hh"
-#  include "nix/util/util.hh"
+#  include "nix/store/s3-url.hh"
 
-#  include <optional>
 #  include <string>
-#  include <variant>
 
 namespace Aws {
 namespace Client {
@@ -46,47 +43,6 @@ struct S3Helper
     };
 
     FileTransferResult getObject(const std::string & bucketName, const std::string & key);
-};
-
-/**
- * Parsed S3 URL.
- */
-struct ParsedS3URL
-{
-    std::string bucket;
-    /**
-     * @see ParsedURL::path. This is a vector for the same reason.
-     * Unlike ParsedURL::path this doesn't include the leading empty segment,
-     * since the bucket name is necessary.
-     */
-    std::vector<std::string> key;
-    std::optional<std::string> profile;
-    std::optional<std::string> region;
-    std::optional<std::string> scheme;
-    /**
-     * The endpoint can be either missing, be an absolute URI (with a scheme like `http:`)
-     * or an authority (so an IP address or a registered name).
-     */
-    std::variant<std::monostate, ParsedURL, ParsedURL::Authority> endpoint;
-
-    std::optional<std::string> getEncodedEndpoint() const
-    {
-        return std::visit(
-            overloaded{
-                [](std::monostate) -> std::optional<std::string> { return std::nullopt; },
-                [](const auto & authorityOrUrl) -> std::optional<std::string> { return authorityOrUrl.to_string(); },
-            },
-            endpoint);
-    }
-
-    static ParsedS3URL parse(const ParsedURL & uri);
-
-    /**
-     * Convert this ParsedS3URL to HTTPS ParsedURL for use with curl's AWS SigV4 authentication
-     */
-    ParsedURL toHttpsUrl() const;
-
-    auto operator<=>(const ParsedS3URL & other) const = default;
 };
 
 } // namespace nix

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -329,7 +329,7 @@ sources = files(
   'remote-store.cc',
   'restricted-store.cc',
   's3-binary-cache-store.cc',
-  's3.cc',
+  's3-url.cc',
   'serve-protocol-connection.cc',
   'serve-protocol.cc',
   'sqlite.cc',

--- a/src/libstore/s3-url.cc
+++ b/src/libstore/s3-url.cc
@@ -1,17 +1,17 @@
-#include "nix/store/s3.hh"
-#include "nix/util/split.hh"
-#include "nix/util/url.hh"
-#include "nix/util/util.hh"
-#include "nix/util/canon-path.hh"
-#include "nix/util/strings-inline.hh"
+#include "nix/store/s3-url.hh"
 
-#include <ranges>
+#if NIX_WITH_S3_SUPPORT
 
-namespace nix {
+#  include "nix/util/error.hh"
+#  include "nix/util/split.hh"
+#  include "nix/util/strings-inline.hh"
+
+#  include <ranges>
+#  include <string_view>
 
 using namespace std::string_view_literals;
 
-#if NIX_WITH_S3_SUPPORT
+namespace nix {
 
 ParsedS3URL ParsedS3URL::parse(const ParsedURL & parsed)
 try {
@@ -116,6 +116,6 @@ ParsedURL ParsedS3URL::toHttpsUrl() const
         endpoint);
 }
 
-#endif
-
 } // namespace nix
+
+#endif


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

Move ParsedS3URL from s3.cc/.hh into dedicated s3-url.cc/.hh files.
This separates URL parsing utilities (which are protocol-agnostic) from
the AWS SDK-specific S3Helper implementation, making the code cleaner
and enabling reuse by future curl-based S3 implementation.

## Context

Extracted from #13752

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
