### PR TITLE
libexpr: remove Displacement field from ExprAttrs::AttrDef

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -1238,7 +1238,7 @@ void ExprAttrs::eval(EvalState & state, Env & env, Value & v)
            been substituted into the bodies of the other attributes.
            Hence we need __overrides.) */
         if (hasOverrides) {
-            Value * vOverrides = (*bindings.bindings)[overrides->second.displ].value;
+            Value * vOverrides = (*bindings.bindings)[std::distance(attrs.begin(), overrides)].value;
             state.forceAttrs(
                 *vOverrides,
                 [&]() { return vOverrides->determinePos(noPos); },
@@ -1247,8 +1247,8 @@ void ExprAttrs::eval(EvalState & state, Env & env, Value & v)
             for (auto & i : *vOverrides->attrs()) {
                 AttrDefs::iterator j = attrs.find(i.name);
                 if (j != attrs.end()) {
-                    (*bindings.bindings)[j->second.displ] = i;
-                    env2.values[j->second.displ] = i.value;
+                    (*bindings.bindings)[std::distance(attrs.begin(), j)] = i;
+                    env2.values[std::distance(attrs.begin(), j)] = i.value;
                 } else
                     bindings.push_back(i);
             }

--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -382,13 +382,12 @@ struct ExprAttrs : Expr
         };
 
         Kind kind;
-        Expr * e;
         PosIdx pos;
-        Displacement displ = 0; // displacement
+        Expr * e;
         AttrDef(Expr * e, const PosIdx & pos, Kind kind = Kind::Plain)
             : kind(kind)
-            , e(e)
-            , pos(pos) {};
+            , pos(pos)
+            , e(e) {};
         AttrDef() {};
 
         template<typename T>

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -410,7 +410,7 @@ void ExprAttrs::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> 
 
             Displacement displ = 0;
             for (auto & i : attrs)
-                newEnv->vars.emplace_back(i.first, i.second.displ = displ++);
+                newEnv->vars.emplace_back(i.first, displ++);
             return newEnv;
         }();
 
@@ -490,7 +490,7 @@ void ExprLet::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & 
 
         Displacement displ = 0;
         for (auto & i : attrs->attrs)
-            newEnv->vars.emplace_back(i.first, i.second.displ = displ++);
+            newEnv->vars.emplace_back(i.first, displ++);
         return newEnv;
     }();
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Waste of 4 bytes (per attr definition, and there are a lot of attr definitions). It's just the offset into the `std::map`, and can be calculated where it's needed using `std::distance()`.

I also reordered the remaining fields to avoid padding

Saves ~1% memory (~10MB)

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 

CC @xokdvium @NaN-git
