### PR TITLE
Fix some characterization tests

### DIFF
--- a/src/libstore-tests/data/store-reference/local_3.txt
+++ b/src/libstore-tests/data/store-reference/local_3.txt
@@ -1,1 +1,1 @@
-local://?root=/foo bar/baz
+local://?root=/foo%20bar/baz

--- a/src/libstore-tests/data/store-reference/local_3_no_percent.txt
+++ b/src/libstore-tests/data/store-reference/local_3_no_percent.txt
@@ -1,0 +1,1 @@
+local://?root=/foo bar/baz

--- a/src/libstore-tests/store-reference.cc
+++ b/src/libstore-tests/store-reference.cc
@@ -100,8 +100,11 @@ URI_TEST(local_1, localExample_1)
 
 URI_TEST(local_2, localExample_2)
 
-/* Test path with spaces */
+/* Test path with encoded spaces */
 URI_TEST(local_3, localExample_3)
+
+/* Test path with spaces that are improperly not encoded */
+URI_TEST_READ(local_3_no_percent, localExample_3)
 
 URI_TEST_READ(local_shorthand_1, localExample_1)
 

--- a/src/libutil-tests/data/hash/blake3-base64.json
+++ b/src/libutil-tests/data/hash/blake3-base64.json
@@ -1,5 +1,5 @@
 {
-    "algorithm": "blake3",
-    "format": "base64",
-    "hash": "nnDuFEmWX7YtBJBAoe0G7Dd0MNpuwTFz58T//NKL6YA="
+  "algorithm": "blake3",
+  "format": "base64",
+  "hash": "nnDuFEmWX7YtBJBAoe0G7Dd0MNpuwTFz58T//NKL6YA="
 }

--- a/src/libutil-tests/data/hash/sha256-base64.json
+++ b/src/libutil-tests/data/hash/sha256-base64.json
@@ -1,5 +1,5 @@
 {
-    "algorithm": "sha256",
-    "format": "base64",
-    "hash": "8OTC92xYkW7CWPJGhRvqCR0U1CR6L8PhhpRGGxgW4Ts="
+  "algorithm": "sha256",
+  "format": "base64",
+  "hash": "8OTC92xYkW7CWPJGhRvqCR0U1CR6L8PhhpRGGxgW4Ts="
 }


### PR DESCRIPTION
## Motivation

A few changes had cropped up with `_NIX_TEST_ACCEPT=1`:

1. Blake hashing test JSON had a different indentation

2. Store URI had improper non-quoted spaces

(1) was is just fixed, as we trust nlohmann JSON to parse JSON correctly, regardless of whitespace.

For (2), the existing URL was made a read-only test, since we very much wish to continue parsing such invalid URLs directly. And then the original read/write test was updated to properly percent-encode the space, as the normal form should be.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
