### PR TITLE
Simplify meson for S3 support via aws-crt-cpp

### DIFF
--- a/src/libstore/meson.build
+++ b/src/libstore/meson.build
@@ -142,27 +142,16 @@ deps_public += nlohmann_json
 sqlite = dependency('sqlite3', 'sqlite', version : '>=3.6.19')
 deps_private += sqlite
 
-# Curl-based S3 store support
-# Check if curl supports AWS SigV4 (requires >= 7.75.0)
-curl_supports_aws_sigv4 = curl.version().version_compare('>= 7.75.0')
-# AWS CRT C++ for lightweight credential management
-aws_crt_cpp = cxx.find_library('aws-crt-cpp', required : false)
+s3_aws_auth = get_option('s3-aws-auth')
+aws_crt_cpp = cxx.find_library('aws-crt-cpp', required : s3_aws_auth)
 
-curl_s3_store_opt = get_option('curl-s3-store').require(
-  curl_supports_aws_sigv4,
-  error_message : 'curl-based S3 support requires curl >= 7.75.0',
-).require(
-  aws_crt_cpp.found(),
-  error_message : 'curl-based S3 support requires aws-crt-cpp',
-)
-
-if curl_s3_store_opt.enabled()
+if s3_aws_auth.enabled()
   deps_other += aws_crt_cpp
   aws_c_common = cxx.find_library('aws-c-common', required : true)
   deps_other += aws_c_common
 endif
 
-configdata_pub.set('NIX_WITH_AWS_AUTH', curl_s3_store_opt.enabled().to_int())
+configdata_pub.set('NIX_WITH_AWS_AUTH', s3_aws_auth.enabled().to_int())
 
 subdir('nix-meson-build-support/generate-header')
 
@@ -346,7 +335,7 @@ sources = files(
 )
 
 # AWS credentials code requires AWS CRT, so only compile when enabled
-if curl_s3_store_opt.enabled()
+if s3_aws_auth.enabled()
   sources += files('aws-creds.cc')
 endif
 

--- a/src/libstore/meson.options
+++ b/src/libstore/meson.options
@@ -35,8 +35,7 @@ option(
 )
 
 option(
-  'curl-s3-store',
+  's3-aws-auth',
   type : 'feature',
-  value : 'disabled',
-  description : 'Enable curl-based S3 binary cache store support (requires aws-crt-cpp and curl >= 7.75.0)',
+  description : 'build support for AWS authentication with S3',
 )

--- a/src/libstore/package.nix
+++ b/src/libstore/package.nix
@@ -75,7 +75,7 @@ mkMesonLibrary (finalAttrs: {
   mesonFlags = [
     (lib.mesonEnable "seccomp-sandboxing" stdenv.hostPlatform.isLinux)
     (lib.mesonBool "embedded-sandbox-shell" embeddedSandboxShell)
-    (lib.mesonEnable "curl-s3-store" withAWS)
+    (lib.mesonEnable "s3-aws-auth" withAWS)
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Get the option naming in order, since it's now the only S3 implementation. Also simplify the meson.build significantly by eliminating version checks for cURL.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
