### PR TITLE
fix(libutil/tarfile): normalize legacy HTTP Content-Encoding names

### DIFF
--- a/src/libutil-tests/compression.cc
+++ b/src/libutil-tests/compression.cc
@@ -75,6 +75,30 @@ TEST(decompress, decompressInvalidInputThrowsCompressionError)
 }
 
 /* ----------------------------------------------------------------------------
+ * legacy HTTP Content-Encoding names (RFC 9110)
+ * --------------------------------------------------------------------------*/
+
+TEST(decompress, decompressXGzipCompressed)
+{
+    // Test that x-gzip (legacy HTTP Content-Encoding) works like gzip
+    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
+    auto compressedData = compress("gzip", str);
+    auto o = decompress("x-gzip", compressedData);
+
+    ASSERT_EQ(o, str);
+}
+
+TEST(decompress, decompressXBzip2Compressed)
+{
+    // Test that x-bzip2 (legacy HTTP Content-Encoding) works like bzip2
+    auto str = "slfja;sljfklsa;jfklsjfkl;sdjfkl;sadjfkl;sdjf;lsdfjsadlf";
+    auto compressedData = compress("bzip2", str);
+    auto o = decompress("x-bzip2", compressedData);
+
+    ASSERT_EQ(o, str);
+}
+
+/* ----------------------------------------------------------------------------
  * compression sinks
  * --------------------------------------------------------------------------*/
 


### PR DESCRIPTION
## Motivation

Nix failed to download files served with `Content-Encoding: x-gzip`
because libarchive doesn't recognize the legacy `x-*` compression
format names. Per RFC 9110 §8.4.1.3, HTTP recipients should treat
these as equivalent to their standard counterparts.

Adds `normalizeCompressionMethod()` to map legacy encoding names
before passing to libarchive:
- `x-gzip` → `gzip`
- `x-compress` → `compress`
- `x-bzip2` → `bzip2`

## Context

Fixes: #14324

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
