### PR TITLE
libstore/outputs-spec: Drop usage of std::regex

### DIFF
--- a/src/libstore/outputs-spec.cc
+++ b/src/libstore/outputs-spec.cc
@@ -1,10 +1,10 @@
-#include <regex>
 #include <nlohmann/json.hpp>
+#include <string_view>
 
+#include "nix/store/path.hh"
+#include "nix/store/store-dir-config.hh"
 #include "nix/util/util.hh"
-#include "nix/util/regex-combinators.hh"
 #include "nix/store/outputs-spec.hh"
-#include "nix/store/path-regex.hh"
 #include "nix/util/strings-inline.hh"
 
 namespace nix {
@@ -19,31 +19,27 @@ bool OutputsSpec::contains(const std::string & outputName) const
         raw);
 }
 
-static std::string outputSpecRegexStr = regex::either(regex::group(R"(\*)"), regex::group(regex::list(nameRegexStr)));
-
 std::optional<OutputsSpec> OutputsSpec::parseOpt(std::string_view s)
 {
-    static std::regex regex(std::string{outputSpecRegexStr});
-
-    std::cmatch match;
-    if (!std::regex_match(s.cbegin(), s.cend(), match, regex))
+    try {
+        return parse(s);
+    } catch (BadStorePathName &) {
         return std::nullopt;
-
-    if (match[1].matched)
-        return {OutputsSpec::All{}};
-
-    if (match[2].matched)
-        return OutputsSpec::Names{tokenizeString<StringSet>({match[2].first, match[2].second}, ",")};
-
-    assert(false);
+    }
 }
 
 OutputsSpec OutputsSpec::parse(std::string_view s)
 {
-    std::optional spec = parseOpt(s);
-    if (!spec)
-        throw Error("invalid outputs specifier '%s'", s);
-    return std::move(*spec);
+    using namespace std::string_view_literals;
+
+    if (s == "*"sv)
+        return OutputsSpec::All{};
+
+    auto names = splitString<StringSet>(s, ",");
+    for (const auto & name : names)
+        checkName(name);
+
+    return OutputsSpec::Names{std::move(names)};
 }
 
 std::optional<std::pair<std::string_view, ExtendedOutputsSpec>> ExtendedOutputsSpec::parseOpt(std::string_view s)


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

std::regex is a really bad tool for parsing things, since it tends to overflow the stack pretty badly. See the build failure under ASan in [^].

[^]: https://hydra.nixos.org/build/310077167/nixlog/5

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
