### PR TITLE
nix-profile{,-daemon}.fish: set NIX_PROFILES to use $NIX_LINK

### DIFF
--- a/scripts/nix-profile-daemon.fish.in
+++ b/scripts/nix-profile-daemon.fish.in
@@ -53,7 +53,7 @@ end
 
 # Set up environment.
 # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
-set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $NIX_LINK"
 
 # Populate bash completions, .desktop files, etc
 if test -z "$XDG_DATA_DIRS"

--- a/scripts/nix-profile.fish.in
+++ b/scripts/nix-profile.fish.in
@@ -58,7 +58,7 @@ end
 
 # Set up environment.
 # This part should be kept in sync with nixpkgs:nixos/modules/programs/environment.nix
-set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
+set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $NIX_LINK"
 
 # Populate bash completions, .desktop files, etc
 if test -z "$XDG_DATA_DIRS"


### PR DESCRIPTION
## Motivation

In the fish scripts, `NIX_PROFILES` is currently set to `... $HOME/.nix-profile`, even though the scripts compute `NIX_LINK` (respecting `XDG_STATE_HOME`).

The sh equivalents already export:

https://github.com/NixOS/nix/blob/ad2360c59f7460c48ea982c32e55bfc01bfe527c/scripts/nix-profile.sh.in#L37

https://github.com/NixOS/nix/blob/ad2360c59f7460c48ea982c32e55bfc01bfe527c/scripts/nix-profile-daemon.sh.in#L31

To keep fish in sync with sh behavior and respect XDG, I changed to using `$NIX_LINK` in fish.

## Context

This is related to point 5 in #9441

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
