### PR TITLE
refactor(libstore): use string_view in HttpBinaryCacheStore::makeRequest

### DIFF
--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -161,7 +161,7 @@ void HttpBinaryCacheStore::upsertFile(
     }
 }
 
-FileTransferRequest HttpBinaryCacheStore::makeRequest(const std::string & path)
+FileTransferRequest HttpBinaryCacheStore::makeRequest(std::string_view path)
 {
     /* Otherwise the last path fragment will get discarded. */
     auto cacheUriWithTrailingSlash = config->cacheUri;

--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -86,7 +86,7 @@ protected:
         const std::string & mimeType,
         uint64_t sizeHint) override;
 
-    FileTransferRequest makeRequest(const std::string & path);
+    FileTransferRequest makeRequest(std::string_view path);
 
     void getFile(const std::string & path, Sink & sink) override;
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

`std::string_view` >>> `const std::string &`

## Context

Part-Of: #14330

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
