### PR TITLE
refactor(libstore): expose DummyStoreImpl in header for testability

### DIFF
--- a/src/libstore/include/nix/store/dummy-store-impl.hh
+++ b/src/libstore/include/nix/store/dummy-store-impl.hh
@@ -8,6 +8,7 @@
 namespace nix {
 
 struct MemorySourceAccessor;
+class WholeStoreViewAccessor;
 
 /**
  * Enough of the Dummy Store exposed for sake of writing unit tests
@@ -35,6 +36,60 @@ struct DummyStore : virtual Store
         , config(config)
     {
     }
+};
+
+/**
+ * Full implementation of DummyStore.
+ * Exposed in the header so it can be inherited from in tests.
+ */
+class DummyStoreImpl : public DummyStore
+{
+protected:
+    /**
+     * This view conceptually just borrows the file systems objects of
+     * each store object from `contents`, and combines them together
+     * into one store-wide source accessor.
+     *
+     * This is needed just in order to implement `Store::getFSAccessor`.
+     */
+    ref<WholeStoreViewAccessor> wholeStoreView;
+
+public:
+    using Config = DummyStoreConfig;
+
+    DummyStoreImpl(ref<const Config> config);
+
+    void queryPathInfoUncached(
+        const StorePath & path, Callback<std::shared_ptr<const ValidPathInfo>> callback) noexcept override;
+
+    /**
+     * The dummy store is incapable of *not* trusting! :)
+     */
+    virtual std::optional<TrustedFlag> isTrustedClient() override;
+
+    std::optional<StorePath> queryPathFromHashPart(const std::string & hashPart) override;
+
+    void addToStore(const ValidPathInfo & info, Source & source, RepairFlag repair, CheckSigsFlag checkSigs) override;
+
+    virtual StorePath addToStoreFromDump(
+        Source & source,
+        std::string_view name,
+        FileSerialisationMethod dumpMethod = FileSerialisationMethod::NixArchive,
+        ContentAddressMethod hashMethod = FileIngestionMethod::NixArchive,
+        HashAlgorithm hashAlgo = HashAlgorithm::SHA256,
+        const StorePathSet & references = StorePathSet(),
+        RepairFlag repair = NoRepair) override;
+
+    void registerDrvOutput(const Realisation & output) override;
+
+    void narFromPath(const StorePath & path, Sink & sink) override;
+
+    void queryRealisationUncached(
+        const DrvOutput &, Callback<std::shared_ptr<const Realisation>> callback) noexcept override;
+
+    std::shared_ptr<SourceAccessor> getFSAccessor(const StorePath & path, bool requireValidPath) override;
+
+    ref<SourceAccessor> getFSAccessor(bool requireValidPath) override;
 };
 
 } // namespace nix


### PR DESCRIPTION
## Motivation

Move DummyStoreImpl from dummy-store.cc to dummy-store-impl.hh to allow
tests to inherit from it and use gmock for method mocking.

## Context

Needed for: #14219

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
