### PR TITLE
dev-shell: Disable separateDebugInfo

### DIFF
--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -70,6 +70,9 @@ pkgs.nixComponents2.nix-util.overrideAttrs (
 
     # We use this shell with the local checkout, not unpackPhase.
     src = null;
+    # Workaround https://sourceware.org/pipermail/gdb-patches/2025-October/221398.html
+    # Remove when gdb fix is rolled out everywhere.
+    separateDebugInfo = false;
 
     env = {
       # For `make format`, to work without installing pre-commit
@@ -93,38 +96,44 @@ pkgs.nixComponents2.nix-util.overrideAttrs (
       ++ map (transformFlag "libcmd") (ignoreCrossFile pkgs.nixComponents2.nix-cmd.mesonFlags);
 
     nativeBuildInputs =
-      attrs.nativeBuildInputs or [ ]
-      ++ pkgs.nixComponents2.nix-util.nativeBuildInputs
-      ++ pkgs.nixComponents2.nix-store.nativeBuildInputs
-      ++ pkgs.nixComponents2.nix-fetchers.nativeBuildInputs
-      ++ pkgs.nixComponents2.nix-expr.nativeBuildInputs
-      ++ lib.optionals havePerl pkgs.nixComponents2.nix-perl-bindings.nativeBuildInputs
-      ++ lib.optionals buildCanExecuteHost pkgs.nixComponents2.nix-manual.externalNativeBuildInputs
-      ++ pkgs.nixComponents2.nix-internal-api-docs.nativeBuildInputs
-      ++ pkgs.nixComponents2.nix-external-api-docs.nativeBuildInputs
-      ++ pkgs.nixComponents2.nix-functional-tests.externalNativeBuildInputs
-      ++ lib.optional (
-        !buildCanExecuteHost
-        # Hack around https://github.com/nixos/nixpkgs/commit/bf7ad8cfbfa102a90463433e2c5027573b462479
-        && !(stdenv.hostPlatform.isWindows && stdenv.buildPlatform.isDarwin)
-        && stdenv.hostPlatform.emulatorAvailable pkgs.buildPackages
-        && lib.meta.availableOn stdenv.buildPlatform (stdenv.hostPlatform.emulator pkgs.buildPackages)
-      ) pkgs.buildPackages.mesonEmulatorHook
-      ++ [
-        pkgs.buildPackages.cmake
-        pkgs.buildPackages.gnused
-        pkgs.buildPackages.shellcheck
-        pkgs.buildPackages.changelog-d
-        modular.pre-commit.settings.package
-        (pkgs.writeScriptBin "pre-commit-hooks-install" modular.pre-commit.settings.installationScript)
-        pkgs.buildPackages.nixfmt-rfc-style
-        pkgs.buildPackages.shellcheck
-        pkgs.buildPackages.gdb
-      ]
-      ++ lib.optional (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) (
-        lib.hiPrio pkgs.buildPackages.clang-tools
-      )
-      ++ lib.optional stdenv.hostPlatform.isLinux pkgs.buildPackages.mold-wrapped;
+      let
+        inputs =
+          attrs.nativeBuildInputs or [ ]
+          ++ pkgs.nixComponents2.nix-util.nativeBuildInputs
+          ++ pkgs.nixComponents2.nix-store.nativeBuildInputs
+          ++ pkgs.nixComponents2.nix-fetchers.nativeBuildInputs
+          ++ pkgs.nixComponents2.nix-expr.nativeBuildInputs
+          ++ lib.optionals havePerl pkgs.nixComponents2.nix-perl-bindings.nativeBuildInputs
+          ++ lib.optionals buildCanExecuteHost pkgs.nixComponents2.nix-manual.externalNativeBuildInputs
+          ++ pkgs.nixComponents2.nix-internal-api-docs.nativeBuildInputs
+          ++ pkgs.nixComponents2.nix-external-api-docs.nativeBuildInputs
+          ++ pkgs.nixComponents2.nix-functional-tests.externalNativeBuildInputs
+          ++ lib.optional (
+            !buildCanExecuteHost
+            # Hack around https://github.com/nixos/nixpkgs/commit/bf7ad8cfbfa102a90463433e2c5027573b462479
+            && !(stdenv.hostPlatform.isWindows && stdenv.buildPlatform.isDarwin)
+            && stdenv.hostPlatform.emulatorAvailable pkgs.buildPackages
+            && lib.meta.availableOn stdenv.buildPlatform (stdenv.hostPlatform.emulator pkgs.buildPackages)
+          ) pkgs.buildPackages.mesonEmulatorHook
+          ++ [
+            pkgs.buildPackages.cmake
+            pkgs.buildPackages.gnused
+            pkgs.buildPackages.shellcheck
+            pkgs.buildPackages.changelog-d
+            modular.pre-commit.settings.package
+            (pkgs.writeScriptBin "pre-commit-hooks-install" modular.pre-commit.settings.installationScript)
+            pkgs.buildPackages.nixfmt-rfc-style
+            pkgs.buildPackages.shellcheck
+            pkgs.buildPackages.gdb
+          ]
+          ++ lib.optional (stdenv.cc.isClang && stdenv.hostPlatform == stdenv.buildPlatform) (
+            lib.hiPrio pkgs.buildPackages.clang-tools
+          )
+          ++ lib.optional stdenv.hostPlatform.isLinux pkgs.buildPackages.mold-wrapped;
+      in
+      # FIXME: separateDebugInfo = false doesn't actually prevent -Wa,--compress-debug-sections
+      # from making its way into NIX_CFLAGS_COMPILE.
+      lib.filter (p: !lib.hasInfix "separate-debug-info" p) inputs;
 
     buildInputs = [
       pkgs.gbenchmark


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This breaks gdb pretty-printers inserted into .debug_gdb_scripts section, because it implies --compress-debug-sections=zlib, -Wa,--compress-debug-sections. This is very unfortunate, because then gdb can't use pretty printers for Boost.Unordered (which are very useful, since boost::unoredred_flat_map is impossible to debug). This seems perfectly fine to disable in the dev-shell for the time being.

See [1], [2], [3] for further references.

With this change I'm able to use boost's pretty-printers out-of-the box:

```
p *importResolutionCache
$2 = boost::concurrent_flat_map with 1 elements = {[{accessor = {p = std::shared_ptr<nix::SourceAccessor> (use count 5, weak count 1) = {
        get() = 0x555555d830a8}}, path = {static root = {static root = <same as static member of an already seen type>, path = "/"},
      path = "/derivation-internal.nix"}}] = {accessor = {p = std::shared_ptr<nix::SourceAccessor> (use count 5, weak count 1) = {
        get() = 0x555555d830a8}}, path = {static root = {static root = <same as static member of an already seen type>, path = "/"},
      path = "/derivation-internal.nix"}}}
```

When combined with a simple `add-auto-load-safe-path ~/code` in .gdbinit

[1]: https://gerrit.lix.systems/c/lix/+/3880
[2]: https://git.lix.systems/lix-project/lix/issues/1003
[3]: https://sourceware.org/pipermail/gdb-patches/2025-October/221398.html

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
