### PR TITLE
Fix misleading error messages for missing NARs due to stale cache

### DIFF
--- a/src/libstore/build/substitution-goal.cc
+++ b/src/libstore/build/substitution-goal.cc
@@ -268,16 +268,18 @@ Goal::Co PathSubstitutionGoal::tryToRun(
     try {
         promise.get_future().get();
     } catch (std::exception & e) {
-        printError(e.what());
-
         /* Cause the parent build to fail unless --fallback is given,
            or the substitute has disappeared. The latter case behaves
            the same as the substitute never having existed in the
            first place. */
         try {
             throw;
-        } catch (SubstituteGone &) {
+        } catch (SubstituteGone & sg) {
+            /* Missing NARs are expected when they've been garbage collected.
+               This is not a failure, so log as a warning instead of an error. */
+            logWarning({.msg = sg.info().msg});
         } catch (...) {
+            printError(e.what());
             substituterFailed = true;
         }
 

--- a/tests/functional/binary-cache.sh
+++ b/tests/functional/binary-cache.sh
@@ -111,7 +111,13 @@ clearStore
 
 mv "$cacheDir/nar" "$cacheDir/nar2"
 
-nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result"
+nix-build --substituters "file://$cacheDir" --no-require-sigs dependencies.nix -o "$TEST_ROOT/result" 2>&1 | tee "$TEST_ROOT/log"
+
+# Verify that missing NARs produce warnings, not errors
+# The build should succeed despite the warnings
+grepQuiet "does not exist in binary cache" "$TEST_ROOT/log"
+# Ensure the message is not at error level by checking that the command succeeded
+[ -e "$TEST_ROOT/result" ]
 
 mv "$cacheDir/nar2" "$cacheDir/nar"
 


### PR DESCRIPTION
When Nix's SQLite narinfo cache indicates a NAR exists, but the NAR
has been garbage collected from the binary cache, Nix displays error
messages even though the operation succeeds via fallback. This is
misleading because the cached narinfo is simply outdated.

This changes SubstituteGone exceptions to produce warnings instead of
errors, accurately reflecting that this is an expected cache coherency
issue, not an actual failure.

Fixes https://github.com/NixOS/nix/issues/11411