### PR TITLE
progress-bar: use dynamic size units

### DIFF
--- a/src/libutil-tests/util.cc
+++ b/src/libutil-tests/util.cc
@@ -147,6 +147,59 @@ TEST(string2Int, trivialConversions)
 }
 
 /* ----------------------------------------------------------------------------
+ * getSizeUnit
+ * --------------------------------------------------------------------------*/
+
+TEST(getSizeUnit, misc)
+{
+    ASSERT_EQ(getSizeUnit(0), SizeUnit::Base);
+    ASSERT_EQ(getSizeUnit(100), SizeUnit::Base);
+    ASSERT_EQ(getSizeUnit(100), SizeUnit::Base);
+    ASSERT_EQ(getSizeUnit(972), SizeUnit::Base);
+    ASSERT_EQ(getSizeUnit(973), SizeUnit::Base); // FIXME: should round down
+    ASSERT_EQ(getSizeUnit(1024), SizeUnit::Base);
+    ASSERT_EQ(getSizeUnit(-1024), SizeUnit::Base);
+    ASSERT_EQ(getSizeUnit(1024 * 1024), SizeUnit::Kilo);
+    ASSERT_EQ(getSizeUnit(1100 * 1024), SizeUnit::Mega);
+    ASSERT_EQ(getSizeUnit(2ULL * 1024 * 1024 * 1024), SizeUnit::Giga);
+    ASSERT_EQ(getSizeUnit(2100ULL * 1024 * 1024 * 1024), SizeUnit::Tera);
+}
+
+/* ----------------------------------------------------------------------------
+ * getCommonSizeUnit
+ * --------------------------------------------------------------------------*/
+
+TEST(getCommonSizeUnit, misc)
+{
+    ASSERT_EQ(getCommonSizeUnit({0}), SizeUnit::Base);
+    ASSERT_EQ(getCommonSizeUnit({0, 100}), SizeUnit::Base);
+    ASSERT_EQ(getCommonSizeUnit({100, 0}), SizeUnit::Base);
+    ASSERT_EQ(getCommonSizeUnit({100, 1024 * 1024}), std::nullopt);
+    ASSERT_EQ(getCommonSizeUnit({1024 * 1024, 100}), std::nullopt);
+    ASSERT_EQ(getCommonSizeUnit({1024 * 1024, 1024 * 1024}), SizeUnit::Kilo);
+    ASSERT_EQ(getCommonSizeUnit({2100ULL * 1024 * 1024 * 1024, 2100ULL * 1024 * 1024 * 1024}), SizeUnit::Tera);
+}
+
+/* ----------------------------------------------------------------------------
+ * renderSizeWithoutUnit
+ * --------------------------------------------------------------------------*/
+
+TEST(renderSizeWithoutUnit, misc)
+{
+    ASSERT_EQ(renderSizeWithoutUnit(0, SizeUnit::Base, true), "   0.0");
+    ASSERT_EQ(renderSizeWithoutUnit(100, SizeUnit::Base, true), "   0.1");
+    ASSERT_EQ(renderSizeWithoutUnit(100, SizeUnit::Base), "0.1");
+    ASSERT_EQ(renderSizeWithoutUnit(972, SizeUnit::Base, true), "   0.9");
+    ASSERT_EQ(renderSizeWithoutUnit(973, SizeUnit::Base, true), "   1.0"); // FIXME: should round down
+    ASSERT_EQ(renderSizeWithoutUnit(1024, SizeUnit::Base, true), "   1.0");
+    ASSERT_EQ(renderSizeWithoutUnit(-1024, SizeUnit::Base, true), "  -1.0");
+    ASSERT_EQ(renderSizeWithoutUnit(1024 * 1024, SizeUnit::Kilo, true), "1024.0");
+    ASSERT_EQ(renderSizeWithoutUnit(1100 * 1024, SizeUnit::Mega, true), "   1.1");
+    ASSERT_EQ(renderSizeWithoutUnit(2ULL * 1024 * 1024 * 1024, SizeUnit::Giga, true), "   2.0");
+    ASSERT_EQ(renderSizeWithoutUnit(2100ULL * 1024 * 1024 * 1024, SizeUnit::Tera, true), "   2.1");
+}
+
+/* ----------------------------------------------------------------------------
  * renderSize
  * --------------------------------------------------------------------------*/
 

