### PR TITLE
libexpr: allocate ExprOpHasAttr's AttrPath in Exprs::alloc

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -348,10 +348,14 @@ struct ExprSelect : Expr
 struct ExprOpHasAttr : Expr
 {
     Expr * e;
-    AttrPath attrPath;
-    ExprOpHasAttr(Expr * e, AttrPath attrPath)
+    std::span<AttrName> attrPath;
+
+    ExprOpHasAttr(std::pmr::polymorphic_allocator<char> alloc, Expr * e, std::vector<AttrName> attrPath)
         : e(e)
-        , attrPath(std::move(attrPath)) {};
+        , attrPath({alloc.allocate_object<AttrName>(attrPath.size()), attrPath.size()})
+    {
+        std::ranges::copy(attrPath, this->attrPath.begin());
+    };
 
     PosIdx getPos() const override
     {

--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -261,7 +261,7 @@ expr_op
   | expr_op OR expr_op { $$ = new ExprOpOr(state->at(@2), $1, $3); }
   | expr_op IMPL expr_op { $$ = new ExprOpImpl(state->at(@2), $1, $3); }
   | expr_op UPDATE expr_op { $$ = new ExprOpUpdate(state->at(@2), $1, $3); }
-  | expr_op '?' attrpath { $$ = new ExprOpHasAttr($1, std::move(*$3)); delete $3; }
+  | expr_op '?' attrpath { $$ = new ExprOpHasAttr(state->alloc, $1, std::move(*$3)); delete $3; }
   | expr_op '+' expr_op
     { $$ = new ExprConcatStrings(state->at(@2), false, new std::vector<std::pair<PosIdx, Expr *> >({{state->at(@1), $1}, {state->at(@3), $3}})); }
   | expr_op '-' expr_op { $$ = new ExprCall(state->at(@2), new ExprVar(state->s.sub), {$1, $3}); }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

For big picture motivation, see [the tracking issue](https://github.com/NixOS/nix/issues/14088)

This PR moves the data from the vector `ExprOpHasAttr::attrPath` into our `Exprs` arena, and then refers to it by a `std::span<AttrName>`. Unlike [for `ExprSelect`](https://github.com/NixOS/nix/pull/14124), here we do not benefit from separating out the length and start pointer of the `std::span`, since alignment would bring us back up to 16 bytes anyways..

- Removes 8 bytes per `ExprOpHasAttr` by going from `std::vector` (24 bytes) to `std::span<AttrName>` (16 bytes)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
