### PR TITLE
Further `registerOutputs` cleanups

### DIFF
--- a/src/libstore/unix/build/derivation-builder.cc
+++ b/src/libstore/unix/build/derivation-builder.cc
@@ -1783,16 +1783,26 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                 if (buildMode == bmRepair) {
                     /* Path already exists, need to replace it */
                     replaceValidPath(store.toRealPath(finalDestPath), actualPath);
+                    /* Optimize store object we just replaced with new
+                       (not-yet-optimized) data. */
+                    store.optimisePath(
+                        store.toRealPath(finalDestPath), NoRepair); // FIXME: combine with scanForReferences()
                 } else if (store.isValidPath(newInfo.path)) {
                     /* Path already exists because CA path produced by something
                        else. No moving needed. */
                     assert(newInfo.ca);
                     /* Can delete our scratch copy now. */
                     deletePath(actualPath);
+                    /* Presume already-existing store object is already
+                       optimized. */
                 } else {
                     auto destPath = store.toRealPath(finalDestPath);
                     deletePath(destPath);
                     movePath(actualPath, destPath);
+                    /* Optimize store object we just installed from new
+                       (not-yet-optimized) data. */
+                    store.optimisePath(
+                        store.toRealPath(finalDestPath), NoRepair); // FIXME: combine with scanForReferences()
                 }
             }
 
@@ -1803,10 +1813,6 @@ SingleDrvOutputs DerivationBuilderImpl::registerOutputs()
                 else
                     debug("unreferenced input: '%1%'", store.printStorePath(i));
             }
-
-            if (!store.isValidPath(newInfo.path))
-                store.optimisePath(
-                    store.toRealPath(finalDestPath), NoRepair); // FIXME: combine with scanForReferences()
 
             newInfo.deriver = drvPath;
             newInfo.ultimate = true;


### PR DESCRIPTION
## Motivation

This does some more simplifications/improvements after #14280 fixed the bug.

The first commit is no behavior change, and just simplifies the control flow.

The second commit I believes improves behavior by ensuring that we also call `optimisePath` in the repair case, while still not unnecessarily doing it in the already-built case.

## Context

#14280

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
