### PR TITLE
Allow access to the result of fetchClosure

### DIFF
--- a/src/libexpr/primops/fetchClosure.cc
+++ b/src/libexpr/primops/fetchClosure.cc
@@ -64,6 +64,8 @@ static void runFetchClosureWithRewrite(
              .pos = state.positions[pos]});
     }
 
+    state.allowClosure(toPath);
+
     state.mkStorePathString(toPath, v);
 }
 
@@ -91,6 +93,8 @@ static void runFetchClosureWithContentAddressedPath(
              .pos = state.positions[pos]});
     }
 
+    state.allowClosure(fromPath);
+
     state.mkStorePathString(fromPath, v);
 }
 
@@ -114,6 +118,8 @@ static void runFetchClosureWithInputAddressedPath(
                  state.store->printStorePath(fromPath)),
              .pos = state.positions[pos]});
     }
+
+    state.allowClosure(fromPath);
 
     state.mkStorePathString(fromPath, v);
 }

--- a/tests/functional/dependencies.builder0.sh
+++ b/tests/functional/dependencies.builder0.sh
@@ -17,4 +17,6 @@ ln -s "$out" "$out"/self
 echo program > "$out"/program
 chmod +x "$out"/program
 
+echo '1 + 2' > "$out"/foo.nix
+
 echo FOO

--- a/tests/functional/fetchClosure.sh
+++ b/tests/functional/fetchClosure.sh
@@ -99,6 +99,14 @@ clearStore
 
 [ -e "$caPath" ]
 
+# Test import-from-derivation on the result of fetchClosure.
+[[ $(nix eval -v --expr "
+  import \"\${builtins.fetchClosure {
+    fromStore = \"file://$cacheDir\";
+    fromPath = $caPath;
+  }}/foo.nix\"
+") = 3 ]]
+
 # Check that URL query parameters aren't allowed.
 clearStore
 narCache=$TEST_ROOT/nar-cache


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

There is no reason not to allow importing from a `fetchClosure` call.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
