### PR TITLE
Use types to show that structured attrs are always JSON objects

### DIFF
--- a/src/libexpr/primops.cc
+++ b/src/libexpr/primops.cc
@@ -1374,7 +1374,7 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
             pos,
             "while evaluating the `__structuredAttrs` "
             "attribute passed to builtins.derivationStrict"))
-        jsonObject = StructuredAttrs{.structuredAttrs = json::object()};
+        jsonObject = StructuredAttrs{};
 
     /* Check whether null attributes should be ignored. */
     bool ignoreNulls = false;

--- a/src/libstore/build/derivation-env-desugar.cc
+++ b/src/libstore/build/derivation-env-desugar.cc
@@ -25,7 +25,7 @@ DesugaredEnv DesugaredEnv::create(
     if (drv.structuredAttrs) {
         auto json = drv.structuredAttrs->prepareStructuredAttrs(store, drvOptions, inputPaths, drv.outputs);
         res.atFileEnvPair("NIX_ATTRS_SH_FILE", ".attrs.sh") = StructuredAttrs::writeShell(json);
-        res.atFileEnvPair("NIX_ATTRS_JSON_FILE", ".attrs.json") = json.dump();
+        res.atFileEnvPair("NIX_ATTRS_JSON_FILE", ".attrs.json") = static_cast<nlohmann::json>(std::move(json)).dump();
     } else {
         /* In non-structured mode, set all bindings either directory in the
            environment or via a file, as specified by

--- a/src/libstore/include/nix/store/parsed-derivations.hh
+++ b/src/libstore/include/nix/store/parsed-derivations.hh
@@ -18,7 +18,7 @@ struct StructuredAttrs
 {
     static constexpr std::string_view envVarName{"__json"};
 
-    nlohmann::json structuredAttrs;
+    nlohmann::json::object_t structuredAttrs;
 
     bool operator==(const StructuredAttrs &) const = default;
 
@@ -45,7 +45,7 @@ struct StructuredAttrs
      */
     static void checkKeyNotInUse(const StringPairs & env);
 
-    nlohmann::json prepareStructuredAttrs(
+    nlohmann::json::object_t prepareStructuredAttrs(
         Store & store,
         const DerivationOptions & drvOptions,
         const StorePathSet & inputPaths,
@@ -62,7 +62,7 @@ struct StructuredAttrs
      * `prepareStructuredAttrs`, *not* the original `structuredAttrs`
      * field.
      */
-    static std::string writeShell(const nlohmann::json & prepared);
+    static std::string writeShell(const nlohmann::json::object_t & prepared);
 };
 
 } // namespace nix

--- a/src/libstore/parsed-derivations.cc
+++ b/src/libstore/parsed-derivations.cc
@@ -33,7 +33,8 @@ std::optional<StructuredAttrs> StructuredAttrs::tryExtract(StringPairs & env)
 
 std::pair<std::string_view, std::string> StructuredAttrs::unparse() const
 {
-    return {envVarName, structuredAttrs.dump()};
+    // TODO don't copy the JSON object just to dump it.
+    return {envVarName, static_cast<nlohmann::json>(structuredAttrs).dump()};
 }
 
 void StructuredAttrs::checkKeyNotInUse(const StringPairs & env)
@@ -97,7 +98,7 @@ static nlohmann::json pathInfoToJSON(Store & store, const StorePathSet & storePa
     return jsonList;
 }
 
-nlohmann::json StructuredAttrs::prepareStructuredAttrs(
+nlohmann::json::object_t StructuredAttrs::prepareStructuredAttrs(
     Store & store,
     const DerivationOptions & drvOptions,
     const StorePathSet & inputPaths,
@@ -120,7 +121,7 @@ nlohmann::json StructuredAttrs::prepareStructuredAttrs(
     return json;
 }
 
-std::string StructuredAttrs::writeShell(const nlohmann::json & json)
+std::string StructuredAttrs::writeShell(const nlohmann::json::object_t & json)
 {
 
     auto handleSimpleType = [](const nlohmann::json & value) -> std::optional<std::string> {
@@ -144,7 +145,7 @@ std::string StructuredAttrs::writeShell(const nlohmann::json & json)
 
     std::string jsonSh;
 
-    for (auto & [key, value] : json.items()) {
+    for (auto & [key, value] : json) {
 
         if (!std::regex_match(key, shVarName))
             continue;

--- a/src/nix/nix-build/nix-build.cc
+++ b/src/nix/nix-build/nix-build.cc
@@ -600,7 +600,7 @@ static void main_nix_build(int argc, char ** argv)
             structuredAttrsRC = StructuredAttrs::writeShell(json);
 
             auto attrsJSON = (tmpDir.path() / ".attrs.json").string();
-            writeFile(attrsJSON, json.dump());
+            writeFile(attrsJSON, static_cast<nlohmann::json>(std::move(json)).dump());
 
             auto attrsSH = (tmpDir.path() / ".attrs.sh").string();
             writeFile(attrsSH, structuredAttrsRC);


### PR DESCRIPTION
## Motivation

Before we just had partial code accessing it. Now, we use `nlohmann::json::object_t`, which is a `std::map`, to enforce this by construction.

## Context

Depends on #14351

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
