### PR TITLE
refactor(libstore): add `HttpBinaryCacheStore::upload` method

### DIFF
--- a/src/libstore/include/nix/store/http-binary-cache-store.hh
+++ b/src/libstore/include/nix/store/http-binary-cache-store.hh
@@ -85,6 +85,37 @@ protected:
 
     FileTransferRequest makeRequest(std::string_view path);
 
+    /**
+     * Uploads data to the binary cache.
+     *
+     * This is a lower-level method that handles the actual upload after
+     * compression has been applied. It does not handle compression or
+     * error wrapping - those are the caller's responsibility.
+     *
+     * @param path The path in the binary cache to upload to
+     * @param source The data source (should already be compressed if needed)
+     * @param sizeHint Size hint for the data
+     * @param mimeType The MIME type of the content
+     * @param contentEncoding Optional Content-Encoding header value (e.g., "xz", "br")
+     */
+    void upload(
+        std::string_view path,
+        RestartableSource & source,
+        uint64_t sizeHint,
+        std::string_view mimeType,
+        std::optional<std::string_view> contentEncoding);
+
+    /**
+     * Uploads data to the binary cache (CompressedSource overload).
+     *
+     * This overload infers both the size and compression method from the CompressedSource.
+     *
+     * @param path The path in the binary cache to upload to
+     * @param source The compressed source (knows size and compression method)
+     * @param mimeType The MIME type of the content
+     */
+    void upload(std::string_view path, CompressedSource & source, std::string_view mimeType);
+
     void getFile(const std::string & path, Sink & sink) override;
 
     void getFile(const std::string & path, Callback<std::optional<std::string>> callback) noexcept override;


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

Introduce protected `upload` method overloads in `HttpBinaryCacheStore`
that handle the actual upload after compression has been applied. This
separates compression concerns (in `upsertFile`) from upload mechanics
(in `upload`).

Two overloads are provided:

1. `upload(path, RestartableSource &, sizeHint, mimeType, contentEncoding)`
2. `upload(path, CompressedSource &, mimeType)`

## Context

Part-Of: #14330
Depends-On: #14420

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
