### PR TITLE
libstore: Move {narinfo,ls,log}-compression settings from BinaryCache…

### DIFF
--- a/src/libstore/include/nix/store/binary-cache-store.hh
+++ b/src/libstore/include/nix/store/binary-cache-store.hh
@@ -59,21 +59,6 @@ struct BinaryCacheStoreConfig : virtual StoreConfig
           The meaning and accepted values depend on the compression method selected.
           `-1` specifies that the default compression level should be used.
         )"};
-
-    const Setting<std::string> narinfoCompression{
-        this, "", "narinfo-compression", "Compression method for `.narinfo` files."};
-
-    const Setting<std::string> lsCompression{this, "", "ls-compression", "Compression method for `.ls` files."};
-
-    const Setting<std::string> logCompression{
-        this,
-        "",
-        "log-compression",
-        R"(
-          Compression method for `log/*` files. It is recommended to
-          use a compression method supported by most web browsers
-          (e.g. `brotli`).
-        )"};
 };
 
 /**

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -17,6 +17,21 @@ struct HttpBinaryCacheStoreConfig : std::enable_shared_from_this<HttpBinaryCache
 
     ParsedURL cacheUri;
 
+    const Setting<std::string> narinfoCompression{
+        this, "", "narinfo-compression", "Compression method for `.narinfo` files."};
+
+    const Setting<std::string> lsCompression{this, "", "ls-compression", "Compression method for `.ls` files."};
+
+    const Setting<std::string> logCompression{
+        this,
+        "",
+        "log-compression",
+        R"(
+          Compression method for `log/*` files. It is recommended to
+          use a compression method supported by most web browsers
+          (e.g. `brotli`).
+        )"};
+
     static const std::string name()
     {
         return "HTTP Binary Cache Store";


### PR DESCRIPTION
…StoreConfig to HttpBinaryCacheStoreConfig

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

These settings are only implemented for the http store and should not be there for the file:// stores.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

These changes have not been released yet. Added in https://github.com/NixOS/nix/pull/14120.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
