### PR TITLE
libutil: Ensure that CanonPath does not contain NUL bytes

### DIFF
--- a/src/libutil-tests/canon-path.cc
+++ b/src/libutil-tests/canon-path.cc
@@ -42,6 +42,15 @@ TEST(CanonPath, basic)
     }
 }
 
+TEST(CanonPath, nullBytes)
+{
+    std::string s = "/hello/world";
+    s[8] = '\0';
+    ASSERT_THROW(CanonPath("/").push(std::string(1, '\0')), BadCanonPath);
+    ASSERT_THROW(CanonPath(std::string_view(s)), BadCanonPath);
+    ASSERT_THROW(CanonPath(s, CanonPath::root), BadCanonPath);
+}
+
 TEST(CanonPath, from_existing)
 {
     CanonPath p0("foo//bar/");

--- a/src/libutil/canon-path.cc
+++ b/src/libutil/canon-path.cc
@@ -3,6 +3,8 @@
 #include "nix/util/file-path-impl.hh"
 #include "nix/util/strings-inline.hh"
 
+#include <cstring>
+
 namespace nix {
 
 const CanonPath CanonPath::root = CanonPath("/");
@@ -12,7 +14,22 @@ static std::string absPathPure(std::string_view path)
     return canonPathInner<UnixPathTrait>(path, [](auto &, auto &) {});
 }
 
+static void ensureNoNullBytes(std::string_view s)
+{
+    if (std::memchr(s.data(), '\0', s.size())) [[unlikely]] {
+        using namespace std::string_view_literals;
+        auto str = replaceStrings(std::string(s), "\0"sv, "␀"sv);
+        throw BadCanonPath("path segment '%s' must not contain null (\\0) bytes", str);
+    }
+}
+
 CanonPath::CanonPath(std::string_view raw)
+    : path(absPathPure(concatStrings("/", raw)))
+{
+    ensureNoNullBytes(raw);
+}
+
+CanonPath::CanonPath(const char * raw)
     : path(absPathPure(concatStrings("/", raw)))
 {
 }
@@ -20,6 +37,7 @@ CanonPath::CanonPath(std::string_view raw)
 CanonPath::CanonPath(std::string_view raw, const CanonPath & root)
     : path(absPathPure(raw.size() > 0 && raw[0] == '/' ? raw : concatStrings(root.abs(), "/", raw)))
 {
+    ensureNoNullBytes(raw);
 }
 
 CanonPath::CanonPath(const std::vector<std::string> & elems)
@@ -80,6 +98,7 @@ void CanonPath::push(std::string_view c)
 {
     assert(c.find('/') == c.npos);
     assert(c != "." && c != "..");
+    ensureNoNullBytes(c);
     if (!isRoot())
         path += '/';
     path += c;

--- a/src/libutil/include/nix/util/canon-path.hh
+++ b/src/libutil/include/nix/util/canon-path.hh
@@ -1,6 +1,7 @@
 #pragma once
 ///@file
 
+#include "nix/util/error.hh"
 #include <string>
 #include <optional>
 #include <cassert>
@@ -12,6 +13,8 @@
 
 namespace nix {
 
+MakeError(BadCanonPath, Error);
+
 /**
  * A canonical representation of a path. It ensures the following:
  *
@@ -22,6 +25,8 @@ namespace nix {
  * - A slash is never followed by a slash (i.e. no empty components).
  *
  * - There are no components equal to '.' or '..'.
+ *
+ * - It does not contain NUL bytes.
  *
  * `CanonPath` are "virtual" Nix paths for abstract file system objects;
  * they are always Unix-style paths, regardless of what OS Nix is
@@ -51,10 +56,7 @@ public:
      */
     CanonPath(std::string_view raw);
 
-    explicit CanonPath(const char * raw)
-        : CanonPath(std::string_view(raw))
-    {
-    }
+    explicit CanonPath(const char * raw);
 
     struct unchecked_t
     {};


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This, alongside the other invariants of the CanonPath is important
to uphold. std::filesystem happily crashes on NUL bytes in the constructor,
as we've seen with `path:%00` prior to https://github.com/NixOS/nix/commit/c436b7a32afaf01d62f828697ddf5c49d4f8678c.
Best to stay clear of NUL bytes when we're talking about syscalls, especially
on Unix where strings are null terminated.

Very nice to have if we decide to switch over to pascal-style strings.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
