### PR TITLE
parser.y: remove some unnecessary copies

### DIFF
--- a/src/libexpr/parser.y
+++ b/src/libexpr/parser.y
@@ -440,11 +440,11 @@ binds1
   ;
 
 attrs
-  : attrs attr { $$ = std::move($1); $$.emplace_back(AttrName(state->symbols.create($2)), state->at(@2)); }
+  : attrs attr { $$ = std::move($1); $$.emplace_back(state->symbols.create($2), state->at(@2)); }
   | attrs string_attr
     { $$ = std::move($1);
       std::visit(overloaded {
-          [&](std::string_view str) { $$.emplace_back(AttrName(state->symbols.create(str)), state->at(@2)); },
+          [&](std::string_view str) { $$.emplace_back(state->symbols.create(str), state->at(@2)); },
           [&](Expr * expr) {
               throw ParseError({
                   .msg = HintFmt("dynamic attributes not allowed in inherit"),
@@ -457,19 +457,19 @@ attrs
   ;
 
 attrpath
-  : attrpath '.' attr { $$ = std::move($1); $$.push_back(AttrName(state->symbols.create($3))); }
+  : attrpath '.' attr { $$ = std::move($1); $$.emplace_back(state->symbols.create($3)); }
   | attrpath '.' string_attr
     { $$ = std::move($1);
       std::visit(overloaded {
-          [&](std::string_view str) { $$.push_back(AttrName(state->symbols.create(str))); },
-          [&](Expr * expr) { $$.push_back(AttrName(expr)); }
+          [&](std::string_view str) { $$.emplace_back(state->symbols.create(str)); },
+          [&](Expr * expr) { $$.emplace_back(expr); }
       }, std::move($3));
     }
-  | attr { $$.push_back(AttrName(state->symbols.create($1))); }
+  | attr { $$.emplace_back(state->symbols.create($1)); }
   | string_attr
     { std::visit(overloaded {
-          [&](std::string_view str) { $$.push_back(AttrName(state->symbols.create(str))); },
-          [&](Expr * expr) { $$.push_back(AttrName(expr)); }
+          [&](std::string_view str) { $$.emplace_back(state->symbols.create(str)); },
+          [&](Expr * expr) { $$.emplace_back(expr); }
       }, std::move($1));
     }
   ;


### PR DESCRIPTION
 @xokdvium pointed out to me #14314 introduced a couple of unnecessary copies. As I was fixing that I noticed more unneccessary copies since we construct `AttrName`s and then `push_back()` them into a vector, we can `emplace_back()` them directly instead.

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Speeds up parsing by ~3%

```
$ poop -d 60000 '../master/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix' '../feature/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix'
Benchmark 1 (153 runs): ../master/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           393ms ± 18.1ms     369ms …  561ms          3 ( 2%)        0%
  peak_rss            105MB ±  224KB     105MB …  106MB          1 ( 1%)        0%
  cpu_cycles         1.45G  ± 71.5M     1.38G  … 2.17G           5 ( 3%)        0%
  instructions       3.44G  ± 9.05K     3.44G  … 3.44G           0 ( 0%)        0%
  cache_references   27.8M  ± 4.12M     25.5M  … 64.5M          11 ( 7%)        0%
  cache_misses       1.99M  ± 60.1K     1.87M  … 2.14M           0 ( 0%)        0%
  branch_misses      4.03M  ±  100K     3.92M  … 4.50M           3 ( 2%)        0%
Benchmark 2 (158 runs): ../feature/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           381ms ± 8.61ms     363ms …  407ms          2 ( 1%)        ⚡-  3.0% ±  0.8%
  peak_rss            105MB ±  235KB     105MB …  106MB          0 ( 0%)          -  0.0% ±  0.0%
  cpu_cycles         1.41G  ± 30.3M     1.35G  … 1.52G           4 ( 3%)        ⚡-  3.2% ±  0.8%
  instructions       3.41G  ± 10.4K     3.41G  … 3.41G           0 ( 0%)          -  0.7% ±  0.0%
  cache_references   27.5M  ± 3.02M     25.7M  … 49.7M          12 ( 8%)          -  0.9% ±  2.9%
  cache_misses       1.94M  ± 58.7K     1.83M  … 2.09M           2 ( 1%)        ⚡-  2.3% ±  0.7%
  branch_misses      3.97M  ± 99.5K     3.86M  … 4.36M           4 ( 3%)          -  1.4% ±  0.6%
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
