### PR TITLE
Remove duplicate shellcheck in dev-shell.nix

### DIFF
--- a/packaging/dev-shell.nix
+++ b/packaging/dev-shell.nix
@@ -118,7 +118,6 @@ pkgs.nixComponents2.nix-util.overrideAttrs (
           ++ [
             pkgs.buildPackages.cmake
             pkgs.buildPackages.gnused
-            pkgs.buildPackages.shellcheck
             pkgs.buildPackages.changelog-d
             modular.pre-commit.settings.package
             (pkgs.writeScriptBin "pre-commit-hooks-install" modular.pre-commit.settings.installationScript)


### PR DESCRIPTION

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
