### PR TITLE
tests: Fix splicing in functional tests for nix-cli

### DIFF
--- a/tests/functional/package.nix
+++ b/tests/functional/package.nix
@@ -60,7 +60,10 @@ mkMesonDerivation (
     ];
 
     nativeBuildInputs = finalAttrs.passthru.externalNativeBuildInputs ++ [
-      nix-cli
+      # Explicitly splice the hostHost variant to fix LLVM tests. The nix-cli
+      # has to be in PATH, but must come from the host context where it's built
+      # with libc++.
+      (nix-cli.__spliced.hostHost or nix-cli)
     ];
 
     buildInputs = [


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This is necessary to fix `nix-everything-llvm`.
The problem here is that `nix-cli` is taken from the previous stage that is built with `libstdc++`, but this derivation builds plugins with `libc++` and the plugin load fails miserably.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
