### PR TITLE
Improved backwards compatibility hack for git URLs using dir=...

### DIFF
--- a/src/libfetchers/git.cc
+++ b/src/libfetchers/git.cc
@@ -523,7 +523,7 @@ struct GitInputScheme : InputScheme
                However, new versions of nix parsing old flake.lock files would pass the dir=
                query parameter in the "url" attribute to git, which will then complain.
 
-               For this reason, we filtering the `dir` query parameter from the URL
+               For this reason, we are filtering the `dir` query parameter from the URL
                before passing it to git. */
             url.query.erase("dir");
             repoInfo.location = url;


### PR DESCRIPTION
## Motivation

In old versions of Nix, if you had a flake input like

```
inputs.foo.url = "git+https://foo/bar?dir=subdir";
```

it would result in a lock file entry like

```
 "original": {
   "dir": "subdir",
   "type": "git",
   "url": "https://foo/bar?dir=subdir"
 }
```

New versions of Nix remove `?dir=subdir` from the `url` field, since the subdirectory is intended for `FlakeRef`, not the fetcher (and specifically the remote server), that is, the flakeref is parsed into

```
 "original": {
   "dir": "subdir",
   "type": "git",
   "url": "https://foo/bar"
 }
```

However, new versions of nix parsing old flake.lock files would pass the dir= query parameter in the "url" attribute to git, which will then complain.

Some mitigations for this issue were added before:
* https://github.com/NixOS/nix/commit/9f72d5bce9205c9f45dcb0e06b9573ccca5724ac cleared all query attributes from file-scheme git URLs, but didn't touch other schemes (e.g. https or ssh). This PR removes the `dir` query parameter from all git URLs.
* https://github.com/NixOS/nix/commit/d00682beb2fc0ba62fb87752ba429cc0f4c4345e ensured that newer nix versions wouldn't consider flake.lock files out-of-date that had these unnecessary dir=... attributes


## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
