### PR TITLE
packaging: only override `toml11` when necessary

### DIFF
--- a/packaging/dependencies.nix
+++ b/packaging/dependencies.nix
@@ -57,15 +57,20 @@ scope: {
         prevAttrs.postInstall;
   });
 
-  toml11 = pkgs.toml11.overrideAttrs rec {
-    version = "4.4.0";
-    src = pkgs.fetchFromGitHub {
-      owner = "ToruNiina";
-      repo = "toml11";
-      tag = "v${version}";
-      hash = "sha256-sgWKYxNT22nw376ttGsTdg0AMzOwp8QH3E8mx0BZJTQ=";
-    };
-  };
+  # TODO: Remove this when https://github.com/NixOS/nixpkgs/pull/442682 is included in a stable release
+  toml11 =
+    if lib.versionAtLeast pkgs.toml11.version "4.4.0" then
+      pkgs.toml11
+    else
+      pkgs.toml11.overrideAttrs rec {
+        version = "4.4.0";
+        src = pkgs.fetchFromGitHub {
+          owner = "ToruNiina";
+          repo = "toml11";
+          tag = "v${version}";
+          hash = "sha256-sgWKYxNT22nw376ttGsTdg0AMzOwp8QH3E8mx0BZJTQ=";
+        };
+      };
 
   # TODO Hack until https://github.com/NixOS/nixpkgs/issues/45462 is fixed.
   boost =


### PR DESCRIPTION
## Motivation

v4.4.0 hit Nixpkgs in https://github.com/NixOS/nixpkgs/pull/442682.
Ideally we'd just use that, but this keeps the fallback behavior until
it's more widespread

This also fixes a build failure of this flake against a recent `nixos-unstable` (https://github.com/NixOS/nixpkgs/commit/c9b6fb798541223bbb396d287d16f43520250518 for example), which is caused by `toml11` now requiring submodules in its source after the above bump (which we overrideAttrs away here)

## Context

- Fix for the mentioned submodule requirement: https://github.com/NixOS/nixpkgs/pull/450200

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
