### PR TITLE
Create JSON Schema for Store Paths

### DIFF
--- a/doc/manual/package.nix
+++ b/doc/manual/package.nix
@@ -36,6 +36,7 @@ mkMesonDerivation (finalAttrs: {
         # For example JSON
         ../../src/libutil-tests/data/hash
         ../../src/libstore-tests/data/content-address
+        ../../src/libstore-tests/data/store-path
         ../../src/libstore-tests/data/derived-path
         # Too many different types of files to filter for now
         ../../doc/manual

--- a/doc/manual/source/SUMMARY.md.in
+++ b/doc/manual/source/SUMMARY.md.in
@@ -119,6 +119,7 @@
   - [JSON Formats](protocols/json/index.md)
     - [Hash](protocols/json/hash.md)
     - [Content Address](protocols/json/content-address.md)
+    - [Store Path](protocols/json/store-path.md)
     - [Store Object Info](protocols/json/store-object-info.md)
     - [Derivation](protocols/json/derivation.md)
     - [Deriving Path](protocols/json/deriving-path.md)

--- a/doc/manual/source/protocols/json/meson.build
+++ b/doc/manual/source/protocols/json/meson.build
@@ -11,6 +11,7 @@ json_schema_config = files('json-schema-for-humans-config.yaml')
 schemas = [
   'hash-v1',
   'content-address-v1',
+  'store-path-v1',
   'derivation-v3',
   'deriving-path-v1',
 ]

--- a/doc/manual/source/protocols/json/schema/derivation-v3.yaml
+++ b/doc/manual/source/protocols/json/schema/derivation-v3.yaml
@@ -85,7 +85,7 @@ properties:
       > ]
       > ```
     items:
-      type: string
+      $ref: "store-path-v1.yaml"
 
   inputDrvs:
     type: object
@@ -103,13 +103,15 @@ properties:
       > ```
       >
       > specifies that this derivation depends on the `dev` output of `curl`, and the `out` output of `unzip`.
-    additionalProperties:
-      title: Store Path
-      description: |
-        A store path to a derivation, mapped to the outputs of that derivation.
-      oneOf:
-      - "$ref": "#/$defs/outputNames"
-      - "$ref": "#/$defs/dynamicOutputs"
+    patternProperties:
+      "^[0123456789abcdfghijklmnpqrsvwxyz]{32}-.+\\.drv$":
+        title: Store Path
+        description: |
+          A store path to a derivation, mapped to the outputs of that derivation.
+        oneOf:
+        - "$ref": "#/$defs/outputNames"
+        - "$ref": "#/$defs/dynamicOutputs"
+    additionalProperties: false
 
   system:
     type: string
@@ -155,7 +157,7 @@ properties:
     type: object
     properties:
       path:
-        type: string
+        $ref: "store-path-v1.yaml"
         title: Output path
         description: |
           The output path, if known in advance.

--- a/doc/manual/source/protocols/json/schema/deriving-path-v1.yaml
+++ b/doc/manual/source/protocols/json/schema/deriving-path-v1.yaml
@@ -7,7 +7,7 @@ oneOf:
   - title: Constant
     description: |
       See [Constant](@docroot@/store/derivation/index.md#deriving-path-constant) deriving path.
-    type: string
+    $ref: "store-path-v1.yaml"
   - title: Output
     description: |
       See [Output](@docroot@/store/derivation/index.md#deriving-path-output) deriving path.

--- a/doc/manual/source/protocols/json/schema/store-path-v1
+++ b/doc/manual/source/protocols/json/schema/store-path-v1
@@ -1,0 +1,1 @@
+../../../../../../src/libstore-tests/data/store-path

--- a/doc/manual/source/protocols/json/schema/store-path-v1.yaml
+++ b/doc/manual/source/protocols/json/schema/store-path-v1.yaml
@@ -1,0 +1,32 @@
+"$schema": "http://json-schema.org/draft-07/schema"
+"$id": "https://nix.dev/manual/nix/latest/protocols/json/schema/store-path-v1.json"
+title: Store Path
+description: |
+  A [store path](@docroot@/store/store-path.md) identifying a store object.
+
+  This schema describes the JSON representation of store paths as used in various Nix JSON APIs.
+
+  > **Warning**
+  >
+  > This JSON format is currently
+  > [**experimental**](@docroot@/development/experimental-features.md#xp-feature-nix-command)
+  > and subject to change.
+
+  ## Format
+
+  Store paths in JSON are represented as strings containing just the hash and name portion, without the store directory prefix.
+
+  For example: `"g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv"`
+
+  (If the store dir is `/nix/store`, then this corresponds to the path `/nix/store/g1w7hy3qg1w7hy3qg1w7hy3qg1w7hy3q-foo.drv`.)
+
+  ## Structure
+
+  The format follows this pattern: `${digest}-${name}`
+
+  - **hash**: Digest rendered in a custom variant of [Base32](https://en.wikipedia.org/wiki/Base32) (20 arbitrary bytes become 32 ASCII characters)
+  - **name**: The package name and optional version/suffix information
+
+type: string
+pattern: "^[0123456789abcdfghijklmnpqrsvwxyz]{32}-.+$"
+minLength: 34

--- a/doc/manual/source/protocols/json/store-path.md
+++ b/doc/manual/source/protocols/json/store-path.md
@@ -1,0 +1,15 @@
+{{#include store-path-v1-fixed.md}}
+
+## Examples
+
+### Simple store path
+
+```json
+{{#include schema/store-path-v1/simple.json}}
+```
+
+<!--
+## Raw Schema
+
+[JSON Schema for Store Path v1](schema/store-path-v1.json)
+-->

--- a/src/json-schema-checks/meson.build
+++ b/src/json-schema-checks/meson.build
@@ -39,6 +39,13 @@ schemas = [
     ],
   },
   {
+    'stem' : 'store-path',
+    'schema' : schema_dir / 'store-path-v1.yaml',
+    'files' : [
+      'simple.json',
+    ],
+  },
+  {
     'stem' : 'derivation',
     'schema' : schema_dir / 'derivation-v3.yaml',
     'files' : [

--- a/src/json-schema-checks/package.nix
+++ b/src/json-schema-checks/package.nix
@@ -22,6 +22,7 @@ mkMesonDerivation (finalAttrs: {
     ../../doc/manual/source/protocols/json/schema
     ../../src/libutil-tests/data/hash
     ../../src/libstore-tests/data/content-address
+    ../../src/libstore-tests/data/store-path
     ../../src/libstore-tests/data/derivation
     ../../src/libstore-tests/data/derived-path
     ./.

--- a/src/json-schema-checks/store-path
+++ b/src/json-schema-checks/store-path
@@ -1,0 +1,1 @@
+../../src/libstore-tests/data/store-path


### PR DESCRIPTION
## Motivation

More JSON schema in the docs.

## Context

We immediately use this in the JSON schemas for Derivation and Deriving Path, but we cannot yet use it in Store Object Info because those paths *do* include the store dir currently.

Prep commit:

> It now captures the stable non-recursive format (just an output set) and the unstable recursive form for dynamic derivations.

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
