### PR TITLE
libutil: Fix renderAuthorityAndPath unreachable for path:/ URLs

### DIFF
--- a/src/libutil-tests/url.cc
+++ b/src/libutil-tests/url.cc
@@ -868,6 +868,12 @@ TEST_P(ParsedURLPathSegmentsTest, segmentsAreCorrect)
     EXPECT_EQ(encodeUrlPath(segments), testCase.path);
 }
 
+TEST_P(ParsedURLPathSegmentsTest, to_string)
+{
+    const auto & testCase = GetParam();
+    EXPECT_EQ(testCase.url, parseURL(testCase.url).to_string());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ParsedURL,
     ParsedURLPathSegmentsTest,
@@ -885,6 +891,13 @@ INSTANTIATE_TEST_SUITE_P(
             .path = "",
             .skipEmpty = false,
             .description = "empty_authority_empty_path",
+        },
+        ParsedURLPathSegmentsTestCase{
+            .url = "path:/",
+            .segments = {"", ""},
+            .path = "/",
+            .skipEmpty = false,
+            .description = "empty_authority_root_path",
         },
         ParsedURLPathSegmentsTestCase{
             .url = "scheme:///",

--- a/src/libutil/url.cc
+++ b/src/libutil/url.cc
@@ -350,7 +350,7 @@ std::string ParsedURL::renderAuthorityAndPath() const
            must either be empty or begin with a slash ("/") character. */
         assert(path.empty() || path.front().empty());
         res += authority->to_string();
-    } else if (std::ranges::equal(std::views::take(path, 2), std::views::repeat("", 2))) {
+    } else if (std::ranges::equal(std::views::take(path, 3), std::views::repeat("", 3))) {
         /* If a URI does not contain an authority component, then the path cannot begin
            with two slash characters ("//") */
         unreachable();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This was mistakenly triggered by path:/ URL, since the `//` would correspond to 3 empty segments.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

Fixes https://github.com/NixOS/nix/issues/14188.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
