### PR TITLE
meson: Only enable b_lto for nixexpr-parser when b_lto is enabled glo…

### DIFF
--- a/src/libexpr/meson.build
+++ b/src/libexpr/meson.build
@@ -223,7 +223,7 @@ parser_library = static_library(
   # by plonking down GIMPLE in the archive.
   override_options : [
     'b_ndebug=@0@'.format(not get_option('debug')),
-    'b_lto=@0@'.format(cxx.get_id() != 'gcc'),
+    'b_lto=@0@'.format(get_option('b_lto') and cxx.get_id() != 'gcc'),
   ],
 )
 


### PR DESCRIPTION
…bally

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Fixes debug builds with clang.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
