### PR TITLE
libexpr: store ExprList data in Exprs::alloc

### DIFF
--- a/src/libexpr/include/nix/expr/nixexpr.hh
+++ b/src/libexpr/include/nix/expr/nixexpr.hh
@@ -442,8 +442,14 @@ struct ExprAttrs : Expr
 
 struct ExprList : Expr
 {
-    std::vector<Expr *> elems;
-    ExprList() {};
+    std::span<Expr *> elems;
+
+    ExprList(std::pmr::polymorphic_allocator<char> & alloc, std::vector<Expr *> exprs)
+        : elems({alloc.allocate_object<Expr *>(exprs.size()), exprs.size()})
+    {
+        std::ranges::copy(exprs, elems.begin());
+    };
+
     COMMON_METHODS
     Value * maybeThunk(EvalState & state, Env & env) override;
 


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

For big-picture motivation, see [the tracking issue](https://github.com/nixos/nix/issues/14088)

This PR moves the ExprList data into our allocator.

- Saves 8 bytes per ExprList (std::vector -> std::span)
- Adds up to 2MB or 1.6% of memory used in parsing.

```
poop -d 60000 '../master/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix' '../feature/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix'
Benchmark 1 (169 runs): ../master/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           356ms ± 7.08ms     344ms …  379ms          3 ( 2%)        0%
  peak_rss            106MB ±  226KB     105MB …  106MB          5 ( 3%)        0%
  cpu_cycles         1.39G  ± 31.2M     1.34G  … 1.48G           2 ( 1%)        0%
  instructions       3.44G  ± 10.4K     3.44G  … 3.44G           1 ( 1%)        0%
  cache_references   27.6M  ± 1.45M     26.1M  … 40.5M          10 ( 6%)        0%
  cache_misses       1.95M  ± 50.1K     1.86M  … 2.10M           2 ( 1%)        0%
  branch_misses      4.04M  ± 97.0K     3.92M  … 4.33M           0 ( 0%)        0%
Benchmark 2 (173 runs): ../feature/result/bin/nix-instantiate --parse ../../nixpkgs/pkgs/development/haskell-modules/hackage-packages.nix
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           348ms ± 7.84ms     334ms …  382ms          6 ( 3%)        ⚡-  2.3% ±  0.4%
  peak_rss            104MB ±  251KB     103MB …  104MB          3 ( 2%)        ⚡-  1.6% ±  0.0%
  cpu_cycles         1.36G  ± 31.5M     1.30G  … 1.51G           7 ( 4%)        ⚡-  2.7% ±  0.5%
  instructions       3.43G  ± 10.3K     3.43G  … 3.43G           4 ( 2%)          -  0.3% ±  0.0%
  cache_references   28.4M  ± 4.14M     26.4M  … 65.5M          15 ( 9%)          +  2.8% ±  2.4%
  cache_misses       1.90M  ± 40.1K     1.82M  … 2.02M           1 ( 1%)        ⚡-  2.3% ±  0.5%
  branch_misses      3.97M  ± 84.6K     3.86M  … 4.25M           1 ( 1%)        ⚡-  1.9% ±  0.5%
```

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

- [tracking issue](https://github.com/nixos/nix/issues/14088)

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol).
