### PR TITLE
docs: add s3:ListBucket to S3 read permissions

### DIFF
--- a/src/libstore/s3-binary-cache-store.md
+++ b/src/libstore/s3-binary-cache-store.md
@@ -27,7 +27,8 @@ like the following to be accessible:
             "Sid": "AllowDirectReads",
             "Action": [
                 "s3:GetObject",
-                "s3:GetBucketLocation"
+                "s3:GetBucketLocation",
+                "s3:ListBucket"
             ],
             "Effect": "Allow",
             "Resource": [
@@ -51,7 +52,7 @@ Consult the documentation linked above for further details.
 
 ### Authenticated reads to your S3 binary cache
 
-Your bucket will need a bucket policy allowing the desired users to perform the `s3:GetObject` and `s3:GetBucketLocation` action on all objects in the bucket.
+Your bucket will need a bucket policy allowing the desired users to perform the `s3:GetObject`, `s3:GetBucketLocation`, and `s3:ListBucket` actions on all objects in the bucket.
 The [anonymous policy given above](#anonymous-reads-to-your-s3-compatible-binary-cache) can be updated to have a restricted `Principal` to support this.
 
 ### Authenticated writes to your S3-compatible binary cache


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

The `s3:ListBucket` permission is required for read operations on S3
binary caches, not just for writes. Without this permission, users get
"Access Denied" errors when running nix-build.

## Context

Fixes: #7743

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
