### PR TITLE
nix-store --print-env: fix shell quoting on _args output

### DIFF
--- a/src/nix/nix-store/nix-store.cc
+++ b/src/nix/nix-store/nix-store.cc
@@ -15,6 +15,7 @@
 #include "nix/store/globals.hh"
 #include "nix/store/path-with-outputs.hh"
 #include "nix/store/export-import.hh"
+#include "nix/util/strings.hh"
 
 #include "man-pages.hh"
 
@@ -535,17 +536,9 @@ static void opPrintEnv(Strings opFlags, Strings opArgs)
     for (auto & i : drv.env)
         logger->cout("export %1%; %1%=%2%\n", i.first, escapeShellArgAlways(i.second));
 
-    /* Also output the arguments.  This doesn't preserve whitespace in
-       arguments. */
-    cout << "export _args; _args='";
-    bool first = true;
-    for (auto & i : drv.args) {
-        if (!first)
-            cout << ' ';
-        first = false;
-        cout << escapeShellArgAlways(i);
-    }
-    cout << "'\n";
+    /* Also output the arguments. */
+    std::string argsStr = concatStringsSep(" ", drv.args);
+    cout << "export _args; _args=" << escapeShellArgAlways(argsStr) << "\n";
 }
 
 static void opReadLog(Strings opFlags, Strings opArgs)

--- a/tests/functional/meson.build
+++ b/tests/functional/meson.build
@@ -160,6 +160,7 @@ suites = [
       'nix-profile.sh',
       'suggestions.sh',
       'store-info.sh',
+      'store-print-env.sh',
       'fetchClosure.sh',
       'completions.sh',
       'impure-derivations.sh',

--- a/tests/functional/store-print-env.sh
+++ b/tests/functional/store-print-env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+source common.sh
+
+clearStoreIfPossible
+
+# Regression test for nix-store --print-env argument escaping
+# This tests that arguments in _args are properly escaped as a single string
+# rather than double-escaped which could lead to command injection
+
+cat > "$TEST_ROOT/test-args.nix" <<'EOF'
+derivation {
+  name = "test-print-env-args";
+  system = builtins.currentSystem;
+  builder = "/bin/sh";
+  args = [ "-c" "echo hello world" ];
+}
+EOF
+
+drvPath=$(nix-instantiate "$TEST_ROOT/test-args.nix")
+output=$(nix-store --print-env "$drvPath" | grep "^export _args")
+
+# The output should be: export _args; _args='-c echo hello world'
+# NOT: export _args; _args=''-c' 'echo hello world''
+
+# Test that it can be safely evaluated
+eval "$output"
+expected="-c echo hello world"
+# shellcheck disable=SC2154 # _args is set by the eval above
+if [ "$_args" != "$expected" ]; then
+    echo "ERROR: _args not properly escaped!"
+    echo "Expected: $expected"
+    echo "Got: $_args"
+    echo "Raw output: $output"
+    exit 1
+fi


### PR DESCRIPTION
The previous implementation double-quoted the _args variable by escaping each argument individually and then wrapping them all in single quotes, producing output like: _args=''-e' 'arg1' 'arg2''

This fix concatenates all arguments into a single string first, then escapes that string once, producing correct output like: _args='-e arg1 arg2'

This prevents potential command injection issues when the output is sourced in shell scripts.

Fixes #14327

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
