### PR TITLE
libstore: Properly check for running SSH masters

### DIFF
--- a/src/libstore/ssh.cc
+++ b/src/libstore/ssh.cc
@@ -206,7 +206,7 @@ std::unique_ptr<SSHMaster::Connection> SSHMaster::startCommand(Strings && comman
 
     // Wait for the SSH connection to be established,
     // So that we don't overwrite the password prompt with our progress bar.
-    if (!fakeSSH && !useMaster && !isMasterRunning()) {
+    if (!fakeSSH && !isMasterRunning()) {
         std::string reply;
         try {
             reply = readLine(out.readSide.get());


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

I'm using SSH control sockets for most of my SSH connections. This breaks remote `ssh-ng://` stores when a control socket exists that has not been created by Nix. See #14132 

## Context

<!-- Provide context. Reference open issues if available. -->

https://github.com/NixOS/nix/blob/251479bdda9b96c964c38ed77a415a9f4514dc6f/src/libstore/ssh.cc#L110-L115

Nix tries to check whether the SSH password prompt has been shown and the connection has been established by using `LocalCommand=echo started`, this will echo "started" when the connection is first established. **But** this *won't* echo "started" when the connection is part of an SSH master. The crux here is that we need to detect whether the the connection will be part of an SSH master to determine whether we'll need to swallow the "started" line before proceeding.

---

https://github.com/NixOS/nix/blob/251479bdda9b96c964c38ed77a415a9f4514dc6f/src/libstore/ssh.cc#L207-L220

The check in `SSHMaster::startCommand` is wrong, because we don't care for the `SSHMaster::useMaster` flag. The only relevant information is whether we're using a master in the background, be it the one created by Nix with `SSHMaster::useMaster = true` or from my previous connection with `SSHMaster::useMaster = false`.

---

This is my first excursion into the Nix SSH code. I hope my understanding of the problem is correct. But this change seems to resolve my issue.

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
