### PR TITLE
fix(libstore/build/derivation-goal): don't assert on partially valid outputs

### DIFF
--- a/src/libstore/build/derivation-goal.cc
+++ b/src/libstore/build/derivation-goal.cc
@@ -278,7 +278,23 @@ Goal::Co DerivationGoal::haveDerivation(bool storeDerivation)
                 }
             }
 
-            assert(success.builtOutputs.count(wantedOutput) > 0);
+            /* If the wanted output is not in builtOutputs (e.g., because it
+               was already valid and therefore not re-registered), we need to
+               add it ourselves to ensure we return the correct information. */
+            if (success.builtOutputs.count(wantedOutput) == 0) {
+                debug(
+                    "BUG! wanted output '%s' not in builtOutputs, working around by adding it manually", wantedOutput);
+                success.builtOutputs = {{
+                    wantedOutput,
+                    {
+                        assertPathValidity(),
+                        {
+                            .drvHash = outputHash,
+                            .outputName = wantedOutput,
+                        },
+                    },
+                }};
+            }
         }
     }
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes: #14130 (maybe?)

## Context

Claude-aided debugging:
  1. A derivation has multiple outputs (e.g., `out` and `dev`)
  2. One output (`out`) is already valid in the store
  3. Another output (`dev`) is NOT valid
  4. User requests to build the already-valid output (`out`)
  5. Since not ALL outputs are valid, `DerivationGoal` cannot return early—it must proceed with the build
  6. `DerivationGoal` delegates to `DerivationBuildingGoal` to rebuild the entire derivation
  7. In `registerOutputs()` (derivation-builder.cc:1383-1388), already-valid outputs are skipped to avoid unnecessary re-registration
  8. The `wantedOutput` (`out`) is skipped, so it's NOT added to `builtOutputs`
  9. Back in `DerivationGoal`, the code tries to filter `builtOutputs` to only contain `wantedOutput`
  10. Assertion fails because `wantedOutput` is not in `builtOutputs`

I'm still trying to write a reproducer to validate...

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
