### PR TITLE
flake.nix: Add nix run .#open-manual

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -471,6 +471,27 @@
         }
       );
 
+      apps = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgsFor.${system}.native;
+          opener = if pkgs.stdenv.isDarwin then "open" else "xdg-open";
+        in
+        {
+          open-manual = {
+            type = "app";
+            program = "${pkgs.writeShellScript "open-nix-manual" ''
+              manual_path="${self.packages.${system}.nix-manual}/share/doc/nix/manual/index.html"
+              if ! ${opener} "$manual_path"; then
+                echo "Failed to open manual with ${opener}. Manual is located at:"
+                echo "$manual_path"
+              fi
+            ''}";
+            meta.description = "Open the Nix manual in your browser";
+          };
+        }
+      );
+
       devShells =
         let
           makeShell = import ./packaging/dev-shell.nix { inherit lib devFlake; };


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Great for reviewing the rendered manual
locally:
`nix run .#open-manual`
PR:
`nix run github:NixOS/nix/refs/pull/14320/head#open-manual`

## Context


<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
