### PR TITLE
JSON Schema for `DerivedPath`

### DIFF
--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -35,6 +35,7 @@ mkMesonDerivation (finalAttrs: {
         ../../.version
         # For example JSON
         ../../src/libutil-tests/data/hash
+        ../../src/libstore-tests/data/derived-path
         # Too many different types of files to filter for now
         ../../doc/manual
         ./.

--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -120,6 +120,7 @@
     - [Hash](protocols/json/hash.md)
     - [Store Object Info](protocols/json/store-object-info.md)
     - [Derivation](protocols/json/derivation.md)
+    - [Deriving Path](protocols/json/deriving-path.md)
   - [Serving Tarball Flakes](protocols/tarball-fetcher.md)
   - [Store Path Specification](protocols/store-path.md)
   - [Nix Archive (NAR) Format](protocols/nix-archive.md)

--- a/doc/manual/source/protocols/json/deriving-path.md
+++ b/doc/manual/source/protocols/json/deriving-path.md
@@ -1,0 +1,21 @@
+{{#include deriving-path-v1-fixed.md}}
+
+## Examples
+
+### Constant
+
+```json
+{{#include schema/deriving-path-v1/single_opaque.json}}
+```
+
+### Output of static derivation
+
+```json
+{{#include schema/deriving-path-v1/single_built.json}}
+```
+
+### Output of dynamic derivation
+
+```json
+{{#include schema/deriving-path-v1/single_built_built.json}}
+```

--- a/doc/manual/source/protocols/json/meson.build
+++ b/doc/manual/source/protocols/json/meson.build
@@ -11,6 +11,7 @@ json_schema_config = files('json-schema-for-humans-config.yaml')
 schemas = [
   'hash-v1',
   'derivation-v3',
+  'deriving-path-v1',
 ]
 
 schema_files = files()

--- a/doc/manual/source/protocols/json/schema/deriving-path-v1
+++ b/doc/manual/source/protocols/json/schema/deriving-path-v1
@@ -1,0 +1,1 @@
+../../../../../../src/libstore-tests/data/derived-path

--- a/doc/manual/source/protocols/json/schema/deriving-path-v1.yaml
+++ b/doc/manual/source/protocols/json/schema/deriving-path-v1.yaml
@@ -1,0 +1,27 @@
+"$schema": http://json-schema.org/draft-04/schema#
+"$id": https://nix.dev/manual/nix/latest/protocols/json/schema/deriving-path-v1.json
+title: Deriving Path
+description: |
+  This schema describes the JSON representation of Nix's [Deriving Path](@docroot@/store/derivation/index.md#deriving-path).
+oneOf:
+  - title: Constant
+    description: |
+      See [Constant](@docroot@/store/derivation/index.md#deriving-path-constant) deriving path.
+    type: string
+  - title: Output
+    description: |
+      See [Output](@docroot@/store/derivation/index.md#deriving-path-output) deriving path.
+    type: object
+    properties:
+      drvPath:
+        "$ref": "#"
+        description: |
+          A deriving path to a [Derivation](@docroot@/store/derivation/index.md#store-derivation), whose output is being referred to.
+      output:
+        type: string
+        description: |
+          The name of an output produced by that derivation (e.g. "out", "doc", etc.).
+    required:
+      - drvPath
+      - output
+    additionalProperties: false

--- a/src/json-schema-checks/deriving-path
+++ b/src/json-schema-checks/deriving-path
@@ -1,0 +1,1 @@
+../../src/libstore-tests/data/derived-path

--- a/src/json-schema-checks/meson.build
+++ b/src/json-schema-checks/meson.build
@@ -52,6 +52,15 @@ schemas = [
   #     'output-inputAddressed.json',
   #   ],
   # },
+  {
+    'stem' : 'deriving-path',
+    'schema' : schema_dir / 'deriving-path-v1.yaml',
+    'files' : [
+      'single_opaque.json',
+      'single_built.json',
+      'single_built_built.json',
+    ],
+  },
 ]
 
 # Validate each example against the schema

--- a/src/json-schema-checks/package.nix
+++ b/src/json-schema-checks/package.nix
@@ -22,6 +22,7 @@ mkMesonDerivation (finalAttrs: {
     ../../doc/manual/source/protocols/json/schema
     ../../src/libutil-tests/data/hash
     ../../src/libstore-tests/data/derivation
+    ../../src/libstore-tests/data/derived-path
     ./.
   ];
 


### PR DESCRIPTION
## Motivation

Continuing to document our (unstable/experimental) JSON interfaces.

## Context

Note that this is "deriving path" in the manual -- the great sed of the code base to bring it in sync has yet to happen yet

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
