### PR TITLE
Don't build getPtsName() on Windows

### DIFF
--- a/src/libutil/terminal.cc
+++ b/src/libutil/terminal.cc
@@ -179,9 +179,10 @@ std::pair<unsigned short, unsigned short> getWindowSize()
     return *windowSize.lock();
 }
 
+#ifndef _WIN32
 std::string getPtsName(int fd)
 {
-#ifdef __APPLE__
+#  ifdef __APPLE__
     static std::mutex ptsnameMutex;
     // macOS doesn't have ptsname_r, use mutex-protected ptsname
     std::lock_guard<std::mutex> lock(ptsnameMutex);
@@ -190,7 +191,7 @@ std::string getPtsName(int fd)
         throw SysError("getting pseudoterminal slave name");
     }
     return name;
-#else
+#  else
     // Use thread-safe ptsname_r on platforms that support it
     // PTY names are typically short:
     // - Linux: /dev/pts/N (where N is usually < 1000)
@@ -201,7 +202,8 @@ std::string getPtsName(int fd)
         throw SysError("getting pseudoterminal slave name");
     }
     return buf;
-#endif
+#  endif
 }
+#endif
 
 } // namespace nix


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

It's not needed and breaks the build.

https://hydra.nixos.org/build/309215536

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