--- a/src/libutil/include/nix/util/util.hh
+++ b/src/libutil/include/nix/util/util.hh
@@ -99,6 +99,42 @@ N string2IntWithUnitPrefix(std::string_view s)
     throw UsageError("'%s' is not an integer", s);
 }
 
+// Base also uses 'K', because it should also displayed as KiB => 100 Bytes => 0.1 KiB
+#define NIX_UTIL_SIZE_UNITS               \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Base, 'K')  \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Kilo, 'K')  \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Mega, 'M')  \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Giga, 'G')  \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Tera, 'T')  \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Peta, 'P')  \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Exa, 'E')   \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Zetta, 'Z') \
+    NIX_UTIL_DEFINE_SIZE_UNIT(Yotta, 'Y')
+
+enum class SizeUnit {
+#define NIX_UTIL_DEFINE_SIZE_UNIT(name, suffix) name,
+    NIX_UTIL_SIZE_UNITS
+#undef NIX_UTIL_DEFINE_SIZE_UNIT
+};
+
+constexpr inline auto sizeUnits = std::to_array<SizeUnit>({
+#define NIX_UTIL_DEFINE_SIZE_UNIT(name, suffix) SizeUnit::name,
+    NIX_UTIL_SIZE_UNITS
+#undef NIX_UTIL_DEFINE_SIZE_UNIT
+});
+
+SizeUnit getSizeUnit(int64_t value);
+
+/**
+ * Returns the unit if all values would be rendered using the same unit
+ * otherwise returns `std::nullopt`.
+ */
+std::optional<SizeUnit> getCommonSizeUnit(std::initializer_list<int64_t> values);
+
+std::string renderSizeWithoutUnit(int64_t value, SizeUnit unit, bool align = false);
+
+char getSizeUnitSuffix(SizeUnit unit);
+
 /**
  * Pretty-print a byte value, e.g. 12433615056 is rendered as `11.6
  * GiB`. If `align` is set, the number will be right-justified by


### PR DESCRIPTION
<!--

IMPORTANT

Nix is a non-trivial project, so for your contribution to be successful,
it really is important to follow the contributing guidelines:

https://github.com/NixOS/nix/blob/master/CONTRIBUTING.md

Even if you've contributed to open source before, take a moment to read it,
so you understand the process and the expectations.

- what information to include in commit messages
- proper attribution
- volunteering contributions effectively
- how to get help and our review process.

PR stuck in review? We have two Nix team meetings per week online that are open for everyone in a jitsi conference:

- https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com

-->

## Motivation

I've also implemented the changes from #14364 for the progress bar now.

Although it works, I am not quite happy with it.

If I copy something big from one host to another, the total size will probably be >1GiB. The problem now is that the current progress stays as 0 for way too long because the already transferred bytes are still below 0.1GiB.

<img width="1105" height="59" alt="2025-10-30_09-54" src="https://github.com/user-attachments/assets/54bf518d-871c-4fba-8777-4660e03ed1c3" />

and after like 10 seconds it looks like that:

<img width="1092" height="56" alt="2025-10-30_09-59" src="https://github.com/user-attachments/assets/4d340119-0766-45e0-9f6e-9ac0c071d502" />


This problem could be fixed by not displaying the unit only once for a `X/X/X GiB` block, but instead for every block: `X GiB/ X GiB/X GiB`.

In the reality, this could look like this: `100KiB/25MiB/1GiB`. But I am afraid this could be too verbose.

Maybe the community or maintainers could express some kind of opinion in the direction this should be going.

Also, this could just be a me-problem, because I am expecting that the number is always changing because it was like that till now.

## Context

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

---

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).

The Nix maintainer team uses a [GitHub project board](https://github.com/orgs/NixOS/projects/19) to [schedule and track reviews](https://github.com/NixOS/nix/tree/master/maintainers#project-board-protocol). 
