### PR TITLE
Inline `realisationFetched`

### DIFF
--- a/src/libstore/include/nix/store/build/drv-output-substitution-goal.hh
+++ b/src/libstore/include/nix/store/build/drv-output-substitution-goal.hh
@@ -32,8 +32,6 @@ public:
     DrvOutputSubstitutionGoal(const DrvOutput & id, Worker & worker);
 
     Co init();
-    Co
-    realisationFetched(Goals waitees, std::shared_ptr<const UnkeyedRealisation> outputInfo, nix::ref<nix::Store> sub);
 
     void timedOut(Error && ex) override
     {


### PR DESCRIPTION
## Motivation

Now that we are using coroutines, we don't need this to be a separate method of `DrvOutputSubstitutionGoal`.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
