### PR TITLE
docs: remove incorrect claim re gc --print-dead

### DIFF
--- a/doc/manual/source/command-ref/nix-store/gc.md
+++ b/doc/manual/source/command-ref/nix-store/gc.md
@@ -48,8 +48,7 @@ The behaviour of the collector is also influenced by the
 configuration file.
 
 By default, the collector prints the total number of freed bytes when it
-finishes (or when it is interrupted). With `--print-dead`, it prints the
-number of bytes that would be freed.
+finishes (or when it is interrupted).
 
 {{#include ./opt-common.md}}
 


### PR DESCRIPTION
## Motivation

Update the `nix-store --gc` documentation to match its actual behaviour.

Ideally the behaviour of `nix-store --gc` would be updated to re-add function that was removed, and that has been requested in #7591, but that is a much more significant change.  In the meantime, it's useful to at least have the documentation match the expected behaviour.

## Context

In 4250b641d8e8edc4cb7def9bc463c7e4ff82e144, `nix-store --gc --print-dead` gained the ability to report how much space would be freed by running garbage collection.  Based on code reading and `git bisect`, I think that function broke in 7ab68961e4d7c30485efde1fb9dcb6edbdea9b5c, but the documentation wasn't updated at that time.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated nix-store --gc command documentation to clarify default output behavior regarding bytes freed with the --print-dead flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->