### PR TITLE
libstore/filetransfer: Add HttpMethod::PUT

### DIFF
--- a/src/libstore/filetransfer.cc
+++ b/src/libstore/filetransfer.cc
@@ -394,9 +394,11 @@ struct curlFileTransfer : public FileTransfer
                 if (request.method == HttpMethod::POST) {
                     curl_easy_setopt(req, CURLOPT_POST, 1L);
                     curl_easy_setopt(req, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t) request.data->length());
-                } else {
+                } else if (request.method == HttpMethod::PUT) {
                     curl_easy_setopt(req, CURLOPT_UPLOAD, 1L);
                     curl_easy_setopt(req, CURLOPT_INFILESIZE_LARGE, (curl_off_t) request.data->length());
+                } else {
+                    unreachable();
                 }
                 curl_easy_setopt(req, CURLOPT_READFUNCTION, readCallbackWrapper);
                 curl_easy_setopt(req, CURLOPT_READDATA, this);

--- a/src/libstore/http-binary-cache-store.cc
+++ b/src/libstore/http-binary-cache-store.cc
@@ -141,7 +141,7 @@ void HttpBinaryCacheStore::upsertFile(
     uint64_t sizeHint)
 {
     auto req = makeRequest(path);
-
+    req.method = HttpMethod::PUT;
     auto data = StreamToSourceAdapter(istream).drain();
 
     auto compressionMethod = getCompressionMethod(path);

--- a/src/libstore/include/nix/store/filetransfer.hh
+++ b/src/libstore/include/nix/store/filetransfer.hh
@@ -88,6 +88,7 @@ extern const unsigned int RETRY_TIME_MS_DEFAULT;
  */
 enum struct HttpMethod {
     GET,
+    PUT,
     HEAD,
     POST,
     DELETE,
@@ -147,7 +148,9 @@ struct FileTransferRequest
         case HttpMethod::HEAD:
         case HttpMethod::GET:
             return "download";
+        case HttpMethod::PUT:
         case HttpMethod::POST:
+            assert(data);
             return "upload";
         case HttpMethod::DELETE:
             return "delet";

--- a/src/libstore/s3-binary-cache-store.cc
+++ b/src/libstore/s3-binary-cache-store.cc
@@ -101,6 +101,7 @@ std::string
 S3BinaryCacheStore::uploadPart(std::string_view key, std::string_view uploadId, uint64_t partNumber, std::string data)
 {
     auto req = makeRequest(key);
+    req.method = HttpMethod::PUT;
     req.setupForS3();
 
     auto url = req.uri.parsed();


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

This got lost in f1968ea38e51201b37962a9cfd80775989a56d46 and now we had incorrect logs that confused "downloading" when we were in fact "uploading" things.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

The incorrect logs message can be observed in https://github.com/NixOS/nix/pull/14406#issue-3563700538.

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
