### PR TITLE
fix(libutil): avoid dangling reference warning in Hash deserialization

### DIFF
--- a/src/libutil/hash.cc
+++ b/src/libutil/hash.cc
@@ -509,7 +509,7 @@ Hash adl_serializer<Hash>::from_json(const json & json, const ExperimentalFeatur
     auto & obj = getObject(json);
     auto algo = parseHashAlgo(getString(valueAt(obj, "algorithm")), xpSettings);
     auto format = parseHashFormat(getString(valueAt(obj, "format")));
-    auto & hashS = getString(valueAt(obj, "hash"));
+    auto hashS = getString(valueAt(obj, "hash"));
     return Hash::parseExplicitFormatUnprefixed(hashS, algo, format, xpSettings);
 }
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Changed the hashS variable from a reference to a copy to eliminate the
`-Wdangling-reference` compiler warning.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
