### PR TITLE
libstore: Include missing header to fix compile with libc++ 20

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -18,6 +18,7 @@
 #include <boost/unordered/unordered_flat_set.hpp>
 #include <boost/regex.hpp>
 #include <queue>
+#include <thread>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

-->

## Motivation

nix was failing to build against [LLVM's libc++](https://libcxx.llvm.org/) (20.1.8 exactly in my case) due to a missing `<thread>` include:
```
src/libstore/gc.cc:121:39: error: no member named 'sleep_for' in namespace 'std::this_thread'
  121 |                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
      |                     ~~~~~~~~~~~~~~~~~~^
```

## Context

Ref: https://en.cppreference.com/w/cpp/thread.html
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
