### PR TITLE
fetchers: add helpful hint for file+git URL scheme error

### DIFF
--- a/src/libfetchers/fetchers.cc
+++ b/src/libfetchers/fetchers.cc
@@ -5,6 +5,7 @@
 #include "nix/util/json-utils.hh"
 #include "nix/fetchers/fetch-settings.hh"
 #include "nix/fetchers/fetch-to-store.hh"
+#include "nix/util/url.hh"
 
 #include <nlohmann/json.hpp>
 
@@ -63,6 +64,12 @@ Input Input::fromURL(const Settings & settings, const ParsedURL & url, bool requ
             fixupInput(*res);
             return std::move(*res);
         }
+    }
+
+    // Provide a helpful hint when user tries file+git instead of git+file
+    auto parsedScheme = parseUrlScheme(url.scheme);
+    if (parsedScheme.application == "file" && parsedScheme.transport == "git") {
+        throw Error("input '%s' is unsupported; did you mean 'git+file' instead of 'file+git'?", url);
     }
 
     throw Error("input '%s' is unsupported", url);


### PR DESCRIPTION
Adds an error message hint when `file+git` is used rather than `git+file` to guide users to the correct URL scheme format.

When:
```
  inputs = {
    nixpkgs.url = "file+git:///home/user/git/nixpkgs";
```
Changes:
```
error: input 'file+git:///home/user/git/nixpkgs' is unsupported
```
to
```
error: input 'file+git:///home/user/git/nixpkgs' is unsupported; did you mean 'git+file' instead of 'file+git'?
```

This catches both direct fetcher uses and flake references. With that being said I'm not entirely sure if this was the correct spot for the check, any input about this would be great. 
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation
Like @roberth brought up, at least one user has probably used `file+git://` when they really meant `git+file://`, maybe thinking of it as "a file-based git repository" if they are not familiar with how schemes are nested. This may save some users from resorting to `path:///` and copying an entire repo which can be very slow.

("at least one user" is definitely not me a few months ago...)
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context
- Closes: #13797
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
