### PR TITLE
feat(libstore): support S3 Transfer Acceleration

### DIFF
--- a/doc/manual/rl-next/s3-transfer-acceleration.md
+++ b/doc/manual/rl-next/s3-transfer-acceleration.md
@@ -1,0 +1,30 @@
+---
+synopsis: "S3 Transfer Acceleration support for faster remote cache access"
+issues: [12973]
+prs: [14277]
+---
+
+S3 binary cache stores now support AWS S3 Transfer Acceleration for faster
+uploads and downloads when accessing buckets from geographically distant
+locations.
+
+Transfer Acceleration routes S3 requests through CloudFront edge locations,
+which can significantly improve performance for users far from the bucket's
+region. For example, US-based users accessing Tokyo-region buckets can see
+substantial speed improvements.
+
+To enable transfer acceleration, add `use-transfer-acceleration=true` to your
+S3 URL:
+
+```console
+$ nix copy nixpkgs.hello \
+  --to 's3://my-cache?region=ap-northeast-1&use-transfer-acceleration=true'
+```
+
+Requirements:
+- Bucket names cannot contain dots (periods)
+- Transfer Acceleration must be enabled on the S3 bucket
+- Additional AWS charges apply for Transfer Acceleration
+
+This feature only applies to AWS S3 buckets and has no effect when using custom
+endpoints for S3-compatible services.

--- a/src/libstore/include/nix/store/s3-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/s3-binary-cache-store.hh
@@ -113,11 +113,38 @@ struct S3BinaryCacheStoreConfig : HttpBinaryCacheStoreConfig
           https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
         )"};
 
+#if NIX_WITH_AWS_AUTH
+    const Setting<bool> use_transfer_acceleration{
+        this,
+        false,
+        "use-transfer-acceleration",
+        R"(
+          Whether to use AWS S3 Transfer Acceleration for faster uploads and downloads
+          by routing transfers through CloudFront edge locations. This is particularly
+          useful when accessing S3 buckets from geographically distant locations.
+
+          When enabled, requests are routed to `bucket-name.s3-accelerate.amazonaws.com`
+          instead of the standard regional endpoint.
+
+          > **Note**
+          >
+          > Transfer Acceleration does not support bucket names with dots (periods).
+          > Bucket names like `my.bucket.name` will not work with this setting.
+          >
+          > This setting only applies to AWS S3 buckets. It has no effect when using
+          > custom endpoints for S3-compatible services.
+          >
+          > Additional charges apply for Transfer Acceleration. See AWS documentation
+          > for pricing details.
+        )"};
+#endif
+
     /**
      * Set of settings that are part of the S3 URI itself.
      * These are needed for region specification and other S3-specific settings.
      */
-    const std::set<const AbstractSetting *> s3UriSettings = {&profile, &region, &scheme, &endpoint};
+    const std::set<const AbstractSetting *> s3UriSettings = {
+        &profile, &region, &scheme, &endpoint, &use_transfer_acceleration};
 
     static const std::string name()
     {

--- a/src/libstore/include/nix/store/s3-url.hh
+++ b/src/libstore/include/nix/store/s3-url.hh
@@ -27,6 +27,9 @@ struct ParsedS3URL
     std::optional<std::string> region;
     std::optional<std::string> scheme;
     std::optional<std::string> versionId;
+#if NIX_WITH_AWS_AUTH
+    bool use_transfer_acceleration;
+#endif
     /**
      * The endpoint can be either missing, be an absolute URI (with a scheme like `http:`)
      * or an authority (so an IP address or a registered name).

--- a/src/libstore/s3-binary-cache-store.md
+++ b/src/libstore/s3-binary-cache-store.md
@@ -84,6 +84,27 @@ Your account will need an IAM policy to support uploading to the bucket:
 }
 ```
 
+### S3 Transfer Acceleration
+
+For faster uploads and downloads when accessing S3 buckets from geographically distant locations, you can enable AWS S3 Transfer Acceleration. This routes transfers through CloudFront edge locations for improved performance.
+
+To enable transfer acceleration, add the `use-transfer-acceleration=true` parameter to your S3 URL:
+
+```console
+$ nix copy nixpkgs.hello \
+  --to 's3://example-nix-cache?use-transfer-acceleration=true&region=ap-northeast-1'
+```
+
+#### Requirements for Transfer Acceleration
+
+- Bucket names cannot contain dots (`.`) - e.g., `my.bucket.name` will not work
+- Transfer Acceleration must be enabled on your S3 bucket (see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html))
+- Additional charges apply for Transfer Acceleration (see AWS pricing)
+
+> **Note**
+>
+> Transfer Acceleration only works with AWS S3 buckets. It has no effect when using custom endpoints for S3-compatible services like MinIO.
+
 ### Examples
 
 With bucket policies and authentication set up as described above, uploading works via [`nix copy`](@docroot@/command-ref/new-cli/nix3-copy.md) (experimental).
@@ -100,6 +121,13 @@ With bucket policies and authentication set up as described above, uploading wor
   ```console
   $ nix copy nixpkgs.hello --to \
     's3://example-nix-cache?profile=cache-upload&scheme=https&endpoint=minio.example.com'
+  ```
+
+- To use S3 Transfer Acceleration for faster transfers from distant locations:
+
+  ```console
+  $ nix copy nixpkgs.hello \
+    --to 's3://my-cache?profile=cache-upload&region=ap-northeast-1&use-transfer-acceleration=true'
   ```
 
 )"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Implements AWS S3 Transfer Acceleration for binary cache stores to
improve upload and download performance when accessing S3 buckets from
geographically distant locations. Transfers are routed through
CloudFront edge locations for better performance.

Usage:
```
nix copy nixpkgs.hello \
  --to 's3://my-cache?region=ap-northeast-1&use-transfer-acceleration=true'
```

Requirements:
- DNS-compliant bucket names (3-63 chars, lowercase, numbers, hyphens)
- No dots in bucket names
- Transfer Acceleration enabled on the S3 bucket
- Only applies to AWS S3 (ignored for custom endpoints)

## Context

Fixes: #12973

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
