### PR TITLE
ci: Add Coverity Scan workflow for static analysis

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,34 @@
+name: "Coverity Scan"
+
+on:
+  # FIXME: This is here for testing, should be removed before merging
+  pull_request:
+  push:
+    branches:
+      - master
+      - coverity-test
+
+permissions: read-all
+
+jobs:
+  coverity:
+    name: Coverity static analysis
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/install-nix-action
+        with:
+          dogfood: false
+          extra_nix_config: experimental-features = nix-command flakes
+      - name: configure
+        run: nix develop --configure
+      - uses: vapier/coverity-scan-action@v1
+        with:
+          project: NixOS/nix
+          token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          email: foo@example.com
+          build_language: cxx
+          command: nix develop --build
+          version: ${{ github.sha }}


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Coverity is a really powerful C/++ static analysis tool that is free for FOSS, this is just to see if it could work for us at all.

This will fail while the secret is not added to the repo, which is pending discussion in today's team meeting.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
