### PR TITLE
Restore `ServeProto::Command::ImportPaths`

### DIFF
--- a/src/libstore/include/nix/store/serve-protocol-connection.hh
+++ b/src/libstore/include/nix/store/serve-protocol-connection.hh
@@ -82,6 +82,8 @@ struct ServeProto::BasicClientConnection
     BuildResult getBuildDerivationResponse(const StoreDirConfig & store);
 
     void narFromPath(const StoreDirConfig & store, const StorePath & path, std::function<void(Source &)> fun);
+
+    void importPaths(const StoreDirConfig & store, std::function<void(Sink &)> fun);
 };
 
 struct ServeProto::BasicServerConnection

--- a/src/libstore/include/nix/store/serve-protocol.hh
+++ b/src/libstore/include/nix/store/serve-protocol.hh
@@ -108,6 +108,13 @@ enum struct ServeProto::Command : uint64_t {
     QueryValidPaths = 1,
     QueryPathInfos = 2,
     DumpStorePath = 3,
+    /**
+     * @note This is no longer used by Nix (as a client), but it is used
+     * by Hydra. We should therefore not remove it until Hydra no longer
+     * uses it either.
+     */
+    ImportPaths = 4,
+    // ExportPaths = 5,
     BuildPaths = 6,
     QueryClosure = 7,
     BuildDerivation = 8,

--- a/src/libstore/serve-protocol-connection.cc
+++ b/src/libstore/serve-protocol-connection.cc
@@ -93,4 +93,14 @@ void ServeProto::BasicClientConnection::narFromPath(
     fun(from);
 }
 
+void ServeProto::BasicClientConnection::importPaths(const StoreDirConfig & store, std::function<void(Sink &)> fun)
+{
+    to << ServeProto::Command::ImportPaths;
+    fun(to);
+    to.flush();
+
+    if (readInt(from) != 1)
+        throw Error("remote machine failed to import closure");
+}
+
 } // namespace nix

--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -986,6 +986,16 @@ static void opServe(Strings opFlags, Strings opArgs)
             store->narFromPath(store->parseStorePath(readString(in)), out);
             break;
 
+        case ServeProto::Command::ImportPaths: {
+            if (!writeAllowed)
+                throw Error("importing paths is not allowed");
+            // FIXME: should we skip sig checking?
+            importPaths(*store, in, NoCheckSigs);
+            // indicate success
+            out << 1;
+            break;
+        }
+
         case ServeProto::Command::BuildPaths: {
 
             if (!writeAllowed)


### PR DESCRIPTION
## Motivation

This partially reverts commit 5e46df973f496cbdf375bfa24f27c156d24458e9, partially reversing changes made to 8c789db05b0bb4cd8dccc544b930837da52f423a.

## Context

We do this because Hydra, while using the newer version of the protocol, still uses this command, even though Nix (as a client) doesn't use it. On that basis, we don't want to remove it (or consider it only part of the older versions of the protocol) until Hydra no longer uses the Legacy SSH Protocol.

This is still used by hydra https://github.com/NixOS/hydra/pull/1531.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
