### PR TITLE
Consolidate logic choosing where we can/should build a bit

### DIFF
--- a/src/libstore/build/derivation-builder.cc
+++ b/src/libstore/build/derivation-builder.cc
@@ -1,0 +1,27 @@
+#include "nix/util/json-utils.hh"
+#include "nix/store/build/derivation-builder.hh"
+
+namespace nlohmann {
+
+using namespace nix;
+
+ExternalBuilder adl_serializer<ExternalBuilder>::from_json(const json & json)
+{
+    auto obj = getObject(json);
+    return {
+        .systems = valueAt(obj, "systems"),
+        .program = valueAt(obj, "program"),
+        .args = valueAt(obj, "args"),
+    };
+}
+
+void adl_serializer<ExternalBuilder>::to_json(json & json, const ExternalBuilder & eb)
+{
+    json = {
+        {"systems", eb.systems},
+        {"program", eb.program},
+        {"args", eb.args},
+    };
+}
+
+} // namespace nlohmann

--- a/src/libstore/globals.cc
+++ b/src/libstore/globals.cc
@@ -258,6 +258,15 @@ Path Settings::getDefaultSSLCertFile()
     return "";
 }
 
+const ExternalBuilder * Settings::findExternalDerivationBuilderIfSupported(const Derivation & drv)
+{
+    if (auto it = std::ranges::find_if(
+            externalBuilders.get(), [&](const auto & handler) { return handler.systems.contains(drv.platform); });
+        it != externalBuilders.get().end())
+        return &*it;
+    return nullptr;
+}
+
 std::string nixVersion = PACKAGE_VERSION;
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
@@ -378,8 +387,6 @@ unsigned int MaxBuildJobsSetting::parse(const std::string & str) const
             throw UsageError("configuration setting '%s' should be 'auto' or an integer", name);
     }
 }
-
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Settings::ExternalBuilder, systems, program, args);
 
 template<>
 Settings::ExternalBuilders BaseSetting<Settings::ExternalBuilders>::parse(const std::string & str) const

--- a/src/libstore/include/nix/store/build/derivation-builder.hh
+++ b/src/libstore/include/nix/store/build/derivation-builder.hh
@@ -1,12 +1,15 @@
 #pragma once
 ///@file
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "nix/store/build-result.hh"
 #include "nix/store/derivation-options.hh"
 #include "nix/store/build/derivation-building-misc.hh"
 #include "nix/store/derivations.hh"
 #include "nix/store/parsed-derivations.hh"
 #include "nix/util/processes.hh"
+#include "nix/util/json-impls.hh"
 #include "nix/store/restricted-store.hh"
 #include "nix/store/build/derivation-env-desugar.hh"
 
@@ -179,9 +182,28 @@ struct DerivationBuilder : RestrictionContext
     virtual bool killChild() = 0;
 };
 
+struct ExternalBuilder
+{
+    StringSet systems;
+    Path program;
+    std::vector<std::string> args;
+};
+
 #ifndef _WIN32 // TODO enable `DerivationBuilder` on Windows
 std::unique_ptr<DerivationBuilder> makeDerivationBuilder(
     LocalStore & store, std::unique_ptr<DerivationBuilderCallbacks> miscMethods, DerivationBuilderParams params);
+
+/**
+ * @param handler Must be chosen such that it supports the given
+ * derivation.
+ */
+std::unique_ptr<DerivationBuilder> makeExternalDerivationBuilder(
+    LocalStore & store,
+    std::unique_ptr<DerivationBuilderCallbacks> miscMethods,
+    DerivationBuilderParams params,
+    const ExternalBuilder & handler);
 #endif
 
 } // namespace nix
+
+JSON_IMPL(nix::ExternalBuilder)

--- a/src/libstore/include/nix/store/globals.hh
+++ b/src/libstore/include/nix/store/globals.hh
@@ -1373,13 +1373,6 @@ public:
           Set it to 1 to warn on all paths.
         )"};
 
