### PR TITLE
fix(libstore): improve http-binary-cache-store S3 compatibility

### DIFF
--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -78,7 +78,11 @@ public:
     void init() override
     {
         // FIXME: do this lazily?
-        if (auto cacheInfo = diskCache->upToDateCacheExists(config->cacheUri.to_string())) {
+        // For consistent cache key handling, use the reference without parameters
+        // This matches what's used in Store::queryPathInfo() lookups
+        auto cacheKey = config->getReference().render(/*withParams=*/false);
+
+        if (auto cacheInfo = diskCache->upToDateCacheExists(cacheKey)) {
             config->wantMassQuery.setDefault(cacheInfo->wantMassQuery);
             config->priority.setDefault(cacheInfo->priority);
         } else {
@@ -87,8 +91,7 @@ public:
             } catch (UploadToHTTP &) {
                 throw Error("'%s' does not appear to be a binary cache", config->cacheUri.to_string());
             }
-            diskCache->createCache(
-                config->cacheUri.to_string(), config->storeDir, config->wantMassQuery, config->priority);
+            diskCache->createCache(cacheKey, config->storeDir, config->wantMassQuery, config->priority);
         }
     }
 
@@ -184,7 +187,16 @@ protected:
            field which is
            `nar/15f99rdaf26k39knmzry4xd0d97wp6yfpnfk1z9avakis7ipb9yg.nar?hash=zphkqn2wg8mnvbkixnl2aadkbn0rcnfj`
            (note the query param) and that gets passed here. */
-        return FileTransferRequest(parseURLRelative(path, cacheUriWithTrailingSlash));
+        auto result = parseURLRelative(path, cacheUriWithTrailingSlash);
+
+        /* For S3 URLs, preserve query parameters from the base URL when the
+           relative path doesn't have its own query parameters. This is needed
+           to preserve S3-specific parameters like endpoint and region. */
+        if (config->cacheUri.scheme == "s3" && result.query.empty()) {
+            result.query = config->cacheUri.query;
+        }
+
+        return FileTransferRequest(result);
     }
 
     void getFile(const std::string & path, Sink & sink) override


### PR DESCRIPTION
## Motivation

This commit adds two key fixes to http-binary-cache-store.cc to
properly support the new curl-based S3 implementation:

1. **Consistent cache key handling**: Use `getReference().render(withParams=false)`
   for disk cache keys instead of `cacheUri.to_string()`. This ensures cache
   keys are consistent with the S3 implementation and don't include query
   parameters, which matches the behavior expected by Store::queryPathInfo()
   lookups.

2. **S3 query parameter preservation**: When generating file transfer requests
   for S3 URLs, preserve query parameters from the base URL (region, endpoint,
   etc.) when the relative path doesn't have its own query parameters. This
   ensures S3-specific configuration is propagated to all requests.

## Context

Carve out of #13752, should have made it onto #14198 but I missed it.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
