### PR TITLE
nix-2.32 needs boost-1.87+ for `try_emplace_and_cvisit`

### DIFF
--- a/src/libutil/meson.build
+++ b/src/libutil/meson.build
@@ -64,7 +64,7 @@ boost = dependency(
     'url',
   ],
   include_type : 'system',
-  version : '>=1.82.0',
+  version : '>=1.87.0',
 )
 # boost is a public dependency, but not a pkg-config dependency unfortunately, so we
 # put in `deps_other`.


### PR DESCRIPTION
# Motivation

Since 2.32, nix now requires boost 1.87 or later to build, due to using `unordered::concurrent_flat_map`'s `try_emplace_and_cvisit`

## Context

Avoids this build error:

`../src/libexpr/eval.cc: In member function ‘void nix::EvalState::evalFile(const nix::SourcePath&, nix::Value&, bool)’: ../src/libexpr/eval.cc:1096:20: error: ‘class boost::unordered::concurrent_flat_map<nix::SourcePath, nix::Value*, std::hash<nix::SourcePath>, std::equal_to<nix::SourcePath>, traceable_allocator<std::pair<const nix::SourcePath, nix::Value*> > >’ has no member named ‘try_emplace_and_cvisit’; did you mean ‘try_emplace_or_cvisit’?`
```
 1096 |     fileEvalCache->try_emplace_and_cvisit(
      |                    ^~~~~~~~~~~~~~~~~~~~~~
      |                    try_emplace_or_cvisit
```
See https://github.com/boostorg/unordered/commit/834580b53948eec553c232dda40beefc68b3e8f9 from last year

(Sadly Fedora is still on boost-1.83 ...)

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
