### PR TITLE
feat(libstore/filetransfer): add username/password authentication support

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -426,6 +426,14 @@ struct curlFileTransfer : public FileTransfer
             curl_easy_setopt(req, CURLOPT_ERRORBUFFER, errbuf);
             errbuf[0] = 0;
 
+            // Set up username/password authentication if provided
+            if (request.usernameAuth) {
+                curl_easy_setopt(req, CURLOPT_USERNAME, request.usernameAuth->username.c_str());
+                if (request.usernameAuth->password) {
+                    curl_easy_setopt(req, CURLOPT_PASSWORD, request.usernameAuth->password->c_str());
+                }
+            }
+
             result.data.clear();
             result.bodySize = 0;
         }

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -77,6 +77,17 @@ extern FileTransferSettings fileTransferSettings;
 
 extern const unsigned int RETRY_TIME_MS_DEFAULT;
 
+/**
+ * Username and optional password for HTTP basic authentication.
+ * These are used with curl's CURLOPT_USERNAME and CURLOPT_PASSWORD options
+ * for various protocols including HTTP, FTP, and others.
+ */
+struct UsernameAuth
+{
+    std::string username;
+    std::optional<std::string> password;
+};
+
 struct FileTransferRequest
 {
     ValidURL uri;
@@ -92,6 +103,11 @@ struct FileTransferRequest
     std::optional<std::string> data;
     std::string mimeType;
     std::function<void(std::string_view data)> dataCallback;
+    /**
+     * Optional username and password for HTTP basic authentication.
+     * When provided, these credentials will be used with curl's CURLOPT_USERNAME/PASSWORD option.
+     */
+    std::optional<UsernameAuth> usernameAuth;
 
     FileTransferRequest(ValidURL uri)
         : uri(std::move(uri))


### PR DESCRIPTION
## Motivation

Add a `UsernameAuth` struct and optional `usernameAuth` field to
`FileTransferRequest` to support programmatic username/password
authentication.

This uses curl's `CURLOPT_USERNAME`/`CURLOPT_PASSWORD` options, which
works with multiple protocols (HTTP, FTP, etc.) and is not specific to
any particular authentication scheme.

The primary motivation is to enable S3 authentication refactoring where
AWS credentials (access key ID and secret access key) can be passed
through this general-purpose mechanism, reducing the amount of
S3-specific code behind `#if NIX_WITH_CURL_S3` guards.

## Context

This is a carve-out #14170 which is a carve-out of #13752

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
