### PR TITLE
nix store copy-sigs: Use http-connections setting to control parallelism

### DIFF
--- a/src/nix/sigs.cc
+++ b/src/nix/sigs.cc
@@ -3,6 +3,7 @@
 #include "nix/main/shared.hh"
 #include "nix/store/store-open.hh"
 #include "nix/util/thread-pool.hh"
+#include "nix/store/filetransfer.hh"
 
 #include <atomic>
 
@@ -38,7 +39,7 @@ struct CmdCopySigs : StorePathsCommand
         for (auto & s : substituterUris)
             substituters.push_back(openStore(s));
 
-        ThreadPool pool;
+        ThreadPool pool{fileTransferSettings.httpConnections};
 
         std::atomic<size_t> added{0};
 


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Previously it used the `ThreadPool` default, i.e. `std::thread::hardware_concurrency()`. But copying signatures is not primarily CPU-bound so it makes more sense to use the `http-connections` setting (since we're typically copying from/to a binary cache).

Taken from https://github.com/DeterminateSystems/nix-src/pull/80.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
