### PR TITLE
libutil: Print stack trace on assertion failure

### DIFF
--- a/nix-meson-build-support/common/assert-fail/meson.build
+++ b/nix-meson-build-support/common/assert-fail/meson.build
@@ -1,0 +1,32 @@
+can_wrap_assert_fail_test_code = '''
+#include <cstdlib>
+#include <cassert>
+
+int main()
+{
+    assert(0);
+}
+
+extern "C" void * __real___assert_fail(const char *, const char *, unsigned int, const char *);
+
+extern "C" void *
+__wrap___assert_fail(const char *, const char *, unsigned int, const char *)
+{
+    return __real___assert_fail(nullptr, nullptr, 0, nullptr);
+}
+'''
+
+wrap_assert_fail_args = [ '-Wl,--wrap=__assert_fail' ]
+
+can_wrap_assert_fail = cxx.links(
+  can_wrap_assert_fail_test_code,
+  args : wrap_assert_fail_args,
+  name : 'linker can wrap __assert_fail',
+)
+
+if can_wrap_assert_fail
+  deps_other += declare_dependency(
+    sources : 'wrap-assert-fail.cc',
+    link_args : wrap_assert_fail_args,
+  )
+endif

--- a/nix-meson-build-support/common/assert-fail/wrap-assert-fail.cc
+++ b/nix-meson-build-support/common/assert-fail/wrap-assert-fail.cc
@@ -1,0 +1,17 @@
+#include "nix/util/error.hh"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cinttypes>
+#include <string_view>
+
+extern "C" [[noreturn]] void __attribute__((weak))
+__wrap___assert_fail(const char * assertion, const char * file, unsigned int line, const char * function)
+{
+    char buf[512];
+    int n =
+        snprintf(buf, sizeof(buf), "Assertion '%s' failed in %s at %s:%" PRIuLEAST32, assertion, function, file, line);
+    if (n < 0)
+        nix::panic("Assertion failed and could not format error message");
+    nix::panic(std::string_view(buf, std::min(static_cast<int>(sizeof(buf)), n)));
+}

--- a/nix-meson-build-support/common/meson.build
+++ b/nix-meson-build-support/common/meson.build
@@ -44,3 +44,5 @@ endif
 
 # Darwin ld doesn't like "X.Y.Zpre"
 nix_soversion = meson.project_version().split('pre')[0]
+
+subdir('assert-fail')


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This change overrides `__assert_fail` on glibc/musl
to instead call std::terminate that we have a custom handler for. This ensures that we have more context to diagnose issues encountered by users in the wild.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
