### PR TITLE
feat(libstore): add builtin fetchurl S3 credential pre-resolution

### DIFF
--- a/src/libstore/builtins/fetchurl.cc
+++ b/src/libstore/builtins/fetchurl.cc
@@ -33,12 +33,25 @@ static void builtinFetchurl(const BuiltinBuilderContext & ctx)
 
     /* Note: have to use a fresh fileTransfer here because we're in
        a forked process. */
+    debug("[pid=%d] builtin:fetchurl creating fresh FileTransfer instance", getpid());
     auto fileTransfer = makeFileTransfer();
 
     auto fetch = [&](const std::string & url) {
         auto source = sinkToSource([&](Sink & sink) {
             FileTransferRequest request(ValidURL{url});
             request.decompress = false;
+
+#if NIX_WITH_CURL_S3
+            // Use pre-resolved credentials if available
+            if (ctx.awsCredentials && request.uri.scheme() == "s3") {
+                debug("[pid=%d] Using pre-resolved AWS credentials from parent process", getpid());
+                request.usernameAuth = UsernameAuth{
+                    .username = ctx.awsCredentials->accessKeyId,
+                    .password = ctx.awsCredentials->secretAccessKey,
+                };
+                request.preResolvedAwsSessionToken = ctx.awsCredentials->sessionToken;
+            }
+#endif
 
             auto decompressor = makeDecompressionSink(unpack && hasSuffix(mainUrl, ".xz") ? "xz" : "none", sink);
             fileTransfer->download(std::move(request), *decompressor);

--- a/src/libstore/include/nix/store/builtins.hh
+++ b/src/libstore/include/nix/store/builtins.hh
@@ -2,6 +2,11 @@
 ///@file
 
 #include "nix/store/derivations.hh"
+#include "nix/store/config.hh"
+
+#if NIX_WITH_CURL_S3
+#  include "nix/store/aws-creds.hh"
+#endif
 
 namespace nix {
 
@@ -12,6 +17,14 @@ struct BuiltinBuilderContext
     std::string netrcData;
     std::string caFileData;
     Path tmpDirInSandbox;
+
+#if NIX_WITH_CURL_S3
+    /**
+     * Pre-resolved AWS credentials for S3 URLs in builtin:fetchurl.
+     * When present, these should be used instead of creating new credential providers.
+     */
+    std::optional<AwsCredentials> awsCredentials;
+#endif
 };
 
 using BuiltinBuilder = std::function<void(const BuiltinBuilderContext &)>;

--- a/src/libstore/unix/build/linux-derivation-builder.cc
+++ b/src/libstore/unix/build/linux-derivation-builder.cc
@@ -276,6 +276,12 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
 
     void startChild() override
     {
+        RunChildArgs args{
+#  if NIX_WITH_CURL_S3
+            .awsCredentials = preResolveAwsCredentials(),
+#  endif
+        };
+
         /* Set up private namespaces for the build:
 
            - The PID namespace causes the build to start as PID 1.
@@ -343,7 +349,7 @@ struct ChrootLinuxDerivationBuilder : ChrootDerivationBuilder, LinuxDerivationBu
                 if (usingUserNamespace)
                     options.cloneFlags |= CLONE_NEWUSER;
 
-                pid_t child = startProcess([&]() { runChild(); }, options);
+                pid_t child = startProcess([this, args = std::move(args)]() { runChild(std::move(args)); }, options);
 
                 writeFull(sendPid.writeSide.get(), fmt("%d\n", child));
                 _exit(0);


### PR DESCRIPTION
## Motivation

Add support for pre-resolving AWS credentials in the parent process
before forking for builtin:fetchurl. This avoids recreating credential
providers in the forked child process.

## Context

Carve out of #13752

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
