### PR TITLE
refactor(libutil): remove `showBytes()` in favor of `renderSize()`

### DIFF
--- a/src/libmain/include/nix/main/shared.hh
+++ b/src/libmain/include/nix/main/shared.hh
@@ -89,8 +89,6 @@ extern volatile ::sig_atomic_t blockInt;
 
 /* GC helpers. */
 
-std::string showBytes(uint64_t bytes);
-
 struct GCResults;
 
 struct PrintFreed

--- a/src/libmain/shared.cc
+++ b/src/libmain/shared.cc
@@ -406,7 +406,7 @@ RunPager::~RunPager()
 PrintFreed::~PrintFreed()
 {
     if (show)
-        std::cout << fmt("%d store paths deleted, %s freed\n", results.paths.size(), showBytes(results.bytesFreed));
+        std::cout << fmt("%d store paths deleted, %s freed\n", results.paths.size(), renderSize(results.bytesFreed));
 }
 
 } // namespace nix

--- a/src/libstore/optimise-store.cc
+++ b/src/libstore/optimise-store.cc
@@ -312,7 +312,7 @@ void LocalStore::optimiseStore()
 
     optimiseStore(stats);
 
-    printInfo("%s freed by hard-linking %d files", showBytes(stats.bytesFreed), stats.filesLinked);
+    printInfo("%s freed by hard-linking %d files", renderSize(stats.bytesFreed), stats.filesLinked);
 }
 
 void LocalStore::optimisePath(const Path & path, RepairFlag repair)

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -333,8 +333,6 @@ struct overloaded : Ts...
 template<class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
 
-std::string showBytes(uint64_t bytes);
-
 /**
  * Provide an addition operator between strings and string_views
  * inexplicably omitted from the standard library.

--- a/src/libutil/util.cc
+++ b/src/libutil/util.cc
@@ -256,9 +256,4 @@ std::pair<std::string_view, std::string_view> getLine(std::string_view s)
     }
 }
 
-std::string showBytes(uint64_t bytes)
-{
-    return fmt("%.2f MiB", bytes / (1024.0 * 1024.0));
-}
-
 } // namespace nix


### PR DESCRIPTION
## Motivation

The `showBytes()` function was redundant with `renderSize()` as the
latter automatically selects the appropriate unit (KiB, MiB, GiB, etc.)
based on the value, whereas `showBytes()` always formatted as MiB
regardless of size.

## Context

I found myself using `showBytes()` not knowing about `renderSize()`

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
