### PR TITLE
zsh/completion: put compdef on first line

### DIFF
--- a/misc/zsh/completion.zsh
+++ b/misc/zsh/completion.zsh
@@ -1,5 +1,5 @@
-# shellcheck disable=all
 #compdef nix
+# shellcheck disable=all
 
 function _nix() {
   local ifs_bk="$IFS"


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Some zsh setups (including mine) do not load the completion if `#compdef` is not on the first line. So we move the `# shellcheck` comment to the second line to avoid this issue.

<!-- Briefly explain what the change is about and why it is desirable. -->

## Context

The `# shellcheck` comment is introduced in https://github.com/NixOS/nix/commit/8839bab84d97acc8531bf44399b5ca1269dd6f21 so cc @fzakaria for comments and review!

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
