### PR TITLE
nix {cat,ls}: Add back missing checks for file descriptors

### DIFF
--- a/src/nix/cat.cc
+++ b/src/nix/cat.cc
@@ -76,6 +76,8 @@ struct CmdCatNar : StoreCommand, MixCat
     void run(ref<Store> store) override
     {
         AutoCloseFD fd = open(narPath.c_str(), O_RDONLY);
+        if (!fd)
+            throw SysError("opening NAR file '%s'", narPath);
         auto source = FdSource{fd.get()};
         auto narAccessor = makeNarAccessor(source);
         auto listing = listNar(narAccessor, CanonPath::root, true);

--- a/src/nix/ls.cc
+++ b/src/nix/ls.cc
@@ -146,6 +146,8 @@ struct CmdLsNar : Command, MixLs
     void run() override
     {
         AutoCloseFD fd = open(narPath.c_str(), O_RDONLY);
+        if (!fd)
+            throw SysError("opening NAR file '%s'", narPath);
         auto source = FdSource{fd.get()};
         auto narAccessor = makeNarAccessor(source);
         auto listing = listNar(narAccessor, CanonPath::root, true);


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I didn't catch this during the review of https://github.com/NixOS/nix/pull/14273. This fixes that mistake.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
