### PR TITLE
Enable JSON schema testing for derivation outputs

### DIFF
--- a/src/json-schema-checks/meson.build
+++ b/src/json-schema-checks/meson.build
@@ -46,20 +46,19 @@ schemas = [
       'simple-derivation.json',
     ],
   },
-  # # Not sure how to make subschema work
-  # {
-  #   'stem': 'derivation',
-  #   'schema': schema_dir / 'derivation-v3.yaml#output',
-  #   'files' : [
-  #     'output-caFixedFlat.json',
-  #     'output-caFixedNAR.json',
-  #     'output-caFixedText.json',
-  #     'output-caFloating.json',
-  #     'output-deferred.json',
-  #     'output-impure.json',
-  #     'output-inputAddressed.json',
-  #   ],
-  # },
+  {
+    'stem' : 'derivation',
+    'schema' : schema_dir / 'derivation-v3.yaml#/$defs/output',
+    'files' : [
+      'output-caFixedFlat.json',
+      'output-caFixedNAR.json',
+      'output-caFixedText.json',
+      'output-caFloating.json',
+      'output-deferred.json',
+      'output-impure.json',
+      'output-inputAddressed.json',
+    ],
+  },
   {
     'stem' : 'deriving-path',
     'schema' : schema_dir / 'deriving-path-v1.yaml',


### PR DESCRIPTION
## Motivation

More testing is better!

## Context

I figured out what the problem was: the fragment needs to start with a `/`.
---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
