### PR TITLE
libexpr: allocate ExprAttrs data in Exprs::alloc

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -365,72 +365,271 @@ struct ExprOpHasAttr : Expr
     COMMON_METHODS
 };
 
+struct AttrDefBuilder;
+
+struct AttrDef
+{
+    enum class Kind {
+        /** `attr = expr;` */
+        Plain,
+        /** `inherit attr1 attrn;` */
+        Inherited,
+        /** `inherit (expr) attr1 attrn;` */
+        InheritedFrom,
+    };
+
+    Kind kind;
+    PosIdx pos;
+    Expr * e;
+    AttrDef(std::pmr::polymorphic_allocator<char> & alloc, AttrDefBuilder const & builder);
+
+    template<typename T>
+    const T & chooseByKind(const T & plain, const T & inherited, const T & inheritedFrom) const
+    {
+        switch (kind) {
+        case Kind::Plain:
+            return plain;
+        case Kind::Inherited:
+            return inherited;
+        default:
+        case Kind::InheritedFrom:
+            return inheritedFrom;
+        }
+    }
+};
+
+struct ExprAttrsBuilder;
+
+struct AttrDefBuilder
+{
+    AttrDef::Kind kind;
+    PosIdx pos;
+    std::variant<Expr *, ExprAttrsBuilder *> e;
+    AttrDefBuilder(std::variant<Expr *, ExprAttrsBuilder *> e, const PosIdx & pos, AttrDef::Kind kind = AttrDef::Kind::Plain)
+        : kind(kind)
+        , pos(pos)
+        , e(e) {};
+    AttrDefBuilder() {};
+};
+
+struct DynamicAttrDefBuilder;
+
+struct DynamicAttrDef
+{
+    Expr *nameExpr, *valueExpr;
+    PosIdx pos;
+    DynamicAttrDef(std::pmr::polymorphic_allocator<char> & alloc, DynamicAttrDefBuilder const & builder);
+};
+
+struct DynamicAttrDefBuilder
+{
+    Expr *nameExpr;
+    std::variant<Expr *, ExprAttrsBuilder *> valueExpr;
+    PosIdx pos;
+    DynamicAttrDefBuilder(Expr * nameExpr, std::variant<Expr *, ExprAttrsBuilder *> valueExpr, const PosIdx & pos)
+        : nameExpr(nameExpr)
+        , valueExpr(valueExpr)
+        , pos(pos) {};
+};
+
+/**
+ * All of the information for ExprAttrs, but mutable and in a not-optimized layout.
+ */
+struct ExprAttrsBuilder {
+    bool recursive;
+    PosIdx pos;
+    std::map<Symbol, AttrDefBuilder> attrs;
+    std::vector<Expr *> inheritFromExprs;
+    std::vector<DynamicAttrDefBuilder> dynamicAttrs;
+
+    ExprAttrsBuilder(const PosIdx & pos)
+        : recursive(false)
+        , pos(pos) {};
+    ExprAttrsBuilder()
+        : recursive(false) {};
+};
+
 struct ExprAttrs : Expr
 {
     bool recursive;
     PosIdx pos;
 
-    struct AttrDef
+    uint32_t nAttrs;
+    uint16_t nInheritFromExprs;
+    uint16_t nDynamicAttrs;
+    /**
+     * Both the names and values arrays are sorted according to the order of
+     * the *names*.
+     */
+    Symbol * attrNamesStart;
+    AttrDef * attrValuesStart;
+
+    Expr ** inheritFromExprsStart;
+    DynamicAttrDef * dynamicAttrsStart;
+
+    ExprAttrs(std::pmr::polymorphic_allocator<char> & alloc, ExprAttrsBuilder * builder)
+        : recursive(builder->recursive)
+        , pos(builder->pos)
+        , nAttrs(builder->attrs.size())
+        , nInheritFromExprs(builder->inheritFromExprs.size())
+        , nDynamicAttrs(builder->dynamicAttrs.size())
+        , attrNamesStart(alloc.allocate_object<Symbol>(nAttrs))
+        , attrValuesStart(alloc.allocate_object<AttrDef>(nAttrs))
+        , inheritFromExprsStart(alloc.allocate_object<Expr *>(nInheritFromExprs))
+        , dynamicAttrsStart(alloc.allocate_object<DynamicAttrDef>(nDynamicAttrs))
     {
-        enum class Kind {
-            /** `attr = expr;` */
-            Plain,
-            /** `inherit attr1 attrn;` */
-            Inherited,
-            /** `inherit (expr) attr1 attrn;` */
-            InheritedFrom,
-        };
-
-        Kind kind;
-        Expr * e;
-        PosIdx pos;
-        Displacement displ = 0; // displacement
-        AttrDef(Expr * e, const PosIdx & pos, Kind kind = Kind::Plain)
-            : kind(kind)
-            , e(e)
-            , pos(pos) {};
-        AttrDef() {};
-
-        template<typename T>
-        const T & chooseByKind(const T & plain, const T & inherited, const T & inheritedFrom) const
-        {
-            switch (kind) {
-            case Kind::Plain:
-                return plain;
-            case Kind::Inherited:
-                return inherited;
-            default:
-            case Kind::InheritedFrom:
-                return inheritedFrom;
-            }
+        for (auto const & [n, e] : enumerate(builder->attrs)) {
+            auto & [name, value] = e;
+            attrNamesStart[n] = name;
+            attrValuesStart[n] = AttrDef(alloc, value);
         }
-    };
 
-    typedef std::map<Symbol, AttrDef> AttrDefs;
-    AttrDefs attrs;
-    std::unique_ptr<std::vector<Expr *>> inheritFromExprs;
+        std::ranges::copy(builder->inheritFromExprs, inheritFromExprsStart);
 
-    struct DynamicAttrDef
-    {
-        Expr *nameExpr, *valueExpr;
-        PosIdx pos;
-        DynamicAttrDef(Expr * nameExpr, Expr * valueExpr, const PosIdx & pos)
-            : nameExpr(nameExpr)
-            , valueExpr(valueExpr)
-            , pos(pos) {};
-    };
+        for (auto const & [n, dynAttr] : enumerate(builder->dynamicAttrs))
+            dynamicAttrsStart[n] = DynamicAttrDef(alloc, dynAttr);
 
-    typedef std::vector<DynamicAttrDef> DynamicAttrDefs;
-    DynamicAttrDefs dynamicAttrs;
+        delete builder;
+    }
+
+    /**
+     * We can skip the circus if the attrs is empty
+     */
     ExprAttrs(const PosIdx & pos)
         : recursive(false)
-        , pos(pos) {};
+        , pos(pos)
+        , nAttrs(0)
+        , nInheritFromExprs(0)
+        , nDynamicAttrs(0)
+        , attrNamesStart(nullptr)
+        , attrValuesStart(nullptr)
+        , inheritFromExprsStart(nullptr)
+        , dynamicAttrsStart(nullptr)
+    {
+    }
+
     ExprAttrs()
-        : recursive(false) {};
+        : ExprAttrs(noPos)
+    {
+    }
+
 
     PosIdx getPos() const override
     {
         return pos;
+    }
+
+    std::span<Symbol> getAttrNames() const {
+        return {attrNamesStart, nAttrs};
+    }
+
+    std::span<AttrDef> getAttrValues() const {
+        return {attrValuesStart, nAttrs};
+    }
+
+    std::span<Expr *> getInheritFromExprs() const
+    {
+        return {inheritFromExprsStart, nInheritFromExprs};
+    }
+
+    std::span<DynamicAttrDef> getDynamicAttrs() const
+    {
+        return {dynamicAttrsStart, nDynamicAttrs};
+    }
+
+    /**
+     * Association map for looking up a value by name, or iterating over all
+     * (name, value) pairs. This is meant to mimic what std::map can do, but
+     * without the extra overhead necessary to be mutable. The layout does not
+     * need to be optimized as it is created temporarily on-demand
+     */
+    struct AttrDefs {
+        uint32_t nAttrs;
+        Symbol * attrNamesStart;
+        AttrDef * attrValuesStart;
+
+        AttrDef * find(Symbol s)
+        {
+            auto attrNamesEnd = attrNamesStart + nAttrs;
+            auto found = std::lower_bound(attrNamesStart, attrNamesEnd, s);
+
+            if (found == attrNamesEnd || *found != s)
+                return nullptr;
+
+            auto idx = found - attrNamesStart;
+            return &attrValuesStart[idx];
+
+        }
+
+        inline size_t displ(AttrDef * attr)
+        {
+            assert(attrValuesStart <= attr && attr < attrValuesStart + nAttrs);
+
+            return attr - attrValuesStart;
+        }
+
+        size_t size()
+        {
+            return nAttrs;
+        }
+
+        // XXX: help I don't know how to C++ I'm making this up
+        class iterator
+        {
+        friend struct AttrDefs;
+        public:
+            using value_type = std::pair<Symbol, AttrDef>;
+            using pointer_type = std::pair<Symbol *, AttrDef *>;
+            using reference_type = std::pair<Symbol &, AttrDef &>;
+            using difference_type = uint32_t;
+            using iterator_category = std::input_iterator_tag;
+
+        private:
+            uint32_t idx = 0;
+            Symbol * attrNamesStart;
+            AttrDef * attrValuesStart;
+            iterator(uint32_t idx, Symbol * attrNamesStart, AttrDef * attrValuesStart)
+                : idx(idx)
+                , attrNamesStart(attrNamesStart)
+                , attrValuesStart(attrValuesStart)
+            {};
+        public:
+            reference_type operator*() const
+            {
+                return {attrNamesStart[idx], attrValuesStart[idx]};
+            }
+
+            iterator & operator++()
+            {
+                ++idx;
+                return *this;
+            }
+
+            iterator & operator+=(difference_type diff)
+            {
+                idx += diff;
+                return *this;
+            }
+
+            std::strong_ordering operator<=>(const iterator & rhs) const = default;
+        };
+
+        using const_iterator = iterator;
+
+        iterator begin() const &
+        {
+            return {0, attrNamesStart, attrValuesStart};
+        }
+
+        iterator end() const &
+        {
+            return {nAttrs, attrNamesStart, attrValuesStart};
+        }
+    };
+
+    AttrDefs getAttrs() const
+    {
+        return {nAttrs, attrNamesStart, attrValuesStart};
     }
 
     COMMON_METHODS

--- a/src/libexpr/include/nix/expr/parser-state.hh
+++ b/src/libexpr/include/nix/expr/parser-state.hh
@@ -91,8 +91,8 @@ struct ParserState
     void dupAttr(const AttrPath & attrPath, const PosIdx pos, const PosIdx prevPos);
     void dupAttr(Symbol attr, const PosIdx pos, const PosIdx prevPos);
     void addAttr(
-        ExprAttrs * attrs, AttrPath && attrPath, const ParserLocation & loc, Expr * e, const ParserLocation & exprLoc);
-    void addAttr(ExprAttrs * attrs, AttrPath & attrPath, const Symbol & symbol, ExprAttrs::AttrDef && def);
+        ExprAttrsBuilder * attrs, AttrPath && attrPath, const ParserLocation & loc, std::variant<Expr *, ExprAttrsBuilder *> & e, const ParserLocation & exprLoc);
+    void addAttr(ExprAttrsBuilder * attrs, AttrPath & attrPath, const Symbol & symbol, AttrDefBuilder && def);
     Formals * validateFormals(Formals * formals, PosIdx pos = noPos, Symbol arg = {});
     Expr * stripIndentation(const PosIdx pos, std::vector<std::pair<PosIdx, std::variant<Expr *, StringToken>>> && es);
     PosIdx at(const ParserLocation & loc);
