### PR TITLE
exportReferencesGraph: Handle heterogeneous arrays

### DIFF
--- a/tests/functional/structured-attrs.nix
+++ b/tests/functional/structured-attrs.nix
@@ -82,4 +82,8 @@ mkDerivation {
   "foo$" = "BAD";
 
   exportReferencesGraph.refs = [ dep ];
+  exportReferencesGraph.refs2 = [
+    dep
+    [ dep ]
+  ]; # regression test for heterogeneous arrays
 }

--- a/tests/functional/structured-attrs.sh
+++ b/tests/functional/structured-attrs.sh
@@ -2,9 +2,8 @@
 
 source common.sh
 
-# 27ce722638 required some incompatible changes to the nix file, so skip this
-# tests for the older versions
-requireDaemonNewerThan "2.4pre20210712"
+# https://github.com/NixOS/nix/pull/14189
+requireDaemonNewerThan "2.33"
 
 clearStoreIfPossible
 


### PR DESCRIPTION


<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This barfed with

```
error: [json.exception.type_error.302] type must be string, but is array
```

on `nix build github:malt3/bazel-env#bazel-env` because it has a `exportReferencesGraph` with a value like `["string",...["string"]]`.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