-    struct ExternalBuilder
-    {
-        StringSet systems;
-        Path program;
-        std::vector<std::string> args;
-    };
-
     using ExternalBuilders = std::vector<ExternalBuilder>;
 
     Setting<ExternalBuilders> externalBuilders{
@@ -1443,6 +1436,12 @@ public:
         //        Current system: 'aarch64-darwin' with features {apple-virt, benchmark, big-parallel, nixos-test}
         // Xp::ExternalBuilders
     };
+
+    /**
+     * Finds the first external derivation builder that supports this
+     * derivation, or else returns a null pointer.
+     */
+    const ExternalBuilder * findExternalDerivationBuilderIfSupported(const Derivation & drv);
 };
 
 // FIXME: don't use a global variable.

--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -298,6 +298,7 @@ sources = files(
   'aws-creds.cc',
   'binary-cache-store.cc',
   'build-result.cc',
+  'build/derivation-builder.cc',
   'build/derivation-building-goal.cc',
   'build/derivation-check.cc',
   'build/derivation-env-desugar.cc',

--- a/src/libstore/unix/build/external-derivation-builder.cc
+++ b/src/libstore/unix/build/external-derivation-builder.cc
@@ -2,30 +2,17 @@ namespace nix {
 
 struct ExternalDerivationBuilder : DerivationBuilderImpl
 {
-    Settings::ExternalBuilder externalBuilder;
+    ExternalBuilder externalBuilder;
 
     ExternalDerivationBuilder(
         LocalStore & store,
         std::unique_ptr<DerivationBuilderCallbacks> miscMethods,
         DerivationBuilderParams params,
-        Settings::ExternalBuilder externalBuilder)
+        ExternalBuilder externalBuilder)
         : DerivationBuilderImpl(store, std::move(miscMethods), std::move(params))
         , externalBuilder(std::move(externalBuilder))
     {
         experimentalFeatureSettings.require(Xp::ExternalBuilders);
-    }
-
-    static std::unique_ptr<ExternalDerivationBuilder> newIfSupported(
-        LocalStore & store, std::unique_ptr<DerivationBuilderCallbacks> & miscMethods, DerivationBuilderParams & params)
-    {
-        if (auto it = std::ranges::find_if(
-                settings.externalBuilders.get(),
-                [&](const auto & handler) { return handler.systems.contains(params.drv.platform); });
-            it != settings.externalBuilders.get().end()) {
-            return std::make_unique<ExternalDerivationBuilder>(
-                store, std::move(miscMethods), std::move(params), *it);
-        }
-        return {};
     }
 
     Path tmpDirInSandbox() override
@@ -40,8 +27,6 @@ struct ExternalDerivationBuilder : DerivationBuilderImpl
         tmpDir = topTmpDir + "/build";
         createDir(tmpDir, 0700);
     }
-
-    void checkSystem() override {}
 
     void startChild() override
     {
@@ -120,5 +105,14 @@ struct ExternalDerivationBuilder : DerivationBuilderImpl
         });
     }
 };
+
+std::unique_ptr<DerivationBuilder> makeExternalDerivationBuilder(
+    LocalStore & store,
+    std::unique_ptr<DerivationBuilderCallbacks> miscMethods,
+    DerivationBuilderParams params,
+    const ExternalBuilder & handler)
+{
+    return std::make_unique<ExternalDerivationBuilder>(store, std::move(miscMethods), std::move(params), handler);
+}
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

I want to separate "policy" from "mechanism".

Now the logic to decide how to build (a policy choice, though with some hard constraints) is all in derivation building goal, and all in the same spot. build hook, external builder, or local builder --- the choice between all three is made in the same spot --- pure policy.

Now, if you want to use the external deriation builder, you simply provide the `ExternalBuilder` you wish to use, and there is no additional checking --- pure mechanism. It is the responsibility of the caller to choose an external builder that works for the derivation in question.

Also, `checkSystem()` was the only thing throwing `BuildError` from `startBuilder`. Now that that is gone, we can now remove the `try...catch` around that.

## Context

Now that #14145 I can be sure I am not messing up the external builder, which was an issue before.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
