### PR TITLE
build(libstore): add NIX_WITH_CURL_S3 build option

### DIFF
--- a/src/libstore-tests/s3-url.cc
+++ b/src/libstore-tests/s3-url.cc
@@ -1,7 +1,7 @@
 #include "nix/store/s3-url.hh"
 #include "nix/util/tests/gmock-matchers.hh"
 
-#if NIX_WITH_S3_SUPPORT
+#if NIX_WITH_S3_SUPPORT || NIX_WITH_CURL_S3
 
 #  include <gtest/gtest.h>
 #  include <gmock/gmock.h>

--- a/src/libstore/aws-creds.cc
+++ b/src/libstore/aws-creds.cc
@@ -1,6 +1,6 @@
 #include "nix/store/aws-creds.hh"
 
-#if NIX_WITH_S3_SUPPORT
+#if NIX_WITH_CURL_S3
 
 #  include <aws/crt/Types.h>
 #  include "nix/store/s3-url.hh"

--- a/src/libstore/include/nix/store/aws-creds.hh
+++ b/src/libstore/include/nix/store/aws-creds.hh
@@ -2,7 +2,7 @@
 ///@file
 #include "nix/store/config.hh"
 
-#if NIX_WITH_S3_SUPPORT
+#if NIX_WITH_CURL_S3
 
 #  include "nix/store/s3-url.hh"
 #  include "nix/util/error.hh"

--- a/src/libstore/include/nix/store/s3-url.hh
+++ b/src/libstore/include/nix/store/s3-url.hh
@@ -2,7 +2,7 @@
 ///@file
 #include "nix/store/config.hh"
 
-#if NIX_WITH_S3_SUPPORT
+#if NIX_WITH_S3_SUPPORT || NIX_WITH_CURL_S3
 
 #  include "nix/util/url.hh"
 #  include "nix/util/util.hh"

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -164,6 +164,33 @@ if aws_s3.found()
 endif
 deps_other += aws_s3
 
+# Curl-based S3 store support (alternative to AWS SDK)
+# Check if curl supports AWS SigV4 (requires >= 7.75.0)
+curl_supports_aws_sigv4 = curl.version().version_compare('>= 7.75.0')
+# AWS CRT C++ for lightweight credential management
+aws_crt_cpp = cxx.find_library('aws-crt-cpp', required : false)
+
+curl_s3_store_opt = get_option('curl-s3-store').require(
+  curl_supports_aws_sigv4,
+  error_message : 'curl-based S3 support requires curl >= 7.75.0',
+).require(
+  aws_crt_cpp.found(),
+  error_message : 'curl-based S3 support requires aws-crt-cpp',
+)
+
+# Make AWS SDK and curl-based S3 mutually exclusive
+if aws_s3.found() and curl_s3_store_opt.enabled()
+  error(
+    'Cannot enable both AWS SDK S3 support and curl-based S3 support. Please choose one.',
+  )
+endif
+
+if curl_s3_store_opt.enabled()
+  deps_other += aws_crt_cpp
+endif
+
+configdata_pub.set('NIX_WITH_CURL_S3', curl_s3_store_opt.enabled().to_int())
+
 subdir('nix-meson-build-support/generate-header')
 
 generated_headers = []

--- a/src/libstore/meson.options
+++ b/src/libstore/meson.options
@@ -33,3 +33,10 @@ option(
   value : '/nix/var/log/nix',
   description : 'path to store logs in for Nix',
 )
+
+option(
+  'curl-s3-store',
+  type : 'feature',
+  value : 'disabled',
+  description : 'Enable curl-based S3 binary cache store support (requires aws-crt-cpp and curl >= 7.75.0)',
+)

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -10,6 +10,7 @@
   boost,
   curl,
   aws-sdk-cpp,
+  aws-crt-cpp,
   libseccomp,
   nlohmann_json,
   sqlite,
@@ -25,6 +26,8 @@
   withAWS ?
     # Default is this way because there have been issues building this dependency
     stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin),
+
+  withCurlS3 ? false,
 }:
 
 let
@@ -64,7 +67,8 @@ mkMesonLibrary (finalAttrs: {
     sqlite
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux libseccomp
-  ++ lib.optional withAWS aws-sdk-cpp;
+  ++ lib.optional withAWS aws-sdk-cpp
+  ++ lib.optional withCurlS3 aws-crt-cpp;
 
   propagatedBuildInputs = [
     nix-util
@@ -74,6 +78,7 @@ mkMesonLibrary (finalAttrs: {
   mesonFlags = [
     (lib.mesonEnable "seccomp-sandboxing" stdenv.hostPlatform.isLinux)
     (lib.mesonBool "embedded-sandbox-shell" embeddedSandboxShell)
+    (lib.mesonEnable "curl-s3-store" withCurlS3)
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")

--- a/src/libstore/s3-url.cc
+++ b/src/libstore/s3-url.cc
@@ -1,6 +1,6 @@
 #include "nix/store/s3-url.hh"
 
-#if NIX_WITH_S3_SUPPORT
+#if NIX_WITH_S3_SUPPORT || NIX_WITH_CURL_S3
 
 #  include "nix/util/error.hh"
 #  include "nix/util/split.hh"


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Introduce a new build option 'curl-s3-store' for the curl-based S3
implementation, separate from the existing AWS SDK-based 's3-store'.
The two options are mutually exclusive to avoid conflicts.

Users can enable the new implementation with:
`-Dcurl-s3-store=enabled -Ds3-store=disabled`

## Context

Extracted from #13752


---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
