### PR TITLE
fix(libstore): Rewrite hard linking message to be more clear

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -907,7 +907,7 @@ void LocalStore::collectGarbage(const GCOptions & options, GCResults & results)
 #endif
             ;
 
-        printInfo("note: currently hard linking saves %s", renderSize(unsharedSize - actualSize - overhead));
+        printInfo("note: hard linking is currently saving %s", renderSize(unsharedSize - actualSize - overhead));
     }
 
     /* While we're at it, vacuum the database. */


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I saw the hard linking message on my own `sudo nix-collect-garbage -d` and assumed that I could shave off 30G+ from the nix store.
<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

"Currently hard linking saves" is grammatically incorrect and should be "Currently**,** hard linking saves". "Currently, hard linking saves" implies that hard linking is not being done at the moment. 

"Hard linking is currently saving" explicitly states that the hard linking has already been applied.

<!-- Provide context. Reference open issues if available. -->

I couldn't find an open issue about this, however the consensus in the Nix Cult discord is that this is bad wording.
<!-- Non-trivial change: Briefly outline the implementation strategy. -->

This is a non-trivial message change and isn't likely to impact any use cases.

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