@@ -113,7 +113,7 @@ inline void ParserState::dupAttr(Symbol attr, const PosIdx pos, const PosIdx pre
 }
 
 inline void ParserState::addAttr(
-    ExprAttrs * attrs, AttrPath && attrPath, const ParserLocation & loc, Expr * e, const ParserLocation & exprLoc)
+    ExprAttrsBuilder * attrs, AttrPath && attrPath, const ParserLocation & loc, std::variant<Expr *, ExprAttrsBuilder *> & e, const ParserLocation & exprLoc)
 {
     AttrPath::iterator i;
     // All attrpaths have at least one attr
@@ -122,36 +122,41 @@ inline void ParserState::addAttr(
     // Checking attrPath validity.
     // ===========================
     for (i = attrPath.begin(); i + 1 < attrPath.end(); i++) {
-        ExprAttrs * nested;
+        ExprAttrsBuilder * nested;
         if (i->symbol) {
-            ExprAttrs::AttrDefs::iterator j = attrs->attrs.find(i->symbol);
+            decltype(attrs->attrs)::iterator j = attrs->attrs.find(i->symbol);
             if (j != attrs->attrs.end()) {
-                nested = dynamic_cast<ExprAttrs *>(j->second.e);
-                if (!nested) {
-                    attrPath.erase(i + 1, attrPath.end());
-                    dupAttr(attrPath, pos, j->second.pos);
-                }
+                std::visit(overloaded {
+                    [&](ExprAttrsBuilder * builder) { nested = builder; },
+                    [&](Expr * expr) {
+                        attrPath.erase(i + 1, attrPath.end());
+                        dupAttr(attrPath, pos, j->second.pos);
+                    }},
+                j->second.e);
             } else {
-                nested = new ExprAttrs;
-                attrs->attrs[i->symbol] = ExprAttrs::AttrDef(nested, pos);
+                nested = new ExprAttrsBuilder;
+                attrs->attrs[i->symbol] = AttrDefBuilder(nested, pos);
             }
         } else {
-            nested = new ExprAttrs;
-            attrs->dynamicAttrs.push_back(ExprAttrs::DynamicAttrDef(i->expr, nested, pos));
+            nested = new ExprAttrsBuilder;
+            attrs->dynamicAttrs.push_back(DynamicAttrDefBuilder(i->expr, nested, pos));
         }
         attrs = nested;
     }
     // Expr insertion.
     // ==========================
     if (i->symbol) {
-        addAttr(attrs, attrPath, i->symbol, ExprAttrs::AttrDef(e, pos));
+        addAttr(attrs, attrPath, i->symbol, AttrDefBuilder(e, pos));
     } else {
-        attrs->dynamicAttrs.push_back(ExprAttrs::DynamicAttrDef(i->expr, e, pos));
+        attrs->dynamicAttrs.push_back(DynamicAttrDefBuilder(i->expr, e, pos));
     }
 
     auto it = lexerState.positionToDocComment.find(pos);
     if (it != lexerState.positionToDocComment.end()) {
-        e->setDocComment(it->second);
+        std::visit(overloaded {
+            [&](Expr * e) { e->setDocComment(it->second); },
+            [](ExprAttrsBuilder * e) {}},
+        e);
         lexerState.positionToDocComment.emplace(at(exprLoc), it->second);
     }
 }
@@ -161,30 +166,30 @@ inline void ParserState::addAttr(
  * symbol as its last element.
  */
 inline void
-ParserState::addAttr(ExprAttrs * attrs, AttrPath & attrPath, const Symbol & symbol, ExprAttrs::AttrDef && def)
+ParserState::addAttr(ExprAttrsBuilder * attrs, AttrPath & attrPath, const Symbol & symbol, AttrDefBuilder && def)
 {
-    ExprAttrs::AttrDefs::iterator j = attrs->attrs.find(symbol);
+    decltype(attrs->attrs)::iterator j = attrs->attrs.find(symbol);
     if (j != attrs->attrs.end()) {
         // This attr path is already defined. However, if both
         // e and the expr pointed by the attr path are two attribute sets,
         // we want to merge them.
         // Otherwise, throw an error.
-        auto ae = dynamic_cast<ExprAttrs *>(def.e);
-        auto jAttrs = dynamic_cast<ExprAttrs *>(j->second.e);
+        auto ae_ = std::get_if<ExprAttrsBuilder *>(&def.e);
+        auto jAttrs_ = std::get_if<ExprAttrsBuilder *>(&j->second.e);
 
         // N.B. In a world in which we are less bound by our past mistakes, we
         // would also test that jAttrs and ae are not recursive. The effect of
         // not doing so is that any `rec` marker on ae is discarded, and any
         // `rec` marker on jAttrs will apply to the attributes in ae.
         // See https://github.com/NixOS/nix/issues/9020.
-        if (jAttrs && ae) {
-            if (ae->inheritFromExprs && !jAttrs->inheritFromExprs)
-                jAttrs->inheritFromExprs = std::make_unique<std::vector<Expr *>>();
+        if (jAttrs_ && ae_) {
+            ExprAttrsBuilder * ae = *ae_;
+            ExprAttrsBuilder * jAttrs = *jAttrs_;
             for (auto & ad : ae->attrs) {
-                if (ad.second.kind == ExprAttrs::AttrDef::Kind::InheritedFrom) {
-                    auto & sel = dynamic_cast<ExprSelect &>(*ad.second.e);
+                if (ad.second.kind == AttrDef::Kind::InheritedFrom) {
+                    auto & sel = dynamic_cast<ExprSelect &>(*std::get<Expr *>(ad.second.e));
                     auto & from = dynamic_cast<ExprInheritFrom &>(*sel.e);
-                    from.displ += jAttrs->inheritFromExprs->size();
+                    from.displ += jAttrs->inheritFromExprs.size();
                 }
                 attrPath.emplace_back(AttrName(ad.first));
                 addAttr(jAttrs, attrPath, ad.first, std::move(ad.second));
@@ -196,20 +201,23 @@ ParserState::addAttr(ExprAttrs * attrs, AttrPath & attrPath, const Symbol & symb
                 std::make_move_iterator(ae->dynamicAttrs.begin()),
                 std::make_move_iterator(ae->dynamicAttrs.end()));
             ae->dynamicAttrs.clear();
-            if (ae->inheritFromExprs) {
-                jAttrs->inheritFromExprs->insert(
-                    jAttrs->inheritFromExprs->end(),
-                    std::make_move_iterator(ae->inheritFromExprs->begin()),
-                    std::make_move_iterator(ae->inheritFromExprs->end()));
-                ae->inheritFromExprs = nullptr;
+            if (!ae->inheritFromExprs.empty()) {
+                jAttrs->inheritFromExprs.insert(
+                    jAttrs->inheritFromExprs.end(),
+                    std::make_move_iterator(ae->inheritFromExprs.begin()),
+                    std::make_move_iterator(ae->inheritFromExprs.end()));
             }
+            delete(ae);
         } else {
             dupAttr(attrPath, def.pos, j->second.pos);
         }
     } else {
         // This attr path is not defined. Let's create it.
         attrs->attrs.emplace(symbol, def);
-        def.e->setName(symbol);
+        std::visit(overloaded {
+            [&](Expr * e) { e->setName(symbol); },
+            [](ExprAttrsBuilder * e) {}},
+        def.e);
     }
 }
 

--- a/src/libexpr/nixexpr.cc
+++ b/src/libexpr/nixexpr.cc
@@ -14,6 +14,24 @@ namespace nix {
 Counter Expr::nrExprs;
 
 ExprBlackHole eBlackHole;
+AttrDef::AttrDef(std::pmr::polymorphic_allocator<char> & alloc, AttrDefBuilder const & builder)
+    : kind(builder.kind)
+    , pos(builder.pos)
+{
+    std::visit(overloaded {
+        [&](Expr * expr) { e = expr; },
+        [&](ExprAttrsBuilder * attrs_builder) { e = new ExprAttrs(alloc, attrs_builder); }},
+    builder.e);
+}
+DynamicAttrDef::DynamicAttrDef(std::pmr::polymorphic_allocator<char> & alloc, DynamicAttrDefBuilder const & builder)
+    : nameExpr(builder.nameExpr)
+    , pos(builder.pos)
+{
+    std::visit(overloaded {
+        [&](Expr * expr) { valueExpr = expr; },
+        [&](ExprAttrsBuilder * attrs_builder) { valueExpr = new ExprAttrs(alloc, attrs_builder); }},
+    builder.valueExpr);
+}
 
 // FIXME: remove, because *symbols* are abstract and do not have a single
 //        textual representation; see printIdentifier()
@@ -74,12 +92,12 @@ void ExprOpHasAttr::show(const SymbolTable & symbols, std::ostream & str) const
 
 void ExprAttrs::showBindings(const SymbolTable & symbols, std::ostream & str) const
 {
-    typedef const decltype(attrs)::value_type * Attr;
+    typedef std::pair<Symbol, AttrDef> Attr;
     std::vector<Attr> sorted;
-    for (auto & i : attrs)
-        sorted.push_back(&i);
+    for (auto const & i : getAttrs())
+        sorted.push_back(i);
     std::sort(sorted.begin(), sorted.end(), [&](Attr a, Attr b) {
-        std::string_view sa = symbols[a->first], sb = symbols[b->first];
+        std::string_view sa = symbols[a.first], sb = symbols[b.first];
         return sa < sb;
     });
     std::vector<Symbol> inherits;
@@ -87,16 +105,16 @@ void ExprAttrs::showBindings(const SymbolTable & symbols, std::ostream & str) co
     // The assignment of displacements should be deterministic, so that showBindings is deterministic.
     std::map<Displacement, std::vector<Symbol>> inheritsFrom;
     for (auto & i : sorted) {
-        switch (i->second.kind) {
+        switch (i.second.kind) {
         case AttrDef::Kind::Plain:
             break;
         case AttrDef::Kind::Inherited:
-            inherits.push_back(i->first);
+            inherits.push_back(i.first);
             break;
         case AttrDef::Kind::InheritedFrom: {
-            auto & select = dynamic_cast<ExprSelect &>(*i->second.e);
+            auto & select = dynamic_cast<ExprSelect &>(*i.second.e);
             auto & from = dynamic_cast<ExprInheritFrom &>(*select.e);
-            inheritsFrom[from.displ].push_back(i->first);
+            inheritsFrom[from.displ].push_back(i.first);
             break;
         }
         }
@@ -109,20 +127,20 @@ void ExprAttrs::showBindings(const SymbolTable & symbols, std::ostream & str) co
     }
     for (const auto & [from, syms] : inheritsFrom) {
         str << "inherit (";
-        (*inheritFromExprs)[from]->show(symbols, str);
+        getInheritFromExprs()[from]->show(symbols, str);
         str << ")";
         for (auto sym : syms)
             str << " " << symbols[sym];
         str << "; ";
     }
     for (auto & i : sorted) {
-        if (i->second.kind == AttrDef::Kind::Plain) {
-            str << symbols[i->first] << " = ";
-            i->second.e->show(symbols, str);
+        if (i.second.kind == AttrDef::Kind::Plain) {
+            str << symbols[i.first] << " = ";
+            i.second.e->show(symbols, str);
             str << "; ";
         }
     }
-    for (auto & i : dynamicAttrs) {
+    for (auto & i : getDynamicAttrs()) {
         str << "\"${";
         i.nameExpr->show(symbols, str);
         str << "}\" = ";
@@ -381,7 +399,9 @@ void ExprOpHasAttr::bindVars(EvalState & es, const std::shared_ptr<const StaticE
 std::shared_ptr<const StaticEnv>
 ExprAttrs::bindInheritSources(EvalState & es, const std::shared_ptr<const StaticEnv> & env)
 {
-    if (!inheritFromExprs)
+    auto inheritFromExprs = getInheritFromExprs();
+
+    if (inheritFromExprs.empty())
         return nullptr;
 
     // the inherit (from) source values are inserted into an env of its own, which
@@ -393,7 +413,7 @@ ExprAttrs::bindInheritSources(EvalState & es, const std::shared_ptr<const Static
     // not even *have* an expr that grabs anything from this env since it's fully
     // invisible, but the evaluator does not allow for this yet.
     auto inner = std::make_shared<StaticEnv>(nullptr, env, 0);
-    for (auto from : *inheritFromExprs)
+    for (auto from : inheritFromExprs)
         from->bindVars(es, env);
 
     return inner;
@@ -401,36 +421,38 @@ ExprAttrs::bindInheritSources(EvalState & es, const std::shared_ptr<const Static
 
 void ExprAttrs::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env)
 {
+    auto attrs = getAttrs();
+
     if (es.debugRepl)
         es.exprEnvs.insert(std::make_pair(this, env));
 
     if (recursive) {
         auto newEnv = [&]() -> std::shared_ptr<const StaticEnv> {
-            auto newEnv = std::make_shared<StaticEnv>(nullptr, env, attrs.size());
+            auto newEnv = std::make_shared<StaticEnv>(nullptr, env, nAttrs);
 
             Displacement displ = 0;
-            for (auto & i : attrs)
-                newEnv->vars.emplace_back(i.first, i.second.displ = displ++);
+            for (auto const & i : attrs)
+                newEnv->vars.emplace_back(i.first, displ++);
             return newEnv;
         }();
 
         // No need to sort newEnv since attrs is in sorted order.
 
         auto inheritFromEnv = bindInheritSources(es, newEnv);
-        for (auto & i : attrs)
+        for (auto const & i : attrs)
             i.second.e->bindVars(es, i.second.chooseByKind(newEnv, env, inheritFromEnv));
 
-        for (auto & i : dynamicAttrs) {
+        for (auto i : getDynamicAttrs()) {
             i.nameExpr->bindVars(es, newEnv);
             i.valueExpr->bindVars(es, newEnv);
         }
     } else {
         auto inheritFromEnv = bindInheritSources(es, env);
 
-        for (auto & i : attrs)
+        for (auto const & i : attrs)
             i.second.e->bindVars(es, i.second.chooseByKind(env, env, inheritFromEnv));
 
-        for (auto & i : dynamicAttrs) {
+        for (auto i : getDynamicAttrs()) {
             i.nameExpr->bindVars(es, env);
             i.valueExpr->bindVars(es, env);
         }
@@ -486,18 +508,18 @@ void ExprCall::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> &
 void ExprLet::bindVars(EvalState & es, const std::shared_ptr<const StaticEnv> & env)
 {
     auto newEnv = [&]() -> std::shared_ptr<const StaticEnv> {
-        auto newEnv = std::make_shared<StaticEnv>(nullptr, env, attrs->attrs.size());
+        auto newEnv = std::make_shared<StaticEnv>(nullptr, env, attrs->nAttrs);
 
         Displacement displ = 0;
-        for (auto & i : attrs->attrs)
-            newEnv->vars.emplace_back(i.first, i.second.displ = displ++);
+        for (auto const & i : attrs->getAttrs())
+            newEnv->vars.emplace_back(i.first, displ++);
         return newEnv;
     }();
 
     // No need to sort newEnv since attrs->attrs is in sorted order.
 
     auto inheritFromEnv = attrs->bindInheritSources(es, newEnv);
-    for (auto & i : attrs->attrs)
+    for (auto const & i : attrs->getAttrs())
         i.second.e->bindVars(es, i.second.chooseByKind(newEnv, env, inheritFromEnv));
 
     if (es.debugRepl)

--- a/tests/functional/lang/parse-fail-utf8.err.exp
+++ b/tests/functional/lang/parse-fail-utf8.err.exp
@@ -1,4 +1,4 @@
-error: syntax error, unexpected invalid token, expecting end of file
+error: syntax error, unexpected invalid token
        at «stdin»:1:5:
             1| 123 é 4
              |     ^


### PR DESCRIPTION
:warning: not to be merged until all the XXX comments are dealt with
- Someone please help me write a proper C++ iterator I'm so lost
- I'm not sure what the tradeoff is between finalizing `ExprAttrs` as they're created and finalizing them all after parsing when we crawl the AST for `bindVars()`.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

For big-picture motivation, see [the tracking issue](https://github.com/NixOS/nix/issues/14088)

This PR moves the data in `ExprAttrs` nodes into the bump allocator, allowing us to store only immutable data and thereby save space. In the case of `ExprAttrs`, this is more involved because they can be nested within each other, and the inner ones must remain mutable until the outermost one is complete. e.g.
```
{
  a = { b = 3;};
  a = { c = 4;};
}
```
We add `c = 4;` into the first `a` attrset while we're parsing.

This PR saves 40 bytes per `ExprAttrs`
- `std::map` (48 bytes) becomes two pointers and a `uint32_t` length (20 bytes)
- `std::vector` (24 bytes) becomes a pointer and a `uint16_t` length (10 bytes)
- `std::unique_ptr<std::vector>` (8 bytes) becomes a pointer and a `uint16_t` length (10 bytes)

- saves an additional 24 bytes for the `std::vector` contained within the `std::unique_ptr` when it's non-null

This PR also removes the `Displacement` field of `AttrDef`. It's now cheap (O(1)) to calculate on the spot when we need it, which saves us 8 bytes per AttrDef. (4 bytes for the field, 4 bytes for padding)
This is ~1% of memory on its own

We also save when we trim the excess capacity off the ends of vectors and maps when we make them immutable

All told this saves us ~3.7% of memory usage

## Alternative design

Rather than finalizing each `ExprAttrs` as they're created, we could leave them as `ExprAttrsBuilder` until the `bindVars()` step, and then while we're crawling the AST for that, also finalize `ExprAttrs`

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
