### PR TITLE
fix(libexpr/lexer): fix flex warning about default rule

### DIFF
--- a/src/libexpr/lexer.l
+++ b/src/libexpr/lexer.l
@@ -243,6 +243,14 @@ or          { return OR_KW; }
   return HPATH;
 }
 
+<PATH_START>{ANY} |
+<PATH_START><<EOF>> {
+  /* This should be unreachable: PATH_START is only entered after matching
+     PATH_SEG or HPATH_START, and we rewind to re-parse those same patterns.
+     This rule exists to satisfy flex's %option nodefault requirement. */
+  unreachable();
+}
+
 {PATH} {
   if (yytext[yyleng-1] == '/')
     PUSH_STATE(INPATH_SLASH);


### PR DESCRIPTION

<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

We were getting this flex lexer warning during build:
```
../src/libexpr/lexer.l:333: warning, -s option given but default rule can be matched
```

The lexer uses `%option nodefault` but the `PATH_START` state only had
rules for specific patterns (`PATH_SEG` and `HPATH_START`) without a
catch-all rule to handle unexpected input.

Added a catch-all rule that pops the state and re-parses in the previous
context, matching the pattern used in the `INPATH` state.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
