### PR TITLE
nix store dump-path: Refuse to write NARs to the terminal

### DIFF
--- a/src/nix/dump-path.cc
+++ b/src/nix/dump-path.cc
@@ -4,6 +4,14 @@
 
 using namespace nix;
 
+static FdSink getNarSink()
+{
+    auto fd = getStandardOutput();
+    if (isatty(fd))
+        throw UsageError("refusing to write NAR to a terminal");
+    return FdSink(std::move(fd));
+}
+
 struct CmdDumpPath : StorePathCommand
 {
     std::string description() override
@@ -20,7 +28,7 @@ struct CmdDumpPath : StorePathCommand
 
     void run(ref<Store> store, const StorePath & storePath) override
     {
-        FdSink sink(getStandardOutput());
+        auto sink = getNarSink();
         store->narFromPath(storePath, sink);
         sink.flush();
     }
@@ -51,7 +59,7 @@ struct CmdDumpPath2 : Command
 
     void run() override
     {
-        FdSink sink(getStandardOutput());
+        auto sink = getNarSink();
         dumpPath(path, sink);
         sink.flush();
     }


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Like GNU tar, don't spam the user's terminal with gibberish when they forget to pipe the output somewhere else.

Cherry-picked from https://github.com/DeterminateSystems/nix-src/pull/232.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
